### PR TITLE
fix(release): skip Create GitHub Release for workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,7 @@ jobs:
           verbose: true
 
       - name: Create GitHub Release
+        if: github.event_name == 'push'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Adds `if: github.event_name == 'push'` guard to the **Create GitHub Release** step so it only fires on tag-push triggers, not manual `workflow_dispatch` re-publishes.
- When triggered via `workflow_dispatch` the tag already exists; only PyPI publish is needed.
- v0.7.0 PyPI publish already succeeded (both `.whl` and `.tar.gz` live); the overall job was marked failed solely because this step errored.

Closes #293

## Test plan

- [ ] Tag push (`v*`) → full job runs including GitHub Release creation ✓
- [ ] `workflow_dispatch` → PyPI publish runs, Create GitHub Release step is skipped ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)