### PR TITLE
fix(automation): plan-reviewer correctness — bundle A (#552 #553 #560 #561 #563 #565)

### DIFF
--- a/docs/release-notes/plan-reviewer-final-verdict.md
+++ b/docs/release-notes/plan-reviewer-final-verdict.md
@@ -1,0 +1,83 @@
+# Plan reviewer: skip semantic changed — APPROVED-only short-circuit
+
+**Affected component:** `hephaestus.automation.plan_reviewer`
+**Issues:** #550 (epic), #552, #553, #560, #561, #563, #565
+**Ships with:** PR landing the bundle-A fixes against epic #550
+
+## What changed
+
+Before this release the plan reviewer treated *any* prior `## 🔍 Plan Review`
+comment as a terminal signal and short-circuited the issue forever — even if
+the prior review had said `**Verdict: REVISE**` or `**Verdict: BLOCK**`. Once
+the planner amended the plan, the reviewer never re-evaluated it.
+
+After this release the reviewer short-circuits **only** when the latest plan
+review carries the `**Verdict: APPROVED**` marker on its own line. REVISE,
+BLOCK, or any pre-marker review body re-triggers a fresh review on the next
+loop run.
+
+Two correctness fixes ride along:
+
+1. **Last-line-wins verdict parsing.** The gate now extracts every line
+   matching `^**Verdict: (APPROVED|REVISE|BLOCK)**$` from the review body
+   (regex, multiline) and uses the LAST match — matching the contract the
+   prompt gives Claude (`prompts.py:474-475`). The previous substring `in`
+   check could mis-fire True on a body that quoted the marker in prose or
+   discussed APPROVED before settling on BLOCK.
+
+2. **GraphQL comment fetch.** `_fetch_issue_comments` now queries the
+   GitHub GraphQL API directly with
+   `comments(last: 100, orderBy: {field: UPDATED_AT, direction: DESC})`
+   instead of `gh issue view --comments`, which silently capped at 100 in
+   chronological order. Issues with 100+ comments could previously have
+   their actual-latest review fall off the head of the list.
+
+## Operational impact: one-time Claude call burst
+
+Because the skip condition tightened from *"any prior review"* to
+*"APPROVED-only"*, every existing open issue whose latest plan review is
+non-APPROVED (REVISE / BLOCK / pre-marker) will be re-reviewed on the first
+loop run after this lands. This is intentional — those issues should have
+been re-reviewed all along — but it means a one-time spike in Claude calls
+across the HomericIntelligence fleet.
+
+### Estimating the spike per repo
+
+Run this in each repo to count issues that will re-trigger:
+
+```bash
+gh issue list --state open --limit 1000 --json number,comments --jq '
+  [.[]
+   | select(any(.comments[]; .body | startswith("## 🔍 Plan Review")))
+   | select(
+       all(
+         .comments[]
+         | select(.body | startswith("## 🔍 Plan Review"))
+         ; (.body | contains("**Verdict: APPROVED**")) | not
+       )
+     )
+   | .number
+  ]
+  | length
+'
+```
+
+Multiply by the per-review Claude token cost to get a one-time budget delta.
+Subsequent loop runs return to baseline — only the *first* loop after
+deploy pays the back-fill cost.
+
+## Mitigations
+
+- **Watch fleet quota.** The reviewer respects per-agent rate-limit
+  back-off (`scan_quota_reset` + `wait_until`); a quota hit during the spike
+  delays but does not corrupt the review.
+- **Per-repo rollout.** If the bulk count above is uncomfortable for any
+  single repo, schedule that repo's first post-deploy loop during a
+  low-traffic window.
+
+## No action required from operators if
+
+- The repo has zero open issues with prior plan reviews, or
+- All prior plan reviews already carry `**Verdict: APPROVED**`.
+
+In either case the short-circuit gate behaves identically to before.

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import subprocess
 import threading
 import time
@@ -39,6 +40,16 @@ logger = logging.getLogger(__name__)
 _PLAN_MARKERS = PLAN_COMMENT_MARKERS
 
 # Prefix used by this reviewer when posting review comments.
+#
+# IMPORTANT: byte-exact case-sensitive match assumption. Idempotency rests on
+# ``body.startswith(_REVIEW_PREFIX)``. Both sides come from the same writer
+# (this module) and GitHub stores comment bodies verbatim, so today this is
+# safe. If a future GitHub or tooling change ever normalizes the U+1F50D
+# magnifying-glass emoji to a different Unicode form (e.g. NFD vs NFC), or
+# alters spacing/case, ``startswith`` will silently miss and the reviewer
+# will post a duplicate review every loop. If that becomes a concern,
+# NFC-normalize both sides via ``unicodedata.normalize("NFC", ...)`` before
+# comparison. See issue #565.
 _REVIEW_PREFIX = "## 🔍 Plan Review"
 
 # Verdict marker emitted by Claude at the end of every plan review. See
@@ -52,6 +63,18 @@ _REVIEW_PREFIX = "## 🔍 Plan Review"
 # marker re-runs the reviewer so the plan can be re-evaluated after the
 # planner amends it.
 _FINAL_VERDICT_MARKER = "**Verdict: APPROVED**"
+
+# Regex that extracts every well-formed verdict line in a review body. We
+# parse with ``MULTILINE`` and take the LAST match, mirroring the
+# instruction Claude is given in :data:`prompts.PLAN_REVIEW_PROMPT` —
+# *"readers take only the LAST matching line in your response."* A substring
+# check is unsafe because the body may discuss earlier verdicts (e.g.
+# ``**Verdict: APPROVED**`` followed by ``**Verdict: BLOCK**``) or quote
+# the marker in prose; only the trailing line counts.
+_VERDICT_LINE_RE = re.compile(
+    r"^\*\*Verdict: (APPROVED|REVISE|BLOCK)\*\*\s*$",
+    re.MULTILINE,
+)
 
 # Fallback marker appended by _post_review when Claude's output omits the
 # verdict line entirely (defence-in-depth — keeps the short-circuit gate
@@ -80,6 +103,10 @@ class PlanReviewer:
         self.options = options
         self.status_tracker = StatusTracker(options.max_workers)
         self.lock = threading.Lock()
+        # Per-instance cache for ``_fetch_issue_comments`` (#A3-009, #560).
+        # Initialised here rather than lazily so mypy sees the type and the
+        # ThreadPoolExecutor invariant is unambiguous.
+        self._comments_cache: dict[int, list[dict[str, Any]]] = {}
 
     def run(self) -> dict[int, WorkerResult]:
         """Run the plan reviewer on all issues.
@@ -121,13 +148,15 @@ class PlanReviewer:
                         with self.lock:
                             results[issue_num] = result
                         if result.success:
-                            logger.info("Issue #%s: plan review completed", issue_num)
+                            logger.info("Issue %s: plan review completed", issue_ref(issue_num))
                         else:
                             logger.error(
-                                "Issue #%s: plan review failed: %s", issue_num, result.error
+                                "Issue %s: plan review failed: %s",
+                                issue_ref(issue_num),
+                                result.error,
                             )
                     except Exception as e:
-                        logger.error("Issue #%s raised exception: %s", issue_num, e)
+                        logger.error("Issue %s raised exception: %s", issue_ref(issue_num), e)
                         with self.lock:
                             results[issue_num] = WorkerResult(
                                 issue_number=issue_num,
@@ -170,15 +199,15 @@ class PlanReviewer:
             # out of re-review forever after the first interim verdict.)
             if self._latest_review_is_final(issue_number):
                 logger.info(
-                    "Issue #%s: latest plan review is APPROVED, skipping",
-                    issue_number,
+                    "Issue %s: latest plan review is APPROVED, skipping",
+                    issue_ref(issue_number),
                 )
                 return WorkerResult(issue_number=issue_number, success=True)
 
             # Skip if no plan exists
             plan_text = self._get_latest_plan(issue_number)
             if plan_text is None:
-                logger.info("Issue #%s: no plan comment found, skipping", issue_number)
+                logger.info("Issue %s: no plan comment found, skipping", issue_ref(issue_number))
                 return WorkerResult(issue_number=issue_number, success=True)
 
             # Fetch issue details for context
@@ -230,7 +259,7 @@ class PlanReviewer:
             return WorkerResult(issue_number=issue_number, success=True)
 
         except Exception as e:
-            logger.error("Issue #%s: unexpected error: %s", issue_number, e)
+            logger.error("Issue %s: unexpected error: %s", issue_ref(issue_number), e)
             return WorkerResult(
                 issue_number=issue_number,
                 success=False,
@@ -254,32 +283,69 @@ class PlanReviewer:
             List of comment dicts (may be empty on error).
 
         """
-        cache_attr = "_comments_cache"
-        if not hasattr(self, cache_attr):
-            object.__setattr__(self, cache_attr, {})
-        cache: dict[int, list[dict[str, Any]]] = getattr(self, cache_attr)
+        if issue_number in self._comments_cache:
+            return self._comments_cache[issue_number]
 
-        if issue_number in cache:
-            return cache[issue_number]
-
+        # Why GraphQL instead of ``gh issue view --comments``: the CLI's
+        # ``--comments`` JSON field paginates the underlying GraphQL query
+        # at a default cap (≤100 comments) and the CLI does NOT auto-paginate
+        # for ``--json`` output. On a long-running issue with >100 comments
+        # the older ``gh issue view`` call silently truncated the head of
+        # the list, so the "latest plan review" gate could see a stale
+        # APPROVED instead of the real most-recent REVISE/BLOCK. We now ask
+        # GraphQL directly for the *last 100* comments in descending update
+        # order — equivalent to "latest first" — and take the first matching
+        # ``## 🔍 Plan Review`` body in iteration order. Bounded to one API
+        # call. See issue #553. If an issue legitimately accumulates more
+        # than 100 plan-review comments in its history, a follow-up issue
+        # will be needed to add real pagination; in practice plans are
+        # revised a handful of times, not 100+.
+        repo = get_repo_slug(get_repo_root())
+        owner, name = repo.split("/", 1)
+        query = (
+            "query($owner:String!,$name:String!,$number:Int!){"
+            "  repository(owner:$owner,name:$name){"
+            "    issue(number:$number){"
+            "      comments(last: 100, orderBy: {field: UPDATED_AT, direction: DESC}){"
+            "        nodes{ body updatedAt }"
+            "      }"
+            "    }"
+            "  }"
+            "}"
+        )
         try:
             result = _gh_call(
                 [
-                    "issue",
-                    "view",
-                    str(issue_number),
-                    "--comments",
-                    "--json",
-                    "comments",
+                    "api",
+                    "graphql",
+                    "-f",
+                    f"query={query}",
+                    "-F",
+                    f"owner={owner}",
+                    "-F",
+                    f"name={name}",
+                    "-F",
+                    f"number={issue_number}",
                 ],
             )
             data = json.loads(result.stdout)
-            comments: list[dict[str, Any]] = data.get("comments", [])
+            nodes = (
+                data.get("data", {})
+                .get("repository", {})
+                .get("issue", {})
+                .get("comments", {})
+                .get("nodes", [])
+            )
+            # GraphQL returned newest-first (DESC by UPDATED_AT). Reverse to
+            # chronological order so downstream iteration semantics ("walk
+            # forward, last match wins") match the previous ``gh issue view``
+            # behaviour. Bounded to ≤100 entries by the page-size cap above.
+            comments: list[dict[str, Any]] = list(reversed(nodes))
         except Exception as e:
-            logger.warning("Failed to fetch comments for issue #%s: %s", issue_number, e)
+            logger.warning("Failed to fetch comments for issue %s: %s", issue_ref(issue_number), e)
             comments = []
 
-        cache[issue_number] = comments
+        self._comments_cache[issue_number] = comments
         return comments
 
     def _get_latest_plan(self, issue_number: int) -> str | None:
@@ -339,16 +405,24 @@ class PlanReviewer:
         if latest_review_body is None:
             return False
 
-        is_final = _FINAL_VERDICT_MARKER in latest_review_body
+        # Extract every well-formed verdict line (regex anchored to line
+        # boundaries). Per the prompt contract, ONLY the LAST matching
+        # verdict line counts — Claude may discuss multiple verdict options
+        # in prose before settling, so a substring ``in`` check is unsafe
+        # (it would fire True on ``**Verdict: APPROVED**`` followed by
+        # ``**Verdict: BLOCK**``, or on a quoted marker inside discussion).
+        # See issue #552.
+        matches = _VERDICT_LINE_RE.findall(latest_review_body)
+        is_final = bool(matches) and matches[-1] == "APPROVED"
         if is_final:
             logger.debug(
-                "Issue #%s: latest plan review is APPROVED (final)",
-                issue_number,
+                "Issue %s: latest plan review is APPROVED (final)",
+                issue_ref(issue_number),
             )
         else:
             logger.debug(
-                "Issue #%s: latest plan review is non-final (no APPROVED marker)",
-                issue_number,
+                "Issue %s: latest plan review is non-final (no APPROVED marker)",
+                issue_ref(issue_number),
             )
         return is_final
 
@@ -516,8 +590,8 @@ class PlanReviewer:
         """
         if "**Verdict:" not in review_text:
             logger.warning(
-                "Issue #%s: review body missing verdict line; appending fallback REVISE",
-                issue_number,
+                "Issue %s: review body missing verdict line; appending fallback REVISE",
+                issue_ref(issue_number),
             )
             review_text = f"{review_text.rstrip()}\n\n{_FALLBACK_VERDICT_LINE}\n"
         comment_body = f"{_REVIEW_PREFIX}\n\n{review_text}"

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -1,6 +1,7 @@
 """Tests for the PlanReviewer automation."""
 
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -28,10 +29,44 @@ def reviewer(mock_options: PlanReviewerOptions) -> PlanReviewer:
 
 
 def _make_gh_result(payload: Any) -> MagicMock:
-    """Return a mock CompletedProcess with JSON stdout."""
+    """Return a mock CompletedProcess emulating the GraphQL response shape.
+
+    The legacy ``{"comments": [...]}`` payload (from ``gh issue view --comments``)
+    is automatically translated into the new GraphQL envelope
+    ``{"data": {"repository": {"issue": {"comments": {"nodes": [...]}}}}}``
+    with ``nodes`` in descending order (newest first) to match real GraphQL
+    output (see ``orderBy: {field: UPDATED_AT, direction: DESC}`` in
+    ``_fetch_issue_comments``). Production code reverses ``nodes`` back to
+    chronological order, so test inputs continue to be authored in
+    chronological order — the helper hides the reversal.
+
+    Tests that want to drive the raw GraphQL envelope can pass it directly
+    (any payload not matching ``{"comments": [...]}`` is forwarded as-is).
+    """
     mock = MagicMock()
-    mock.stdout = json.dumps(payload)
+    if isinstance(payload, dict) and set(payload.keys()) == {"comments"}:
+        nodes = list(reversed(payload["comments"]))
+        graphql_payload = {"data": {"repository": {"issue": {"comments": {"nodes": nodes}}}}}
+        mock.stdout = json.dumps(graphql_payload)
+    else:
+        mock.stdout = json.dumps(payload)
     return mock
+
+
+@pytest.fixture(autouse=True)
+def _patch_repo_helpers() -> Any:
+    """Stub repo discovery helpers used by the GraphQL fetch."""
+    with (
+        patch(
+            "hephaestus.automation.plan_reviewer.get_repo_root",
+            return_value=Path("/tmp/repo"),
+        ),
+        patch(
+            "hephaestus.automation.plan_reviewer.get_repo_slug",
+            return_value="owner/name",
+        ),
+    ):
+        yield
 
 
 class TestGetLatestPlan:
@@ -158,6 +193,100 @@ class TestLatestReviewIsFinal:
         """Gh failure → _fetch_issue_comments returns [], gate returns False."""
         with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
             mock_gh.side_effect = RuntimeError("gh failed")
+            assert reviewer._latest_review_is_final(123) is False
+
+    def test_false_when_approved_precedes_block_in_same_body(self, reviewer: PlanReviewer) -> None:
+        """Only the LAST verdict line counts — APPROVED then BLOCK → False.
+
+        Claude is allowed to discuss multiple verdict options in prose; the
+        prompt instructs readers to take only the LAST matching line.
+        Substring ``in`` would mis-fire True here.
+        """
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {
+                "body": (
+                    "## 🔍 Plan Review\n\n"
+                    "Initial impression: looked sound.\n\n"
+                    "**Verdict: APPROVED**\n\n"
+                    "On reflection a fatal correctness bug surfaced.\n\n"
+                    "**Verdict: BLOCK**"
+                )
+            },
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is False
+
+    def test_true_when_block_precedes_approved_in_same_body(self, reviewer: PlanReviewer) -> None:
+        """BLOCK then APPROVED → True (last verdict line wins)."""
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {
+                "body": (
+                    "## 🔍 Plan Review\n\n"
+                    "First-pass concern.\n\n"
+                    "**Verdict: BLOCK**\n\n"
+                    "After re-reading, concern was unfounded.\n\n"
+                    "**Verdict: APPROVED**"
+                )
+            },
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is True
+
+    def test_false_when_marker_is_quoted_in_discussion(self, reviewer: PlanReviewer) -> None:
+        """A quoted marker in prose must not fire the gate.
+
+        The substring check used to return True on inline mentions like
+        ``avoid using **Verdict: APPROVED** here`` — the regex requires the
+        marker to occupy an entire line.
+        """
+        comments = [
+            {"body": "## Implementation Plan\n\nDo stuff"},
+            {
+                "body": (
+                    "## 🔍 Plan Review\n\n"
+                    "Reviewer note: avoid using **Verdict: APPROVED** here "
+                    "because the plan still has gaps.\n\n"
+                    "**Verdict: REVISE**"
+                )
+            },
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            assert reviewer._latest_review_is_final(123) is False
+
+    def test_handles_150_comments_without_truncating_latest(self, reviewer: PlanReviewer) -> None:
+        """Issues with >100 comments must still surface the latest review.
+
+        The previous ``gh issue view --comments`` call silently capped at
+        100 entries. The GraphQL ``last: 100`` query is bounded too, but
+        because it sorts ``UPDATED_AT DESC`` it always brings the newest
+        100 — which includes the actual most-recent plan-review comment
+        even when the issue has 150+ historical comments. See issue #553.
+        """
+        # Build 150 noise comments, then sandwich the real reviews so the
+        # latest review (REVISE) is well past index 100 in chronological
+        # order. After the helper reverses to DESC order to mimic GraphQL,
+        # the production code reverses back to chronological — the test
+        # still authors the list chronologically.
+        chronological: list[dict[str, Any]] = []
+        for i in range(120):
+            chronological.append({"body": f"Drive-by comment {i}"})
+        chronological.append({"body": "## 🔍 Plan Review\n\nOld pass.\n\n**Verdict: APPROVED**"})
+        for i in range(120, 145):
+            chronological.append({"body": f"Drive-by comment {i}"})
+        chronological.append({"body": "## 🔍 Plan Review\n\nNew concerns.\n\n**Verdict: REVISE**"})
+        # Total = 120 + 1 + 25 + 1 = 147; trim the OLDEST entries so the
+        # remaining 100 (newest) still include both reviews. Real GraphQL
+        # would do exactly this via ``last: 100`` + DESC ordering.
+        newest_100 = chronological[-100:]
+
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": newest_100})
+            # The latest review is REVISE → not final → re-run.
             assert reviewer._latest_review_is_final(123) is False
 
     def test_approved_marker_anywhere_in_latest_review_counts(self, reviewer: PlanReviewer) -> None:


### PR DESCRIPTION
Six related correctness and quality fixes to the plan reviewer's APPROVED short-circuit gate, all confined to `hephaestus/automation/plan_reviewer.py`, its tests, and a new release note.

Highlights:

- **#552** — verdict parsing switches from substring `in` to a multiline regex that takes the LAST `^**Verdict: (APPROVED|REVISE|BLOCK)**$` line. Aligns the gate with the contract `prompts.py:474-475` gives Claude.
- **#553** — `_fetch_issue_comments` now uses an explicit GraphQL query (`comments(last: 100, orderBy: {field: UPDATED_AT, direction: DESC})`) so issues with 100+ comments still surface the real latest review.
- **#560** — `_comments_cache` is initialised in `__init__` with an explicit annotation instead of `hasattr` + `object.__setattr__`.
- **#561** — every `"Issue #%s"` log line in plan_reviewer.py now uses `issue_ref(n)` for grep-consistency.
- **#565** — a comment beside `_REVIEW_PREFIX` documents the byte-exact match assumption.
- **#563** — `docs/release-notes/plan-reviewer-final-verdict.md` announces the APPROVED-only skip semantic and gives operators a `gh issue list --jq` snippet to quantify the one-time Claude-call spike per repo.

Test evidence:

- `pixi run pytest tests/unit/automation/test_plan_reviewer.py --no-cov` — **30 passed** (4 new tests: `test_false_when_approved_precedes_block_in_same_body`, `test_true_when_block_precedes_approved_in_same_body`, `test_false_when_marker_is_quoted_in_discussion`, `test_handles_150_comments_without_truncating_latest`).
- `pixi run pytest tests/unit --no-cov -q` — **2351 passed, 15 failed, 11 skipped**. All 15 failures are pre-existing `scripts/*.py --help` smoke tests that error with `ModuleNotFoundError: No module named 'hephaestus'` in the worktree's pixi env (unrelated to this change; reproduces on a clean stash of `main`).
- `pixi run ruff check` and `pixi run ruff format --check` — clean on the two modified Python files.

Closes #552
Closes #553
Closes #560
Closes #561
Closes #563
Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)