### PR TITLE
refactor(config): consolidate get_setting/get_config_value (W10)

### DIFF
--- a/hephaestus/config/utils.py
+++ b/hephaestus/config/utils.py
@@ -14,6 +14,7 @@ Usage:
 import contextlib
 import json
 import os
+import warnings
 from pathlib import Path
 from typing import Any, cast
 
@@ -284,18 +285,34 @@ def merge_with_env(
     return merge_configs(config, env_config)
 
 
-# Example usage function
 def get_config_value(
     key_path: str,
     default: Any | None = None,
     config_files: list[str] | None = None,
     convert_bools: bool = False,
 ) -> Any:
-    """High-level function to get a configuration value with full merging.
+    """High-level convenience wrapper — **deprecated**, use :func:`get_setting` instead.
 
-    Loads defaults, then user config, then environment variables.
-    Environment variables use double underscores (``__``) as nesting
-    delimiters — see :func:`merge_with_env` for details.
+    ``get_config_value`` and ``get_setting`` have overlapping apparent purpose,
+    violating POLA.  ``get_setting`` is the canonical function for retrieving a
+    value from an already-loaded config dict using dot-notation.
+
+    Migration path::
+
+        # Old (deprecated):
+        value = get_config_value("database.host", default="localhost",
+                                 config_files=["config.yaml"])
+
+        # New (explicit pipeline — preferred):
+        config = load_config("config.yaml")
+        config = merge_with_env(config)
+        value = get_setting(config, "database.host", default="localhost")
+
+    This wrapper will be removed in a future release.
+
+    .. deprecated::
+        Use :func:`load_config`, :func:`merge_with_env`, and :func:`get_setting`
+        together to build an explicit, auditable configuration pipeline.
 
     Args:
         key_path: Dot-separated path to setting
@@ -309,7 +326,15 @@ def get_config_value(
         Configuration value or default
 
     """
-    config = {}
+    warnings.warn(
+        "get_config_value() is deprecated and will be removed in a future release. "
+        "Use load_config(), merge_with_env(), and get_setting() to build an explicit "
+        "configuration pipeline instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    config: dict[str, Any] = {}
 
     # Load default config if exists
     default_config_path = Path("config/default.yaml")

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -550,31 +550,65 @@ class TestLoadYamlConfig:
 
 
 class TestGetConfigValue:
-    """Tests for get_config_value."""
+    """Tests for get_config_value (deprecated wrapper around get_setting).
+
+    All calls to get_config_value must pass through pytest.warns(DeprecationWarning)
+    because the function emits a DeprecationWarning on every call.
+    """
+
+    def test_emits_deprecation_warning(self):
+        """get_config_value emits a DeprecationWarning on every call."""
+        with pytest.warns(DeprecationWarning, match="get_config_value\\(\\) is deprecated"):
+            get_config_value("nonexistent.key", default="fallback")
+
+    def test_deprecation_warning_mentions_get_setting(self):
+        """DeprecationWarning message references the replacement functions."""
+        with pytest.warns(DeprecationWarning) as warning_list:
+            get_config_value("nonexistent.key")
+        assert len(warning_list) == 1
+        msg = str(warning_list[0].message)
+        assert "get_setting" in msg
 
     def test_returns_default_when_not_found(self):
         """Returns default when config key is not found."""
-        result = get_config_value("nonexistent.key", default="fallback")
+        with pytest.warns(DeprecationWarning):
+            result = get_config_value("nonexistent.key", default="fallback")
         assert result == "fallback"
 
     def test_returns_none_when_no_default(self):
         """Returns None when key not found and no default given."""
-        result = get_config_value("nonexistent.key")
+        with pytest.warns(DeprecationWarning):
+            result = get_config_value("nonexistent.key")
         assert result is None
 
     def test_with_config_files(self, tmp_config_yaml):
         """Loads from provided config_files list."""
-        result = get_config_value("database.host", config_files=[str(tmp_config_yaml)])
+        with pytest.warns(DeprecationWarning):
+            result = get_config_value("database.host", config_files=[str(tmp_config_yaml)])
         assert result == "localhost"
 
     def test_convert_bools_false_by_default(self, monkeypatch):
         """Boolean-like env vars stay as strings by default."""
         monkeypatch.setenv("HEPHAESTUS_FLAG", "true")
-        result = get_config_value("flag")
+        with pytest.warns(DeprecationWarning):
+            result = get_config_value("flag")
         assert result == "true"
 
     def test_convert_bools_propagated_to_merge_with_env(self, monkeypatch):
         """convert_bools=True converts boolean-like env var strings to bool."""
         monkeypatch.setenv("HEPHAESTUS_FEATURE__ENABLED", "yes")
-        result = get_config_value("feature.enabled", convert_bools=True)
+        with pytest.warns(DeprecationWarning):
+            result = get_config_value("feature.enabled", convert_bools=True)
         assert result is True
+
+    def test_delegates_to_get_setting(self, tmp_config_yaml):
+        """get_config_value delegates to get_setting for the actual lookup."""
+        # Verify the result matches what the explicit pipeline would return.
+        with pytest.warns(DeprecationWarning):
+            deprecated_result = get_config_value(
+                "database.port", config_files=[str(tmp_config_yaml)]
+            )
+        config = load_config(tmp_config_yaml)
+        config = merge_with_env(config)
+        canonical_result = get_setting(config, "database.port")
+        assert deprecated_result == canonical_result


### PR DESCRIPTION
## Summary

- Designates `get_setting()` as the canonical function for config lookups (lower-level, clearer name, used in all scripts and examples)
- Adds `DeprecationWarning` to `get_config_value()` with migration guidance pointing callers to the explicit `load_config → merge_with_env → get_setting` pipeline
- Updates `TestGetConfigValue` to assert the warning fires on every call and that the deprecated wrapper still delegates correctly to `get_setting()`

Resolves the POLA violation from issue #330: two public functions with overlapping apparent purpose now have a clear canonical/deprecated relationship.

## Migration path

```python
# Old (deprecated):
value = get_config_value("database.host", default="localhost", config_files=["config.yaml"])

# New (explicit pipeline — preferred):
config = load_config("config.yaml")
config = merge_with_env(config)
value = get_setting(config, "database.host", default="localhost")
```

## Test plan

- [x] All 2039 unit tests pass (`83.19%` coverage)
- [x] `ruff check` — no issues
- [x] `mypy` — no issues
- [x] Python pre-commit hooks (`ruff-check-python`, `ruff-format-python`, `mypy-check-python`) — all passed
- [x] `test_emits_deprecation_warning` — `pytest.warns(DeprecationWarning)` asserted on every `get_config_value()` call
- [x] `test_deprecation_warning_mentions_get_setting` — warning message references the replacement
- [x] `test_delegates_to_get_setting` — deprecated wrapper produces same result as the explicit pipeline

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)