### PR TITLE
Fix false-positive malformed key detection in ConfigLinter

### DIFF
--- a/hephaestus/validation/config_lint.py
+++ b/hephaestus/validation/config_lint.py
@@ -94,6 +94,47 @@ class ConfigLinter:
 
         return len(self.errors) == 0
 
+    @staticmethod
+    def _is_valid_yaml_key_line(line: str) -> bool:
+        """Check whether a line with a colon matches a valid YAML construct.
+
+        Args:
+            line: The line (after stripping inline comments).
+
+        Returns:
+            True if the line looks like a valid YAML key or construct.
+
+        """
+        s = line.strip()
+        return bool(
+            not s
+            or "://" in line
+            or re.match(r"^\s*[\w\-]+:", line)
+            or re.match(r'^\s*["\'][^"\']+["\']:', line)
+            or re.match(r"^\s*\{", line)
+            or re.match(r"^\s*-\s", line)
+            or re.match(r"^\s*---", line)
+            or re.match(r"^\s*\.\.\.", line)
+        )
+
+    @staticmethod
+    def _is_block_scalar_continuation(line: str, stripped: str, block_scalar_indent: int) -> bool:
+        """Check if a line is a continuation of a block scalar.
+
+        Args:
+            line: Raw line (for indentation measurement).
+            stripped: The stripped line content.
+            block_scalar_indent: Indent level of the block scalar's parent key.
+
+        Returns:
+            True if the line continues the block scalar.
+
+        """
+        if stripped == "":
+            return True
+        current_indent = len(line) - len(line.lstrip())
+        return current_indent > block_scalar_indent
+
     def _check_yaml_syntax(self, content: str, filepath: Path) -> bool:
         """Check if YAML syntax is valid.
 
@@ -109,22 +150,39 @@ class ConfigLinter:
             lines = content.split("\n")
             brace_count = 0
             bracket_count = 0
+            in_block_scalar = False
+            block_scalar_indent = 0
 
             for i, line in enumerate(lines):
-                # Skip comments
-                stripped = line.split("#")[0]
+                stripped = line.strip()
+
+                # Track block scalar context (| and > multi-line strings)
+                if in_block_scalar:
+                    if self._is_block_scalar_continuation(line, stripped, block_scalar_indent):
+                        continue
+                    in_block_scalar = False
+
+                # Skip comment-only lines
+                if stripped.startswith("#"):
+                    continue
+
+                # Strip inline comments (naive — doesn't handle # in quotes,
+                # but matches the pre-existing behavior)
+                comment_stripped = line.split("#")[0]
 
                 # Count braces and brackets
-                brace_count += stripped.count("{") - stripped.count("}")
-                bracket_count += stripped.count("[") - stripped.count("]")
+                brace_count += comment_stripped.count("{") - comment_stripped.count("}")
+                bracket_count += comment_stripped.count("[") - comment_stripped.count("]")
 
-                # Check for common issues
-                # Not a URL: skip lines with "://"
-                if (
-                    ":" in stripped
-                    and not re.match(r"^\s*[\w\-]+:", stripped)
-                    and "://" not in stripped
-                ):
+                # Detect block scalar start (key: | or key: >)
+                if re.match(r"^\s*[\w\"\'\-][^:]*:\s*[|>]", stripped):
+                    in_block_scalar = True
+                    block_scalar_indent = len(line) - len(line.lstrip())
+                    continue
+
+                # Malformed key check — only warn when a colon is present
+                # but the line doesn't match any valid YAML construct
+                if ":" in comment_stripped and not self._is_valid_yaml_key_line(comment_stripped):
                     self.warnings.append(f"{filepath}:{i + 1} - Possible malformed key")
 
             if brace_count != 0:

--- a/tests/unit/config/test_config_lint.py
+++ b/tests/unit/config/test_config_lint.py
@@ -119,6 +119,80 @@ class TestLintFile:
         assert any("batch_size" in w for w in linter.warnings)
 
 
+class TestYamlSyntaxFalsePositives:
+    """Tests that valid YAML constructs do not trigger false-positive malformed key warnings."""
+
+    @pytest.mark.parametrize(
+        "yaml_content, description",
+        [
+            ('description: "Time: 3:00pm"\n', "colon in quoted value"),
+            ("created: 2024-01-15T10:30:00\n", "inline ISO timestamp"),
+            ('"my key": value\n', "double-quoted key"),
+            ("'my key': value\n", "single-quoted key"),
+            ("mapping: {key: value}\n", "flow mapping in value"),
+            ("{key: value, other: 2}\n", "top-level flow mapping"),
+            ('items:\n  - "key: value"\n', "list item with colon in value"),
+            ("items:\n  - name: foo\n", "list item as mapping"),
+            ("url: https://example.com\n", "URL value"),
+            ("key: value\n", "simple key-value pair"),
+            ("---\nkey: value\n", "document separator"),
+            ("key: value\n...\n", "document end marker"),
+            (
+                "desc: |\n  Line with: colon\n  Another: line\n",
+                "literal block scalar",
+            ),
+            (
+                "desc: >\n  Line with: colon\n  Another: line\n",
+                "folded block scalar",
+            ),
+            ("# comment with: colon\nkey: value\n", "comment with colon"),
+            ("message: 'Error: something failed'\n", "colon in single-quoted value"),
+        ],
+        ids=lambda d: d if isinstance(d, str) and ":" not in d else None,
+    )
+    def test_no_false_positive_warning(
+        self,
+        linter: ConfigLinter,
+        yaml_file: Any,
+        yaml_content: str,
+        description: str,
+    ) -> None:
+        """Valid YAML construct should not produce a malformed key warning."""
+        path = yaml_file(yaml_content)
+        linter.lint_file(path)
+        malformed_warnings = [w for w in linter.warnings if "malformed key" in w.lower()]
+        assert malformed_warnings == [], f"False positive for {description}: {malformed_warnings}"
+
+    def test_actual_malformed_key_still_detected(
+        self,
+        linter: ConfigLinter,
+        yaml_file: Any,
+    ) -> None:
+        """A genuinely suspicious line should still produce a warning."""
+        # A line like "  @weird:stuff" has a colon but doesn't match any valid pattern
+        path = yaml_file("key: value\n@weird:stuff\n")
+        linter.lint_file(path)
+        malformed_warnings = [w for w in linter.warnings if "malformed key" in w.lower()]
+        assert len(malformed_warnings) == 1
+
+    def test_block_scalar_skips_inner_lines(
+        self,
+        linter: ConfigLinter,
+        yaml_file: Any,
+    ) -> None:
+        """Lines inside block scalars should not be checked for malformed keys."""
+        content = (
+            "description: |\n"
+            "  not a key: this is block scalar text\n"
+            "  another: line\n"
+            "next_key: value\n"
+        )
+        path = yaml_file(content)
+        linter.lint_file(path)
+        malformed_warnings = [w for w in linter.warnings if "malformed key" in w.lower()]
+        assert malformed_warnings == []
+
+
 class TestPrintResults:
     """Tests for ConfigLinter.print_results."""
 


### PR DESCRIPTION
## Summary
- Improved `ConfigLinter._check_yaml_syntax()` to recognize valid YAML constructs containing colons: quoted keys (`"my key": value`), flow mappings (`{key: value}`), list items (`- name: foo`), block scalars (`|`/`>`), ISO timestamps, document separators (`---`/`...`), and colons within quoted values
- Added block scalar state tracking to skip lines inside `|` and `>` multi-line strings
- Extracted `_is_valid_yaml_key_line()` and `_is_block_scalar_continuation()` helpers to keep complexity manageable
- Added 18 new parametrized unit tests covering all false-positive cases from issue plus regression test for genuine malformed keys

Closes #64

## Test plan
- [x] All 30 unit tests pass (`pixi run pytest tests/unit/config/test_config_lint.py -v`)
- [x] `description: "Time: 3:00pm"` no longer triggers a warning
- [x] Quoted keys, flow mappings, timestamps, block scalars all pass cleanly
- [x] Genuinely malformed keys (e.g. `@weird:stuff`) still produce warnings
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)