### PR TITLE
chore(packaging): mark Production/Stable and add Python 3.11/3.12 classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,11 +13,13 @@ authors = [
     { name = "Micah Villmow <research@villmow.us>" },
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Utilities",


### PR DESCRIPTION
## Summary

`pyproject.toml` trove classifiers declared `Development Status :: 4 - Beta` while
the project targets a 1.0 release, and listed only Python 3.10 and 3.13 despite CI
testing 3.10–3.13.

## Changes

- `Development Status :: 4 - Beta` → `5 - Production/Stable`.
- Added `Programming Language :: Python :: 3.11` and `:: 3.12`.

## Verification

`check-toml` pre-commit hook passes.

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)