### PR TITLE
Add test for empty string input to install_package

### DIFF
--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -257,3 +257,8 @@ class TestInstallPackage:
         """Reject package names containing shell injection characters."""
         with pytest.raises(ValueError, match="Invalid package name"):
             install_package(malicious_input)
+
+    def test_empty_string_raises_value_error(self) -> None:
+        """Empty string is rejected by package name validation."""
+        with pytest.raises(ValueError, match="Invalid package name"):
+            install_package("")


### PR DESCRIPTION
## Summary
- Adds `test_empty_string_raises_value_error` to `TestInstallPackage` in `tests/unit/utils/test_general_utils.py`
- Verifies that `install_package("")` raises `ValueError` since the regex validation (`+` quantifier) rejects empty strings

Closes #128

## Test plan
- [x] New test passes: `pytest tests/unit/utils/test_general_utils.py::TestInstallPackage::test_empty_string_raises_value_error -v`
- [x] Full unit test suite passes: 395 tests passed
- [x] Pre-commit hooks pass (ruff format, ruff check, mypy)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)