### PR TITLE
fix(license): update copyright year to 2024-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Micah Villmow
+Copyright (c) 2024-2026, Micah Villmow
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Closes #331

## Summary
- Updated BSD 3-Clause LICENSE copyright year from `2024` to `2024-2026` to accurately reflect the active maintenance period of the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)