### PR TITLE
feat(config): add opt-in boolean conversion to merge_with_env

### DIFF
--- a/hephaestus/config/utils.py
+++ b/hephaestus/config/utils.py
@@ -21,6 +21,9 @@ from hephaestus.logging.utils import get_logger
 
 _logger = get_logger(__name__)
 
+_BOOL_TRUTHY: frozenset[str] = frozenset({"true", "yes", "on", "1"})
+_BOOL_FALSY: frozenset[str] = frozenset({"false", "no", "off", "0"})
+
 try:
     import yaml
 
@@ -150,7 +153,11 @@ def load_yaml_config(config_path: str | Path) -> dict[str, Any]:
     return load_config(config_path)
 
 
-def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[str, Any]:
+def merge_with_env(
+    config: dict[str, Any],
+    prefix: str = "HEPHAESTUS_",
+    convert_bools: bool = False,
+) -> dict[str, Any]:
     """Merge configuration with environment variables.
 
     Environment variables with the given prefix are mapped to config keys.
@@ -166,6 +173,10 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
     Args:
         config: Base configuration dictionary
         prefix: Environment variable prefix to look for
+        convert_bools: If True, convert boolean-like string values
+            (true/false/yes/no/on/off/1/0, case-insensitive) to Python
+            bool. When enabled, "1" and "0" become True/False instead
+            of int. Defaults to False for backward compatibility.
 
     Returns:
         Configuration merged with environment variables
@@ -192,13 +203,19 @@ def merge_with_env(config: dict[str, Any], prefix: str = "HEPHAESTUS_") -> dict[
             )
             continue
 
-        # Try to convert to int or float if possible
-        typed_value: int | float | str = value
-        try:
-            typed_value = int(value)
-        except ValueError:
-            with contextlib.suppress(ValueError):
-                typed_value = float(value)
+        # Try to convert to bool, int, or float if possible
+        typed_value: int | float | bool | str = value
+        lower_value = value.lower()
+        if convert_bools and lower_value in _BOOL_TRUTHY:
+            typed_value = True
+        elif convert_bools and lower_value in _BOOL_FALSY:
+            typed_value = False
+        else:
+            try:
+                typed_value = int(value)
+            except ValueError:
+                with contextlib.suppress(ValueError):
+                    typed_value = float(value)
 
         # Set nested keys
         current = env_config

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -347,6 +347,53 @@ class TestMergeWithEnv:
         result = merge_with_env({})
         assert result == {"a": 1, "b": 2, "c": 3}
 
+    def test_bool_conversion_disabled_by_default(self, monkeypatch):
+        """Boolean-like values stay as strings when convert_bools is not set."""
+        monkeypatch.setenv("HEPHAESTUS_DEBUG", "true")
+        result = merge_with_env({})
+        assert result["debug"] == "true"
+
+    def test_bool_true_values(self, monkeypatch):
+        """Each truthy boolean string converts to True."""
+        for val in ("true", "yes", "on", "1", "TRUE", "Yes", "ON"):
+            monkeypatch.setenv("HEPHAESTUS_FLAG", val)
+            result = merge_with_env({}, convert_bools=True)
+            assert result["flag"] is True, f"{val!r} should convert to True"
+
+    def test_bool_false_values(self, monkeypatch):
+        """Each falsy boolean string converts to False."""
+        for val in ("false", "no", "off", "0", "FALSE", "No", "OFF"):
+            monkeypatch.setenv("HEPHAESTUS_FLAG", val)
+            result = merge_with_env({}, convert_bools=True)
+            assert result["flag"] is False, f"{val!r} should convert to False"
+
+    def test_bool_case_insensitive(self, monkeypatch):
+        """Mixed-case boolean strings are converted correctly."""
+        monkeypatch.setenv("HEPHAESTUS_FLAG", "tRuE")
+        result = merge_with_env({}, convert_bools=True)
+        assert result["flag"] is True
+
+    def test_bool_conversion_does_not_affect_non_bool_strings(self, monkeypatch):
+        """Non-boolean strings remain as strings with convert_bools enabled."""
+        monkeypatch.setenv("HEPHAESTUS_NAME", "hello")
+        result = merge_with_env({}, convert_bools=True)
+        assert result["name"] == "hello"
+
+    def test_bool_1_0_override_int(self, monkeypatch):
+        """'1' becomes True and '0' becomes False when convert_bools is True."""
+        monkeypatch.setenv("HEPHAESTUS_A", "1")
+        monkeypatch.setenv("HEPHAESTUS_B", "0")
+        result = merge_with_env({}, convert_bools=True)
+        assert result["a"] is True
+        assert result["b"] is False
+
+    def test_int_conversion_when_bools_disabled(self, monkeypatch):
+        """'1' stays as int 1 when convert_bools is False (regression guard)."""
+        monkeypatch.setenv("HEPHAESTUS_PORT", "1")
+        result = merge_with_env({})
+        assert result["port"] == 1
+        assert isinstance(result["port"], int)
+
 
 class TestLoadYamlConfig:
     """Tests for load_yaml_config."""


### PR DESCRIPTION
## Summary
- Add `convert_bools` parameter to `merge_with_env()` that converts boolean-like env var values (`true`/`false`/`yes`/`no`/`on`/`off`/`1`/`0`, case-insensitive) to Python `bool`
- Defaults to `False` for full backward compatibility — existing callers are unaffected
- When enabled, boolean conversion takes priority over int/float (e.g., `"1"` → `True` instead of `1`)

Closes #135

## Test plan
- [x] 7 new unit tests covering truthy values, falsy values, case-insensitivity, non-bool passthrough, 1/0 override, default-off behavior, and regression guard
- [x] All 401 existing unit tests still pass
- [x] Ruff lint and format checks pass
- [x] `hephaestus/config/utils.py` coverage at 93.62%

🤖 Generated with [Claude Code](https://claude.com/claude-code)