### PR TITLE
feat(ci): make releases fully manual; disable auto-tag

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,10 +1,7 @@
 name: Auto Tag Release
 
 on:
-  workflow_run:
-    workflows: [Test]
-    types: [completed]
-    branches: [main]
+  workflow_dispatch:  # manual only — auto-tagging is disabled
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,12 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to release (e.g. v0.7.0)"
-        required: true
-        default: "v0.7.0"
+        description: "Tag to release (leave blank to use latest tag)"
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -83,9 +80,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.tag || github.ref }}
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          INPUT_TAG="${{ github.event.inputs.tag }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Releasing tag: ${TAG}"
+          git checkout "${TAG}"
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.9.5
@@ -106,9 +116,9 @@ jobs:
       - name: Verify tag matches package version
         shell: bash
         env:
-          TAG_REF: ${{ github.event.inputs.tag || github.ref_name }}
+          TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          TAG_VERSION="${TAG_REF#v}"
+          TAG_VERSION="${TAG#v}"
           PKG_VERSION=$(pixi run python -c "import hephaestus; print(hephaestus.__version__)")
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
@@ -125,9 +135,9 @@ jobs:
           verbose: true
 
       - name: Create GitHub Release
-        if: github.event_name == 'push'
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true
           files: dist/*
         env:


### PR DESCRIPTION
## Summary

- **`release.yml`**: Remove `push: tags: v*` trigger — `workflow_dispatch` only. Tag input defaults to blank; a "Resolve tag" step picks the latest `vX.Y.Z` tag at runtime when no input is supplied. GitHub Release is always created (not only on `push` events).
- **`auto-tag.yml`**: Disable automatic `workflow_run` trigger — `workflow_dispatch` only. Tags must be pushed manually.

## How to release

1. Push a tag manually: `git tag v0.7.X && git push origin v0.7.X`
2. Trigger the Release workflow: `gh workflow run release.yml --repo HomericIntelligence/ProjectHephaestus` (picks up the latest tag automatically), or supply `--field tag=v0.7.X` to target a specific tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)