### PR TITLE
feat(logging): add structured JSON logging support

### DIFF
--- a/hephaestus/constants.py
+++ b/hephaestus/constants.py
@@ -20,3 +20,6 @@ DEFAULT_EXCLUDE_DIRS: frozenset[str] = frozenset(
 
 # Standard log format used across all logging utilities.
 LOG_FORMAT: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+# Base field names included in every JSON log record.
+JSON_LOG_FIELDS: tuple[str, ...] = ("timestamp", "level", "logger", "message")

--- a/hephaestus/logging/__init__.py
+++ b/hephaestus/logging/__init__.py
@@ -1,5 +1,6 @@
 """Enhanced logging utilities for the HomericIntelligence ecosystem."""
 
+from .formatters import JsonFormatter
 from .utils import (
     ContextLogger,
     get_logger,
@@ -8,6 +9,7 @@ from .utils import (
 
 __all__ = [
     "ContextLogger",
+    "JsonFormatter",
     "get_logger",
     "setup_logging",
 ]

--- a/hephaestus/logging/formatters.py
+++ b/hephaestus/logging/formatters.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""JSON log formatter for structured logging.
+
+Provides a ``logging.Formatter`` subclass that outputs each log record as a
+single JSON line, suitable for ingestion by log aggregation systems such as
+Loki/Promtail in the ProjectArgus observability stack.
+
+Usage:
+    import logging
+    from hephaestus.logging.formatters import JsonFormatter
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+    logger = logging.getLogger("my.service")
+    logger.addHandler(handler)
+    logger.info("hello", extra={"request_id": "abc-123"})
+"""
+
+import json
+import logging
+import traceback
+from datetime import datetime, timezone
+from typing import Any
+
+# Fields that are reserved for the formatter and cannot be overridden by
+# context or extra data.  If a context key collides with one of these, it
+# is prefixed with ``ctx_`` to avoid silent data loss.
+RESERVED_FIELDS: frozenset[str] = frozenset(
+    {"timestamp", "level", "logger", "message", "exception", "stack_info"}
+)
+
+
+class JsonFormatter(logging.Formatter):
+    """Formatter that serialises log records to single-line JSON.
+
+    Standard fields included in every record:
+    - ``timestamp`` – ISO 8601 UTC timestamp
+    - ``level`` – log level name (e.g. ``INFO``)
+    - ``logger`` – logger name
+    - ``message`` – formatted log message
+
+    Any *extra* dict entries attached to the record (e.g. via
+    ``ContextLogger.bind()``) are merged as top-level keys.  If an extra
+    key collides with a reserved field name it is automatically prefixed
+    with ``ctx_`` so that the original field is never shadowed.
+
+    Exception and stack information, when present, are serialised into
+    ``exception`` and ``stack_info`` string fields respectively.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format *record* as a JSON string.
+
+        Args:
+            record: The log record to format.
+
+        Returns:
+            A single-line JSON string representing the log record.
+
+        """
+        log_dict: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        # Merge extra/context fields, prefixing collisions with ``ctx_``.
+        if hasattr(record, "_context_extras"):
+            extras: dict[str, Any] = record._context_extras
+        else:
+            # Fall back to detecting manually-set extra keys by comparing
+            # against the default LogRecord attributes.
+            extras = {
+                k: v
+                for k, v in record.__dict__.items()
+                if k not in _DEFAULT_RECORD_ATTRS and k != "_context_extras"
+            }
+
+        for key, value in extras.items():
+            if key in RESERVED_FIELDS:
+                log_dict[f"ctx_{key}"] = value
+            else:
+                log_dict[key] = value
+
+        if record.exc_info and record.exc_info[0] is not None:
+            log_dict["exception"] = "".join(traceback.format_exception(*record.exc_info))
+
+        if record.stack_info:
+            log_dict["stack_info"] = record.stack_info
+
+        return json.dumps(log_dict, default=str)
+
+
+# Set of attribute names present on a default LogRecord so we can detect
+# user-supplied extras.
+_DEFAULT_RECORD_ATTRS: frozenset[str] = frozenset(
+    logging.LogRecord("", 0, "", 0, None, None, None).__dict__.keys()
+)

--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.constants import LOG_FORMAT
+from hephaestus.logging.formatters import JsonFormatter
 
 # Module-level lock protects the check-then-add TOCTOU in get_logger()
 _handler_setup_lock = threading.Lock()
@@ -64,6 +65,7 @@ def get_logger(
     level: int | None = None,
     log_file: str | None = None,
     context: dict[str, Any] | None = None,
+    json_format: bool = False,
 ) -> ContextLogger:
     """Get a configured logger instance with optional context.
 
@@ -72,6 +74,7 @@ def get_logger(
         level: Logging level (defaults to INFO)
         log_file: Optional file to log to
         context: Optional context dictionary to include in logs
+        json_format: If True, use structured JSON output instead of plain text
 
     Returns:
         Configured ContextLogger instance
@@ -80,7 +83,7 @@ def get_logger(
     logger = logging.getLogger(name)
     logger.setLevel(level or logging.INFO)
 
-    formatter = logging.Formatter(LOG_FORMAT)
+    formatter: logging.Formatter = JsonFormatter() if json_format else logging.Formatter(LOG_FORMAT)
 
     # Lock protects the check-then-add TOCTOU race condition during concurrent initialization
     with _handler_setup_lock:
@@ -119,20 +122,27 @@ def setup_logging(
     log_file: str | None = None,
     format_string: str | None = None,
     log_to_stderr: bool = False,
+    json_format: bool = False,
 ) -> None:
     """Set up global logging configuration.
 
     Args:
         level: Default logging level
         log_file: Optional file to log to
-        format_string: Custom log format
+        format_string: Custom log format (ignored when *json_format* is True)
         log_to_stderr: Whether to also log to stderr
+        json_format: If True, use structured JSON output instead of plain text
 
     """
-    format_string = format_string or LOG_FORMAT
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
-    formatter = logging.Formatter(format_string)
+
+    formatter: logging.Formatter
+    if json_format:
+        formatter = JsonFormatter()
+    else:
+        format_string = format_string or LOG_FORMAT
+        formatter = logging.Formatter(format_string)
 
     # Deduplicate stdout StreamHandler
     has_stdout = any(

--- a/tests/unit/logging/test_formatters.py
+++ b/tests/unit/logging/test_formatters.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Tests for the JsonFormatter structured logging formatter."""
+
+import json
+import logging
+from collections.abc import Callable
+from datetime import datetime
+
+import pytest
+
+from hephaestus.logging.formatters import RESERVED_FIELDS, JsonFormatter
+
+
+@pytest.fixture()
+def formatter() -> JsonFormatter:
+    """Return a fresh JsonFormatter instance."""
+    return JsonFormatter()
+
+
+@pytest.fixture()
+def make_record() -> Callable[..., logging.LogRecord]:
+    """Return a factory that creates a LogRecord with optional extras."""
+
+    def _make(
+        msg: str = "test message",
+        level: int = logging.INFO,
+        name: str = "test.logger",
+        exc_info: tuple | None = None,
+        extra: dict | None = None,
+    ) -> logging.LogRecord:
+        record = logging.LogRecord(
+            name=name,
+            level=level,
+            pathname="test.py",
+            lineno=1,
+            msg=msg,
+            args=None,
+            exc_info=exc_info,
+        )
+        if extra:
+            for k, v in extra.items():
+                setattr(record, k, v)
+        return record
+
+    return _make
+
+
+class TestJsonFormatterOutput:
+    """Tests for basic JsonFormatter output."""
+
+    def test_output_is_valid_json(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Formatted output must be parseable as JSON."""
+        record = make_record()
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert isinstance(parsed, dict)
+
+    def test_standard_fields_present(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """All standard fields must be present in JSON output."""
+        record = make_record(msg="hello world", level=logging.WARNING, name="my.logger")
+        parsed = json.loads(formatter.format(record))
+        assert parsed["message"] == "hello world"
+        assert parsed["level"] == "WARNING"
+        assert parsed["logger"] == "my.logger"
+        assert "timestamp" in parsed
+
+    def test_timestamp_is_iso8601(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Timestamp must be a valid ISO 8601 string."""
+        record = make_record()
+        parsed = json.loads(formatter.format(record))
+        # datetime.fromisoformat will raise on invalid format
+        dt = datetime.fromisoformat(parsed["timestamp"])
+        assert dt.tzinfo is not None  # must include timezone
+
+    def test_message_with_percent_formatting(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Lazy %s formatting in the message must be resolved."""
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="test.py",
+            lineno=1,
+            msg="hello %s",
+            args=("world",),
+            exc_info=None,
+        )
+        parsed = json.loads(formatter.format(record))
+        assert parsed["message"] == "hello world"
+
+
+class TestJsonFormatterExtras:
+    """Tests for extra/context field handling."""
+
+    def test_extra_fields_included(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Extra fields set on the record appear in JSON output."""
+        record = make_record(extra={"request_id": "abc-123", "service": "keystone"})
+        parsed = json.loads(formatter.format(record))
+        assert parsed["request_id"] == "abc-123"
+        assert parsed["service"] == "keystone"
+
+    def test_reserved_field_collision_prefixed(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Context keys that collide with reserved names get a ctx_ prefix."""
+        record = make_record(extra={"level": "custom_value", "message": "override"})
+        parsed = json.loads(formatter.format(record))
+        # Original reserved fields remain intact
+        assert parsed["level"] == "INFO"
+        assert parsed["message"] == "test message"
+        # Colliding extras are prefixed
+        assert parsed["ctx_level"] == "custom_value"
+        assert parsed["ctx_message"] == "override"
+
+    def test_non_serializable_value_uses_str(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Non-JSON-serializable extra values fall back to str()."""
+
+        class Custom:
+            def __str__(self) -> str:
+                return "custom-repr"
+
+        record = make_record(extra={"obj": Custom()})
+        parsed = json.loads(formatter.format(record))
+        assert parsed["obj"] == "custom-repr"
+
+
+class TestJsonFormatterExceptions:
+    """Tests for exception and stack info serialisation."""
+
+    def test_exception_field_present(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """When exc_info is set, an 'exception' field appears in the JSON."""
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            exc_info = sys.exc_info()
+
+        record = make_record(exc_info=exc_info)
+        parsed = json.loads(formatter.format(record))
+        assert "exception" in parsed
+        assert "ValueError: boom" in parsed["exception"]
+        assert "Traceback" in parsed["exception"]
+
+    def test_no_exception_field_when_no_exc_info(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """No 'exception' field when there is no exception."""
+        record = make_record()
+        parsed = json.loads(formatter.format(record))
+        assert "exception" not in parsed
+
+    def test_stack_info_included(
+        self, formatter: JsonFormatter, make_record: Callable[..., logging.LogRecord]
+    ) -> None:
+        """Stack info is serialised when present."""
+        record = make_record()
+        record.stack_info = "Stack (most recent call last):\n  File test.py"
+        parsed = json.loads(formatter.format(record))
+        assert "stack_info" in parsed
+        assert "test.py" in parsed["stack_info"]
+
+
+class TestReservedFields:
+    """Tests for the RESERVED_FIELDS constant."""
+
+    def test_reserved_fields_contains_standard_keys(self) -> None:
+        """RESERVED_FIELDS must contain all standard JSON log fields."""
+        expected = {"timestamp", "level", "logger", "message", "exception", "stack_info"}
+        assert expected == RESERVED_FIELDS

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """Tests for logging utilities."""
 
+import io
+import json
 import logging
 import os
 import sys
 import threading
+from io import StringIO
 from pathlib import Path
 
+from hephaestus.logging.formatters import JsonFormatter
 from hephaestus.logging.utils import (
     ContextLogger,
     get_logger,
@@ -162,8 +166,6 @@ class TestGetLogger:
 
     def test_no_duplicate_output_with_root_handlers(self) -> None:
         """Messages appear once even when root logger has handlers."""
-        import io
-
         # Set up root logger with a capturing handler
         root = logging.getLogger()
         capture_stream = io.StringIO()
@@ -195,6 +197,46 @@ class TestGetLogger:
         assert logger1.logger.propagate is False
         logger2 = get_logger("test.subsequent_propagate")
         assert logger2.logger.propagate is False
+
+    def test_json_format_uses_json_formatter(self) -> None:
+        """get_logger with json_format=True uses JsonFormatter on handlers."""
+        logger = get_logger("test.json_fmt", json_format=True)
+        for handler in logger.logger.handlers:
+            assert isinstance(handler.formatter, JsonFormatter)
+
+    def test_json_format_output_is_json(self) -> None:
+        """get_logger with json_format=True produces valid JSON output."""
+        logger = get_logger("test.json_output", json_format=True)
+        # Capture output from the handler
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logger.logger.handlers[0].formatter)
+        logger.logger.addHandler(handler)
+        try:
+            logger.info("hello json")
+            output = stream.getvalue().strip()
+            parsed = json.loads(output)
+            assert parsed["message"] == "hello json"
+            assert parsed["level"] == "INFO"
+        finally:
+            logger.logger.removeHandler(handler)
+
+    def test_json_format_with_context(self) -> None:
+        """Bound context fields appear in JSON output."""
+        logger = get_logger("test.json_ctx", json_format=True)
+        bound = logger.bind(request_id="req-42", service="odyssey")
+        stream = StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(logger.logger.handlers[0].formatter)
+        bound.logger.addHandler(handler)
+        try:
+            bound.info("ctx test")
+            output = stream.getvalue().strip()
+            parsed = json.loads(output)
+            assert parsed["request_id"] == "req-42"
+            assert parsed["service"] == "odyssey"
+        finally:
+            bound.logger.removeHandler(handler)
 
 
 class TestContextLogger:
@@ -466,6 +508,35 @@ class TestSetupLogging:
             basenames = {h.baseFilename for h in file_handlers}
             assert os.path.abspath(log_a) in basenames
             assert os.path.abspath(log_b) in basenames
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_json_format_configures_json_formatter(self) -> None:
+        """setup_logging with json_format=True uses JsonFormatter on all handlers."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(json_format=True)
+            assert len(root.handlers) >= 1
+            for handler in root.handlers:
+                assert isinstance(handler.formatter, JsonFormatter)
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_json_format_with_log_file(self, tmp_path: Path) -> None:
+        """setup_logging with json_format=True also applies to file handler."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            log_file = str(tmp_path / "json_setup.log")
+            setup_logging(json_format=True, log_file=log_file)
+            file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+            assert len(file_handlers) >= 1
+            assert isinstance(file_handlers[0].formatter, JsonFormatter)
         finally:
             root.handlers.clear()
             root.handlers.extend(saved)


### PR DESCRIPTION
## Summary

- Add `JsonFormatter` that outputs log records as single-line JSON for integration with log aggregation systems (Loki/Promtail in ProjectArgus)
- Add `json_format: bool = False` parameter to `get_logger()` and `setup_logging()` — backward-compatible, opt-in
- Context fields from `ContextLogger.bind()` merge as top-level JSON keys; reserved field collisions are auto-prefixed with `ctx_`

## Files Changed

| File | Change |
|------|--------|
| `hephaestus/logging/formatters.py` | **New** — `JsonFormatter(logging.Formatter)` with ISO 8601 UTC timestamps, exception serialization, reserved-field collision handling |
| `hephaestus/logging/utils.py` | Added `json_format` param to `get_logger()` and `setup_logging()` |
| `hephaestus/logging/__init__.py` | Export `JsonFormatter` |
| `hephaestus/constants.py` | Added `JSON_LOG_FIELDS` constant |
| `tests/unit/logging/test_formatters.py` | **New** — 11 tests covering JSON output, extras, collisions, exceptions, stack info |
| `tests/unit/logging/test_utils.py` | 5 new tests for `json_format=True` paths in `get_logger()` and `setup_logging()` |

## Test plan

- [x] All 451 existing + new tests pass (`pixi run pytest tests/ --no-cov -q`)
- [x] `ruff check` passes with no errors
- [x] `ruff format --check` passes
- [ ] Verify JSON output is parseable by Loki/Promtail (manual)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)