### PR TITLE
fix(ci): remove dead workflow_run guard from auto-tag.yml

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,12 +10,6 @@ jobs:
   auto-tag:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Only run when the Test workflow succeeded on main AND was not triggered
-    # by a tag-push event (prevents infinite loop — tags don't trigger workflow_run
-    # but guard anyway in case the trigger source changes).
-    if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.actor.login != 'github-actions[bot]'
 
     steps:
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
Closes #338

## Summary
- Removed the dead `if:` guard on the `auto-tag` job that referenced `github.event.workflow_run.*` fields.
- These fields are never populated since the workflow uses `workflow_dispatch` only; the condition always evaluated to `false` and could mislead maintainers about how the workflow is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)