### PR TITLE
fix(deps): allow library extras in dep-sync check and wire it into pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,18 @@ repos:
         pass_filenames: false
         files: ^(pyproject\.toml|pixi\.toml)$
 
+  # Dependency-sync check: requirements*.txt entries must exist in pixi.toml
+  # and fall within the declared range. See hephaestus.config.dep_sync.
+  - repo: local
+    hooks:
+      - id: check-dep-sync
+        name: Check dependency declarations are consistent
+        description: Validate requirements*.txt entries against pixi.toml
+        entry: pixi run hephaestus-check-dep-sync
+        language: system
+        pass_filenames: false
+        files: ^(pyproject\.toml|pixi\.toml|pixi\.lock|requirements.*\.txt)$
+
   # Forbid silent-failure workarounds (|| true / continue-on-error: true).
   # See HomericIntelligence/Odysseus#280.
   - repo: local

--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -4,9 +4,10 @@ Provides two main operations:
 
 **Check** (``hephaestus-check-dep-sync``): Validates that every package pinned in
 ``requirements*.txt`` has a corresponding entry in ``pixi.toml`` and that the
-pinned version falls within the ``pixi.toml`` range constraint.  Also reports if
-``pyproject.toml`` still carries ``[project.dependencies]`` (which should be
-managed in ``pixi.toml`` instead).
+pinned version falls within the ``pixi.toml`` range constraint. For a library
+distributed via PyPI, ``[project.dependencies]`` and ``[project.optional-dependencies]``
+in ``pyproject.toml`` are the public install contract and are intentionally
+**not** flagged.
 
 **Sync** (``hephaestus-sync-requirements``): Re-generates ``requirements.txt`` and
 ``requirements-dev.txt`` from the pixi-resolved environment (``pixi list --json``),
@@ -213,30 +214,6 @@ def parse_requirements(path: Path) -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def check_pyproject_no_deps(path: Path) -> list[str]:
-    """Return errors if ``pyproject.toml`` carries managed dependency sections.
-
-    Flags ``[project.dependencies]`` and ``[project.optional-dependencies]``
-    which should be managed in ``pixi.toml`` instead.
-
-    Args:
-        path: Path to ``pyproject.toml``.
-
-    Returns:
-        List of error strings.
-
-    """
-    errors: list[str] = []
-    if not path.exists():
-        return errors
-    text = path.read_text(encoding="utf-8")
-    if re.search(r"^\[project\.dependencies\]", text, re.MULTILINE):
-        errors.append("pyproject.toml contains [project.dependencies] — remove it")
-    if "[project.optional-dependencies]" in text:
-        errors.append("pyproject.toml contains [project.optional-dependencies] — remove it")
-    return errors
-
-
 def check_requirements_against_pixi(
     repo_root: Path,
     pixi_deps_lower: dict[str, str],
@@ -297,7 +274,6 @@ def check_dep_sync(repo_root: Path | None = None) -> list[str]:
     pixi_deps_lower = {k.lower(): v for k, v in pixi_deps.items()}
 
     errors.extend(check_requirements_against_pixi(repo_root, pixi_deps_lower))
-    errors.extend(check_pyproject_no_deps(repo_root / "pyproject.toml"))
     return errors
 
 

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -14,7 +14,6 @@ from hephaestus.config.dep_sync import (
     _parse_version,
     _version_satisfies,
     check_dep_sync,
-    check_pyproject_no_deps,
     check_requirements_against_pixi,
     check_requirements_up_to_date,
     generate_requirements_content,
@@ -228,32 +227,6 @@ class TestParseRequirements:
         req.write_text("")
         result = parse_requirements(req)
         assert result == {}
-
-
-class TestCheckPyprojectNoDeps:
-    """Tests for check_pyproject_no_deps()."""
-
-    def test_no_deps_returns_empty(self, tmp_path: Path) -> None:
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text("[project]\nname = 'foo'\n")
-        errors = check_pyproject_no_deps(pyproject)
-        assert errors == []
-
-    def test_flags_project_dependencies(self, tmp_path: Path) -> None:
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text("[project.dependencies]\nrequests = '>=2'\n")
-        errors = check_pyproject_no_deps(pyproject)
-        assert any("[project.dependencies]" in e for e in errors)
-
-    def test_flags_optional_dependencies(self, tmp_path: Path) -> None:
-        pyproject = tmp_path / "pyproject.toml"
-        pyproject.write_text("[project.optional-dependencies]\ndev = ['pytest']\n")
-        errors = check_pyproject_no_deps(pyproject)
-        assert any("[project.optional-dependencies]" in e for e in errors)
-
-    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
-        errors = check_pyproject_no_deps(tmp_path / "nonexistent.toml")
-        assert errors == []
 
 
 class TestCheckRequirementsAgainstPixi:


### PR DESCRIPTION
## Summary

`hephaestus-check-dep-sync` existed but was wired to nothing — and **failed** on
the project's own pyproject.toml because `check_pyproject_no_deps` forbade
`[project.optional-dependencies]`. That policy fits an application project, not a
PyPI library: hephaestus *needs* `[project.dependencies]` and
`[project.optional-dependencies]` (otherwise `pip install hephaestus[github]`
doesn't work).

## Changes

- `hephaestus/config/dep_sync.py`: delete `check_pyproject_no_deps` + its call
  site; update the module docstring to reflect library reality.
- `tests/unit/config/test_dep_sync.py`: drop the obsolete test class + import.
- `.pre-commit-config.yaml`: add a `check-dep-sync` hook that runs on changes to
  pyproject.toml / pixi.toml / pixi.lock / requirements*.txt.

## Verification

`hephaestus-check-dep-sync` → `OK: all dependency declarations are consistent`;
`pixi run pytest tests/unit/config/test_dep_sync.py` → 76 passed; pre-commit hook
passes.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)