### PR TITLE
test(automation): add coverage for 6 previously-excluded modules (W8)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -547,8 +547,8 @@ packages:
   requires_python: '>=3.10'
 - pypi: ./
   name: homericintelligence-hephaestus
-  version: 0.7.3.dev49+g3c6caa436.d20260510
-  sha256: 02a88f82b3e9caf878e801099e7dc987c275f9604d354a6e59a8d2d2543def50
+  version: 0.7.3.dev49+g3d8f5f5b6.d20260510
+  sha256: 443585e139d25a0897b8e6bda1dc0d06f5223a38e2235770b9f53fac825cee54
   requires_dist:
   - packaging>=21.0
   - pydantic>=2.0,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,20 +187,18 @@ source = ["hephaestus"]
 omit = [
     "*/tests/*",
     "*/__init__.py",
-    # Orchestration modules require live claude/gh CLI — integration test territory
+    # Full orchestration loops require a live claude/gh CLI — integration test territory.
+    # Pure-function helpers in these modules are tested in tests/unit/automation/ instead.
     "hephaestus/automation/implementer.py",
-    "hephaestus/automation/pr_manager.py",
     "hephaestus/automation/planner.py",
-    "hephaestus/automation/follow_up.py",
-    "hephaestus/automation/learn.py",
     "hephaestus/automation/address_review.py",
     "hephaestus/automation/ci_driver.py",
+    # curses_ui.py uses a live terminal; cannot be unit-tested without a real TTY
     "hephaestus/automation/curses_ui.py",
-    "hephaestus/automation/dependency_resolver.py",
-    "hephaestus/automation/git_utils.py",
+    # github_api.py shells out to gh CLI for every call; fully integration-only
     "hephaestus/automation/github_api.py",
+    # pr_reviewer.py drives a full Claude session against a live PR; integration-only
     "hephaestus/automation/pr_reviewer.py",
-    "hephaestus/automation/worktree_manager.py",
     "hephaestus/github/fleet_sync.py",
     "hephaestus/github/tidy.py",
 ]


### PR DESCRIPTION
## Summary

- Removes 6 modules from `[tool.coverage.run] omit` in `pyproject.toml` that already have unit tests in `tests/unit/automation/`
- All 6 modules had test files written prior to this PR; the omit list was simply never updated to reflect their testability
- The remaining 7 entries in the omit list are truly integration-only (live `claude`/`gh` CLI loops) or require a live TTY (`curses_ui.py`)

## Modules brought into coverage measurement

| Module | Before | After |
|---|---|---|
| `hephaestus/automation/pr_manager.py` | omitted | 91.58% |
| `hephaestus/automation/follow_up.py` | omitted | 82.43% |
| `hephaestus/automation/learn.py` | omitted | 89.74% |
| `hephaestus/automation/dependency_resolver.py` | omitted | 63.16% |
| `hephaestus/automation/git_utils.py` | omitted | 63.64% |
| `hephaestus/automation/worktree_manager.py` | omitted | 88.83% |

**Total coverage delta:** The `fail_under=80` threshold is met at **82.76%** with all 2036 unit tests passing (6 skipped).

## Modules kept in omit list (with justification)

- `implementer.py`, `planner.py`, `address_review.py`, `ci_driver.py` — full orchestration loops that drive live `claude --resume` sessions; no pure functions to unit-test without major refactor
- `curses_ui.py` — requires a live TTY; cannot be unit-tested without a real terminal
- `github_api.py` — every function shells out to `gh` CLI; fully integration-only
- `pr_reviewer.py` — drives a full Claude session against a live PR; integration-only

## Test plan

- [x] `pixi run pytest tests/unit -q --tb=short` — 2036 passed, 6 skipped
- [x] `pixi run pytest tests/unit --cov=hephaestus --cov-fail-under=80 -q` — 82.76% total coverage, threshold met
- [x] `pixi run ruff check hephaestus/ tests/` — all checks passed
- [x] `pixi run mypy` — no issues in 231 source files
- [x] `pre-commit run ruff-format-python ruff-check-python mypy-check-python check-version-single-source check-unit-test-structure --all-files` — all passed

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)