### PR TITLE
feat: add justfile for ecosystem convention consistency

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,37 @@
+# ProjectHephaestus task runner
+# Convention: justfile delegates to pixi tasks
+
+default:
+    @just --list
+
+# === Test ===
+
+# Run tests (accepts optional args, e.g. `just test tests/unit/`)
+test *ARGS:
+    pixi run pytest {{ ARGS }}
+
+# === Code Quality ===
+
+# Run linter
+lint *ARGS:
+    pixi run lint {{ ARGS }}
+
+# Run formatter
+format:
+    pixi run format
+
+# Run type checker
+typecheck:
+    pixi run mypy hephaestus/
+
+# === Security ===
+
+# Run dependency audit
+audit:
+    pixi run audit
+
+# === Checks ===
+
+# Run pre-commit hooks on all files
+pre-commit:
+    pixi run pre-commit run --all-files


### PR DESCRIPTION
## Summary

- Adds a `justfile` at the repository root that delegates to existing `pixi run` tasks, matching the HomericIntelligence ecosystem convention (justfile + pixi)
- Recipes: `test`, `lint`, `format`, `typecheck`, `audit`, `pre-commit`
- `test` and `lint` accept `*ARGS` for parameterized invocation (e.g., `just test tests/unit/ -v`)

Closes #35

## Test plan

- [x] `just --list` displays all recipes with descriptions
- [x] `just test` runs full test suite (435 tests pass)
- [x] Parameterized recipes work (e.g., `just test tests/unit/`)
- [x] Existing tests unaffected (82.13% coverage maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)