### PR TITLE
chore: prepare v0.3.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:
@@ -58,11 +58,37 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pixi-
 
+      - name: Verify tag matches package version
+        shell: bash
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          TAG_VERSION="${TAG_REF#v}"
+          PKG_VERSION=$(python -c "
+          import re, pathlib
+          text = pathlib.Path('pyproject.toml').read_text()
+          m = re.search(r'^version\s*=\s*\"(.+?)\"', text, re.MULTILINE)
+          print(m.group(1))
+          ")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version check passed: $TAG_VERSION"
+
       - name: Build package
         run: pixi run python -m build
 
       - name: Publish to PyPI
-        # Pinned to v1.12.2 (sha: 9c65b…) for supply-chain safety
+        # Pinned to v1.12.2 (sha: 76f52b…) for supply-chain safety
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9e4905c3b51a7d2d4c89f09
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to ProjectHephaestus are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-03-17
+
+### Fixed
+
+- Changed `write_file`, `safe_write`, `ensure_directory`, and `save_data` to return `None` instead of `True` — these functions raise on failure, so the bool return was misleading
+- Removed unnecessary `cast(str | bytes, ...)` in `read_file` (`io/utils.py`)
+- Fixed cache key format inconsistency between `test.yml` and `release.yml` workflows
+- Updated `docs/README.md` subpackage count to match actual structure
+- Fixed project URLs in `pyproject.toml` to point to `HomericIntelligence/ProjectHephaestus`
+
+### Added
+
+- Tag-version consistency check in release workflow — prevents publishing when git tag doesn't match `pyproject.toml` version
+- GitHub Release with artifacts created automatically on tag push
+- `COMPATIBILITY.md` documenting backwards compatibility policy for v0.x and planned v1.0
+- Python 3.10 and 3.11 classifiers plus `Topic` classifiers in `pyproject.toml`
+
+### Changed
+
+- Converted `__init__.py` from eager imports to lazy loading via PEP 562 (`__getattr__`) for faster `import hephaestus`
+- CI coverage threshold aligned to 80% across `test.yml`, `release.yml`, and `pyproject.toml`
+- Coverage upload limited to single matrix entry (ubuntu/3.12) to avoid duplicate reports
+
 ## [0.3.1] - 2026-03-15
 
 ### Fixed

--- a/pixi.lock
+++ b/pixi.lock
@@ -880,8 +880,8 @@ packages:
   timestamp: 1773314012590
 - pypi: ./
   name: hephaestus
-  version: 0.3.0
-  sha256: e4daaed388800ae54bd25f54f877b6238e7c89d18c7a5b4beaf96a9f9e67c07e
+  version: 0.3.2
+  sha256: 2fa01869772047cdb3c430822a1f858d13dca914f134aa6879eb07302cbee127
   requires_dist:
   - pyyaml>=6.0,<7
   - pytest>=9.0,<10 ; extra == 'dev'

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "project-hephaestus"
-version = "0.3.0"
+version = "0.3.2"
 description = "Shared utilities and tooling for the HomericIntelligence ecosystem"
 channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hephaestus"
-version = "0.3.0"
+version = "0.3.2"
 description = "Shared utilities and tooling for the HomericIntelligence ecosystem"
 readme = "README.md"
 license = {text = "BSD 3-Clause"}
@@ -17,7 +17,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Utilities",
 ]
 keywords = ["utilities", "helpers", "tooling", "homericintelligence"]
 dependencies = [
@@ -44,9 +48,9 @@ hephaestus-system-info = "hephaestus.system.info:main"
 hephaestus-download-dataset = "hephaestus.datasets.downloader:main"
 
 [project.urls]
-Homepage = "https://github.com/mvillmow/ProjectHephaestus"
-Repository = "https://github.com/mvillmow/ProjectHephaestus"
-Issues = "https://github.com/mvillmow/ProjectHephaestus/issues"
+Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"
+Repository = "https://github.com/HomericIntelligence/ProjectHephaestus"
+Issues = "https://github.com/HomericIntelligence/ProjectHephaestus/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["hephaestus"]


### PR DESCRIPTION
## Summary

- Bump version to 0.3.2 in `pyproject.toml` and `pixi.toml`
- Add tag-version verification step to release workflow (prevents mismatched tag/version publishes)
- Add GitHub Release with wheel/sdist artifacts via `softprops/action-gh-release@v2`
- Fix project URLs from `mvillmow/` to `HomericIntelligence/` org
- Add Python 3.10/3.11 classifiers and Topic classifiers
- Add 0.3.2 CHANGELOG section documenting all remediation branch changes

## After merge

```bash
git tag v0.3.2 && git push origin v0.3.2
```

This triggers the release workflow: test → build → PyPI publish → GitHub Release.

## Test plan

- [x] All 358 unit tests pass (81.65% coverage)
- [ ] Verify `PYPI_API_TOKEN` secret exists in repo settings
- [ ] After merge: tag v0.3.2, confirm release workflow succeeds
- [ ] Verify GitHub Release page has wheel and sdist attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)