### PR TITLE
fix(cli): expose the CLI framework through the hephaestus.cli barrel

### DIFF
--- a/hephaestus/cli/__init__.py
+++ b/hephaestus/cli/__init__.py
@@ -1,5 +1,25 @@
 """Command-line interface tools."""
 
 from hephaestus.cli.colors import Colors
+from hephaestus.cli.utils import (
+    COMMAND_REGISTRY,
+    CommandRegistry,
+    add_logging_args,
+    confirm_action,
+    create_parser,
+    format_output,
+    format_table,
+    register_command,
+)
 
-__all__ = ["Colors"]
+__all__ = [
+    "COMMAND_REGISTRY",
+    "Colors",
+    "CommandRegistry",
+    "add_logging_args",
+    "confirm_action",
+    "create_parser",
+    "format_output",
+    "format_table",
+    "register_command",
+]

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -18,9 +18,22 @@ from importlib.metadata import version as _pkg_version
 from typing import Any
 
 try:
-    __version__ = _pkg_version("hephaestus")
+    # The PyPI distribution name is "HomericIntelligence-Hephaestus", which
+    # importlib.metadata does NOT normalize to the import name "hephaestus".
+    __version__ = _pkg_version("HomericIntelligence-Hephaestus")
 except PackageNotFoundError:
     __version__ = "unknown"
+
+__all__ = [
+    "COMMAND_REGISTRY",
+    "CommandRegistry",
+    "add_logging_args",
+    "confirm_action",
+    "create_parser",
+    "format_output",
+    "format_table",
+    "register_command",
+]
 
 
 class CommandRegistry:

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -201,3 +201,29 @@ class TestFormatOutput:
     def test_scalar_text(self) -> None:
         """Text format of a scalar returns its string representation."""
         assert format_output(42) == "42"
+
+
+class TestCliBarrelExports:
+    """Regression tests for #462: the cli package barrel exposes the framework."""
+
+    def test_framework_symbols_importable_from_cli_package(self) -> None:
+        """The CLI framework must be reachable via `from hephaestus.cli import ...`."""
+        from hephaestus.cli import (  # noqa: F401 - import is the assertion
+            COMMAND_REGISTRY,
+            Colors,
+            CommandRegistry,
+            add_logging_args,
+            confirm_action,
+            create_parser,
+            format_output,
+            format_table,
+            register_command,
+        )
+
+    def test_cli_all_lists_framework(self) -> None:
+        """hephaestus.cli.__all__ lists the framework symbols, not just Colors."""
+        import hephaestus.cli as cli
+
+        for symbol in ("create_parser", "COMMAND_REGISTRY", "format_table", "Colors"):
+            assert symbol in cli.__all__
+            assert hasattr(cli, symbol)


### PR DESCRIPTION
## Summary

`hephaestus/cli/__init__.py` exported only `Colors`. The CLI framework
(`CommandRegistry`, `COMMAND_REGISTRY`, `create_parser`, `add_logging_args`,
`confirm_action`, `format_table`, `format_output`, `register_command`) lived in
`cli/utils.py` and was unreachable via `from hephaestus.cli import create_parser`.

## Changes

- `cli/__init__.py`: re-export the framework symbols; `__all__` lists them + `Colors`.
- `cli/utils.py`: add an `__all__`; also fix the `__version__` lookup that used the
  wrong distribution name `"hephaestus"` (same bug class as #434) and resolved to
  `"unknown"`.
- `tests/unit/cli/test_utils.py`: regression test asserting the barrel exposes the
  framework.

## Verification

`from hephaestus.cli import create_parser, COMMAND_REGISTRY, format_table` works;
`pixi run pytest tests/unit/cli` → 28 passed; import-cycle test passes; `ruff` +
`mypy` clean.

Closes #462

🤖 Generated with [Claude Code](https://claude.com/claude-code)