### PR TITLE
fix(ci): make release version check cache-immune via hatchling version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,11 @@ jobs:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
           TAG_VERSION="${TAG#v}"
-          PKG_VERSION=$(pixi run python -c "import hephaestus; print(hephaestus.__version__)")
+          # Resolve the version straight from hatch-vcs against the checked-out git
+          # tree. This reads the tag, not installed-package metadata, so it is
+          # immune to a stale editable install restored from the actions cache
+          # (the previous `import hephaestus` check returned "unknown" that way).
+          PKG_VERSION=$(pixi run hatchling version)
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
             exit 1
@@ -134,7 +138,17 @@ jobs:
           echo "Version check passed: $TAG_VERSION"
 
       - name: Build package
-        run: pixi run python -m build
+        shell: bash
+        run: |
+          # hatch-vcs derives the version from git; a dirty tree would taint it
+          # with a +dirty/.devN suffix and publish a wrong version.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Working tree is dirty — refusing to build"
+            git status --porcelain
+            exit 1
+          fi
+          pixi run python -m build
+          ls -1 dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Problem

The previous Release run ([25867222424](https://github.com/HomericIntelligence/ProjectHephaestus/actions/runs/25867222424/job/76014321698)) failed at **"Verify tag matches package version"** in `build-and-publish`:

```
Tag version (0.7.4) does not match package version (unknown)
```

So `v0.7.4` was tagged but **never published to PyPI**.

## Root cause

- `hephaestus/__init__.py` resolves `__version__` via `importlib.metadata.version("hephaestus")` — it reads the **installed package's `.dist-info` metadata**.
- `pixi.toml` installs the project as `editable = true`, and the job restores the `.pixi` environment from the actions cache (the failing step ran in 0.7s — no reinstall). The cached editable install's metadata carried a stale `unknown` version.
- The verify step compared tag `0.7.4` against `unknown` and failed. `test`/`type-check` pass only because they never check the version.

## Fix

- Resolve the version with `pixi run hatchling version`, which reads the hatch-vcs source (git tags) against the checked-out tree. This is **cache-immune** — it does not touch `.dist-info`.
- Assert a clean working tree before `python -m build` so hatch-vcs never embeds a `+dirty`/`.devN` suffix into a published artifact.

`hephaestus/__init__.py`'s runtime version logic is intentionally left unchanged — `importlib.metadata` is correct for an *installed* package; the bug was only the CI step misusing it against an editable+cached install.

## Verification

Confirmed locally: `pixi run hatchling version` reads git directly (prints `0.7.5.dev1+gb91d3da02` on current main; will print exactly `0.8.0` when checked out at the `v0.8.0` tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)