### PR TITLE
fix(version): derive canonical version from git tags, not [project].version

### DIFF
--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -2,10 +2,14 @@
 
 """Version consistency checks and atomic version bumping.
 
+The project uses hatch-vcs dynamic versioning: the **canonical version is
+derived from git tags**, not stored in any file. These checks therefore compare
+secondary version declarations against the git-derived canonical version.
+
 Provides three operations:
 
-1. ``check_version_consistency`` — compare pyproject.toml [project].version
-   with pixi.toml [workspace].version (if present) and fail if they differ.
+1. ``check_version_consistency`` — verify pixi.toml [workspace].version (if
+   present) matches the canonical git-tag version.
 
 2. ``check_package_version_consistency`` — broader multi-source scan: pixi.toml,
    ``__init__.py`` ``__version__``, and optional skill markdown files.
@@ -22,12 +26,18 @@ Usage:
 import argparse
 import importlib
 import re
+import subprocess
 import sys
 import types
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 from pathlib import Path
 
 from hephaestus.utils.helpers import get_repo_root
 from hephaestus.version.manager import VersionManager, parse_version
+
+# PyPI distribution name used for the importlib.metadata fallback.
+_DIST_NAME = "HomericIntelligence-Hephaestus"
 
 # tomllib ships with Python 3.11+; fall back to the tomli backport on 3.10.
 _tomllib: types.ModuleType | None = None
@@ -63,48 +73,77 @@ def _parse_version_tuple(version_str: str) -> tuple[int, ...]:
     return tuple(int(p) for p in version_str.split("."))
 
 
-def _get_pyproject_version(repo_root: Path) -> str:
-    """Read the version from ``pyproject.toml`` ``[project].version``.
+def _version_from_git_tag(repo_root: Path) -> str | None:
+    """Return the latest semver git tag (without a leading ``v``), or None.
+
+    This is the same authority hatch-vcs uses to compute the dynamic version.
 
     Args:
         repo_root: Repository root directory.
 
     Returns:
-        The version string, e.g. ``"0.5.0"``.
-
-    Raises:
-        SystemExit: With code 1 if the file is missing, malformed, or lacks the field.
+        A ``"X.Y.Z"`` string, or ``None`` if no matching tag exists or git is
+        unavailable.
 
     """
-    pyproject_path = repo_root / "pyproject.toml"
-    if not pyproject_path.is_file():
-        print(f"ERROR: pyproject.toml not found: {pyproject_path}", file=sys.stderr)
-        sys.exit(1)
-
-    if _tomllib is None:
-        print(
-            "ERROR: tomllib/tomli is required to parse TOML files. "
-            "Install tomli on Python 3.10: pip install tomli",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     try:
-        with open(pyproject_path, "rb") as fh:
-            data = _tomllib.load(fh)
-    except Exception as exc:
-        print(f"ERROR: Could not parse {pyproject_path}: {exc}", file=sys.stderr)
-        sys.exit(1)
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    tag = result.stdout.strip().lstrip("v")
+    match = re.match(r"^\d+\.\d+\.\d+", tag)
+    return match.group(0) if match else None
 
-    version = data.get("project", {}).get("version")
-    if not version:
+
+def _version_from_metadata() -> str | None:
+    """Return the installed distribution's base version (no dev/local suffix), or None.
+
+    Returns:
+        A ``"X.Y.Z"`` string, or ``None`` if the package is not installed.
+
+    """
+    try:
+        raw = _dist_version(_DIST_NAME)
+    except PackageNotFoundError:
+        return None
+    match = re.match(r"^\d+\.\d+\.\d+", raw)
+    return match.group(0) if match else None
+
+
+def _get_canonical_version(repo_root: Path) -> str:
+    """Return the canonical project version.
+
+    Under hatch-vcs dynamic versioning the canonical version is derived from git
+    tags. This prefers the latest ``v*`` git tag and falls back to the installed
+    distribution metadata.
+
+    Args:
+        repo_root: Repository root directory.
+
+    Returns:
+        The canonical version string, e.g. ``"0.9.0"``.
+
+    Raises:
+        SystemExit: With code 1 if no canonical version can be determined.
+
+    """
+    version = _version_from_git_tag(repo_root) or _version_from_metadata()
+    if version is None:
         print(
-            f"ERROR: No [project].version found in {pyproject_path}",
+            "ERROR: could not determine the canonical version.\n"
+            "  This project uses hatch-vcs dynamic versioning; a vX.Y.Z git tag\n"
+            "  or an installed distribution is required.",
             file=sys.stderr,
         )
         sys.exit(1)
-
-    return str(version)
+    return version
 
 
 def _get_pixi_version(repo_root: Path) -> str | None:
@@ -198,11 +237,11 @@ def _find_aspirational_versions(
 
 
 def check_version_consistency(repo_root: Path, verbose: bool = False) -> int:
-    """Compare pyproject.toml and pixi.toml package versions.
+    """Verify pixi.toml's version (if any) matches the canonical git-tag version.
 
-    Passes if pixi.toml has no version field (expected state when pyproject.toml
-    is the single source of truth). Fails if both files declare a version and
-    they differ.
+    Passes if pixi.toml has no version field (expected state — the canonical
+    version comes from git tags via hatch-vcs). Fails if pixi.toml declares a
+    version that differs from the canonical version.
 
     Args:
         repo_root: Root directory of the repository.
@@ -212,32 +251,33 @@ def check_version_consistency(repo_root: Path, verbose: bool = False) -> int:
         0 if versions are consistent (or pixi.toml has no version), 1 otherwise.
 
     """
-    pyproject_version = _get_pyproject_version(repo_root)
+    canonical_version = _get_canonical_version(repo_root)
     pixi_version = _get_pixi_version(repo_root)
 
     if verbose:
-        print(f"pyproject.toml [project].version: {pyproject_version}")
+        print(f"Canonical version (git tag / metadata): {canonical_version}")
 
     if pixi_version is None:
         if verbose:
-            print("pixi.toml: no [workspace].version (pyproject.toml is single source)")
+            print("pixi.toml: no [workspace].version (canonical version is git-derived)")
         return 0
 
     if verbose:
-        print(f"pixi.toml [workspace].version:    {pixi_version}")
+        print(f"pixi.toml [workspace].version:          {pixi_version}")
 
-    if pyproject_version != pixi_version:
+    if canonical_version != pixi_version:
         print(
             "ERROR: version mismatch:\n"
-            f"  pyproject.toml: {pyproject_version}\n"
-            f"  pixi.toml:      {pixi_version}\n"
-            "pyproject.toml is the single source of truth — update pixi.toml to match.",
+            f"  canonical (git tag): {canonical_version}\n"
+            f"  pixi.toml:           {pixi_version}\n"
+            "The canonical version is derived from git tags — update or remove "
+            "the pixi.toml version.",
             file=sys.stderr,
         )
         return 1
 
     if verbose:
-        print(f"OK: version is consistent ({pyproject_version})")
+        print(f"OK: version is consistent ({canonical_version})")
     return 0
 
 
@@ -351,9 +391,9 @@ def check_package_version_consistency(
         0 if all checks pass, 1 if any fail.
 
     """
-    canonical = _get_pyproject_version(repo_root)
+    canonical = _get_canonical_version(repo_root)
     if verbose:
-        print(f"Canonical version (pyproject.toml): {canonical}")
+        print(f"Canonical version (git tag / metadata): {canonical}")
 
     all_errors: list[str] = []
     all_errors.extend(_check_pixi_version_errors(repo_root, canonical, verbose))
@@ -385,10 +425,14 @@ def bump_version(
 ) -> int:
     """Increment the project version by one semver step.
 
-    Reads the current version from ``pyproject.toml``, computes the new version
-    by incrementing ``part`` (major/minor/patch), and delegates all file writes
-    to :class:`~hephaestus.version.manager.VersionManager`.  After writing,
-    runs :func:`check_version_consistency` to validate the result.
+    Reads the current canonical version (latest git tag), computes the new
+    version by incrementing ``part`` (major/minor/patch), and delegates writes of
+    secondary files (``VERSION``, ``__init__.py``) to
+    :class:`~hephaestus.version.manager.VersionManager`.
+
+    Note: under hatch-vcs the authoritative version is set by creating a git tag
+    (``vX.Y.Z``). This helper computes and records the next version in secondary
+    files; the release is finalised by tagging — see ``docs/RELEASING.md``.
 
     Args:
         repo_root: Root directory of the repository.
@@ -400,7 +444,7 @@ def bump_version(
         0 on success, 1 on failure.
 
     """
-    current_str = _get_pyproject_version(repo_root)
+    current_str = _get_canonical_version(repo_root)
     try:
         current = parse_version(current_str)
     except ValueError as exc:
@@ -443,10 +487,10 @@ def bump_version(
 
     print(f"Version bumped: {current_str} -> {new_str}")
     print()
-    print("Next steps:")
-    print("  1. pixi install   # regenerates pixi.lock")
-    print("  2. git add pyproject.toml pixi.lock")
-    print(f'  3. git commit -m "chore(release): bump version to {new_str}"')
+    print("Next steps (hatch-vcs derives the published version from the git tag):")
+    print(f'  1. git tag -s v{new_str} -m "Release v{new_str}"')
+    print(f"  2. git push origin v{new_str}")
+    print("  See docs/RELEASING.md for the full release workflow.")
     return 0
 
 

--- a/tests/unit/version/test_consistency.py
+++ b/tests/unit/version/test_consistency.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 
-"""Tests for hephaestus.version.consistency module."""
+"""Tests for hephaestus.version.consistency module.
+
+The project uses hatch-vcs dynamic versioning: the canonical version comes from
+git tags, not a file. Tests inject a canonical version by monkeypatching
+``_version_from_git_tag`` rather than writing a static ``[project].version``.
+"""
 
 from pathlib import Path
 
 import pytest
 
+import hephaestus.version.consistency as consistency
 from hephaestus.version.consistency import (
     bump_version,
     check_package_version_consistency,
@@ -13,15 +19,18 @@ from hephaestus.version.consistency import (
 )
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers / fixtures
 # ---------------------------------------------------------------------------
 
 
-def _write_pyproject(tmp_path: Path, version: str) -> None:
-    """Write a minimal pyproject.toml with the given project version."""
-    (tmp_path / "pyproject.toml").write_text(
-        f'[project]\nname = "test-pkg"\nversion = "{version}"\n'
-    )
+@pytest.fixture
+def set_canonical(monkeypatch: pytest.MonkeyPatch):
+    """Return a callable that pins the canonical (git-tag) version for a test."""
+
+    def _set(version: str) -> None:
+        monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: version)
+
+    return _set
 
 
 def _write_pixi(tmp_path: Path, version: str | None) -> None:
@@ -39,29 +48,29 @@ def _write_pixi(tmp_path: Path, version: str | None) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_check_version_consistency_no_pixi(tmp_path):
+def test_check_version_consistency_no_pixi(tmp_path, set_canonical):
     """Pass when pixi.toml is absent."""
-    _write_pyproject(tmp_path, "1.2.3")
+    set_canonical("1.2.3")
     assert check_version_consistency(tmp_path) == 0
 
 
-def test_check_version_consistency_pixi_no_version(tmp_path):
+def test_check_version_consistency_pixi_no_version(tmp_path, set_canonical):
     """Pass when pixi.toml has no [workspace].version."""
-    _write_pyproject(tmp_path, "1.2.3")
+    set_canonical("1.2.3")
     _write_pixi(tmp_path, None)
     assert check_version_consistency(tmp_path) == 0
 
 
-def test_check_version_consistency_matching(tmp_path):
-    """Pass when both files have the same version."""
-    _write_pyproject(tmp_path, "1.2.3")
+def test_check_version_consistency_matching(tmp_path, set_canonical):
+    """Pass when pixi.toml version matches the canonical git-tag version."""
+    set_canonical("1.2.3")
     _write_pixi(tmp_path, "1.2.3")
     assert check_version_consistency(tmp_path) == 0
 
 
-def test_check_version_consistency_mismatch(tmp_path, capsys):
-    """Fail when versions differ."""
-    _write_pyproject(tmp_path, "1.2.3")
+def test_check_version_consistency_mismatch(tmp_path, set_canonical, capsys):
+    """Fail when pixi.toml version differs from the canonical version."""
+    set_canonical("1.2.3")
     _write_pixi(tmp_path, "1.2.4")
     result = check_version_consistency(tmp_path)
     assert result == 1
@@ -69,20 +78,29 @@ def test_check_version_consistency_mismatch(tmp_path, capsys):
     assert "mismatch" in err.lower() or "1.2.3" in err
 
 
-def test_check_version_consistency_verbose(tmp_path, capsys):
+def test_check_version_consistency_verbose(tmp_path, set_canonical, capsys):
     """Verbose mode prints versions even when consistent."""
-    _write_pyproject(tmp_path, "0.5.0")
+    set_canonical("0.5.0")
     result = check_version_consistency(tmp_path, verbose=True)
     assert result == 0
     out = capsys.readouterr().out
     assert "0.5.0" in out
 
 
-def test_check_version_consistency_missing_pyproject(tmp_path):
-    """Exit 1 when pyproject.toml is missing."""
+def test_check_version_consistency_no_canonical_source(tmp_path, monkeypatch):
+    """Exit 1 when no canonical version can be determined (no tag, not installed)."""
+    monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: None)
     with pytest.raises(SystemExit) as exc_info:
         check_version_consistency(tmp_path)
     assert exc_info.value.code == 1
+
+
+def test_canonical_falls_back_to_metadata(tmp_path, monkeypatch):
+    """When no git tag exists, the canonical version falls back to dist metadata."""
+    monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: "7.8.9")
+    assert consistency._get_canonical_version(tmp_path) == "7.8.9"
 
 
 # ---------------------------------------------------------------------------
@@ -90,24 +108,24 @@ def test_check_version_consistency_missing_pyproject(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_check_package_consistency_minimal(tmp_path):
-    """Pass with just pyproject.toml."""
-    _write_pyproject(tmp_path, "0.3.0")
+def test_check_package_consistency_minimal(tmp_path, set_canonical):
+    """Pass with no secondary version sources to compare."""
+    set_canonical("0.3.0")
     assert check_package_version_consistency(tmp_path) == 0
 
 
-def test_check_package_consistency_init_match(tmp_path):
-    """Pass when __init__.py __version__ matches."""
-    _write_pyproject(tmp_path, "0.3.0")
+def test_check_package_consistency_init_match(tmp_path, set_canonical):
+    """Pass when __init__.py __version__ matches the canonical version."""
+    set_canonical("0.3.0")
     init = tmp_path / "mypkg" / "__init__.py"
     init.parent.mkdir()
     init.write_text('__version__ = "0.3.0"\n')
     assert check_package_version_consistency(tmp_path, package_init=init) == 0
 
 
-def test_check_package_consistency_init_mismatch(tmp_path, capsys):
-    """Fail when __init__.py __version__ does not match."""
-    _write_pyproject(tmp_path, "0.3.0")
+def test_check_package_consistency_init_mismatch(tmp_path, set_canonical, capsys):
+    """Fail when __init__.py __version__ does not match the canonical version."""
+    set_canonical("0.3.0")
     init = tmp_path / "mypkg" / "__init__.py"
     init.parent.mkdir()
     init.write_text('__version__ = "0.2.0"\n')
@@ -117,186 +135,25 @@ def test_check_package_consistency_init_mismatch(tmp_path, capsys):
     assert "0.2.0" in err or "mismatch" in err.lower()
 
 
-def test_check_package_consistency_init_missing(tmp_path):
+def test_check_package_consistency_init_missing(tmp_path, set_canonical):
     """Skip (not fail) when --package-init path does not exist."""
-    _write_pyproject(tmp_path, "0.3.0")
+    set_canonical("0.3.0")
     missing = tmp_path / "doesnotexist" / "__init__.py"
     assert check_package_version_consistency(tmp_path, package_init=missing) == 0
 
 
-def test_check_package_consistency_no_version_in_init(tmp_path):
+def test_check_package_consistency_no_version_in_init(tmp_path, set_canonical):
     """Skip __version__ check when init has no __version__ attribute."""
-    _write_pyproject(tmp_path, "0.3.0")
+    set_canonical("0.3.0")
     init = tmp_path / "mypkg" / "__init__.py"
     init.parent.mkdir()
     init.write_text("# no version here\n")
     assert check_package_version_consistency(tmp_path, package_init=init) == 0
 
 
-# ---------------------------------------------------------------------------
-# bump_version
-# ---------------------------------------------------------------------------
-
-
-def _minimal_repo(tmp_path: Path, version: str) -> Path:
-    """Set up a minimal repo at tmp_path with pyproject.toml at version."""
-    _write_pyproject(tmp_path, version)
-    return tmp_path
-
-
-def test_bump_version_patch(tmp_path):
-    """Patch bump increments patch part and resets nothing."""
-    _minimal_repo(tmp_path, "1.2.3")
-    result = bump_version(tmp_path, "patch", verbose=False)
-    assert result == 0
-    content = (tmp_path / "pyproject.toml").read_text()
-    assert '"1.2.4"' in content
-
-
-def test_bump_version_minor(tmp_path):
-    """Minor bump increments minor and resets patch to 0."""
-    _minimal_repo(tmp_path, "1.2.3")
-    result = bump_version(tmp_path, "minor", verbose=False)
-    assert result == 0
-    content = (tmp_path / "pyproject.toml").read_text()
-    assert '"1.3.0"' in content
-
-
-def test_bump_version_major(tmp_path):
-    """Major bump increments major and resets minor and patch to 0."""
-    _minimal_repo(tmp_path, "1.2.3")
-    result = bump_version(tmp_path, "major", verbose=False)
-    assert result == 0
-    content = (tmp_path / "pyproject.toml").read_text()
-    assert '"2.0.0"' in content
-
-
-def test_bump_version_dry_run(tmp_path):
-    """Dry run does not modify any file."""
-    _minimal_repo(tmp_path, "1.0.0")
-    result = bump_version(tmp_path, "patch", dry_run=True, verbose=False)
-    assert result == 0
-    # pyproject.toml must be unchanged
-    content = (tmp_path / "pyproject.toml").read_text()
-    assert '"1.0.0"' in content
-
-
-def test_bump_version_dry_run_output(tmp_path, capsys):
-    """Dry run prints the proposed version change."""
-    _minimal_repo(tmp_path, "2.3.4")
-    bump_version(tmp_path, "minor", dry_run=True, verbose=False)
-    out = capsys.readouterr().out
-    assert "2.4.0" in out
-
-
-def test_bump_version_invalid_part(tmp_path, capsys):
-    """Invalid part argument returns exit code 1."""
-    _minimal_repo(tmp_path, "1.0.0")
-    result = bump_version(tmp_path, "invalid", verbose=False)
-    assert result == 1
-    err = capsys.readouterr().err
-    assert "invalid" in err.lower()
-
-
-def test_bump_version_missing_pyproject(tmp_path):
-    """Missing pyproject.toml causes SystemExit(1)."""
-    with pytest.raises(SystemExit) as exc_info:
-        bump_version(tmp_path, "patch")
-    assert exc_info.value.code == 1
-
-
-def test_bump_version_verbose(tmp_path, capsys):
-    """Verbose mode prints bump message."""
-    _minimal_repo(tmp_path, "0.1.0")
-    bump_version(tmp_path, "patch", verbose=True)
-    out = capsys.readouterr().out
-    assert "0.1.1" in out
-
-
-# ---------------------------------------------------------------------------
-# CLI main entry points (smoke tests via monkeypatch of sys.argv)
-# ---------------------------------------------------------------------------
-
-
-def test_check_version_consistency_main_pass(tmp_path, monkeypatch, capsys):
-    """CLI passes when pyproject.toml has no matching pixi.toml version."""
-    from hephaestus.version.consistency import check_version_consistency_main
-
-    _write_pyproject(tmp_path, "1.0.0")
-    monkeypatch.setattr(
-        "sys.argv",
-        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
-    )
-    result = check_version_consistency_main()
-    assert result == 0
-
-
-def test_check_version_consistency_main_mismatch(tmp_path, monkeypatch, capsys):
-    """CLI fails when versions differ."""
-    from hephaestus.version.consistency import check_version_consistency_main
-
-    _write_pyproject(tmp_path, "1.0.0")
-    _write_pixi(tmp_path, "1.0.1")
-    monkeypatch.setattr(
-        "sys.argv",
-        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
-    )
-    result = check_version_consistency_main()
-    assert result == 1
-
-
-def test_check_package_versions_main_pass(tmp_path, monkeypatch):
-    """CLI passes with minimal repo and --verbose flag."""
-    from hephaestus.version.consistency import check_package_versions_main
-
-    _write_pyproject(tmp_path, "2.0.0")
-    monkeypatch.setattr(
-        "sys.argv",
-        ["hephaestus-check-package-versions", "--repo-root", str(tmp_path), "--verbose"],
-    )
-    result = check_package_versions_main()
-    assert result == 0
-
-
-def test_bump_version_main_dry_run(tmp_path, monkeypatch, capsys):
-    """CLI --dry-run flag prints proposed change without writing."""
-    from hephaestus.version.consistency import bump_version_main
-
-    _minimal_repo(tmp_path, "3.0.0")
-    monkeypatch.setattr(
-        "sys.argv",
-        ["hephaestus-bump-version", "minor", "--repo-root", str(tmp_path), "--dry-run"],
-    )
-    result = bump_version_main()
-    assert result == 0
-    out = capsys.readouterr().out
-    assert "3.1.0" in out
-    # File must be unchanged
-    assert '"3.0.0"' in (tmp_path / "pyproject.toml").read_text()
-
-
-def test_bump_version_main_patch(tmp_path, monkeypatch):
-    """CLI patch bump actually modifies the file."""
-    from hephaestus.version.consistency import bump_version_main
-
-    _minimal_repo(tmp_path, "0.5.2")
-    monkeypatch.setattr(
-        "sys.argv",
-        ["hephaestus-bump-version", "patch", "--repo-root", str(tmp_path)],
-    )
-    result = bump_version_main()
-    assert result == 0
-    assert '"0.5.3"' in (tmp_path / "pyproject.toml").read_text()
-
-
-# ---------------------------------------------------------------------------
-# check_package_version_consistency with pixi mismatch
-# ---------------------------------------------------------------------------
-
-
-def test_check_package_consistency_pixi_mismatch(tmp_path, capsys):
-    """Fail when pixi.toml [workspace].version differs from pyproject.toml."""
-    _write_pyproject(tmp_path, "1.0.0")
+def test_check_package_consistency_pixi_mismatch(tmp_path, set_canonical, capsys):
+    """Fail when pixi.toml [workspace].version differs from the canonical version."""
+    set_canonical("1.0.0")
     _write_pixi(tmp_path, "0.9.0")
     result = check_package_version_consistency(tmp_path)
     assert result == 1
@@ -304,8 +161,185 @@ def test_check_package_consistency_pixi_mismatch(tmp_path, capsys):
     assert "0.9.0" in err
 
 
-def test_check_package_consistency_pixi_match(tmp_path):
-    """Pass when pixi.toml [workspace].version matches pyproject.toml."""
-    _write_pyproject(tmp_path, "1.0.0")
+def test_check_package_consistency_pixi_match(tmp_path, set_canonical):
+    """Pass when pixi.toml [workspace].version matches the canonical version."""
+    set_canonical("1.0.0")
     _write_pixi(tmp_path, "1.0.0")
     assert check_package_version_consistency(tmp_path) == 0
+
+
+def test_check_package_consistency_scan_skills_clean(tmp_path, set_canonical):
+    """scan_skills passes when skill markdown has no aspirational versions."""
+    set_canonical("1.0.0")
+    skills = tmp_path / ".claude-plugin" / "skills"
+    skills.mkdir(parents=True)
+    (skills / "demo.md").write_text("# Demo skill\n\nNo versions here.\n")
+    assert check_package_version_consistency(tmp_path, scan_skills=True) == 0
+
+
+def test_check_package_consistency_scan_skills_aspirational(tmp_path, set_canonical, capsys):
+    """scan_skills fails when a skill references a version above the canonical one."""
+    set_canonical("1.0.0")
+    skills = tmp_path / ".claude-plugin" / "skills"
+    skills.mkdir(parents=True)
+    (skills / "demo.md").write_text("# Demo\n\nRequires v2.5.0 of the toolchain.\n")
+    result = check_package_version_consistency(tmp_path, scan_skills=True)
+    assert result == 1
+    assert "2.5.0" in capsys.readouterr().err
+
+
+def test_check_package_consistency_scan_skills_ignores_code_blocks(tmp_path, set_canonical):
+    """Versions inside fenced code blocks are not treated as aspirational."""
+    set_canonical("1.0.0")
+    skills = tmp_path / ".claude-plugin" / "skills"
+    skills.mkdir(parents=True)
+    (skills / "demo.md").write_text("# Demo\n\n```\npip install foo==9.9.9\n```\n")
+    assert check_package_version_consistency(tmp_path, scan_skills=True) == 0
+
+
+# ---------------------------------------------------------------------------
+# bump_version
+# ---------------------------------------------------------------------------
+
+
+def test_bump_version_patch(tmp_path, set_canonical):
+    """Patch bump computes the next patch version."""
+    set_canonical("1.2.3")
+    result = bump_version(tmp_path, "patch", verbose=False)
+    assert result == 0
+    assert "1.2.4" in (tmp_path / "VERSION").read_text()
+
+
+def test_bump_version_minor(tmp_path, set_canonical):
+    """Minor bump increments minor and resets patch to 0."""
+    set_canonical("1.2.3")
+    result = bump_version(tmp_path, "minor", verbose=False)
+    assert result == 0
+    assert "1.3.0" in (tmp_path / "VERSION").read_text()
+
+
+def test_bump_version_major(tmp_path, set_canonical):
+    """Major bump increments major and resets minor and patch to 0."""
+    set_canonical("1.2.3")
+    result = bump_version(tmp_path, "major", verbose=False)
+    assert result == 0
+    assert "2.0.0" in (tmp_path / "VERSION").read_text()
+
+
+def test_bump_version_dry_run(tmp_path, set_canonical):
+    """Dry run does not write a VERSION file."""
+    set_canonical("1.0.0")
+    result = bump_version(tmp_path, "patch", dry_run=True, verbose=False)
+    assert result == 0
+    assert not (tmp_path / "VERSION").exists()
+
+
+def test_bump_version_dry_run_output(tmp_path, set_canonical, capsys):
+    """Dry run prints the proposed version change."""
+    set_canonical("2.3.4")
+    bump_version(tmp_path, "minor", dry_run=True, verbose=False)
+    assert "2.4.0" in capsys.readouterr().out
+
+
+def test_bump_version_invalid_part(tmp_path, set_canonical, capsys):
+    """Invalid part argument returns exit code 1."""
+    set_canonical("1.0.0")
+    result = bump_version(tmp_path, "invalid", verbose=False)
+    assert result == 1
+    assert "invalid" in capsys.readouterr().err.lower()
+
+
+def test_bump_version_no_canonical_source(tmp_path, monkeypatch):
+    """No determinable canonical version causes SystemExit(1)."""
+    monkeypatch.setattr(consistency, "_version_from_git_tag", lambda _root: None)
+    monkeypatch.setattr(consistency, "_version_from_metadata", lambda: None)
+    with pytest.raises(SystemExit) as exc_info:
+        bump_version(tmp_path, "patch")
+    assert exc_info.value.code == 1
+
+
+def test_bump_version_verbose(tmp_path, set_canonical, capsys):
+    """Verbose mode prints the bump message."""
+    set_canonical("0.1.0")
+    bump_version(tmp_path, "patch", verbose=True)
+    assert "0.1.1" in capsys.readouterr().out
+
+
+def test_bump_version_next_steps_mention_git_tag(tmp_path, set_canonical, capsys):
+    """The post-bump guidance points at git tagging, not editing pyproject.toml."""
+    set_canonical("1.0.0")
+    bump_version(tmp_path, "patch", verbose=False)
+    out = capsys.readouterr().out
+    assert "git tag" in out
+    assert "v1.0.1" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI main entry points (smoke tests via monkeypatch of sys.argv)
+# ---------------------------------------------------------------------------
+
+
+def test_check_version_consistency_main_pass(tmp_path, set_canonical, monkeypatch):
+    """CLI passes when pixi.toml has no conflicting version."""
+    from hephaestus.version.consistency import check_version_consistency_main
+
+    set_canonical("1.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
+    )
+    assert check_version_consistency_main() == 0
+
+
+def test_check_version_consistency_main_mismatch(tmp_path, set_canonical, monkeypatch):
+    """CLI fails when versions differ."""
+    from hephaestus.version.consistency import check_version_consistency_main
+
+    set_canonical("1.0.0")
+    _write_pixi(tmp_path, "1.0.1")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-check-version-consistency", "--repo-root", str(tmp_path)],
+    )
+    assert check_version_consistency_main() == 1
+
+
+def test_check_package_versions_main_pass(tmp_path, set_canonical, monkeypatch):
+    """CLI passes with a minimal repo and the --verbose flag."""
+    from hephaestus.version.consistency import check_package_versions_main
+
+    set_canonical("2.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-check-package-versions", "--repo-root", str(tmp_path), "--verbose"],
+    )
+    assert check_package_versions_main() == 0
+
+
+def test_bump_version_main_dry_run(tmp_path, set_canonical, monkeypatch, capsys):
+    """CLI --dry-run flag prints the proposed change without writing."""
+    from hephaestus.version.consistency import bump_version_main
+
+    set_canonical("3.0.0")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-bump-version", "minor", "--repo-root", str(tmp_path), "--dry-run"],
+    )
+    result = bump_version_main()
+    assert result == 0
+    assert "3.1.0" in capsys.readouterr().out
+    assert not (tmp_path / "VERSION").exists()
+
+
+def test_bump_version_main_patch(tmp_path, set_canonical, monkeypatch):
+    """CLI patch bump computes and records the next patch version."""
+    from hephaestus.version.consistency import bump_version_main
+
+    set_canonical("0.5.2")
+    monkeypatch.setattr(
+        "sys.argv",
+        ["hephaestus-bump-version", "patch", "--repo-root", str(tmp_path)],
+    )
+    result = bump_version_main()
+    assert result == 0
+    assert "0.5.3" in (tmp_path / "VERSION").read_text()


### PR DESCRIPTION
## Summary

`hephaestus/version/consistency.py` read `data["project"]["version"]` from
`pyproject.toml`. The project uses **hatch-vcs dynamic versioning** —
`pyproject.toml` declares `dynamic = ["version"]` and has no `[project].version`
key — so `_get_pyproject_version()` found nothing and called `sys.exit(1)`,
crashing all three console scripts:

- `hephaestus-check-version-consistency`
- `hephaestus-check-package-versions`
- `hephaestus-bump-version`

## Changes

- Replace `_get_pyproject_version()` with `_get_canonical_version()`, deriving the
  version from the latest `vX.Y.Z` git tag (the same authority hatch-vcs uses),
  with a fallback to installed-distribution metadata.
- Update `check_version_consistency`, `check_package_version_consistency`, and
  `bump_version` to use it; correct the post-bump guidance to point at `git tag`.
- Rewrite `tests/unit/version/test_consistency.py` to inject the canonical version
  via a fixture; add coverage for the metadata fallback and the `scan_skills` path.

## Verification

All three CLIs now run successfully against the real repo:

```
hephaestus-check-version-consistency  -> exit 0 (canonical 0.9.0)
hephaestus-check-package-versions     -> exit 0
hephaestus-bump-version patch --dry-run -> "Would bump version: 0.9.0 -> 0.9.1"
```

`pixi run pytest tests/unit/version/test_consistency.py` → 31 passed. `mypy` clean.

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)