### PR TITLE
fix(logging): prevent ContextLogger.process from mutating caller's extra dict

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -31,9 +31,9 @@ class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
 
     def process(self, msg: Any, kwargs: Any) -> tuple[Any, Any]:
         """Add context information to log messages."""
-        extra = kwargs.get("extra", {})
-        extra.update(self._context)
-        kwargs["extra"] = extra
+        with self._context_lock:
+            context = self._context.copy()
+        kwargs["extra"] = {**kwargs.get("extra", {}), **context}
         return msg, kwargs
 
     def bind(self, **kwargs: Any) -> "ContextLogger":

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -72,6 +72,24 @@ class TestContextLogger:
         _msg, kwargs = logger.process("hello", {})
         assert kwargs["extra"]["x"] == 42
 
+    def test_process_does_not_mutate_caller_extra(self) -> None:
+        """process() must not mutate the caller-provided extra dict."""
+        logger = get_logger("test.no_mutate", context={"ctx_key": "ctx_val"})
+        caller_extra: dict[str, str] = {"request_id": "abc"}
+        original_extra = caller_extra.copy()
+
+        logger.process("msg", {"extra": caller_extra})
+
+        assert caller_extra == original_extra
+
+    def test_process_includes_bound_context(self, capfd: object) -> None:
+        """Context added via bind() appears in process() output."""
+        base = get_logger("test.bound_context")
+        bound = base.bind(user="alice", session="s1")
+        _msg, kwargs = bound.process("hello", {})
+        assert kwargs["extra"]["user"] == "alice"
+        assert kwargs["extra"]["session"] == "s1"
+
     def test_bind_thread_safe(self) -> None:
         """Concurrent bind() calls do not corrupt context."""
         base = get_logger("test.thread_safe", context={"base": 0})


### PR DESCRIPTION
## Summary
- **Fix mutation bug**: `ContextLogger.process()` now creates a new dict (`{**caller_extra, **context}`) instead of calling `extra.update()` on the caller-provided dict, preventing context leakage when a caller reuses the same extra dict across log calls.
- **Fix thread safety**: `process()` now acquires `_context_lock` when reading `self._context`, consistent with `bind()` and `unbind()`, ensuring safe concurrent access.
- **Add tests**: Two new unit tests verify that the caller's extra dict is not mutated and that bound context appears in `process()` output.

Closes #60

## Test plan
- [x] `test_process_does_not_mutate_caller_extra` — passes extra dict, logs, verifies dict unchanged
- [x] `test_process_includes_bound_context` — binds context, verifies it appears in process output
- [x] All 15 existing logging tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)