### PR TITLE
feat(ci): add mypy type-checking to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.12"]
-        test-type: [unit, integration]
+        test-type: [unit, integration, mypy]
 
     steps:
       - uses: actions/checkout@v6
@@ -55,6 +55,10 @@ jobs:
         if: matrix.test-type == 'integration'
         run: |
           pixi run pytest tests/integration --override-ini="addopts=" -v --strict-markers
+
+      - name: Run mypy type checking
+        if: matrix.test-type == 'mypy'
+        run: pixi run mypy
 
       - name: Build wheel smoke test
         if: matrix.test-type == 'integration'

--- a/pixi.toml
+++ b/pixi.toml
@@ -9,6 +9,7 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 test = "pytest"
 lint = "ruff check hephaestus scripts tests"
 format = "ruff format hephaestus scripts tests"
+mypy = "mypy hephaestus/"
 audit = "pixi run --environment lint pip-audit"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Add `mypy` as a new matrix entry (`test-type: mypy`) in `.github/workflows/test.yml` so type errors are caught before merge
- Add a `mypy` task to `pixi.toml` for convenient local invocation via `pixi run mypy`
- No existing mypy errors — all 36 source files pass cleanly

Closes #55

## Test plan
- [x] `pixi run mypy` passes locally (Success: no issues found in 36 source files)
- [x] All 384 unit tests pass
- [x] All 51 integration tests pass
- [ ] CI workflow shows 3 matrix entries (unit, integration, mypy) and all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)