### PR TITLE
fix(io): raise ValueError in save_data for unknown extensions

### DIFF
--- a/hephaestus/io/utils.py
+++ b/hephaestus/io/utils.py
@@ -237,14 +237,13 @@ def save_data(
         True if successful, False otherwise
 
     Raises:
-        ValueError: If format is unsafe and allow_unsafe_deserialization is False.
+        ValueError: If format cannot be determined from the file extension
+            and no format_hint is provided, or if format is unsafe and
+            allow_unsafe_deserialization is False.
 
     """
     filepath = Path(filepath)
-    try:
-        fmt = _detect_format(filepath, format_hint)
-    except ValueError:
-        fmt = "json"  # default for unknown extensions
+    fmt = _detect_format(filepath, format_hint)
 
     if fmt in _UNSAFE_FORMATS and not allow_unsafe_deserialization:
         raise ValueError(

--- a/tests/unit/io/test_utils.py
+++ b/tests/unit/io/test_utils.py
@@ -243,11 +243,11 @@ class TestSaveData:
         with pytest.raises(ValueError, match="unsafe deserialization"):
             save_data({"x": 1}, f)
 
-    def test_default_format_json(self, tmp_path: Path) -> None:
-        """Unknown extension defaults to JSON."""
+    def test_unknown_extension_raises(self, tmp_path: Path) -> None:
+        """Unknown extension raises ValueError instead of silently defaulting."""
         f = tmp_path / "out.dat"
-        assert save_data({"x": 1}, f)
-        assert json.loads(f.read_text()) == {"x": 1}
+        with pytest.raises(ValueError, match="Could not determine"):
+            save_data({"x": 1}, f)
 
     def test_raises_on_io_error(self, tmp_path: Path) -> None:
         """IOError is raised (not silently swallowed) when write fails."""


### PR DESCRIPTION
## Summary
- Removed the `try/except ValueError` fallback in `save_data()` that silently defaulted to JSON for unknown file extensions
- `save_data()` now lets the `ValueError` from `_detect_format()` propagate naturally, matching `load_data()` behavior
- Updated docstring to document the `ValueError` raise condition
- Updated unit test to verify `ValueError` is raised for unknown extensions

Closes #53

## Test plan
- [x] `save_data(data, "file.xyz")` raises `ValueError` instead of creating a JSON file
- [x] `load_data` and `save_data` have symmetric behavior for unknown formats
- [x] All 35 IO unit tests pass
- [x] Full test suite (435 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)