### PR TITLE
[Test] Add integration tests for CLI entry points

### DIFF
--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Integration tests verifying CLI entry points are importable and respond to --help."""
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+# Entry point modules and their main() functions, matching pyproject.toml [project.scripts]
+ENTRY_POINTS = [
+    ("hephaestus.git.changelog", "main"),
+    ("hephaestus.github.pr_merge", "main"),
+    ("hephaestus.system.info", "main"),
+    ("hephaestus.datasets.downloader", "main"),
+]
+
+
+class TestCLIEntryPointImports:
+    """Verify each CLI entry point's main() function is importable and callable."""
+
+    @pytest.mark.parametrize(
+        "module_path,func_name",
+        ENTRY_POINTS,
+        ids=[
+            "hephaestus-changelog",
+            "hephaestus-merge-prs",
+            "hephaestus-system-info",
+            "hephaestus-download-dataset",
+        ],
+    )
+    def test_main_importable_and_callable(self, module_path: str, func_name: str) -> None:
+        """Each entry point's main() must be importable and callable."""
+        mod = importlib.import_module(module_path)
+        main_func = getattr(mod, func_name, None)
+        assert main_func is not None, f"{module_path}.{func_name} not found"
+        assert callable(main_func), f"{module_path}.{func_name} is not callable"
+
+
+class TestCLIEntryPointHelp:
+    """Verify each CLI entry point responds to --help with exit code 0."""
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [ep[0] for ep in ENTRY_POINTS],
+        ids=[
+            "hephaestus-changelog",
+            "hephaestus-merge-prs",
+            "hephaestus-system-info",
+            "hephaestus-download-dataset",
+        ],
+    )
+    def test_help_exits_cleanly(self, module_path: str) -> None:
+        """Running the entry point with --help must exit with code 0."""
+        result = subprocess.run(
+            [sys.executable, "-m", module_path, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"{module_path} --help exited with code {result.returncode}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+        assert "usage:" in result.stdout.lower(), f"{module_path} --help did not produce usage text"


### PR DESCRIPTION
## Summary
- Add `tests/integration/test_cli_entry_points.py` with 8 tests covering all four CLI entry points
- **Import tests**: Verify each `main()` function is importable and callable
- **Help tests**: Verify each entry point responds to `--help` with exit code 0 and produces usage text

## Closes
Closes #52

## Test plan
- [x] All 8 new tests pass (`pixi run pytest tests/integration/test_cli_entry_points.py -v`)
- [x] Full integration suite (59 tests) passes with no regressions
- [x] `ruff check` and `ruff format` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)