### PR TITLE
Fix save_data silently ignoring unsupported format_hint values

### DIFF
--- a/hephaestus/io/utils.py
+++ b/hephaestus/io/utils.py
@@ -22,6 +22,9 @@ logger = get_logger(__name__)
 # Formats that require unsafe deserialization (e.g. pickle)
 _UNSAFE_FORMATS = {"pickle"}
 
+# All supported serialization formats
+_SUPPORTED_FORMATS = {"json", "yaml", "pickle"}
+
 
 def read_file(filepath: str | Path, mode: str = "r") -> str | bytes:
     """Read content from a file.
@@ -159,6 +162,11 @@ def _detect_format(filepath: Path, format_hint: str | None) -> str:
 
     """
     if format_hint is not None:
+        if format_hint not in _SUPPORTED_FORMATS:
+            raise ValueError(
+                f"Unsupported format: '{format_hint}'. "
+                f"Supported formats: {sorted(_SUPPORTED_FORMATS)}"
+            )
         return format_hint
     ext = filepath.suffix.lower()
     if ext == ".json":
@@ -237,14 +245,12 @@ def save_data(
         True if successful, False otherwise
 
     Raises:
-        ValueError: If format is unsafe and allow_unsafe_deserialization is False.
+        ValueError: If format is unsafe and allow_unsafe_deserialization is False,
+            or if format is unsupported or cannot be determined.
 
     """
     filepath = Path(filepath)
-    try:
-        fmt = _detect_format(filepath, format_hint)
-    except ValueError:
-        fmt = "json"  # default for unknown extensions
+    fmt = _detect_format(filepath, format_hint)
 
     if fmt in _UNSAFE_FORMATS and not allow_unsafe_deserialization:
         raise ValueError(
@@ -264,4 +270,6 @@ def save_data(
 
         with open(filepath, "wb") as f:
             pickle.dump(data, f)
+    else:
+        raise ValueError(f"Unsupported format: '{fmt}'")
     return True

--- a/tests/unit/io/test_utils.py
+++ b/tests/unit/io/test_utils.py
@@ -183,6 +183,16 @@ class TestDetectFormat:
         with pytest.raises(ValueError, match="Could not determine"):
             _detect_format(tmp_path / "f.xyz", None)
 
+    def test_unsupported_format_hint_raises(self, tmp_path: Path) -> None:
+        """Unsupported format_hint raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported format"):
+            _detect_format(tmp_path / "f.txt", "csv")
+
+    def test_unknown_format_hint_raises(self, tmp_path: Path) -> None:
+        """Unknown format_hint raises ValueError."""
+        with pytest.raises(ValueError, match="Unsupported format"):
+            _detect_format(tmp_path / "f.txt", "xml")
+
 
 class TestLoadData:
     """Tests for load_data."""
@@ -221,6 +231,13 @@ class TestLoadData:
         result = load_data(f, format_hint="json")
         assert result == {"a": 1}
 
+    def test_unsupported_format_hint_raises(self, tmp_path: Path) -> None:
+        """Unsupported format_hint raises ValueError."""
+        f = tmp_path / "data.json"
+        f.write_text(json.dumps({"a": 1}))
+        with pytest.raises(ValueError, match="Unsupported format"):
+            load_data(f, format_hint="csv")
+
 
 class TestSaveData:
     """Tests for save_data."""
@@ -243,11 +260,30 @@ class TestSaveData:
         with pytest.raises(ValueError, match="unsafe deserialization"):
             save_data({"x": 1}, f)
 
-    def test_default_format_json(self, tmp_path: Path) -> None:
-        """Unknown extension defaults to JSON."""
+    def test_unknown_extension_without_hint_raises(self, tmp_path: Path) -> None:
+        """Unknown extension without format_hint raises ValueError."""
         f = tmp_path / "out.dat"
-        assert save_data({"x": 1}, f)
-        assert json.loads(f.read_text()) == {"x": 1}
+        with pytest.raises(ValueError, match="Could not determine"):
+            save_data({"x": 1}, f)
+
+    def test_unsupported_format_hint_raises(self, tmp_path: Path) -> None:
+        """Unsupported format_hint raises ValueError."""
+        f = tmp_path / "out.csv"
+        with pytest.raises(ValueError, match="Unsupported format"):
+            save_data({"x": 1}, f, format_hint="csv")
+
+    def test_unknown_format_hint_raises(self, tmp_path: Path) -> None:
+        """Unknown format_hint raises ValueError."""
+        f = tmp_path / "out.xml"
+        with pytest.raises(ValueError, match="Unsupported format"):
+            save_data({"x": 1}, f, format_hint="xml")
+
+    def test_unsupported_format_no_file_written(self, tmp_path: Path) -> None:
+        """No file is written when format_hint is unsupported."""
+        f = tmp_path / "out.csv"
+        with pytest.raises(ValueError):
+            save_data({"x": 1}, f, format_hint="csv")
+        assert not f.exists()
 
     def test_raises_on_io_error(self, tmp_path: Path) -> None:
         """IOError is raised (not silently swallowed) when write fails."""


### PR DESCRIPTION
## Summary
- Add `_SUPPORTED_FORMATS` constant and validate `format_hint` in `_detect_format()` before returning it, raising `ValueError` for unsupported values like `'csv'` or `'xml'`
- Remove the `try/except ValueError` fallback in `save_data()` that silently defaulted unknown extensions to JSON
- Add `else: raise ValueError` to `save_data()`'s `if/elif` dispatch chain, matching `load_data()`'s existing guard at line 218

## Test plan
- [x] `_detect_format()` raises `ValueError` for unsupported `format_hint` values (`csv`, `xml`)
- [x] `save_data()` raises `ValueError` for unsupported `format_hint` values
- [x] `save_data()` raises `ValueError` for unknown extensions without a `format_hint` (no longer silently defaults to JSON)
- [x] `load_data()` raises `ValueError` for unsupported `format_hint` values
- [x] No file is written when `format_hint` is unsupported
- [x] All existing tests for supported formats (JSON, YAML, pickle) still pass
- [x] Full unit test suite passes (400 tests)
- [x] Linter and formatter pass

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)