### PR TITLE
refactor(automation): extract SECRET_FILE_EXTENSIONS to shared module

### DIFF
--- a/hephaestus/automation/_secret_patterns.py
+++ b/hephaestus/automation/_secret_patterns.py
@@ -1,0 +1,25 @@
+"""Shared secret-file detection constants for the automation package.
+
+These patterns are used to identify files that should never be staged or
+committed during automated workflows.  Centralising them here prevents
+divergence between the modules that perform file-filtering (e.g.
+``pr_manager``) and any future modules that need the same check.
+"""
+
+from __future__ import annotations
+
+# Exact basenames that are always considered secrets regardless of extension.
+SECRET_FILE_NAMES: frozenset[str] = frozenset(
+    {
+        ".env",
+        ".secret",
+        "credentials.json",
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+    }
+)
+
+# File extensions whose presence indicates a cryptographic key or certificate.
+SECRET_FILE_EXTENSIONS: frozenset[str] = frozenset({".key", ".pem", ".pfx", ".p12"})

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -13,23 +13,13 @@ import logging
 from pathlib import Path
 from typing import cast
 
+from ._secret_patterns import SECRET_FILE_EXTENSIONS, SECRET_FILE_NAMES
 from .git_utils import run
 from .github_api import _gh_call, fetch_issue_info, gh_pr_create
 from .prompts import get_pr_description
 from .status_tracker import StatusTracker
 
 logger = logging.getLogger(__name__)
-
-_SECRET_FILES = {
-    ".env",
-    ".secret",
-    "credentials.json",
-    "id_rsa",
-    "id_dsa",
-    "id_ecdsa",
-    "id_ed25519",
-}
-_SECRET_EXTENSIONS = {".key", ".pem", ".pfx", ".p12"}
 
 
 def commit_changes(issue_number: int, worktree_path: Path) -> None:
@@ -85,7 +75,8 @@ def commit_changes(issue_number: int, worktree_path: Path) -> None:
         filename = Path(filename_part).name
 
         # Skip secret files (never stage these)
-        if filename in _SECRET_FILES or any(filename.endswith(ext) for ext in _SECRET_EXTENSIONS):
+        has_secret_ext = any(filename.endswith(ext) for ext in SECRET_FILE_EXTENSIONS)
+        if filename in SECRET_FILE_NAMES or has_secret_ext:
             logger.warning(f"Skipping potential secret file: {filename_part}")
             continue
 

--- a/tests/unit/automation/test_secret_patterns.py
+++ b/tests/unit/automation/test_secret_patterns.py
@@ -1,0 +1,68 @@
+"""Tests for hephaestus.automation._secret_patterns."""
+
+from __future__ import annotations
+
+import pytest
+
+from hephaestus.automation._secret_patterns import (
+    SECRET_FILE_EXTENSIONS,
+    SECRET_FILE_NAMES,
+)
+
+
+class TestSecretFileNames:
+    """Tests for SECRET_FILE_NAMES."""
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(SECRET_FILE_NAMES, frozenset)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            ".env",
+            ".secret",
+            "credentials.json",
+            "id_rsa",
+            "id_dsa",
+            "id_ecdsa",
+            "id_ed25519",
+        ],
+    )
+    def test_contains_expected_names(self, name: str) -> None:
+        assert name in SECRET_FILE_NAMES, f"Expected {name!r} in SECRET_FILE_NAMES"
+
+    def test_immutable(self) -> None:
+        with pytest.raises(AttributeError):
+            SECRET_FILE_NAMES.add("should_fail")  # type: ignore[attr-defined]
+
+
+class TestSecretFileExtensions:
+    """Tests for SECRET_FILE_EXTENSIONS."""
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(SECRET_FILE_EXTENSIONS, frozenset)
+
+    @pytest.mark.parametrize(
+        "ext",
+        [
+            ".env",
+            ".pem",
+            ".key",
+            ".pfx",
+            ".p12",
+        ],
+    )
+    def test_contains_expected_extensions(self, ext: str) -> None:
+        # .env is in SECRET_FILE_NAMES; the others are in SECRET_FILE_EXTENSIONS.
+        # Test that at least one of the two sets contains each expected pattern.
+        assert ext in SECRET_FILE_EXTENSIONS or ext in SECRET_FILE_NAMES, (
+            f"Expected {ext!r} in SECRET_FILE_EXTENSIONS or SECRET_FILE_NAMES"
+        )
+
+    @pytest.mark.parametrize("ext", [".pem", ".key", ".pfx", ".p12"])
+    def test_extensions_in_secret_file_extensions(self, ext: str) -> None:
+        assert ext in SECRET_FILE_EXTENSIONS, f"Expected {ext!r} in SECRET_FILE_EXTENSIONS"
+
+    def test_immutable(self) -> None:
+        with pytest.raises(AttributeError):
+            SECRET_FILE_EXTENSIONS.add("should_fail")  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Extracts the secret-file detection constants (`_SECRET_FILES`, `_SECRET_EXTENSIONS`) from `pr_manager.py` into a new private module `hephaestus/automation/_secret_patterns.py`
- Exports `SECRET_FILE_NAMES: frozenset[str]` and `SECRET_FILE_EXTENSIONS: frozenset[str]` — immutable by design to prevent accidental mutation
- Updates `pr_manager.py` to import the shared constants instead of defining them locally
- Adds `tests/unit/automation/test_secret_patterns.py` with parametrized tests covering expected entries, frozenset type, and immutability

## Test plan

- [x] `pixi run pytest tests/unit -q --tb=short --no-cov` — 2056 passed, 6 skipped
- [x] `pixi run ruff check hephaestus/ tests/` — All checks passed
- [x] `pixi run mypy` — Success: no issues found in 233 source files
- [x] `pre-commit run ruff-format-python ruff-check-python mypy-check-python check-unit-test-structure` — all passed
- [x] `pre-commit run check-shell-injection ruff-check-complexity detect-private-key` — all passed

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)