### PR TITLE
fix(logging): copy context dict in ContextLogger.__init__

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -25,8 +25,9 @@ class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
 
     def __init__(self, logger: logging.Logger, context: dict[str, Any] | None = None) -> None:
         """Initialize with logger and optional context dict."""
-        super().__init__(logger, context or {})
-        self._context = context or {}
+        ctx = dict(context) if context else {}
+        super().__init__(logger, ctx)
+        self._context = ctx
         self._context_lock = threading.Lock()
 
     def process(self, msg: Any, kwargs: Any) -> tuple[Any, Any]:

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -66,6 +66,29 @@ class TestContextLogger:
         assert "a" not in unbound._context
         assert unbound._context["b"] == 2
 
+    def test_init_copies_context_dict(self) -> None:
+        """__init__ stores a copy, not the caller's original dict."""
+        caller_dict: dict[str, object] = {"key": "value"}
+        logger = ContextLogger(logging.getLogger("test.copy"), caller_dict)
+        assert logger._context is not caller_dict
+        assert logger._context == caller_dict
+
+    def test_init_isolates_from_caller_mutation(self) -> None:
+        """Mutating the caller's dict after construction does not affect the logger."""
+        caller_dict: dict[str, object] = {"key": "original"}
+        logger = ContextLogger(logging.getLogger("test.isolate"), caller_dict)
+        caller_dict["key"] = "mutated"
+        caller_dict["new_key"] = "surprise"
+        assert logger._context["key"] == "original"
+        assert "new_key" not in logger._context
+
+    def test_get_logger_isolates_context(self) -> None:
+        """get_logger() also isolates the context dict from caller mutation."""
+        caller_dict: dict[str, object] = {"req": "abc"}
+        logger = get_logger("test.get_logger_isolate", context=caller_dict)
+        caller_dict["req"] = "changed"
+        assert logger._context["req"] == "abc"
+
     def test_process_adds_extra(self) -> None:
         """process() merges context into kwargs['extra']."""
         logger = get_logger("test.process", context={"x": 42})


### PR DESCRIPTION
## Summary
- **Fix**: `ContextLogger.__init__` now makes a shallow copy of the `context` dict instead of storing it by reference. This prevents the caller from silently mutating the logger's context after construction.
- **Root cause**: `self._context = context or {}` stored the caller's dict directly. Also fixed the `super().__init__()` call to pass the copied dict for consistency.
- **Tests**: Added 3 regression tests covering identity check, mutation isolation, and the `get_logger()` entry point.

Closes #120

## Test plan
- [x] `test_init_copies_context_dict` — verifies `_context is not` the caller's original dict
- [x] `test_init_isolates_from_caller_mutation` — mutates caller dict, asserts logger unaffected
- [x] `test_get_logger_isolates_context` — same check via `get_logger()` public API
- [x] All 16 logging tests pass
- [x] Full 397-test unit suite passes with no regressions
- [x] Ruff lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)