### PR TITLE
Fix shell-metachar injection risk in install_package

### DIFF
--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -11,6 +11,8 @@ import unicodedata
 from pathlib import Path
 from typing import Any
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 from hephaestus.logging.utils import get_logger
 
 logger = get_logger(__name__)
@@ -189,22 +191,38 @@ def get_proj_root(proj_name: str) -> str:
 
 
 def install_package(package_name: str, upgrade: bool = False) -> bool:
-    """Install Python package with pip.
+    """Install a single Python package with pip.
+
+    Validates the package name using the PEP 508 requirement parser from
+    the ``packaging`` library. Supports extras (e.g. ``pkg[extra1,extra2]``)
+    and version specifiers (e.g. ``pkg>=1.0,<2``), but rejects URL-based
+    requirements for security.
 
     Args:
-        package_name: Name of package to install (must be a valid PyPI package name)
-        upgrade: Whether to upgrade if already installed
+        package_name: A single PEP 508 requirement string
+            (e.g. ``"requests"``, ``"pkg[extra]>=1.0"``).
+        upgrade: Whether to upgrade if already installed.
 
     Returns:
-        True if installation successful, False otherwise
+        True if installation successful, False otherwise.
 
     Raises:
-        ValueError: If package_name contains invalid characters
+        ValueError: If package_name is not a valid PEP 508 requirement
+            or uses a URL-based requirement.
 
     """
-    # Validate package name: only alphanumerics, hyphens, underscores, dots, brackets, ==, >=, <=
-    if not re.match(r"^[A-Za-z0-9_\-\.\[\],>=<!\s]+$", package_name):
-        raise ValueError(f"Invalid package name: {package_name!r}")
+    if not package_name or not package_name.strip():
+        raise ValueError(f"Invalid package requirement: {package_name!r}")
+
+    # Validate using the canonical PEP 508 requirement parser
+    try:
+        req = Requirement(package_name)
+    except InvalidRequirement as e:
+        raise ValueError(f"Invalid package requirement: {package_name!r}") from e
+
+    # Reject URL-based requirements for security
+    if req.url is not None:
+        raise ValueError(f"URL-based requirements are not supported: {package_name!r}")
 
     cmd = [sys.executable, "-m", "pip", "install"]
     if upgrade:

--- a/pixi.lock
+++ b/pixi.lock
@@ -881,8 +881,9 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.4.0
-  sha256: 5cf27ab367bce8879d509b9e81064a5994b7ca673e2d221add2fe462530dab5e
+  sha256: 9416554d3b38b1ae0bfceef7e0a2ce037e7065ebfb1400e05f56bd20af54bf08
   requires_dist:
+  - packaging>=21.0
   - pyyaml>=6.0,<7
   - pytest>=9.0,<10 ; extra == 'dev'
   - pytest-cov>=7.0,<8 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 keywords = ["utilities", "helpers", "tooling", "homericintelligence"]
 dependencies = [
+    "packaging>=21.0",
     "pyyaml>=6.0,<7",
 ]
 

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -217,3 +217,46 @@ class TestInstallPackage:
         install_package("some-package", upgrade=True)
         cmd = mock_run.call_args[0][0]
         assert "--upgrade" in cmd
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "requests",
+            "my-package",
+            "my_package",
+            "pkg.name",
+            "pkg[extra1]",
+            "pkg[extra1,extra2]",
+            "pkg>=1.0",
+            "pkg>=1.0,<2",
+            "pkg==1.2.3",
+            "pkg!=1.3",
+        ],
+    )
+    @patch("hephaestus.utils.helpers.run_subprocess")
+    def test_valid_requirement_accepted(self, mock_run, name):
+        """Accepts valid PEP 508 requirement strings."""
+        mock_run.return_value = MagicMock(returncode=0)
+        assert install_package(name) is True
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "pkg1 pkg2",
+            "pkg; rm -rf /",
+            "",
+            "   ",
+            "pkg && echo pwned",
+            "pkg | cat /etc/passwd",
+            "pkg\nnewline",
+        ],
+    )
+    def test_invalid_requirement_rejected(self, name):
+        """Rejects invalid or dangerous requirement strings."""
+        with pytest.raises(ValueError, match="Invalid package requirement"):
+            install_package(name)
+
+    def test_url_requirement_rejected(self):
+        """Rejects URL-based requirements for security."""
+        with pytest.raises(ValueError, match="URL-based requirements are not supported"):
+            install_package("pkg @ https://evil.com/malware.tar.gz")


### PR DESCRIPTION
## Summary

- Replaced the overly permissive custom regex in `install_package()` with `packaging.requirements.Requirement` (PEP 508 parser) for proper input validation
- Rejected URL-based requirements (`pkg @ https://...`) for security
- Added empty/whitespace-only input rejection
- Added `packaging>=21.0` as an explicit dependency in `pyproject.toml`
- Added comprehensive parametrized tests covering valid PEP 508 strings, shell injection attempts, and URL-based requirements

Closes #31

## Test plan

- [x] All 54 unit tests pass (including 10 valid-input and 7 invalid-input parametrized cases + 1 URL rejection test)
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean  
- [x] `mypy` — clean
- [x] `helpers.py` coverage at 94.83%

🤖 Generated with [Claude Code](https://claude.com/claude-code)