### PR TITLE
fix(ci): enforce locked: true in CI pixi invocations

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           pixi-version: v0.63.2
           environments: lint
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
@@ -449,7 +449,7 @@ jobs:
         with:
           pixi-version: v0.63.2
           environments: lint
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           pixi-version: v0.63.2
           environments: lint
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: v0.63.2
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@v5
@@ -59,7 +59,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: v0.63.2
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@v5
@@ -108,7 +108,7 @@ jobs:
         uses: prefix-dev/setup-pixi@v0.9.5
         with:
           pixi-version: v0.63.2
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@v5

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           pixi-version: v0.63.2
           environments: lint
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
         with:
           pixi-version: v0.63.2
-          locked: false
+          locked: true
 
       - name: Cache pixi environments
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5


### PR DESCRIPTION
## Summary

All 8 `setup-pixi` invocations passed `locked: false`. The committed `pixi.lock`
was not enforced in CI test/lint/release runs — pixi was free to re-resolve to
newer packages than the lockfile records, defeating the point of committing a lock.

## Changes

Switch every `locked: false` → `locked: true` across `_required.yml`, `test.yml`,
`security.yml`, `pre-commit.yml`, and `release.yml`.

## Verification

`yamllint` passes; 0 occurrences of `locked: false` remain.

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)