### PR TITLE
fix(automation): unblock phases 2-3 of the automation loop (#574)

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -155,7 +155,7 @@ class IssueImplementer:
         ui_msg = f"{prefix}: {msg}" if prefix else msg
         self.log_manager.log(tid, ui_msg)
 
-    def run(self) -> dict[int, WorkerResult]:
+    def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # one-extra-branch for #574 early-exit; orchestration body is intentionally linear
         """Run the implementer.
 
         Returns:
@@ -165,6 +165,19 @@ class IssueImplementer:
         # Health check mode
         if self.options.health_check:
             return self._health_check()
+
+        # Short-circuit when there's nothing to implement. The CLI's auto-
+        # discovery branch (implementer.main → gh_list_open_issues) sets
+        # ``args.issues = []`` for repos with zero open issues, then defaults
+        # ``epic_number=0``. Without this guard we fall through to
+        # ``load_epic(0)`` and pay 5 retries × exponential backoff against
+        # ``gh issue view 0`` before crashing — wasting ~12s per empty repo
+        # and dominating wall-clock for the parallel-repos loop. Mirrors
+        # ``planner.py:107-108`` which warns and returns ``{}`` on the same
+        # condition. See #574.
+        if not self.options.issues and not self.options.epic_number:
+            logger.warning("No issues to implement (repo has no open issues / nothing discovered)")
+            return {}
 
         # Load issues or epic and resolve dependencies
         if self.options.issues:

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -25,7 +25,7 @@ from hephaestus.github.rate_limit import wait_until
 from .claude_invoke import invoke_claude_with_session, scan_quota_reset
 from .claude_models import reviewer_model
 from .claude_timeouts import plan_reviewer_claude_timeout
-from .git_utils import get_repo_root, get_repo_slug, issue_ref
+from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref
 from .github_api import _gh_call, gh_issue_comment, gh_issue_json
 from .models import PLAN_COMMENT_MARKERS, PlanReviewerOptions, WorkerResult
 from .prompts import get_plan_review_prompt
@@ -292,8 +292,11 @@ class PlanReviewer:
         # than 100 plan-review comments in its history, a follow-up issue
         # will be needed to add real pagination; in practice plans are
         # revised a handful of times, not 100+.
-        repo = get_repo_slug(get_repo_root())
-        owner, name = repo.split("/", 1)
+        # get_repo_slug returns only the short repo name (e.g. "AchaeanFleet");
+        # GraphQL needs the (owner, name) pair, which get_repo_info supplies.
+        # Earlier code tried `get_repo_slug(...).split("/", 1)` and crashed on
+        # every issue with "not enough values to unpack" (#574).
+        owner, name = get_repo_info(get_repo_root())
         query = (
             "query($owner:String!,$name:String!,$number:Int!){"
             "  repository(owner:$owner,name:$name){"

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -386,3 +386,86 @@ class TestPlanReviewVerdictGate:
 
         assert result.plan_review_not_approved is True
         assert ImplementationPhase.WAITING_FOR_PLAN_REVIEW in captured_phases
+
+
+# ---------------------------------------------------------------------------
+# #574 — run() must short-circuit cleanly when there are no issues and no epic
+# ---------------------------------------------------------------------------
+
+
+class TestRunWithNothingToImplement:
+    """#574 regression: implementer must short-circuit on empty input.
+
+    When the CLI's auto-discovery returns zero open issues AND no epic is
+    specified, ``IssueImplementer.run()`` must NOT fall through to
+    ``load_epic(0)`` (which would retry-storm against ``gh issue view 0``).
+    Mirrors the planner's ``if not issues_to_plan: warn; return {}`` pattern.
+    """
+
+    def test_run_with_no_issues_and_no_epic_short_circuits(self, tmp_path: Path) -> None:
+        """No issues and epic=0 → run() returns {} after a warning, never calls load_epic."""
+        options = ImplementerOptions(
+            issues=[],
+            epic_number=0,
+            dry_run=False,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+            health_check=False,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            impl = IssueImplementer(options)
+
+        with patch.object(impl.resolver, "load_epic") as mock_load_epic:
+            result = impl.run()
+
+        assert result == {}
+        mock_load_epic.assert_not_called()
+
+    def test_run_with_issues_still_proceeds(self, tmp_path: Path) -> None:
+        """Sanity check: the short-circuit must NOT fire when issues are present."""
+        options = ImplementerOptions(
+            issues=[42],
+            epic_number=0,
+            dry_run=True,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+            health_check=False,
+            analyze_only=True,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            impl = IssueImplementer(options)
+
+        with (
+            patch.object(impl, "_load_issues") as mock_load_issues,
+            patch.object(impl.resolver, "detect_cycles"),
+            patch.object(impl, "_analyze_dependencies", return_value={}),
+        ):
+            impl.run()
+
+        mock_load_issues.assert_called_once_with([42])
+
+    def test_run_with_epic_but_no_issues_still_proceeds(self, tmp_path: Path) -> None:
+        """Sanity check: the short-circuit must NOT fire when an epic is given."""
+        options = ImplementerOptions(
+            issues=[],
+            epic_number=123,
+            dry_run=True,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+            health_check=False,
+            analyze_only=True,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            impl = IssueImplementer(options)
+
+        with (
+            patch.object(impl.resolver, "load_epic") as mock_load_epic,
+            patch.object(impl.resolver, "detect_cycles"),
+            patch.object(impl, "_analyze_dependencies", return_value={}),
+        ):
+            impl.run()
+
+        mock_load_epic.assert_called_once_with(123)

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -55,7 +55,12 @@ def _make_gh_result(payload: Any) -> MagicMock:
 
 @pytest.fixture(autouse=True)
 def _patch_repo_helpers() -> Any:
-    """Stub repo discovery helpers used by the GraphQL fetch."""
+    """Stub repo discovery helpers used by the GraphQL fetch.
+
+    ``_fetch_issue_comments`` calls ``get_repo_info`` for the GraphQL query
+    (#574). ``get_repo_slug`` is still patched for any code path that asks
+    for the short slug (logger prefixes, etc.).
+    """
     with (
         patch(
             "hephaestus.automation.plan_reviewer.get_repo_root",
@@ -63,7 +68,11 @@ def _patch_repo_helpers() -> Any:
         ),
         patch(
             "hephaestus.automation.plan_reviewer.get_repo_slug",
-            return_value="owner/name",
+            return_value="name",
+        ),
+        patch(
+            "hephaestus.automation.plan_reviewer.get_repo_info",
+            return_value=("owner", "name"),
         ),
     ):
         yield
@@ -573,3 +582,33 @@ class TestFetchIssueCommentsCache:
             result = reviewer._fetch_issue_comments(999)
 
         assert result == []
+
+    def test_uses_owner_repo_tuple_from_get_repo_info(self, reviewer: PlanReviewer) -> None:
+        """Regression test for #574 — derive owner+name from get_repo_info.
+
+        ``_fetch_issue_comments`` must obtain ``owner`` and ``name`` from
+        ``get_repo_info`` (which returns a tuple) rather than calling
+        ``get_repo_slug(...).split('/', 1)`` (which crashes with "not enough
+        values to unpack" because the slug is just the repo name with no
+        owner prefix).
+
+        We assert the GraphQL call receives the owner and name as SEPARATE
+        ``-F`` flags, derived from ``get_repo_info``'s tuple, not from a
+        string-split of the slug.
+        """
+        reviewer._comments_cache.clear()
+        with (
+            patch(
+                "hephaestus.automation.plan_reviewer.get_repo_info",
+                return_value=("HomericIntelligence", "ProjectMnemosyne"),
+            ) as mock_info,
+            patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh,
+        ):
+            mock_gh.return_value = _make_gh_result({"comments": []})
+            reviewer._fetch_issue_comments(1928)
+
+        mock_info.assert_called_once()
+        gh_args = mock_gh.call_args[0][0]
+        joined = " ".join(gh_args)
+        assert "owner=HomericIntelligence" in joined
+        assert "name=ProjectMnemosyne" in joined


### PR DESCRIPTION
## Summary

Two regressions introduced by the audit swarm (PR #571 Bundle A and PR #573 Bundle B) prevented the automation loop from running phases 2-6 reliably:

### Bug 1 — Plan reviewer crashed on every issue

`hephaestus/automation/plan_reviewer.py:295-296` called `get_repo_slug` (which returns just the short repo name like `"AchaeanFleet"`) and then tried to `split("/", 1)` it, raising:

```
ValueError: not enough values to unpack (expected 2, got 1)
```

Every issue failed. Phase 2 (review-plans) was effectively dead.

**Fix**: use `get_repo_info(get_repo_root())` which returns the `(owner, name)` tuple GraphQL needs.

### Bug 2 — Implementer retry-stormed on "epic #0"

`hephaestus/automation/implementer.py:IssueImplementer.run()` fell through to `self.resolver.load_epic(0)` when:
- `args.issues = []` (CLI auto-discovery returned no open issues), AND
- `args.epic` was None (no `--epic` flag)

`gh issue view 0` returned 404 → 5 retries × exponential backoff → ~12s wasted per empty-discovery repo → crash. With 15 repos and `PARALLEL_REPOS=1`, this dominated wall-clock and made the script feel hung.

**Fix**: mirror `planner.py:107-108`'s pattern — log a warning and return `{}` when there are no issues AND no epic.

## Test evidence

- `pixi run pytest tests/unit/automation/test_plan_reviewer.py tests/unit/automation/test_implementer.py --no-cov`: **56/56 pass**.
- 4 new tests:
  - `test_uses_owner_repo_tuple_from_get_repo_info` — assert GraphQL receives `owner=...` and `name=...` as separate -F flags.
  - `test_run_with_no_issues_and_no_epic_short_circuits` — assert run() returns {} and never calls load_epic.
  - `test_run_with_issues_still_proceeds` — sanity, short-circuit does NOT fire when issues are present.
  - `test_run_with_epic_but_no_issues_still_proceeds` — sanity, short-circuit does NOT fire when epic is given.
- `pixi run ruff check + format --check`: clean.
- `pixi run mypy`: **clean across 251 source files**.
- End-to-end smoke against `HomericIntelligence/ProjectMnemosyne` (2 open issues, both already planned): phase 1 done banner fires, phase 2 starts the GraphQL fetch with the correct `owner=HomericIntelligence -F name=ProjectMnemosyne` pattern (no unpack error).

## After this lands

`./scripts/run_automation_loop.sh` (vanilla, no args) will deliver the user's stated expected behavior:
1. All 6 phases visible per repo.
2. Plan phase skips per-issue when already planned.
3. Plan-review phase skips per-issue when last verdict is APPROVED; otherwise posts a fresh review.
4. Implement / review-prs / address-review / drive-green phases run for issues whose plans are APPROVED (gated by #551's `is_plan_review_approved`).
5. Repos with zero open issues skip phase 3 cleanly with a single-line warning.

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)