### PR TITLE
fix: marketplace.json source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "hephaestus",
       "description": "Shared tooling plugin for the HomericIntelligence ecosystem. Provides /advise (search skills registry), /learn (capture session learnings), /myrmidon-swarm (hierarchical agent orchestration), and /repo-analyze variants (repository auditing).",
       "version": "1.0.0",
-      "source": ".",
+      "source": "./",
       "category": "tooling",
       "tags": ["advise", "learn", "myrmidon-swarm", "repo-analyze", "orchestration", "skills"]
     }


### PR DESCRIPTION
Use './' instead of '.' for root-level plugin source.