### PR TITLE
chore: forbid ::warning:: advisory pattern; schema-fetch fail-fast

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -64,6 +64,35 @@ jobs:
           fi
           echo 'OK: no "continue-on-error: true" found'
 
+      - name: "Reject advisory annotation pattern"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          # The advisory-annotation pattern in workflow run blocks is morally
+          # equivalent to continue-on-error: true: it lets a tool fail without
+          # failing the CI step. The runbook (Bucket F) requires every tool
+          # to be fail-fast. The only legitimate annotation is informational
+          # text not tied to a tool's exit code — those should use
+          # echo "WARN:" to stdout instead. See docs/runbooks/no-silent-failures.md.
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            # Exempt this workflow file (heredoc would otherwise self-match).
+            case "$f" in
+              .github/workflows/_required.yml) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nF '::warning::' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found advisory annotations above. Make the underlying tool fail-fast or use echo "WARN:" to stdout. See HomericIntelligence/Odysseus#282 Bucket F.'
+            exit 1
+          fi
+          echo 'OK: no advisory annotations found'
+
   lint:
     name: lint
     runs-on: ubuntu-24.04
@@ -148,7 +177,7 @@ jobs:
           if [ -f pixi.lock ]; then
             pixi install --locked
           else
-            echo "::warning::pixi.toml present but pixi.lock missing — running unlocked"
+            echo "WARN: pixi.toml present but pixi.lock missing — running unlocked"
             pixi install
           fi
 
@@ -395,20 +424,16 @@ jobs:
       - name: Validate GitHub workflow schemas
         run: |
           set -euo pipefail
-          # Probe the remote schema first so a schemastore.org outage emits a
-          # clear notice instead of being swallowed by `continue-on-error: true`.
-          schema_url="https://json.schemastore.org/github-workflow"
-          if ! curl -fsSL --max-time 15 -o /tmp/github-workflow.schema.json "$schema_url"; then
-            echo "::warning::Could not fetch $schema_url — skipping schema validation"
-            exit 0
-          fi
+          # Use check-jsonschema's bundled `vendor.github-workflows` schema so
+          # the job is network-free and fail-fast. No schemastore.org probe and
+          # no advisory `::warning::` outage fallback (Bucket F anti-pattern).
           mapfile -t wf_files < <(find .github/workflows -name "*.yml")
           if [ "${#wf_files[@]}" -eq 0 ]; then
             echo "No workflow files to validate"
             exit 0
           fi
           check-jsonschema \
-            --schemafile /tmp/github-workflow.schema.json \
+            --builtin-schema vendor.github-workflows \
             "${wf_files[@]}"
 
   deps-version-sync:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,6 +168,25 @@ repos:
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: true
 
+      - id: forbid-advisory-warnings
+        name: "forbid advisory ::warning:: pattern in workflow run blocks"
+        description: >
+          The advisory-warning workflow annotation is morally equivalent to
+          `continue-on-error: true` when it replaces a tool's failure exit
+          with a benign-looking warning. The CI step still passes, the
+          underlying problem still goes unfixed. Make the step fail-fast
+          instead. The only legitimate use is annotating a step that runs
+          BEFORE the failing tool (e.g., advising on a deprecated config),
+          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
+        language: pygrep
+        # Match the GitHub Actions advisory-annotation prefix. We exempt
+        # this workflow file (the lint rule itself contains the literal
+        # for self-documentation) via the `exclude` regex below.
+        entry: '::warning::'
+        files: ^\.github/workflows/.*\.ya?ml$
+        exclude: ^\.github/workflows/_required\.yml$
+        pass_filenames: true
+
   # Shellcheck for shell scripts
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1


### PR DESCRIPTION
## Summary

Ports the Bucket F regression guard from HomericIntelligence/Odysseus#282 and refactors the lone advisory-annotation site in this repo to fail-fast.

Per the user's 2026-05-10 no-silent-failures clarification, the `::warning::` advisory pattern is morally equivalent to `continue-on-error: true`: the CI step still passes even when the wrapped tool reports a real issue. It is now classified as **Bucket F** alongside `|| true` and `continue-on-error: true`.

## Changes

### `.pre-commit-config.yaml`
- Adds `forbid-advisory-warnings` pygrep hook alongside the existing `forbid-or-true` and `forbid-continue-on-error` hooks (verbatim from Odysseus#282).
- Self-exempts `.github/workflows/_required.yml` since the lint rule itself contains the literal `::warning::` for self-documentation.

### `.github/workflows/_required.yml`
- Adds the matching `Reject advisory annotation pattern` step to the `forbid-suppressions` job.
- **Refactors the assigned advisory site (schema-fetch fallback, was line 401):**
  - Before: `curl -fsSL https://json.schemastore.org/github-workflow` + `if ! curl ...; then echo "::warning::Could not fetch ... — skipping schema validation"; exit 0; fi`
  - After: `check-jsonschema --builtin-schema vendor.github-workflows ...` (network-free, fail-fast — the schema is bundled with check-jsonschema 0.36+).
- Converts the informational `pixi.lock missing` annotation (line 151, pixi-check job's lockfile-absence fallback path — does not wrap a tool's exit) from `::warning::` to `echo "WARN: ..."` per the runbook's guidance on legitimate informational annotations. Required so the new pygrep + CI guard pass on existing content.

## Refactor table

| File:line | Tool / pattern | Before | After |
|---|---|---|---|
| `.github/workflows/_required.yml:395-411` | `check-jsonschema` schema-fetch | `curl` + `if ! ...; then echo "::warning::schemastore.org outage"; exit 0; fi` | `check-jsonschema --builtin-schema vendor.github-workflows` (network-free) |
| `.github/workflows/_required.yml:151` | `pixi install` lockfile-absence informational | `echo "::warning::pixi.toml present but pixi.lock missing — running unlocked"` | `echo "WARN: pixi.toml present but pixi.lock missing — running unlocked"` |

## Local-run findings

- `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml`: `ok -- validation done` — no schema findings, safe to flip to fail-fast.
- No `::warning::` left in `.github/workflows/` outside the exempted `_required.yml` self-documentation.

## Test plan

- [x] `pre-commit run forbid-or-true --all-files`: Passed
- [x] `pre-commit run forbid-continue-on-error --all-files`: Passed
- [x] `pre-commit run forbid-advisory-warnings --all-files`: Passed
- [x] `check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml`: ok -- validation done
- [x] Simulated the new `Reject advisory annotation pattern` CI step locally — exits 0 with `OK: no advisory annotations found`
- [ ] CI green on PR

Refs HomericIntelligence/Odysseus#280, HomericIntelligence/Odysseus#282

🤖 Generated with [Claude Code](https://claude.com/claude-code)