### PR TITLE
[L9] feat(discovery): add hephaestus.discovery subpackage

### DIFF
--- a/hephaestus/agents/__init__.py
+++ b/hephaestus/agents/__init__.py
@@ -1,0 +1,41 @@
+"""Agent markdown file utilities: frontmatter parsing, loading, and statistics."""
+
+from hephaestus.agents.frontmatter import (
+    FRONTMATTER_PATTERN,
+    check_agent_file,
+    extract_frontmatter_full,
+    extract_frontmatter_parsed,
+    extract_frontmatter_raw,
+    extract_frontmatter_with_lines,
+    validate_agents_main,
+    validate_frontmatter,
+)
+from hephaestus.agents.loader import (
+    AgentInfo,
+    find_agent_files,
+    load_agent,
+    load_all_agents,
+)
+from hephaestus.agents.stats import (
+    collect_agent_stats,
+    format_stats_json,
+    format_stats_text,
+)
+
+__all__ = [
+    "FRONTMATTER_PATTERN",
+    "AgentInfo",
+    "check_agent_file",
+    "collect_agent_stats",
+    "extract_frontmatter_full",
+    "extract_frontmatter_parsed",
+    "extract_frontmatter_raw",
+    "extract_frontmatter_with_lines",
+    "find_agent_files",
+    "format_stats_json",
+    "format_stats_text",
+    "load_agent",
+    "load_all_agents",
+    "validate_agents_main",
+    "validate_frontmatter",
+]

--- a/hephaestus/agents/frontmatter.py
+++ b/hephaestus/agents/frontmatter.py
@@ -1,0 +1,290 @@
+"""YAML frontmatter extraction and validation for agent markdown files.
+
+Provides generic utilities for working with ``---`` delimited YAML frontmatter
+blocks in markdown files.  No agent-schema assumptions are baked in — callers
+pass their own required/optional field specifications.
+
+Usage::
+
+    from hephaestus.agents.frontmatter import extract_frontmatter_parsed, validate_frontmatter
+
+    parsed = extract_frontmatter_parsed(content)
+    if parsed is not None:
+        _raw, data = parsed
+        errors = validate_frontmatter(data, required_fields={"name": str, "description": str})
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml as _yaml
+except ModuleNotFoundError:
+    _yaml = None  # type: ignore[assignment]
+
+#: Compiled regex that matches a ``---`` frontmatter block at the start of a file.
+FRONTMATTER_PATTERN: re.Pattern[str] = re.compile(r"^---\s*\n(.*?\n)---\s*\n", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def extract_frontmatter_raw(content: str) -> str | None:
+    """Extract the raw YAML frontmatter text from *content*.
+
+    Args:
+        content: Full markdown file content.
+
+    Returns:
+        The YAML block between the ``---`` markers, or ``None`` if not found.
+
+    """
+    match = FRONTMATTER_PATTERN.match(content)
+    return match.group(1) if match else None
+
+
+def extract_frontmatter_with_lines(
+    content: str,
+) -> tuple[str, int, int] | None:
+    """Extract frontmatter with 1-indexed line numbers.
+
+    Args:
+        content: Full markdown file content.
+
+    Returns:
+        ``(frontmatter_text, start_line, end_line)`` or ``None`` if not found.
+        *start_line* is always 1 (the opening ``---``).
+
+    """
+    match = FRONTMATTER_PATTERN.match(content)
+    if match:
+        frontmatter = match.group(1)
+        end_line = content[: match.end()].count("\n")
+        return (frontmatter, 1, end_line)
+    return None
+
+
+def extract_frontmatter_parsed(
+    content: str,
+) -> tuple[str, dict[str, Any]] | None:
+    """Extract and parse frontmatter to a dict.
+
+    Args:
+        content: Full markdown file content.
+
+    Returns:
+        ``(raw_text, parsed_dict)`` or ``None`` if not found, not a mapping,
+        or YAML is invalid.
+
+    """
+    if _yaml is None:
+        return None
+    match = FRONTMATTER_PATTERN.match(content)
+    if not match:
+        return None
+    frontmatter = match.group(1)
+    try:
+        parsed = _yaml.safe_load(frontmatter)
+        if isinstance(parsed, dict):
+            return (frontmatter, parsed)
+    except _yaml.YAMLError:
+        pass
+    return None
+
+
+def extract_frontmatter_full(
+    content: str,
+) -> tuple[str, dict[str, Any], int, int] | None:
+    """Extract frontmatter with both parsed dict and line numbers.
+
+    Args:
+        content: Full markdown file content.
+
+    Returns:
+        ``(raw_text, parsed_dict, start_line, end_line)`` or ``None``.
+
+    """
+    if _yaml is None:
+        return None
+    match = FRONTMATTER_PATTERN.match(content)
+    if not match:
+        return None
+    frontmatter = match.group(1)
+    try:
+        parsed = _yaml.safe_load(frontmatter)
+        if isinstance(parsed, dict):
+            end_line = content[: match.end()].count("\n")
+            return (frontmatter, parsed, 1, end_line)
+    except _yaml.YAMLError:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_frontmatter(
+    frontmatter: dict[str, Any],
+    required_fields: dict[str, type] | None = None,
+    optional_fields: dict[str, type] | None = None,
+) -> list[str]:
+    """Validate frontmatter structure against required and optional field specs.
+
+    Args:
+        frontmatter: Parsed YAML frontmatter dict.
+        required_fields: Mapping of field name → expected type that must be present.
+            Defaults to ``{"name": str, "description": str, "tools": str, "model": str}``.
+        optional_fields: Mapping of field name → expected type that may be present.
+            Defaults to ``{"level": int, "section": str, "workflow_phase": str}``.
+
+    Returns:
+        List of error strings; empty means valid.
+
+    """
+    if required_fields is None:
+        required_fields = {"name": str, "description": str, "tools": str, "model": str}
+    if optional_fields is None:
+        optional_fields = {"level": int, "section": str, "workflow_phase": str}
+
+    errors: list[str] = []
+
+    for field, expected_type in required_fields.items():
+        if field not in frontmatter:
+            errors.append(f"Missing required field: '{field}'")
+        elif not isinstance(frontmatter[field], expected_type):
+            actual = type(frontmatter[field]).__name__
+            errors.append(f"Field '{field}' should be {expected_type.__name__}, got {actual}")
+
+    for field, expected_type in optional_fields.items():
+        if field in frontmatter and not isinstance(frontmatter[field], expected_type):
+            actual = type(frontmatter[field]).__name__
+            errors.append(f"Field '{field}' should be {expected_type.__name__}, got {actual}")
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# File-level helpers
+# ---------------------------------------------------------------------------
+
+
+def check_agent_file(
+    file_path: Path,
+    required_fields: dict[str, type] | None = None,
+    optional_fields: dict[str, type] | None = None,
+) -> tuple[bool, list[str]]:
+    """Check a single agent markdown file for valid frontmatter.
+
+    Args:
+        file_path: Path to the agent markdown file.
+        required_fields: Field spec passed to :func:`validate_frontmatter`.
+        optional_fields: Field spec passed to :func:`validate_frontmatter`.
+
+    Returns:
+        ``(is_valid, error_messages)``
+
+    """
+    if _yaml is None:
+        return False, ["pyyaml is required: pip install pyyaml"]
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return False, [f"Failed to read file: {exc}"]
+
+    result = extract_frontmatter_with_lines(content)
+    if result is None:
+        return False, ["No YAML frontmatter found (should start with --- and end with ---)"]
+
+    frontmatter_text, _start, _end = result
+
+    try:
+        frontmatter = _yaml.safe_load(frontmatter_text)
+    except _yaml.YAMLError as exc:
+        return False, [f"YAML syntax error: {exc}"]
+
+    if frontmatter is None:
+        return False, ["Empty frontmatter"]
+    if not isinstance(frontmatter, dict):
+        return False, [f"Frontmatter should be a YAML mapping, got {type(frontmatter).__name__}"]
+
+    errors = validate_frontmatter(frontmatter, required_fields, optional_fields)
+    return len(errors) == 0, errors
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def validate_agents_main(argv: list[str] | None = None) -> int:
+    """CLI entry point: validate agent frontmatter files in a directory.
+
+    Args:
+        argv: Argument list (default: ``sys.argv[1:]``).
+
+    Returns:
+        Exit code: 0 if all files are valid, 1 if any are invalid.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate frontmatter in agent markdown files",
+        epilog="Example: %(prog)s --agents-dir .claude/agents",
+    )
+    parser.add_argument(
+        "--agents-dir",
+        type=Path,
+        default=None,
+        help="Path to agents directory (default: <repo-root>/.claude/agents)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Treat warnings as errors",
+    )
+    args = parser.parse_args(argv)
+
+    if args.agents_dir is not None:
+        agents_dir = args.agents_dir
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        agents_dir = get_repo_root() / ".claude" / "agents"
+
+    if not agents_dir.is_dir():
+        print(f"ERROR: agents directory not found: {agents_dir}", file=sys.stderr)
+        return 1
+
+    md_files = sorted(agents_dir.glob("*.md"))
+    if not md_files:
+        print(f"No agent files found in {agents_dir}", file=sys.stderr)
+        return 1
+
+    invalid_count = 0
+    for file_path in md_files:
+        is_valid, errors = check_agent_file(file_path)
+        if is_valid:
+            print(f"  OK  {file_path.name}")
+        else:
+            invalid_count += 1
+            print(f"FAIL  {file_path.name}")
+            for err in errors:
+                print(f"      - {err}")
+
+    total = len(md_files)
+    print(f"\n{total - invalid_count}/{total} agents valid")
+
+    return 0 if invalid_count == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(validate_agents_main())

--- a/hephaestus/agents/loader.py
+++ b/hephaestus/agents/loader.py
@@ -1,0 +1,179 @@
+"""Agent markdown file discovery and loading primitives.
+
+Provides a generic :class:`AgentInfo` data class and functions for discovering
+and loading agent markdown files from a directory.  No hardcoded path
+assumptions — callers supply the agents directory.
+
+Usage::
+
+    from hephaestus.agents.loader import load_all_agents, AgentInfo
+
+    agents = load_all_agents(Path(".claude/agents"))
+    for agent in agents:
+        print(agent.name, agent.level, agent.get_tools_list())
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.frontmatter import extract_frontmatter_raw
+
+try:
+    import yaml as _yaml
+except ModuleNotFoundError:
+    _yaml = None  # type: ignore[assignment]
+
+
+class AgentInfo:
+    """Metadata container for a single agent markdown file.
+
+    Attributes:
+        file_path: Path to the agent markdown file.
+        name: Agent name from frontmatter.
+        description: Agent description from frontmatter.
+        tools: Comma-separated tools string from frontmatter.
+        model: Model assignment (e.g. ``"sonnet"``, ``"opus"``, ``"haiku"``).
+        level: Inferred or explicit agent level (0 = orchestrator, 5 = junior).
+        raw_frontmatter: The original frontmatter dict.
+
+    """
+
+    def __init__(self, file_path: Path, frontmatter: dict[str, Any]) -> None:
+        """Initialise from path and parsed frontmatter dict.
+
+        Args:
+            file_path: Path to the markdown file.
+            frontmatter: Parsed YAML frontmatter dictionary.
+
+        """
+        self.file_path = file_path
+        self.raw_frontmatter = frontmatter
+        self.name: str = frontmatter.get("name", "unknown")
+        self.description: str = frontmatter.get("description", "No description")
+        self.tools: str = frontmatter.get("tools", "")
+        self.model: str = frontmatter.get("model", "unknown")
+        self.level: int = self._infer_level(frontmatter)
+
+    def _infer_level(self, frontmatter: dict[str, Any]) -> int:
+        """Infer agent level from frontmatter or fall back to name heuristics.
+
+        Level hierarchy (0 = highest, 5 = lowest):
+
+        - 0: Meta-orchestrator
+        - 1: Section orchestrators
+        - 2: Design agents
+        - 3: Component specialists
+        - 4: Senior engineers
+        - 5: Junior engineers
+
+        Args:
+            frontmatter: Parsed frontmatter dictionary.
+
+        Returns:
+            Integer level (0–5).
+
+        """
+        if "level" in frontmatter:
+            return int(frontmatter["level"])
+
+        name = self.name.lower()
+        if "chief-architect" in name:
+            return 0
+        if "orchestrator" in name:
+            return 1
+        if "design" in name:
+            return 2
+        if "specialist" in name:
+            return 3
+        if "junior" in name:
+            return 5
+        if "senior" in name or "engineer" in name:
+            return 4
+        return 3  # Default to middle level
+
+    def get_tools_list(self) -> list[str]:
+        """Return individual tool names from the comma-separated tools string.
+
+        Returns:
+            List of stripped tool name strings.
+
+        """
+        if not self.tools:
+            return []
+        return [t.strip() for t in self.tools.split(",") if t.strip()]
+
+    def __repr__(self) -> str:
+        """Return a concise string representation."""
+        return f"AgentInfo(level={self.level}, name={self.name!r})"
+
+
+# ---------------------------------------------------------------------------
+# Discovery and loading
+# ---------------------------------------------------------------------------
+
+
+def find_agent_files(agents_dir: Path) -> list[Path]:
+    """Return a sorted list of ``*.md`` files in *agents_dir*.
+
+    Args:
+        agents_dir: Directory to search.
+
+    Returns:
+        Sorted list of ``.md`` file paths.
+
+    """
+    return sorted(agents_dir.glob("*.md"))
+
+
+def load_agent(file_path: Path) -> AgentInfo | None:
+    """Load a single agent from a markdown file.
+
+    Args:
+        file_path: Path to the agent markdown file.
+
+    Returns:
+        :class:`AgentInfo` on success, ``None`` if the file cannot be read,
+        has no frontmatter, or has invalid YAML.
+
+    """
+    if _yaml is None:
+        return None
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    frontmatter_text = extract_frontmatter_raw(content)
+    if frontmatter_text is None:
+        return None
+
+    try:
+        frontmatter = _yaml.safe_load(frontmatter_text)
+    except _yaml.YAMLError:
+        return None
+
+    if not isinstance(frontmatter, dict):
+        return None
+
+    return AgentInfo(file_path, frontmatter)
+
+
+def load_all_agents(agents_dir: Path) -> list[AgentInfo]:
+    """Load all agent configurations from *agents_dir*.
+
+    Args:
+        agents_dir: Directory containing agent markdown files.
+
+    Returns:
+        List of :class:`AgentInfo` objects for successfully loaded agents.
+
+    """
+    agents = []
+    for file_path in find_agent_files(agents_dir):
+        agent = load_agent(file_path)
+        if agent is not None:
+            agents.append(agent)
+    return agents

--- a/hephaestus/agents/stats.py
+++ b/hephaestus/agents/stats.py
@@ -1,0 +1,262 @@
+"""Agent statistics aggregation and reporting.
+
+Analyzes agent markdown files and generates statistics about the agent
+hierarchy: counts by level, tool usage frequencies, skill references,
+and delegation links between agents.
+
+Usage::
+
+    from hephaestus.agents.stats import collect_agent_stats, format_stats_text
+
+    agents = load_all_agents(Path(".claude/agents"))
+    stats = collect_agent_stats(agents)
+    print(format_stats_text(stats))
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.loader import AgentInfo, load_all_agents
+
+# ---------------------------------------------------------------------------
+# Stats computation
+# ---------------------------------------------------------------------------
+
+
+def _extract_delegation_targets(agent: AgentInfo) -> list[dict[str, str]]:
+    """Extract ``[text](./file.md)`` style delegation links from agent content.
+
+    Args:
+        agent: Loaded :class:`~hephaestus.agents.loader.AgentInfo`.
+
+    Returns:
+        List of ``{"target": stem, "description": link_text}`` dicts.
+
+    """
+    try:
+        content = agent.file_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    links = re.findall(r"\[([^\]]+)\]\(\./([^)]+\.md)\)", content)
+    return [
+        {"target": link_file.replace(".md", ""), "description": text} for text, link_file in links
+    ]
+
+
+def _extract_skill_refs(agent: AgentInfo) -> list[str]:
+    r"""Extract backtick-quoted skill name references from agent content.
+
+    Matches patterns like ``\`skill-name\` skill``.
+
+    Args:
+        agent: Loaded :class:`~hephaestus.agents.loader.AgentInfo`.
+
+    Returns:
+        Deduplicated list of skill name strings.
+
+    """
+    try:
+        content = agent.file_path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    matches = re.findall(r"`([a-z0-9-]+)`\s+skill", content.lower())
+    return list(set(matches))
+
+
+def collect_agent_stats(agents: list[AgentInfo]) -> dict[str, Any]:
+    """Aggregate statistics across a list of agents.
+
+    Args:
+        agents: Loaded agent objects (from :func:`~hephaestus.agents.loader.load_all_agents`).
+
+    Returns:
+        Stats dict with keys:
+
+        - ``"total_agents"`` — total count
+        - ``"by_level"`` — ``{level: [names]}``
+        - ``"by_tool"`` — ``{tool: [agent_names]}``
+        - ``"tool_frequency"`` — ``{tool: count}``
+        - ``"by_skill"`` — ``{skill: [agent_names]}``
+        - ``"skill_frequency"`` — ``{skill: count}``
+        - ``"delegation_graph"`` — ``{agent_name: [{target, description}]}``
+        - ``"agents_without_level"`` — names where level defaulted
+
+    """
+    stats: dict[str, Any] = {
+        "total_agents": len(agents),
+        "by_level": defaultdict(list),
+        "by_tool": defaultdict(list),
+        "by_skill": defaultdict(list),
+        "delegation_graph": defaultdict(list),
+        "tool_frequency": defaultdict(int),
+        "skill_frequency": defaultdict(int),
+        "agents_without_level": [],
+    }
+
+    for agent in agents:
+        # Level grouping
+        if "level" in agent.raw_frontmatter:
+            stats["by_level"][agent.level].append(agent.name)
+        else:
+            stats["agents_without_level"].append(agent.name)
+
+        # Tool usage
+        for tool in agent.get_tools_list():
+            stats["by_tool"][tool].append(agent.name)
+            stats["tool_frequency"][tool] += 1
+
+        # Skill references
+        for skill in _extract_skill_refs(agent):
+            stats["by_skill"][skill].append(agent.name)
+            stats["skill_frequency"][skill] += 1
+
+        # Delegation graph
+        stats["delegation_graph"][agent.name].extend(_extract_delegation_targets(agent))
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Formatters
+# ---------------------------------------------------------------------------
+
+
+def format_stats_text(stats: dict[str, Any]) -> str:
+    """Render stats as a plain text report.
+
+    Args:
+        stats: Dict produced by :func:`collect_agent_stats`.
+
+    Returns:
+        Multi-line text report string.
+
+    """
+    sep = "=" * 60
+    lines: list[str] = [sep, "Agent System Statistics Report", sep, ""]
+
+    lines += ["OVERVIEW", "-" * 60, f"Total Agents: {stats['total_agents']}", ""]
+
+    lines += ["AGENTS BY LEVEL", "-" * 60]
+    for level in sorted(stats["by_level"]):
+        names = sorted(stats["by_level"][level])
+        lines.append(f"  Level {level}: {len(names)} agent(s)")
+    if stats["agents_without_level"]:
+        lines.append(f"  No level: {len(stats['agents_without_level'])} agent(s)")
+    lines.append("")
+
+    lines += ["TOP TOOLS (by frequency)", "-" * 60]
+    top_tools = sorted(stats["tool_frequency"].items(), key=lambda x: -x[1])[:10]
+    for tool, count in top_tools:
+        lines.append(f"  {tool}: {count}")
+    lines.append("")
+
+    lines += ["TOP SKILLS (by reference count)", "-" * 60]
+    top_skills = sorted(stats["skill_frequency"].items(), key=lambda x: -x[1])[:10]
+    if top_skills:
+        for skill, count in top_skills:
+            lines.append(f"  {skill}: {count}")
+    else:
+        lines.append("  (none)")
+    lines.append("")
+
+    lines.append(sep)
+    return "\n".join(lines)
+
+
+def format_stats_json(stats: dict[str, Any]) -> str:
+    """Render stats as a JSON string.
+
+    Args:
+        stats: Dict produced by :func:`collect_agent_stats`.
+
+    Returns:
+        JSON-formatted string.
+
+    """
+    import json
+
+    # Convert defaultdicts to plain dicts for serialisation
+    serialisable: dict[str, Any] = {
+        "total_agents": stats["total_agents"],
+        "by_level": {str(k): v for k, v in stats["by_level"].items()},
+        "tool_frequency": dict(stats["tool_frequency"]),
+        "skill_frequency": dict(stats["skill_frequency"]),
+        "agents_without_level": stats["agents_without_level"],
+    }
+    return json.dumps(serialisable, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """CLI entry point: generate agent statistics report.
+
+    Returns:
+        Exit code: 0 for success, 1 on error.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate statistics for agent markdown files",
+        epilog="Example: %(prog)s --agents-dir .claude/agents --format text",
+    )
+    parser.add_argument(
+        "--agents-dir",
+        type=Path,
+        default=None,
+        help="Path to agents directory (default: <repo-root>/.claude/agents)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write output to file instead of stdout",
+    )
+
+    args = parser.parse_args()
+
+    if args.agents_dir is not None:
+        agents_dir = args.agents_dir
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        agents_dir = get_repo_root() / ".claude" / "agents"
+
+    if not agents_dir.is_dir():
+        print(f"ERROR: agents directory not found: {agents_dir}", file=sys.stderr)
+        return 1
+
+    agents = load_all_agents(agents_dir)
+    if not agents:
+        print(f"No agent files found in {agents_dir}", file=sys.stderr)
+        return 1
+
+    stats = collect_agent_stats(agents)
+
+    output = format_stats_json(stats) if args.format == "json" else format_stats_text(stats)
+
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+        print(f"Written to {args.output}")
+    else:
+        print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hephaestus/ci/__init__.py
+++ b/hephaestus/ci/__init__.py
@@ -1,0 +1,49 @@
+"""CI utilities for GitHub Actions and local development workflows."""
+
+from hephaestus.ci.docker_timing import (
+    build_summary_table,
+    compute_reduction,
+    count_cached_layers,
+)
+from hephaestus.ci.precommit import (
+    check_threshold,
+    check_version_consistency,
+    check_version_drift,
+    emit_warning,
+    extract_external_hooks,
+    format_summary_table,
+    load_pixi_versions,
+    load_precommit_config,
+    normalize_version,
+    parse_pixi_constraint,
+    write_step_summary,
+)
+from hephaestus.ci.workflows import (
+    check_inventory,
+    collect_workflow_files,
+    collect_yml_files,
+    parse_readme_table,
+    validate_workflow,
+)
+
+__all__ = [
+    "build_summary_table",
+    "check_inventory",
+    "check_threshold",
+    "check_version_consistency",
+    "check_version_drift",
+    "collect_workflow_files",
+    "collect_yml_files",
+    "compute_reduction",
+    "count_cached_layers",
+    "emit_warning",
+    "extract_external_hooks",
+    "format_summary_table",
+    "load_pixi_versions",
+    "load_precommit_config",
+    "normalize_version",
+    "parse_pixi_constraint",
+    "parse_readme_table",
+    "validate_workflow",
+    "write_step_summary",
+]

--- a/hephaestus/ci/docker_timing.py
+++ b/hephaestus/ci/docker_timing.py
@@ -1,0 +1,92 @@
+"""Docker build cache efficiency utilities.
+
+Provides helper functions for measuring Docker build cache hit rates and
+rendering GitHub Actions step summary tables.
+
+No Docker daemon is required to import this module — all functions operate on
+plain text (build log strings) or pure arithmetic.
+
+Usage::
+
+    from hephaestus.ci.docker_timing import (
+        build_summary_table,
+        compute_reduction,
+        count_cached_layers,
+    )
+
+    cached = count_cached_layers(build_log)
+    reduction = compute_reduction(cold_seconds, warm_seconds)
+    table = build_summary_table(cold_seconds, warm_seconds, cached, reduction)
+"""
+
+from __future__ import annotations
+
+
+def count_cached_layers(build_log: str) -> int:
+    """Count the number of CACHED layer lines in a docker build --progress=plain log.
+
+    BuildKit emits ``#N CACHED`` lines for each layer restored from the local
+    layer cache.  This count indicates how effective the cache was for a build.
+
+    Args:
+        build_log: Full stdout+stderr from ``docker build --progress=plain``.
+
+    Returns:
+        Number of lines containing the word ``CACHED`` (case-insensitive).
+
+    """
+    return build_log.upper().count("CACHED")
+
+
+def compute_reduction(cold_seconds: int, warm_seconds: int) -> float:
+    """Compute the percentage reduction in build time from cold to warm build.
+
+    Args:
+        cold_seconds: Wall-clock seconds for the cold (no-cache) build.
+        warm_seconds: Wall-clock seconds for the warm (source-change) rebuild.
+
+    Returns:
+        Percentage reduction, rounded to one decimal place.
+        Returns 0.0 if *cold_seconds* is zero to avoid division by zero.
+
+    """
+    if cold_seconds <= 0:
+        return 0.0
+    reduction = (cold_seconds - warm_seconds) / cold_seconds * 100
+    return round(reduction, 1)
+
+
+def build_summary_table(
+    cold_seconds: int,
+    warm_seconds: int,
+    cached_layers: int,
+    reduction: float,
+    acceptance_threshold: float = 30.0,
+) -> str:
+    """Render a Markdown table summarising the before/after build timing.
+
+    The table is written to ``$GITHUB_STEP_SUMMARY`` by the CI report step so
+    it appears as a structured summary in the GitHub Actions UI.
+
+    Args:
+        cold_seconds: Wall-clock seconds for the cold build.
+        warm_seconds: Wall-clock seconds for the warm rebuild.
+        cached_layers: Number of ``CACHED`` layers in the warm build log.
+        reduction: Percentage time reduction (from :func:`compute_reduction`).
+        acceptance_threshold: Minimum reduction % to pass (default 30).
+
+    Returns:
+        Markdown string containing the full summary table.
+
+    """
+    verdict = "PASS" if reduction >= acceptance_threshold else "FAIL"
+    return (
+        "## Docker Build Timing: Source-Only Change Cache Efficiency\n\n"
+        "| Metric | Value |\n"
+        "|--------|-------|\n"
+        f"| Cold build (no cache) | {cold_seconds}s |\n"
+        f"| Warm rebuild (source change only) | {warm_seconds}s |\n"
+        f"| Reduction | {reduction}% |\n"
+        f"| Cached layers (warm build) | {cached_layers} |\n"
+        f"| Acceptance criterion (≥{acceptance_threshold:.0f}%) | {verdict} |\n"
+    )

--- a/hephaestus/ci/precommit.py
+++ b/hephaestus/ci/precommit.py
@@ -1,0 +1,449 @@
+"""Pre-commit CI utilities for GitHub Actions integration.
+
+Provides two tools:
+
+**Benchmark** (``hephaestus-bench-precommit``): Accepts elapsed time, file
+count, and hook status; emits a Markdown summary table and a GitHub Actions
+warning annotation if runtime exceeds the threshold.
+
+**Version check** (``hephaestus-check-precommit-versions``): Validates that
+external pre-commit hook ``rev`` values in ``.pre-commit-config.yaml`` match
+the corresponding ``pixi.toml`` lower-bound versions, preventing version drift.
+
+Usage::
+
+    hephaestus-bench-precommit --elapsed 45 --files 300 --status passed
+    hephaestus-check-precommit-versions
+    hephaestus-check-precommit-versions --config .pre-commit-config.yaml --pixi pixi.toml
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# TOML loading (tomllib on 3.11+, tomli on 3.10, manual fallback)
+# ---------------------------------------------------------------------------
+_tomllib = None
+for _mod_name in ("tomllib", "tomli"):
+    try:
+        _tomllib = importlib.import_module(_mod_name)
+        break
+    except ModuleNotFoundError:
+        continue
+
+try:
+    import yaml as _yaml
+except ModuleNotFoundError:
+    _yaml = None  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Benchmark helpers
+# ---------------------------------------------------------------------------
+
+#: Default mapping from external pre-commit repo URL to pixi.toml package name.
+DEFAULT_HOOK_TO_PIXI_MAP: dict[str, str] = {
+    "https://github.com/pre-commit/mirrors-mypy": "mypy",
+    "https://github.com/kynan/nbstripout": "nbstripout",
+    "https://github.com/pre-commit/pre-commit-hooks": "pre-commit-hooks",
+}
+
+
+def format_summary_table(elapsed_s: int, file_count: int, hook_status: str) -> str:
+    """Format a Markdown table summarising the pre-commit benchmark run.
+
+    Args:
+        elapsed_s: Wall-clock seconds the hooks took to complete.
+        file_count: Number of files processed.
+        hook_status: Result string, e.g. ``"passed"`` or ``"failed"``.
+
+    Returns:
+        Markdown-formatted table string including a trailing newline.
+
+    """
+    status_icon = "✅" if hook_status == "passed" else "❌"
+    return (
+        "## Pre-commit Hook Benchmark\n\n"
+        "| Metric | Value |\n"
+        "|--------|-------|\n"
+        f"| Hook status | {status_icon} {hook_status} |\n"
+        f"| Elapsed time | {elapsed_s}s |\n"
+        f"| Files processed | {file_count} |\n"
+    )
+
+
+def check_threshold(elapsed_s: int, threshold_s: int = 120) -> bool:
+    """Return ``True`` if the elapsed time exceeds the threshold.
+
+    Args:
+        elapsed_s: Measured runtime in seconds.
+        threshold_s: Maximum acceptable runtime in seconds (default 120).
+
+    Returns:
+        ``True`` when slow (elapsed_s > threshold_s), ``False`` otherwise.
+
+    """
+    return elapsed_s > threshold_s
+
+
+def emit_warning(message: str) -> None:
+    """Emit a GitHub Actions warning annotation to stdout.
+
+    Args:
+        message: Warning text to emit.
+
+    """
+    print(f"::warning::{message}")
+
+
+def write_step_summary(content: str, summary_path: str | None = None) -> None:
+    """Append content to the GitHub Actions step summary file if the path is set.
+
+    Args:
+        content: Markdown content to write.
+        summary_path: Path to the summary file; defaults to ``$GITHUB_STEP_SUMMARY``.
+
+    """
+    path = summary_path or os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a") as fh:
+        fh.write(content)
+
+
+# ---------------------------------------------------------------------------
+# Version-check helpers
+# ---------------------------------------------------------------------------
+
+
+def normalize_version(rev: str) -> str:
+    """Strip a leading ``v`` from a git tag so it can be compared numerically.
+
+    Args:
+        rev: A git tag such as ``"v1.19.1"`` or ``"0.7.1"``.
+
+    Returns:
+        Version string without leading ``v``, e.g. ``"1.19.1"``.
+
+    """
+    return rev.lstrip("v")
+
+
+def load_precommit_config(config_path: Path) -> list[dict[str, Any]]:
+    """Parse ``.pre-commit-config.yaml`` and return the list of repo entries.
+
+    Args:
+        config_path: Path to ``.pre-commit-config.yaml``.
+
+    Returns:
+        List of repo dicts from the ``repos`` key.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValueError: If the YAML is missing the ``repos`` key or yaml is unavailable.
+
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(f"Pre-commit config not found: {config_path}")
+
+    if _yaml is None:
+        raise ValueError("pyyaml is required: pip install pyyaml")
+
+    with config_path.open() as fh:
+        data = _yaml.safe_load(fh)
+
+    if not isinstance(data, dict) or "repos" not in data:
+        raise ValueError(f"No 'repos' key in {config_path}")
+
+    repos: list[dict[str, Any]] = data["repos"]
+    return repos
+
+
+def extract_external_hooks(repos: list[dict[str, Any]]) -> dict[str, str]:
+    """Extract external (non-local) repo URLs and their ``rev`` values.
+
+    Args:
+        repos: List of repo dicts from ``.pre-commit-config.yaml``.
+
+    Returns:
+        Dict mapping repo URL to rev string.
+
+    """
+    result: dict[str, str] = {}
+    for repo in repos:
+        url = repo.get("repo", "")
+        rev = repo.get("rev", "")
+        if url and url != "local" and rev:
+            result[url] = rev
+    return result
+
+
+def parse_pixi_constraint(constraint: str) -> str | None:
+    """Extract the lower-bound version from a pixi/conda version constraint.
+
+    Handles patterns like:
+    - ``>=1.19.1,<2``  → ``"1.19.1"``
+    - ``==0.26.1``     → ``"0.26.1"``
+    - ``>=0.7.1``      → ``"0.7.1"``
+    - ``0.12.1``       → ``"0.12.1"`` (bare version)
+
+    Args:
+        constraint: A pixi version constraint string.
+
+    Returns:
+        Lower-bound version string, or None if unparseable.
+
+    """
+    match = re.search(r"[><=]=?\s*(\d+\.\d+[\.\d]*)", constraint)
+    if match:
+        return match.group(1)
+    bare = re.match(r"^(\d+\.\d+[\.\d]*)$", constraint.strip())
+    if bare:
+        return bare.group(1)
+    return None
+
+
+def _parse_pixi_dependencies_fallback(pixi_path: Path) -> dict[str, str]:
+    """Minimal line-by-line parser for ``[dependencies]`` when tomllib is unavailable.
+
+    Args:
+        pixi_path: Path to ``pixi.toml``.
+
+    Returns:
+        Dict mapping package name (lowercased) to lower-bound version string.
+
+    """
+    deps: dict[str, str] = {}
+    in_deps = False
+    for line in pixi_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped == "[dependencies]":
+            in_deps = True
+            continue
+        if stripped.startswith("[") and stripped != "[dependencies]":
+            in_deps = False
+            continue
+        if in_deps and "=" in stripped and not stripped.startswith("#"):
+            key, _, value = stripped.partition("=")
+            pkg = key.strip().lower()
+            constraint = value.strip().strip('"')
+            version = parse_pixi_constraint(constraint)
+            if version:
+                deps[pkg] = version
+    return deps
+
+
+def load_pixi_versions(pixi_path: Path) -> dict[str, str]:
+    """Parse ``pixi.toml`` and return a dict mapping package name to lower-bound version.
+
+    Args:
+        pixi_path: Path to ``pixi.toml``.
+
+    Returns:
+        Dict mapping package name (lowercased) to lower-bound version string.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+
+    """
+    if not pixi_path.exists():
+        raise FileNotFoundError(f"pixi.toml not found: {pixi_path}")
+
+    if _tomllib is not None:
+        from typing import cast
+
+        _load = getattr(_tomllib, "load")
+        with pixi_path.open("rb") as fh:
+            data = cast(dict[str, Any], _load(fh))
+        deps: dict[str, str] = {}
+        for pkg, constraint in data.get("dependencies", {}).items():
+            version = parse_pixi_constraint(str(constraint))
+            if version:
+                deps[pkg.lower()] = version
+        return deps
+
+    return _parse_pixi_dependencies_fallback(pixi_path)
+
+
+def _version_tuple(version: str) -> tuple[int, ...]:
+    """Convert a version string to a comparable tuple of integers.
+
+    Args:
+        version: Version string, e.g. ``"1.19.1"``.
+
+    Returns:
+        Tuple of ints, e.g. ``(1, 19, 1)``.
+
+    """
+    parts = []
+    for part in version.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+def check_version_drift(
+    external_hooks: dict[str, str],
+    pixi_versions: dict[str, str],
+    hook_to_pixi_map: dict[str, str] | None = None,
+) -> list[str]:
+    """Compare external hook revs against pixi.toml lower-bound versions.
+
+    Args:
+        external_hooks: Dict mapping repo URL to rev (from ``.pre-commit-config.yaml``).
+        pixi_versions: Dict mapping package name to lower-bound version (from ``pixi.toml``).
+        hook_to_pixi_map: Custom URL→package mapping; defaults to :data:`DEFAULT_HOOK_TO_PIXI_MAP`.
+
+    Returns:
+        List of human-readable drift messages (empty if everything is consistent).
+
+    """
+    mapping = hook_to_pixi_map if hook_to_pixi_map is not None else DEFAULT_HOOK_TO_PIXI_MAP
+    issues: list[str] = []
+    for repo_url, rev in external_hooks.items():
+        pkg_name = mapping.get(repo_url)
+        if pkg_name is None:
+            continue
+        pixi_version = pixi_versions.get(pkg_name.lower())
+        if pixi_version is None:
+            issues.append(
+                f"MISSING: '{pkg_name}' is used in .pre-commit-config.yaml "
+                f"(rev={rev!r}) but has no entry in pixi.toml. "
+                f"Add '{pkg_name} = \">={normalize_version(rev)}\"' to pixi.toml."
+            )
+            continue
+        hook_version = normalize_version(rev)
+        if _version_tuple(hook_version) != _version_tuple(pixi_version):
+            issues.append(
+                f"DRIFT: '{pkg_name}' — .pre-commit-config.yaml rev is "
+                f"{hook_version!r} but pixi.toml lower bound is {pixi_version!r}. "
+                f"They must match."
+            )
+    return issues
+
+
+def check_version_consistency(
+    precommit_path: Path | None = None,
+    pixi_path: Path | None = None,
+    hook_to_pixi_map: dict[str, str] | None = None,
+) -> list[str]:
+    """Top-level check: load both config files and return drift issues.
+
+    Args:
+        precommit_path: Path to ``.pre-commit-config.yaml`` (defaults to repo root).
+        pixi_path: Path to ``pixi.toml`` (defaults to repo root).
+        hook_to_pixi_map: Custom URL→package mapping; defaults to :data:`DEFAULT_HOOK_TO_PIXI_MAP`.
+
+    Returns:
+        List of drift/missing messages (empty means consistent).
+
+    """
+    from hephaestus.utils.helpers import get_repo_root
+
+    root = get_repo_root()
+    if precommit_path is None:
+        precommit_path = root / ".pre-commit-config.yaml"
+    if pixi_path is None:
+        pixi_path = root / "pixi.toml"
+
+    repos = load_precommit_config(precommit_path)
+    external_hooks = extract_external_hooks(repos)
+    pixi_versions = load_pixi_versions(pixi_path)
+    return check_version_drift(external_hooks, pixi_versions, hook_to_pixi_map)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def bench_precommit_main(argv: list[str] | None = None) -> int:
+    """CLI entry-point for the pre-commit benchmark helper.
+
+    Returns:
+        Always 0 — timing regressions are non-blocking.
+
+    """
+    parser = argparse.ArgumentParser(description="Report pre-commit hook benchmark results.")
+    parser.add_argument("--elapsed", type=int, required=True, help="Elapsed time in seconds.")
+    parser.add_argument("--files", type=int, default=0, help="Number of files processed.")
+    parser.add_argument(
+        "--status", default="passed", help='Hook exit status string, e.g. "passed" or "failed".'
+    )
+    parser.add_argument(
+        "--threshold", type=int, default=120, help="Warning threshold in seconds (default: 120)."
+    )
+
+    args = parser.parse_args(argv)
+
+    table = format_summary_table(args.elapsed, args.files, args.status)
+    print(table)
+    write_step_summary(table)
+
+    if check_threshold(args.elapsed, args.threshold):
+        emit_warning(
+            f"Pre-commit hooks took {args.elapsed}s, "
+            f"which exceeds the {args.threshold}s threshold. "
+            "Consider reviewing hook configuration for performance regressions."
+        )
+
+    return 0
+
+
+def check_precommit_versions_main(argv: list[str] | None = None) -> int:
+    """CLI entry-point for pre-commit version drift detection.
+
+    Returns:
+        Exit code: 0 for success, 1 for drift detected or error.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Check .pre-commit-config.yaml revs match pixi.toml versions"
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to .pre-commit-config.yaml (default: repo root)",
+    )
+    parser.add_argument(
+        "--pixi",
+        type=Path,
+        default=None,
+        help="Path to pixi.toml (default: repo root)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        issues = check_version_consistency(
+            precommit_path=args.config,
+            pixi_path=args.pixi,
+        )
+    except FileNotFoundError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if issues:
+        print("Pre-commit version drift detected:")
+        for issue in issues:
+            print(f"  - {issue}")
+        print(
+            "\nFix: update the rev in .pre-commit-config.yaml or the version "
+            "constraint in pixi.toml so they match."
+        )
+        return 1
+
+    print("OK: all pre-commit hook versions are consistent with pixi.toml")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_precommit_versions_main())

--- a/hephaestus/ci/precommit.py
+++ b/hephaestus/ci/precommit.py
@@ -258,7 +258,7 @@ def load_pixi_versions(pixi_path: Path) -> dict[str, str]:
     if _tomllib is not None:
         from typing import cast
 
-        _load = getattr(_tomllib, "load")
+        _load = _tomllib.load
         with pixi_path.open("rb") as fh:
             data = cast(dict[str, Any], _load(fh))
         deps: dict[str, str] = {}

--- a/hephaestus/ci/workflows.py
+++ b/hephaestus/ci/workflows.py
@@ -168,9 +168,7 @@ def _is_local_reference_step(step: object) -> bool:
     return uses.startswith("./.github/actions/") or uses.startswith("./.github/workflows/")
 
 
-def _check_job_steps(
-    workflow_file: Path, job_name: str, steps: list[Any]
-) -> list[Violation]:
+def _check_job_steps(workflow_file: Path, job_name: str, steps: list[Any]) -> list[Violation]:
     """Check a single job's steps for checkout-first ordering violations.
 
     Args:
@@ -218,9 +216,7 @@ def validate_workflow(workflow_file: Path) -> list[Violation]:
 
     """
     if _yaml is None:
-        print(
-            f"WARNING: Skipping {workflow_file} (pyyaml not installed)", file=sys.stderr
-        )
+        print(f"WARNING: Skipping {workflow_file} (pyyaml not installed)", file=sys.stderr)
         return []
 
     if workflow_file.stat().st_size > _MAX_FILE_SIZE:
@@ -259,7 +255,6 @@ def validate_workflow(workflow_file: Path) -> list[Violation]:
         violations.extend(_check_job_steps(workflow_file, str(job_name), steps))
 
     return violations
-
 
 
 def collect_workflow_files(paths: list[str]) -> list[Path]:
@@ -398,10 +393,7 @@ def validate_workflow_checkout_main() -> int:
         print(f"\nFound {len(all_violations)} violation(s) in {len(workflow_files)} file(s).")
         return 1
 
-    print(
-        f"OK: {len(workflow_files)} workflow file(s) checked. "
-        "All pass checkout-first invariant."
-    )
+    print(f"OK: {len(workflow_files)} workflow file(s) checked. All pass checkout-first invariant.")
     return 0
 
 

--- a/hephaestus/ci/workflows.py
+++ b/hephaestus/ci/workflows.py
@@ -1,0 +1,409 @@
+"""GitHub Actions workflow validation utilities.
+
+Provides two checks:
+
+**Inventory check** (``hephaestus-check-workflow-inventory``): Detects drift
+between ``.github/workflows/*.yml`` files on disk and the workflow table in
+``.github/workflows/README.md``.
+
+**Checkout-order check** (``hephaestus-validate-workflow-checkout``): Validates
+that composite action and reusable workflow references
+(``uses: ./.github/actions/X`` or ``uses: ./.github/workflows/X``) are always
+preceded by an ``actions/checkout`` step within the same job.
+
+Usage::
+
+    hephaestus-check-workflow-inventory
+    hephaestus-check-workflow-inventory --repo-root /path/to/repo
+    hephaestus-validate-workflow-checkout
+    hephaestus-validate-workflow-checkout .github/workflows/ci.yml
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any, NamedTuple
+
+try:
+    import yaml as _yaml
+except ModuleNotFoundError:
+    _yaml = None  # type: ignore[assignment]
+
+# Security limit: skip workflow files larger than 1 MB
+_MAX_FILE_SIZE = 1_048_576
+
+# Matches a .yml filename (with or without a markdown hyperlink) inside a
+# pipe-delimited table cell.  Examples:
+#   | validate-workflows.yml |
+#   | [comprehensive-tests.yml](#anchor) |
+_TABLE_FILENAME_RE = re.compile(r"\|\s*\[?([a-zA-Z0-9_.-]+\.yml)\]?[^|]*\|")
+
+
+# ---------------------------------------------------------------------------
+# Inventory check
+# ---------------------------------------------------------------------------
+
+
+def collect_yml_files(repo_root: Path) -> set[str]:
+    """Return basenames of ``*.yml`` files in ``.github/workflows/``, excluding worktrees.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        Set of ``.yml`` basenames (e.g. ``{"ci.yml", "release.yml"}``).
+
+    """
+    workflows_dir = repo_root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return set()
+
+    result: set[str] = set()
+    for path in workflows_dir.glob("*.yml"):
+        try:
+            rel = path.relative_to(repo_root)
+        except ValueError:
+            rel = path
+        if any(part == "worktrees" for part in rel.parts):
+            continue
+        result.add(path.name)
+    return result
+
+
+def parse_readme_table(readme_path: Path) -> set[str]:
+    """Parse ``.github/workflows/README.md`` and return documented ``.yml`` filenames.
+
+    Only lines containing a pipe-delimited table cell with a ``.yml`` filename
+    are considered.  Both plain and hyperlinked forms are matched.
+
+    Args:
+        readme_path: Path to the README.md file to parse.
+
+    Returns:
+        Set of documented ``.yml`` basenames.
+
+    """
+    if not readme_path.is_file():
+        return set()
+
+    content = readme_path.read_text(encoding="utf-8")
+    found: set[str] = set()
+    for line in content.splitlines():
+        for match in _TABLE_FILENAME_RE.finditer(line):
+            found.add(match.group(1))
+    return found
+
+
+def check_inventory(repo_root: Path) -> tuple[list[str], list[str]]:
+    """Compare on-disk ``.yml`` files against the README table.
+
+    Args:
+        repo_root: Absolute path to the repository root.
+
+    Returns:
+        A tuple ``(undocumented, missing_files)`` where:
+
+        - ``undocumented``: filenames present on disk but absent from README table
+        - ``missing_files``: filenames in README table but absent from disk
+
+    """
+    readme_path = repo_root / ".github" / "workflows" / "README.md"
+    on_disk = collect_yml_files(repo_root)
+    in_readme = parse_readme_table(readme_path)
+
+    undocumented = sorted(on_disk - in_readme)
+    missing_files = sorted(in_readme - on_disk)
+    return undocumented, missing_files
+
+
+# ---------------------------------------------------------------------------
+# Checkout-order check
+# ---------------------------------------------------------------------------
+
+
+class Violation(NamedTuple):
+    """A single checkout-order violation."""
+
+    workflow_file: Path
+    job_name: str
+    step_index: int
+    step_name: str
+    composite_action: str
+
+
+def _is_checkout_step(step: object) -> bool:
+    """Return True if the step uses ``actions/checkout`` (any version or hash).
+
+    Args:
+        step: A step dict from a workflow YAML.
+
+    Returns:
+        True if the step is an actions/checkout step.
+
+    """
+    if not isinstance(step, dict):
+        return False
+    uses = step.get("uses", "")
+    return isinstance(uses, str) and uses.startswith("actions/checkout")
+
+
+def _is_local_reference_step(step: object) -> bool:
+    """Return True if the step references a local composite action or reusable workflow.
+
+    Args:
+        step: A step dict from a workflow YAML.
+
+    Returns:
+        True if the step uses a local ``./.github/actions/`` or ``./.github/workflows/`` ref.
+
+    """
+    if not isinstance(step, dict):
+        return False
+    uses = step.get("uses", "")
+    if not isinstance(uses, str):
+        return False
+    return uses.startswith("./.github/actions/") or uses.startswith("./.github/workflows/")
+
+
+def _check_job_steps(
+    workflow_file: Path, job_name: str, steps: list[Any]
+) -> list[Violation]:
+    """Check a single job's steps for checkout-first ordering violations.
+
+    Args:
+        workflow_file: Path to the workflow YAML file (for error reporting).
+        job_name: Name of the job being checked.
+        steps: List of step dicts from the job.
+
+    Returns:
+        List of :class:`Violation` objects found in this job.
+
+    """
+    violations: list[Violation] = []
+    checked_out = False
+    for idx, step in enumerate(steps):
+        if _is_checkout_step(step):
+            checked_out = True
+            continue
+        if _is_local_reference_step(step) and not checked_out:
+            step_name = (
+                step.get("name", f"(unnamed step {idx + 1})")
+                if isinstance(step, dict)
+                else f"(step {idx + 1})"
+            )
+            composite_action = step.get("uses", "") if isinstance(step, dict) else ""
+            violations.append(
+                Violation(
+                    workflow_file=workflow_file,
+                    job_name=str(job_name),
+                    step_index=idx + 1,
+                    step_name=str(step_name),
+                    composite_action=str(composite_action),
+                )
+            )
+    return violations
+
+
+def validate_workflow(workflow_file: Path) -> list[Violation]:
+    """Validate checkout-first ordering for all jobs in a workflow file.
+
+    Args:
+        workflow_file: Path to the workflow YAML file.
+
+    Returns:
+        List of :class:`Violation` objects; empty list means the file passes.
+
+    """
+    if _yaml is None:
+        print(
+            f"WARNING: Skipping {workflow_file} (pyyaml not installed)", file=sys.stderr
+        )
+        return []
+
+    if workflow_file.stat().st_size > _MAX_FILE_SIZE:
+        print(
+            f"WARNING: Skipping {workflow_file} (exceeds {_MAX_FILE_SIZE} byte limit)",
+            file=sys.stderr,
+        )
+        return []
+
+    with open(workflow_file, encoding="utf-8") as fh:
+        try:
+            data: Any = _yaml.safe_load(fh)
+        except _yaml.YAMLError as exc:
+            print(
+                f"WARNING: Skipping {workflow_file} (YAML parse error: {exc})",
+                file=sys.stderr,
+            )
+            return []
+
+    if not isinstance(data, dict):
+        return []
+
+    jobs = data.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    violations: list[Violation] = []
+    for job_name, job_data in jobs.items():
+        if not isinstance(job_data, dict):
+            continue
+
+        steps = job_data.get("steps")
+        if not isinstance(steps, list):
+            continue
+
+        violations.extend(_check_job_steps(workflow_file, str(job_name), steps))
+
+    return violations
+
+
+
+def collect_workflow_files(paths: list[str]) -> list[Path]:
+    """Expand the given paths into a list of workflow YAML files.
+
+    Args:
+        paths: File paths or directory paths. Directories are searched for
+               ``*.yml`` and ``*.yaml`` files non-recursively.
+
+    Returns:
+        Deduplicated list of :class:`~pathlib.Path` objects for each candidate.
+
+    """
+    files: list[Path] = []
+    for raw in paths:
+        p = Path(raw)
+        if p.is_file():
+            files.append(p)
+        elif p.is_dir():
+            files.extend(sorted(p.glob("*.yml")))
+            files.extend(sorted(p.glob("*.yaml")))
+        else:
+            print(f"WARNING: Path not found: {p}", file=sys.stderr)
+
+    seen: set[Path] = set()
+    result: list[Path] = []
+    for f in files:
+        key = f.resolve()
+        if key not in seen:
+            seen.add(key)
+            result.append(f)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def check_workflow_inventory_main() -> int:
+    """CLI entry point for workflow inventory drift detection.
+
+    Returns:
+        Exit code: 0 for success, 1 for drift detected.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Detect drift between .github/workflows/*.yml files and README.md table.",
+        epilog="Example: %(prog)s --repo-root /path/to/repo",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect via git)",
+    )
+    args = parser.parse_args()
+
+    if args.repo_root is not None:
+        repo_root = args.repo_root
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    undocumented, missing_files = check_inventory(repo_root)
+
+    if not undocumented and not missing_files:
+        print("OK: workflow inventory is in sync.")
+        return 0
+
+    print("ERROR: workflow inventory drift detected!\n")
+
+    if undocumented:
+        print("Files on disk but NOT documented in .github/workflows/README.md:")
+        for name in undocumented:
+            print(f"  + {name}")
+        print()
+
+    if missing_files:
+        print("Files documented in README.md table but NOT present on disk:")
+        for name in missing_files:
+            print(f"  - {name}")
+        print()
+
+    print(
+        "Fix: update the Workflow Summary table in .github/workflows/README.md "
+        "so it exactly matches the *.yml files on disk."
+    )
+    return 1
+
+
+def validate_workflow_checkout_main() -> int:
+    """CLI entry point for checkout-order validation.
+
+    Returns:
+        Exit code: 0 for success, 1 for violations found.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate that composite actions are preceded by actions/checkout.",
+        epilog="Example: %(prog)s .github/workflows/ci.yml",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="Workflow files or directories (default: .github/workflows/)",
+    )
+    args = parser.parse_args()
+
+    target_paths: list[str] = args.paths
+    if not target_paths:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+        target_paths = [str(repo_root / ".github" / "workflows")]
+
+    workflow_files = collect_workflow_files(target_paths)
+
+    if not workflow_files:
+        print("No workflow files found to validate.")
+        return 0
+
+    all_violations: list[Violation] = []
+    for wf_file in workflow_files:
+        all_violations.extend(validate_workflow(wf_file))
+
+    if all_violations:
+        for v in all_violations:
+            print(
+                f"\nERROR: {v.workflow_file} :: job '{v.job_name}' :: step {v.step_index} "
+                f"uses '{v.composite_action}'\n"
+                f"       but actions/checkout is not a preceding step.\n"
+                f"       Composite actions and reusable workflows require checkout first."
+            )
+        print(f"\nFound {len(all_violations)} violation(s) in {len(workflow_files)} file(s).")
+        return 1
+
+    print(
+        f"OK: {len(workflow_files)} workflow file(s) checked. "
+        "All pass checkout-first invariant."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_workflow_inventory_main())

--- a/hephaestus/config/__init__.py
+++ b/hephaestus/config/__init__.py
@@ -1,6 +1,14 @@
 """Configuration management utilities."""
 
-from .utils import (
+from hephaestus.config.dep_sync import (
+    check_dep_sync,
+    check_requirements_up_to_date,
+    generate_requirements_content,
+    parse_pixi_toml,
+    parse_requirements,
+    sync_requirements,
+)
+from hephaestus.config.utils import (
     get_config_value,
     get_setting,
     load_config,
@@ -11,11 +19,17 @@ from .utils import (
 )
 
 __all__ = [
+    "check_dep_sync",
+    "check_requirements_up_to_date",
+    "generate_requirements_content",
     "get_config_value",
     "get_setting",
     "load_config",
     "load_yaml_config",
     "merge_configs",
     "merge_with_env",
+    "parse_pixi_toml",
+    "parse_requirements",
+    "sync_requirements",
     "validate_config",
 ]

--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -1,0 +1,550 @@
+"""Validate and synchronize dependency declarations across project config files.
+
+Provides two main operations:
+
+**Check** (``hephaestus-check-dep-sync``): Validates that every package pinned in
+``requirements*.txt`` has a corresponding entry in ``pixi.toml`` and that the
+pinned version falls within the ``pixi.toml`` range constraint.  Also reports if
+``pyproject.toml`` still carries ``[project.dependencies]`` (which should be
+managed in ``pixi.toml`` instead).
+
+**Sync** (``hephaestus-sync-requirements``): Re-generates ``requirements.txt`` and
+``requirements-dev.txt`` from the pixi-resolved environment (``pixi list --json``),
+so that pip-only contexts (Docker, CI fallback) stay in sync with the authoritative
+pixi lock.
+
+Usage::
+
+    hephaestus-check-dep-sync
+    hephaestus-check-dep-sync --repo-root /path/to/repo
+
+    hephaestus-sync-requirements
+    hephaestus-sync-requirements --check   # verify without writing
+    hephaestus-sync-requirements --repo-root /path/to/repo
+
+Exit codes:
+    0  All checks pass (or sync succeeded)
+    1  Violations detected (check) or sync failed
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+# Header written at the top of every auto-generated requirements file.
+_GENERATED_HEADER = """\
+# AUTO-GENERATED from pixi.toml — do not edit manually.
+# Regenerate with: hephaestus-sync-requirements
+# These files exist for pip-only contexts (Docker, CI fallback).
+"""
+
+
+# ---------------------------------------------------------------------------
+# Version comparison helpers
+# ---------------------------------------------------------------------------
+
+
+class VersionRange(NamedTuple):
+    """A single version constraint (operator + version tuple)."""
+
+    op: str
+    version: tuple[int, ...]
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a dotted version string into a tuple of ints.
+
+    Args:
+        v: Version string like ``"1.2.3"``.
+
+    Returns:
+        Tuple of integers, e.g. ``(1, 2, 3)``.
+
+    """
+    return tuple(int(x) for x in re.split(r"[.\-]", v) if x.isdigit())
+
+
+def _parse_constraints(spec: str) -> list[VersionRange]:
+    """Parse a pixi.toml version spec into a list of :class:`VersionRange`.
+
+    Args:
+        spec: Version specification string, e.g. ``">=1.2.0,<2"``.
+
+    Returns:
+        List of parsed constraints.
+
+    """
+    constraints: list[VersionRange] = []
+    spec = spec.strip().strip('"').strip("'")
+    for part in spec.split(","):
+        part = part.strip()
+        m = re.match(r"(>=|<=|>|<|==|!=|~=)(.+)", part)
+        if m:
+            op, ver = m.group(1), m.group(2)
+            constraints.append(VersionRange(op=op, version=_parse_version(ver)))
+    return constraints
+
+
+def _version_satisfies(version: tuple[int, ...], constraints: list[VersionRange]) -> bool:
+    """Return True if *version* satisfies all *constraints*.
+
+    Args:
+        version: Parsed version tuple.
+        constraints: List of constraints to check against.
+
+    Returns:
+        True if all constraints are satisfied.
+
+    """
+    for c in constraints:
+        v = version + (0,) * max(0, len(c.version) - len(version))
+        cv = c.version + (0,) * max(0, len(version) - len(c.version))
+        ops = {
+            ">=": v >= cv,
+            "<=": v <= cv,
+            ">": v > cv,
+            "<": v < cv,
+            "==": v == cv,
+            "!=": v != cv,
+        }
+        satisfied = ops.get(c.op, True)
+        if not satisfied:
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_pixi_toml(path: Path) -> dict[str, str]:
+    """Extract package→version-spec from ``pixi.toml`` dependency sections.
+
+    Reads ``[dependencies]`` and ``[pypi-dependencies]`` sections using a
+    simple line-by-line parser (avoids a TOML dependency for 3.10 compat).
+
+    Args:
+        path: Path to ``pixi.toml``.
+
+    Returns:
+        Dict mapping package name to version spec string.
+
+    """
+    deps: dict[str, str] = {}
+    in_deps = False
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[dependencies]") or stripped.startswith(
+            "[pypi-dependencies]"
+        ):
+            in_deps = True
+            continue
+        if stripped.startswith("[") and in_deps:
+            in_deps = False
+            continue
+        if in_deps and "=" in stripped and not stripped.startswith("#"):
+            line_no_comment = stripped.split("#")[0].strip()
+            m = re.match(r'(\S+)\s*=\s*"([^"]+)"', line_no_comment)
+            if m:
+                deps[m.group(1)] = m.group(2)
+    return deps
+
+
+def parse_requirements(path: Path) -> dict[str, str]:
+    """Extract package→pinned-version from a requirements file.
+
+    Args:
+        path: Path to the requirements file.
+
+    Returns:
+        Dict mapping package name (lowercased) to pinned version string.
+
+    """
+    pins: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or stripped.startswith("-r"):
+            continue
+        stripped = stripped.split("#")[0].strip()
+        m = re.match(r"([a-zA-Z0-9_.-]+)==(.+)", stripped)
+        if m:
+            pins[m.group(1).lower()] = m.group(2).strip()
+    return pins
+
+
+# ---------------------------------------------------------------------------
+# Check operations
+# ---------------------------------------------------------------------------
+
+
+def check_pyproject_no_deps(path: Path) -> list[str]:
+    """Return errors if ``pyproject.toml`` carries managed dependency sections.
+
+    Flags ``[project.dependencies]`` and ``[project.optional-dependencies]``
+    which should be managed in ``pixi.toml`` instead.
+
+    Args:
+        path: Path to ``pyproject.toml``.
+
+    Returns:
+        List of error strings.
+
+    """
+    errors: list[str] = []
+    if not path.exists():
+        return errors
+    text = path.read_text(encoding="utf-8")
+    if re.search(r"^\[project\.dependencies\]", text, re.MULTILINE):
+        errors.append("pyproject.toml contains [project.dependencies] — remove it")
+    if "[project.optional-dependencies]" in text:
+        errors.append(
+            "pyproject.toml contains [project.optional-dependencies] — remove it"
+        )
+    return errors
+
+
+def check_requirements_against_pixi(
+    repo_root: Path,
+    pixi_deps_lower: dict[str, str],
+) -> list[str]:
+    """Check that requirements files are consistent with ``pixi.toml``.
+
+    Args:
+        repo_root: Repository root directory.
+        pixi_deps_lower: Lowercased package→spec dict from ``pixi.toml``.
+
+    Returns:
+        List of error strings.
+
+    """
+    errors: list[str] = []
+    for req_name in ("requirements.txt", "requirements-dev.txt"):
+        req_path = repo_root / req_name
+        if not req_path.exists():
+            continue
+        pins = parse_requirements(req_path)
+        for pkg, pinned_ver in pins.items():
+            if pkg not in pixi_deps_lower:
+                errors.append(
+                    f"{req_name}: {pkg}=={pinned_ver} has no matching entry in pixi.toml"
+                )
+                continue
+            constraints = _parse_constraints(pixi_deps_lower[pkg])
+            if constraints:
+                ver_tuple = _parse_version(pinned_ver)
+                if not _version_satisfies(ver_tuple, constraints):
+                    errors.append(
+                        f"{req_name}: {pkg}=={pinned_ver} falls outside "
+                        f"pixi.toml constraint '{pixi_deps_lower[pkg]}'"
+                    )
+    return errors
+
+
+def check_dep_sync(repo_root: Path | None = None) -> list[str]:
+    """Run all dependency consistency checks.
+
+    Args:
+        repo_root: Repository root.  Defaults to auto-detection via git.
+
+    Returns:
+        List of error messages (empty = all checks passed).
+
+    """
+    if repo_root is None:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    errors: list[str] = []
+    pixi_path = repo_root / "pixi.toml"
+
+    if not pixi_path.exists():
+        return ["pixi.toml not found"]
+
+    pixi_deps = parse_pixi_toml(pixi_path)
+    pixi_deps_lower = {k.lower(): v for k, v in pixi_deps.items()}
+
+    errors.extend(check_requirements_against_pixi(repo_root, pixi_deps_lower))
+    errors.extend(check_pyproject_no_deps(repo_root / "pyproject.toml"))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Sync operations
+# ---------------------------------------------------------------------------
+
+
+def get_pixi_packages() -> dict[str, str]:
+    """Return ``{package_name: version}`` from ``pixi list --json``.
+
+    Returns:
+        Dict mapping package names to resolved version strings.
+
+    Raises:
+        SystemExit: With code 1 if ``pixi list`` fails.
+
+    """
+    result = subprocess.run(
+        ["pixi", "list", "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"ERROR: pixi list --json failed: {result.stderr}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    data: list[dict[str, str]] = json.loads(result.stdout)
+    return {pkg["name"]: pkg["version"] for pkg in data}
+
+
+def generate_requirements_content(
+    packages: list[str],
+    resolved: dict[str, str],
+    include_base: str | None = None,
+    section_comments: dict[str, str] | None = None,
+) -> str:
+    """Build a requirements file string with exact pins.
+
+    Args:
+        packages: Package names to include.
+        resolved: Mapping of package name to resolved version.
+        include_base: Optional ``-r <file>`` line to prepend.
+        section_comments: Optional per-package inline comments.
+
+    Returns:
+        Full file content as a string.
+
+    """
+    comments = section_comments or {}
+    lines: list[str] = [_GENERATED_HEADER]
+    if include_base:
+        lines += [include_base, ""]
+
+    for pkg in packages:
+        version = resolved.get(pkg)
+        if version is None:
+            print(
+                f"WARNING: {pkg} not found in pixi environment, skipping",
+                file=sys.stderr,
+            )
+            continue
+        comment = comments.get(pkg, "")
+        suffix = f"  {comment}" if comment else ""
+        lines.append(f"{pkg}=={version}{suffix}")
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def sync_requirements(
+    repo_root: Path,
+    resolved: dict[str, str],
+    core_packages: list[str],
+    dev_packages: list[str],
+    core_comments: dict[str, str] | None = None,
+    dev_comments: dict[str, str] | None = None,
+) -> list[Path]:
+    """Write ``requirements.txt`` and ``requirements-dev.txt`` under *repo_root*.
+
+    Args:
+        repo_root: Repository root directory.
+        resolved: Package-to-version mapping from pixi.
+        core_packages: Packages for ``requirements.txt``.
+        dev_packages: Packages for ``requirements-dev.txt``.
+        core_comments: Per-package comments for ``requirements.txt``.
+        dev_comments: Per-package comments for ``requirements-dev.txt``.
+
+    Returns:
+        List of paths written.
+
+    """
+    req_txt = generate_requirements_content(
+        core_packages, resolved, section_comments=core_comments
+    )
+    req_dev_txt = generate_requirements_content(
+        dev_packages,
+        resolved,
+        include_base="-r requirements.txt",
+        section_comments=dev_comments,
+    )
+    paths: list[Path] = []
+    for name, content in [
+        ("requirements.txt", req_txt),
+        ("requirements-dev.txt", req_dev_txt),
+    ]:
+        path = repo_root / name
+        path.write_text(content, encoding="utf-8")
+        paths.append(path)
+        print(f"Wrote {path}")
+    return paths
+
+
+def check_requirements_up_to_date(
+    repo_root: Path,
+    resolved: dict[str, str],
+    core_packages: list[str],
+    dev_packages: list[str],
+    core_comments: dict[str, str] | None = None,
+    dev_comments: dict[str, str] | None = None,
+) -> bool:
+    """Return True if existing requirements files match expected content.
+
+    Args:
+        repo_root: Repository root directory.
+        resolved: Package-to-version mapping from pixi.
+        core_packages: Packages for ``requirements.txt``.
+        dev_packages: Packages for ``requirements-dev.txt``.
+        core_comments: Per-package comments for ``requirements.txt``.
+        dev_comments: Per-package comments for ``requirements-dev.txt``.
+
+    Returns:
+        True if both files are current, False if any are missing or out of date.
+
+    """
+    expected = {
+        "requirements.txt": generate_requirements_content(
+            core_packages, resolved, section_comments=core_comments
+        ),
+        "requirements-dev.txt": generate_requirements_content(
+            dev_packages,
+            resolved,
+            include_base="-r requirements.txt",
+            section_comments=dev_comments,
+        ),
+    }
+    ok = True
+    for name, expected_content in expected.items():
+        path = repo_root / name
+        if not path.exists():
+            print(f"FAIL: {name} does not exist", file=sys.stderr)
+            ok = False
+            continue
+        if path.read_text(encoding="utf-8") != expected_content:
+            print(
+                f"FAIL: {name} is out of date — "
+                f"regenerate with: hephaestus-sync-requirements",
+                file=sys.stderr,
+            )
+            ok = False
+    return ok
+
+
+# ---------------------------------------------------------------------------
+# CLI entry points
+# ---------------------------------------------------------------------------
+
+
+def check_dep_sync_main() -> int:
+    """CLI entry point for dependency consistency checking.
+
+    Returns:
+        Exit code (0 if all checks pass, 1 if violations found).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate dependency consistency across project config files",
+        epilog="Example: %(prog)s --repo-root /path/to/repo",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect via git)",
+    )
+    args = parser.parse_args()
+
+    errors = check_dep_sync(args.repo_root)
+    if errors:
+        print("Dependency sync check FAILED:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("OK: all dependency declarations are consistent")
+    return 0
+
+
+def sync_requirements_main() -> int:
+    """CLI entry point for requirements-file synchronisation.
+
+    Reads pixi-resolved packages and writes (or checks) requirements files.
+    Callers should pass ``--core`` / ``--dev`` flags to specify which packages
+    belong in each file, or rely on the calling repo's wrapper script.
+
+    Returns:
+        Exit code (0 on success, 1 on failure).
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Sync requirements*.txt from pixi-resolved environment",
+        epilog="Example: %(prog)s --check",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify files are up-to-date without writing (exit 1 if not)",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root (default: auto-detect via git)",
+    )
+    parser.add_argument(
+        "--core",
+        nargs="*",
+        default=[],
+        metavar="PKG",
+        help="Core packages for requirements.txt",
+    )
+    parser.add_argument(
+        "--dev",
+        nargs="*",
+        default=[],
+        metavar="PKG",
+        help="Dev-only packages for requirements-dev.txt",
+    )
+
+    args = parser.parse_args()
+
+    if args.repo_root is not None:
+        repo_root: Path = args.repo_root
+    else:
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+
+    resolved = get_pixi_packages()
+
+    if args.check:
+        ok = check_requirements_up_to_date(
+            repo_root,
+            resolved,
+            core_packages=args.core,
+            dev_packages=args.dev,
+        )
+        if ok:
+            print("OK: requirements files are up-to-date")
+            return 0
+        return 1
+
+    sync_requirements(
+        repo_root,
+        resolved,
+        core_packages=args.core,
+        dev_packages=args.dev,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check_dep_sync_main())

--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -141,9 +141,7 @@ def parse_pixi_toml(path: Path) -> dict[str, str]:
     in_deps = False
     for line in path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
-        if stripped.startswith("[dependencies]") or stripped.startswith(
-            "[pypi-dependencies]"
-        ):
+        if stripped.startswith("[dependencies]") or stripped.startswith("[pypi-dependencies]"):
             in_deps = True
             continue
         if stripped.startswith("[") and in_deps:
@@ -204,9 +202,7 @@ def check_pyproject_no_deps(path: Path) -> list[str]:
     if re.search(r"^\[project\.dependencies\]", text, re.MULTILINE):
         errors.append("pyproject.toml contains [project.dependencies] — remove it")
     if "[project.optional-dependencies]" in text:
-        errors.append(
-            "pyproject.toml contains [project.optional-dependencies] — remove it"
-        )
+        errors.append("pyproject.toml contains [project.optional-dependencies] — remove it")
     return errors
 
 
@@ -232,9 +228,7 @@ def check_requirements_against_pixi(
         pins = parse_requirements(req_path)
         for pkg, pinned_ver in pins.items():
             if pkg not in pixi_deps_lower:
-                errors.append(
-                    f"{req_name}: {pkg}=={pinned_ver} has no matching entry in pixi.toml"
-                )
+                errors.append(f"{req_name}: {pkg}=={pinned_ver} has no matching entry in pixi.toml")
                 continue
             constraints = _parse_constraints(pixi_deps_lower[pkg])
             if constraints:
@@ -367,9 +361,7 @@ def sync_requirements(
         List of paths written.
 
     """
-    req_txt = generate_requirements_content(
-        core_packages, resolved, section_comments=core_comments
-    )
+    req_txt = generate_requirements_content(core_packages, resolved, section_comments=core_comments)
     req_dev_txt = generate_requirements_content(
         dev_packages,
         resolved,
@@ -430,8 +422,7 @@ def check_requirements_up_to_date(
             continue
         if path.read_text(encoding="utf-8") != expected_content:
             print(
-                f"FAIL: {name} is out of date — "
-                f"regenerate with: hephaestus-sync-requirements",
+                f"FAIL: {name} is out of date — regenerate with: hephaestus-sync-requirements",
                 file=sys.stderr,
             )
             ok = False

--- a/hephaestus/discovery/__init__.py
+++ b/hephaestus/discovery/__init__.py
@@ -1,0 +1,27 @@
+"""Filesystem discovery utilities for agents, skills, and CLAUDE.md blocks.
+
+Provides generic, path-agnostic functions for discovering and organizing
+resources from codebases.  No hardcoded paths or project-specific names.
+
+Usage::
+
+    from hephaestus.discovery import discover_agents, discover_skills, extract_blocks
+
+    agents = discover_agents(Path(".claude/agents"))
+    skills = discover_skills(Path(".claude/skills"))
+"""
+
+from hephaestus.discovery.agents import discover_agents, organize_agents, parse_agent_level
+from hephaestus.discovery.blocks import discover_blocks, extract_blocks
+from hephaestus.discovery.skills import discover_skills, get_skill_category, organize_skills
+
+__all__ = [
+    "discover_agents",
+    "discover_blocks",
+    "discover_skills",
+    "extract_blocks",
+    "get_skill_category",
+    "organize_agents",
+    "organize_skills",
+    "parse_agent_level",
+]

--- a/hephaestus/discovery/agents.py
+++ b/hephaestus/discovery/agents.py
@@ -1,0 +1,87 @@
+"""Agent discovery and organisation utilities.
+
+Generic filesystem walker for discovering agent markdown files and classifying
+them by hierarchy level.  Callers supply the directory; no paths are hardcoded.
+
+Usage::
+
+    from hephaestus.discovery.agents import discover_agents, organize_agents
+
+    agents = discover_agents(Path(".claude/agents"))
+    # {0: [Path(...chief.md)], 1: [Path(...orchestrator.md)], ...}
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+
+def parse_agent_level(file_path: Path) -> int | None:
+    """Extract the level from an agent markdown file's YAML frontmatter.
+
+    Reads only the ``level:`` key from the frontmatter; does not invoke a full
+    YAML parser so no extra dependency is required.
+
+    Args:
+        file_path: Path to agent markdown file.
+
+    Returns:
+        Integer level (0–5) if found, ``None`` otherwise.
+
+    """
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = re.search(r"^level:\s*(\d+)", content, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def discover_agents(source_dir: Path) -> dict[int, list[Path]]:
+    """Scan *source_dir* and classify agent files by hierarchy level.
+
+    Only files with an explicit ``level:`` frontmatter key are included.
+    Agents without a level are silently skipped.
+
+    Args:
+        source_dir: Directory containing agent ``*.md`` files.
+
+    Returns:
+        Dict mapping level (0–5) to a sorted list of agent file paths.
+
+    """
+    result: dict[int, list[Path]] = {i: [] for i in range(6)}
+    for agent_file in sorted(source_dir.glob("*.md")):
+        level = parse_agent_level(agent_file)
+        if level is not None and 0 <= level <= 5:
+            result[level].append(agent_file)
+    return result
+
+
+def organize_agents(source_dir: Path, dest_dir: Path) -> dict[int, list[str]]:
+    """Copy agents from *source_dir* into *dest_dir*, organised by level.
+
+    Creates ``L0``–``L5`` subdirectories under *dest_dir* and copies each
+    agent file into the appropriate sub-directory.
+
+    Args:
+        source_dir: Directory containing source agent ``*.md`` files.
+        dest_dir: Destination root directory; level subdirs are created here.
+
+    Returns:
+        Dict mapping level to list of copied filenames.
+
+    """
+    for level in range(6):
+        (dest_dir / f"L{level}").mkdir(parents=True, exist_ok=True)
+
+    agents_by_level = discover_agents(source_dir)
+    stats: dict[int, list[str]] = {i: [] for i in range(6)}
+    for level, agent_files in agents_by_level.items():
+        for agent_file in agent_files:
+            dest_path = dest_dir / f"L{level}" / agent_file.name
+            shutil.copy2(agent_file, dest_path)
+            stats[level].append(agent_file.name)
+    return stats

--- a/hephaestus/discovery/blocks.py
+++ b/hephaestus/discovery/blocks.py
@@ -1,0 +1,93 @@
+"""CLAUDE.md block extraction utilities.
+
+Provides generic block-extraction helpers for splitting a markdown file into
+named sections.  Block definitions (line ranges + filenames) are supplied by
+the caller — no project-specific defaults are baked in.
+
+Usage::
+
+    from hephaestus.discovery.blocks import extract_blocks
+
+    blocks = [
+        ("B01", 1, 11, "B01-overview.md"),
+        ("B02", 13, 67, "B02-rules.md"),
+    ]
+    created = extract_blocks(Path("CLAUDE.md"), Path("out/"), blocks)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# A block definition: (block_id, start_line, end_line, output_filename)
+# Lines are 1-indexed (same convention as most editors and grep output).
+BlockDef = tuple[str, int, int, str]
+
+
+def discover_blocks(
+    claude_md_path: Path,
+    block_defs: list[BlockDef] | None = None,
+) -> list[BlockDef]:
+    """Return block definitions for a CLAUDE.md file.
+
+    If *block_defs* is provided it is returned as-is after validating that
+    *claude_md_path* exists.  When no definitions are supplied the function
+    raises :exc:`ValueError` — automatic section detection is intentionally
+    not implemented because markdown headings vary too much across projects.
+
+    Args:
+        claude_md_path: Path to the CLAUDE.md file.
+        block_defs: Explicit block definitions ``(id, start, end, filename)``.
+            Lines are 1-indexed.
+
+    Returns:
+        The resolved list of block definitions.
+
+    Raises:
+        FileNotFoundError: If *claude_md_path* does not exist.
+        ValueError: If *block_defs* is ``None`` (no automatic detection).
+
+    """
+    if not claude_md_path.exists():
+        raise FileNotFoundError(f"CLAUDE.md not found: {claude_md_path}")
+    if block_defs is None:
+        raise ValueError(
+            "block_defs must be provided; automatic section detection is not implemented. "
+            "Pass an explicit list of (id, start_line, end_line, filename) tuples."
+        )
+    return block_defs
+
+
+def extract_blocks(
+    source_file: Path,
+    output_dir: Path,
+    block_defs: list[BlockDef] | None = None,
+) -> list[Path]:
+    """Extract sections of *source_file* into separate files.
+
+    Args:
+        source_file: Markdown file to split (typically ``CLAUDE.md``).
+        output_dir: Directory where extracted block files are written.
+            Created if it does not exist.
+        block_defs: Block definitions ``(id, start, end, filename)``.
+            Lines are 1-indexed.  Passed through to :func:`discover_blocks`.
+
+    Returns:
+        List of paths to the created block files.
+
+    Raises:
+        FileNotFoundError: If *source_file* does not exist.
+        ValueError: If *block_defs* is ``None``.
+
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    resolved = discover_blocks(source_file, block_defs)
+    lines = source_file.read_text(encoding="utf-8").splitlines(keepends=True)
+
+    created: list[Path] = []
+    for _block_id, start, end, filename in resolved:
+        block_lines = lines[start - 1 : end]
+        output_path = output_dir / filename
+        output_path.write_text("".join(block_lines), encoding="utf-8")
+        created.append(output_path)
+    return created

--- a/hephaestus/discovery/skills.py
+++ b/hephaestus/discovery/skills.py
@@ -1,0 +1,146 @@
+"""Skill discovery and organisation utilities.
+
+Generic filesystem walker for discovering skill directories and files,
+optionally classifying them by category.  Category-to-skill mappings are
+caller-supplied so no project-specific names are baked in.
+
+Usage::
+
+    from hephaestus.discovery.skills import discover_skills, get_skill_category
+
+    skills = discover_skills(Path(".claude/skills"))
+    # {"other": [Path(...), ...]}  — all skills in the "other" bucket
+
+    # With custom mappings:
+    mappings = {"github": ["gh-review-pr", "gh-create-pr-linked"]}
+    skills = discover_skills(Path(".claude/skills"), category_mappings=mappings)
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+
+def get_skill_category(
+    skill_name: str,
+    category_mappings: dict[str, list[str]] | None = None,
+) -> str:
+    """Determine the category for *skill_name*.
+
+    First checks *category_mappings* for an explicit entry, then tries
+    well-known prefix conventions (``gh-``, ``mojo-``, ``phase-``, etc.).
+    Falls back to ``"other"`` when no match is found.
+
+    Args:
+        skill_name: Skill directory or file name (without ``.md`` extension).
+        category_mappings: Optional ``{category: [skill_name, ...]}`` dict.
+
+    Returns:
+        Category string.
+
+    """
+    if category_mappings:
+        for category, skills in category_mappings.items():
+            if skill_name in skills:
+                return category
+
+    # Prefix-based fallback
+    prefix_map: list[tuple[str, str]] = [
+        ("gh-", "github"),
+        ("mojo-", "mojo"),
+        ("phase-", "workflow"),
+        ("quality-", "quality"),
+        ("worktree-", "worktree"),
+        ("doc-", "documentation"),
+        ("agent-", "agent"),
+    ]
+    for prefix, category in prefix_map:
+        if skill_name.startswith(prefix):
+            return category
+
+    return "other"
+
+
+def discover_skills(
+    source_dir: Path,
+    category_mappings: dict[str, list[str]] | None = None,
+) -> dict[str, list[Path]]:
+    """Scan *source_dir* and classify skills by category.
+
+    Skill directories and ``*.md`` files (excluding templates) are discovered.
+
+    Args:
+        source_dir: Directory containing skill subdirectories and/or files.
+        category_mappings: Optional explicit ``{category: [skill_name, ...]}``
+            mapping passed through to :func:`get_skill_category`.
+
+    Returns:
+        Dict mapping category name to a sorted list of skill paths.
+        Always includes an ``"other"`` key.
+
+    """
+    skill_dirs = sorted(
+        d for d in source_dir.iterdir() if d.is_dir() and not d.name.startswith(".")
+    )
+    skill_files = sorted(
+        f
+        for f in source_dir.iterdir()
+        if f.is_file() and f.suffix == ".md" and "TEMPLATE" not in f.name
+    )
+    all_skills = skill_dirs + skill_files
+
+    categories: set[str] = {"other"}
+    if category_mappings:
+        categories |= set(category_mappings.keys())
+
+    result: dict[str, list[Path]] = {cat: [] for cat in sorted(categories)}
+
+    for skill_path in all_skills:
+        skill_name = skill_path.stem if skill_path.is_file() else skill_path.name
+        category = get_skill_category(skill_name, category_mappings)
+        if category not in result:
+            result[category] = []
+        result[category].append(skill_path)
+
+    return result
+
+
+def organize_skills(
+    source_dir: Path,
+    dest_dir: Path,
+    category_mappings: dict[str, list[str]] | None = None,
+) -> dict[str, list[str]]:
+    """Copy skills from *source_dir* into *dest_dir*, organised by category.
+
+    Creates a subdirectory per category under *dest_dir* and copies each
+    skill directory or file into it.
+
+    Args:
+        source_dir: Directory containing skill subdirs/files.
+        dest_dir: Destination root directory; category subdirs are created here.
+        category_mappings: Optional explicit mapping for :func:`get_skill_category`.
+
+    Returns:
+        Dict mapping category to list of organised skill names.
+
+    """
+    skills_by_category = discover_skills(source_dir, category_mappings)
+
+    for category in skills_by_category:
+        (dest_dir / category).mkdir(parents=True, exist_ok=True)
+
+    stats: dict[str, list[str]] = {cat: [] for cat in skills_by_category}
+    for category, skill_paths in skills_by_category.items():
+        for skill_path in skill_paths:
+            skill_name = skill_path.stem if skill_path.is_file() else skill_path.name
+            dest_path = dest_dir / category / skill_name
+            if skill_path.is_dir():
+                if dest_path.exists():
+                    shutil.rmtree(dest_path)
+                shutil.copytree(skill_path, dest_path)
+            else:
+                shutil.copy2(skill_path, dest_path.with_suffix(skill_path.suffix))
+            stats[category].append(skill_name)
+
+    return stats

--- a/hephaestus/github/__init__.py
+++ b/hephaestus/github/__init__.py
@@ -3,26 +3,37 @@
 Provides utilities for working with GitHub repositories, PRs, and automation.
 """
 
-from .pr_merge import (
-    detect_repo_from_remote,
-    local_branch_exists,
-)
-from .pr_merge import (
-    main as merge_prs,
-)
-from .rate_limit import (
+from hephaestus.github.pr_merge import detect_repo_from_remote, local_branch_exists
+from hephaestus.github.pr_merge import main as merge_prs
+from hephaestus.github.rate_limit import (
     detect_claude_usage_limit,
     detect_rate_limit,
     parse_reset_epoch,
     wait_until,
 )
+from hephaestus.github.stats import (
+    collect_stats,
+    format_stats_table,
+    get_commits_stats,
+    get_current_repo,
+    get_issues_stats,
+    get_prs_stats,
+    validate_date,
+)
 
 __all__ = [
+    "collect_stats",
     "detect_claude_usage_limit",
     "detect_rate_limit",
     "detect_repo_from_remote",
+    "format_stats_table",
+    "get_commits_stats",
+    "get_current_repo",
+    "get_issues_stats",
+    "get_prs_stats",
     "local_branch_exists",
     "merge_prs",
     "parse_reset_epoch",
+    "validate_date",
     "wait_until",
 ]

--- a/hephaestus/github/stats.py
+++ b/hephaestus/github/stats.py
@@ -115,9 +115,7 @@ def get_issues_stats(
     return {"total": total, "open": open_count, "closed": total - open_count}
 
 
-def get_prs_stats(
-    start_date: str, end_date: str, author: str | None, repo: str
-) -> dict[str, int]:
+def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str) -> dict[str, int]:
     """Return PR counts (total / merged / open / closed) for the given date range.
 
     Args:
@@ -219,15 +217,11 @@ def get_commits_stats(
     if result.returncode != 0:
         return {"total": 0}
 
-    total = sum(
-        int(line.strip()) for line in result.stdout.strip().split("\n") if line.strip()
-    )
+    total = sum(int(line.strip()) for line in result.stdout.strip().split("\n") if line.strip())
     return {"total": total}
 
 
-def collect_stats(
-    start_date: str, end_date: str, author: str | None, repo: str
-) -> dict[str, Any]:
+def collect_stats(start_date: str, end_date: str, author: str | None, repo: str) -> dict[str, Any]:
     """Collect all stats (issues, PRs, commits) for the given date range.
 
     Args:
@@ -315,9 +309,7 @@ def main() -> int:
     parser.add_argument("start_date", help="Start date (YYYY-MM-DD)")
     parser.add_argument("end_date", help="End date (YYYY-MM-DD)")
     parser.add_argument("--author", help="Filter by author username")
-    parser.add_argument(
-        "--repo", help="Repository (owner/repo), defaults to current repo"
-    )
+    parser.add_argument("--repo", help="Repository (owner/repo), defaults to current repo")
 
     args = parser.parse_args()
 

--- a/hephaestus/github/stats.py
+++ b/hephaestus/github/stats.py
@@ -1,0 +1,349 @@
+"""GitHub contribution statistics via the ``gh`` CLI.
+
+Fetches and displays issue, PR, and commit counts for a date range.  Uses
+``gh api`` subprocess calls instead of PyGithub so no token management is
+required beyond a working ``gh auth`` session.
+
+Usage::
+
+    hephaestus-github-stats 2026-01-01 2026-01-31
+    hephaestus-github-stats 2026-01-01 2026-01-31 --author mvillmow
+    hephaestus-github-stats 2026-01-01 2026-01-31 --repo owner/repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from datetime import datetime
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_date(date_string: str) -> bool:
+    """Validate that a string matches the ``YYYY-MM-DD`` format.
+
+    Args:
+        date_string: Candidate date string.
+
+    Returns:
+        True if the string is a valid ISO date, False otherwise.
+
+    """
+    try:
+        datetime.strptime(date_string, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
+
+
+def get_current_repo() -> str:
+    """Return the current repository name in ``owner/repo`` format via ``gh``.
+
+    Returns:
+        Repository name string.
+
+    Raises:
+        SystemExit: With code 1 if ``gh repo view`` fails.
+
+    """
+    result = subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(f"Error: Failed to get repo name: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Stats collectors
+# ---------------------------------------------------------------------------
+
+
+def get_issues_stats(
+    start_date: str, end_date: str, author: str | None, repo: str
+) -> dict[str, int]:
+    """Return issue counts (total / open / closed) for the given date range.
+
+    Args:
+        start_date: Start date in ``YYYY-MM-DD`` format.
+        end_date: End date in ``YYYY-MM-DD`` format.
+        author: Optional GitHub username to filter by.
+        repo: Repository in ``owner/repo`` format.
+
+    Returns:
+        Dict with keys ``"total"``, ``"open"``, ``"closed"``.
+
+    """
+    base_parts = [f"repo:{repo}", "type:issue", f"created:{start_date}..{end_date}"]
+    if author:
+        base_parts.append(f"author:{author}")
+    base_query = " ".join(base_parts)
+
+    result = subprocess.run(
+        ["gh", "api", "search/issues", "-f", f"q={base_query}", "--jq", ".total_count"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {"total": 0, "open": 0, "closed": 0}
+
+    total = int(result.stdout.strip())
+
+    result_open = subprocess.run(
+        [
+            "gh",
+            "api",
+            "search/issues",
+            "-f",
+            f"q={base_query} state:open",
+            "--jq",
+            ".total_count",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    open_count = int(result_open.stdout.strip()) if result_open.returncode == 0 else 0
+
+    return {"total": total, "open": open_count, "closed": total - open_count}
+
+
+def get_prs_stats(
+    start_date: str, end_date: str, author: str | None, repo: str
+) -> dict[str, int]:
+    """Return PR counts (total / merged / open / closed) for the given date range.
+
+    Args:
+        start_date: Start date in ``YYYY-MM-DD`` format.
+        end_date: End date in ``YYYY-MM-DD`` format.
+        author: Optional GitHub username to filter by.
+        repo: Repository in ``owner/repo`` format.
+
+    Returns:
+        Dict with keys ``"total"``, ``"merged"``, ``"open"``, ``"closed"``.
+
+    """
+    base_parts = [f"repo:{repo}", "type:pr", f"created:{start_date}..{end_date}"]
+    if author:
+        base_parts.append(f"author:{author}")
+    base_query = " ".join(base_parts)
+
+    result = subprocess.run(
+        ["gh", "api", "search/issues", "-f", f"q={base_query}", "--jq", ".total_count"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return {"total": 0, "merged": 0, "open": 0, "closed": 0}
+
+    total = int(result.stdout.strip())
+
+    result_merged = subprocess.run(
+        [
+            "gh",
+            "api",
+            "search/issues",
+            "-f",
+            f"q={base_query} is:merged",
+            "--jq",
+            ".total_count",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    merged = int(result_merged.stdout.strip()) if result_merged.returncode == 0 else 0
+
+    result_open = subprocess.run(
+        [
+            "gh",
+            "api",
+            "search/issues",
+            "-f",
+            f"q={base_query} state:open",
+            "--jq",
+            ".total_count",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    open_count = int(result_open.stdout.strip()) if result_open.returncode == 0 else 0
+
+    return {
+        "total": total,
+        "merged": merged,
+        "open": open_count,
+        "closed": total - merged - open_count,
+    }
+
+
+def get_commits_stats(
+    start_date: str, end_date: str, author: str | None, repo: str
+) -> dict[str, int]:
+    """Return commit count for the given date range.
+
+    Args:
+        start_date: Start date in ``YYYY-MM-DD`` format.
+        end_date: End date in ``YYYY-MM-DD`` format.
+        author: Optional GitHub username to filter by.
+        repo: Repository in ``owner/repo`` format.
+
+    Returns:
+        Dict with key ``"total"``.
+
+    """
+    owner, repo_name = repo.split("/", 1)
+
+    params = [
+        "gh",
+        "api",
+        f"repos/{owner}/{repo_name}/commits",
+        "--paginate",
+        "-f",
+        f"since={start_date}T00:00:00Z",
+        "-f",
+        f"until={end_date}T23:59:59Z",
+        "--jq",
+        "length",
+    ]
+    if author:
+        params += ["-f", f"author={author}"]
+
+    result = subprocess.run(params, capture_output=True, text=True)
+    if result.returncode != 0:
+        return {"total": 0}
+
+    total = sum(
+        int(line.strip()) for line in result.stdout.strip().split("\n") if line.strip()
+    )
+    return {"total": total}
+
+
+def collect_stats(
+    start_date: str, end_date: str, author: str | None, repo: str
+) -> dict[str, Any]:
+    """Collect all stats (issues, PRs, commits) for the given date range.
+
+    Args:
+        start_date: Start date in ``YYYY-MM-DD`` format.
+        end_date: End date in ``YYYY-MM-DD`` format.
+        author: Optional GitHub username to filter by.
+        repo: Repository in ``owner/repo`` format.
+
+    Returns:
+        Dict with keys ``"issues"``, ``"prs"``, ``"commits"``.
+
+    """
+    return {
+        "issues": get_issues_stats(start_date, end_date, author, repo),
+        "prs": get_prs_stats(start_date, end_date, author, repo),
+        "commits": get_commits_stats(start_date, end_date, author, repo),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+
+def format_stats_table(stats: dict[str, Any]) -> str:
+    """Render a text table from the collected stats dict.
+
+    Args:
+        stats: Dict with ``"issues"``, ``"prs"``, ``"commits"`` keys.
+
+    Returns:
+        Multi-line string with formatted table.
+
+    """
+    sep = "=" * 60
+    lines = [
+        sep,
+        "GitHub Contribution Statistics",
+        sep,
+        "",
+        "ISSUES",
+        "-" * 60,
+        f"  Total:  {stats['issues']['total']:>6}",
+        f"  Open:   {stats['issues']['open']:>6}",
+        f"  Closed: {stats['issues']['closed']:>6}",
+        "",
+        "PULL REQUESTS",
+        "-" * 60,
+        f"  Total:  {stats['prs']['total']:>6}",
+        f"  Merged: {stats['prs']['merged']:>6}",
+        f"  Open:   {stats['prs']['open']:>6}",
+        f"  Closed: {stats['prs']['closed']:>6}",
+        "",
+        "COMMITS",
+        "-" * 60,
+        f"  Total:  {stats['commits']['total']:>6}",
+        "",
+        sep,
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    """CLI entry point for GitHub contribution statistics.
+
+    Returns:
+        Exit code: 0 for success, 1 for invalid arguments or errors.
+
+    """
+    parser = argparse.ArgumentParser(
+        description="Get GitHub contribution statistics",
+        epilog=(
+            "Examples:\n"
+            "  hephaestus-github-stats 2026-01-01 2026-01-31\n"
+            "  hephaestus-github-stats 2026-01-01 2026-01-31 --author mvillmow\n"
+            "  hephaestus-github-stats 2026-01-01 2026-01-31 --repo owner/repo"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("start_date", help="Start date (YYYY-MM-DD)")
+    parser.add_argument("end_date", help="End date (YYYY-MM-DD)")
+    parser.add_argument("--author", help="Filter by author username")
+    parser.add_argument(
+        "--repo", help="Repository (owner/repo), defaults to current repo"
+    )
+
+    args = parser.parse_args()
+
+    if not validate_date(args.start_date):
+        print(f"Error: Invalid start date format: {args.start_date}", file=sys.stderr)
+        print("Expected format: YYYY-MM-DD", file=sys.stderr)
+        return 1
+
+    if not validate_date(args.end_date):
+        print(f"Error: Invalid end date format: {args.end_date}", file=sys.stderr)
+        print("Expected format: YYYY-MM-DD", file=sys.stderr)
+        return 1
+
+    repo = args.repo if args.repo else get_current_repo()
+
+    print(f"Repository: {repo}")
+    print(f"Date range: {args.start_date} to {args.end_date}")
+    if args.author:
+        print(f"Author: {args.author}")
+    print()
+    print("Fetching statistics...")
+
+    stats = collect_stats(args.start_date, args.end_date, args.author, repo)
+    print(format_stats_table(stats))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pixi.lock
+++ b/pixi.lock
@@ -937,7 +937,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.6.0
-  sha256: 8b4193f9fbb209b18bcf79e04d0145838510ef8466d73b8418416f1659431b79
+  sha256: cb1cfbcb0a5dab71edaf015b142d1abce02d96e5f23174d0827307e6252730aa
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pixi.lock
+++ b/pixi.lock
@@ -937,7 +937,7 @@ packages:
 - pypi: ./
   name: homericintelligence-hephaestus
   version: 0.6.0
-  sha256: cb1cfbcb0a5dab71edaf015b142d1abce02d96e5f23174d0827307e6252730aa
+  sha256: d95c5e56a806dcb13d61f5619bbf1f750c9042102e19c5f2d7ea4621024d05ad
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ hephaestus-check-precommit-versions = "hephaestus.ci.precommit:check_precommit_v
 hephaestus-check-workflow-inventory = "hephaestus.ci.workflows:check_workflow_inventory_main"
 hephaestus-validate-workflow-checkout = "hephaestus.ci.workflows:validate_workflow_checkout_main"
 hephaestus-github-stats = "hephaestus.github.stats:main"
+hephaestus-agent-stats = "hephaestus.agents.stats:main"
+hephaestus-validate-agents = "hephaestus.agents.frontmatter:validate_agents_main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ hephaestus-check-stale-scripts = "hephaestus.validation.stale_scripts:main"
 hephaestus-mypy-each-file = "hephaestus.validation.mypy_per_file:main"
 hephaestus-check-links = "hephaestus.markdown.link_fixer:main"
 hephaestus-validate-anchors = "hephaestus.markdown.anchors:main"
+hephaestus-check-dep-sync = "hephaestus.config.dep_sync:check_dep_sync_main"
+hephaestus-sync-requirements = "hephaestus.config.dep_sync:sync_requirements_main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ hephaestus-bench-precommit = "hephaestus.ci.precommit:bench_precommit_main"
 hephaestus-check-precommit-versions = "hephaestus.ci.precommit:check_precommit_versions_main"
 hephaestus-check-workflow-inventory = "hephaestus.ci.workflows:check_workflow_inventory_main"
 hephaestus-validate-workflow-checkout = "hephaestus.ci.workflows:validate_workflow_checkout_main"
+hephaestus-github-stats = "hephaestus.github.stats:main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ hephaestus-check-links = "hephaestus.markdown.link_fixer:main"
 hephaestus-validate-anchors = "hephaestus.markdown.anchors:main"
 hephaestus-check-dep-sync = "hephaestus.config.dep_sync:check_dep_sync_main"
 hephaestus-sync-requirements = "hephaestus.config.dep_sync:sync_requirements_main"
+hephaestus-bench-precommit = "hephaestus.ci.precommit:bench_precommit_main"
+hephaestus-check-precommit-versions = "hephaestus.ci.precommit:check_precommit_versions_main"
+hephaestus-check-workflow-inventory = "hephaestus.ci.workflows:check_workflow_inventory_main"
+hephaestus-validate-workflow-checkout = "hephaestus.ci.workflows:validate_workflow_checkout_main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/scripts/shell/cleanup-stale-worktrees.sh
+++ b/scripts/shell/cleanup-stale-worktrees.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+#
+# Clean up stale git worktrees for closed/merged GitHub issues.
+#
+# Detects stale worktrees via two independent signals:
+#   1. Associated GitHub issue is closed (CLOSED state)
+#   2. Branch is merged into main
+#
+# Usage:
+#   ./scripts/shell/cleanup-stale-worktrees.sh [OPTIONS]
+#
+# Options:
+#   --force           Auto-cleanup without prompting (non-interactive)
+#   --log-file PATH   Override default log file path
+#   --dry-run         Show what would be cleaned without making changes
+#   --help            Show this help message
+#
+# Logs cleanup actions to ~/.cache/hephaestus/worktree-cleanup.log by default.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+DEFAULT_LOG_FILE="${HOME}/.cache/hephaestus/worktree-cleanup.log"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $1"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+log_skip()  { echo -e "${BLUE}[SKIP]${NC}  $1"; }
+
+# Append a timestamped entry to the log file.
+# Arguments:
+#   $1  action  (REMOVED | SKIPPED | DRY_RUN)
+#   $2  path
+#   $3  branch
+#   $4  issue   (number or "none")
+log_action() {
+    local action="$1" path="$2" branch="$3" issue="$4"
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    mkdir -p "$(dirname "$LOG_FILE")"
+    echo "${timestamp} ${action} path=${path} branch=${branch} issue=${issue}" >> "$LOG_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+FORCE=false
+DRY_RUN=false
+LOG_FILE="$DEFAULT_LOG_FILE"
+
+usage() {
+    sed -n '/^# Usage:/,/^[^#]/{ /^#/{ s/^# \{0,1\}//; p }; /^[^#]/q }' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force)    FORCE=true;        shift ;;
+        --dry-run)  DRY_RUN=true;      shift ;;
+        --log-file) LOG_FILE="$2";     shift 2 ;;
+        --help|-h)  usage; exit 0 ;;
+        *) log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Detect main branch dynamically
+# ---------------------------------------------------------------------------
+get_main_branch() {
+    git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+        | sed 's@^refs/remotes/origin/@@' \
+        || echo "main"
+}
+
+# ---------------------------------------------------------------------------
+# Parse `git worktree list --porcelain` into parallel arrays.
+# Outputs lines of the form: <path> <branch>
+# Skips bare worktrees and worktrees with detached HEAD.
+# ---------------------------------------------------------------------------
+list_worktrees() {
+    local path="" branch=""
+    while IFS= read -r line; do
+        if [[ $line =~ ^worktree[[:space:]](.+)$ ]]; then
+            path="${BASH_REMATCH[1]}"
+            branch=""
+        elif [[ $line =~ ^branch[[:space:]]refs/heads/(.+)$ ]]; then
+            branch="${BASH_REMATCH[1]}"
+        elif [[ -z "$line" ]]; then
+            # End of stanza — emit if we have both fields
+            if [[ -n "$path" && -n "$branch" ]]; then
+                echo "$path $branch"
+            fi
+            path=""
+            branch=""
+        fi
+    done < <(git worktree list --porcelain; echo "")
+}
+
+# ---------------------------------------------------------------------------
+# Check if a branch is merged into main.
+# Arguments: $1 branch, $2 main_branch
+# ---------------------------------------------------------------------------
+is_merged() {
+    local branch="$1" main_branch="$2"
+    git branch --merged "$main_branch" 2>/dev/null | grep -qE "(^|\s)${branch}$"
+}
+
+# ---------------------------------------------------------------------------
+# Check if a GitHub issue is closed.
+# Arguments: $1 issue_number
+# Returns 0 if closed, 1 otherwise.
+# Echos the issue state on stdout for the caller.
+# ---------------------------------------------------------------------------
+issue_state() {
+    local issue="$1"
+    gh issue view "$issue" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN"
+}
+
+# ---------------------------------------------------------------------------
+# Safety: check for uncommitted changes in a worktree.
+# Arguments: $1 worktree_path
+# Returns 0 if dirty, 1 if clean.
+# ---------------------------------------------------------------------------
+is_dirty() {
+    local path="$1"
+    [[ -n "$(git -C "$path" status --porcelain 2>/dev/null)" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Safety: check if a worktree is locked.
+# Arguments: $1 worktree_path
+# ---------------------------------------------------------------------------
+is_locked() {
+    local path="$1"
+    git worktree list --porcelain 2>/dev/null \
+        | grep -A 3 "^worktree ${path}$" \
+        | grep -q "^locked"
+}
+
+# ---------------------------------------------------------------------------
+# Remove a worktree and optionally delete its branch.
+# Arguments: $1 path, $2 branch, $3 issue
+# ---------------------------------------------------------------------------
+remove_worktree() {
+    local path="$1" branch="$2" issue="$3"
+
+    if $DRY_RUN; then
+        log_info "[DRY-RUN] Would remove: ${path} (branch: ${branch}, issue: #${issue})"
+        log_action "DRY_RUN" "$path" "$branch" "$issue"
+        return 0
+    fi
+
+    if git worktree remove "$path" 2>/dev/null; then
+        log_info "Removed worktree: ${path}"
+        # Best-effort branch deletion (may already be gone)
+        if git branch -d "$branch" 2>/dev/null; then
+            log_info "Deleted branch: ${branch}"
+        fi
+        log_action "REMOVED" "$path" "$branch" "$issue"
+    else
+        log_warn "git worktree remove failed for ${path} — try: git worktree remove --force ${path}"
+        log_action "SKIPPED" "$path" "$branch" "$issue"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    local main_branch
+    main_branch=$(get_main_branch)
+    local root_dir
+    root_dir=$(git rev-parse --show-toplevel)
+
+    local stale_count=0 cleaned_count=0 skipped_count=0
+
+    echo "Scanning worktrees (main branch: ${main_branch})..."
+    echo ""
+
+    while IFS=' ' read -r wt_path wt_branch; do
+        # Skip the main worktree
+        if [[ "$wt_path" == "$root_dir" ]]; then
+            continue
+        fi
+
+        # Extract leading issue number from branch name (e.g. "736-description" → "736")
+        local issue_number=""
+        issue_number=$(echo "$wt_branch" | grep -oP '^\d+' || true)
+
+        # Determine staleness: issue closed OR branch merged
+        local is_stale=false reason=""
+
+        if [[ -n "$issue_number" ]]; then
+            local state
+            state=$(issue_state "$issue_number")
+            if [[ "$state" == "CLOSED" ]]; then
+                is_stale=true
+                reason="issue #${issue_number} is CLOSED"
+            fi
+        fi
+
+        if ! $is_stale && is_merged "$wt_branch" "$main_branch"; then
+            is_stale=true
+            reason="branch merged into ${main_branch}"
+        fi
+
+        if ! $is_stale; then
+            continue
+        fi
+
+        stale_count=$((stale_count + 1))
+        echo "Stale worktree found:"
+        echo "  Path:   ${wt_path}"
+        echo "  Branch: ${wt_branch}"
+        echo "  Reason: ${reason}"
+
+        # Safety: skip dirty worktrees
+        if is_dirty "$wt_path"; then
+            log_warn "Skipping (uncommitted changes present): ${wt_path}"
+            log_action "SKIPPED" "$wt_path" "$wt_branch" "${issue_number:-none}"
+            skipped_count=$((skipped_count + 1))
+            echo ""
+            continue
+        fi
+
+        # Safety: skip locked worktrees
+        if is_locked "$wt_path"; then
+            log_warn "Skipping (worktree is locked): ${wt_path}"
+            log_action "SKIPPED" "$wt_path" "$wt_branch" "${issue_number:-none}"
+            skipped_count=$((skipped_count + 1))
+            echo ""
+            continue
+        fi
+
+        if $FORCE || $DRY_RUN; then
+            remove_worktree "$wt_path" "$wt_branch" "${issue_number:-none}"
+            if ! $DRY_RUN; then cleaned_count=$((cleaned_count + 1)); fi
+        else
+            local reply
+            read -r -p "  Remove worktree? (y/N) " reply
+            if [[ $reply =~ ^[Yy]$ ]]; then
+                remove_worktree "$wt_path" "$wt_branch" "${issue_number:-none}"
+                cleaned_count=$((cleaned_count + 1))
+            else
+                log_skip "Kept: ${wt_path}"
+                log_action "SKIPPED" "$wt_path" "$wt_branch" "${issue_number:-none}"
+                skipped_count=$((skipped_count + 1))
+            fi
+        fi
+
+        echo ""
+    done < <(list_worktrees)
+
+    echo "--------------------------------------"
+    if [[ $stale_count -eq 0 ]]; then
+        log_info "No stale worktrees found."
+    else
+        local mode_label=""
+        $DRY_RUN && mode_label=" [DRY-RUN]"
+        log_info "Summary${mode_label}: ${stale_count} stale found, ${cleaned_count} cleaned, ${skipped_count} skipped."
+        if [[ $cleaned_count -gt 0 ]] || $DRY_RUN; then
+            log_info "Log: ${LOG_FILE}"
+        fi
+    fi
+}
+
+main "$@"

--- a/scripts/shell/install_hooks.sh
+++ b/scripts/shell/install_hooks.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Install git hooks from scripts/hooks/ into .git/hooks/.
+#
+# Usage:
+#   bash scripts/shell/install_hooks.sh
+#
+# Hooks installed:
+#   pre-push  — runs pytest with coverage check before every push
+#
+# Exit codes:
+#   0 = all hooks installed successfully
+#   1 = must be run from repository root or git repo not found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HOOKS_SRC="${SCRIPT_DIR}/../hooks"
+HOOKS_DST="${REPO_ROOT}/.git/hooks"
+
+# Verify we're inside a git repo
+if [[ ! -d "${HOOKS_DST}" ]]; then
+    echo "Error: .git/hooks not found — run this script from the repository root."
+    exit 1
+fi
+
+installed=0
+for src in "${HOOKS_SRC}"/*; do
+    hook_name="$(basename "${src}")"
+    dst="${HOOKS_DST}/${hook_name}"
+
+    if [[ -e "${dst}" && ! -L "${dst}" ]]; then
+        echo "Backing up existing ${hook_name} → ${dst}.bak"
+        cp "${dst}" "${dst}.bak"
+    fi
+
+    cp "${src}" "${dst}"
+    chmod +x "${dst}"
+    echo "Installed ${hook_name} → .git/hooks/${hook_name}"
+    installed=$((installed + 1))
+done
+
+echo ""
+echo "Installed ${installed} hook(s). Run 'git push' to verify."

--- a/scripts/shell/preflight_check.sh
+++ b/scripts/shell/preflight_check.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# Pre-flight check before starting work on a GitHub issue.
+#
+# Runs 6 checks in order, stopping immediately on critical failures.
+# Critical failures (exit 1): closed issue, merged PR, worktree conflict
+# Warnings (exit 0): existing commits, open PRs, existing branches
+#
+# Usage:
+#   bash /path/to/scripts/shell/preflight_check.sh <issue-number>
+#   bash "$(dirname "${BASH_SOURCE[0]}")/preflight_check.sh" <issue-number>
+#
+# Exit codes:
+#   0 = all checks passed (or only warnings)
+#   1 = critical failure - do not proceed
+
+# Self-locating: works regardless of caller's CWD
+# shellcheck disable=SC2034
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+set -uo pipefail
+
+ISSUE="${1:-}"
+
+if [[ -z "$ISSUE" ]]; then
+    echo "Error: issue number required"
+    echo "Usage: $0 <issue-number>"
+    exit 1
+fi
+
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+pass()  { echo -e "${GREEN}[PASS]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+stop()  { echo -e "${RED}[STOP]${NC} $*"; }
+info()  { echo -e "${CYAN}[INFO]${NC} $*"; }
+
+echo "Pre-flight check for issue #${ISSUE}"
+echo "========================================"
+
+# ---------------------------------------------------------------------------
+# Check 1: Issue State (CRITICAL)
+# ---------------------------------------------------------------------------
+STATE_JSON=$(gh issue view "$ISSUE" --json state,title,closedAt 2>/dev/null) || {
+    stop "Check 1: Cannot fetch issue #${ISSUE} - verify issue number"
+    exit 1
+}
+ISSUE_STATE=$(echo "$STATE_JSON" | jq -r '.state')
+ISSUE_TITLE=$(echo "$STATE_JSON" | jq -r '.title')
+
+if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+    CLOSED_AT=$(echo "$STATE_JSON" | jq -r '.closedAt')
+    stop "Check 1: Issue #${ISSUE} is CLOSED (${CLOSED_AT})"
+    echo "         Title: ${ISSUE_TITLE}"
+    echo "         Do not proceed - work may already be complete."
+    exit 1
+fi
+pass "Check 1: Issue #${ISSUE} is OPEN - \"${ISSUE_TITLE}\""
+
+# ---------------------------------------------------------------------------
+# Check 2: Existing commits (WARNING)
+# ---------------------------------------------------------------------------
+EXISTING_COMMITS=$(git log --all --oneline --grep="#${ISSUE}" 2>/dev/null | head -5)
+if [[ -n "$EXISTING_COMMITS" ]]; then
+    warn "Check 2: Found existing commits referencing #${ISSUE}"
+    echo "$EXISTING_COMMITS" | while IFS= read -r line; do
+        echo "         $line"
+    done
+else
+    pass "Check 2: No existing commits found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 3: PR Search (CRITICAL if merged, WARNING if open)
+# Uses a single GraphQL search query with closingIssuesReferences for precise
+# match — searches ALL PRs (not just the 100 most recent) in one API call.
+# Falls back to the REST N+1 approach if GraphQL fails.
+# ---------------------------------------------------------------------------
+MERGED_PRS=""
+OPEN_PRS=""
+
+# Fetch repo owner/name for the GraphQL query
+REPO_FULL=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null) || REPO_FULL=""
+
+_graphql_check3() {
+    local repo="$1" issue="$2"
+    local query merged="" open="" pr_num pr_title pr_state
+    # shellcheck disable=SC2016  # $q is a GraphQL variable, not a shell variable
+    query='query($q:String!){search(query:$q,type:ISSUE,first:100){nodes{...on PullRequest{number,title,state,closingIssuesReferences(first:25){nodes{number}}}}}}'
+    local result
+    result=$(gh api graphql -f "query=${query}" -f "q=repo:${repo} is:pr ${issue}" 2>/dev/null) || return 1
+    while IFS= read -r pr_entry; do
+        pr_num=$(echo "$pr_entry" | jq -r '.number')
+        pr_title=$(echo "$pr_entry" | jq -r '.title')
+        pr_state=$(echo "$pr_entry" | jq -r '.state')
+        [[ -z "$pr_num" || "$pr_num" == "null" ]] && continue
+        if echo "$pr_entry" | jq -e ".closingIssuesReferences.nodes[] | select(.number == ${issue})" >/dev/null 2>&1; then
+            if [[ "$pr_state" == "MERGED" ]]; then
+                merged+="${pr_num}: ${pr_title}"$'\n'
+            elif [[ "$pr_state" == "OPEN" ]]; then
+                open+="${pr_num}: ${pr_title}"$'\n'
+            fi
+        fi
+    done < <(echo "$result" | jq -c '.data.search.nodes[]' 2>/dev/null)
+    MERGED_PRS="${merged%$'\n'}"
+    OPEN_PRS="${open%$'\n'}"
+}
+
+_rest_check3() {
+    local issue="$1"
+    local candidate_json merged="" open=""
+    candidate_json=$(gh pr list --state all --json number,title,state --limit 100 2>/dev/null) || return 1
+    while IFS= read -r pr_entry; do
+        local pr_num pr_title pr_state closes
+        pr_num=$(echo "$pr_entry" | jq -r '.number')
+        pr_title=$(echo "$pr_entry" | jq -r '.title')
+        pr_state=$(echo "$pr_entry" | jq -r '.state')
+        [[ -z "$pr_num" || "$pr_num" == "null" ]] && continue
+        closes=$(gh pr view "$pr_num" --json closingIssuesReferences \
+            --jq '.closingIssuesReferences[].number' 2>/dev/null)
+        if echo "$closes" | grep -qx "$issue"; then
+            if [[ "$pr_state" == "MERGED" ]]; then
+                merged+="${pr_num}: ${pr_title}"$'\n'
+            elif [[ "$pr_state" == "OPEN" ]]; then
+                open+="${pr_num}: ${pr_title}"$'\n'
+            fi
+        fi
+    done < <(echo "$candidate_json" | jq -c '.[]')
+    MERGED_PRS="${merged%$'\n'}"
+    OPEN_PRS="${open%$'\n'}"
+}
+
+if [[ -n "$REPO_FULL" ]] && _graphql_check3 "$REPO_FULL" "$ISSUE"; then
+    : # GraphQL succeeded
+else
+    _rest_check3 "$ISSUE"
+fi
+
+if [[ -n "$MERGED_PRS" ]]; then
+    stop "Check 3: Issue #${ISSUE} already has a MERGED PR"
+    echo "$MERGED_PRS" | while IFS= read -r line; do
+        echo "         PR #${line}"
+    done
+    echo "         Do not proceed - likely duplicate work."
+    exit 1
+elif [[ -n "$OPEN_PRS" ]]; then
+    warn "Check 3: Issue #${ISSUE} has an OPEN PR - coordinate before proceeding"
+    echo "$OPEN_PRS" | while IFS= read -r line; do
+        echo "         PR #${line}"
+    done
+else
+    pass "Check 3: No conflicting PRs found"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 4: Worktree conflicts (CRITICAL)
+# ---------------------------------------------------------------------------
+WORKTREE_MATCH=$(git worktree list 2>/dev/null | grep "$ISSUE" || true)
+if [[ -n "$WORKTREE_MATCH" ]]; then
+    stop "Check 4: Worktree already exists for issue #${ISSUE}"
+    echo "         ${WORKTREE_MATCH}"
+    echo "         Navigate to existing worktree or remove it first."
+    exit 1
+fi
+pass "Check 4: No worktree conflicts"
+
+# ---------------------------------------------------------------------------
+# Check 5: Existing branches (WARNING)
+# ---------------------------------------------------------------------------
+EXISTING_BRANCHES=$(git branch --list "*${ISSUE}*" 2>/dev/null | sed 's/^[* ]*//')
+if [[ -n "$EXISTING_BRANCHES" ]]; then
+    warn "Check 5: Existing branches found for #${ISSUE}"
+    echo "$EXISTING_BRANCHES" | while IFS= read -r line; do
+        echo "         ${line}"
+    done
+else
+    pass "Check 5: No existing branches"
+fi
+
+# ---------------------------------------------------------------------------
+# Check 6: Context gathering (INFO - only reached if checks 1-5 pass)
+# ---------------------------------------------------------------------------
+COMMENT_COUNT=$(gh issue view "$ISSUE" --comments 2>/dev/null | grep -c "^--$" || echo "0")
+info "Check 6: Issue context loaded (${COMMENT_COUNT} comment separator(s) found)"
+
+echo "========================================"
+echo -e "${GREEN}Pre-flight checks PASSED for issue #${ISSUE}${NC}"
+echo "SAFE TO PROCEED with implementation."

--- a/scripts/shell/setup_api_key.sh
+++ b/scripts/shell/setup_api_key.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Helper script to export ANTHROPIC_API_KEY from Claude CLI credentials
+# This is necessary for container execution which needs the key in environment
+
+set -euo pipefail
+
+CREDENTIALS_FILE="$HOME/.claude/.credentials.json"
+
+if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+    echo "Error: Claude credentials file not found at $CREDENTIALS_FILE" >&2
+    echo "Please run 'claude' to authenticate first." >&2
+    exit 1
+fi
+
+# Extract access token from Claude credentials
+API_KEY=$(python3 -c "
+import json
+import sys
+try:
+    with open('$CREDENTIALS_FILE', 'r') as f:
+        creds = json.load(f)
+    token = creds.get('claudeAiOauth', {}).get('accessToken', '')
+    if not token:
+        print('Error: No access token found in credentials', file=sys.stderr)
+        sys.exit(1)
+    print(token)
+except Exception as e:
+    print(f'Error reading credentials: {e}', file=sys.stderr)
+    sys.exit(1)
+")
+
+if [[ -z "$API_KEY" ]]; then
+    echo "Error: Failed to extract API key from credentials" >&2
+    exit 1
+fi
+
+export ANTHROPIC_API_KEY="$API_KEY"
+echo "ANTHROPIC_API_KEY exported successfully"
+
+# If arguments provided, execute them
+if [[ $# -gt 0 ]]; then
+    exec "$@"
+fi

--- a/tests/unit/agents/test_frontmatter.py
+++ b/tests/unit/agents/test_frontmatter.py
@@ -1,0 +1,153 @@
+"""Tests for hephaestus.agents.frontmatter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.agents.frontmatter import (
+    check_agent_file,
+    extract_frontmatter_full,
+    extract_frontmatter_parsed,
+    extract_frontmatter_raw,
+    extract_frontmatter_with_lines,
+    validate_frontmatter,
+)
+
+_VALID_FM = (
+    "---\nname: test-agent\ndescription: A test\ntools: Read,Write\nmodel: sonnet\n---\n# Body\n"
+)
+_NO_FM = "# Just markdown\n\nNo frontmatter here.\n"
+_INVALID_YAML = "---\nkey: [unclosed\n---\n# Body\n"
+
+
+class TestExtractFrontmatterRaw:
+    """Tests for extract_frontmatter_raw()."""
+
+    def test_extracts_content(self) -> None:
+        result = extract_frontmatter_raw(_VALID_FM)
+        assert result is not None
+        assert "name: test-agent" in result
+
+    def test_no_frontmatter_returns_none(self) -> None:
+        assert extract_frontmatter_raw(_NO_FM) is None
+
+    def test_empty_string(self) -> None:
+        assert extract_frontmatter_raw("") is None
+
+
+class TestExtractFrontmatterWithLines:
+    """Tests for extract_frontmatter_with_lines()."""
+
+    def test_returns_tuple(self) -> None:
+        result = extract_frontmatter_with_lines(_VALID_FM)
+        assert result is not None
+        _fm_text, start, end = result
+        assert start == 1
+        assert end > start
+
+    def test_no_frontmatter_returns_none(self) -> None:
+        assert extract_frontmatter_with_lines(_NO_FM) is None
+
+
+class TestExtractFrontmatterParsed:
+    """Tests for extract_frontmatter_parsed()."""
+
+    def test_parses_to_dict(self) -> None:
+        result = extract_frontmatter_parsed(_VALID_FM)
+        assert result is not None
+        _text, data = result
+        assert data["name"] == "test-agent"
+        assert data["model"] == "sonnet"
+
+    def test_no_frontmatter_returns_none(self) -> None:
+        assert extract_frontmatter_parsed(_NO_FM) is None
+
+    def test_invalid_yaml_returns_none(self) -> None:
+        assert extract_frontmatter_parsed(_INVALID_YAML) is None
+
+
+class TestExtractFrontmatterFull:
+    """Tests for extract_frontmatter_full()."""
+
+    def test_returns_four_tuple(self) -> None:
+        result = extract_frontmatter_full(_VALID_FM)
+        assert result is not None
+        assert len(result) == 4
+        _text, data, start, _end = result
+        assert isinstance(data, dict)
+        assert start == 1
+
+    def test_no_frontmatter_returns_none(self) -> None:
+        assert extract_frontmatter_full(_NO_FM) is None
+
+
+class TestValidateFrontmatter:
+    """Tests for validate_frontmatter()."""
+
+    def test_valid_frontmatter(self) -> None:
+        fm = {"name": "agent", "description": "desc", "tools": "Read", "model": "sonnet"}
+        errors = validate_frontmatter(fm)
+        assert errors == []
+
+    def test_missing_required_field(self) -> None:
+        fm = {"name": "agent", "description": "desc", "tools": "Read"}
+        errors = validate_frontmatter(fm)
+        assert any("model" in e for e in errors)
+
+    def test_wrong_type(self) -> None:
+        fm = {"name": 123, "description": "desc", "tools": "Read", "model": "sonnet"}
+        errors = validate_frontmatter(fm)
+        assert any("name" in e for e in errors)
+
+    def test_optional_wrong_type(self) -> None:
+        fm = {
+            "name": "agent",
+            "description": "desc",
+            "tools": "Read",
+            "model": "sonnet",
+            "level": "not-an-int",
+        }
+        errors = validate_frontmatter(fm)
+        assert any("level" in e for e in errors)
+
+    def test_custom_required_fields(self) -> None:
+        errors = validate_frontmatter(
+            {"title": "Hello"},
+            required_fields={"title": str},
+            optional_fields={},
+        )
+        assert errors == []
+
+    def test_empty_frontmatter_all_missing(self) -> None:
+        errors = validate_frontmatter({})
+        assert len(errors) == 4  # name, description, tools, model
+
+
+class TestCheckAgentFile:
+    """Tests for check_agent_file()."""
+
+    def test_valid_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "agent.md"
+        f.write_text(_VALID_FM)
+        is_valid, errors = check_agent_file(f)
+        assert is_valid is True
+        assert errors == []
+
+    def test_no_frontmatter(self, tmp_path: Path) -> None:
+        f = tmp_path / "agent.md"
+        f.write_text(_NO_FM)
+        is_valid, errors = check_agent_file(f)
+        assert is_valid is False
+        assert errors
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        is_valid, errors = check_agent_file(tmp_path / "nonexistent.md")
+        assert is_valid is False
+        assert errors
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        f = tmp_path / "agent.md"
+        f.write_text(_INVALID_YAML)
+        is_valid, errors = check_agent_file(f)
+        assert is_valid is False
+        assert errors

--- a/tests/unit/agents/test_loader.py
+++ b/tests/unit/agents/test_loader.py
@@ -1,0 +1,135 @@
+"""Tests for hephaestus.agents.loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.agents.loader import AgentInfo, find_agent_files, load_agent, load_all_agents
+
+_VALID_FM = (
+    "---\nname: test-agent\ndescription: A test\n"
+    "tools: Read,Write,Edit\nmodel: sonnet\n---\n# Body\n"
+)
+_ORCHESTRATOR_FM = (
+    "---\nname: orchestrator-main\ndescription: Orchestrates\ntools: Read\nmodel: opus\n---\n"
+)
+_CHIEF_FM = "---\nname: chief-architect\ndescription: Chief\ntools: Read\nmodel: opus\n---\n"
+_JUNIOR_FM = "---\nname: junior-engineer\ndescription: Junior\ntools: Read\nmodel: haiku\n---\n"
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(content)
+    return path
+
+
+class TestAgentInfo:
+    """Tests for AgentInfo class."""
+
+    def test_basic_attributes(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", _VALID_FM)
+        fm = {
+            "name": "test-agent",
+            "description": "A test",
+            "tools": "Read,Write",
+            "model": "sonnet",
+        }
+        agent = AgentInfo(f, fm)
+        assert agent.name == "test-agent"
+        assert agent.model == "sonnet"
+        assert agent.description == "A test"
+
+    def test_get_tools_list(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", _VALID_FM)
+        agent = AgentInfo(
+            f,
+            {"name": "x", "description": "x", "tools": "Read, Write, Edit", "model": "sonnet"},
+        )
+        tools = agent.get_tools_list()
+        assert "Read" in tools
+        assert "Write" in tools
+        assert "Edit" in tools
+
+    def test_empty_tools_list(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", "---\nname: x\n---\n")
+        agent = AgentInfo(f, {"name": "x", "description": "", "tools": "", "model": ""})
+        assert agent.get_tools_list() == []
+
+    def test_level_from_frontmatter(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", "---\nname: x\nlevel: 2\n---\n")
+        agent = AgentInfo(f, {"name": "x", "level": 2})
+        assert agent.level == 2
+
+    def test_chief_architect_level_0(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "chief.md", _CHIEF_FM)
+        agent = AgentInfo(f, {"name": "chief-architect"})
+        assert agent.level == 0
+
+    def test_orchestrator_level_1(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "orch.md", _ORCHESTRATOR_FM)
+        agent = AgentInfo(f, {"name": "orchestrator-main"})
+        assert agent.level == 1
+
+    def test_junior_level_5(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "junior.md", _JUNIOR_FM)
+        agent = AgentInfo(f, {"name": "junior-engineer"})
+        assert agent.level == 5
+
+    def test_repr(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", _VALID_FM)
+        agent = AgentInfo(f, {"name": "test-agent"})
+        assert "test-agent" in repr(agent)
+
+
+class TestFindAgentFiles:
+    """Tests for find_agent_files()."""
+
+    def test_finds_md_files(self, tmp_path: Path) -> None:
+        (tmp_path / "a.md").write_text("# A")
+        (tmp_path / "b.md").write_text("# B")
+        (tmp_path / "not.txt").write_text("text")
+        result = find_agent_files(tmp_path)
+        names = [p.name for p in result]
+        assert "a.md" in names
+        assert "b.md" in names
+        assert "not.txt" not in names
+
+    def test_sorted_order(self, tmp_path: Path) -> None:
+        for name in ["z.md", "a.md", "m.md"]:
+            (tmp_path / name).write_text("# x")
+        result = find_agent_files(tmp_path)
+        names = [p.name for p in result]
+        assert names == sorted(names)
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        assert find_agent_files(tmp_path) == []
+
+
+class TestLoadAgent:
+    """Tests for load_agent()."""
+
+    def test_valid_agent(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", _VALID_FM)
+        agent = load_agent(f)
+        assert agent is not None
+        assert agent.name == "test-agent"
+
+    def test_no_frontmatter_returns_none(self, tmp_path: Path) -> None:
+        f = _write(tmp_path / "agent.md", "# No frontmatter\n")
+        assert load_agent(f) is None
+
+    def test_nonexistent_file_returns_none(self, tmp_path: Path) -> None:
+        assert load_agent(tmp_path / "nonexistent.md") is None
+
+
+class TestLoadAllAgents:
+    """Tests for load_all_agents()."""
+
+    def test_loads_multiple(self, tmp_path: Path) -> None:
+        _write(tmp_path / "a.md", _VALID_FM)
+        _write(tmp_path / "b.md", _ORCHESTRATOR_FM)
+        _write(tmp_path / "bad.md", "# No frontmatter")
+        agents = load_all_agents(tmp_path)
+        assert len(agents) == 2
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        assert load_all_agents(tmp_path) == []

--- a/tests/unit/agents/test_stats.py
+++ b/tests/unit/agents/test_stats.py
@@ -1,0 +1,239 @@
+"""Tests for hephaestus.agents.stats."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.agents.loader import AgentInfo
+from hephaestus.agents.stats import (
+    _extract_delegation_targets,
+    _extract_skill_refs,
+    collect_agent_stats,
+    format_stats_json,
+    format_stats_text,
+)
+
+_VALID_FM = (
+    "---\nname: test-agent\ndescription: A test\n"
+    "tools: Read,Write,Edit\nmodel: sonnet\n---\n# Body\n"
+)
+_ORCHESTRATOR_FM = (
+    "---\nname: orchestrator-main\ndescription: Orchestrates\ntools: Read\nmodel: opus\n---\n"
+)
+_CHIEF_FM = "---\nname: chief-architect\ndescription: Chief\ntools: Read\nmodel: opus\n---\n"
+
+
+def _make_agent(path: Path, content: str, frontmatter: dict) -> AgentInfo:
+    path.write_text(content)
+    return AgentInfo(path, frontmatter)
+
+
+class TestExtractDelegationTargets:
+    """Tests for _extract_delegation_targets()."""
+
+    def test_extracts_links(self, tmp_path: Path) -> None:
+        content = "---\nname: x\n---\nSee [specialist](./specialist-agent.md).\n"
+        agent = _make_agent(tmp_path / "a.md", content, {"name": "x"})
+        targets = _extract_delegation_targets(agent)
+        assert len(targets) == 1
+        assert targets[0]["target"] == "specialist-agent"
+        assert targets[0]["description"] == "specialist"
+
+    def test_no_links(self, tmp_path: Path) -> None:
+        agent = _make_agent(tmp_path / "a.md", _VALID_FM, {"name": "test-agent"})
+        assert _extract_delegation_targets(agent) == []
+
+    def test_multiple_links(self, tmp_path: Path) -> None:
+        content = "---\nname: x\n---\nDelegates to [alpha](./alpha.md) and [beta](./beta.md).\n"
+        agent = _make_agent(tmp_path / "a.md", content, {"name": "x"})
+        targets = _extract_delegation_targets(agent)
+        assert len(targets) == 2
+        names = {t["target"] for t in targets}
+        assert names == {"alpha", "beta"}
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        agent = AgentInfo(tmp_path / "nonexistent.md", {"name": "x"})
+        assert _extract_delegation_targets(agent) == []
+
+
+class TestExtractSkillRefs:
+    """Tests for _extract_skill_refs()."""
+
+    def test_extracts_skill_names(self, tmp_path: Path) -> None:
+        content = "---\nname: x\n---\nUse the `commit` skill to commit changes.\n"
+        agent = _make_agent(tmp_path / "a.md", content, {"name": "x"})
+        skills = _extract_skill_refs(agent)
+        assert "commit" in skills
+
+    def test_no_skills_returns_empty(self, tmp_path: Path) -> None:
+        agent = _make_agent(tmp_path / "a.md", _VALID_FM, {"name": "test-agent"})
+        assert _extract_skill_refs(agent) == []
+
+    def test_deduplicates(self, tmp_path: Path) -> None:
+        content = "---\nname: x\n---\nUse `commit` skill here and `commit` skill there.\n"
+        agent = _make_agent(tmp_path / "a.md", content, {"name": "x"})
+        skills = _extract_skill_refs(agent)
+        assert skills.count("commit") == 1
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        agent = AgentInfo(tmp_path / "nonexistent.md", {"name": "x"})
+        assert _extract_skill_refs(agent) == []
+
+
+class TestCollectAgentStats:
+    """Tests for collect_agent_stats()."""
+
+    def test_empty_list(self) -> None:
+        stats = collect_agent_stats([])
+        assert stats["total_agents"] == 0
+        assert stats["agents_without_level"] == []
+
+    def test_total_count(self, tmp_path: Path) -> None:
+        agents = [
+            _make_agent(tmp_path / "a.md", _VALID_FM, {"name": "a", "tools": "Read"}),
+            _make_agent(
+                tmp_path / "b.md", _ORCHESTRATOR_FM, {"name": "orchestrator-main", "tools": "Read"}
+            ),
+        ]
+        stats = collect_agent_stats(agents)
+        assert stats["total_agents"] == 2
+
+    def test_by_level_grouping(self, tmp_path: Path) -> None:
+        agents = [
+            _make_agent(tmp_path / "c.md", _CHIEF_FM, {"name": "chief-architect", "level": 0}),
+            _make_agent(
+                tmp_path / "o.md", _ORCHESTRATOR_FM, {"name": "orchestrator-main", "level": 1}
+            ),
+        ]
+        stats = collect_agent_stats(agents)
+        assert "chief-architect" in stats["by_level"][0]
+        assert "orchestrator-main" in stats["by_level"][1]
+
+    def test_agents_without_level(self, tmp_path: Path) -> None:
+        agent = _make_agent(tmp_path / "a.md", _VALID_FM, {"name": "test-agent"})
+        stats = collect_agent_stats([agent])
+        assert "test-agent" in stats["agents_without_level"]
+
+    def test_agents_with_explicit_level_not_in_without_level(self, tmp_path: Path) -> None:
+        agent = _make_agent(
+            tmp_path / "a.md",
+            "---\nname: x\nlevel: 3\n---\n",
+            {"name": "x", "level": 3},
+        )
+        stats = collect_agent_stats([agent])
+        assert "x" not in stats["agents_without_level"]
+        assert "x" in stats["by_level"][3]
+
+    def test_tool_frequency(self, tmp_path: Path) -> None:
+        agents = [
+            _make_agent(tmp_path / "a.md", _VALID_FM, {"name": "a", "tools": "Read,Write"}),
+            _make_agent(tmp_path / "b.md", _ORCHESTRATOR_FM, {"name": "b", "tools": "Read"}),
+        ]
+        stats = collect_agent_stats(agents)
+        assert stats["tool_frequency"]["Read"] == 2
+        assert stats["tool_frequency"]["Write"] == 1
+
+    def test_by_tool_entries(self, tmp_path: Path) -> None:
+        agents = [
+            _make_agent(tmp_path / "a.md", _VALID_FM, {"name": "a", "tools": "Read"}),
+        ]
+        stats = collect_agent_stats(agents)
+        assert "a" in stats["by_tool"]["Read"]
+
+    def test_skill_frequency(self, tmp_path: Path) -> None:
+        content = "---\nname: a\n---\nUse the `commit` skill.\n"
+        agent = _make_agent(tmp_path / "a.md", content, {"name": "a", "tools": ""})
+        stats = collect_agent_stats([agent])
+        assert stats["skill_frequency"].get("commit", 0) >= 1
+
+    def test_delegation_graph(self, tmp_path: Path) -> None:
+        content = "---\nname: a\n---\nDelegate to [worker](./worker.md).\n"
+        agent = _make_agent(tmp_path / "a.md", content, {"name": "a", "tools": ""})
+        stats = collect_agent_stats([agent])
+        assert len(stats["delegation_graph"]["a"]) == 1
+        assert stats["delegation_graph"]["a"][0]["target"] == "worker"
+
+
+class TestFormatStatsText:
+    """Tests for format_stats_text()."""
+
+    def _make_stats(self, tmp_path: Path) -> dict:
+        agents = [
+            _make_agent(tmp_path / "c.md", _CHIEF_FM, {"name": "chief-architect"}),
+            _make_agent(
+                tmp_path / "a.md", _VALID_FM, {"name": "test-agent", "tools": "Read,Write"}
+            ),
+        ]
+        return collect_agent_stats(agents)
+
+    def test_contains_overview(self, tmp_path: Path) -> None:
+        stats = self._make_stats(tmp_path)
+        text = format_stats_text(stats)
+        assert "Total Agents" in text
+        assert "2" in text
+
+    def test_contains_level_section(self, tmp_path: Path) -> None:
+        stats = self._make_stats(tmp_path)
+        text = format_stats_text(stats)
+        assert "AGENTS BY LEVEL" in text
+
+    def test_contains_tools_section(self, tmp_path: Path) -> None:
+        stats = self._make_stats(tmp_path)
+        text = format_stats_text(stats)
+        assert "TOP TOOLS" in text
+
+    def test_contains_skills_section(self, tmp_path: Path) -> None:
+        stats = self._make_stats(tmp_path)
+        text = format_stats_text(stats)
+        assert "TOP SKILLS" in text
+
+    def test_none_skills_placeholder(self, tmp_path: Path) -> None:
+        agents = [_make_agent(tmp_path / "a.md", _VALID_FM, {"name": "a", "tools": ""})]
+        stats = collect_agent_stats(agents)
+        text = format_stats_text(stats)
+        assert "(none)" in text
+
+    def test_returns_string(self, tmp_path: Path) -> None:
+        stats = self._make_stats(tmp_path)
+        assert isinstance(format_stats_text(stats), str)
+
+
+class TestFormatStatsJson:
+    """Tests for format_stats_json()."""
+
+    def test_valid_json(self, tmp_path: Path) -> None:
+        import json
+
+        agents = [_make_agent(tmp_path / "a.md", _VALID_FM, {"name": "a", "tools": "Read"})]
+        stats = collect_agent_stats(agents)
+        result = format_stats_json(stats)
+        parsed = json.loads(result)
+        assert "total_agents" in parsed
+
+    def test_contains_tool_frequency(self, tmp_path: Path) -> None:
+        import json
+
+        agents = [_make_agent(tmp_path / "a.md", _VALID_FM, {"name": "a", "tools": "Read"})]
+        stats = collect_agent_stats(agents)
+        result = format_stats_json(stats)
+        parsed = json.loads(result)
+        assert "tool_frequency" in parsed
+
+    def test_by_level_keys_are_strings(self, tmp_path: Path) -> None:
+        import json
+
+        agents = [_make_agent(tmp_path / "c.md", _CHIEF_FM, {"name": "chief-architect"})]
+        stats = collect_agent_stats(agents)
+        result = format_stats_json(stats)
+        parsed = json.loads(result)
+        for key in parsed["by_level"]:
+            assert isinstance(key, str)
+
+    def test_agents_without_level_included(self, tmp_path: Path) -> None:
+        import json
+
+        agents = [_make_agent(tmp_path / "a.md", _VALID_FM, {"name": "test-agent"})]
+        stats = collect_agent_stats(agents)
+        result = format_stats_json(stats)
+        parsed = json.loads(result)
+        assert "test-agent" in parsed["agents_without_level"]

--- a/tests/unit/ci/test_docker_timing.py
+++ b/tests/unit/ci/test_docker_timing.py
@@ -1,0 +1,82 @@
+"""Tests for hephaestus.ci.docker_timing."""
+
+from __future__ import annotations
+
+from hephaestus.ci.docker_timing import (
+    build_summary_table,
+    compute_reduction,
+    count_cached_layers,
+)
+
+
+class TestCountCachedLayers:
+    """Tests for count_cached_layers()."""
+
+    def test_no_cached(self) -> None:
+        assert count_cached_layers("") == 0
+
+    def test_single_cached(self) -> None:
+        assert count_cached_layers("#1 CACHED") == 1
+
+    def test_multiple_cached(self) -> None:
+        log = "#1 CACHED\n#2 CACHED\n#3 [1/5] FROM ...\n#4 CACHED"
+        assert count_cached_layers(log) == 3
+
+    def test_case_insensitive(self) -> None:
+        assert count_cached_layers("cached CACHED CaChEd") == 3
+
+
+class TestComputeReduction:
+    """Tests for compute_reduction()."""
+
+    def test_50_percent(self) -> None:
+        assert compute_reduction(100, 50) == 50.0
+
+    def test_zero_cold_returns_zero(self) -> None:
+        assert compute_reduction(0, 10) == 0.0
+
+    def test_negative_cold_returns_zero(self) -> None:
+        assert compute_reduction(-5, 10) == 0.0
+
+    def test_rounds_to_one_decimal(self) -> None:
+        result = compute_reduction(300, 199)
+        assert result == round((300 - 199) / 300 * 100, 1)
+
+    def test_full_reduction(self) -> None:
+        assert compute_reduction(100, 0) == 100.0
+
+    def test_no_reduction(self) -> None:
+        assert compute_reduction(100, 100) == 0.0
+
+
+class TestBuildSummaryTable:
+    """Tests for build_summary_table()."""
+
+    def test_contains_header(self) -> None:
+        table = build_summary_table(120, 60, 10, 50.0)
+        assert "Docker Build Timing" in table
+
+    def test_pass_verdict(self) -> None:
+        table = build_summary_table(100, 50, 5, 50.0)
+        assert "PASS" in table
+
+    def test_fail_verdict(self) -> None:
+        table = build_summary_table(100, 80, 2, 20.0)
+        assert "FAIL" in table
+
+    def test_contains_values(self) -> None:
+        table = build_summary_table(120, 60, 8, 50.0)
+        assert "120s" in table
+        assert "60s" in table
+        assert "50.0%" in table
+        assert "8" in table
+
+    def test_custom_threshold(self) -> None:
+        # reduction=20%, threshold=15% → PASS
+        table = build_summary_table(100, 80, 3, 20.0, acceptance_threshold=15.0)
+        assert "PASS" in table
+
+    def test_custom_threshold_fail(self) -> None:
+        # reduction=20%, threshold=25% → FAIL
+        table = build_summary_table(100, 80, 3, 20.0, acceptance_threshold=25.0)
+        assert "FAIL" in table

--- a/tests/unit/ci/test_precommit.py
+++ b/tests/unit/ci/test_precommit.py
@@ -1,0 +1,193 @@
+"""Tests for hephaestus.ci.precommit."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.ci.precommit import (
+    check_threshold,
+    check_version_drift,
+    emit_warning,
+    extract_external_hooks,
+    format_summary_table,
+    normalize_version,
+    parse_pixi_constraint,
+    write_step_summary,
+)
+
+
+class TestFormatSummaryTable:
+    """Tests for format_summary_table()."""
+
+    def test_passed_status(self) -> None:
+        table = format_summary_table(45, 300, "passed")
+        assert "passed" in table
+        assert "45s" in table
+        assert "300" in table
+
+    def test_failed_status(self) -> None:
+        table = format_summary_table(10, 5, "failed")
+        assert "failed" in table
+
+    def test_contains_header(self) -> None:
+        table = format_summary_table(0, 0, "passed")
+        assert "Pre-commit Hook Benchmark" in table
+
+    def test_markdown_table_format(self) -> None:
+        table = format_summary_table(30, 100, "passed")
+        assert "|" in table
+
+
+class TestCheckThreshold:
+    """Tests for check_threshold()."""
+
+    def test_below_threshold(self) -> None:
+        assert check_threshold(60, 120) is False
+
+    def test_above_threshold(self) -> None:
+        assert check_threshold(150, 120) is True
+
+    def test_equal_threshold_not_slow(self) -> None:
+        assert check_threshold(120, 120) is False
+
+    def test_default_threshold(self) -> None:
+        assert check_threshold(121) is True
+        assert check_threshold(119) is False
+
+
+class TestEmitWarning:
+    """Tests for emit_warning()."""
+
+    def test_outputs_annotation(self, capsys: pytest.CaptureFixture) -> None:
+        emit_warning("slow hooks")
+        captured = capsys.readouterr()
+        assert "::warning::slow hooks" in captured.out
+
+
+class TestWriteStepSummary:
+    """Tests for write_step_summary()."""
+
+    def test_writes_to_path(self, tmp_path: Path) -> None:
+        summary_file = tmp_path / "summary.md"
+        write_step_summary("## Test\n", str(summary_file))
+        assert summary_file.read_text() == "## Test\n"
+
+    def test_appends_to_existing(self, tmp_path: Path) -> None:
+        summary_file = tmp_path / "summary.md"
+        summary_file.write_text("existing\n")
+        write_step_summary("new\n", str(summary_file))
+        assert summary_file.read_text() == "existing\nnew\n"
+
+    def test_no_path_no_write(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("GITHUB_STEP_SUMMARY", raising=False)
+        # Should not raise even with no path set
+        write_step_summary("content")
+
+
+class TestNormalizeVersion:
+    """Tests for normalize_version()."""
+
+    def test_strips_v(self) -> None:
+        assert normalize_version("v1.19.1") == "1.19.1"
+
+    def test_no_v(self) -> None:
+        assert normalize_version("0.7.1") == "0.7.1"
+
+    def test_empty_string(self) -> None:
+        assert normalize_version("") == ""
+
+
+class TestParsePixiConstraint:
+    """Tests for parse_pixi_constraint()."""
+
+    def test_gte_range(self) -> None:
+        assert parse_pixi_constraint(">=1.19.1,<2") == "1.19.1"
+
+    def test_exact(self) -> None:
+        assert parse_pixi_constraint("==0.26.1") == "0.26.1"
+
+    def test_gte_only(self) -> None:
+        assert parse_pixi_constraint(">=0.7.1") == "0.7.1"
+
+    def test_bare_version(self) -> None:
+        assert parse_pixi_constraint("0.12.1") == "0.12.1"
+
+    def test_unparseable(self) -> None:
+        assert parse_pixi_constraint("*") is None
+
+
+class TestExtractExternalHooks:
+    """Tests for extract_external_hooks()."""
+
+    def test_extracts_external_repos(self) -> None:
+        repos = [
+            {"repo": "https://github.com/pre-commit/mirrors-mypy", "rev": "v1.19.1"},
+            {"repo": "local"},
+        ]
+        result = extract_external_hooks(repos)
+        assert "https://github.com/pre-commit/mirrors-mypy" in result
+        assert result["https://github.com/pre-commit/mirrors-mypy"] == "v1.19.1"
+        assert "local" not in result
+
+    def test_skips_missing_rev(self) -> None:
+        repos = [{"repo": "https://github.com/some/tool", "rev": ""}]
+        result = extract_external_hooks(repos)
+        assert result == {}
+
+    def test_empty_repos(self) -> None:
+        assert extract_external_hooks([]) == {}
+
+
+class TestCheckVersionDrift:
+    """Tests for check_version_drift()."""
+
+    def test_no_drift(self) -> None:
+        hooks = {"https://github.com/pre-commit/mirrors-mypy": "v1.19.1"}
+        pixi = {"mypy": "1.19.1"}
+        mapping = {"https://github.com/pre-commit/mirrors-mypy": "mypy"}
+        issues = check_version_drift(hooks, pixi, mapping)
+        assert issues == []
+
+    def test_drift_detected(self) -> None:
+        hooks = {"https://github.com/pre-commit/mirrors-mypy": "v1.20.0"}
+        pixi = {"mypy": "1.19.1"}
+        mapping = {"https://github.com/pre-commit/mirrors-mypy": "mypy"}
+        issues = check_version_drift(hooks, pixi, mapping)
+        assert len(issues) == 1
+        assert "DRIFT" in issues[0]
+
+    def test_missing_pixi_entry(self) -> None:
+        hooks = {"https://github.com/pre-commit/mirrors-mypy": "v1.19.1"}
+        mapping = {"https://github.com/pre-commit/mirrors-mypy": "mypy"}
+        issues = check_version_drift(hooks, {}, mapping)
+        assert len(issues) == 1
+        assert "MISSING" in issues[0]
+
+    def test_unmapped_url_skipped(self) -> None:
+        hooks = {"https://github.com/some/unmapped-tool": "v1.0.0"}
+        issues = check_version_drift(hooks, {}, {})
+        assert issues == []
+
+
+class TestBenchPrecommitMain:
+    """Tests for bench_precommit_main() CLI entry point."""
+
+    def test_basic_run(self, capsys: pytest.CaptureFixture) -> None:
+        from hephaestus.ci.precommit import bench_precommit_main
+
+        result = bench_precommit_main(["--elapsed", "45", "--files", "100", "--status", "passed"])
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "45s" in captured.out
+
+    def test_slow_emits_warning(self, capsys: pytest.CaptureFixture) -> None:
+        from hephaestus.ci.precommit import bench_precommit_main
+
+        result = bench_precommit_main(
+            ["--elapsed", "200", "--files", "50", "--status", "passed", "--threshold", "120"]
+        )
+        assert result == 0
+        captured = capsys.readouterr()
+        assert "::warning::" in captured.out

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -76,9 +76,7 @@ class TestParseReadmeTable:
 class TestCheckInventory:
     """Tests for check_inventory()."""
 
-    def _setup(
-        self, tmp_path: Path, on_disk: list[str], in_readme: list[str]
-    ) -> None:
+    def _setup(self, tmp_path: Path, on_disk: list[str], in_readme: list[str]) -> None:
         workflows = tmp_path / ".github" / "workflows"
         workflows.mkdir(parents=True)
         for name in on_disk:
@@ -210,9 +208,7 @@ class TestCollectWorkflowFiles:
         result = collect_workflow_files([str(f), str(f)])
         assert len(result) == 1
 
-    def test_missing_path_warns(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture
-    ) -> None:
+    def test_missing_path_warns(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         collect_workflow_files([str(tmp_path / "nonexistent.yml")])
         captured = capsys.readouterr()
         assert "WARNING" in captured.err
@@ -221,9 +217,7 @@ class TestCollectWorkflowFiles:
 class TestCLIEntryPoints:
     """Tests for check_workflow_inventory_main() and validate_workflow_checkout_main()."""
 
-    def test_inventory_in_sync(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_inventory_in_sync(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from hephaestus.ci.workflows import check_workflow_inventory_main
 
         workflows = tmp_path / ".github" / "workflows"
@@ -235,9 +229,7 @@ class TestCLIEntryPoints:
         )
         assert check_workflow_inventory_main() == 0
 
-    def test_inventory_drift(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_inventory_drift(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from hephaestus.ci.workflows import check_workflow_inventory_main
 
         workflows = tmp_path / ".github" / "workflows"
@@ -260,7 +252,5 @@ class TestCLIEntryPoints:
             "      - uses: actions/checkout@v4\n"
             "      - uses: ./.github/actions/setup\n"
         )
-        monkeypatch.setattr(
-            "sys.argv", ["hephaestus-validate-workflow-checkout", str(wf)]
-        )
+        monkeypatch.setattr("sys.argv", ["hephaestus-validate-workflow-checkout", str(wf)])
         assert validate_workflow_checkout_main() == 0

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -1,0 +1,266 @@
+"""Tests for hephaestus.ci.workflows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.ci.workflows import (
+    Violation,
+    _is_checkout_step,
+    _is_local_reference_step,
+    check_inventory,
+    collect_workflow_files,
+    collect_yml_files,
+    parse_readme_table,
+    validate_workflow,
+)
+
+
+class TestCollectYmlFiles:
+    """Tests for collect_yml_files()."""
+
+    def test_finds_yml_files(self, tmp_path: Path) -> None:
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: CI")
+        (workflows / "release.yml").write_text("name: Release")
+        result = collect_yml_files(tmp_path)
+        assert "ci.yml" in result
+        assert "release.yml" in result
+
+    def test_no_workflows_dir(self, tmp_path: Path) -> None:
+        assert collect_yml_files(tmp_path) == set()
+
+    def test_excludes_worktrees(self, tmp_path: Path) -> None:
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: CI")
+        # Worktree path — create a worktrees subdir
+        worktree_wf = tmp_path / "worktrees" / "branch" / ".github" / "workflows"
+        worktree_wf.mkdir(parents=True)
+        (worktree_wf / "ci.yml").write_text("name: CI (worktree copy)")
+        result = collect_yml_files(tmp_path)
+        # Only one ci.yml should appear (from main .github/workflows/)
+        assert "ci.yml" in result
+        assert len([f for f in result if f == "ci.yml"]) == 1
+
+
+class TestParseReadmeTable:
+    """Tests for parse_readme_table()."""
+
+    def test_parses_plain_filename(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text("| ci.yml | Runs tests |\n")
+        result = parse_readme_table(readme)
+        assert "ci.yml" in result
+
+    def test_parses_linked_filename(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text("| [release.yml](#release) | Creates releases |\n")
+        result = parse_readme_table(readme)
+        assert "release.yml" in result
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        result = parse_readme_table(tmp_path / "nonexistent.md")
+        assert result == set()
+
+    def test_ignores_non_table_lines(self, tmp_path: Path) -> None:
+        readme = tmp_path / "README.md"
+        readme.write_text("# Workflows\n\nThis repo uses ci.yml for testing.\n")
+        result = parse_readme_table(readme)
+        assert "ci.yml" not in result
+
+
+class TestCheckInventory:
+    """Tests for check_inventory()."""
+
+    def _setup(
+        self, tmp_path: Path, on_disk: list[str], in_readme: list[str]
+    ) -> None:
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        for name in on_disk:
+            (workflows / name).write_text(f"name: {name}")
+        readme = workflows / "README.md"
+        table_rows = "\n".join(f"| {name} | desc |" for name in in_readme)
+        readme.write_text(f"# Workflows\n\n{table_rows}\n")
+
+    def test_in_sync(self, tmp_path: Path) -> None:
+        self._setup(tmp_path, ["ci.yml"], ["ci.yml"])
+        undoc, missing = check_inventory(tmp_path)
+        assert undoc == []
+        assert missing == []
+
+    def test_undocumented_file(self, tmp_path: Path) -> None:
+        self._setup(tmp_path, ["ci.yml", "new.yml"], ["ci.yml"])
+        undoc, _missing = check_inventory(tmp_path)
+        assert "new.yml" in undoc
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        self._setup(tmp_path, ["ci.yml"], ["ci.yml", "phantom.yml"])
+        _, missing = check_inventory(tmp_path)
+        assert "phantom.yml" in missing
+
+
+class TestIsCheckoutStep:
+    """Tests for _is_checkout_step()."""
+
+    def test_checkout_step(self) -> None:
+        assert _is_checkout_step({"uses": "actions/checkout@v4"}) is True
+
+    def test_checkout_without_version(self) -> None:
+        assert _is_checkout_step({"uses": "actions/checkout"}) is True
+
+    def test_non_checkout(self) -> None:
+        assert _is_checkout_step({"uses": "actions/setup-python@v4"}) is False
+
+    def test_not_dict(self) -> None:
+        assert _is_checkout_step("not a dict") is False
+
+    def test_no_uses_key(self) -> None:
+        assert _is_checkout_step({"run": "echo hello"}) is False
+
+
+class TestIsLocalReferenceStep:
+    """Tests for _is_local_reference_step()."""
+
+    def test_local_action(self) -> None:
+        assert _is_local_reference_step({"uses": "./.github/actions/setup"}) is True
+
+    def test_local_workflow(self) -> None:
+        assert _is_local_reference_step({"uses": "./.github/workflows/reusable.yml"}) is True
+
+    def test_external_action(self) -> None:
+        assert _is_local_reference_step({"uses": "actions/checkout@v4"}) is False
+
+    def test_not_dict(self) -> None:
+        assert _is_local_reference_step("str") is False
+
+    def test_no_uses_key(self) -> None:
+        assert _is_local_reference_step({"run": "echo hi"}) is False
+
+
+class TestValidateWorkflow:
+    """Tests for validate_workflow()."""
+
+    def _write_workflow(self, path: Path, content: str) -> Path:
+        path.write_text(content)
+        return path
+
+    def test_valid_checkout_first(self, tmp_path: Path) -> None:
+        wf = self._write_workflow(
+            tmp_path / "ci.yml",
+            """
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+""",
+        )
+        assert validate_workflow(wf) == []
+
+    def test_checkout_missing_violation(self, tmp_path: Path) -> None:
+        wf = self._write_workflow(
+            tmp_path / "ci.yml",
+            """
+jobs:
+  build:
+    steps:
+      - uses: ./.github/actions/setup
+""",
+        )
+        violations = validate_workflow(wf)
+        assert len(violations) == 1
+        assert isinstance(violations[0], Violation)
+        assert violations[0].job_name == "build"
+
+    def test_no_jobs(self, tmp_path: Path) -> None:
+        wf = self._write_workflow(tmp_path / "ci.yml", "name: empty\n")
+        assert validate_workflow(wf) == []
+
+    def test_large_file_skipped(self, tmp_path: Path) -> None:
+        wf = tmp_path / "big.yml"
+        wf.write_bytes(b"x" * (1_048_576 + 1))
+        assert validate_workflow(wf) == []
+
+
+class TestCollectWorkflowFiles:
+    """Tests for collect_workflow_files()."""
+
+    def test_finds_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "ci.yml"
+        f.write_text("name: CI")
+        result = collect_workflow_files([str(f)])
+        assert f in result
+
+    def test_finds_directory(self, tmp_path: Path) -> None:
+        (tmp_path / "ci.yml").write_text("name: CI")
+        (tmp_path / "release.yaml").write_text("name: Release")
+        result = collect_workflow_files([str(tmp_path)])
+        names = [p.name for p in result]
+        assert "ci.yml" in names
+        assert "release.yaml" in names
+
+    def test_deduplicates(self, tmp_path: Path) -> None:
+        f = tmp_path / "ci.yml"
+        f.write_text("name: CI")
+        result = collect_workflow_files([str(f), str(f)])
+        assert len(result) == 1
+
+    def test_missing_path_warns(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        collect_workflow_files([str(tmp_path / "nonexistent.yml")])
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+
+
+class TestCLIEntryPoints:
+    """Tests for check_workflow_inventory_main() and validate_workflow_checkout_main()."""
+
+    def test_inventory_in_sync(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.ci.workflows import check_workflow_inventory_main
+
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: CI")
+        (workflows / "README.md").write_text("| ci.yml | CI workflow |\n")
+        monkeypatch.setattr(
+            "sys.argv", ["hephaestus-check-workflow-inventory", "--repo-root", str(tmp_path)]
+        )
+        assert check_workflow_inventory_main() == 0
+
+    def test_inventory_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.ci.workflows import check_workflow_inventory_main
+
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: CI")
+        (workflows / "README.md").write_text("| other.yml | Other |\n")
+        monkeypatch.setattr(
+            "sys.argv", ["hephaestus-check-workflow-inventory", "--repo-root", str(tmp_path)]
+        )
+        assert check_workflow_inventory_main() == 1
+
+    def test_checkout_valid(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        from hephaestus.ci.workflows import validate_workflow_checkout_main
+
+        wf = tmp_path / "ci.yml"
+        wf.write_text(
+            "jobs:\n  build:\n    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "      - uses: ./.github/actions/setup\n"
+        )
+        monkeypatch.setattr(
+            "sys.argv", ["hephaestus-validate-workflow-checkout", str(wf)]
+        )
+        assert validate_workflow_checkout_main() == 0

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -1,0 +1,498 @@
+"""Tests for hephaestus.config.dep_sync."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.config.dep_sync import (
+    VersionRange,
+    _parse_constraints,
+    _parse_version,
+    _version_satisfies,
+    check_dep_sync,
+    check_pyproject_no_deps,
+    check_requirements_against_pixi,
+    check_requirements_up_to_date,
+    generate_requirements_content,
+    parse_pixi_toml,
+    parse_requirements,
+    sync_requirements,
+)
+
+
+class TestParseVersion:
+    """Tests for _parse_version()."""
+
+    def test_simple_version(self) -> None:
+        assert _parse_version("1.2.3") == (1, 2, 3)
+
+    def test_single_component(self) -> None:
+        assert _parse_version("2") == (2,)
+
+    def test_two_components(self) -> None:
+        assert _parse_version("1.0") == (1, 0)
+
+    def test_with_dash(self) -> None:
+        assert _parse_version("1.2-3") == (1, 2, 3)
+
+    def test_ignores_non_digits(self) -> None:
+        # Letters between dots are ignored
+        assert _parse_version("1.a.3") == (1, 3)
+
+    def test_four_components(self) -> None:
+        assert _parse_version("1.2.3.4") == (1, 2, 3, 4)
+
+
+class TestParseConstraints:
+    """Tests for _parse_constraints()."""
+
+    def test_single_gte(self) -> None:
+        result = _parse_constraints(">=1.0.0")
+        assert result == [VersionRange(op=">=", version=(1, 0, 0))]
+
+    def test_range(self) -> None:
+        result = _parse_constraints(">=1.2.0,<2")
+        assert len(result) == 2
+        assert result[0].op == ">="
+        assert result[1].op == "<"
+
+    def test_exact(self) -> None:
+        result = _parse_constraints("==1.5.0")
+        assert result == [VersionRange(op="==", version=(1, 5, 0))]
+
+    def test_strips_quotes(self) -> None:
+        result = _parse_constraints('">=1.0,<2"')
+        assert len(result) == 2
+
+    def test_empty_spec(self) -> None:
+        result = _parse_constraints("")
+        assert result == []
+
+    def test_not_equal(self) -> None:
+        result = _parse_constraints("!=1.0.0")
+        assert result == [VersionRange(op="!=", version=(1, 0, 0))]
+
+
+class TestVersionSatisfies:
+    """Tests for _version_satisfies()."""
+
+    def test_gte_satisfied(self) -> None:
+        constraints = [VersionRange(op=">=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 2, 0), constraints) is True
+
+    def test_gte_not_satisfied(self) -> None:
+        constraints = [VersionRange(op=">=", version=(2, 0, 0))]
+        assert _version_satisfies((1, 9, 9), constraints) is False
+
+    def test_lt_satisfied(self) -> None:
+        constraints = [VersionRange(op="<", version=(2,))]
+        assert _version_satisfies((1, 9, 9), constraints) is True
+
+    def test_lt_not_satisfied(self) -> None:
+        constraints = [VersionRange(op="<", version=(2,))]
+        assert _version_satisfies((2, 0, 0), constraints) is False
+
+    def test_range_satisfied(self) -> None:
+        constraints = _parse_constraints(">=1.0.0,<2")
+        assert _version_satisfies((1, 5, 0), constraints) is True
+
+    def test_range_below(self) -> None:
+        constraints = _parse_constraints(">=1.0.0,<2")
+        assert _version_satisfies((0, 9, 0), constraints) is False
+
+    def test_range_above(self) -> None:
+        constraints = _parse_constraints(">=1.0.0,<2")
+        assert _version_satisfies((2, 0, 0), constraints) is False
+
+    def test_exact_match(self) -> None:
+        constraints = [VersionRange(op="==", version=(1, 5, 0))]
+        assert _version_satisfies((1, 5, 0), constraints) is True
+
+    def test_exact_no_match(self) -> None:
+        constraints = [VersionRange(op="==", version=(1, 5, 0))]
+        assert _version_satisfies((1, 5, 1), constraints) is False
+
+    def test_not_equal_mismatch(self) -> None:
+        constraints = [VersionRange(op="!=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 0, 1), constraints) is True
+
+    def test_not_equal_match(self) -> None:
+        constraints = [VersionRange(op="!=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 0, 0), constraints) is False
+
+    def test_pads_shorter_version(self) -> None:
+        # (2,) compared to constraint (2, 0, 0) — should be equal
+        constraints = [VersionRange(op="==", version=(2, 0, 0))]
+        assert _version_satisfies((2,), constraints) is True
+
+    def test_empty_constraints_always_true(self) -> None:
+        assert _version_satisfies((1, 0, 0), []) is True
+
+    def test_unknown_op_treated_as_true(self) -> None:
+        constraints = [VersionRange(op="~=", version=(1, 0, 0))]
+        assert _version_satisfies((1, 0, 0), constraints) is True
+
+
+class TestParsePixiToml:
+    """Tests for parse_pixi_toml()."""
+
+    def test_reads_dependencies(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\npydantic = ">=2.0,<3"\n'
+        )
+        result = parse_pixi_toml(pixi)
+        assert result["pyyaml"] == ">=6.0,<7"
+        assert result["pydantic"] == ">=2.0,<3"
+
+    def test_reads_pypi_dependencies(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            "[pypi-dependencies]\nrequests = \">=2.28,<3\"\n"
+        )
+        result = parse_pixi_toml(pixi)
+        assert result["requests"] == ">=2.28,<3"
+
+    def test_ignores_comments(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text("[dependencies]\n# This is a comment\npyyaml = \">=6.0\"\n")
+        result = parse_pixi_toml(pixi)
+        assert "pyyaml" in result
+        assert len(result) == 1
+
+    def test_stops_at_next_section(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text(
+            "[dependencies]\npyyaml = \">=6.0\"\n\n[feature.dev.dependencies]\npytest = \">=9.0\"\n"
+        )
+        result = parse_pixi_toml(pixi)
+        assert "pyyaml" in result
+        assert "pytest" not in result
+
+    def test_inline_comment_stripped(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text('[dependencies]\nrequests = ">=2.28" # HTTP client\n')
+        result = parse_pixi_toml(pixi)
+        assert result["requests"] == ">=2.28"
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        pixi = tmp_path / "pixi.toml"
+        pixi.write_text("")
+        result = parse_pixi_toml(pixi)
+        assert result == {}
+
+
+class TestParseRequirements:
+    """Tests for parse_requirements()."""
+
+    def test_basic_pins(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("pyyaml==6.0.1\npydantic==2.5.0\n")
+        result = parse_requirements(req)
+        assert result["pyyaml"] == "6.0.1"
+        assert result["pydantic"] == "2.5.0"
+
+    def test_skips_comments(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("# comment\npyyaml==6.0.1\n")
+        result = parse_requirements(req)
+        assert len(result) == 1
+
+    def test_skips_include_lines(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("-r requirements.txt\npyyaml==6.0.1\n")
+        result = parse_requirements(req)
+        assert len(result) == 1
+
+    def test_lowercases_package_names(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("PyYAML==6.0.1\n")
+        result = parse_requirements(req)
+        assert "pyyaml" in result
+
+    def test_strips_inline_comment(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("pyyaml==6.0.1  # some comment\n")
+        result = parse_requirements(req)
+        assert result["pyyaml"] == "6.0.1"
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        req = tmp_path / "requirements.txt"
+        req.write_text("")
+        result = parse_requirements(req)
+        assert result == {}
+
+
+class TestCheckPyprojectNoDeps:
+    """Tests for check_pyproject_no_deps()."""
+
+    def test_no_deps_returns_empty(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project]\nname = 'foo'\n")
+        errors = check_pyproject_no_deps(pyproject)
+        assert errors == []
+
+    def test_flags_project_dependencies(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project.dependencies]\nrequests = '>=2'\n")
+        errors = check_pyproject_no_deps(pyproject)
+        assert any("[project.dependencies]" in e for e in errors)
+
+    def test_flags_optional_dependencies(self, tmp_path: Path) -> None:
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text("[project.optional-dependencies]\ndev = ['pytest']\n")
+        errors = check_pyproject_no_deps(pyproject)
+        assert any("[project.optional-dependencies]" in e for e in errors)
+
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        errors = check_pyproject_no_deps(tmp_path / "nonexistent.toml")
+        assert errors == []
+
+
+class TestCheckRequirementsAgainstPixi:
+    """Tests for check_requirements_against_pixi()."""
+
+    def _write_req(self, tmp_path: Path, name: str, content: str) -> None:
+        (tmp_path / name).write_text(content)
+
+    def test_valid_pin_passes(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "pyyaml==6.0.1\n")
+        errors = check_requirements_against_pixi(
+            tmp_path, {"pyyaml": ">=6.0,<7"}
+        )
+        assert errors == []
+
+    def test_pin_outside_range_fails(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "pyyaml==7.0.0\n")
+        errors = check_requirements_against_pixi(
+            tmp_path, {"pyyaml": ">=6.0,<7"}
+        )
+        assert len(errors) == 1
+        assert "pyyaml" in errors[0]
+
+    def test_pkg_not_in_pixi_fails(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "requests==2.31.0\n")
+        errors = check_requirements_against_pixi(tmp_path, {})
+        assert len(errors) == 1
+        assert "requests" in errors[0]
+
+    def test_skips_missing_files(self, tmp_path: Path) -> None:
+        errors = check_requirements_against_pixi(tmp_path, {})
+        assert errors == []
+
+    def test_checks_both_req_files(self, tmp_path: Path) -> None:
+        self._write_req(tmp_path, "requirements.txt", "pyyaml==6.0.1\n")
+        self._write_req(tmp_path, "requirements-dev.txt", "pytest==9.0.0\n")
+        errors = check_requirements_against_pixi(
+            tmp_path, {"pyyaml": ">=6.0,<7", "pytest": ">=9.0,<10"}
+        )
+        assert errors == []
+
+
+class TestCheckDepSync:
+    """Tests for check_dep_sync()."""
+
+    def test_no_pixi_toml_returns_error(self, tmp_path: Path) -> None:
+        errors = check_dep_sync(tmp_path)
+        assert errors == ["pixi.toml not found"]
+
+    def test_clean_state_returns_empty(self, tmp_path: Path) -> None:
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("pyyaml==6.0.1\n")
+        errors = check_dep_sync(tmp_path)
+        assert errors == []
+
+    def test_out_of_range_pin_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("pyyaml==7.1.0\n")
+        errors = check_dep_sync(tmp_path)
+        assert len(errors) >= 1
+
+
+class TestGenerateRequirementsContent:
+    """Tests for generate_requirements_content()."""
+
+    def test_basic_output(self) -> None:
+        content = generate_requirements_content(
+            ["pyyaml"], {"pyyaml": "6.0.1"}
+        )
+        assert "pyyaml==6.0.1" in content
+
+    def test_includes_header(self) -> None:
+        content = generate_requirements_content(["pyyaml"], {"pyyaml": "6.0.1"})
+        assert "AUTO-GENERATED" in content
+
+    def test_include_base_prepended(self) -> None:
+        content = generate_requirements_content(
+            ["pytest"], {"pytest": "9.0.0"}, include_base="-r requirements.txt"
+        )
+        assert "-r requirements.txt" in content
+
+    def test_section_comments(self) -> None:
+        content = generate_requirements_content(
+            ["pyyaml"],
+            {"pyyaml": "6.0.1"},
+            section_comments={"pyyaml": "# YAML parser"},
+        )
+        assert "# YAML parser" in content
+
+    def test_missing_package_warns(self, capsys: pytest.CaptureFixture) -> None:
+        content = generate_requirements_content(["missing-pkg"], {})
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "missing-pkg" not in content
+
+    def test_ends_with_newline(self) -> None:
+        content = generate_requirements_content(["pyyaml"], {"pyyaml": "6.0.1"})
+        assert content.endswith("\n")
+
+
+class TestSyncRequirements:
+    """Tests for sync_requirements() and check_requirements_up_to_date()."""
+
+    def test_writes_files(self, tmp_path: Path) -> None:
+        paths = sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1", "pytest": "9.0.0"},
+            core_packages=["pyyaml"],
+            dev_packages=["pytest"],
+        )
+        assert len(paths) == 2
+        assert (tmp_path / "requirements.txt").exists()
+        assert (tmp_path / "requirements-dev.txt").exists()
+
+    def test_core_content(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        content = (tmp_path / "requirements.txt").read_text()
+        assert "pyyaml==6.0.1" in content
+
+    def test_dev_includes_base(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1", "pytest": "9.0.0"},
+            core_packages=["pyyaml"],
+            dev_packages=["pytest"],
+        )
+        dev_content = (tmp_path / "requirements-dev.txt").read_text()
+        assert "-r requirements.txt" in dev_content
+
+    def test_up_to_date_returns_true(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        ok = check_requirements_up_to_date(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        assert ok is True
+
+    def test_out_of_date_returns_false(self, tmp_path: Path) -> None:
+        sync_requirements(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        ok = check_requirements_up_to_date(
+            tmp_path,
+            {"pyyaml": "6.0.2"},  # different version
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        assert ok is False
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        ok = check_requirements_up_to_date(
+            tmp_path,
+            {"pyyaml": "6.0.1"},
+            core_packages=["pyyaml"],
+            dev_packages=[],
+        )
+        assert ok is False
+
+
+class TestCLIEntryPoints:
+    """Tests for check_dep_sync_main() and sync_requirements_main() CLI entry points."""
+
+    def test_check_dep_sync_main_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import check_dep_sync_main
+
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
+        assert check_dep_sync_main() == 0
+
+    def test_check_dep_sync_main_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import check_dep_sync_main
+
+        (tmp_path / "pixi.toml").write_text(
+            '[dependencies]\npyyaml = ">=6.0,<7"\n'
+        )
+        (tmp_path / "requirements.txt").write_text("pyyaml==8.0.0\n")
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
+        assert check_dep_sync_main() == 1
+
+    def test_sync_requirements_main_check_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import sync_requirements_main
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-sync-requirements",
+                "--check",
+                "--repo-root",
+                str(tmp_path),
+                "--core",
+                "pyyaml",
+            ],
+        )
+        mock_packages = {"pyyaml": "6.0.1"}
+        with patch("hephaestus.config.dep_sync.get_pixi_packages", return_value=mock_packages):
+            # Files don't exist yet — check mode should return 1
+            result = sync_requirements_main()
+        assert result == 1
+
+    def test_sync_requirements_main_write_mode(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.config.dep_sync import sync_requirements_main
+
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "hephaestus-sync-requirements",
+                "--repo-root",
+                str(tmp_path),
+                "--core",
+                "pyyaml",
+            ],
+        )
+        mock_packages = {"pyyaml": "6.0.1"}
+        with patch("hephaestus.config.dep_sync.get_pixi_packages", return_value=mock_packages):
+            result = sync_requirements_main()
+        assert result == 0
+        assert (tmp_path / "requirements.txt").exists()

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -141,24 +141,20 @@ class TestParsePixiToml:
 
     def test_reads_dependencies(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
-        pixi.write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\npydantic = ">=2.0,<3"\n'
-        )
+        pixi.write_text('[dependencies]\npyyaml = ">=6.0,<7"\npydantic = ">=2.0,<3"\n')
         result = parse_pixi_toml(pixi)
         assert result["pyyaml"] == ">=6.0,<7"
         assert result["pydantic"] == ">=2.0,<3"
 
     def test_reads_pypi_dependencies(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
-        pixi.write_text(
-            "[pypi-dependencies]\nrequests = \">=2.28,<3\"\n"
-        )
+        pixi.write_text('[pypi-dependencies]\nrequests = ">=2.28,<3"\n')
         result = parse_pixi_toml(pixi)
         assert result["requests"] == ">=2.28,<3"
 
     def test_ignores_comments(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
-        pixi.write_text("[dependencies]\n# This is a comment\npyyaml = \">=6.0\"\n")
+        pixi.write_text('[dependencies]\n# This is a comment\npyyaml = ">=6.0"\n')
         result = parse_pixi_toml(pixi)
         assert "pyyaml" in result
         assert len(result) == 1
@@ -166,7 +162,7 @@ class TestParsePixiToml:
     def test_stops_at_next_section(self, tmp_path: Path) -> None:
         pixi = tmp_path / "pixi.toml"
         pixi.write_text(
-            "[dependencies]\npyyaml = \">=6.0\"\n\n[feature.dev.dependencies]\npytest = \">=9.0\"\n"
+            '[dependencies]\npyyaml = ">=6.0"\n\n[feature.dev.dependencies]\npytest = ">=9.0"\n'
         )
         result = parse_pixi_toml(pixi)
         assert "pyyaml" in result
@@ -260,16 +256,12 @@ class TestCheckRequirementsAgainstPixi:
 
     def test_valid_pin_passes(self, tmp_path: Path) -> None:
         self._write_req(tmp_path, "requirements.txt", "pyyaml==6.0.1\n")
-        errors = check_requirements_against_pixi(
-            tmp_path, {"pyyaml": ">=6.0,<7"}
-        )
+        errors = check_requirements_against_pixi(tmp_path, {"pyyaml": ">=6.0,<7"})
         assert errors == []
 
     def test_pin_outside_range_fails(self, tmp_path: Path) -> None:
         self._write_req(tmp_path, "requirements.txt", "pyyaml==7.0.0\n")
-        errors = check_requirements_against_pixi(
-            tmp_path, {"pyyaml": ">=6.0,<7"}
-        )
+        errors = check_requirements_against_pixi(tmp_path, {"pyyaml": ">=6.0,<7"})
         assert len(errors) == 1
         assert "pyyaml" in errors[0]
 
@@ -300,17 +292,13 @@ class TestCheckDepSync:
         assert errors == ["pixi.toml not found"]
 
     def test_clean_state_returns_empty(self, tmp_path: Path) -> None:
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         (tmp_path / "requirements.txt").write_text("pyyaml==6.0.1\n")
         errors = check_dep_sync(tmp_path)
         assert errors == []
 
     def test_out_of_range_pin_fails(self, tmp_path: Path) -> None:
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         (tmp_path / "requirements.txt").write_text("pyyaml==7.1.0\n")
         errors = check_dep_sync(tmp_path)
         assert len(errors) >= 1
@@ -320,9 +308,7 @@ class TestGenerateRequirementsContent:
     """Tests for generate_requirements_content()."""
 
     def test_basic_output(self) -> None:
-        content = generate_requirements_content(
-            ["pyyaml"], {"pyyaml": "6.0.1"}
-        )
+        content = generate_requirements_content(["pyyaml"], {"pyyaml": "6.0.1"})
         assert "pyyaml==6.0.1" in content
 
     def test_includes_header(self) -> None:
@@ -436,9 +422,7 @@ class TestCLIEntryPoints:
     ) -> None:
         from hephaestus.config.dep_sync import check_dep_sync_main
 
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
         assert check_dep_sync_main() == 0
 
@@ -447,9 +431,7 @@ class TestCLIEntryPoints:
     ) -> None:
         from hephaestus.config.dep_sync import check_dep_sync_main
 
-        (tmp_path / "pixi.toml").write_text(
-            '[dependencies]\npyyaml = ">=6.0,<7"\n'
-        )
+        (tmp_path / "pixi.toml").write_text('[dependencies]\npyyaml = ">=6.0,<7"\n')
         (tmp_path / "requirements.txt").write_text("pyyaml==8.0.0\n")
         monkeypatch.setattr("sys.argv", ["hephaestus-check-dep-sync", "--repo-root", str(tmp_path)])
         assert check_dep_sync_main() == 1

--- a/tests/unit/discovery/test_agents.py
+++ b/tests/unit/discovery/test_agents.py
@@ -1,0 +1,86 @@
+"""Tests for hephaestus.discovery.agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.discovery.agents import discover_agents, organize_agents, parse_agent_level
+
+_FM_LEVEL_2 = "---\nname: design-agent\nlevel: 2\ntools: Read\nmodel: sonnet\n---\n"
+_FM_NO_LEVEL = "---\nname: unknown-agent\ntools: Read\nmodel: sonnet\n---\n"
+
+
+class TestParseAgentLevel:
+    """Tests for parse_agent_level()."""
+
+    def test_extracts_level(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.md"
+        f.write_text(_FM_LEVEL_2)
+        assert parse_agent_level(f) == 2
+
+    def test_no_level_returns_none(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.md"
+        f.write_text(_FM_NO_LEVEL)
+        assert parse_agent_level(f) is None
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert parse_agent_level(tmp_path / "nonexistent.md") is None
+
+    def test_level_zero(self, tmp_path: Path) -> None:
+        f = tmp_path / "a.md"
+        f.write_text("---\nname: chief\nlevel: 0\n---\n")
+        assert parse_agent_level(f) == 0
+
+
+class TestDiscoverAgents:
+    """Tests for discover_agents()."""
+
+    def test_classifies_by_level(self, tmp_path: Path) -> None:
+        (tmp_path / "chief.md").write_text("---\nname: chief\nlevel: 0\n---\n")
+        (tmp_path / "design.md").write_text(_FM_LEVEL_2)
+        result = discover_agents(tmp_path)
+        assert len(result[0]) == 1
+        assert len(result[2]) == 1
+
+    def test_agents_without_level_excluded(self, tmp_path: Path) -> None:
+        (tmp_path / "unlevel.md").write_text(_FM_NO_LEVEL)
+        result = discover_agents(tmp_path)
+        assert all(len(v) == 0 for v in result.values())
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        result = discover_agents(tmp_path)
+        assert all(len(v) == 0 for v in result.values())
+        assert set(result.keys()) == set(range(6))
+
+    def test_out_of_range_level_excluded(self, tmp_path: Path) -> None:
+        (tmp_path / "bad.md").write_text("---\nname: x\nlevel: 99\n---\n")
+        result = discover_agents(tmp_path)
+        assert all(len(v) == 0 for v in result.values())
+
+
+class TestOrganizeAgents:
+    """Tests for organize_agents()."""
+
+    def test_creates_level_dirs(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+        (src / "a.md").write_text("---\nname: a\nlevel: 1\n---\n")
+        organize_agents(src, dst)
+        assert (dst / "L1").is_dir()
+
+    def test_copies_agent_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+        (src / "a.md").write_text("---\nname: a\nlevel: 1\n---\n")
+        result = organize_agents(src, dst)
+        assert "a.md" in result[1]
+        assert (dst / "L1" / "a.md").exists()
+
+    def test_returns_stats(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+        result = organize_agents(src, dst)
+        assert set(result.keys()) == set(range(6))

--- a/tests/unit/discovery/test_blocks.py
+++ b/tests/unit/discovery/test_blocks.py
@@ -1,0 +1,75 @@
+"""Tests for hephaestus.discovery.blocks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.discovery.blocks import discover_blocks, extract_blocks
+
+_SAMPLE_MD = "Line 1\nLine 2\nLine 3\nLine 4\nLine 5\n"
+_BLOCK_DEFS = [("B01", 1, 2, "B01-first.md"), ("B02", 4, 5, "B02-last.md")]
+
+
+class TestDiscoverBlocks:
+    """Tests for discover_blocks()."""
+
+    def test_returns_provided_defs(self, tmp_path: Path) -> None:
+        f = tmp_path / "CLAUDE.md"
+        f.write_text(_SAMPLE_MD)
+        result = discover_blocks(f, _BLOCK_DEFS)
+        assert result == _BLOCK_DEFS
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            discover_blocks(tmp_path / "nonexistent.md", _BLOCK_DEFS)
+
+    def test_no_defs_raises_value_error(self, tmp_path: Path) -> None:
+        f = tmp_path / "CLAUDE.md"
+        f.write_text(_SAMPLE_MD)
+        with pytest.raises(ValueError, match="block_defs must be provided"):
+            discover_blocks(f, None)
+
+
+class TestExtractBlocks:
+    """Tests for extract_blocks()."""
+
+    def test_creates_output_dir(self, tmp_path: Path) -> None:
+        src = tmp_path / "CLAUDE.md"
+        src.write_text(_SAMPLE_MD)
+        out = tmp_path / "blocks"
+        extract_blocks(src, out, _BLOCK_DEFS)
+        assert out.is_dir()
+
+    def test_creates_block_files(self, tmp_path: Path) -> None:
+        src = tmp_path / "CLAUDE.md"
+        src.write_text(_SAMPLE_MD)
+        out = tmp_path / "blocks"
+        created = extract_blocks(src, out, _BLOCK_DEFS)
+        assert len(created) == 2
+        for path in created:
+            assert path.exists()
+
+    def test_block_content_correct(self, tmp_path: Path) -> None:
+        src = tmp_path / "CLAUDE.md"
+        src.write_text(_SAMPLE_MD)
+        out = tmp_path / "blocks"
+        extract_blocks(src, out, _BLOCK_DEFS)
+        b01 = (out / "B01-first.md").read_text()
+        assert b01 == "Line 1\nLine 2\n"
+        b02 = (out / "B02-last.md").read_text()
+        assert b02 == "Line 4\nLine 5\n"
+
+    def test_returns_paths(self, tmp_path: Path) -> None:
+        src = tmp_path / "CLAUDE.md"
+        src.write_text(_SAMPLE_MD)
+        out = tmp_path / "blocks"
+        result = extract_blocks(src, out, _BLOCK_DEFS)
+        assert all(isinstance(p, Path) for p in result)
+
+    def test_no_defs_raises(self, tmp_path: Path) -> None:
+        src = tmp_path / "CLAUDE.md"
+        src.write_text(_SAMPLE_MD)
+        with pytest.raises(ValueError):
+            extract_blocks(src, tmp_path / "out", None)

--- a/tests/unit/discovery/test_skills.py
+++ b/tests/unit/discovery/test_skills.py
@@ -1,0 +1,122 @@
+"""Tests for hephaestus.discovery.skills."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.discovery.skills import discover_skills, get_skill_category, organize_skills
+
+_MAPPINGS = {
+    "github": ["gh-review-pr", "gh-create-pr"],
+    "workflow": ["phase-plan", "phase-implement"],
+}
+
+
+class TestGetSkillCategory:
+    """Tests for get_skill_category()."""
+
+    def test_explicit_mapping(self) -> None:
+        assert get_skill_category("gh-review-pr", _MAPPINGS) == "github"
+
+    def test_prefix_fallback_gh(self) -> None:
+        assert get_skill_category("gh-unknown") == "github"
+
+    def test_prefix_fallback_mojo(self) -> None:
+        assert get_skill_category("mojo-format") == "mojo"
+
+    def test_prefix_fallback_phase(self) -> None:
+        assert get_skill_category("phase-plan") == "workflow"
+
+    def test_prefix_fallback_quality(self) -> None:
+        assert get_skill_category("quality-check") == "quality"
+
+    def test_prefix_fallback_worktree(self) -> None:
+        assert get_skill_category("worktree-create") == "worktree"
+
+    def test_prefix_fallback_doc(self) -> None:
+        assert get_skill_category("doc-generate") == "documentation"
+
+    def test_prefix_fallback_agent(self) -> None:
+        assert get_skill_category("agent-run") == "agent"
+
+    def test_unknown_falls_back_to_other(self) -> None:
+        assert get_skill_category("custom-skill") == "other"
+
+    def test_no_mappings_uses_prefix_only(self) -> None:
+        assert get_skill_category("gh-review-pr") == "github"
+
+
+class TestDiscoverSkills:
+    """Tests for discover_skills()."""
+
+    def test_finds_skill_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / "gh-review-pr").mkdir()
+        result = discover_skills(tmp_path)
+        assert any(p.name == "gh-review-pr" for p in result["github"])
+
+    def test_finds_skill_files(self, tmp_path: Path) -> None:
+        (tmp_path / "my-skill.md").write_text("# skill")
+        result = discover_skills(tmp_path)
+        assert any(p.name == "my-skill.md" for p in result["other"])
+
+    def test_skips_template_files(self, tmp_path: Path) -> None:
+        (tmp_path / "TEMPLATE.md").write_text("# template")
+        result = discover_skills(tmp_path)
+        all_paths = [p for paths in result.values() for p in paths]
+        assert not any(p.name == "TEMPLATE.md" for p in all_paths)
+
+    def test_skips_hidden_dirs(self, tmp_path: Path) -> None:
+        (tmp_path / ".hidden").mkdir()
+        result = discover_skills(tmp_path)
+        all_paths = [p for paths in result.values() for p in paths]
+        assert not any(p.name == ".hidden" for p in all_paths)
+
+    def test_with_custom_mappings(self, tmp_path: Path) -> None:
+        (tmp_path / "my-special-skill").mkdir()
+        mappings = {"custom": ["my-special-skill"]}
+        result = discover_skills(tmp_path, mappings)
+        assert any(p.name == "my-special-skill" for p in result["custom"])
+
+    def test_empty_directory(self, tmp_path: Path) -> None:
+        result = discover_skills(tmp_path)
+        assert "other" in result
+        assert all(len(v) == 0 for v in result.values())
+
+
+class TestOrganizeSkills:
+    """Tests for organize_skills()."""
+
+    def test_creates_category_dirs(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "gh-review-pr").mkdir()
+        dst = tmp_path / "dst"
+        organize_skills(src, dst)
+        assert (dst / "github").is_dir()
+
+    def test_copies_skill_dir(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        skill_dir = src / "gh-review-pr"
+        skill_dir.mkdir()
+        (skill_dir / "README.md").write_text("# skill")
+        dst = tmp_path / "dst"
+        result = organize_skills(src, dst)
+        assert "gh-review-pr" in result["github"]
+        assert (dst / "github" / "gh-review-pr" / "README.md").exists()
+
+    def test_copies_skill_file(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "my-skill.md").write_text("# skill")
+        dst = tmp_path / "dst"
+        result = organize_skills(src, dst)
+        assert "my-skill" in result["other"]
+        assert (dst / "other" / "my-skill.md").exists()
+
+    def test_returns_stats(self, tmp_path: Path) -> None:
+        src = tmp_path / "src"
+        src.mkdir()
+        dst = tmp_path / "dst"
+        result = organize_skills(src, dst)
+        assert "other" in result

--- a/tests/unit/github/test_stats.py
+++ b/tests/unit/github/test_stats.py
@@ -70,9 +70,7 @@ class TestGetIssuesStats:
             get_issues_stats("2026-01-01", "2026-01-31", "mvillmow", "owner/repo")
         # Verify author was part of the query string
         first_call_args = mock_run.call_args_list[0][0][0]
-        query_arg = next(
-            (a for a in first_call_args if "author:" in a), ""
-        )
+        query_arg = next((a for a in first_call_args if "author:" in a), "")
         assert "author:mvillmow" in query_arg
 
 

--- a/tests/unit/github/test_stats.py
+++ b/tests/unit/github/test_stats.py
@@ -1,0 +1,220 @@
+"""Tests for hephaestus.github.stats."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.github.stats import (
+    collect_stats,
+    format_stats_table,
+    get_commits_stats,
+    get_issues_stats,
+    get_prs_stats,
+    validate_date,
+)
+
+
+class TestValidateDate:
+    """Tests for validate_date()."""
+
+    def test_valid_date(self) -> None:
+        assert validate_date("2026-01-15") is True
+
+    def test_invalid_format(self) -> None:
+        assert validate_date("01/15/2026") is False
+
+    def test_non_existent_date(self) -> None:
+        assert validate_date("2026-13-01") is False
+
+    def test_empty_string(self) -> None:
+        assert validate_date("") is False
+
+    def test_year_only(self) -> None:
+        assert validate_date("2026") is False
+
+
+class TestGetIssuesStats:
+    """Tests for get_issues_stats()."""
+
+    def _make_mock(self, returncode: int, stdout: str) -> MagicMock:
+        m = MagicMock()
+        m.returncode = returncode
+        m.stdout = stdout
+        return m
+
+    def test_returns_counts(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_mock(0, "10\n"),
+                self._make_mock(0, "3\n"),
+            ]
+            result = get_issues_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result["total"] == 10
+        assert result["open"] == 3
+        assert result["closed"] == 7
+
+    def test_gh_failure_returns_zeros(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._make_mock(1, "")
+            result = get_issues_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result == {"total": 0, "open": 0, "closed": 0}
+
+    def test_author_filter_included_in_query(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_mock(0, "5\n"),
+                self._make_mock(0, "2\n"),
+            ]
+            get_issues_stats("2026-01-01", "2026-01-31", "mvillmow", "owner/repo")
+        # Verify author was part of the query string
+        first_call_args = mock_run.call_args_list[0][0][0]
+        query_arg = next(
+            (a for a in first_call_args if "author:" in a), ""
+        )
+        assert "author:mvillmow" in query_arg
+
+
+class TestGetPrsStats:
+    """Tests for get_prs_stats()."""
+
+    def _make_mock(self, returncode: int, stdout: str) -> MagicMock:
+        m = MagicMock()
+        m.returncode = returncode
+        m.stdout = stdout
+        return m
+
+    def test_returns_counts(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                self._make_mock(0, "8\n"),
+                self._make_mock(0, "5\n"),
+                self._make_mock(0, "1\n"),
+            ]
+            result = get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result["total"] == 8
+        assert result["merged"] == 5
+        assert result["open"] == 1
+        assert result["closed"] == 2
+
+    def test_gh_failure_returns_zeros(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._make_mock(1, "")
+            result = get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result == {"total": 0, "merged": 0, "open": 0, "closed": 0}
+
+
+class TestGetCommitsStats:
+    """Tests for get_commits_stats()."""
+
+    def _make_mock(self, returncode: int, stdout: str) -> MagicMock:
+        m = MagicMock()
+        m.returncode = returncode
+        m.stdout = stdout
+        return m
+
+    def test_returns_count(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._make_mock(0, "42\n")
+            result = get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result["total"] == 42
+
+    def test_sums_paginated_output(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._make_mock(0, "30\n12\n")
+            result = get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result["total"] == 42
+
+    def test_gh_failure_returns_zero(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._make_mock(1, "")
+            result = get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert result == {"total": 0}
+
+    def test_author_param_passed(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._make_mock(0, "5\n")
+            get_commits_stats("2026-01-01", "2026-01-31", "mvillmow", "owner/repo")
+        call_args = mock_run.call_args[0][0]
+        assert "author=mvillmow" in " ".join(call_args)
+
+
+class TestCollectStats:
+    """Tests for collect_stats()."""
+
+    def test_returns_all_categories(self) -> None:
+        issues = {"total": 1, "open": 0, "closed": 1}
+        prs = {"total": 2, "merged": 1, "open": 0, "closed": 1}
+        commits = {"total": 3}
+        with (
+            patch("hephaestus.github.stats.get_issues_stats", return_value=issues),
+            patch("hephaestus.github.stats.get_prs_stats", return_value=prs),
+            patch("hephaestus.github.stats.get_commits_stats", return_value=commits),
+        ):
+            result = collect_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert "issues" in result
+        assert "prs" in result
+        assert "commits" in result
+
+
+class TestFormatStatsTable:
+    """Tests for format_stats_table()."""
+
+    def _make_stats(self) -> dict:
+        return {
+            "issues": {"total": 10, "open": 3, "closed": 7},
+            "prs": {"total": 8, "merged": 5, "open": 1, "closed": 2},
+            "commits": {"total": 42},
+        }
+
+    def test_contains_header(self) -> None:
+        table = format_stats_table(self._make_stats())
+        assert "GitHub Contribution Statistics" in table
+
+    def test_contains_issue_counts(self) -> None:
+        table = format_stats_table(self._make_stats())
+        assert "10" in table
+        assert "ISSUES" in table
+
+    def test_contains_pr_counts(self) -> None:
+        table = format_stats_table(self._make_stats())
+        assert "PULL REQUESTS" in table
+        assert "8" in table
+
+    def test_contains_commit_count(self) -> None:
+        table = format_stats_table(self._make_stats())
+        assert "COMMITS" in table
+        assert "42" in table
+
+
+class TestMain:
+    """Tests for main() CLI entry point."""
+
+    def test_invalid_start_date(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hephaestus.github.stats import main
+
+        monkeypatch.setattr("sys.argv", ["hephaestus-github-stats", "bad-date", "2026-01-31"])
+        assert main() == 1
+
+    def test_invalid_end_date(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hephaestus.github.stats import main
+
+        monkeypatch.setattr("sys.argv", ["hephaestus-github-stats", "2026-01-01", "not-a-date"])
+        assert main() == 1
+
+    def test_valid_dates_run(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from hephaestus.github.stats import main
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["hephaestus-github-stats", "2026-01-01", "2026-01-31", "--repo", "owner/repo"],
+        )
+        mock_stats = {
+            "issues": {"total": 1, "open": 0, "closed": 1},
+            "prs": {"total": 1, "merged": 1, "open": 0, "closed": 0},
+            "commits": {"total": 5},
+        }
+        with patch("hephaestus.github.stats.collect_stats", return_value=mock_stats):
+            result = main()
+        assert result == 0


### PR DESCRIPTION
## Summary

- Adds `hephaestus.discovery` subpackage ported from `src/scylla/discovery/`
- All functions are path-agnostic — no hardcoded project names or directories
- `agents.py`: `parse_agent_level` (regex frontmatter reader), `discover_agents` (by explicit level), `organize_agents` (copies into L0–L5)
- `blocks.py`: `extract_blocks` / `discover_blocks` — splits markdown by caller-supplied line ranges; no magic auto-detection (raises `ValueError` if no defs given)
- `skills.py`: `get_skill_category` (explicit mapping + prefix fallback), `discover_skills`, `organize_skills` — `category_mappings` is caller-supplied

## Divergence from Scylla source

- `blocks.py` removes the `DEFAULT_BLOCKS` constant (Odyssey-specific line ranges) and raises `ValueError` instead of silently falling back
- `skills.py` removes `CATEGORY_MAPPINGS` constant (Scylla skill names); consumers pass their own mappings
- `agents.py` keeps `parse_agent_level` regex approach (no yaml dep) rather than delegating to `hephaestus.agents.loader` to avoid circular imports and keep this module dependency-free

## Test plan
- [ ] `pixi run pytest tests/unit/discovery/ -v` — 39 tests pass
- [ ] `pixi run ruff check hephaestus/discovery/ tests/unit/discovery/` — clean
- [ ] `pixi run mypy` — no issues (193 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)