### PR TITLE
fix(pixi): drop --no-build-isolation from dev-install for CI compatibility

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -25,7 +25,14 @@ docs = "pdoc hephaestus --output-dir docs/api"
 # tree perpetually dirty. Keeping it out of the lock removes that churn. The
 # pixi-based CI jobs (ruff/mypy/yamllint) analyse source directly and do not
 # need the package installed. See issue #456; lockfile-v7 follow-up is #455.
-dev-install = "pip install -e . --no-build-isolation --no-deps"
+# `--no-deps` keeps pip from re-resolving runtime deps that pixi already
+# manages. We deliberately omit `--no-build-isolation`: pip's editable build
+# subprocess loads the backend from its own ephemeral env, and across
+# `pixi run` boundaries the parent pixi env's hatchling is not always visible
+# to that subprocess. Letting pip create an isolated build env (which fetches
+# hatchling/hatch-vcs/editables from PyPI) is slower on first run but works
+# reliably in both local and CI contexts.
+dev-install = "pip install -e . --no-deps"
 
 [dependencies]
 python = ">=3.10"


### PR DESCRIPTION
## Summary

`pixi run dev-install` used `--no-build-isolation` — fine locally, but in CI's
pre-commit job pip's editable build subprocess could not locate `hatchling.build`
even though it existed in the parent pixi env:

```
BackendUnavailable: Cannot import 'hatchling.build'
```

This blocked PR #479 and any other PR exercising the pre-commit dev-install path.

## Changes

`pixi.toml`: `dev-install = "pip install -e . --no-deps"` (no more
`--no-build-isolation`). `--no-deps` kept because pixi manages runtime deps.

## Verification

`pixi run dev-install` succeeds locally; `pixi.lock` still doesn't churn (the
editable self-install path stays outside the lock).

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)