### PR TITLE
fix(pre-commit): make hephaestus-* hooks explicitly target the default env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,7 +102,9 @@ repos:
       - id: check-unit-test-structure
         name: Check unit test structure
         description: Enforce tests/unit/ mirrors hephaestus/ and has no loose test files
-        entry: pixi run hephaestus-check-test-structure
+        # --environment default is explicit because the pre-commit CI job runs
+        # in the lint env; the hephaestus-* console scripts live in default.
+        entry: pixi run --environment default hephaestus-check-test-structure
         language: system
         pass_filenames: false
         files: ^(hephaestus|tests/unit)/
@@ -148,7 +150,9 @@ repos:
       - id: check-dep-sync
         name: Check dependency declarations are consistent
         description: Validate requirements*.txt entries against pixi.toml
-        entry: pixi run hephaestus-check-dep-sync
+        # --environment default is explicit because the pre-commit CI job runs
+        # in the lint env; the hephaestus-* console scripts live in default.
+        entry: pixi run --environment default hephaestus-check-dep-sync
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|pixi\.toml|pixi\.lock|requirements.*\.txt)$


### PR DESCRIPTION
## Summary

`check-unit-test-structure` and `check-dep-sync` invoked `pixi run hephaestus-*`.
The pre-commit CI job runs in the **lint** pixi env, so when pre-commit invoked
those hooks, `pixi run` resolved inside the lint env (which doesn't have the
package console scripts) and exited with `command not found`.

## Changes

Both hooks now use `pixi run --environment default hephaestus-...`. The package
is installed into the default env by the preceding `pixi run dev-install` step
(#525); the explicit flag ensures pre-commit reaches it regardless of which env
launched pre-commit.

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)