### PR TITLE
fix(logging): add force=True to setup_logging() for proper reconfiguration

### DIFF
--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -108,14 +108,14 @@ def setup_logging(
     """
     format_string = format_string or LOG_FORMAT
 
-    handlers = [logging.StreamHandler(sys.stdout)]
+    handlers: list[logging.Handler] = [logging.StreamHandler(sys.stdout)]
 
     if log_to_stderr:
         handlers.append(logging.StreamHandler(sys.stderr))
 
-    logging.basicConfig(level=level, format=format_string, handlers=handlers)
-
     if log_file:
         file_handler = logging.FileHandler(log_file)
         file_handler.setFormatter(logging.Formatter(format_string))
-        logging.getLogger().addHandler(file_handler)
+        handlers.append(file_handler)
+
+    logging.basicConfig(level=level, format=format_string, handlers=handlers, force=True)

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -129,3 +129,133 @@ class TestSetupLogging:
         finally:
             root.handlers.clear()
             root.handlers.extend(saved)
+
+    def test_change_log_to_stderr_on(self) -> None:
+        """Calling setup_logging again with log_to_stderr=True adds a stderr handler."""
+        import sys
+
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(log_to_stderr=False)
+            stderr_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+            ]
+            assert len(stderr_handlers) == 0
+
+            setup_logging(log_to_stderr=True)
+            stderr_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+            ]
+            assert len(stderr_handlers) == 1
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_change_log_to_stderr_off(self) -> None:
+        """Calling setup_logging again without log_to_stderr removes stderr handler."""
+        import sys
+
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(log_to_stderr=True)
+            stderr_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+            ]
+            assert len(stderr_handlers) == 1
+
+            setup_logging(log_to_stderr=False)
+            stderr_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler) and h.stream is sys.stderr
+            ]
+            assert len(stderr_handlers) == 0
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_change_log_level(self) -> None:
+        """Calling setup_logging again with a different level updates root level."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(level=logging.INFO)
+            assert root.level == logging.INFO
+
+            setup_logging(level=logging.DEBUG)
+            assert root.level == logging.DEBUG
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_change_log_file(self, tmp_path: Path) -> None:
+        """Calling setup_logging with log_file adds a FileHandler."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging()
+            file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+            assert len(file_handlers) == 0
+
+            log_file = str(tmp_path / "change.log")
+            setup_logging(log_file=log_file)
+            file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+            assert len(file_handlers) == 1
+            assert file_handlers[0].baseFilename == log_file
+        finally:
+            for h in root.handlers:
+                if isinstance(h, logging.FileHandler):
+                    h.close()
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_change_remove_log_file(self, tmp_path: Path) -> None:
+        """Calling setup_logging without log_file removes FileHandler."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            log_file = str(tmp_path / "remove.log")
+            setup_logging(log_file=log_file)
+            file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+            assert len(file_handlers) == 1
+
+            setup_logging()
+            file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+            assert len(file_handlers) == 0
+        finally:
+            for h in root.handlers:
+                if isinstance(h, logging.FileHandler):
+                    h.close()
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
+    def test_change_format_string(self) -> None:
+        """Calling setup_logging with a new format updates handler formatters."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(format_string="%(message)s")
+            for h in root.handlers:
+                assert h.formatter._fmt == "%(message)s"  # type: ignore[union-attr]
+
+            custom_fmt = "%(levelname)s - %(message)s"
+            setup_logging(format_string=custom_fmt)
+            for h in root.handlers:
+                assert h.formatter._fmt == custom_fmt  # type: ignore[union-attr]
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)


### PR DESCRIPTION
## Summary
- **Fix**: Add `force=True` to `logging.basicConfig()` in `setup_logging()` so that subsequent calls with different parameters correctly replace the handler configuration instead of being silently ignored.
- **Fix**: Move `FileHandler` creation into the `handlers` list passed to `basicConfig()` (previously added after the call, which would survive `force=True` replacement).
- **Test**: Add 6 new tests covering parameter changes: stderr on/off toggle, log level change, log file add/remove, and format string change.

Closes #125

## Test plan
- [x] All 6 new `TestSetupLogging` tests pass (parameter change scenarios)
- [x] All 3 existing `TestSetupLogging` tests still pass (no regressions)
- [x] Full test suite (451 tests) passes with `pixi run pytest tests/ -v --no-cov`
- [x] `ruff check` and `ruff format --check` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)