### PR TITLE
fix(ci): enable verbose PyPI publish to diagnose 403 Forbidden

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Enables `verbose: true` on `pypa/gh-action-pypi-publish` to get detailed error messages from PyPI
- The release workflow currently fails with `403 Forbidden` during upload — OIDC token exchange succeeds but PyPI rejects the upload, likely due to a trusted publisher configuration mismatch
- Verbose output will show the exact OIDC claims and rejection reason

## Context
Related issues: #36, #37, #38

The `pypi` environment protection rules have been fixed (now accepts `v*` tags), but the upload itself fails. We need the verbose output to identify the exact mismatch between the workflow's OIDC identity and PyPI's trusted publisher configuration.

## Test plan
- [ ] Merge this PR
- [ ] Delete and re-push v0.4.0 tag to trigger release workflow
- [ ] Review verbose output to identify the 403 root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)