### PR TITLE
fix(ci): SHA-pin all actions in release/auto-tag/pre-commit workflows

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,19 +12,19 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           environments: lint
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -34,7 +34,7 @@ jobs:
             pixi-${{ runner.os }}-
 
       - name: Cache pre-commit environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload pre-commit diff
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: pre-commit-diffs
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,19 +21,19 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -50,19 +50,19 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -81,7 +81,7 @@ jobs:
     environment: pypi
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -105,13 +105,13 @@ jobs:
           git checkout "${TAG}"
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
           locked: false
 
       - name: Cache pixi environments
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:
           path: |
             .pixi
@@ -151,7 +151,7 @@ jobs:
           ls -1 dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           verbose: true
 
@@ -176,7 +176,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.existing.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true


### PR DESCRIPTION
## Summary

`release.yml`, `auto-tag.yml`, and `pre-commit.yml` used mutable version tags
(`@v6.0.2`, `@v0.9.5`, `@v5`, `@v7`, `@release/v1`, `@v3`). For workflows with
elevated permissions (`id-token: write`, `contents: write`) that publish to PyPI /
push tags, a compromised upstream tag would execute attacker-controlled code with
publish credentials. `_required.yml` already SHA-pins everything.

## Changes

SHA-pin every external action across the three workflows. Actions pinned:

- `actions/checkout` → `de0fac2e...  # v6.0.2`
- `actions/cache` → `27d5ce7f...  # v5`
- `actions/upload-artifact` → `043fb46d...  # v7.0.1`
- `prefix-dev/setup-pixi` → `1b2de7f3...  # v0.9.5`
- `pypa/gh-action-pypi-publish` → `cef22109...  # release/v1`
- `softprops/action-gh-release` → `b4309332...  # v3.0.0`

## Verification

`yamllint` passes; pre-commit workflow hooks pass.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)