### PR TITLE
docs(readme): widen install version pin from <1 to <2

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Add to `pyproject.toml`:
 ```toml
 [project]
 dependencies = [
-    "homericintelligence-hephaestus>=0.6.0,<1",
+    "homericintelligence-hephaestus>=0.6.0,<2",
 ]
 ```
 
@@ -140,7 +140,7 @@ Or add a PyPI entry to `pixi.toml`:
 
 ```toml
 [pypi-dependencies]
-homericintelligence-hephaestus = ">=0.6.0,<1"
+homericintelligence-hephaestus = ">=0.6.0,<2"
 ```
 
 Then run `pixi install` to resolve the dependency.


### PR DESCRIPTION
## Summary

The README's "Installing in Another Project" examples pinned
`homericintelligence-hephaestus` to `>=0.6.0,<1`. The `<1` upper bound excludes the
1.0 release — every consumer following the README would be locked out of 1.x.

## Changes

- `README.md`: both install examples (`pyproject.toml` and `pixi.toml`) now use `<2`.

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)