### PR TITLE
fix(reviewers): allowedTools, idempotency, thread provenance, slot protocol (W15c)

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -1,0 +1,150 @@
+"""Shared helpers for the PR / plan reviewer trio.
+
+Extracts utilities that were previously duplicated across
+``pr_reviewer.py`` and ``address_review.py``.
+
+Provides:
+- ``parse_json_block``: Extract the last ```json``` block from Claude output.
+- ``find_pr_for_issue``: Locate the open PR for a GitHub issue (two or three
+  lookup strategies depending on the caller's needs).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from .github_api import _gh_call
+
+logger = logging.getLogger(__name__)
+
+
+def parse_json_block(text: str) -> dict[str, Any]:
+    """Extract the last ```json ... ``` block from Claude's response.
+
+    Args:
+        text: Claude's full response text.
+
+    Returns:
+        Parsed dict, or a default dict with empty collections on failure.
+
+    """
+    matches = re.findall(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if not matches:
+        return {"comments": [], "summary": "No structured output from analysis"}
+    try:
+        return dict(json.loads(matches[-1]))
+    except json.JSONDecodeError:
+        return {"comments": [], "summary": "Failed to parse structured output from analysis"}
+
+
+def find_pr_for_issue(
+    issue_number: int,
+    *,
+    extra_strategies: bool = False,
+    _load_review_state_fn: Any = None,
+) -> int | None:
+    """Find the open PR for a single issue.
+
+    Always tries two strategies:
+
+    1. Branch name lookup (``{issue}-auto-impl``).
+    2. PR-body text search (``#{issue} in:body``).
+
+    When ``extra_strategies=True`` a third strategy is attempted between 1
+    and 2: the stored ``pr_number`` from the on-disk review state is
+    checked via ``gh pr view``.  The caller supplies ``_load_review_state_fn``
+    (a zero-arg callable that returns a ``ReviewState | None``) to keep this
+    module free of circular imports.
+
+    Args:
+        issue_number: GitHub issue number.
+        extra_strategies: When True, also check the on-disk review state.
+        _load_review_state_fn: Callable ``() -> ReviewState | None`` used
+            when ``extra_strategies=True``.
+
+    Returns:
+        PR number if found, ``None`` otherwise.
+
+    """
+    # Strategy 1: branch-name lookup
+    branch_name = f"{issue_number}-auto-impl"
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "list",
+                "--head",
+                branch_name,
+                "--state",
+                "open",
+                "--json",
+                "number",
+                "--limit",
+                "1",
+            ],
+            check=False,
+        )
+        pr_data = json.loads(result.stdout or "[]")
+        if pr_data:
+            pr_number = int(pr_data[0]["number"])
+            logger.info("Found PR #%d for issue #%d via branch name", pr_number, issue_number)
+            return pr_number
+    except Exception as e:
+        logger.debug("Branch-name lookup failed for issue #%d: %s", issue_number, e)
+
+    # Strategy 2 (optional): on-disk review state
+    if extra_strategies and _load_review_state_fn is not None:
+        review_state = _load_review_state_fn()
+        if review_state is not None and review_state.pr_number:
+            try:
+                result = _gh_call(
+                    [
+                        "pr",
+                        "view",
+                        str(review_state.pr_number),
+                        "--json",
+                        "number,state",
+                    ],
+                    check=False,
+                )
+                pr_data = json.loads(result.stdout or "{}")
+                if pr_data.get("state", "").upper() == "OPEN":
+                    pr_number = int(review_state.pr_number)
+                    logger.info(
+                        "Found PR #%d for issue #%d via review state",
+                        pr_number,
+                        issue_number,
+                    )
+                    return pr_number
+            except Exception as e:
+                logger.debug("Review state PR lookup failed for issue #%d: %s", issue_number, e)
+
+    # Strategy 3: PR-body text search
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--search",
+                f"#{issue_number} in:body",
+                "--json",
+                "number",
+                "--limit",
+                "5",
+            ],
+            check=False,
+        )
+        pr_data = json.loads(result.stdout or "[]")
+        if pr_data:
+            pr_number = int(pr_data[0]["number"])
+            logger.info("Found PR #%d for issue #%d via body search", pr_number, issue_number)
+            return pr_number
+    except Exception as e:
+        logger.debug("Body search failed for issue #%d: %s", issue_number, e)
+
+    return None

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -25,12 +25,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ._review_utils import find_pr_for_issue
 from .claude_models import implementer_model
 from .claude_timeouts import address_review_claude_timeout
 from .curses_ui import CursesUI, ThreadLogManager
 from .git_utils import get_repo_root, run
 from .github_api import (
-    _gh_call,
     gh_pr_list_unresolved_threads,
     gh_pr_resolve_thread,
     write_secure,
@@ -156,9 +156,12 @@ class AddressReviewer:
         with ThreadPoolExecutor(max_workers=self.options.max_workers) as executor:
             futures: dict[Future[Any], int] = {}
 
-            for idx, (issue_num, pr_num) in enumerate(pr_map.items()):
-                slot_id = idx % self.options.max_workers
-                future = executor.submit(self._address_issue, issue_num, pr_num, slot_id)
+            for issue_num, pr_num in pr_map.items():
+                # Slot acquisition happens inside _address_issue via
+                # self.status_tracker.acquire_slot() so workers that exceed
+                # max_workers block rather than racing on a pre-assigned index
+                # (#A3-005).
+                future = executor.submit(self._address_issue, issue_num, pr_num)
                 futures[future] = issue_num
 
             # Backoff on repeated wait() failures so a flapping condition
@@ -202,20 +205,20 @@ class AddressReviewer:
         self._print_summary(results)
         return results
 
-    def _address_issue(self, issue_number: int, pr_number: int, slot_id: int) -> WorkerResult:
+    def _address_issue(self, issue_number: int, pr_number: int) -> WorkerResult:
         """Address unresolved review threads for a single issue.
 
         The pr_number is pre-discovered by run() — no Claude agent is ever launched
         for issues that have no open PR.
 
         Flow:
-        1. List unresolved threads
-        2. Load impl session_id from state file
-        3. Load/create review state
-        4. Checkout worktree for the PR branch
-        5. Run Claude fix session
-        6. Parse JSON from Claude output
-        7. DRY-RUN GUARD: return before any writes if dry_run
+        1. Acquire worker slot via StatusTracker
+        2. List unresolved threads
+        3. DRY-RUN GUARD: return before any worktree/state mutations if dry_run
+        4. Load impl session_id from state file
+        5. Load/create review state
+        6. Checkout worktree for the PR branch
+        7. Run Claude fix session
         8. Commit changes if any
         9. Push branch
         10. Resolve addressed threads
@@ -225,18 +228,26 @@ class AddressReviewer:
         Args:
             issue_number: GitHub issue number
             pr_number: Pre-discovered open PR number for this issue
-            slot_id: Worker slot ID for status updates
 
         Returns:
             WorkerResult
 
         """
+        # Step 1: Acquire slot (mirrors pr_reviewer/_review_pr pattern, fixes A3-005)
+        slot_id = self.status_tracker.acquire_slot()
+        if slot_id is None:
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error="Failed to acquire worker slot",
+            )
+
         thread_id = threading.get_ident()
         self.status_tracker.update_slot(slot_id, f"#{issue_number}: Starting")
         self._log("info", f"Addressing PR #{pr_number} for issue #{issue_number}", thread_id)
 
         try:
-            # Step 2: List unresolved threads
+            # Step 1: List unresolved threads
             self.status_tracker.update_slot(slot_id, f"#{issue_number}: Listing threads")
             threads = gh_pr_list_unresolved_threads(pr_number, dry_run=self.options.dry_run)
             if not threads:
@@ -256,6 +267,21 @@ class AddressReviewer:
                 f"Found {len(threads)} unresolved thread(s) on PR #{pr_number}",
                 thread_id,
             )
+
+            # Step 2: DRY-RUN GUARD — must come before any worktree creation or
+            # state mutation so that dry-run leaves no side-effects on disk (#A3-004).
+            if self.options.dry_run:
+                self._log(
+                    "info",
+                    f"[DRY RUN] Would address {len(threads)} unresolved thread(s) "
+                    f"and push for PR #{pr_number}",
+                    thread_id,
+                )
+                return WorkerResult(
+                    issue_number=issue_number,
+                    success=True,
+                    pr_number=pr_number,
+                )
 
             # Step 3: Load impl session_id
             session_id = self._load_impl_session_id(issue_number)
@@ -304,36 +330,20 @@ class AddressReviewer:
                 thread_id,
             )
 
-            # Step 8: DRY-RUN GUARD
-            if self.options.dry_run:
-                self._log(
-                    "info",
-                    f"[DRY RUN] Would resolve {len(addressed)} thread(s) "
-                    f"and push for PR #{pr_number}",
-                    thread_id,
-                )
-                return WorkerResult(
-                    issue_number=issue_number,
-                    success=True,
-                    pr_number=pr_number,
-                    branch_name=branch_name,
-                    worktree_path=str(worktree_path),
-                )
-
-            # Step 9: Commit changes if any
+            # Step 7: Commit changes if any
             self.status_tracker.update_slot(slot_id, f"#{issue_number}: Committing")
             self._commit_if_changes(issue_number, worktree_path)
 
-            # Step 10: Push branch
+            # Step 8: Push branch
             self.status_tracker.update_slot(slot_id, f"#{issue_number}: Pushing")
             self._push_branch(branch_name, worktree_path)
 
-            # Step 11: Resolve addressed threads
+            # Step 9: Resolve addressed threads
             self.status_tracker.update_slot(slot_id, f"#{issue_number}: Resolving threads")
             presented_thread_ids = {t["id"] for t in threads}
             self._resolve_addressed_threads(addressed, replies, presented_thread_ids)
 
-            # Step 12: Update review state
+            # Step 10: Update review state
             with self.state_lock:
                 existing_ids = set(review_state.addressed_thread_ids)
                 for tid in addressed:
@@ -385,7 +395,10 @@ class AddressReviewer:
     def _find_pr_for_issue(self, issue_number: int) -> int | None:
         """Find the open PR for a single issue.
 
-        Tries branch name lookup first, then falls back to body search.
+        Delegates to :func:`_review_utils.find_pr_for_issue` using the
+        three-strategy variant (branch-name, on-disk review state, body
+        search) so that the stored ``pr_number`` from a previous reviewer
+        run is also consulted.
 
         Args:
             issue_number: GitHub issue number
@@ -394,83 +407,11 @@ class AddressReviewer:
             PR number if found, None otherwise
 
         """
-        # Strategy 1: Look for branch named {issue}-auto-impl
-        branch_name = f"{issue_number}-auto-impl"
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--head",
-                    branch_name,
-                    "--state",
-                    "open",
-                    "--json",
-                    "number",
-                    "--limit",
-                    "1",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                pr_number = pr_data[0]["number"]
-                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via branch name")
-                return int(pr_number)
-        except Exception as e:
-            logger.debug(f"Branch-name lookup failed for issue #{issue_number}: {e}")
-
-        # Strategy 2: Check review state for stored pr_number
-        review_state = self._load_review_state(issue_number)
-        if review_state and review_state.pr_number:
-            # Verify the PR is still open
-            try:
-                result = _gh_call(
-                    [
-                        "pr",
-                        "view",
-                        str(review_state.pr_number),
-                        "--json",
-                        "number,state",
-                    ],
-                    check=False,
-                )
-                pr_data = json.loads(result.stdout or "{}")
-                if pr_data.get("state", "").upper() == "OPEN":
-                    logger.info(
-                        f"Found PR #{review_state.pr_number} for issue #{issue_number} "
-                        "via review state"
-                    )
-                    return int(review_state.pr_number)
-            except Exception as e:
-                logger.debug(f"Review state PR lookup failed for issue #{issue_number}: {e}")
-
-        # Strategy 3: Search PR body for issue reference
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--state",
-                    "open",
-                    "--search",
-                    f"#{issue_number} in:body",
-                    "--json",
-                    "number",
-                    "--limit",
-                    "5",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                pr_number = pr_data[0]["number"]
-                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via body search")
-                return int(pr_number)
-        except Exception as e:
-            logger.debug(f"Body search failed for issue #{issue_number}: {e}")
-
-        return None
+        return find_pr_for_issue(
+            issue_number,
+            extra_strategies=True,
+            _load_review_state_fn=lambda: self._load_review_state(issue_number),
+        )
 
     def _load_impl_session_id(self, issue_number: int) -> str | None:
         """Load the implementer's Claude session ID from state file.
@@ -641,23 +582,40 @@ class AddressReviewer:
                         timeout=claude_timeout,
                     )
                 except subprocess.CalledProcessError as e:
-                    stderr = e.stderr or ""
-                    # Fall back to fresh session on session-not-found errors
-                    if any(
-                        phrase in stderr.lower()
-                        for phrase in ("session not found", "invalid session", "session expired")
-                    ):
+                    stderr = (e.stderr or "").lower()
+                    stdout = (e.stdout or "").lower()
+                    combined = stderr + stdout
+                    # Well-known "session gone" phrases (#A3-010 extended list)
+                    session_error_phrases = (
+                        "session not found",
+                        "invalid session",
+                        "session expired",
+                        "no such session",
+                        "session does not exist",
+                        "cannot resume",
+                        "resume failed",
+                        "failed to resume",
+                    )
+                    # Fall back to fresh session on any --resume failure:
+                    # either a known "session gone" phrase in stderr/stdout,
+                    # OR any non-zero exit from a --resume invocation (the
+                    # phrase list can never be exhaustive, so we default to
+                    # fresh-session on unknown errors too — losing the resume
+                    # context is preferable to a hard failure).
+                    if any(phrase in combined for phrase in session_error_phrases) or True:
                         logger.warning(
-                            f"Session {session_id!r} not found for issue #{issue_number}; "
-                            "falling back to fresh session"
+                            "Session %r resume failed for issue #%d (exit=%d, reason=%r); "
+                            "falling back to fresh session",
+                            session_id,
+                            issue_number,
+                            e.returncode,
+                            (e.stderr or "")[:120],
                         )
                         result = run(
                             _build_cmd(with_resume=False),
                             cwd=worktree_path,
                             timeout=claude_timeout,
                         )
-                    else:
-                        raise
             else:
                 result = run(
                     _build_cmd(with_resume=False),

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -653,6 +653,13 @@ def gh_pr_review_post(
         for c in comments
     ]
 
+    # The mutation returns only the review-level comment nodes.  Each
+    # inline comment belongs to exactly one review thread; we ask for the
+    # ``pullRequestReviewThread`` on every comment so we can collect the
+    # thread IDs created by *this* review only — not every unresolved thread
+    # on the PR.  This fixes the "foreign thread" bug (#375) where the old
+    # approach fetched ``pullRequest { reviewThreads(last: 50) }`` and
+    # returned pre-existing threads from human reviewers.
     mutation = """
 mutation AddReview(
   $prId: ID!, $body: String!,
@@ -664,9 +671,12 @@ mutation AddReview(
   ) {
     pullRequestReview {
       id
-      pullRequest {
-        reviewThreads(last: 50) {
-          nodes { id isResolved }
+      comments(first: 50) {
+        nodes {
+          pullRequestReviewThread {
+            id
+            isResolved
+          }
         }
       }
     }
@@ -695,10 +705,21 @@ mutation AddReview(
     data = json.loads(result.stdout)
     _check_graphql_errors(data, f"gh_pr_review_post(pr={pr_number})")
     review_data = data.get("data", {}).get("addPullRequestReview", {}).get("pullRequestReview", {})
-    thread_nodes = review_data.get("pullRequest", {}).get("reviewThreads", {}).get("nodes", [])
-    thread_ids: list[str] = [
-        node["id"] for node in thread_nodes if not node.get("isResolved", True)
-    ]
+    comment_nodes = review_data.get("comments", {}).get("nodes", [])
+
+    # Deduplicate: multiple comments may belong to the same thread (e.g.
+    # multi-line comments), so collect unique thread IDs using a dict to
+    # preserve insertion order.
+    seen: dict[str, None] = {}
+    for comment_node in comment_nodes:
+        thread_info = comment_node.get("pullRequestReviewThread")
+        if thread_info is None:
+            continue
+        tid = thread_info.get("id")
+        if tid and not thread_info.get("isResolved", False):
+            seen[tid] = None
+
+    thread_ids: list[str] = list(seen)
     logger.info(f"Posted PR review on #{pr_number}; created {len(thread_ids)} thread(s)")
     return thread_ids
 

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -200,8 +200,53 @@ class PlanReviewer:
         finally:
             self.status_tracker.release_slot(acquired_slot)
 
+    def _fetch_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        """Fetch all comments for an issue, caching the result per instance.
+
+        Both ``_has_existing_review`` and ``_get_latest_plan`` call this
+        helper so the ``gh issue view --comments`` API is hit only once per
+        issue per worker invocation (#A3-009).
+
+        Args:
+            issue_number: GitHub issue number.
+
+        Returns:
+            List of comment dicts (may be empty on error).
+
+        """
+        cache_attr = "_comments_cache"
+        if not hasattr(self, cache_attr):
+            object.__setattr__(self, cache_attr, {})
+        cache: dict[int, list[dict[str, Any]]] = getattr(self, cache_attr)
+
+        if issue_number in cache:
+            return cache[issue_number]
+
+        try:
+            result = _gh_call(
+                [
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--comments",
+                    "--json",
+                    "comments",
+                ],
+            )
+            data = json.loads(result.stdout)
+            comments: list[dict[str, Any]] = data.get("comments", [])
+        except Exception as e:
+            logger.warning(f"Failed to fetch comments for issue #{issue_number}: {e}")
+            comments = []
+
+        cache[issue_number] = comments
+        return comments
+
     def _get_latest_plan(self, issue_number: int) -> str | None:
-        """Fetch comments and return the body of the last comment that looks like a plan.
+        """Return the body of the last comment that looks like a plan.
+
+        Uses :meth:`_fetch_issue_comments` so the API call is shared with
+        :meth:`_has_existing_review`.
 
         Args:
             issue_number: GitHub issue number.
@@ -210,35 +255,22 @@ class PlanReviewer:
             Plan comment body text, or None if no plan comment is found.
 
         """
-        try:
-            result = _gh_call(
-                [
-                    "issue",
-                    "view",
-                    str(issue_number),
-                    "--comments",
-                    "--json",
-                    "comments",
-                ],
-            )
-            data = json.loads(result.stdout)
-            comments: list[dict[str, Any]] = data.get("comments", [])
+        comments = self._fetch_issue_comments(issue_number)
 
-            # Walk in reverse to find the *last* plan comment
-            for comment in reversed(comments):
-                body: str = comment.get("body", "")
-                if any(marker in body for marker in _PLAN_MARKERS):
-                    logger.debug(f"Found plan comment for issue #{issue_number}")
-                    return body
+        # Walk in reverse to find the *last* plan comment
+        for comment in reversed(comments):
+            body: str = comment.get("body", "")
+            if any(marker in body for marker in _PLAN_MARKERS):
+                logger.debug(f"Found plan comment for issue #{issue_number}")
+                return body
 
-            return None
-
-        except Exception as e:
-            logger.warning(f"Failed to fetch comments for issue #{issue_number}: {e}")
-            return None
+        return None
 
     def _has_existing_review(self, issue_number: int) -> bool:
         """Check whether any comment is already a plan review.
+
+        Uses :meth:`_fetch_issue_comments` so the API call is shared with
+        :meth:`_get_latest_plan`.
 
         Args:
             issue_number: GitHub issue number.
@@ -247,31 +279,15 @@ class PlanReviewer:
             True if a review comment already exists.
 
         """
-        try:
-            result = _gh_call(
-                [
-                    "issue",
-                    "view",
-                    str(issue_number),
-                    "--comments",
-                    "--json",
-                    "comments",
-                ],
-            )
-            data = json.loads(result.stdout)
-            comments: list[dict[str, Any]] = data.get("comments", [])
+        comments = self._fetch_issue_comments(issue_number)
 
-            for comment in comments:
-                body: str = comment.get("body", "")
-                if body.startswith(_REVIEW_PREFIX):
-                    logger.debug(f"Found existing review for issue #{issue_number}")
-                    return True
+        for comment in comments:
+            body: str = comment.get("body", "")
+            if body.startswith(_REVIEW_PREFIX):
+                logger.debug(f"Found existing review for issue #{issue_number}")
+                return True
 
-            return False
-
-        except Exception as e:
-            logger.warning(f"Failed to check for existing review on issue #{issue_number}: {e}")
-            return False
+        return False
 
     def _run_claude_analysis(
         self,
@@ -316,7 +332,16 @@ class PlanReviewer:
 
         try:
             result = subprocess.run(
-                ["claude", "--model", reviewer_model(), "--print", "--output-format", "text"],
+                [
+                    "claude",
+                    "--model",
+                    reviewer_model(),
+                    "--print",
+                    "--output-format",
+                    "text",
+                    "--allowedTools",
+                    "Read,Glob,Grep",
+                ],
                 input=prompt,
                 capture_output=True,
                 text=True,

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -16,7 +16,6 @@ import argparse
 import contextlib
 import json
 import logging
-import re
 import subprocess
 import threading
 import time
@@ -25,6 +24,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ._review_utils import find_pr_for_issue, parse_json_block
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
 from .curses_ui import CursesUI, ThreadLogManager
@@ -41,6 +41,9 @@ logger = logging.getLogger(__name__)
 def _parse_json_block(text: str) -> dict[str, Any]:
     """Extract the last ```json ... ``` block from Claude's response.
 
+    Thin wrapper around :func:`_review_utils.parse_json_block` kept for
+    backward compatibility with existing callers and tests.
+
     Args:
         text: Claude's full response text
 
@@ -48,13 +51,7 @@ def _parse_json_block(text: str) -> dict[str, Any]:
         Parsed dict with keys "comments" and "summary", or defaults if not found
 
     """
-    matches = re.findall(r"```json\s*(.*?)\s*```", text, re.DOTALL)
-    if not matches:
-        return {"comments": [], "summary": "No structured output from analysis"}
-    try:
-        return dict(json.loads(matches[-1]))
-    except json.JSONDecodeError:
-        return {"comments": [], "summary": "Failed to parse structured output from analysis"}
+    return parse_json_block(text)
 
 
 class PRReviewer:
@@ -164,6 +161,9 @@ class PRReviewer:
     def _find_pr_for_issue(self, issue_number: int) -> int | None:
         """Find the open PR for a single issue.
 
+        Delegates to :func:`_review_utils.find_pr_for_issue` (two-strategy
+        variant: branch-name lookup then body search).
+
         Args:
             issue_number: GitHub issue number
 
@@ -171,58 +171,7 @@ class PRReviewer:
             PR number if found, None otherwise
 
         """
-        # Strategy 1: Look for branch named {issue}-auto-impl
-        branch_name = f"{issue_number}-auto-impl"
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--head",
-                    branch_name,
-                    "--state",
-                    "open",
-                    "--json",
-                    "number",
-                    "--limit",
-                    "1",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                pr_number = pr_data[0]["number"]
-                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via branch name")
-                return int(pr_number)
-        except Exception as e:
-            logger.debug(f"Branch-name lookup failed for issue #{issue_number}: {e}")
-
-        # Strategy 2: Search PR body for issue reference
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--state",
-                    "open",
-                    "--search",
-                    f"#{issue_number} in:body",
-                    "--json",
-                    "number",
-                    "--limit",
-                    "5",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                pr_number = pr_data[0]["number"]
-                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via body search")
-                return int(pr_number)
-        except Exception as e:
-            logger.debug(f"Body search failed for issue #{issue_number}: {e}")
-
-        return None
+        return find_pr_for_issue(issue_number)
 
     def _gather_pr_context(
         self,
@@ -387,7 +336,7 @@ class PRReviewer:
                     "--permission-mode",
                     "dontAsk",
                     "--allowedTools",
-                    "Read,Glob,Grep,Bash",
+                    "Read,Glob,Grep",
                 ],
                 cwd=worktree_path,
                 timeout=pr_reviewer_claude_timeout(),
@@ -436,6 +385,14 @@ class PRReviewer:
     def _get_or_create_state(self, issue_number: int, pr_number: int) -> ReviewState:
         """Get or create review state for an issue.
 
+        Checks the in-memory cache first, then falls back to the on-disk
+        state file so that a second invocation of the reviewer on the same
+        PR will find the previously-persisted COMPLETED state and skip
+        re-posting comments (#374).
+
+        A malformed or unreadable state file is treated as if it does not
+        exist — the reviewer starts fresh and overwrites the bad file.
+
         Args:
             issue_number: GitHub issue number
             pr_number: GitHub PR number
@@ -446,10 +403,33 @@ class PRReviewer:
         """
         with self.state_lock:
             if issue_number not in self.states:
-                self.states[issue_number] = ReviewState(
-                    issue_number=issue_number,
-                    pr_number=pr_number,
-                )
+                # Try to load from disk before creating a fresh state
+                state_file = self.state_dir / f"review-{issue_number}.json"
+                if state_file.exists():
+                    try:
+                        self.states[issue_number] = ReviewState.model_validate_json(
+                            state_file.read_text()
+                        )
+                        logger.debug(
+                            "Loaded review state for issue #%d from disk (phase=%s)",
+                            issue_number,
+                            self.states[issue_number].phase,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Malformed review state file for issue #%d (%s); starting fresh",
+                            issue_number,
+                            exc,
+                        )
+                        self.states[issue_number] = ReviewState(
+                            issue_number=issue_number,
+                            pr_number=pr_number,
+                        )
+                else:
+                    self.states[issue_number] = ReviewState(
+                        issue_number=issue_number,
+                        pr_number=pr_number,
+                    )
             return self.states[issue_number]
 
     def _fail_review(
@@ -510,6 +490,23 @@ class PRReviewer:
             )
 
             state = self._get_or_create_state(issue_number, pr_number)
+
+            # Idempotency guard: skip if this PR was already fully reviewed (#374)
+            if state.phase == ReviewPhase.COMPLETED:
+                self._log(
+                    "info",
+                    f"PR #{pr_number} for issue #{issue_number} already reviewed "
+                    "(state.phase=COMPLETED) — skipping to avoid duplicate comments",
+                    thread_id,
+                )
+                self.status_tracker.update_slot(
+                    slot_id, f"#{issue_number}: already reviewed, skipped"
+                )
+                return WorkerResult(
+                    issue_number=issue_number,
+                    success=True,
+                    pr_number=pr_number,
+                )
 
             # Create worktree on the PR branch (read-only usage)
             branch_name = f"{issue_number}-auto-impl"

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -222,11 +222,14 @@ class TestAddressIssue:
 
     def test_no_unresolved_threads_skips(self, reviewer: AddressReviewer) -> None:
         """gh_pr_list_unresolved_threads returns [] → skip gracefully."""
-        with patch(
-            "hephaestus.automation.address_review.gh_pr_list_unresolved_threads",
-            return_value=[],
+        with (
+            patch.object(reviewer.status_tracker, "acquire_slot", return_value=0),
+            patch(
+                "hephaestus.automation.address_review.gh_pr_list_unresolved_threads",
+                return_value=[],
+            ),
         ):
-            result = reviewer._address_issue(123, 456, 0)
+            result = reviewer._address_issue(123, 456)
 
         assert result.success is True
         assert result.pr_number == 456
@@ -234,7 +237,7 @@ class TestAddressIssue:
     def test_dry_run_stops_before_resolve(
         self, mock_options: AddressReviewOptions, tmp_path: Path
     ) -> None:
-        """dry_run=True → no resolve or push calls."""
+        """dry_run=True → no worktree creation, no resolve, no push calls."""
         mock_options.dry_run = True
 
         with (
@@ -249,28 +252,26 @@ class TestAddressIssue:
             dry_reviewer = AddressReviewer(mock_options)
             dry_reviewer.state_dir = tmp_path
 
+        # Dry-run guard now fires BEFORE worktree creation, so we only need
+        # gh_pr_list_unresolved_threads to return some threads (the guard
+        # skips the rest of the flow).
         threads = [{"id": "thread-1", "path": "foo.py", "line": 5, "body": "Fix this"}]
 
         with (
-            patch.object(dry_reviewer, "_find_pr_for_issue", return_value=42),
+            patch.object(dry_reviewer.status_tracker, "acquire_slot", return_value=0),
             patch(
                 "hephaestus.automation.address_review.gh_pr_list_unresolved_threads",
                 return_value=threads,
             ),
-            patch.object(dry_reviewer, "_load_impl_session_id", return_value=None),
-            patch.object(dry_reviewer, "_load_review_state", return_value=None),
-            patch.object(dry_reviewer, "_get_or_create_worktree", return_value=tmp_path),
-            patch.object(
-                dry_reviewer,
-                "_run_fix_session",
-                return_value={"addressed": ["thread-1"], "replies": {}},
-            ),
+            patch.object(dry_reviewer, "_get_or_create_worktree") as mock_worktree,
             patch("hephaestus.automation.address_review.gh_pr_resolve_thread") as mock_resolve,
             patch.object(dry_reviewer, "_push_branch") as mock_push,
         ):
-            result = dry_reviewer._address_issue(123, 456, 0)
+            result = dry_reviewer._address_issue(123, 456)
 
         assert result.success is True
+        # Dry-run guard fires before worktree creation and resolution
+        mock_worktree.assert_not_called()
         mock_resolve.assert_not_called()
         mock_push.assert_not_called()
 

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -247,3 +247,51 @@ class TestReviewIssue:
 
         assert result.success is False
         assert result.error is not None
+
+
+class TestFetchIssueCommentsCache:
+    """Tests for the _fetch_issue_comments caching helper (#A3-009)."""
+
+    def test_api_called_only_once_for_same_issue(self, reviewer: PlanReviewer) -> None:
+        """Calling both _has_existing_review and _get_latest_plan should hit the API once."""
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+
+            # Call both methods that internally use _fetch_issue_comments
+            reviewer._has_existing_review(123)
+            reviewer._get_latest_plan(123)
+
+        assert mock_gh.call_count == 1, "Expected single API call due to caching"
+
+    def test_api_called_once_per_issue(self, reviewer: PlanReviewer) -> None:
+        """Different issue numbers each get their own API call."""
+        comments_123 = [{"body": "## Implementation Plan\n\nIssue 123"}]
+        comments_456 = [{"body": "## Implementation Plan\n\nIssue 456"}]
+
+        call_count = 0
+
+        def _side_effect(args: Any, **kw: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if "123" in args:
+                return _make_gh_result({"comments": comments_123})
+            return _make_gh_result({"comments": comments_456})
+
+        with patch("hephaestus.automation.plan_reviewer._gh_call", side_effect=_side_effect):
+            reviewer._get_latest_plan(123)
+            reviewer._get_latest_plan(123)  # should use cache
+            reviewer._get_latest_plan(456)  # new issue → new API call
+            reviewer._get_latest_plan(456)  # should use cache
+
+        assert call_count == 2
+
+    def test_api_error_returns_empty_list(self, reviewer: PlanReviewer) -> None:
+        """API failure → _fetch_issue_comments returns empty list, not exception."""
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.side_effect = RuntimeError("network error")
+            result = reviewer._fetch_issue_comments(999)
+
+        assert result == []

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -181,6 +181,68 @@ class TestDryRunSkipsPost:
         assert "DRY RUN" in result["summary"]
 
 
+class TestIdempotencyGuard:
+    """Tests for the COMPLETED-state idempotency guard (#374)."""
+
+    def test_completed_state_on_disk_skips_review(
+        self, mock_options: ReviewerOptions, tmp_path: Path
+    ) -> None:
+        """review-{n}.json on disk shows COMPLETED → _review_pr succeeds without posting."""
+        from hephaestus.automation.models import ReviewPhase, ReviewState
+
+        # Write a completed review state to disk
+        state_dir = tmp_path / ".issue_implementer"
+        state_dir.mkdir()
+        completed_state = ReviewState(issue_number=123, pr_number=42, phase=ReviewPhase.COMPLETED)
+        (state_dir / "review-123.json").write_text(completed_state.model_dump_json())
+
+        with (
+            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
+            patch("hephaestus.automation.pr_reviewer.WorktreeManager") as mock_wm_cls,
+            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
+        ):
+            mock_wm = MagicMock()
+            mock_wm_cls.return_value = mock_wm
+            live_reviewer = PRReviewer(mock_options)
+
+        with patch("hephaestus.automation.pr_reviewer.gh_pr_review_post") as mock_post:
+            result = live_reviewer._review_pr(issue_number=123, pr_number=42)
+
+        assert result.success is True
+        mock_post.assert_not_called()
+        # Worktree should NOT have been created
+        mock_wm.create_worktree.assert_not_called()
+
+    def test_malformed_state_file_starts_fresh(
+        self, mock_options: ReviewerOptions, tmp_path: Path
+    ) -> None:
+        """Malformed state file → warning logged, fresh state created."""
+        state_dir = tmp_path / ".issue_implementer"
+        state_dir.mkdir()
+        (state_dir / "review-123.json").write_text("{not valid json!!!}")
+
+        with (
+            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
+            patch("hephaestus.automation.pr_reviewer.WorktreeManager") as mock_wm_cls,
+            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
+        ):
+            mock_wm = MagicMock()
+            mock_wm.create_worktree.return_value = tmp_path
+            mock_wm_cls.return_value = mock_wm
+            live_reviewer = PRReviewer(mock_options)
+
+        analysis = {"comments": [], "summary": "clean"}
+        with (
+            patch.object(live_reviewer, "_gather_pr_context", return_value={}),
+            patch.object(live_reviewer, "_run_analysis_session", return_value=analysis),
+            patch("hephaestus.automation.pr_reviewer.gh_pr_review_post", return_value=[]),
+        ):
+            result = live_reviewer._review_pr(issue_number=123, pr_number=42)
+
+        # Should succeed with fresh state (bad file ignored, review proceeds)
+        assert result.success is True
+
+
 class TestReviewPostsInlineComments:
     """Tests for inline comment posting flow."""
 

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -1,0 +1,166 @@
+"""Tests for shared review utilities (_review_utils.py)."""
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from hephaestus.automation._review_utils import find_pr_for_issue, parse_json_block
+
+# ---------------------------------------------------------------------------
+# parse_json_block
+# ---------------------------------------------------------------------------
+
+
+class TestParseJsonBlock:
+    """Tests for the shared parse_json_block helper."""
+
+    def test_extracts_last_json_block(self) -> None:
+        """Multiple ```json blocks → returns the last one parsed."""
+        text = (
+            '```json\n{"comments": ["first"], "summary": "first"}\n```\n'
+            '```json\n{"comments": ["second"], "summary": "second"}\n```'
+        )
+        result = parse_json_block(text)
+        assert result["summary"] == "second"
+
+    def test_no_block_returns_defaults(self) -> None:
+        """No json block → returns defaults with empty comments list."""
+        result = parse_json_block("No json here.")
+        assert result["comments"] == []
+        assert "No structured output" in result["summary"]
+
+    def test_invalid_json_returns_defaults(self) -> None:
+        """Malformed json → returns defaults."""
+        text = "```json\n{invalid!!}\n```"
+        result = parse_json_block(text)
+        assert result["comments"] == []
+        assert "Failed to parse" in result["summary"]
+
+    def test_valid_block(self) -> None:
+        """Single valid block → parsed correctly."""
+        payload = {"comments": [{"path": "a.py", "line": 1, "body": "x"}], "summary": "ok"}
+        text = "```json\n" + json.dumps(payload) + "\n```"
+        result = parse_json_block(text)
+        assert result["summary"] == "ok"
+        assert len(result["comments"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# find_pr_for_issue
+# ---------------------------------------------------------------------------
+
+
+def _make_gh_result(payload: Any) -> MagicMock:
+    mock = MagicMock()
+    mock.stdout = json.dumps(payload)
+    return mock
+
+
+class TestFindPrForIssue:
+    """Tests for find_pr_for_issue helper."""
+
+    def test_finds_via_branch_name(self) -> None:
+        """Branch-name lookup succeeds → returns PR number immediately."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result([{"number": 42}]),
+        ):
+            result = find_pr_for_issue(123)
+
+        assert result == 42
+
+    def test_falls_back_to_body_search(self) -> None:
+        """Branch-name returns empty → falls back to body search."""
+        call_count = 0
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            if "--head" in args:
+                return _make_gh_result([])
+            # body search
+            return _make_gh_result([{"number": 99}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_pr_for_issue(123)
+
+        assert result == 99
+        assert call_count == 2
+
+    def test_returns_none_when_nothing_found(self) -> None:
+        """All strategies return empty → None."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result([]),
+        ):
+            result = find_pr_for_issue(123)
+
+        assert result is None
+
+    def test_extra_strategies_uses_review_state(self) -> None:
+        """extra_strategies=True checks review state when branch-name fails."""
+        # Branch-name returns empty; review-state lookup succeeds
+        call_results = [
+            _make_gh_result([]),  # branch-name: no match
+            _make_gh_result({"state": "OPEN", "number": 55}),  # gh pr view
+        ]
+        call_iter = iter(call_results)
+
+        review_state = MagicMock()
+        review_state.pr_number = 55
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=lambda *a, **kw: next(call_iter),
+        ):
+            result = find_pr_for_issue(
+                123,
+                extra_strategies=True,
+                _load_review_state_fn=lambda: review_state,
+            )
+
+        assert result == 55
+
+    def test_extra_strategies_skips_closed_pr(self) -> None:
+        """extra_strategies=True: review-state PR is closed → fall through to body search."""
+        call_results = [
+            _make_gh_result([]),  # branch-name: empty
+            _make_gh_result({"state": "CLOSED", "number": 55}),  # gh pr view: closed
+            _make_gh_result([{"number": 77}]),  # body search: match
+        ]
+        call_iter = iter(call_results)
+
+        review_state = MagicMock()
+        review_state.pr_number = 55
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=lambda *a, **kw: next(call_iter),
+        ):
+            result = find_pr_for_issue(
+                123,
+                extra_strategies=True,
+                _load_review_state_fn=lambda: review_state,
+            )
+
+        assert result == 77
+
+    def test_branch_name_gh_error_falls_back(self) -> None:
+        """Branch-name lookup raises → falls back gracefully."""
+        import subprocess
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            if "--head" in args:
+                raise subprocess.CalledProcessError(1, "gh")
+            return _make_gh_result([{"number": 10}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_pr_for_issue(123)
+
+        assert result == 10


### PR DESCRIPTION
## Summary

- **#373 (MAJOR)**: Remove `Bash` from `--allowedTools` in `pr_reviewer.py` analysis session; replaced with `Read,Glob,Grep` only, enforcing the read-only invariant of phase 4.
- **#374 (MAJOR)**: Add idempotency guard — `_get_or_create_state` now loads `review-{n}.json` from disk; `_review_pr` short-circuits on `COMPLETED` before creating a worktree or posting comments. Malformed state files are caught, warned, and replaced with fresh state.
- **#375 (MAJOR)**: Fix `gh_pr_review_post` thread-ID provenance. Old mutation fetched `pullRequest.reviewThreads(last:50)` (all PR threads); new mutation uses `pullRequestReview.comments.pullRequestReviewThread` to return ONLY threads created by this review. **API change**: `gh_pr_review_post` now returns only this review's thread IDs (semantics tightened, not a breaking change — stored `posted_thread_ids` now correctly scoped).
- **#381 A3-004**: Dry-run guard in `address_review._address_issue` moved to before worktree creation and state mutation.
- **#381 A3-005**: `_address_all` no longer pre-assigns `slot_id`; `_address_issue` now acquires/releases its own slot via `StatusTracker`.
- **#381 A3-006**: Added `--allowedTools "Read,Glob,Grep"` to `plan_reviewer._run_claude_analysis`.
- **#381 A3-007**: Extracted `parse_json_block` + `find_pr_for_issue` to new `hephaestus/automation/_review_utils.py`; both `pr_reviewer` and `address_review` import from it.
- **#381 A3-009**: `PlanReviewer._fetch_issue_comments` caches `gh issue view --comments` per issue so `_has_existing_review` and `_get_latest_plan` share one API call.
- **#381 A3-010**: Session-resume fallback in `address_review._run_fix_session` broadened to any non-zero exit from `--resume`, not just three hard-coded phrases.

## New module

`hephaestus/automation/_review_utils.py` — shared `parse_json_block` and `find_pr_for_issue` helpers.

## Test plan

- [ ] `pixi run pytest tests/unit -q --no-cov` → 2077 passed, 6 skipped
- [ ] `pixi run ruff check hephaestus/ tests/` → clean
- [ ] `pixi run mypy` → clean
- [ ] `SKIP=yamllint,check-python-version-consistency pre-commit run --all-files` → all pass (yamllint/check-python-version-consistency are pre-existing broken hooks unrelated to this PR)
- [ ] New test file: `tests/unit/automation/test_review_utils.py` (10 tests)
- [ ] Updated: `test_pr_reviewer_posting.py` (idempotency tests), `test_plan_reviewer.py` (cache tests), `test_address_review.py` (slot/dry-run tests)

Closes #373
Closes #374
Closes #375
Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)