### PR TITLE
fix(version): make check_version_single_source validate the real invariant

### DIFF
--- a/scripts/check_version_single_source.py
+++ b/scripts/check_version_single_source.py
@@ -1,19 +1,32 @@
 #!/usr/bin/env python3
-"""Check that pyproject.toml is the single source of truth for the project version.
+"""Check that the project version has exactly one source of truth.
 
-Validates that:
-- pyproject.toml has a valid version under [project]
-- pixi.toml does NOT have a version field under [workspace]
+This project uses hatch-vcs dynamic versioning: the version is derived from git
+tags, not stored in any file. The single-source-of-truth invariant is therefore:
 
-This prevents version drift by ensuring only one authoritative version source exists.
+- ``pyproject.toml`` declares ``version`` in ``[project].dynamic`` and has NO
+  static ``[project].version`` field.
+- ``pyproject.toml`` configures ``[tool.hatch.version]`` with ``source = "vcs"``.
+- ``pixi.toml`` has no ``version`` field under ``[workspace]``.
+
+Any deviation (a reintroduced static version, a removed dynamic declaration, a
+pixi workspace version) means the version now has two — or zero — authorities.
 
 Usage:
     python scripts/check_version_single_source.py
 """
 
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on Python 3.10
+    import tomli as tomllib
 
 
 def get_repo_root() -> Path:
@@ -26,20 +39,52 @@ def get_repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
-def check_pyproject_has_version(repo_root: Path) -> bool:
-    """Verify pyproject.toml has a version under [project]."""
+def _load_toml(path: Path) -> dict[str, Any]:
+    """Parse a TOML file into a dict."""
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def check_pyproject_dynamic_version(repo_root: Path) -> bool:
+    """Verify pyproject.toml uses hatch-vcs dynamic versioning with no static version.
+
+    Returns True only when the version has exactly one authority (git tags via
+    hatch-vcs). Returns False if a static ``[project].version`` was reintroduced
+    or the dynamic/hatch-vcs configuration is missing.
+    """
     pyproject_path = repo_root / "pyproject.toml"
     if not pyproject_path.exists():
         print(f"ERROR: pyproject.toml not found at {pyproject_path}")
         return False
 
-    content = pyproject_path.read_text()
-    match = re.search(r'\[project\].*?version\s*=\s*"([^"]+)"', content, re.DOTALL)
-    if not match:
-        print("ERROR: No version found under [project] in pyproject.toml")
+    data = _load_toml(pyproject_path)
+    project = data.get("project", {})
+
+    if "version" in project:
+        print(
+            'ERROR: pyproject.toml [project] has a static "version" field.\n'
+            "  This project uses hatch-vcs dynamic versioning (version from git tags).\n"
+            '  Remove [project].version and keep "version" in [project].dynamic.'
+        )
         return False
 
-    print(f'OK: pyproject.toml [project] version = "{match.group(1)}"')
+    dynamic = project.get("dynamic", [])
+    if "version" not in dynamic:
+        print(
+            'ERROR: pyproject.toml [project].dynamic does not contain "version".\n'
+            "  hatch-vcs dynamic versioning requires it."
+        )
+        return False
+
+    hatch_version = data.get("tool", {}).get("hatch", {}).get("version", {})
+    if hatch_version.get("source") != "vcs":
+        print(
+            'ERROR: pyproject.toml [tool.hatch.version] source is not "vcs".\n'
+            "  Expected hatch-vcs as the single version authority."
+        )
+        return False
+
+    print("OK: pyproject.toml uses hatch-vcs dynamic versioning (single source)")
     return True
 
 
@@ -63,7 +108,7 @@ def check_pixi_no_version(repo_root: Path) -> bool:
     version_match = re.search(r"^\s*version\s*=", workspace_content, re.MULTILINE)
     if version_match:
         print("ERROR: pixi.toml [workspace] contains a 'version' field.")
-        print("  pyproject.toml is the single source of truth for the project version.")
+        print("  pyproject.toml (hatch-vcs) is the single source of truth for the version.")
         print("  Remove the version field from pixi.toml [workspace].")
         return False
 
@@ -75,7 +120,7 @@ def main() -> int:
     """Check version single source of truth. Returns 0 if OK, 1 if issues found."""
     repo_root = get_repo_root()
 
-    pyproject_ok = check_pyproject_has_version(repo_root)
+    pyproject_ok = check_pyproject_dynamic_version(repo_root)
     pixi_ok = check_pixi_no_version(repo_root)
 
     if pyproject_ok and pixi_ok:

--- a/tests/unit/scripts/test_check_version_single_source.py
+++ b/tests/unit/scripts/test_check_version_single_source.py
@@ -1,4 +1,10 @@
-"""Tests for scripts/check_version_single_source.py."""
+"""Tests for scripts/check_version_single_source.py.
+
+This project uses hatch-vcs dynamic versioning. The checker validates that the
+version has exactly one authority (git tags via hatch-vcs): no static
+``[project].version``, ``version`` present in ``[project].dynamic``,
+``[tool.hatch.version].source == "vcs"``, and no pixi ``[workspace].version``.
+"""
 
 import sys
 from pathlib import Path
@@ -10,50 +16,90 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
 
 from check_version_single_source import (
     check_pixi_no_version,
-    check_pyproject_has_version,
+    check_pyproject_dynamic_version,
+)
+
+# A valid hatch-vcs pyproject.toml fragment (the real project's configuration).
+VALID_PYPROJECT = (
+    '[project]\nname = "mypkg"\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n'
 )
 
 
-class TestCheckPyprojectHasVersion:
-    """Tests for check_pyproject_has_version()."""
+class TestCheckPyprojectDynamicVersion:
+    """Tests for check_pyproject_dynamic_version()."""
 
-    def test_returns_true_when_version_present(self, tmp_path: Path) -> None:
-        """Returns True when pyproject.toml has [project].version."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[project]\nname = "mypkg"\nversion = "1.2.3"\n')
-        assert check_pyproject_has_version(tmp_path) is True
+    def test_returns_true_for_valid_hatch_vcs_config(self, tmp_path: Path) -> None:
+        """Returns True when version is dynamic and hatch-vcs is the source."""
+        (tmp_path / "pyproject.toml").write_text(VALID_PYPROJECT)
+        assert check_pyproject_dynamic_version(tmp_path) is True
 
     def test_returns_false_when_pyproject_missing(self, tmp_path: Path) -> None:
         """Returns False when pyproject.toml does not exist."""
-        assert check_pyproject_has_version(tmp_path) is False
+        assert check_pyproject_dynamic_version(tmp_path) is False
 
-    def test_returns_false_when_no_version_in_project(self, tmp_path: Path) -> None:
-        """Returns False when [project] section has no version key."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[project]\nname = "mypkg"\ndescription = "no version"\n')
-        assert check_pyproject_has_version(tmp_path) is False
+    def test_returns_false_when_static_version_reintroduced(self, tmp_path: Path) -> None:
+        """Returns False when a static [project].version is present (regression for #435).
 
-    def test_returns_false_when_version_only_in_other_section(self, tmp_path: Path) -> None:
-        """Returns False when version exists only in a non-[project] section."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[tool.poetry]\nversion = "1.0.0"\n\n[project]\nname = "mypkg"\n')
-        assert check_pyproject_has_version(tmp_path) is False
+        The old regex-based checker would have matched an unrelated quoted string
+        and reported a false PASS; the rewritten checker must FAIL here.
+        """
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "mypkg"\n'
+            'version = "1.2.3"\n'
+            'dynamic = ["version"]\n\n'
+            "[tool.hatch.version]\n"
+            'source = "vcs"\n'
+        )
+        assert check_pyproject_dynamic_version(tmp_path) is False
+
+    def test_returns_false_when_dynamic_missing_version(self, tmp_path: Path) -> None:
+        """Returns False when [project].dynamic does not contain 'version'."""
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "mypkg"\ndynamic = []\n\n[tool.hatch.version]\nsource = "vcs"\n'
+        )
+        assert check_pyproject_dynamic_version(tmp_path) is False
+
+    def test_returns_false_when_hatch_source_not_vcs(self, tmp_path: Path) -> None:
+        """Returns False when [tool.hatch.version].source is not 'vcs'."""
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "mypkg"\n'
+            'dynamic = ["version"]\n\n'
+            "[tool.hatch.version]\n"
+            'path = "mypkg/__init__.py"\n'
+        )
+        assert check_pyproject_dynamic_version(tmp_path) is False
+
+    def test_does_not_match_entry_point_strings(self, tmp_path: Path) -> None:
+        """A [project.scripts] entry point must not be mistaken for a version.
+
+        Regression for #435: the old DOTALL regex captured
+        'pkg.module:main' from [project.scripts] as the version.
+        """
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "mypkg"\n'
+            'dynamic = ["version"]\n\n'
+            "[project.scripts]\n"
+            'mypkg-cli = "mypkg.cli:main"\n\n'
+            "[tool.hatch.version]\n"
+            'source = "vcs"\n'
+        )
+        assert check_pyproject_dynamic_version(tmp_path) is True
 
     def test_prints_ok_on_success(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        """Prints OK message with version when found."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[project]\nversion = "2.0.0"\n')
-        check_pyproject_has_version(tmp_path)
-        captured = capsys.readouterr()
-        assert "2.0.0" in captured.out
+        """Prints OK message when configuration is valid."""
+        (tmp_path / "pyproject.toml").write_text(VALID_PYPROJECT)
+        check_pyproject_dynamic_version(tmp_path)
+        assert "OK" in capsys.readouterr().out
 
     def test_prints_error_on_missing_file(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
         """Prints ERROR message when pyproject.toml is missing."""
-        check_pyproject_has_version(tmp_path)
-        captured = capsys.readouterr()
-        assert "ERROR" in captured.out
+        check_pyproject_dynamic_version(tmp_path)
+        assert "ERROR" in capsys.readouterr().out
 
 
 class TestCheckPixiNoVersion:
@@ -97,30 +143,24 @@ class TestCheckPixiNoVersion:
         pixi = tmp_path / "pixi.toml"
         pixi.write_text('[workspace]\nversion = "0.1.0"\n')
         check_pixi_no_version(tmp_path)
-        captured = capsys.readouterr()
-        assert "ERROR" in captured.out
+        assert "ERROR" in capsys.readouterr().out
 
     def test_prints_ok_when_no_version(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         """Prints OK message when pixi.toml has no workspace version."""
         pixi = tmp_path / "pixi.toml"
         pixi.write_text('[workspace]\nname = "myproject"\n')
         check_pixi_no_version(tmp_path)
-        captured = capsys.readouterr()
-        assert "OK" in captured.out
+        assert "OK" in capsys.readouterr().out
 
 
 class TestMain:
     """Tests for main()."""
 
     def test_returns_0_when_all_ok(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns 0 when pyproject.toml has version and pixi.toml has none."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[project]\nversion = "1.0.0"\n')
-        pixi = tmp_path / "pixi.toml"
-        pixi.write_text('[workspace]\nname = "myproject"\n')
+        """Returns 0 for a valid hatch-vcs pyproject.toml and a versionless pixi.toml."""
+        (tmp_path / "pyproject.toml").write_text(VALID_PYPROJECT)
+        (tmp_path / "pixi.toml").write_text('[workspace]\nname = "myproject"\n')
 
-        monkeypatch.chdir(tmp_path)
-        # Patch get_repo_root in the module's namespace
         import check_version_single_source as mod
 
         monkeypatch.setattr(mod, "get_repo_root", lambda: tmp_path)
@@ -135,14 +175,30 @@ class TestMain:
         monkeypatch.setattr(mod, "get_repo_root", lambda: tmp_path)
         assert mod.main() == 1
 
+    def test_returns_1_when_static_version_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns 1 when a static [project].version is reintroduced."""
+        (tmp_path / "pyproject.toml").write_text(
+            "[project]\n"
+            'name = "mypkg"\n'
+            'version = "1.0.0"\n'
+            'dynamic = ["version"]\n\n'
+            "[tool.hatch.version]\n"
+            'source = "vcs"\n'
+        )
+
+        import check_version_single_source as mod
+
+        monkeypatch.setattr(mod, "get_repo_root", lambda: tmp_path)
+        assert mod.main() == 1
+
     def test_returns_1_when_pixi_has_version(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Returns 1 when pixi.toml [workspace] has a version field."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[project]\nversion = "1.0.0"\n')
-        pixi = tmp_path / "pixi.toml"
-        pixi.write_text('[workspace]\nversion = "1.0.0"\n')
+        (tmp_path / "pyproject.toml").write_text(VALID_PYPROJECT)
+        (tmp_path / "pixi.toml").write_text('[workspace]\nversion = "1.0.0"\n')
 
         import check_version_single_source as mod
 
@@ -153,10 +209,15 @@ class TestMain:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Returns 0 when pixi.toml does not exist (only pyproject.toml)."""
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text('[project]\nversion = "1.0.0"\n')
+        (tmp_path / "pyproject.toml").write_text(VALID_PYPROJECT)
 
         import check_version_single_source as mod
 
         monkeypatch.setattr(mod, "get_repo_root", lambda: tmp_path)
+        assert mod.main() == 0
+
+    def test_passes_against_real_repo_pyproject(self) -> None:
+        """The checker must PASS on the actual repository configuration."""
+        import check_version_single_source as mod
+
         assert mod.main() == 0


### PR DESCRIPTION
## Summary

`scripts/check_version_single_source.py` used a `re.DOTALL` regex to find
`[project].version`. The project uses **hatch-vcs dynamic versioning** and has no
static `[project].version` field, so the regex skipped `dynamic = ["version"]` and
matched the first quoted string after `[project]` — an entry-point string in
`[project.scripts]` — reporting:

```
OK: pyproject.toml [project] version = "hephaestus.validation.python_version:main"
Version single source of truth: PASS
```

The pre-commit hook validated nothing.

## Changes

- `scripts/check_version_single_source.py`: parse `pyproject.toml` with `tomllib`
  and validate the real invariant — no static `[project].version`, `version` in
  `[project].dynamic`, `[tool.hatch.version].source == "vcs"`, no pixi workspace version.
- `tests/unit/scripts/test_check_version_single_source.py`: rewritten with regression
  tests proving a reintroduced static version FAILS and a stray entry-point string is
  not mistaken for a version.

## Verification

- `python scripts/check_version_single_source.py` → PASS (exit 0) on real config.
- `pixi run pytest tests/unit/scripts/test_check_version_single_source.py` → 21 passed.
- `pixi run mypy` → clean.

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)