### PR TITLE
fix(config): use double underscore as nesting delimiter in merge_with_env

### DIFF
--- a/hephaestus/config/utils.py
+++ b/hephaestus/config/utils.py
@@ -294,6 +294,8 @@ def get_config_value(
     """High-level function to get a configuration value with full merging.
 
     Loads defaults, then user config, then environment variables.
+    Environment variables use double underscores (``__``) as nesting
+    delimiters — see :func:`merge_with_env` for details.
 
     Args:
         key_path: Dot-separated path to setting

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -528,6 +528,12 @@ class TestMergeWithEnv:
         assert result["port"] == 1
         assert isinstance(result["port"], int)
 
+    def test_triple_underscore_edge_case(self, monkeypatch):
+        """Triple underscore splits as __ + _, preserving leading _ in segment."""
+        monkeypatch.setenv("HEPHAESTUS_A___B", "val")
+        result = merge_with_env({})
+        assert result == {"a": {"_b": "val"}}
+
 
 class TestLoadYamlConfig:
     """Tests for load_yaml_config."""


### PR DESCRIPTION
## Summary

- Adds an edge-case regression test for triple-underscore env var names (e.g. `HEPHAESTUS_A___B` → `{"a": {"_b": "val"}}`) on top of main's already-complete double-underscore delimiter implementation
- Main's implementation (commit 4199811) already includes the core fix plus conflict warnings, bool conversion, and sorted processing — this PR contributes the complementary triple-underscore test case

## Conflict resolution

Branch 29's original fix introduced double-underscore nesting semantics. Main already has a more complete implementation of the same fix. Resolved by accepting main's superior implementation and integrating the unique triple-underscore edge case test from this branch.

## Test plan

- [x] `pixi run pytest tests/unit/config/test_utils.py -v` — 64 passed

Closes #29 (original issue).