### PR TITLE
feat(automation): consolidate follow-ups into one sectioned issue + strict scope policy

### DIFF
--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -1,8 +1,22 @@
-"""Follow-up issue creation functions for issue implementation.
+"""Follow-up issue creation for issue implementation.
 
-Provides:
-- Parsing follow-up items from Claude JSON responses
-- Creating follow-up GitHub issues after implementation
+Policy (2026-05-10): one consolidated GitHub issue per implementation, sectioned
+by category (core / security / safety / critical_bug). Follow-ups are tightly
+scoped — see ``prompts.FOLLOW_UP_PROMPT`` for the rules. Out-of-scope items
+that the model considered but rejected are returned to the caller so they can
+be recorded in the PR body rather than filed as separate issues.
+
+Public surface:
+
+- ``parse_follow_up_response(text)`` — returns a typed result with
+  ``follow_ups`` and ``rejected`` lists.
+- ``run_follow_up_issues(...)`` — resumes the Claude session, parses the
+  response, files at most one consolidated issue, and returns the parsed
+  ``FollowUpResponse`` (or ``None`` if Claude failed). The rejected list is
+  also persisted to ``state_dir/follow-up-rejected-{issue_number}.json``
+  so callers that don't read the return value still have access.
+- ``render_rejected_for_pr_body(rejected)`` — markdown helper for embedding
+  the rejected list into a PR body.
 """
 
 from __future__ import annotations
@@ -11,34 +25,69 @@ import contextlib
 import json
 import logging
 import re
-import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from .claude_timeouts import follow_up_claude_timeout
 from .git_utils import run
 from .github_api import gh_issue_comment, gh_issue_create
-from .issue_dedup import extract_new_info, find_duplicate_open_issue
 from .prompts import get_follow_up_prompt
 
 logger = logging.getLogger(__name__)
 
 
-def _extract_outer_json_array(text: str) -> str | None:
-    """Find and return the outermost JSON array ``[...]`` in *text*.
+_ALLOWED_CATEGORIES: frozenset[str] = frozenset({"core", "security", "safety", "critical_bug"})
+_MAX_FOLLOW_UPS = 3
+_CATEGORY_LABELS: dict[str, list[str]] = {
+    "core": ["follow-up", "core"],
+    "security": ["follow-up", "security"],
+    "safety": ["follow-up", "safety"],
+    "critical_bug": ["follow-up", "bug"],
+}
+_SECTION_HEADINGS: dict[str, str] = {
+    "core": "## Core library",
+    "security": "## Security",
+    "safety": "## Safety",
+    "critical_bug": "## Critical bug",
+}
 
-    Uses a balanced-bracket scan to avoid the greedy/non-greedy pitfall of
-    regex-based extraction, which either over-consumes (greedy ``.*``) or
-    stops too early inside nested structures (non-greedy ``.*?``).
 
-    Args:
-        text: String that may contain a JSON array.
+@dataclass(frozen=True)
+class FollowUpItem:
+    """A single accepted follow-up item under one of the four categories."""
 
-    Returns:
-        The first outermost ``[...]`` substring, or ``None`` if not found.
+    category: str
+    title: str
+    body: str
 
+
+@dataclass(frozen=True)
+class RejectedItem:
+    """A follow-up the model considered but excluded under the scope rules."""
+
+    title: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class FollowUpResponse:
+    """Parsed result of the follow-up Claude session."""
+
+    follow_ups: list[FollowUpItem] = field(default_factory=list)
+    rejected: list[RejectedItem] = field(default_factory=list)
+
+
+def _extract_outer_json_object(text: str) -> str | None:
+    """Find and return the outermost JSON object ``{...}`` in *text*.
+
+    Uses a balanced-brace scan so prose containing additional ``{`` or
+    nested objects does not confuse the boundary detection. Carries the
+    A5-07 lesson (originally applied to the array variant in the prior
+    schema): a greedy regex over-consumes, a non-greedy regex stops too
+    early inside nested structures.
     """
-    start = text.find("[")
+    start = text.find("{")
     if start == -1:
         return None
     depth = 0
@@ -52,164 +101,260 @@ def _extract_outer_json_array(text: str) -> str | None:
         if ch == "\\" and in_string:
             escape_next = True
             continue
-        if ch == '"' and not escape_next:
+        if ch == '"':
             in_string = not in_string
             continue
         if in_string:
             continue
-        if ch == "[":
+        if ch == "{":
             depth += 1
-        elif ch == "]":
+        elif ch == "}":
             depth -= 1
             if depth == 0:
                 return text[start : i + 1]
     return None
 
 
-def parse_follow_up_items(text: str) -> list[dict[str, Any]]:
-    """Parse follow-up items from Claude's JSON response.
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    """Extract the first JSON object from ``text``.
 
-    Args:
-        text: Claude's response text (may contain JSON in code blocks)
-
-    Returns:
-        List of follow-up item dictionaries with title, body, labels
-
+    Looks for a fenced ```json ... ``` block first, then falls back to a
+    balanced-brace scan over the bare text. Returns ``None`` if nothing
+    parseable is found.
     """
-    # Try to extract JSON from code blocks or bare JSON.
-    # Code-block extraction uses a non-greedy inner match to stop at the
-    # first closing fence.  The bare-JSON fallback previously used a greedy
-    # `.*` which would over-consume when multiple arrays were present.
-    # We now use a balanced-bracket scanner to find the outermost `[...]`
-    # block reliably (A5-07).
-    json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
-    if json_match:
-        json_str = json_match.group(1)
-    else:
-        json_str = _extract_outer_json_array(text)
-        if json_str is None:
-            logger.warning("No JSON array found in follow-up response")
-            return []
+    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    candidate = fenced.group(1) if fenced else _extract_outer_json_object(text)
+    if candidate is None:
+        return None
 
     try:
-        items = json.loads(json_str)
-        if not isinstance(items, list):
-            logger.warning("Follow-up response is not a JSON array")
-            return []
-
-        # Validate and filter items
-        valid_items = []
-        for item in items[:5]:  # Cap at 5
-            if not isinstance(item, dict):
-                continue
-            if "title" not in item or "body" not in item:
-                logger.warning(f"Skipping follow-up item missing required fields: {item}")
-                continue
-
-            # Ensure labels is a list
-            if "labels" not in item or not isinstance(item["labels"], list):
-                item["labels"] = []
-
-            valid_items.append(item)
-
-        return valid_items
-
-    except json.JSONDecodeError as e:
-        logger.warning(f"Failed to parse follow-up JSON: {e}")
-        return []
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return parsed
 
 
-def _create_follow_up_issues(
-    items: list[dict[str, Any]],
+def _classify_follow_up_entry(
+    item: Any,
+) -> tuple[FollowUpItem, None] | tuple[None, RejectedItem | None]:
+    """Validate one ``follow_ups`` entry.
+
+    Returns ``(item, None)`` if accepted, ``(None, RejectedItem)`` if demoted
+    due to an invalid category, or ``(None, None)`` if the entry should be
+    silently dropped (missing required fields).
+    """
+    if not isinstance(item, dict):
+        return None, None
+    category = item.get("category")
+    title = item.get("title")
+    body = item.get("body")
+    if not isinstance(title, str) or not isinstance(body, str) or not title.strip():
+        logger.warning("Skipping follow-up with missing title/body: %r", item)
+        return None, None
+    if category not in _ALLOWED_CATEGORIES:
+        logger.warning("Demoting follow-up %r to rejected: invalid category %r", title, category)
+        reason = f"Invalid category {category!r}; allowed values are {sorted(_ALLOWED_CATEGORIES)}."
+        return None, RejectedItem(title=title, reason=reason)
+    return FollowUpItem(category=category, title=title.strip(), body=body), None
+
+
+def _parse_rejected_entry(item: Any) -> RejectedItem | None:
+    """Validate one ``rejected`` entry, returning ``None`` if it should be dropped."""
+    if not isinstance(item, dict):
+        return None
+    title = item.get("title")
+    reason = item.get("reason", "")
+    if not isinstance(title, str) or not title.strip():
+        return None
+    if not isinstance(reason, str):
+        reason = str(reason)
+    return RejectedItem(title=title.strip(), reason=reason.strip())
+
+
+def parse_follow_up_response(text: str) -> FollowUpResponse:
+    """Parse the sectioned follow-up schema from Claude's response.
+
+    Tolerates fenced JSON, bare JSON, and silently drops malformed items
+    (logged at WARNING). Items with categories outside the allowed set are
+    demoted to the rejected list with a synthesised reason — the model is
+    supposed to enforce categories itself, but defence in depth.
+    """
+    obj = _extract_json_object(text)
+    if obj is None:
+        logger.warning("No JSON object found in follow-up response")
+        return FollowUpResponse()
+
+    raw_follow_ups = obj.get("follow_ups", [])
+    raw_rejected = obj.get("rejected", [])
+    if not isinstance(raw_follow_ups, list):
+        logger.warning("follow_ups was not a list; ignoring")
+        raw_follow_ups = []
+    if not isinstance(raw_rejected, list):
+        logger.warning("rejected was not a list; ignoring")
+        raw_rejected = []
+
+    accepted: list[FollowUpItem] = []
+    rejected: list[RejectedItem] = []
+
+    for item in raw_follow_ups[:_MAX_FOLLOW_UPS]:
+        good, demoted = _classify_follow_up_entry(item)
+        if good is not None:
+            accepted.append(good)
+        elif demoted is not None:
+            rejected.append(demoted)
+
+    if len(raw_follow_ups) > _MAX_FOLLOW_UPS:
+        logger.warning(
+            "Follow-up cap exceeded: model returned %d items, kept first %d",
+            len(raw_follow_ups),
+            _MAX_FOLLOW_UPS,
+        )
+
+    for item in raw_rejected:
+        parsed = _parse_rejected_entry(item)
+        if parsed is not None:
+            rejected.append(parsed)
+
+    return FollowUpResponse(follow_ups=accepted, rejected=rejected)
+
+
+def parse_follow_up_items(text: str) -> list[dict[str, Any]]:
+    """Backward-compatible adapter returning a flat list of dicts.
+
+    Pre-2026-05-10 callers expected ``[{"title", "body", "labels"}, ...]``.
+    The new schema is structured differently, so this adapter projects
+    accepted follow-ups into the legacy shape. Rejected items are NOT
+    surfaced through this function — call ``parse_follow_up_response`` to
+    see them.
+    """
+    response = parse_follow_up_response(text)
+    return [
+        {
+            "title": item.title,
+            "body": item.body,
+            "labels": list(_CATEGORY_LABELS.get(item.category, ["follow-up"])),
+        }
+        for item in response.follow_ups
+    ]
+
+
+def _build_consolidated_body(
+    response: FollowUpResponse,
+    issue_number: int,
+) -> str:
+    """Render a single sectioned issue body covering all accepted follow-ups."""
+    lines: list[str] = [
+        f"_Consolidated follow-up from implementation of #{issue_number}._",
+        "",
+        (
+            "Each section below lists scope-checked follow-up items discovered "
+            "during implementation. Items are restricted to core library "
+            "defects, security, safety hazards, or critical functional bugs."
+        ),
+        "",
+    ]
+    by_category: dict[str, list[FollowUpItem]] = {}
+    for item in response.follow_ups:
+        by_category.setdefault(item.category, []).append(item)
+
+    for category in ("critical_bug", "safety", "security", "core"):
+        if not by_category.get(category):
+            continue
+        lines.append(_SECTION_HEADINGS[category])
+        lines.append("")
+        for entry in by_category[category]:
+            lines.append(f"### {entry.title}")
+            lines.append("")
+            lines.append(entry.body.strip())
+            lines.append("")
+
+    if response.rejected:
+        lines.append("---")
+        lines.append("")
+        lines.append(
+            "_The implementer also considered the items below and rejected "
+            "them as out of scope; they are recorded in the PR body, not "
+            "filed as separate issues._"
+        )
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _consolidated_labels(response: FollowUpResponse) -> list[str]:
+    """Pick labels for the consolidated issue based on which categories appear."""
+    labels: set[str] = {"follow-up"}
+    for item in response.follow_ups:
+        labels.update(_CATEGORY_LABELS.get(item.category, []))
+    return sorted(labels)
+
+
+def _file_consolidated_issue(
+    response: FollowUpResponse,
     issue_number: int,
     status_tracker: Any | None,
     slot_id: int | None,
-    dry_run: bool = False,
-) -> list[int]:
-    """Create GitHub issues from follow-up item list.
+    dry_run: bool,
+) -> int | None:
+    """File the single consolidated follow-up issue.
 
-    Args:
-        items: List of follow-up item dicts with title, body, and optional labels.
-        issue_number: Parent issue number (for cross-references and status labels).
-        status_tracker: Optional StatusTracker for slot updates.
-        slot_id: Worker slot ID for status updates.
-        dry_run: If True, log what would be filed without calling
-            ``gh_issue_create`` or ``gh_issue_comment``. Defence-in-depth: the
-            implementer phase already short-circuits the entire post-impl
-            block under dry-run, but this guards future callers.
-
-    Returns:
-        List of created issue numbers (empty in dry-run).
-
+    Returns the new issue number on success, ``None`` if there was nothing
+    to file or the call was suppressed by ``dry_run``. Failures are logged
+    and swallowed — follow-up filing must never block the PR pipeline.
     """
-    created_issues = []
-    for i, item in enumerate(items, 1):
-        try:
-            if slot_id is not None and status_tracker is not None:
-                status_tracker.update_slot(
-                    slot_id, f"#{issue_number}: Creating follow-up {i}/{len(items)}"
-                )
+    if not response.follow_ups:
+        return None
 
-            # Dedup: skip filing if a near-duplicate open issue already exists.
-            # When found, post a comment on the existing issue with any new
-            # information — but only if the new body actually adds something.
-            duplicate = find_duplicate_open_issue(item["title"], item["body"])
-            if duplicate is not None:
-                new_info = extract_new_info(item["body"], duplicate.body)
-                if new_info:
-                    update_comment = (
-                        f"Additional context from #{issue_number} "
-                        f"(would have been a separate issue, "
-                        f"deduplicated against this one):\n\n{new_info}"
-                    )
-                    if dry_run:
-                        logger.info(
-                            "[DRY RUN] Would update duplicate #%d with new context "
-                            "from #%d (skipped duplicate %r)",
-                            duplicate.number,
-                            issue_number,
-                            item["title"],
-                        )
-                    else:
-                        try:
-                            gh_issue_comment(duplicate.number, update_comment)
-                            logger.info(
-                                f"Updated existing issue #{duplicate.number} with new "
-                                f"context from #{issue_number} "
-                                f"(skipped duplicate '{item['title']}')"
-                            )
-                        except Exception as e:  # comment is best-effort
-                            logger.warning(
-                                f"Failed to comment on duplicate #{duplicate.number}: {e}"
-                            )
-                else:
-                    logger.info(
-                        f"Skipped pure-duplicate follow-up '{item['title']}' "
-                        f"(matches existing #{duplicate.number}, no new info)"
-                    )
-                time.sleep(1)
-                continue
+    if slot_id is not None and status_tracker is not None:
+        status_tracker.update_slot(
+            slot_id, f"#{issue_number}: Filing 1 consolidated follow-up issue"
+        )
 
-            body_with_ref = f"{item['body']}\n\n_Follow-up from #{issue_number}_"
-            if dry_run:
-                logger.info(
-                    "[DRY RUN] Would create follow-up issue %r (parent #%d)",
-                    item["title"],
-                    issue_number,
-                )
-            else:
-                new_issue_num = gh_issue_create(
-                    title=item["title"],
-                    body=body_with_ref,
-                    labels=item.get("labels"),
-                )
-                created_issues.append(new_issue_num)
-            time.sleep(1)
-        except (
-            Exception
-        ) as e:  # broad catch: GitHub API can fail in many ways; continue with others
-            logger.warning(f"Failed to create follow-up issue '{item['title']}': {e}")
-    return created_issues
+    categories = sorted({i.category for i in response.follow_ups})
+    title = (
+        f"Follow-up from #{issue_number}: "
+        f"{len(response.follow_ups)} item(s) ({', '.join(categories)})"
+    )
+    if len(title) > 80:
+        title = f"Follow-up from #{issue_number} ({len(response.follow_ups)} items)"
+
+    body = _build_consolidated_body(response, issue_number)
+    labels = _consolidated_labels(response)
+
+    if dry_run:
+        logger.info(
+            "[DRY RUN] Would create consolidated follow-up issue %r (parent #%d, %d items)",
+            title,
+            issue_number,
+            len(response.follow_ups),
+        )
+        return None
+
+    try:
+        return gh_issue_create(title=title, body=body, labels=labels)
+    except Exception as e:  # broad: GitHub API can fail in many ways; non-blocking
+        logger.warning(
+            "Failed to create consolidated follow-up issue for #%d: %s",
+            issue_number,
+            e,
+        )
+        return None
+
+
+def _persist_rejected(
+    rejected: list[RejectedItem],
+    issue_number: int,
+    state_dir: Path,
+) -> None:
+    """Write rejected items to a JSON file for offline inspection / PR-body rendering."""
+    if not rejected:
+        return
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path = state_dir / f"follow-up-rejected-{issue_number}.json"
+    payload = [{"title": r.title, "reason": r.reason} for r in rejected]
+    with contextlib.suppress(Exception):
+        path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
 def run_follow_up_issues(
@@ -220,29 +365,30 @@ def run_follow_up_issues(
     status_tracker: Any | None = None,
     slot_id: int | None = None,
     dry_run: bool = False,
-) -> None:
-    """Resume Claude session to identify and file follow-up issues.
+) -> FollowUpResponse | None:
+    """Resume the implementation Claude session and file ONE consolidated follow-up issue.
 
-    Args:
-        session_id: Claude session ID to resume
-        worktree_path: Path to git worktree
-        issue_number: Parent issue number
-        state_dir: Directory for state/log files
-        status_tracker: StatusTracker instance for slot updates (optional)
-        slot_id: Worker slot ID for status updates
-        dry_run: If True, run Claude analysis but suppress
-            ``gh_issue_create``/``gh_issue_comment``. Defence-in-depth (the
-            implementer-phase caller already short-circuits in dry-run).
+    Returns the parsed ``FollowUpResponse`` so callers can render the rejected
+    items into the PR body. Returns ``None`` if Claude failed or the response
+    was unparseable — in that case the caller should not block the PR
+    pipeline.
 
+    Side effects:
+
+    - Creates ``state_dir`` if missing.
+    - Writes ``state_dir/follow-up-{issue_number}.log`` with the raw Claude output.
+    - Writes ``state_dir/follow-up-rejected-{issue_number}.json`` with the
+      rejected list.
+    - Files at most ONE GitHub issue (the consolidated one), and posts a single
+      summary comment on the parent issue when something was filed.
+    - In ``dry_run`` mode, all GitHub side effects are suppressed.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
 
-    # Write follow-up prompt to temp file in worktree
     prompt_file = worktree_path / f".claude-followup-{issue_number}.md"
     prompt_file.write_text(get_follow_up_prompt(issue_number))
 
     try:
-        # Resume session and get follow-up items
         result = run(
             [
                 "claude",
@@ -256,63 +402,89 @@ def run_follow_up_issues(
             timeout=follow_up_claude_timeout(),
         )
 
-        # Save successful output to log file
         follow_up_log = state_dir / f"follow-up-{issue_number}.log"
         follow_up_log.write_text(result.stdout or "")
 
-        # Parse JSON output
         try:
             data = json.loads(result.stdout)
             response_text = data.get("result", "")
         except (json.JSONDecodeError, AttributeError) as e:
-            logger.warning(f"Could not parse follow-up response for issue #{issue_number}: {e}")
-            return
+            logger.warning("Could not parse follow-up response for issue #%d: %s", issue_number, e)
+            return None
 
-        # Extract follow-up items
-        items = parse_follow_up_items(response_text)
+        response = parse_follow_up_response(response_text)
+        _persist_rejected(response.rejected, issue_number, state_dir)
 
-        if not items:
-            logger.info(f"No follow-up items identified for issue #{issue_number}")
-            return
+        if not response.follow_ups and not response.rejected:
+            logger.info("No follow-up items identified for issue #%d", issue_number)
+            return response
 
-        created_issues = _create_follow_up_issues(
-            items, issue_number, status_tracker, slot_id, dry_run=dry_run
+        new_issue = _file_consolidated_issue(
+            response, issue_number, status_tracker, slot_id, dry_run=dry_run
         )
 
-        # Post summary comment on parent issue (suppressed in dry-run)
-        if created_issues:
-            summary = f"Created {len(created_issues)} follow-up issue(s): " + ", ".join(
-                f"#{num}" for num in created_issues
+        if new_issue is not None:
+            summary = (
+                f"Filed consolidated follow-up issue #{new_issue} covering "
+                f"{len(response.follow_ups)} item(s)"
             )
-            if dry_run:
-                logger.info("[DRY RUN] Would post follow-up summary to #%d", issue_number)
-            else:
-                try:
-                    gh_issue_comment(issue_number, summary)
-                    logger.info(f"Posted follow-up summary to issue #{issue_number}")
-                except Exception as e:  # broad catch: GitHub API call; non-critical summary post
-                    logger.warning(f"Failed to post follow-up summary: {e}")
+            if response.rejected:
+                summary += (
+                    f"; {len(response.rejected)} additional item(s) were "
+                    "considered and rejected as out of scope (see PR body)."
+                )
+            try:
+                gh_issue_comment(issue_number, summary)
+                logger.info("Posted follow-up summary to issue #%d", issue_number)
+            except Exception as e:  # non-critical summary post
+                logger.warning("Failed to post follow-up summary: %s", e)
 
         logger.info(
-            f"Follow-up issues completed for #{issue_number}: created {len(created_issues)}"
+            "Follow-up complete for #%d: filed=%s accepted=%d rejected=%d",
+            issue_number,
+            new_issue if new_issue is not None else "none",
+            len(response.follow_ups),
+            len(response.rejected),
         )
+        return response
 
     except (
         Exception
-    ) as e:  # broad catch: top-level follow-up boundary; non-blocking, must not propagate
-        logger.warning(f"Follow-up issues failed for issue #{issue_number}: {e}")
-
-        # Save failure output to log file
+    ) as e:  # broad: top-level boundary; follow-up failure must NEVER block the PR pipeline
+        logger.warning("Follow-up issues failed for issue #%d: %s", issue_number, e)
         follow_up_log = state_dir / f"follow-up-{issue_number}.log"
         error_output = f"FAILED: {e}\n"
         if hasattr(e, "stdout"):
             error_output += f"\nSTDOUT:\n{e.stdout or ''}"
         if hasattr(e, "stderr"):
             error_output += f"\nSTDERR:\n{e.stderr or ''}"
-        follow_up_log.write_text(error_output)
-
-        # Non-blocking: never re-raise
+        with contextlib.suppress(Exception):
+            follow_up_log.write_text(error_output)
+        return None
     finally:
-        # Clean up temp file
         with contextlib.suppress(Exception):
             prompt_file.unlink()
+
+
+def render_rejected_for_pr_body(rejected: list[RejectedItem]) -> str:
+    """Render the rejected list as a markdown section suitable for inclusion in a PR body.
+
+    Returns an empty string if there are no rejected items so the caller can
+    unconditionally append the result.
+    """
+    if not rejected:
+        return ""
+    lines = [
+        "",
+        "## Considered & rejected follow-ups",
+        "",
+        (
+            "_The implementer considered the items below during the follow-up "
+            "scope check and rejected them under the policy "
+            "(core / security / safety / critical_bug only)._"
+        ),
+        "",
+    ]
+    for item in rejected:
+        lines.append(f"- **{item.title}** — {item.reason}".rstrip())
+    return "\n".join(lines).rstrip() + "\n"

--- a/hephaestus/automation/prompts.py
+++ b/hephaestus/automation/prompts.py
@@ -187,42 +187,100 @@ None found
 """
 
 FOLLOW_UP_PROMPT = """
-Review your work on issue #{issue_number} and identify any follow-up tasks,
-enhancements, or edge cases discovered during implementation.
+Review your work on issue #{issue_number} and identify follow-up items
+**discovered during implementation** that fall within strict scope.
 
-**Output format:**
-Return a JSON array of follow-up items (max 5). Each item must have:
-- `title`: Brief, specific title (under 70 characters)
-- `body`: Detailed description of the follow-up work
-- `labels`: Array of relevant labels from:
-  ["enhancement", "bug", "testing", "documentation", "refactor", "research"]
+## Scope (HARD GUARDRAIL)
 
-If there are no follow-up items, return an empty array: `[]`
+A follow-up is allowed ONLY when it is one of:
 
-**Example:**
+1. **core** — A defect, gap, or required change in the **core library functionality**
+   that this repository directly owns. Adding tests for the code you just wrote
+   counts as core. Adding tests for unrelated modules does NOT.
+2. **security** — A concrete security finding (input validation, secret handling,
+   permission boundary, etc.). Generic "we should review security some day" does NOT.
+3. **safety** — A reliability / safety hazard with a concrete repro path
+   (data loss, deadlock, leaked resources, race condition, missing cleanup).
+4. **critical_bug** — A functional bug with user-visible impact and a concrete repro.
+   Cosmetic, theoretical, or nitpick bugs do NOT qualify here — and minor bugs
+   should be filed manually, not via this automation.
+
+Anything else is OUT OF SCOPE and MUST be rejected. In particular, the
+following are explicitly NOT follow-ups:
+
+- New features, enhancements, or "nice to have" expansions
+- Documentation polish, README rewrites, contributor-guide additions
+- Refactors driven by aesthetic preferences rather than concrete defects
+- Test coverage for code outside what you just touched
+- Tooling/CI/dependency suggestions unrelated to the implementation
+- Cross-repo migrations, ecosystem-wide changes
+- Speculative research, "consider switching to X", "evaluate Y"
+- Anything that would expand the issue's domain into new areas
+- Anything you could just do in this PR but chose not to
+
+If in doubt, REJECT. Filing fewer follow-ups is the goal.
+
+## Output format (single JSON object)
+
+Return EXACTLY one JSON object with two arrays. Both arrays may be empty.
+
 ```json
-[
-  {{
-    "title": "Add edge case handling for empty input",
-    "body": "During implementation, discovered that empty input returns
-misleading error. Should add validation and specific error message.",
-    "labels": ["enhancement", "bug"]
-  }},
-  {{
-    "title": "Add integration tests for new feature",
-    "body": "Current tests only cover unit level. Need integration tests
-to verify end-to-end behavior with real GitHub API.",
-    "labels": ["testing"]
-  }}
-]
+{{
+  "follow_ups": [
+    {{
+      "category": "core" | "security" | "safety" | "critical_bug",
+      "title": "Short specific title (<70 chars)",
+      "body": "Concrete description with file:line evidence and a sketch fix"
+    }}
+  ],
+  "rejected": [
+    {{
+      "title": "Item you considered but rejected",
+      "reason": "One sentence: which scope rule it failed and why"
+    }}
+  ]
+}}
 ```
 
-**Guidelines:**
-- Only include concrete, actionable items discovered during this implementation
-- Don't include speculative future features
-- Keep descriptions concise but specific enough for another developer
-- Max 5 items - prioritize the most important
-- Return `[]` if no follow-ups needed
+Each `follow_ups` item MUST include `category`. The four allowed values are
+`core`, `security`, `safety`, `critical_bug`. Any other category is rejected
+by the parser.
+
+The `rejected` list is for items you considered but excluded under the scope
+rules. List them so the operator can see what was suppressed — they will be
+recorded in the PR body, not filed as issues. Keep it short; only include
+items where the rejection itself is informative.
+
+## Caps and quality bar
+
+- HARD CAP: at most **3** follow-ups in `follow_ups`. Pick the most important.
+  More than 3 means you are over-scoping.
+- Each `body` MUST cite `file:line` evidence or a concrete repro path.
+- Do NOT pad. If there are no qualifying items, return
+  `{{"follow_ups": [], "rejected": []}}`.
+
+## Examples
+
+**Good** (qualifies as `safety`):
+```json
+{{
+  "category": "safety",
+  "title": "Worktree leaks on SIGINT at implementer.py:402",
+  "body": "Worktree created before the dry-run guard; SIGINT leaks .worktrees/issue-N."
+}}
+```
+
+**Bad** (rejected as out-of-scope feature expansion):
+```json
+{{"title": "Add a web dashboard for automation status",
+  "reason": "Feature expansion into a new domain (web UI); not a defect in core functionality."}}
+```
+
+**Bad** (rejected as documentation polish):
+```json
+{{"title": "Improve README intro section",
+  "reason": "Documentation polish; not a defect, security, safety, or bug."}}
+```
 """
 
 

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -1,4 +1,4 @@
-"""Tests for the follow_up module."""
+"""Tests for the follow_up module (consolidated-issue policy, 2026-05-10)."""
 
 import json
 from pathlib import Path
@@ -6,283 +6,361 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from hephaestus.automation.follow_up import (
-    _create_follow_up_issues,
+    FollowUpItem,
+    FollowUpResponse,
+    RejectedItem,
     parse_follow_up_items,
+    parse_follow_up_response,
+    render_rejected_for_pr_body,
     run_follow_up_issues,
 )
-from hephaestus.automation.issue_dedup import IssueMatch
 
 
-class TestParseFollowUpItems:
-    """Tests for parse_follow_up_items."""
+class TestParseFollowUpResponse:
+    """Tests for parse_follow_up_response (the new sectioned schema)."""
 
-    def test_parses_json_in_code_block(self) -> None:
-        """Extracts items from fenced JSON code block."""
-        text = '```json\n[{"title": "T1", "body": "B1", "labels": ["bug"]}]\n```'
-        items = parse_follow_up_items(text)
-        assert len(items) == 1
-        assert items[0]["title"] == "T1"
-        assert items[0]["body"] == "B1"
-        assert items[0]["labels"] == ["bug"]
-
-    def test_parses_bare_json_array(self) -> None:
-        """Extracts items from bare JSON array without code block."""
-        text = 'Some text\n[{"title": "T2", "body": "B2"}]\nmore text'
-        items = parse_follow_up_items(text)
-        assert len(items) == 1
-        assert items[0]["title"] == "T2"
-        assert items[0]["labels"] == []  # default
-
-    def test_returns_empty_on_no_json(self) -> None:
-        """Returns empty list when no JSON array found."""
-        items = parse_follow_up_items("No JSON here.")
-        assert items == []
-
-    def test_caps_at_five_items(self) -> None:
-        """Caps returned items at 5 even if more are present."""
-        raw = json.dumps([{"title": f"T{i}", "body": f"B{i}"} for i in range(10)])
-        items = parse_follow_up_items(raw)
-        assert len(items) == 5
-
-    def test_skips_items_missing_required_fields(self) -> None:
-        """Skips items without title or body."""
-        raw = json.dumps(
-            [
-                {"title": "Good", "body": "Body"},
-                {"title": "Missing body"},
-                {"body": "Missing title"},
-            ]
+    def test_parses_fenced_json_object(self) -> None:
+        text = (
+            "```json\n"
+            '{"follow_ups": [{"category": "core", "title": "T1", "body": "B1"}],'
+            ' "rejected": [{"title": "R1", "reason": "out of scope"}]}\n'
+            "```"
         )
-        items = parse_follow_up_items(raw)
-        assert len(items) == 1
-        assert items[0]["title"] == "Good"
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].category == "core"
+        assert response.follow_ups[0].title == "T1"
+        assert response.follow_ups[0].body == "B1"
+        assert len(response.rejected) == 1
+        assert response.rejected[0].title == "R1"
+        assert response.rejected[0].reason == "out of scope"
 
-    def test_skips_non_dict_items(self) -> None:
-        """Skips non-dict entries in the array."""
-        raw = json.dumps(
-            [
-                {"title": "T1", "body": "B1"},
-                "not a dict",
-                42,
-            ]
+    def test_parses_bare_json_object(self) -> None:
+        text = (
+            "Some prose...\n"
+            '{"follow_ups": [{"category": "safety", "title": "T", "body": "B"}],'
+            ' "rejected": []}'
+            "\nmore prose"
         )
-        items = parse_follow_up_items(raw)
-        assert len(items) == 1
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].category == "safety"
 
-    def test_ensures_labels_is_list(self) -> None:
-        """Sets labels to [] when missing or not a list."""
-        raw = json.dumps(
-            [
-                {"title": "T1", "body": "B1", "labels": "not-a-list"},
-            ]
-        )
-        items = parse_follow_up_items(raw)
-        assert items[0]["labels"] == []
+    def test_returns_empty_when_no_json(self) -> None:
+        response = parse_follow_up_response("No JSON here.")
+        assert response.follow_ups == []
+        assert response.rejected == []
+
+    def test_returns_empty_when_root_not_object(self) -> None:
+        response = parse_follow_up_response("[1, 2, 3]")
+        assert response.follow_ups == []
+        assert response.rejected == []
 
     def test_returns_empty_on_invalid_json(self) -> None:
-        """Returns empty list on malformed JSON."""
-        items = parse_follow_up_items("[{bad json")
-        assert items == []
+        response = parse_follow_up_response("{not valid")
+        assert response.follow_ups == []
 
-    def test_returns_empty_when_root_not_array(self) -> None:
-        """Returns empty list when JSON root is not an array."""
-        items = parse_follow_up_items('{"key": "value"}')
-        assert items == []
+    def test_caps_at_three_items(self) -> None:
+        items = [{"category": "core", "title": f"T{i}", "body": f"B{i}"} for i in range(10)]
+        text = json.dumps({"follow_ups": items, "rejected": []})
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 3
+
+    def test_invalid_category_demoted_to_rejected(self) -> None:
+        text = json.dumps(
+            {
+                "follow_ups": [
+                    {"category": "enhancement", "title": "Bad cat", "body": "..."},
+                    {"category": "core", "title": "Good", "body": "..."},
+                ],
+                "rejected": [],
+            }
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].title == "Good"
+        assert len(response.rejected) == 1
+        assert response.rejected[0].title == "Bad cat"
+        assert "enhancement" in response.rejected[0].reason
+
+    def test_skips_items_missing_required_fields(self) -> None:
+        text = json.dumps(
+            {
+                "follow_ups": [
+                    {"category": "core", "title": "Good", "body": "Body"},
+                    {"category": "core", "title": "No body"},
+                    {"category": "core", "body": "No title"},
+                    {"category": "core", "title": "", "body": "Empty title"},
+                ],
+                "rejected": [],
+            }
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].title == "Good"
+
+    def test_handles_non_list_follow_ups_gracefully(self) -> None:
+        text = json.dumps({"follow_ups": "not a list", "rejected": []})
+        response = parse_follow_up_response(text)
+        assert response.follow_ups == []
+
+    def test_skips_rejected_items_with_missing_title(self) -> None:
+        text = json.dumps(
+            {
+                "follow_ups": [],
+                "rejected": [
+                    {"title": "Good", "reason": "r"},
+                    {"reason": "no title"},
+                    {"title": "", "reason": "empty"},
+                ],
+            }
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.rejected) == 1
+        assert response.rejected[0].title == "Good"
+
+
+class TestParseFollowUpItemsLegacyAdapter:
+    """The legacy adapter must keep returning a flat dict list for older callers."""
+
+    def test_projects_to_legacy_shape(self) -> None:
+        text = json.dumps(
+            {
+                "follow_ups": [
+                    {"category": "security", "title": "T", "body": "B"},
+                ],
+                "rejected": [],
+            }
+        )
+        items = parse_follow_up_items(text)
+        assert len(items) == 1
+        assert items[0]["title"] == "T"
+        assert items[0]["body"] == "B"
+        assert "follow-up" in items[0]["labels"]
+        assert "security" in items[0]["labels"]
+
+    def test_returns_empty_on_no_json(self) -> None:
+        assert parse_follow_up_items("No JSON here.") == []
 
 
 class TestRunFollowUpIssues:
-    """Tests for run_follow_up_issues."""
+    """Tests for run_follow_up_issues (consolidated-issue policy)."""
 
-    def _make_claude_output(self, items: list[dict[str, Any]]) -> str:
-        """Build fake JSON claude output with follow-up items."""
-        return json.dumps({"result": json.dumps(items)})
+    def _make_claude_output(self, payload: dict[str, Any]) -> str:
+        return json.dumps({"result": json.dumps(payload)})
 
-    def test_creates_issues_and_posts_summary(self, tmp_path: Path) -> None:
-        """Creates follow-up issues and posts a summary comment."""
+    def test_files_one_consolidated_issue(self, tmp_path: Path) -> None:
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
-        items = [
-            {"title": "Follow 1", "body": "Body 1", "labels": []},
-            {"title": "Follow 2", "body": "Body 2", "labels": []},
-        ]
+        payload = {
+            "follow_ups": [
+                {"category": "core", "title": "C1", "body": "BC1"},
+                {"category": "safety", "title": "S1", "body": "BS1"},
+            ],
+            "rejected": [],
+        }
         mock_result = MagicMock()
-        mock_result.stdout = self._make_claude_output(items)
+        mock_result.stdout = self._make_claude_output(payload)
 
         with (
             patch("hephaestus.automation.follow_up.run", return_value=mock_result),
             patch(
-                "hephaestus.automation.follow_up.find_duplicate_open_issue",
-                return_value=None,
-            ),
-            patch(
-                "hephaestus.automation.follow_up.gh_issue_create", side_effect=[101, 102]
+                "hephaestus.automation.follow_up.gh_issue_create", return_value=999
             ) as mock_create,
             patch("hephaestus.automation.follow_up.gh_issue_comment") as mock_comment,
-            patch("hephaestus.automation.follow_up.time.sleep"),
         ):
-            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+            response = run_follow_up_issues("sess", worktree_path, 42, tmp_path)
 
-        assert mock_create.call_count == 2
+        assert response is not None
+        assert len(response.follow_ups) == 2
+        # Exactly ONE issue filed regardless of item count
+        mock_create.assert_called_once()
+        title = mock_create.call_args.kwargs["title"]
+        body = mock_create.call_args.kwargs["body"]
+        labels = mock_create.call_args.kwargs["labels"]
+        assert "Follow-up from #42" in title
+        assert "## Core library" in body
+        assert "## Safety" in body
+        assert "follow-up" in labels
+        assert "core" in labels
+        assert "safety" in labels
+        # Summary comment posted on parent
         mock_comment.assert_called_once()
-        comment_body = mock_comment.call_args[0][1]
-        assert "#101" in comment_body
-        assert "#102" in comment_body
+        assert "#999" in mock_comment.call_args.args[1]
 
     def test_no_items_skips_issue_creation(self, tmp_path: Path) -> None:
-        """Does nothing when no items are identified."""
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
         mock_result = MagicMock()
-        mock_result.stdout = json.dumps({"result": "No follow-ups needed."})
+        mock_result.stdout = self._make_claude_output({"follow_ups": [], "rejected": []})
 
         with (
             patch("hephaestus.automation.follow_up.run", return_value=mock_result),
             patch("hephaestus.automation.follow_up.gh_issue_create") as mock_create,
+            patch("hephaestus.automation.follow_up.gh_issue_comment") as mock_comment,
         ):
-            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+            response = run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        assert response is not None
+        mock_create.assert_not_called()
+        mock_comment.assert_not_called()
+
+    def test_persists_rejected_list(self, tmp_path: Path) -> None:
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        payload = {
+            "follow_ups": [
+                {"category": "core", "title": "Real", "body": "..."},
+            ],
+            "rejected": [
+                {"title": "Web dashboard", "reason": "Feature expansion."},
+                {"title": "README polish", "reason": "Doc polish."},
+            ],
+        }
+        mock_result = MagicMock()
+        mock_result.stdout = self._make_claude_output(payload)
+
+        with (
+            patch("hephaestus.automation.follow_up.run", return_value=mock_result),
+            patch("hephaestus.automation.follow_up.gh_issue_create", return_value=1234),
+            patch("hephaestus.automation.follow_up.gh_issue_comment"),
+        ):
+            response = run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+
+        rejected_path = tmp_path / "follow-up-rejected-42.json"
+        assert rejected_path.exists()
+        persisted = json.loads(rejected_path.read_text())
+        assert len(persisted) == 2
+        assert persisted[0]["title"] == "Web dashboard"
+        # Returned response carries the rejected list too
+        assert response is not None
+        assert len(response.rejected) == 2
+
+    def test_dry_run_suppresses_github_calls(self, tmp_path: Path) -> None:
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        payload = {
+            "follow_ups": [
+                {"category": "core", "title": "T", "body": "B"},
+            ],
+            "rejected": [],
+        }
+        mock_result = MagicMock()
+        mock_result.stdout = self._make_claude_output(payload)
+
+        with (
+            patch("hephaestus.automation.follow_up.run", return_value=mock_result),
+            patch("hephaestus.automation.follow_up.gh_issue_create") as mock_create,
+            patch("hephaestus.automation.follow_up.gh_issue_comment") as mock_comment,
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path, dry_run=True)
 
         mock_create.assert_not_called()
+        mock_comment.assert_not_called()
 
     def test_failure_writes_log_and_does_not_raise(self, tmp_path: Path) -> None:
-        """On failure, writes FAILED log and does not propagate exception."""
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
         with patch(
-            "hephaestus.automation.follow_up.run", side_effect=RuntimeError("claude failed")
+            "hephaestus.automation.follow_up.run",
+            side_effect=RuntimeError("claude failed"),
         ):
-            # Should not raise
-            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+            response = run_follow_up_issues("sess", worktree_path, 42, tmp_path)
 
+        assert response is None
         log_file = tmp_path / "follow-up-42.log"
         assert log_file.exists()
         assert log_file.read_text().startswith("FAILED:")
 
     def test_cleans_up_prompt_file_on_success(self, tmp_path: Path) -> None:
-        """Prompt file is removed after successful run."""
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
         mock_result = MagicMock()
-        mock_result.stdout = json.dumps({"result": "[]"})
+        mock_result.stdout = self._make_claude_output({"follow_ups": [], "rejected": []})
 
-        with (
-            patch("hephaestus.automation.follow_up.run", return_value=mock_result),
-            patch("hephaestus.automation.follow_up.time.sleep"),
-        ):
+        with patch("hephaestus.automation.follow_up.run", return_value=mock_result):
             run_follow_up_issues("sess", worktree_path, 42, tmp_path)
 
         prompt_file = worktree_path / ".claude-followup-42.md"
         assert not prompt_file.exists()
 
     def test_cleans_up_prompt_file_on_failure(self, tmp_path: Path) -> None:
-        """Prompt file is removed even after failure."""
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
-        with patch("hephaestus.automation.follow_up.run", side_effect=RuntimeError("fail")):
+        with patch(
+            "hephaestus.automation.follow_up.run",
+            side_effect=RuntimeError("fail"),
+        ):
             run_follow_up_issues("sess", worktree_path, 42, tmp_path)
 
         prompt_file = worktree_path / ".claude-followup-42.md"
         assert not prompt_file.exists()
 
-    def test_status_tracker_updated_per_item(self, tmp_path: Path) -> None:
-        """Status tracker is called for each item when slot_id is provided."""
+    def test_status_tracker_updated_once_for_consolidated_issue(self, tmp_path: Path) -> None:
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
-        items = [{"title": "T1", "body": "B1", "labels": []}]
+        payload = {
+            "follow_ups": [
+                {"category": "core", "title": "T1", "body": "B1"},
+                {"category": "core", "title": "T2", "body": "B2"},
+            ],
+            "rejected": [],
+        }
         mock_result = MagicMock()
-        mock_result.stdout = self._make_claude_output(items)
+        mock_result.stdout = self._make_claude_output(payload)
         mock_tracker = MagicMock()
 
         with (
             patch("hephaestus.automation.follow_up.run", return_value=mock_result),
-            patch(
-                "hephaestus.automation.follow_up.find_duplicate_open_issue",
-                return_value=None,
-            ),
             patch("hephaestus.automation.follow_up.gh_issue_create", return_value=201),
             patch("hephaestus.automation.follow_up.gh_issue_comment"),
-            patch("hephaestus.automation.follow_up.time.sleep"),
         ):
             run_follow_up_issues("sess", worktree_path, 42, tmp_path, mock_tracker, slot_id=1)
 
-        mock_tracker.update_slot.assert_called_once_with(1, "#42: Creating follow-up 1/1")
+        # New policy: tracker is updated ONCE for the consolidated filing,
+        # not once per item.
+        mock_tracker.update_slot.assert_called_once()
+        assert "consolidated" in mock_tracker.update_slot.call_args.args[1]
 
 
-class TestCreateFollowUpIssuesDedup:
-    """Dedup behavior in _create_follow_up_issues."""
+class TestRenderRejectedForPRBody:
+    """Tests for render_rejected_for_pr_body."""
 
-    def test_skips_creation_when_pure_duplicate(self) -> None:
-        """When dedup finds a duplicate with no new info, skip filing entirely."""
-        items = [{"title": "Add JWT helper", "body": "JWT helper missing"}]
-        existing = IssueMatch(
-            number=42, title="Add JWT helper", body="JWT helper missing", similarity=0.95
-        )
-        with (
-            patch(
-                "hephaestus.automation.follow_up.find_duplicate_open_issue",
-                return_value=existing,
-            ),
-            patch(
-                "hephaestus.automation.follow_up.extract_new_info",
-                return_value="",
-            ),
-            patch("hephaestus.automation.follow_up.gh_issue_create") as mock_create,
-            patch("hephaestus.automation.follow_up.gh_issue_comment") as mock_comment,
-            patch("hephaestus.automation.follow_up.time.sleep"),
-        ):
-            created = _create_follow_up_issues(items, 7, None, None)
+    def test_returns_empty_when_none_rejected(self) -> None:
+        assert render_rejected_for_pr_body([]) == ""
 
-        assert created == []
-        mock_create.assert_not_called()
-        mock_comment.assert_not_called()
+    def test_renders_markdown_section(self) -> None:
+        rejected = [
+            RejectedItem(title="Add web dashboard", reason="Feature expansion."),
+            RejectedItem(title="README polish", reason="Doc polish."),
+        ]
+        rendered = render_rejected_for_pr_body(rejected)
+        assert "## Considered & rejected follow-ups" in rendered
+        assert "Add web dashboard" in rendered
+        assert "Feature expansion." in rendered
+        assert "README polish" in rendered
 
-    def test_comments_on_duplicate_when_new_info(self) -> None:
-        """When dedup finds a duplicate with new info, comment on existing instead of creating."""
-        items = [{"title": "Add JWT helper", "body": "old + new info"}]
-        existing = IssueMatch(number=42, title="Add JWT helper", body="old", similarity=0.92)
-        with (
-            patch(
-                "hephaestus.automation.follow_up.find_duplicate_open_issue",
-                return_value=existing,
-            ),
-            patch(
-                "hephaestus.automation.follow_up.extract_new_info",
-                return_value="new info para",
-            ),
-            patch("hephaestus.automation.follow_up.gh_issue_create") as mock_create,
-            patch("hephaestus.automation.follow_up.gh_issue_comment") as mock_comment,
-            patch("hephaestus.automation.follow_up.time.sleep"),
-        ):
-            created = _create_follow_up_issues(items, 7, None, None)
 
-        assert created == []
-        mock_create.assert_not_called()
-        mock_comment.assert_called_once()
-        assert mock_comment.call_args[0][0] == 42
-        assert "new info para" in mock_comment.call_args[0][1]
+class TestDataclasses:
+    """Tests for the frozen dataclasses exposed by follow_up."""
 
-    def test_creates_issue_when_no_duplicate(self) -> None:
-        """When no duplicate is found, fall through to gh_issue_create."""
-        items = [{"title": "Brand new topic", "body": "details", "labels": ["x"]}]
-        with (
-            patch(
-                "hephaestus.automation.follow_up.find_duplicate_open_issue",
-                return_value=None,
-            ),
-            patch(
-                "hephaestus.automation.follow_up.gh_issue_create",
-                return_value=999,
-            ) as mock_create,
-            patch("hephaestus.automation.follow_up.gh_issue_comment") as mock_comment,
-            patch("hephaestus.automation.follow_up.time.sleep"),
-        ):
-            created = _create_follow_up_issues(items, 7, None, None)
+    def test_follow_up_item_is_frozen(self) -> None:
+        item = FollowUpItem(category="core", title="T", body="B")
+        try:
+            item.title = "other"  # type: ignore[misc]
+        except Exception:
+            return
+        raise AssertionError("FollowUpItem should be frozen")
 
-        assert created == [999]
-        mock_create.assert_called_once()
-        mock_comment.assert_not_called()
+    def test_follow_up_response_defaults(self) -> None:
+        r = FollowUpResponse()
+        assert r.follow_ups == []
+        assert r.rejected == []

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -61,6 +61,23 @@ class TestFollowUpPrompt:
         out = prompts.get_follow_up_prompt(123)
         assert "123" in out
 
+    def test_declares_scope_categories(self) -> None:
+        out = prompts.get_follow_up_prompt(1)
+        # The four categories the parser will accept must all be named
+        # explicitly in the prompt.
+        for category in ("core", "security", "safety", "critical_bug"):
+            assert category in out
+
+    def test_explicitly_rejects_feature_expansion(self) -> None:
+        out = prompts.get_follow_up_prompt(1)
+        # The prompt must explicitly tell Claude NOT to file follow-ups for
+        # feature expansion / nice-to-haves / documentation polish.
+        assert "OUT OF SCOPE" in out or "out of scope" in out.lower()
+        assert "rejected" in out.lower()
+        # Output schema is the new sectioned object (not the legacy flat array)
+        assert "follow_ups" in out
+        assert "category" in out
+
 
 class TestPRDescription:
     """Tests for p r description."""


### PR DESCRIPTION
## Summary

Replaces the previous "up to 5 separate GitHub issues per implementation"
behavior with a **single consolidated issue** per implementation, sectioned
by category. Tightens `FOLLOW_UP_PROMPT` so Claude can no longer file follow-ups
that expand the issue's scope into new domains.

## Why

The previous follow-up automation was filing too many issues, doing
extraneous work outside the repo's actual scope (cross-repo, doc polish,
speculative research, refactors driven by aesthetics). The user's directive
on 2026-05-10: only file follow-ups that fall under **core library
functionality, security, safety, or critical functional bugs** — and ship
all of them as a single GitHub issue, not five.

## Changes

- `hephaestus/automation/prompts.py` — rewrote `FOLLOW_UP_PROMPT` with:
  - Four allowed categories: `core`, `security`, `safety`, `critical_bug`.
  - Explicit OUT-OF-SCOPE list (features, doc polish, refactors, cross-repo,
    "consider X", coverage for unrelated code, anything that expands scope).
  - HARD CAP of 3 follow-ups per implementation.
  - Output schema: a single JSON object with `follow_ups` and `rejected` arrays.
- `hephaestus/automation/follow_up.py` — replaced the per-item filing model:
  - `parse_follow_up_response(text) -> FollowUpResponse` — typed result with
    `follow_ups` and `rejected` lists.
  - `run_follow_up_issues(...)` now files **at most one** consolidated issue,
    and writes the rejected list to `state_dir/follow-up-rejected-{N}.json`
    so the implementer can render it into the PR body.
  - `render_rejected_for_pr_body(rejected)` — markdown helper for embedding
    the rejected list into a PR body.
  - `parse_follow_up_items()` retained as a thin adapter projecting the new
    schema into the legacy `[{title, body, labels}, ...]` shape (backward
    compat).
  - Cross-issue dedup against existing open issues was dropped — no longer
    needed because there's only ever one consolidated issue per
    implementation, and the consolidated issue is filed under
    `parent_issue_number → consolidated_followup_issue_number` which is
    already a 1:1 mapping.
- Tests: rewrote `test_follow_up.py` for the new schema. Added prompt-content
  assertions to `test_prompts.py` to lock in the scope guardrails.

## Backward compat

- `run_follow_up_issues()` public signature unchanged except the return type
  is now `FollowUpResponse | None` (was `None`). Existing callers that
  ignored the return value continue to work.
- `parse_follow_up_items()` legacy adapter retained.
- `IssueImplementer._parse_follow_up_items` and `_run_follow_up_issues`
  thin wrappers in `implementer.py` are unaffected.

## Validation

- 2044 unit tests pass; 83.16% coverage (>= 80% threshold).
- `pixi run ruff check` clean.
- `pixi run mypy` clean.
- `pixi run pre-commit run --all-files` all hooks pass.
- Branch rebased onto `origin/main`.

## Out of scope

- Existing follow-up issues already filed under the old policy are not
  retroactively swept (per session decision: behavior change applies going
  forward only). A separate audit can clean those up if desired.
- The `IssueImplementer` does not yet pass the rejected list into the PR
  body it creates — that is a one-line change in `implementer.py` and is
  deferred to avoid colliding with PR #394 (the ongoing SRP refactor of
  `implementer.py`). After #394 lands, a small follow-up wires
  `render_rejected_for_pr_body(response.rejected)` into the PR body builder.

## Test plan

- [x] Unit tests (2044 pass, 83.16% coverage)
- [x] ruff, mypy, pre-commit all clean
- [ ] End-to-end: run `hephaestus-implement-issues --issues <N> --dry-run -v`
      after merge against a known issue and verify (a) at most one
      consolidated issue is filed, (b) the rejected list is persisted to
      the state dir, (c) Claude's output respects the new scope categories.