### PR TITLE
fix(ci): switch PyPI publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: test
+    environment: pypi
 
     steps:
       - uses: actions/checkout@v6
@@ -80,10 +81,7 @@ jobs:
         run: pixi run python -m build
 
       - name: Publish to PyPI
-        # Pinned to v1.12.2 (sha: 76f52b…) for supply-chain safety
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9e4905c3b51a7d2d4c89f09
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary

- Replace broken pinned SHA (`76f52bc...`) for `pypa/gh-action-pypi-publish` with `release/v1`
- Switch from `PYPI_API_TOKEN` secret to OIDC trusted publishing (no secrets needed)
- Add `environment: pypi` to the build-and-publish job (required for OIDC)

Fixes the failed v0.3.2 and v0.4.0 release workflows. Unblocks Odyssey PR #4903.

## Manual Steps Required Before Re-triggering

**On PyPI** (https://pypi.org/manage/project/hephaestus/settings/publishing/):
1. Add trusted publisher:
   - Owner: `HomericIntelligence`
   - Repository: `ProjectHephaestus`
   - Workflow: `release.yml`
   - Environment: `pypi`

**On GitHub** (repo Settings → Environments):
1. Create environment named exactly `pypi`

## Re-trigger v0.4.0 Release

After merging this PR and completing manual setup:

```bash
git push origin --delete v0.4.0
git tag -d v0.4.0
git tag v0.4.0
git push origin v0.4.0
```

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Configure PyPI trusted publisher
- [ ] Create GitHub `pypi` environment
- [ ] Re-tag v0.4.0 and confirm release workflow succeeds
- [ ] Verify `pip install hephaestus==0.4.0` works
- [ ] Confirm Odyssey PR #4903 CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)