### PR TITLE
fix(version): resolve __version__ against correct distribution name

### DIFF
--- a/hephaestus/__init__.py
+++ b/hephaestus/__init__.py
@@ -8,7 +8,9 @@ from importlib.metadata import version as _pkg_version
 from typing import Any
 
 try:
-    __version__ = _pkg_version("hephaestus")
+    # The PyPI distribution name is "HomericIntelligence-Hephaestus", which
+    # importlib.metadata does NOT normalize to the import name "hephaestus".
+    __version__ = _pkg_version("HomericIntelligence-Hephaestus")
 except PackageNotFoundError:
     __version__ = "unknown"
 

--- a/tests/integration/test_package_import.py
+++ b/tests/integration/test_package_import.py
@@ -73,6 +73,26 @@ class TestTopLevelImports:
         assert hephaestus.__version__
         assert isinstance(hephaestus.__version__, str)
 
+    def test_version_resolves_against_installed_distribution(self):
+        """__version__ must resolve from distribution metadata, not fall back to 'unknown'.
+
+        Regression test for #433: importlib.metadata.version() must be called with the
+        PyPI distribution name ("HomericIntelligence-Hephaestus"), not the import name
+        ("hephaestus"), which it does not normalize to the same key.
+        """
+        from importlib.metadata import PackageNotFoundError
+        from importlib.metadata import version as pkg_version
+
+        import hephaestus
+
+        try:
+            expected = pkg_version("HomericIntelligence-Hephaestus")
+        except PackageNotFoundError:
+            pytest.skip("package not installed; metadata-based version unavailable")
+
+        assert hephaestus.__version__ == expected
+        assert hephaestus.__version__ != "unknown"
+
     @pytest.mark.parametrize("symbol", TOP_LEVEL_SYMBOLS)
     def test_top_level_symbol_importable(self, symbol):
         """Each symbol in __all__ must be accessible from the top-level package."""


### PR DESCRIPTION
## Summary

`hephaestus/__init__.py` called `importlib.metadata.version("hephaestus")`, but the
PyPI distribution name is `HomericIntelligence-Hephaestus`. `importlib.metadata` does
not normalize the import name to the distribution name, so the lookup raised
`PackageNotFoundError` and `__version__` silently became `"unknown"` for every
installed user.

## Changes

- `hephaestus/__init__.py`: look up `HomericIntelligence-Hephaestus`.
- `tests/integration/test_package_import.py`: regression test asserting `__version__`
  matches distribution metadata and is not `"unknown"`.

## Verification

`pixi run pytest tests/integration/test_package_import.py` — 51 passed.

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)