### PR TITLE
fix(packaging): restrict sdist to package source and metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,19 @@ version-file = "hephaestus/_version.py"
 [tool.hatch.build.targets.wheel]
 packages = ["hephaestus"]
 
+[tool.hatch.build.targets.sdist]
+# Ship only the package source plus essential metadata. Without this,
+# hatchling includes the whole repo (CI workflows, .claude config, tests,
+# scripts) in the source distribution. only-include uses exact path
+# anchoring so nested README.md files (.github/, docs/, scripts/) and
+# .gitignore are not swept in.
+only-include = [
+    "hephaestus",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py310"


### PR DESCRIPTION
## Summary

The source distribution had no `[tool.hatch.build.targets.sdist]` config, so
hatchling bundled the whole repo — **179 non-distributable files**: `.github/`
workflows, `.claude/` AI config, `.claude-plugin/` manifests, `tests/`, `scripts/`,
`pixi.lock`, and dev config. Users installing from sdist received CI workflows and
Claude Code settings.

## Changes

- `pyproject.toml`: add `[tool.hatch.build.targets.sdist]` with an `only-include`
  list (`hephaestus`, `README.md`, `LICENSE`, `pyproject.toml`). `only-include`
  anchors paths exactly so nested `README.md` files are not swept in.

## Verification

Rebuilt sdist: now contains the 108 `hephaestus/` files + `README.md` + `LICENSE` +
`pyproject.toml` + `PKG-INFO` + `.gitignore` (always added by hatchling, harmless).
Zero `.github/` / `.claude*/` / `tests/` / `scripts/` entries. Wheel unchanged.

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)