### PR TITLE
docs(security): refresh version support table

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "hooks": {},
   "enabledPlugins": {
     "hephaestus@ProjectHephaestus": true,
     "safety-net@cc-marketplace": true

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ ProjectHephaestus provides standardized utility functions and tools that can be 
 - **Consistency**: Standardized interfaces and patterns
 - **Reliability**: Comprehensive testing and error handling
 
+**Project Status:** See [docs/ROADMAP.md](docs/ROADMAP.md) for the public roadmap and current focus areas.
+
 ## Directory Structure
 
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,13 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 0.4.x   | Yes       |
-| 0.3.x   | Yes       |
-| < 0.3   | No        |
+As of 2026-05-10. Python >= 3.10 required.
+
+| Version | Supported            |
+|---------|----------------------|
+| 0.7.x   | ✅ Supported         |
+| 0.6.x   | ✅ Supported         |
+| < 0.6   | ❌ End of life       |
 
 ## Reporting a Vulnerability
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,55 @@
+# ProjectHephaestus Roadmap
+
+## Vision
+
+ProjectHephaestus is the foundational utilities and tooling repository of the HomericIntelligence ecosystem, providing standardized components that support development across all other projects. We prioritize modularity, reliability, and consistency across a diverse set of cross-cutting concerns: configuration management, logging, GitHub automation, and agent coordination.
+
+## Current Focus (Q2 2026)
+
+The project is currently focused on addressing findings from the strict 2026-04-28 repository audit (Epic #310). This ongoing work spans:
+
+1. **Strict Audit Remediation** — Addressing 29 major, minor, and nitpick findings across 15 audit dimensions. Focus areas include improving automation module test coverage, fixing f-string logging anti-patterns, and hardening the 6-phase review-PR pipeline.
+
+2. **Automation Package Stabilization** — Refactoring and hardening the automation modules (PR review, CI driver, issue implementation) to improve single responsibility, observability, and idempotency. This includes fixing critical bugs in the CI state machine and worktree management.
+
+3. **CLI Tool Coverage Expansion** — Expanding the CLI entry point test suite from 13 of 37 declared tools to full coverage, ensuring all command-line interfaces are properly validated.
+
+4. **Test Coverage Hardening** — Bringing 6 excluded automation modules into coverage measurement with mocked unit tests for core orchestration logic.
+
+5. **Security & Dependency Management** — Hard-blocking pip-audit failures in CI and resolving dependency consistency issues across pixi.toml and pyproject.toml.
+
+## Near-term (Next 1-2 Quarters)
+
+Assuming audit remediation is complete:
+
+1. **Multi-platform CI Support** — Extend GitHub Actions test matrix to include macOS and Windows alongside Ubuntu, addressing the gap between pixi.toml multi-platform claims and CI reality (#321 context).
+
+2. **Cross-Repository Coverage** — Expand hephaestus utility adoption across other HomericIntelligence projects. Standardize configuration loading, logging setup, and subprocess execution patterns.
+
+3. **API Surface Documentation** — Auto-generate API reference documentation for all public modules, including previously undocumented functions (e.g., `retry_with_jitter()`, complete CLI reference).
+
+4. **Observability and Health Checks** — Add structured health reporting for long-running components (e.g., NATSSubscriberThread), supporting the broader ProjectArgus (observability) initiative.
+
+## Long-term (4+ Quarters Out)
+
+Conservative, directional items:
+
+1. **Agent Coordination Framework** — Explore deeper integration with ProjectMyrmidons for agent swarm coordination patterns, building on existing entry points for orchestration.
+
+2. **Benchmark Suite Expansion** — Enhance the benchmark comparison utilities to support cross-project performance tracking and regression detection.
+
+3. **Configuration Ecosystem** — Investigate dynamic configuration patterns (ProjectProteus integration) and configuration composition across multiple environments.
+
+## How We Plan
+
+ProjectHephaestus uses an Epic-and-children issue pattern for project planning. Major initiatives are tracked as Epic issues (labeled `epic`), with breakdown into concrete child issues tagged by audit section and severity.
+
+**Exemplar:** Epic #310 (Strict audit 2026-04-28) contains 29 child issues spanning all 15 audit dimensions, with clear scoping and evidence-based requirements.
+
+We also capture session learnings in ProjectMnemosyne via the `/learn` skill, preserving team knowledge about patterns, anti-patterns, and decisions across the ecosystem.
+
+## Updating This Roadmap
+
+This roadmap is reviewed and updated at the end of each release cycle (typically monthly). As new Epics are created or project priorities shift, the roadmap is refreshed to reflect current focus areas. To propose changes, open an issue and reference this document.
+
+Last updated: 2026-05-09


### PR DESCRIPTION
## Summary

Automation strict fixes and audit cleanup for the 6-phase pipeline:

1. **#325**: Refresh SECURITY.md version support table
   - Current version (0.7.x) marked as supported
   - Previous minor (0.6.x) marked as supported  
   - Versions prior to 0.6 marked end of life
   - Python requirement (>=3.10) documented
   - Last reviewed date updated to 2026-05-10

2. **#327**: Remove empty hooks block from .claude/settings.json
   - Empty hooks configuration adds no value (YAGNI violation)
   - Verified JSON validity and pre-commit validation

3. **#326**: Add public roadmap and link from README
   - New file: `docs/ROADMAP.md` — comprehensive roadmap covering vision, current focus on audit remediation, near-term ecosystem expansion, and long-term coordination patterns
   - Updated `README.md` — added prominent link to roadmap in the overview section
   - All pre-commit checks pass (markdown lint, YAML, etc.)

Closes #325
Closes #327
Closes #326