### PR TITLE
fix(ci): run bats shell tests in CI

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -401,6 +401,33 @@ jobs:
       - name: Run integration tests
         run: pytest tests/integration --override-ini="addopts=" -v --strict-markers
 
+  shell-tests:
+    name: shell-tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0  # v0.9.5
+        with:
+          pixi-version: v0.63.2
+          locked: true
+
+      - name: Cache pixi environments
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
+        with:
+          path: |
+            .pixi
+            ~/.cache/rattler/cache
+          key: pixi-shell-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          restore-keys: |
+            pixi-shell-${{ runner.os }}-
+
+      - name: Run bats shell tests
+        run: pixi run test-shell
+
   build:
     name: build
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

`tests/shell/justfile/test_justfile.bats` and `tests/shell/scripts/test_repo_ordering.bats`
existed but were never executed by CI. `pixi run test-shell` and `bats-core` were
already configured — only the workflow wiring was missing.

## Changes

Add a `shell-tests` job to `_required.yml` that runs `pixi run test-shell` in the
default pixi environment.

## Verification

26 bats tests pass locally; `yamllint` clean (pre-existing line-length warnings only).

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)