### PR TITLE
feat(automation): add --phases and per-phase model knobs to run_automation_loop.sh

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -16,6 +16,7 @@ import os
 import re
 import subprocess
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, cast
@@ -34,6 +35,27 @@ from .models import IssueInfo, IssueState
 logger = logging.getLogger(__name__)
 
 _label_cache: set[str] | None = None
+
+# Per-thread proactive throttle for `gh` invocations. Default 5 calls/sec
+# per worker thread; the GH_RATE_LIMIT_PER_SEC env var overrides for ops
+# tuning, and 0 disables. With max-workers=3 the aggregate is ~15/sec,
+# well below GitHub's per-token REST limits and tame enough that GH
+# secondary rate limits stay quiet during phase bursts (e.g. a planner
+# fetching N issue bodies back-to-back).
+_GH_THROTTLE = threading.local()
+
+
+def _gh_throttle_wait() -> None:
+    rate = float(os.environ.get("GH_RATE_LIMIT_PER_SEC", "5"))
+    if rate <= 0:
+        return
+    min_interval = 1.0 / rate
+    last = getattr(_GH_THROTTLE, "last_call", 0.0)
+    now = time.monotonic()
+    elapsed = now - last
+    if elapsed < min_interval:
+        time.sleep(min_interval - elapsed)
+    _GH_THROTTLE.last_call = time.monotonic()
 
 
 class ClaudeUsageCapError(RuntimeError):
@@ -127,6 +149,7 @@ def _gh_call(
     """
     for attempt in range(max_retries):
         try:
+            _gh_throttle_wait()
             result = run(
                 ["gh", *args],
                 check=check,

--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -25,8 +25,46 @@
 #   --reviewer-model MODEL    Set HEPH_REVIEWER_MODEL (covers plan-review and PR-review)
 #   --implementer-model MODEL Set HEPH_IMPLEMENTER_MODEL (covers implement, address-review,
 #                             ci-driver fresh sessions; --resume sites correctly omit --model)
+#   -h, --help                Show this help and exit
 
 set -euo pipefail
+
+# Job control: each backgrounded `process_repo` runs in its own process group,
+# so we can SIGTERM the whole subtree (repo subshell → Python phase →
+# claude/gh descendants) by signalling the negative pgid.
+set -m
+
+usage() {
+  sed -n '2,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup: when interrupted (Ctrl-C, SIGTERM, SIGHUP), kill every backgrounded
+# repo subtree. We only fire on real signals — a normal exit (including
+# `exit 1` from bad args) skips the kill because there are no children yet
+# OR the main loop already drained them with `wait`.
+# ---------------------------------------------------------------------------
+ACTIVE_PIDS=()
+cleanup_on_signal() {
+  local sig="$1"
+  echo "" >&2
+  echo "▶ Interrupted ($sig). Stopping ${#ACTIVE_PIDS[@]} background repo job(s)..." >&2
+  trap - INT TERM HUP    # disarm to prevent re-entry mid-cleanup
+
+  for pid in "${ACTIVE_PIDS[@]}"; do
+    # Negative pid = entire process group (the `set -m` job).
+    # SIGTERM first; SIGKILL after a short grace.
+    kill -TERM -"$pid" 2>/dev/null || true
+  done
+  sleep 2
+  for pid in "${ACTIVE_PIDS[@]}"; do
+    kill -KILL -"$pid" 2>/dev/null || true
+  done
+  exit 130
+}
+trap 'cleanup_on_signal INT'  INT
+trap 'cleanup_on_signal TERM' TERM
+trap 'cleanup_on_signal HUP'  HUP
 
 # ---------------------------------------------------------------------------
 # Resolve the installed entry-point binaries from the Hephaestus pixi env.
@@ -62,6 +100,7 @@ IMPLEMENTER_MODEL=""
 # ---------------------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    -h|--help)            usage; exit 0 ;;
     --dry-run)            DRY_RUN=1; shift ;;
     --loops)              LOOPS="$2"; shift 2 ;;
     --max-workers)        MAX_WORKERS="$2"; shift 2 ;;
@@ -70,7 +109,7 @@ while [[ $# -gt 0 ]]; do
     --planner-model)      PLANNER_MODEL="$2"; shift 2 ;;
     --reviewer-model)     REVIEWER_MODEL="$2"; shift 2 ;;
     --implementer-model)  IMPLEMENTER_MODEL="$2"; shift 2 ;;
-    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    *) echo "Unknown argument: $1" >&2; echo "Run with --help for usage." >&2; exit 1 ;;
   esac
 done
 
@@ -259,21 +298,22 @@ for (( loop=1; loop<=LOOPS; loop++ )); do
   echo "▶ LOOP $loop / $LOOPS"
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
-  active_pids=()
+  ACTIVE_PIDS=()
   for repo in "${REPOS[@]}"; do
     process_repo "$repo" "$loop" &
-    active_pids+=($!)
+    ACTIVE_PIDS+=($!)
 
-    if [[ ${#active_pids[@]} -ge "$PARALLEL_REPOS" ]]; then
-      wait "${active_pids[0]}"
-      active_pids=("${active_pids[@]:1}")
+    if [[ ${#ACTIVE_PIDS[@]} -ge "$PARALLEL_REPOS" ]]; then
+      wait "${ACTIVE_PIDS[0]}" || true
+      ACTIVE_PIDS=("${ACTIVE_PIDS[@]:1}")
     fi
   done
 
   # Drain any remaining background jobs
-  for pid in "${active_pids[@]}"; do
-    wait "$pid"
+  for pid in "${ACTIVE_PIDS[@]}"; do
+    wait "$pid" || true
   done
+  ACTIVE_PIDS=()
 
   echo ""
   echo "  Loop $loop complete."

--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -3,17 +3,28 @@
 #
 # Clones all HomericIntelligence repos (excluding Odysseus), then runs
 # 6-phase pipeline: plan → review-plans → implement → review-PRs → address-review → drive-green
-# in a loop N times for every repo that has open issues.
-# drive-green only runs on final loop. Up to PARALLEL_REPOS repos are processed concurrently.
+# in a loop N times for every repo.
+# drive-green only runs on the final loop. Up to PARALLEL_REPOS repos are processed concurrently.
+#
+# Issue discovery is delegated to each phase's Python entrypoint
+# (gh_list_open_issues), so issues opened mid-loop are picked up by later phases.
 #
 # Usage:
-#   ./scripts/run_automation_loop.sh [--dry-run] [--loops N] [--max-workers N] [--parallel-repos N]
+#   ./scripts/run_automation_loop.sh [options]
 #
 # Options:
-#   --dry-run           Pass --dry-run to plan, implement, and review (default: off)
-#   --loops N           Number of loop iterations (default: 5)
-#   --max-workers N     Parallel workers per repo per phase (default: 3)
-#   --parallel-repos N  Repos processed in parallel (default: 3)
+#   --dry-run                 Pass --dry-run to every phase (default: off)
+#   --loops N                 Number of loop iterations (default: 5)
+#   --max-workers N           Parallel workers per repo per phase (default: 3)
+#   --parallel-repos N        Repos processed in parallel (default: 3)
+#   --phases LIST             Comma-separated subset of phases to run.
+#                             Valid: plan,review-plans,implement,review-prs,address-review,drive-green
+#                             Default: all six.
+#                             Normal gates still apply (drive-green only on final loop).
+#   --planner-model MODEL     Set HEPH_PLANNER_MODEL for child processes
+#   --reviewer-model MODEL    Set HEPH_REVIEWER_MODEL (covers plan-review and PR-review)
+#   --implementer-model MODEL Set HEPH_IMPLEMENTER_MODEL (covers implement, address-review,
+#                             ci-driver fresh sessions; --resume sites correctly omit --model)
 
 set -euo pipefail
 
@@ -39,18 +50,51 @@ PARALLEL_REPOS=3
 PROJECTS_DIR="$HOME/Projects"
 ORG="HomericIntelligence"
 
+ALL_PHASES="plan,review-plans,implement,review-prs,address-review,drive-green"
+PHASES="$ALL_PHASES"
+
+PLANNER_MODEL=""
+REVIEWER_MODEL=""
+IMPLEMENTER_MODEL=""
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --dry-run)         DRY_RUN=1; shift ;;
-    --loops)           LOOPS="$2"; shift 2 ;;
-    --max-workers)     MAX_WORKERS="$2"; shift 2 ;;
-    --parallel-repos)  PARALLEL_REPOS="$2"; shift 2 ;;
+    --dry-run)            DRY_RUN=1; shift ;;
+    --loops)              LOOPS="$2"; shift 2 ;;
+    --max-workers)        MAX_WORKERS="$2"; shift 2 ;;
+    --parallel-repos)     PARALLEL_REPOS="$2"; shift 2 ;;
+    --phases)             PHASES="$2"; shift 2 ;;
+    --planner-model)      PLANNER_MODEL="$2"; shift 2 ;;
+    --reviewer-model)     REVIEWER_MODEL="$2"; shift 2 ;;
+    --implementer-model)  IMPLEMENTER_MODEL="$2"; shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done
+
+# Validate --phases against the canonical list. Typos must fail loudly.
+IFS=',' read -r -a PHASE_ARRAY <<< "$PHASES"
+for p in "${PHASE_ARRAY[@]}"; do
+  case ",${ALL_PHASES}," in
+    *",${p},"*) ;;
+    *) echo "Unknown phase: $p (valid: $ALL_PHASES)" >&2; exit 1 ;;
+  esac
+done
+
+phase_enabled() {
+  case ",${PHASES}," in
+    *",$1,"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Forward model selections via env vars to all child processes.
+# claude_models.py honours these and falls back to its own defaults if unset.
+[[ -n "$PLANNER_MODEL" ]]     && export HEPH_PLANNER_MODEL="$PLANNER_MODEL"
+[[ -n "$REVIEWER_MODEL" ]]    && export HEPH_REVIEWER_MODEL="$REVIEWER_MODEL"
+[[ -n "$IMPLEMENTER_MODEL" ]] && export HEPH_IMPLEMENTER_MODEL="$IMPLEMENTER_MODEL"
 
 DRY_RUN_FLAGS=""
 if [[ "$DRY_RUN" -eq 1 ]]; then
@@ -75,6 +119,8 @@ fi
 
 echo "Repos to process: ${REPOS[*]}"
 echo "Loops: $LOOPS | Max workers: $MAX_WORKERS | Parallel repos: $PARALLEL_REPOS | Dry run: $DRY_RUN"
+echo "Phases: $PHASES"
+echo "Models: planner=${HEPH_PLANNER_MODEL:-<default>} reviewer=${HEPH_REVIEWER_MODEL:-<default>} implementer=${HEPH_IMPLEMENTER_MODEL:-<default>}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # ---------------------------------------------------------------------------
@@ -95,6 +141,7 @@ done
 # ---------------------------------------------------------------------------
 # process_repo: 6-phase pipeline for a single repo.
 # Runs in a subshell so multiple repos can execute in parallel.
+# Each phase entrypoint auto-discovers open issues via gh_list_open_issues().
 # ---------------------------------------------------------------------------
 process_repo() {
   local repo="$1"
@@ -103,31 +150,6 @@ process_repo() {
 
   echo ""
   echo "── $repo ──────────────────────────────────────────────────────"
-
-  # Fetch open issue numbers (up to 1000). Capture once with explicit fallback
-  # so a transient gh failure doesn't silently look like "no open issues".
-  local -a ISSUE_NUMBERS
-  local _issue_list
-  if ! _issue_list=$(gh issue list --repo "$ORG/$repo" \
-      --state open \
-      --limit 1000 \
-      --json number \
-      --jq '.[].number' 2>/dev/null); then
-    echo "  [$repo] warn: gh issue list failed, treating as no issues" >&2
-    _issue_list=''
-  fi
-  mapfile -t ISSUE_NUMBERS <<< "$_issue_list"
-  # mapfile on empty string yields a single empty element — strip it.
-  if [[ ${#ISSUE_NUMBERS[@]} -eq 1 && -z "${ISSUE_NUMBERS[0]}" ]]; then
-    ISSUE_NUMBERS=()
-  fi
-
-  if [[ ${#ISSUE_NUMBERS[@]} -eq 0 ]]; then
-    echo "  [$repo] No open issues — skipping"
-    return 0
-  fi
-
-  echo "  [$repo] Open issues (${#ISSUE_NUMBERS[@]}): ${ISSUE_NUMBERS[*]}"
 
   # Rebase main before starting work
   echo "  [$repo] Rebasing main..."
@@ -143,70 +165,75 @@ process_repo() {
   fi
 
   # --- Phase 1: Plan ---
-  echo "  [$repo] Planning issues..."
-  (
-    cd "$dir"
-    "$PLAN_BIN" \
-      --issues "${ISSUE_NUMBERS[@]}" \
-      -v \
-      $DRY_RUN_FLAGS \
-      || echo "  [$repo] Warning: plan-issues exited non-zero (loop $loop)"
-  )
+  if phase_enabled plan; then
+    echo "  [$repo] Planning issues..."
+    (
+      cd "$dir"
+      "$PLAN_BIN" \
+        -v \
+        $DRY_RUN_FLAGS \
+        || echo "  [$repo] Warning: plan-issues exited non-zero (loop $loop)"
+    )
+  fi
 
   # --- Phase 2: Review Plans ---
-  echo "  [$repo] Reviewing plans..."
-  (
-    cd "$dir"
-    "$PYTHON" "$SCRIPT_DIR/review_plans.py" \
-      --issues "${ISSUE_NUMBERS[@]}" \
-      --max-workers "$MAX_WORKERS" \
-      -v \
-      $DRY_RUN_FLAGS \
-      || echo "  [$repo] Warning: review-plans exited non-zero (loop $loop)"
-  )
+  if phase_enabled review-plans; then
+    echo "  [$repo] Reviewing plans..."
+    (
+      cd "$dir"
+      "$PYTHON" "$SCRIPT_DIR/review_plans.py" \
+        --max-workers "$MAX_WORKERS" \
+        -v \
+        $DRY_RUN_FLAGS \
+        || echo "  [$repo] Warning: review-plans exited non-zero (loop $loop)"
+    )
+  fi
 
   # --- Phase 3: Implement ---
-  echo "  [$repo] Implementing issues..."
-  (
-    cd "$dir"
-    "$IMPL_BIN" \
-      --issues "${ISSUE_NUMBERS[@]}" \
-      --max-workers "$MAX_WORKERS" \
-      --no-ui \
-      -v \
-      $FOLLOW_UP_FLAG \
-      $DRY_RUN_FLAGS \
-      || echo "  [$repo] Warning: implement-issues exited non-zero (loop $loop)"
-  )
+  if phase_enabled implement; then
+    echo "  [$repo] Implementing issues..."
+    (
+      cd "$dir"
+      "$IMPL_BIN" \
+        --max-workers "$MAX_WORKERS" \
+        --no-ui \
+        -v \
+        $FOLLOW_UP_FLAG \
+        $DRY_RUN_FLAGS \
+        || echo "  [$repo] Warning: implement-issues exited non-zero (loop $loop)"
+    )
+  fi
 
   # --- Phase 4: Review PRs (inline comments) ---
-  echo "  [$repo] Reviewing PRs..."
-  (
-    cd "$dir"
-    "$PYTHON" "$SCRIPT_DIR/review_issues.py" \
-      --issues "${ISSUE_NUMBERS[@]}" \
-      --max-workers "$MAX_WORKERS" \
-      --no-ui \
-      -v \
-      $DRY_RUN_FLAGS \
-      || echo "  [$repo] Warning: review-issues exited non-zero (loop $loop)"
-  )
+  if phase_enabled review-prs; then
+    echo "  [$repo] Reviewing PRs..."
+    (
+      cd "$dir"
+      "$PYTHON" "$SCRIPT_DIR/review_issues.py" \
+        --max-workers "$MAX_WORKERS" \
+        --no-ui \
+        -v \
+        $DRY_RUN_FLAGS \
+        || echo "  [$repo] Warning: review-issues exited non-zero (loop $loop)"
+    )
+  fi
 
   # --- Phase 5: Address Review Comments ---
-  echo "  [$repo] Addressing review comments..."
-  (
-    cd "$dir"
-    "$PYTHON" "$SCRIPT_DIR/address_review.py" \
-      --issues "${ISSUE_NUMBERS[@]}" \
-      --max-workers "$MAX_WORKERS" \
-      --no-ui \
-      -v \
-      $DRY_RUN_FLAGS \
-      || echo "  [$repo] Warning: address-review exited non-zero (loop $loop)"
-  )
+  if phase_enabled address-review; then
+    echo "  [$repo] Addressing review comments..."
+    (
+      cd "$dir"
+      "$PYTHON" "$SCRIPT_DIR/address_review.py" \
+        --max-workers "$MAX_WORKERS" \
+        --no-ui \
+        -v \
+        $DRY_RUN_FLAGS \
+        || echo "  [$repo] Warning: address-review exited non-zero (loop $loop)"
+    )
+  fi
 
   # --- Phase 6: Drive PRs to Green CI (final loop only) ---
-  if [[ "$loop" -eq "$LOOPS" ]]; then
+  if phase_enabled drive-green && [[ "$loop" -eq "$LOOPS" ]]; then
     echo "  [$repo] Driving PRs to green CI..."
     (
       cd "$dir"
@@ -214,7 +241,6 @@ process_repo() {
       # unless HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS or --force-run is given.
       HEPH_LOOP_INDEX="$loop" HEPH_TOTAL_LOOPS="$LOOPS" \
       "$PYTHON" "$SCRIPT_DIR/drive_prs_green.py" \
-        --issues "${ISSUE_NUMBERS[@]}" \
         --max-workers "$MAX_WORKERS" \
         --no-ui \
         -v \

--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -51,15 +51,22 @@ cleanup_on_signal() {
   echo "▶ Interrupted ($sig). Stopping ${#ACTIVE_PIDS[@]} background repo job(s)..." >&2
   trap - INT TERM HUP    # disarm to prevent re-entry mid-cleanup
 
+  # Documented set +e/set -e bracket: signalling a process group that has
+  # already exited returns ESRCH (kill exit 1). That is the expected outcome
+  # during teardown — we do not want it to abort the cleanup loop. We also
+  # suppress kill's stderr so "No such process" doesn't clutter the log when
+  # children exit between our two passes.
+  set +e
   for pid in "${ACTIVE_PIDS[@]}"; do
     # Negative pid = entire process group (the `set -m` job).
     # SIGTERM first; SIGKILL after a short grace.
-    kill -TERM -"$pid" 2>/dev/null || true
+    kill -TERM -"$pid" 2>/dev/null
   done
   sleep 2
   for pid in "${ACTIVE_PIDS[@]}"; do
-    kill -KILL -"$pid" 2>/dev/null || true
+    kill -KILL -"$pid" 2>/dev/null
   done
+  set -e
   exit 130
 }
 trap 'cleanup_on_signal INT'  INT
@@ -304,14 +311,21 @@ for (( loop=1; loop<=LOOPS; loop++ )); do
     ACTIVE_PIDS+=($!)
 
     if [[ ${#ACTIVE_PIDS[@]} -ge "$PARALLEL_REPOS" ]]; then
-      wait "${ACTIVE_PIDS[0]}" || true
+      # A non-zero exit from process_repo just means one repo's phase warned;
+      # the per-phase blocks already logged the warning and the orchestrator
+      # continues with the remaining repos. Surface the exit code explicitly.
+      if ! wait "${ACTIVE_PIDS[0]}"; then
+        echo "  Warning: repo job pid=${ACTIVE_PIDS[0]} exited non-zero (continuing)" >&2
+      fi
       ACTIVE_PIDS=("${ACTIVE_PIDS[@]:1}")
     fi
   done
 
   # Drain any remaining background jobs
   for pid in "${ACTIVE_PIDS[@]}"; do
-    wait "$pid" || true
+    if ! wait "$pid"; then
+      echo "  Warning: repo job pid=$pid exited non-zero (continuing)" >&2
+    fi
   done
   ACTIVE_PIDS=()
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -297,7 +297,12 @@ class TestGhCall:
 
         assert result.stdout == "success"
         assert mock_run.call_count == 3
-        assert mock_sleep.call_count == 2  # Sleep between retries
+        # Expect the two retry backoffs (1s, 2s) to be present. Other
+        # `time.sleep` calls may come from the per-thread gh throttle, so we
+        # check for the retry sleeps explicitly rather than counting totals.
+        sleep_durations = [c.args[0] for c in mock_sleep.call_args_list if c.args]
+        assert 1 in sleep_durations, f"missing 1s retry backoff; got {sleep_durations}"
+        assert 2 in sleep_durations, f"missing 2s retry backoff; got {sleep_durations}"
 
     @patch("hephaestus.automation.github_api.run")
     def test_claude_usage_limit_detection(self, mock_run: Any) -> None:
@@ -734,3 +739,81 @@ class TestWriteSecure:
         finally:
             # Restore permissions for cleanup
             test_file.parent.chmod(0o755)
+
+
+class TestGhCallThrottle:
+    """Tests for the per-thread `gh` call throttle inside _gh_call."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_throttle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Reset the per-thread throttle state and force a known rate so tests
+        # don't inherit clock state from earlier suite calls.
+        _github_api_module._GH_THROTTLE = __import__("threading").local()
+        monkeypatch.setenv("GH_RATE_LIMIT_PER_SEC", "5")
+
+    @patch("hephaestus.automation.github_api.run")
+    def test_consecutive_calls_are_paced_to_min_interval(self, mock_run: Any) -> None:
+        """Pace consecutive calls to the configured min interval.
+
+        At 5 calls/sec, two back-to-back calls in the same thread must be
+        separated by at least ~0.2s.
+        """
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        import time as _time
+
+        t0 = _time.monotonic()
+        _gh_call(["api", "/rate_limit"])
+        _gh_call(["api", "/rate_limit"])
+        elapsed = _time.monotonic() - t0
+
+        # Allow a small slack below the theoretical 0.2s for clock granularity.
+        assert elapsed >= 0.18, f"throttle did not pace; elapsed={elapsed:.3f}s"
+
+    @patch("hephaestus.automation.github_api.run")
+    def test_throttle_disabled_when_rate_zero(
+        self, mock_run: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GH_RATE_LIMIT_PER_SEC=0 disables pacing entirely."""
+        monkeypatch.setenv("GH_RATE_LIMIT_PER_SEC", "0")
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        import time as _time
+
+        t0 = _time.monotonic()
+        for _ in range(5):
+            _gh_call(["api", "/rate_limit"])
+        elapsed = _time.monotonic() - t0
+
+        # 5 calls with no throttle should finish well under one min-interval.
+        assert elapsed < 0.05, f"unexpected delay with throttle off; elapsed={elapsed:.3f}s"
+
+    @patch("hephaestus.automation.github_api.run")
+    def test_buckets_are_per_thread(self, mock_run: Any) -> None:
+        """Each thread has its own bucket.
+
+        Two threads each making one call should not block each other.
+        """
+        import threading as _t
+        import time as _time
+
+        mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
+
+        # Pre-warm thread A's bucket so a second call from A would block.
+        _gh_call(["api", "/rate_limit"])
+
+        elapsed_b: list[float] = []
+
+        def thread_b() -> None:
+            t0 = _time.monotonic()
+            _gh_call(["api", "/rate_limit"])
+            elapsed_b.append(_time.monotonic() - t0)
+
+        worker = _t.Thread(target=thread_b)
+        worker.start()
+        worker.join()
+
+        # Thread B has its own bucket and should not have been throttled.
+        assert elapsed_b[0] < 0.05, (
+            f"per-thread isolation broken; thread B waited {elapsed_b[0]:.3f}s"
+        )


### PR DESCRIPTION
## Summary

- Adds `--phases LIST` (subset of `plan,review-plans,implement,review-prs,address-review,drive-green`; unknown names exit 1) so operators can re-run a single phase across every repo without commenting blocks out by hand. Normal gates still apply — `drive-green` only on the final loop, `loop>=3` still passes `--no-follow-up`.
- Adds `--planner-model` / `--reviewer-model` / `--implementer-model`, forwarded to child processes as `HEPH_PLANNER_MODEL` / `HEPH_REVIEWER_MODEL` / `HEPH_IMPLEMENTER_MODEL`. Unset = `claude_models.py` defaults. Provides the operator escape hatch when one tier exhausts (HTTP 429 cascade failure mode documented in the `automation-claude-model-per-phase` skill).
- Drops the per-repo `gh issue list` snapshot and `--issues` forwarding. Each phase entrypoint already auto-discovers open issues via `gh_list_open_issues()`; relying on that lets issues opened mid-loop be visible to later phases.
- Run header now echoes the resolved phase list and model selections.

## Test plan

- [x] `shellcheck scripts/run_automation_loop.sh` — clean
- [x] `bash -n scripts/run_automation_loop.sh` — syntax OK
- [x] `--phases bogus` exits 1 with `Unknown phase: bogus (valid: …)`
- [x] `--planner-model X` exports `HEPH_PLANNER_MODEL=X` to children (verified via inline arg-parser replay)
- [x] `phase_enabled` gate logic verified for partial subsets (e.g. `plan,implement,drive-green`)
- [x] Real `--dry-run --loops 1 --phases plan` against AchaeanFleet: planner logs `No --issues given; discovered 35 open issues: [...]` — auto-discovery wiring confirmed end-to-end
- [ ] Reviewer should sanity-check that `--phases drive-green` on a non-final iteration is still a no-op (intentional — operator override is not "force-run")