### PR TITLE
ci: add ruff lint and format check to CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,42 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.63.2
+
+      - name: Cache pixi environments
+        uses: actions/cache@v5
+        with:
+          path: |
+            .pixi
+            ~/.cache/rattler/cache
+          key: pixi-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          restore-keys: |
+            pixi-${{ runner.os }}-
+
+      - name: Lint check
+        run: pixi run ruff check hephaestus scripts tests
+
+      - name: Format check
+        run: pixi run ruff format --check hephaestus scripts tests
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Adds a separate `lint` job to `test.yml` that runs `ruff check` and `ruff format --check` on `hephaestus/`, `scripts/`, and `tests/` directories
- Lint job runs in parallel with the existing test matrix for faster CI feedback
- Adds workflow-level concurrency controls (`cancel-in-progress`) and least-privilege permissions (`contents: read`)

Closes #56

## Test plan
- [x] Verified current codebase passes `ruff check` and `ruff format --check` locally
- [x] Validated workflow YAML syntax
- [ ] Confirm lint and test jobs both appear and pass in CI after push

🤖 Generated with [Claude Code](https://claude.com/claude-code)