### PR TITLE
test(coverage): stop omitting fleet_sync.py and tidy.py from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,8 +217,6 @@ omit = [
     "hephaestus/automation/github_api.py",
     # pr_reviewer.py drives a full Claude session against a live PR; integration-only
     "hephaestus/automation/pr_reviewer.py",
-    "hephaestus/github/fleet_sync.py",
-    "hephaestus/github/tidy.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

The coverage omit list excluded `hephaestus/github/{fleet_sync,tidy}.py` despite
both having dedicated unit-test files exercising their pure-function helpers
(`_ci_state`, `parse_problem_branches`, `get_resign_email`). The omit hid real
coverage measurement.

## Changes

`pyproject.toml`: drop both files from `[tool.coverage.run] omit`.

## Verification

Full suite still passes the 80% gate: **80.55%**, 2341 tests passed.

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)