### PR TITLE
fix(justfile): just typecheck no longer double-scans hephaestus

### DIFF
--- a/justfile
+++ b/justfile
@@ -49,9 +49,9 @@ format:
 format-check:
     pixi run ruff format --check {{ src_dirs }}
 
-# Run type checking
+# Run type checking on the package only (use `pixi run mypy` for everything)
 typecheck:
-    pixi run mypy {{ pkg_dir }}
+    pixi run mypy-pkg
 
 # Run all pre-commit hooks on all files
 precommit:

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,10 @@ test-shell = "bats --recursive tests/shell"
 lint = "ruff check hephaestus scripts tests"
 format = "ruff format hephaestus scripts tests"
 mypy = "mypy hephaestus/ scripts/ tests/"
+# Scoped to the package only; consumed by `just typecheck` so the justfile
+# recipe does not double-scan by appending `hephaestus` to the default
+# `mypy` task's argument list.
+mypy-pkg = "mypy hephaestus/"
 audit = "pixi run --environment lint pip-audit"
 docs = "pdoc hephaestus --output-dir docs/api"
 # Editable install of this package into the pixi environment, for local dev


### PR DESCRIPTION
## Summary

`just typecheck` ran `pixi run mypy hephaestus`, but the pixi `mypy` task already
contained `hephaestus/ scripts/ tests/`. Pixi appended the arg, producing
`mypy hephaestus/ scripts/ tests/ hephaestus` — `hephaestus` listed twice — which
mypy rejected with `Duplicate module named "hephaestus"`. `just check` inherited
the break.

## Changes

- `pixi.toml`: add `mypy-pkg = "mypy hephaestus/"` (no-args, package-scoped).
- `justfile`: `typecheck` now invokes `pixi run mypy-pkg`. Default `pixi run mypy`
  remains unchanged.

## Verification

`just typecheck` clean; `pixi run mypy` still clean.

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)