### PR TITLE
feat(automation): plan reviewer strict rubric (#578)

### DIFF
--- a/hephaestus/automation/prompts.py
+++ b/hephaestus/automation/prompts.py
@@ -450,6 +450,10 @@ _UNTRUSTED_NOTICE = (
 PLAN_REVIEW_PROMPT = """
 Review the implementation plan for GitHub issue #{issue_number}.
 
+{strict_rubric}
+
+---
+
 {untrusted_notice}
 
 **Issue Title (untrusted):** {issue_title}
@@ -639,6 +643,7 @@ def get_plan_review_prompt(
         issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
         plan_text_block=_fence_untrusted("PLAN_TEXT", plan_text, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        strict_rubric=_PLAN_STRICT_RUBRIC.strip(),
     )
 
 
@@ -868,6 +873,45 @@ offending principle by name (e.g. "Verdict: NOGO — P2/YAGNI: diff adds
 a config flag with no current consumer; P7/POLA: new flag's default
 inverts the existing convention.").
 """
+
+
+# ---------------------------------------------------------------------------
+# Per-stage strict rubric: PLAN REVIEW
+#
+# Composes the shared strict-grading + anti-inflation rules with plan-stage
+# dimensions and the seven software-engineering principles. Injected into
+# PLAN_REVIEW_PROMPT so the standalone plan reviewer grades plans against
+# the same strict rubric the loop reviewer uses.
+# ---------------------------------------------------------------------------
+
+_PLAN_STRICT_RUBRIC = (
+    _STRICT_GRADING_AND_ANTI_INFLATION
+    + """
+Stage-specific dimensions for plan review:
+
+- Requirements alignment: does the plan map every acceptance criterion in
+  the issue to a concrete step? Flag any criterion left unaddressed or
+  vaguely waved at.
+- Plan completeness: are setup, implementation, test, and rollback steps
+  all named? Flag missing test plan, missing verification, or implicit
+  "and then it works" gaps.
+- Concreteness (file paths exist): does the plan name real files,
+  functions, and module paths that exist (or will be created with stated
+  paths)? Flag hand-wavy "update the relevant module" wording.
+- Risk surface: does the plan avoid destructive operations, irreversible
+  decisions, and changes outside the issue's stated scope? Flag any
+  step that mutates shared state, deletes data, or touches unrelated
+  subsystems without justification.
+- Verification plan: are the verification steps concrete enough for the
+  implementer to copy-paste-run? Flag plans that say "run the tests"
+  without naming which tests or "check that it works" without a check.
+- Stage handoff: does the implementer receive everything they need
+  (file paths, function signatures, test names, commands) to execute
+  the plan without re-deriving it? Flag plans that defer key decisions
+  to the implementer.
+"""
+    + _SEVEN_PRINCIPLES_DIMENSIONS
+)
 
 
 PLAN_LOOP_REVIEW_PROMPT = """

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -243,3 +243,45 @@ class TestSharedRubricConstants:
     def test_anti_inflation_rules_have_default_is_f(self) -> None:
         """The anti-inflation block must restate the DEFAULT IS F rule."""
         assert "DEFAULT IS F" in prompts._STRICT_GRADING_AND_ANTI_INFLATION
+
+
+class TestPlanReviewStrictRubric:
+    """Tests for the strict rubric injected into PLAN_REVIEW_PROMPT (#578)."""
+
+    def _render(self) -> str:
+        return prompts.get_plan_review_prompt(
+            issue_number=123,
+            issue_title="title",
+            issue_body="body",
+            plan_text="plan text",
+        )
+
+    def test_plan_review_prompt_contains_strict_rubric(self) -> None:
+        """All seven principle markers must appear in the rendered prompt."""
+        out = self._render()
+        for marker in (
+            "P1 — KISS",
+            "P2 — YAGNI",
+            "P3 — TDD",
+            "P4 — DRY",
+            "P5 — SOLID",
+            "P6 — Modularity",
+            "P7 — POLA",
+        ):
+            assert marker in out, f"missing principle marker: {marker!r}"
+        # The shared anti-inflation block must also be embedded.
+        assert "DEFAULT IS F" in out
+
+    def test_plan_review_prompt_preserves_verdict_format(self) -> None:
+        """The trailing **Verdict: ...** lines the regex parser depends on."""
+        out = self._render()
+        assert "**Verdict: APPROVED**" in out
+        assert "**Verdict: REVISE**" in out
+        assert "**Verdict: BLOCK**" in out
+
+    def test_plan_review_prompt_contains_stage_dimensions(self) -> None:
+        """The plan-specific stage dimensions must be enumerated in the prompt."""
+        out = self._render()
+        assert "Requirements alignment" in out
+        assert "Plan completeness" in out
+        assert "Stage handoff" in out


### PR DESCRIPTION
Inject _PLAN_STRICT_RUBRIC into PLAN_REVIEW_PROMPT so the standalone plan reviewer applies the same strict-grading + anti-inflation rules and seven software-engineering principles used by the loop reviewer.

The new constant composes:
- _STRICT_GRADING_AND_ANTI_INFLATION (shared baseline #577)
- six plan-stage dimensions: Requirements alignment / Plan completeness / Concreteness / Risk surface / Verification plan / Stage handoff
- _SEVEN_PRINCIPLES_DIMENSIONS (shared baseline #577)

The trailing **Verdict: APPROVED/REVISE/BLOCK** output format is preserved verbatim so plan_reviewer._latest_review_is_final regex parser keeps working untouched.

Scope: hephaestus/automation/prompts.py and tests/unit/automation/test_prompts.py only. plan_reviewer.py is unchanged.

Verification:
- pixi run pytest tests/unit/automation/test_prompts.py tests/unit/automation/test_plan_reviewer.py -v --no-cov - 54 passed
- pixi run pytest tests/unit --no-cov -q - 2400 passed, 11 skipped
- pixi run ruff check / format - clean
- pixi run mypy - clean (251 source files)

Closes #578