### PR TITLE
feat(shell): add coredump-host-handler and run-under-gdb forensic utilities

### DIFF
--- a/scripts/shell/coredump-host-handler.sh
+++ b/scripts/shell/coredump-host-handler.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+#
+# coredump-host-handler.sh — pipe-mode core_pattern handler
+#
+# Invoked by the Linux kernel (as PID 1 of the HOST namespace) when any
+# process with `ulimit -c > 0` crashes. The kernel pipes the full ELF core
+# on stdin and passes positional args set via core_pattern format tokens.
+#
+# Why a pipe handler: when the crashing process runs inside a container
+# (Podman/Docker), a plain `core_pattern` file path is resolved against the
+# *container's* mount namespace, so the kernel silently writes nothing the
+# host can see. A pipe handler runs in the HOST namespace and can write to
+# a host-side directory that survives container teardown.
+#
+# Install:
+#   sudo cp scripts/shell/coredump-host-handler.sh \
+#     /usr/local/bin/coredump-host-handler.sh
+#   sudo chmod +x /usr/local/bin/coredump-host-handler.sh
+#   echo "|/usr/local/bin/coredump-host-handler.sh %p %e %t %s %P" \
+#     | sudo tee /proc/sys/kernel/core_pattern
+#
+# core_pattern tokens (must match the install line above, in order):
+#   %p  PID of crashing process (in its own PID namespace)
+#   %e  executable basename
+#   %t  time of crash (seconds since epoch)
+#   %s  signal number
+#   %P  global PID (host namespace) — captured, not used in the filename
+#
+# Environment variables:
+#   COREDUMP_TARGET_DIRS   Colon-separated list of candidate output dirs,
+#                          tried in order; the first that already exists
+#                          wins. If none exist, the LAST entry is created.
+#                          Default: "/tmp/crash-bundle/cores".
+#                          A CI job typically points this at its workspace,
+#                          e.g. "/home/runner/work/<repo>/<repo>/crash-bundle/cores".
+#   COREDUMP_MAX_BYTES     Cap on core size written to disk, in bytes.
+#                          Default: 4 GiB. Prevents a runaway process from
+#                          filling the host disk.
+#
+# Manual test (does NOT hang — the TTY guard prevents blocking on a terminal):
+#   echo "fake core data" | \
+#     ./scripts/shell/coredump-host-handler.sh 1234 myproc 1700000000 11 5678
+#
+# Exit code note: the kernel ignores this handler's exit code entirely. Every
+# failure path therefore logs to handler.log instead of relying on exit
+# status — a missing handler.log is the only signal that the handler did not
+# run at all.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Arguments (from core_pattern tokens)
+# ---------------------------------------------------------------------------
+PID="${1:-unknown}"
+EXE="${2:-unknown}"
+TIME="${3:-0}"
+SIGNAL="${4:-0}"
+# $5 = global (host) PID — captured by the format string but unused here.
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DEFAULT_TARGET_DIRS="/tmp/crash-bundle/cores"
+TARGET_DIRS="${COREDUMP_TARGET_DIRS:-$DEFAULT_TARGET_DIRS}"
+MAX_BYTES="${COREDUMP_MAX_BYTES:-$((4 * 1024 * 1024 * 1024))}"
+
+# ---------------------------------------------------------------------------
+# TTY guard
+# ---------------------------------------------------------------------------
+# When invoked by the kernel, stdin is a pipe carrying the core ELF — not a
+# terminal. When invoked manually for testing with no piped input, stdin IS a
+# terminal and reading from it would hang forever. Bail out early in that case.
+if [ -t 0 ]; then
+    echo "coredump-host-handler: stdin is a TTY — refusing to run (would block)." >&2
+    echo "  This script is meant to be invoked by the kernel via core_pattern." >&2
+    echo "  Manual test: echo somecore | $0 <pid> <exe> <time> <signal> [<gpid>]" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve the destination directory
+# ---------------------------------------------------------------------------
+# Walk the candidate list in order; the first existing directory wins. If none
+# exist, fall back to the LAST candidate and create it. Running as host PID 1
+# means well-known host paths (e.g. a GitHub Actions workspace) are reachable.
+TARGET=""
+LAST_CANDIDATE=""
+IFS=':' read -r -a _candidates <<< "$TARGET_DIRS"
+for candidate in "${_candidates[@]}"; do
+    [ -n "$candidate" ] || continue
+    LAST_CANDIDATE="$candidate"
+    if [ -d "$candidate" ]; then
+        TARGET="$candidate"
+        break
+    fi
+done
+if [ -z "$TARGET" ]; then
+    TARGET="${LAST_CANDIDATE:-/tmp/crash-bundle/cores}"
+fi
+
+mkdir -p "$TARGET"
+
+# LOG_DIR must be resolved BEFORE the first log write below.
+LOG_DIR="$(dirname "$TARGET")"
+
+# ---------------------------------------------------------------------------
+# Write the core ELF
+# ---------------------------------------------------------------------------
+OUT="$TARGET/core.${PID}.${EXE}.${TIME}.sig${SIGNAL}"
+if ! head -c "$MAX_BYTES" > "$OUT"; then
+    echo "$(date -Iseconds) ERROR: failed to write core to $OUT" \
+        >> "$LOG_DIR/handler.log" 2>/dev/null
+fi
+if ! chmod 644 "$OUT" 2>/dev/null; then
+    echo "$(date -Iseconds) WARNING: chmod 644 $OUT failed (file may be unreadable)" \
+        >> "$LOG_DIR/handler.log" 2>/dev/null
+fi
+
+# ---------------------------------------------------------------------------
+# Log the capture
+# ---------------------------------------------------------------------------
+SIZE=$(stat -c %s "$OUT" 2>/dev/null || echo "?")
+{
+    printf '%s wrote %s (%s bytes) signal=%s exe=%s\n' \
+        "$(date -Iseconds)" "$OUT" "$SIZE" "$SIGNAL" "$EXE"
+} >> "$LOG_DIR/handler.log" 2>/dev/null
+
+# Kernel-invoked: if the log append failed (e.g. LOG_DIR is unwritable), there
+# is no safe way to surface the error — the kernel has no channel for our exit
+# code. Failure here is silent by design; a downstream artifact-upload step
+# should surface a missing handler.log as "handler was not invoked".
+true

--- a/scripts/shell/run-under-gdb.sh
+++ b/scripts/shell/run-under-gdb.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# run-under-gdb.sh — run any command under gdb to catch crash signals that
+# the program's own in-process signal handler would otherwise swallow.
+#
+# Some runtimes (JIT compilers, sanitizer runtimes, language VMs) install
+# their own SIGABRT/SIGSEGV/SIGILL handlers that catch a fatal signal, print
+# a terse post-handler trace, and exit cleanly — so the kernel never produces
+# a core and the *real* faulting frame is lost. Running the command under gdb
+# stops the inferior in the debugger BEFORE its own handler runs, so a real
+# ELF core and a full backtrace can be captured at the moment of fault.
+#
+# Usage:
+#   run-under-gdb.sh <core-dir> <command> [args...]
+#
+#   <core-dir>   Directory for cores and gdb logs (created if absent).
+#   <command>    The program to run. Resolved via PATH if not an absolute
+#                path. All remaining arguments are passed to it verbatim.
+#
+# Environment variables:
+#   RUN_UNDER_GDB=0       Skip gdb entirely and exec the command directly
+#                         (local-dev escape hatch — gdb adds overhead).
+#   GDB_CMD_PREFIX        Optional command prefix inserted before `gdb`, e.g.
+#                         "pixi run --" or "conda run -n env --", so gdb and
+#                         its inferior inherit an activated environment.
+#                         Default: empty (gdb is run directly).
+#
+# Output files (written on crash):
+#   <core-dir>/core.gdb.<timestamp>  — ELF core (multi-MB)
+#   <core-dir>/gdb-<timestamp>.log   — backtrace + threads + shared libraries
+#
+# Exit code:
+#   - 0 / N            normal exit with the inferior's own exit code N
+#   - 128 + signo      the inferior was stopped by a caught signal
+#                      (134 = SIGABRT, 139 = SIGSEGV, 132 = SIGILL, ...)
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+    echo "[run-under-gdb] usage: $0 <core-dir> <command> [args...]" >&2
+    exit 1
+fi
+
+CORE_DIR="$1"
+shift
+CMD="$1"
+shift
+
+# Escape hatch: RUN_UNDER_GDB=0 bypasses gdb for local dev where overhead matters.
+if [ "${RUN_UNDER_GDB:-1}" = "0" ]; then
+    exec "$CMD" "$@"
+fi
+
+mkdir -p "$CORE_DIR"
+TS=$(date +%s)
+GDB_LOG="${CORE_DIR}/gdb-${TS}.log"
+CORE_FILE="${CORE_DIR}/core.gdb.${TS}"
+
+# Resolve the command to a concrete executable path so gdb has a real ELF
+# file argument. An absolute/relative path is used as-is; a bare name is
+# resolved via PATH. If resolution fails, fall back to running it directly.
+if [ -x "$CMD" ]; then
+    CMD_BIN="$CMD"
+else
+    CMD_BIN=$(command -v "$CMD" 2>/dev/null || echo "")
+fi
+if [ -z "$CMD_BIN" ] || [ ! -x "$CMD_BIN" ]; then
+    echo "[run-under-gdb] WARNING: could not resolve '$CMD'; running directly without gdb" >&2
+    exec "$CMD" "$@"
+fi
+
+# Write the gdb command script to a temp file. Multi-line gdb scripts passed
+# via repeated -ex flags are not portable across gdb versions; -x <file> is.
+GDB_SCRIPT=$(mktemp /tmp/run-under-gdb-XXXXXX.gdb)
+EXIT_CODE_FILE="${CORE_DIR}/exit-${TS}.code"
+# shellcheck disable=SC2064
+trap "rm -f '$GDB_SCRIPT'" EXIT
+
+# The gdb script uses Python event hooks rather than a plain gdb-script `if`
+# because:
+#  1. `handle SIG* stop` + a `hook-stop` block fires on EVERY stop event,
+#     including normal exit, where `generate-core-file` then fails with
+#     "You can't do that without a process to debug".
+#  2. `--return-child-result` is unreliable in batch mode for processes
+#     killed by *handled* signals: gdb often exits 0 even when the inferior
+#     died on a signal, masking the failure entirely.
+# Python events cleanly distinguish gdb.SignalEvent (real crash) from
+# gdb.ExitedEvent (clean exit) and record the intended exit code to a file
+# that this wrapper reads back afterwards.
+cat > "$GDB_SCRIPT" <<GDBEOF
+set pagination off
+set confirm off
+set logging file ${GDB_LOG}
+set logging overwrite on
+set logging enabled on
+
+python
+import gdb
+EXIT_FILE = "${EXIT_CODE_FILE}"
+CORE_FILE = "${CORE_FILE}"
+# POSIX shell convention for signal-terminated processes (128 + signo).
+SIG_MAP = {"SIGABRT": 6, "SIGSEGV": 11, "SIGBUS": 7, "SIGFPE": 8, "SIGILL": 4}
+state = {"signaled": False}
+
+def write_exit(code):
+    with open(EXIT_FILE, "w") as f:
+        f.write(str(code))
+
+# Default = 1 covers the case where neither handler fires (e.g. gdb itself dies).
+write_exit(1)
+
+def on_stop(event):
+    # We never set breakpoints, so the only stop events we expect are signals.
+    if isinstance(event, gdb.SignalEvent):
+        signo = event.stop_signal
+        print("[run-under-gdb] caught " + signo + "; dumping " + CORE_FILE)
+        gdb.execute("generate-core-file " + CORE_FILE)
+        gdb.execute("bt full")
+        gdb.execute("info threads")
+        gdb.execute("info sharedlibrary")
+        state["signaled"] = True
+        write_exit(128 + SIG_MAP.get(signo, 1))
+
+def on_exit(event):
+    # gdb fires Exited after the post-signal kill too. If we already captured
+    # a signal, do not overwrite that exit code with the kill's exit code.
+    if state["signaled"]:
+        return
+    code = getattr(event, "exit_code", None)
+    write_exit(code if code is not None else 0)
+
+gdb.events.stop.connect(on_stop)
+gdb.events.exited.connect(on_exit)
+end
+
+# Intercept crash signals before the inferior's own handlers run.
+# "nopass" prevents the signal from being delivered to the inferior.
+handle SIGABRT stop nopass print
+handle SIGSEGV stop nopass print
+handle SIGBUS  stop nopass print
+handle SIGILL  stop nopass print
+handle SIGFPE  stop nopass print
+
+run
+
+set logging enabled off
+quit
+GDBEOF
+
+echo "[run-under-gdb] gdb log  : ${GDB_LOG}" >&2
+echo "[run-under-gdb] core file: ${CORE_FILE} (written on crash)" >&2
+echo "[run-under-gdb] binary   : ${CMD_BIN}" >&2
+echo "[run-under-gdb] args     : $*" >&2
+
+# GDB_CMD_PREFIX lets the caller run gdb inside an environment activator
+# (e.g. "pixi run --") so gdb and its inferior inherit the activated env.
+# Unquoted on purpose: the prefix is a word list, not a single argument.
+# `set -e` would abort here if gdb exits non-zero before we read the exit
+# file; disable it just for this invocation.
+set +e
+${GDB_CMD_PREFIX:-} gdb -batch -nx -x "$GDB_SCRIPT" --args "$CMD_BIN" "$@"
+gdb_status=$?
+set -e
+
+# Prefer the Python-recorded exit code; fall back to gdb's own status if the
+# file is missing (gdb crashed before the python hook fired).
+if [ -r "$EXIT_CODE_FILE" ]; then
+    inferior_exit=$(cat "$EXIT_CODE_FILE")
+    rm -f "$EXIT_CODE_FILE"
+    exit "$inferior_exit"
+fi
+exit "$gdb_status"


### PR DESCRIPTION
## Summary

Two project-agnostic crash-forensics shell utilities for `scripts/shell/`, generalized from debugging tooling originally written for ProjectOdyssey's investigation of a Mojo JIT codegen bug (modular/modular#6413).

### `coredump-host-handler.sh`

Kernel pipe-mode `core_pattern` handler. A plain file-path `core_pattern` is resolved against a *container's* mount namespace, so when a containerized process crashes the kernel silently writes nothing the host can see. A pipe handler runs in the host PID/mount namespace and writes somewhere that survives container teardown.

Generalized from ProjectOdyssey's copy:
- hard-coded `/home/runner/work/ProjectOdyssey/...` target path → `COREDUMP_TARGET_DIRS` (colon-separated candidate list)
- 4 GiB size cap → `COREDUMP_MAX_BYTES`
- **fixed a latent bug**: `LOG_DIR` was used before it was defined

### `run-under-gdb.sh`

Runs any command under `gdb -batch` with Python event hooks, so a real ELF core + full backtrace are captured *before* the inferior's own in-process signal handler can swallow the fault (JIT runtimes, sanitizer runtimes, language VMs commonly do this).

Generalized from ProjectOdyssey's `mojo-under-gdb.sh`:
- takes an arbitrary `<command> [args...]` instead of hard-coding `mojo`
- resolves the binary via `PATH` generically
- the `pixi run` env-activation assumption → optional `GDB_CMD_PREFIX` env var (empty by default)
- `MOJO_UNDER_GDB` escape hatch generalized to `RUN_UNDER_GDB`

## Verification

- [x] ShellCheck — **Passed** (both files)
- [x] Full pre-commit suite — **Passed** (trailing-whitespace, end-of-files, silent-failure guard, etc.)
- [x] Follows `scripts/shell/` conventions: `#!/usr/bin/env bash`, `set -euo pipefail`, documented header block, env-var-driven config

## Follow-up

A patch release (`v0.7.1`) including these scripts will let ProjectOdyssey pin Hephaestus and source `coredump-host-handler.sh` from the package rather than vendoring its own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)