### PR TITLE
feat(automation): shared strict-grading + seven-principles rubric blocks (baseline for #576)

### DIFF
--- a/hephaestus/automation/prompts.py
+++ b/hephaestus/automation/prompts.py
@@ -778,6 +778,98 @@ critique → Verdict: NOGO. When in doubt, NOGO.
 """
 
 
+# ---------------------------------------------------------------------------
+# Shared rubric building blocks consumed by the per-stage strict-simplify
+# review prompts. These constants are the single source of truth for the
+# grading scale, anti-inflation rules, and the seven graded software-
+# engineering principles from CLAUDE.md `## Key Development Principles`.
+#
+# They are intentionally additive: the existing `_STRICT_REVIEW_RUBRIC` and
+# `_STRICT_REVIEW_OUTPUT_FORMAT` constants above are preserved for backward
+# compatibility while sub-issues #578-#581 migrate each review site over to
+# stage-tailored rubrics that compose these blocks.
+# ---------------------------------------------------------------------------
+
+_STRICT_GRADING_AND_ANTI_INFLATION = """
+GRADING (every dimension starts at F; A must be EARNED with concrete evidence):
+- A  (93-100%) Exemplary. ZERO critical/major findings; ≤2 minor. RARE.
+- B  (80-89%)  Solid. ZERO critical findings, ≤1 major.
+- C  (70-79%)  Mediocre. Multiple gaps that should be prioritized.
+- D  (60-69%)  Poor. Fundamental practices missing or broken.
+- F  (<60%)    Failing / misaligned / dangerous.
+
+ANTI-INFLATION RULES (MANDATORY):
+- DEFAULT IS F. Find concrete evidence to justify ANY upgrade.
+- "It looks done" is NOT sufficient.
+- Do NOT give credit for plans, TODOs, or follow-up issues — grade what THIS
+  artifact delivers right now.
+- Do NOT round up. 74% is C, not C+ or B-.
+- If you catch yourself wanting to give B+ or higher, re-examine whether you
+  verified EVERY dimension or skimmed.
+"""
+
+
+_SEVEN_PRINCIPLES_DIMENSIONS = """
+**Software-engineering principles (graded — each can DROP a verdict, not just keep it):**
+
+P1 — KISS — Keep It Simple Stupid.
+    Is this the simplest solution that meets the requirement? Flag any
+    abstraction layer, generic interface, configuration knob, or
+    indirection without a current concrete consumer. Robust ≠ defensive
+    cruft. A robust simple solution beats a defensive complex one.
+
+P2 — YAGNI — You Ain't Gonna Need It.
+    Every diff hunk / planned-change must map to a stated requirement
+    in THIS issue. Flag scope creep, opportunistic refactors mixed in,
+    or "while we're here" additions. Features built for hypothetical
+    future requirements are findings.
+
+P3 — TDD — Test Driven Development.
+    Do tests drive the implementation? Look for test-first evidence:
+    tests that define behavior contracts, high coverage of edge cases,
+    and tests that landed alongside (not after) the code. For plan
+    reviews: does the plan name the tests that will define each
+    acceptance criterion? For impl reviews: does the diff include tests
+    proportional to the production code?
+
+P4 — DRY — Don't Repeat Yourself.
+    If two near-identical code/text blocks exist, prefer extracting a
+    helper — UNLESS the extraction would itself add complexity. Flag
+    BOTH "left duplicated where it should be DRYed" AND "DRYed
+    prematurely into an over-general helper". Cite specific
+    duplications with file:line.
+
+P5 — SOLID — five sub-principles, grade each that applies:
+    - SRP (Single Responsibility): each module/class/function has ONE
+      reason to change.
+    - OCP (Open-Closed): open for extension, closed for modification.
+    - LSP (Liskov Substitution): subtypes substitutable for base types.
+    - ISP (Interface Segregation): no client forced to depend on
+      methods it doesn't use.
+    - DIP (Dependency Inversion): high-level depends on abstractions,
+      not concretions.
+    Flag the specific sub-principle violated; vague "SOLID violation"
+    is insufficient.
+
+P6 — Modularity — develop independent modules through well-defined
+    interfaces. Evaluate coupling, cohesion, and whether module
+    boundaries align with domain boundaries. Flag implicit coupling
+    (shared globals, unexported state, hidden initialization order).
+
+P7 — POLA — Principle Of Least Astonishment.
+    Create intuitive and predictable interfaces. Flag surprising
+    defaults, inconsistent naming, non-obvious side effects, silent
+    failures, or behavior that contradicts the docstring/name.
+
+**Verdict floor (mandatory):** if ANY of P1–P7 reveals a critical or
+major finding, the verdict CANNOT be GO/APPROVED even if every other
+dimension scores A. Reviewer must explicitly downgrade and cite the
+offending principle by name (e.g. "Verdict: NOGO — P2/YAGNI: diff adds
+a config flag with no current consumer; P7/POLA: new flag's default
+inverts the existing convention.").
+"""
+
+
 PLAN_LOOP_REVIEW_PROMPT = """
 {rubric}
 

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -216,3 +216,30 @@ class TestUntrustedFencing:
         assert self._fence_present(out, "ISSUE_BODY")
         assert self._fence_present(out, "DIFF_TEXT")
         assert prompts._UNTRUSTED_NOTICE in out
+
+
+class TestSharedRubricConstants:
+    """Tests for the shared strict-grading and seven-principles rubric blocks.
+
+    These constants (added for issue #577) are the single source of truth
+    consumed by the per-stage strict-simplify review prompts implemented in
+    sub-issues #578-#581.
+    """
+
+    def test_seven_principles_block_has_all_seven(self) -> None:
+        """All seven CLAUDE.md principles must appear as named graded dimensions."""
+        block = prompts._SEVEN_PRINCIPLES_DIMENSIONS
+        for marker in (
+            "P1 — KISS",
+            "P2 — YAGNI",
+            "P3 — TDD",
+            "P4 — DRY",
+            "P5 — SOLID",
+            "P6 — Modularity",
+            "P7 — POLA",
+        ):
+            assert marker in block, f"missing principle marker: {marker!r}"
+
+    def test_anti_inflation_rules_have_default_is_f(self) -> None:
+        """The anti-inflation block must restate the DEFAULT IS F rule."""
+        assert "DEFAULT IS F" in prompts._STRICT_GRADING_AND_ANTI_INFLATION


### PR DESCRIPTION
Baseline PR for the strict-simplify reviewer epic (#576). Adds two new shared rubric building blocks to hephaestus/automation/prompts.py that subsequent sub-issues (#578-#581) will compose into stage-tailored review prompts.

## New constants

- `_STRICT_GRADING_AND_ANTI_INFLATION` — A/B/C/D/F grading scale with percentage bands, plus the mandatory anti-inflation rules (DEFAULT IS F, no rounding, no credit for plans/TODOs, etc.).
- `_SEVEN_PRINCIPLES_DIMENSIONS` — all seven CLAUDE.md `## Key Development Principles` as named, individually-graded review dimensions:
  - P1 — KISS
  - P2 — YAGNI
  - P3 — TDD
  - P4 — DRY
  - P5 — SOLID (with SRP / OCP / LSP / ISP / DIP sub-principles)
  - P6 — Modularity
  - P7 — POLA

  The block ends with a verdict floor clause: any critical or major principle finding forces NOGO/REVISE/BLOCK even when every other dimension scores A.

## Back-compat

This PR is purely additive. The existing `_STRICT_REVIEW_RUBRIC` and `_STRICT_REVIEW_OUTPUT_FORMAT` constants remain in place — sub-issues #578-#581 will migrate the four review sites (`PLAN_REVIEW_PROMPT`, `PLAN_LOOP_REVIEW_PROMPT`, `IMPL_LOOP_REVIEW_PROMPT`, `PR_REVIEW_ANALYSIS_PROMPT`) over to the new shared blocks one at a time.

## Tests

Added to `tests/unit/automation/test_prompts.py`:
- `test_seven_principles_block_has_all_seven` — asserts each of the seven principle markers is a substring of `_SEVEN_PRINCIPLES_DIMENSIONS`.
- `test_anti_inflation_rules_have_default_is_f` — asserts the DEFAULT IS F rule is present in `_STRICT_GRADING_AND_ANTI_INFLATION`.

Verification:
- `pixi run pytest tests/unit/automation/test_prompts.py -v --no-cov` — 19 passed.
- `pixi run ruff check` + `ruff format --check` on changed files — clean.
- `pixi run mypy` — clean (250 source files).

Closes #577