### PR TITLE
feat(automation): PR reviewer strict rubric (#581)

### DIFF
--- a/hephaestus/automation/prompts.py
+++ b/hephaestus/automation/prompts.py
@@ -508,6 +508,10 @@ Analyze PR #{pr_number} linked to issue #{issue_number}.
 
 ---
 
+{strict_rubric}
+
+---
+
 **Policy checks (MANDATORY — run these BEFORE any code-quality review):**
 
 This repository enforces three non-negotiable PR properties. If ANY check fails,
@@ -694,6 +698,7 @@ def get_pr_review_analysis_prompt(
         auto_merge_state_block=_fence_untrusted("AUTO_MERGE_STATE", auto_merge_state, nonce),
         commits_signing_block=_fence_untrusted("COMMITS_SIGNING_STATE", signing_state_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        strict_rubric=_PR_STRICT_RUBRIC.strip(),
     )
 
 
@@ -909,6 +914,50 @@ Stage-specific dimensions for plan review:
   (file paths, function signatures, test names, commands) to execute
   the plan without re-deriving it? Flag plans that defer key decisions
   to the implementer.
+"""
+    + _SEVEN_PRINCIPLES_DIMENSIONS
+)
+
+
+# ---------------------------------------------------------------------------
+# Per-stage strict rubric: PR REVIEW
+#
+# Composes the shared strict-grading + anti-inflation rules with PR-stage
+# dimensions and the seven software-engineering principles. Injected into
+# PR_REVIEW_ANALYSIS_PROMPT so the standalone PR reviewer grades PRs against
+# the same strict rubric the loop reviewer uses.
+#
+# IMPORTANT: this rubric is injected BEFORE the existing policy-checks block
+# (Closes #N / auto-merge / signed commits). The policy-checks block remains
+# the highest-priority gate and produces a hard BLOCK verdict on any failure.
+# The trailing JSON output block at the end of PR_REVIEW_ANALYSIS_PROMPT is
+# preserved byte-exact; pr_reviewer.py:_parse_json_block extracts the LAST
+# fenced JSON block and would break if that block were altered.
+# ---------------------------------------------------------------------------
+
+_PR_STRICT_RUBRIC = (
+    _STRICT_GRADING_AND_ANTI_INFLATION
+    + """
+Stage-specific dimensions for PR review:
+
+- Policy compliance: the three mandatory policy gates below (Closes #N /
+  auto-merge / signed commits) are graded as a single dimension. BLOCK on
+  any violation, regardless of other dimensions. This dimension's verdict
+  CANNOT be overridden by code-quality scores.
+- Diff review of CHANGED lines only: review ONLY the lines this PR modifies
+  in the diff. Do NOT comment on pre-existing code that is merely visible
+  as context, and do NOT propose refactors of unrelated subsystems. Flag
+  every comment whose `line` falls outside the diff hunks as scope-bleed.
+- Inline-comment quality: every inline comment must be ACTIONABLE — name
+  the file, line, and the concrete change required. Reject vague
+  "consider …", "might want to …", or "you could …" phrasing. Each
+  comment must be specific enough that the author can apply it without
+  asking follow-up questions.
+- CI failure analysis: when the CI Status block above is non-empty and
+  reports failures, the review MUST identify the failing check by name
+  and either (a) point to the diff hunk responsible, or (b) state
+  explicitly that the failure is unrelated to the diff. Silent acceptance
+  of red CI is a finding.
 """
     + _SEVEN_PRINCIPLES_DIMENSIONS
 )

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -285,3 +285,77 @@ class TestPlanReviewStrictRubric:
         assert "Requirements alignment" in out
         assert "Plan completeness" in out
         assert "Stage handoff" in out
+
+
+class TestPRReviewStrictRubric:
+    """Tests for the strict rubric injected into PR_REVIEW_ANALYSIS_PROMPT (#581)."""
+
+    def _render(self) -> str:
+        return prompts.get_pr_review_analysis_prompt(
+            pr_number=42,
+            issue_number=123,
+            pr_diff="diff --git a/x b/x",
+            issue_body="issue body",
+            ci_status="ci status",
+            pr_description="Closes #123",
+            auto_merge_enabled=True,
+            commits_signing_state=[{"oid": "abc", "signature_valid": True, "signer": "alice"}],
+        )
+
+    def test_pr_review_prompt_contains_strict_rubric(self) -> None:
+        """All seven principle markers AND stage-specific dimensions appear."""
+        out = self._render()
+        for marker in (
+            "P1 — KISS",
+            "P2 — YAGNI",
+            "P3 — TDD",
+            "P4 — DRY",
+            "P5 — SOLID",
+            "P6 — Modularity",
+            "P7 — POLA",
+        ):
+            assert marker in out, f"missing principle marker: {marker!r}"
+        # PR-stage specific dimensions
+        assert "Diff review of CHANGED lines" in out
+        assert "Inline-comment quality" in out
+        # Shared anti-inflation block
+        assert "DEFAULT IS F" in out
+
+    def test_pr_review_prompt_preserves_json_block(self) -> None:
+        """The trailing fenced JSON block must remain byte-exact at the end.
+
+        ``pr_reviewer.py:_parse_json_block`` extracts the LAST fenced JSON
+        block. Any breakage here would break the PR reviewer's output parser.
+        """
+        out = self._render()
+        # The canonical JSON skeleton string must appear (formatted with
+        # single curly braces after str.format).
+        json_skeleton = (
+            '{"comments": [{"path": "...", "line": 1, "side": "RIGHT", '
+            '"body": "..."}], "summary": "..."}'
+        )
+        assert json_skeleton in out
+        assert '"summary":' in out
+        # Verify the JSON skeleton sits inside the LAST fenced ```json block,
+        # with no further fenced blocks after it (parser takes LAST).
+        last_json_fence_start = out.rfind("```json")
+        assert last_json_fence_start != -1, "no ```json fence found"
+        after_fence = out[last_json_fence_start:]
+        assert json_skeleton in after_fence
+        # No additional fenced blocks after the JSON's closing fence.
+        closing_fence = after_fence.find("```", len("```json"))
+        assert closing_fence != -1, "JSON fence is not closed"
+        trailing = after_fence[closing_fence + 3 :]
+        assert "```" not in trailing, (
+            "extra fenced block after the JSON output block would break "
+            "pr_reviewer._parse_json_block (it takes the LAST fence)"
+        )
+
+    def test_pr_review_prompt_preserves_policy_gates(self) -> None:
+        """The three policy gates remain present and verbatim."""
+        out = self._render()
+        assert "Closes #N" in out
+        # auto-merge appears in multiple casings; check case-insensitively.
+        assert "auto-merge" in out.lower()
+        # Signed-commits gate is named via the signature_valid JSON field.
+        assert "signature_valid" in out


### PR DESCRIPTION
Inject `_PR_STRICT_RUBRIC` into `PR_REVIEW_ANALYSIS_PROMPT` so the standalone PR reviewer grades PRs against the shared strict-grading + anti-inflation rules and the seven software-engineering principles.

The rubric is injected AFTER the untrusted-content blocks but BEFORE the existing mandatory policy gates (Closes #N / auto-merge / signed commits), which remain the highest-priority gate. The trailing fenced JSON output block at the end of the prompt is byte-exact unchanged so `pr_reviewer.py:_parse_json_block` (last-fence-wins) keeps working.

## Stage-specific dimensions added

- Policy compliance (BLOCKs on any of the three gates)
- Diff review of CHANGED lines only (no scope-bleed)
- Inline-comment quality (actionable, not "consider …")
- CI failure analysis when CI status is non-empty

## Tests added

- `test_pr_review_prompt_contains_strict_rubric` — asserts P1–P7 markers and stage-specific dimensions appear.
- `test_pr_review_prompt_preserves_json_block` — asserts the JSON skeleton sits inside the LAST fenced ```json block with no fenced blocks after it (parser invariant).
- `test_pr_review_prompt_preserves_policy_gates` — asserts the three policy gates remain.

All 40 tests in `tests/unit/automation/test_prompts.py` and `tests/unit/automation/test_pr_reviewer_posting.py` pass. ruff + mypy clean. Pre-existing unrelated failures in `tests/unit/scripts/test_scripts_smoke.py` exist on `main` and are not caused by this change.

Scope is limited to `hephaestus/automation/prompts.py` and `tests/unit/automation/test_prompts.py` — `pr_reviewer.py` is not touched.

Closes #581