### PR TITLE
fix(config): use double underscore as nesting delimiter in merge_with_env

### DIFF
--- a/hephaestus/config/utils.py
+++ b/hephaestus/config/utils.py
@@ -154,7 +154,13 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
     """Merge configuration with environment variables.
 
     Environment variables with the given prefix are mapped to config keys.
-    For example, HEPHAESTUS_DATABASE_HOST becomes database.host
+    Double underscores (``__``) denote nesting levels, while single
+    underscores are preserved as literal underscores in the key name.
+
+    Examples:
+        ``HEPHAESTUS_DATABASE__HOST``          → ``database.host``
+        ``HEPHAESTUS_DATABASE__MAX_CONNECTIONS`` → ``database.max_connections``
+        ``HEPHAESTUS_LOG_LEVEL``               → ``log_level``
 
     Args:
         config: Base configuration dictionary
@@ -168,8 +174,13 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
 
     for key, value in os.environ.items():
         if key.startswith(prefix):
-            # Convert HEPHAESTUS_DATABASE_HOST to database.host
-            config_key = key[len(prefix) :].lower().replace("_", ".")
+            # Strip prefix and lowercase the remainder
+            raw_key = key[len(prefix) :].lower()
+
+            # Split on double underscore for nesting; single underscores
+            # are preserved as literal characters in each segment.
+            segments = raw_key.split("__")
+
             # Try to convert to int or float if possible
             typed_value: int | float | str = value
             try:
@@ -179,13 +190,12 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
                     typed_value = float(value)
 
             # Set nested keys
-            keys = config_key.split(".")
             current = env_config
-            for k in keys[:-1]:
-                if k not in current:
-                    current[k] = {}
-                current = current[k]
-            current[keys[-1]] = typed_value
+            for segment in segments[:-1]:
+                if segment not in current:
+                    current[segment] = {}
+                current = current[segment]
+            current[segments[-1]] = typed_value
 
     return merge_configs(config, env_config)
 
@@ -197,6 +207,8 @@ def get_config_value(
     """High-level function to get a configuration value with full merging.
 
     Loads defaults, then user config, then environment variables.
+    Environment variables use double underscores (``__``) as nesting
+    delimiters — see :func:`merge_with_env` for details.
 
     Args:
         key_path: Dot-separated path to setting

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -172,8 +172,8 @@ class TestMergeWithEnv:
     """Tests for merge_with_env."""
 
     def test_env_variable_overrides(self, monkeypatch):
-        """Environment variable overrides config value."""
-        monkeypatch.setenv("HEPHAESTUS_DATABASE_HOST", "envhost")
+        """Environment variable with __ nesting overrides config value."""
+        monkeypatch.setenv("HEPHAESTUS_DATABASE__HOST", "envhost")
         config = {"database": {"host": "localhost"}}
         result = merge_with_env(config)
         assert result["database"]["host"] == "envhost"
@@ -202,6 +202,36 @@ class TestMergeWithEnv:
         config = {"a": 1}
         result = merge_with_env(config)
         assert result == {"a": 1}
+
+    def test_single_underscore_preserved(self, monkeypatch):
+        """Single underscore is preserved as literal in the key name."""
+        monkeypatch.setenv("HEPHAESTUS_MAX_CONNECTIONS", "100")
+        result = merge_with_env({})
+        assert result["max_connections"] == 100
+
+    def test_double_underscore_nesting(self, monkeypatch):
+        """Double underscore creates nested config keys."""
+        monkeypatch.setenv("HEPHAESTUS_DATABASE__HOST", "dbhost")
+        result = merge_with_env({})
+        assert result == {"database": {"host": "dbhost"}}
+
+    def test_mixed_nesting_and_underscore(self, monkeypatch):
+        """Double underscore nests, single underscore preserved in segment."""
+        monkeypatch.setenv("HEPHAESTUS_DATABASE__MAX_CONNECTIONS", "50")
+        result = merge_with_env({})
+        assert result == {"database": {"max_connections": 50}}
+
+    def test_deep_double_underscore_nesting(self, monkeypatch):
+        """Multiple double underscores create deeply nested keys."""
+        monkeypatch.setenv("HEPHAESTUS_A__B__C", "deep")
+        result = merge_with_env({})
+        assert result == {"a": {"b": {"c": "deep"}}}
+
+    def test_triple_underscore_edge_case(self, monkeypatch):
+        """Triple underscore splits as __ + _, preserving leading _ in segment."""
+        monkeypatch.setenv("HEPHAESTUS_A___B", "val")
+        result = merge_with_env({})
+        assert result == {"a": {"_b": "val"}}
 
 
 class TestLoadYamlConfig:


### PR DESCRIPTION
## Summary

- Changed `merge_with_env()` to use `__` (double underscore) as the nesting delimiter instead of `_`, following the Django/Flask convention
- Single underscores are now preserved as literal characters in config key segments (e.g., `HEPHAESTUS_MAX_CONNECTIONS` → `max_connections`)
- Updated docstrings on `merge_with_env()` and `get_config_value()` with the new convention and examples

## Examples

| Environment Variable | Config Key |
|---|---|
| `HEPHAESTUS_DATABASE__HOST` | `database.host` |
| `HEPHAESTUS_DATABASE__MAX_CONNECTIONS` | `database.max_connections` |
| `HEPHAESTUS_LOG_LEVEL` | `log_level` |

## Test plan

- [x] Updated existing `test_env_variable_overrides` to use `__` nesting
- [x] Added `test_single_underscore_preserved` — single `_` stays literal
- [x] Added `test_double_underscore_nesting` — `__` creates nesting
- [x] Added `test_mixed_nesting_and_underscore` — `DATABASE__MAX_CONNECTIONS` → `database.max_connections`
- [x] Added `test_deep_double_underscore_nesting` — `A__B__C` → `a.b.c`
- [x] Added `test_triple_underscore_edge_case` — `A___B` → `a._b`
- [x] All 389 unit tests pass
- [x] Linting and formatting clean

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)