### PR TITLE
fix(config): warn on nesting conflicts in merge_with_env

### DIFF
--- a/hephaestus/config/utils.py
+++ b/hephaestus/config/utils.py
@@ -159,6 +159,10 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
     Environment variables that produce empty key segments (e.g., trailing
     or consecutive underscores) are skipped with a warning.
 
+    When two environment variables conflict on nesting (e.g.,
+    ``HEPHAESTUS_A=scalar`` and ``HEPHAESTUS_A_B=nested``), the
+    last variable in sorted order wins and a warning is logged.
+
     Args:
         config: Base configuration dictionary
         prefix: Environment variable prefix to look for
@@ -169,35 +173,61 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
     """
     env_config: dict[str, Any] = {}
 
-    for key, value in os.environ.items():
-        if key.startswith(prefix):
-            # Convert HEPHAESTUS_DATABASE_HOST to database.host
-            config_key = key[len(prefix) :].lower().replace("_", ".")
+    # Sort env vars for deterministic processing order
+    env_vars = sorted(
+        ((k, v) for k, v in os.environ.items() if k.startswith(prefix)),
+        key=lambda item: item[0],
+    )
 
-            # Filter out empty segments from malformed env var names
-            keys = [k for k in config_key.split(".") if k]
-            if not keys:
+    for key, value in env_vars:
+        # Convert HEPHAESTUS_DATABASE_HOST to database.host
+        config_key = key[len(prefix) :].lower().replace("_", ".")
+
+        # Filter out empty segments from malformed env var names
+        keys = [k for k in config_key.split(".") if k]
+        if not keys:
+            _logger.warning(
+                "Skipping malformed env var %r: produces no valid config keys",
+                key,
+            )
+            continue
+
+        # Try to convert to int or float if possible
+        typed_value: int | float | str = value
+        try:
+            typed_value = int(value)
+        except ValueError:
+            with contextlib.suppress(ValueError):
+                typed_value = float(value)
+
+        # Set nested keys
+        current = env_config
+        for k in keys[:-1]:
+            existing = current.get(k)
+            if existing is None:
+                current[k] = {}
+            elif not isinstance(existing, dict):
                 _logger.warning(
-                    "Skipping malformed env var %r: produces no valid config keys",
+                    "Environment variable '%s' requires nesting under key '%s', "
+                    "which was already set to a scalar value. "
+                    "The scalar value is being overwritten by a dict.",
                     key,
+                    k,
                 )
-                continue
+                current[k] = {}
+            current = current[k]
 
-            # Try to convert to int or float if possible
-            typed_value: int | float | str = value
-            try:
-                typed_value = int(value)
-            except ValueError:
-                with contextlib.suppress(ValueError):
-                    typed_value = float(value)
-
-            # Set nested keys
-            current = env_config
-            for k in keys[:-1]:
-                if k not in current:
-                    current[k] = {}
-                current = current[k]
-            current[keys[-1]] = typed_value
+        leaf = keys[-1]
+        existing_leaf = current.get(leaf)
+        if isinstance(existing_leaf, dict):
+            _logger.warning(
+                "Environment variable '%s' sets key '%s' to a scalar, "
+                "but it was already a nested dict from other environment variables. "
+                "The nested dict is being overwritten by the scalar value.",
+                key,
+                leaf,
+            )
+        current[leaf] = typed_value
 
     return merge_configs(config, env_config)
 

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -245,6 +245,108 @@ class TestMergeWithEnv:
             config_logger.propagate = original_propagate
         assert any("malformed env var" in r.message.lower() for r in caplog.records)
 
+    def test_nesting_conflict_scalar_then_nest_warns(self, monkeypatch, caplog):
+        """Scalar overwritten by nesting logs a warning.
+
+        HEPHAESTUS_A=1 sets a=1, then HEPHAESTUS_A_B=2 needs to nest
+        under 'a', overwriting the scalar with a dict.
+        """
+        monkeypatch.setenv("HEPHAESTUS_A", "1")
+        monkeypatch.setenv("HEPHAESTUS_A_B", "2")
+        import logging
+
+        config_logger = logging.getLogger("hephaestus.config.utils")
+        original_propagate = config_logger.propagate
+        config_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger="hephaestus.config.utils"):
+                result = merge_with_env({})
+        finally:
+            config_logger.propagate = original_propagate
+        assert result["a"]["b"] == 2
+        assert any("scalar value is being overwritten by a dict" in msg for msg in caplog.messages)
+
+    def test_nesting_conflict_deep_scalar_then_nest_warns(self, monkeypatch, caplog):
+        """Scalar at intermediate key overwritten by deeper nesting warns.
+
+        HEPHAESTUS_A_B=1 sets a.b=1, then HEPHAESTUS_A_B_C=2 needs to
+        nest under a.b, overwriting the scalar 1 with a dict.
+        """
+        monkeypatch.setenv("HEPHAESTUS_A_B", "1")
+        monkeypatch.setenv("HEPHAESTUS_A_B_C", "2")
+        import logging
+
+        config_logger = logging.getLogger("hephaestus.config.utils")
+        original_propagate = config_logger.propagate
+        config_logger.propagate = True
+        try:
+            with caplog.at_level(logging.WARNING, logger="hephaestus.config.utils"):
+                result = merge_with_env({})
+        finally:
+            config_logger.propagate = original_propagate
+        assert result["a"]["b"]["c"] == 2
+        assert any("scalar value is being overwritten by a dict" in msg for msg in caplog.messages)
+
+    def test_nesting_conflict_leaf_dict_overwritten_warns(self, monkeypatch, caplog):
+        """Nested dict at leaf overwritten by scalar logs a warning.
+
+        With sorted processing and underscore delimiter, the scalar key
+        always sorts before the nested key (HEPHAESTUS_A < HEPHAESTUS_A_B).
+        We reverse the processing order to exercise the defensive leaf
+        dict-overwrite warning path.
+        """
+        import logging
+        from unittest.mock import patch
+
+        monkeypatch.setenv("HEPHAESTUS_A", "2")
+        monkeypatch.setenv("HEPHAESTUS_A_B", "1")
+
+        original_sorted = sorted
+
+        def reverse_sorted(iterable, **kwargs):
+            """Reverse sort to process nested keys before scalar keys."""
+            return list(reversed(original_sorted(iterable, **kwargs)))
+
+        config_logger = logging.getLogger("hephaestus.config.utils")
+        original_propagate = config_logger.propagate
+        config_logger.propagate = True
+        try:
+            with (
+                patch("hephaestus.config.utils.sorted", side_effect=reverse_sorted),
+                caplog.at_level(logging.WARNING, logger="hephaestus.config.utils"),
+            ):
+                result = merge_with_env({})
+        finally:
+            config_logger.propagate = original_propagate
+
+        # A_B processed first → {a: {b: 1}}, then A → a=2 overwrites dict
+        assert result["a"] == 2
+        assert any(
+            "nested dict is being overwritten by the scalar value" in msg for msg in caplog.messages
+        )
+
+    def test_no_conflict_no_warning(self, monkeypatch, caplog):
+        """Non-conflicting env vars produce no warnings."""
+        monkeypatch.setenv("HEPHAESTUS_X_Y", "1")
+        monkeypatch.setenv("HEPHAESTUS_X_Z", "2")
+        monkeypatch.setenv("HEPHAESTUS_W", "3")
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="hephaestus.config.utils"):
+            result = merge_with_env({})
+        assert result["x"]["y"] == 1
+        assert result["x"]["z"] == 2
+        assert result["w"] == 3
+        assert not any("overwritten" in msg for msg in caplog.messages)
+
+    def test_sorted_processing_deterministic(self, monkeypatch):
+        """Env vars are processed in sorted order for deterministic results."""
+        monkeypatch.setenv("HEPHAESTUS_C", "3")
+        monkeypatch.setenv("HEPHAESTUS_A", "1")
+        monkeypatch.setenv("HEPHAESTUS_B", "2")
+        result = merge_with_env({})
+        assert result == {"a": 1, "b": 2, "c": 3}
+
 
 class TestLoadYamlConfig:
     """Tests for load_yaml_config."""


### PR DESCRIPTION
## Summary
- Detects and logs warnings when environment variables conflict on nesting in `merge_with_env()` (e.g., `HEPHAESTUS_A=scalar` and `HEPHAESTUS_A_B=nested`)
- Handles both conflict directions: scalar overwritten by dict, and dict overwritten by scalar
- Sorts env vars for deterministic processing order regardless of OS/Python dict iteration

## Test plan
- [x] Added `test_nesting_conflict_scalar_then_nest_warns` — verifies warning when scalar is overwritten by nesting
- [x] Added `test_nesting_conflict_deep_scalar_then_nest_warns` — verifies warning at deeper nesting levels
- [x] Added `test_nesting_conflict_leaf_dict_overwritten_warns` — verifies warning when dict leaf is overwritten by scalar
- [x] Added `test_no_conflict_no_warning` — verifies no spurious warnings for non-conflicting vars
- [x] Added `test_sorted_processing_deterministic` — verifies deterministic processing order
- [x] All 399 existing unit tests pass
- [x] Ruff lint and format checks pass

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)