### PR TITLE
ci: add mypy type check step to lint job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Format check
         run: pixi run ruff format --check hephaestus scripts tests
 
+      - name: Type check
+        run: pixi run mypy hephaestus/
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- Adds a "Type check" step (`pixi run mypy hephaestus/`) to the `lint` job in the CI workflow, after the existing ruff lint and format checks
- Provides CI enforcement for type safety, following the same pattern established in PR #105 for ruff — pre-commit hooks exist but can be bypassed, so CI is the backstop

Closes #107

## Test plan
- [x] Verified `pixi run mypy hephaestus/` passes locally with zero violations (36 source files)
- [x] All 445 existing tests pass (82.11% coverage)
- [ ] CI `lint` job should show the new "Type check" step and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)