### PR TITLE
Fix get_logger ignoring log_file on subsequent calls

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -13,6 +13,7 @@ Usage:
 """
 
 import logging
+import os
 import sys
 import threading
 from typing import Any
@@ -73,17 +74,26 @@ def get_logger(
     logger = logging.getLogger(name)
     logger.setLevel(level or logging.INFO)
 
-    # Prevent adding handlers multiple times
-    if not logger.handlers:
-        formatter = logging.Formatter(LOG_FORMAT)
+    formatter = logging.Formatter(LOG_FORMAT)
 
-        # Console handler
+    # Add console handler only if one doesn't already exist
+    has_console = any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        for h in logger.handlers
+    )
+    if not has_console:
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
-        # File handler (optional)
-        if log_file:
+    # Add file handler if log_file is specified and no handler for this path exists
+    if log_file:
+        resolved = os.path.abspath(log_file)
+        has_file = any(
+            isinstance(h, logging.FileHandler) and h.baseFilename == resolved
+            for h in logger.handlers
+        )
+        if not has_file:
             file_handler = logging.FileHandler(log_file)
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -43,6 +43,41 @@ class TestGetLogger:
         handler_types = [type(h) for h in logger.logger.handlers]
         assert logging.FileHandler in handler_types
 
+    def test_log_file_added_on_subsequent_call(self, tmp_path: Path) -> None:
+        """log_file handler is added even when logger already has handlers."""
+        log_file = str(tmp_path / "subsequent.log")
+        # First call without log_file
+        get_logger("test.subsequent_file")
+        # Second call with log_file
+        logger = get_logger("test.subsequent_file", log_file=log_file)
+        file_handlers = [
+            h for h in logger.logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        assert len(file_handlers) == 1
+        assert file_handlers[0].baseFilename == str(Path(log_file).resolve())
+
+    def test_no_duplicate_console_handler(self) -> None:
+        """Calling get_logger twice does not duplicate the console handler."""
+        get_logger("test.no_dup_console")
+        logger = get_logger("test.no_dup_console")
+        console_handlers = [
+            h
+            for h in logger.logger.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(console_handlers) == 1
+
+    def test_no_duplicate_file_handler_same_path(self, tmp_path: Path) -> None:
+        """Calling get_logger twice with the same log_file does not duplicate the handler."""
+        log_file = str(tmp_path / "dup.log")
+        get_logger("test.dup_file", log_file=log_file)
+        logger = get_logger("test.dup_file", log_file=log_file)
+        file_handlers = [
+            h for h in logger.logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+        assert len(file_handlers) == 1
+
 
 class TestContextLogger:
     """Tests for ContextLogger adapter."""


### PR DESCRIPTION
## Summary
- Refactored `get_logger()` handler guard to check for specific handler types instead of using blanket `if not logger.handlers:`
- Console handler is only added if no `StreamHandler` (excluding `FileHandler`) already exists on the logger
- File handler is only added if no `FileHandler` with the same resolved path already exists
- This ensures `get_logger("name", log_file="path")` always attaches the file handler, even on subsequent calls

## Tests Added
- `test_log_file_added_on_subsequent_call` — verifies the primary fix (issue #54)
- `test_no_duplicate_console_handler` — regression guard for issue #32
- `test_no_duplicate_file_handler_same_path` — prevents duplicate file handlers for the same path

All 438 tests pass.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)