### PR TITLE
refactor(github,automation): fix f-string logging and de-duplicate _find_pr_for_issue

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -122,7 +122,9 @@ def find_pr_for_issue(
             except Exception as e:
                 logger.debug("Review state PR lookup failed for issue #%d: %s", issue_number, e)
 
-    # Strategy 3: PR-body text search
+    # Strategy 3: PR-body text search.
+    # Search for the canonical "Closes #N" link so we don't false-match a PR
+    # that merely mentions the issue number in passing ("related to #123").
     try:
         result = _gh_call(
             [
@@ -131,7 +133,7 @@ def find_pr_for_issue(
                 "--state",
                 "open",
                 "--search",
-                f"#{issue_number} in:body",
+                f"Closes #{issue_number} in:body",
                 "--json",
                 "number",
                 "--limit",

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -29,6 +29,7 @@ from hephaestus.agents.runtime import (
     session_agent_matches,
 )
 
+from ._review_utils import find_pr_for_issue
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
 from .claude_timeouts import ci_driver_claude_timeout
@@ -391,7 +392,10 @@ class CIDriver:
     def _find_pr_for_issue(self, issue_number: int) -> int | None:
         """Find the open PR for a single issue.
 
-        Tries branch-name lookup first, then body search.
+        Delegates to :func:`_review_utils.find_pr_for_issue` (two-strategy
+        branch-name + body search). Sharing the helper with
+        :class:`AddressReviewer` and :class:`PRReviewer` keeps strategy
+        evolution in one place.
 
         Args:
             issue_number: GitHub issue number.
@@ -400,65 +404,7 @@ class CIDriver:
             PR number if found, None otherwise.
 
         """
-        # Strategy 1: Look for branch named {issue}-auto-impl
-        branch_name = f"{issue_number}-auto-impl"
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--head",
-                    branch_name,
-                    "--state",
-                    "open",
-                    "--json",
-                    "number",
-                    "--limit",
-                    "1",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                pr_number = pr_data[0]["number"]
-                logger.info("Found PR #%s for issue #%s via branch name", pr_number, issue_number)
-                return int(pr_number)
-        except Exception as e:
-            logger.debug("Branch-name lookup failed for issue #%s: %s", issue_number, e)
-
-        # Strategy 2: Search PR body for issue reference using the canonical
-        # "Closes #N" pattern so we don't accidentally match a PR that merely
-        # mentions the issue number in passing (e.g. "related to #123").
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--state",
-                    "open",
-                    "--search",
-                    f"Closes #{issue_number} in:body",
-                    "--json",
-                    "number,title",
-                    "--limit",
-                    "5",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                pr_number = pr_data[0]["number"]
-                logger.info(
-                    "Found PR #%s for issue #%s via body search (title: %r)",
-                    pr_number,
-                    issue_number,
-                    pr_data[0].get("title", ""),
-                )
-                return int(pr_number)
-        except Exception as e:
-            logger.debug("Body search failed for issue #%s: %s", issue_number, e)
-
-        return None
+        return find_pr_for_issue(issue_number)
 
     def _get_pr_branch(self, pr_number: int) -> str:
         """Get the head branch name of a PR.

--- a/hephaestus/github/gh_subprocess.py
+++ b/hephaestus/github/gh_subprocess.py
@@ -64,7 +64,7 @@ def _gh_call(
                         wait_until(reset_epoch)
                     else:
                         wait_seconds = min(60 * (2**attempt), 300)
-                        logger.warning(f"Rate limited but no reset time, waiting {wait_seconds}s")
+                        logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
                         time.sleep(wait_seconds)
                     continue
                 else:
@@ -80,14 +80,16 @@ def _gh_call(
                 r"invalid argument",
             ]
             if any(re.search(pattern, stderr, re.IGNORECASE) for pattern in non_transient_patterns):
-                logger.error(f"Non-transient error detected: {stderr[:200]}")
+                logger.error("Non-transient error detected: %s", stderr[:200])
                 raise
 
             if attempt == max_retries - 1:
                 raise
 
             wait_seconds = 2**attempt
-            logger.warning(f"gh call failed (attempt {attempt + 1}), retrying in {wait_seconds}s")
+            logger.warning(
+                "gh call failed (attempt %s), retrying in %ss", attempt + 1, wait_seconds
+            )
             time.sleep(wait_seconds)
 
     raise RuntimeError("gh call failed after all retries")

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -656,8 +656,9 @@ class TestBodySearch:
 
     def test_body_search_uses_closes_pattern(self, driver: CIDriver) -> None:
         """The search string must use 'Closes #<N> in:body'."""
-        # Make the branch-name lookup return nothing so we fall through to body search
-        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh:
+        # _find_pr_for_issue now delegates to _review_utils.find_pr_for_issue;
+        # patch _gh_call at its actual call site there.
+        with patch("hephaestus.automation._review_utils._gh_call") as mock_gh:
             mock_gh.return_value = MagicMock(stdout="[]")
             driver._find_pr_for_issue(42)
 


### PR DESCRIPTION
## Summary

Two related code-quality MAJOR findings:

1. `gh_subprocess.py` had three `logger.warning/error(f"…")` calls — the only
   file still carrying the ROADMAP anti-pattern. Convert to `%`-style.
2. `ci_driver.CIDriver._find_pr_for_issue` duplicated 70 lines that
   `_review_utils.find_pr_for_issue` already provides. Replace with delegation.

While consolidating, tighten `_review_utils`' body-search pattern from `#N
in:body` to `Closes #N in:body` so it matches the stricter behavior asserted
by the ci_driver regression test (#382/A4-10) and doesn't false-match PRs that
merely mention an issue number in passing. Patch the ci_driver test to patch
`_gh_call` at its real call site in `_review_utils`.

## Verification

`pixi run pytest tests/unit/automation tests/unit/github` → 684 passed;
`ruff` + `mypy` clean.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)