### PR TITLE
Fix duplicate handlers in get_logger

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -19,6 +19,10 @@ from typing import Any
 
 from hephaestus.constants import LOG_FORMAT
 
+# Registry tracking which handler keys have been configured for each logger name.
+# Maps logger name -> set of handler keys (e.g. {"console", "/path/to/file.log"}).
+_configured_loggers: dict[str, set[str]] = {}
+
 
 class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
     """Logger adapter that adds context information to log messages."""
@@ -73,20 +77,25 @@ def get_logger(
     logger = logging.getLogger(name)
     logger.setLevel(level or logging.INFO)
 
-    # Prevent adding handlers multiple times
-    if not logger.handlers:
-        formatter = logging.Formatter(LOG_FORMAT)
+    configured = _configured_loggers.setdefault(name, set())
+    formatter = logging.Formatter(LOG_FORMAT)
 
-        # Console handler
+    # Console handler — add once per logger name
+    if "console" not in configured:
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
+        configured.add("console")
 
-        # File handler (optional)
-        if log_file:
-            file_handler = logging.FileHandler(log_file)
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
+    # File handler — add if a new file path is requested
+    if log_file and log_file not in configured:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+        configured.add(log_file)
+
+    # Prevent duplicate messages from parent loggers
+    logger.propagate = False
 
     return ContextLogger(logger, context)
 

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -5,11 +5,26 @@ import logging
 import threading
 from pathlib import Path
 
+import pytest
+
 from hephaestus.logging.utils import (
     ContextLogger,
+    _configured_loggers,
     get_logger,
     setup_logging,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clean_logging_registry() -> None:  # type: ignore[misc]
+    """Reset the handler registry and remove test loggers after each test."""
+    yield  # type: ignore[misc]
+    # Teardown: remove any test loggers we created
+    for name in list(_configured_loggers):
+        if name.startswith("test."):
+            _configured_loggers.pop(name, None)
+            logger = logging.getLogger(name)
+            logger.handlers.clear()
 
 
 class TestGetLogger:
@@ -42,6 +57,42 @@ class TestGetLogger:
         logger = get_logger("test.file_handler", log_file=log_file)
         handler_types = [type(h) for h in logger.logger.handlers]
         assert logging.FileHandler in handler_types
+
+    def test_no_duplicate_handlers_on_repeated_calls(self) -> None:
+        """Calling get_logger twice with the same name adds only one StreamHandler."""
+        get_logger("test.dup")
+        logger2 = get_logger("test.dup")
+        stream_handlers = [
+            h for h in logger2.logger.handlers if isinstance(h, logging.StreamHandler)
+        ]
+        assert len(stream_handlers) == 1
+
+    def test_adds_file_handler_on_second_call(self, tmp_path: Path) -> None:
+        """A file handler is added when requested on a subsequent call."""
+        get_logger("test.lazy_file")
+        log_file = str(tmp_path / "lazy.log")
+        logger2 = get_logger("test.lazy_file", log_file=log_file)
+        file_handlers = [h for h in logger2.logger.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+    def test_does_not_duplicate_same_file_handler(self, tmp_path: Path) -> None:
+        """Requesting the same log_file twice adds only one FileHandler."""
+        log_file = str(tmp_path / "dup_file.log")
+        get_logger("test.dup_file", log_file=log_file)
+        logger2 = get_logger("test.dup_file", log_file=log_file)
+        file_handlers = [h for h in logger2.logger.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+    def test_propagate_false(self) -> None:
+        """get_logger sets propagate=False to prevent duplicate parent output."""
+        logger = get_logger("test.propagate")
+        assert logger.logger.propagate is False
+
+    def test_level_updated_on_second_call(self) -> None:
+        """A second call with a different level updates the logger's level."""
+        get_logger("test.level_update", level=logging.INFO)
+        logger2 = get_logger("test.level_update", level=logging.DEBUG)
+        assert logger2.logger.level == logging.DEBUG
 
 
 class TestContextLogger:


### PR DESCRIPTION
## Summary
- Replace naive `if not logger.handlers` guard with a module-level `_configured_loggers` registry that tracks handler types per logger name
- Console handlers are added once per logger name; file handlers are added only for new file paths
- Set `logger.propagate = False` to prevent duplicate messages from parent loggers
- Level is updated on every call so subsequent calls with a different level take effect

## Test plan
- [x] Added `test_no_duplicate_handlers_on_repeated_calls` — verifies only 1 StreamHandler after 2 calls
- [x] Added `test_adds_file_handler_on_second_call` — verifies file handler added on subsequent call
- [x] Added `test_does_not_duplicate_same_file_handler` — verifies same file path doesn't duplicate
- [x] Added `test_propagate_false` — verifies propagate is disabled
- [x] Added `test_level_updated_on_second_call` — verifies level changes take effect
- [x] All 389 existing unit tests pass with no regressions
- [x] Ruff lint, format, and mypy all pass clean

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)