### PR TITLE
Remove duplicated version from pixi.toml and add drift detection

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,5 @@
 [workspace]
 name = "project-hephaestus"
-version = "0.4.0"
 description = "Shared utilities and tooling for the HomericIntelligence ecosystem"
 channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]

--- a/scripts/check_python_version_consistency.py
+++ b/scripts/check_python_version_consistency.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 """Check Python version consistency across project config files.
 
-Verifies that requires-python in pyproject.toml, python_version in mypy config,
-and target-version in ruff config are all consistent.
+Verifies that:
+1. requires-python in pyproject.toml, python_version in mypy config,
+   and target-version in ruff config are all consistent.
+2. If pixi.toml has a [workspace] version, it matches pyproject.toml's
+   [project] version (catches accidental re-introduction of the duplicate).
 
 Usage:
     python scripts/check_python_version_consistency.py
@@ -49,9 +52,48 @@ def extract_pyproject_versions(content: str) -> dict[str, str]:
     return versions
 
 
-def main() -> int:
-    """Check Python version consistency. Returns 0 if OK, 1 if inconsistent."""
-    repo_root = get_repo_root()
+def extract_project_version(content: str) -> str | None:
+    """Extract the [project] version from pyproject.toml content.
+
+    Args:
+        content: The pyproject.toml file content.
+
+    Returns:
+        The version string, or None if not found.
+
+    """
+    match = re.search(r'\[project\]\s*\n(?:.*\n)*?version\s*=\s*"([^"]+)"', content)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_pixi_workspace_version(content: str) -> str | None:
+    """Extract the [workspace] version from pixi.toml content, if present.
+
+    Args:
+        content: The pixi.toml file content.
+
+    Returns:
+        The version string, or None if the field is absent.
+
+    """
+    match = re.search(r'\[workspace\]\s*\n(?:.*\n)*?version\s*=\s*"([^"]+)"', content)
+    if match:
+        return match.group(1)
+    return None
+
+
+def check_python_versions(repo_root: Path) -> int:
+    """Check Python version consistency across pyproject.toml settings.
+
+    Args:
+        repo_root: Path to the repository root.
+
+    Returns:
+        0 if consistent, 1 if inconsistent.
+
+    """
     pyproject_path = repo_root / "pyproject.toml"
 
     if not pyproject_path.exists():
@@ -80,6 +122,70 @@ def main() -> int:
         print(f"  {key}: {val}")
     print("\nAll version specifications must agree on the same Python version.")
     return 1
+
+
+def check_pixi_version_drift(repo_root: Path) -> int:
+    """Check that pixi.toml workspace version, if present, matches pyproject.toml.
+
+    The version field was intentionally removed from pixi.toml to avoid
+    duplication. This check catches accidental re-introduction with a
+    mismatched value.
+
+    Args:
+        repo_root: Path to the repository root.
+
+    Returns:
+        0 if OK (no version in pixi.toml, or versions match), 1 if drift detected.
+
+    """
+    pyproject_path = repo_root / "pyproject.toml"
+    pixi_path = repo_root / "pixi.toml"
+
+    if not pyproject_path.exists():
+        print("ERROR: pyproject.toml not found")
+        return 1
+
+    if not pixi_path.exists():
+        print("ERROR: pixi.toml not found")
+        return 1
+
+    pyproject_content = pyproject_path.read_text()
+    pixi_content = pixi_path.read_text()
+
+    pixi_version = extract_pixi_workspace_version(pixi_content)
+    if pixi_version is None:
+        print("OK: pixi.toml has no workspace version (single source of truth in pyproject.toml)")
+        return 0
+
+    project_version = extract_project_version(pyproject_content)
+    if project_version is None:
+        print("ERROR: Could not extract [project] version from pyproject.toml")
+        return 1
+
+    if pixi_version == project_version:
+        print(
+            f"OK: pixi.toml workspace version ({pixi_version}) "
+            f"matches pyproject.toml ({project_version})"
+        )
+        return 0
+
+    print("ERROR: Version drift detected between pixi.toml and pyproject.toml!")
+    print(f"  pixi.toml [workspace] version: {pixi_version}")
+    print(f"  pyproject.toml [project] version: {project_version}")
+    print("\nRemove the version from pixi.toml [workspace] — pyproject.toml is the single source.")
+    return 1
+
+
+def main() -> int:
+    """Check Python version consistency. Returns 0 if OK, 1 if inconsistent."""
+    repo_root = get_repo_root()
+
+    python_result = check_python_versions(repo_root)
+    pixi_result = check_pixi_version_drift(repo_root)
+
+    if python_result != 0 or pixi_result != 0:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_check_python_version_consistency.py
+++ b/tests/unit/scripts/test_check_python_version_consistency.py
@@ -1,0 +1,198 @@
+"""Tests for scripts/check_python_version_consistency.py."""
+
+import pytest
+from check_python_version_consistency import (
+    check_pixi_version_drift,
+    check_python_versions,
+    extract_pixi_workspace_version,
+    extract_project_version,
+    extract_pyproject_versions,
+    main,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: minimal config file contents
+# ---------------------------------------------------------------------------
+
+PYPROJECT_CONSISTENT = """\
+[project]
+name = "test"
+version = "0.4.0"
+requires-python = ">=3.10"
+
+[tool.mypy]
+python_version = "3.10"
+
+[tool.ruff]
+target-version = "py310"
+"""
+
+PYPROJECT_INCONSISTENT = """\
+[project]
+name = "test"
+version = "0.4.0"
+requires-python = ">=3.10"
+
+[tool.mypy]
+python_version = "3.11"
+
+[tool.ruff]
+target-version = "py310"
+"""
+
+PIXI_NO_VERSION = """\
+[workspace]
+name = "test"
+description = "A test project"
+channels = ["conda-forge"]
+"""
+
+PIXI_MATCHING_VERSION = """\
+[workspace]
+name = "test"
+version = "0.4.0"
+description = "A test project"
+channels = ["conda-forge"]
+"""
+
+PIXI_MISMATCHED_VERSION = """\
+[workspace]
+name = "test"
+version = "0.3.0"
+description = "A test project"
+channels = ["conda-forge"]
+"""
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: extraction helpers
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPyprojectVersions:
+    """Tests for extract_pyproject_versions."""
+
+    def test_extracts_all_three_versions(self) -> None:
+        versions = extract_pyproject_versions(PYPROJECT_CONSISTENT)
+        assert versions == {
+            "requires-python": "3.10",
+            "mypy.python_version": "3.10",
+            "ruff.target-version": "3.10",
+        }
+
+    def test_detects_inconsistency(self) -> None:
+        versions = extract_pyproject_versions(PYPROJECT_INCONSISTENT)
+        assert versions["mypy.python_version"] == "3.11"
+        assert versions["requires-python"] == "3.10"
+
+    def test_empty_content(self) -> None:
+        versions = extract_pyproject_versions("")
+        assert versions == {}
+
+
+class TestExtractProjectVersion:
+    """Tests for extract_project_version."""
+
+    def test_extracts_version(self) -> None:
+        assert extract_project_version(PYPROJECT_CONSISTENT) == "0.4.0"
+
+    def test_missing_version(self) -> None:
+        content = "[project]\nname = 'test'\n"
+        assert extract_project_version(content) is None
+
+    def test_no_project_section(self) -> None:
+        assert extract_project_version("") is None
+
+
+class TestExtractPixiWorkspaceVersion:
+    """Tests for extract_pixi_workspace_version."""
+
+    def test_returns_version_when_present(self) -> None:
+        assert extract_pixi_workspace_version(PIXI_MATCHING_VERSION) == "0.4.0"
+
+    def test_returns_none_when_absent(self) -> None:
+        assert extract_pixi_workspace_version(PIXI_NO_VERSION) is None
+
+    def test_empty_content(self) -> None:
+        assert extract_pixi_workspace_version("") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: check functions using tmp_path
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPythonVersions:
+    """Tests for check_python_versions."""
+
+    def test_consistent_versions(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        assert check_python_versions(tmp_path) == 0
+
+    def test_inconsistent_versions(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_INCONSISTENT)
+        assert check_python_versions(tmp_path) == 1
+
+    def test_missing_pyproject(self, tmp_path: pytest.TempPathFactory) -> None:
+        assert check_python_versions(tmp_path) == 1
+
+
+class TestCheckPixiVersionDrift:
+    """Tests for check_pixi_version_drift."""
+
+    def test_no_pixi_version_field(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        (tmp_path / "pixi.toml").write_text(PIXI_NO_VERSION)
+        assert check_pixi_version_drift(tmp_path) == 0
+
+    def test_pixi_version_matches_pyproject(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        (tmp_path / "pixi.toml").write_text(PIXI_MATCHING_VERSION)
+        assert check_pixi_version_drift(tmp_path) == 0
+
+    def test_pixi_version_mismatches_pyproject(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        (tmp_path / "pixi.toml").write_text(PIXI_MISMATCHED_VERSION)
+        assert check_pixi_version_drift(tmp_path) == 1
+
+    def test_pyproject_missing(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pixi.toml").write_text(PIXI_MATCHING_VERSION)
+        assert check_pixi_version_drift(tmp_path) == 1
+
+    def test_pixi_missing(self, tmp_path: pytest.TempPathFactory) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        assert check_pixi_version_drift(tmp_path) == 1
+
+
+class TestMain:
+    """Tests for main() using monkeypatch to control repo root."""
+
+    def test_all_ok(
+        self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        (tmp_path / "pixi.toml").write_text(PIXI_NO_VERSION)
+        monkeypatch.setattr(
+            "check_python_version_consistency.get_repo_root", lambda: tmp_path
+        )
+        assert main() == 0
+
+    def test_pixi_drift_fails(
+        self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_CONSISTENT)
+        (tmp_path / "pixi.toml").write_text(PIXI_MISMATCHED_VERSION)
+        monkeypatch.setattr(
+            "check_python_version_consistency.get_repo_root", lambda: tmp_path
+        )
+        assert main() == 1
+
+    def test_python_version_inconsistency_fails(
+        self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text(PYPROJECT_INCONSISTENT)
+        (tmp_path / "pixi.toml").write_text(PIXI_NO_VERSION)
+        monkeypatch.setattr(
+            "check_python_version_consistency.get_repo_root", lambda: tmp_path
+        )
+        assert main() == 1


### PR DESCRIPTION
## Summary
- Removed `version = "0.4.0"` from `pixi.toml` `[workspace]` section — pixi doesn't require it, and `pyproject.toml` is the single source of truth
- Extended `scripts/check_python_version_consistency.py` to detect if a version is re-introduced in `pixi.toml` and verify it matches `pyproject.toml`
- Added 20 unit tests covering extraction helpers, drift detection, and the integrated `main()` function

## Test plan
- [x] `pixi install --locked` succeeds without the version field
- [x] `python scripts/check_python_version_consistency.py` returns 0 with both OK messages
- [x] All 20 new unit tests pass (`pixi run pytest tests/unit/scripts/ -v`)
- [x] Full test suite passes (404 tests, 82.13% coverage)
- [x] Pre-commit hook `check-python-version-consistency` passes
- [x] Ruff lint clean on all changed files

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)