### PR TITLE
fix(ci): fix release.yml for hatch-vcs auto-versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: v0.63.2
+          locked: false
 
       - name: Cache pixi environments
         uses: actions/cache@v5
@@ -47,11 +51,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: v0.63.2
+          locked: false
 
       - name: Cache pixi environments
         uses: actions/cache@v5
@@ -76,11 +84,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: v0.63.2
+          locked: false
 
       - name: Cache pixi environments
         uses: actions/cache@v5
@@ -98,14 +109,9 @@ jobs:
           TAG_REF: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           TAG_VERSION="${TAG_REF#v}"
-          PKG_VERSION=$(python -c "
-          import re, pathlib
-          text = pathlib.Path('pyproject.toml').read_text()
-          m = re.search(r'^version\s*=\s*\"(.+?)\"', text, re.MULTILINE)
-          print(m.group(1))
-          ")
+          PKG_VERSION=$(pixi run python -c "import hephaestus; print(hephaestus.__version__)")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match pyproject.toml version ($PKG_VERSION)"
+            echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
             exit 1
           fi
           echo "Version check passed: $TAG_VERSION"

--- a/pixi.lock
+++ b/pixi.lock
@@ -1150,8 +1150,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: homericintelligence-hephaestus
-  version: 0.7.1.dev13+g379982e2b.d20260422
-  sha256: 17f27214e302c133c55d82ee770a83cdacaf802dace653563f1835e8a57e8a29
+  version: 0.7.1.dev15+g4980b1978.d20260422
+  sha256: b6e5a214d04bede6a107ee28e5fc5fbe43cee039bb4f5beb22c491149a199829
   requires_dist:
   - packaging>=21.0
   - pydantic>=2.0,<3


### PR DESCRIPTION
## Summary

Fixes `release.yml` which was missed when `locked: false` was applied to all other pixi workflows.

- Add `locked: false` to all three `setup-pixi` steps in `release.yml`
- Add `fetch-depth: 0` and `fetch-tags: true` to all checkout steps so hatch-vcs can read tag history
- Replace pyproject.toml version-regex check with `import hephaestus; print(hephaestus.__version__)` — `pyproject.toml` no longer has a hardcoded `version` string since switching to `dynamic = ["version"]`

## Root cause

`v0.7.2` tag triggered `release.yml` but that workflow still ran `pixi install --locked`, which rejects the workspace because hatch-vcs embeds the git SHA in the editable package version. The `locked: false` fix from PR #298 only covered `test.yml`, `security.yml`, and `pre-commit.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)