### PR TITLE
chore(ci): revert test matrix to ubuntu-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,11 +51,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # macOS and Windows are tracked separately in #539 — the test suite is
+        # mostly Linux-pinned (paths, file modes, curses, fcntl) and the
+        # cross-OS port is a multi-session effort, not blocking 1.0. The
+        # runtime fixes already in place (#533/#534/#536/#537/#538) stay.
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         test-type: [unit, integration]
-    # `shell: bash` for every run step keeps the same script working on
-    # Windows runners (which would otherwise default to PowerShell).
+    # `shell: bash` is harmless on ubuntu and keeps the matrix re-expansion
+    # trivial once #539 is picked up.
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
## Summary

PR #477 expanded the test matrix to ubuntu/macOS/Windows. The expansion surfaced
many cross-OS test portability issues. I've fixed the **runtime** ones in this
sweep (#533, #534, #536, #537, #538) but the test suite has many more
Linux-pinned assertions (Windows file permissions, POSIX-only forensics, path
encoding) that require platform-aware fixtures — a multi-session porting
effort that's blocking unrelated PRs (e.g. #479).

## Changes

`test.yml`: matrix back to `[ubuntu-latest]`. Runtime Windows-compat fixes
(curses lazy, fcntl lazy, tzdata dep) stay in place — they're correct regardless.

The full cross-OS port stays open as a tracker in #539.

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)