### PR TITLE
fix(tests): bats pixi/just sync allow-list dev-install and mypy-pkg

### DIFF
--- a/tests/shell/justfile/test_justfile.bats
+++ b/tests/shell/justfile/test_justfile.bats
@@ -107,9 +107,13 @@ JUSTFILE="${REPO_ROOT}/justfile"
     while IFS= read -r task; do
         # 'audit' runs in a separate lint environment — skip for the default workflow.
         # 'mypy' pixi task is exposed as 'typecheck' in the justfile (UX alias).
+        # 'mypy-pkg' is the package-only backend of 'typecheck' (no user-facing alias).
+        # 'dev-install' is a one-time setup hook documented in CONTRIBUTING.md.
         case "$task" in
-            audit) continue ;;
-            mypy)  continue ;;
+            audit)        continue ;;
+            mypy)         continue ;;
+            mypy-pkg)     continue ;;
+            dev-install)  continue ;;
         esac
         if ! echo "$just_recipes" | grep -qx "$task"; then
             missing="${missing} ${task}"


### PR DESCRIPTION
## Summary

The bats test "all pixi tasks have a corresponding just recipe" failed after
recent PRs added two intentionally-pixi-only tasks:

- `mypy-pkg` (#515): package-only backend of `just typecheck`; no user alias.
- `dev-install` (#457): one-time setup hook documented in CONTRIBUTING.md.

Add both to the existing skip allow-list alongside `audit` and `mypy`.

## Verification

`pixi run test-shell` → all 26 bats tests pass.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)