### PR TITLE
fix(utils): tighten install_package regex to block shell metacharacters

### DIFF
--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -203,7 +203,9 @@ def install_package(package_name: str, upgrade: bool = False) -> bool:
 
     """
     # Validate package name: only alphanumerics, hyphens, underscores, dots, brackets, ==, >=, <=
-    if not re.match(r"^[A-Za-z0-9_\-\.\[\],>=<!\s]+$", package_name):
+    # Uses re.fullmatch and literal space (not \s) to block newlines/tabs.
+    # Excludes ! to prevent shell history expansion.
+    if not re.fullmatch(r"[A-Za-z0-9_\-.\[\],>=< ]+", package_name):
         raise ValueError(f"Invalid package name: {package_name!r}")
 
     cmd = [sys.executable, "-m", "pip", "install"]

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -217,3 +217,30 @@ class TestInstallPackage:
         install_package("some-package", upgrade=True)
         cmd = mock_run.call_args[0][0]
         assert "--upgrade" in cmd
+
+    def test_rejects_newline_in_package_name(self):
+        """Rejects package names containing newlines."""
+        with pytest.raises(ValueError, match="Invalid package name"):
+            install_package("pkg\nmalicious")
+
+    def test_rejects_exclamation_mark_in_package_name(self):
+        """Rejects package names containing exclamation marks."""
+        with pytest.raises(ValueError, match="Invalid package name"):
+            install_package("pkg!exploit")
+
+    def test_rejects_tab_in_package_name(self):
+        """Rejects package names containing tab characters."""
+        with pytest.raises(ValueError, match="Invalid package name"):
+            install_package("pkg\texploit")
+
+    @patch("hephaestus.utils.helpers.run_subprocess")
+    def test_accepts_version_constraints(self, mock_run):
+        """Accepts valid package names with version constraints."""
+        mock_run.return_value = MagicMock(returncode=0)
+        assert install_package("torch>=2.0,<3") is True
+
+    @patch("hephaestus.utils.helpers.run_subprocess")
+    def test_accepts_extras(self, mock_run):
+        """Accepts valid package names with extras."""
+        mock_run.return_value = MagicMock(returncode=0)
+        assert install_package("pkg[extra]") is True


### PR DESCRIPTION
## Summary
- Replaced `\s` with a literal space in the `install_package()` validation regex to block newlines and tabs
- Removed `!` from allowed characters to prevent shell history expansion
- Switched from `re.match()` to `re.fullmatch()` for clarity
- Added 5 unit tests covering rejection of newlines, tabs, and `!`, plus acceptance of version constraints and extras

Closes #62

## Test plan
- [x] `install_package("pkg\nmalicious")` raises `ValueError`
- [x] `install_package("pkg!exploit")` raises `ValueError`
- [x] `install_package("pkg\texploit")` raises `ValueError`
- [x] `install_package("torch>=2.0,<3")` succeeds
- [x] `install_package("pkg[extra]")` succeeds
- [x] All 41 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)