### PR TITLE
[Perf] planner: move skip-check into worker pool (kills phase-1 startup stall)

### DIFF
--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -138,30 +138,24 @@ class Planner:
     def _filter_issues(self) -> list[int]:
         """Filter issues based on options.
 
+        Only does the cheap, batched check here: skip closed issues using one
+        GraphQL call per 100 via :func:`prefetch_issue_states`. The
+        already-planned check happens per-issue inside :meth:`_plan_issue` so
+        it runs in parallel with the worker pool instead of blocking on N
+        sequential ``gh issue view --comments`` round-trips before any worker
+        starts (#548).
+
         Returns:
             List of issue numbers to plan
 
         """
-        issues_to_plan = []
-
         # Batch fetch issue states if we need to check for closed issues
         cached_states = {}
         if self.options.skip_closed:
             cached_states = prefetch_issue_states(self.options.issues)
 
+        issues_to_plan = []
         for issue_num in self.options.issues:
-            # Check if already planned (unless force)
-            if not self.options.force and self._has_existing_plan(issue_num):
-                logger.info("Issue #%s already has a plan, skipping", issue_num)
-                with self.lock:
-                    self.results[issue_num] = PlanResult(
-                        issue_number=issue_num,
-                        success=True,
-                        plan_already_exists=True,
-                    )
-                continue
-
-            # Check if closed (using cached states)
             if self.options.skip_closed:
                 state = cached_states.get(issue_num)
                 if state and state.value == "CLOSED":
@@ -231,6 +225,25 @@ class Planner:
             )
 
         try:
+            # Skip-if-already-planned moved here from _filter_issues (#548) so
+            # the check runs inside the thread pool (parallel, overlapped with
+            # actual planning work) instead of as a serial pre-pass that
+            # blocked all workers behind N ``gh issue view --comments`` calls.
+            if not self.options.force:
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: checking existing plan"
+                )
+                if self._has_existing_plan(issue_number):
+                    logger.info("Issue #%s already has a plan, skipping", issue_number)
+                    self.status_tracker.update_slot(
+                        slot_id, f"{issue_ref(issue_number)}: plan exists, skipped"
+                    )
+                    return PlanResult(
+                        issue_number=issue_number,
+                        success=True,
+                        plan_already_exists=True,
+                    )
+
             self.status_tracker.update_slot(slot_id, f"Planning {issue_ref(issue_number)}")
 
             if self.options.dry_run:

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -227,6 +227,7 @@ class TestPlanIssueNOGOExhausted:
     def test_nogo_exhausted_plan_result_success_false(self, planner: Planner) -> None:
         """All-NOGO loop must produce PlanResult(success=False) not PlanResult(success=True)."""
         with (
+            patch.object(planner, "_has_existing_plan", return_value=False),
             patch.object(
                 planner,
                 "_run_plan_review_loop",
@@ -243,6 +244,7 @@ class TestPlanIssueNOGOExhausted:
     def test_go_plan_result_success_true(self, planner: Planner) -> None:
         """A GO loop must still produce PlanResult(success=True)."""
         with (
+            patch.object(planner, "_has_existing_plan", return_value=False),
             patch.object(
                 planner,
                 "_run_plan_review_loop",
@@ -253,3 +255,97 @@ class TestPlanIssueNOGOExhausted:
             result = planner._plan_issue(123)
 
         assert result.success is True
+
+    def test_existing_plan_short_circuits_in_worker(self, planner: Planner) -> None:
+        """In-worker skip path (#548).
+
+        When a plan already exists, _plan_issue must return early with
+        plan_already_exists=True and NOT invoke the review loop or post a
+        plan. This is the parallel replacement for the old serial pre-pass
+        in _filter_issues.
+        """
+        with (
+            patch.object(planner, "_has_existing_plan", return_value=True),
+            patch.object(planner, "_run_plan_review_loop") as mock_loop,
+            patch.object(planner, "_post_plan") as mock_post,
+        ):
+            result = planner._plan_issue(123)
+
+        assert result.success is True
+        assert result.plan_already_exists is True
+        mock_loop.assert_not_called()
+        mock_post.assert_not_called()
+
+    def test_force_bypasses_existing_plan_check(self, planner: Planner) -> None:
+        """With force=True, the skip-check must be bypassed (#548).
+
+        _plan_issue must NOT call _has_existing_plan and must run the review
+        loop unconditionally. Keeps --force semantics intact after moving the
+        skip-check into the worker.
+        """
+        planner.options.force = True
+        with (
+            patch.object(planner, "_has_existing_plan") as mock_check,
+            patch.object(
+                planner,
+                "_run_plan_review_loop",
+                return_value=("plan", _go_review(), 1, True),
+            ) as mock_loop,
+            patch.object(planner, "_post_plan"),
+        ):
+            result = planner._plan_issue(123)
+
+        mock_check.assert_not_called()
+        mock_loop.assert_called_once()
+        assert result.success is True
+        assert result.plan_already_exists is False
+
+
+class TestFilterIssues:
+    """Regression guards for #548.
+
+    _filter_issues must NOT do per-issue plan lookups (those moved into the
+    worker). If these tests fail, the per-issue gh round-trip stall at phase
+    1 startup has been re-introduced.
+    """
+
+    def test_filter_does_not_call_has_existing_plan(self, planner: Planner) -> None:
+        """The serial _gh_call pre-pass is gone.
+
+        _filter_issues must not invoke _has_existing_plan, even once.
+        """
+        with (
+            patch.object(planner, "_has_existing_plan") as mock_check,
+            patch(
+                "hephaestus.automation.planner.prefetch_issue_states",
+                return_value={},
+            ),
+        ):
+            result = planner._filter_issues()
+
+        mock_check.assert_not_called()
+        assert result == [123]
+
+    def test_filter_still_skips_closed_issues(self, planner: Planner) -> None:
+        """Closed-issue filtering (cheap, batched GraphQL) stays in the pre-pass."""
+        from hephaestus.automation.models import IssueState
+
+        with patch(
+            "hephaestus.automation.planner.prefetch_issue_states",
+            return_value={123: IssueState.CLOSED},
+        ):
+            result = planner._filter_issues()
+
+        assert result == []
+
+    def test_filter_passes_open_issues_through(self, planner: Planner) -> None:
+        """Open issues survive the pre-pass and are returned for the worker pool."""
+        from hephaestus.automation.models import IssueState
+
+        with patch(
+            "hephaestus.automation.planner.prefetch_issue_states",
+            return_value={123: IssueState.OPEN},
+        ):
+            result = planner._filter_issues()
+
+        assert result == [123]


### PR DESCRIPTION
## Problem

`Planner._filter_issues` did a serial, single-threaded pre-pass: for every issue in `--issues`, it called `gh issue view N --comments` *before* any planning worker started. With ~20+ issues per repo this manifested as a multi-minute stall at the start of phase 1 of `run_automation_loop.sh`, with the log filling with `Issue #N already has a plan, skipping` lines and nothing else happening. The check was also redundant with `Implementer._has_plan` at `hephaestus/automation/implementer.py:583`, which already gates each issue per-worker.

## Fix

Moved `_has_existing_plan` out of `_filter_issues` and into `_plan_issue` (the per-issue worker). Same log line, same `PlanResult(plan_already_exists=True)` marker, same external semantics — but now running inside the `ThreadPoolExecutor` so up to `--parallel` checks happen concurrently and overlap with planning work for issues that need it. `_filter_issues` keeps the cheap, batched closed-issue filter (`prefetch_issue_states` is one GraphQL call per 100 issues).

No CLI surface change. No orchestrator change.

## Testing

Added focused tests in `tests/unit/automation/test_planner_loop.py`:

- `test_existing_plan_short_circuits_in_worker` — happy path: when a plan exists, worker returns early with `plan_already_exists=True` and never calls the review loop or `_post_plan`.
- `test_force_bypasses_existing_plan_check` — `--force` skips the check entirely and runs the review loop unconditionally.
- `TestFilterIssues` regression class (3 tests) — guards `_filter_issues` against re-introducing per-issue `gh` round-trips:
  - `_has_existing_plan` is never called from the filter
  - Closed issues are still filtered (batched GraphQL path intact)
  - Open issues pass through unchanged

Updated two existing tests (`test_nogo_exhausted_plan_result_success_false`, `test_go_plan_result_success_true`) to patch `_has_existing_plan` — they were implicitly relying on it not being called and would have flaked against real `gh` state.

Results:
- `pytest tests/unit/automation/`: **523 passed**
- `pytest tests/unit/automation/test_planner*.py`: **42 passed**
- `ruff check` / `ruff format`: clean
- `mypy`: success, no issues in 249 source files

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)