### PR TITLE
feat(validation): add doc_config, stale_scripts, mypy_per_file modules (L2)

### DIFF
--- a/hephaestus/validation/__init__.py
+++ b/hephaestus/validation/__init__.py
@@ -7,6 +7,7 @@ from hephaestus.validation.audit import (
 from hephaestus.validation.complexity import check_max_complexity
 from hephaestus.validation.config_lint import ConfigLinter
 from hephaestus.validation.coverage import check_coverage, parse_coverage_report
+from hephaestus.validation.doc_config import check_doc_config_consistency
 from hephaestus.validation.doc_policy import (
     Finding as DocPolicyFinding,
 )
@@ -44,6 +45,7 @@ from hephaestus.validation.markdown import (
     validate_readme,
     validate_relative_link,
 )
+from hephaestus.validation.mypy_per_file import check_mypy_per_file
 from hephaestus.validation.python_version import check_python_version_consistency
 from hephaestus.validation.readme_commands import (
     CodeBlock,
@@ -51,6 +53,7 @@ from hephaestus.validation.readme_commands import (
     ValidationReport,
     ValidationResult,
 )
+from hephaestus.validation.stale_scripts import check_stale_scripts, find_stale_scripts
 from hephaestus.validation.structure import StructureValidator
 from hephaestus.validation.test_structure import (
     check_no_loose_test_files,
@@ -74,11 +77,14 @@ __all__ = [
     "ValidationReport",
     "ValidationResult",
     "check_coverage",
+    "check_doc_config_consistency",
     "check_markdown_formatting",
     "check_max_complexity",
+    "check_mypy_per_file",
     "check_no_loose_test_files",
     "check_python_version_consistency",
     "check_required_sections",
+    "check_stale_scripts",
     "check_test_directory_mirrors",
     "check_test_structure",
     "count_markdown_issues",
@@ -88,6 +94,7 @@ __all__ = [
     "filter_audit_results",
     "find_markdown_files",
     "find_readmes",
+    "find_stale_scripts",
     "is_genuine_fragment",
     "is_shadowing_pattern",
     "parse_coverage_report",

--- a/hephaestus/validation/doc_config.py
+++ b/hephaestus/validation/doc_config.py
@@ -1,0 +1,486 @@
+"""Enforce consistency between documentation metric values and authoritative config sources.
+
+Checks that values documented in CLAUDE.md and README.md match what is configured in
+``pyproject.toml``:
+
+1. Coverage threshold in CLAUDE.md matches ``fail_under`` in ``[tool.coverage.report]``.
+2. ``--cov=<path>`` in README.md matches ``addopts`` in ``[tool.pytest.ini_options]``.
+3. If ``--cov-fail-under=N`` is present in ``addopts``, it must match ``fail_under`` in
+   ``[tool.coverage.report]``.  Absent is OK — ``[tool.coverage.report].fail_under`` is
+   the single source of truth.
+4. Test count in README.md is within 10% of actual ``pytest --collect-only`` count.
+
+Usage::
+
+    hephaestus-check-doc-config
+    hephaestus-check-doc-config --repo-root /path/to/repo --verbose
+
+Exit codes:
+    0  All checks pass
+    1  One or more checks failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+_tomllib = None
+for _mod_name in ("tomllib", "tomli"):
+    try:
+        _tomllib = importlib.import_module(_mod_name)
+        break
+    except ModuleNotFoundError:
+        continue
+
+
+def _load_pyproject(repo_root: Path) -> dict[str, Any]:
+    """Load ``pyproject.toml`` using tomllib/tomli.
+
+    Args:
+        repo_root: Root directory of the repository.
+
+    Returns:
+        Parsed TOML data as a nested dict.
+
+    Raises:
+        SystemExit: With code 1 if the file is missing, unreadable, or tomllib is
+            unavailable.
+
+    """
+    pyproject_path = repo_root / "pyproject.toml"
+    if not pyproject_path.is_file():
+        print(f"ERROR: pyproject.toml not found: {pyproject_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if _tomllib is None:
+        print(
+            "ERROR: tomllib/tomli is required to parse pyproject.toml. "
+            "Install tomli for Python < 3.11: pip install tomli",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        with open(pyproject_path, "rb") as f:
+            return cast(dict[str, Any], _tomllib.load(f))
+    except Exception as exc:
+        print(f"ERROR: Could not parse {pyproject_path}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def load_coverage_threshold(repo_root: Path) -> int:
+    """Read ``fail_under`` from ``[tool.coverage.report]`` in ``pyproject.toml``.
+
+    Args:
+        repo_root: Repository root containing ``pyproject.toml``.
+
+    Returns:
+        Integer value of ``fail_under``.
+
+    Raises:
+        SystemExit: If the key is absent or ``pyproject.toml`` is unreadable.
+
+    """
+    data = _load_pyproject(repo_root)
+    try:
+        threshold = data["tool"]["coverage"]["report"]["fail_under"]
+    except KeyError:
+        print(
+            "ERROR: [tool.coverage.report].fail_under not found in pyproject.toml",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return int(threshold)
+
+
+def extract_cov_path(repo_root: Path) -> str:
+    """Read the ``--cov=<path>`` value from ``[tool.pytest.ini_options].addopts``.
+
+    Args:
+        repo_root: Repository root containing ``pyproject.toml``.
+
+    Returns:
+        Package path string (e.g. ``"hephaestus"``).
+
+    Raises:
+        SystemExit: If the key is missing or no ``--cov=`` flag is found.
+
+    """
+    data = _load_pyproject(repo_root)
+    addopts = data.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", [])
+    addopts_items: list[str] = addopts.split() if isinstance(addopts, str) else list(addopts)
+
+    for item in addopts_items:
+        m = re.match(r"^--cov=(.+)$", item)
+        if m:
+            return m.group(1)
+
+    print(
+        "ERROR: No --cov=<path> found in [tool.pytest.ini_options].addopts",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def extract_cov_fail_under_from_addopts(repo_root: Path) -> int | None:
+    """Read ``--cov-fail-under=N`` from ``[tool.pytest.ini_options].addopts``, if present.
+
+    Args:
+        repo_root: Repository root containing ``pyproject.toml``.
+
+    Returns:
+        Integer threshold if the flag is present, ``None`` otherwise.
+
+    """
+    data = _load_pyproject(repo_root)
+    addopts = data.get("tool", {}).get("pytest", {}).get("ini_options", {}).get("addopts", [])
+    addopts_items: list[str] = addopts.split() if isinstance(addopts, str) else list(addopts)
+
+    for item in addopts_items:
+        m = re.match(r"^--cov-fail-under=(\d+)$", item)
+        if m:
+            return int(m.group(1))
+    return None
+
+
+def check_claude_md_threshold(repo_root: Path, expected: int) -> list[str]:
+    """Check that CLAUDE.md documents the correct coverage threshold.
+
+    Searches for ``<N>%+ test coverage`` (or ``<N>% test coverage``) and verifies
+    the integer matches *expected*.
+
+    Args:
+        repo_root: Repository root.
+        expected: Authoritative threshold value from ``pyproject.toml``.
+
+    Returns:
+        List of error strings (empty if all checks pass).
+
+    """
+    claude_md = repo_root / "CLAUDE.md"
+    if not claude_md.exists():
+        return [f"CLAUDE.md not found at {claude_md}"]
+
+    text = claude_md.read_text(encoding="utf-8")
+    matches = re.findall(r"(\d+)%\+?\s+test coverage", text)
+    if not matches:
+        return [
+            "CLAUDE.md: No coverage threshold mention found "
+            "(expected pattern: '<N>%+ test coverage')"
+        ]
+
+    errors: list[str] = []
+    for raw in matches:
+        found = int(raw)
+        if found != expected:
+            errors.append(
+                f"CLAUDE.md: Coverage threshold mismatch — "
+                f"CLAUDE.md says {found}%, pyproject.toml says {expected}%"
+            )
+    return errors
+
+
+def check_readme_cov_path(repo_root: Path, expected_path: str) -> list[str]:
+    """Check that all ``--cov=<path>`` occurrences in README.md match *expected_path*.
+
+    Args:
+        repo_root: Repository root.
+        expected_path: Authoritative ``--cov`` path from ``pyproject.toml``.
+
+    Returns:
+        List of error strings (empty if all checks pass or README has no ``--cov``).
+
+    """
+    readme = repo_root / "README.md"
+    if not readme.exists():
+        return [f"README.md not found at {readme}"]
+
+    text = readme.read_text(encoding="utf-8")
+    occurrences = re.findall(r"--cov=(\S+)", text)
+    if not occurrences:
+        return []
+
+    errors: list[str] = []
+    for path in occurrences:
+        if path != expected_path:
+            errors.append(
+                f"README.md: --cov path mismatch — "
+                f"README.md has '--cov={path}', pyproject.toml uses '--cov={expected_path}'"
+            )
+    return errors
+
+
+def check_addopts_cov_fail_under(repo_root: Path, expected: int) -> list[str]:
+    """Check that ``--cov-fail-under`` in addopts matches ``fail_under`` (if present).
+
+    If absent, the check passes — ``[tool.coverage.report].fail_under`` is the single
+    source of truth and pytest-cov reads it directly.
+
+    Args:
+        repo_root: Repository root.
+        expected: Authoritative threshold from ``[tool.coverage.report].fail_under``.
+
+    Returns:
+        List of error strings (empty if consistent or flag is absent).
+
+    """
+    addopts_threshold = extract_cov_fail_under_from_addopts(repo_root)
+    if addopts_threshold is None:
+        return []
+    if addopts_threshold != expected:
+        return [
+            f"pyproject.toml: --cov-fail-under mismatch — "
+            f"addopts has --cov-fail-under={addopts_threshold}, "
+            f"but [tool.coverage.report].fail_under={expected}"
+        ]
+    return []
+
+
+def collect_actual_test_count(repo_root: Path) -> int | None:
+    """Run ``pytest --collect-only -q`` and return the number of collected tests.
+
+    Args:
+        repo_root: Repository root where pytest should be invoked.
+
+    Returns:
+        Integer test count, or ``None`` if collection fails or is unparseable.
+
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "-q", "tests/"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+
+    output = result.stdout + result.stderr
+    m = re.search(r"(\d+)\s+(?:tests?\s+)?(?:selected|collected)", output)
+    if m:
+        count = int(m.group(1))
+        return count if count > 0 else None
+    return None
+
+
+def check_readme_test_count(
+    repo_root: Path, actual_count: int, tolerance: float = 0.10
+) -> list[str]:
+    """Check that test count claims in README.md are within *tolerance* of *actual_count*.
+
+    Searches for patterns like ``3,500+ tests`` or ``3172 tests``.
+
+    Args:
+        repo_root: Repository root.
+        actual_count: Authoritative test count from ``pytest --collect-only``.
+        tolerance: Fractional tolerance (default 0.10 = 10%).
+
+    Returns:
+        List of error strings (empty if consistent or no hardcoded count found).
+
+    """
+    readme = repo_root / "README.md"
+    if not readme.exists():
+        return [f"README.md not found at {readme}"]
+
+    text = readme.read_text(encoding="utf-8")
+    raw_matches = re.findall(r"(\d[\d,]*)\+?\s+tests?", text, re.IGNORECASE)
+    if not raw_matches:
+        return []
+
+    errors: list[str] = []
+    for raw in raw_matches:
+        doc_count = int(raw.replace(",", ""))
+        if abs(doc_count - actual_count) / actual_count > tolerance:
+            errors.append(
+                f"README.md: Test count mismatch — "
+                f"README.md says {doc_count}, actual pytest count is {actual_count} "
+                f"(tolerance: {int(tolerance * 100)}%)"
+            )
+    return errors
+
+
+def check_doc_config_consistency(
+    repo_root: Path,
+    verbose: bool = False,
+    skip_test_count: bool = False,
+) -> int:
+    """Run all doc/config consistency checks and return an exit code.
+
+    Checks:
+    1. CLAUDE.md coverage threshold vs ``[tool.coverage.report].fail_under``.
+    2. README.md ``--cov=<path>`` vs ``[tool.pytest.ini_options].addopts``.
+    3. ``--cov-fail-under`` in addopts (if present) vs ``fail_under``.
+    4. README.md hardcoded test count vs ``pytest --collect-only`` (skipped if
+       *skip_test_count* is True or pytest is unavailable).
+
+    Args:
+        repo_root: Repository root containing ``pyproject.toml``.
+        verbose: If True, print passing check names as well.
+        skip_test_count: If True, skip the live ``pytest --collect-only`` check.
+
+    Returns:
+        0 if all checks pass, 1 if any fail.
+
+    """
+    all_errors: list[str] = []
+
+    expected_threshold = load_coverage_threshold(repo_root)
+    all_errors.extend(_run_threshold_check(repo_root, expected_threshold, verbose))
+    all_errors.extend(_run_cov_path_check(repo_root, verbose))
+    all_errors.extend(_run_addopts_check(repo_root, expected_threshold, verbose))
+
+    if not skip_test_count:
+        all_errors.extend(_run_test_count_check(repo_root, verbose))
+
+    if all_errors:
+        for error in all_errors:
+            print(error, file=sys.stderr)
+        print(
+            f"\nFound {len(all_errors)} doc/config consistency violation(s).",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def _run_threshold_check(repo_root: Path, expected: int, verbose: bool) -> list[str]:
+    """Run CLAUDE.md coverage threshold check and print verbose result.
+
+    Args:
+        repo_root: Repository root.
+        expected: Expected threshold integer.
+        verbose: Print pass message if True.
+
+    Returns:
+        List of error strings (empty if passing).
+
+    """
+    errors = check_claude_md_threshold(repo_root, expected)
+    if not errors and verbose:
+        print(f"PASS: CLAUDE.md coverage threshold matches pyproject.toml ({expected}%)")
+    return errors
+
+
+def _run_cov_path_check(repo_root: Path, verbose: bool) -> list[str]:
+    """Run README.md --cov path check and print verbose result.
+
+    Args:
+        repo_root: Repository root.
+        verbose: Print pass message if True.
+
+    Returns:
+        List of error strings (empty if passing).
+
+    """
+    expected_cov_path = extract_cov_path(repo_root)
+    errors = check_readme_cov_path(repo_root, expected_cov_path)
+    if not errors and verbose:
+        print(f"PASS: README.md --cov path matches pyproject.toml (--cov={expected_cov_path})")
+    return errors
+
+
+def _run_addopts_check(repo_root: Path, expected: int, verbose: bool) -> list[str]:
+    """Run addopts --cov-fail-under consistency check and print verbose result.
+
+    Args:
+        repo_root: Repository root.
+        expected: Expected threshold integer.
+        verbose: Print pass message if True.
+
+    Returns:
+        List of error strings (empty if passing).
+
+    """
+    errors = check_addopts_cov_fail_under(repo_root, expected)
+    if not errors and verbose:
+        addopts_val = extract_cov_fail_under_from_addopts(repo_root)
+        if addopts_val is not None:
+            print(
+                f"PASS: addopts --cov-fail-under matches "
+                f"[tool.coverage.report].fail_under ({expected}%)"
+            )
+        else:
+            print(
+                f"PASS: No --cov-fail-under in addopts — "
+                f"[tool.coverage.report].fail_under ({expected}%) is single source of truth"
+            )
+    return errors
+
+
+def _run_test_count_check(repo_root: Path, verbose: bool) -> list[str]:
+    """Run pytest test-count check and print verbose result.
+
+    Args:
+        repo_root: Repository root.
+        verbose: Print pass/skip message if True.
+
+    Returns:
+        List of error strings (empty if passing or skipped).
+
+    """
+    actual_count = collect_actual_test_count(repo_root)
+    if actual_count is None:
+        if verbose:
+            print("SKIP: Could not collect actual test count (pytest unavailable)")
+        return []
+    errors = check_readme_test_count(repo_root, actual_count)
+    if not errors and verbose:
+        print(f"PASS: README.md test count is within 10% of actual ({actual_count})")
+    return errors
+
+
+def main() -> int:
+    """CLI entry point for doc/config consistency checking.
+
+    Returns:
+        Exit code (0 if all checks pass, 1 if any fail).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Enforce consistency between doc metric values and pyproject.toml",
+        epilog="Example: %(prog)s --repo-root /path/to/repo --verbose",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detected via git)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print passing check names",
+    )
+    parser.add_argument(
+        "--skip-test-count",
+        action="store_true",
+        help="Skip the live pytest --collect-only test count check",
+    )
+
+    args = parser.parse_args()
+
+    if args.repo_root is not None:
+        repo_root: Path = args.repo_root
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    return check_doc_config_consistency(
+        repo_root=repo_root,
+        verbose=args.verbose,
+        skip_test_count=args.skip_test_count,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hephaestus/validation/mypy_per_file.py
+++ b/hephaestus/validation/mypy_per_file.py
@@ -1,0 +1,147 @@
+"""Run mypy on each file individually to avoid duplicate-module-name errors.
+
+When multiple files in different subdirectories share the same basename (e.g.
+``examples/alexnet/download.py`` and ``examples/resnet/download.py``), passing them
+all to a single ``mypy`` invocation causes a ``Duplicate module named`` error.
+
+This wrapper separates mypy flags from file paths, then runs mypy once per file and
+aggregates exit codes.
+
+Usage::
+
+    hephaestus-mypy-each-file [mypy-flags...] file1.py file2.py ...
+    hephaestus-mypy-each-file --ignore-missing-imports examples/**/*.py
+
+Exit codes:
+    0  All per-file mypy runs passed
+    Non-zero  At least one file failed — last non-zero exit code is returned
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# mypy flags that consume the next argument as their value.
+_FLAGS_WITH_VALUE: frozenset[str] = frozenset(
+    {
+        "--python-version",
+        "--config-file",
+        "--shadow-file",
+        "--exclude",
+        "--package",
+        "--module",
+    }
+)
+
+
+def split_flags_and_files(args: list[str]) -> tuple[list[str], list[str]]:
+    """Separate mypy flags from file paths.
+
+    Flags start with ``-``.  Flags listed in ``_FLAGS_WITH_VALUE`` consume the
+    next positional argument as their value.
+
+    Args:
+        args: Raw argument list (excluding the program name).
+
+    Returns:
+        A ``(flags, files)`` tuple.
+
+    """
+    flags: list[str] = []
+    files: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg.startswith("-"):
+            flags.append(arg)
+            if arg in _FLAGS_WITH_VALUE:
+                i += 1
+                if i < len(args):
+                    flags.append(args[i])
+        else:
+            files.append(arg)
+        i += 1
+    return flags, files
+
+
+def run_mypy_per_file(
+    files: list[str],
+    flags: list[str] | None = None,
+    python_executable: str | None = None,
+) -> int:
+    """Run mypy once per file and aggregate exit codes.
+
+    Args:
+        files: File paths to type-check.
+        flags: Extra mypy flags to pass to every invocation.
+        python_executable: Python interpreter to invoke mypy with (default: ``sys.executable``).
+
+    Returns:
+        0 if all runs passed, otherwise the last non-zero return code.
+
+    """
+    if not files:
+        print("mypy-each-file: no files to check", file=sys.stderr)
+        return 0
+
+    executable = python_executable or sys.executable
+    extra_flags: list[str] = flags or []
+
+    overall_rc = 0
+    for filepath in files:
+        cmd = [executable, "-m", "mypy", *extra_flags, filepath]
+        result = subprocess.run(cmd, capture_output=False)
+        if result.returncode != 0:
+            overall_rc = result.returncode
+
+    return overall_rc
+
+
+def check_mypy_per_file(
+    files: list[str | Path],
+    flags: list[str] | None = None,
+) -> int:
+    """Public API: run mypy per-file and return an exit code.
+
+    Args:
+        files: File paths to type-check (strings or :class:`Path` objects).
+        flags: Extra mypy flags.
+
+    Returns:
+        0 if all runs passed, otherwise the last non-zero return code.
+
+    """
+    return run_mypy_per_file([str(f) for f in files], flags=flags)
+
+
+def main() -> int:
+    """CLI entry point.
+
+    Accepts mypy flags and file paths.  All flags (arguments starting with ``-``)
+    are forwarded to mypy; everything else is treated as a file path.
+
+    Returns:
+        Aggregated exit code from all mypy runs.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Run mypy on each file individually (avoids duplicate-module-name errors)",
+        usage="%(prog)s [mypy-flags...] file1.py file2.py ...",
+        add_help=True,
+    )
+    # We parse just --help / -h normally; all remaining args are passed through.
+    parser.parse_known_args(sys.argv[1:])
+
+    raw_args = sys.argv[1:]
+    # Strip --help handled above so it doesn't end up as a file path.
+    raw_args = [a for a in raw_args if a not in ("-h", "--help")]
+
+    flags, files = split_flags_and_files(raw_args)
+    return run_mypy_per_file(files, flags=flags)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hephaestus/validation/stale_scripts.py
+++ b/hephaestus/validation/stale_scripts.py
@@ -1,0 +1,304 @@
+"""Detect scripts in ``scripts/`` with no references in CI configs or other scripts.
+
+A script is considered potentially stale if its filename does not appear in any of:
+
+- ``.github/**/*.yml`` (GitHub Actions workflows)
+- ``justfile``
+- ``.pre-commit-config.yaml``
+- other ``scripts/*.py`` files (cross-references)
+- ``docs/**/*.md`` (documentation)
+
+Known utility/library scripts (``common.py``, ``conftest.py``, ``__init__.py``) are
+excluded from consideration.
+
+Usage::
+
+    hephaestus-check-stale-scripts
+    hephaestus-check-stale-scripts --repo-root /path/to/repo --strict
+    hephaestus-check-stale-scripts --exclude test_ --verbose
+
+Exit codes:
+    0  No stale scripts found (or warnings only without ``--strict``)
+    1  Stale scripts detected (only with ``--strict``)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Scripts that are imported by other scripts (not invoked directly) — always active.
+_ALWAYS_ACTIVE: frozenset[str] = frozenset(
+    {
+        "common.py",
+        "conftest.py",
+        "__init__.py",
+        "setup.py",
+    }
+)
+
+# Name prefixes/substrings that mark a script as always-active (e.g. pytest test files).
+_ACTIVE_PATTERNS: tuple[str, ...] = ("test_", "conftest")
+
+
+def _is_always_active(script_name: str) -> bool:
+    """Return True if *script_name* should always be considered active.
+
+    Args:
+        script_name: Basename of the script file.
+
+    Returns:
+        True if the script is in the known-utilities set or matches an active pattern.
+
+    """
+    if script_name in _ALWAYS_ACTIVE:
+        return True
+    return any(pat in script_name for pat in _ACTIVE_PATTERNS)
+
+
+def get_all_scripts(
+    scripts_dir: Path,
+    extensions: tuple[str, ...] = (".py", ".sh", ".mojo"),
+) -> list[str]:
+    """Return basenames of all script files in *scripts_dir*.
+
+    Args:
+        scripts_dir: Path to the ``scripts/`` directory.
+        extensions: File suffixes to include.
+
+    Returns:
+        Sorted list of basenames.
+
+    """
+    return sorted(
+        p.name
+        for p in scripts_dir.rglob("*")
+        if p.is_file() and p.suffix in extensions and not p.name.startswith(".")
+    )
+
+
+def get_reference_targets(repo_root: Path) -> list[Path]:
+    """Collect files that may reference script names.
+
+    Includes GitHub Actions workflows, justfile, pre-commit config, other scripts,
+    and documentation.
+
+    Args:
+        repo_root: Root of the repository.
+
+    Returns:
+        List of Path objects for files to search.
+
+    """
+    targets: list[Path] = []
+
+    github_dir = repo_root / ".github"
+    if github_dir.is_dir():
+        targets.extend(github_dir.rglob("*.yml"))
+
+    for name in ("justfile", ".pre-commit-config.yaml"):
+        candidate = repo_root / name
+        if candidate.is_file():
+            targets.append(candidate)
+
+    scripts_dir = repo_root / "scripts"
+    if scripts_dir.is_dir():
+        targets.extend(scripts_dir.rglob("*.py"))
+
+    docs_dir = repo_root / "docs"
+    if docs_dir.is_dir():
+        targets.extend(docs_dir.rglob("*.md"))
+
+    return targets
+
+
+def _script_referenced_by_name(script_name: str, targets: list[Path], own_path: Path) -> bool:
+    """Return True if *script_name* appears in at least one target file (not itself).
+
+    Args:
+        script_name: Basename to search for.
+        targets: Files to search through.
+        own_path: Resolved path of the script itself (excluded from search).
+
+    Returns:
+        True if an external reference exists.
+
+    """
+    for target in targets:
+        if target.resolve() == own_path:
+            continue
+        try:
+            content = target.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if script_name in content:
+            return True
+    return False
+
+
+def _script_referenced_by_import(script_stem: str, targets: list[Path], own_path: Path) -> bool:
+    """Return True if *script_stem* appears as a Python import or path reference.
+
+    Catches patterns like ``from scripts.check_stale_scripts import`` or
+    ``run scripts/check_stale_scripts``.
+
+    Args:
+        script_stem: Stem (name without suffix) of the script.
+        targets: Files to search through.
+        own_path: Resolved path of the script itself (excluded from search).
+
+    Returns:
+        True if an import reference exists.
+
+    """
+    pattern = re.compile(r"(?:from|import|run)\s+(?:\w+/)*" + re.escape(script_stem) + r"\b")
+    for target in targets:
+        if target.resolve() == own_path:
+            continue
+        try:
+            content = target.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        if pattern.search(content):
+            return True
+    return False
+
+
+def find_stale_scripts(
+    repo_root: Path,
+    exclude_pattern: str | None = None,
+) -> list[str]:
+    """Return basenames of scripts with no external references.
+
+    Scripts in ``_ALWAYS_ACTIVE`` or matching ``_ACTIVE_PATTERNS`` are excluded.
+    If *exclude_pattern* is given, any script whose name contains that substring is
+    also excluded.
+
+    Args:
+        repo_root: Root of the repository.
+        exclude_pattern: Optional substring; matching scripts are excluded.
+
+    Returns:
+        Sorted list of possibly-stale script basenames.
+
+    """
+    scripts_dir = repo_root / "scripts"
+    if not scripts_dir.is_dir():
+        return []
+
+    all_scripts = get_all_scripts(scripts_dir)
+    targets = get_reference_targets(repo_root)
+
+    stale: list[str] = []
+    for script_name in all_scripts:
+        if _is_always_active(script_name):
+            continue
+        if exclude_pattern and exclude_pattern in script_name:
+            continue
+        own_path = (scripts_dir / script_name).resolve()
+        stem = Path(script_name).stem
+        referenced = _script_referenced_by_name(
+            script_name, targets, own_path
+        ) or _script_referenced_by_import(stem, targets, own_path)
+        if not referenced:
+            stale.append(script_name)
+
+    return stale
+
+
+def check_stale_scripts(
+    repo_root: Path,
+    strict: bool = False,
+    verbose: bool = False,
+    exclude_pattern: str | None = None,
+) -> int:
+    """Run stale-script detection and return an exit code.
+
+    Args:
+        repo_root: Root of the repository.
+        strict: If True, return exit code 1 when stale scripts are found.
+        verbose: If True, print summary counts before results.
+        exclude_pattern: Optional substring; scripts containing it are excluded.
+
+    Returns:
+        0 if no stale scripts (or in warning mode), 1 if stale scripts found and
+        *strict* is True.
+
+    """
+    scripts_dir = repo_root / "scripts"
+
+    stale = find_stale_scripts(repo_root, exclude_pattern=exclude_pattern)
+
+    if verbose and scripts_dir.is_dir():
+        all_scripts = get_all_scripts(scripts_dir)
+        print(f"Total scripts: {len(all_scripts)}")
+        print(f"Stale candidates: {len(stale)}\n")
+
+    if stale:
+        prefix = "ERROR" if strict else "WARNING"
+        print(f"{prefix}: Found {len(stale)} possibly stale script(s):\n")
+        for script_name in stale:
+            print(f"  scripts/{script_name}")
+        print("\nConsider removing these scripts if they are no longer needed.")
+        return 1 if strict else 0
+
+    print("No stale script candidates found.")
+    return 0
+
+
+def main() -> int:
+    """CLI entry point for stale-script detection.
+
+    Returns:
+        Exit code (0 unless ``--strict`` and stale scripts are found).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Detect scripts/ files with no references in CI configs or other scripts",
+        epilog="Example: %(prog)s --strict --verbose",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detected via git)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit 1 when stale scripts are found (default: warn only, exit 0)",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print summary counts before results",
+    )
+    parser.add_argument(
+        "--exclude",
+        metavar="PATTERN",
+        default=None,
+        help="Exclude scripts whose name contains PATTERN (e.g. 'test_')",
+    )
+
+    args = parser.parse_args()
+
+    if args.repo_root is not None:
+        repo_root: Path = args.repo_root
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    return check_stale_scripts(
+        repo_root=repo_root,
+        strict=args.strict,
+        verbose=args.verbose,
+        exclude_pattern=args.exclude,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pixi.lock
+++ b/pixi.lock
@@ -937,7 +937,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.6.0
-  sha256: 43f6d97921c70207441d3808ed6bd5c7ac6ea26b277492df14b372ea833f16a1
+  sha256: 61bba6c7860f798e5f077c8e5da87b0a1a2221bbb913dd2eb68b6a67ef7d029f
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pixi.lock
+++ b/pixi.lock
@@ -937,7 +937,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.6.0
-  sha256: 61bba6c7860f798e5f077c8e5da87b0a1a2221bbb913dd2eb68b6a67ef7d029f
+  sha256: 1e1e20c675d36695e656c89b7e103ca9a435d684aa52ba8d126d6d1e6951fd7f
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ hephaestus-audit-doc-policy = "hephaestus.validation.doc_policy:main"
 hephaestus-check-version-consistency = "hephaestus.version.consistency:check_version_consistency_main"
 hephaestus-check-package-versions = "hephaestus.version.consistency:check_package_versions_main"
 hephaestus-bump-version = "hephaestus.version.consistency:bump_version_main"
+hephaestus-check-doc-config = "hephaestus.validation.doc_config:main"
+hephaestus-check-stale-scripts = "hephaestus.validation.stale_scripts:main"
+hephaestus-mypy-each-file = "hephaestus.validation.mypy_per_file:main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/tests/unit/validation/test_doc_config.py
+++ b/tests/unit/validation/test_doc_config.py
@@ -1,0 +1,298 @@
+"""Tests for hephaestus.validation.doc_config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.validation.doc_config import (
+    check_addopts_cov_fail_under,
+    check_claude_md_threshold,
+    check_doc_config_consistency,
+    check_readme_cov_path,
+    check_readme_test_count,
+    collect_actual_test_count,
+    extract_cov_fail_under_from_addopts,
+    extract_cov_path,
+    load_coverage_threshold,
+    main,
+)
+
+
+def _write_pyproject(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "pyproject.toml"
+    p.write_text(content)
+    return p
+
+
+def _minimal_pyproject(
+    fail_under: int = 80,
+    addopts: str | None = None,
+    extra: str = "",
+) -> str:
+    addopts_line = 'addopts = ["--cov=hephaestus", "--cov-report=term-missing"]'
+    if addopts is not None:
+        addopts_line = addopts
+    return f"""
+[project]
+name = "test-project"
+version = "1.0.0"
+
+[tool.pytest.ini_options]
+{addopts_line}
+
+[tool.coverage.report]
+fail_under = {fail_under}
+{extra}
+"""
+
+
+class TestLoadCoverageThreshold:
+    """Tests for load_coverage_threshold()."""
+
+    def test_reads_fail_under(self, tmp_path: Path) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject(fail_under=75))
+        assert load_coverage_threshold(tmp_path) == 75
+
+    def test_missing_pyproject_exits(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            load_coverage_threshold(tmp_path)
+        assert exc.value.code == 1
+
+    def test_missing_key_exits(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            "[project]\nname = 'x'\nversion = '1'\n[tool.coverage.report]\n",
+        )
+        with pytest.raises(SystemExit) as exc:
+            load_coverage_threshold(tmp_path)
+        assert exc.value.code == 1
+
+
+class TestExtractCovPath:
+    """Tests for extract_cov_path()."""
+
+    def test_reads_cov_path(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            _minimal_pyproject(addopts='addopts = ["--cov=mypackage"]'),
+        )
+        assert extract_cov_path(tmp_path) == "mypackage"
+
+    def test_missing_cov_flag_exits(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            _minimal_pyproject(addopts='addopts = ["-v"]'),
+        )
+        with pytest.raises(SystemExit) as exc:
+            extract_cov_path(tmp_path)
+        assert exc.value.code == 1
+
+    def test_addopts_as_string(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            _minimal_pyproject(addopts='addopts = "--cov=mypackage -v"'),
+        )
+        assert extract_cov_path(tmp_path) == "mypackage"
+
+
+class TestExtractCovFailUnder:
+    """Tests for extract_cov_fail_under_from_addopts()."""
+
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject())
+        assert extract_cov_fail_under_from_addopts(tmp_path) is None
+
+    def test_reads_value(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            _minimal_pyproject(addopts='addopts = ["--cov=x", "--cov-fail-under=90"]'),
+        )
+        assert extract_cov_fail_under_from_addopts(tmp_path) == 90
+
+
+class TestCheckClaudeMdThreshold:
+    """Tests for check_claude_md_threshold()."""
+
+    def test_matching_threshold(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
+        assert check_claude_md_threshold(tmp_path, 80) == []
+
+    def test_mismatch(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("We maintain 75%+ test coverage.")
+        errors = check_claude_md_threshold(tmp_path, 80)
+        assert len(errors) == 1
+        assert "75%" in errors[0]
+        assert "80%" in errors[0]
+
+    def test_no_mention(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("No coverage info here.")
+        errors = check_claude_md_threshold(tmp_path, 80)
+        assert len(errors) == 1
+        assert "No coverage threshold" in errors[0]
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        errors = check_claude_md_threshold(tmp_path, 80)
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+    def test_percent_without_plus(self, tmp_path: Path) -> None:
+        (tmp_path / "CLAUDE.md").write_text("We require 80% test coverage.")
+        assert check_claude_md_threshold(tmp_path, 80) == []
+
+
+class TestCheckReadmeCovPath:
+    """Tests for check_readme_cov_path()."""
+
+    def test_matching_path(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("pytest --cov=mypackage")
+        assert check_readme_cov_path(tmp_path, "mypackage") == []
+
+    def test_mismatch(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("pytest --cov=oldpackage")
+        errors = check_readme_cov_path(tmp_path, "newpackage")
+        assert len(errors) == 1
+        assert "oldpackage" in errors[0]
+
+    def test_no_cov_flag(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("Just run pytest")
+        assert check_readme_cov_path(tmp_path, "anything") == []
+
+    def test_missing_readme(self, tmp_path: Path) -> None:
+        errors = check_readme_cov_path(tmp_path, "pkg")
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+
+class TestCheckAddoptsCovFailUnder:
+    """Tests for check_addopts_cov_fail_under()."""
+
+    def test_absent_is_ok(self, tmp_path: Path) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject())
+        assert check_addopts_cov_fail_under(tmp_path, 80) == []
+
+    def test_matching_value(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            _minimal_pyproject(addopts='addopts = ["--cov=x", "--cov-fail-under=80"]'),
+        )
+        assert check_addopts_cov_fail_under(tmp_path, 80) == []
+
+    def test_mismatch(self, tmp_path: Path) -> None:
+        _write_pyproject(
+            tmp_path,
+            _minimal_pyproject(addopts='addopts = ["--cov=x", "--cov-fail-under=70"]'),
+        )
+        errors = check_addopts_cov_fail_under(tmp_path, 80)
+        assert len(errors) == 1
+        assert "70" in errors[0]
+        assert "80" in errors[0]
+
+
+class TestCheckReadmeTestCount:
+    """Tests for check_readme_test_count()."""
+
+    def test_within_tolerance(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("We have 100 tests.")
+        assert check_readme_test_count(tmp_path, 100) == []
+
+    def test_within_tolerance_comma(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("Over 1,000 tests.")
+        assert check_readme_test_count(tmp_path, 1000) == []
+
+    def test_outside_tolerance(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("We have 50 tests.")
+        errors = check_readme_test_count(tmp_path, 200)
+        assert len(errors) == 1
+        assert "50" in errors[0]
+
+    def test_no_count_in_readme(self, tmp_path: Path) -> None:
+        (tmp_path / "README.md").write_text("No test count here.")
+        assert check_readme_test_count(tmp_path, 100) == []
+
+    def test_missing_readme(self, tmp_path: Path) -> None:
+        errors = check_readme_test_count(tmp_path, 100)
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+
+class TestCollectActualTestCount:
+    """Tests for collect_actual_test_count()."""
+
+    def test_returns_none_on_nonexistent_dir(self, tmp_path: Path) -> None:
+        # No tests/ directory — subprocess will likely return nothing parseable
+        result = collect_actual_test_count(tmp_path)
+        assert result is None or isinstance(result, int)
+
+
+class TestCheckDocConfigConsistency:
+    """Tests for check_doc_config_consistency()."""
+
+    def _setup_valid_repo(self, tmp_path: Path) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject(fail_under=80))
+        (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
+        (tmp_path / "README.md").write_text("Run pytest --cov=hephaestus")
+
+    def test_all_pass(self, tmp_path: Path) -> None:
+        self._setup_valid_repo(tmp_path)
+        result = check_doc_config_consistency(tmp_path, skip_test_count=True)
+        assert result == 0
+
+    def test_threshold_mismatch_fails(self, tmp_path: Path) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject(fail_under=90))
+        (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
+        (tmp_path / "README.md").write_text("")
+        result = check_doc_config_consistency(tmp_path, skip_test_count=True)
+        assert result == 1
+
+    def test_verbose_on_pass(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        self._setup_valid_repo(tmp_path)
+        check_doc_config_consistency(tmp_path, verbose=True, skip_test_count=True)
+        captured = capsys.readouterr()
+        assert "PASS" in captured.out
+
+    def test_missing_pyproject_exits(self, tmp_path: Path) -> None:
+        with pytest.raises(SystemExit) as exc:
+            check_doc_config_consistency(tmp_path, skip_test_count=True)
+        assert exc.value.code == 1
+
+
+class TestMain:
+    """Tests for main() CLI entry point."""
+
+    def test_help(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-doc-config", "--help"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+
+    def test_valid_repo(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject(fail_under=80))
+        (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
+        (tmp_path / "README.md").write_text("Run pytest --cov=hephaestus")
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-check-doc-config",
+                "--repo-root",
+                str(tmp_path),
+                "--skip-test-count",
+            ],
+        )
+        assert main() == 0
+
+    def test_mismatch_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_pyproject(tmp_path, _minimal_pyproject(fail_under=90))
+        (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
+        (tmp_path / "README.md").write_text("")
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-check-doc-config",
+                "--repo-root",
+                str(tmp_path),
+                "--skip-test-count",
+            ],
+        )
+        assert main() == 1

--- a/tests/unit/validation/test_mypy_per_file.py
+++ b/tests/unit/validation/test_mypy_per_file.py
@@ -1,0 +1,163 @@
+"""Tests for hephaestus.validation.mypy_per_file."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.validation.mypy_per_file import (
+    check_mypy_per_file,
+    main,
+    run_mypy_per_file,
+    split_flags_and_files,
+)
+
+
+class TestSplitFlagsAndFiles:
+    """Tests for split_flags_and_files()."""
+
+    def test_no_args(self) -> None:
+        flags, files = split_flags_and_files([])
+        assert flags == []
+        assert files == []
+
+    def test_only_files(self) -> None:
+        flags, files = split_flags_and_files(["a.py", "b.py"])
+        assert flags == []
+        assert files == ["a.py", "b.py"]
+
+    def test_only_flags(self) -> None:
+        flags, files = split_flags_and_files(["--strict", "--ignore-missing-imports"])
+        assert flags == ["--strict", "--ignore-missing-imports"]
+        assert files == []
+
+    def test_mixed(self) -> None:
+        flags, files = split_flags_and_files(
+            ["--ignore-missing-imports", "a.py", "--strict", "b.py"]
+        )
+        assert "--ignore-missing-imports" in flags
+        assert "--strict" in flags
+        assert "a.py" in files
+        assert "b.py" in files
+
+    def test_flag_with_value(self) -> None:
+        flags, files = split_flags_and_files(["--python-version", "3.10", "myfile.py"])
+        assert "--python-version" in flags
+        assert "3.10" in flags
+        assert "myfile.py" in files
+
+    def test_config_file_flag(self) -> None:
+        flags, files = split_flags_and_files(["--config-file", "mypy.ini", "code.py"])
+        assert "--config-file" in flags
+        assert "mypy.ini" in flags
+        assert "code.py" in files
+
+    def test_short_flags(self) -> None:
+        flags, files = split_flags_and_files(["-v", "file.py"])
+        assert "-v" in flags
+        assert "file.py" in files
+
+
+class TestRunMypyPerFile:
+    """Tests for run_mypy_per_file()."""
+
+    def test_no_files_returns_zero(self, capsys: pytest.CaptureFixture) -> None:
+        result = run_mypy_per_file([], flags=[])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "no files" in captured.err
+
+    def test_all_pass_returns_zero(self, tmp_path: Path) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("x: int = 1\n")
+        result = run_mypy_per_file([str(f)], flags=["--ignore-missing-imports"])
+        assert result == 0
+
+    def test_type_error_returns_nonzero(self, tmp_path: Path) -> None:
+        f = tmp_path / "bad.py"
+        # Assign wrong type to a typed variable
+        f.write_text('x: int = "not an int"\n')
+        result = run_mypy_per_file([str(f)], flags=["--ignore-missing-imports"])
+        assert result != 0
+
+    def test_aggregates_multiple_files(self, tmp_path: Path) -> None:
+        good = tmp_path / "good.py"
+        good.write_text("x: int = 1\n")
+        bad = tmp_path / "bad.py"
+        bad.write_text('y: int = "wrong"\n')
+        result = run_mypy_per_file([str(good), str(bad)], flags=["--ignore-missing-imports"])
+        assert result != 0
+
+    def test_custom_python_executable(self, tmp_path: Path) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("x = 1\n")
+        result = run_mypy_per_file(
+            [str(f)],
+            flags=["--ignore-missing-imports"],
+            python_executable=sys.executable,
+        )
+        assert result == 0
+
+    def test_subprocess_called_per_file(self, tmp_path: Path) -> None:
+        files = [str(tmp_path / f"f{i}.py") for i in range(3)]
+        for f in files:
+            Path(f).write_text("x = 1\n")
+
+        call_count = 0
+        original_run = __import__("subprocess").run
+
+        def counting_run(cmd, **kwargs):
+            nonlocal call_count
+            if "mypy" in cmd:
+                call_count += 1
+            return original_run(cmd, **kwargs)
+
+        with patch("subprocess.run", side_effect=counting_run):
+            run_mypy_per_file(files, flags=["--ignore-missing-imports"])
+
+        assert call_count == 3
+
+
+class TestCheckMypyPerFile:
+    """Tests for check_mypy_per_file()."""
+
+    def test_path_objects_accepted(self, tmp_path: Path) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("x: int = 1\n")
+        result = check_mypy_per_file([f], flags=["--ignore-missing-imports"])
+        assert result == 0
+
+    def test_string_paths_accepted(self, tmp_path: Path) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("x: int = 1\n")
+        result = check_mypy_per_file([str(f)], flags=["--ignore-missing-imports"])
+        assert result == 0
+
+
+class TestMain:
+    """Tests for main() CLI entry point."""
+
+    def test_no_files_returns_zero(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        monkeypatch.setattr("sys.argv", ["hephaestus-mypy-each-file"])
+        result = main()
+        assert result == 0
+
+    def test_clean_file_exits_zero(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        f = tmp_path / "clean.py"
+        f.write_text("x: int = 1\n")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["hephaestus-mypy-each-file", "--ignore-missing-imports", str(f)],
+        )
+        assert main() == 0
+
+    def test_help_exits_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["hephaestus-mypy-each-file", "--help"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0

--- a/tests/unit/validation/test_stale_scripts.py
+++ b/tests/unit/validation/test_stale_scripts.py
@@ -1,0 +1,245 @@
+"""Tests for hephaestus.validation.stale_scripts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.validation.stale_scripts import (
+    _is_always_active,
+    check_stale_scripts,
+    find_stale_scripts,
+    get_all_scripts,
+    get_reference_targets,
+    main,
+)
+
+
+def _write_script(scripts_dir: Path, name: str, content: str = "# placeholder\n") -> Path:
+    p = scripts_dir / name
+    p.write_text(content)
+    return p
+
+
+def _write_workflow(tmp_path: Path, name: str, content: str) -> None:
+    workflows = tmp_path / ".github" / "workflows"
+    workflows.mkdir(parents=True, exist_ok=True)
+    (workflows / name).write_text(content)
+
+
+class TestIsAlwaysActive:
+    """Tests for _is_always_active()."""
+
+    def test_common_py(self) -> None:
+        assert _is_always_active("common.py") is True
+
+    def test_conftest(self) -> None:
+        assert _is_always_active("conftest.py") is True
+
+    def test_test_prefix(self) -> None:
+        assert _is_always_active("test_foo.py") is True
+
+    def test_regular_script(self) -> None:
+        assert _is_always_active("bump_version.py") is False
+
+
+class TestGetAllScripts:
+    """Tests for get_all_scripts()."""
+
+    def test_finds_py_files(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "a.py")
+        _write_script(scripts_dir, "b.py")
+        result = get_all_scripts(scripts_dir)
+        assert "a.py" in result
+        assert "b.py" in result
+
+    def test_finds_sh_files(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / "run.sh").write_text("#!/bin/bash\n")
+        result = get_all_scripts(scripts_dir)
+        assert "run.sh" in result
+
+    def test_ignores_dotfiles(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        (scripts_dir / ".hidden.py").write_text("")
+        result = get_all_scripts(scripts_dir)
+        assert ".hidden.py" not in result
+
+    def test_empty_dir(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        assert get_all_scripts(scripts_dir) == []
+
+
+class TestGetReferenceTargets:
+    """Tests for get_reference_targets()."""
+
+    def test_includes_workflow_yml(self, tmp_path: Path) -> None:
+        _write_workflow(tmp_path, "ci.yml", "")
+        targets = get_reference_targets(tmp_path)
+        names = [t.name for t in targets]
+        assert "ci.yml" in names
+
+    def test_includes_justfile(self, tmp_path: Path) -> None:
+        (tmp_path / "justfile").write_text("")
+        targets = get_reference_targets(tmp_path)
+        names = [t.name for t in targets]
+        assert "justfile" in names
+
+    def test_includes_precommit(self, tmp_path: Path) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text("")
+        targets = get_reference_targets(tmp_path)
+        names = [t.name for t in targets]
+        assert ".pre-commit-config.yaml" in names
+
+    def test_includes_scripts(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "helper.py")
+        targets = get_reference_targets(tmp_path)
+        names = [t.name for t in targets]
+        assert "helper.py" in names
+
+    def test_no_directories(self, tmp_path: Path) -> None:
+        targets = get_reference_targets(tmp_path)
+        assert all(t.is_file() for t in targets)
+
+
+class TestFindStaleScripts:
+    """Tests for find_stale_scripts()."""
+
+    def test_referenced_script_not_stale(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "my_tool.py")
+        _write_workflow(tmp_path, "ci.yml", "run: python scripts/my_tool.py")
+        assert find_stale_scripts(tmp_path) == []
+
+    def test_unreferenced_script_is_stale(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "orphan.py")
+        result = find_stale_scripts(tmp_path)
+        assert "orphan.py" in result
+
+    def test_always_active_excluded(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "common.py")
+        assert find_stale_scripts(tmp_path) == []
+
+    def test_exclude_pattern(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "test_helper.py")
+        # Without exclude: test_ is _is_always_active so already excluded
+        # Let's use a non-test name
+        _write_script(scripts_dir, "old_migration.py")
+        result = find_stale_scripts(tmp_path, exclude_pattern="old_migration")
+        assert "old_migration.py" not in result
+
+    def test_cross_referenced_script_not_stale(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "helper.py")
+        _write_script(scripts_dir, "runner.py", "import helper\n")
+        result = find_stale_scripts(tmp_path)
+        # helper.py should be found referenced in runner.py
+        assert "helper.py" not in result
+
+    def test_no_scripts_dir(self, tmp_path: Path) -> None:
+        assert find_stale_scripts(tmp_path) == []
+
+    def test_docs_reference(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "special.py")
+        docs_dir = tmp_path / "docs"
+        docs_dir.mkdir()
+        (docs_dir / "guide.md").write_text("Run `python scripts/special.py` to start.")
+        assert find_stale_scripts(tmp_path) == []
+
+
+class TestCheckStaleScripts:
+    """Tests for check_stale_scripts()."""
+
+    def test_no_stale_returns_zero(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "tool.py")
+        _write_workflow(tmp_path, "ci.yml", "run: python scripts/tool.py")
+        assert check_stale_scripts(tmp_path) == 0
+
+    def test_stale_warning_mode_returns_zero(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "orphan.py")
+        assert check_stale_scripts(tmp_path, strict=False) == 0
+
+    def test_stale_strict_mode_returns_one(self, tmp_path: Path) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "orphan.py")
+        assert check_stale_scripts(tmp_path, strict=True) == 1
+
+    def test_verbose_output(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "tool.py")
+        _write_workflow(tmp_path, "ci.yml", "python scripts/tool.py")
+        check_stale_scripts(tmp_path, verbose=True)
+        captured = capsys.readouterr()
+        assert "Total scripts" in captured.out
+
+
+class TestMain:
+    """Tests for main() CLI entry point."""
+
+    def test_help(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-stale-scripts", "--help"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 0
+
+    def test_no_stale_exits_zero(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "tool.py")
+        _write_workflow(tmp_path, "ci.yml", "python scripts/tool.py")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["hephaestus-check-stale-scripts", "--repo-root", str(tmp_path)],
+        )
+        assert main() == 0
+
+    def test_stale_strict_exits_one(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "orphan.py")
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-check-stale-scripts",
+                "--repo-root",
+                str(tmp_path),
+                "--strict",
+            ],
+        )
+        assert main() == 1
+
+    def test_stale_warning_mode_exits_zero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir()
+        _write_script(scripts_dir, "orphan.py")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["hephaestus-check-stale-scripts", "--repo-root", str(tmp_path)],
+        )
+        assert main() == 0


### PR DESCRIPTION
## Summary

- **`hephaestus.validation.doc_config`** — ports Scylla's `check_doc_config_consistency.py`; enforces consistency between CLAUDE.md/README.md metric values and `pyproject.toml` (coverage threshold, `--cov` path, `--cov-fail-under`, test count). CLI: `hephaestus-check-doc-config`.
- **`hephaestus.validation.stale_scripts`** — merges Odyssey's `check_stale_scripts.py` (exit-0 warn) and `detect_stale_scripts.py` (exit-1 strict) into a single module; detects `scripts/` files unreferenced in CI/justfile/docs. CLI: `hephaestus-check-stale-scripts --strict`.
- **`hephaestus.validation.mypy_per_file`** — ports Odyssey's `mypy-each-file.py`; runs mypy once per file to avoid duplicate-module-name errors in multi-file directories. CLI: `hephaestus-mypy-each-file`.

Part of the sequential PR series porting generic scripts → Hephaestus (L2 of 13).

## Test plan

- [ ] 79 new unit tests covering all public functions and CLI entry points
- [ ] Full suite: 1457 tests, 84.81% coverage (≥ 80% threshold met)
- [ ] `ruff check` + `ruff format` — no issues
- [ ] `mypy` — no issues (163 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)