### PR TITLE
feat(version): add version consistency module with bump-version and check CLIs

### DIFF
--- a/hephaestus/version/__init__.py
+++ b/hephaestus/version/__init__.py
@@ -1,5 +1,16 @@
 """Version management utilities for ProjectHephaestus."""
 
+from hephaestus.version.consistency import (
+    bump_version,
+    check_package_version_consistency,
+    check_version_consistency,
+)
 from hephaestus.version.manager import VersionManager, parse_version
 
-__all__ = ["VersionManager", "parse_version"]
+__all__ = [
+    "VersionManager",
+    "bump_version",
+    "check_package_version_consistency",
+    "check_version_consistency",
+    "parse_version",
+]

--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+
+"""Version consistency checks and atomic version bumping.
+
+Provides three operations:
+
+1. ``check_version_consistency`` — compare pyproject.toml [project].version
+   with pixi.toml [workspace].version (if present) and fail if they differ.
+
+2. ``check_package_version_consistency`` — broader multi-source scan: pixi.toml,
+   ``__init__.py`` ``__version__``, CHANGELOG.md, and optional skill markdown files.
+
+3. ``bump_version`` — compute the next semver string by incrementing a chosen part
+   (major/minor/patch), then delegate writes to :class:`~hephaestus.version.manager.VersionManager`.
+
+Usage:
+    hephaestus-check-version-consistency [--repo-root PATH] [--verbose]
+    hephaestus-check-package-versions [--repo-root PATH] [--scan-skills] [--verbose]
+    hephaestus-bump-version {major,minor,patch} [--repo-root PATH] [--dry-run] [--verbose]
+"""
+
+import argparse
+import importlib
+import re
+import sys
+import types
+from pathlib import Path
+
+from hephaestus.utils.helpers import get_repo_root
+from hephaestus.version.manager import VersionManager, parse_version
+
+# tomllib ships with Python 3.11+; fall back to the tomli backport on 3.10.
+_tomllib: types.ModuleType | None = None
+for _mod_name in ("tomllib", "tomli"):
+    try:
+        _tomllib = importlib.import_module(_mod_name)
+        break
+    except ImportError:
+        continue
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Matches semver-ish: v1.5.0, 1.5.0, etc.
+# Negative lookbehinds exclude URL paths (/en/1.0.0/) and GH Action pins (@v0.8.1).
+_VERSION_RE = re.compile(r"(?<!/)(?<!@)\bv?(\d+\.\d+\.\d+)\b")
+
+# Matches inline code spans so we skip versions inside backticks.
+_INLINE_CODE_RE = re.compile(r"``[^`]+``|`[^`]+`")
+
+
+def _parse_version_tuple(version_str: str) -> tuple[int, ...]:
+    """Parse ``"X.Y.Z"`` into a comparable tuple of ints.
+
+    Args:
+        version_str: A semver string like ``"1.2.3"``.
+
+    Returns:
+        A tuple such as ``(1, 2, 3)``.
+
+    """
+    return tuple(int(p) for p in version_str.split("."))
+
+
+def _get_pyproject_version(repo_root: Path) -> str:
+    """Read the version from ``pyproject.toml`` ``[project].version``.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        The version string, e.g. ``"0.5.0"``.
+
+    Raises:
+        SystemExit: With code 1 if the file is missing, malformed, or lacks the field.
+
+    """
+    pyproject_path = repo_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        print(f"ERROR: pyproject.toml not found: {pyproject_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if _tomllib is None:
+        print(
+            "ERROR: tomllib/tomli is required to parse TOML files. "
+            "Install tomli on Python 3.10: pip install tomli",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        with open(pyproject_path, "rb") as fh:
+            data = _tomllib.load(fh)
+    except Exception as exc:
+        print(f"ERROR: Could not parse {pyproject_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    version = data.get("project", {}).get("version")
+    if not version:
+        print(
+            f"ERROR: No [project].version found in {pyproject_path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return str(version)
+
+
+def _get_pixi_version(repo_root: Path) -> str | None:
+    """Read the version from ``pixi.toml`` ``[workspace].version`` if present.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        The version string, or ``None`` if the file is absent or has no version.
+
+    """
+    if _tomllib is None:
+        return None
+
+    pixi_path = repo_root / "pixi.toml"
+    if not pixi_path.is_file():
+        return None
+
+    try:
+        with open(pixi_path, "rb") as fh:
+            data = _tomllib.load(fh)
+    except Exception:
+        return None
+
+    version = data.get("workspace", {}).get("version")
+    return str(version) if version else None
+
+
+def _strip_inline_code(line: str) -> str:
+    """Replace inline code spans with whitespace so embedded versions are ignored.
+
+    Args:
+        line: A single line of text.
+
+    Returns:
+        The line with inline code contents replaced by spaces.
+
+    """
+    return _INLINE_CODE_RE.sub(lambda m: " " * len(m.group(0)), line)
+
+
+def _find_aspirational_versions(
+    file_path: Path,
+    canonical_tuple: tuple[int, ...],
+    label: str,
+) -> list[str]:
+    """Find version references in a file that exceed the canonical version.
+
+    Skips versions inside fenced code blocks and inline code spans; those
+    typically reference external tool versions rather than the project's own.
+
+    Args:
+        file_path: Path to scan.
+        canonical_tuple: The canonical version as a comparable int tuple.
+        label: Human-readable label for error messages.
+
+    Returns:
+        List of error strings, one per aspirational version found.
+
+    """
+    content = file_path.read_text(encoding="utf-8")
+    errors: list[str] = []
+    in_code_block = False
+
+    for line_num, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+
+        scannable = _strip_inline_code(line)
+        for match in _VERSION_RE.finditer(scannable):
+            version_str = match.group(1)
+            version_tuple = _parse_version_tuple(version_str)
+            if version_tuple > canonical_tuple:
+                canonical_str = ".".join(str(p) for p in canonical_tuple)
+                errors.append(
+                    f"{label}:{line_num}: aspirational version reference "
+                    f"'v{version_str}' exceeds canonical version '{canonical_str}'"
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_version_consistency(repo_root: Path, verbose: bool = False) -> int:
+    """Compare pyproject.toml and pixi.toml package versions.
+
+    Passes if pixi.toml has no version field (expected state when pyproject.toml
+    is the single source of truth). Fails if both files declare a version and
+    they differ.
+
+    Args:
+        repo_root: Root directory of the repository.
+        verbose: If True, print versions even when they match.
+
+    Returns:
+        0 if versions are consistent (or pixi.toml has no version), 1 otherwise.
+
+    """
+    pyproject_version = _get_pyproject_version(repo_root)
+    pixi_version = _get_pixi_version(repo_root)
+
+    if verbose:
+        print(f"pyproject.toml [project].version: {pyproject_version}")
+
+    if pixi_version is None:
+        if verbose:
+            print("pixi.toml: no [workspace].version (pyproject.toml is single source)")
+        return 0
+
+    if verbose:
+        print(f"pixi.toml [workspace].version:    {pixi_version}")
+
+    if pyproject_version != pixi_version:
+        print(
+            "ERROR: version mismatch:\n"
+            f"  pyproject.toml: {pyproject_version}\n"
+            f"  pixi.toml:      {pixi_version}\n"
+            "pyproject.toml is the single source of truth — update pixi.toml to match.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if verbose:
+        print(f"OK: version is consistent ({pyproject_version})")
+    return 0
+
+
+def _check_pixi_version_errors(repo_root: Path, canonical: str, verbose: bool) -> list[str]:
+    """Return errors if pixi.toml version field differs from canonical.
+
+    Args:
+        repo_root: Repository root directory.
+        canonical: The canonical version from pyproject.toml.
+        verbose: If True, print a PASS line when consistent.
+
+    Returns:
+        List of error strings (empty if consistent or no pixi version).
+
+    """
+    pixi_version = _get_pixi_version(repo_root)
+    if pixi_version is not None and pixi_version != canonical:
+        return [
+            f"pixi.toml [workspace].version mismatch: '{pixi_version}' vs canonical '{canonical}'"
+        ]
+    if verbose:
+        state = pixi_version if pixi_version else "no version (expected)"
+        print(f"PASS: pixi.toml — {state}")
+    return []
+
+
+def _check_init_version_errors(
+    package_init: Path | None, canonical: str, verbose: bool
+) -> list[str]:
+    """Return errors if package __init__.py __version__ differs from canonical.
+
+    Args:
+        package_init: Path to the package ``__init__.py``, or None to skip.
+        canonical: The canonical version from pyproject.toml.
+        verbose: If True, print PASS/INFO lines.
+
+    Returns:
+        List of error strings (empty if consistent or check skipped).
+
+    """
+    if package_init is None:
+        return []
+    if not package_init.is_file():
+        if verbose:
+            print(f"INFO: {package_init} not found — skipping __version__ check")
+        return []
+    content = package_init.read_text(encoding="utf-8")
+    m = re.search(r'^__version__\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+    if m and m.group(1) != canonical:
+        return [f"{package_init}: __version__ is '{m.group(1)}', expected '{canonical}'"]
+    if verbose and m:
+        print(f"PASS: {package_init} __version__ matches ({canonical})")
+    return []
+
+
+def _check_skill_version_errors(
+    repo_root: Path, canonical_tuple: tuple[int, ...], verbose: bool
+) -> list[str]:
+    """Return errors for aspirational versions in skill markdown files.
+
+    Args:
+        repo_root: Repository root directory.
+        canonical_tuple: The canonical version as a comparable tuple.
+        verbose: If True, print PASS when no errors found.
+
+    Returns:
+        List of error strings (empty if all files are clean).
+
+    """
+    skip_dirs = {"worktrees"}
+    scan_dirs = [
+        repo_root / ".claude-plugin" / "skills",
+        repo_root / ".claude",
+    ]
+    errors: list[str] = []
+    for scan_dir in scan_dirs:
+        if not scan_dir.is_dir():
+            continue
+        for md_file in sorted(scan_dir.rglob("*.md")):
+            if any(part in skip_dirs for part in md_file.parts):
+                continue
+            rel = md_file.relative_to(repo_root)
+            errors.extend(_find_aspirational_versions(md_file, canonical_tuple, str(rel)))
+    if not errors and verbose:
+        print("PASS: skill markdown files have no aspirational version references")
+    return errors
+
+
+def check_package_version_consistency(
+    repo_root: Path,
+    package_init: Path | None = None,
+    scan_skills: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Run multi-source package version consistency checks.
+
+    Checks:
+    1. pixi.toml [workspace].version matches pyproject.toml (if present).
+    2. ``<package>/__init__.py`` ``__version__`` matches pyproject.toml (if present).
+    3. CHANGELOG.md has no version references higher than canonical (if present).
+    4. (opt-in) Skill markdown files have no aspirational version references.
+
+    Args:
+        repo_root: Root directory of the repository.
+        package_init: Explicit path to a ``__init__.py`` to check.  If ``None``,
+            the check is skipped (auto-detection is not performed to keep this
+            function fast and side-effect free).
+        scan_skills: If True, also scan ``{.claude-plugin/skills,  .claude}/`` markdown.
+        verbose: If True, print passing check names.
+
+    Returns:
+        0 if all checks pass, 1 if any fail.
+
+    """
+    canonical = _get_pyproject_version(repo_root)
+    if verbose:
+        print(f"Canonical version (pyproject.toml): {canonical}")
+
+    all_errors: list[str] = []
+    all_errors.extend(_check_pixi_version_errors(repo_root, canonical, verbose))
+    all_errors.extend(_check_init_version_errors(package_init, canonical, verbose))
+
+    canonical_tuple = _parse_version_tuple(canonical)
+    changelog_path = repo_root / "CHANGELOG.md"
+    if changelog_path.is_file():
+        changelog_errors = _find_aspirational_versions(
+            changelog_path, canonical_tuple, "CHANGELOG.md"
+        )
+        all_errors.extend(changelog_errors)
+        if not changelog_errors and verbose:
+            print("PASS: CHANGELOG.md has no aspirational version references")
+
+    if scan_skills:
+        all_errors.extend(_check_skill_version_errors(repo_root, canonical_tuple, verbose))
+
+    if all_errors:
+        for error in all_errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        print(
+            f"\nFound {len(all_errors)} package version consistency violation(s).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if verbose:
+        print(f"\nOK: all package version checks passed ({canonical})")
+    return 0
+
+
+def bump_version(
+    repo_root: Path,
+    part: str,
+    dry_run: bool = False,
+    verbose: bool = False,
+) -> int:
+    """Increment the project version by one semver step.
+
+    Reads the current version from ``pyproject.toml``, computes the new version
+    by incrementing ``part`` (major/minor/patch), and delegates all file writes
+    to :class:`~hephaestus.version.manager.VersionManager`.  After writing,
+    runs :func:`check_version_consistency` to validate the result.
+
+    Args:
+        repo_root: Root directory of the repository.
+        part: Which part to increment — ``"major"``, ``"minor"``, or ``"patch"``.
+        dry_run: If True, print what would change without writing.
+        verbose: If True, print additional details.
+
+    Returns:
+        0 on success, 1 on failure.
+
+    """
+    current_str = _get_pyproject_version(repo_root)
+    try:
+        current = parse_version(current_str)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if part == "major":
+        new = (current[0] + 1, 0, 0)
+    elif part == "minor":
+        new = (current[0], current[1] + 1, 0)
+    elif part == "patch":
+        new = (current[0], current[1], current[2] + 1)
+    else:
+        print(
+            f"ERROR: invalid part '{part}': must be 'major', 'minor', or 'patch'",
+            file=sys.stderr,
+        )
+        return 1
+
+    new_str = f"{new[0]}.{new[1]}.{new[2]}"
+
+    if dry_run:
+        print(f"Would bump version: {current_str} -> {new_str}")
+        return 0
+
+    if verbose:
+        print(f"Bumping version: {current_str} -> {new_str}")
+
+    manager = VersionManager(repo_root=repo_root)
+    manager.update(new_str, verbose=verbose)
+
+    # Validate consistency after writing
+    result = check_version_consistency(repo_root, verbose=verbose)
+    if result != 0:
+        print(
+            "ERROR: post-bump consistency check failed; files may be in an inconsistent state.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Version bumped: {current_str} -> {new_str}")
+    print()
+    print("Next steps:")
+    print("  1. pixi install   # regenerates pixi.lock")
+    print("  2. git add pyproject.toml pixi.lock")
+    print(f'  3. git commit -m "chore(release): bump version to {new_str}"')
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def check_version_consistency_main() -> int:
+    """CLI entry point for hephaestus-check-version-consistency.
+
+    Returns:
+        Exit code (0 if consistent, 1 on mismatch).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Detect version drift between pyproject.toml and pixi.toml",
+        epilog="Example: %(prog)s --repo-root /path/to/repo --verbose",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root directory (default: auto-detected from pyproject.toml)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print parsed versions even when they match",
+    )
+    args = parser.parse_args()
+    root = args.repo_root or get_repo_root()
+    return check_version_consistency(root, verbose=args.verbose)
+
+
+def check_package_versions_main() -> int:
+    """CLI entry point for hephaestus-check-package-versions.
+
+    Returns:
+        Exit code (0 if all checks pass, 1 otherwise).
+
+    """
+    parser = argparse.ArgumentParser(
+        description=("Enforce package version consistency across all version declaration sites"),
+        epilog="Example: %(prog)s --scan-skills --verbose",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root directory (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--package-init",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the package __init__.py to check for __version__. "
+            "Example: hephaestus/__init__.py"
+        ),
+    )
+    parser.add_argument(
+        "--scan-skills",
+        action="store_true",
+        help="Also scan .claude-plugin/skills/ and .claude/ markdown files",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print passing check names and canonical version",
+    )
+    args = parser.parse_args()
+    root = args.repo_root or get_repo_root()
+    init_path: Path | None = args.package_init
+    if init_path is not None and not init_path.is_absolute():
+        init_path = root / init_path
+    return check_package_version_consistency(
+        root,
+        package_init=init_path,
+        scan_skills=args.scan_skills,
+        verbose=args.verbose,
+    )
+
+
+def bump_version_main() -> int:
+    """CLI entry point for hephaestus-bump-version.
+
+    Returns:
+        Exit code (0 on success, 1 on failure).
+
+    """
+    parser = argparse.ArgumentParser(
+        description=("Bump project version in pyproject.toml (and secondary files) atomically"),
+        epilog="Example: %(prog)s patch --verbose",
+    )
+    parser.add_argument(
+        "part",
+        choices=["major", "minor", "patch"],
+        help="Which version part to bump",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root directory (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would change without writing",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print additional details",
+    )
+    args = parser.parse_args()
+    root = args.repo_root or get_repo_root()
+    return bump_version(root, part=args.part, dry_run=args.dry_run, verbose=args.verbose)

--- a/pixi.lock
+++ b/pixi.lock
@@ -937,7 +937,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.6.0
-  sha256: a118111852bcae07750c0badfe956b0d34d13ddc2f48a81fbb9a422df39bd804
+  sha256: 43f6d97921c70207441d3808ed6bd5c7ac6ea26b277492df14b372ea833f16a1
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ hephaestus-check-docstrings = "hephaestus.validation.docstrings:main"
 hephaestus-check-tier-labels = "hephaestus.validation.tier_labels:main"
 hephaestus-fix-markdown = "hephaestus.markdown.fixer:main"
 hephaestus-audit-doc-policy = "hephaestus.validation.doc_policy:main"
+hephaestus-check-version-consistency = "hephaestus.version.consistency:check_version_consistency_main"
+hephaestus-check-package-versions = "hephaestus.version.consistency:check_package_versions_main"
+hephaestus-bump-version = "hephaestus.version.consistency:bump_version_main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+
+"""Tests for hephaestus.version.consistency module."""
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.version.consistency import (
+    bump_version,
+    check_package_version_consistency,
+    check_version_consistency,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_pyproject(tmp_path: Path, version: str) -> None:
+    """Write a minimal pyproject.toml with the given project version."""
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "test-pkg"\nversion = "{version}"\n'
+    )
+
+
+def _write_pixi(tmp_path: Path, version: str | None) -> None:
+    """Write a minimal pixi.toml; omit the version field if None."""
+    if version is None:
+        (tmp_path / "pixi.toml").write_text('[workspace]\nname = "test-pkg"\n')
+    else:
+        (tmp_path / "pixi.toml").write_text(
+            f'[workspace]\nname = "test-pkg"\nversion = "{version}"\n'
+        )
+
+
+# ---------------------------------------------------------------------------
+# check_version_consistency
+# ---------------------------------------------------------------------------
+
+
+def test_check_version_consistency_no_pixi(tmp_path):
+    """Pass when pixi.toml is absent."""
+    _write_pyproject(tmp_path, "1.2.3")
+    assert check_version_consistency(tmp_path) == 0
+
+
+def test_check_version_consistency_pixi_no_version(tmp_path):
+    """Pass when pixi.toml has no [workspace].version."""
+    _write_pyproject(tmp_path, "1.2.3")
+    _write_pixi(tmp_path, None)
+    assert check_version_consistency(tmp_path) == 0
+
+
+def test_check_version_consistency_matching(tmp_path):
+    """Pass when both files have the same version."""
+    _write_pyproject(tmp_path, "1.2.3")
+    _write_pixi(tmp_path, "1.2.3")
+    assert check_version_consistency(tmp_path) == 0
+
+
+def test_check_version_consistency_mismatch(tmp_path, capsys):
+    """Fail when versions differ."""
+    _write_pyproject(tmp_path, "1.2.3")
+    _write_pixi(tmp_path, "1.2.4")
+    result = check_version_consistency(tmp_path)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "mismatch" in err.lower() or "1.2.3" in err
+
+
+def test_check_version_consistency_verbose(tmp_path, capsys):
+    """Verbose mode prints versions even when consistent."""
+    _write_pyproject(tmp_path, "0.5.0")
+    result = check_version_consistency(tmp_path, verbose=True)
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "0.5.0" in out
+
+
+def test_check_version_consistency_missing_pyproject(tmp_path):
+    """Exit 1 when pyproject.toml is missing."""
+    with pytest.raises(SystemExit) as exc_info:
+        check_version_consistency(tmp_path)
+    assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# check_package_version_consistency
+# ---------------------------------------------------------------------------
+
+
+def test_check_package_consistency_minimal(tmp_path):
+    """Pass with just pyproject.toml and no CHANGELOG."""
+    _write_pyproject(tmp_path, "0.3.0")
+    assert check_package_version_consistency(tmp_path) == 0
+
+
+def test_check_package_consistency_init_match(tmp_path):
+    """Pass when __init__.py __version__ matches."""
+    _write_pyproject(tmp_path, "0.3.0")
+    init = tmp_path / "mypkg" / "__init__.py"
+    init.parent.mkdir()
+    init.write_text('__version__ = "0.3.0"\n')
+    assert check_package_version_consistency(tmp_path, package_init=init) == 0
+
+
+def test_check_package_consistency_init_mismatch(tmp_path, capsys):
+    """Fail when __init__.py __version__ does not match."""
+    _write_pyproject(tmp_path, "0.3.0")
+    init = tmp_path / "mypkg" / "__init__.py"
+    init.parent.mkdir()
+    init.write_text('__version__ = "0.2.0"\n')
+    result = check_package_version_consistency(tmp_path, package_init=init)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "0.2.0" in err or "mismatch" in err.lower()
+
+
+def test_check_package_consistency_init_missing(tmp_path):
+    """Skip (not fail) when --package-init path does not exist."""
+    _write_pyproject(tmp_path, "0.3.0")
+    missing = tmp_path / "doesnotexist" / "__init__.py"
+    assert check_package_version_consistency(tmp_path, package_init=missing) == 0
+
+
+def test_check_package_consistency_no_version_in_init(tmp_path):
+    """Skip __version__ check when init has no __version__ attribute."""
+    _write_pyproject(tmp_path, "0.3.0")
+    init = tmp_path / "mypkg" / "__init__.py"
+    init.parent.mkdir()
+    init.write_text("# no version here\n")
+    assert check_package_version_consistency(tmp_path, package_init=init) == 0
+
+
+def test_check_package_consistency_changelog_ok(tmp_path):
+    """Pass when CHANGELOG has no aspirational versions."""
+    _write_pyproject(tmp_path, "1.0.0")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n## [0.9.0]\n- Released\n## [1.0.0]\n- Current\n"
+    )
+    assert check_package_version_consistency(tmp_path) == 0
+
+
+def test_check_package_consistency_changelog_aspirational(tmp_path, capsys):
+    """Fail when CHANGELOG references a future version."""
+    _write_pyproject(tmp_path, "1.0.0")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n## [1.0.0]\n- Current\n## [1.1.0]\n- Coming soon\n"
+    )
+    result = check_package_version_consistency(tmp_path)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "1.1.0" in err
+
+
+def test_check_package_consistency_changelog_in_codeblock_ignored(tmp_path):
+    """Versions inside fenced code blocks are not flagged."""
+    _write_pyproject(tmp_path, "1.0.0")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n## [1.0.0]\nSee:\n```\nversion = 1.9.0\n```\n"
+    )
+    assert check_package_version_consistency(tmp_path) == 0
+
+
+def test_check_package_consistency_changelog_in_inline_code_ignored(tmp_path):
+    """Versions inside inline code spans are not flagged."""
+    _write_pyproject(tmp_path, "1.0.0")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n## [1.0.0]\nSee `version = 9.9.9` for details.\n"
+    )
+    assert check_package_version_consistency(tmp_path) == 0
+
+
+def test_check_package_consistency_no_changelog(tmp_path):
+    """Pass silently when no CHANGELOG.md exists."""
+    _write_pyproject(tmp_path, "0.5.0")
+    assert check_package_version_consistency(tmp_path) == 0
+
+
+# ---------------------------------------------------------------------------
+# bump_version
+# ---------------------------------------------------------------------------
+
+
+def _minimal_repo(tmp_path: Path, version: str) -> Path:
+    """Set up a minimal repo at tmp_path with pyproject.toml at version."""
+    _write_pyproject(tmp_path, version)
+    return tmp_path
+
+
+def test_bump_version_patch(tmp_path):
+    """Patch bump increments patch part and resets nothing."""
+    _minimal_repo(tmp_path, "1.2.3")
+    result = bump_version(tmp_path, "patch", verbose=False)
+    assert result == 0
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert '"1.2.4"' in content
+
+
+def test_bump_version_minor(tmp_path):
+    """Minor bump increments minor and resets patch to 0."""
+    _minimal_repo(tmp_path, "1.2.3")
+    result = bump_version(tmp_path, "minor", verbose=False)
+    assert result == 0
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert '"1.3.0"' in content
+
+
+def test_bump_version_major(tmp_path):
+    """Major bump increments major and resets minor and patch to 0."""
+    _minimal_repo(tmp_path, "1.2.3")
+    result = bump_version(tmp_path, "major", verbose=False)
+    assert result == 0
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert '"2.0.0"' in content
+
+
+def test_bump_version_dry_run(tmp_path):
+    """Dry run does not modify any file."""
+    _minimal_repo(tmp_path, "1.0.0")
+    result = bump_version(tmp_path, "patch", dry_run=True, verbose=False)
+    assert result == 0
+    # pyproject.toml must be unchanged
+    content = (tmp_path / "pyproject.toml").read_text()
+    assert '"1.0.0"' in content
+
+
+def test_bump_version_dry_run_output(tmp_path, capsys):
+    """Dry run prints the proposed version change."""
+    _minimal_repo(tmp_path, "2.3.4")
+    bump_version(tmp_path, "minor", dry_run=True, verbose=False)
+    out = capsys.readouterr().out
+    assert "2.4.0" in out
+
+
+def test_bump_version_invalid_part(tmp_path, capsys):
+    """Invalid part argument returns exit code 1."""
+    _minimal_repo(tmp_path, "1.0.0")
+    result = bump_version(tmp_path, "invalid", verbose=False)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "invalid" in err.lower()
+
+
+def test_bump_version_missing_pyproject(tmp_path):
+    """Missing pyproject.toml causes SystemExit(1)."""
+    with pytest.raises(SystemExit) as exc_info:
+        bump_version(tmp_path, "patch")
+    assert exc_info.value.code == 1
+
+
+def test_bump_version_verbose(tmp_path, capsys):
+    """Verbose mode prints bump message."""
+    _minimal_repo(tmp_path, "0.1.0")
+    bump_version(tmp_path, "patch", verbose=True)
+    out = capsys.readouterr().out
+    assert "0.1.1" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI main entry points (smoke tests via monkeypatch of sys.argv)
+# ---------------------------------------------------------------------------
+
+
+def test_check_version_consistency_main_pass(tmp_path, monkeypatch, capsys):
+    """CLI passes when pyproject.toml has no matching pixi.toml version."""
+    from hephaestus.version.consistency import check_version_consistency_main
+
+    _write_pyproject(tmp_path, "1.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
+    )
+    result = check_version_consistency_main()
+    assert result == 0
+
+
+def test_check_version_consistency_main_mismatch(tmp_path, monkeypatch, capsys):
+    """CLI fails when versions differ."""
+    from hephaestus.version.consistency import check_version_consistency_main
+
+    _write_pyproject(tmp_path, "1.0.0")
+    _write_pixi(tmp_path, "1.0.1")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
+    )
+    result = check_version_consistency_main()
+    assert result == 1
+
+
+def test_check_package_versions_main_pass(tmp_path, monkeypatch):
+    """CLI passes with minimal repo and --verbose flag."""
+    from hephaestus.version.consistency import check_package_versions_main
+
+    _write_pyproject(tmp_path, "2.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-check-package-versions", "--repo-root", str(tmp_path), "--verbose"],
+    )
+    result = check_package_versions_main()
+    assert result == 0
+
+
+def test_bump_version_main_dry_run(tmp_path, monkeypatch, capsys):
+    """CLI --dry-run flag prints proposed change without writing."""
+    from hephaestus.version.consistency import bump_version_main
+
+    _minimal_repo(tmp_path, "3.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-bump-version", "minor", "--repo-root", str(tmp_path), "--dry-run"],
+    )
+    result = bump_version_main()
+    assert result == 0
+    out = capsys.readouterr().out
+    assert "3.1.0" in out
+    # File must be unchanged
+    assert '"3.0.0"' in (tmp_path / "pyproject.toml").read_text()
+
+
+def test_bump_version_main_patch(tmp_path, monkeypatch):
+    """CLI patch bump actually modifies the file."""
+    from hephaestus.version.consistency import bump_version_main
+
+    _minimal_repo(tmp_path, "0.5.2")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-bump-version", "patch", "--repo-root", str(tmp_path)],
+    )
+    result = bump_version_main()
+    assert result == 0
+    assert '"0.5.3"' in (tmp_path / "pyproject.toml").read_text()
+
+
+# ---------------------------------------------------------------------------
+# check_package_version_consistency with pixi mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_check_package_consistency_pixi_mismatch(tmp_path, capsys):
+    """Fail when pixi.toml [workspace].version differs from pyproject.toml."""
+    _write_pyproject(tmp_path, "1.0.0")
+    _write_pixi(tmp_path, "0.9.0")
+    result = check_package_version_consistency(tmp_path)
+    assert result == 1
+    err = capsys.readouterr().err
+    assert "0.9.0" in err
+
+
+def test_check_package_consistency_pixi_match(tmp_path):
+    """Pass when pixi.toml [workspace].version matches pyproject.toml."""
+    _write_pyproject(tmp_path, "1.0.0")
+    _write_pixi(tmp_path, "1.0.0")
+    assert check_package_version_consistency(tmp_path) == 0


### PR DESCRIPTION
## Summary

- Adds `hephaestus.version.consistency` module porting version consistency tooling from ProjectScylla scripts
- Three public functions: `check_version_consistency`, `check_package_version_consistency`, `bump_version`
- Three new CLI entry points: `hephaestus-check-version-consistency`, `hephaestus-check-package-versions`, `hephaestus-bump-version`
- 31 unit tests; full suite: 1409 passed, 84.38% coverage

## What this ports

From `ProjectScylla/scripts/`:
- `check_version_consistency.py` → compares pyproject.toml vs pixi.toml
- `check_package_version_consistency.py` → multi-source scan (pixi, __init__, CHANGELOG, skills)
- `bump_version.py` → atomic semver increment via VersionManager

## Changes

- `hephaestus/version/consistency.py` — new module (581 lines)
- `hephaestus/version/__init__.py` — export new symbols
- `pyproject.toml` — three new `[project.scripts]` entries
- `tests/unit/version/test_consistency.py` — 31 tests

## Test plan

- [x] `pixi run pytest tests/unit/ -q` — 1409 passed, 7 skipped, 84.38% coverage ≥ 80%
- [x] `pre-commit run --all-files` — all hooks pass
- [x] `pixi run mypy hephaestus/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)