### PR TITLE
fix(automation): apply #574 fix to review_state.py (missed copy)

### DIFF
--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -24,7 +24,7 @@ import logging
 import re
 from typing import Any
 
-from .git_utils import get_repo_root, get_repo_slug, issue_ref
+from .git_utils import get_repo_info, get_repo_root, issue_ref
 from .github_api import _gh_call
 
 logger = logging.getLogger(__name__)
@@ -84,8 +84,11 @@ def _fetch_issue_comments_graphql(issue_number: int) -> list[dict[str, Any]]:
         Returns an empty list on any failure.
 
     """
-    repo = get_repo_slug(get_repo_root())
-    owner, name = repo.split("/", 1)
+    # get_repo_slug returns only the short repo name (e.g. "ProjectMnemosyne");
+    # GraphQL needs the (owner, name) pair, which get_repo_info supplies.
+    # PR #575 fixed this in plan_reviewer.py but missed the identical bug here,
+    # crashing every implementer-side APPROVED-gate check (#588).
+    owner, name = get_repo_info(get_repo_root())
     query = (
         "query($owner:String!,$name:String!,$number:Int!){"
         "  repository(owner:$owner,name:$name){"

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -158,8 +158,8 @@ class TestIsPlanReviewApprovedWithFetch:
                 return_value="/tmp/repo",
             ),
             patch(
-                "hephaestus.automation.review_state.get_repo_slug",
-                return_value="owner/name",
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("owner", "name"),
             ),
         ):
             yield
@@ -184,3 +184,33 @@ class TestIsPlanReviewApprovedWithFetch:
             side_effect=RuntimeError("network down"),
         ):
             assert is_plan_review_approved(123) is False
+
+    def test_uses_owner_repo_tuple_from_get_repo_info(self) -> None:
+        """Regression test for #588 — derive owner+name from get_repo_info.
+
+        ``_fetch_issue_comments_graphql`` must obtain ``owner`` and ``name``
+        from ``get_repo_info`` (which returns a tuple) rather than calling
+        ``get_repo_slug(...).split('/', 1)`` (which crashes with "not enough
+        values to unpack" because the slug is just the repo name with no
+        owner prefix). This mirrors the fix in PR #575 for the same bug
+        pattern in ``plan_reviewer.py``; #588 caught the missed copy here.
+        """
+        mock_result = MagicMock()
+        mock_result.stdout = _graphql_payload([])
+        with (
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("HomericIntelligence", "ProjectMnemosyne"),
+            ) as mock_info,
+            patch(
+                "hephaestus.automation.review_state._gh_call",
+                return_value=mock_result,
+            ) as mock_gh,
+        ):
+            is_plan_review_approved(1928)
+
+        mock_info.assert_called_once()
+        gh_args = mock_gh.call_args[0][0]
+        joined = " ".join(gh_args)
+        assert "owner=HomericIntelligence" in joined
+        assert "name=ProjectMnemosyne" in joined


### PR DESCRIPTION
## Summary

PR #575 (closing #574) fixed `get_repo_slug(...).split("/", 1)` in `plan_reviewer.py` — but the **identical bug** was duplicated in `review_state.py:87-88` and survived untouched. That copy is the production hot path for the implementer's APPROVED-plan-review gate (`implementer.py:629` → `is_plan_review_approved` → `_fetch_issue_comments_graphql` → CRASH).

Result before this fix: every issue the implementer tries to gate would `ValueError`-crash, failing phase 3 for every repo with any open issues. The strict-mode review of the session's other PRs missed this because the test fixture patched `get_repo_slug` to return a slash-bearing string, which split cleanly but semantically violated the documented contract.

## Changes

- `hephaestus/automation/review_state.py:87-91`: replace `get_repo_slug(...).split("/", 1)` with `get_repo_info(get_repo_root())`. Update import.
- `tests/unit/automation/test_review_state.py:155-164`: patch `get_repo_info` returning `("owner", "name")` instead of the contract-violating `get_repo_slug → "owner/name"`.
- Add `test_uses_owner_repo_tuple_from_get_repo_info` — regression test mirroring the equivalent in `test_plan_reviewer.py`.

## Verification

- `pixi run pytest tests/unit/automation/test_review_state.py tests/unit/automation/test_implementer.py --no-cov`: **42/42 pass**.
- `pixi run ruff check` + `ruff format --check`: clean.
- `pixi run mypy`: clean across 251 source files.

## How was this caught

`/hephaestus:repo-analyze-strict-full` scoped to the session's PRs #567-#587. Three reviewers were dispatched; Reviewer A (Part 1 regression review) traced the implementer's APPROVED-gate call path from `implementer.py:629` outward and discovered `review_state.py:87-88` had the same bug pattern PR #575 was supposed to fix.

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)