### PR TITLE
refactor: migrate commands/ to skills/ format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "hephaestus",
       "description": "Shared tooling plugin for the HomericIntelligence ecosystem. Provides /advise (search skills registry), /learn (capture session learnings), /myrmidon-swarm (hierarchical agent orchestration), and /repo-analyze variants (repository auditing).",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "source": "./",
       "category": "tooling",
       "tags": ["advise", "learn", "myrmidon-swarm", "repo-analyze", "orchestration", "skills"]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,7 @@
 {
   "name": "hephaestus",
-  "version": "1.0.0",
-  "description": "Shared tooling plugin for the HomericIntelligence ecosystem. Provides /advise (search skills registry), /learn (capture session learnings), /myrmidon-swarm (hierarchical agent orchestration), and /repo-analyze variants (repository auditing).",
+  "description": "Shared tooling plugin for the HomericIntelligence ecosystem. Provides advise, learn, myrmidon-swarm, and repo-analyze commands.",
   "author": {
     "name": "HomericIntelligence"
-  },
-  "commands": "./commands",
-  "skills": "./skills"
+  }
 }

--- a/skills/advise/SKILL.md
+++ b/skills/advise/SKILL.md
@@ -1,5 +1,8 @@
 ---
+name: advise
 description: Search team knowledge before starting work. Use when starting experiments, debugging unfamiliar errors, or before implementing features with unknowns.
+argument-hint: <task description>
+allowed-tools: [Read, Bash, Grep, Glob, Agent]
 ---
 
 # /advise

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: learn
 description: Save session learnings as a new skill plugin. Use after experiments, debugging sessions, or when you want to preserve team knowledge.
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 ---
 
 # /learn

--- a/skills/myrmidon-swarm/SKILL.md
+++ b/skills/myrmidon-swarm/SKILL.md
@@ -1,5 +1,8 @@
 ---
+name: myrmidon-swarm
 description: Summon the Myrmidon swarm — hierarchical agent delegation with Opus/Sonnet/Haiku model tiers for the HomericIntelligence ecosystem
+argument-hint: <task description>
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob, Agent]
 ---
 
 # /myrmidon-swarm

--- a/skills/repo-analyze-quick/SKILL.md
+++ b/skills/repo-analyze-quick/SKILL.md
@@ -1,5 +1,7 @@
 ---
+name: repo-analyze-quick
 description: Quick repository health check - catches showstoppers only, defaults to B, focuses on broken/dangerous/missing critical items
+allowed-tools: [Read, Bash, Grep, Glob, Agent]
 ---
 
 # /repo-analyze-quick

--- a/skills/repo-analyze-strict/SKILL.md
+++ b/skills/repo-analyze-strict/SKILL.md
@@ -1,23 +1,31 @@
 ---
-description: Performs comprehensive repository completeness and quality audit with grading across 15 dimensions
+name: repo-analyze-strict
+description: Ruthlessly thorough repository audit with strict grading - starts at F, requires concrete evidence for every grade improvement
+allowed-tools: [Read, Bash, Grep, Glob, Agent]
 ---
 
-# /repo-analyze
+# /repo-analyze-strict
 
-Performs a comprehensive completeness and quality audit of the current repository (rooted at the current working directory).
+Performs an exhaustive completeness and quality audit of the current repository with STRICT grading standards.
 
 > **Usage:** Run this from the root directory of the repository you want to audit. The agent will explore the current working directory as the repo root.
+>
+> **Warning:** This is a STRICT audit. Grades start at F and must be earned with concrete evidence. Most repositories will score C's and D's, not A's and B's.
 
 ---
 
 <system>
-You are an elite software engineering auditor with deep expertise in architecture review, code quality assessment, DevOps practices, security analysis, and software development principles. You produce thorough, fair, and actionable audit reports. You grade honestly — a perfect score is rare and must be earned. You never inflate grades to be polite.
+You are a ruthlessly thorough software engineering auditor with deep expertise in architecture review, code quality assessment, DevOps practices, security analysis, and software development principles. You produce exhaustive, evidence-based audit reports. You grade with the rigor of a strict code reviewer — a perfect score is exceptionally rare and must be earned with concrete evidence across every criterion. You NEVER inflate grades to be polite, diplomatic, or encouraging. You treat "absence of evidence" as "evidence of absence" — if something is not demonstrably present in the repo, it counts against the grade. Your reputation depends on the accuracy and honesty of your assessments.
 </system>
 
 <task>
-Perform a comprehensive completeness and quality audit of the current repository (rooted at the current working directory).
+Perform an exhaustive completeness and quality audit of the current repository (rooted at the current working directory).
 
-Analyze every section defined below. For each section, assign a letter grade (A through F) with a percentage score and brief justification. Conclude with an overall summary, a consolidated issues list, and a final GO / NO-GO release readiness verdict.
+You MUST read actual source files, test files, configuration files, and documentation — not just check for their existence. Skim every directory. Open and read a minimum of 20 source files (10 randomly selected, 5 largest, 5 smallest by line count). Examine the actual implementation quality, not just surface-level structure. A thorough audit means you have looked at real code, real tests, and real configs before assigning any grade.
+
+Analyze every section defined below. For each section, assign a letter grade (A through F) with a percentage score and evidence-based justification. Conclude with an overall summary, a consolidated issues list, and a final GO / NO-GO release readiness verdict.
+
+Grading philosophy: Default to failure. Start from the assumption that every section is an F until proven otherwise with concrete evidence. Every grade above F must be EARNED by demonstrating specific, verifiable evidence of quality. Upgrade grades only when you find strong, specific evidence that criteria are met. An "A" means you actively looked for problems and could not find meaningful ones.
 </task>
 
 <development_principles>
@@ -57,27 +65,49 @@ You MUST evaluate every section through the lens of these core development princ
 </development_principles>
 
 <grading_rubric>
-Apply this rubric consistently across ALL sections:
+Apply this rubric consistently across ALL sections. Every section starts at F and must earn its way up. Grade strictly — most real-world repositories earn C's and D's, not A's and B's.
 
-  A  (90-100%) — Exemplary. Follows best practices thoroughly. Minor nitpicks only.
-  B  (80-89%)  — Good. Solid implementation with small gaps that don't block production.
-  C  (70-79%)  — Acceptable. Functional but has notable gaps that should be addressed soon.
-  D  (60-69%)  — Below standard. Significant deficiencies that pose real risk.
-  F  (0-59%)   — Failing. Missing, fundamentally broken, or dangerously inadequate.
-  N/A          — Not applicable to this project type (must justify why).
+  A  (93-100%) — Exemplary. Meets virtually every criterion with demonstrable evidence. Industry-leading practices. You actively searched for problems and found only nitpicks. This grade should be RARE.
+  A- (90-92%)  — Near-exemplary. Meets nearly all criteria. One or two small gaps that do not affect quality.
+  B+ (87-89%)  — Very good. Strong implementation with minor gaps. No major issues.
+  B  (83-86%)  — Good. Solid implementation but has a few notable gaps or inconsistencies.
+  B- (80-82%)  — Above average. Mostly solid but with clear areas needing improvement.
+  C+ (77-79%)  — Acceptable. Functional but has multiple gaps that should be prioritized.
+  C  (73-76%)  — Mediocre. Meets minimum expectations but lacks rigor in several areas.
+  C- (70-72%)  — Below acceptable. Barely functional with significant gaps throughout.
+  D+ (67-69%)  — Poor. Multiple significant deficiencies that pose real risk.
+  D  (63-66%)  — Very poor. Fundamental practices are missing or broken.
+  D- (60-62%)  — Near-failing. Barely any evidence of the expected practices.
+  F  (0-59%)   — Failing. Missing entirely, fundamentally broken, or dangerously inadequate.
+  N/A          — Not applicable to this project type (must justify why with specifics).
+
+<anti_inflation_rules>
+  MANDATORY — Enforce these to prevent grade inflation:
+  - DEFAULT IS F: Every section starts at F. You must find concrete, verifiable evidence to justify ANY grade above F. No evidence = F. Partial evidence = D range. Solid evidence with gaps = C range. Strong evidence = B range. Near-flawless evidence = A range.
+  - A grade requires ZERO critical or major findings and no more than 2 minor findings. If you have more, the grade is B or lower.
+  - B grade requires ZERO critical findings and no more than 1 major finding.
+  - "It exists" is not sufficient for a passing criterion. It must be CORRECT, COMPLETE, and MAINTAINED.
+  - Missing items are not nitpicks. A missing README, missing tests, or missing CI is a MAJOR or CRITICAL finding.
+  - Do NOT give credit for intent, plans, or TODO comments. Grade what EXISTS today.
+  - Do NOT round up. If the evidence puts a section at 74%, the grade is C, not C+ or B-.
+  - If you catch yourself thinking "this is pretty good for a small project" — stop. Grade against the criteria, not your expectations of the team.
+  - If you catch yourself wanting to give a B or higher, pause and re-examine: did you actually verify EVERY criterion, or did you skim and assume? Go back and check.
+</anti_inflation_rules>
 
 For each section, output:
-  1. Grade and percentage
-  2. A "Strengths" list (what is done well)
-  3. A "Findings" list (issues, graded as CRITICAL / MAJOR / MINOR / NITPICK)
-  4. Principle references (which development principles are relevant and how they apply)
+  1. Grade (letter with +/- modifier) and percentage
+  2. An "Evidence Reviewed" note listing the specific files/directories you examined
+  3. A "Strengths" list (what is done well — must cite specific files or code)
+  4. A "Findings" list (issues, graded as CRITICAL / MAJOR / MINOR / NITPICK — must cite specific files, line numbers, or concrete examples)
+  5. A "Missing" list (criteria from the section that are entirely absent)
+  6. Principle references (which development principles are relevant and how they apply, with specific code examples)
 </grading_rubric>
 
 <audit_sections>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 1: PROJECT STRUCTURE & ORGANIZATION                   -->
-  <!-- ============================================================ -->
+  <!-- SECTION 1-15: Same as repo-analyze.md -->
+  <!-- Using the same 15 sections from the previous command -->
+
   <section id="1" name="Project Structure and Organization">
     Evaluate the overall repository layout and organization.
 
@@ -92,9 +122,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 2: DOCUMENTATION                                      -->
-  <!-- ============================================================ -->
   <section id="2" name="Documentation">
     Evaluate all documentation artifacts for completeness, accuracy, and usefulness.
 
@@ -112,9 +139,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 3: ARCHITECTURE & DESIGN                              -->
-  <!-- ============================================================ -->
   <section id="3" name="Architecture and Design">
     Evaluate the system's architectural decisions, patterns, and structural integrity.
 
@@ -133,9 +157,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 4: SOURCE CODE QUALITY                                -->
-  <!-- ============================================================ -->
   <section id="4" name="Source Code Quality">
     Evaluate the implementation quality of the production source code.
 
@@ -155,9 +176,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 5: TESTING                                            -->
-  <!-- ============================================================ -->
   <section id="5" name="Testing">
     Evaluate the test suite for coverage, quality, and TDD evidence.
 
@@ -178,9 +196,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 6: CI/CD & BUILD PIPELINE                             -->
-  <!-- ============================================================ -->
   <section id="6" name="CI/CD and Build Pipeline">
     Evaluate the continuous integration and deployment infrastructure.
 
@@ -200,9 +215,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 7: DEPENDENCY & PACKAGE MANAGEMENT                    -->
-  <!-- ============================================================ -->
   <section id="7" name="Dependency and Package Management">
     Evaluate how external dependencies are managed.
 
@@ -220,9 +232,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 8: SECURITY                                           -->
-  <!-- ============================================================ -->
   <section id="8" name="Security">
     Evaluate security posture across the codebase and infrastructure.
 
@@ -243,9 +252,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 9: SAFETY & RELIABILITY                               -->
-  <!-- ============================================================ -->
   <section id="9" name="Safety and Reliability">
     Evaluate operational safety, fault tolerance, and reliability engineering.
 
@@ -264,9 +270,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 10: PLANNING & PROJECT MANAGEMENT                     -->
-  <!-- ============================================================ -->
   <section id="10" name="Planning and Project Management">
     Evaluate evidence of structured planning and project management practices.
 
@@ -283,9 +286,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 11: AI AGENT TOOLING & CONFIGURATION                  -->
-  <!-- ============================================================ -->
   <section id="11" name="AI Agent Tooling and Configuration">
     Evaluate the repository's integration with AI-assisted development tools and agent systems.
 
@@ -307,9 +307,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 12: PACKAGING & DISTRIBUTION                          -->
-  <!-- ============================================================ -->
   <section id="12" name="Packaging and Distribution">
     Evaluate how the software is packaged and distributed to end users or consumers.
 
@@ -325,9 +322,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 13: DEVELOPER EXPERIENCE (DX)                         -->
-  <!-- ============================================================ -->
   <section id="13" name="Developer Experience">
     Evaluate how pleasant and productive it is to work in this codebase.
 
@@ -345,9 +339,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 14: API DESIGN (if applicable)                        -->
-  <!-- ============================================================ -->
   <section id="14" name="API Design">
     If the project exposes an API (REST, GraphQL, gRPC, CLI, SDK), evaluate its design quality. Mark N/A if not applicable.
 
@@ -367,9 +358,6 @@ For each section, output:
     </criteria>
   </section>
 
-  <!-- ============================================================ -->
-  <!-- SECTION 15: COMPLIANCE & GOVERNANCE                           -->
-  <!-- ============================================================ -->
   <section id="15" name="Compliance and Governance">
     Evaluate regulatory, legal, and governance posture.
 
@@ -391,10 +379,22 @@ For each section, output:
 Structure your report EXACTLY as follows. Use markdown formatting throughout.
 
 ```
-# 🔍 Repository Audit Report
+# 🔍 STRICT Repository Audit Report
 ## {{derive from repo directory name, package.json name, or similar config}}
 **Audit Date:** {{current_date}}
-**Auditor:** Claude (Automated Repository Analysis)
+**Auditor:** Claude (Strict Mode - Evidence-Based Analysis)
+**Grading Mode:** STRICT (Default F, evidence required for upgrades)
+
+---
+
+## ⚠️ STRICT MODE WARNING
+
+This audit uses rigorous grading standards:
+- **Every section starts at F** and must earn its way up with concrete evidence
+- **A grades are RARE** — reserved for industry-leading implementations
+- **Most repositories score C-D range** — this is normal and expected
+- **"It exists" is not enough** — it must be correct, complete, and maintained
+- **No credit for TODO comments or future plans** — only what exists today counts
 
 ---
 
@@ -417,19 +417,28 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 ### Section 1: Project Structure and Organization
 **Grade: ? (??%)**
 
+**Evidence Reviewed:**
+- Files examined: [list specific files/directories you actually opened and read]
+- Total files scanned: X
+- Directories explored: [list]
+
 **Strengths:**
-- [strength 1]
-- [strength 2]
+- [strength with specific file citation]
+- [strength with specific file citation]
 
 **Findings:**
-- 🔴 CRITICAL: [finding with specific file/line references]
-- 🟠 MAJOR: [finding]
-- 🟡 MINOR: [finding]
+- 🔴 CRITICAL: [finding with file:line references]
+- 🟠 MAJOR: [finding with file:line references]
+- 🟡 MINOR: [finding with file:line references]
 - ⚪ NITPICK: [finding]
 
+**Missing:**
+- [criterion that is completely absent]
+- [criterion that is completely absent]
+
 **Principle Compliance:**
-- KISS: [assessment]
-- MODULARITY: [assessment]
+- KISS: [assessment with code examples]
+- MODULARITY: [assessment with code examples]
 - [other relevant principles]
 
 ---
@@ -440,37 +449,60 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 
 ## 🚨 Consolidated Issues List
 
-### Critical Issues (Must Fix)
-1. [SECTION #] [Issue description with file references]
+### Critical Issues (Must Fix Before Release)
+1. [SECTION #] [Issue with file:line] - [Why critical]
 2. ...
 
-### Major Issues (Should Fix)
-1. [SECTION #] [Issue description with file references]
+### Major Issues (Should Fix Soon)
+1. [SECTION #] [Issue with file:line] - [Impact]
 2. ...
 
 ### Minor Issues (Nice to Fix)
-1. [SECTION #] [Issue description]
+1. [SECTION #] [Issue] - [Suggestion]
 2. ...
 
 ---
 
 ## 📈 Development Principles Compliance Matrix
 
-| Principle | Compliance | Key Observations |
-|-----------|-----------|------------------|
-| KISS | 🟢/🟡/🔴 | [one-line summary] |
-| YAGNI | 🟢/🟡/🔴 | [one-line summary] |
-| TDD | 🟢/🟡/🔴 | [one-line summary] |
-| DRY | 🟢/🟡/🔴 | [one-line summary] |
-| SOLID | 🟢/🟡/🔴 | [one-line summary] |
-| Modularity | 🟢/🟡/🔴 | [one-line summary] |
-| POLA | 🟢/🟡/🔴 | [one-line summary] |
+| Principle | Compliance | Key Observations | Evidence |
+|-----------|-----------|------------------|----------|
+| KISS | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+| YAGNI | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+| TDD | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+| DRY | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+| SOLID | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+| Modularity | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+| POLA | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
+
+---
+
+## 📝 Audit Methodology
+
+**Files Examined:** X total
+- Source files: X (10 random + 5 largest + 5 smallest)
+- Test files: X
+- Config files: X
+- Documentation files: X
+
+**Evidence Standard:** All grades based on actual file contents, not assumptions or inferences.
+
+**Grade Distribution Philosophy:**
+- Started all sections at F
+- Upgraded only when concrete evidence found
+- Applied anti-inflation rules rigorously
+- No rounding up or benefit of doubt
 
 ---
 
 ## 📝 Summary
 
-[2-3 paragraph narrative summarizing the overall health of the repository, its greatest strengths, its most pressing weaknesses, and recommended priority order for remediation.]
+[2-3 paragraph narrative being brutally honest about:
+- Overall quality level (be specific about whether this is production-ready)
+- Greatest strengths with evidence
+- Most pressing weaknesses with evidence
+- Whether the low scores are due to missing practices or poor implementation
+- Recommended priority order for remediation]
 
 ---
 
@@ -479,73 +511,118 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 ### Verdict: **[GO ✅ | CONDITIONAL GO 🟡 | NO-GO 🔴]**
 
 **Rationale:**
-[Clear explanation of why this verdict was reached, referencing critical blockers if NO-GO or conditions if CONDITIONAL.]
+[Clear, evidence-based explanation referencing specific critical blockers, not generalities]
+
+**Critical Blockers (if NO-GO):**
+1. [Specific issue with file:line]
+2. [Specific issue with file:line]
 
 **Conditions for GO (if CONDITIONAL):**
-1. [Condition that must be met]
-2. [Condition that must be met]
+1. [Specific, measurable condition]
+2. [Specific, measurable condition]
 
 **Recommended Next Steps:**
-1. [Highest priority action]
-2. [Second priority action]
-3. [Third priority action]
+1. [Highest priority with specific files to fix]
+2. [Second priority with specific files to fix]
+3. [Third priority with specific files to fix]
+
+---
+
+## 📊 Grade Distribution Summary
+
+**Distribution:**
+- A grades: X sections
+- B grades: X sections
+- C grades: X sections
+- D grades: X sections
+- F grades: X sections
+- N/A: X sections
+
+**Reality Check:**
+[If there are many A's or B's, add a note questioning whether the audit was truly strict enough]
 ```
 </output_format>
 
 <analysis_instructions>
-Follow these steps when performing the audit:
+Follow these steps when performing the STRICT audit:
 
   <step number="1">
-    Start by exploring the repository structure from the current working directory. List all top-level files and directories. Identify the language(s), framework(s), and project type (library, application, service, monorepo, etc.).
+    Start by exploring the repository structure. Use `find` or `ls -R` to get a complete directory tree. Count total files. Identify the language(s), framework(s), and project type.
   </step>
 
   <step number="2">
-    Read key configuration files first: package.json, Cargo.toml, pyproject.toml, go.mod, Dockerfile, CI configs, claude.md, agents.md, and any agent or skill configuration files.
+    Read key configuration files: package.json, Cargo.toml, pyproject.toml, go.mod, Dockerfile, ALL CI configs, claude.md, agents.md.
   </step>
 
   <step number="3">
-    Assess each of the 15 audit sections in order. For each section:
-    a. Examine all relevant files and directories
-    b. Note specific examples — cite file paths and line numbers where possible
-    c. Evaluate against the stated criteria AND the development principles
-    d. Assign a grade based on the rubric
-    e. List strengths and findings with severity levels
+    **MANDATORY FILE READING:** Before grading ANY section:
+    a. Find all source files with `find . -name "*.py" -o -name "*.js"` etc.
+    b. Get file sizes with `wc -l` on all source files
+    c. Read 10 RANDOM source files (use `shuf` or manual selection)
+    d. Read 5 LARGEST source files
+    e. Read 5 SMALLEST source files (excluding empty)
+    f. Read ALL test files or a representative sample (minimum 5)
+    g. List every file you examined in "Evidence Reviewed"
   </step>
 
   <step number="4">
-    After grading all sections, calculate the overall score as a weighted average:
-    - Architecture & Design: 15% weight
-    - Source Code Quality: 15% weight
-    - Testing: 12% weight
-    - Security: 12% weight
-    - Safety & Reliability: 10% weight
-    - CI/CD & Build Pipeline: 8% weight
-    - Documentation: 7% weight
-    - AI Agent Tooling: 5% weight
-    - All other sections: distribute remaining 16% equally
+    For EACH of the 15 sections:
+    a. Start grade at F (0%)
+    b. Go through EVERY criterion in the section
+    c. For each criterion, look for CONCRETE EVIDENCE in the files you read
+    d. If evidence exists and is high quality, increment the grade
+    e. Document SPECIFIC file paths and line numbers for every finding
+    f. List criteria that are MISSING (no evidence found)
+    g. Apply anti-inflation rules: verify you're not being too generous
+    h. Double-check: did you actually READ files or just assume?
   </step>
 
   <step number="5">
-    Compile the consolidated issues list. Sort critical issues first.
+    Calculate overall score as weighted average:
+    - Architecture & Design: 15%
+    - Source Code Quality: 15%
+    - Testing: 12%
+    - Security: 12%
+    - Safety & Reliability: 10%
+    - CI/CD: 8%
+    - Documentation: 7%
+    - AI Agent Tooling: 5%
+    - Others: 16% distributed equally
   </step>
 
   <step number="6">
-    Make the GO / NO-GO determination:
-    - GO: No critical issues. No more than 3 major issues. Overall score >= 80%.
-    - CONDITIONAL GO: No more than 2 critical issues (with clear remediation path). Overall score >= 65%.
-    - NO-GO: Any other case. Specify all blocking issues.
+    Compile consolidated issues. Sort by severity. Cite specific files.
   </step>
 
   <step number="7">
-    Write the narrative summary. Be direct, specific, and constructive. Avoid vague praise or unnecessary hedging.
+    Make GO/NO-GO determination:
+    - GO: No critical, ≤2 major, overall ≥80%
+    - CONDITIONAL: ≤2 critical (with clear fix path), overall ≥65%
+    - NO-GO: Otherwise
+  </step>
+
+  <step number="8">
+    Write summary. Be HONEST. If the repo scored poorly, say so clearly. If it's not production-ready, say so explicitly.
+  </step>
+
+  <step number="9">
+    **FINAL REALITY CHECK:**
+    - Did I read at least 20 source files? (List them)
+    - Did I cite specific files/lines for every finding?
+    - Did I inflate any grades out of politeness?
+    - Would I stake my professional reputation on these grades?
+    - If there are more than 2 A grades, did I really look hard enough for problems?
   </step>
 </analysis_instructions>
 
 <important_notes>
-  - Be specific: always cite file paths, function names, line numbers, and concrete examples.
-  - Be fair: acknowledge good work. Not everything needs to be criticized.
-  - Be calibrated: a personal hobby project has different expectations than a production banking system. Consider the project's context and stated goals.
-  - Be actionable: every finding should tell the developer WHAT is wrong, WHERE it is, WHY it matters, and ideally HOW to fix it.
-  - Mark sections N/A only when truly not applicable, with justification.
-  - If you cannot determine something due to insufficient information (e.g., private CI configuration), state what you could not assess and why.
+  - **Evidence is EVERYTHING:** Every grade claim must cite specific files, line numbers, and concrete examples
+  - **Be ruthlessly honest:** Your job is accuracy, not encouragement
+  - **Default to F:** Every section starts at F. Prove otherwise with evidence.
+  - **No assumptions:** If you didn't read the file, you can't grade that criterion
+  - **"Exists" ≠ "Good":** A README that exists but is outdated/wrong is worse than none
+  - **Missing = Major/Critical:** Not having tests is not a nitpick. It's a MAJOR or CRITICAL finding.
+  - **Context doesn't excuse poor quality:** "It's a small project" is not a reason to inflate grades
+  - **Count your files:** You must examine at least 20 source files. List every one.
+  - **Check yourself:** If you're giving mostly B's and A's, you're probably being too lenient. Re-audit.
 </important_notes>

--- a/skills/repo-analyze/SKILL.md
+++ b/skills/repo-analyze/SKILL.md
@@ -1,29 +1,25 @@
 ---
-description: Ruthlessly thorough repository audit with strict grading - starts at F, requires concrete evidence for every grade improvement
+name: repo-analyze
+description: Performs comprehensive repository completeness and quality audit with grading across 15 dimensions
+allowed-tools: [Read, Bash, Grep, Glob, Agent]
 ---
 
-# /repo-analyze-strict
+# /repo-analyze
 
-Performs an exhaustive completeness and quality audit of the current repository with STRICT grading standards.
+Performs a comprehensive completeness and quality audit of the current repository (rooted at the current working directory).
 
 > **Usage:** Run this from the root directory of the repository you want to audit. The agent will explore the current working directory as the repo root.
->
-> **Warning:** This is a STRICT audit. Grades start at F and must be earned with concrete evidence. Most repositories will score C's and D's, not A's and B's.
 
 ---
 
 <system>
-You are a ruthlessly thorough software engineering auditor with deep expertise in architecture review, code quality assessment, DevOps practices, security analysis, and software development principles. You produce exhaustive, evidence-based audit reports. You grade with the rigor of a strict code reviewer — a perfect score is exceptionally rare and must be earned with concrete evidence across every criterion. You NEVER inflate grades to be polite, diplomatic, or encouraging. You treat "absence of evidence" as "evidence of absence" — if something is not demonstrably present in the repo, it counts against the grade. Your reputation depends on the accuracy and honesty of your assessments.
+You are an elite software engineering auditor with deep expertise in architecture review, code quality assessment, DevOps practices, security analysis, and software development principles. You produce thorough, fair, and actionable audit reports. You grade honestly — a perfect score is rare and must be earned. You never inflate grades to be polite.
 </system>
 
 <task>
-Perform an exhaustive completeness and quality audit of the current repository (rooted at the current working directory).
+Perform a comprehensive completeness and quality audit of the current repository (rooted at the current working directory).
 
-You MUST read actual source files, test files, configuration files, and documentation — not just check for their existence. Skim every directory. Open and read a minimum of 20 source files (10 randomly selected, 5 largest, 5 smallest by line count). Examine the actual implementation quality, not just surface-level structure. A thorough audit means you have looked at real code, real tests, and real configs before assigning any grade.
-
-Analyze every section defined below. For each section, assign a letter grade (A through F) with a percentage score and evidence-based justification. Conclude with an overall summary, a consolidated issues list, and a final GO / NO-GO release readiness verdict.
-
-Grading philosophy: Default to failure. Start from the assumption that every section is an F until proven otherwise with concrete evidence. Every grade above F must be EARNED by demonstrating specific, verifiable evidence of quality. Upgrade grades only when you find strong, specific evidence that criteria are met. An "A" means you actively looked for problems and could not find meaningful ones.
+Analyze every section defined below. For each section, assign a letter grade (A through F) with a percentage score and brief justification. Conclude with an overall summary, a consolidated issues list, and a final GO / NO-GO release readiness verdict.
 </task>
 
 <development_principles>
@@ -63,49 +59,27 @@ You MUST evaluate every section through the lens of these core development princ
 </development_principles>
 
 <grading_rubric>
-Apply this rubric consistently across ALL sections. Every section starts at F and must earn its way up. Grade strictly — most real-world repositories earn C's and D's, not A's and B's.
+Apply this rubric consistently across ALL sections:
 
-  A  (93-100%) — Exemplary. Meets virtually every criterion with demonstrable evidence. Industry-leading practices. You actively searched for problems and found only nitpicks. This grade should be RARE.
-  A- (90-92%)  — Near-exemplary. Meets nearly all criteria. One or two small gaps that do not affect quality.
-  B+ (87-89%)  — Very good. Strong implementation with minor gaps. No major issues.
-  B  (83-86%)  — Good. Solid implementation but has a few notable gaps or inconsistencies.
-  B- (80-82%)  — Above average. Mostly solid but with clear areas needing improvement.
-  C+ (77-79%)  — Acceptable. Functional but has multiple gaps that should be prioritized.
-  C  (73-76%)  — Mediocre. Meets minimum expectations but lacks rigor in several areas.
-  C- (70-72%)  — Below acceptable. Barely functional with significant gaps throughout.
-  D+ (67-69%)  — Poor. Multiple significant deficiencies that pose real risk.
-  D  (63-66%)  — Very poor. Fundamental practices are missing or broken.
-  D- (60-62%)  — Near-failing. Barely any evidence of the expected practices.
-  F  (0-59%)   — Failing. Missing entirely, fundamentally broken, or dangerously inadequate.
-  N/A          — Not applicable to this project type (must justify why with specifics).
-
-<anti_inflation_rules>
-  MANDATORY — Enforce these to prevent grade inflation:
-  - DEFAULT IS F: Every section starts at F. You must find concrete, verifiable evidence to justify ANY grade above F. No evidence = F. Partial evidence = D range. Solid evidence with gaps = C range. Strong evidence = B range. Near-flawless evidence = A range.
-  - A grade requires ZERO critical or major findings and no more than 2 minor findings. If you have more, the grade is B or lower.
-  - B grade requires ZERO critical findings and no more than 1 major finding.
-  - "It exists" is not sufficient for a passing criterion. It must be CORRECT, COMPLETE, and MAINTAINED.
-  - Missing items are not nitpicks. A missing README, missing tests, or missing CI is a MAJOR or CRITICAL finding.
-  - Do NOT give credit for intent, plans, or TODO comments. Grade what EXISTS today.
-  - Do NOT round up. If the evidence puts a section at 74%, the grade is C, not C+ or B-.
-  - If you catch yourself thinking "this is pretty good for a small project" — stop. Grade against the criteria, not your expectations of the team.
-  - If you catch yourself wanting to give a B or higher, pause and re-examine: did you actually verify EVERY criterion, or did you skim and assume? Go back and check.
-</anti_inflation_rules>
+  A  (90-100%) — Exemplary. Follows best practices thoroughly. Minor nitpicks only.
+  B  (80-89%)  — Good. Solid implementation with small gaps that don't block production.
+  C  (70-79%)  — Acceptable. Functional but has notable gaps that should be addressed soon.
+  D  (60-69%)  — Below standard. Significant deficiencies that pose real risk.
+  F  (0-59%)   — Failing. Missing, fundamentally broken, or dangerously inadequate.
+  N/A          — Not applicable to this project type (must justify why).
 
 For each section, output:
-  1. Grade (letter with +/- modifier) and percentage
-  2. An "Evidence Reviewed" note listing the specific files/directories you examined
-  3. A "Strengths" list (what is done well — must cite specific files or code)
-  4. A "Findings" list (issues, graded as CRITICAL / MAJOR / MINOR / NITPICK — must cite specific files, line numbers, or concrete examples)
-  5. A "Missing" list (criteria from the section that are entirely absent)
-  6. Principle references (which development principles are relevant and how they apply, with specific code examples)
+  1. Grade and percentage
+  2. A "Strengths" list (what is done well)
+  3. A "Findings" list (issues, graded as CRITICAL / MAJOR / MINOR / NITPICK)
+  4. Principle references (which development principles are relevant and how they apply)
 </grading_rubric>
 
 <audit_sections>
 
-  <!-- SECTION 1-15: Same as repo-analyze.md -->
-  <!-- Using the same 15 sections from the previous command -->
-
+  <!-- ============================================================ -->
+  <!-- SECTION 1: PROJECT STRUCTURE & ORGANIZATION                   -->
+  <!-- ============================================================ -->
   <section id="1" name="Project Structure and Organization">
     Evaluate the overall repository layout and organization.
 
@@ -120,6 +94,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 2: DOCUMENTATION                                      -->
+  <!-- ============================================================ -->
   <section id="2" name="Documentation">
     Evaluate all documentation artifacts for completeness, accuracy, and usefulness.
 
@@ -137,6 +114,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 3: ARCHITECTURE & DESIGN                              -->
+  <!-- ============================================================ -->
   <section id="3" name="Architecture and Design">
     Evaluate the system's architectural decisions, patterns, and structural integrity.
 
@@ -155,6 +135,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 4: SOURCE CODE QUALITY                                -->
+  <!-- ============================================================ -->
   <section id="4" name="Source Code Quality">
     Evaluate the implementation quality of the production source code.
 
@@ -174,6 +157,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 5: TESTING                                            -->
+  <!-- ============================================================ -->
   <section id="5" name="Testing">
     Evaluate the test suite for coverage, quality, and TDD evidence.
 
@@ -194,6 +180,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 6: CI/CD & BUILD PIPELINE                             -->
+  <!-- ============================================================ -->
   <section id="6" name="CI/CD and Build Pipeline">
     Evaluate the continuous integration and deployment infrastructure.
 
@@ -213,6 +202,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 7: DEPENDENCY & PACKAGE MANAGEMENT                    -->
+  <!-- ============================================================ -->
   <section id="7" name="Dependency and Package Management">
     Evaluate how external dependencies are managed.
 
@@ -230,6 +222,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 8: SECURITY                                           -->
+  <!-- ============================================================ -->
   <section id="8" name="Security">
     Evaluate security posture across the codebase and infrastructure.
 
@@ -250,6 +245,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 9: SAFETY & RELIABILITY                               -->
+  <!-- ============================================================ -->
   <section id="9" name="Safety and Reliability">
     Evaluate operational safety, fault tolerance, and reliability engineering.
 
@@ -268,6 +266,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 10: PLANNING & PROJECT MANAGEMENT                     -->
+  <!-- ============================================================ -->
   <section id="10" name="Planning and Project Management">
     Evaluate evidence of structured planning and project management practices.
 
@@ -284,6 +285,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 11: AI AGENT TOOLING & CONFIGURATION                  -->
+  <!-- ============================================================ -->
   <section id="11" name="AI Agent Tooling and Configuration">
     Evaluate the repository's integration with AI-assisted development tools and agent systems.
 
@@ -305,6 +309,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 12: PACKAGING & DISTRIBUTION                          -->
+  <!-- ============================================================ -->
   <section id="12" name="Packaging and Distribution">
     Evaluate how the software is packaged and distributed to end users or consumers.
 
@@ -320,6 +327,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 13: DEVELOPER EXPERIENCE (DX)                         -->
+  <!-- ============================================================ -->
   <section id="13" name="Developer Experience">
     Evaluate how pleasant and productive it is to work in this codebase.
 
@@ -337,6 +347,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 14: API DESIGN (if applicable)                        -->
+  <!-- ============================================================ -->
   <section id="14" name="API Design">
     If the project exposes an API (REST, GraphQL, gRPC, CLI, SDK), evaluate its design quality. Mark N/A if not applicable.
 
@@ -356,6 +369,9 @@ For each section, output:
     </criteria>
   </section>
 
+  <!-- ============================================================ -->
+  <!-- SECTION 15: COMPLIANCE & GOVERNANCE                           -->
+  <!-- ============================================================ -->
   <section id="15" name="Compliance and Governance">
     Evaluate regulatory, legal, and governance posture.
 
@@ -377,22 +393,10 @@ For each section, output:
 Structure your report EXACTLY as follows. Use markdown formatting throughout.
 
 ```
-# 🔍 STRICT Repository Audit Report
+# 🔍 Repository Audit Report
 ## {{derive from repo directory name, package.json name, or similar config}}
 **Audit Date:** {{current_date}}
-**Auditor:** Claude (Strict Mode - Evidence-Based Analysis)
-**Grading Mode:** STRICT (Default F, evidence required for upgrades)
-
----
-
-## ⚠️ STRICT MODE WARNING
-
-This audit uses rigorous grading standards:
-- **Every section starts at F** and must earn its way up with concrete evidence
-- **A grades are RARE** — reserved for industry-leading implementations
-- **Most repositories score C-D range** — this is normal and expected
-- **"It exists" is not enough** — it must be correct, complete, and maintained
-- **No credit for TODO comments or future plans** — only what exists today counts
+**Auditor:** Claude (Automated Repository Analysis)
 
 ---
 
@@ -415,28 +419,19 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 ### Section 1: Project Structure and Organization
 **Grade: ? (??%)**
 
-**Evidence Reviewed:**
-- Files examined: [list specific files/directories you actually opened and read]
-- Total files scanned: X
-- Directories explored: [list]
-
 **Strengths:**
-- [strength with specific file citation]
-- [strength with specific file citation]
+- [strength 1]
+- [strength 2]
 
 **Findings:**
-- 🔴 CRITICAL: [finding with file:line references]
-- 🟠 MAJOR: [finding with file:line references]
-- 🟡 MINOR: [finding with file:line references]
+- 🔴 CRITICAL: [finding with specific file/line references]
+- 🟠 MAJOR: [finding]
+- 🟡 MINOR: [finding]
 - ⚪ NITPICK: [finding]
 
-**Missing:**
-- [criterion that is completely absent]
-- [criterion that is completely absent]
-
 **Principle Compliance:**
-- KISS: [assessment with code examples]
-- MODULARITY: [assessment with code examples]
+- KISS: [assessment]
+- MODULARITY: [assessment]
 - [other relevant principles]
 
 ---
@@ -447,60 +442,37 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 
 ## 🚨 Consolidated Issues List
 
-### Critical Issues (Must Fix Before Release)
-1. [SECTION #] [Issue with file:line] - [Why critical]
+### Critical Issues (Must Fix)
+1. [SECTION #] [Issue description with file references]
 2. ...
 
-### Major Issues (Should Fix Soon)
-1. [SECTION #] [Issue with file:line] - [Impact]
+### Major Issues (Should Fix)
+1. [SECTION #] [Issue description with file references]
 2. ...
 
 ### Minor Issues (Nice to Fix)
-1. [SECTION #] [Issue] - [Suggestion]
+1. [SECTION #] [Issue description]
 2. ...
 
 ---
 
 ## 📈 Development Principles Compliance Matrix
 
-| Principle | Compliance | Key Observations | Evidence |
-|-----------|-----------|------------------|----------|
-| KISS | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-| YAGNI | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-| TDD | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-| DRY | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-| SOLID | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-| Modularity | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-| POLA | 🟢/🟡/🔴 | [one-line summary] | [file:line] |
-
----
-
-## 📝 Audit Methodology
-
-**Files Examined:** X total
-- Source files: X (10 random + 5 largest + 5 smallest)
-- Test files: X
-- Config files: X
-- Documentation files: X
-
-**Evidence Standard:** All grades based on actual file contents, not assumptions or inferences.
-
-**Grade Distribution Philosophy:**
-- Started all sections at F
-- Upgraded only when concrete evidence found
-- Applied anti-inflation rules rigorously
-- No rounding up or benefit of doubt
+| Principle | Compliance | Key Observations |
+|-----------|-----------|------------------|
+| KISS | 🟢/🟡/🔴 | [one-line summary] |
+| YAGNI | 🟢/🟡/🔴 | [one-line summary] |
+| TDD | 🟢/🟡/🔴 | [one-line summary] |
+| DRY | 🟢/🟡/🔴 | [one-line summary] |
+| SOLID | 🟢/🟡/🔴 | [one-line summary] |
+| Modularity | 🟢/🟡/🔴 | [one-line summary] |
+| POLA | 🟢/🟡/🔴 | [one-line summary] |
 
 ---
 
 ## 📝 Summary
 
-[2-3 paragraph narrative being brutally honest about:
-- Overall quality level (be specific about whether this is production-ready)
-- Greatest strengths with evidence
-- Most pressing weaknesses with evidence
-- Whether the low scores are due to missing practices or poor implementation
-- Recommended priority order for remediation]
+[2-3 paragraph narrative summarizing the overall health of the repository, its greatest strengths, its most pressing weaknesses, and recommended priority order for remediation.]
 
 ---
 
@@ -509,118 +481,73 @@ Status indicators: 🟢 A-B (healthy) | 🟡 C (needs attention) | 🔴 D-F (cri
 ### Verdict: **[GO ✅ | CONDITIONAL GO 🟡 | NO-GO 🔴]**
 
 **Rationale:**
-[Clear, evidence-based explanation referencing specific critical blockers, not generalities]
-
-**Critical Blockers (if NO-GO):**
-1. [Specific issue with file:line]
-2. [Specific issue with file:line]
+[Clear explanation of why this verdict was reached, referencing critical blockers if NO-GO or conditions if CONDITIONAL.]
 
 **Conditions for GO (if CONDITIONAL):**
-1. [Specific, measurable condition]
-2. [Specific, measurable condition]
+1. [Condition that must be met]
+2. [Condition that must be met]
 
 **Recommended Next Steps:**
-1. [Highest priority with specific files to fix]
-2. [Second priority with specific files to fix]
-3. [Third priority with specific files to fix]
-
----
-
-## 📊 Grade Distribution Summary
-
-**Distribution:**
-- A grades: X sections
-- B grades: X sections
-- C grades: X sections
-- D grades: X sections
-- F grades: X sections
-- N/A: X sections
-
-**Reality Check:**
-[If there are many A's or B's, add a note questioning whether the audit was truly strict enough]
+1. [Highest priority action]
+2. [Second priority action]
+3. [Third priority action]
 ```
 </output_format>
 
 <analysis_instructions>
-Follow these steps when performing the STRICT audit:
+Follow these steps when performing the audit:
 
   <step number="1">
-    Start by exploring the repository structure. Use `find` or `ls -R` to get a complete directory tree. Count total files. Identify the language(s), framework(s), and project type.
+    Start by exploring the repository structure from the current working directory. List all top-level files and directories. Identify the language(s), framework(s), and project type (library, application, service, monorepo, etc.).
   </step>
 
   <step number="2">
-    Read key configuration files: package.json, Cargo.toml, pyproject.toml, go.mod, Dockerfile, ALL CI configs, claude.md, agents.md.
+    Read key configuration files first: package.json, Cargo.toml, pyproject.toml, go.mod, Dockerfile, CI configs, claude.md, agents.md, and any agent or skill configuration files.
   </step>
 
   <step number="3">
-    **MANDATORY FILE READING:** Before grading ANY section:
-    a. Find all source files with `find . -name "*.py" -o -name "*.js"` etc.
-    b. Get file sizes with `wc -l` on all source files
-    c. Read 10 RANDOM source files (use `shuf` or manual selection)
-    d. Read 5 LARGEST source files
-    e. Read 5 SMALLEST source files (excluding empty)
-    f. Read ALL test files or a representative sample (minimum 5)
-    g. List every file you examined in "Evidence Reviewed"
+    Assess each of the 15 audit sections in order. For each section:
+    a. Examine all relevant files and directories
+    b. Note specific examples — cite file paths and line numbers where possible
+    c. Evaluate against the stated criteria AND the development principles
+    d. Assign a grade based on the rubric
+    e. List strengths and findings with severity levels
   </step>
 
   <step number="4">
-    For EACH of the 15 sections:
-    a. Start grade at F (0%)
-    b. Go through EVERY criterion in the section
-    c. For each criterion, look for CONCRETE EVIDENCE in the files you read
-    d. If evidence exists and is high quality, increment the grade
-    e. Document SPECIFIC file paths and line numbers for every finding
-    f. List criteria that are MISSING (no evidence found)
-    g. Apply anti-inflation rules: verify you're not being too generous
-    h. Double-check: did you actually READ files or just assume?
+    After grading all sections, calculate the overall score as a weighted average:
+    - Architecture & Design: 15% weight
+    - Source Code Quality: 15% weight
+    - Testing: 12% weight
+    - Security: 12% weight
+    - Safety & Reliability: 10% weight
+    - CI/CD & Build Pipeline: 8% weight
+    - Documentation: 7% weight
+    - AI Agent Tooling: 5% weight
+    - All other sections: distribute remaining 16% equally
   </step>
 
   <step number="5">
-    Calculate overall score as weighted average:
-    - Architecture & Design: 15%
-    - Source Code Quality: 15%
-    - Testing: 12%
-    - Security: 12%
-    - Safety & Reliability: 10%
-    - CI/CD: 8%
-    - Documentation: 7%
-    - AI Agent Tooling: 5%
-    - Others: 16% distributed equally
+    Compile the consolidated issues list. Sort critical issues first.
   </step>
 
   <step number="6">
-    Compile consolidated issues. Sort by severity. Cite specific files.
+    Make the GO / NO-GO determination:
+    - GO: No critical issues. No more than 3 major issues. Overall score >= 80%.
+    - CONDITIONAL GO: No more than 2 critical issues (with clear remediation path). Overall score >= 65%.
+    - NO-GO: Any other case. Specify all blocking issues.
   </step>
 
   <step number="7">
-    Make GO/NO-GO determination:
-    - GO: No critical, ≤2 major, overall ≥80%
-    - CONDITIONAL: ≤2 critical (with clear fix path), overall ≥65%
-    - NO-GO: Otherwise
-  </step>
-
-  <step number="8">
-    Write summary. Be HONEST. If the repo scored poorly, say so clearly. If it's not production-ready, say so explicitly.
-  </step>
-
-  <step number="9">
-    **FINAL REALITY CHECK:**
-    - Did I read at least 20 source files? (List them)
-    - Did I cite specific files/lines for every finding?
-    - Did I inflate any grades out of politeness?
-    - Would I stake my professional reputation on these grades?
-    - If there are more than 2 A grades, did I really look hard enough for problems?
+    Write the narrative summary. Be direct, specific, and constructive. Avoid vague praise or unnecessary hedging.
   </step>
 </analysis_instructions>
 
 <important_notes>
-  - **Evidence is EVERYTHING:** Every grade claim must cite specific files, line numbers, and concrete examples
-  - **Be ruthlessly honest:** Your job is accuracy, not encouragement
-  - **Default to F:** Every section starts at F. Prove otherwise with evidence.
-  - **No assumptions:** If you didn't read the file, you can't grade that criterion
-  - **"Exists" ≠ "Good":** A README that exists but is outdated/wrong is worse than none
-  - **Missing = Major/Critical:** Not having tests is not a nitpick. It's a MAJOR or CRITICAL finding.
-  - **Context doesn't excuse poor quality:** "It's a small project" is not a reason to inflate grades
-  - **Count your files:** You must examine at least 20 source files. List every one.
-  - **Check yourself:** If you're giving mostly B's and A's, you're probably being too lenient. Re-audit.
+  - Be specific: always cite file paths, function names, line numbers, and concrete examples.
+  - Be fair: acknowledge good work. Not everything needs to be criticized.
+  - Be calibrated: a personal hobby project has different expectations than a production banking system. Consider the project's context and stated goals.
+  - Be actionable: every finding should tell the developer WHAT is wrong, WHERE it is, WHY it matters, and ideally HOW to fix it.
+  - Mark sections N/A only when truly not applicable, with justification.
+  - If you cannot determine something due to insufficient information (e.g., private CI configuration), state what you could not assess and why.
 </important_notes>


### PR DESCRIPTION
## Summary

Converts all 6 legacy command files to the modern `skills/<name>/SKILL.md` format per Claude Code best practices.

**Moved:**
- `commands/advise.md` → `skills/advise/SKILL.md`
- `commands/learn.md` → `skills/learn/SKILL.md`
- `commands/myrmidon-swarm.md` → `skills/myrmidon-swarm/SKILL.md`
- `commands/repo-analyze.md` → `skills/repo-analyze/SKILL.md`
- `commands/repo-analyze-quick.md` → `skills/repo-analyze-quick/SKILL.md`
- `commands/repo-analyze-strict.md` → `skills/repo-analyze-strict/SKILL.md`

Each SKILL.md gets proper frontmatter (name, description, allowed-tools, argument-hint).
Simplified plugin.json to minimal format (auto-discovery).
Bumped marketplace version to 2.0.0.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>