### PR TITLE
ci(release): consolidate auto-tag + release into one-click workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,7 +1,12 @@
 name: Auto Tag Release
 
 on:
-  workflow_dispatch:  # manual only — auto-tagging is disabled
+  workflow_dispatch:
+    inputs:
+      bump_kind:
+        description: "Version component to bump: patch | minor | major"
+        required: false
+        default: "patch"
 
 permissions:
   contents: write
@@ -23,13 +28,15 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Compute next patch version and push tag
+      - name: Compute next version and push tag
         shell: bash
+        env:
+          BUMP_KIND: ${{ github.event.inputs.bump_kind || 'patch' }}
         run: |
-          # Find the highest existing vX.Y.Z tag and increment patch
+          # Find the highest existing vX.Y.Z tag and increment the requested component
           LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
           if [ -z "${LATEST_TAG}" ]; then
-            # No tags yet — start at v0.7.1 (first auto-tagged release)
+            # No tags yet — start at v0.7.0 base
             LATEST="0.7.0"
           else
             LATEST="${LATEST_TAG#v}"
@@ -38,7 +45,18 @@ jobs:
           MAJOR=$(echo "${LATEST}" | cut -d. -f1)
           MINOR=$(echo "${LATEST}" | cut -d. -f2)
           PATCH=$(echo "${LATEST}" | cut -d. -f3)
-          NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          case "${BUMP_KIND}" in
+            major)
+              NEXT="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              NEXT="${MAJOR}.$((MINOR + 1)).0"
+              ;;
+            patch|*)
+              NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+              ;;
+          esac
           TAG="v${NEXT}"
 
           # Idempotent: skip if tag already exists
@@ -47,7 +65,8 @@ jobs:
             exit 0
           fi
 
-          echo "Creating tag: ${TAG}"
+          echo "Creating tag: ${TAG} (bump: ${BUMP_KIND})"
           git tag "${TAG}"
           git push origin "${TAG}"
           echo "Created and pushed tag: ${TAG}"
+          # release.yml triggers automatically on push: tags: ['v*']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"  # fires automatically when auto-tag.yml pushes a vX.Y.Z tag
   workflow_dispatch:
     inputs:
       tag:
@@ -87,9 +90,13 @@ jobs:
         id: tag
         shell: bash
         run: |
+          # Priority: explicit input > tag-push ref > latest tag
           INPUT_TAG="${{ github.event.inputs.tag }}"
+          REF_TAG="${{ github.ref }}"
           if [ -n "$INPUT_TAG" ]; then
             TAG="$INPUT_TAG"
+          elif [[ "$REF_TAG" == refs/tags/* ]]; then
+            TAG="${REF_TAG#refs/tags/}"
           else
             TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
           fi

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,49 @@
+# Releasing ProjectHephaestus
+
+## One-Click Release (normal path)
+
+1. Go to **Actions → Auto Tag Release → Run workflow**.
+2. Choose `bump_kind`:
+   - `patch` (default) — bug fixes, e.g. `0.7.3 → 0.7.4`
+   - `minor` — backwards-compatible features, e.g. `0.7.3 → 0.8.0`
+   - `major` — breaking changes, e.g. `0.7.3 → 1.0.0`
+3. Click **Run workflow**.
+
+That is the only manual step. The pipeline then runs automatically:
+
+```
+workflow_dispatch (Auto Tag Release)
+  └─ computes next vX.Y.Z
+  └─ git tag + push → triggers:
+       Release workflow (on: push: tags: v*)
+         ├─ test job (pytest)
+         ├─ type-check job (mypy)
+         └─ build-and-publish job
+              ├─ verify tag == package version
+              ├─ build wheel + sdist
+              ├─ publish to PyPI (trusted publishing)
+              └─ create GitHub Release with auto-generated notes
+```
+
+## Pre-Release Checklist
+
+Before triggering the workflow, ensure:
+
+- [ ] All changes merged to `main` and CI is green.
+- [ ] `pyproject.toml` `[project].version` matches the **current** released version (the tag step
+  will increment it in the tag name, but the package version at HEAD must equal the *new* tag or
+  the "verify tag matches package version" step will fail). Update `pyproject.toml` and run
+  `pixi run python -m hephaestus.version.manager` before merging if needed.
+- [ ] `pixi.lock` is up to date (`pixi install` produces no changes).
+
+## Manual Tag + Release (escape hatch)
+
+If `auto-tag.yml` is skipped and a tag was pushed manually, the **Release** workflow also accepts
+a `workflow_dispatch` with an optional explicit `tag` input. Leave it blank to use the latest tag,
+or supply a tag name (e.g. `v0.8.0`) to release a specific ref.
+
+## PyPI Trusted Publishing
+
+Publishing uses OIDC trusted publishing — no `PYPI_API_TOKEN` secret is needed. The workflow runs
+in the `pypi` GitHub Environment which must have the corresponding trusted publisher configured on
+PyPI. See the [PyPI documentation](https://docs.pypi.org/trusted-publishers/) for setup.


### PR DESCRIPTION
## Summary

- Adds `on: push: tags: ['v*']` trigger to `release.yml` so it fires automatically when `auto-tag.yml` pushes a version tag — no second manual dispatch needed.
- Adds `bump_kind` input (`patch`/`minor`/`major`, default `patch`) to `auto-tag.yml` so a single `workflow_dispatch` controls patch, minor, or major bumps.
- Updates tag-resolution logic in `release.yml` to prefer the pushed tag ref (`github.ref`) over the latest-tag fallback.
- Adds `docs/RELEASING.md` with one-click release instructions.

## Before (two-step process)

1. Run **Auto Tag Release** via `workflow_dispatch` → pushes a `v*` tag.
2. Manually run **Release** via `workflow_dispatch` → builds, publishes, creates GH release.

Human error risk: step 2 could be forgotten or run with the wrong tag.

## After (one-click)

1. Run **Auto Tag Release** via `workflow_dispatch`, choose `bump_kind` (`patch`/`minor`/`major`).
2. Done. The pushed tag automatically triggers **Release** via `on: push: tags: ['v*']`.

## Test plan

- [ ] YAML parses cleanly: `python -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — verified.
- [ ] `check-yaml` pre-commit hook passes on both files — verified.
- [ ] `release.yml` `on:` block contains both `push.tags` and `workflow_dispatch`.
- [ ] `auto-tag.yml` `on:` block contains `workflow_dispatch.inputs.bump_kind`.
- [ ] `docs/RELEASING.md` created with one-click instructions.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)