### PR TITLE
test(markdown): add coverage for utils.py constants integration and edge cases

### DIFF
--- a/tests/unit/markdown/test_utils.py
+++ b/tests/unit/markdown/test_utils.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 
+from hephaestus.constants import DEFAULT_EXCLUDE_DIRS
 from hephaestus.markdown.utils import find_markdown_files
 
 
@@ -81,3 +82,57 @@ class TestFindMarkdownFiles:
         result = find_markdown_files(tmp_path, exclude_dirs=None)
 
         assert len(result) == 1
+
+    def test_excludes_all_default_dirs(self, tmp_path: Path) -> None:
+        """Excludes files in every entry of DEFAULT_EXCLUDE_DIRS."""
+        (tmp_path / "README.md").write_text("# Root")
+        for dirname in DEFAULT_EXCLUDE_DIRS:
+            excluded = tmp_path / dirname
+            excluded.mkdir()
+            (excluded / "file.md").write_text("# Excluded")
+
+        result = find_markdown_files(tmp_path)
+
+        assert result == [tmp_path / "README.md"]
+
+    def test_accepts_frozenset_exclude_dirs(self, tmp_path: Path) -> None:
+        """Accepts frozenset as exclude_dirs parameter."""
+        skip_dir = tmp_path / "skip"
+        skip_dir.mkdir()
+        (skip_dir / "file.md").write_text("# Skipped")
+        (tmp_path / "README.md").write_text("# Included")
+
+        result = find_markdown_files(tmp_path, exclude_dirs=frozenset({"skip"}))
+
+        assert len(result) == 1
+        assert result[0].name == "README.md"
+
+    def test_empty_directory_no_files(self, tmp_path: Path) -> None:
+        """Returns empty list for a truly empty directory."""
+        result = find_markdown_files(tmp_path)
+
+        assert result == []
+
+    def test_excludes_deeply_nested_dir(self, tmp_path: Path) -> None:
+        """Excludes files when excluded directory name appears deep in path."""
+        nested = tmp_path / "a" / "b" / "node_modules" / "c"
+        nested.mkdir(parents=True)
+        (nested / "file.md").write_text("# Deep excluded")
+        (tmp_path / "README.md").write_text("# Included")
+
+        result = find_markdown_files(tmp_path)
+
+        assert result == [tmp_path / "README.md"]
+
+    def test_returns_only_md_files_among_mixed(self, tmp_path: Path) -> None:
+        """Returns only .md files when mixed file types are present."""
+        (tmp_path / "doc.md").write_text("# Doc")
+        (tmp_path / "notes.txt").write_text("notes")
+        (tmp_path / "guide.rst").write_text("guide")
+        (tmp_path / "script.py").write_text("pass")
+        (tmp_path / "data.json").write_text("{}")
+
+        result = find_markdown_files(tmp_path)
+
+        assert len(result) == 1
+        assert result[0].name == "doc.md"


### PR DESCRIPTION
## Summary

- Adds 5 new tests to `tests/unit/markdown/test_utils.py` for `find_markdown_files`:
  - **`test_excludes_all_default_dirs`** — verifies every entry in `DEFAULT_EXCLUDE_DIRS` is excluded
  - **`test_accepts_frozenset_exclude_dirs`** — validates `frozenset[str]` union type branch
  - **`test_empty_directory_no_files`** — tests truly empty directory (no files at all)
  - **`test_excludes_deeply_nested_dir`** — verifies exclusion works at arbitrary depth via `f.parts` check
  - **`test_returns_only_md_files_among_mixed`** — confirms only `.md` files returned among `.txt`, `.rst`, `.py`, `.json`
- Achieves **100% statement and branch coverage** on `hephaestus/markdown/utils.py`

## Test plan

- [x] All 12 tests (7 existing + 5 new) pass
- [x] `ruff check` and `ruff format` report no issues
- [x] `hephaestus/markdown/utils.py` at 100% coverage

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)