### PR TITLE
ci: harden workflows — pin actions, block pip-audit, clarify matrix (W2)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -22,14 +22,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           environments: lint
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -87,7 +87,7 @@ jobs:
           fi
       - name: Setup pixi
         if: steps.detect.outputs.skip == 'false'
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.67.2
           cache: true
@@ -176,12 +176,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Cache pip packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
@@ -206,12 +206,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Cache pip packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-3.12-${{ hashFiles('pyproject.toml') }}
@@ -235,12 +235,12 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
       - name: Cache pip packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-3.12-build-${{ hashFiles('pyproject.toml') }}
@@ -268,14 +268,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           environments: lint
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -286,7 +286,6 @@ jobs:
 
       - name: Run pip-audit
         id: pip-audit
-        continue-on-error: true
         run: pixi run --environment lint pip-audit
 
       - name: Post pip-audit summary
@@ -335,7 +334,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 
@@ -360,7 +359,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,17 +19,17 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           environments: lint
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,16 +18,16 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -56,15 +56,15 @@ jobs:
         test-type: [unit, integration]
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/pip
           key: pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.test-type == 'unit' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- Block pip-audit failures from being silently swallowed in required CI
- SHA-pin all floating GitHub Actions references to match the existing policy in `_required.yml`
- Clarify and close the multi-platform matrix issue by documenting the intentional linux-only platform policy

## Changes

### #313 — pip-audit now blocks PRs
Removed `continue-on-error: true` from the `pip-audit` step in `.github/workflows/_required.yml:289`. Vulnerability scan failures now hard-fail the `security/dependency-scan` job, preventing CVE-vulnerable dependencies from merging.

The standalone `security.yml` pip-audit job was already blocking (no `continue-on-error`) — confirmed no change needed there.

### #320 — Uniform SHA-pin policy
**Policy chosen: SHA-pin with inline version comment** (matches `_required.yml` existing approach).

Applied to `test.yml` and `security.yml`. Also completed pinning of the remaining floating actions in `_required.yml` (`prefix-dev/setup-pixi`, `actions/cache`, `actions/setup-python` were still on floating tags there).

**Pinned action SHAs:**

| Action | Floating tag | SHA |
|--------|-------------|-----|
| `actions/checkout` | `v6.0.2` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `prefix-dev/setup-pixi` | `v0.9.5` | `1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0` |
| `actions/cache` | `v5` | `27d5ce7f107fe9357f9df03efb73ab90386fccae` |
| `actions/setup-python` | `v6` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` |
| `codecov/codecov-action` | `v6` | `57e3a136b779b570ffcdbf80b3bdc90e7fab3de2` |

Note: `pre-commit.yml` also has floating tags but is outside this wave's scope (W12).

### #321 — Multi-platform matrix (closed by comment, no CI changes)
`pixi.toml` line 5 explicitly reads `platforms = ["linux-64"] # Do not re-enable, "win-64", "osx-64", "osx-arm64"]`. The audit issue's claim was incorrect — the file declares linux-64 only with all other platforms intentionally commented out. The ubuntu-only CI matrix is consistent with this policy. Issue closed via `gh issue close 321 --reason completed` with explanation.

## Test plan

- [x] `pixi run pytest tests/unit -q --tb=short` → 2036 passed, 0 failures
- [x] `pixi run pre-commit run --all-files` → all hooks passed
- [x] YAML syntax validation: `python3 -c "import yaml; yaml.safe_load(open(...))"` → OK for all 3 files
- [x] Issue #321 closed with clarification comment

Closes #313
Closes #320
Refs #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)