### PR TITLE
chore(ci): add unified required-checks workflow

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -1,0 +1,295 @@
+name: Required Checks
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: required-${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.63.2
+          environments: lint
+          locked: false
+
+      - name: Cache pixi environments
+        uses: actions/cache@v5
+        with:
+          path: |
+            .pixi
+            ~/.cache/rattler/cache
+          key: pixi-lint-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          restore-keys: |
+            pixi-lint-${{ runner.os }}-
+
+      - name: Ruff check
+        run: pixi run --environment lint ruff check hephaestus scripts tests
+
+      - name: Ruff format check
+        run: pixi run --environment lint ruff format --check hephaestus scripts tests
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.63.2
+          environments: lint
+          locked: false
+
+      - name: Cache pixi environments
+        uses: actions/cache@v5
+        with:
+          path: |
+            .pixi
+            ~/.cache/rattler/cache
+          key: pixi-lint-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          restore-keys: |
+            pixi-lint-${{ runner.os }}-
+
+      - name: mypy
+        run: pixi run --environment lint mypy hephaestus/ scripts/ tests/
+
+  unit-tests:
+    name: unit-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-3.12-
+
+      - name: Install package
+        run: pip install -e ".[dev]"
+
+      - name: Run unit tests
+        run: pytest tests/unit --override-ini="addopts=" -v --strict-markers --cov=hephaestus --cov-report=term-missing --cov-fail-under=80
+
+      - name: Check unit test structure
+        run: python scripts/check_unit_test_structure.py
+
+  integration-tests:
+    name: integration-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-3.12-
+
+      - name: Install package
+        run: pip install -e ".[dev]"
+
+      - name: Run integration tests
+        run: pytest tests/integration --override-ini="addopts=" -v --strict-markers
+
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-3.12-build-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            pip-${{ runner.os }}-3.12-build-
+
+      - name: Install build deps
+        run: pip install build hatchling hatch-vcs
+
+      - name: Build wheel and sdist
+        run: python -m build --no-isolation
+
+      - name: Smoke-test installed wheel
+        run: |
+          pip install dist/homericintelligence_hephaestus-*.whl --force-reinstall
+          python -c "import hephaestus; print('Package version:', hephaestus.__version__)"
+          python -c "from hephaestus import slugify, retry_with_backoff, setup_logging; print('OK')"
+
+  security/dependency-scan:
+    name: security/dependency-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          pixi-version: v0.63.2
+          environments: lint
+          locked: false
+
+      - name: Cache pixi environments
+        uses: actions/cache@v5
+        with:
+          path: |
+            .pixi
+            ~/.cache/rattler/cache
+          key: pixi-lint-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          restore-keys: |
+            pixi-lint-${{ runner.os }}-
+
+      - name: Run pip-audit
+        id: pip-audit
+        run: pixi run --environment lint pip-audit
+
+      - name: Post pip-audit summary
+        if: always()
+        env:
+          AUDIT_OUTCOME: ${{ steps.pip-audit.outcome }}
+        run: |
+          {
+            echo "## pip-audit Security Scan"
+            echo ""
+            if [ "$AUDIT_OUTCOME" = "success" ]; then
+              echo "No HIGH/CRITICAL vulnerabilities found."
+            else
+              echo "Vulnerabilities detected — see job logs for details."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  security/secrets-scan:
+    name: security/secrets-scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Gitleaks secrets scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  schema-validation:
+    name: schema-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
+      - name: Validate GitHub workflow schemas
+        run: |
+          find .github/workflows -name "*.yml" | \
+            xargs check-jsonschema \
+              --schemafile https://json.schemastore.org/github-workflow
+
+  deps/version-sync:
+    name: deps/version-sync
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install package (for __version__)
+        run: pip install -e "." --no-deps
+
+      - name: Check version consistency
+        run: |
+          set -euo pipefail
+
+          # Extract version from pyproject.toml via hatch-vcs (dynamic)
+          DYNAMIC=$(python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              d = tomllib.load(f)
+          dynamic = d.get('project', {}).get('dynamic', [])
+          print('dynamic' if 'version' in dynamic else 'static')
+          ")
+          echo "Version strategy: $DYNAMIC"
+
+          # Resolve the actual installed version
+          PKG_VERSION=$(python -c "import hephaestus; print(hephaestus.__version__)")
+          echo "Installed __version__: $PKG_VERSION"
+
+          # If a VERSION file exists, cross-check it
+          if [ -f VERSION ]; then
+            FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+            echo "VERSION file: $FILE_VERSION"
+            if [ "$PKG_VERSION" != "$FILE_VERSION" ]; then
+              echo "ERROR: __version__ ($PKG_VERSION) does not match VERSION file ($FILE_VERSION)"
+              exit 1
+            fi
+            echo "Version files are in sync."
+          else
+            echo "No VERSION file present — skipping file cross-check."
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/_required.yml` with **9 canonical status-check names** for the org-wide `homeric-main-baseline` branch ruleset
- No path filters — runs on every PR and push to `main`
- Concurrency group prevents redundant runs on rapid pushes

## Jobs

| Job name (exact context string) | Pattern | Implementation |
|---|---|---|
| `lint` | A | `pixi run --environment lint ruff check` + `ruff format --check` |
| `typecheck` | A | `pixi run --environment lint mypy` |
| `unit-tests` | B (direct at 3.12) | `pytest tests/unit` with `--cov-fail-under=80` + structure check |
| `integration-tests` | B (direct at 3.12) | `pytest tests/integration` |
| `build` | A | `python -m build --no-isolation` + wheel smoke-test |
| `security/dependency-scan` | A | `pixi run --environment lint pip-audit` (no path filter) |
| `security/secrets-scan` | A | `gitleaks/gitleaks-action@v2` |
| `schema-validation` | A | `check-jsonschema` against SchemaStore GitHub workflow schema |
| `deps/version-sync` | A | `tomllib` parses `pyproject.toml`; cross-checks `VERSION` file if present |

## Notes

- `unit-tests` and `integration-tests` use Pattern B: re-run directly at Python 3.12 (the existing required-check key version) rather than depending on the matrix in `test.yml` across workflow files
- `security/dependency-scan` replicates `security.yml`'s pip-audit step but **without** the path filter, satisfying the ruleset requirement that it always runs
- `build` uses `fetch-depth: 0` so `hatch-vcs` can resolve the version from git tags

🤖 Generated with Claude Code