### PR TITLE
refactor(retry): consolidate retry_with_jitter, honor max_delay, fix __init__ exports (W4)

### DIFF
--- a/hephaestus/__init__.py
+++ b/hephaestus/__init__.py
@@ -67,6 +67,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "human_readable_size": ("hephaestus.utils", "human_readable_size"),
     "install_package": ("hephaestus.utils", "install_package"),
     "retry_with_backoff": ("hephaestus.utils", "retry_with_backoff"),
+    # Deprecated shim — prefer retry_with_backoff(jitter=True, max_delay=...) directly.
+    # Retained for backwards compatibility; will be removed in a future major version.
+    "retry_with_jitter": ("hephaestus.utils", "retry_with_jitter"),
     "run_subprocess": ("hephaestus.utils", "run_subprocess"),
     "slugify": ("hephaestus.utils", "slugify"),
     # validation (v0.5.0)

--- a/hephaestus/resilience/subprocess_resilience.py
+++ b/hephaestus/resilience/subprocess_resilience.py
@@ -115,16 +115,11 @@ def resilient_call(
     if circuit_breaker_name:
         cb = get_circuit_breaker(circuit_breaker_name)
 
-    # Compute a backoff_factor that approximates max_delay capping.
-    # retry_with_backoff uses: delay = initial_delay * (backoff_factor ** attempt)
-    # We use factor=2 and rely on max_retries to bound total wait.
-    # max_delay is accepted for API compatibility but not directly enforced here.
-    _ = max_delay  # acknowledged: Hephaestus retry_with_backoff has no max_delay param
-
     @retry_with_backoff(
         max_retries=max_retries,
         initial_delay=initial_delay,
         backoff_factor=2,
+        max_delay=max_delay,
         retry_on=TRANSIENT_SUBPROCESS_ERRORS,
         logger=logger.warning,
         jitter=True,

--- a/hephaestus/utils/retry.py
+++ b/hephaestus/utils/retry.py
@@ -164,19 +164,22 @@ def retry_on_network_error(
     )
 
 
-# Compatibility function that matches Hephaestus existing API
+# Backwards-compatibility shim — delegates to retry_with_backoff to avoid DRY violation.
+# Deprecated: call retry_with_backoff(jitter=True, max_delay=...) directly instead.
 def retry_with_jitter(
     func: Callable[..., Any], max_retries: int = 3, base_delay: float = 1.0, max_delay: float = 60.0
 ) -> Any:
     """Retry a function with exponential backoff and jitter.
 
-    Compatible with existing Hephaestus retry utilities.
+    .. deprecated::
+        Use :func:`retry_with_backoff` with ``jitter=True`` and ``max_delay`` directly.
+        This shim will be removed in a future major version.
 
     Args:
         func: Function to retry
         max_retries: Maximum number of retry attempts
-        base_delay: Base delay in seconds
-        max_delay: Maximum delay between retries
+        base_delay: Base delay in seconds (``initial_delay`` in retry_with_backoff)
+        max_delay: Maximum delay cap between retries
 
     Returns:
         Result of successful function call
@@ -185,22 +188,20 @@ def retry_with_jitter(
         Exception: Last exception raised if all retries fail
 
     """
-    last_exception: Exception | None = None
+    import warnings
 
-    for attempt in range(max_retries + 1):
-        try:
-            return func()
-        except Exception as e:  # broad catch intentional: generic retry must handle all exceptions
-            last_exception = e
-            if attempt < max_retries:
-                # Calculate delay with exponential backoff and jitter
-                delay = min(base_delay * (2**attempt), max_delay)
-                # Add jitter (±25%)
-                jitter = random.uniform(-0.25 * delay, 0.25 * delay)
-                time.sleep(max(0.1, delay + jitter))
-            else:
-                break
+    warnings.warn(
+        "retry_with_jitter() is deprecated; use "
+        "retry_with_backoff(jitter=True, max_delay=...) instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
-    if last_exception is not None:
-        raise last_exception
-    raise RuntimeError("retry_with_jitter: no exception but no return value")
+    decorated = retry_with_backoff(
+        max_retries=max_retries,
+        initial_delay=base_delay,
+        backoff_factor=2,
+        jitter=True,
+        max_delay=max_delay,
+    )
+    return decorated(func)()

--- a/tests/unit/resilience/test_subprocess_resilience.py
+++ b/tests/unit/resilience/test_subprocess_resilience.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +11,7 @@ from hephaestus.resilience.circuit_breaker import reset_all_circuit_breakers
 from hephaestus.resilience.subprocess_resilience import (
     TRANSIENT_ERROR_PATTERNS,
     is_transient_subprocess_error,
+    resilient_call,
 )
 
 
@@ -93,3 +95,54 @@ class TestTransientErrorPatterns:
         ]
         for pattern in essential:
             assert pattern in TRANSIENT_ERROR_PATTERNS, f"Missing pattern: {pattern}"
+
+
+class TestResilientCall:
+    """Tests for resilient_call() — especially max_delay enforcement."""
+
+    def test_succeeds_on_first_call(self) -> None:
+        """resilient_call returns the function result on first success."""
+        result = resilient_call(lambda: 42)
+        assert result == 42
+
+    @patch("time.sleep")
+    def test_max_delay_is_honored(self, mock_sleep) -> None:
+        """No individual retry sleep substantially exceeds max_delay.
+
+        Sets max_delay=0.1 with a high initial_delay so that without capping
+        the delays would far exceed 0.1 s (initial_delay=10.0 → first raw
+        delay = 10.0 s).  Asserts every time.sleep() call stays within
+        max_delay + 25% jitter headroom, which is the documented contract of
+        retry_with_backoff: the cap is applied *before* jitter so the actual
+        sleep value can reach max_delay * 1.25 at most.
+        """
+        call_count = 0
+
+        def transient_flaky() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("connection refused")
+
+        max_delay = 0.1
+        resilient_call(transient_flaky, max_retries=3, initial_delay=10.0, max_delay=max_delay)
+
+        # Without max_delay the first sleep would be ~10 s; confirm it is
+        # effectively capped near max_delay (allowing ±25% jitter on top).
+        upper_bound = max_delay * 1.25 + 0.001  # 1 ms floating-point headroom
+        for call in mock_sleep.call_args_list:
+            assert call[0][0] <= upper_bound, (
+                f"Sleep of {call[0][0]:.4f}s exceeds max_delay cap of {upper_bound:.4f}s; "
+                "max_delay is not being honored."
+            )
+
+    @patch("time.sleep")
+    def test_raises_after_max_retries(self, mock_sleep) -> None:
+        """Raises the last exception when all retries are exhausted."""
+        with pytest.raises(ConnectionError, match="always fails"):
+            resilient_call(
+                lambda: (_ for _ in ()).throw(ConnectionError("always fails")),
+                max_retries=2,
+                initial_delay=0.01,
+                max_delay=0.1,
+            )

--- a/tests/unit/utils/test_retry.py
+++ b/tests/unit/utils/test_retry.py
@@ -201,12 +201,18 @@ class TestRetryOnNetworkError:
 
 
 class TestRetryWithJitter:
-    """Tests for retry_with_jitter function."""
+    """Tests for retry_with_jitter backwards-compatibility shim.
+
+    retry_with_jitter() is deprecated — it now delegates to retry_with_backoff().
+    All tests assert that a DeprecationWarning is emitted and that the
+    behaviour is identical to the direct retry_with_backoff(jitter=True) call.
+    """
 
     @patch("time.sleep")
     def test_succeeds_on_first_call(self, mock_sleep):
         """Succeeds without retrying when first call works."""
-        result = retry_with_jitter(lambda: 99, max_retries=3, base_delay=0.01)
+        with pytest.warns(DeprecationWarning, match="retry_with_jitter"):
+            result = retry_with_jitter(lambda: 99, max_retries=3, base_delay=0.01)
         assert result == 99
         mock_sleep.assert_not_called()
 
@@ -222,19 +228,21 @@ class TestRetryWithJitter:
                 raise RuntimeError("fail")
             return "done"
 
-        result = retry_with_jitter(flaky, max_retries=3, base_delay=0.01)
+        with pytest.warns(DeprecationWarning, match="retry_with_jitter"):
+            result = retry_with_jitter(flaky, max_retries=3, base_delay=0.01)
         assert result == "done"
         assert call_count == 3
 
     @patch("time.sleep")
     def test_raises_after_exhaustion(self, mock_sleep):
         """Raises exception when all retries fail."""
-        with pytest.raises(RuntimeError, match="always fails"):
-            retry_with_jitter(
-                lambda: (_ for _ in ()).throw(RuntimeError("always fails")),
-                max_retries=2,
-                base_delay=0.01,
-            )
+        with pytest.warns(DeprecationWarning, match="retry_with_jitter"):
+            with pytest.raises(RuntimeError, match="always fails"):
+                retry_with_jitter(
+                    lambda: (_ for _ in ()).throw(RuntimeError("always fails")),
+                    max_retries=2,
+                    base_delay=0.01,
+                )
 
     @patch("time.sleep")
     def test_max_delay_respected(self, mock_sleep):
@@ -248,7 +256,13 @@ class TestRetryWithJitter:
                 raise RuntimeError("fail")
             return "ok"
 
-        retry_with_jitter(flaky, max_retries=4, base_delay=1.0, max_delay=2.0)
+        with pytest.warns(DeprecationWarning, match="retry_with_jitter"):
+            retry_with_jitter(flaky, max_retries=4, base_delay=1.0, max_delay=2.0)
         # All sleep calls should be <= max_delay * 1.25 (jitter upper bound)
         for c in mock_sleep.call_args_list:
             assert c[0][0] <= 2.0 * 1.25 + 0.1
+
+    def test_emits_deprecation_warning(self):
+        """retry_with_jitter() always emits DeprecationWarning."""
+        with pytest.warns(DeprecationWarning, match="retry_with_backoff"):
+            retry_with_jitter(lambda: None)


### PR DESCRIPTION
## Summary

- **#316 (DRY)**: `retry_with_jitter()` now delegates to `retry_with_backoff(jitter=True, max_delay=...)` instead of reimplementing the backoff algorithm. Kept as a backwards-compatible shim with a `DeprecationWarning` so callers continue to work unchanged.
- **#318 / #337 (POLA)**: `resilient_call()` now passes its `max_delay` parameter through to `retry_with_backoff`. The stale `_ = max_delay` discard is removed. Callers who set `max_delay` will now see it honoured.
- **#329 (API surface)**: `retry_with_jitter` added to `hephaestus/__init__.py` `_LAZY_IMPORTS` so its stability status is visible. Not added to `__all__` (deprecated symbols should not appear in star-imports).

## Test plan

- [ ] `tests/unit/utils/test_retry.py` — existing `TestRetryWithJitter` tests updated to `pytest.warns(DeprecationWarning)`; new `test_emits_deprecation_warning` assertion; all backoff tests continue passing.
- [ ] `tests/unit/resilience/test_subprocess_resilience.py` — new `TestResilientCall` class with `test_max_delay_is_honored` (sets `max_delay=0.1`, `initial_delay=10.0`; asserts every sleep ≤ `max_delay * 1.25`).
- [ ] `pixi run pytest tests/unit -q` → 2040 passed, 6 skipped, 83.33% coverage (>80%).
- [ ] `pixi run ruff check hephaestus/ tests/` → clean.
- [ ] `pixi run mypy` → clean (231 source files).
- [ ] All local pre-commit hooks (ruff-format-python, ruff-check-python, mypy-check-python, check-unit-test-structure, check-shell-injection) → passed.

Closes #316
Closes #318
Closes #329
Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)