### PR TITLE
fix(automation): handle GraphQL rate-limit avalanche in planner loop

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -407,9 +407,7 @@ def _check_graphql_errors(data: dict[str, Any], context: str) -> None:
         err_type = err.get("type", "") if isinstance(err, dict) else ""
         if err_type == "RATE_LIMITED" or "rate limit" in msg.lower():
             reset = gh_rate_limit_reset_epoch() or 0
-            raise GitHubRateLimitError(
-                f"GraphQL {context} rate-limited: {msg}", reset_epoch=reset
-            )
+            raise GitHubRateLimitError(f"GraphQL {context} rate-limited: {msg}", reset_epoch=reset)
 
     raise RuntimeError(f"GraphQL {context} failed: {errors!r}")
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -25,6 +25,8 @@ from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_claude_usage_limit,
     detect_rate_limit,
+    gh_global_throttle_acquire,
+    gh_rate_limit_reset_epoch,
     wait_until,
 )
 
@@ -56,6 +58,35 @@ def _gh_throttle_wait() -> None:
     if elapsed < min_interval:
         time.sleep(min_interval - elapsed)
     _GH_THROTTLE.last_call = time.monotonic()
+
+
+class GitHubRateLimitError(RuntimeError):
+    """Raised when GitHub reports the API rate limit has been exceeded.
+
+    Subclasses :class:`RuntimeError` so existing ``except RuntimeError``
+    handlers continue to catch it; callers that want rate-limit-specific
+    handling (e.g. exit cleanly instead of aborting a batch) should catch
+    this class explicitly.
+
+    Attributes:
+        reset_epoch: Unix timestamp at which the relevant rate-limit
+            window resets, or ``0`` if the reset time could not be
+            determined.
+
+    """
+
+    def __init__(self, message: str, reset_epoch: int = 0) -> None:
+        """Initialise the error with an optional reset epoch.
+
+        Args:
+            message: Human-readable error description, typically the
+                upstream GitHub message.
+            reset_epoch: Unix timestamp at which the limit resets, or
+                ``0`` if unknown.
+
+        """
+        super().__init__(message)
+        self.reset_epoch: int = reset_epoch
 
 
 class ClaudeUsageCapError(RuntimeError):
@@ -238,7 +269,7 @@ def _gh_call(
     args: list[str],
     check: bool = True,
     retry_on_rate_limit: bool = True,
-    max_retries: int = 3,
+    max_retries: int = 6,
 ) -> subprocess.CompletedProcess[str]:
     """Call gh CLI with rate limit handling.
 
@@ -259,6 +290,7 @@ def _gh_call(
     """
     for attempt in range(max_retries):
         try:
+            gh_global_throttle_acquire()
             _gh_throttle_wait()
             result = run(
                 ["gh", *args],
@@ -269,26 +301,18 @@ def _gh_call(
             return result
         except subprocess.CalledProcessError as e:
             stderr = e.stderr if e.stderr else ""
-
             _raise_if_claude_usage(stderr, e)
 
-            # Check for rate limit (regardless of retry_on_rate_limit flag)
-            reset_epoch = detect_rate_limit(stderr)
+            reset_epoch = _extract_reset_epoch(e)
             if reset_epoch is not None:
-                if retry_on_rate_limit:
-                    if reset_epoch > 0:
-                        wait_until(reset_epoch)
-                    else:
-                        # No reset time, use exponential backoff
-                        wait_seconds = min(60 * (2**attempt), 300)  # Max 5 minutes
-                        logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
-                        time.sleep(wait_seconds)
-                    continue
-                else:
-                    # Don't retry, but provide clear error message
-                    raise RuntimeError(
-                        f"GitHub API rate limit reached. Reset at epoch {reset_epoch}"
-                    ) from e
+                _handle_rate_limit_attempt(
+                    reset_epoch=reset_epoch,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    retry_on_rate_limit=retry_on_rate_limit,
+                    cause=e,
+                )
+                continue
 
             if _is_non_transient_error(stderr):
                 logger.error("Non-transient error detected: %s", stderr[:200])
@@ -296,19 +320,71 @@ def _gh_call(
                     _log_token_scope_remediation(args, stderr)
                 raise
 
-            # Last retry attempt, re-raise
             if attempt == max_retries - 1:
                 raise
 
-            # Transient error (network, timeout, 5xx), retry with backoff
             wait_seconds = 2**attempt
             logger.warning(
                 "gh call failed (attempt %s), retrying in %ss", attempt + 1, wait_seconds
             )
             time.sleep(wait_seconds)
+        except GitHubRateLimitError as e:
+            # Raised from inside _check_graphql_errors when the JSON payload
+            # carries a RATE_LIMITED entry (HTTP 200, gh exits 0).
+            _handle_rate_limit_attempt(
+                reset_epoch=e.reset_epoch,
+                attempt=attempt,
+                max_retries=max_retries,
+                retry_on_rate_limit=retry_on_rate_limit,
+                cause=e,
+            )
+            continue
 
     # Should not reach here, but satisfy type checker
     raise RuntimeError("gh call failed after all retries")
+
+
+def _extract_reset_epoch(e: subprocess.CalledProcessError) -> int | None:
+    """Return a rate-limit reset epoch parsed from a failed ``gh`` invocation.
+
+    Inspects stderr first (REST CLI message form) and falls back to stdout
+    because GraphQL rate-limit errors arrive in the JSON payload that gh
+    streams to stdout. Returns ``None`` if the failure is not rate-limit-
+    related.
+    """
+    stderr = e.stderr if e.stderr else ""
+    epoch = detect_rate_limit(stderr)
+    if epoch is None and e.stdout:
+        epoch = detect_rate_limit(e.stdout)
+    return epoch
+
+
+def _handle_rate_limit_attempt(
+    *,
+    reset_epoch: int,
+    attempt: int,
+    max_retries: int,
+    retry_on_rate_limit: bool,
+    cause: BaseException,
+) -> None:
+    """Wait for a rate-limit reset, or raise :class:`GitHubRateLimitError`.
+
+    Centralises the "we got rate-limited; should we retry?" decision so the
+    two except-blocks in :func:`_gh_call` share identical behavior. Raises
+    immediately if retries are disabled or exhausted; otherwise sleeps and
+    returns so the caller can ``continue`` the retry loop.
+    """
+    if not retry_on_rate_limit or attempt == max_retries - 1:
+        raise GitHubRateLimitError(
+            f"GitHub API rate limit reached. Reset at epoch {reset_epoch}",
+            reset_epoch=reset_epoch,
+        ) from cause
+    if reset_epoch > 0:
+        wait_until(reset_epoch)
+        return
+    wait_seconds = min(60 * (2**attempt), 300)  # cap at 5 minutes
+    logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
+    time.sleep(wait_seconds)
 
 
 def _check_graphql_errors(data: dict[str, Any], context: str) -> None:
@@ -323,8 +399,19 @@ def _check_graphql_errors(data: dict[str, Any], context: str) -> None:
     operation failed.
     """
     errors = data.get("errors")
-    if errors:
-        raise RuntimeError(f"GraphQL {context} failed: {errors!r}")
+    if not errors:
+        return
+
+    for err in errors:
+        msg = err.get("message", "") if isinstance(err, dict) else ""
+        err_type = err.get("type", "") if isinstance(err, dict) else ""
+        if err_type == "RATE_LIMITED" or "rate limit" in msg.lower():
+            reset = gh_rate_limit_reset_epoch() or 0
+            raise GitHubRateLimitError(
+                f"GraphQL {context} rate-limited: {msg}", reset_epoch=reset
+            )
+
+    raise RuntimeError(f"GraphQL {context} failed: {errors!r}")
 
 
 def gh_issue_json(issue_number: int) -> dict[str, Any]:

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -29,6 +29,7 @@ from .claude_models import advise_model, learn_model, planner_model, reviewer_mo
 from .claude_timeouts import planner_claude_timeout
 from .git_utils import get_repo_root
 from .github_api import (
+    GitHubRateLimitError,
     _gh_call,
     gh_issue_comment,
     gh_issue_json,
@@ -1009,7 +1010,18 @@ def main() -> int:
     log.info("Starting issue planner")
 
     if not args.issues:
-        discovered = gh_list_open_issues()
+        try:
+            discovered = gh_list_open_issues()
+        except GitHubRateLimitError as e:
+            # Don't smear a 100-line traceback across the driver's loop output
+            # when the only problem is that the GraphQL hourly budget is gone.
+            # Exit cleanly so run_automation_loop.sh moves on to the next repo.
+            log.error(
+                "GitHub API rate-limited; cannot discover issues this run "
+                "(reset at epoch %s). Skipping cleanly.",
+                e.reset_epoch,
+            )
+            return 0
         log.info("No --issues given; discovered %s open issues: %s", len(discovered), discovered)
         args.issues = discovered
 

--- a/hephaestus/github/rate_limit.py
+++ b/hephaestus/github/rate_limit.py
@@ -14,11 +14,16 @@ Usage:
 from __future__ import annotations
 
 import datetime as dt
+import json
 import logging
+import os
 import re
 import signal
+import subprocess
+import tempfile
 import time
 from datetime import timezone
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +36,15 @@ except ImportError:  # pragma: no cover – Python 3.8 backport
 #   "Limit reached ... resets 2:30pm (America/Los_Angeles)"
 RATE_LIMIT_RE = re.compile(
     r"Limit reached.*resets\s+(?P<time>[0-9:apm]+)\s*\((?P<tz>[^)]+)\)",
+    re.IGNORECASE,
+)
+
+# Regex matching GitHub GraphQL rate-limit messages, e.g.:
+#   "GraphQL: API rate limit exceeded for user ID 4211002"
+#   "GraphQL: API rate limit already exceeded for user ID 4211002"
+# Also matches the bare phrase inside JSON error payloads.
+GRAPHQL_RATE_LIMIT_RE = re.compile(
+    r"(?:GraphQL:\s*)?API rate limit (?:already )?exceeded",
     re.IGNORECASE,
 )
 
@@ -130,18 +144,173 @@ def parse_reset_epoch(time_str: str, tz: str) -> int:
 def detect_rate_limit(text: str) -> int | None:
     """Detect a rate-limit message in *text* and return the reset epoch.
 
+    Recognises two phrasings:
+
+    * The ``gh`` CLI REST limit message that includes a reset time and
+      timezone, e.g. ``"Limit reached ... resets 2:30pm (America/Los_Angeles)"``.
+    * The GraphQL limit message, e.g. ``"GraphQL: API rate limit exceeded
+      for user ID NNNN"`` — this form does not embed a reset time, so the
+      function falls back to :func:`gh_rate_limit_reset_epoch` (a one-shot
+      ``gh api rate_limit`` probe with a short cache). When that probe
+      cannot answer, ``0`` is returned as a sentinel meaning "rate limited
+      with unknown reset" — callers should interpret it as a request to
+      back off without a fixed deadline.
+
     Args:
-        text: Text to search (typically ``gh`` CLI stderr output).
+        text: Text to search (typically ``gh`` CLI stderr output, or a
+            GraphQL JSON error payload rendered as a string).
 
     Returns:
-        Unix timestamp when the rate limit resets, or ``None`` if no
-        rate-limit message is found.
+        Unix timestamp when the rate limit resets, ``0`` if rate-limited
+        with unknown reset, or ``None`` if no rate-limit message is found.
 
     """
     m = RATE_LIMIT_RE.search(text)
-    if not m:
-        return None
-    return parse_reset_epoch(m.group("time"), m.group("tz"))
+    if m:
+        return parse_reset_epoch(m.group("time"), m.group("tz"))
+    if GRAPHQL_RATE_LIMIT_RE.search(text):
+        probed = gh_rate_limit_reset_epoch()
+        return probed if probed is not None else 0
+    return None
+
+
+# Cached ``gh api rate_limit`` probe. Keyed by () — the cache holds the
+# most recent (epoch, fetched_at_monotonic) tuple. The TTL is short
+# because the reset window itself only updates hourly, but we still
+# revalidate every ~30s so that after a wait the next caller doesn't
+# act on a stale "0 remaining" view.
+_RATE_LIMIT_PROBE_TTL = 30.0
+_rate_limit_probe_cache: dict[str, tuple[int | None, float]] = {}
+
+
+def gh_rate_limit_reset_epoch(resource: str = "graphql") -> int | None:
+    """Return the upcoming reset epoch for a GitHub API resource, or ``None``.
+
+    Calls ``gh api rate_limit`` to fetch the current rate-limit window for
+    *resource* (one of ``"graphql"``, ``"core"``, ``"search"``, …). Results
+    are cached for :data:`_RATE_LIMIT_PROBE_TTL` seconds to avoid recursive
+    probe storms when rate-limit detection is happening in tight loops.
+
+    Args:
+        resource: Resource name as it appears under ``.resources`` in the
+            ``gh api rate_limit`` JSON. Defaults to ``"graphql"`` since
+            that is what hephaestus's hot paths consume.
+
+    Returns:
+        Unix timestamp when the resource's window resets, or ``None`` if
+        the probe failed (gh missing, auth missing, network error, etc.).
+
+    """
+    cached = _rate_limit_probe_cache.get(resource)
+    now = time.monotonic()
+    if cached is not None and (now - cached[1]) < _RATE_LIMIT_PROBE_TTL:
+        return cached[0]
+
+    try:
+        result = subprocess.run(
+            ["gh", "api", "rate_limit"],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=10,
+        )
+        payload = json.loads(result.stdout)
+        reset_val = payload.get("resources", {}).get(resource, {}).get("reset")
+        epoch = int(reset_val) if reset_val is not None else None
+    except (subprocess.SubprocessError, json.JSONDecodeError, ValueError, OSError) as e:
+        logger.debug("gh api rate_limit probe failed: %s", e)
+        epoch = None
+
+    _rate_limit_probe_cache[resource] = (epoch, now)
+    return epoch
+
+
+# ---------------------------------------------------------------------------
+# Cross-process token-bucket throttle
+#
+# The per-thread throttle in github_api.py only paces a single Python
+# process. When run_automation_loop.sh fans out 3 repos × 3 planner
+# workers, we get up to 9 independent processes hammering ``gh`` at
+# their own per-thread cap. The bucket below is shared via a flock'd
+# state file so all callers compose into a single global rate budget.
+# ---------------------------------------------------------------------------
+
+_DEFAULT_GLOBAL_RATE = 10.0  # tokens per second
+_DEFAULT_BURST = 30.0  # max tokens stored
+
+
+def _global_throttle_state_path() -> Path:
+    base = os.environ.get("HEPHAESTUS_RATE_DIR")
+    if not base:
+        runtime = os.environ.get("XDG_RUNTIME_DIR")
+        base = runtime if runtime else tempfile.gettempdir()
+    return Path(base) / "hephaestus_gh_rate.json"
+
+
+def gh_global_throttle_acquire() -> None:
+    """Block until one token from the global ``gh`` rate budget is available.
+
+    The bucket is shared across all processes on this machine via a small
+    JSON state file guarded by ``fcntl.flock``. Refill rate defaults to
+    ``10`` tokens/sec with a burst of ``30``; both can be overridden with
+    ``HEPHAESTUS_GH_GLOBAL_RATE`` (calls/sec) and ``HEPHAESTUS_GH_GLOBAL_BURST``.
+    Setting the rate to ``0`` disables the throttle entirely (useful for
+    tests and for callers that already hold a known budget).
+
+    On platforms without ``fcntl`` (Windows) the throttle silently no-ops;
+    the per-thread throttle in :mod:`hephaestus.automation.github_api`
+    still applies.
+    """
+    rate = float(os.environ.get("HEPHAESTUS_GH_GLOBAL_RATE", _DEFAULT_GLOBAL_RATE))
+    if rate <= 0:
+        return
+    burst = float(os.environ.get("HEPHAESTUS_GH_GLOBAL_BURST", _DEFAULT_BURST))
+
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover — Windows path
+        return
+
+    state_path = _global_throttle_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Loop because the bucket may be empty when we first acquire the lock;
+    # we sleep for the time required to refill one token, then retry.
+    while True:
+        with state_path.open("a+") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                fh.seek(0)
+                raw = fh.read()
+                try:
+                    state = json.loads(raw) if raw else {}
+                except json.JSONDecodeError:
+                    state = {}
+
+                tokens = float(state.get("tokens", burst))
+                updated = float(state.get("updated", 0.0))
+                now = time.monotonic()
+                if updated <= 0.0:
+                    updated = now
+
+                tokens = min(burst, tokens + (now - updated) * rate)
+                wait = 0.0
+                if tokens >= 1.0:
+                    tokens -= 1.0
+                else:
+                    wait = (1.0 - tokens) / rate
+                    # Don't deduct when waiting — we'll re-acquire and try
+                    # again with a refilled budget.
+
+                fh.seek(0)
+                fh.truncate()
+                json.dump({"tokens": tokens, "updated": now}, fh)
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+        if wait <= 0.0:
+            return
+        time.sleep(wait)
 
 
 def _parse_reset_with_date(date_str: str, time_str: str, tz: str) -> int:
@@ -251,6 +420,15 @@ def wait_until(epoch: int) -> None:
         nonlocal interrupted
         interrupted = True
 
+    # Defensive safety: if ``time.sleep`` returns instantly (e.g. because a
+    # test has monkeypatched it), the print-driven countdown loop below
+    # would otherwise busy-spin and OOM the process. Watch monotonic_ns
+    # across iterations and bail out if too many iterations occur in too
+    # little wall-clock time.
+    start_mono = time.monotonic_ns()
+    iterations = 0
+    iteration_cap = 100_000  # ~27hrs at 1Hz; well above any real countdown
+
     old_handler = signal.signal(signal.SIGINT, handler)
     try:
         while True:
@@ -269,6 +447,16 @@ def wait_until(epoch: int) -> None:
                 flush=True,
             )
             time.sleep(1)
+            iterations += 1
+            if iterations >= iteration_cap:
+                # Either the system clock is broken or sleep is mocked;
+                # either way, stop spinning and let the caller proceed.
+                elapsed_s = (time.monotonic_ns() - start_mono) / 1e9
+                logger.warning(
+                    "wait_until iteration cap reached after %.2fs; bailing out", elapsed_s
+                )
+                print()
+                return
     finally:
         signal.signal(signal.SIGINT, old_handler)
 

--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -368,6 +368,24 @@ for (( loop=1; loop<=LOOPS; loop++ )); do
 
   echo ""
   echo "  Loop $loop complete."
+
+  # Inter-loop GraphQL budget probe. Runs unless HEPHAESTUS_RATE_GUARD=0.
+  # When the remaining budget would be exhausted by the next loop (default
+  # threshold 200 calls), sleep until the upstream reset rather than burning
+  # the next loop on retry storms.
+  if [[ "${HEPHAESTUS_RATE_GUARD:-1}" != "0" && "$loop" -lt "$LOOPS" ]]; then
+    threshold="${HEPHAESTUS_RATE_GUARD_THRESHOLD:-200}"
+    remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null || echo "")
+    reset=$(gh api rate_limit --jq '.resources.graphql.reset' 2>/dev/null || echo "")
+    if [[ -n "$remaining" && -n "$reset" && "$remaining" -lt "$threshold" ]]; then
+      now=$(date +%s)
+      wait=$((reset - now + 5))
+      if (( wait > 0 )); then
+        echo "  Rate budget low (${remaining}/${threshold} GraphQL remaining); sleeping ${wait}s until reset"
+        sleep "$wait"
+      fi
+    fi
+  fi
 done
 
 echo ""

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -9,6 +9,8 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 from hephaestus.automation.github_api import (
+    GitHubRateLimitError,
+    _check_graphql_errors,
     _gh_call,
     fetch_issue_info,
     gh_create_label,
@@ -878,3 +880,106 @@ class TestGhCallThrottle:
         assert elapsed_b[0] < 0.05, (
             f"per-thread isolation broken; thread B waited {elapsed_b[0]:.3f}s"
         )
+
+
+class TestGraphQLRateLimitDetection:
+    """Tests for GitHubRateLimitError raised from GraphQL JSON payloads."""
+
+    def test_raises_on_rate_limited_type(self) -> None:
+        data = {
+            "errors": [
+                {"type": "RATE_LIMITED", "message": "API rate limit exceeded"}
+            ]
+        }
+        with patch(
+            "hephaestus.automation.github_api.gh_rate_limit_reset_epoch",
+            return_value=1700000000,
+        ):
+            with pytest.raises(GitHubRateLimitError) as ei:
+                _check_graphql_errors(data, "test")
+        assert ei.value.reset_epoch == 1700000000
+
+    def test_raises_on_rate_limit_in_message(self) -> None:
+        data = {"errors": [{"message": "API rate limit exceeded for user 1"}]}
+        with patch(
+            "hephaestus.automation.github_api.gh_rate_limit_reset_epoch",
+            return_value=None,
+        ):
+            with pytest.raises(GitHubRateLimitError) as ei:
+                _check_graphql_errors(data, "ctx")
+        # Probe returned None → reset_epoch sentinel 0
+        assert ei.value.reset_epoch == 0
+
+    def test_raises_runtimeerror_for_other_errors(self) -> None:
+        data = {"errors": [{"type": "FORBIDDEN", "message": "no perms"}]}
+        with pytest.raises(RuntimeError) as ei:
+            _check_graphql_errors(data, "ctx")
+        assert not isinstance(ei.value, GitHubRateLimitError)
+
+    def test_no_raise_when_no_errors(self) -> None:
+        _check_graphql_errors({"data": {"viewer": {"login": "x"}}}, "ctx")
+
+
+class TestGhCallRateLimitFromStdout:
+    """Tests for _gh_call detecting rate-limit messages on stdout.
+
+    These tests mock both the per-thread and cross-process throttles, the
+    real wait callsite, and ``gh_rate_limit_reset_epoch`` in the namespace
+    where ``detect_rate_limit`` looks it up. Skipping any one of those
+    mocks lets the test reach real I/O or a wait loop — the latter, in
+    combination with mocking ``time.sleep`` at the module level, can
+    runaway-print until the process hits OOM (because ``time`` is shared
+    and ``wait_until`` polls in ``while True``).
+    """
+
+    @patch("hephaestus.github.rate_limit.gh_rate_limit_reset_epoch")
+    @patch("hephaestus.automation.github_api.gh_global_throttle_acquire")
+    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.automation.github_api.wait_until")
+    def test_retries_on_graphql_message_in_stdout(
+        self,
+        mock_wait: Any,
+        mock_run: Any,
+        _mock_throttle: Any,
+        mock_probe: Any,
+    ) -> None:
+        """Cover detection of GraphQL rate-limit messages on stderr.
+
+        ``gh issue list`` emits the GraphQL message on stderr; the JSON
+        payload may also appear on stdout in some failure modes — both must
+        be inspected.
+        """
+        mock_probe.return_value = 1_700_000_000  # arbitrary past epoch
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(
+                1,
+                "gh",
+                "",
+                "GraphQL: API rate limit already exceeded for user ID 1",
+            ),
+            Mock(stdout="ok"),
+        ]
+        result = _gh_call(["issue", "list"])
+        assert result.stdout == "ok"
+        assert mock_run.call_count == 2
+        mock_wait.assert_called_once()
+
+    @patch("hephaestus.github.rate_limit.gh_rate_limit_reset_epoch")
+    @patch("hephaestus.automation.github_api.gh_global_throttle_acquire")
+    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.automation.github_api.wait_until")
+    @patch("hephaestus.automation.github_api.time.sleep")
+    def test_raises_after_exhausting_retries(
+        self,
+        _mock_sleep: Any,
+        _mock_wait: Any,
+        mock_run: Any,
+        _mock_throttle: Any,
+        mock_probe: Any,
+    ) -> None:
+        mock_probe.return_value = None  # forces detect_rate_limit -> 0 sentinel
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, "gh", "", "GraphQL: API rate limit already exceeded for user ID 1"
+        )
+        with pytest.raises(GitHubRateLimitError):
+            _gh_call(["issue", "list"], max_retries=2)

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -886,11 +886,7 @@ class TestGraphQLRateLimitDetection:
     """Tests for GitHubRateLimitError raised from GraphQL JSON payloads."""
 
     def test_raises_on_rate_limited_type(self) -> None:
-        data = {
-            "errors": [
-                {"type": "RATE_LIMITED", "message": "API rate limit exceeded"}
-            ]
-        }
+        data = {"errors": [{"type": "RATE_LIMITED", "message": "API rate limit exceeded"}]}
         with patch(
             "hephaestus.automation.github_api.gh_rate_limit_reset_epoch",
             return_value=1700000000,

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -317,9 +317,7 @@ class TestGraphQLRateLimit:
             "GraphQL: API rate limit already exceeded."
         )
         # Should not call the probe — the REST regex matches first.
-        with patch(
-            "hephaestus.github.rate_limit.gh_rate_limit_reset_epoch"
-        ) as mock_probe:
+        with patch("hephaestus.github.rate_limit.gh_rate_limit_reset_epoch") as mock_probe:
             result = detect_rate_limit(text)
             mock_probe.assert_not_called()
         assert isinstance(result, int)
@@ -381,9 +379,7 @@ class TestGlobalThrottle:
         assert elapsed < 0.05
         assert not (tmp_path / "hephaestus_gh_rate.json").exists()
 
-    def test_first_call_succeeds_immediately_with_full_burst(
-        self, monkeypatch, tmp_path
-    ) -> None:
+    def test_first_call_succeeds_immediately_with_full_burst(self, monkeypatch, tmp_path) -> None:
         monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_RATE", "1000")
         monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_BURST", "10")
         monkeypatch.setenv("HEPHAESTUS_RATE_DIR", str(tmp_path))

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -8,10 +8,14 @@ from unittest.mock import patch
 
 from hephaestus.github.rate_limit import (
     ALLOWED_TIMEZONES,
+    GRAPHQL_RATE_LIMIT_RE,
     RATE_LIMIT_RE,
+    _rate_limit_probe_cache,
     detect_claude_usage_cap,
     detect_claude_usage_limit,
     detect_rate_limit,
+    gh_global_throttle_acquire,
+    gh_rate_limit_reset_epoch,
     parse_reset_epoch,
     wait_until,
 )
@@ -272,3 +276,132 @@ class TestDetectClaudeUsageCap:
         )
         epoch = detect_claude_usage_cap(json_blob)
         assert epoch is not None
+
+
+class TestGraphQLRateLimit:
+    """Tests for the GraphQL rate-limit code path in detect_rate_limit()."""
+
+    def setup_method(self) -> None:
+        # Each test starts with a clean probe cache so mocks behave deterministically.
+        _rate_limit_probe_cache.clear()
+
+    def test_regex_matches_already_exceeded(self) -> None:
+        text = "GraphQL: API rate limit already exceeded for user ID 4211002"
+        assert GRAPHQL_RATE_LIMIT_RE.search(text) is not None
+
+    def test_regex_matches_plain_exceeded(self) -> None:
+        text = "API rate limit exceeded for installation ID 99"
+        assert GRAPHQL_RATE_LIMIT_RE.search(text) is not None
+
+    def test_regex_no_match_on_unrelated(self) -> None:
+        assert GRAPHQL_RATE_LIMIT_RE.search("everything is fine") is None
+
+    def test_detect_rate_limit_uses_probe_when_graphql_message_seen(self) -> None:
+        """When the GraphQL phrase appears, fall back to gh_rate_limit_reset_epoch."""
+        text = "GraphQL: API rate limit already exceeded for user ID 4211002"
+        with patch(
+            "hephaestus.github.rate_limit.gh_rate_limit_reset_epoch",
+            return_value=1_700_000_000,
+        ):
+            assert detect_rate_limit(text) == 1_700_000_000
+
+    def test_detect_rate_limit_returns_zero_sentinel_when_probe_fails(self) -> None:
+        text = "GraphQL: API rate limit exceeded for user ID 1"
+        with patch("hephaestus.github.rate_limit.gh_rate_limit_reset_epoch", return_value=None):
+            assert detect_rate_limit(text) == 0
+
+    def test_detect_rate_limit_prefers_rest_message_over_graphql(self) -> None:
+        """REST message has a real reset time embedded; prefer it."""
+        text = (
+            "Limit reached for resource core, resets 2:30pm (UTC). "
+            "GraphQL: API rate limit already exceeded."
+        )
+        # Should not call the probe — the REST regex matches first.
+        with patch(
+            "hephaestus.github.rate_limit.gh_rate_limit_reset_epoch"
+        ) as mock_probe:
+            result = detect_rate_limit(text)
+            mock_probe.assert_not_called()
+        assert isinstance(result, int)
+        assert result > 0
+
+
+class TestGhRateLimitResetEpoch:
+    """Tests for gh_rate_limit_reset_epoch() probe and cache."""
+
+    def setup_method(self) -> None:
+        _rate_limit_probe_cache.clear()
+
+    def test_returns_reset_from_gh_api(self) -> None:
+        payload = '{"resources": {"graphql": {"reset": 1700000000, "remaining": 0}}}'
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = payload
+            mock_run.return_value.returncode = 0
+            assert gh_rate_limit_reset_epoch() == 1700000000
+
+    def test_caches_within_ttl(self) -> None:
+        """Second call within TTL must not re-invoke gh."""
+        payload = '{"resources": {"graphql": {"reset": 1700000000}}}'
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = payload
+            mock_run.return_value.returncode = 0
+            gh_rate_limit_reset_epoch()
+            gh_rate_limit_reset_epoch()
+            assert mock_run.call_count == 1
+
+    def test_returns_none_on_subprocess_failure(self) -> None:
+        import subprocess as sp
+
+        with patch("subprocess.run", side_effect=sp.CalledProcessError(1, "gh")):
+            assert gh_rate_limit_reset_epoch() is None
+
+    def test_returns_none_on_invalid_json(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "not json"
+            mock_run.return_value.returncode = 0
+            assert gh_rate_limit_reset_epoch() is None
+
+    def test_returns_none_when_resource_missing(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = '{"resources": {}}'
+            mock_run.return_value.returncode = 0
+            assert gh_rate_limit_reset_epoch() is None
+
+
+class TestGlobalThrottle:
+    """Tests for gh_global_throttle_acquire (cross-process token bucket)."""
+
+    def test_no_op_when_rate_zero(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_RATE", "0")
+        monkeypatch.setenv("HEPHAESTUS_RATE_DIR", str(tmp_path))
+        # Should return effectively immediately and never touch the state file.
+        before = time.monotonic()
+        gh_global_throttle_acquire()
+        elapsed = time.monotonic() - before
+        assert elapsed < 0.05
+        assert not (tmp_path / "hephaestus_gh_rate.json").exists()
+
+    def test_first_call_succeeds_immediately_with_full_burst(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_RATE", "1000")
+        monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_BURST", "10")
+        monkeypatch.setenv("HEPHAESTUS_RATE_DIR", str(tmp_path))
+        before = time.monotonic()
+        gh_global_throttle_acquire()
+        elapsed = time.monotonic() - before
+        assert elapsed < 0.1
+        assert (tmp_path / "hephaestus_gh_rate.json").exists()
+
+    def test_rapid_calls_eventually_throttle(self, monkeypatch, tmp_path) -> None:
+        """With burst=2 and rate=10/sec, the third call must wait ~0.1s."""
+        monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_RATE", "10")
+        monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_BURST", "2")
+        monkeypatch.setenv("HEPHAESTUS_RATE_DIR", str(tmp_path))
+        gh_global_throttle_acquire()
+        gh_global_throttle_acquire()
+        before = time.monotonic()
+        gh_global_throttle_acquire()
+        elapsed = time.monotonic() - before
+        # Refilling 1 token at 10/sec costs ~0.1s. Accept generous bounds for CI noise.
+        assert elapsed >= 0.05


### PR DESCRIPTION
## Summary
- Detects the GraphQL rate-limit phrasing (`API rate limit (already) exceeded`) and reads the real reset epoch via a cached `gh api rate_limit` probe instead of treating it as a transient error
- Catches `RATE_LIMITED` entries inside GraphQL JSON payloads and raises a new `GitHubRateLimitError` that `_gh_call` retries cleanly
- Adds a cross-process flock-backed token-bucket throttle so the 9+ concurrent `gh` callers spawned by the automation loop share a single budget
- Makes `hephaestus-plan-issues` exit 0 on `GitHubRateLimitError` so the shell driver stops dumping a 100-line traceback per stuck repo
- Adds an inter-loop budget probe in `run_automation_loop.sh` that sleeps until reset when the GraphQL budget is low
- Caps `wait_until` iterations so a future mocked-sleep mishap can't OOM the host (root cause of an earlier 4 GiB test runaway)

## Why
Running `scripts/run_automation_loop.sh` across 14 repos × 5 loops × 3 parallel × 3 phases produces ~210 planner invocations. The first one drained GitHub's GraphQL hourly budget and every subsequent one crashed with a giant traceback storm because `detect_rate_limit` only matched the REST CLI message format — the GraphQL form fell through to the `transient error` branch, burned 3 retries 1s/2s apart, then aborted.

## Test plan
- [x] `pixi run pytest tests/unit/github/test_rate_limit.py tests/unit/automation/test_github_api.py` — 113 passed
- [x] `pixi run pytest tests/unit` (with coverage) — 2255 passed, 8 skipped, 82.73% coverage
- [x] `pixi run ruff check hephaestus/ scripts/ tests/` — clean
- [x] `pixi run mypy` — clean (246 files)
- [ ] Manual: run `scripts/run_automation_loop.sh` against the 14-repo fleet with an exhausted budget and confirm clean skip + inter-loop sleep instead of traceback storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)