### PR TITLE
chore(deps): reconcile pyproject.toml/pixi.toml/pixi.lock (W3)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -12,6 +12,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.4.0-py314h680f03e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bats-core-1.13.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py314he299d4b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -267,6 +268,14 @@ packages:
   purls: []
   size: 7546
   timestamp: 1777848733980
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bats-core-1.13.0-ha770c72_0.conda
+  sha256: fab4ddcbe6769acf4c2e28e474cb40d1d7dc17c78fef9c248230ed4dbb7fea96
+  md5: 09b12d1a94df246266ab95a7a2fe9d35
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 48710
+  timestamp: 1762537439832
 - pypi: https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl
   name: boolean-py
   version: '5.0'
@@ -547,10 +556,10 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: homericintelligence-hephaestus
-  version: 0.7.3.dev49+g3d8f5f5b6.d20260510
-  sha256: 443585e139d25a0897b8e6bda1dc0d06f5223a38e2235770b9f53fac825cee54
+  version: 0.7.3.dev54+gd2cb8afa5
+  sha256: 19a74c22876a0d3a8d92b72f58cefa118e02645d3323040b7b3a86ff62d3cec4
   requires_dist:
-  - packaging>=21.0
+  - packaging>=21.0,<27
   - pydantic>=2.0,<3
   - pyyaml>=6.0,<7
   - defusedxml>=0.7,<1 ; extra == 'all'

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,7 +17,6 @@ python = ">=3.10"
 pip = "*"
 pydantic = ">=2.12.5,<3"
 pygments = ">=2.20.0"  # CVE-2026-4539
-requests = ">=2.33.0"  # CVE-2026-25645
 pygithub = ">=2.9.1,<3"
 
 [pypi-dependencies]
@@ -33,6 +32,7 @@ ruff = ">=0.1.0,<1"
 mypy = ">=1.8.0,<2"
 yamllint = ">=1.35.0,<2"
 just = ">=1.25.0,<2"
+bats-core = ">=1.11.0,<2"
 
 [feature.dev.pypi-dependencies]
 pip-audit = ">=2.7,<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 keywords = ["utilities", "helpers", "tooling", "homericintelligence"]
 dependencies = [
-    "packaging>=21.0",
+    "packaging>=21.0,<27",
     "pyyaml>=6.0,<7",
     "pydantic>=2.0,<3",
 ]


### PR DESCRIPTION
## Summary

- Remove `requests` from `pixi.toml` runtime deps — not imported anywhere in `hephaestus/`, `tests/`, or `scripts/` (`grep -rn 'import requests'` returned no results)
- Add upper bound `<27` to `packaging` in `pyproject.toml` — consistent with the major-version-bound pattern used by all other direct deps (`pyyaml>=6.0,<7`, `pydantic>=2.0,<3`)
- Add `bats-core>=1.11.0,<2` to `[feature.dev.dependencies]` in `pixi.toml` — `tests/shell/justfile/test_justfile.bats` uses bats and it was previously undeclared
- Sync `pixi.lock` after the above `pixi.toml` changes

Closes #322
Closes #323
Closes #335

## Test plan

- [x] `pixi install --no-progress` — lockfile synced without conflicts
- [x] `pixi run pytest tests/unit -q --tb=short` — 2036 passed, 6 skipped, coverage 83.19%
- [x] `pixi run ruff check hephaestus/ tests/ scripts/` — all checks passed
- [x] `pixi run mypy` — no issues found in 231 source files
- [x] `pre-commit run check-shell-injection ruff-format-python ruff-check-python mypy-check-python --all-files` — all passed (yamllint hook has pre-existing Python 3.9 env incompatibility unrelated to these changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)