### PR TITLE
docs(scripts): list all 22 scripts in scripts/README.md

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,61 +1,93 @@
 # Scripts Directory
 
-This directory contains CLI wrapper scripts for ProjectHephaestus utilities.
+CLI wrapper scripts and shell helpers for ProjectHephaestus. Most Python
+scripts here are thin wrappers around the corresponding `hephaestus.*` module
+exposed via a `[project.scripts]` entry — they exist for local invocation
+without needing the console script on `$PATH`.
 
 ## Available Scripts
 
-### Validation Scripts
+### Validation / pre-commit checks
 
-- **check_unit_test_structure.py** - Verify unit test directory mirrors source structure
-- **check_python_version_consistency.py** - Check Python version consistency across config files
-- **validate_readme_commands.py** - Validate commands in README code blocks
+- **`check_cli_table_sync.py`** — Verify the README CLI table documents every
+  `[project.scripts]` entry. Wired into pre-commit.
+- **`check_python_version_consistency.py`** — Check the Python version is
+  consistent across pyproject.toml, pixi.toml, and CI configs.
+- **`check_tier_labels.py`** — Check the `tier-X` issue/PR labels match the
+  policy.
+- **`check_unit_test_structure.py`** — Verify `tests/unit/` mirrors the
+  `hephaestus/` subpackage layout. Wired into pre-commit.
+- **`check_version_single_source.py`** — Validate the project has a single
+  authoritative version source (hatch-vcs git tags) and `pixi.toml` has no
+  version field. Wired into pre-commit.
+- **`audit_doc_policy.py`** — Audit documentation against the CLAUDE.md doc
+  policy (e.g. no CHANGELOG.md).
+- **`validate_readme_commands.py`** — Validate that commands shown in README
+  code blocks actually run.
+- **`check-symlinks.sh`** — Detect broken symlinks in the repo.
 
-### Markdown Scripts
+### Markdown
 
-- **fix_invalid_links.py** - Fix invalid absolute path links in markdown files
+- **`fix_invalid_links.py`** — Fix invalid absolute-path links in markdown
+  files (wraps `hephaestus.markdown.link_fixer`).
 
-### Git/GitHub Scripts
+### Automation pipeline (Claude/Codex agent orchestration)
 
-- **merge_prs.py** - Merge pull requests with successful CI/CD
+Each of these is a tiny wrapper around the matching `hephaestus.automation.*`
+module — most users invoke the `hephaestus-*` console scripts instead.
 
-### Version Scripts
+- **`plan_issues.py`** → `hephaestus-plan-issues` (bulk issue planning).
+- **`implement_issues.py`** → `hephaestus-implement-issues` (bulk issue
+  implementation in parallel worktrees).
+- **`review_issues.py`** → read-only issue review.
+- **`review_plans.py`** → plan-phase review.
+- **`address_review.py`** → resolve PR review threads.
+- **`drive_prs_green.py`** → drive open PRs to green CI.
+- **`run_automation_loop.sh`** — Glue script that drives the full 6-phase
+  pipeline (plan → review → implement → review → PR → follow-up).
 
-- **update_version.py** - Update version numbers across project files
+### GitHub
 
-### Benchmark Scripts
+- **`merge_prs.py`** → `hephaestus-merge-prs` (merge open PRs with green CI).
 
-- **compare_benchmarks.py** - Compare benchmark results across runs
+### Versioning
 
-### Demo/Testing Scripts
+- **`update_version.py`** — Update secondary version files (`VERSION`,
+  `__init__.py`) via `hephaestus.version.manager`. The canonical version comes
+  from git tags via hatch-vcs — see [`../docs/RELEASING.md`](../docs/RELEASING.md).
 
-- **demo_cli.py** - Demo CLI functionality
-- **run_tests.py** - Run test suite
-- **example_usage.py** - Usage examples
+### Benchmarks / demos
+
+- **`compare_benchmarks.py`** — Compare benchmark results across runs.
+- **`demo_cli.py`** — Demo CLI functionality.
+- **`example_usage.py`** — Usage examples.
+- **`run_tests.py`** — Hand-rolled test runner kept as a fallback for
+  environments without pytest; prefer `pixi run test`.
 
 ## Usage
 
 ```bash
-# Check unit test structure
-python scripts/check_unit_test_structure.py
+# Pre-commit-checked validators
+python3 scripts/check_unit_test_structure.py
+python3 scripts/check_version_single_source.py
+python3 scripts/check_cli_table_sync.py
 
-# Merge PRs (requires GITHUB_TOKEN)
-python scripts/merge_prs.py --dry-run
+# Markdown link fixer
+python3 scripts/fix_invalid_links.py .
 
-# Fix invalid markdown links
-python scripts/fix_invalid_links.py .
+# Automation pipeline (shell glue)
+scripts/run_automation_loop.sh
 
-# Validate README commands
-python scripts/validate_readme_commands.py
-
-# Update project version
-python scripts/update_version.py 0.4.0
+# Symlink check
+scripts/check-symlinks.sh
 ```
 
 ## Design Principles
 
 Following CLAUDE.md guidelines:
 
-- **KISS** (Keep It Simple, Stupid) - Scripts are thin wrappers
-- **DRY** (Don't Repeat Yourself) - Logic lives in hephaestus modules
-- **YAGNI** (You Aren't Gonna Need It) - Only port what's reusable
-- **Modularity** - Clear separation between CLI and core logic
+- **KISS** (Keep It Simple, Stupid) — Scripts are thin wrappers
+- **DRY** (Don't Repeat Yourself) — Logic lives in `hephaestus.*` modules; the
+  scripts here just expose CLI entry points or shell glue
+- **YAGNI** (You Aren't Gonna Need It) — Only port what's reusable
+- **Modularity** — Clear separation between CLI and core logic


### PR DESCRIPTION
## Summary

`scripts/README.md` documented 10 of 22 scripts. 12 were undocumented including
significant automation/CI ones.

## Changes

Rewrite `scripts/README.md` to group every script by purpose, note which are thin
wrappers around `hephaestus.*` modules, and update the Usage section.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)