### PR TITLE
feat(docs): add pdoc API reference generation via just docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Build artifacts
 build/
 
+# Auto-generated API reference (pdoc output)
+docs/api/
+
 # hatch-vcs generated version file
 hephaestus/_version.py
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,17 @@ ProjectHephaestus is the shared utilities and tooling library for the HomericInt
 - **hephaestus.version** — Version management utilities
 - **hephaestus.validation** — README and config validation
 
+## API Reference
+
+Auto-generated API documentation can be produced with [pdoc](https://pdoc.dev/):
+
+```bash
+just docs        # outputs to docs/api/
+```
+
+The generated `docs/api/` directory is git-ignored; run the command locally to browse
+full function signatures, docstrings, and type annotations for all 37+ CLI entry points.
+
 ## Setup
 
 See the [README](../README.md) for installation and development setup instructions.

--- a/justfile
+++ b/justfile
@@ -60,6 +60,10 @@ check: lint format-check typecheck
 audit:
     pixi run --environment lint pip-audit
 
+# Generate API reference documentation with pdoc (output: docs/api/)
+docs:
+    pixi run docs
+
 # Full CI-equivalent run: bootstrap, check, and test
 all: bootstrap check test
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,7 @@ lint = "ruff check hephaestus scripts tests"
 format = "ruff format hephaestus scripts tests"
 mypy = "mypy hephaestus/ scripts/ tests/"
 audit = "pixi run --environment lint pip-audit"
+docs = "pdoc hephaestus --output-dir docs/api"
 
 [dependencies]
 python = ">=3.10"
@@ -36,6 +37,7 @@ just = ">=1.25.0,<2"
 [feature.dev.pypi-dependencies]
 pip-audit = ">=2.7,<3"
 build = ">=1.0,<2"
+pdoc = ">=14.0,<15"
 
 [feature.lint.dependencies]
 ruff = ">=0.1.0,<1"


### PR DESCRIPTION
Closes #340

## Summary
- Added `pdoc>=14.0,<15` to `[feature.dev.pypi-dependencies]` in `pixi.toml`.
- Added a `docs` task in `pixi.toml` (`pdoc hephaestus --output-dir docs/api`).
- Added a `docs` recipe in `justfile` wrapping `pixi run docs`.
- Added `docs/api/` to `.gitignore` so generated HTML is not tracked in git.
- Updated `docs/index.md` to explain how to generate the API reference locally with `just docs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)