### PR TITLE
fix(logging): replace all-or-nothing handler guard with per-type checks

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -15,6 +15,7 @@ Usage:
 import logging
 import sys
 import threading
+from pathlib import Path
 from typing import Any
 
 from hephaestus.constants import LOG_FORMAT
@@ -75,17 +76,26 @@ def get_logger(
     logger = logging.getLogger(name)
     logger.setLevel(level or logging.INFO)
 
-    # Prevent adding handlers multiple times
-    if not logger.handlers:
-        formatter = logging.Formatter(LOG_FORMAT)
+    formatter = logging.Formatter(LOG_FORMAT)
 
-        # Console handler
+    # Add console handler if one doesn't already exist
+    has_console = any(
+        isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        for h in logger.handlers
+    )
+    if not has_console:
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
-        # File handler (optional)
-        if log_file:
+    # Add file handler if requested and not already present for this path
+    if log_file:
+        resolved = str(Path(log_file).resolve())
+        has_file = any(
+            isinstance(h, logging.FileHandler) and h.baseFilename == resolved
+            for h in logger.handlers
+        )
+        if not has_file:
             file_handler = logging.FileHandler(log_file)
             file_handler.setFormatter(formatter)
             logger.addHandler(file_handler)

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -43,6 +43,76 @@ class TestGetLogger:
         handler_types = [type(h) for h in logger.logger.handlers]
         assert logging.FileHandler in handler_types
 
+    def test_file_handler_added_after_console_only_call(self, tmp_path: Path) -> None:
+        """Calling get_logger with log_file after a console-only call adds the file handler."""
+        name = "test.file_after_console"
+        logger1 = get_logger(name)
+        assert len(logger1.logger.handlers) == 1
+
+        log_file = str(tmp_path / "late.log")
+        logger2 = get_logger(name, log_file=log_file)
+
+        console_handlers = [
+            h
+            for h in logger2.logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        file_handlers = [h for h in logger2.logger.handlers if isinstance(h, logging.FileHandler)]
+        assert len(console_handlers) == 1
+        assert len(file_handlers) == 1
+
+    def test_no_duplicate_console_handler(self) -> None:
+        """Repeated calls without log_file do not add duplicate console handlers."""
+        name = "test.no_dup_console"
+        get_logger(name)
+        get_logger(name)
+
+        underlying = logging.getLogger(name)
+        console_handlers = [
+            h
+            for h in underlying.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(console_handlers) == 1
+
+    def test_no_duplicate_file_handler_same_path(self, tmp_path: Path) -> None:
+        """Repeated calls with the same log_file do not add duplicate file handlers."""
+        name = "test.no_dup_file"
+        log_file = str(tmp_path / "same.log")
+        get_logger(name, log_file=log_file)
+        get_logger(name, log_file=log_file)
+
+        underlying = logging.getLogger(name)
+        file_handlers = [h for h in underlying.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+    def test_different_file_handlers_both_added(self, tmp_path: Path) -> None:
+        """Calls with different log_file paths add separate file handlers."""
+        name = "test.diff_files"
+        file_a = str(tmp_path / "a.log")
+        file_b = str(tmp_path / "b.log")
+        get_logger(name, log_file=file_a)
+        get_logger(name, log_file=file_b)
+
+        underlying = logging.getLogger(name)
+        file_handlers = [h for h in underlying.handlers if isinstance(h, logging.FileHandler)]
+        base_filenames = {h.baseFilename for h in file_handlers}
+        assert len(file_handlers) == 2
+        assert str(Path(file_a).resolve()) in base_filenames
+        assert str(Path(file_b).resolve()) in base_filenames
+
+    def test_idempotent_full_call(self, tmp_path: Path) -> None:
+        """Identical calls with both console and file produce no extra handlers."""
+        name = "test.idempotent"
+        log_file = str(tmp_path / "idem.log")
+        get_logger(name, log_file=log_file)
+        count_after_first = len(logging.getLogger(name).handlers)
+
+        get_logger(name, log_file=log_file)
+        count_after_second = len(logging.getLogger(name).handlers)
+
+        assert count_after_first == count_after_second
+
 
 class TestContextLogger:
     """Tests for ContextLogger adapter."""


### PR DESCRIPTION
## Summary
- Replace the flawed `if not logger.handlers` guard in `get_logger()` with per-handler-type `isinstance` checks
- Console `StreamHandler` is now added only if one doesn't already exist (excluding `FileHandler` subclasses)
- `FileHandler` is deduplicated by resolved absolute path via `baseFilename`, allowing multiple distinct file destinations
- Add 5 new unit tests covering the deduplication edge cases (file-after-console, no-duplicate-console, no-duplicate-file, different-files, idempotent-full-call)

Closes #123

## Test plan
- [x] All 18 logging unit tests pass (5 new + 13 existing)
- [x] Full test suite passes (450/450)
- [x] `hephaestus/logging/utils.py` at 100% coverage
- [x] ruff lint and format checks pass
- [x] Existing callers (`get_logger(__name__)` without `log_file`) behave identically — no behavioral regression

🤖 Generated with [Claude Code](https://claude.ai/claude-code)