### PR TITLE
chore(deps): bump codecov/codecov-action from 6.0.0 to 6.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.test-type == 'unit' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Bumps codecov/codecov-action SHA pin from v6.0.0 to v6.0.1 (security fix: prevent template injection in `run:` steps — VULN-1652).

Replaces Dependabot PR #467, which CI rejects under `pr-policy` because the upstream Dependabot commit is unsigned. Closing #467 once this lands.

Diff is a single SHA replacement in `.github/workflows/test.yml`.

Closes #544