### PR TITLE
feat(automation): inject _PR_STRICT_RUBRIC into PR review prompt

### DIFF
--- a/hephaestus/automation/prompts.py
+++ b/hephaestus/automation/prompts.py
@@ -508,6 +508,10 @@ Analyze PR #{pr_number} linked to issue #{issue_number}.
 
 ---
 
+{strict_rubric}
+
+---
+
 **Policy checks (MANDATORY — run these BEFORE any code-quality review):**
 
 This repository enforces three non-negotiable PR properties. If ANY check fails,
@@ -694,6 +698,7 @@ def get_pr_review_analysis_prompt(
         auto_merge_state_block=_fence_untrusted("AUTO_MERGE_STATE", auto_merge_state, nonce),
         commits_signing_block=_fence_untrusted("COMMITS_SIGNING_STATE", signing_state_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        strict_rubric=_PR_STRICT_RUBRIC.strip(),
     )
 
 
@@ -794,6 +799,40 @@ critique → Verdict: NOGO. When in doubt, NOGO.
 # compatibility while sub-issues #578-#581 migrate each review site over to
 # stage-tailored rubrics that compose these blocks.
 # ---------------------------------------------------------------------------
+
+_PR_STRICT_RUBRIC_DIMENSIONS = """
+**PR-review-specific graded dimensions (each starts at F; promote only on
+concrete evidence from the artifacts above):**
+
+D1 — Policy compliance (HIGHEST PRIORITY / BLOCK gate).
+    The three mandatory gates below (Closes #N / auto-merge / signed
+    commits) are graded as a single dimension. ANY violation forces an
+    overall BLOCK verdict, regardless of every other dimension's grade.
+    Policy compliance is NEVER weighed against code quality — it is a
+    hard precondition.
+
+D2 — Diff review of CHANGED lines only.
+    Restrict findings to lines actually modified in the PR diff above.
+    Do NOT comment on pre-existing code outside the diff hunks, even if
+    it has issues — that is scope-bleed and a finding against the
+    reviewer, not the PR. If a changed line depends on unchanged code,
+    cite the changed line and reference (not critique) the dependency.
+
+D3 — Inline-comment quality.
+    Every inline comment MUST be actionable and specific. Reject filler
+    like "consider …", "you might want to …", "maybe …", or vague
+    style nags. Each comment must name the concrete defect, the
+    expected behavior, and (where non-obvious) a suggested fix or
+    citation. Comments that fail this bar must be omitted, not
+    softened.
+
+D4 — CI failure analysis (only when CI Status block is non-empty).
+    When the CI Status block reports failures, the review MUST identify
+    the failing job(s), quote the relevant error signal, and tie each
+    failure to a diff hunk (or note "unrelated to diff" with evidence).
+    Silently ignoring red CI is a major finding against the review.
+"""
+
 
 _STRICT_GRADING_AND_ANTI_INFLATION = """
 GRADING (every dimension starts at F; A must be EARNED with concrete evidence):
@@ -910,6 +949,25 @@ Stage-specific dimensions for plan review:
   the plan without re-deriving it? Flag plans that defer key decisions
   to the implementer.
 """
+    + _SEVEN_PRINCIPLES_DIMENSIONS
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-stage strict rubric: PR REVIEW
+#
+# Composite rubric injected into PR_REVIEW_ANALYSIS_PROMPT (site 4 / #581).
+# Order: strict grading scale → PR-specific dimensions (D1 policy is the
+# BLOCK gate) → seven software-engineering principles. The existing
+# policy-checks block in PR_REVIEW_ANALYSIS_PROMPT remains the
+# authoritative description of the three gates referenced by D1, and the
+# trailing JSON output format remains byte-exact for `_parse_json_block`.
+# ---------------------------------------------------------------------------
+_PR_STRICT_RUBRIC = (
+    _STRICT_GRADING_AND_ANTI_INFLATION
+    + "\n"
+    + _PR_STRICT_RUBRIC_DIMENSIONS
+    + "\n"
     + _SEVEN_PRINCIPLES_DIMENSIONS
 )
 

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -74,6 +74,72 @@ class TestPRReviewAnalysisPrompt:
         assert "auto_merge_enabled=true" in on
         assert "auto_merge_enabled=false" in off
 
+    def test_pr_review_prompt_contains_strict_rubric(self) -> None:
+        """Prompt must embed the strict rubric.
+
+        Verifies the strict-grading scale, PR-specific dimensions, and the
+        seven software-engineering principles (P1–P7) are all present.
+        """
+        out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
+        # Strict-grading / anti-inflation markers.
+        assert "DEFAULT IS F" in out
+        assert "ANTI-INFLATION RULES" in out
+        # PR-specific stage dimensions.
+        assert "D1 — Policy compliance" in out
+        assert "D2 — Diff review of CHANGED lines only" in out
+        assert "D3 — Inline-comment quality" in out
+        assert "D4 — CI failure analysis" in out
+        # Seven principles markers.
+        for marker in (
+            "P1 — KISS",
+            "P2 — YAGNI",
+            "P3 — TDD",
+            "P4 — DRY",
+            "P5 — SOLID",
+            "P6 — Modularity",
+            "P7 — POLA",
+        ):
+            assert marker in out, f"missing seven-principle marker: {marker}"
+
+    def test_pr_review_prompt_preserves_json_block(self) -> None:
+        """The trailing JSON fenced block must remain byte-exact.
+
+        `pr_reviewer.py:_parse_json_block` extracts the LAST fenced JSON
+        block — any change to the schema or fence ordering breaks parsing.
+        """
+        out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
+        # The schema example must appear verbatim.
+        assert (
+            '{"comments": [{"path": "...", "line": 1, "side": "RIGHT", "body": "..."}], '
+            '"summary": "..."}'
+        ) in out
+        # The LGTM example must appear verbatim.
+        assert '{"comments": [], "summary": "LGTM"}' in out
+        # The last fenced code block in the prompt must be the JSON block — the
+        # parser takes the LAST one. Verify the closing ``` after the JSON
+        # block is the final fence in the prompt.
+        last_fence_close = out.rfind("```")
+        assert last_fence_close != -1
+        # The fence immediately preceding the final close must open a ```json
+        # block (no other fenced block may follow it).
+        preceding_open = out.rfind("```", 0, last_fence_close)
+        assert preceding_open != -1
+        assert out[preceding_open : preceding_open + 7] == "```json"
+
+    def test_pr_review_prompt_preserves_policy_gates(self) -> None:
+        """All three policy gates must still appear in the prompt.
+
+        Closes #N, auto-merge, and signed commits remain alongside the new
+        rubric — the rubric references them as the highest-priority BLOCK
+        gate.
+        """
+        out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
+        assert "Closes #N" in out
+        assert "auto-merge" in out.lower()
+        assert "Signed commits" in out or "signed commits" in out.lower()
+        # The mandatory policy-checks header must remain.
+        assert "Policy checks (MANDATORY" in out
+
     def test_passes_commit_signing_state(self) -> None:
         out = prompts.get_pr_review_analysis_prompt(
             pr_number=1,


### PR DESCRIPTION
Injects a PR-stage strict rubric into `PR_REVIEW_ANALYSIS_PROMPT`
between the untrusted-content blocks and the existing mandatory
policy-checks section. The trailing JSON output block at the end of the
prompt is preserved byte-exact so `pr_reviewer.py:_parse_json_block`
continues to extract `{"comments": [...], "summary": "..."}` from the
LAST fenced JSON block.

The new `_PR_STRICT_RUBRIC` composes three shared blocks added by the
baseline (#577):

- `_STRICT_GRADING_AND_ANTI_INFLATION` — F-default scale + anti-inflation.
- `_PR_STRICT_RUBRIC_DIMENSIONS` — PR-stage dimensions: D1 policy
  compliance (highest-priority BLOCK gate, framed around the existing
  three mandatory gates), D2 diff review of CHANGED lines only, D3
  inline-comment quality (no "consider …" filler), and D4 CI failure
  analysis when CI Status is non-empty.
- `_SEVEN_PRINCIPLES_DIMENSIONS` — P1–P7 from CLAUDE.md.

Scope is limited to `hephaestus/automation/prompts.py` and
`tests/unit/automation/test_prompts.py`. `pr_reviewer.py` is untouched.

## Verification

- `pixi run pytest tests/unit/automation/test_prompts.py tests/unit/automation/test_pr_reviewer_posting.py -v --no-cov` — 37 passed.
- Full `pixi run pytest tests/unit -q --no-cov` — only pre-existing,
  unrelated `tests/unit/scripts/test_scripts_smoke.py` failures
  (`ModuleNotFoundError: No module named 'hephaestus'` in subprocess
  smoke tests, unrelated to this change).
- `pixi run ruff check` clean, `pixi run ruff format` clean,
  `pixi run mypy` Success: no issues found in 250 source files.

Closes #581

Part of #576.

🤖 Generated with [Claude Code](https://claude.com/claude-code)