### PR TITLE
Fix comment stripping to handle # inside quoted strings

### DIFF
--- a/hephaestus/validation/config_lint.py
+++ b/hephaestus/validation/config_lint.py
@@ -95,6 +95,39 @@ class ConfigLinter:
         return len(self.errors) == 0
 
     @staticmethod
+    def _strip_inline_comment(line: str) -> str:
+        """Strip inline YAML comments while preserving # inside quoted strings.
+
+        Per YAML spec, # is a comment delimiter only when:
+        - It is preceded by whitespace (or is the first character)
+        - It is NOT inside a single-quoted or double-quoted scalar
+
+        Args:
+            line: A single line of YAML text
+
+        Returns:
+            The line with any inline comment removed
+
+        """
+        in_single_quote = False
+        in_double_quote = False
+
+        for i, char in enumerate(line):
+            if char == "'" and not in_double_quote:
+                in_single_quote = not in_single_quote
+            elif char == '"' and not in_single_quote:
+                in_double_quote = not in_double_quote
+            elif (
+                char == "#"
+                and not in_single_quote
+                and not in_double_quote
+                and (i == 0 or line[i - 1] in (" ", "\t"))
+            ):
+                return line[:i]
+
+        return line
+
+    @staticmethod
     def _is_valid_yaml_key_line(line: str) -> bool:
         """Check whether a line with a colon matches a valid YAML construct.
 
@@ -166,9 +199,8 @@ class ConfigLinter:
                 if stripped.startswith("#"):
                     continue
 
-                # Strip inline comments (naive — doesn't handle # in quotes,
-                # but matches the pre-existing behavior)
-                comment_stripped = line.split("#")[0]
+                # Strip inline comments, preserving # inside quoted strings
+                comment_stripped = self._strip_inline_comment(line)
 
                 # Count braces and brackets
                 brace_count += comment_stripped.count("{") - comment_stripped.count("}")

--- a/tests/unit/config/test_config_lint.py
+++ b/tests/unit/config/test_config_lint.py
@@ -334,6 +334,64 @@ class TestBlockScalarBraceCounting:
         assert any("Unmatched braces" in e for e in linter.errors)
 
 
+class TestStripInlineComment:
+    """Tests for ConfigLinter._strip_inline_comment."""
+
+    @pytest.mark.parametrize(
+        ("line", "expected"),
+        [
+            ('color: "#FF0000"', 'color: "#FF0000"'),
+            ("color: '#FF0000'", "color: '#FF0000'"),
+            ('desc: "text with # in middle"', 'desc: "text with # in middle"'),
+            ("value: plain text # comment", "value: plain text "),
+            (
+                'value: "quoted # not comment" # real',
+                'value: "quoted # not comment" ',
+            ),
+            ("# full line comment", ""),
+            ("value: plain text", "value: plain text"),
+            ("value: no#space", "value: no#space"),
+            ("", ""),
+            ("  # indented comment", "  "),
+            ("key: 'single # hash' # comment", "key: 'single # hash' "),
+        ],
+        ids=[
+            "hex-color-double-quotes",
+            "hex-color-single-quotes",
+            "hash-mid-double-string",
+            "legitimate-inline-comment",
+            "quoted-hash-and-real-comment",
+            "full-line-comment",
+            "no-hash",
+            "hash-without-preceding-space",
+            "empty-line",
+            "indented-comment",
+            "single-quoted-hash-and-comment",
+        ],
+    )
+    def test_strip_inline_comment(self, line: str, expected: str) -> None:
+        """_strip_inline_comment handles various quote/comment scenarios."""
+        assert ConfigLinter._strip_inline_comment(line) == expected
+
+
+class TestLintFileQuotedHash:
+    """Integration tests for hex colors and quoted # in YAML files."""
+
+    def test_hex_color_no_false_brace_error(self, linter: ConfigLinter, yaml_file: Any) -> None:
+        """YAML with hex color in quotes should not produce brace mismatch errors."""
+        path = yaml_file('color: "#FF0000"\n')
+        result = linter.lint_file(path)
+        assert result is True
+        assert not any("brace" in e.lower() for e in linter.errors)
+
+    def test_quoted_hash_preserves_content(self, linter: ConfigLinter, yaml_file: Any) -> None:
+        """YAML with # inside quotes passes linting without syntax errors."""
+        path = yaml_file('title: "Section # 1"\ndesc: "Item #2"\n')
+        result = linter.lint_file(path)
+        assert result is True
+        assert linter.errors == []
+
+
 class TestPrintResults:
     """Tests for ConfigLinter.print_results."""
 


### PR DESCRIPTION
## Summary
- Replace naive `line.split('#')[0]` in `ConfigLinter._check_yaml_syntax()` with a quote-state-aware `_strip_inline_comment()` static method
- The new method tracks single/double quote context character-by-character, only treating `#` as a comment delimiter when preceded by whitespace and outside quoted scalars (per YAML spec)
- Prevents false positives where `color: "#FF0000"` would have the hex color truncated

## Test plan
- [x] 11 parametrized unit tests covering: hex colors in double/single quotes, hash mid-string, legitimate inline comments, mixed quoted hash + real comment, full-line comments, no-hash lines, hash without preceding space, empty lines, indented comments
- [x] 2 integration tests verifying hex color YAML files pass linting without false brace mismatch errors
- [x] All 407 existing unit tests pass
- [x] Ruff lint and format checks pass

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)