### PR TITLE
style(automation): convert f-string logging to %-style (#317)

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -97,7 +97,7 @@ class AddressReviewer:
             Dictionary mapping issue number to WorkerResult
 
         """
-        logger.info(f"Starting address review for issues: {self.options.issues}")
+        logger.info("Starting address review for issues: %s", self.options.issues)
 
         # Pre-discover PRs — only submit workers for issues that have an open PR.
         # This prevents Claude from being launched for issues with no PR at all.
@@ -106,7 +106,7 @@ class AddressReviewer:
             logger.warning("No open PRs found for the specified issues — nothing to address")
             return {}
 
-        logger.info(f"Found {len(pr_map)} PR(s) to address: {pr_map}")
+        logger.info("Found %s PR(s) to address: %s", len(pr_map), pr_map)
 
         # Start UI if enabled and not dry run
         if not self.options.dry_run and self.options.enable_ui:
@@ -150,7 +150,7 @@ class AddressReviewer:
             if pr_number is not None:
                 pr_map[issue_num] = pr_number
             else:
-                logger.info(f"Issue #{issue_num}: no open PR found, skipping")
+                logger.info("Issue #%s: no open PR found, skipping", issue_num)
         return pr_map
 
     def _address_all(self, pr_map: dict[int, int]) -> dict[int, WorkerResult]:
@@ -201,13 +201,13 @@ class AddressReviewer:
                         result = future.result()
                         results[issue_num] = result
                         if result.success:
-                            logger.info(f"Issue #{issue_num} address review completed")
+                            logger.info("Issue #%s address review completed", issue_num)
                         else:
                             logger.error(
-                                f"Issue #{issue_num} address review failed: {result.error}"
+                                "Issue #%s address review failed: %s", issue_num, result.error
                             )
                     except Exception as e:
-                        logger.error(f"Issue #{issue_num} raised exception: {e}")
+                        logger.error("Issue #%s raised exception: %s", issue_num, e)
                         results[issue_num] = WorkerResult(
                             issue_number=issue_num,
                             success=False,
@@ -438,7 +438,7 @@ class AddressReviewer:
         state_file = self.state_dir / f"issue-{issue_number}.json"
         if not state_file.exists():
             logger.warning(
-                f"No implementation state for issue #{issue_number}, will use fresh session"
+                "No implementation state for issue #%s, will use fresh session", issue_number
             )
             return None
         try:
@@ -446,7 +446,7 @@ class AddressReviewer:
             session_id: str | None = data.get("session_id")
             return session_id
         except Exception as e:
-            logger.warning(f"Could not load impl session for #{issue_number}: {e}")
+            logger.warning("Could not load impl session for #%s: %s", issue_number, e)
             return None
 
     def _load_review_state(self, issue_number: int) -> ReviewState | None:
@@ -466,7 +466,7 @@ class AddressReviewer:
             data = json.loads(state_file.read_text())
             return ReviewState.model_validate(data)
         except Exception as e:
-            logger.warning(f"Could not load review state for #{issue_number}: {e}")
+            logger.warning("Could not load review state for #%s: %s", issue_number, e)
             return None
 
     def _save_review_state(self, state: ReviewState) -> None:
@@ -504,7 +504,7 @@ class AddressReviewer:
             existing_path = Path(review_state.worktree_path)
             if existing_path.exists() and (existing_path / ".git").exists():
                 logger.info(
-                    f"Reusing existing worktree at {existing_path} for issue #{issue_number}"
+                    "Reusing existing worktree at %s for issue #%s", existing_path, issue_number
                 )
                 # Register with worktree manager so cleanup works
                 with self.worktree_manager.lock:
@@ -512,7 +512,7 @@ class AddressReviewer:
                 return existing_path
 
         # Create new worktree
-        logger.info(f"Creating new worktree for issue #{issue_number} on branch {branch_name}")
+        logger.info("Creating new worktree for issue #%s on branch %s", issue_number, branch_name)
         return self.worktree_manager.create_worktree(issue_number, branch_name)
 
     def _run_fix_session(  # noqa: C901  # session-resume + fallback + cleanup + parse error paths
@@ -540,7 +540,7 @@ class AddressReviewer:
 
         """
         if self.options.dry_run:
-            logger.info(f"[DRY RUN] Would run fix session for PR #{pr_number}")
+            logger.info("[DRY RUN] Would run fix session for PR #%s", pr_number)
             return {"addressed": [], "replies": {}}
 
         threads_json = json.dumps(
@@ -646,8 +646,9 @@ class AddressReviewer:
 
             parsed = self._parse_json_block(response_text, issue_number=issue_number)
             logger.info(
-                f"Fix session complete for PR #{pr_number}; "
-                f"addressed {len(parsed.get('addressed', []))} thread(s)"
+                "Fix session complete for PR #%s; addressed %s thread(s)",
+                pr_number,
+                len(parsed.get("addressed", [])),
             )
             return parsed
 
@@ -779,7 +780,7 @@ class AddressReviewer:
             try:
                 gh_pr_resolve_thread(thread_id, reply, dry_run=self.options.dry_run)
             except Exception as e:
-                logger.warning(f"Could not resolve thread {thread_id}: {e}")
+                logger.warning("Could not resolve thread %s: %s", thread_id, e)
 
     def _commit_if_changes(self, issue_number: int, worktree_path: Path) -> None:
         """Commit any pending changes in the worktree.
@@ -797,17 +798,17 @@ class AddressReviewer:
             capture_output=True,
         )
         if not result.stdout.strip():
-            logger.info(f"No changes to commit for issue #{issue_number}")
+            logger.info("No changes to commit for issue #%s", issue_number)
             return
 
         try:
             from .pr_manager import commit_changes
 
             commit_changes(issue_number, worktree_path)
-            logger.info(f"Committed fix changes for issue #{issue_number}")
+            logger.info("Committed fix changes for issue #%s", issue_number)
         except RuntimeError as e:
             # commit_changes raises RuntimeError if nothing to commit; already checked above
-            logger.warning(f"Commit skipped for issue #{issue_number}: {e}")
+            logger.warning("Commit skipped for issue #%s: %s", issue_number, e)
 
     def _push_branch(self, branch_name: str, worktree_path: Path) -> None:
         """Push the branch to origin.
@@ -825,7 +826,7 @@ class AddressReviewer:
                 ["git", "push", "origin", branch_name],
                 cwd=worktree_path,
             )
-            logger.info(f"Pushed branch {branch_name} to origin")
+            logger.info("Pushed branch %s to origin", branch_name)
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to push branch {branch_name}: {e}") from e
 
@@ -869,15 +870,15 @@ class AddressReviewer:
         logger.info("=" * 60)
         logger.info("Address Review Summary")
         logger.info("=" * 60)
-        logger.info(f"Total issues: {total}")
-        logger.info(f"Successful: {successful}")
-        logger.info(f"Failed: {failed}")
+        logger.info("Total issues: %s", total)
+        logger.info("Successful: %s", successful)
+        logger.info("Failed: %s", failed)
 
         if failed > 0:
             logger.info("\nFailed issues:")
             for issue_num, result in results.items():
                 if not result.success:
-                    logger.info(f"  #{issue_num}: {result.error}")
+                    logger.info("  #%s: %s", issue_num, result.error)
 
 
 def _setup_logging(verbose: bool = False) -> None:
@@ -962,7 +963,7 @@ def main() -> int:
     _setup_logging(args.verbose)
 
     log = logging.getLogger(__name__)
-    log.info(f"Starting address review for issues: {args.issues}")
+    log.info("Starting address review for issues: %s", args.issues)
 
     from hephaestus.utils.terminal import terminal_guard
 
@@ -981,7 +982,7 @@ def main() -> int:
 
             failed = [num for num, result in results.items() if not result.success]
             if failed:
-                log.error(f"Failed to address review for {len(failed)} issue(s): {failed}")
+                log.error("Failed to address review for %s issue(s): %s", len(failed), failed)
                 return 1
 
             log.info("Address review complete")

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -67,8 +67,9 @@ class CIDriver:
 
         """
         logger.info(
-            f"Starting CI driver for {len(self.options.issues)} issue(s) "
-            f"with {self.options.max_workers} parallel workers"
+            "Starting CI driver for %s issue(s) with %s parallel workers",
+            len(self.options.issues),
+            self.options.max_workers,
         )
 
         if not self.options.issues:
@@ -82,7 +83,7 @@ class CIDriver:
             logger.warning("No open PRs found for the specified issues — nothing to drive")
             return {}
 
-        logger.info(f"Found {len(pr_map)} PR(s) to drive to green: {pr_map}")
+        logger.info("Found %s PR(s) to drive to green: %s", len(pr_map), pr_map)
 
         results: dict[int, WorkerResult] = {}
 
@@ -110,11 +111,13 @@ class CIDriver:
                             with self.lock:
                                 results[issue_num] = result
                             if result.success:
-                                logger.info(f"Issue #{issue_num}: CI drive completed")
+                                logger.info("Issue #%s: CI drive completed", issue_num)
                             else:
-                                logger.error(f"Issue #{issue_num}: CI drive failed: {result.error}")
+                                logger.error(
+                                    "Issue #%s: CI drive failed: %s", issue_num, result.error
+                                )
                         except Exception as e:
-                            logger.error(f"Issue #{issue_num} raised exception: {e}")
+                            logger.error("Issue #%s raised exception: %s", issue_num, e)
                             with self.lock:
                                 results[issue_num] = WorkerResult(
                                     issue_number=issue_num,
@@ -157,7 +160,7 @@ class CIDriver:
             if pr_number is not None:
                 pr_map[issue_num] = pr_number
             else:
-                logger.info(f"Issue #{issue_num}: no open PR found, skipping")
+                logger.info("Issue #%s: no open PR found, skipping", issue_num)
         return pr_map
 
     def _drive_issue(  # noqa: C901  # poll loop + required-check classification + fix path
@@ -207,7 +210,7 @@ class CIDriver:
             while True:
                 checks = gh_pr_checks(pr_number, dry_run=self.options.dry_run)
                 if not checks:
-                    logger.info(f"Issue #{issue_number}: no CI checks found for PR #{pr_number}")
+                    logger.info("Issue #%s: no CI checks found for PR #%s", issue_number, pr_number)
                     return WorkerResult(
                         issue_number=issue_number, success=True, pr_number=pr_number
                     )
@@ -230,9 +233,11 @@ class CIDriver:
                 sleep_secs = min(2**poll_attempt, 60)
                 if poll_elapsed + sleep_secs > _ci_poll_max_wait:
                     logger.warning(
-                        f"Issue #{issue_number}: CI checks still pending after "
-                        f"{poll_elapsed}s (limit {_ci_poll_max_wait}s), "
-                        f"treating as not yet failing"
+                        "Issue #%s: CI checks still pending after %ss (limit %ss), "
+                        "treating as not yet failing",
+                        issue_number,
+                        poll_elapsed,
+                        _ci_poll_max_wait,
                     )
                     return WorkerResult(
                         issue_number=issue_number, success=True, pr_number=pr_number
@@ -244,8 +249,11 @@ class CIDriver:
                     f"{poll_elapsed}s elapsed)",
                 )
                 logger.debug(
-                    f"Issue #{issue_number}: CI checks pending, sleeping {sleep_secs}s "
-                    f"(attempt {poll_attempt + 1}, {poll_elapsed}s elapsed)"
+                    "Issue #%s: CI checks pending, sleeping %ss (attempt %s, %ss elapsed)",
+                    issue_number,
+                    sleep_secs,
+                    poll_attempt + 1,
+                    poll_elapsed,
                 )
                 time.sleep(sleep_secs)
                 poll_elapsed += sleep_secs
@@ -262,8 +270,9 @@ class CIDriver:
                 # DRY-RUN GUARD before auto-merge
                 if self.options.dry_run:
                     logger.info(
-                        f"[dry_run] Would enable auto-merge for PR #{pr_number} "
-                        f"(issue #{issue_number})"
+                        "[dry_run] Would enable auto-merge for PR #%s (issue #%s)",
+                        pr_number,
+                        issue_number,
                     )
                     return WorkerResult(
                         issue_number=issue_number, success=True, pr_number=pr_number
@@ -282,8 +291,10 @@ class CIDriver:
                 # All concluded but none are green and none are "failure" —
                 # e.g. all cancelled.  Nothing for us to fix.
                 logger.info(
-                    f"Issue #{issue_number}: PR #{pr_number} checks concluded with "
-                    "non-green, non-failure conclusions (e.g. cancelled)"
+                    "Issue #%s: PR #%s checks concluded with non-green, non-failure conclusions "
+                    "(e.g. cancelled)",
+                    issue_number,
+                    pr_number,
                 )
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
@@ -300,7 +311,7 @@ class CIDriver:
             )
 
         except Exception as e:
-            logger.error(f"Issue #{issue_number}: unexpected error: {e}")
+            logger.error("Issue #%s: unexpected error: %s", issue_number, e)
             return WorkerResult(
                 issue_number=issue_number,
                 success=False,
@@ -338,8 +349,10 @@ class CIDriver:
 
             if self.options.dry_run:
                 logger.info(
-                    f"[dry_run] Would run CI fix session for PR #{pr_number} "
-                    f"(issue #{issue_number}, iteration {iteration + 1})"
+                    "[dry_run] Would run CI fix session for PR #%s (issue #%s, iteration %s)",
+                    pr_number,
+                    issue_number,
+                    iteration + 1,
                 )
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
@@ -352,11 +365,13 @@ class CIDriver:
             )
             if fixed:
                 logger.info(
-                    f"Issue #{issue_number}: CI fix applied successfully (attempt {iteration + 1})"
+                    "Issue #%s: CI fix applied successfully (attempt %s)",
+                    issue_number,
+                    iteration + 1,
                 )
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
-            logger.warning(f"Issue #{issue_number}: CI fix attempt {iteration + 1} failed")
+            logger.warning("Issue #%s: CI fix attempt %s failed", issue_number, iteration + 1)
 
         return None
 
@@ -393,10 +408,10 @@ class CIDriver:
             pr_data = json.loads(result.stdout or "[]")
             if pr_data:
                 pr_number = pr_data[0]["number"]
-                logger.info(f"Found PR #{pr_number} for issue #{issue_number} via branch name")
+                logger.info("Found PR #%s for issue #%s via branch name", pr_number, issue_number)
                 return int(pr_number)
         except Exception as e:
-            logger.debug(f"Branch-name lookup failed for issue #{issue_number}: {e}")
+            logger.debug("Branch-name lookup failed for issue #%s: %s", issue_number, e)
 
         # Strategy 2: Search PR body for issue reference using the canonical
         # "Closes #N" pattern so we don't accidentally match a PR that merely
@@ -421,12 +436,14 @@ class CIDriver:
             if pr_data:
                 pr_number = pr_data[0]["number"]
                 logger.info(
-                    f"Found PR #{pr_number} for issue #{issue_number} via body search "
-                    f"(title: {pr_data[0].get('title', '')!r})"
+                    "Found PR #%s for issue #%s via body search (title: %r)",
+                    pr_number,
+                    issue_number,
+                    pr_data[0].get("title", ""),
                 )
                 return int(pr_number)
         except Exception as e:
-            logger.debug(f"Body search failed for issue #{issue_number}: {e}")
+            logger.debug("Body search failed for issue #%s: %s", issue_number, e)
 
         return None
 
@@ -449,7 +466,7 @@ class CIDriver:
             branch: str = data.get("headRefName", f"pr-{pr_number}")
             return branch
         except Exception as e:
-            logger.warning(f"Could not fetch branch for PR #{pr_number}: {e}")
+            logger.warning("Could not fetch branch for PR #%s: %s", pr_number, e)
             return f"pr-{pr_number}"
 
     def _get_worktree_path(self, issue_number: int, pr_number: int) -> Path:
@@ -474,7 +491,7 @@ class CIDriver:
                     if wt.exists():
                         return wt
             except Exception as e:
-                logger.debug(f"Could not read review state for issue #{issue_number}: {e}")
+                logger.debug("Could not read review state for issue #%s: %s", issue_number, e)
 
         # Fallback: create a new worktree for the PR head branch
         branch = self._get_pr_branch(pr_number)
@@ -528,12 +545,12 @@ class CIDriver:
                     )
                     logs.append(f"=== {run_name} ===\n{log_result.stdout[:3000]}")
                 except Exception as log_err:
-                    logger.debug(f"Could not fetch log for run {run_id}: {log_err}")
+                    logger.debug("Could not fetch log for run %s: %s", run_id, log_err)
 
             return "\n\n".join(logs)[:10000]
 
         except Exception as e:
-            logger.warning(f"Could not fetch CI logs for PR #{pr_number}: {e}")
+            logger.warning("Could not fetch CI logs for PR #%s: %s", pr_number, e)
             return ""
 
     def _load_impl_session_id(self, issue_number: int) -> str | None:
@@ -548,17 +565,17 @@ class CIDriver:
         """
         state_file = self.state_dir / f"state-{issue_number}.json"
         if not state_file.exists():
-            logger.debug(f"No implementer state file for issue #{issue_number}")
+            logger.debug("No implementer state file for issue #%s", issue_number)
             return None
 
         try:
             data = json.loads(state_file.read_text())
             session_id: str | None = data.get("session_id")
             if session_id:
-                logger.debug(f"Loaded session_id for issue #{issue_number}: {session_id[:8]}...")
+                logger.debug("Loaded session_id for issue #%s: %s...", issue_number, session_id[:8])
             return session_id
         except Exception as e:
-            logger.warning(f"Could not load session_id for issue #{issue_number}: {e}")
+            logger.warning("Could not load session_id for issue #%s: %s", issue_number, e)
             return None
 
     def _run_ci_fix_session(
@@ -635,7 +652,7 @@ class CIDriver:
             # If --resume failed, retry without it
             if result.returncode != 0 and session_id:
                 logger.warning(
-                    f"Issue #{issue_number}: --resume session failed, retrying without it"
+                    "Issue #%s: --resume session failed, retrying without it", issue_number
                 )
                 result = subprocess.run(
                     base_cmd,
@@ -650,25 +667,31 @@ class CIDriver:
                 # Push the fixes
                 try:
                     run(["git", "push", "origin", "HEAD"], cwd=worktree_path)
-                    logger.info(f"Issue #{issue_number}: pushed CI fixes for PR #{pr_number}")
+                    logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
                     return True
                 except Exception as push_err:
-                    logger.error(f"Issue #{issue_number}: git push failed after CI fix: {push_err}")
+                    logger.error(
+                        "Issue #%s: git push failed after CI fix: %s", issue_number, push_err
+                    )
                     return False
 
             logger.error(
-                f"Issue #{issue_number}: Claude CI fix session returned exit code "
-                f"{result.returncode}: {result.stderr[:300]}"
+                "Issue #%s: Claude CI fix session returned exit code %s: %s",
+                issue_number,
+                result.returncode,
+                result.stderr[:300],
             )
             return False
 
         except subprocess.TimeoutExpired:
             logger.error(
-                f"Issue #{issue_number}: Claude CI fix session timed out for PR #{pr_number}"
+                "Issue #%s: Claude CI fix session timed out for PR #%s", issue_number, pr_number
             )
             return False
         except Exception as e:
-            logger.error(f"Issue #{issue_number}: CI fix session failed for PR #{pr_number}: {e}")
+            logger.error(
+                "Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e
+            )
             return False
 
     def _enable_auto_merge(self, pr_number: int) -> bool:
@@ -689,29 +712,34 @@ class CIDriver:
         """
         try:
             _gh_call(["pr", "merge", str(pr_number), "--auto", "--rebase"])
-            logger.info(f"Enabled auto-merge for PR #{pr_number}")
+            logger.info("Enabled auto-merge for PR #%s", pr_number)
             return True
         except subprocess.CalledProcessError as e:
             logger.warning(
-                f"Could not enable auto-merge (--rebase) for PR #{pr_number}: {e}; "
-                "will attempt squash-merge fallback if force_merge_on_stall is set"
+                "Could not enable auto-merge (--rebase) for PR #%s: %s; "
+                "will attempt squash-merge fallback if force_merge_on_stall is set",
+                pr_number,
+                e,
             )
 
         if not self.options.force_merge_on_stall:
             logger.error(
-                f"PR #{pr_number}: auto-merge failed and force_merge_on_stall is not set; "
-                "skipping squash-merge fallback"
+                "PR #%s: auto-merge failed and force_merge_on_stall is not set; "
+                "skipping squash-merge fallback",
+                pr_number,
             )
             return False
 
         # Fallback: direct squash merge
         try:
             _gh_call(["pr", "merge", str(pr_number), "--squash", "--delete-branch"])
-            logger.info(f"Squash-merged PR #{pr_number} via fallback")
+            logger.info("Squash-merged PR #%s via fallback", pr_number)
             return True
         except subprocess.CalledProcessError as fallback_err:
             logger.error(
-                f"PR #{pr_number}: both auto-merge and squash-merge fallback failed: {fallback_err}"
+                "PR #%s: both auto-merge and squash-merge fallback failed: %s",
+                pr_number,
+                fallback_err,
             )
             return False
 
@@ -752,15 +780,15 @@ class CIDriver:
         logger.info("=" * 60)
         logger.info("CI Driver Summary")
         logger.info("=" * 60)
-        logger.info(f"Total issues: {total}")
-        logger.info(f"Successful: {successful}")
-        logger.info(f"Failed: {failed}")
+        logger.info("Total issues: %s", total)
+        logger.info("Successful: %s", successful)
+        logger.info("Failed: %s", failed)
 
         if failed > 0:
             logger.info("Failed issues:")
             for issue_num, result in results.items():
                 if not result.success:
-                    logger.info(f"  #{issue_num}: {result.error}")
+                    logger.info("  #%s: %s", issue_num, result.error)
 
 
 # ---------------------------------------------------------------------------
@@ -902,7 +930,7 @@ def main() -> int:
         return 2
     log.debug("ci_driver gate passed: %s", reason)
 
-    log.info(f"Starting CI driver for issues: {args.issues}")
+    log.info("Starting CI driver for issues: %s", args.issues)
 
     try:
         options = CIDriverOptions(
@@ -918,7 +946,7 @@ def main() -> int:
 
         failed = [num for num, result in results.items() if not result.success]
         if failed:
-            log.error(f"CI drive failed for {len(failed)} issue(s): {failed}")
+            log.error("CI drive failed for %s issue(s): %s", len(failed), failed)
             return 1
 
         log.info("CI driver complete")

--- a/hephaestus/automation/curses_ui.py
+++ b/hephaestus/automation/curses_ui.py
@@ -163,7 +163,7 @@ class CursesUI:
         try:
             curses.wrapper(self._curses_main)
         except Exception as e:
-            logger.error(f"CursesUI error: {e}")
+            logger.error("CursesUI error: %s", e)
         finally:
             # Always reset running flag so UI can be restarted
             self.running = False

--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -74,7 +74,7 @@ class DependencyResolver:
             RuntimeError: If epic cannot be loaded
 
         """
-        logger.info(f"Loading epic #{epic_number}")
+        logger.info("Loading epic #%s", epic_number)
 
         # Fetch epic issue
         epic = fetch_issue_info(epic_number)
@@ -84,7 +84,7 @@ class DependencyResolver:
         sub_issues = self._parse_sub_issues(epic)
 
         if not sub_issues:
-            logger.warning(f"Epic #{epic_number} has no sub-issues")
+            logger.warning("Epic #%s has no sub-issues", epic_number)
             return
 
         # Prefetch states for efficiency
@@ -93,7 +93,7 @@ class DependencyResolver:
         # Fetch each sub-issue and its dependencies
         for issue_num in sub_issues:
             if self.skip_closed and cached_states.get(issue_num) == IssueState.CLOSED:
-                logger.info(f"Skipping closed issue #{issue_num}")
+                logger.info("Skipping closed issue #%s", issue_num)
                 self.completed.add(issue_num)
                 continue
 
@@ -105,9 +105,9 @@ class DependencyResolver:
                 self._load_dependencies(issue, cached_states)
 
             except Exception as e:
-                logger.error(f"Failed to load issue #{issue_num}: {e}")
+                logger.error("Failed to load issue #%s: %s", issue_num, e)
 
-        logger.info(f"Loaded {len(self.graph.issues)} issues from epic")
+        logger.info("Loaded %s issues from epic", len(self.graph.issues))
 
     def _parse_sub_issues(self, epic: IssueInfo) -> list[int]:
         """Parse sub-issue numbers from epic body.
@@ -198,7 +198,7 @@ class DependencyResolver:
                 continue
 
             if self.skip_closed and cached_states.get(dep_num) == IssueState.CLOSED:
-                logger.info(f"Dependency #{dep_num} is closed, marking complete")
+                logger.info("Dependency #%s is closed, marking complete", dep_num)
                 self.completed.add(dep_num)
                 continue
 
@@ -211,7 +211,7 @@ class DependencyResolver:
                         visited.add(child_dep)
                         queue.append((child_dep, depth + 1))
             except Exception as e:
-                logger.error(f"Failed to load dependency #{dep_num}: {e}")
+                logger.error("Failed to load dependency #%s: %s", dep_num, e)
 
     def detect_cycles(self) -> list[list[int]]:
         """Detect cyclic dependencies in the graph.
@@ -251,7 +251,7 @@ class DependencyResolver:
 
         for issue_num in self.graph.issues:
             if issue_num not in visited and dfs(issue_num, set(), []):
-                logger.error(f"Cycle detected: {cycles[-1]}")
+                logger.error("Cycle detected: %s", cycles[-1])
 
         if cycles:
             raise CyclicDependencyError(f"Found {len(cycles)} dependency cycle(s): {cycles}")
@@ -291,7 +291,7 @@ class DependencyResolver:
 
         """
         self.completed.add(issue_number)
-        logger.debug(f"Marked issue #{issue_number} as completed")
+        logger.debug("Marked issue #%s as completed", issue_number)
 
     def topological_sort(self) -> list[int]:
         """Perform topological sort of the dependency graph.

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -80,7 +80,7 @@ def gh_list_labels(refresh: bool = False) -> set[str]:
         _label_cache = {item["name"] for item in data}
         return _label_cache
     except Exception as e:
-        logger.warning(f"Could not fetch label list: {e}; proceeding without validation")
+        logger.warning("Could not fetch label list: %s; proceeding without validation", e)
         return set()
 
 
@@ -99,7 +99,7 @@ def gh_create_label(name: str, color: str = "ededed", description: str = "") -> 
     _gh_call(cmd)
     if _label_cache is not None:
         _label_cache.add(name)
-    logger.info(f"Created missing label '{name}'")
+    logger.info("Created missing label '%s'", name)
 
 
 def _gh_call(
@@ -160,7 +160,7 @@ def _gh_call(
                     else:
                         # No reset time, use exponential backoff
                         wait_seconds = min(60 * (2**attempt), 300)  # Max 5 minutes
-                        logger.warning(f"Rate limited but no reset time, waiting {wait_seconds}s")
+                        logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
                         time.sleep(wait_seconds)
                     continue
                 else:
@@ -182,7 +182,7 @@ def _gh_call(
                 r"invalid argument",
             ]
             if any(re.search(pattern, stderr, re.IGNORECASE) for pattern in non_transient_patterns):
-                logger.error(f"Non-transient error detected: {stderr[:200]}")
+                logger.error("Non-transient error detected: %s", stderr[:200])
                 raise
 
             # Last retry attempt, re-raise
@@ -191,7 +191,9 @@ def _gh_call(
 
             # Transient error (network, timeout, 5xx), retry with backoff
             wait_seconds = 2**attempt
-            logger.warning(f"gh call failed (attempt {attempt + 1}), retrying in {wait_seconds}s")
+            logger.warning(
+                "gh call failed (attempt %s), retrying in %ss", attempt + 1, wait_seconds
+            )
             time.sleep(wait_seconds)
 
     # Should not reach here, but satisfy type checker
@@ -249,7 +251,7 @@ def gh_issue_comment(issue_number: int, body: str) -> None:
     """
     try:
         _gh_call(["issue", "comment", str(issue_number), "--body", body])
-        logger.info(f"Posted comment to issue #{issue_number}")
+        logger.info("Posted comment to issue #%s", issue_number)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to post comment to issue #{issue_number}: {e}") from e
 
@@ -304,7 +306,7 @@ def gh_issue_create(title: str, body: str, labels: list[str] | None = None) -> i
             if m and labels:
                 missing_label = m.group(1)
                 logger.warning(
-                    f"Label '{missing_label}' not found after pre-create; recreating and retrying"
+                    "Label '%s' not found after pre-create; recreating and retrying", missing_label
                 )
                 gh_create_label(missing_label)
                 result = _gh_call(cmd)
@@ -317,7 +319,7 @@ def gh_issue_create(title: str, body: str, labels: list[str] | None = None) -> i
         except (ValueError, IndexError) as e:
             raise RuntimeError(f"Failed to parse issue number from output: {output}") from e
 
-        logger.info(f"Created issue #{issue_number}")
+        logger.info("Created issue #%s", issue_number)
         return issue_number
 
     except subprocess.CalledProcessError as e:
@@ -401,15 +403,15 @@ def gh_pr_create(
         except (ValueError, IndexError) as e:
             raise RuntimeError(f"Failed to parse PR number from output: {output}") from e
 
-        logger.info(f"Created PR #{pr_number}")
+        logger.info("Created PR #%s", pr_number)
 
         # Enable auto-merge if requested
         if auto_merge:
             try:
                 _gh_call(["pr", "merge", str(pr_number), "--auto", "--rebase"])
-                logger.info(f"Enabled auto-merge for PR #{pr_number}")
+                logger.info("Enabled auto-merge for PR #%s", pr_number)
             except Exception as e:
-                logger.warning(f"Failed to enable auto-merge for PR #{pr_number}: {e}")
+                logger.warning("Failed to enable auto-merge for PR #%s: %s", pr_number, e)
 
         return pr_number
 
@@ -448,15 +450,15 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
         for key, issue_data in repo_data.items():
             if key.startswith("issue") and issue_data:
                 states[issue_data["number"]] = IssueState(issue_data["state"])
-        logger.debug(f"Fetched states for {len(batch)} issues")
+        logger.debug("Fetched states for %s issues", len(batch))
     except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError) as e:
-        logger.warning(f"Failed to batch fetch issue states: {e}")
+        logger.warning("Failed to batch fetch issue states: %s", e)
         for num in batch:
             try:
                 issue_data = gh_issue_json(num)
                 states[num] = IssueState(issue_data["state"])
             except Exception as e2:
-                logger.warning(f"Failed to fetch state for issue #{num}: {e2}")
+                logger.warning("Failed to fetch state for issue #%s: %s", num, e2)
     return states
 
 
@@ -476,13 +478,13 @@ def prefetch_issue_states(issue_numbers: list[int]) -> dict[int, IssueState]:
     try:
         owner, repo = get_repo_info()
     except RuntimeError as e:
-        logger.warning(f"Failed to get repo info: {e}")
+        logger.warning("Failed to get repo info: %s", e)
         return {}
 
     # Sanitize owner and repo to prevent GraphQL injection
     # Owner and repo should be alphanumeric with hyphens/underscores
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner) or not re.match(r"^[a-zA-Z0-9_-]+$", repo):
-        logger.error(f"Invalid owner/repo format: {owner}/{repo}")
+        logger.error("Invalid owner/repo format: %s/%s", owner, repo)
         return {}
 
     batch_size = 100
@@ -512,7 +514,7 @@ def is_issue_closed(issue_number: int, cached_states: dict[int, IssueState] | No
         issue_data = gh_issue_json(issue_number)
         return cast(bool, issue_data["state"] == "CLOSED")
     except Exception as e:
-        logger.warning(f"Failed to check if issue #{issue_number} is closed: {e}")
+        logger.warning("Failed to check if issue #%s is closed: %s", issue_number, e)
         return False
 
 
@@ -602,7 +604,7 @@ def write_secure(path: Path, content: str) -> None:
         with os.fdopen(fd, "w") as f:
             f.write(content)
         os.replace(temp_path, path)
-        logger.debug(f"Wrote {len(content)} bytes to {path}")
+        logger.debug("Wrote %s bytes to %s", len(content), path)
     except Exception:
         # Clean up temp file on error
         with contextlib.suppress(OSError):
@@ -632,7 +634,9 @@ def gh_pr_review_post(
     """
     if dry_run:
         logger.info(
-            f"[dry_run] Would post PR review on #{pr_number} with {len(comments)} inline comments"
+            "[dry_run] Would post PR review on #%s with %s inline comments",
+            pr_number,
+            len(comments),
         )
         return []
 
@@ -720,7 +724,7 @@ mutation AddReview(
             seen[tid] = None
 
     thread_ids: list[str] = list(seen)
-    logger.info(f"Posted PR review on #{pr_number}; created {len(thread_ids)} thread(s)")
+    logger.info("Posted PR review on #%s; created %s thread(s)", pr_number, len(thread_ids))
     return thread_ids
 
 
@@ -739,14 +743,14 @@ def gh_pr_list_unresolved_threads(
 
     """
     if dry_run:
-        logger.info(f"[dry_run] Would list unresolved threads for PR #{pr_number}")
+        logger.info("[dry_run] Would list unresolved threads for PR #%s", pr_number)
         return []
 
     owner, repo = get_repo_info()
 
     # Sanitize owner/repo to prevent injection (same pattern as prefetch_issue_states)
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner) or not re.match(r"^[a-zA-Z0-9_-]+$", repo):
-        logger.error(f"Invalid owner/repo format: {owner}/{repo}")
+        logger.error("Invalid owner/repo format: %s/%s", owner, repo)
         return []
 
     query = f"""
@@ -796,7 +800,7 @@ query GetThreads {{
             }
         )
 
-    logger.debug(f"Found {len(threads)} unresolved thread(s) on PR #{pr_number}")
+    logger.debug("Found %s unresolved thread(s) on PR #%s", len(threads), pr_number)
     return threads
 
 
@@ -814,7 +818,7 @@ def gh_pr_resolve_thread(
 
     """
     if dry_run:
-        logger.info(f"[dry_run] Would resolve thread {thread_id!r} with reply: {reply_body!r}")
+        logger.info("[dry_run] Would resolve thread %r with reply: %r", thread_id, reply_body)
         return
 
     # Step 1: post a reply to the thread via GraphQL addPullRequestReviewComment
@@ -869,7 +873,7 @@ mutation ResolveThread($threadId: ID!) {
             json.loads(resolve_result.stdout or "{}"),
             f"gh_pr_resolve_thread.resolve(thread={thread_id})",
         )
-    logger.info(f"Resolved review thread {thread_id!r}")
+    logger.info("Resolved review thread %r", thread_id)
 
 
 def gh_pr_checks(
@@ -888,7 +892,7 @@ def gh_pr_checks(
 
     """
     if dry_run:
-        logger.info(f"[dry_run] Would fetch CI checks for PR #{pr_number}")
+        logger.info("[dry_run] Would fetch CI checks for PR #%s", pr_number)
         return []
 
     result = _gh_call(
@@ -906,5 +910,5 @@ def gh_pr_checks(
         for item in raw
     ]
 
-    logger.debug(f"Fetched {len(checks)} CI check(s) for PR #{pr_number}")
+    logger.debug("Fetched %s CI check(s) for PR #%s", len(checks), pr_number)
     return checks

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -157,17 +157,17 @@ class IssueImplementer:
 
         # Load issues or epic and resolve dependencies
         if self.options.issues:
-            logger.info(f"Loading issues: {self.options.issues}")
+            logger.info("Loading issues: %s", self.options.issues)
             self._load_issues(self.options.issues)
         else:
-            logger.info(f"Loading epic #{self.options.epic_number}")
+            logger.info("Loading epic #%s", self.options.epic_number)
             self.resolver.load_epic(self.options.epic_number)
 
         # Detect cycles
         try:
             self.resolver.detect_cycles()
         except CyclicDependencyError as e:
-            logger.error(f"Dependency cycle detected: {e}")
+            logger.error("Dependency cycle detected: %s", e)
             return {}
 
         # Analyze only mode
@@ -181,7 +181,7 @@ class IssueImplementer:
         if self.options.enable_learn:
             retro_results = self._rerun_failed_learns()
             if retro_results:
-                logger.info(f"Re-ran {len(retro_results)} failed learn(s)")
+                logger.info("Re-ran %s failed learn(s)", len(retro_results))
 
         # Start UI if enabled and not in dry run
         if not self.options.dry_run and self.options.enable_ui:
@@ -215,7 +215,7 @@ class IssueImplementer:
 
         for issue_num in issue_numbers:
             if self.options.skip_closed and cached_states.get(issue_num) == IssueState.CLOSED:
-                logger.info(f"Skipping closed issue #{issue_num}")
+                logger.info("Skipping closed issue #%s", issue_num)
                 self.resolver.completed.add(issue_num)
                 continue
 
@@ -229,9 +229,9 @@ class IssueImplementer:
             except (
                 Exception
             ) as e:  # broad catch: network errors, API failures, JSON parsing all possible
-                logger.error(f"Failed to load issue #{issue_num}: {e}")
+                logger.error("Failed to load issue #%s: %s", issue_num, e)
 
-        logger.info(f"Loaded {len(self.resolver.graph.issues)} issues")
+        logger.info("Loaded %s issues", len(self.resolver.graph.issues))
 
     def _health_check(self) -> dict[int, WorkerResult]:
         """Perform health check of dependencies and environment.
@@ -247,21 +247,21 @@ class IssueImplementer:
             run(["gh", "--version"], check=True)
             logger.info("gh CLI available")
         except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-            logger.error(f"gh CLI not available: {e}")
+            logger.error("gh CLI not available: %s", e)
 
         # Check git
         try:
             run(["git", "--version"], check=True)
             logger.info("git available")
         except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-            logger.error(f"git not available: {e}")
+            logger.error("git not available: %s", e)
 
         # Check Claude Code
         try:
             run(["claude", "--version"], check=True)
             logger.info("Claude Code available")
         except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-            logger.error(f"Claude Code not available: {e}")
+            logger.error("Claude Code not available: %s", e)
 
         # Check repository
         try:
@@ -269,9 +269,9 @@ class IssueImplementer:
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 capture_output=True,
             ).stdout.strip()
-            logger.info(f"In git repository (branch: {branch})")
+            logger.info("In git repository (branch: %s)", branch)
         except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-            logger.error(f"Not in git repository: {e}")
+            logger.error("Not in git repository: %s", e)
 
         logger.info("Health check complete")
         return {}
@@ -287,10 +287,10 @@ class IssueImplementer:
         logger.info("=" * 60)
 
         stats = self.resolver.get_stats()
-        logger.info(f"Total issues: {stats['total_issues']}")
-        logger.info(f"Completed: {stats['completed_issues']}")
-        logger.info(f"Remaining: {stats['remaining_issues']}")
-        logger.info(f"Ready: {stats['ready_issues']}")
+        logger.info("Total issues: %s", stats["total_issues"])
+        logger.info("Completed: %s", stats["completed_issues"])
+        logger.info("Remaining: %s", stats["remaining_issues"])
+        logger.info("Ready: %s", stats["ready_issues"])
 
         # Show topological order
         try:
@@ -300,9 +300,9 @@ class IssueImplementer:
                 issue = self.resolver.graph.issues[issue_num]
                 deps = self.resolver.graph.get_dependencies(issue_num)
                 dep_str = f" (depends on: {deps})" if deps else ""
-                logger.info(f"  {i}. #{issue_num}: {issue.title}{dep_str}")
+                logger.info("  %s. #%s: %s%s", i, issue_num, issue.title, dep_str)
         except CyclicDependencyError as e:
-            logger.error(f"Failed to compute topological order: {e}")
+            logger.error("Failed to compute topological order: %s", e)
 
         return {}
 
@@ -360,12 +360,12 @@ class IssueImplementer:
 
                         if result.success:
                             self.resolver.mark_completed(issue_num)
-                            logger.info(f"Issue #{issue_num} completed successfully")
+                            logger.info("Issue #%s completed successfully", issue_num)
                         else:
-                            logger.error(f"Issue #{issue_num} failed: {result.error}")
+                            logger.error("Issue #%s failed: %s", issue_num, result.error)
 
                     except Exception as e:  # broad catch: worker threads can raise any exception
-                        logger.error(f"Issue #{issue_num} raised exception: {e}")
+                        logger.error("Issue #%s raised exception: %s", issue_num, e)
                         results[issue_num] = WorkerResult(
                             issue_number=issue_num,
                             success=False,
@@ -382,11 +382,11 @@ class IssueImplementer:
         skipped_issues = all_issues - attempted_issues - self.resolver.completed
 
         if skipped_issues:
-            logger.warning(f"Skipped {len(skipped_issues)} issue(s) due to failed dependencies:")
+            logger.warning("Skipped %s issue(s) due to failed dependencies:", len(skipped_issues))
             for issue_num in sorted(skipped_issues):
                 deps = self.resolver.graph.get_dependencies(issue_num)
                 failed_deps = [d for d in deps if d not in self.resolver.completed]
-                logger.warning(f"  #{issue_num}: blocked by failed issue(s) {failed_deps}")
+                logger.warning("  #%s: blocked by failed issue(s) %s", issue_num, failed_deps)
 
         self._print_summary(results)
         return results
@@ -823,16 +823,16 @@ class IssueImplementer:
 
             # Verify worktree exists
             if not state.worktree_path:
-                logger.warning(f"Skipping learn re-run for #{issue_number}: no worktree_path")
+                logger.warning("Skipping learn re-run for #%s: no worktree_path", issue_number)
                 continue
 
             worktree_path = Path(state.worktree_path)
             if not worktree_path.exists():
-                logger.warning(f"Skipping learn re-run for #{issue_number}: worktree not found")
+                logger.warning("Skipping learn re-run for #%s: worktree not found", issue_number)
                 continue
 
             # Re-run learn
-            logger.info(f"Re-running failed learn for issue #{issue_number}")
+            logger.info("Re-running failed learn for issue #%s", issue_number)
             success = self._run_learn(state.session_id, worktree_path, issue_number, slot_id=None)
 
             # Update and save state
@@ -845,8 +845,10 @@ class IssueImplementer:
         if results:
             success_count = sum(1 for s in results.values() if s)
             logger.info(
-                f"Re-ran {len(results)} learn(s): {success_count} succeeded, "
-                f"{len(results) - success_count} failed"
+                "Re-ran %s learn(s): %s succeeded, %s failed",
+                len(results),
+                success_count,
+                len(results) - success_count,
             )
 
         return results
@@ -1163,8 +1165,10 @@ class IssueImplementer:
             return output
         except Exception as e:
             logger.error(
-                f"#{issue_number} R{iteration}: impl reviewer call failed: {e}; "
-                "treating as NOGO so the loop continues"
+                "#%s R%s: impl reviewer call failed: %s; treating as NOGO so the loop continues",
+                issue_number,
+                iteration,
+                e,
             )
             return (
                 f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
@@ -1196,7 +1200,7 @@ class IssueImplementer:
                 )
                 diff = fb.stdout or ""
         except Exception as e:
-            logger.warning(f"diff collection failed for {branch_name}: {e}")
+            logger.warning("diff collection failed for %s: %s", branch_name, e)
             return ""
 
         max_chars = 200_000
@@ -1226,7 +1230,7 @@ class IssueImplementer:
             )
             return (fb.stdout or "").strip()
         except Exception as e:
-            logger.warning(f"changed-files collection failed for {branch_name}: {e}")
+            logger.warning("changed-files collection failed for %s: %s", branch_name, e)
             return ""
 
     def _save_review_log(self, issue_number: int, iteration: int, review_text: str) -> None:
@@ -1235,7 +1239,7 @@ class IssueImplementer:
             log_file = self.state_dir / f"review-{issue_number}-r{iteration}.log"
             log_file.write_text(review_text)
         except Exception as e:
-            logger.warning(f"#{issue_number}: failed to save review log r{iteration}: {e}")
+            logger.warning("#%s: failed to save review log r%s: %s", issue_number, iteration, e)
 
     def _save_review_iteration_state(
         self, issue_number: int, iterations_run: int, prior_review: str
@@ -1345,7 +1349,7 @@ class IssueImplementer:
 
         """
         if self.options.dry_run:
-            logger.info(f"[DRY RUN] Would run Claude Code for issue #{issue_number}")
+            logger.info("[DRY RUN] Would run Claude Code for issue #%s", issue_number)
             return None
 
         self.state_dir.mkdir(parents=True, exist_ok=True)
@@ -1386,7 +1390,7 @@ class IssueImplementer:
                     reset_epoch = _claude_quota_reset_epoch(err_text)
                     if reset_epoch is not None and reset_epoch > 0:
                         logger.warning(
-                            f"Claude usage cap hit for issue #{issue_number}; waiting for reset"
+                            "Claude usage cap hit for issue #%s; waiting for reset", issue_number
                         )
                         wait_until(reset_epoch)
                     raise RuntimeError(f"Claude Code failed: {err_text or 'is_error=true'}")
@@ -1399,8 +1403,8 @@ class IssueImplementer:
 
                 return cast(str | None, session_id)
             except (json.JSONDecodeError, AttributeError):
-                logger.warning(f"Could not parse session_id for issue #{issue_number}")
-                logger.debug(f"Claude stdout: {result.stdout[:500]}")
+                logger.warning("Could not parse session_id for issue #%s", issue_number)
+                logger.debug("Claude stdout: %s", result.stdout[:500])
 
                 # Save output even if JSON parsing failed
                 log_file = self.state_dir / f"claude-{issue_number}.log"
@@ -1408,12 +1412,12 @@ class IssueImplementer:
 
                 return None
         except subprocess.CalledProcessError as e:
-            logger.error(f"Claude Code failed for issue #{issue_number}")
-            logger.error(f"Exit code: {e.returncode}")
+            logger.error("Claude Code failed for issue #%s", issue_number)
+            logger.error("Exit code: %s", e.returncode)
             if e.stdout:
-                logger.error(f"Stdout: {e.stdout[:1000]}")
+                logger.error("Stdout: %s", e.stdout[:1000])
             if e.stderr:
-                logger.error(f"Stderr: {e.stderr[:1000]}")
+                logger.error("Stderr: %s", e.stderr[:1000])
 
             # Save failure output to log file
             log_file = self.state_dir / f"claude-{issue_number}.log"
@@ -1427,7 +1431,9 @@ class IssueImplementer:
             # seconds. The Claude CLI puts its 429 message in stdout JSON.
             reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
             if reset_epoch is not None and reset_epoch > 0:
-                logger.warning(f"Claude usage cap hit for issue #{issue_number}; waiting for reset")
+                logger.warning(
+                    "Claude usage cap hit for issue #%s; waiting for reset", issue_number
+                )
                 wait_until(reset_epoch)
 
             raise RuntimeError(f"Claude Code failed: {e.stderr or e.stdout}") from e
@@ -1495,9 +1501,9 @@ class IssueImplementer:
                     state = ImplementationState.model_validate_json(f.read())
                     with self.state_lock:
                         self.states[state.issue_number] = state
-                logger.info(f"Loaded state for issue #{state.issue_number}")
+                logger.info("Loaded state for issue #%s", state.issue_number)
             except (json.JSONDecodeError, ValueError, OSError) as e:
-                logger.error(f"Failed to load state from {state_file}: {e}")
+                logger.error("Failed to load state from %s: %s", state_file, e)
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print implementation summary."""
@@ -1510,21 +1516,21 @@ class IssueImplementer:
         logger.info("=" * 60)
         logger.info("Implementation Summary")
         logger.info("=" * 60)
-        logger.info(f"Total issues: {total}")
-        logger.info(f"Successful: {successful}")
-        logger.info(f"Failed: {failed}")
+        logger.info("Total issues: %s", total)
+        logger.info("Successful: %s", successful)
+        logger.info("Failed: %s", failed)
 
         if successful > 0:
             logger.info("\nSuccessful PRs:")
             for issue_num, result in results.items():
                 if result.success and result.pr_number:
-                    logger.info(f"  #{issue_num}: PR #{result.pr_number}")
+                    logger.info("  #%s: PR #%s", issue_num, result.pr_number)
 
         if failed > 0:
             logger.info("\nFailed issues:")
             for issue_num, result in results.items():
                 if not result.success:
-                    logger.info(f"  #{issue_num}: {result.error}")
+                    logger.info("  #%s: %s", issue_num, result.error)
 
         preserved = self.worktree_manager.preserved
         if preserved:
@@ -1533,12 +1539,12 @@ class IssueImplementer:
             issues_arg = " ".join(str(n) for n in issue_nums)
             logger.info("\nPreserved worktrees (contain uncommitted changes):")
             for issue_num, path in preserved:
-                logger.info(f"  #{issue_num}: {path}")
+                logger.info("  #%s: %s", issue_num, path)
             logger.info("\nRerun these issues after inspecting/cleaning the worktrees:")
-            logger.info(f"  {script} --issues {issues_arg} --resume")
+            logger.info("  %s --issues %s --resume", script, issues_arg)
             logger.info("To discard them instead:")
             for _, path in preserved:
-                logger.info(f"  git worktree remove --force {path}")
+                logger.info("  git worktree remove --force %s", path)
 
 
 def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
@@ -1689,7 +1695,7 @@ def main() -> int:
     if not args.health_check and not args.epic and not args.issues:
         discovered = gh_list_open_issues()
         log.info(
-            f"No --issues/--epic given; discovered {len(discovered)} open issues: {discovered}"
+            "No --issues/--epic given; discovered %s open issues: %s", len(discovered), discovered
         )
         args.issues = discovered
 
@@ -1711,9 +1717,9 @@ def main() -> int:
     if args.health_check:
         log.info("Running health check")
     elif args.issues:
-        log.info(f"Starting implementation of issues: {args.issues}")
+        log.info("Starting implementation of issues: %s", args.issues)
     else:
-        log.info(f"Starting implementation of epic #{args.epic}")
+        log.info("Starting implementation of epic #%s", args.epic)
 
     from hephaestus.utils.terminal import terminal_guard
 
@@ -1725,7 +1731,7 @@ def main() -> int:
             if not args.health_check and not args.analyze:
                 failed = [num for num, result in results.items() if not result.success]
                 if failed:
-                    log.error(f"Failed to implement {len(failed)} issue(s): {failed}")
+                    log.error("Failed to implement %s issue(s): %s", len(failed), failed)
                     return 1
 
             log.info("Complete")

--- a/hephaestus/automation/issue_dedup.py
+++ b/hephaestus/automation/issue_dedup.py
@@ -205,7 +205,7 @@ def find_duplicate_open_issue(
     except Exception as e:
         # Search is best-effort; on failure, behave as if no duplicate exists
         # so the caller files the issue normally.
-        logger.warning(f"Duplicate search failed for '{title[:60]}': {e}")
+        logger.warning("Duplicate search failed for '%s': %s", title[:60], e)
         return None
 
     best: IssueMatch | None = None
@@ -222,8 +222,11 @@ def find_duplicate_open_issue(
 
     if best:
         logger.info(
-            f"Duplicate detected: '{title[:60]}' ~ #{best.number} "
-            f"'{best.title[:60]}' (score={best.similarity:.2f})"
+            "Duplicate detected: '%s' ~ #%s '%s' (score=%.2f)",
+            title[:60],
+            best.number,
+            best.title[:60],
+            best.similarity,
         )
     return best
 

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -73,11 +73,11 @@ def run_learn(
         )
         # Write output to log file
         log_file.write_text(result.stdout or "")
-        logger.info(f"Learn completed for issue #{issue_number}")
-        logger.info(f"Learn log: {log_file}")
+        logger.info("Learn completed for issue #%s", issue_number)
+        logger.info("Learn log: %s", log_file)
         return True
     except Exception as e:  # broad catch: external claude process; non-blocking, must not propagate
-        logger.warning(f"Learn failed for issue #{issue_number}: {e}")
+        logger.warning("Learn failed for issue #%s: %s", issue_number, e)
 
         # Save failure output to log file
         error_output = f"FAILED: {e}\n"

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -68,8 +68,9 @@ class PlanReviewer:
 
         """
         logger.info(
-            f"Reviewing plans for {len(self.options.issues)} issue(s) "
-            f"with {self.options.max_workers} parallel workers"
+            "Reviewing plans for %s issue(s) with %s parallel workers",
+            len(self.options.issues),
+            self.options.max_workers,
         )
 
         if not self.options.issues:
@@ -99,11 +100,13 @@ class PlanReviewer:
                         with self.lock:
                             results[issue_num] = result
                         if result.success:
-                            logger.info(f"Issue #{issue_num}: plan review completed")
+                            logger.info("Issue #%s: plan review completed", issue_num)
                         else:
-                            logger.error(f"Issue #{issue_num}: plan review failed: {result.error}")
+                            logger.error(
+                                "Issue #%s: plan review failed: %s", issue_num, result.error
+                            )
                     except Exception as e:
-                        logger.error(f"Issue #{issue_num} raised exception: {e}")
+                        logger.error("Issue #%s raised exception: %s", issue_num, e)
                         with self.lock:
                             results[issue_num] = WorkerResult(
                                 issue_number=issue_num,
@@ -140,13 +143,13 @@ class PlanReviewer:
 
             # Skip if already reviewed
             if self._has_existing_review(issue_number):
-                logger.info(f"Issue #{issue_number}: already has a plan review, skipping")
+                logger.info("Issue #%s: already has a plan review, skipping", issue_number)
                 return WorkerResult(issue_number=issue_number, success=True)
 
             # Skip if no plan exists
             plan_text = self._get_latest_plan(issue_number)
             if plan_text is None:
-                logger.info(f"Issue #{issue_number}: no plan comment found, skipping")
+                logger.info("Issue #%s: no plan comment found, skipping", issue_number)
                 return WorkerResult(issue_number=issue_number, success=True)
 
             # Fetch issue details for context
@@ -178,8 +181,10 @@ class PlanReviewer:
             # --- DRY-RUN GUARD: no GitHub writes beyond this point ---
             if self.options.dry_run:
                 logger.info(
-                    f"[DRY RUN] Would post plan review to issue #{issue_number}:\n"
-                    f"{_REVIEW_PREFIX}\n{review_text[:200]}..."
+                    "[DRY RUN] Would post plan review to issue #%s:\n%s\n%s...",
+                    issue_number,
+                    _REVIEW_PREFIX,
+                    review_text[:200],
                 )
                 return WorkerResult(issue_number=issue_number, success=True)
 
@@ -190,7 +195,7 @@ class PlanReviewer:
             return WorkerResult(issue_number=issue_number, success=True)
 
         except Exception as e:
-            logger.error(f"Issue #{issue_number}: unexpected error: {e}")
+            logger.error("Issue #%s: unexpected error: %s", issue_number, e)
             return WorkerResult(
                 issue_number=issue_number,
                 success=False,
@@ -236,7 +241,7 @@ class PlanReviewer:
             data = json.loads(result.stdout)
             comments: list[dict[str, Any]] = data.get("comments", [])
         except Exception as e:
-            logger.warning(f"Failed to fetch comments for issue #{issue_number}: {e}")
+            logger.warning("Failed to fetch comments for issue #%s: %s", issue_number, e)
             comments = []
 
         cache[issue_number] = comments
@@ -261,7 +266,7 @@ class PlanReviewer:
         for comment in reversed(comments):
             body: str = comment.get("body", "")
             if any(marker in body for marker in _PLAN_MARKERS):
-                logger.debug(f"Found plan comment for issue #{issue_number}")
+                logger.debug("Found plan comment for issue #%s", issue_number)
                 return body
 
         return None
@@ -284,7 +289,7 @@ class PlanReviewer:
         for comment in comments:
             body: str = comment.get("body", "")
             if body.startswith(_REVIEW_PREFIX):
-                logger.debug(f"Found existing review for issue #{issue_number}")
+                logger.debug("Found existing review for issue #%s", issue_number)
                 return True
 
         return False
@@ -367,26 +372,28 @@ class PlanReviewer:
                     )
 
                 logger.error(
-                    f"Claude returned exit code {result.returncode} for issue #{issue_number}: "
-                    f"{(stderr or stdout)[:200]}"
+                    "Claude returned exit code %s for issue #%s: %s",
+                    result.returncode,
+                    issue_number,
+                    (stderr or stdout)[:200],
                 )
                 return None
 
             output: str = (result.stdout or "").strip()
             if not output:
-                logger.error(f"Claude returned empty output for issue #{issue_number}")
+                logger.error("Claude returned empty output for issue #%s", issue_number)
                 return None
 
             return output
 
         except subprocess.TimeoutExpired:
-            logger.error(f"Claude timed out reviewing plan for issue #{issue_number}")
+            logger.error("Claude timed out reviewing plan for issue #%s", issue_number)
             return None
         except FileNotFoundError:
             logger.error("'claude' CLI not found in PATH; cannot run plan review")
             return None
         except Exception as e:
-            logger.error(f"Unexpected error calling Claude for issue #{issue_number}: {e}")
+            logger.error("Unexpected error calling Claude for issue #%s: %s", issue_number, e)
             return None
 
     def _post_review(self, issue_number: int, review_text: str) -> None:
@@ -399,7 +406,7 @@ class PlanReviewer:
         """
         comment_body = f"{_REVIEW_PREFIX}\n\n{review_text}"
         gh_issue_comment(issue_number, comment_body)
-        logger.info(f"Posted plan review to issue #{issue_number}")
+        logger.info("Posted plan review to issue #%s", issue_number)
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print a summary of plan review results.
@@ -415,15 +422,15 @@ class PlanReviewer:
         logger.info("=" * 60)
         logger.info("Plan Review Summary")
         logger.info("=" * 60)
-        logger.info(f"Total issues: {total}")
-        logger.info(f"Successful: {successful}")
-        logger.info(f"Failed: {failed}")
+        logger.info("Total issues: %s", total)
+        logger.info("Successful: %s", successful)
+        logger.info("Failed: %s", failed)
 
         if failed > 0:
             logger.info("Failed issues:")
             for issue_num, result in results.items():
                 if not result.success:
-                    logger.info(f"  #{issue_num}: {result.error}")
+                    logger.info("  #%s: %s", issue_num, result.error)
 
 
 # ---------------------------------------------------------------------------
@@ -522,7 +529,7 @@ def main() -> int:
     # post two reviews on the same issue.
     args.issues = list(dict.fromkeys(args.issues))
 
-    log.info(f"Starting plan review for issues: {args.issues}")
+    log.info("Starting plan review for issues: %s", args.issues)
 
     try:
         options = PlanReviewerOptions(
@@ -538,7 +545,7 @@ def main() -> int:
 
         failed = [num for num, result in results.items() if not result.success]
         if failed:
-            log.error(f"Failed to review {len(failed)} plan(s) for issue(s): {failed}")
+            log.error("Failed to review %s plan(s) for issue(s): %s", len(failed), failed)
             return 1
 
         log.info("Plan review complete")

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -76,8 +76,9 @@ class Planner:
 
         """
         logger.info(
-            f"Planning {len(self.options.issues)} issues "
-            f"with {self.options.parallel} parallel workers"
+            "Planning %s issues with %s parallel workers",
+            len(self.options.issues),
+            self.options.parallel,
         )
 
         # Filter closed issues if requested
@@ -103,7 +104,7 @@ class Planner:
                     with self.lock:
                         self.results[issue_num] = result
                 except Exception as e:
-                    logger.error(f"Failed to plan issue #{issue_num}: {e}")
+                    logger.error("Failed to plan issue #%s: %s", issue_num, e)
                     with self.lock:
                         self.results[issue_num] = PlanResult(
                             issue_number=issue_num,
@@ -131,7 +132,7 @@ class Planner:
         for issue_num in self.options.issues:
             # Check if already planned (unless force)
             if not self.options.force and self._has_existing_plan(issue_num):
-                logger.info(f"Issue #{issue_num} already has a plan, skipping")
+                logger.info("Issue #%s already has a plan, skipping", issue_num)
                 with self.lock:
                     self.results[issue_num] = PlanResult(
                         issue_number=issue_num,
@@ -144,7 +145,7 @@ class Planner:
             if self.options.skip_closed:
                 state = cached_states.get(issue_num)
                 if state and state.value == "CLOSED":
-                    logger.info(f"Issue #{issue_num} is closed, skipping")
+                    logger.info("Issue #%s is closed, skipping", issue_num)
                     continue
 
             issues_to_plan.append(issue_num)
@@ -180,13 +181,13 @@ class Planner:
             for comment in comments:
                 body = comment.get("body", "")
                 if any(marker in body for marker in PLAN_COMMENT_MARKERS):
-                    logger.debug(f"Found existing plan for issue #{issue_number}")
+                    logger.debug("Found existing plan for issue #%s", issue_number)
                     return True
 
             return False
 
         except Exception as e:
-            logger.warning(f"Failed to check for existing plan on issue #{issue_number}: {e}")
+            logger.warning("Failed to check for existing plan on issue #%s: %s", issue_number, e)
             return False
 
     def _plan_issue(self, issue_number: int) -> PlanResult:
@@ -211,7 +212,7 @@ class Planner:
             self.status_tracker.update_slot(slot_id, f"Planning issue #{issue_number}")
 
             if self.options.dry_run:
-                logger.info(f"[DRY RUN] Would plan issue #{issue_number}")
+                logger.info("[DRY RUN] Would plan issue #%s", issue_number)
                 return PlanResult(issue_number=issue_number, success=True)
 
             # Run the strict review loop: advise → loop[plan → learn → review]
@@ -244,7 +245,7 @@ class Planner:
             return PlanResult(issue_number=issue_number, success=True)
 
         except Exception as e:
-            logger.error(f"Failed to plan issue #{issue_number}: {e}")
+            logger.error("Failed to plan issue #%s: %s", issue_number, e)
             return PlanResult(
                 issue_number=issue_number,
                 success=False,
@@ -381,10 +382,10 @@ class Planner:
                         text=True,
                         timeout=30,
                     )
-                    logger.debug(f"ProjectMnemosyne refreshed at {mnemosyne_root}")
+                    logger.debug("ProjectMnemosyne refreshed at %s", mnemosyne_root)
                 except Exception as e:
                     logger.warning(
-                        f"Failed to refresh ProjectMnemosyne (using existing clone): {e}"
+                        "Failed to refresh ProjectMnemosyne (using existing clone): %s", e
                     )
                 return True
 
@@ -398,7 +399,7 @@ class Planner:
                     if mnemosyne_root.exists():
                         return True
 
-                    logger.info(f"Cloning ProjectMnemosyne to {mnemosyne_root}...")
+                    logger.info("Cloning ProjectMnemosyne to %s...", mnemosyne_root)
                     subprocess.run(
                         [
                             "gh",
@@ -427,7 +428,7 @@ class Planner:
                     return False
 
                 except subprocess.CalledProcessError as e:
-                    logger.warning(f"Failed to clone ProjectMnemosyne: {e.stderr or e}")
+                    logger.warning("Failed to clone ProjectMnemosyne: %s", e.stderr or e)
                     return False
 
                 finally:
@@ -456,14 +457,16 @@ class Planner:
             marketplace_path = mnemosyne_root / ".claude-plugin" / "marketplace.json"
             if not marketplace_path.exists():
                 logger.warning(
-                    f"Marketplace file not found at {marketplace_path}; "
-                    "attempting recovery re-clone of ProjectMnemosyne"
+                    "Marketplace file not found at %s; "
+                    "attempting recovery re-clone of ProjectMnemosyne",
+                    marketplace_path,
                 )
                 shutil.rmtree(mnemosyne_root, ignore_errors=True)
                 if not self._ensure_mnemosyne(mnemosyne_root) or not marketplace_path.exists():
                     logger.error(
-                        f"Recovery failed: marketplace.json still missing at {marketplace_path}; "
-                        "skipping advise step"
+                        "Recovery failed: marketplace.json still missing at %s; "
+                        "skipping advise step",
+                        marketplace_path,
                     )
                     return self._advise_skipped(f"marketplace.json missing at {marketplace_path}")
 
@@ -477,13 +480,13 @@ class Planner:
 
             # Call Claude with shorter timeout. /advise is light search work
             # so it runs on the cheap model.
-            logger.info(f"Running advise for issue #{issue_number}...")
+            logger.info("Running advise for issue #%s...", issue_number)
             findings = self._call_claude(advise_prompt, model=advise_model(), timeout=180)
 
             return findings
 
         except Exception as e:
-            logger.warning(f"Advise step failed for issue #{issue_number}: {e}")
+            logger.warning("Advise step failed for issue #%s: %s", issue_number, e)
             return self._advise_skipped(f"unexpected error: {e}")
 
     @staticmethod
@@ -636,7 +639,7 @@ class Planner:
 """
 
         gh_issue_comment(issue_number, comment_body)
-        logger.info(f"Posted plan to issue #{issue_number}")
+        logger.info("Posted plan to issue #%s", issue_number)
 
     # ------------------------------------------------------------------
     # Strict review loop — advise → loop[plan → learn → review] → post
@@ -710,12 +713,15 @@ class Planner:
 
             verdict = parse_review_verdict(review_text)
             logger.info(
-                f"#{issue_number} R{iteration}: Verdict={verdict.verdict} "
-                f"Grade={verdict.grade or '?'}"
+                "#%s R%s: Verdict=%s Grade=%s",
+                issue_number,
+                iteration,
+                verdict.verdict,
+                verdict.grade or "?",
             )
 
             if verdict.is_go:
-                logger.info(f"#{issue_number}: GO on iteration {iteration} — loop terminated")
+                logger.info("#%s: GO on iteration %s — loop terminated", issue_number, iteration)
                 final_verdict_is_go = True
                 break
 
@@ -724,8 +730,10 @@ class Planner:
 
         if not final_verdict_is_go:
             logger.warning(
-                f"#{issue_number}: review loop exhausted {iterations_run} iteration(s) "
-                "without a GO verdict — plan posted with NOGO-exhausted status"
+                "#%s: review loop exhausted %s iteration(s) without a GO verdict — "
+                "plan posted with NOGO-exhausted status",
+                issue_number,
+                iterations_run,
             )
 
         return plan, review_text, iterations_run, final_verdict_is_go
@@ -764,7 +772,7 @@ class Planner:
         try:
             return self._call_claude(prompt, model=learn_model(), timeout=120)
         except Exception as e:
-            logger.warning(f"#{issue_number}: planner-learnings capture failed (non-fatal): {e}")
+            logger.warning("#%s: planner-learnings capture failed (non-fatal): %s", issue_number, e)
             return ""
 
     def _run_plan_review(
@@ -814,8 +822,10 @@ class Planner:
             )
         except Exception as e:
             logger.error(
-                f"#{issue_number} R{iteration}: reviewer call failed: {e}; "
-                "treating as NOGO so the loop continues"
+                "#%s R%s: reviewer call failed: %s; treating as NOGO so the loop continues",
+                issue_number,
+                iteration,
+                e,
             )
             return (
                 f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
@@ -832,16 +842,16 @@ class Planner:
         logger.info("=" * 60)
         logger.info("Planning Summary")
         logger.info("=" * 60)
-        logger.info(f"Total issues: {total}")
-        logger.info(f"Successfully planned: {successful - already_planned}")
-        logger.info(f"Already planned: {already_planned}")
-        logger.info(f"Failed: {failed}")
+        logger.info("Total issues: %s", total)
+        logger.info("Successfully planned: %s", successful - already_planned)
+        logger.info("Already planned: %s", already_planned)
+        logger.info("Failed: %s", failed)
 
         if failed > 0:
             logger.info("\nFailed issues:")
             for issue_num, result in self.results.items():
                 if not result.success:
-                    logger.info(f"  #{issue_num}: {result.error}")
+                    logger.info("  #%s: %s", issue_num, result.error)
 
 
 def _setup_logging(verbose: bool = False) -> None:
@@ -956,7 +966,7 @@ def main() -> int:
 
     if not args.issues:
         discovered = gh_list_open_issues()
-        log.info(f"No --issues given; discovered {len(discovered)} open issues: {discovered}")
+        log.info("No --issues given; discovered %s open issues: %s", len(discovered), discovered)
         args.issues = discovered
 
     # Dedupe while preserving first-seen order. dict.fromkeys is the
@@ -964,7 +974,7 @@ def main() -> int:
     # would race two workers on the same issue and produce double-posts.
     args.issues = list(dict.fromkeys(args.issues))
 
-    log.info(f"Issues to plan: {args.issues}")
+    log.info("Issues to plan: %s", args.issues)
 
     try:
         options = PlannerOptions(
@@ -982,7 +992,7 @@ def main() -> int:
 
         failed = [num for num, result in results.items() if not result.success]
         if failed:
-            log.error(f"Failed to plan {len(failed)} issue(s): {failed}")
+            log.error("Failed to plan %s issue(s): %s", len(failed), failed)
             return 1
 
         log.info("Planning complete")

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -78,7 +78,7 @@ def commit_changes(issue_number: int, worktree_path: Path) -> None:
         # Skip secret files (never stage these)
         has_secret_ext = any(filename.endswith(ext) for ext in SECRET_FILE_EXTENSIONS)
         if filename in SECRET_FILE_NAMES or has_secret_ext:
-            logger.warning(f"Skipping potential secret file: {filename_part}")
+            logger.warning("Skipping potential secret file: %s", filename_part)
             continue
 
         files_to_add.append(filename_part)
@@ -152,7 +152,7 @@ def ensure_pr_created(
             f"No commit found for issue #{issue_number}. Claude did not create any commits."
         )
 
-    logger.info(f"Commit exists: {result.stdout.strip()[:80]}")
+    logger.info("Commit exists: %s", result.stdout.strip()[:80])
 
     # Check if branch was pushed, if not push it
     _update_slot(f"#{issue_number}: Pushing branch")
@@ -163,11 +163,11 @@ def ensure_pr_created(
         check=False,
     )
     if not result.stdout.strip():
-        logger.warning(f"Branch {branch_name} not pushed, pushing now...")
+        logger.warning("Branch %s not pushed, pushing now...", branch_name)
         run(["git", "push", "-u", "origin", branch_name], cwd=worktree_path)
-        logger.info(f"Pushed branch {branch_name} to origin")
+        logger.info("Pushed branch %s to origin", branch_name)
     else:
-        logger.info(f"Branch {branch_name} already on origin")
+        logger.info("Branch %s already on origin", branch_name)
 
     # Check if PR exists, if not create it
     _update_slot(f"#{issue_number}: Creating PR")
@@ -177,15 +177,15 @@ def ensure_pr_created(
         pr_data = json.loads(result.stdout)
         if pr_data and len(pr_data) > 0:
             pr_number = cast(int, pr_data[0]["number"])
-            logger.info(f"PR #{pr_number} already exists")
+            logger.info("PR #%s already exists", pr_number)
             return pr_number
     except Exception as e:  # broad catch: gh CLI + JSON parsing; fallback is to create PR
-        logger.debug(f"Could not find existing PR: {e}")
+        logger.debug("Could not find existing PR: %s", e)
 
     # PR doesn't exist, create it
-    logger.warning(f"No PR found for branch {branch_name}, creating one...")
+    logger.warning("No PR found for branch %s, creating one...", branch_name)
     pr_number = create_pr(issue_number, branch_name, auto_merge)
-    logger.info(f"Created PR #{pr_number}")
+    logger.info("Created PR #%s", pr_number)
     return pr_number
 
 

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -109,7 +109,7 @@ class PRReviewer:
             Dictionary mapping issue number to WorkerResult
 
         """
-        logger.info(f"Starting PR review for issues: {self.options.issues}")
+        logger.info("Starting PR review for issues: %s", self.options.issues)
 
         # Discover PRs for all issues
         pr_map = self._discover_prs(self.options.issues)
@@ -118,7 +118,7 @@ class PRReviewer:
             logger.warning("No open PRs found for the specified issues")
             return {}
 
-        logger.info(f"Found {len(pr_map)} PR(s) to review: {pr_map}")
+        logger.info("Found %s PR(s) to review: %s", len(pr_map), pr_map)
 
         # Start UI if enabled
         if not self.options.dry_run and self.options.enable_ui:
@@ -154,7 +154,7 @@ class PRReviewer:
             if pr_number is not None:
                 pr_map[issue_num] = pr_number
             else:
-                logger.warning(f"No open PR found for issue #{issue_num}")
+                logger.warning("No open PR found for issue #%s", issue_num)
 
         return pr_map
 
@@ -307,7 +307,7 @@ class PRReviewer:
 
         """
         if self.options.dry_run:
-            logger.info(f"[DRY RUN] Would run analysis session for PR #{pr_number}")
+            logger.info("[DRY RUN] Would run analysis session for PR #%s", pr_number)
             return {"comments": [], "summary": "[DRY RUN] analysis skipped"}
 
         prompt = get_pr_review_analysis_prompt(
@@ -352,8 +352,9 @@ class PRReviewer:
 
             parsed = _parse_json_block(response_text)
             logger.info(
-                f"Analysis complete for PR #{pr_number}; "
-                f"found {len(parsed.get('comments', []))} inline comment(s)"
+                "Analysis complete for PR #%s; found %s inline comment(s)",
+                pr_number,
+                len(parsed.get("comments", [])),
             )
             return parsed
 
@@ -637,11 +638,11 @@ class PRReviewer:
                         result = future.result()
                         results[issue_num] = result
                         if result.success:
-                            logger.info(f"Issue #{issue_num} PR review completed")
+                            logger.info("Issue #%s PR review completed", issue_num)
                         else:
-                            logger.error(f"Issue #{issue_num} PR review failed: {result.error}")
+                            logger.error("Issue #%s PR review failed: %s", issue_num, result.error)
                     except Exception as e:
-                        logger.error(f"Issue #{issue_num} raised exception: {e}")
+                        logger.error("Issue #%s raised exception: %s", issue_num, e)
                         results[issue_num] = WorkerResult(
                             issue_number=issue_num,
                             success=False,
@@ -665,15 +666,15 @@ class PRReviewer:
         logger.info("=" * 60)
         logger.info("PR Review Summary")
         logger.info("=" * 60)
-        logger.info(f"Total PRs: {total}")
-        logger.info(f"Successful: {successful}")
-        logger.info(f"Failed: {failed}")
+        logger.info("Total PRs: %s", total)
+        logger.info("Successful: %s", successful)
+        logger.info("Failed: %s", failed)
 
         if failed > 0:
             logger.info("\nFailed issues:")
             for issue_num, result in results.items():
                 if not result.success:
-                    logger.info(f"  #{issue_num}: {result.error}")
+                    logger.info("  #%s: %s", issue_num, result.error)
 
 
 def _setup_logging(verbose: bool = False) -> None:
@@ -758,7 +759,7 @@ def main() -> int:
     _setup_logging(args.verbose)
 
     log = logging.getLogger(__name__)
-    log.info(f"Starting PR review for issues: {args.issues}")
+    log.info("Starting PR review for issues: %s", args.issues)
 
     from hephaestus.automation.models import ReviewerOptions
     from hephaestus.utils.terminal import terminal_guard
@@ -777,7 +778,7 @@ def main() -> int:
 
             failed = [num for num, result in results.items() if not result.success]
             if failed:
-                log.error(f"Failed to review {len(failed)} PR(s) for issue(s): {failed}")
+                log.error("Failed to review %s PR(s) for issue(s): %s", len(failed), failed)
                 return 1
 
             log.info("PR review complete")

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -73,7 +73,7 @@ class WorktreeManager:
         self.preserved: list[tuple[int, Path]] = []
         self.lock = threading.Lock()
 
-        logger.debug(f"Initialized WorktreeManager at {self.base_dir}")
+        logger.debug("Initialized WorktreeManager at %s", self.base_dir)
 
     @property
     def base_branch(self) -> str:
@@ -136,7 +136,7 @@ class WorktreeManager:
         """
         with self.lock:
             if issue_number in self.worktrees:
-                logger.warning(f"Worktree for issue #{issue_number} already exists")
+                logger.warning("Worktree for issue #%s already exists", issue_number)
                 return self.worktrees[issue_number]
 
             if branch_name is None:
@@ -146,7 +146,7 @@ class WorktreeManager:
 
             # Remove existing directory if present
             if worktree_path.exists():
-                logger.warning(f"Removing existing worktree directory: {worktree_path}")
+                logger.warning("Removing existing worktree directory: %s", worktree_path)
                 # Try git worktree remove first to clean up git metadata
                 try:
                     run(
@@ -155,7 +155,7 @@ class WorktreeManager:
                         check=False,
                     )
                 except Exception as e:
-                    logger.debug(f"git worktree remove failed (expected if not a worktree): {e}")
+                    logger.debug("git worktree remove failed (expected if not a worktree): %s", e)
 
                 # Fallback to direct directory removal
                 if worktree_path.exists():
@@ -165,7 +165,7 @@ class WorktreeManager:
                 try:
                     run(["git", "worktree", "prune"], cwd=self.repo_root, check=False)
                 except Exception as e:
-                    logger.debug(f"git worktree prune failed: {e}")
+                    logger.debug("git worktree prune failed: %s", e)
 
             try:
                 # Check if branch already exists
@@ -182,7 +182,7 @@ class WorktreeManager:
                     branch_exists = False
 
                 if branch_exists:
-                    logger.info(f"Branch {branch_name} already exists, reusing it")
+                    logger.info("Branch %s already exists, reusing it", branch_name)
                     # Create worktree from existing branch
                     run(
                         [
@@ -210,7 +210,7 @@ class WorktreeManager:
                     )
 
                 self.worktrees[issue_number] = worktree_path
-                logger.info(f"Created worktree for issue #{issue_number} at {worktree_path}")
+                logger.info("Created worktree for issue #%s at %s", issue_number, worktree_path)
                 return worktree_path
 
             except Exception as e:
@@ -230,7 +230,7 @@ class WorktreeManager:
         """
         with self.lock:
             if issue_number not in self.worktrees:
-                logger.warning(f"No worktree found for issue #{issue_number}")
+                logger.warning("No worktree found for issue #%s", issue_number)
                 return
 
             worktree_path = self.worktrees[issue_number]
@@ -246,7 +246,7 @@ class WorktreeManager:
                 run(cmd, cwd=self.repo_root)
 
                 del self.worktrees[issue_number]
-                logger.info(f"Removed worktree for issue #{issue_number}")
+                logger.info("Removed worktree for issue #%s", issue_number)
 
             except Exception as e:
                 raise RuntimeError(f"Failed to remove worktree: {e}") from e
@@ -287,10 +287,10 @@ class WorktreeManager:
             try:
                 self.remove_worktree(issue_num, force=force)
             except WorktreeDirtyError as e:
-                logger.info(f"Preserved dirty worktree for issue #{e.issue_number} at {e.path}")
+                logger.info("Preserved dirty worktree for issue #%s at %s", e.issue_number, e.path)
                 self.preserved.append((e.issue_number, e.path))
             except Exception as e:
-                logger.error(f"Failed to remove worktree for issue #{issue_num}: {e}")
+                logger.error("Failed to remove worktree for issue #%s: %s", issue_num, e)
 
     def prune_worktrees(self) -> None:
         """Prune stale worktree administrative files.
@@ -301,7 +301,7 @@ class WorktreeManager:
             run(["git", "worktree", "prune"], cwd=self.repo_root)
             logger.info("Pruned stale worktrees")
         except Exception as e:
-            logger.error(f"Failed to prune worktrees: {e}")
+            logger.error("Failed to prune worktrees: %s", e)
 
     def list_worktrees(self) -> list[dict[str, str]]:
         """List all git worktrees in the repository.
@@ -341,7 +341,7 @@ class WorktreeManager:
             return worktrees
 
         except Exception as e:
-            logger.error(f"Failed to list worktrees: {e}")
+            logger.error("Failed to list worktrees: %s", e)
             return []
 
     def ensure_branch_deleted(self, branch_name: str) -> None:
@@ -358,9 +358,9 @@ class WorktreeManager:
                 cwd=self.repo_root,
                 check=False,
             )
-            logger.debug(f"Deleted local branch {branch_name}")
+            logger.debug("Deleted local branch %s", branch_name)
         except Exception as e:
-            logger.warning(f"Failed to delete local branch {branch_name}: {e}")
+            logger.warning("Failed to delete local branch %s: %s", branch_name, e)
 
         # Delete remote branch
         try:
@@ -369,6 +369,6 @@ class WorktreeManager:
                 cwd=self.repo_root,
                 check=False,
             )
-            logger.debug(f"Deleted remote branch {branch_name}")
+            logger.debug("Deleted remote branch %s", branch_name)
         except Exception as e:
-            logger.warning(f"Failed to delete remote branch {branch_name}: {e}")
+            logger.warning("Failed to delete remote branch %s: %s", branch_name, e)


### PR DESCRIPTION
## Summary

Closes #317 — the f-string anti-pattern follow-up that was deferred from PR #394
(W1) after sibling waves W15a/b/c/d merged ahead and made the original cross-cutting
conversion uneconomic to rebase. Now that main has settled, the mechanical conversion
runs cleanly with zero conflicts (drop-and-redo pattern from ProjectMnemosyne skill
\`feature-on-refactor-rebase-port\` v1.1.0).

## Approach

AST-based script walks every \`logger.X(f\"...\")\` call in \`hephaestus/automation/*.py\`
and rewrites it to \`logger.X(\"...\", arg1, arg2, ...)\`. Handles plain interpolations,
slicing, repr conversions, numeric format specs, and multi-line concatenated f-strings.
Uses a hand-rolled balanced-paren scanner because Python's AST \`end_col_offset\`
overstates the position by 2 for lines containing multi-byte UTF-8 characters.

## Per-file conversion counts

255 total: implementer.py:54, ci_driver.py:43, planner.py:30, github_api.py:27,
address_review.py:24, plan_reviewer.py:22, worktree_manager.py:17, pr_reviewer.py:14,
dependency_resolver.py:9, pr_manager.py:9, learn.py:3, curses_ui.py:1, issue_dedup.py:1.

The 7 lines that exceeded the 100-char limit after conversion were split via Python's
implicit string concatenation.

## Validation

- 2181 unit tests pass, 83.35% coverage (>= 80% threshold)
- ruff clean (zero G004 violations remaining)
- mypy clean (236 source files)
- pre-commit all 22 hooks pass
- Branch is on origin/main

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>