### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.7.0)"
+        required: true
+        default: "v0.7.0"
 
 permissions:
   contents: write


### PR DESCRIPTION
Allows manually triggering the release/publish workflow for existing tags (e.g. v0.7.0 which was created via gh release create and didn't fire the push trigger).