### PR TITLE
feat: add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "ProjectHephaestus",
+  "owner": {
+    "name": "HomericIntelligence",
+    "url": "https://github.com/HomericIntelligence"
+  },
+  "description": "Shared tooling and commands for the HomericIntelligence agentic ecosystem",
+  "version": "1.0.0",
+  "plugins": [
+    {
+      "name": "hephaestus",
+      "description": "Shared tooling plugin for the HomericIntelligence ecosystem. Provides /advise (search skills registry), /learn (capture session learnings), /myrmidon-swarm (hierarchical agent orchestration), and /repo-analyze variants (repository auditing).",
+      "version": "1.0.0",
+      "source": ".",
+      "category": "tooling",
+      "tags": ["advise", "learn", "myrmidon-swarm", "repo-analyze", "orchestration", "skills"]
+    }
+  ]
+}


### PR DESCRIPTION
Enables ProjectHephaestus to be registered as a Claude Code marketplace so the hephaestus plugin can be installed ecosystem-wide.