### PR TITLE
[Feat] Port config.dep_sync from Odyssey + shell helpers from Scylla (L4)

### DIFF
--- a/hephaestus/config/__init__.py
+++ b/hephaestus/config/__init__.py
@@ -1,6 +1,14 @@
 """Configuration management utilities."""
 
-from .utils import (
+from hephaestus.config.dep_sync import (
+    check_dep_sync,
+    check_requirements_up_to_date,
+    generate_requirements_content,
+    parse_pixi_toml,
+    parse_requirements,
+    sync_requirements,
+)
+from hephaestus.config.utils import (
     get_config_value,
     get_setting,
     load_config,
@@ -11,11 +19,17 @@ from .utils import (
 )
 
 __all__ = [
+    "check_dep_sync",
+    "check_requirements_up_to_date",
+    "generate_requirements_content",
     "get_config_value",
     "get_setting",
     "load_config",
     "load_yaml_config",
     "merge_configs",
     "merge_with_env",
+    "parse_pixi_toml",
+    "parse_requirements",
+    "sync_requirements",
     "validate_config",
 ]

--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -1,0 +1,550 @@
+"""Validate and synchronize dependency declarations across project config files.
+
+Provides two main operations:
+
+**Check** (``hephaestus-check-dep-sync``): Validates that every package pinned in
+``requirements*.txt`` has a corresponding entry in ``pixi.toml`` and that the
+pinned version falls within the ``pixi.toml`` range constraint.  Also reports if
+``pyproject.toml`` still carries ``[project.dependencies]`` (which should be
+managed in ``pixi.toml`` instead).
+
+**Sync** (``hephaestus-sync-requirements``): Re-generates ``requirements.txt`` and
+``requirements-dev.txt`` from the pixi-resolved environment (``pixi list --json``),
+so that pip-only contexts (Docker, CI fallback) stay in sync with the authoritative
+pixi lock.
+
+Usage::
+
+    hephaestus-check-dep-sync
+    hephaestus-check-dep-sync --repo-root /path/to/repo
+
+    hephaestus-sync-requirements
+    hephaestus-sync-requirements --check   # verify without writing
+    hephaestus-sync-requirements --repo-root /path/to/repo
+
+Exit codes:
+    0  All checks pass (or sync succeeded)
+    1  Violations detected (check) or sync failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# Header written at the top of every auto-generated requirements file.
+_GENERATED_HEADER = """\
+# AUTO-GENERATED from pixi.toml — do not edit manually.
+# Regenerate with: hephaestus-sync-requirements
+# These files exist for pip-only contexts (Docker, CI fallback).
+"""
+
+
+# ---------------------------------------------------------------------------
+# Version comparison helpers
+# ---------------------------------------------------------------------------
+
+
+class VersionRange(NamedTuple):
+    """A single version constraint (operator + version tuple)."""
+
+    op: str
+    version: tuple[int, ...]
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a tuple of ints.
+
+    Args:
+        v: Version string like ``"1.2.3"``.
+
+    Returns:
+        Tuple of integers, e.g. ``(1, 2, 3)``.
+
+    """
+    return tuple(int(x) for x in re.split(r"[.\-]", v) if x.isdigit())
+
+
+def _parse_constraints(spec: str) -> list[VersionRange]:
+    """Parse a pixi.toml version spec into a list of :class:`VersionRange`.
+
+    Args:
+        spec: Version specification string, e.g. ``">=1.2.0,<2"``.
+
+    Returns:
+        List of parsed constraints.
+
+    """
+    constraints: list[VersionRange] = []
+    spec = spec.strip().strip('"').strip("'")
+    for part in spec.split(","):
+        part = part.strip()
+        m = re.match(r"(>=|<=|>|<|==|!=|~=)(.+)", part)
+        if m:
+            op, ver = m.group(1), m.group(2)
+            constraints.append(VersionRange(op=op, version=_parse_version(ver)))
+    return constraints
+
+
+def _version_satisfies(version: tuple[int, ...], constraints: list[VersionRange]) -> bool:
+    """Return True if *version* satisfies all *constraints*.
+
+    Args:
+        version: Parsed version tuple.
+        constraints: List of constraints to check against.
+
+    Returns:
+        True if all constraints are satisfied.
+
+    """
+    for c in constraints:
+        v = version + (0,) * max(0, len(c.version) - len(version))
+        cv = c.version + (0,) * max(0, len(version) - len(c.version))
+        ops = {
+            ">=": v >= cv,
+            "<=": v <= cv,
+            ">": v > cv,
+            "<": v < cv,
+            "==": v == cv,
+            "!=": v != cv,
+        }
+        satisfied = ops.get(c.op, True)
+        if not satisfied:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_pixi_toml(path: Path) -> dict[str, str]:
+    """Extract package→version-spec from ``pixi.toml`` dependency sections.
+
+    Reads ``[dependencies]`` and ``[pypi-dependencies]`` sections using a
+    simple line-by-line parser (avoids a TOML dependency for 3.10 compat).
+
+    Args:
+        path: Path to ``pixi.toml``.
+
+    Returns:
+        Dict mapping package name to version spec string.
+
+    """
+    deps: dict[str, str] = {}
+    in_deps = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[dependencies]") or stripped.startswith(
+            "[pypi-dependencies]"
+        ):
+            in_deps = True
+            continue
+        if stripped.startswith("[") and in_deps:
+            in_deps = False
+            continue
+        if in_deps and "=" in stripped and not stripped.startswith("#"):
+            line_no_comment = stripped.split("#")[0].strip()
+            m = re.match(r'(\S+)\s*=\s*"([^"]+)"', line_no_comment)
+            if m:
+                deps[m.group(1)] = m.group(2)
+    return deps
+
+
+def parse_requirements(path: Path) -> dict[str, str]:
+    """Extract package→pinned-version from a requirements file.
+
+    Args:
+        path: Path to the requirements file.
+
+    Returns:
+        Dict mapping package name (lowercased) to pinned version string.
+
+    """
+    pins: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-r"):
+            continue
+        stripped = stripped.split("#")[0].strip()
+        m = re.match(r"([a-zA-Z0-9_.-]+)==(.+)", stripped)
+        if m:
+            pins[m.group(1).lower()] = m.group(2).strip()
+    return pins
+
+
+# ---------------------------------------------------------------------------
+# Check operations
+# ---------------------------------------------------------------------------
+
+
+def check_pyproject_no_deps(path: Path) -> list[str]:
+    """Return errors if ``pyproject.toml`` carries managed dependency sections.
+
+    Flags ``[project.dependencies]`` and ``[project.optional-dependencies]``
+    which should be managed in ``pixi.toml`` instead.
+
+    Args:
+        path: Path to ``pyproject.toml``.
+
+    Returns:
+        List of error strings.
+
+    """
+    errors: list[str] = []
+    if not path.exists():
+        return errors
+    text = path.read_text(encoding="utf-8")
+    if re.search(r"^\[project\.dependencies\]", text, re.MULTILINE):
+        errors.append("pyproject.toml contains [project.dependencies] — remove it")
+    if "[project.optional-dependencies]" in text:
+        errors.append(
+            "pyproject.toml contains [project.optional-dependencies] — remove it"
+        )
+    return errors
+
+
+def check_requirements_against_pixi(
+    repo_root: Path,
+    pixi_deps_lower: dict[str, str],
+) -> list[str]:
+    """Check that requirements files are consistent with ``pixi.toml``.
+
+    Args:
+        repo_root: Repository root directory.
+        pixi_deps_lower: Lowercased package→spec dict from ``pixi.toml``.
+
+    Returns:
+        List of error strings.
+
+    """
+    errors: list[str] = []
+    for req_name in ("requirements.txt", "requirements-dev.txt"):
+        req_path = repo_root / req_name
+        if not req_path.exists():
+            continue
+        pins = parse_requirements(req_path)
+        for pkg, pinned_ver in pins.items():
+            if pkg not in pixi_deps_lower:
+                errors.append(
+                    f"{req_name}: {pkg}=={pinned_ver} has no matching entry in pixi.toml"
+                )
+                continue
+            constraints = _parse_constraints(pixi_deps_lower[pkg])
+            if constraints:
+                ver_tuple = _parse_version(pinned_ver)
+                if not _version_satisfies(ver_tuple, constraints):
+                    errors.append(
+                        f"{req_name}: {pkg}=={pinned_ver} falls outside "
+                        f"pixi.toml constraint '{pixi_deps_lower[pkg]}'"
+                    )
+    return errors
+
+
+def check_dep_sync(repo_root: Path | None = None) -> list[str]:
+    """Run all dependency consistency checks.
+
+    Args:
+        repo_root: Repository root.  Defaults to auto-detection via git.
+
+    Returns:
+        List of error messages (empty = all checks passed).
+
+    """
+    if repo_root is None:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    errors: list[str] = []
+    pixi_path = repo_root / "pixi.toml"
+
+    if not pixi_path.exists():
+        return ["pixi.toml not found"]
+
+    pixi_deps = parse_pixi_toml(pixi_path)
+    pixi_deps_lower = {k.lower(): v for k, v in pixi_deps.items()}
+
+    errors.extend(check_requirements_against_pixi(repo_root, pixi_deps_lower))
+    errors.extend(check_pyproject_no_deps(repo_root / "pyproject.toml"))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Sync operations
+# ---------------------------------------------------------------------------
+
+
+def get_pixi_packages() -> dict[str, str]:
+    """Return ``{package_name: version}`` from ``pixi list --json``.
+
+    Returns:
+        Dict mapping package names to resolved version strings.
+
+    Raises:
+        SystemExit: With code 1 if ``pixi list`` fails.
+
+    """
+    result = subprocess.run(
+        ["pixi", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"ERROR: pixi list --json failed: {result.stderr}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    data: list[dict[str, str]] = json.loads(result.stdout)
+    return {pkg["name"]: pkg["version"] for pkg in data}
+
+
+def generate_requirements_content(
+    packages: list[str],
+    resolved: dict[str, str],
+    include_base: str | None = None,
+    section_comments: dict[str, str] | None = None,
+) -> str:
+    """Build a requirements file string with exact pins.
+
+    Args:
+        packages: Package names to include.
+        resolved: Mapping of package name to resolved version.
+        include_base: Optional ``-r <file>`` line to prepend.
+        section_comments: Optional per-package inline comments.
+
+    Returns:
+        Full file content as a string.
+
+    """
+    comments = section_comments or {}
+    lines: list[str] = [_GENERATED_HEADER]
+    if include_base:
+        lines += [include_base, ""]
+
+    for pkg in packages:
+        version = resolved.get(pkg)
+        if version is None:
+            print(
+                f"WARNING: {pkg} not found in pixi environment, skipping",
+                file=sys.stderr,
+            )
+            continue
+        comment = comments.get(pkg, "")
+        suffix = f"  {comment}" if comment else ""
+        lines.append(f"{pkg}=={version}{suffix}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def sync_requirements(
+    repo_root: Path,
+    resolved: dict[str, str],
+    core_packages: list[str],
+    dev_packages: list[str],
+    core_comments: dict[str, str] | None = None,
+    dev_comments: dict[str, str] | None = None,
+) -> list[Path]:
+    """Write ``requirements.txt`` and ``requirements-dev.txt`` under *repo_root*.
+
+    Args:
+        repo_root: Repository root directory.
+        resolved: Package-to-version mapping from pixi.
+        core_packages: Packages for ``requirements.txt``.
+        dev_packages: Packages for ``requirements-dev.txt``.
+        core_comments: Per-package comments for ``requirements.txt``.
+        dev_comments: Per-package comments for ``requirements-dev.txt``.
+
+    Returns:
+        List of paths written.
+
+    """
+    req_txt = generate_requirements_content(
+        core_packages, resolved, section_comments=core_comments
+    )
+    req_dev_txt = generate_requirements_content(
+        dev_packages,
+        resolved,
+        include_base="-r requirements.txt",
+        section_comments=dev_comments,
+    )
+    paths: list[Path] = []
+    for name, content in [
+        ("requirements.txt", req_txt),
+        ("requirements-dev.txt", req_dev_txt),
+    ]:
+        path = repo_root / name
+        path.write_text(content, encoding="utf-8")
+        paths.append(path)
+        print(f"Wrote {path}")
+    return paths
+
+
+def check_requirements_up_to_date(
+    repo_root: Path,
+    resolved: dict[str, str],
+    core_packages: list[str],
+    dev_packages: list[str],
+    core_comments: dict[str, str] | None = None,
+    dev_comments: dict[str, str] | None = None,
+) -> bool:
+    """Return True if existing requirements files match expected content.
+
+    Args:
+        repo_root: Repository root directory.
+        resolved: Package-to-version mapping from pixi.
+        core_packages: Packages for ``requirements.txt``.
+        dev_packages: Packages for ``requirements-dev.txt``.
+        core_comments: Per-package comments for ``requirements.txt``.
+        dev_comments: Per-package comments for ``requirements-dev.txt``.
+
+    Returns:
+        True if both files are current, False if any are missing or out of date.
+
+    """
+    expected = {
+        "requirements.txt": generate_requirements_content(
+            core_packages, resolved, section_comments=core_comments
+        ),
+        "requirements-dev.txt": generate_requirements_content(
+            dev_packages,
+            resolved,
+            include_base="-r requirements.txt",
+            section_comments=dev_comments,
+        ),
+    }
+    ok = True
+    for name, expected_content in expected.items():
+        path = repo_root / name
+        if not path.exists():
+            print(f"FAIL: {name} does not exist", file=sys.stderr)
+            ok = False
+            continue
+        if path.read_text(encoding="utf-8") != expected_content:
+            print(
+                f"FAIL: {name} is out of date — "
+                f"regenerate with: hephaestus-sync-requirements",
+                file=sys.stderr,
+            )
+            ok = False
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def check_dep_sync_main() -> int:
+    """CLI entry point for dependency consistency checking.
+
+    Returns:
+        Exit code (0 if all checks pass, 1 if violations found).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate dependency consistency across project config files",
+        epilog="Example: %(prog)s --repo-root /path/to/repo",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect via git)",
+    )
+    args = parser.parse_args()
+
+    errors = check_dep_sync(args.repo_root)
+    if errors:
+        print("Dependency sync check FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("OK: all dependency declarations are consistent")
+    return 0
+
+
+def sync_requirements_main() -> int:
+    """CLI entry point for requirements-file synchronisation.
+
+    Reads pixi-resolved packages and writes (or checks) requirements files.
+    Callers should pass ``--core`` / ``--dev`` flags to specify which packages
+    belong in each file, or rely on the calling repo's wrapper script.
+
+    Returns:
+        Exit code (0 on success, 1 on failure).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Sync requirements*.txt from pixi-resolved environment",
+        epilog="Example: %(prog)s --check",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify files are up-to-date without writing (exit 1 if not)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect via git)",
+    )
+    parser.add_argument(
+        "--core",
+        nargs="*",
+        default=[],
+        metavar="PKG",
+        help="Core packages for requirements.txt",
+    )
+    parser.add_argument(
+        "--dev",
+        nargs="*",
+        default=[],
+        metavar="PKG",
+        help="Dev-only packages for requirements-dev.txt",
+    )
+
+    args = parser.parse_args()
+
+    if args.repo_root is not None:
+        repo_root: Path = args.repo_root
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    resolved = get_pixi_packages()
+
+    if args.check:
+        ok = check_requirements_up_to_date(
+            repo_root,
+            resolved,
+            core_packages=args.core,
+            dev_packages=args.dev,
+        )
+        if ok:
+            print("OK: requirements files are up-to-date")
+            return 0
+        return 1
+
+    sync_requirements(
+        repo_root,
+        resolved,
+        core_packages=args.core,
+        dev_packages=args.dev,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_dep_sync_main())

--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -141,9 +141,7 @@ def parse_pixi_toml(path: Path) -> dict[str, str]:
     in_deps = False
     for line in path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
-        if stripped.startswith("[dependencies]") or stripped.startswith(
-            "[pypi-dependencies]"
-        ):
+        if stripped.startswith("[dependencies]") or stripped.startswith("[pypi-dependencies]"):
             in_deps = True
             continue
         if stripped.startswith("[") and in_deps:
@@ -204,9 +202,7 @@ def check_pyproject_no_deps(path: Path) -> list[str]:
     if re.search(r"^\[project\.dependencies\]", text, re.MULTILINE):
         errors.append("pyproject.toml contains [project.dependencies] — remove it")
     if "[project.optional-dependencies]" in text:
-        errors.append(
-            "pyproject.toml contains [project.optional-dependencies] — remove it"
-        )
+        errors.append("pyproject.toml contains [project.optional-dependencies] — remove it")
     return errors
 
 
@@ -232,9 +228,7 @@ def check_requirements_against_pixi(
         pins = parse_requirements(req_path)
         for pkg, pinned_ver in pins.items():
             if pkg not in pixi_deps_lower:
-                errors.append(
-                    f"{req_name}: {pkg}=={pinned_ver} has no matching entry in pixi.toml"
-                )
+                errors.append(f"{req_name}: {pkg}=={pinned_ver} has no matching entry in pixi.toml")
                 continue
             constraints = _parse_constraints(pixi_deps_lower[pkg])
             if constraints:
@@ -367,9 +361,7 @@ def sync_requirements(
         List of paths written.
 
     """
-    req_txt = generate_requirements_content(
-        core_packages, resolved, section_comments=core_comments
-    )
+    req_txt = generate_requirements_content(core_packages, resolved, section_comments=core_comments)
     req_dev_txt = generate_requirements_content(
         dev_packages,
         resolved,
@@ -430,8 +422,7 @@ def check_requirements_up_to_date(
             continue
         if path.read_text(encoding="utf-8") != expected_content:
             print(
-                f"FAIL: {name} is out of date — "
-                f"regenerate with: hephaestus-sync-requirements",
+                f"FAIL: {name} is out of date — regenerate with: hephaestus-sync-requirements",
                 file=sys.stderr,
             )
             ok = False

--- a/pixi.lock
+++ b/pixi.lock
@@ -937,7 +937,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.6.0
-  sha256: 8b4193f9fbb209b18bcf79e04d0145838510ef8466d73b8418416f1659431b79
+  sha256: cb1cfbcb0a5dab71edaf015b142d1abce02d96e5f23174d0827307e6252730aa
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ hephaestus-check-stale-scripts = "hephaestus.validation.stale_scripts:main"
 hephaestus-mypy-each-file = "hephaestus.validation.mypy_per_file:main"
 hephaestus-check-links = "hephaestus.markdown.link_fixer:main"
 hephaestus-validate-anchors = "hephaestus.markdown.anchors:main"
+hephaestus-check-dep-sync = "hephaestus.config.dep_sync:check_dep_sync_main"
+hephaestus-sync-requirements = "hephaestus.config.dep_sync:sync_requirements_main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/scripts/shell/cleanup-stale-worktrees.sh
+++ b/scripts/shell/cleanup-stale-worktrees.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Clean up stale git worktrees for closed/merged GitHub issues.
+#
+# Detects stale worktrees via two independent signals:
+#   1. Associated GitHub issue is closed (CLOSED state)
+#   2. Branch is merged into main
+#
+# Usage:
+#   ./scripts/shell/cleanup-stale-worktrees.sh [OPTIONS]
+#
+# Options:
+#   --force           Auto-cleanup without prompting (non-interactive)
+#   --log-file PATH   Override default log file path
+#   --dry-run         Show what would be cleaned without making changes
+#   --help            Show this help message
+#
+# Logs cleanup actions to ~/.cache/hephaestus/worktree-cleanup.log by default.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+DEFAULT_LOG_FILE="${HOME}/.cache/hephaestus/worktree-cleanup.log"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $1"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+log_skip()  { echo -e "${BLUE}[SKIP]${NC}  $1"; }
+
+# Append a timestamped entry to the log file.
+# Arguments:
+#   $1  action  (REMOVED | SKIPPED | DRY_RUN)
+#   $2  path
+#   $3  branch
+#   $4  issue   (number or "none")
+log_action() {
+    local action="$1" path="$2" branch="$3" issue="$4"
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    mkdir -p "$(dirname "$LOG_FILE")"
+    echo "${timestamp} ${action} path=${path} branch=${branch} issue=${issue}" >> "$LOG_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+FORCE=false
+DRY_RUN=false
+LOG_FILE="$DEFAULT_LOG_FILE"
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/{ /^#/{ s/^# \{0,1\}//; p }; /^[^#]/q }' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force)    FORCE=true;        shift ;;
+        --dry-run)  DRY_RUN=true;      shift ;;
+        --log-file) LOG_FILE="$2";     shift 2 ;;
+        --help|-h)  usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Detect main branch dynamically
+# ---------------------------------------------------------------------------
+get_main_branch() {
+    git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+        | sed 's@^refs/remotes/origin/@@' \
+        || echo "main"
+}
+
+# ---------------------------------------------------------------------------
+# Parse `git worktree list --porcelain` into parallel arrays.
+# Outputs lines of the form: <path> <branch>
+# Skips bare worktrees and worktrees with detached HEAD.
+# ---------------------------------------------------------------------------
+list_worktrees() {
+    local path="" branch=""
+    while IFS= read -r line; do
+        if [[ $line =~ ^worktree[[:space:]](.+)$ ]]; then
+            path="${BASH_REMATCH[1]}"
+            branch=""
+        elif [[ $line =~ ^branch[[:space:]]refs/heads/(.+)$ ]]; then
+            branch="${BASH_REMATCH[1]}"
+        elif [[ -z "$line" ]]; then
+            # End of stanza — emit if we have both fields
+            if [[ -n "$path" && -n "$branch" ]]; then
+                echo "$path $branch"
+            fi
+            path=""
+            branch=""
+        fi
+    done < <(git worktree list --porcelain; echo "")
+}
+
+# ---------------------------------------------------------------------------
+# Check if a branch is merged into main.
+# Arguments: $1 branch, $2 main_branch
+# ---------------------------------------------------------------------------
+is_merged() {
+    local branch="$1" main_branch="$2"
+    git branch --merged "$main_branch" 2>/dev/null | grep -qE "(^|\s)${branch}$"
+}
+
+# ---------------------------------------------------------------------------
+# Check if a GitHub issue is closed.
+# Arguments: $1 issue_number
+# Returns 0 if closed, 1 otherwise.
+# Echos the issue state on stdout for the caller.
+# ---------------------------------------------------------------------------
+issue_state() {
+    local issue="$1"
+    gh issue view "$issue" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN"
+}
+
+# ---------------------------------------------------------------------------
+# Safety: check for uncommitted changes in a worktree.
+# Arguments: $1 worktree_path
+# Returns 0 if dirty, 1 if clean.
+# ---------------------------------------------------------------------------
+is_dirty() {
+    local path="$1"
+    [[ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Safety: check if a worktree is locked.
+# Arguments: $1 worktree_path
+# ---------------------------------------------------------------------------
+is_locked() {
+    local path="$1"
+    git worktree list --porcelain 2>/dev/null \
+        | grep -A 3 "^worktree ${path}$" \
+        | grep -q "^locked"
+}
+
+# ---------------------------------------------------------------------------
+# Remove a worktree and optionally delete its branch.
+# Arguments: $1 path, $2 branch, $3 issue
+# ---------------------------------------------------------------------------
+remove_worktree() {
+    local path="$1" branch="$2" issue="$3"
+
+    if $DRY_RUN; then
+        log_info "[DRY-RUN] Would remove: ${path} (branch: ${branch}, issue: #${issue})"
+        log_action "DRY_RUN" "$path" "$branch" "$issue"
+        return 0
+    fi
+
+    if git worktree remove "$path" 2>/dev/null; then
+        log_info "Removed worktree: ${path}"
+        # Best-effort branch deletion (may already be gone)
+        if git branch -d "$branch" 2>/dev/null; then
+            log_info "Deleted branch: ${branch}"
+        fi
+        log_action "REMOVED" "$path" "$branch" "$issue"
+    else
+        log_warn "git worktree remove failed for ${path} — try: git worktree remove --force ${path}"
+        log_action "SKIPPED" "$path" "$branch" "$issue"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    local main_branch
+    main_branch=$(get_main_branch)
+    local root_dir
+    root_dir=$(git rev-parse --show-toplevel)
+
+    local stale_count=0 cleaned_count=0 skipped_count=0
+
+    echo "Scanning worktrees (main branch: ${main_branch})..."
+    echo ""
+
+    while IFS=' ' read -r wt_path wt_branch; do
+        # Skip the main worktree
+        if [[ "$wt_path" == "$root_dir" ]]; then
+            continue
+        fi
+
+        # Extract leading issue number from branch name (e.g. "736-description" → "736")
+        local issue_number=""
+        issue_number=$(echo "$wt_branch" | grep -oP '^\d+' || true)
+
+        # Determine staleness: issue closed OR branch merged
+        local is_stale=false reason=""
+
+        if [[ -n "$issue_number" ]]; then
+            local state
+            state=$(issue_state "$issue_number")
+            if [[ "$state" == "CLOSED" ]]; then
+                is_stale=true
+                reason="issue #${issue_number} is CLOSED"
+            fi
+        fi
+
+        if ! $is_stale && is_merged "$wt_branch" "$main_branch"; then
+            is_stale=true
+            reason="branch merged into ${main_branch}"
+        fi
+
+        if ! $is_stale; then
+            continue
+        fi
+
+        stale_count=$((stale_count + 1))
+        echo "Stale worktree found:"
+        echo "  Path:   ${wt_path}"
+        echo "  Branch: ${wt_branch}"
+        echo "  Reason: ${reason}"
+
+        # Safety: skip dirty worktrees
+        if is_dirty "$wt_path"; then
+            log_warn "Skipping (uncommitted changes present): ${wt_path}"
+            log_action "SKIPPED" "$wt_path" "$wt_branch" "${issue_number:-none}"
+            skipped_count=$((skipped_count + 1))
+            echo ""
+            continue
+        fi
+
+        # Safety: skip locked worktrees
+        if is_locked "$wt_path"; then
+            log_warn "Skipping (worktree is locked): ${wt_path}"
+            log_action "SKIPPED" "$wt_path" "$wt_branch" "${issue_number:-none}"
+            skipped_count=$((skipped_count + 1))
+            echo ""
+            continue
+        fi
+
+        if $FORCE || $DRY_RUN; then
+            remove_worktree "$wt_path" "$wt_branch" "${issue_number:-none}"
+            if ! $DRY_RUN; then cleaned_count=$((cleaned_count + 1)); fi
+        else
+            local reply
+            read -r -p "  Remove worktree? (y/N) " reply
+            if [[ $reply =~ ^[Yy]$ ]]; then
+                remove_worktree "$wt_path" "$wt_branch" "${issue_number:-none}"
+                cleaned_count=$((cleaned_count + 1))
+            else
+                log_skip "Kept: ${wt_path}"
+                log_action "SKIPPED" "$wt_path" "$wt_branch" "${issue_number:-none}"
+                skipped_count=$((skipped_count + 1))
+            fi
+        fi
+
+        echo ""
+    done < <(list_worktrees)
+
+    echo "--------------------------------------"
+    if [[ $stale_count -eq 0 ]]; then
+        log_info "No stale worktrees found."
+    else
+        local mode_label=""
+        $DRY_RUN && mode_label=" [DRY-RUN]"
+        log_info "Summary${mode_label}: ${stale_count} stale found, ${cleaned_count} cleaned, ${skipped_count} skipped."
+        if [[ $cleaned_count -gt 0 ]] || $DRY_RUN; then
+            log_info "Log: ${LOG_FILE}"
+        fi
+    fi
+}
+
+main "$@"

--- a/scripts/shell/install_hooks.sh
+++ b/scripts/shell/install_hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Install git hooks from scripts/hooks/ into .git/hooks/.
+#
+# Usage:
+#   bash scripts/shell/install_hooks.sh
+#
+# Hooks installed:
+#   pre-push  — runs pytest with coverage check before every push
+#
+# Exit codes:
+#   0 = all hooks installed successfully
+#   1 = must be run from repository root or git repo not found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOOKS_SRC="${SCRIPT_DIR}/../hooks"
+HOOKS_DST="${REPO_ROOT}/.git/hooks"
+
+# Verify we're inside a git repo
+if [[ ! -d "${HOOKS_DST}" ]]; then
+    echo "Error: .git/hooks not found — run this script from the repository root."
+    exit 1
+fi
+
+installed=0
+for src in "${HOOKS_SRC}"/*; do
+    hook_name="$(basename "${src}")"
+    dst="${HOOKS_DST}/${hook_name}"
+
+    if [[ -e "${dst}" && ! -L "${dst}" ]]; then
+        echo "Backing up existing ${hook_name} → ${dst}.bak"
+        cp "${dst}" "${dst}.bak"
+    fi
+
+    cp "${src}" "${dst}"
+    chmod +x "${dst}"
+    echo "Installed ${hook_name} → .git/hooks/${hook_name}"
+    installed=$((installed + 1))
+done
+
+echo ""
+echo "Installed ${installed} hook(s). Run 'git push' to verify."

--- a/scripts/shell/preflight_check.sh
+++ b/scripts/shell/preflight_check.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# Pre-flight check before starting work on a GitHub issue.
+#
+# Runs 6 checks in order, stopping immediately on critical failures.
+# Critical failures (exit 1): closed issue, merged PR, worktree conflict
+# Warnings (exit 0): existing commits, open PRs, existing branches
+#
+# Usage:
+#   bash /path/to/scripts/shell/preflight_check.sh <issue-number>
+#   bash "$(dirname "${BASH_SOURCE[0]}")/preflight_check.sh" <issue-number>
+#
+# Exit codes:
+#   0 = all checks passed (or only warnings)
+#   1 = critical failure - do not proceed
+
+# Self-locating: works regardless of caller's CWD
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set -uo pipefail
+
+ISSUE="${1:-}"
+
+if [[ -z "$ISSUE" ]]; then
+    echo "Error: issue number required"
+    echo "Usage: $0 <issue-number>"
+    exit 1
+fi
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass()  { echo -e "${GREEN}[PASS]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+stop()  { echo -e "${RED}[STOP]${NC} $*"; }
+info()  { echo -e "${CYAN}[INFO]${NC} $*"; }
+
+echo "Pre-flight check for issue #${ISSUE}"
+echo "========================================"
+
+# ---------------------------------------------------------------------------
+# Check 1: Issue State (CRITICAL)
+# ---------------------------------------------------------------------------
+STATE_JSON=$(gh issue view "$ISSUE" --json state,title,closedAt 2>/dev/null) || {
+    stop "Check 1: Cannot fetch issue #${ISSUE} - verify issue number"
+    exit 1
+}
+ISSUE_STATE=$(echo "$STATE_JSON" | jq -r '.state')
+ISSUE_TITLE=$(echo "$STATE_JSON" | jq -r '.title')
+
+if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+    CLOSED_AT=$(echo "$STATE_JSON" | jq -r '.closedAt')
+    stop "Check 1: Issue #${ISSUE} is CLOSED (${CLOSED_AT})"
+    echo "         Title: ${ISSUE_TITLE}"
+    echo "         Do not proceed - work may already be complete."
+    exit 1
+fi
+pass "Check 1: Issue #${ISSUE} is OPEN - \"${ISSUE_TITLE}\""
+
+# ---------------------------------------------------------------------------
+# Check 2: Existing commits (WARNING)
+# ---------------------------------------------------------------------------
+EXISTING_COMMITS=$(git log --all --oneline --grep="#${ISSUE}" 2>/dev/null | head -5)
+if [[ -n "$EXISTING_COMMITS" ]]; then
+    warn "Check 2: Found existing commits referencing #${ISSUE}"
+    echo "$EXISTING_COMMITS" | while IFS= read -r line; do
+        echo "         $line"
+    done
+else
+    pass "Check 2: No existing commits found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: PR Search (CRITICAL if merged, WARNING if open)
+# Uses a single GraphQL search query with closingIssuesReferences for precise
+# match — searches ALL PRs (not just the 100 most recent) in one API call.
+# Falls back to the REST N+1 approach if GraphQL fails.
+# ---------------------------------------------------------------------------
+MERGED_PRS=""
+OPEN_PRS=""
+
+# Fetch repo owner/name for the GraphQL query
+REPO_FULL=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || REPO_FULL=""
+
+_graphql_check3() {
+    local repo="$1" issue="$2"
+    local query merged="" open="" pr_num pr_title pr_state
+    # shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable
+    query='query($q:String!){search(query:$q,type:ISSUE,first:100){nodes{...on PullRequest{number,title,state,closingIssuesReferences(first:25){nodes{number}}}}}}'
+    local result
+    result=$(gh api graphql -f "query=${query}" -f "q=repo:${repo} is:pr ${issue}" 2>/dev/null) || return 1
+    while IFS= read -r pr_entry; do
+        pr_num=$(echo "$pr_entry" | jq -r '.number')
+        pr_title=$(echo "$pr_entry" | jq -r '.title')
+        pr_state=$(echo "$pr_entry" | jq -r '.state')
+        [[ -z "$pr_num" || "$pr_num" == "null" ]] && continue
+        if echo "$pr_entry" | jq -e ".closingIssuesReferences.nodes[] | select(.number == ${issue})" >/dev/null 2>&1; then
+            if [[ "$pr_state" == "MERGED" ]]; then
+                merged+="${pr_num}: ${pr_title}"$'\n'
+            elif [[ "$pr_state" == "OPEN" ]]; then
+                open+="${pr_num}: ${pr_title}"$'\n'
+            fi
+        fi
+    done < <(echo "$result" | jq -c '.data.search.nodes[]' 2>/dev/null)
+    MERGED_PRS="${merged%$'\n'}"
+    OPEN_PRS="${open%$'\n'}"
+}
+
+_rest_check3() {
+    local issue="$1"
+    local candidate_json merged="" open=""
+    candidate_json=$(gh pr list --state all --json number,title,state --limit 100 2>/dev/null) || return 1
+    while IFS= read -r pr_entry; do
+        local pr_num pr_title pr_state closes
+        pr_num=$(echo "$pr_entry" | jq -r '.number')
+        pr_title=$(echo "$pr_entry" | jq -r '.title')
+        pr_state=$(echo "$pr_entry" | jq -r '.state')
+        [[ -z "$pr_num" || "$pr_num" == "null" ]] && continue
+        closes=$(gh pr view "$pr_num" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[].number' 2>/dev/null)
+        if echo "$closes" | grep -qx "$issue"; then
+            if [[ "$pr_state" == "MERGED" ]]; then
+                merged+="${pr_num}: ${pr_title}"$'\n'
+            elif [[ "$pr_state" == "OPEN" ]]; then
+                open+="${pr_num}: ${pr_title}"$'\n'
+            fi
+        fi
+    done < <(echo "$candidate_json" | jq -c '.[]')
+    MERGED_PRS="${merged%$'\n'}"
+    OPEN_PRS="${open%$'\n'}"
+}
+
+if [[ -n "$REPO_FULL" ]] && _graphql_check3 "$REPO_FULL" "$ISSUE"; then
+    : # GraphQL succeeded
+else
+    _rest_check3 "$ISSUE"
+fi
+
+if [[ -n "$MERGED_PRS" ]]; then
+    stop "Check 3: Issue #${ISSUE} already has a MERGED PR"
+    echo "$MERGED_PRS" | while IFS= read -r line; do
+        echo "         PR #${line}"
+    done
+    echo "         Do not proceed - likely duplicate work."
+    exit 1
+elif [[ -n "$OPEN_PRS" ]]; then
+    warn "Check 3: Issue #${ISSUE} has an OPEN PR - coordinate before proceeding"
+    echo "$OPEN_PRS" | while IFS= read -r line; do
+        echo "         PR #${line}"
+    done
+else
+    pass "Check 3: No conflicting PRs found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Worktree conflicts (CRITICAL)
+# ---------------------------------------------------------------------------
+WORKTREE_MATCH=$(git worktree list 2>/dev/null | grep "$ISSUE" || true)
+if [[ -n "$WORKTREE_MATCH" ]]; then
+    stop "Check 4: Worktree already exists for issue #${ISSUE}"
+    echo "         ${WORKTREE_MATCH}"
+    echo "         Navigate to existing worktree or remove it first."
+    exit 1
+fi
+pass "Check 4: No worktree conflicts"
+
+# ---------------------------------------------------------------------------
+# Check 5: Existing branches (WARNING)
+# ---------------------------------------------------------------------------
+EXISTING_BRANCHES=$(git branch --list "*${ISSUE}*" 2>/dev/null | sed 's/^[* ]*//')
+if [[ -n "$EXISTING_BRANCHES" ]]; then
+    warn "Check 5: Existing branches found for #${ISSUE}"
+    echo "$EXISTING_BRANCHES" | while IFS= read -r line; do
+        echo "         ${line}"
+    done
+else
+    pass "Check 5: No existing branches"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 6: Context gathering (INFO - only reached if checks 1-5 pass)
+# ---------------------------------------------------------------------------
+COMMENT_COUNT=$(gh issue view "$ISSUE" --comments 2>/dev/null | grep -c "^--$" || echo "0")
+info "Check 6: Issue context loaded (${COMMENT_COUNT} comment separator(s) found)"
+
+echo "========================================"
+echo -e "${GREEN}Pre-flight checks PASSED for issue #${ISSUE}${NC}"
+echo "SAFE TO PROCEED with implementation."

--- a/scripts/shell/setup_api_key.sh
+++ b/scripts/shell/setup_api_key.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Helper script to export ANTHROPIC_API_KEY from Claude CLI credentials
+# This is necessary for container execution which needs the key in environment
+
+set -euo pipefail
+
+CREDENTIALS_FILE="$HOME/.claude/.credentials.json"
+
+if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+    echo "Error: Claude credentials file not found at $CREDENTIALS_FILE" >&2
+    echo "Please run 'claude' to authenticate first." >&2
+    exit 1
+fi
+
+# Extract access token from Claude credentials
+API_KEY=$(python3 -c "
+import json
+import sys
+try:
+    with open('$CREDENTIALS_FILE', 'r') as f:
+        creds = json.load(f)
+    token = creds.get('claudeAiOauth', {}).get('accessToken', '')
+    if not token:
+        print('Error: No access token found in credentials', file=sys.stderr)
+        sys.exit(1)
+    print(token)
+except Exception as e:
+    print(f'Error reading credentials: {e}', file=sys.stderr)
+    sys.exit(1)
+")
+
+if [[ -z "$API_KEY" ]]; then
+    echo "Error: Failed to extract API key from credentials" >&2
+    exit 1
+fi
+
+export ANTHROPIC_API_KEY="$API_KEY"
+echo "ANTHROPIC_API_KEY exported successfully"
+
+# If arguments provided, execute them
+if [[ $# -gt 0 ]]; then
+    exec "$@"
+fi

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -1,0 +1,498 @@
+"""Tests for hephaestus.config.dep_sync."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.config.dep_sync import (
+    VersionRange,
+    _parse_constraints,
+    _parse_version,
+    _version_satisfies,
+    check_dep_sync,
+    check_pyproject_no_deps,
+    check_requirements_against_pixi,
+    check_requirements_up_to_date,
+    generate_requirements_content,
+    parse_pixi_toml,
+    parse_requirements,
+    sync_requirements,
+)
+
+
+class TestParseVersion:
+    """Tests for _parse_version()."""
+
+    def test_simple_version(self) -> None:
+        assert _parse_version("1.2.3") == (1, 2, 3)
+
+    def test_single_component(self) -> None:
+        assert _parse_version("2") == (2,)
+
+    def test_two_components(self) -> None:
+        assert _parse_version("1.0") == (1, 0)
+
+    def test_with_dash(self) -> None:
+        assert _parse_version("1.2-3") == (1, 2, 3)
+
+    def test_ignores_non_digits(self) -> None:
+        # Letters between dots are ignored
+        assert _parse_version("1.a.3") == (1, 3)
+
+    def test_four_components(self) -> None:
+        assert _parse_version("1.2.3.4") == (1, 2, 3, 4)
+
+
+class TestParseConstraints:
+    """Tests for _parse_constraints()."""
+
+    def test_single_gte(self) -> None:
+        result = _parse_constraints(">=1.0.0")
+        assert result == [VersionRange(op=">=", version=(1, 0, 0))]
+
+    def test_range(self) -> None:
+        result = _parse_constraints(">=1.2.0,<2")
+        assert len(result) == 2
+        assert result[0].op == ">="
+        assert result[1].op == "<"
+
+    def test_exact(self) -> None:
+        result = _parse_constraints("==1.5.0")
+        assert result == [VersionRange(op="==", version=(1, 5, 0))]
+
+    def test_strips_quotes(self) -> None:
+        result = _parse_constraints('">=1.0,<2"')
+        assert len(result) == 2
+
+    def test_empty_spec(self) -> None:
+        result = _parse_constraints("")
+        assert result == []
+
+    def test_not_equal(self) -> None:
+        result = _parse_constraints("!=1.0.0")
+        assert result == [VersionRange(op="!=", version=(1, 0, 0))]
+
+
+class TestVersionSatisfies:
+    """Tests for _version_satisfies()."""
+
+    def test_gte_satisfied(self) -> None:
+        constraints = [VersionRange(op=">=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 2, 0), constraints) is True
+
+    def test_gte_not_satisfied(self) -> None:
+        constraints = [VersionRange(op=">=", version=(2, 0, 0))]
+        assert _version_satisfies((1, 9, 9), constraints) is False
+
+    def test_lt_satisfied(self) -> None:
+        constraints = [VersionRange(op="<", version=(2,))]
+        assert _version_satisfies((1, 9, 9), constraints) is True
+
+    def test_lt_not_satisfied(self) -> None:
+        constraints = [VersionRange(op="<", version=(2,))]
+        assert _version_satisfies((2, 0, 0), constraints) is False
+
+    def test_range_satisfied(self) -> None:
+        constraints = _parse_constraints(">=1.0.0,<2")
+        assert _version_satisfies((1, 5, 0), constraints) is True
+
+    def test_range_below(self) -> None:
+        constraints = _parse_constraints(">=1.0.0,<2")
+        assert _version_satisfies((0, 9, 0), constraints) is False
+
+    def test_range_above(self) -> None:
+        constraints = _parse_constraints(">=1.0.0,<2")
+        assert _version_satisfies((2, 0, 0), constraints) is False
+
+    def test_exact_match(self) -> None:
+        constraints = [VersionRange(op="==", version=(1, 5, 0))]
+        assert _version_satisfies((1, 5, 0), constraints) is True
+
+    def test_exact_no_match(self) -> None:
+        constraints = [VersionRange(op="==", version=(1, 5, 0))]
+        assert _version_satisfies((1, 5, 1), constraints) is False
+
+    def test_not_equal_mismatch(self) -> None:
+        constraints = [VersionRange(op="!=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 0, 1), constraints) is True
+
+    def test_not_equal_match(self) -> None:
+        constraints = [VersionRange(op="!=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 0, 0), constraints) is False
+
+    def test_pads_shorter_version(self) -> None:
+        # (2,) compared to constraint (2, 0, 0) — should be equal
+        constraints = [VersionRange(op="==", version=(2, 0, 0))]
+        assert _version_satisfies((2,), constraints) is True
+
+    def test_empty_constraints_always_true(self) -> None:
+        assert _version_satisfies((1, 0, 0), []) is True
+
+    def test_unknown_op_treated_as_true(self) -> None:
+        constraints = [VersionRange(op="~=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 0, 0), constraints) is True
+
+
+class TestParsePixiToml:
+    """Tests for parse_pixi_toml()."""
+
+    def test_reads_dependencies(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\npydantic = ">=2.0,<3"\n'
+        )
+        result = parse_pixi_toml(pixi)
+        assert result["pyyaml"] == ">=6.0,<7"
+        assert result["pydantic"] == ">=2.0,<3"
+
+    def test_reads_pypi_dependencies(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            "[pypi-dependencies]\nrequests = \">=2.28,<3\"\n"
+        )
+        result = parse_pixi_toml(pixi)
+        assert result["requests"] == ">=2.28,<3"
+
+    def test_ignores_comments(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text("[dependencies]\n# This is a comment\npyyaml = \">=6.0\"\n")
+        result = parse_pixi_toml(pixi)
+        assert "pyyaml" in result
+        assert len(result) == 1
+
+    def test_stops_at_next_section(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            "[dependencies]\npyyaml = \">=6.0\"\n\n[feature.dev.dependencies]\npytest = \">=9.0\"\n"
+        )
+        result = parse_pixi_toml(pixi)
+        assert "pyyaml" in result
+        assert "pytest" not in result
+
+    def test_inline_comment_stripped(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text('[dependencies]\nrequests = ">=2.28" # HTTP client\n')
+        result = parse_pixi_toml(pixi)
+        assert result["requests"] == ">=2.28"
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text("")
+        result = parse_pixi_toml(pixi)
+        assert result == {}
+
+
+class TestParseRequirements:
+    """Tests for parse_requirements()."""
+
+    def test_basic_pins(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("pyyaml==6.0.1\npydantic==2.5.0\n")
+        result = parse_requirements(req)
+        assert result["pyyaml"] == "6.0.1"
+        assert result["pydantic"] == "2.5.0"
+
+    def test_skips_comments(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("# comment\npyyaml==6.0.1\n")
+        result = parse_requirements(req)
+        assert len(result) == 1
+
+    def test_skips_include_lines(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("-r requirements.txt\npyyaml==6.0.1\n")
+        result = parse_requirements(req)
+        assert len(result) == 1
+
+    def test_lowercases_package_names(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("PyYAML==6.0.1\n")
+        result = parse_requirements(req)
+        assert "pyyaml" in result
+
+    def test_strips_inline_comment(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("pyyaml==6.0.1  # some comment\n")
+        result = parse_requirements(req)
+        assert result["pyyaml"] == "6.0.1"
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("")
+        result = parse_requirements(req)
+        assert result == {}
+
+
+class TestCheckPyprojectNoDeps:
+    """Tests for check_pyproject_no_deps()."""
+
+    def test_no_deps_returns_empty(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'foo'\n")
+        errors = check_pyproject_no_deps(pyproject)
+        assert errors == []
+
+    def test_flags_project_dependencies(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project.dependencies]\nrequests = '>=2'\n")
+        errors = check_pyproject_no_deps(pyproject)
+        assert any("[project.dependencies]" in e for e in errors)
+
+    def test_flags_optional_dependencies(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project.optional-dependencies]\ndev = ['pytest']\n")
+        errors = check_pyproject_no_deps(pyproject)
+        assert any("[project.optional-dependencies]" in e for e in errors)
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        errors = check_pyproject_no_deps(tmp_path / "nonexistent.toml")
+        assert errors == []
+
+
+class TestCheckRequirementsAgainstPixi:
+    """Tests for check_requirements_against_pixi()."""
+
+    def _write_req(self, tmp_path: Path, name: str, content: str) -> None:
+        (tmp_path / name).write_text(content)
+
+    def test_valid_pin_passes(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "pyyaml==6.0.1\n")
+        errors = check_requirements_against_pixi(
+            tmp_path, {"pyyaml": ">=6.0,<7"}
+        )
+        assert errors == []
+
+    def test_pin_outside_range_fails(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "pyyaml==7.0.0\n")
+        errors = check_requirements_against_pixi(
+            tmp_path, {"pyyaml": ">=6.0,<7"}
+        )
+        assert len(errors) == 1
+        assert "pyyaml" in errors[0]
+
+    def test_pkg_not_in_pixi_fails(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "requests==2.31.0\n")
+        errors = check_requirements_against_pixi(tmp_path, {})
+        assert len(errors) == 1
+        assert "requests" in errors[0]
+
+    def test_skips_missing_files(self, tmp_path: Path) -> None:
+        errors = check_requirements_against_pixi(tmp_path, {})
+        assert errors == []
+
+    def test_checks_both_req_files(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "pyyaml==6.0.1\n")
+        self._write_req(tmp_path, "requirements-dev.txt", "pytest==9.0.0\n")
+        errors = check_requirements_against_pixi(
+            tmp_path, {"pyyaml": ">=6.0,<7", "pytest": ">=9.0,<10"}
+        )
+        assert errors == []
+
+
+class TestCheckDepSync:
+    """Tests for check_dep_sync()."""
+
+    def test_no_pixi_toml_returns_error(self, tmp_path: Path) -> None:
+        errors = check_dep_sync(tmp_path)
+        assert errors == ["pixi.toml not found"]
+
+    def test_clean_state_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("pyyaml==6.0.1\n")
+        errors = check_dep_sync(tmp_path)
+        assert errors == []
+
+    def test_out_of_range_pin_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("pyyaml==7.1.0\n")
+        errors = check_dep_sync(tmp_path)
+        assert len(errors) >= 1
+
+
+class TestGenerateRequirementsContent:
+    """Tests for generate_requirements_content()."""
+
+    def test_basic_output(self) -> None:
+        content = generate_requirements_content(
+            ["pyyaml"], {"pyyaml": "6.0.1"}
+        )
+        assert "pyyaml==6.0.1" in content
+
+    def test_includes_header(self) -> None:
+        content = generate_requirements_content(["pyyaml"], {"pyyaml": "6.0.1"})
+        assert "AUTO-GENERATED" in content
+
+    def test_include_base_prepended(self) -> None:
+        content = generate_requirements_content(
+            ["pytest"], {"pytest": "9.0.0"}, include_base="-r requirements.txt"
+        )
+        assert "-r requirements.txt" in content
+
+    def test_section_comments(self) -> None:
+        content = generate_requirements_content(
+            ["pyyaml"],
+            {"pyyaml": "6.0.1"},
+            section_comments={"pyyaml": "# YAML parser"},
+        )
+        assert "# YAML parser" in content
+
+    def test_missing_package_warns(self, capsys: pytest.CaptureFixture) -> None:
+        content = generate_requirements_content(["missing-pkg"], {})
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "missing-pkg" not in content
+
+    def test_ends_with_newline(self) -> None:
+        content = generate_requirements_content(["pyyaml"], {"pyyaml": "6.0.1"})
+        assert content.endswith("\n")
+
+
+class TestSyncRequirements:
+    """Tests for sync_requirements() and check_requirements_up_to_date()."""
+
+    def test_writes_files(self, tmp_path: Path) -> None:
+        paths = sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1", "pytest": "9.0.0"},
+            core_packages=["pyyaml"],
+            dev_packages=["pytest"],
+        )
+        assert len(paths) == 2
+        assert (tmp_path / "requirements.txt").exists()
+        assert (tmp_path / "requirements-dev.txt").exists()
+
+    def test_core_content(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        content = (tmp_path / "requirements.txt").read_text()
+        assert "pyyaml==6.0.1" in content
+
+    def test_dev_includes_base(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1", "pytest": "9.0.0"},
+            core_packages=["pyyaml"],
+            dev_packages=["pytest"],
+        )
+        dev_content = (tmp_path / "requirements-dev.txt").read_text()
+        assert "-r requirements.txt" in dev_content
+
+    def test_up_to_date_returns_true(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        ok = check_requirements_up_to_date(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        assert ok is True
+
+    def test_out_of_date_returns_false(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        ok = check_requirements_up_to_date(
+            tmp_path,
+            {"pyyaml": "6.0.2"},  # different version
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        assert ok is False
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        ok = check_requirements_up_to_date(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        assert ok is False
+
+
+class TestCLIEntryPoints:
+    """Tests for check_dep_sync_main() and sync_requirements_main() CLI entry points."""
+
+    def test_check_dep_sync_main_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import check_dep_sync_main
+
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
+        assert check_dep_sync_main() == 0
+
+    def test_check_dep_sync_main_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import check_dep_sync_main
+
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("pyyaml==8.0.0\n")
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
+        assert check_dep_sync_main() == 1
+
+    def test_sync_requirements_main_check_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import sync_requirements_main
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-sync-requirements",
+                "--check",
+                "--repo-root",
+                str(tmp_path),
+                "--core",
+                "pyyaml",
+            ],
+        )
+        mock_packages = {"pyyaml": "6.0.1"}
+        with patch("hephaestus.config.dep_sync.get_pixi_packages", return_value=mock_packages):
+            # Files don't exist yet — check mode should return 1
+            result = sync_requirements_main()
+        assert result == 1
+
+    def test_sync_requirements_main_write_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import sync_requirements_main
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-sync-requirements",
+                "--repo-root",
+                str(tmp_path),
+                "--core",
+                "pyyaml",
+            ],
+        )
+        mock_packages = {"pyyaml": "6.0.1"}
+        with patch("hephaestus.config.dep_sync.get_pixi_packages", return_value=mock_packages):
+            result = sync_requirements_main()
+        assert result == 0
+        assert (tmp_path / "requirements.txt").exists()

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -141,24 +141,20 @@ class TestParsePixiToml:
 
     def test_reads_dependencies(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
-        pixi.write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\npydantic = ">=2.0,<3"\n'
-        )
+        pixi.write_text('[dependencies]\npyyaml = ">=6.0,<7"\npydantic = ">=2.0,<3"\n')
         result = parse_pixi_toml(pixi)
         assert result["pyyaml"] == ">=6.0,<7"
         assert result["pydantic"] == ">=2.0,<3"
 
     def test_reads_pypi_dependencies(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
-        pixi.write_text(
-            "[pypi-dependencies]\nrequests = \">=2.28,<3\"\n"
-        )
+        pixi.write_text('[pypi-dependencies]\nrequests = ">=2.28,<3"\n')
         result = parse_pixi_toml(pixi)
         assert result["requests"] == ">=2.28,<3"
 
     def test_ignores_comments(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
-        pixi.write_text("[dependencies]\n# This is a comment\npyyaml = \">=6.0\"\n")
+        pixi.write_text('[dependencies]\n# This is a comment\npyyaml = ">=6.0"\n')
         result = parse_pixi_toml(pixi)
         assert "pyyaml" in result
         assert len(result) == 1
@@ -166,7 +162,7 @@ class TestParsePixiToml:
     def test_stops_at_next_section(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
         pixi.write_text(
-            "[dependencies]\npyyaml = \">=6.0\"\n\n[feature.dev.dependencies]\npytest = \">=9.0\"\n"
+            '[dependencies]\npyyaml = ">=6.0"\n\n[feature.dev.dependencies]\npytest = ">=9.0"\n'
         )
         result = parse_pixi_toml(pixi)
         assert "pyyaml" in result
@@ -260,16 +256,12 @@ class TestCheckRequirementsAgainstPixi:
 
     def test_valid_pin_passes(self, tmp_path: Path) -> None:
         self._write_req(tmp_path, "requirements.txt", "pyyaml==6.0.1\n")
-        errors = check_requirements_against_pixi(
-            tmp_path, {"pyyaml": ">=6.0,<7"}
-        )
+        errors = check_requirements_against_pixi(tmp_path, {"pyyaml": ">=6.0,<7"})
         assert errors == []
 
     def test_pin_outside_range_fails(self, tmp_path: Path) -> None:
         self._write_req(tmp_path, "requirements.txt", "pyyaml==7.0.0\n")
-        errors = check_requirements_against_pixi(
-            tmp_path, {"pyyaml": ">=6.0,<7"}
-        )
+        errors = check_requirements_against_pixi(tmp_path, {"pyyaml": ">=6.0,<7"})
         assert len(errors) == 1
         assert "pyyaml" in errors[0]
 
@@ -300,17 +292,13 @@ class TestCheckDepSync:
         assert errors == ["pixi.toml not found"]
 
     def test_clean_state_returns_empty(self, tmp_path: Path) -> None:
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         (tmp_path / "requirements.txt").write_text("pyyaml==6.0.1\n")
         errors = check_dep_sync(tmp_path)
         assert errors == []
 
     def test_out_of_range_pin_fails(self, tmp_path: Path) -> None:
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         (tmp_path / "requirements.txt").write_text("pyyaml==7.1.0\n")
         errors = check_dep_sync(tmp_path)
         assert len(errors) >= 1
@@ -320,9 +308,7 @@ class TestGenerateRequirementsContent:
     """Tests for generate_requirements_content()."""
 
     def test_basic_output(self) -> None:
-        content = generate_requirements_content(
-            ["pyyaml"], {"pyyaml": "6.0.1"}
-        )
+        content = generate_requirements_content(["pyyaml"], {"pyyaml": "6.0.1"})
         assert "pyyaml==6.0.1" in content
 
     def test_includes_header(self) -> None:
@@ -436,9 +422,7 @@ class TestCLIEntryPoints:
     ) -> None:
         from hephaestus.config.dep_sync import check_dep_sync_main
 
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
         assert check_dep_sync_main() == 0
 
@@ -447,9 +431,7 @@ class TestCLIEntryPoints:
     ) -> None:
         from hephaestus.config.dep_sync import check_dep_sync_main
 
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         (tmp_path / "requirements.txt").write_text("pyyaml==8.0.0\n")
         monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
         assert check_dep_sync_main() == 1


### PR DESCRIPTION
## Summary

- Adds `hephaestus.config.dep_sync` module ported from ProjectOdyssey's `check_dep_sync.py` + `sync_requirements.py`, with two new CLI entry points:
  - `hephaestus-check-dep-sync` — validates that `requirements*.txt` pins fall within `pixi.toml` constraints, and flags leftover `[project.dependencies]` sections
  - `hephaestus-sync-requirements` — regenerates `requirements.txt` / `requirements-dev.txt` from `pixi list --json`; supports `--check` for CI validation mode
- Ports 4 generic shell scripts from ProjectScylla into `scripts/shell/` (log path in `cleanup-stale-worktrees.sh` updated from `.cache/scylla/` → `.cache/hephaestus/`):
  - `cleanup-stale-worktrees.sh`
  - `install_hooks.sh`
  - `preflight_check.sh`
  - `setup_api_key.sh`
- 66 new unit tests in `tests/unit/config/test_dep_sync.py`

## Test plan

- [x] `pixi run ruff check hephaestus/config/dep_sync.py tests/unit/config/test_dep_sync.py` — all checks passed
- [x] `pixi run mypy` — no issues in 167 source files
- [x] `pixi run pytest tests/unit` — 1562 passed, 7 skipped, 85.34% coverage (≥80%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)