### PR TITLE
docs(security): update stale supported-versions table

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-As of 2026-05-10. Python >= 3.10 required.
+As of 2026-05-24. Python >= 3.10 required.
 
-| Version | Supported            |
-|---------|----------------------|
-| 0.7.x   | ✅ Supported         |
-| 0.6.x   | ✅ Supported         |
-| < 0.6   | ❌ End of life       |
+| Version | Supported       |
+|---------|-----------------|
+| 1.x     | ✅ Supported    |
+| 0.9.x   | ✅ Supported    |
+| < 0.9   | ❌ End of life  |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

`SECURITY.md` listed 0.7.x and 0.6.x as supported and omitted 0.8.x / 0.9.x
entirely. The current version is 0.9.0 targeting 1.0.

## Changes

Update the table to: 1.x supported, 0.9.x supported (last 0.x line), older 0.x EOL.
Refresh the date header.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)