### PR TITLE
fix(deps): align pyproject ranges with pixi.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["utilities", "helpers", "tooling", "homericintelligence"]
 dependencies = [
     "packaging>=21.0,<27",
     "pyyaml>=6.0,<7",
-    "pydantic>=2.0,<3",
+    "pydantic>=2.12.5,<3",
 ]
 
 [project.optional-dependencies]
@@ -37,9 +37,9 @@ dev = [
     "pytest-cov>=7.0,<8",
     "pre-commit>=3.0,<5",
     "ruff>=0.1.0,<1",
-    "mypy>=1.8.0,<3",
+    "mypy>=1.8.0,<2",
     "build>=1.0,<2",
-    "pip-audit>=2.6,<3",
+    "pip-audit>=2.7,<3",
     "tomli>=2.0,<3;python_version<'3.11'",
 ]
 github = [


### PR DESCRIPTION
## Summary

pyproject.toml and pixi.toml declared different bounds for three shared dev deps —
CI tested only the pixi bounds, so `pip install .[dev]` could resolve untested
versions (e.g. pydantic 2.0–2.12.4 or mypy 2.x).

## Changes

- `pydantic`: `>=2.0,<3` → `>=2.12.5,<3` (matches pixi).
- `mypy`: `>=1.8.0,<3` → `>=1.8.0,<2` (matches pixi).
- `pip-audit`: `>=2.6,<3` → `>=2.7,<3` (matches pixi).

## Verification

`check-toml` pre-commit hook passes.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)