### PR TITLE
chore(release): bump version to 0.7.0

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -936,8 +936,8 @@ packages:
   timestamp: 1773314012590
 - pypi: ./
   name: homericintelligence-hephaestus
-  version: 0.6.0
-  sha256: 0ef0c9c3ebbed5320321e51f15d7ef5f39a4303aae4793518de4a0c3de398070
+  version: 0.7.0
+  sha256: a42968995da7d731d99d44627d2931a4edd60f2783e5c1907c7c78481a718234
   requires_dist:
   - packaging>=21.0
   - pyyaml>=6.0,<7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "HomericIntelligence-Hephaestus"
-version = "0.6.0"
+version = "0.7.0"
 description = "Shared utilities and tooling for the HomericIntelligence ecosystem"
 readme = "README.md"
 license = {text = "BSD 3-Clause"}


### PR DESCRIPTION
## Summary

- Bumps package version from 0.6.0 to 0.7.0
- Releases all L1–L11 port work: `hephaestus.version.consistency`, `hephaestus.validation` extensions, `hephaestus.markdown` anchors, `hephaestus.config.dep_sync`, `hephaestus.ci`, `hephaestus.github.stats`, `hephaestus.agents`, `hephaestus.discovery`, `hephaestus.nats`, `hephaestus.datasets` expansion

## New modules in 0.7.0
- `hephaestus.version.consistency` — version bump + consistency checks
- `hephaestus.validation.doc_config`, `stale_scripts`, `mypy_per_file`, `type_aliases`, `complexity`, `test_structure`
- `hephaestus.markdown.anchors` — installation anchor validation; `link_fixer` gets `--check` mode
- `hephaestus.config.dep_sync` — dep sync check + requirements sync
- `hephaestus.ci` — `docker_timing`, `precommit`, `workflows` submodules
- `hephaestus.github.stats` — repo statistics
- `hephaestus.agents` — frontmatter, loader, stats (generic agent primitives)
- `hephaestus.discovery` — filesystem walker for agents, skills, CLAUDE.md blocks
- `hephaestus.nats` — generic NATS JetStream subscriber (optional dep: `nats-py`)
- `hephaestus.datasets` — CIFAR-10/100, EMNIST, Fashion-MNIST downloaders added

🤖 Generated with [Claude Code](https://claude.com/claude-code)