### PR TITLE
docs(contributing): add mutual cross-references between CONTRIBUTING.md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
 # Contributing to ProjectHephaestus
 
+> **See also:** [`docs/contributing.md`](docs/contributing.md) for a concise summary of
+> development principles (KISS, YAGNI, DRY, SOLID, Modularity) used in this project.
+
 Thank you for considering contributing to ProjectHephaestus! We welcome contributions from the community.
 
 ## Code of Conduct

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,9 @@
 # Contributing to ProjectHephaestus
 
+> **Canonical source:** The root [`CONTRIBUTING.md`](../CONTRIBUTING.md) is the authoritative
+> contributing guide covering setup, code style, testing, and the PR process. This page
+> summarises the key development principles; refer to the root file for complete details.
+
 ## Development Guidelines
 
 Follow the principles outlined in [CLAUDE.md](../CLAUDE.md):


### PR DESCRIPTION
Closes #336

## Summary
- Added a canonical-source callout to `docs/contributing.md` pointing readers to the root `CONTRIBUTING.md` as the authoritative guide.
- Added a see-also note to `CONTRIBUTING.md` pointing at `docs/contributing.md` for the development-principles summary.
- Readers can now navigate between both files without risk of following stale or conflicting information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)