### PR TITLE
fix(github): stop re-exporting CLI main() functions as library API

### DIFF
--- a/hephaestus/github/__init__.py
+++ b/hephaestus/github/__init__.py
@@ -1,11 +1,15 @@
 """GitHub utilities for ProjectHephaestus.
 
 Provides utilities for working with GitHub repositories, PRs, and automation.
+
+The CLI entry points for this subpackage (``hephaestus-merge-prs``,
+``hephaestus-fleet-sync``, ``hephaestus-tidy``) are intentionally NOT exported
+here: they are ``argparse``-driven ``main()`` functions that call ``sys.exit()``
+and are not safe for programmatic use. Run them as console scripts, or import
+them directly from their submodules (e.g. ``hephaestus.github.pr_merge:main``).
 """
 
-from hephaestus.github.fleet_sync import main as fleet_sync
 from hephaestus.github.pr_merge import detect_repo_from_remote, local_branch_exists
-from hephaestus.github.pr_merge import main as merge_prs
 from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_claude_usage_limit,
@@ -22,7 +26,6 @@ from hephaestus.github.stats import (
     get_prs_stats,
     validate_date,
 )
-from hephaestus.github.tidy import main as tidy
 
 __all__ = [
     "collect_stats",
@@ -30,16 +33,13 @@ __all__ = [
     "detect_claude_usage_limit",
     "detect_rate_limit",
     "detect_repo_from_remote",
-    "fleet_sync",
     "format_stats_table",
     "get_commits_stats",
     "get_current_repo",
     "get_issues_stats",
     "get_prs_stats",
     "local_branch_exists",
-    "merge_prs",
     "parse_reset_epoch",
-    "tidy",
     "validate_date",
     "wait_until",
 ]

--- a/tests/integration/test_package_import.py
+++ b/tests/integration/test_package_import.py
@@ -48,7 +48,7 @@ SUBPACKAGE_SYMBOLS = [
     ("hephaestus.logging", ["setup_logging", "get_logger", "ContextLogger", "JsonFormatter"]),
     ("hephaestus.system", ["get_system_info", "format_system_info"]),
     ("hephaestus.datasets", ["DatasetDownloader"]),
-    ("hephaestus.github", ["detect_repo_from_remote", "local_branch_exists", "merge_prs"]),
+    ("hephaestus.github", ["detect_repo_from_remote", "local_branch_exists", "collect_stats"]),
     ("hephaestus.config", ["load_config", "get_setting", "get_config_value", "merge_configs"]),
     ("hephaestus.cli", ["Colors"]),
     ("hephaestus.utils", ["slugify", "retry_with_backoff", "flatten_dict", "get_repo_root"]),


### PR DESCRIPTION
## Summary

`hephaestus/github/__init__.py` re-exported `merge_prs`, `fleet_sync`, and `tidy` —
`argparse`-driven CLI `main()` functions that call `sys.exit()` — as if they were
library API. `from hephaestus.github import merge_prs` then calling it yields an
unexpected `SystemExit`.

## Changes

- `github/__init__.py`: remove `merge_prs`/`fleet_sync`/`tidy` from imports and
  `__all__`. They remain available as console scripts and via submodule imports
  (`hephaestus.github.pr_merge:main`). Genuine library helpers stay exported.
- `tests/integration/test_package_import.py`: updated github symbol list.

## Verification

The barrel no longer exposes the CLI mains; submodule `main` imports and console
scripts still work; `pixi run pytest tests/unit/github tests/integration` → 221
passed; import-cycle test passes; `ruff` + `mypy` clean.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)