### PR TITLE
docs(releasing): add rollback procedure and correct pre-release checklist

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -30,11 +30,12 @@ workflow_dispatch (Auto Tag Release)
 Before triggering the workflow, ensure:
 
 - [ ] All changes merged to `main` and CI is green.
-- [ ] `pyproject.toml` `[project].version` matches the **current** released version (the tag step
-  will increment it in the tag name, but the package version at HEAD must equal the *new* tag or
-  the "verify tag matches package version" step will fail). Update `pyproject.toml` and run
-  `pixi run python -m hephaestus.version.manager` before merging if needed.
 - [ ] `pixi.lock` is up to date (`pixi install` produces no changes).
+- [ ] No open issues in the milestone you are releasing.
+
+The version itself does **not** need to be edited in any file: this project uses
+hatch-vcs dynamic versioning, so the package version is derived from the git tag the
+`auto-tag` workflow pushes. There is no `[project].version` field to bump.
 
 ## Manual Tag + Release (escape hatch)
 
@@ -47,3 +48,73 @@ or supply a tag name (e.g. `v0.8.0`) to release a specific ref.
 Publishing uses OIDC trusted publishing — no `PYPI_API_TOKEN` secret is needed. The workflow runs
 in the `pypi` GitHub Environment which must have the corresponding trusted publisher configured on
 PyPI. See the [PyPI documentation](https://docs.pypi.org/trusted-publishers/) for setup.
+
+## Rollback
+
+A release produces a published-then-immutable PyPI artifact plus a git tag and a
+GitHub Release. Options are listed below by escalating impact; prefer the lowest-impact
+option that addresses the problem.
+
+### 1. Yank from PyPI (recommended for shipped-but-broken releases)
+
+[Yanking](https://pypi.org/help/#yanked) keeps the release on PyPI for users who pin
+the exact version, but hides it from new resolvers. Existing installs are not affected.
+
+Yanking is performed by a project owner from the PyPI web UI:
+
+```text
+PyPI project page → Manage → Releases → vX.Y.Z → Options → Yank
+```
+
+### 2. Edit or delete the GitHub Release
+
+```bash
+# Mark as pre-release (hides from "Latest"):
+gh release edit vX.Y.Z --prerelease
+
+# Or delete the GitHub Release entry:
+gh release delete vX.Y.Z --cleanup-tag    # also deletes the git tag
+gh release delete vX.Y.Z                  # GitHub Release only; tag stays
+```
+
+The release workflow is **idempotent** (see #432): re-running it on an existing tag
+re-attaches build artifacts without duplicating the GitHub Release.
+
+### 3. Ship a hotfix (preferred for forward-fix)
+
+Yanking does not retract a bad release for users already on it. The cleanest fix is
+a new patch release:
+
+```bash
+# 1. Branch from the bad tag
+git checkout -b hotfix/vX.Y.Zp1 vX.Y.Z
+
+# 2. Apply the fix (with tests). One issue per PR per CONTRIBUTING.md.
+
+# 3. Open + merge a PR targeting main.
+
+# 4. Trigger the Auto Tag Release workflow with bump_kind=patch.
+```
+
+The new patch publishes via the normal release pipeline and supersedes the bad
+release for new installs.
+
+### 4. Delete the git tag (last resort)
+
+Once a tag is pushed and a PyPI release published, deleting the tag does not
+unpublish PyPI and breaks reproducibility for anyone who fetched the tag. Use only
+for tags that **never** reached PyPI:
+
+```bash
+git push --delete origin vX.Y.Z
+git tag -d vX.Y.Z
+```
+
+### Recovery summary
+
+| Situation | Action |
+|-----------|--------|
+| Bad release on PyPI, fix is ready | Ship a patch (option 3); optionally yank the bad version (option 1). |
+| Bad release on PyPI, no fix yet | Yank (option 1) + mark the GitHub Release as pre-release (option 2). |
+| Tag pushed but PyPI publish failed | Delete the tag (option 4) and re-trigger after fixing the workflow. |
+| GitHub Release notes are wrong | `gh release edit vX.Y.Z --notes-file …` — no PyPI impact. |


### PR DESCRIPTION
## Summary

`docs/RELEASING.md` had two defects: no rollback procedure (operational risk for a
1.0 release) and a pre-release checklist still telling maintainers to edit
`pyproject.toml [project].version` — a field that doesn't exist under hatch-vcs (#437).

## Changes

- Add a **Rollback** section: yank from PyPI, edit/delete the GitHub Release, ship a
  hotfix, last-resort tag deletion, plus a recovery-summary table.
- Correct the pre-release checklist to reflect hatch-vcs reality (no file edit needed).

## Verification

`markdownlint-cli2` passes.

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)