### PR TITLE
fix(io): consolidate write_secure into one atomic, restrictive-perms function

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -29,6 +29,7 @@ from hephaestus.github.rate_limit import (
     gh_rate_limit_reset_epoch,
     wait_until,
 )
+from hephaestus.io.utils import write_secure as io_write_secure
 
 from .claude_timeouts import gh_cli_timeout
 from .git_utils import get_repo_info, run
@@ -891,32 +892,18 @@ def fetch_issue_info(issue_number: int) -> IssueInfo:
 
 
 def write_secure(path: Path, content: str) -> None:
-    """Write content to file securely using atomic write.
+    """Write content to a file atomically with restrictive permissions.
+
+    Thin wrapper over the canonical :func:`hephaestus.io.utils.write_secure` so
+    automation state files share one atomic, ``0o600`` write implementation.
 
     Args:
         path: Destination file path
         content: Content to write
 
     """
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Write to temp file first, then atomic rename
-    fd, temp_path = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-    )
-
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write(content)
-        os.replace(temp_path, path)
-        logger.debug("Wrote %s bytes to %s", len(content), path)
-    except Exception:
-        # Clean up temp file on error
-        with contextlib.suppress(OSError):
-            os.unlink(temp_path)
-        raise
+    io_write_secure(path, content)
+    logger.debug("Wrote %s bytes to %s", len(content), path)
 
 
 def gh_pr_review_post(

--- a/hephaestus/io/utils.py
+++ b/hephaestus/io/utils.py
@@ -146,7 +146,13 @@ def write_secure(
     content: str,
     permissions: int = 0o600,
 ) -> None:
-    """Write content to file with restrictive permissions.
+    """Write content to a file atomically and with restrictive permissions.
+
+    The content is written to a temporary file in the same directory —
+    ``chmod``-ed to ``permissions`` before any content is written so it is never
+    world-readable — then moved into place with :func:`os.replace`, which is
+    atomic on POSIX and Windows. An interrupted write therefore never leaves a
+    partial or wrongly-permissioned file at ``filepath``.
 
     Args:
         filepath: Path to file
@@ -159,11 +165,25 @@ def write_secure(
     """
     filepath = Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    # Open with target permissions atomically to eliminate the race window
-    # between create (umask-default perms) and chmod.
-    fd = os.open(str(filepath), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, permissions)
-    with os.fdopen(fd, "w") as fh:
-        fh.write(content)
+
+    # Create the temp file in the same directory so os.replace() stays on one
+    # filesystem, then restrict its permissions before writing any content.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=filepath.parent,
+        prefix=f".{filepath.name}.",
+        suffix=".tmp",
+    )
+    try:
+        os.chmod(tmp_name, permissions)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_name, filepath)
+    except BaseException:
+        with suppress(OSError):
+            os.unlink(tmp_name)
+        raise
 
 
 def _detect_format(filepath: Path, format_hint: str | None) -> str:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -897,6 +897,17 @@ class TestWriteSecure:
             # Restore permissions for cleanup
             test_file.parent.chmod(0o755)
 
+    def test_writes_with_restrictive_permissions(self, tmp_path: Any) -> None:
+        """github_api.write_secure delegates to io.write_secure → 0o600 perms.
+
+        Regression for #443: the automation copy of write_secure used to write
+        with default permissions; consolidating onto hephaestus.io.write_secure
+        means state files are owner-only.
+        """
+        test_file = tmp_path / "state.json"
+        write_secure(test_file, "{}")
+        assert oct(test_file.stat().st_mode & 0o777) == oct(0o600)
+
 
 class TestGhCallThrottle:
     """Tests for the per-thread `gh` call throttle inside _gh_call."""

--- a/tests/unit/io/test_utils.py
+++ b/tests/unit/io/test_utils.py
@@ -197,6 +197,41 @@ class TestWriteSecure:
         write_secure(f, "new")
         assert f.read_text() == "new"
 
+    def test_write_is_atomic_on_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failure mid-write leaves the original file intact, never partial.
+
+        Regression for #443: write_secure must write via a temp file and atomic
+        rename so an interrupted write cannot corrupt the target.
+        """
+        f = tmp_path / "secret.txt"
+        f.write_text("original-secret")
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("simulated write failure")
+
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError, match="simulated write failure"):
+            write_secure(f, "new-secret-that-must-not-land")
+
+        assert f.read_text() == "original-secret"
+
+    def test_failed_write_leaves_no_temp_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed write cleans up its temporary file."""
+        f = tmp_path / "secret.txt"
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("simulated failure")
+
+        monkeypatch.setattr(os, "replace", boom)
+        with pytest.raises(OSError, match="simulated failure"):
+            write_secure(f, "data")
+
+        assert list(tmp_path.iterdir()) == []
+
 
 class TestDetectFormat:
     """Tests for _detect_format helper."""


### PR DESCRIPTION
## Summary

Two divergent `write_secure` implementations existed: `io.utils.write_secure` set
`0o600` perms but was not atomic; `automation.github_api.write_secure` was atomic
but wrote with default perms. Each lacked what the other had.

## Changes

- `hephaestus/io/utils.py`: `write_secure` is now both atomic (temp file +
  `os.replace`) and permission-restricting (temp file `chmod`-ed before content).
- `hephaestus/automation/github_api.py`: `write_secure` is now a thin re-export of
  the canonical `hephaestus.io` function — all callers converge.
- Tests: atomicity-on-failure for `io.write_secure`; `0o600` perms for the
  automation re-export.

## Verification

`pixi run pytest tests/unit/io tests/unit/automation` → 122 passed; the
import-cycle test still passes. `ruff` + `mypy` clean.

Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)