### PR TITLE
test+docs: full CLI entry-point coverage and README sync (W7)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,17 @@ repos:
         pass_filenames: false
         files: ^pixi\.(toml|lock)$
 
+  # CLI table sync check
+  - repo: local
+    hooks:
+      - id: check-cli-table-sync
+        name: Check README CLI table sync
+        description: Ensure README.md CLI table documents every pyproject.toml [project.scripts] entry
+        entry: python3 scripts/check_cli_table_sync.py
+        language: system
+        pass_filenames: false
+        files: ^(README\.md|pyproject\.toml)$
+
   # Test structure enforcement
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -194,13 +194,89 @@ config = merge_with_env({}, convert_bools=True)
 
 ## CLI Commands
 
-Three command-line tools are installed as console scripts when you install the package:
+<!-- CLI table generated from pyproject.toml [project.scripts]. Keep in sync via
+     `python3 scripts/check_cli_table_sync.py` (also enforced in pre-commit). -->
+
+38 console scripts are installed when you install the package.  Run any command
+with `--help` to see full usage.
+
+### Automation
 
 | Command | Description |
 |---|---|
-| `hephaestus-merge-prs` | Automate merging of GitHub pull requests |
-| `hephaestus-system-info` | Collect and display system/environment information |
-| `hephaestus-download-dataset` | Download datasets with retry and progress reporting |
+| `hephaestus-plan-issues` | Bulk issue planning using Claude Code |
+| `hephaestus-implement-issues` | Bulk issue implementation using Claude Code in parallel worktrees |
+| `hephaestus-review-prs` | Read-only PR review automation using Claude Code in parallel worktrees |
+
+### GitHub
+
+| Command | Description |
+|---|---|
+| `hephaestus-fleet-sync` | Sync all PRs across the HomericIntelligence fleet |
+| `hephaestus-github-stats` | GitHub contribution statistics via the `gh` CLI |
+| `hephaestus-merge-prs` | Merge open PRs with successful CI/CD using GitHub API |
+| `hephaestus-tidy` | Single-repo gh-tidy wrapper with Myrmidon swarm for conflict resolution |
+
+### System & Data
+
+| Command | Description |
+|---|---|
+| `hephaestus-agent-stats` | Agent statistics aggregation and reporting |
+| `hephaestus-download-dataset` | Dataset downloading utilities for ProjectHephaestus |
+| `hephaestus-system-info` | System information collection utilities for ProjectHephaestus |
+
+### Validation
+
+| Command | Description |
+|---|---|
+| `hephaestus-audit-doc-policy` | Audit documentation command examples for policy violations |
+| `hephaestus-check-complexity` | Check cyclomatic complexity against a threshold |
+| `hephaestus-check-coverage` | Check test coverage against configurable thresholds |
+| `hephaestus-check-doc-config` | Enforce consistency between documentation metric values and authoritative config sources |
+| `hephaestus-check-docstrings` | Check Python docstrings for genuine sentence fragments |
+| `hephaestus-check-python-version` | Check Python version consistency across project configuration files |
+| `hephaestus-check-readmes` | Markdown validation utilities for HomericIntelligence projects |
+| `hephaestus-check-stale-scripts` | Detect scripts in `scripts/` with no references in CI configs or other scripts |
+| `hephaestus-check-test-structure` | Validate unit test directory structure |
+| `hephaestus-check-tier-labels` | Enforce tier label consistency across all project Markdown files |
+| `hephaestus-check-type-aliases` | Detect type alias shadowing patterns in Python code |
+| `hephaestus-filter-audit` | Filter pip-audit JSON output to fail only on HIGH/CRITICAL severity vulnerabilities |
+| `hephaestus-mypy-each-file` | Run mypy on each file individually to avoid duplicate-module-name errors |
+| `hephaestus-validate-agents` | YAML frontmatter extraction and validation for agent markdown files |
+| `hephaestus-validate-links` | Markdown validation utilities for HomericIntelligence projects |
+| `hephaestus-validate-schemas` | Validate YAML configuration files against JSON schemas |
+
+### Markdown
+
+| Command | Description |
+|---|---|
+| `hephaestus-check-links` | Fix or validate invalid absolute path links in markdown files |
+| `hephaestus-fix-markdown` | Markdown linting fixer utilities for ProjectHephaestus |
+| `hephaestus-validate-anchors` | Validate anchor fragments in markdown links against actual headings |
+
+### CI / Pre-commit
+
+| Command | Description |
+|---|---|
+| `hephaestus-bench-precommit` | Pre-commit CI utilities for GitHub Actions integration (benchmark) |
+| `hephaestus-check-precommit-versions` | Pre-commit CI utilities for GitHub Actions integration (version check) |
+| `hephaestus-check-workflow-inventory` | GitHub Actions workflow validation utilities (inventory check) |
+| `hephaestus-validate-workflow-checkout` | GitHub Actions workflow validation utilities (checkout validation) |
+
+### Configuration & Dependencies
+
+| Command | Description |
+|---|---|
+| `hephaestus-check-dep-sync` | Validate and synchronize dependency declarations across project config files |
+| `hephaestus-sync-requirements` | Synchronize dependency declarations across project config files |
+
+### Version Management
+
+| Command | Description |
+|---|---|
+| `hephaestus-bump-version` | Version consistency checks and atomic version bumping |
+| `hephaestus-check-package-versions` | Check package version consistency across config files |
+| `hephaestus-check-version-consistency` | Version consistency checks across config files |
 
 ### Examples
 
@@ -216,6 +292,10 @@ hephaestus-download-dataset --help
 
 # Merge open PRs
 hephaestus-merge-prs --help
+
+# Run all validation checks
+hephaestus-check-coverage --help
+hephaestus-check-complexity --help
 ```
 
 ## Development Guidelines

--- a/scripts/check_cli_table_sync.py
+++ b/scripts/check_cli_table_sync.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Check that README.md CLI table is in sync with pyproject.toml [project.scripts].
+
+This script is wired into pre-commit (see .pre-commit-config.yaml) and runs
+whenever README.md or pyproject.toml changes.  It succeeds silently when the
+README mentions every command declared in [project.scripts] and exits non-zero
+with a clear diff otherwise.
+
+Usage:
+    python3 scripts/check_cli_table_sync.py
+
+Exit codes:
+    0  All pyproject.toml scripts are documented in README.md.
+    1  One or more scripts are missing from the README CLI section.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover — only on Python 3.10
+    try:
+        import tomli as tomllib  # type: ignore[no-redef, unused-ignore]
+    except ModuleNotFoundError:
+        print(
+            "ERROR: tomllib (stdlib, Python 3.11+) or tomli (pip install tomli) required.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+README = REPO_ROOT / "README.md"
+
+# Regex that matches a backtick-quoted command name anywhere in the README.
+_BACKTICK_CMD_RE = re.compile(r"`(hephaestus-[a-z0-9-]+)`")
+
+
+def _load_scripts() -> set[str]:
+    """Return the set of command names from pyproject.toml [project.scripts]."""
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    scripts: dict[str, str] = data.get("project", {}).get("scripts", {})
+    return set(scripts.keys())
+
+
+def _readme_documented_commands() -> set[str]:
+    """Return all ``hephaestus-*`` commands mentioned in README.md."""
+    readme_text = README.read_text(encoding="utf-8")
+    return set(_BACKTICK_CMD_RE.findall(readme_text))
+
+
+def main() -> int:
+    """Run the sync check and print a diff if out of sync.
+
+    Returns:
+        0 if in sync, 1 if out of sync.
+
+    """
+    declared = _load_scripts()
+    documented = _readme_documented_commands()
+
+    missing = sorted(declared - documented)
+    extra = sorted(documented - declared)
+
+    ok = True
+
+    if missing:
+        ok = False
+        print("ERROR: The following commands are declared in pyproject.toml but NOT documented")
+        print("       in README.md.  Add them to the CLI Commands section and run this script")
+        print("       to verify.\n")
+        for cmd in missing:
+            print(f"  - {cmd}")
+        print()
+
+    if extra:
+        # Extra entries are not an error — they could appear in prose / examples
+        # that postdate a removal.  Just warn.
+        print("WARNING: The following commands appear in README.md but NOT in pyproject.toml.")
+        print("         They may be stale; consider removing them.\n")
+        for cmd in extra:
+            print(f"  - {cmd}")
+        print()
+
+    if ok:
+        print(f"OK: all {len(declared)} pyproject.toml scripts are documented in README.md.")
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **#315** [MAJOR] CLI entry-point smoke test: Already resolved in origin/main (commit 1137a5f) — the test file at `tests/integration/test_cli_entry_points.py` was rewritten to dynamically parse `pyproject.toml` at collection time and parametrize over all 38 declared scripts.  No action needed here.
- **#332** [MINOR] README CLI table: Expanded from 3 hand-picked entries to all 38 declared `[project.scripts]` entries, grouped by category with descriptions from module docstrings.
- Added `scripts/check_cli_table_sync.py` + pre-commit hook `check-cli-table-sync` so the README table stays in sync automatically — failing pre-commit if a new script is added to `pyproject.toml` without being documented in `README.md`.

## CLI entry points actually tested

38 scripts declared in `pyproject.toml [project.scripts]` (verified via `python3 -c "import tomllib; ..."`).  Issue #315 claimed 37 but the actual count is 38.

`tests/integration/test_cli_entry_points.py` covers all 38 via:
- `TestCLITargetImportable` — importability check for every `module:attr` target
- `TestCLIHelpFlag` — `--help` smoke test via installed console script binary

## Test plan

- [x] `pixi run ruff check hephaestus/ tests/ scripts/` → clean
- [x] `pixi run mypy` → clean (232 source files)
- [x] `pixi run pytest tests/unit -q` → 2038 passed, 6 skipped, 83.19% coverage
- [x] `pixi run pytest tests/integration -q` → 138 passed
- [x] `pixi run pre-commit run --all-files` → all hooks pass including new `check-cli-table-sync`
- [x] `python3 scripts/check_cli_table_sync.py` → `OK: all 38 pyproject.toml scripts are documented in README.md.`

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)