### PR TITLE
fix(logging): make setup_logging() idempotent

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -108,14 +108,14 @@ def setup_logging(
     """
     format_string = format_string or LOG_FORMAT
 
-    handlers = [logging.StreamHandler(sys.stdout)]
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
 
     if log_to_stderr:
         handlers.append(logging.StreamHandler(sys.stderr))
 
-    logging.basicConfig(level=level, format=format_string, handlers=handlers)
-
     if log_file:
-        file_handler = logging.FileHandler(log_file)
-        file_handler.setFormatter(logging.Formatter(format_string))
-        logging.getLogger().addHandler(file_handler)
+        handlers.append(logging.FileHandler(log_file))
+
+    # force=True clears existing root handlers before adding new ones,
+    # making repeated calls idempotent instead of accumulating duplicates.
+    logging.basicConfig(level=level, format=format_string, handlers=handlers, force=True)

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -115,7 +115,6 @@ class TestSetupLogging:
         import sys
 
         root = logging.getLogger()
-        # basicConfig is a no-op if handlers already exist; clear them first.
         saved = list(root.handlers)
         root.handlers.clear()
         try:
@@ -127,5 +126,71 @@ class TestSetupLogging:
             ]
             assert len(stderr_handlers) >= 1
         finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_idempotent_handler_count(self) -> None:
+        """Calling setup_logging() twice produces the same handler count as once."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(level=logging.INFO)
+            count_after_first = len(root.handlers)
+
+            setup_logging(level=logging.INFO)
+            count_after_second = len(root.handlers)
+
+            assert count_after_first == count_after_second
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_idempotent_with_log_file(self, tmp_path: Path) -> None:
+        """Repeated calls with log_file do not duplicate file handlers."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        log_file = str(tmp_path / "idem.log")
+        try:
+            setup_logging(log_file=log_file)
+            count_first = len(root.handlers)
+
+            setup_logging(log_file=log_file)
+            count_second = len(root.handlers)
+
+            assert count_first == count_second
+            file_handlers = [
+                h for h in root.handlers if isinstance(h, logging.FileHandler)
+            ]
+            assert len(file_handlers) == 1
+        finally:
+            for h in root.handlers:
+                if isinstance(h, logging.FileHandler):
+                    h.close()
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_idempotent_no_duplicate_output(self, tmp_path: Path) -> None:
+        """Calling setup_logging() twice does not produce duplicate log lines."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        log_file = str(tmp_path / "output.log")
+        try:
+            setup_logging(log_file=log_file)
+            setup_logging(log_file=log_file)
+
+            root.warning("single line test")
+
+            for h in root.handlers:
+                h.flush()
+
+            content = Path(log_file).read_text()
+            assert content.count("single line test") == 1
+        finally:
+            for h in root.handlers:
+                if isinstance(h, logging.FileHandler):
+                    h.close()
             root.handlers.clear()
             root.handlers.extend(saved)


### PR DESCRIPTION
## Summary
- Use `force=True` in `logging.basicConfig()` to clear existing root handlers before adding new ones, preventing duplicate handlers on repeated calls
- Move `FileHandler` creation into the `handlers` list passed to `basicConfig()` instead of appending separately, so it's also covered by the force-clear
- Add 3 unit tests verifying idempotency: handler count stability, file handler deduplication, and no duplicate log output

## Test plan
- [x] `test_idempotent_handler_count` — calling `setup_logging()` twice yields the same handler count as once
- [x] `test_idempotent_with_log_file` — repeated calls with `log_file` produce exactly one `FileHandler`
- [x] `test_idempotent_no_duplicate_output` — a log message after two `setup_logging()` calls appears exactly once in the file
- [x] All existing logging tests continue to pass
- [x] `log_to_stderr` and `log_file` parameters still work correctly

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)