### PR TITLE
fix(deps): add tzdata as a Windows-conditional dependency for ZoneInfo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
     "packaging>=21.0,<27",
     "pyyaml>=6.0,<7",
     "pydantic>=2.12.5,<3",
+    # IANA timezone data is bundled with Python on POSIX but not on Windows;
+    # rate_limit.py uses ZoneInfo which needs it on Windows.
+    "tzdata; platform_system == 'Windows'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

`hephaestus.github.rate_limit` uses `zoneinfo.ZoneInfo` to parse GitHub
rate-limit reset times. `ZoneInfo` needs IANA timezone data — bundled with
CPython on POSIX, missing on Windows (Python relies on the optional `tzdata`
PyPI package). On Windows ZoneInfo raised `ModuleNotFoundError: No module
named 'tzdata'` on first use, breaking the Windows test matrix.

## Changes

`pyproject.toml`: add `tzdata; platform_system == "Windows"` to runtime
dependencies so pip installs it on Windows automatically.

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)