### PR TITLE
fix(io): return None from write_file/safe_write/ensure_directory/save_data

### DIFF
--- a/hephaestus/io/utils.py
+++ b/hephaestus/io/utils.py
@@ -47,16 +47,13 @@ def write_file(
     filepath: str | Path,
     content: str | bytes,
     mode: str = "w",
-) -> bool:
+) -> None:
     """Write content to a file.
 
     Args:
         filepath: Path to file
         content: Content to write
         mode: File open mode ('w' for text, 'wb' for binary)
-
-    Returns:
-        True if successful
 
     Raises:
         OSError: If the file cannot be written
@@ -66,40 +63,32 @@ def write_file(
     filepath.parent.mkdir(parents=True, exist_ok=True)
     with open(filepath, mode) as f:
         f.write(content)
-    return True
 
 
-def ensure_directory(path: str | Path) -> bool:
+def ensure_directory(path: str | Path) -> None:
     """Ensure directory exists, creating it if necessary.
 
     Args:
         path: Path to directory
-
-    Returns:
-        True if successful
 
     Raises:
         OSError: If the directory cannot be created
 
     """
     Path(path).mkdir(parents=True, exist_ok=True)
-    return True
 
 
 def safe_write(
     filepath: str | Path,
     content: str | bytes,
     backup: bool = True,
-) -> bool:
+) -> None:
     """Write content to file safely with optional backup.
 
     Args:
         filepath: Path to file
         content: Content to write
         backup: Whether to create backup of existing file
-
-    Returns:
-        True if successful
 
     Raises:
         OSError: If the file cannot be written
@@ -119,7 +108,6 @@ def safe_write(
         filepath.write_text(content)
     else:
         filepath.write_bytes(content)
-    return True
 
 
 def write_secure(
@@ -223,7 +211,7 @@ def save_data(
     filepath: str | Path,
     format_hint: str | None = None,
     allow_unsafe_deserialization: bool = False,
-) -> bool:
+) -> None:
     """Save data to file with automatic format detection.
 
     Args:
@@ -232,9 +220,6 @@ def save_data(
         format_hint: Optional format hint ('json', 'yaml', 'pickle')
         allow_unsafe_deserialization: If False (default), raise ValueError for
             formats that can execute arbitrary code (e.g. pickle).
-
-    Returns:
-        True if successful, False otherwise
 
     Raises:
         ValueError: If format is unsafe and allow_unsafe_deserialization is False.
@@ -264,4 +249,3 @@ def save_data(
 
         with open(filepath, "wb") as f:
             pickle.dump(data, f)
-    return True

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -66,8 +66,7 @@ def test_ensure_directory():
     try:
         with tempfile.TemporaryDirectory() as temp_dir:
             test_path = Path(temp_dir) / "test" / "nested" / "directory"
-            result = ensure_directory(test_path)
-            assert result
+            ensure_directory(test_path)
             assert test_path.exists()
         print("✓ ensure_directory tests passed")
         return True

--- a/tests/unit/io/test_utils.py
+++ b/tests/unit/io/test_utils.py
@@ -24,17 +24,17 @@ class TestEnsureDirectory:
     def test_creates_nested_directories(self, tmp_path: Path) -> None:
         """Nested directories are created."""
         target = tmp_path / "a" / "b" / "c"
-        assert ensure_directory(target)
+        ensure_directory(target)
         assert target.exists()
 
     def test_existing_directory(self, tmp_path: Path) -> None:
-        """Existing directory returns True without error."""
-        assert ensure_directory(tmp_path)
+        """Existing directory succeeds without error."""
+        ensure_directory(tmp_path)
 
     def test_string_path(self, tmp_path: Path) -> None:
         """Accepts string path."""
         target = str(tmp_path / "str_dir")
-        assert ensure_directory(target)
+        ensure_directory(target)
 
     def test_raises_on_failure(self, tmp_path: Path) -> None:
         """Raises OSError when directory cannot be created."""
@@ -72,13 +72,13 @@ class TestWriteFile:
     def test_writes_text(self, tmp_path: Path) -> None:
         """Writes text content."""
         f = tmp_path / "out.txt"
-        assert write_file(f, "content")
+        write_file(f, "content")
         assert f.read_text() == "content"
 
     def test_creates_parent_dirs(self, tmp_path: Path) -> None:
         """Creates missing parent directories."""
         f = tmp_path / "sub" / "file.txt"
-        assert write_file(f, "hi")
+        write_file(f, "hi")
         assert f.exists()
 
 
@@ -88,13 +88,13 @@ class TestSafeWrite:
     def test_writes_text_content(self, tmp_path: Path) -> None:
         """Writes text content to file."""
         f = tmp_path / "test.txt"
-        assert safe_write(f, "Hello World")
+        safe_write(f, "Hello World")
         assert f.read_text() == "Hello World"
 
     def test_writes_binary_content(self, tmp_path: Path) -> None:
         """Writes bytes content to file."""
         f = tmp_path / "test.bin"
-        assert safe_write(f, b"\xff\xfe")
+        safe_write(f, b"\xff\xfe")
         assert f.read_bytes() == b"\xff\xfe"
 
     def test_backup_created(self, tmp_path: Path) -> None:
@@ -228,13 +228,13 @@ class TestSaveData:
     def test_save_json(self, tmp_path: Path) -> None:
         """Saves data as JSON."""
         f = tmp_path / "out.json"
-        assert save_data({"k": 1}, f)
+        save_data({"k": 1}, f)
         assert json.loads(f.read_text()) == {"k": 1}
 
     def test_save_yaml(self, tmp_path: Path) -> None:
         """Saves data as YAML."""
         f = tmp_path / "out.yaml"
-        assert save_data({"k": 1}, f)
+        save_data({"k": 1}, f)
         assert "k:" in f.read_text()
 
     def test_unsafe_format_blocked_by_default(self, tmp_path: Path) -> None:
@@ -246,7 +246,7 @@ class TestSaveData:
     def test_default_format_json(self, tmp_path: Path) -> None:
         """Unknown extension defaults to JSON."""
         f = tmp_path / "out.dat"
-        assert save_data({"x": 1}, f)
+        save_data({"x": 1}, f)
         assert json.loads(f.read_text()) == {"x": 1}
 
     def test_raises_on_io_error(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Changed `write_file`, `safe_write`, `ensure_directory`, and `save_data` in `hephaestus/io/utils.py` to return `None` instead of `True`
- These functions raise on failure, so the boolean return was redundant and misleading
- Aligns code with CHANGELOG v0.3.2 which already documented this change

## Changes

- **`hephaestus/io/utils.py`**: Updated return type annotations (`-> bool` → `-> None`), removed `return True` statements, removed "Returns" docstring sections for all four functions
- **`tests/unit/io/test_utils.py`**: Removed `assert` wrapping on return values (10 call sites), updated docstring for `test_existing_directory`
- **`scripts/run_tests.py`**: Removed `result = ensure_directory(...)` / `assert result` pattern in smoke test

## Test plan

- [x] All 35 IO unit tests pass
- [x] All 384 unit tests pass
- [x] mypy type checking passes
- [x] No callers outside tests/scripts depend on the boolean return value

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)