### PR TITLE
fix(github): make fleet_sync resign email configurable, not hardcoded

### DIFF
--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -25,6 +25,7 @@ import argparse
 import contextlib
 import json
 import logging
+import os
 import subprocess
 import sys
 import tempfile
@@ -42,9 +43,47 @@ logger = get_logger(__name__)
 
 ORG = "HomericIntelligence"
 
-FLEET_NOREPLY = "4211002+mvillmow@users.noreply.github.com"
 
-RESIGN_EXEC = f"git -c user.email={FLEET_NOREPLY} commit --amend --no-edit -S --reset-author"
+def get_resign_email() -> str:
+    """Return the email address used to re-sign rebased commits.
+
+    Resolution order:
+
+    1. ``$FLEET_GIT_EMAIL`` if set and non-empty.
+    2. ``git config --global --get user.email``.
+    3. ``git config --get user.email`` (any scope).
+
+    Raises :class:`RuntimeError` if none is configured — fleet_sync must never
+    silently re-sign with a fallback identity that doesn't belong to the
+    operator.
+    """
+    env = os.environ.get("FLEET_GIT_EMAIL", "").strip()
+    if env:
+        return env
+    for args in (["--global"], []):
+        result = subprocess.run(
+            ["git", "config", *args, "--get", "user.email"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        email = result.stdout.strip()
+        if result.returncode == 0 and email:
+            return email
+    raise RuntimeError(
+        "fleet_sync: no resign email configured. Set FLEET_GIT_EMAIL=<address> "
+        "or `git config --global user.email <address>` before running."
+    )
+
+
+def get_resign_exec() -> str:
+    """Return the ``git commit --amend`` shell command used as ``rebase --exec``.
+
+    The email is resolved lazily so changes to ``$FLEET_GIT_EMAIL`` or git config
+    between calls take effect without restarting the process.
+    """
+    return f"git -c user.email={get_resign_email()} commit --amend --no-edit -S --reset-author"
+
 
 ALL_REPOS: list[str] = [
     "Odysseus",
@@ -257,7 +296,7 @@ def rebase_and_resign(pr: PRInfo, clone_dir: Path, dry_run: bool = False) -> boo
         _git(["fetch", "origin", base], cwd=work, dry_run=dry_run)
 
         result = _git(
-            ["rebase", f"origin/{base}", "--exec", RESIGN_EXEC],
+            ["rebase", f"origin/{base}", "--exec", get_resign_exec()],
             cwd=work,
             dry_run=dry_run,
             check=False,
@@ -377,6 +416,8 @@ def resolve_conflict_with_agent(
                 check=True,
             )
             commit_count = commit_count_result.stdout.strip()
+            resign_email = get_resign_email()
+            resign_exec = get_resign_exec()
 
             prompt = f"""You are resolving merge conflicts in a git rebase.
 
@@ -395,10 +436,10 @@ For each conflicted file:
 4. Stage the file: git add <file>
 
 After ALL conflicts are resolved:
-1. Continue the rebase: git -c user.email={FLEET_NOREPLY} rebase --continue
+1. Continue the rebase: git -c user.email={resign_email} rebase --continue
    (repeat if more conflicts appear)
 2. Re-sign all commits:
-   git rebase HEAD~{commit_count} --exec '{RESIGN_EXEC}'
+   git rebase HEAD~{commit_count} --exec '{resign_exec}'
 3. Push: git push --force-with-lease origin {branch}
 
 Rules:

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -161,3 +161,63 @@ class TestPRInfo:
         )
         pr1.conflict_files.append("file.txt")
         assert pr2.conflict_files == [], "conflict_files must not be a shared mutable default"
+
+
+class TestGetResignEmail:
+    """Regression tests for #497: resign email is configurable, not hardcoded."""
+
+    def test_env_var_takes_precedence(self, monkeypatch) -> None:
+        """FLEET_GIT_EMAIL is used when set."""
+        from hephaestus.github.fleet_sync import get_resign_email
+
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "alice@example.com")
+        assert get_resign_email() == "alice@example.com"
+
+    def test_empty_env_var_falls_through_to_git_config(self, monkeypatch) -> None:
+        """An empty FLEET_GIT_EMAIL falls back to git config."""
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "")
+
+        # Stub subprocess.run so the test does not depend on the operator's
+        # actual git config.
+        class _Result:
+            def __init__(self) -> None:
+                self.returncode = 0
+                self.stdout = "bob@example.com\n"
+
+        # Target the attribute by dotted path so strict mypy (implicit_reexport=False)
+        # doesn't complain about fleet_sync not re-exporting `subprocess`.
+        monkeypatch.setattr(
+            "hephaestus.github.fleet_sync.subprocess.run",
+            lambda *a, **k: _Result(),
+        )
+        assert fleet_sync.get_resign_email() == "bob@example.com"
+
+    def test_no_config_raises_runtime_error(self, monkeypatch) -> None:
+        """When nothing is configured, fleet_sync fails loudly rather than guess."""
+        import pytest
+
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.delenv("FLEET_GIT_EMAIL", raising=False)
+
+        class _EmptyResult:
+            returncode = 1
+            stdout = ""
+
+        monkeypatch.setattr(
+            "hephaestus.github.fleet_sync.subprocess.run",
+            lambda *a, **k: _EmptyResult(),
+        )
+        with pytest.raises(RuntimeError, match="no resign email configured"):
+            fleet_sync.get_resign_email()
+
+    def test_get_resign_exec_embeds_resolved_email(self, monkeypatch) -> None:
+        """get_resign_exec() inlines the resolved email into the git command."""
+        from hephaestus.github.fleet_sync import get_resign_exec
+
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "carol@example.com")
+        cmd = get_resign_exec()
+        assert "user.email=carol@example.com" in cmd
+        assert "commit --amend --no-edit -S --reset-author" in cmd


### PR DESCRIPTION
## Summary

`hephaestus/github/fleet_sync.py:45` hardcoded a personal GitHub noreply email
(`4211002+mvillmow@...`) into PyPI-published code. Every user of
`hephaestus-fleet-sync` got their amended rebase commits authored as that
specific person — breaking reusability, mis-attributing commits, and embedding
personally-identifiable data in the public distribution.

## Changes

- `hephaestus/github/fleet_sync.py`: replace the constants with `get_resign_email()`
  (env-var → git-config → fail-loud) and `get_resign_exec()` (lazy resolution).
- Update both call sites (rebase `--exec` and the conflict-resolution prompt
  template) to use the resolvers.
- 4 regression tests cover precedence, git-config fallback, fail-loud, and
  exec-string embedding.

## Verification

`pixi run pytest tests/unit/github/test_fleet_sync.py` → 20 passed; `ruff` +
`mypy` clean.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)