### PR TITLE
fix(automation): pass --issues to review/address/drive phases in loop script

### DIFF
--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -6,8 +6,15 @@
 # in a loop N times for every repo.
 # drive-green only runs on the final loop. Up to PARALLEL_REPOS repos are processed concurrently.
 #
-# Issue discovery is delegated to each phase's Python entrypoint
-# (gh_list_open_issues), so issues opened mid-loop are picked up by later phases.
+# Issue discovery:
+#   - plan, implement: each phase's Python entrypoint auto-discovers via
+#     gh_list_open_issues(), so issues opened mid-loop by an earlier phase are
+#     picked up by these phases automatically.
+#   - review-plans, review-prs, address-review, drive-green: these entrypoints
+#     declare --issues as REQUIRED (no auto-discovery). The orchestrator
+#     discovers open issues once per repo per loop (`gh issue list`) and passes
+#     them via --issues. Repos with zero open issues skip these four phases
+#     cleanly with a "No open issues — skipping" log line.
 #
 # Usage:
 #   ./scripts/run_automation_loop.sh [options]
@@ -266,6 +273,25 @@ process_repo() {
     FOLLOW_UP_FLAG="--no-follow-up"
   fi
 
+  # Discover this repo's open issues once per loop iteration. Four of the six
+  # phases (plan_reviewer, pr_reviewer, address_review, ci_driver) declare
+  # --issues as REQUIRED in argparse and have no auto-discovery — invoking them
+  # without --issues fails with exit code 2, which the `|| echo Warning…`
+  # clauses below would silently swallow. We share the same list across all
+  # four phases so a single `gh` call covers them. The `plan` and `implement`
+  # phases intentionally do NOT consume this list — both auto-discover via
+  # gh_list_open_issues() inside their main(), which lets them pick up issues
+  # opened mid-loop by an earlier phase.
+  local OPEN_ISSUES=()
+  mapfile -t OPEN_ISSUES < <(
+    gh issue list --repo "$ORG/$repo" --state open --limit 200 \
+      --json number --jq '.[].number' 2>/dev/null
+  )
+  local ISSUE_ARGS=()
+  if [[ ${#OPEN_ISSUES[@]} -gt 0 ]]; then
+    ISSUE_ARGS=(--issues "${OPEN_ISSUES[@]}")
+  fi
+
   # --- Phase 1: Plan ---
   if phase_enabled plan; then
     echo "  [$repo] Planning issues..."
@@ -280,15 +306,20 @@ process_repo() {
 
   # --- Phase 2: Review Plans ---
   if phase_enabled review-plans; then
-    echo "  [$repo] Reviewing plans..."
-    (
-      cd "$dir"
-      "$PYTHON" "$SCRIPT_DIR/review_plans.py" \
-        --max-workers "$MAX_WORKERS" \
-        -v \
-        $DRY_RUN_FLAGS \
-        || echo "  [$repo] Warning: review-plans exited non-zero (loop $loop)"
-    )
+    if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
+      echo "  [$repo] No open issues — skipping review-plans"
+    else
+      echo "  [$repo] Reviewing plans..."
+      (
+        cd "$dir"
+        "$PYTHON" "$SCRIPT_DIR/review_plans.py" \
+          "${ISSUE_ARGS[@]}" \
+          --max-workers "$MAX_WORKERS" \
+          -v \
+          $DRY_RUN_FLAGS \
+          || echo "  [$repo] Warning: review-plans exited non-zero (loop $loop)"
+      )
+    fi
   fi
 
   # --- Phase 3: Implement ---
@@ -308,47 +339,62 @@ process_repo() {
 
   # --- Phase 4: Review PRs (inline comments) ---
   if phase_enabled review-prs; then
-    echo "  [$repo] Reviewing PRs..."
-    (
-      cd "$dir"
-      "$PYTHON" "$SCRIPT_DIR/review_issues.py" \
-        --max-workers "$MAX_WORKERS" \
-        --no-ui \
-        -v \
-        $DRY_RUN_FLAGS \
-        || echo "  [$repo] Warning: review-issues exited non-zero (loop $loop)"
-    )
+    if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
+      echo "  [$repo] No open issues — skipping review-prs"
+    else
+      echo "  [$repo] Reviewing PRs..."
+      (
+        cd "$dir"
+        "$PYTHON" "$SCRIPT_DIR/review_issues.py" \
+          "${ISSUE_ARGS[@]}" \
+          --max-workers "$MAX_WORKERS" \
+          --no-ui \
+          -v \
+          $DRY_RUN_FLAGS \
+          || echo "  [$repo] Warning: review-issues exited non-zero (loop $loop)"
+      )
+    fi
   fi
 
   # --- Phase 5: Address Review Comments ---
   if phase_enabled address-review; then
-    echo "  [$repo] Addressing review comments..."
-    (
-      cd "$dir"
-      "$PYTHON" "$SCRIPT_DIR/address_review.py" \
-        --max-workers "$MAX_WORKERS" \
-        --no-ui \
-        -v \
-        $DRY_RUN_FLAGS \
-        || echo "  [$repo] Warning: address-review exited non-zero (loop $loop)"
-    )
+    if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
+      echo "  [$repo] No open issues — skipping address-review"
+    else
+      echo "  [$repo] Addressing review comments..."
+      (
+        cd "$dir"
+        "$PYTHON" "$SCRIPT_DIR/address_review.py" \
+          "${ISSUE_ARGS[@]}" \
+          --max-workers "$MAX_WORKERS" \
+          --no-ui \
+          -v \
+          $DRY_RUN_FLAGS \
+          || echo "  [$repo] Warning: address-review exited non-zero (loop $loop)"
+      )
+    fi
   fi
 
   # --- Phase 6: Drive PRs to Green CI (final loop only) ---
   if phase_enabled drive-green && [[ "$loop" -eq "$LOOPS" ]]; then
-    echo "  [$repo] Driving PRs to green CI..."
-    (
-      cd "$dir"
-      # Defence-in-depth: ci_driver also checks these envs and refuses to run
-      # unless HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS or --force-run is given.
-      HEPH_LOOP_INDEX="$loop" HEPH_TOTAL_LOOPS="$LOOPS" \
-      "$PYTHON" "$SCRIPT_DIR/drive_prs_green.py" \
-        --max-workers "$MAX_WORKERS" \
-        --no-ui \
-        -v \
-        $DRY_RUN_FLAGS \
-        || echo "  [$repo] Warning: drive-prs-green exited non-zero (loop $loop)"
-    )
+    if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
+      echo "  [$repo] No open issues — skipping drive-green"
+    else
+      echo "  [$repo] Driving PRs to green CI..."
+      (
+        cd "$dir"
+        # Defence-in-depth: ci_driver also checks these envs and refuses to run
+        # unless HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS or --force-run is given.
+        HEPH_LOOP_INDEX="$loop" HEPH_TOTAL_LOOPS="$LOOPS" \
+        "$PYTHON" "$SCRIPT_DIR/drive_prs_green.py" \
+          "${ISSUE_ARGS[@]}" \
+          --max-workers "$MAX_WORKERS" \
+          --no-ui \
+          -v \
+          $DRY_RUN_FLAGS \
+          || echo "  [$repo] Warning: drive-prs-green exited non-zero (loop $loop)"
+      )
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary

`scripts/run_automation_loop.sh` was silently dead from `review-plans` onward
because four of its six phases — `plan_reviewer`, `pr_reviewer`,
`address_review`, and `ci_driver` — declare `--issues` as REQUIRED in argparse
but the shell was invoking them without it. Each phase exited with argparse
error 2 every loop, and the `|| echo "Warning: <phase> exited non-zero"`
clauses swallowed the failure so the orchestrator reported success while
posting zero review comments, resolving zero threads, and never enabling
auto-merge.

This patch discovers each repo's open issues once per loop in `process_repo`
(a single `gh issue list` call shared across the four phases) and passes
them via `--issues`. Repos with zero open issues skip those four phases
cleanly with a `No open issues — skipping` log line instead of triggering a
swallowed argparse failure.

The `plan` and `implement` phases intentionally still receive no `--issues`
flag — both auto-discover via `gh_list_open_issues()` inside their `main()`
(`planner.py:1059`, `implementer.py:1862`), and we want them to keep picking
up issues opened mid-loop by an earlier phase.

The script header docstring is updated to reflect the actual two-tier
discovery contract.

## Verification

- `bash -n scripts/run_automation_loop.sh` → syntax OK
- `pre-commit run --files scripts/run_automation_loop.sh` → ShellCheck +
  silent-failure linter pass
- `./scripts/run_automation_loop.sh --help` → renders the updated docstring

End-to-end smoke (manual, post-merge):

```bash
./scripts/run_automation_loop.sh --loops 1 --parallel-repos 1 --dry-run \
  2>&1 | tee /tmp/auto-loop-verify.log
grep -E '^\s+\[.*\] (Planning|Reviewing plans|Implementing|Reviewing PRs|Addressing|Driving)' \
  /tmp/auto-loop-verify.log    # expect all six banner kinds present
grep -E "Warning: (review-plans|review-issues|address-review|drive-prs-green) exited non-zero" \
  /tmp/auto-loop-verify.log    # expect no output
```

Closes #542