### PR TITLE
fix(security): close 3 defects in datasets/downloader.py

### DIFF
--- a/hephaestus/datasets/downloader.py
+++ b/hephaestus/datasets/downloader.py
@@ -25,7 +25,9 @@ Usage::
 
 from __future__ import annotations
 
+import contextlib
 import gzip
+import hashlib
 import pickle
 import struct
 import sys
@@ -39,6 +41,56 @@ from urllib.request import Request, urlopen
 from hephaestus.logging.utils import get_logger
 
 logger = get_logger(__name__)
+
+# Per-file MD5 checksums for integrity verification. Values are the
+# upstream-published MD5s used by torchvision; they detect MITM tampering and
+# CDN corruption. MD5 is fit-for-purpose here because the checksum comes from
+# a trusted source (the dataset distributor), not the network response.
+_DATASET_MD5: dict[str, str] = {
+    # CIFAR
+    "cifar-10-python.tar.gz": "c58f30108f718f92721af3b95e74349a",
+    "cifar-100-python.tar.gz": "eb9058c3a382ffc7106e4002c42a8d85",
+    # Fashion-MNIST
+    "train-images-idx3-ubyte.gz": "8d4fb7e6c68d591d4c3dfef9ec88bf0d",
+    "train-labels-idx1-ubyte.gz": "25c81989df183df01b3e8a0aad5dffbe",
+    "t10k-images-idx3-ubyte.gz": "bef4ecab320f06d8554ea6380940ec79",
+    "t10k-labels-idx1-ubyte.gz": "bb300cfdad3c16e7a12a480ee83cd310",
+}
+
+
+def _file_md5(path: Path) -> str:
+    """Return the hex MD5 digest of *path*'s contents."""
+    h = hashlib.md5(usedforsecurity=False)
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def _verify_or_remove(path: Path, filename: str) -> bool:
+    """Verify *path* against the known MD5 for *filename*.
+
+    Returns True if the file matches the expected MD5 (or no checksum is known —
+    in which case the caller proceeds without verification, logged). Returns
+    False if the checksum is known and does not match; in that case the file is
+    removed so the next download attempt produces a fresh copy.
+    """
+    expected = _DATASET_MD5.get(filename)
+    if expected is None:
+        logger.warning("No checksum recorded for %s — skipping verification", filename)
+        return True
+    actual = _file_md5(path)
+    if actual == expected:
+        return True
+    logger.error(
+        "Checksum mismatch for %s: expected %s, got %s — discarding download",
+        filename,
+        expected,
+        actual,
+    )
+    with contextlib.suppress(OSError):
+        path.unlink()
+    return False
 
 
 class DatasetDownloader:
@@ -118,6 +170,9 @@ class DatasetDownloader:
                                 )
 
                 print()  # terminates the progress bar line
+                if not _verify_or_remove(output_path, filename):
+                    last_error = "checksum mismatch"
+                    continue
                 return True
 
             except HTTPError as e:
@@ -222,7 +277,7 @@ class FashionMNISTDownloader(DatasetDownloader):
 
     def __init__(self) -> None:
         """Initialize with the Fashion-MNIST dataset URL."""
-        super().__init__("http://fashion-mnist.s3-website.eu-central-1.amazonaws.com")
+        super().__init__("https://fashion-mnist.s3-website.eu-central-1.amazonaws.com")
         self.files = [
             ("train-images-idx3-ubyte.gz", "train_images.idx"),
             ("train-labels-idx1-ubyte.gz", "train_labels.idx"),
@@ -313,7 +368,9 @@ class CIFAR10Downloader(DatasetDownloader):
         batch_dir = output_path / "cifar-10-batches-py"
         try:
             with tarfile.open(tar_path) as tf:
-                tf.extractall(output_path)
+                # filter='data' (Python 3.12+) rejects members with absolute or
+                # ../-traversing paths, blocking the CWE-22 zip-slip class.
+                tf.extractall(output_path, filter="data")
         except (tarfile.TarError, OSError) as exc:
             logger.error("Failed to extract CIFAR-10 tarball: %s", exc)
             return False
@@ -434,7 +491,9 @@ class CIFAR100Downloader(DatasetDownloader):
         logger.info("Extracting CIFAR-100 tarball...")
         try:
             with tarfile.open(tar_path) as tf:
-                tf.extractall(output_path)
+                # filter='data' (Python 3.12+) rejects members with absolute or
+                # ../-traversing paths, blocking the CWE-22 zip-slip class.
+                tf.extractall(output_path, filter="data")
         except (tarfile.TarError, OSError) as exc:
             logger.error("Failed to extract CIFAR-100 tarball: %s", exc)
             return False

--- a/tests/unit/datasets/test_downloader.py
+++ b/tests/unit/datasets/test_downloader.py
@@ -402,9 +402,9 @@ class TestSecurityHardening:
 
     def test_extractall_uses_data_filter(self) -> None:
         """Both CIFAR extract sites pass filter='data' to extractall (CWE-22)."""
-        import hephaestus.datasets.downloader as mod
+        from hephaestus.datasets.downloader import __file__ as downloader_file
 
-        src = Path(mod.__file__).read_text()
+        src = Path(downloader_file).read_text()
         # Two extract sites, both with the filter.
         assert src.count('tf.extractall(output_path, filter="data")') == 2
         # No bare extractall(output_path) without filter.

--- a/tests/unit/datasets/test_downloader.py
+++ b/tests/unit/datasets/test_downloader.py
@@ -352,3 +352,65 @@ class TestEMNISTDownloader:
     @patch.object(DatasetDownloader, "download_with_retry", return_value=False)
     def test_download_failure_all_mirrors(self, _mock, tmp_path: Path) -> None:
         assert EMNISTDownloader().download_emnist("balanced", str(tmp_path)) is False
+
+
+class TestSecurityHardening:
+    """Regression tests for #478: checksum verification + safe tar extraction."""
+
+    def test_dataset_md5_includes_known_files(self) -> None:
+        """The per-file MD5 map covers CIFAR + Fashion-MNIST downloads."""
+        from hephaestus.datasets.downloader import _DATASET_MD5
+
+        for name in (
+            "cifar-10-python.tar.gz",
+            "cifar-100-python.tar.gz",
+            "train-images-idx3-ubyte.gz",
+            "t10k-images-idx3-ubyte.gz",
+        ):
+            assert name in _DATASET_MD5
+
+    def test_verify_or_remove_passes_for_correct_md5(self, tmp_path: Path) -> None:
+        """A file matching the known MD5 verifies True and is kept."""
+        from hephaestus.datasets.downloader import _DATASET_MD5, _verify_or_remove
+
+        name = "cifar-10-python.tar.gz"
+        target = tmp_path / name
+        target.write_bytes(b"")  # MD5 of empty = d41d8cd98f00b204e9800998ecf8427e
+        # Patch the expected MD5 to the digest of the bytes we just wrote.
+        with patch.dict(_DATASET_MD5, {name: "d41d8cd98f00b204e9800998ecf8427e"}):
+            assert _verify_or_remove(target, name) is True
+        assert target.exists()
+
+    def test_verify_or_remove_removes_on_mismatch(self, tmp_path: Path) -> None:
+        """A file failing the MD5 check is verified False AND deleted."""
+        from hephaestus.datasets.downloader import _verify_or_remove
+
+        target = tmp_path / "cifar-10-python.tar.gz"
+        target.write_bytes(b"tampered content")
+        # The real MD5 in _DATASET_MD5 will not match — the helper must remove.
+        assert _verify_or_remove(target, "cifar-10-python.tar.gz") is False
+        assert not target.exists()
+
+    def test_verify_or_remove_unknown_filename_passes_with_warning(self, tmp_path: Path) -> None:
+        """A file with no recorded checksum is allowed through (logged)."""
+        from hephaestus.datasets.downloader import _verify_or_remove
+
+        target = tmp_path / "novel.bin"
+        target.write_bytes(b"x")
+        assert _verify_or_remove(target, "novel.bin") is True
+        assert target.exists()
+
+    def test_extractall_uses_data_filter(self) -> None:
+        """Both CIFAR extract sites pass filter='data' to extractall (CWE-22)."""
+        import hephaestus.datasets.downloader as mod
+
+        src = Path(mod.__file__).read_text()
+        # Two extract sites, both with the filter.
+        assert src.count('tf.extractall(output_path, filter="data")') == 2
+        # No bare extractall(output_path) without filter.
+        assert "tf.extractall(output_path)\n" not in src
+
+    def test_fashion_mnist_url_is_https(self) -> None:
+        """Fashion-MNIST downloader uses HTTPS, not plain HTTP."""
+        d = FashionMNISTDownloader()
+        assert d.base_url.startswith("https://")


### PR DESCRIPTION
## Summary

Three related security gaps in `hephaestus/datasets/downloader.py`:

1. **Unsafe `tarfile.extractall()`** (CIFAR-10/100 sites) — no path filter, so a
   crafted tarball can write outside the target directory (CWE-22 zip-slip).
2. **No checksum verification** — MITM or compromised CDN could substitute
   malicious content undetected.
3. **Plain HTTP for Fashion-MNIST** — contradicted SECURITY.md's HTTPS claim.

## Changes

- Pass `filter='data'` to both `tf.extractall(...)` calls. The backport is in
  Python 3.10.12 / 3.11.4 / 3.12+, all supported versions.
- Add `_DATASET_MD5` (per-file upstream-published MD5s, matching torchvision) and a
  `_verify_or_remove` helper that runs inside `download_with_retry` so every
  download is checksum-checked; mismatches discard the file and the retry loop
  re-attempts.
- Switch the Fashion-MNIST base URL from `http://` to `https://`.
- 6 regression tests cover the MD5 map, verify-or-remove behavior on
  match/mismatch/unknown, the extract filter, and the HTTPS URL.

## Verification

`pixi run pytest tests/unit/datasets` → 42 passed; `ruff` + `mypy` clean.

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)