### PR TITLE
fix(git): use tab delimiter in changelog to handle pipe chars in commits

### DIFF
--- a/hephaestus/git/changelog.py
+++ b/hephaestus/git/changelog.py
@@ -79,7 +79,7 @@ def get_commits_between(from_ref: str | None, to_ref: str = "HEAD") -> list[str]
         [
             "log",
             range_spec,
-            "--pretty=format:%h|%s|%an",
+            "--pretty=format:%h%x09%s%x09%an",
             "--no-merges",
         ]
     )
@@ -96,13 +96,13 @@ def parse_commit(commit_line: str) -> tuple[str, str, str, str]:
     Handles conventional commits format: type(scope): message
 
     Args:
-        commit_line: Commit line in format "hash|subject|author"
+        commit_line: Commit line in format "hash<TAB>subject<TAB>author"
 
     Returns:
         Tuple of (hash, type, scope, message)
 
     """
-    parts = commit_line.split("|", 2)
+    parts = commit_line.split("\t", 2)
     if len(parts) != 3:
         return ("", "other", "", commit_line)
 
@@ -120,7 +120,10 @@ def parse_commit(commit_line: str) -> tuple[str, str, str, str]:
         # Extract type and optional scope
         if "(" in prefix and ")" in prefix:
             commit_type = prefix.split("(")[0].strip().lower()
-            scope = prefix.split("(")[1].split(")")[0].strip()
+            # Use index/rindex to handle nested parentheses
+            open_paren = prefix.index("(")
+            close_paren = prefix.rindex(")")
+            scope = prefix[open_paren + 1 : close_paren].strip()
         else:
             commit_type = prefix.strip().lower()
 

--- a/tests/unit/git/test_git_utils.py
+++ b/tests/unit/git/test_git_utils.py
@@ -3,6 +3,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from hephaestus.git.changelog import (
     categorize_commits,
     generate_changelog,
@@ -16,7 +18,7 @@ class TestParseCommit:
 
     def test_parse_conventional_commit(self):
         """Parse a standard conventional commit."""
-        commit = "abc123|feat(api): Add new endpoint|John Doe"
+        commit = "abc123\tfeat(api): Add new endpoint\tJohn Doe"
         hash_val, commit_type, scope, message = parse_commit(commit)
         assert hash_val == "abc123"
         assert commit_type == "feat"
@@ -25,7 +27,7 @@ class TestParseCommit:
 
     def test_parse_commit_without_scope(self):
         """Parse commit without scope."""
-        commit = "def456|fix: Resolve bug|Jane Smith"
+        commit = "def456\tfix: Resolve bug\tJane Smith"
         hash_val, commit_type, scope, message = parse_commit(commit)
         assert hash_val == "def456"
         assert commit_type == "fix"
@@ -34,7 +36,7 @@ class TestParseCommit:
 
     def test_parse_non_conventional_commit(self):
         """Parse a non-conventional commit."""
-        commit = "ghi789|Random commit message|Bob Johnson"
+        commit = "ghi789\tRandom commit message\tBob Johnson"
         hash_val, commit_type, scope, message = parse_commit(commit)
         assert hash_val == "ghi789"
         assert commit_type == "other"
@@ -51,20 +53,20 @@ class TestParseCommit:
 
     def test_parse_commit_type_lowercased(self):
         """Commit type is always lowercased."""
-        commit = "abc123|FEAT(api): Something|Author"
+        commit = "abc123\tFEAT(api): Something\tAuthor"
         _, commit_type, _, _ = parse_commit(commit)
         assert commit_type == "feat"
 
     def test_parse_refactor_commit(self):
         """Parse a refactor commit."""
-        commit = "zzz999|refactor(core): Simplify logic|Dev"
+        commit = "zzz999\trefactor(core): Simplify logic\tDev"
         _, commit_type, scope, _ = parse_commit(commit)
         assert commit_type == "refactor"
         assert scope == "core"
 
     def test_parse_docs_commit(self):
         """Parse a docs commit."""
-        commit = "aaa111|docs: Update README|Dev"
+        commit = "aaa111\tdocs: Update README\tDev"
         _, commit_type, scope, message = parse_commit(commit)
         assert commit_type == "docs"
         assert scope == ""
@@ -72,9 +74,72 @@ class TestParseCommit:
 
     def test_parse_commit_with_colon_in_message(self):
         """Handles message that contains a colon after the prefix."""
-        commit = "abc123|feat(scope): Add feature: with colon|Author"
+        commit = "abc123\tfeat(scope): Add feature: with colon\tAuthor"
         _, _, _, message = parse_commit(commit)
         assert "with colon" in message
+
+    def test_parse_commit_with_pipe_in_subject(self):
+        """Pipe characters in commit subject do not break parsing."""
+        commit = "abc123\tfeat: add A|B toggle\tAuthor"
+        hash_val, commit_type, scope, message = parse_commit(commit)
+        assert hash_val == "abc123"
+        assert commit_type == "feat"
+        assert scope == ""
+        assert message == "add A|B toggle"
+
+    def test_parse_commit_with_multiple_colons(self):
+        """Multiple colons in message are preserved (split on first colon only)."""
+        commit = "abc123\tfix: url: handle https://example.com\tAuthor"
+        hash_val, commit_type, scope, message = parse_commit(commit)
+        assert hash_val == "abc123"
+        assert commit_type == "fix"
+        assert scope == ""
+        assert message == "url: handle https://example.com"
+
+    def test_parse_commit_with_nested_parens_in_scope(self):
+        """Nested parentheses in scope are handled correctly."""
+        commit = "abc123\tfeat(core(sub)): nested scope msg\tAuthor"
+        hash_val, commit_type, scope, message = parse_commit(commit)
+        assert hash_val == "abc123"
+        assert commit_type == "feat"
+        assert scope == "core(sub)"
+        assert message == "nested scope msg"
+
+    def test_parse_commit_empty_string(self):
+        """Empty string returns fallback tuple."""
+        hash_val, commit_type, scope, message = parse_commit("")
+        assert hash_val == ""
+        assert commit_type == "other"
+        assert scope == ""
+        assert message == ""
+
+    def test_parse_commit_only_two_tab_fields(self):
+        """Commit line with only two tab-separated fields falls through."""
+        commit = "abc123\tsubject"
+        hash_val, commit_type, _scope, message = parse_commit(commit)
+        assert hash_val == ""
+        assert commit_type == "other"
+        assert message == "abc123\tsubject"
+
+    @pytest.mark.parametrize(
+        ("commit_line", "expected_type"),
+        [
+            ("a\tfeat: f\tA", "feat"),
+            ("a\tfix: f\tA", "fix"),
+            ("a\tperf: f\tA", "perf"),
+            ("a\tdocs: f\tA", "docs"),
+            ("a\trefactor: f\tA", "refactor"),
+            ("a\ttest: f\tA", "test"),
+            ("a\tci: f\tA", "ci"),
+            ("a\tchore: f\tA", "chore"),
+            ("a\tbuild: f\tA", "build"),
+            ("a\tstyle: f\tA", "style"),
+        ],
+    )
+    def test_parse_commit_all_types(self, commit_line: str, expected_type: str):
+        """All conventional commit types are parsed correctly."""
+        _, commit_type, _, _ = parse_commit(commit_line)
+        assert commit_type == expected_type
 
 
 class TestCategorizeCommits:
@@ -83,10 +148,10 @@ class TestCategorizeCommits:
     def test_categorize_multiple_types(self):
         """Categorizes different commit types correctly."""
         commits = [
-            "abc123|feat(api): Add endpoint|John",
-            "def456|fix: Bug fix|Jane",
-            "ghi789|feat(ui): New button|Bob",
-            "jkl012|docs: Update README|Alice",
+            "abc123\tfeat(api): Add endpoint\tJohn",
+            "def456\tfix: Bug fix\tJane",
+            "ghi789\tfeat(ui): New button\tBob",
+            "jkl012\tdocs: Update README\tAlice",
         ]
         categories = categorize_commits(commits)
         assert "Features" in categories
@@ -103,9 +168,9 @@ class TestCategorizeCommits:
     def test_categorize_with_blank_lines(self):
         """Blank lines are skipped."""
         commits = [
-            "abc123|feat: Feature|John",
+            "abc123\tfeat: Feature\tJohn",
             "",
-            "def456|fix: Fix|Jane",
+            "def456\tfix: Fix\tJane",
         ]
         categories = categorize_commits(commits)
         assert len(categories["Features"]) == 1
@@ -113,23 +178,23 @@ class TestCategorizeCommits:
 
     def test_categorize_unknown_type_goes_to_other(self):
         """Unknown commit type goes to 'Other' category."""
-        commits = ["abc123|unknown: Something|Author"]
+        commits = ["abc123\tunknown: Something\tAuthor"]
         categories = categorize_commits(commits)
         assert "Other" in categories
 
     def test_categorize_all_known_types(self):
         """All standard conventional commit types are categorized."""
         commits = [
-            "a|feat: f|a",
-            "b|fix: f|a",
-            "c|perf: f|a",
-            "d|docs: f|a",
-            "e|refactor: f|a",
-            "f|test: f|a",
-            "g|ci: f|a",
-            "h|chore: f|a",
-            "i|build: f|a",
-            "j|style: f|a",
+            "a\tfeat: f\ta",
+            "b\tfix: f\ta",
+            "c\tperf: f\ta",
+            "d\tdocs: f\ta",
+            "e\trefactor: f\ta",
+            "f\ttest: f\ta",
+            "g\tci: f\ta",
+            "h\tchore: f\ta",
+            "i\tbuild: f\ta",
+            "j\tstyle: f\ta",
         ]
         categories = categorize_commits(commits)
         assert "Features" in categories
@@ -145,13 +210,25 @@ class TestCategorizeCommits:
 
     def test_categorize_returns_tuples(self):
         """Each category entry is a (hash, scope, message) tuple."""
-        commits = ["abc123|feat(api): Add endpoint|Author"]
+        commits = ["abc123\tfeat(api): Add endpoint\tAuthor"]
         categories = categorize_commits(commits)
         entry = categories["Features"][0]
         assert len(entry) == 3
         assert entry[0] == "abc123"
         assert entry[1] == "api"
         assert entry[2] == "Add endpoint"
+
+    def test_categorize_commits_with_pipe_in_message(self):
+        """Commits with pipe characters in subject parse correctly through pipeline."""
+        commits = [
+            "abc123\tfeat: support A|B|C flags\tAuthor",
+            "def456\tfix: handle x|y case\tAuthor",
+        ]
+        categories = categorize_commits(commits)
+        assert len(categories["Features"]) == 1
+        assert categories["Features"][0][2] == "support A|B|C flags"
+        assert len(categories["Bug Fixes"]) == 1
+        assert categories["Bug Fixes"][0][2] == "handle x|y case"
 
 
 class TestGenerateChangelog:
@@ -163,8 +240,8 @@ class TestGenerateChangelog:
         """Generates changelog content with commit data."""
         mock_prev_tag.return_value = "v0.2.0"
         mock_commits.return_value = [
-            "abc123|feat(core): New feature|Author",
-            "def456|fix: Important bugfix|Author",
+            "abc123\tfeat(core): New feature\tAuthor",
+            "def456\tfix: Important bugfix\tAuthor",
         ]
 
         result = generate_changelog("v0.3.0")
@@ -187,7 +264,7 @@ class TestGenerateChangelog:
     @patch("hephaestus.git.changelog.get_commits_between")
     def test_uses_provided_from_ref(self, mock_commits):
         """Uses provided from_ref directly."""
-        mock_commits.return_value = ["abc123|feat: Feature|Author"]
+        mock_commits.return_value = ["abc123\tfeat: Feature\tAuthor"]
         generate_changelog("v0.3.0", from_ref="v0.2.0")
         mock_commits.assert_called_once_with("v0.2.0", "HEAD")
 
@@ -196,7 +273,7 @@ class TestGenerateChangelog:
     def test_scope_formatted_in_output(self, mock_prev_tag, mock_commits):
         """Scoped commits show scope in bold."""
         mock_prev_tag.return_value = None
-        mock_commits.return_value = ["abc123|feat(api): My feature|Author"]
+        mock_commits.return_value = ["abc123\tfeat(api): My feature\tAuthor"]
         result = generate_changelog("v0.3.0")
         assert "**api**:" in result
 
@@ -208,7 +285,7 @@ class TestGetCommitsBetween:
     def test_with_from_ref(self, mock_run):
         """Builds range spec with from_ref..to_ref."""
         mock_run.return_value.returncode = 0
-        mock_run.return_value.stdout = "abc|feat: thing|Author\n"
+        mock_run.return_value.stdout = "abc\tfeat: thing\tAuthor\n"
         result = get_commits_between("v0.1.0", "HEAD")
         assert len(result) == 1
         cmd_args = mock_run.call_args[0][0]
@@ -231,3 +308,12 @@ class TestGetCommitsBetween:
         mock_run.return_value.stdout = ""
         result = get_commits_between("v0.1.0")
         assert result == []
+
+    @patch("subprocess.run")
+    def test_format_string_uses_tab_delimiter(self, mock_run):
+        """Git log format string uses tab (%x09) as delimiter."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = ""
+        get_commits_between("v0.1.0")
+        cmd_args = mock_run.call_args[0][0]
+        assert "--pretty=format:%h%x09%s%x09%an" in cmd_args


### PR DESCRIPTION
## Summary

- **Fixed delimiter bug**: Changed `get_commits_between()` git log format from `%h|%s|%an` to `%h%x09%s%x09%an` (tab-separated). Commit subjects containing `|` characters (e.g. `add A|B toggle`) previously produced garbled changelog entries.
- **Fixed `parse_commit()` split**: Updated from `split("|", 2)` to `split("\t", 2)` to match the new delimiter.
- **Hardened scope extraction**: Replaced chained `split("(")[1].split(")")[0]` with `index("(")`/`rindex(")")` to correctly handle nested parentheses in scope (e.g. `feat(core(sub)): msg`).
- **Added edge-case tests**: Pipe in subject, multiple colons, nested parentheses in scope, empty string, incomplete fields, and parametrized type coverage.
- **Updated all existing tests** to use tab delimiters consistent with the new format string.

Closes #33

## Test plan

- [x] All 38 changelog tests pass (`pixi run pytest tests/unit/git/test_git_utils.py -v`)
- [x] Full unit suite passes (401 tests, 82.14% coverage)
- [x] Ruff lint and format checks pass
- [ ] Verify changelog generation on a real repo with `|` in commit messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)