### PR TITLE
fix(ci): expand test matrix to macOS and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         test-type: [unit, integration]
+    # `shell: bash` for every run step keeps the same script working on
+    # Windows runners (which would otherwise default to PowerShell).
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -77,7 +82,6 @@ jobs:
       - name: Run unit tests
         if: matrix.test-type == 'unit'
         run: pytest tests/unit --override-ini="addopts=" -v --strict-markers --cov=hephaestus --cov-report=term-missing --cov-report=xml --cov-fail-under=80
-        shell: bash
 
       - name: Check unit test structure
         if: matrix.test-type == 'unit'


### PR DESCRIPTION
## Summary

`test.yml` ran tests on `ubuntu-latest` only despite the library being pure-Python
and shipping as `py3-none-any`. The ROADMAP names multi-platform CI as a 1.0 goal.

## Changes

- `test.yml`: matrix `os: [ubuntu-latest, macos-latest, windows-latest]`.
- Add `defaults.run.shell: bash` so existing scripts keep working on Windows runners.

## Verification

`yamllint` clean (one pre-existing line-length warning, not introduced here).

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)