### PR TITLE
Add mypy type-check job to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,35 @@ jobs:
       - name: Run tests
         run: pixi run pytest tests/unit
 
+  type-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.63.2
+
+      - name: Cache pixi environments
+        uses: actions/cache@v5
+        with:
+          path: |
+            .pixi
+            ~/.cache/rattler/cache
+          key: ${{ runner.os }}-pixi-${{ hashFiles('pixi.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pixi-
+
+      - name: Run mypy type checking
+        run: pixi run mypy hephaestus/
+
   build-and-publish:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: test
+    needs: [test, type-check]
     environment: pypi
 
     steps:


### PR DESCRIPTION
## Summary
- Adds a `type-check` job to `release.yml` that runs `pixi run mypy hephaestus/` as a pre-release validation step
- Updates `build-and-publish` to require both `test` and `type-check` (`needs: [test, type-check]`), ensuring type safety is enforced before publishing to PyPI
- The `type-check` and `test` jobs run in parallel for faster feedback

## Verification
- `pixi run mypy hephaestus/` passes locally with zero errors
- YAML syntax validated
- All 394 unit tests pass

## Test plan
- [ ] Verify YAML is valid (done locally)
- [ ] Verify mypy passes on current codebase (done locally)
- [ ] Confirm `build-and-publish` depends on both `test` and `type-check`

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)