### PR TITLE
fix(automation): pass repo_root to prompt builders

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -598,6 +598,7 @@ class IssueImplementer:
                     issue_body=issue.body,
                     branch_name=branch_name,
                     worktree_path=str(worktree_path),
+                    repo_root=str(self.repo_root),
                 ),
                 slot_id=slot_id,
             )

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -520,6 +520,7 @@ class Planner:
                 issue_title=issue_title,
                 issue_body=issue_body,
                 marketplace_path=str(marketplace_path),
+                repo_root=str(repo_root),
             )
 
             # Call Claude with shorter timeout. /advise is light search work


### PR DESCRIPTION
## Summary
- `planner._run_advise` and `implementer._run_implementation` already compute the repo root but weren't forwarding it to `get_advise_prompt` / `get_implementation_prompt`.
- This triggered the `repo_root not provided; injecting absolute path into prompt: ...` warning on every advise/implementation call and leaked the operator's absolute filesystem layout into Claude prompts.

## Changes
- `hephaestus/automation/planner.py`: pass `repo_root=str(repo_root)` to `get_advise_prompt`.
- `hephaestus/automation/implementer.py`: pass `repo_root=str(self.repo_root)` to `get_implementation_prompt`.

## Test plan
- [x] `pixi run pytest tests/unit/automation/test_planner.py tests/unit/automation/test_prompts.py tests/unit/automation/test_implementer.py` — 47 passed
- [ ] Confirm in a live planner run that the `repo_root not provided` warning no longer fires and that `marketplace_path` appears as `build/ProjectMnemosyne/.claude-plugin/marketplace.json` in the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)