### PR TITLE
fix(automation+github): supporting-module hardening cluster (W15d)

### DIFF
--- a/hephaestus/automation/claude_models.py
+++ b/hephaestus/automation/claude_models.py
@@ -10,21 +10,55 @@ reflects the cost/quality tradeoff for each phase:
 
 Each function honors a ``HEPH_<PHASE>_MODEL`` environment variable so an
 operator can override without code changes (e.g. when one tier's quota is
-exhausted).
+exhausted).  Unknown overrides emit a **warning** but are still accepted so
+operators can experiment with preview models without a code change.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
 
 OPUS = "claude-opus-4-7"
 SONNET = "claude-sonnet-4-6"
 HAIKU = "claude-haiku-4-5"
 
+# The set of model IDs the automation suite is tested against.  Overrides
+# to values outside this set are accepted (operators may have preview access)
+# but will trigger a one-time warning so misconfigured env vars are visible.
+_KNOWN_MODELS: frozenset[str] = frozenset({OPUS, SONNET, HAIKU})
+
+
+def _resolve_model(env_var: str, default: str) -> str:
+    """Return the model ID for *env_var*, warning if the value is unknown.
+
+    Args:
+        env_var: Name of the environment variable to check.
+        default: Default model ID to use when the variable is unset.
+
+    Returns:
+        The resolved model ID string.
+
+    """
+    value = os.environ.get(env_var)
+    if value is None:
+        return default
+    if value not in _KNOWN_MODELS:
+        logger.warning(
+            "Unknown model %r set in %s (known: %s). "
+            "Proceeding, but verify the model ID is correct.",
+            value,
+            env_var,
+            ", ".join(sorted(_KNOWN_MODELS)),
+        )
+    return value
+
 
 def planner_model() -> str:
     """Model used to generate implementation plans from issue text."""
-    return os.environ.get("HEPH_PLANNER_MODEL", OPUS)
+    return _resolve_model("HEPH_PLANNER_MODEL", OPUS)
 
 
 def implementer_model() -> str:
@@ -34,19 +68,19 @@ def implementer_model() -> str:
     (e.g. address-review, ci-driver), since ``claude --resume`` is locked
     to the model that created the session.
     """
-    return os.environ.get("HEPH_IMPLEMENTER_MODEL", HAIKU)
+    return _resolve_model("HEPH_IMPLEMENTER_MODEL", HAIKU)
 
 
 def reviewer_model() -> str:
     """Model used by plan/PR reviewers and the review-fix loop."""
-    return os.environ.get("HEPH_REVIEWER_MODEL", SONNET)
+    return _resolve_model("HEPH_REVIEWER_MODEL", SONNET)
 
 
 def advise_model() -> str:
     """Model used by the /advise step inside the planner."""
-    return os.environ.get("HEPH_ADVISE_MODEL", HAIKU)
+    return _resolve_model("HEPH_ADVISE_MODEL", HAIKU)
 
 
 def learn_model() -> str:
     """Model used by /learn and follow-up issue filing."""
-    return os.environ.get("HEPH_LEARN_MODEL", HAIKU)
+    return _resolve_model("HEPH_LEARN_MODEL", HAIKU)

--- a/hephaestus/automation/curses_ui.py
+++ b/hephaestus/automation/curses_ui.py
@@ -191,8 +191,12 @@ class CursesUI:
                 self._refresh_display()
                 time.sleep(0.5)  # Update twice per second
             except curses.error:
-                # Terminal too small or other display error
-                pass
+                # Terminal resize (SIGWINCH) or too-small terminal.
+                # Inform curses of the new dimensions and retry the refresh
+                # so the TUI recovers gracefully instead of silently freezing.
+                if self.stdscr is not None:
+                    with contextlib.suppress(curses.error):
+                        curses.resizeterm(*self.stdscr.getmaxyx())
             except KeyboardInterrupt:
                 break
 

--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -152,19 +152,48 @@ class DependencyResolver:
 
         return list(set(sub_issues))  # Remove duplicates
 
+    _MAX_DEPENDENCY_DEPTH = 100
+
     def _load_dependencies(
         self,
         issue: IssueInfo,
         cached_states: dict[int, IssueState],
     ) -> None:
-        """Recursively load issue dependencies.
+        """Load issue dependencies iteratively using BFS (bounded depth).
+
+        Replaces the previous recursive implementation to avoid Python's
+        default recursion limit on deep or wide dependency chains and to make
+        the depth cap explicit and configurable via ``_MAX_DEPENDENCY_DEPTH``.
 
         Args:
-            issue: Issue to load dependencies for
-            cached_states: Cache of issue states
+            issue: Root issue whose dependencies to load.
+            cached_states: Cache of issue states (consulted before fetching).
+
+        Raises:
+            RuntimeError: If the dependency graph exceeds ``_MAX_DEPENDENCY_DEPTH``
+                levels, which almost certainly indicates a cycle that escaped the
+                cycle-detection pass.
 
         """
+        # BFS queue entries are (issue_number, depth)
+        queue: deque[tuple[int, int]] = deque()
+        visited: set[int] = set()
+
+        # Seed the queue with the direct dependencies of the root issue
         for dep_num in issue.dependencies:
+            queue.append((dep_num, 1))
+            visited.add(dep_num)
+
+        while queue:
+            dep_num, depth = queue.popleft()
+
+            if depth > self._MAX_DEPENDENCY_DEPTH:
+                raise RuntimeError(
+                    f"Dependency graph exceeded {self._MAX_DEPENDENCY_DEPTH} levels "
+                    f"starting from issue #{issue.number}. "
+                    "Check for cycles or reduce the dependency chain depth."
+                )
+
             if dep_num in self.graph.issues or dep_num in self.completed:
                 continue
 
@@ -176,7 +205,11 @@ class DependencyResolver:
             try:
                 dep_issue = fetch_issue_info(dep_num)
                 self.add_issue(dep_issue)
-                self._load_dependencies(dep_issue, cached_states)
+                # Enqueue this issue's own dependencies for the next BFS level
+                for child_dep in dep_issue.dependencies:
+                    if child_dep not in visited:
+                        visited.add(child_dep)
+                        queue.append((child_dep, depth + 1))
             except Exception as e:
                 logger.error(f"Failed to load dependency #{dep_num}: {e}")
 

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -24,6 +24,48 @@ from .prompts import get_follow_up_prompt
 logger = logging.getLogger(__name__)
 
 
+def _extract_outer_json_array(text: str) -> str | None:
+    """Find and return the outermost JSON array ``[...]`` in *text*.
+
+    Uses a balanced-bracket scan to avoid the greedy/non-greedy pitfall of
+    regex-based extraction, which either over-consumes (greedy ``.*``) or
+    stops too early inside nested structures (non-greedy ``.*?``).
+
+    Args:
+        text: String that may contain a JSON array.
+
+    Returns:
+        The first outermost ``[...]`` substring, or ``None`` if not found.
+
+    """
+    start = text.find("[")
+    if start == -1:
+        return None
+    depth = 0
+    in_string = False
+    escape_next = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if escape_next:
+            escape_next = False
+            continue
+        if ch == "\\" and in_string:
+            escape_next = True
+            continue
+        if ch == '"' and not escape_next:
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
 def parse_follow_up_items(text: str) -> list[dict[str, Any]]:
     """Parse follow-up items from Claude's JSON response.
 
@@ -34,16 +76,18 @@ def parse_follow_up_items(text: str) -> list[dict[str, Any]]:
         List of follow-up item dictionaries with title, body, labels
 
     """
-    # Try to extract JSON from code blocks or bare JSON
+    # Try to extract JSON from code blocks or bare JSON.
+    # Code-block extraction uses a non-greedy inner match to stop at the
+    # first closing fence.  The bare-JSON fallback previously used a greedy
+    # `.*` which would over-consume when multiple arrays were present.
+    # We now use a balanced-bracket scanner to find the outermost `[...]`
+    # block reliably (A5-07).
     json_match = re.search(r"```(?:json)?\s*(\[.*?\])\s*```", text, re.DOTALL)
     if json_match:
         json_str = json_match.group(1)
     else:
-        # Try to find bare JSON array
-        json_match = re.search(r"(\[.*\])", text, re.DOTALL)
-        if json_match:
-            json_str = json_match.group(1)
-        else:
+        json_str = _extract_outer_json_array(text)
+        if json_str is None:
             logger.warning("No JSON array found in follow-up response")
             return []
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -20,7 +20,12 @@ import time
 from pathlib import Path
 from typing import Any, cast
 
-from hephaestus.github.rate_limit import detect_claude_usage_limit, detect_rate_limit, wait_until
+from hephaestus.github.rate_limit import (
+    detect_claude_usage_cap,
+    detect_claude_usage_limit,
+    detect_rate_limit,
+    wait_until,
+)
 
 from .claude_timeouts import gh_cli_timeout
 from .git_utils import get_repo_info, run
@@ -29,6 +34,30 @@ from .models import IssueInfo, IssueState
 logger = logging.getLogger(__name__)
 
 _label_cache: set[str] | None = None
+
+
+class ClaudeUsageCapError(RuntimeError):
+    """Raised when the Claude CLI reports that the per-period usage cap has been hit.
+
+    Subclasses :class:`RuntimeError` so that existing ``except RuntimeError``
+    handlers continue to catch it.
+
+    Attributes:
+        reset_epoch: Unix timestamp at which the cap resets, or ``None`` if the
+            reset time could not be determined.
+
+    """
+
+    def __init__(self, message: str, reset_epoch: int | None = None) -> None:
+        """Initialise the error with an optional reset epoch.
+
+        Args:
+            message: Human-readable error description.
+            reset_epoch: Unix timestamp at which the cap resets, or ``None``.
+
+        """
+        super().__init__(message)
+        self.reset_epoch: int | None = reset_epoch
 
 
 def gh_list_labels(refresh: bool = False) -> set[str]:
@@ -92,7 +121,8 @@ def _gh_call(
 
     Raises:
         subprocess.CalledProcessError: If command fails and check=True
-        RuntimeError: If Claude usage limit detected
+        ClaudeUsageCapError: If a Claude per-period usage cap is detected.
+        RuntimeError: For other non-transient or exhausted-retry failures.
 
     """
     for attempt in range(max_retries):
@@ -107,10 +137,18 @@ def _gh_call(
         except subprocess.CalledProcessError as e:
             stderr = e.stderr if e.stderr else ""
 
-            # Check for Claude usage limit
+            # Check for Claude usage cap first (has reset epoch); fall back to
+            # the simpler usage-limit detector when no epoch is available.
+            reset_epoch = detect_claude_usage_cap(stderr)
+            if reset_epoch is not None:
+                raise ClaudeUsageCapError(
+                    f"Claude API usage cap reached. Resets at epoch {reset_epoch}.",
+                    reset_epoch=reset_epoch,
+                ) from e
             if detect_claude_usage_limit(stderr):
-                raise RuntimeError(
-                    "Claude API usage limit reached. Please check your billing."
+                raise ClaudeUsageCapError(
+                    "Claude API usage limit reached. Please check your billing.",
+                    reset_epoch=None,
                 ) from e
 
             # Check for rate limit (regardless of retry_on_rate_limit flag)
@@ -132,12 +170,15 @@ def _gh_call(
                     ) from e
 
             # Check if this is a non-transient error that shouldn't be retried
-            # Permission errors, not found, bad requests should fail fast
+            # Permission errors, not found, bad requests should fail fast.
+            # Each pattern is a standalone alternative; we avoid mixing HTTP
+            # status codes with text phrases in the same regex so a bare "403"
+            # in an unrelated part of stderr doesn't false-trigger.
             non_transient_patterns = [
-                r"403|forbidden|permission denied",
-                r"404|not found",
-                r"400|bad request",
-                r"401|unauthorized",
+                r"(?:^|\s)403(?:\s|$)|forbidden|permission denied",
+                r"(?:^|\s)404(?:\s|$)|not found",
+                r"(?:^|\s)400(?:\s|$)|bad request",
+                r"(?:^|\s)401(?:\s|$)|unauthorized",
                 r"invalid argument",
             ]
             if any(re.search(pattern, stderr, re.IGNORECASE) for pattern in non_transient_patterns):

--- a/hephaestus/automation/issue_dedup.py
+++ b/hephaestus/automation/issue_dedup.py
@@ -69,6 +69,11 @@ _TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]+")
 DEFAULT_TITLE_THRESHOLD = 0.85
 DEFAULT_PARAGRAPH_NEW_THRESHOLD = 0.6
 
+# Titles with fewer than this many content tokens after stopword removal fall
+# back to character tri-gram similarity, which is more reliable for short strings
+# like "Fix typo" or "Add index".
+_SHORT_TITLE_TOKEN_THRESHOLD = 3
+
 
 @dataclass(frozen=True)
 class IssueMatch:
@@ -97,6 +102,52 @@ def _jaccard(a: set[str], b: set[str]) -> float:
     if not union:
         return 0.0
     return len(a & b) / len(union)
+
+
+def _trigrams(text: str) -> set[str]:
+    """Return the set of character tri-grams from *text* (lowercased, spaces collapsed)."""
+    normalized = re.sub(r"\s+", " ", text.lower().strip())
+    if len(normalized) < 3:
+        return {normalized} if normalized else set()
+    return {normalized[i : i + 3] for i in range(len(normalized) - 2)}
+
+
+def _trigram_similarity(a: str, b: str) -> float:
+    """Jaccard similarity over character tri-grams of *a* and *b*.
+
+    Used as a fallback similarity measure for short titles that don't have
+    enough content tokens for reliable Jaccard-on-words scoring.
+    """
+    tg_a = _trigrams(a)
+    tg_b = _trigrams(b)
+    return _jaccard(tg_a, tg_b)
+
+
+def _title_similarity(a: str, b: str) -> float:
+    """Compute the best available similarity score between two issue titles.
+
+    For titles with at least ``_SHORT_TITLE_TOKEN_THRESHOLD`` content tokens,
+    uses token-level Jaccard (fast, high precision).  For shorter titles (e.g.
+    "Fix typo", "Add index") it falls back to character tri-gram Jaccard, which
+    handles short strings far better than the word-level metric.
+
+    Args:
+        a: First issue title.
+        b: Second issue title.
+
+    Returns:
+        Similarity score in [0, 1].
+
+    """
+    tokens_a = _tokens(a)
+    tokens_b = _tokens(b)
+    if (
+        len(tokens_a) >= _SHORT_TITLE_TOKEN_THRESHOLD
+        and len(tokens_b) >= _SHORT_TITLE_TOKEN_THRESHOLD
+    ):
+        return _jaccard(tokens_a, tokens_b)
+    # Short-title fallback: tri-gram similarity
+    return _trigram_similarity(a, b)
 
 
 def _search_keywords(title: str, max_terms: int = 3) -> str:
@@ -157,11 +208,10 @@ def find_duplicate_open_issue(
         logger.warning(f"Duplicate search failed for '{title[:60]}': {e}")
         return None
 
-    candidate_tokens = _tokens(title)
     best: IssueMatch | None = None
     for c in candidates:
         c_title = c.get("title", "") or ""
-        score = _jaccard(candidate_tokens, _tokens(c_title))
+        score = _title_similarity(title, c_title)
         if score >= threshold and (best is None or score > best.similarity):
             best = IssueMatch(
                 number=int(c["number"]),

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from .claude_models import learn_model
 from .claude_timeouts import learn_claude_timeout
 from .git_utils import run
 
@@ -42,11 +43,11 @@ def run_learn(
     state_dir.mkdir(parents=True, exist_ok=True)
     log_file = state_dir / f"learn-{issue_number}.log"
     # /learn is a SIMPLE-complexity task (summarization + file writes), so we
-    # default to sonnet but accept haiku as the fallback when sonnet is
-    # unavailable. We can't route through `call_claude` here because we need
-    # `--resume` semantics with full Bash/Edit tools; instead we add the model
-    # flag directly and rely on Claude CLI's own fallback messaging if sonnet
-    # is down. (The shared `call_claude` helper handles the loop-review paths.)
+    # use the configured learn model (default: Haiku) but accept operator
+    # overrides via HEPH_LEARN_MODEL. We can't route through `call_claude`
+    # here because we need `--resume` semantics with full Bash/Edit tools;
+    # instead we add the model flag directly.
+    # (The shared `call_claude` helper handles the loop-review paths.)
     try:
         result = run(
             [
@@ -61,7 +62,7 @@ def run_learn(
                 ),
                 "--print",
                 "--model",
-                "sonnet",
+                learn_model(),
                 "--permission-mode",
                 "dontAsk",
                 "--allowedTools",

--- a/hephaestus/automation/prompts.py
+++ b/hephaestus/automation/prompts.py
@@ -17,7 +17,46 @@ block (last-fence-wins for JSON; verdict parsers should likewise prefer the
 last matching line in Claude's free-form prose).
 """
 
+import logging
 import secrets
+from pathlib import Path
+
+_prompts_logger = logging.getLogger(__name__)
+
+
+def _relativize_path(path: str, repo_root: str | None) -> str:
+    """Return *path* relative to *repo_root* when possible.
+
+    If *repo_root* is ``None`` or *path* is not under *repo_root*, the
+    original *path* is returned unchanged and a warning is logged so
+    operators know an absolute path is being injected.
+
+    Args:
+        path: Filesystem path to relativize.
+        repo_root: Absolute repository root directory, or ``None``.
+
+    Returns:
+        A repo-relative path string (e.g. ``"worktrees/123-fix"``), or
+        the original *path* if it cannot be made relative.
+
+    """
+    if not path:
+        return path
+    if repo_root is None:
+        _prompts_logger.warning(
+            "repo_root not provided; injecting absolute path into prompt: %s", path
+        )
+        return path
+    try:
+        return str(Path(path).relative_to(repo_root))
+    except ValueError:
+        _prompts_logger.warning(
+            "Path %r is not under repo_root %r; injecting absolute path into prompt.",
+            path,
+            repo_root,
+        )
+        return path
+
 
 IMPLEMENTATION_PROMPT = """
 Implement GitHub issue #{issue_number}.
@@ -193,6 +232,7 @@ def get_implementation_prompt(
     issue_body: str = "",
     branch_name: str = "",
     worktree_path: str = "",
+    repo_root: str | None = None,
 ) -> str:
     """Get the implementation prompt for an issue.
 
@@ -202,17 +242,21 @@ def get_implementation_prompt(
         issue_body: Issue body/description (optional, for backward compatibility)
         branch_name: Git branch name (optional, for backward compatibility)
         worktree_path: Working directory path (optional, for backward compatibility)
+        repo_root: Absolute path to the repository root.  When provided,
+            *worktree_path* is relativized to avoid leaking the operator's
+            filesystem layout into the prompt.
 
     Returns:
         Formatted implementation prompt
 
     """
+    safe_worktree_path = _relativize_path(worktree_path, repo_root)
     return IMPLEMENTATION_PROMPT.format(
         issue_number=issue_number,
         issue_title=issue_title,
         issue_body=issue_body,
         branch_name=branch_name,
-        worktree_path=worktree_path,
+        worktree_path=safe_worktree_path,
     )
 
 
@@ -226,6 +270,7 @@ def get_advise_prompt(
     issue_title: str,
     issue_body: str,
     marketplace_path: str,
+    repo_root: str | None = None,
 ) -> str:
     """Get the advise prompt for searching team knowledge.
 
@@ -234,16 +279,20 @@ def get_advise_prompt(
         issue_title: Issue title
         issue_body: Issue body/description
         marketplace_path: Path to marketplace.json
+        repo_root: Absolute path to the repository root.  When provided,
+            *marketplace_path* is relativized to avoid leaking the operator's
+            filesystem layout into the prompt.
 
     Returns:
         Formatted advise prompt
 
     """
+    safe_marketplace_path = _relativize_path(marketplace_path, repo_root)
     return ADVISE_PROMPT.format(
         issue_number=issue_number,
         issue_title=issue_title,
         issue_body=issue_body,
-        marketplace_path=marketplace_path,
+        marketplace_path=safe_marketplace_path,
     )
 
 

--- a/hephaestus/github/rate_limit.py
+++ b/hephaestus/github/rate_limit.py
@@ -276,6 +276,10 @@ def wait_until(epoch: int) -> None:
 def detect_claude_usage_limit(stderr: str) -> bool:
     """Detect Claude API usage limit from error output.
 
+    Only matches Claude-specific usage-limit messages, not GitHub's own
+    "API usage limit" messages.  The patterns are ordered from most-specific
+    to least-specific.
+
     Args:
         stderr: Standard error output
 
@@ -284,7 +288,11 @@ def detect_claude_usage_limit(stderr: str) -> bool:
 
     """
     patterns = [
-        r"usage limit",
+        # Claude-specific usage-limit phrasing (A5-01: tightened to avoid
+        # false-triggering on GitHub's own "API usage limit" messages)
+        r"Claude.*usage limit",
+        r"out of extra usage",
+        r"claude\.com/upgrade",
         r"quota exceeded",
         r"credit.*exhausted",
         r"billing.*limit|billing.*exceeded",  # More specific to avoid false positives

--- a/tests/unit/automation/test_claude_models.py
+++ b/tests/unit/automation/test_claude_models.py
@@ -54,3 +54,51 @@ class TestModuleStable:
         assert claude_models.OPUS == "claude-opus-4-7"
         assert claude_models.HAIKU == "claude-haiku-4-5"
         assert claude_models.SONNET == "claude-sonnet-4-6"
+
+
+class TestEnvVarValidation:
+    """A5-04: unknown env-var overrides warn but do not crash."""
+
+    def test_known_override_no_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Known model IDs produce no warning."""
+        import logging
+
+        monkeypatch.setenv("HEPH_PLANNER_MODEL", claude_models.HAIKU)
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.claude_models"):
+            result = claude_models.planner_model()
+        assert result == claude_models.HAIKU
+        assert not caplog.records
+
+    def test_unknown_override_warns_but_returns_value(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Unknown model IDs trigger a warning but are still returned (A5-04)."""
+        import logging
+
+        monkeypatch.setenv("HEPH_IMPLEMENTER_MODEL", "claude-preview-99-99")
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.claude_models"):
+            result = claude_models.implementer_model()
+        assert result == "claude-preview-99-99"
+        assert any("Unknown model" in r.message for r in caplog.records)
+
+    def test_all_phase_functions_accept_unknown_model(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All phase functions accept overrides without raising (A5-04)."""
+        model_id = "claude-experimental-0-0"
+        for env_var in (
+            "HEPH_PLANNER_MODEL",
+            "HEPH_IMPLEMENTER_MODEL",
+            "HEPH_REVIEWER_MODEL",
+            "HEPH_ADVISE_MODEL",
+            "HEPH_LEARN_MODEL",
+        ):
+            monkeypatch.setenv(env_var, model_id)
+
+        assert claude_models.planner_model() == model_id
+        assert claude_models.implementer_model() == model_id
+        assert claude_models.reviewer_model() == model_id
+        assert claude_models.advise_model() == model_id
+        assert claude_models.learn_model() == model_id

--- a/tests/unit/automation/test_dependency_resolver.py
+++ b/tests/unit/automation/test_dependency_resolver.py
@@ -184,3 +184,65 @@ class TestDependencyResolver:
         # Should not appear in ready issues
         ready = resolver.get_ready_issues()
         assert 1 not in [i.number for i in ready]
+
+
+class TestLoadDependenciesIterative:
+    """Tests for the iterative BFS _load_dependencies (A5-03)."""
+
+    def test_visited_set_prevents_revisiting(self) -> None:
+        """A dependency already in the graph is not loaded twice (A5-03)."""
+        from unittest.mock import patch
+
+        resolver = DependencyResolver(skip_closed=False)
+        # Pre-populate issue 1 so the BFS should skip re-fetching it.
+        resolver.add_issue(IssueInfo(number=1, title="Already loaded"))
+        issue_with_dep = IssueInfo(number=2, title="Has dep", dependencies=[1])
+
+        with patch("hephaestus.automation.dependency_resolver.fetch_issue_info") as mock_fetch:
+            resolver._load_dependencies(issue_with_dep, {})
+
+        # fetch_issue_info must NOT have been called for dep 1 (already in graph)
+        mock_fetch.assert_not_called()
+
+    def test_depth_cap_raises_runtime_error(self) -> None:
+        """Exceeding _MAX_DEPENDENCY_DEPTH raises RuntimeError (A5-03)."""
+        from unittest.mock import patch
+
+        resolver = DependencyResolver(skip_closed=False)
+        root = IssueInfo(number=0, title="Root", dependencies=[1])
+
+        # Each fetched issue depends on the next, creating a chain of depth > 100.
+        def _make_issue(n: int) -> IssueInfo:
+            return IssueInfo(number=n, title=f"Issue {n}", dependencies=[n + 1])
+
+        with patch(
+            "hephaestus.automation.dependency_resolver.fetch_issue_info",
+            side_effect=lambda n: _make_issue(n),
+        ):
+            with pytest.raises(RuntimeError, match="exceeded"):
+                resolver._load_dependencies(root, {})
+
+    def test_normal_chain_loads_all(self) -> None:
+        """A finite chain (depth < limit) loads all dependencies without error (A5-03)."""
+        from unittest.mock import patch
+
+        resolver = DependencyResolver(skip_closed=False)
+        root = IssueInfo(number=10, title="Root", dependencies=[9])
+
+        # 9 -> 8 -> 7 (depth 3, well within limit)
+        dep_map = {
+            9: IssueInfo(number=9, title="D9", dependencies=[8]),
+            8: IssueInfo(number=8, title="D8", dependencies=[7]),
+            7: IssueInfo(number=7, title="D7", dependencies=[]),
+        }
+
+        with patch(
+            "hephaestus.automation.dependency_resolver.fetch_issue_info",
+            side_effect=lambda n: dep_map[n],
+        ):
+            resolver._load_dependencies(root, {})
+
+        # All three deps should now be in the graph
+        assert 9 in resolver.graph.issues
+        assert 8 in resolver.graph.issues
+        assert 7 in resolver.graph.issues

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -301,13 +301,43 @@ class TestGhCall:
 
     @patch("hephaestus.automation.github_api.run")
     def test_claude_usage_limit_detection(self, mock_run: Any) -> None:
-        """Test detection of Claude usage limit."""
+        """Test detection of Claude usage limit (A5-01/A5-02).
+
+        The error must carry a Claude-specific phrase; a plain "usage limit"
+        without the "Claude" prefix must no longer trigger the detector so
+        GitHub's own API-rate-limit messages are not misidentified.
+        """
         mock_run.side_effect = subprocess.CalledProcessError(
-            1, "gh", stderr="Usage limit exceeded for your account"
+            1, "gh", stderr="Claude AI usage limit exceeded for your account"
         )
 
-        with pytest.raises(RuntimeError, match="Claude API usage limit"):
+        # ClaudeUsageCapError is a RuntimeError subclass, so existing
+        # 'except RuntimeError' callers continue to work.
+        from hephaestus.automation.github_api import ClaudeUsageCapError
+
+        with pytest.raises(ClaudeUsageCapError):
             _gh_call(["issue", "view", "123"])
+
+    @patch("hephaestus.automation.github_api.run")
+    def test_github_usage_limit_not_misidentified(self, mock_run: Any) -> None:
+        """GitHub's own 'usage limit' message must not raise ClaudeUsageCapError (A5-01).
+
+        It should be treated as a transient error and retried instead.
+        """
+        success = Mock()
+        success.stdout = "success"
+        success.returncode = 0
+        # First call fails with a bare "usage limit" (GitHub's message, not Claude's);
+        # second call succeeds to confirm it was retried.
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "gh", stderr="API usage limit exceeded"),
+            success,
+        ]
+
+        with patch("hephaestus.automation.github_api.time.sleep"):
+            result = _gh_call(["issue", "view", "123"], max_retries=2)
+
+        assert result.stdout == "success"
 
 
 # NOTE on patch targets: tests in TestGhCall patch "hephaestus.automation.github_api.run"

--- a/tests/unit/automation/test_issue_dedup.py
+++ b/tests/unit/automation/test_issue_dedup.py
@@ -126,3 +126,59 @@ class TestIssueMatchDataclass:
         m = IssueMatch(number=1, title="t", body="b", similarity=0.9)
         assert m.number == 1
         assert m.similarity == 0.9
+
+
+class TestShortTitleFallback:
+    """A5-06: short titles (<3 content tokens) use tri-gram fallback."""
+
+    def test_fix_typo_matches_fix_typo(self) -> None:
+        """Identical two-token titles should match above threshold (A5-06)."""
+        candidates = [{"number": 7, "title": "Fix typo", "body": ""}]
+        with patch(
+            "hephaestus.automation.issue_dedup._gh_call",
+            return_value=_mock_gh(candidates),
+        ):
+            match = find_duplicate_open_issue("Fix typo", "", threshold=0.5)
+        assert match is not None
+        assert match.number == 7
+
+    def test_fix_typo_does_not_match_unrelated_short_title(self) -> None:
+        """Dissimilar two-token titles should NOT match above threshold (A5-06)."""
+        candidates = [{"number": 8, "title": "Add index", "body": ""}]
+        with patch(
+            "hephaestus.automation.issue_dedup._gh_call",
+            return_value=_mock_gh(candidates),
+        ):
+            match = find_duplicate_open_issue("Fix typo", "", threshold=0.5)
+        assert match is None
+
+    def test_trigrams_function_basic(self) -> None:
+        """_trigrams returns expected character tri-grams."""
+        from hephaestus.automation.issue_dedup import _trigrams
+
+        tg = _trigrams("abc")
+        assert "abc" in tg
+
+    def test_trigram_similarity_identical(self) -> None:
+        """Identical strings have trigram similarity of 1.0."""
+        from hephaestus.automation.issue_dedup import _trigram_similarity
+
+        assert _trigram_similarity("hello world", "hello world") == 1.0
+
+    def test_trigram_similarity_different(self) -> None:
+        """Completely different strings have low trigram similarity."""
+        from hephaestus.automation.issue_dedup import _trigram_similarity
+
+        score = _trigram_similarity("fix typo", "add index")
+        assert score < 0.5
+
+    def test_title_similarity_long_uses_jaccard(self) -> None:
+        """Titles with >=3 content tokens use token Jaccard, not tri-grams."""
+        from hephaestus.automation.issue_dedup import _title_similarity
+
+        # These titles each have 3+ content tokens — should use word Jaccard.
+        score = _title_similarity(
+            "Refactor database connection pool",
+            "Refactor database connection pool",
+        )
+        assert score == 1.0

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -100,3 +100,46 @@ class TestRunLearn:
             result = run_learn("session-abc", worktree_path, 42, tmp_path, slot_id=3)
 
         assert result is True
+
+    def test_uses_learn_model_not_hardcoded_sonnet(self, tmp_path: Path) -> None:
+        """run_learn passes learn_model() to --model instead of hardcoding 'sonnet' (A5-12)."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = "done"
+
+        with (
+            patch("hephaestus.automation.learn.run", return_value=mock_result) as mock_run,
+            patch(
+                "hephaestus.automation.learn.learn_model", return_value="claude-haiku-4-5"
+            ) as mock_learn_model,
+        ):
+            run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        mock_learn_model.assert_called_once()
+        # Verify "--model" "claude-haiku-4-5" appears in the command args
+        cmd_args = mock_run.call_args[0][0]
+        assert "--model" in cmd_args
+        model_idx = cmd_args.index("--model")
+        assert cmd_args[model_idx + 1] == "claude-haiku-4-5"
+
+    def test_learn_model_env_override_respected(self, tmp_path: Path) -> None:
+        """HEPH_LEARN_MODEL env override is used by run_learn (A5-12)."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        mock_result = MagicMock()
+        mock_result.stdout = "done"
+
+        import os
+
+        with (
+            patch.dict(os.environ, {"HEPH_LEARN_MODEL": "claude-opus-4-7"}),
+            patch("hephaestus.automation.learn.run", return_value=mock_result) as mock_run,
+        ):
+            run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        cmd_args = mock_run.call_args[0][0]
+        model_idx = cmd_args.index("--model")
+        assert cmd_args[model_idx + 1] == "claude-opus-4-7"

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -184,8 +184,12 @@ class TestDetectClaudeUsageLimit:
         assert result is False
 
     def test_case_insensitive_detection(self) -> None:
-        """Detects usage limit regardless of case."""
-        result = detect_claude_usage_limit("USAGE LIMIT reached")
+        """Detects Claude-specific usage limit regardless of case (A5-01).
+
+        The tightened pattern requires "Claude" before "usage limit" to avoid
+        false-triggering on GitHub's own "API usage limit" messages.
+        """
+        result = detect_claude_usage_limit("CLAUDE usage limit reached")
         assert result is True
 
     def test_returns_false_for_unrelated_error(self) -> None:
@@ -194,9 +198,29 @@ class TestDetectClaudeUsageLimit:
         assert result is False
 
     def test_partial_match_in_longer_text(self) -> None:
-        """Detects pattern embedded in longer text."""
-        text = "API call failed: usage limit exceeded, please try again later"
+        """Detects Claude-specific usage-limit pattern embedded in longer text (A5-01).
+
+        Plain "usage limit" without "Claude" must NOT match any more — it would
+        false-trigger on GitHub's own "API usage limit" messages.
+        """
+        # Claude-prefixed form should still be detected
+        text = "Claude API call failed: claude usage limit exceeded"
         assert detect_claude_usage_limit(text) is True
+
+    def test_github_api_usage_limit_not_detected(self) -> None:
+        """GitHub's own 'API usage limit' message must not be detected as Claude's (A5-01)."""
+        text = "API call failed: usage limit exceeded, please try again later"
+        assert detect_claude_usage_limit(text) is False
+
+    def test_out_of_extra_usage_detected(self) -> None:
+        """Detects 'out of extra usage' phrase used by Claude CLI."""
+        result = detect_claude_usage_limit("You're out of extra usage for this period")
+        assert result is True
+
+    def test_upgrade_url_detected(self) -> None:
+        """Detects claude.com/upgrade URL in error output."""
+        result = detect_claude_usage_limit("Visit claude.com/upgrade to increase limits")
+        assert result is True
 
 
 class TestDetectClaudeUsageCap:


### PR DESCRIPTION
## Summary

Closes #383

Nine targeted hardening fixes across the supporting automation modules, grouped as the A5 audit cluster from Epic #310.

- **A5-01** `rate_limit.py`: Tighten `r'usage limit'` to Claude-specific patterns (`r'Claude.*usage limit'`, `r'out of extra usage'`, `r'claude\.com/upgrade'`) so GitHub's own "API usage limit" messages no longer false-trigger the Claude cap detector.
- **A5-02** `github_api.py`: Add `ClaudeUsageCapError(RuntimeError)` with `reset_epoch` attribute. `_gh_call` now calls `detect_claude_usage_cap()` first (has epoch), falls back to `detect_claude_usage_limit()`. Also tighten non-transient regex patterns to require word boundaries around HTTP status codes.
- **A5-03** `dependency_resolver.py`: Replace recursive `_load_dependencies()` with iterative BFS + visited set + `_MAX_DEPENDENCY_DEPTH=100` guard. Prevents stack overflow on deep/wide graphs and raises a clear `RuntimeError` on depth breach.
- **A5-04** `claude_models.py`: Add `_resolve_model()` helper that warns (not crashes) when an unknown model ID is set via env var. All five phase functions route through it.
- **A5-05** `prompts.py`: Add `_relativize_path()` helper + optional `repo_root` parameter to `get_implementation_prompt()` and `get_advise_prompt()`. Relativizes absolute paths before injection; falls back with warning when not under repo_root.
- **A5-06** `issue_dedup.py`: Add character tri-gram similarity fallback for short titles (<3 content tokens after stopword removal). "Fix typo" now correctly matches "Fix typo" and doesn't score against unrelated short titles.
- **A5-07** `follow_up.py`: Replace greedy `re.search(r'(\[.*\])')` with `_extract_outer_json_array()` — a balanced-bracket scanner that correctly handles nested arrays/objects and quoted strings.
- **A5-08** `curses_ui.py`: Catch `curses.error` in refresh loop → call `curses.resizeterm(*stdscr.getmaxyx())` so the TUI recovers gracefully on SIGWINCH instead of freezing.
- **A5-12** `learn.py`: Replace hardcoded `'--model', 'sonnet'` with `'--model', learn_model()` so `HEPH_LEARN_MODEL` is honoured.

## Test plan

- [ ] `pixi run pytest tests/unit/github/test_rate_limit.py tests/unit/automation/test_issue_dedup.py tests/unit/automation/test_follow_up.py tests/unit/automation/test_claude_models.py tests/unit/automation/test_learn.py tests/unit/automation/test_dependency_resolver.py tests/unit/automation/test_github_api.py` — all 157 pass
- [ ] `pixi run pytest tests/unit` — 2054 passed, 6 skipped, coverage 83.17%
- [ ] `pixi run ruff check hephaestus/ tests/` — clean
- [ ] `pixi run mypy` — no issues found in 231 source files
- [ ] `pre-commit run ruff-format-python ruff-check-python mypy-check-python --all-files` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)