### PR TITLE
fix(ci): make release workflow idempotent for existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,27 @@ jobs:
         with:
           verbose: true
 
+      - name: Check for existing release
+        id: existing
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # A release may already exist for this tag if it was created
+          # manually or by a previous (partially failed) run of this
+          # workflow. GitHub marks releases immutable, and an immutable
+          # release cannot be updated or have assets added — so the
+          # create/update action below must be skipped when one exists.
+          if gh release view "$TAG" --json isImmutable -q .isImmutable >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release $TAG already exists — skipping creation."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
+        if: steps.existing.outputs.exists == 'false'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
@@ -163,3 +183,19 @@ jobs:
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attach build artifacts to existing release
+        if: steps.existing.outputs.exists == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          # The release already exists. Try to attach the freshly built
+          # artifacts; an immutable release rejects uploads, so treat an
+          # upload failure as non-fatal — the package is already on PyPI.
+          if gh release upload "$TAG" dist/* --clobber; then
+            echo "Attached dist/* to release $TAG."
+          else
+            echo "::notice::Release $TAG is immutable — build artifacts not attached. The package is published to PyPI."
+          fi


### PR DESCRIPTION
## Summary

The `Release` workflow's `Create GitHub Release` step (`softprops/action-gh-release@v3`) fails when a release already exists for the tag. GitHub marks releases immutable; the action's update path tries to change `target_commitish`, which an immutable release rejects:

```
Validation Failed: target_commitish cannot be changed when release is immutable
```

This broke the **v0.9.0** release run ([26232511884](https://github.com/HomericIntelligence/ProjectHephaestus/actions/runs/26232511884)) — the release had been created manually beforehand. PyPI publish itself succeeded.

## Fix

- New **`Check for existing release`** step detects whether a release exists for the tag.
- **`Create GitHub Release`** now runs only when none exists (`if: steps.existing.outputs.exists == 'false'`).
- New **`Attach build artifacts to existing release`** step runs when one does: uploads `dist/*` via `gh release upload --clobber`, treating an upload failure (immutable release) as a non-fatal `::notice::` — the package is already on PyPI.

The workflow is now idempotent: a pre-existing release (manual, or from a partially-failed prior run) no longer fails the job.

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)