### PR TITLE
docs(dx): add minimal .vscode config (extensions + settings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,11 @@ ENV/
 
 # IDE
 .idea/
-.vscode/
+.vscode/*
+# Track only the shared, project-wide VS Code config — personal files
+# (tasks.json, launch.json, etc.) stay ignored.
+!.vscode/extensions.json
+!.vscode/settings.json
 *.swp
 *.swo
 *.orig

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "charliermarsh.ruff",
+    "prefix-dev.pixi-vscode",
+    "tamasfe.even-better-toml",
+    "DavidAnson.vscode-markdownlint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,33 @@
+{
+  "// note": "Minimal VS Code config — relies on .editorconfig for formatting baselines.",
+
+  "python.defaultInterpreterPath": "${workspaceFolder}/.pixi/envs/default/bin/python",
+  "python.terminal.activateEnvironment": false,
+
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestArgs": [
+    "tests/unit",
+    "--no-cov"
+  ],
+
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.organizeImports.ruff": "explicit"
+    }
+  },
+
+  "ruff.organizeImports": true,
+  "ruff.fixAll": false,
+
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.pixi": true,
+    "**/.ruff_cache": true,
+    "**/.mypy_cache": true,
+    "**/.pytest_cache": true,
+    "hephaestus/_version.py": true
+  }
+}


### PR DESCRIPTION
## Summary

The repo had no IDE/editor configuration — VS Code contributors got zero guided
setup despite the project's strict ruff/mypy and 41 CLI entry points.

## Changes

- `.vscode/extensions.json`: recommend Pylance, Ruff, pixi, EvenBetterTOML, markdownlint.
- `.vscode/settings.json`: pixi-managed Python interpreter, Ruff as Python formatter
  (with `organizeImports`), pytest discovery for `tests/unit`. Relies on
  `.editorconfig` for indentation / line endings.
- `.gitignore`: track only the two shared files; personal `tasks.json` / `launch.json`
  stay ignored.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)