### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/tests/shell/scripts/test_repo_ordering.bats
+++ b/tests/shell/scripts/test_repo_ordering.bats
@@ -144,9 +144,9 @@ write_counts() {
 
 
 @test "count_open_issues: empty gh stdout returns 0" {
-    # Repo not in counts file → fake gh emits "0" because awk's awk-then-
-    # default branch handles missing keys. Verifies the caller does NOT
-    # propagate an empty string.
+    # Repo not in counts file → fake gh emits "0" because awk's awk-then-default
+    # branch handles missing keys. Verifies the caller does NOT propagate an
+    # empty string.
     run count_open_issues "TestOrg" Missing
     [ "$status" -eq 0 ]
     [ "$output" = "0" ]


### PR DESCRIPTION
This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/HomericIntelligence/ProjectHephaestus/security/quality/ai-findings).

Re-wraps a comment in `tests/shell/scripts/test_repo_ordering.bats` so it no longer breaks mid-word.

Closes #426