### PR TITLE
Add unit tests for constants.py module

### DIFF
--- a/tests/unit/test_constants.py
+++ b/tests/unit/test_constants.py
@@ -41,7 +41,7 @@ class TestDefaultExcludeDirs:
             assert isinstance(entry, str)
 
     def test_immutability(self) -> None:
-        """frozenset should reject mutation attempts."""
+        """Frozenset should reject mutation attempts."""
         with pytest.raises(AttributeError):
             DEFAULT_EXCLUDE_DIRS.add("new_dir")  # type: ignore[attr-error]
 


### PR DESCRIPTION
## Summary
- Creates `tests/unit/test_constants.py` with 17 tests covering the `hephaestus/constants.py` module
- Tests `DEFAULT_EXCLUDE_DIRS` type (frozenset), contents (all 11 entries), string types, and immutability
- Tests `LOG_FORMAT` type, validity as a `logging.Formatter` format string, and presence of standard fields

## Test plan
- [x] All 17 tests pass (`pixi run python -m pytest tests/unit/test_constants.py -v`)
- [x] `hephaestus/constants.py` at 100% coverage
- [x] Tests catch accidental type changes (frozenset → set)
- [x] Tests catch removal of expected directory entries

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)