### PR TITLE
docs: list all 19 subpackages in README/docs/index/CLAUDE trees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,19 +25,26 @@ ProjectHephaestus is the shared utilities and tooling repository of the HomericI
 
 ```text
 ProjectHephaestus/
-├── hephaestus/                 # Python source code
-│   ├── utils/                  # General utility functions (slugify, retry, subprocess)
-│   ├── config/                 # Configuration management
-│   ├── logging/                # Logging utilities
-│   ├── io/                     # Input/output utilities
-│   ├── cli/                    # Command-line interface tools
-│   ├── system/                 # System information collection
-│   ├── github/                 # GitHub automation (PR merging)
-│   ├── datasets/               # Dataset downloading utilities
-│   ├── markdown/               # Markdown linting and link fixing
+├── hephaestus/                 # Python source code (19 subpackages)
+│   ├── agents/                 # Agent frontmatter + loader + runtime
+│   ├── automation/             # Issue planning / implementation / PR review pipeline
 │   ├── benchmarks/             # Benchmark comparison utilities
-│   ├── version/                # Version management
-│   └── validation/             # README and config validation
+│   ├── ci/                     # CI helpers (precommit, workflows, docker timing)
+│   ├── cli/                    # Command-line interface tools
+│   ├── config/                 # Configuration management
+│   ├── datasets/               # Dataset downloading utilities
+│   ├── discovery/              # Discovery of agents, skills, and code blocks
+│   ├── forensics/              # Coredump capture + gdb post-mortem runner
+│   ├── github/                 # GitHub automation (PR merging, fleet sync, tidy, stats)
+│   ├── io/                     # Input/output utilities
+│   ├── logging/                # Logging utilities
+│   ├── markdown/               # Markdown linting and link fixing
+│   ├── nats/                   # NATS JetStream subscriber (event-driven workflows)
+│   ├── resilience/             # Circuit breaker + retry + subprocess resilience
+│   ├── system/                 # System information collection
+│   ├── utils/                  # General utility functions (slugify, retry, subprocess)
+│   ├── validation/             # README, schema, and structural validation
+│   └── version/                # Version management
 ├── scripts/                    # Automation and maintenance scripts
 ├── tests/                      # Unit and integration tests
 │   ├── unit/                   # Unit tests (mirrors hephaestus/ structure)

--- a/README.md
+++ b/README.md
@@ -21,18 +21,25 @@ ProjectHephaestus/
 ├── pyproject.toml     # Python package configuration
 ├── hephaestus/        # Main package
 │   ├── __init__.py
-│   ├── utils/         # General utility functions (slugify, retry, subprocess)
-│   ├── config/        # Configuration utilities (YAML, JSON, env vars)
-│   ├── io/            # I/O utilities (read, write, safe_write, load/save data)
-│   ├── cli/           # CLI helpers (argument parsing, output formatting)
-│   ├── logging/       # Logging utilities (ContextLogger, setup_logging)
-│   ├── system/        # System information collection
-│   ├── github/        # GitHub automation (PR merging)
-│   ├── datasets/      # Dataset downloading utilities
-│   ├── markdown/      # Markdown linting and link fixing
+│   ├── agents/        # Agent frontmatter + loader + runtime
+│   ├── automation/    # Issue planning / implementation / PR review pipeline
 │   ├── benchmarks/    # Benchmark comparison utilities
-│   ├── version/       # Version management
-│   └── validation/    # README and config validation
+│   ├── ci/            # CI helpers (precommit, workflows, docker timing)
+│   ├── cli/           # CLI helpers (argument parsing, output formatting)
+│   ├── config/        # Configuration utilities (YAML, JSON, env vars)
+│   ├── datasets/      # Dataset downloading utilities
+│   ├── discovery/     # Discovery of agents, skills, and code blocks
+│   ├── forensics/     # Coredump capture + gdb post-mortem runner
+│   ├── github/        # GitHub automation (PR merging, fleet sync, tidy, stats)
+│   ├── io/            # I/O utilities (read, write, safe_write, load/save data)
+│   ├── logging/       # Logging utilities (ContextLogger, setup_logging)
+│   ├── markdown/      # Markdown linting and link fixing
+│   ├── nats/          # NATS JetStream subscriber (event-driven workflows)
+│   ├── resilience/    # Circuit breaker + retry + subprocess resilience primitives
+│   ├── system/        # System information collection
+│   ├── utils/         # General utility functions (slugify, retry, subprocess)
+│   ├── validation/    # README, schema, and structural validation
+│   └── version/       # Version management (hatch-vcs + consistency checks)
 ├── tests/             # Unit tests
 ├── docs/              # Documentation
 ├── scripts/           # Utility scripts

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,18 +8,25 @@ ProjectHephaestus is the shared utilities and tooling library for the HomericInt
 
 ## Subpackages
 
-- **hephaestus.utils** — General utility functions (slugify, retry, subprocess helpers)
+- **hephaestus.agents** — Agent frontmatter, loader, runtime, stats
+- **hephaestus.automation** — Issue planning / implementation / PR review pipeline
+- **hephaestus.benchmarks** — Benchmark comparison and regression detection
+- **hephaestus.ci** — CI helpers (precommit, workflows, docker timing)
+- **hephaestus.cli** — CLI argument parsing and output formatting
 - **hephaestus.config** — Configuration loading and management (YAML, JSON, env vars)
+- **hephaestus.datasets** — Dataset downloading utilities
+- **hephaestus.discovery** — Discovery of agents, skills, and code blocks
+- **hephaestus.forensics** — Coredump capture and gdb post-mortem runner
+- **hephaestus.github** — GitHub automation (PR merging, fleet sync, tidy, stats, rate limit)
 - **hephaestus.io** — File I/O utilities (read, write, safe_write, load/save data)
 - **hephaestus.logging** — Enhanced logging (ContextLogger, setup_logging)
-- **hephaestus.cli** — CLI argument parsing and output formatting
+- **hephaestus.markdown** — Markdown linting, link fixing, anchor validation
+- **hephaestus.nats** — NATS JetStream subscriber for event-driven workflows
+- **hephaestus.resilience** — Circuit breaker + retry + subprocess resilience primitives
 - **hephaestus.system** — System information collection
-- **hephaestus.github** — GitHub automation (PR merging)
-- **hephaestus.datasets** — Dataset downloading utilities
-- **hephaestus.markdown** — Markdown linting and link fixing
-- **hephaestus.benchmarks** — Benchmark comparison and regression detection
-- **hephaestus.version** — Version management utilities
-- **hephaestus.validation** — README and config validation
+- **hephaestus.utils** — General utility functions (slugify, retry, subprocess helpers)
+- **hephaestus.validation** — README, schema, and structural validation
+- **hephaestus.version** — Version management (hatch-vcs + consistency checks)
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

Three docs listed the hephaestus subpackage tree, each omitting the same 7
subpackages (agents, automation, ci, discovery, forensics, nats, resilience).
Only 12 of the actual 19 were listed — yet these missing ones expose console
scripts like `hephaestus-plan-issues`, `hephaestus-coredump-handler`,
`hephaestus-agent-stats`.

## Changes

- `README.md`, `docs/index.md`, `CLAUDE.md`: list all 19 subpackages with one-line
  descriptions matching each package's actual purpose.

## Verification

`markdownlint-cli2` passes on all three files.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)