### PR TITLE
fix(automation,tests): make planner fcntl lazy and skip help-flag for automation CLIs on Windows

### DIFF
--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -10,11 +10,19 @@ Provides:
 from __future__ import annotations
 
 import argparse
-import fcntl
 import json
 import logging
 import shutil
 import subprocess
+
+# fcntl is POSIX-only; CPython does not bundle it on Windows. Import lazily so
+# this module stays importable on Windows for tests that only need its
+# pure-Python helpers. The cross-process file locking that uses fcntl is only
+# reached on the live planner path.
+try:
+    import fcntl
+except ModuleNotFoundError:
+    fcntl = None  # type: ignore[assignment]
 import threading
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -437,7 +445,11 @@ class Planner:
             lock_path.parent.mkdir(parents=True, exist_ok=True)
 
             with open(lock_path, "w") as lock_file:
-                fcntl.flock(lock_file, fcntl.LOCK_EX)
+                # POSIX-only file locking; on Windows fcntl is None and we
+                # degrade gracefully by relying on the in-process thread lock
+                # acquired by the surrounding `with self._mnemosyne_lock:`.
+                if fcntl is not None:
+                    fcntl.flock(lock_file, fcntl.LOCK_EX)
                 try:
                     # Re-check after acquiring file lock
                     if mnemosyne_root.exists():
@@ -476,7 +488,8 @@ class Planner:
                     return False
 
                 finally:
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+                    if fcntl is not None:
+                        fcntl.flock(lock_file, fcntl.LOCK_UN)
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
         """Search team knowledge base for relevant prior learnings.

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -72,6 +72,12 @@ class TestCLIHelpFlag:
 
     @pytest.mark.parametrize("command,module_path,attr", ENTRY_POINTS, ids=ENTRY_POINT_IDS)
     def test_help_flag(self, command: str, module_path: str, attr: str) -> None:
+        # Automation CLIs transitively import POSIX-only stdlib modules
+        # (`curses` for the UI, `fcntl` for cross-process locking in planner).
+        # CPython on Windows ships neither; the CLIs aren't intended for
+        # Windows operators. Skip the help-flag check on that platform.
+        if sys.platform == "win32" and "automation" in module_path:
+            pytest.skip("automation CLIs require POSIX stdlib (curses/fcntl)")
         binary: str | None = shutil.which(command)
         if binary is None:
             pytest.skip(f"{command} not on PATH — install with `pip install -e .` or run via pixi")


### PR DESCRIPTION
## Summary

After the curses fix (#533), the Windows matrix still failed because
`hephaestus.automation.planner` did `import fcntl` at module top. fcntl is
POSIX-only; CPython doesn't bundle it on Windows. Every automation CLI's
`--help` invocation raised `ModuleNotFoundError` on Windows.

## Changes

- `planner.py`: import `fcntl` under try/except; guard the two `fcntl.flock`
  call sites so on Windows we fall back to the in-process thread lock.
- `test_cli_entry_points.py`: extend the Windows skip in `TestCLIHelpFlag`
  (mirroring the same skip already in `TestCLITargetImportable`) so the
  help-flag subprocess test doesn't probe automation CLIs on Windows.

## Verification

`pixi run pytest tests/unit/automation/test_planner.py tests/integration/test_cli_entry_points.py`
→ 108 passed. `ruff` + `mypy` clean.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)