### PR TITLE
fix(nats): subscriber stop() returns bool indicating clean shutdown

### DIFF
--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -358,7 +358,7 @@ class NATSSubscriberThread(threading.Thread):
             self._set_state(SubscriberState.DISCONNECTED)
             await nc.drain()
 
-    def stop(self, timeout: float | None = None) -> None:
+    def stop(self, timeout: float | None = None) -> bool:
         """Signal the subscriber to stop and wait for the thread to finish.
 
         Args:
@@ -366,9 +366,22 @@ class NATSSubscriberThread(threading.Thread):
                 When ``None`` (the default), uses the ``join_timeout``
                 value supplied to the constructor (default 5.0 s).
 
+        Returns:
+            ``True`` if the thread joined cleanly within the timeout (or had
+            already finished); ``False`` if the join timed out and the thread
+            is still running. A ``False`` return also logs a warning so the
+            condition is visible in logs even when the caller ignores it.
+
         """
         effective_timeout = self._join_timeout if timeout is None else timeout
         self._set_state(SubscriberState.STOPPING)
         self._stop_event.set()
         if self.is_alive():
             self.join(timeout=effective_timeout)
+            if self.is_alive():
+                logger.warning(
+                    "NATS subscriber thread did not stop within %.1fs — still running",
+                    effective_timeout,
+                )
+                return False
+        return True

--- a/tests/unit/nats/test_subscriber.py
+++ b/tests/unit/nats/test_subscriber.py
@@ -45,7 +45,25 @@ class TestNATSSubscriberThread:
         thread = NATSSubscriberThread(config=_config(), handler=MagicMock())
         # stop() calls join() — should not raise even if never started
         thread._stop_event.set()
-        thread.stop()
+        # A thread that was never started counts as "joined cleanly" (True).
+        assert thread.stop() is True
+
+    def test_stop_returns_false_on_join_timeout(self) -> None:
+        """When a started thread refuses to exit within the timeout, stop() returns False.
+
+        Regression for #521: stop() previously returned None and silently
+        masked a wedged subscriber thread.
+        """
+        thread = NATSSubscriberThread(config=_config(), handler=MagicMock())
+        # Simulate a wedged thread: is_alive() returns True both before and
+        # after join(), and join() itself is a no-op so we don't need to
+        # actually start a real thread.
+        with (
+            patch.object(NATSSubscriberThread, "is_alive", return_value=True),
+            patch.object(NATSSubscriberThread, "join", return_value=None),
+        ):
+            result = thread.stop(timeout=0.01)
+        assert result is False
 
     def test_stop_event_is_threading_event(self) -> None:
         thread = NATSSubscriberThread(config=_config(), handler=MagicMock())


### PR DESCRIPTION
## Summary

`NATSSubscriberThread.stop()` returned silently regardless of whether the thread
actually joined. A wedged subscriber stayed in `STOPPING` state with no signal
to the caller.

## Changes

- `stop(...) -> bool`: True if joined cleanly (or never started), False on timeout.
- On a timeout, log a warning so the wedge is visible even when callers ignore
  the return.
- Update the existing stop-before-start test to assert the True return; add a
  regression test for the timeout-False path.

## Verification

`pixi run pytest tests/unit/nats` → 58 passed. `ruff` + `mypy` clean.

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)