### PR TITLE
fix(quality): resolve remaining GitHub Code Quality findings

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -67,6 +67,16 @@ from .session_naming import AGENT_IMPLEMENTER, current_trunk_githash
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
+# Public API of this module. `_CLAUDE_IMPL_TIMEOUT` keeps its leading underscore
+# (it is an internal default, not for general use) but is exported because
+# tests assert on it as the documented default.
+__all__ = [
+    "MAX_REVIEW_ITERATIONS",
+    "_CLAUDE_IMPL_TIMEOUT",
+    "IssueImplementer",
+    "main",
+]
+
 MAX_REVIEW_ITERATIONS = 3
 
 # Default Claude implementation timeout in seconds. Actual runtime value is

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -184,10 +184,11 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
         message = getattr(result, "message", None)
         sha = getattr(result, "sha", None)
     except AttributeError:
-        # Fallback for unexpected types
+        # Fallback for unexpected types. `sha` is intentionally not set here:
+        # it is only read in the `if merged:` branch below, and this path
+        # forces merged=False.
         merged = False
         message = str(result)
-        sha = None
 
     if merged:
         logger.info("  PR #%d merged into %s via rebase. sha=%s", pr_number, base_branch, sha)

--- a/hephaestus/utils/terminal.py
+++ b/hephaestus/utils/terminal.py
@@ -36,7 +36,10 @@ def restore_terminal() -> None:
 # stop() / terminal_guard().__exit__ never runs (e.g., daemon thread exit).
 atexit.register(restore_terminal)
 
-_shutdown_requested = False
+# Single-element list so the nested signal handler can mutate the flag
+# without a ``global`` rebind (a closure cannot rebind an outer name, but it
+# can mutate a shared container).
+_shutdown_requested: list[bool] = [False]
 
 
 def install_signal_handlers(shutdown_fn: Callable[[], None]) -> None:
@@ -54,17 +57,15 @@ def install_signal_handlers(shutdown_fn: Callable[[], None]) -> None:
                      signal handler (no locks, no I/O other than print).
 
     """
-    global _shutdown_requested
-    _shutdown_requested = False
+    _shutdown_requested[0] = False
 
     def _handler(signum: int, frame: object) -> None:
-        global _shutdown_requested
-        if _shutdown_requested:
+        if _shutdown_requested[0]:
             # Second signal — force exit immediately
             restore_terminal()
             sys.exit(128 + signum)
         else:
-            _shutdown_requested = True
+            _shutdown_requested[0] = True
             print(
                 f"\nReceived signal {signum}. Shutting down gracefully… "
                 "(press Ctrl+C again to force quit)",

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -43,8 +43,9 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        # Parse and validate version
-        _major, _minor, _patch = parse_version(args.version)
+        # Validate the version string — parse_version raises ValueError on a
+        # malformed version. The parsed tuple itself is not needed here.
+        parse_version(args.version)
 
         # Get repository root
         repo_root = get_repo_root()

--- a/tests/unit/markdown/test_link_fixer.py
+++ b/tests/unit/markdown/test_link_fixer.py
@@ -96,9 +96,13 @@ def test_link_fixer_dry_run(tmp_path):
     options = LinkFixerOptions(verbose=False, dry_run=True)
     fixer = LinkFixer(options)
 
-    _modified, _system_fixes, _absolute_fixes = fixer.fix_file(test_file)
+    modified, system_fixes, absolute_fixes = fixer.fix_file(test_file)
 
-    # Should report as modified but not actually change file
+    # The /home/... link is a system path: report one system-path fix and the
+    # file as modified, but a dry run must not write the change to disk.
+    assert modified is True
+    assert system_fixes == 1
+    assert absolute_fixes == 0
     assert test_file.read_text() == original_content
 
 

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import hephaestus.utils.helpers as _helpers
 from hephaestus.utils.helpers import (
     _format_cmd_for_log,
     flatten_dict,
@@ -15,6 +14,7 @@ from hephaestus.utils.helpers import (
     get_repo_root,
     human_readable_size,
     install_package,
+    logger,
     run_subprocess,
     slugify,
 )
@@ -179,7 +179,7 @@ class TestRunSubprocess:
 
     def test_log_on_error_false_suppresses_error_log(self):
         """When log_on_error=False, failure does not call logger.error."""
-        with patch.object(_helpers.logger, "error") as mock_error:
+        with patch.object(logger, "error") as mock_error:
             with pytest.raises(subprocess.CalledProcessError):
                 run_subprocess(["false"], log_on_error=False)
 
@@ -187,7 +187,7 @@ class TestRunSubprocess:
 
     def test_log_on_error_true_emits_error_log(self):
         """When log_on_error=True (default), failure calls logger.error."""
-        with patch.object(_helpers.logger, "error") as mock_error:
+        with patch.object(logger, "error") as mock_error:
             with pytest.raises(subprocess.CalledProcessError):
                 run_subprocess(["false"], log_on_error=True)
 
@@ -201,7 +201,7 @@ class TestRunSubprocess:
         """
         long_arg = "x" * 10_000
 
-        with patch.object(_helpers.logger, "error") as mock_error:
+        with patch.object(logger, "error") as mock_error:
             with pytest.raises(subprocess.CalledProcessError):
                 run_subprocess(["false", long_arg])
 
@@ -367,14 +367,10 @@ class TestRunSubprocessTimeoutLogging:
 
     def test_timeout_expired_is_logged_and_reraised(self) -> None:
         """TimeoutExpired triggers an error log then re-raises the exception."""
-        from unittest.mock import patch as _patch
-
-        import hephaestus.utils.helpers as _helpers
-
         exc = subprocess.TimeoutExpired(cmd=["sleep", "99"], timeout=1)
         with (
-            _patch("subprocess.run", side_effect=exc),
-            _patch.object(_helpers.logger, "error") as mock_error,
+            patch("subprocess.run", side_effect=exc),
+            patch.object(logger, "error") as mock_error,
         ):
             with pytest.raises(subprocess.TimeoutExpired):
                 run_subprocess(["sleep", "99"], timeout=1)

--- a/tests/unit/utils/test_terminal.py
+++ b/tests/unit/utils/test_terminal.py
@@ -64,7 +64,7 @@ class TestInstallSignalHandlers:
     def test_first_signal_calls_shutdown(self) -> None:
         """First signal calls the shutdown function."""
         shutdown = MagicMock()
-        terminal_module._shutdown_requested = False
+        terminal_module._shutdown_requested[0] = False
 
         install_signal_handlers(shutdown)
 
@@ -75,13 +75,13 @@ class TestInstallSignalHandlers:
 
         handler(signal_module.SIGINT, None)
         shutdown.assert_called_once()
-        assert terminal_module._shutdown_requested is True
+        assert terminal_module._shutdown_requested[0] is True
 
     def test_resets_shutdown_flag_on_install(self) -> None:
         """Re-installing handlers resets the shutdown flag."""
-        terminal_module._shutdown_requested = True
+        terminal_module._shutdown_requested[0] = True
         install_signal_handlers(MagicMock())
-        assert terminal_module._shutdown_requested is False
+        assert terminal_module._shutdown_requested[0] is False
 
 
 class TestTerminalGuard:


### PR DESCRIPTION
## Summary

A fresh GitHub Code Quality scan surfaced findings the earlier pass missed — CodeQL's rules differ from `ruff`'s (ruff treats `_`-prefixed names as intentional; CodeQL does not).

### py/unused-local-variable
| Site | Fix |
|------|-----|
| `scripts/update_version.py:47` | `parse_version()` is called only to validate the version (raises on bad input); unpacked tuple was unused → call without binding. |
| `tests/unit/markdown/test_link_fixer.py:99` | `fix_file()`'s 3-tuple was unpacked into unused names. The test comment claimed behaviour it never asserted → now asserts `modified` / `system_fixes` / `absolute_fixes`. |
| `hephaestus/github/pr_merge.py:190` | `sha = None` in the `except` branch was dead (`sha` is only read under `if merged:`, and that branch forces `merged=False`) → removed. |

### py/unused-global-variable — CodeQL false positives, refactored to satisfy the analyser
Both variables are genuinely used; refactored without changing behaviour:
- `hephaestus/utils/terminal.py` `_shutdown_requested` — read in a nested signal-handler closure. Switched to a single-element list so the closure mutates a shared container instead of rebinding a `global`; CodeQL tracks this correctly. Tests updated.
- `hephaestus/automation/implementer.py` `_CLAUDE_IMPL_TIMEOUT` — asserted on by `test_implementer.py`. Added a module `__all__` declaring the public API.

### py/repeated-import + py/import-and-import-from
`tests/unit/utils/test_general_utils.py` imported `hephaestus.utils.helpers` both as `import ... as _helpers` and `from ... import (...)`, plus a redundant function-local re-import. Consolidated to a single `from` form (added `logger`); dropped redundant function-local imports.

## Verification

- `ruff` — clean
- `mypy` — no issues, 250 files
- `pytest tests/unit` — 2320 passed, 8 skipped

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)