### PR TITLE
fix(io): make safe_write atomic via temp file and os.replace

### DIFF
--- a/hephaestus/io/utils.py
+++ b/hephaestus/io/utils.py
@@ -13,6 +13,8 @@ Usage:
 
 import json
 import os
+import tempfile
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
 
@@ -89,12 +91,18 @@ def safe_write(
     content: str | bytes,
     backup: bool = True,
 ) -> None:
-    """Write content to file safely with optional backup.
+    """Write content to a file atomically, with an optional backup.
+
+    The content is first written to a temporary file in the same directory and
+    then moved into place with :func:`os.replace`, which is atomic on POSIX and
+    Windows. An interrupted write (process kill, OOM, disk-full) therefore never
+    leaves a partially written file at ``filepath`` — the target either still
+    holds its previous contents or does not exist.
 
     Args:
         filepath: Path to file
         content: Content to write
-        backup: Whether to create backup of existing file
+        backup: Whether to create a ``.bak`` copy of an existing file first
 
     Raises:
         OSError: If the file cannot be written
@@ -110,10 +118,27 @@ def safe_write(
             _logger.warning("Could not create backup: %s", e)
 
     ensure_directory(filepath.parent)
-    if isinstance(content, str):
-        filepath.write_text(content)
-    else:
-        filepath.write_bytes(content)
+
+    data = content.encode() if isinstance(content, str) else content
+
+    # Write to a temp file in the same directory so os.replace() stays on one
+    # filesystem (cross-device renames are not atomic and raise OSError).
+    fd, tmp_name = tempfile.mkstemp(
+        dir=filepath.parent,
+        prefix=f".{filepath.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, filepath)
+    except BaseException:
+        # On any failure, do not leave the temp file behind.
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
 
 def write_secure(

--- a/tests/unit/io/test_utils.py
+++ b/tests/unit/io/test_utils.py
@@ -2,6 +2,7 @@
 """Tests for I/O utilities."""
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -112,6 +113,48 @@ class TestSafeWrite:
         f.write_text("original")
         safe_write(f, "updated", backup=False)
         assert not f.with_suffix(".txt.bak").exists()
+
+    def test_leaves_no_temp_files_on_success(self, tmp_path: Path) -> None:
+        """A successful write leaves only the target file, no temp artifacts."""
+        f = tmp_path / "test.txt"
+        safe_write(f, "content")
+        assert [p.name for p in tmp_path.iterdir()] == ["test.txt"]
+
+    def test_write_is_atomic_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure mid-write leaves the original file intact, never partial.
+
+        Regression for #439: safe_write must write via a temp file and atomic
+        rename so an interrupted write cannot corrupt the target.
+        """
+        f = tmp_path / "test.txt"
+        f.write_text("original-intact")
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError, match="simulated write failure"):
+            safe_write(f, "new-content-that-must-not-land", backup=False)
+
+        # The target still holds its original content — no partial write.
+        assert f.read_text() == "original-intact"
+
+    def test_failed_write_leaves_no_temp_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed write cleans up its temporary file."""
+        f = tmp_path / "test.txt"
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError, match="simulated failure"):
+            safe_write(f, "content", backup=False)
+
+        assert list(tmp_path.iterdir()) == []
 
 
 class TestWriteSecure:


### PR DESCRIPTION
## Summary

`io.safe_write()` created a `.bak` backup then called `Path.write_text` /
`write_bytes` directly. That is **not atomic** — a kill, OOM, or disk-full
between open-and-truncate and the final write left a partial or zero-byte file
at the target, despite `safe_write` being the advertised crash-safe public API.

## Changes

- `hephaestus/io/utils.py`: write to a temp file in the same directory, `fsync`,
  then `os.replace()` into place (atomic on POSIX and Windows). On any failure
  the temp file is removed and the target keeps its previous contents.
- `tests/unit/io/test_utils.py`: regression tests for atomicity on simulated
  failure and temp-file cleanup.

## Verification

`pixi run pytest tests/unit/io/test_utils.py` → 47 passed. `ruff` + `mypy` clean.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)