### PR TITLE
fix(plugin): remove marketplace-level version that blocks /plugin update

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,6 @@
     "url": "https://github.com/HomericIntelligence"
   },
   "description": "Shared tooling and commands for the HomericIntelligence agentic ecosystem",
-  "version": "3.0.0",
   "plugins": [
     {
       "name": "hephaestus",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
   "name": "hephaestus",
   "description": "Shared tooling plugin for the HomericIntelligence ecosystem. Provides skill-advisor, advise, learn, myrmidon-swarm, brainstorm, test-driven-development, systematic-debugging, verification, git-worktrees, finish-branch, code-review, repo-analyze, repo-analyze-full, repo-analyze-quick-full, repo-analyze-strict-full, worktree-cleanup, and tidy commands.",
+  "version": "3.0.0",
   "author": {
     "name": "HomericIntelligence"
   }


### PR DESCRIPTION
## Summary

`marketplace.json` had a top-level `"version": "3.0.0"`. Per the Claude Code
plugin docs and an upstream issue
([affaan-m/everything-claude-code#36](https://github.com/affaan-m/everything-claude-code/issues/36)),
the marketplace-level `version` field is optional and **blocks `/plugin update`**.
Per-plugin update detection runs off `plugin.json`'s `version`, which was missing.

## Changes

- `.claude-plugin/marketplace.json`: remove the top-level `version`.
- `.claude-plugin/plugin.json`: add `version: "3.0.0"` (matching the per-plugin
  entry in marketplace.json) so update detection works.

## Verification

Both JSON files parse cleanly.

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)