### PR TITLE
fix(ci): install default pixi env + dev-install in pre-commit job

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -44,6 +44,11 @@ jobs:
       - name: Run pre-commit
         run: |
           pixi install --environment lint
+          # Some hooks (check-dep-sync, check-unit-test-structure) invoke
+          # `pixi run hephaestus-*` which uses the default env. Install the
+          # default env and the package itself so those console scripts resolve.
+          pixi install --environment default
+          pixi run dev-install
           pixi run --environment lint pre-commit run --all-files --show-diff-on-failure
 
       - name: Upload pre-commit diff


### PR DESCRIPTION
## Summary

The pre-commit CI job installed only the `lint` pixi env. The new `check-dep-sync`
and `check-unit-test-structure` hooks invoke `pixi run hephaestus-*` which uses the
**default** env, so in CI those console scripts weren't on PATH and the hooks
failed even when the source was clean.

## Changes

Add `pixi install --environment default` + `pixi run dev-install` to the
`Run pre-commit` step before `pre-commit run --all-files`.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)