### PR TITLE
fix(automation): silent-abort + FINAL-verdict skeleton (baseline for #550 swarm)

### DIFF
--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -41,6 +41,24 @@ _PLAN_MARKERS = PLAN_COMMENT_MARKERS
 # Prefix used by this reviewer when posting review comments.
 _REVIEW_PREFIX = "## 🔍 Plan Review"
 
+# Verdict marker emitted by Claude at the end of every plan review. See
+# PLAN_REVIEW_PROMPT in prompts.py — Claude is instructed to end its
+# response with exactly one of:
+#   **Verdict: APPROVED**  — plan is sound and ready to implement
+#   **Verdict: REVISE**    — plan needs changes (re-review next loop)
+#   **Verdict: BLOCK**     — plan has a fundamental problem
+# We short-circuit the reviewer for an issue only when the LATEST plan
+# review carries APPROVED. Any other verdict (REVISE/BLOCK) or a missing
+# marker re-runs the reviewer so the plan can be re-evaluated after the
+# planner amends it.
+_FINAL_VERDICT_MARKER = "**Verdict: APPROVED**"
+
+# Fallback marker appended by _post_review when Claude's output omits the
+# verdict line entirely (defence-in-depth — keeps the short-circuit gate
+# parseable even if the model misformats). REVISE is the safe default
+# because it triggers re-review on the next loop.
+_FALLBACK_VERDICT_LINE = "**Verdict: REVISE**"
+
 
 class PlanReviewer:
     """Reviews implementation plans posted to GitHub issues by the planner.
@@ -144,9 +162,17 @@ class PlanReviewer:
 
             # --- Read-only checks (safe in dry-run) ---
 
-            # Skip if already reviewed
-            if self._has_existing_review(issue_number):
-                logger.info("Issue #%s: already has a plan review, skipping", issue_number)
+            # Skip only when the LATEST plan review carries the APPROVED
+            # verdict marker. A REVISE/BLOCK verdict, or any older convention
+            # without the marker, re-runs the reviewer so an amended plan
+            # gets a fresh evaluation. (Previously this short-circuited on
+            # any prior `## 🔍 Plan Review` comment, which locked an issue
+            # out of re-review forever after the first interim verdict.)
+            if self._latest_review_is_final(issue_number):
+                logger.info(
+                    "Issue #%s: latest plan review is APPROVED, skipping",
+                    issue_number,
+                )
                 return WorkerResult(issue_number=issue_number, success=True)
 
             # Skip if no plan exists
@@ -217,7 +243,7 @@ class PlanReviewer:
     def _fetch_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
         """Fetch all comments for an issue, caching the result per instance.
 
-        Both ``_has_existing_review`` and ``_get_latest_plan`` call this
+        Both ``_latest_review_is_final`` and ``_get_latest_plan`` call this
         helper so the ``gh issue view --comments`` API is hit only once per
         issue per worker invocation (#A3-009).
 
@@ -260,7 +286,7 @@ class PlanReviewer:
         """Return the body of the last comment that looks like a plan.
 
         Uses :meth:`_fetch_issue_comments` so the API call is shared with
-        :meth:`_has_existing_review`.
+        :meth:`_latest_review_is_final`.
 
         Args:
             issue_number: GitHub issue number.
@@ -280,8 +306,17 @@ class PlanReviewer:
 
         return None
 
-    def _has_existing_review(self, issue_number: int) -> bool:
-        """Check whether any comment is already a plan review.
+    def _latest_review_is_final(self, issue_number: int) -> bool:
+        """Return True iff the LATEST plan review on the issue is APPROVED.
+
+        The reviewer is idempotent only on the APPROVED verdict — see
+        :data:`_FINAL_VERDICT_MARKER` for context. Comments are scanned in
+        chronological order (the order GitHub returns them) and the last
+        matching ``## 🔍 Plan Review`` body wins. Returns False when:
+
+        - No plan review comment exists at all.
+        - The latest plan review's body does not contain the APPROVED marker
+          (e.g. REVISE, BLOCK, or any pre-marker convention).
 
         Uses :meth:`_fetch_issue_comments` so the API call is shared with
         :meth:`_get_latest_plan`.
@@ -290,18 +325,32 @@ class PlanReviewer:
             issue_number: GitHub issue number.
 
         Returns:
-            True if a review comment already exists.
+            True if the latest plan review carries the APPROVED marker.
 
         """
         comments = self._fetch_issue_comments(issue_number)
 
+        latest_review_body: str | None = None
         for comment in comments:
             body: str = comment.get("body", "")
             if body.startswith(_REVIEW_PREFIX):
-                logger.debug("Found existing review for issue #%s", issue_number)
-                return True
+                latest_review_body = body
 
-        return False
+        if latest_review_body is None:
+            return False
+
+        is_final = _FINAL_VERDICT_MARKER in latest_review_body
+        if is_final:
+            logger.debug(
+                "Issue #%s: latest plan review is APPROVED (final)",
+                issue_number,
+            )
+        else:
+            logger.debug(
+                "Issue #%s: latest plan review is non-final (no APPROVED marker)",
+                issue_number,
+            )
+        return is_final
 
     def _run_claude_analysis(
         self,
@@ -454,11 +503,23 @@ class PlanReviewer:
     def _post_review(self, issue_number: int, review_text: str) -> None:
         """Post the plan review as a comment on the issue.
 
+        Defence-in-depth: if Claude's output omits the verdict line entirely
+        (model misformat), append `_FALLBACK_VERDICT_LINE` (= REVISE) so the
+        next-loop short-circuit gate always has a parseable marker. REVISE is
+        the safe default — it re-runs the reviewer rather than silently
+        skipping a possibly-incomplete review.
+
         Args:
             issue_number: GitHub issue number.
             review_text: Review body text from Claude.
 
         """
+        if "**Verdict:" not in review_text:
+            logger.warning(
+                "Issue #%s: review body missing verdict line; appending fallback REVISE",
+                issue_number,
+            )
+            review_text = f"{review_text.rstrip()}\n\n{_FALLBACK_VERDICT_LINE}\n"
         comment_body = f"{_REVIEW_PREFIX}\n\n{review_text}"
         gh_issue_comment(issue_number, comment_body)
         logger.info("Posted plan review to issue #%s", issue_number)

--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -143,15 +143,42 @@ phase_enabled() {
   esac
 }
 
+# ---------------------------------------------------------------------------
+# Phase banner helpers.
+#
+# Every phase block in process_repo wraps its work in a phase_start/phase_done
+# pair so the operator can see (a) which of the 6 phases actually ran for each
+# repo, (b) what exit code each phase returned, and (c) how long it took. A
+# silent abort inside process_repo (e.g. set -e tripping on an unguarded
+# infrastructure command) will be obvious from a missing `done` line.
+#
+# phase_start prints the START banner to stderr and writes the epoch
+# timestamp to stdout, so callers do `t0=$(phase_start …)`.
+# ---------------------------------------------------------------------------
+phase_start() {
+  local repo="$1" idx="$2" name="$3"
+  echo "  [$repo] phase $idx/6 $name START" >&2
+  date +%s
+}
+phase_done() {
+  local repo="$1" idx="$2" name="$3" t0="$4" status="${5:-0}"
+  local now
+  now=$(date +%s)
+  echo "  [$repo] phase $idx/6 $name done in $((now - t0))s (rc=$status)"
+}
+
 # Forward model selections via env vars to all child processes.
 # claude_models.py honours these and falls back to its own defaults if unset.
 [[ -n "$PLANNER_MODEL" ]]     && export HEPH_PLANNER_MODEL="$PLANNER_MODEL"
 [[ -n "$REVIEWER_MODEL" ]]    && export HEPH_REVIEWER_MODEL="$REVIEWER_MODEL"
 [[ -n "$IMPLEMENTER_MODEL" ]] && export HEPH_IMPLEMENTER_MODEL="$IMPLEMENTER_MODEL"
 
-DRY_RUN_FLAGS=""
+# Array form (rather than a string) so `"${DRY_RUN_FLAGS[@]}"` expands to
+# zero argv elements in the off case under `set -u`, matching the
+# `ISSUE_ARGS` pattern established in PR #543.
+DRY_RUN_FLAGS=()
 if [[ "$DRY_RUN" -eq 1 ]]; then
-  DRY_RUN_FLAGS="--dry-run"
+  DRY_RUN_FLAGS=(--dry-run)
 fi
 
 # ---------------------------------------------------------------------------
@@ -249,12 +276,26 @@ process_repo() {
   local loop="$2"
   local dir="$PROJECTS_DIR/$repo"
 
+  # Defang errexit for the function body. Each phase below captures `rc=$?`
+  # explicitly and logs a structured warning on non-zero — that is the
+  # authoritative error handler. An unguarded infrastructure command
+  # (`git fetch`, mapfile + process substitution under `set -m`, a `local`
+  # assignment whose RHS happens to be non-zero) must NOT silently abort
+  # the function and cause phases 2-6 to be skipped. The RETURN trap
+  # restores errexit when the function returns so the outer orchestrator's
+  # `set -e` semantics are unaffected.
+  set +e
+  trap 'set -e' RETURN
+
+  local rc t0
+
   echo ""
   echo "── $repo ──────────────────────────────────────────────────────"
 
   # Rebase main before starting work
   echo "  [$repo] Rebasing main..."
-  git -C "$dir" fetch origin --quiet
+  git -C "$dir" fetch origin --quiet \
+    || echo "  [$repo] Warning: git fetch failed (continuing with stale refs)"
   git -C "$dir" rebase origin/main --quiet 2>/dev/null \
     || git -C "$dir" reset --hard origin/main --quiet 2>/dev/null \
     || echo "  [$repo] Warning: could not rebase, continuing anyway"
@@ -267,10 +308,11 @@ process_repo() {
   export HEPH_TRUNK_GITHASH
   echo "  [$repo] trunk=$HEPH_TRUNK_GITHASH (loop $loop)"
 
-  # On loop 3+, suppress follow-up issue filing to avoid noise
-  local FOLLOW_UP_FLAG=""
+  # On loop 3+, suppress follow-up issue filing to avoid noise.
+  # Array form so `"${FOLLOW_UP_FLAG[@]}"` expands to zero elements when off.
+  local FOLLOW_UP_FLAG=()
   if [[ "$loop" -ge 3 ]]; then
-    FOLLOW_UP_FLAG="--no-follow-up"
+    FOLLOW_UP_FLAG=(--no-follow-up)
   fi
 
   # Discover this repo's open issues once per loop iteration. Four of the six
@@ -294,108 +336,139 @@ process_repo() {
 
   # --- Phase 1: Plan ---
   if phase_enabled plan; then
-    echo "  [$repo] Planning issues..."
+    t0=$(phase_start "$repo" 1 plan)
     (
-      cd "$dir"
+      cd "$dir" || exit 1
       "$PLAN_BIN" \
         -v \
-        $DRY_RUN_FLAGS \
-        || echo "  [$repo] Warning: plan-issues exited non-zero (loop $loop)"
+        "${DRY_RUN_FLAGS[@]}"
     )
+    rc=$?
+    [[ $rc -ne 0 ]] && echo "  [$repo] Warning: plan-issues exited rc=$rc (loop $loop)"
+    phase_done "$repo" 1 plan "$t0" "$rc"
+  else
+    echo "  [$repo] phase 1/6 plan SKIP (disabled by --phases)"
   fi
 
   # --- Phase 2: Review Plans ---
   if phase_enabled review-plans; then
     if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
-      echo "  [$repo] No open issues — skipping review-plans"
+      echo "  [$repo] phase 2/6 review-plans SKIP (no open issues)"
     else
-      echo "  [$repo] Reviewing plans..."
+      t0=$(phase_start "$repo" 2 review-plans)
       (
-        cd "$dir"
+        cd "$dir" || exit 1
         "$PYTHON" "$SCRIPT_DIR/review_plans.py" \
           "${ISSUE_ARGS[@]}" \
           --max-workers "$MAX_WORKERS" \
           -v \
-          $DRY_RUN_FLAGS \
-          || echo "  [$repo] Warning: review-plans exited non-zero (loop $loop)"
+          "${DRY_RUN_FLAGS[@]}"
       )
+      rc=$?
+      [[ $rc -ne 0 ]] && echo "  [$repo] Warning: review-plans exited rc=$rc (loop $loop)"
+      phase_done "$repo" 2 review-plans "$t0" "$rc"
     fi
+  else
+    echo "  [$repo] phase 2/6 review-plans SKIP (disabled by --phases)"
   fi
 
   # --- Phase 3: Implement ---
   if phase_enabled implement; then
-    echo "  [$repo] Implementing issues..."
+    t0=$(phase_start "$repo" 3 implement)
     (
-      cd "$dir"
+      cd "$dir" || exit 1
       "$IMPL_BIN" \
         --max-workers "$MAX_WORKERS" \
         --no-ui \
         -v \
-        $FOLLOW_UP_FLAG \
-        $DRY_RUN_FLAGS \
-        || echo "  [$repo] Warning: implement-issues exited non-zero (loop $loop)"
+        "${FOLLOW_UP_FLAG[@]}" \
+        "${DRY_RUN_FLAGS[@]}"
     )
+    rc=$?
+    [[ $rc -ne 0 ]] && echo "  [$repo] Warning: implement-issues exited rc=$rc (loop $loop)"
+    phase_done "$repo" 3 implement "$t0" "$rc"
+  else
+    echo "  [$repo] phase 3/6 implement SKIP (disabled by --phases)"
   fi
 
   # --- Phase 4: Review PRs (inline comments) ---
   if phase_enabled review-prs; then
     if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
-      echo "  [$repo] No open issues — skipping review-prs"
+      echo "  [$repo] phase 4/6 review-prs SKIP (no open issues)"
     else
-      echo "  [$repo] Reviewing PRs..."
+      t0=$(phase_start "$repo" 4 review-prs)
       (
-        cd "$dir"
+        cd "$dir" || exit 1
         "$PYTHON" "$SCRIPT_DIR/review_issues.py" \
           "${ISSUE_ARGS[@]}" \
           --max-workers "$MAX_WORKERS" \
           --no-ui \
           -v \
-          $DRY_RUN_FLAGS \
-          || echo "  [$repo] Warning: review-issues exited non-zero (loop $loop)"
+          "${DRY_RUN_FLAGS[@]}"
       )
+      rc=$?
+      [[ $rc -ne 0 ]] && echo "  [$repo] Warning: review-issues exited rc=$rc (loop $loop)"
+      phase_done "$repo" 4 review-prs "$t0" "$rc"
     fi
+  else
+    echo "  [$repo] phase 4/6 review-prs SKIP (disabled by --phases)"
   fi
 
   # --- Phase 5: Address Review Comments ---
   if phase_enabled address-review; then
     if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
-      echo "  [$repo] No open issues — skipping address-review"
+      echo "  [$repo] phase 5/6 address-review SKIP (no open issues)"
     else
-      echo "  [$repo] Addressing review comments..."
+      t0=$(phase_start "$repo" 5 address-review)
       (
-        cd "$dir"
+        cd "$dir" || exit 1
         "$PYTHON" "$SCRIPT_DIR/address_review.py" \
           "${ISSUE_ARGS[@]}" \
           --max-workers "$MAX_WORKERS" \
           --no-ui \
           -v \
-          $DRY_RUN_FLAGS \
-          || echo "  [$repo] Warning: address-review exited non-zero (loop $loop)"
+          "${DRY_RUN_FLAGS[@]}"
       )
+      rc=$?
+      [[ $rc -ne 0 ]] && echo "  [$repo] Warning: address-review exited rc=$rc (loop $loop)"
+      phase_done "$repo" 5 address-review "$t0" "$rc"
     fi
+  else
+    echo "  [$repo] phase 5/6 address-review SKIP (disabled by --phases)"
   fi
 
   # --- Phase 6: Drive PRs to Green CI (final loop only) ---
-  if phase_enabled drive-green && [[ "$loop" -eq "$LOOPS" ]]; then
-    if [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
-      echo "  [$repo] No open issues — skipping drive-green"
-    else
-      echo "  [$repo] Driving PRs to green CI..."
-      (
-        cd "$dir"
-        # Defence-in-depth: ci_driver also checks these envs and refuses to run
-        # unless HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS or --force-run is given.
-        HEPH_LOOP_INDEX="$loop" HEPH_TOTAL_LOOPS="$LOOPS" \
-        "$PYTHON" "$SCRIPT_DIR/drive_prs_green.py" \
-          "${ISSUE_ARGS[@]}" \
-          --max-workers "$MAX_WORKERS" \
-          --no-ui \
-          -v \
-          $DRY_RUN_FLAGS \
-          || echo "  [$repo] Warning: drive-prs-green exited non-zero (loop $loop)"
-      )
-    fi
+  if ! phase_enabled drive-green; then
+    echo "  [$repo] phase 6/6 drive-green SKIP (disabled by --phases)"
+  elif [[ "$loop" -ne "$LOOPS" ]]; then
+    echo "  [$repo] phase 6/6 drive-green SKIP (not final loop)"
+  elif [[ ${#OPEN_ISSUES[@]} -eq 0 ]]; then
+    echo "  [$repo] phase 6/6 drive-green SKIP (no open issues)"
+  else
+    t0=$(phase_start "$repo" 6 drive-green)
+    (
+      cd "$dir" || exit 1
+      # Defence-in-depth: ci_driver also checks these envs and refuses to run
+      # unless HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS or --force-run is given.
+      HEPH_LOOP_INDEX="$loop" HEPH_TOTAL_LOOPS="$LOOPS" \
+      "$PYTHON" "$SCRIPT_DIR/drive_prs_green.py" \
+        "${ISSUE_ARGS[@]}" \
+        --max-workers "$MAX_WORKERS" \
+        --no-ui \
+        -v \
+        "${DRY_RUN_FLAGS[@]}"
+    )
+    rc=$?
+    [[ $rc -ne 0 ]] && echo "  [$repo] Warning: drive-prs-green exited rc=$rc (loop $loop)"
+    phase_done "$repo" 6 drive-green "$t0" "$rc"
   fi
+
+  # Always succeed: every phase has logged its own status via phase_done,
+  # so the outer `wait` should report success after a clean run. The
+  # previously-emitted `Warning: repo job pid=… exited non-zero` was
+  # cosmetic noise from set -e tripping on an unguarded infrastructure
+  # command — that path is now closed by the `set +e` above.
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -413,11 +486,13 @@ for (( loop=1; loop<=LOOPS; loop++ )); do
     ACTIVE_PIDS+=($!)
 
     if [[ ${#ACTIVE_PIDS[@]} -ge "$PARALLEL_REPOS" ]]; then
-      # A non-zero exit from process_repo just means one repo's phase warned;
-      # the per-phase blocks already logged the warning and the orchestrator
-      # continues with the remaining repos. Surface the exit code explicitly.
+      # process_repo() always `return 0`; this branch should be unreachable
+      # on a clean run. If it fires, the cause is upstream of the per-phase
+      # error handlers (e.g. the subshell was killed by a signal) — point
+      # the operator at the phase banners that already document each
+      # phase's exit code.
       if ! wait "${ACTIVE_PIDS[0]}"; then
-        echo "  Warning: repo job pid=${ACTIVE_PIDS[0]} exited non-zero (continuing)" >&2
+        echo "  Note: wait() non-zero for pid=${ACTIVE_PIDS[0]} — check phase banners above" >&2
       fi
       ACTIVE_PIDS=("${ACTIVE_PIDS[@]:1}")
     fi
@@ -426,7 +501,7 @@ for (( loop=1; loop<=LOOPS; loop++ )); do
   # Drain any remaining background jobs
   for pid in "${ACTIVE_PIDS[@]}"; do
     if ! wait "$pid"; then
-      echo "  Warning: repo job pid=$pid exited non-zero (continuing)" >&2
+      echo "  Note: wait() non-zero for pid=$pid — check phase banners above" >&2
     fi
   done
   ACTIVE_PIDS=()

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -84,39 +84,128 @@ class TestGetLatestPlan:
         assert result is None
 
 
-class TestHasExistingReview:
-    """Tests for _has_existing_review method."""
+class TestLatestReviewIsFinal:
+    """Tests for the FINAL/APPROVED short-circuit gate.
 
-    def test_has_existing_review_true(self, reviewer: PlanReviewer) -> None:
-        """_has_existing_review returns True when review comment exists."""
+    The reviewer skips an issue only when the LATEST plan-review comment
+    carries the `**Verdict: APPROVED**` marker. REVISE/BLOCK/no-marker
+    re-runs the reviewer so an amended plan gets a fresh evaluation.
+    """
+
+    def test_skip_when_latest_review_is_approved(self, reviewer: PlanReviewer) -> None:
+        """APPROVED in the latest plan-review comment → skip."""
         comments = [
-            {"body": "## 🔍 Plan Review\n\nSome review content"},
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {"body": "## 🔍 Plan Review\n\nLooks good.\n\n**Verdict: APPROVED**"},
         ]
         with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
             mock_gh.return_value = _make_gh_result({"comments": comments})
-            result = reviewer._has_existing_review(123)
+            assert reviewer._latest_review_is_final(123) is True
 
-        assert result is True
-
-    def test_has_existing_review_false_no_review(self, reviewer: PlanReviewer) -> None:
-        """_has_existing_review returns False when no review comment exists."""
+    def test_rerun_when_latest_review_revise(self, reviewer: PlanReviewer) -> None:
+        """REVISE in the latest plan-review comment → re-run (not final)."""
         comments = [
-            {"body": "## Implementation Plan\n\nSome plan"},
-            {"body": "Just a comment"},
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {"body": "## 🔍 Plan Review\n\nNeeds work.\n\n**Verdict: REVISE**"},
         ]
         with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
             mock_gh.return_value = _make_gh_result({"comments": comments})
-            result = reviewer._has_existing_review(123)
+            assert reviewer._latest_review_is_final(123) is False
 
-        assert result is False
+    def test_rerun_when_latest_review_block(self, reviewer: PlanReviewer) -> None:
+        """BLOCK in the latest plan-review comment → re-run (not final)."""
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {"body": "## 🔍 Plan Review\n\nFundamental problem.\n\n**Verdict: BLOCK**"},
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is False
 
-    def test_has_existing_review_false_on_error(self, reviewer: PlanReviewer) -> None:
-        """_has_existing_review returns False when gh call fails."""
+    def test_rerun_when_older_approved_but_newer_revise(self, reviewer: PlanReviewer) -> None:
+        """An older APPROVED followed by a newer REVISE → re-run (latest wins)."""
+        comments = [
+            {"body": "## Implementation Plan\n\nFirst plan"},
+            {"body": "## 🔍 Plan Review\n\nOld pass.\n\n**Verdict: APPROVED**"},
+            {"body": "## Implementation Plan\n\nAmended plan"},
+            {"body": "## 🔍 Plan Review\n\nNew concerns.\n\n**Verdict: REVISE**"},
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is False
+
+    def test_rerun_when_review_lacks_verdict_marker(self, reviewer: PlanReviewer) -> None:
+        """A plan-review comment without any verdict marker → re-run."""
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {"body": "## 🔍 Plan Review\n\nPre-marker convention review body."},
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is False
+
+    def test_rerun_when_no_review_comment_exists(self, reviewer: PlanReviewer) -> None:
+        """No plan-review comment at all → re-run (not final)."""
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {"body": "Some unrelated drive-by comment"},
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is False
+
+    def test_false_on_gh_error(self, reviewer: PlanReviewer) -> None:
+        """Gh failure → _fetch_issue_comments returns [], gate returns False."""
         with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
             mock_gh.side_effect = RuntimeError("gh failed")
-            result = reviewer._has_existing_review(123)
+            assert reviewer._latest_review_is_final(123) is False
 
-        assert result is False
+    def test_approved_marker_anywhere_in_latest_review_counts(self, reviewer: PlanReviewer) -> None:
+        """The marker may appear anywhere in the review body.
+
+        Claude is free to put `**Verdict: APPROVED**` on the last line or
+        anywhere else — we don't require strict end-of-text positioning.
+        """
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {
+                "body": (
+                    "## 🔍 Plan Review\n\n"
+                    "**Verdict: APPROVED**\n\n"
+                    "Long-form rationale follows below..."
+                )
+            },
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is True
+
+
+class TestPostReviewVerdictFallback:
+    """Tests for the defence-in-depth fallback verdict line in _post_review."""
+
+    def test_appends_fallback_when_verdict_missing(self, reviewer: PlanReviewer) -> None:
+        """If Claude output has no `**Verdict:`, _post_review appends REVISE."""
+        with patch("hephaestus.automation.plan_reviewer.gh_issue_comment") as mock_comment:
+            reviewer._post_review(123, "Just analysis prose, no verdict line.")
+
+        mock_comment.assert_called_once()
+        posted_body: str = mock_comment.call_args[0][1]
+        assert "**Verdict: REVISE**" in posted_body
+        assert posted_body.startswith("## 🔍 Plan Review")
+
+    def test_does_not_double_append_when_verdict_present(self, reviewer: PlanReviewer) -> None:
+        """If the review already has any **Verdict: line, no fallback is added."""
+        with patch("hephaestus.automation.plan_reviewer.gh_issue_comment") as mock_comment:
+            reviewer._post_review(
+                123,
+                "Some analysis.\n\n**Verdict: APPROVED**",
+            )
+
+        posted_body: str = mock_comment.call_args[0][1]
+        # exactly one Verdict line, not two
+        assert posted_body.count("**Verdict:") == 1
+        assert "**Verdict: APPROVED**" in posted_body
 
 
 class TestRunClaudeAnalysis:
@@ -164,7 +253,7 @@ class TestReviewIssue:
     def test_review_skipped_if_no_plan(self, reviewer: PlanReviewer) -> None:
         """When issue has no plan comment, _review_issue returns success with no post."""
         with (
-            patch.object(reviewer, "_has_existing_review", return_value=False),
+            patch.object(reviewer, "_latest_review_is_final", return_value=False),
             patch.object(reviewer, "_get_latest_plan", return_value=None),
             patch("hephaestus.automation.plan_reviewer.gh_issue_comment") as mock_comment,
         ):
@@ -173,10 +262,10 @@ class TestReviewIssue:
         assert result.success is True
         mock_comment.assert_not_called()
 
-    def test_review_skipped_if_already_reviewed(self, reviewer: PlanReviewer) -> None:
-        """When latest comment is a plan review, skip posting."""
+    def test_review_skipped_if_latest_review_is_final(self, reviewer: PlanReviewer) -> None:
+        """When the latest plan review is APPROVED, skip posting."""
         with (
-            patch.object(reviewer, "_has_existing_review", return_value=True),
+            patch.object(reviewer, "_latest_review_is_final", return_value=True),
             patch("hephaestus.automation.plan_reviewer.gh_issue_comment") as mock_comment,
         ):
             result = reviewer._review_issue(123, 0)
@@ -185,9 +274,9 @@ class TestReviewIssue:
         mock_comment.assert_not_called()
 
     def test_review_posted(self, reviewer: PlanReviewer) -> None:
-        """When plan exists and no review yet, posts review comment with correct prefix."""
+        """When plan exists and no APPROVED review yet, posts review with correct prefix."""
         with (
-            patch.object(reviewer, "_has_existing_review", return_value=False),
+            patch.object(reviewer, "_latest_review_is_final", return_value=False),
             patch.object(
                 reviewer, "_get_latest_plan", return_value="## Implementation Plan\n\nDo stuff"
             ),
@@ -195,7 +284,7 @@ class TestReviewIssue:
             patch.object(
                 reviewer,
                 "_run_claude_analysis",
-                return_value="Great plan! A few suggestions.",
+                return_value="Great plan! A few suggestions.\n\n**Verdict: APPROVED**",
             ),
             patch("hephaestus.automation.plan_reviewer.gh_issue_comment") as mock_comment,
         ):
@@ -214,7 +303,7 @@ class TestReviewIssue:
         reviewer = PlanReviewer(mock_options)
 
         with (
-            patch.object(reviewer, "_has_existing_review", return_value=False),
+            patch.object(reviewer, "_latest_review_is_final", return_value=False),
             patch.object(
                 reviewer, "_get_latest_plan", return_value="## Implementation Plan\n\nDo stuff"
             ),
@@ -222,7 +311,7 @@ class TestReviewIssue:
             patch.object(
                 reviewer,
                 "_run_claude_analysis",
-                return_value="Review text",
+                return_value="Review text\n\n**Verdict: REVISE**",
             ),
             patch("hephaestus.automation.plan_reviewer.gh_issue_comment") as mock_comment,
         ):
@@ -235,7 +324,7 @@ class TestReviewIssue:
     def test_returns_failure_when_claude_returns_none(self, reviewer: PlanReviewer) -> None:
         """Returns failed WorkerResult when Claude analysis returns None."""
         with (
-            patch.object(reviewer, "_has_existing_review", return_value=False),
+            patch.object(reviewer, "_latest_review_is_final", return_value=False),
             patch.object(
                 reviewer, "_get_latest_plan", return_value="## Implementation Plan\n\nDo stuff"
             ),
@@ -253,7 +342,7 @@ class TestFetchIssueCommentsCache:
     """Tests for the _fetch_issue_comments caching helper (#A3-009)."""
 
     def test_api_called_only_once_for_same_issue(self, reviewer: PlanReviewer) -> None:
-        """Calling both _has_existing_review and _get_latest_plan should hit the API once."""
+        """Calling _latest_review_is_final and _get_latest_plan should hit the API once."""
         comments = [
             {"body": "## Implementation Plan\n\nDo stuff"},
         ]
@@ -261,7 +350,7 @@ class TestFetchIssueCommentsCache:
             mock_gh.return_value = _make_gh_result({"comments": comments})
 
             # Call both methods that internally use _fetch_issue_comments
-            reviewer._has_existing_review(123)
+            reviewer._latest_review_is_final(123)
             reviewer._get_latest_plan(123)
 
         assert mock_gh.call_count == 1, "Expected single API call due to caching"


### PR DESCRIPTION
## Summary

Baseline fix for the user-reported symptom: `run_automation_loop.sh` was appearing to "skip through all the repos because the plans already exist". Investigation showed two real bugs:

1. **Shell silent abort** — `set -euo pipefail` was tripping on an unguarded infrastructure command between phase 1 and phase 2 of `process_repo`, silently aborting the function so phases 2-6 never ran. The `Warning: repo job pid=… exited non-zero (continuing)` line surfaced this but was uninformative.

2. **plan-reviewer over-skip** — `_has_existing_review` skipped on *any* prior `## 🔍 Plan Review` comment, locking issues out of re-review even after a NEEDS_CHANGES verdict.

This PR fixes the immediate symptom but leaves **13 follow-up findings** identified by a strict audit, tracked in epic #550 and sub-issues #551–#566. Most notably #551 — the implementer phase does NOT yet honor the plan-reviewer's verdict — so the end-to-end "implement only APPROVED plans" intent the user described is NOT fully delivered by this PR. The Myrmidon swarm will land those fixes in parallel after this baseline merges.

## Changes

- `scripts/run_automation_loop.sh`: `set +e` + RETURN trap in `process_repo`; `phase_start`/`phase_done` banners with explicit `rc=$?` capture; per-phase SKIP banners; `DRY_RUN_FLAGS`/`FOLLOW_UP_FLAG` arrayified; `return 0`; softened drain-loop warning.
- `hephaestus/automation/plan_reviewer.py`: `_FINAL_VERDICT_MARKER` constant; replace `_has_existing_review` → `_latest_review_is_final` (substring `in` check — known issue, #552 will harden this to last-line regex); fallback REVISE append in `_post_review`.
- `tests/unit/automation/test_plan_reviewer.py`: 10 new tests covering FINAL-verdict gate + fallback; updated 6 existing patches.

## Test evidence

- `pixi run test-shell`: 26/26 bats pass
- `pixi run pytest tests/unit --no-cov -q -x`: 2362 passed, 11 skipped
- `pixi run ruff check` + `ruff format --check`: clean
- Manual smoke against stubbed phase binaries: all 6 phase banners fire; `process_repo` returns 0 in both issues-present and zero-issues paths

## Known issues addressed in follow-up swarm

This PR explicitly does not yet close any audit-finding issue. The swarm will land:
- #551 — implementer doesn't gate on verdict (the load-bearing one)
- #552 — substring-`in` verdict check → regex
- #553 — gh comment pagination
- #554 — stdout/stderr split
- #555 — bats coverage for `process_repo`
- #556 — TestRunClaudeAnalysis patches wrong layer
- #557 — root-cause bisect of original silent abort
- #558-#566 — minors + nitpicks

Refs #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #568