### PR TITLE
Add shell injection tests for install_package

### DIFF
--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -244,3 +244,16 @@ class TestInstallPackage:
         """Accepts valid package names with extras."""
         mock_run.return_value = MagicMock(returncode=0)
         assert install_package("pkg[extra]") is True
+
+    @pytest.mark.parametrize(
+        "malicious_input",
+        [
+            "pkg; rm -rf /",
+            "pkg | cat /etc/passwd",
+            "pkg && echo pwned",
+        ],
+    )
+    def test_shell_injection_rejected(self, malicious_input: str) -> None:
+        """Reject package names containing shell injection characters."""
+        with pytest.raises(ValueError, match="Invalid package name"):
+            install_package(malicious_input)


### PR DESCRIPTION
## Summary
- Adds parametrized tests for common shell injection vectors (semicolons, pipes, ampersands) in `install_package`
- Verifies the input validation regex rejects malicious package name inputs containing shell metacharacters
- Documents the security guarantees of the existing validation

## Test plan
- [x] All 3 parametrized test cases pass — each raises `ValueError`
- [x] All 39 tests in `test_general_utils.py` pass
- [x] Ruff lint and format checks pass

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)