### PR TITLE
feat(ci): add Python 3.13 to CI test matrix and classifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         test-type: [unit, integration]
 
     steps:

--- a/pixi.lock
+++ b/pixi.lock
@@ -933,7 +933,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.4.0
-  sha256: 5cf27ab367bce8879d509b9e81064a5994b7ca673e2d221add2fe462530dab5e
+  sha256: 8364b09635f54ab08d09dbdb6e0fd15652b6422bdf83a435fd43504a7ef4666f
   requires_dist:
   - pyyaml>=6.0,<7
   - pytest>=9.0,<10 ; extra == 'dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",
 ]


### PR DESCRIPTION
## Summary
- Add `"3.13"` to the `python-version` matrix in `.github/workflows/test.yml` so CI runs unit and integration tests on Python 3.13
- Add `"Programming Language :: Python :: 3.13"` trove classifier to `pyproject.toml`
- `pixi.lock` updated automatically due to `pyproject.toml` change

## Testing
- All 384 unit tests pass locally with 82.13% coverage (above 80% threshold)
- No 3.13-specific deprecation warnings or incompatibilities found
- Lint (`ruff check`) and formatting (`ruff format --check`) pass cleanly

## Test plan
- [ ] CI passes on Python 3.12 (no regression)
- [ ] CI passes on Python 3.13 (new)
- [ ] `pyproject.toml` classifiers include 3.13

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)