### PR TITLE
fix(ci): unblock main by following shellcheck source directive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -138,6 +138,9 @@ repos:
         name: ShellCheck
         description: Shell script linter
         files: \.sh$
+        # -x lets shellcheck follow `# shellcheck source=...` directives
+        # (e.g. install.sh sourcing lib/install_helpers.sh).
+        args: [-x]
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/scripts/shell/install.sh
+++ b/scripts/shell/install.sh
@@ -19,6 +19,7 @@
 set -uo pipefail
 
 # ─── Shared helpers (colors, counters, has_cmd, apt_install, etc.) ────────────
+# shellcheck source=scripts/shell/lib/install_helpers.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/install_helpers.sh"
 
 # ─── Script-local helpers ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Pre-commit workflow on main has been red since #348 extracted helpers into \`scripts/shell/lib/install_helpers.sh\` — ShellCheck flags the new \`source\` line with **SC1091** ("Not following: ./lib/install_helpers.sh was not specified as input").
- Fixed by adding a \`# shellcheck source=...\` directive on the source line and passing \`-x\` to the shellcheck pre-commit hook so it actually follows the directive.

## Why

Looking at recent main runs:

| Run | Workflow | Conclusion |
|---|---|---|
| 25353365034 (latest) | Pre-commit | ❌ failure |
| 25301001691 | Pre-commit | ❌ failure |
| 25300966489 | Pre-commit | ❌ failure |

All other workflows (Test, Required Checks, Security) are green. Only the shellcheck step in Pre-commit fails. Net: every push to main since #348 has had a red Pre-commit badge.

## Approach

\`-x\` (\`--external-sources\`) is the correct shellcheck flag for "follow files referenced by \`# shellcheck source=\` directives." With \`-x\` plus the directive, shellcheck statically opens \`scripts/shell/lib/install_helpers.sh\` and lints both files together — silence + real coverage, not silence alone.

Alternative considered: \`# shellcheck disable=SC1091\` on the line. Rejected: it silences without giving shellcheck visibility into the helper's exports. The \`-x\` approach is what the shellcheck wiki recommends.

## Verification

\`\`\`bash
pre-commit run shellcheck --all-files
# ShellCheck.....................................................Passed
\`\`\`

## Test plan

- [ ] CI Pre-commit workflow passes on this PR
- [ ] After merge, next push to main has green Pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)