### PR TITLE
feat(dx): add justfile for one-command bootstrap and dev workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ ProjectHephaestus/
 │   ├── benchmarks/             # Benchmark comparison utilities
 │   ├── version/                # Version management
 │   └── validation/             # README and config validation
+├── justfile                    # One-command developer workflows (just)
 ├── scripts/                    # Automation and maintenance scripts
 ├── tests/                      # Unit and integration tests
 │   ├── unit/                   # Unit tests (mirrors hephaestus/ structure)
@@ -269,25 +270,22 @@ All utility functions must include comprehensive test coverage:
 
 ```bash
 # Run all unit tests
-pixi run pytest tests/unit -v
+just test -v
 
 # Run specific test file
-pixi run pytest tests/unit/utils/test_general_utils.py -v
+just test tests/unit/utils/test_general_utils.py -v
 
 # Run with coverage
-pixi run pytest tests/unit --cov=hephaestus --cov-report=html
+just test --cov=hephaestus --cov-report=html
 ```
 
 ## Environment Setup
 
-This project uses [Pixi](https://pixi.sh) for environment management:
+This project uses [just](https://github.com/casey/just) for one-command workflows and [Pixi](https://pixi.sh) for environment management:
 
 ```bash
-# Install dependencies and create environment
-pixi install
-
-# Run pre-commit hooks (formatting, linting, etc.)
-pre-commit install
+# One-command bootstrap: installs dependencies and configures pre-commit hooks
+just bootstrap
 ```
 
 ## Common Commands
@@ -296,16 +294,19 @@ pre-commit install
 
 ```bash
 # Run tests
-pixi run pytest tests/unit
+just test
 
 # Run linter
-pixi run ruff check hephaestus/ tests/
+just lint
 
 # Run formatter
-pixi run ruff format hephaestus/ tests/
+just format
 
 # Run type checking
-pixi run mypy hephaestus/
+just typecheck
+
+# Run all checks (lint + typecheck + test)
+just check
 ```
 
 ### Pre-commit Hooks
@@ -313,11 +314,11 @@ pixi run mypy hephaestus/
 Pre-commit hooks automatically check code quality:
 
 ```bash
-# Install pre-commit hooks (one-time setup)
-pre-commit install
+# Install pre-commit hooks (included in bootstrap)
+just bootstrap
 
 # Run hooks manually on all files
-pre-commit run --all-files
+just pre-commit
 
 # NEVER skip hooks with --no-verify
 ```
@@ -329,7 +330,7 @@ pre-commit run --all-files
 1. **Import Errors**: Check that `pixi install` has been run
 2. **Dependency Conflicts**: Update `pixi.toml` and run `pixi install`
 3. **Test Failures**: Run tests with verbose output for details
-4. **Formatting Issues**: Run `pixi run ruff format hephaestus/ tests/`
+4. **Formatting Issues**: Run `just format`
 
 ### Getting Help
 
@@ -352,6 +353,7 @@ pre-commit run --all-files
 - `tests/integration/` - Integration tests (package importability, smoke tests)
 - `scripts/` - Automation and maintenance tools
 - `docs/` - Documentation and guides
+- `justfile` - One-command developer workflows (`just bootstrap`, `just test`, etc.)
 - `pyproject.toml` - Project metadata, dependencies, and tool configuration
 - `pixi.toml` - Pixi environment and task definitions
 - `.claude/` - Claude Code configuration and guidance

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProjectHephaestus
 
-Shared utilities and tooling for the HomericIntelligence ecosystem, powered by [Pixi](https://pixi.sh) for environment management.
+Shared utilities and tooling for the HomericIntelligence ecosystem, powered by [Pixi](https://pixi.sh) for environment management and [just](https://github.com/casey/just) for a consistent developer experience.
 
 ## Overview
 
@@ -15,6 +15,7 @@ ProjectHephaestus provides standardized utility functions and tools that can be 
 
 ```
 ProjectHephaestus/
+├── justfile           # One-command developer workflows
 ├── pixi.toml          # Pixi configuration
 ├── pyproject.toml     # Python package configuration
 ├── hephaestus/        # Main package
@@ -38,43 +39,50 @@ ProjectHephaestus/
 └── README.md          # This file
 ```
 
-## Getting Started with Pixi
+## Getting Started
 
-This project uses [Pixi](https://pixi.sh) for environment management, which automatically handles dependencies and creates isolated environments.
+This project uses [just](https://github.com/casey/just) for one-command workflows and [Pixi](https://pixi.sh) for environment management.
 
 ### Prerequisites
 
-Install Pixi by following the [official installation guide](https://pixi.sh/install/).
+- Install [just](https://github.com/casey/just#installation)
+- Install [Pixi](https://pixi.sh/install/)
 
 ### Setup Development Environment
 
 ```bash
-# Install dependencies and create environment
-pixi install
-
-# Activate the environment (optional, as pixi runs commands in the environment automatically)
-pixi shell
+# One-command bootstrap: installs dependencies and configures pre-commit hooks
+just bootstrap
 ```
 
 ### Running Tests
 
 ```bash
-# Run tests using the test feature
-pixi run test
+# Run unit tests
+just test
 
-# Or run tests directly with pytest
-pixi run pytest
+# Run with extra flags
+just test -v
+just test -k test_slugify
 ```
 
 ### Development Commands
 
 ```bash
-# Format code with ruff
-pixi run format
+# Format code
+just format
 
-# Lint code with ruff
-pixi run lint
+# Lint code
+just lint
+
+# Type check
+just typecheck
+
+# Run all checks (lint + typecheck + test)
+just check
 ```
+
+> **Note:** All `just` recipes wrap `pixi run` commands. If you don't have `just` installed, you can use `pixi run` directly (see `pixi.toml` for available tasks).
 
 ## Usage
 
@@ -173,6 +181,7 @@ hephaestus-merge-prs --help
 3. Document all public functions with Google-style docstrings
 4. Use type hints for all function parameters and return values
 5. Keep functions small and focused (single responsibility principle)
+6. Use `just` recipes for all common workflows (run `just` to see available recipes)
 
 ## Contributing
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,55 @@
+# ProjectHephaestus justfile
+# One-command developer experience for the HomericIntelligence ecosystem
+
+# Configurable paths
+src_dirs := "hephaestus scripts tests"
+test_dir := "tests/unit"
+
+# List available recipes
+default:
+    @just --list
+
+# === Setup ===
+
+# Install dependencies and configure pre-commit hooks
+bootstrap:
+    pixi install
+    pixi run pre-commit install
+
+# === Test ===
+
+# Run unit tests (pass extra args: just test -v, just test -k test_slugify)
+test *ARGS:
+    pixi run pytest {{ test_dir }} {{ ARGS }}
+
+# === Lint ===
+
+# Check code with ruff linter
+lint:
+    pixi run ruff check {{ src_dirs }}
+
+# Format code with ruff formatter
+format:
+    pixi run ruff format {{ src_dirs }}
+
+# Run mypy type checking
+typecheck:
+    pixi run mypy hephaestus/
+
+# Run pre-commit hooks on all files
+pre-commit:
+    pixi run pre-commit run --all-files
+
+# === Security ===
+
+# Run pip-audit dependency audit
+audit:
+    pixi run --environment lint pip-audit
+
+# === CI ===
+
+# Run lint, typecheck, and tests (full CI check)
+check:
+    just lint
+    just typecheck
+    just test


### PR DESCRIPTION
## Summary

- **Created `justfile`** with recipes: `bootstrap`, `test`, `lint`, `format`, `typecheck`, `audit`, `pre-commit`, and `check` (combined CI)
- **Updated `README.md`** to reference `just` recipes as the primary DX, with `pixi run` as fallback
- **Updated `CLAUDE.md`** to use `just` commands in Environment Setup, Common Commands, Testing Strategy, Pre-commit Hooks, and Troubleshooting sections

## Motivation

Closes #48 — The repo lacked a one-command bootstrap workflow. Without a justfile, developers had to read documentation to discover the correct `pixi run` commands. In a 12-repo ecosystem, inconsistent DX slows onboarding and increases cognitive load.

## Test plan

- [x] `just --list` shows all recipes
- [x] `just test` — 384 tests pass
- [x] `just lint` — all checks passed
- [x] `just format` — 85 files unchanged
- [x] `just typecheck` — no issues found
- [x] `just pre-commit` — all 21 hooks pass
- [x] Pre-commit validation passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)