### PR TITLE
feat(forensics): add --target-dir option to coredump-handler CLI

### DIFF
--- a/hephaestus/forensics/coredump_handler.py
+++ b/hephaestus/forensics/coredump_handler.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Kernel pipe-mode ``core_pattern`` handler for capturing core dumps.
+r"""Kernel pipe-mode ``core_pattern`` handler for capturing core dumps.
 
 When a process that runs inside a container (Podman/Docker) crashes, a plain
 file-path ``core_pattern`` is resolved against the *container's* mount
@@ -14,6 +14,15 @@ core pattern handler::
 
     HANDLER=$(command -v hephaestus-coredump-handler)
     echo "|${HANDLER} %p %e %t %s %P" | sudo tee /proc/sys/kernel/core_pattern
+
+The kernel invokes a pipe handler with a *minimal environment*, so the
+``COREDUMP_TARGET_DIRS`` env var cannot reach it. When a specific output
+directory is required (e.g. a CI workspace path that a container bind-mount
+maps to), pass it as a literal ``--target-dir`` argument in the
+``core_pattern`` line — the kernel forwards literal args verbatim::
+
+    echo "|${HANDLER} --target-dir /workspace/crash-bundle/cores %p %e %t %s %P" \\
+      | sudo tee /proc/sys/kernel/core_pattern
 
 ``core_pattern`` format tokens (order matters, must match the install line):
 
@@ -159,6 +168,17 @@ def _build_parser() -> argparse.ArgumentParser:
             "with the core ELF on stdin; not meant to be run interactively."
         ),
     )
+    parser.add_argument(
+        "--target-dir",
+        default=None,
+        help=(
+            "explicit output directory for the core file. Takes precedence over "
+            "COREDUMP_TARGET_DIRS and the built-in default. The kernel invokes a "
+            "core_pattern pipe handler with a minimal environment, so an env var "
+            "cannot reach it — pass this literal flag in the core_pattern line "
+            "when a specific directory (e.g. a CI workspace path) is required."
+        ),
+    )
     parser.add_argument("pid", help="PID of the crashing process (%%p)")
     parser.add_argument("exe", help="executable basename (%%e)")
     parser.add_argument("crash_time", help="crash time, seconds since epoch (%%t)")
@@ -175,10 +195,14 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     """Entry point for the ``hephaestus-coredump-handler`` console script.
 
-    Reads configuration from the environment:
+    Configuration precedence for the output directory:
 
-    * ``COREDUMP_TARGET_DIRS`` — colon-separated candidate output dirs.
-    * ``COREDUMP_MAX_BYTES`` — integer cap on core size in bytes.
+    1. ``--target-dir`` CLI option (highest — survives the kernel's minimal
+       handler environment).
+    2. ``COREDUMP_TARGET_DIRS`` env var — colon-separated candidate dirs.
+    3. :data:`DEFAULT_TARGET_DIRS` — the built-in fallback.
+
+    ``COREDUMP_MAX_BYTES`` (env var) caps the core size in bytes.
 
     Args:
         argv: Argument vector (defaults to ``sys.argv[1:]``).
@@ -203,8 +227,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    target_dirs = os.environ.get("COREDUMP_TARGET_DIRS")
-    candidates = target_dirs.split(":") if target_dirs else list(DEFAULT_TARGET_DIRS)
+    # --target-dir wins over the env var, which wins over the built-in default.
+    if args.target_dir:
+        candidates = [args.target_dir]
+    else:
+        target_dirs = os.environ.get("COREDUMP_TARGET_DIRS")
+        candidates = target_dirs.split(":") if target_dirs else list(DEFAULT_TARGET_DIRS)
 
     max_bytes_env = os.environ.get("COREDUMP_MAX_BYTES")
     max_bytes = int(max_bytes_env) if max_bytes_env else DEFAULT_MAX_BYTES

--- a/tests/unit/forensics/test_coredump_handler.py
+++ b/tests/unit/forensics/test_coredump_handler.py
@@ -10,9 +10,20 @@ import pytest
 
 from hephaestus.forensics.coredump_handler import (
     DEFAULT_MAX_BYTES,
+    main,
     resolve_target_dir,
     write_core,
 )
+
+
+class _FakeStdin:
+    """Minimal non-TTY stdin stand-in: ``isatty()`` is False, ``buffer`` reads bytes."""
+
+    def __init__(self, data: bytes) -> None:
+        self.buffer = io.BytesIO(data)
+
+    def isatty(self) -> bool:
+        return False
 
 
 class TestResolveTargetDir:
@@ -105,3 +116,55 @@ class TestWriteCore:
     def test_default_max_bytes_is_4_gib(self) -> None:
         """The documented default cap is 4 GiB."""
         assert DEFAULT_MAX_BYTES == 4 * 1024 * 1024 * 1024
+
+
+class TestMainTargetDir:
+    """Tests for the --target-dir CLI option and its precedence in main()."""
+
+    def test_target_dir_option_directs_the_core_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--target-dir places the core file in the given directory."""
+        cores = tmp_path / "explicit" / "cores"
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b"ELF"))
+        rc = main(["--target-dir", str(cores), "7", "proc", "100", "11"])
+        assert rc == 0
+        assert (cores / "core.7.proc.100.sig11").read_bytes() == b"ELF"
+
+    def test_target_dir_overrides_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--target-dir wins over COREDUMP_TARGET_DIRS."""
+        env_dir = tmp_path / "from-env"
+        env_dir.mkdir()
+        cli_dir = tmp_path / "from-cli"
+        monkeypatch.setenv("COREDUMP_TARGET_DIRS", str(env_dir))
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b"core"))
+        rc = main(["--target-dir", str(cli_dir), "1", "p", "0", "6"])
+        assert rc == 0
+        assert (cli_dir / "core.1.p.0.sig6").is_file()
+        # The env-var directory must NOT have received the core.
+        assert not list(env_dir.iterdir())
+
+    def test_env_var_used_when_no_target_dir_option(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --target-dir, COREDUMP_TARGET_DIRS is honored."""
+        env_dir = tmp_path / "env-cores"
+        monkeypatch.setenv("COREDUMP_TARGET_DIRS", str(env_dir))
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b"x"))
+        rc = main(["2", "q", "0", "4"])
+        assert rc == 0
+        assert (env_dir / "core.2.q.0.sig4").is_file()
+
+    def test_tty_stdin_is_refused(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A TTY stdin is refused with exit code 1 (would otherwise block)."""
+
+        class _TtyStdin:
+            buffer = io.BytesIO(b"")
+
+            def isatty(self) -> bool:
+                return True
+
+        monkeypatch.setattr("sys.stdin", _TtyStdin())
+        assert main(["1", "p", "0", "6"]) == 1


### PR DESCRIPTION
## Summary

Adds an explicit `--target-dir` CLI option to `hephaestus-coredump-handler`.

## Why

The Linux kernel invokes a `core_pattern` pipe handler with a **minimal/empty environment**, so the `COREDUMP_TARGET_DIRS` env var cannot reach it. When a specific output directory is required — e.g. a CI workspace path that a container bind-mount maps to — it must be passed as a literal argument in the `core_pattern` line (the kernel forwards literal args verbatim).

This unblocks ProjectOdyssey's planned consumption: its `coredump-capture` action needs the core written to the workspace path, not the `/tmp` default.

## Changes

- `--target-dir` option in `_build_parser`; precedence in `main()` is now: `--target-dir` > `COREDUMP_TARGET_DIRS` > `DEFAULT_TARGET_DIRS`.
- Module docstring updated (now a raw string) with a `core_pattern` install example using `--target-dir`.
- 4 new unit tests: `--target-dir` placement, env-var override precedence, env-var fallback, TTY-stdin guard.

## Verification

- [x] `ruff format` + `ruff check` — clean
- [x] `mypy` (strict) — no issues across 242 source files
- [x] `tests/unit/forensics/` — 23 passed, 2 skipped
- [x] CLI smoke test — `printf 'FAKECORE' | hephaestus-coredump-handler --target-dir /tmp/.../cores 99 smoketest 12345 11` correctly routes the core to the given directory and logs it

## Follow-up

This is the last change needed before cutting `v0.7.4`, which lets ProjectOdyssey pin a released Hephaestus version containing `hephaestus/forensics/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)