### PR TITLE
[Feature] hephaestus-automation-loop CLI refinements: cwd default, fork-skip, @me issue filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ with `--help` to see full usage.
 
 | Command | Description |
 |---|---|
+| `hephaestus-automation-loop` | Multi-repo 6-phase automation pipeline (plan → review-plans → implement → review-prs → address-review → drive-green) |
 | `hephaestus-plan-issues` | Bulk issue planning using Claude Code or Codex |
 | `hephaestus-implement-issues` | Bulk issue implementation using Claude Code or Codex in parallel worktrees |
 | `hephaestus-review-prs` | Read-only PR review automation using Claude Code or Codex in parallel worktrees |

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -692,7 +692,7 @@ def process_repo(
     result = RepoResult(repo=repo, loop_idx=loop_idx)
     try:
         return _process_repo_inner(repo, loop_idx, cfg, result)
-    except BaseException as exc:
+    except Exception as exc:
         tb = traceback.format_exc()
         result.runner_error = f"{type(exc).__name__}: {exc}\n{tb}"
         LOG.error("[%s] runner crashed: %s", repo, exc)

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1,0 +1,1044 @@
+"""Multi-repo, multi-phase automation loop driver.
+
+Replaces ``scripts/run_automation_loop.sh``. Iterates over all
+non-archived HomericIntelligence repos, running the 6-phase pipeline
+(plan → review-plans → implement → review-prs → address-review →
+drive-green) ``--loops`` times per repo.
+
+The key correctness invariant — and the reason this replaces the bash
+version — is that each phase is a plain ``subprocess.run`` call inside a
+Python ``for`` loop. Phase N failing returns a ``PhaseResult(rc=N)`` and
+control unconditionally proceeds to phase N+1. No shell-option landmine
+(``set -e`` / ``set -m`` / subshell exec-optimization) can silently skip
+the rest of the pipeline.
+
+CLI is flag-compatible with the previous bash script so operator muscle
+memory and any pinned callers keep working.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import logging
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import traceback
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+
+# Canonical phase ordering. Index 0 = phase 1 (plan), index 5 = phase 6
+# (drive-green). Matches the bash version's --phases flag exactly.
+ALL_PHASES: tuple[str, ...] = (
+    "plan",
+    "review-plans",
+    "implement",
+    "review-prs",
+    "address-review",
+    "drive-green",
+)
+
+DEFAULT_PROJECTS_DIR = Path.home() / "Projects"
+
+# Sentinel for ``--org`` invoked with no argument (auto-detect from cwd).
+# Module-level identity guarantees ``args.org is _ORG_AUTODETECT`` is the
+# unambiguous test for "user passed --org but gave no value".
+_ORG_AUTODETECT = object()
+
+
+def _parse_repo_list(value: str) -> list[str]:
+    """Split a comma-separated repo list, stripping whitespace and empties.
+
+    Example: ``"foo, bar,baz"`` → ``["foo", "bar", "baz"]``. Empty input
+    returns an empty list, which the caller treats as "user didn't pass
+    --repos".
+    """
+    return [s.strip() for s in value.split(",") if s.strip()]
+
+
+# Phases 2/4/5/6 declare --issues as required in their argparse. Phases 1
+# and 3 auto-discover. This set drives the "skip when no open issues"
+# branch in process_repo.
+PHASES_REQUIRING_ISSUES: frozenset[str] = frozenset(
+    {"review-plans", "review-prs", "address-review", "drive-green"}
+)
+
+# Sentinel for cooperative shutdown on SIGINT/SIGTERM. Worker threads
+# check this between phases so an in-flight subprocess can still finish
+# but the next phase is skipped.
+_SHUTDOWN_REQUESTED = False
+
+
+def _shutdown_requested() -> bool:
+    return _SHUTDOWN_REQUESTED
+
+
+def _request_shutdown(signum: int, _frame: object) -> None:
+    global _SHUTDOWN_REQUESTED
+    _SHUTDOWN_REQUESTED = True
+    LOG.warning("Signal %s received — requesting cooperative shutdown", signum)
+
+
+@dataclass
+class PhaseResult:
+    """Outcome of a single phase invocation for a single repo+loop."""
+
+    name: str
+    rc: int = 0
+    elapsed_s: float = 0.0
+    skipped: bool = False
+    skip_reason: str | None = None
+    # If subprocess.run itself raised (OSError, TimeoutExpired, …), the
+    # exception text lands here. The phase is treated as rc=1.
+    error: str | None = None
+
+    @property
+    def failed(self) -> bool:
+        """True when the phase ran and returned a non-zero exit code."""
+        return not self.skipped and self.rc != 0
+
+
+@dataclass
+class RepoResult:
+    """Per-repo, per-loop outcome — collection of phase results."""
+
+    repo: str
+    loop_idx: int
+    phases: list[PhaseResult] = field(default_factory=list)
+    # Populated when the WORKER itself crashed (not a phase failure).
+    runner_error: str | None = None
+
+    @property
+    def any_failure(self) -> bool:
+        """True when any phase failed or the worker itself crashed."""
+        return self.runner_error is not None or any(p.failed for p in self.phases)
+
+
+@dataclass
+class LoopConfig:
+    """Top-level CLI-derived configuration."""
+
+    loops: int = 5
+    max_workers: int = 3
+    parallel_repos: int = 1
+    phases: tuple[str, ...] = ALL_PHASES
+    dry_run: bool = False
+    allow_unsafe_phase_order: bool = False
+    planner_model: str = ""
+    reviewer_model: str = ""
+    implementer_model: str = ""
+    # Org is resolved at runtime from --org / --repos / cwd detection; no
+    # hardcoded fallback. Always set by main() before ``run_loop``.
+    org: str = ""
+    projects_dir: Path = DEFAULT_PROJECTS_DIR
+    # Per-phase timeout in seconds. ``None`` disables (the planner /
+    # implementer naturally bound themselves via their own batch caps).
+    phase_timeout_s: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="hephaestus-automation-loop",
+        description="Run the 6-phase automation pipeline across HomericIntelligence repos.",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Pass --dry-run to every phase")
+    p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
+    p.add_argument(
+        "--max-workers",
+        type=int,
+        default=3,
+        help="Parallel workers per repo per phase (default: 3). Passed to each phase binary.",
+    )
+    p.add_argument(
+        "--parallel-repos",
+        type=int,
+        default=1,
+        help="Repos processed in parallel per loop iteration (default: 1)",
+    )
+    p.add_argument(
+        "--phases",
+        default=",".join(ALL_PHASES),
+        help=f"Comma-separated subset of phases to run. Valid: {','.join(ALL_PHASES)}",
+    )
+    p.add_argument(
+        "--allow-unsafe-phase-order",
+        action="store_true",
+        help="Silence dependency-ordering warnings when --phases skips a recommended predecessor",
+    )
+    p.add_argument("--planner-model", default="", help="HEPH_PLANNER_MODEL for child processes")
+    p.add_argument(
+        "--reviewer-model",
+        default="",
+        help="HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review)",
+    )
+    p.add_argument(
+        "--implementer-model",
+        default="",
+        help="HEPH_IMPLEMENTER_MODEL for child processes (implement, address-review, ci-driver)",
+    )
+    p.add_argument(
+        "--org",
+        nargs="?",
+        const=_ORG_AUTODETECT,
+        default=None,
+        help=(
+            "Enumerate non-fork, non-archived repos in a GitHub org. "
+            "Pass `--org NAME` for a specific org, or `--org` alone to auto-detect "
+            "the org from the current repo's git remote. "
+            "Default (no flag): run only for the current repo."
+        ),
+    )
+    p.add_argument(
+        "--projects-dir",
+        type=Path,
+        default=DEFAULT_PROJECTS_DIR,
+        help=f"Local directory containing repo clones (default: {DEFAULT_PROJECTS_DIR})",
+    )
+    p.add_argument(
+        "--phase-timeout",
+        type=float,
+        default=None,
+        help="Per-phase timeout in seconds (default: no timeout)",
+    )
+    p.add_argument(
+        "--repos",
+        type=_parse_repo_list,
+        default=None,
+        help=(
+            "Comma-separated repo list (e.g. `--repos foo,bar`). Overrides org "
+            "enumeration. Space-separated input is NOT accepted."
+        ),
+    )
+    p.add_argument("-v", "--verbose", action="store_true", help="Enable DEBUG logging")
+    return p.parse_args(argv)
+
+
+def _validate_phases(phases_csv: str) -> tuple[str, ...]:
+    selected = tuple(p.strip() for p in phases_csv.split(",") if p.strip())
+    invalid = [p for p in selected if p not in ALL_PHASES]
+    if invalid:
+        raise SystemExit(f"Unknown phase(s): {invalid}. Valid: {','.join(ALL_PHASES)}")
+    return selected
+
+
+def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
+    """Replicate the bash script's dependency-ordering safety warnings."""
+    warnings: list[str] = []
+    selected = set(cfg.phases)
+    if "implement" in selected and "review-plans" not in selected:
+        warnings.append(
+            "--phases includes 'implement' but not 'review-plans'; "
+            "plans will be implemented without review"
+        )
+    if "address-review" in selected and "review-prs" not in selected:
+        warnings.append(
+            "--phases includes 'address-review' but not 'review-prs'; "
+            "there will be no fresh review comments to address"
+        )
+    if (
+        "drive-green" in selected
+        and "implement" not in selected
+        and "address-review" not in selected
+    ):
+        warnings.append(
+            "--phases includes 'drive-green' but neither 'implement' nor "
+            "'address-review'; drive-green will run against PRs not touched this invocation"
+        )
+    return warnings
+
+
+# ---------------------------------------------------------------------------
+# Repo discovery
+# ---------------------------------------------------------------------------
+
+
+def _detect_cwd_repo() -> tuple[str | None, str | None]:
+    """Return ``(org, repo_name)`` for the current working directory.
+
+    Returns ``(None, None)`` when cwd is not inside a git repo or has no
+    parseable github.com origin remote. ``org`` is parsed from
+    ``git remote get-url origin``; ``repo_name`` is the basename of
+    ``git rev-parse --show-toplevel``.
+    """
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return (None, None)
+    repo: str | None = Path(top).name or None
+
+    org: str | None = None
+    try:
+        url = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        url = ""
+    if "github.com" in url:
+        tail = url.split("github.com", 1)[1].lstrip(":/")
+        parts = tail.split("/", 1)
+        if len(parts) == 2:
+            org = parts[0] or None
+
+    return (org, repo)
+
+
+def _gh_list_repos(org: str) -> list[str]:
+    """Return non-archived, non-fork, non-Odysseus repos for ``org``."""
+    out = subprocess.run(
+        [
+            "gh",
+            "repo",
+            "list",
+            org,
+            "--no-archived",
+            "--json",
+            "name,isArchived,isFork",
+            "--limit",
+            "200",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        raise SystemExit(f"gh repo list {org} failed (rc={out.returncode}): {out.stderr.strip()}")
+    try:
+        entries = json.loads(out.stdout or "[]")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"gh repo list returned invalid JSON: {exc}") from exc
+    return [
+        e["name"]
+        for e in entries
+        if not e.get("isArchived", False)
+        and not e.get("isFork", False)
+        and e.get("name") != "Odysseus"
+    ]
+
+
+def _gh_issue_numbers_for(org: str, repo: str, filter_flag: str) -> set[int]:
+    """Return open-issue numbers in ``org/repo`` matching one ``gh issue list`` filter.
+
+    ``filter_flag`` is one of ``"--author"`` / ``"--assignee"``; the value is
+    always ``@me`` (current authenticated gh user). Returns an empty set on
+    any failure (rate limit, auth error, etc.) so callers can fall back
+    safely.
+    """
+    out = subprocess.run(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            f"{org}/{repo}",
+            "--state",
+            "open",
+            filter_flag,
+            "@me",
+            "--limit",
+            "200",
+            "--json",
+            "number",
+            "--jq",
+            ".[].number",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        return set()
+    return {int(x) for x in out.stdout.split() if x.strip().isdigit()}
+
+
+def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
+    """Return open issue numbers in ``org/repo`` authored by OR assigned to ``@me``.
+
+    GitHub treats ``--author`` and ``--assignee`` as AND, so we issue two
+    queries and union the results to get OR semantics. Sorted ascending
+    so the implementer phase processes oldest-first.
+    """
+    union = _gh_issue_numbers_for(org, repo, "--author") | _gh_issue_numbers_for(
+        org, repo, "--assignee"
+    )
+    return sorted(union)
+
+
+def _count_open_issues(org: str, repo: str) -> int:
+    """Return count of ``@me``-authored OR ``@me``-assigned open issues."""
+    return len(_list_open_issue_numbers(org, repo))
+
+
+def _sort_repos_by_open_count(org: str, repos: list[str]) -> list[str]:
+    """Order repos ascending by open-issue count (smallest backlog first)."""
+    counted: list[tuple[int, int, str]] = []
+    for idx, repo in enumerate(repos):
+        counted.append((_count_open_issues(org, repo), idx, repo))
+    counted.sort()
+    return [name for _, _, name in counted]
+
+
+def _resolve_repo_dir(projects_dir: Path, repo: str) -> Path:
+    return projects_dir / repo
+
+
+def _ensure_clone(org: str, repo: str, dest: Path) -> None:
+    """Clone the repo into ``dest`` if not already present."""
+    if (dest / ".git").exists():
+        return
+    LOG.info("Cloning %s/%s -> %s", org, repo, dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    rc = subprocess.run(
+        ["gh", "repo", "clone", f"{org}/{repo}", str(dest)],
+        check=False,
+    ).returncode
+    if rc != 0:
+        raise RuntimeError(f"gh repo clone {org}/{repo} failed (rc={rc})")
+
+
+def _clone_missing_repos(org: str, repos: list[str], projects_dir: Path) -> None:
+    """Sequentially clone any repos not already present.
+
+    Done upfront — before any worker thread starts — so two threads with
+    ``--parallel-repos > 1`` can never race on a missing clone. Matches
+    the bash version's pre-loop clone pass at
+    scripts/run_automation_loop.sh:326-336.
+    """
+    LOG.info("Cloning missing repos ...")
+    for repo in repos:
+        dest = projects_dir / repo
+        if (dest / ".git").exists():
+            LOG.debug("[%s] already cloned at %s", repo, dest)
+            continue
+        try:
+            _ensure_clone(org, repo, dest)
+        except Exception as exc:
+            LOG.error("[%s] clone failed: %s — repo will be marked failed", repo, exc)
+
+
+def _rebase_main(repo: str, repo_dir: Path) -> str:
+    """Fetch + rebase main; return short trunk SHA (or 'unknown')."""
+    subprocess.run(
+        ["git", "-C", str(repo_dir), "fetch", "origin", "--quiet"],
+        check=False,
+    )
+    rb = subprocess.run(
+        ["git", "-C", str(repo_dir), "rebase", "origin/main", "--quiet"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if rb.returncode != 0:
+        # Mid-rebase state; fall back to a hard reset so the loop can continue.
+        # This mirrors the bash script's exact behavior.
+        LOG.warning("[%s] rebase failed, hard-resetting to origin/main", repo)
+        subprocess.run(
+            ["git", "-C", str(repo_dir), "rebase", "--abort"],
+            capture_output=True,
+            check=False,
+        )
+        subprocess.run(
+            ["git", "-C", str(repo_dir), "reset", "--hard", "origin/main", "--quiet"],
+            capture_output=True,
+            check=False,
+        )
+    sha = subprocess.run(
+        ["git", "-C", str(repo_dir), "rev-parse", "--short=7", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return sha.stdout.strip() or "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Phase execution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_phase_bin(phase: str) -> tuple[str, list[str]] | None:
+    """Return ``(executable, leading_args)`` for ``phase``.
+
+    Returns ``None`` if the phase's binary cannot be found on PATH. The
+    caller treats that as a phase-skip rather than a runner crash so a
+    misconfigured pixi env produces a useful per-phase error rather than
+    a tear-down.
+    """
+    script_dir = Path(__file__).resolve().parents[2] / "scripts"
+    if phase == "plan":
+        bin_path = shutil.which("hephaestus-plan-issues")
+        return (bin_path, []) if bin_path else None
+    if phase == "implement":
+        bin_path = shutil.which("hephaestus-implement-issues")
+        return (bin_path, []) if bin_path else None
+    if phase == "review-plans":
+        py = sys.executable
+        return (py, [str(script_dir / "review_plans.py")])
+    if phase == "review-prs":
+        py = sys.executable
+        return (py, [str(script_dir / "review_issues.py")])
+    if phase == "address-review":
+        py = sys.executable
+        return (py, [str(script_dir / "address_review.py")])
+    if phase == "drive-green":
+        py = sys.executable
+        return (py, [str(script_dir / "drive_prs_green.py")])
+    return None
+
+
+# Per-phase argv flag matrix. Mirrors the bash script's per-phase blocks
+# at scripts/run_automation_loop.sh:444-576. Encoded as a table so each
+# phase's flags are obvious at a glance and impossible to duplicate.
+#
+# - "max_workers": pass `--max-workers N`
+# - "no_ui":       pass `--no-ui`
+# - "issues":      pass `--issues N N N` when open_issues is non-empty
+#                  (skip when no open issues — that case is already gated
+#                  in process_repo via the "no open issues" SKIP branch)
+# - "follow_up_loop_threshold": if non-None, pass `--no-follow-up` when
+#                  loop_idx >= threshold (bash equivalent: FOLLOW_UP_FLAG
+#                  set on loop ≥ 3, scripts/run_automation_loop.sh:415-418)
+_PHASE_FLAGS: dict[str, dict[str, object]] = {
+    "plan": {"max_workers": False, "no_ui": False, "issues": False},
+    "review-plans": {"max_workers": True, "no_ui": False, "issues": True},
+    "implement": {
+        "max_workers": True,
+        "no_ui": True,
+        "issues": False,
+        "follow_up_loop_threshold": 3,
+    },
+    "review-prs": {"max_workers": True, "no_ui": True, "issues": True},
+    "address-review": {"max_workers": True, "no_ui": True, "issues": True},
+    "drive-green": {"max_workers": True, "no_ui": True, "issues": True},
+}
+
+
+def _build_phase_argv(
+    phase: str,
+    cfg: LoopConfig,
+    open_issues: list[int],
+    loop_idx: int = 1,
+) -> list[str] | None:
+    """Construct the full argv for ``phase``; ``None`` when binary unresolved."""
+    resolved = _resolve_phase_bin(phase)
+    if resolved is None:
+        return None
+    executable, leading = resolved
+    argv: list[str] = [executable, *leading]
+
+    flags = _PHASE_FLAGS[phase]
+
+    # All phases support -v / --dry-run uniformly.
+    argv.append("-v")
+    if cfg.dry_run:
+        argv.append("--dry-run")
+
+    if flags["issues"] and open_issues:
+        argv.append("--issues")
+        argv.extend(str(n) for n in open_issues)
+
+    if flags["max_workers"]:
+        argv.extend(["--max-workers", str(cfg.max_workers)])
+
+    if flags["no_ui"]:
+        argv.append("--no-ui")
+
+    threshold = flags.get("follow_up_loop_threshold")
+    if isinstance(threshold, int) and loop_idx >= threshold:
+        argv.append("--no-follow-up")
+
+    return argv
+
+
+def _phase_env(
+    cfg: LoopConfig,
+    loop_idx: int,
+    trunk_sha: str,
+    phase: str,
+) -> dict[str, str]:
+    """Build the environment dict for a phase subprocess.
+
+    ``HEPH_LOOP_INDEX`` / ``HEPH_TOTAL_LOOPS`` are scoped to the
+    ``drive-green`` phase only — matching the bash script which set these
+    inline solely for the drive-green subshell (scripts/run_automation_loop.sh:570).
+    The ci_driver.py defense-in-depth check uses these to refuse to run
+    outside the final loop; injecting them into other phases' envs is
+    benign but a behavioral divergence from the bash version.
+    """
+    env = os.environ.copy()
+    if cfg.planner_model:
+        env["HEPH_PLANNER_MODEL"] = cfg.planner_model
+    if cfg.reviewer_model:
+        env["HEPH_REVIEWER_MODEL"] = cfg.reviewer_model
+    if cfg.implementer_model:
+        env["HEPH_IMPLEMENTER_MODEL"] = cfg.implementer_model
+    env["HEPH_TRUNK_GITHASH"] = trunk_sha
+    if phase == "drive-green":
+        env["HEPH_LOOP_INDEX"] = str(loop_idx)
+        env["HEPH_TOTAL_LOOPS"] = str(cfg.loops)
+    return env
+
+
+def run_phase(
+    repo: str,
+    repo_dir: Path,
+    phase: str,
+    cfg: LoopConfig,
+    loop_idx: int,
+    open_issues: list[int],
+    trunk_sha: str,
+) -> PhaseResult:
+    """Run one phase as a subprocess. Never raises — always returns a result.
+
+    Exit codes, timeouts, and OS errors are normalized into ``PhaseResult``
+    so the caller can unconditionally proceed to the next phase.
+    """
+    t0 = time.monotonic()
+    argv = _build_phase_argv(phase, cfg, open_issues, loop_idx=loop_idx)
+    if argv is None:
+        return PhaseResult(
+            name=phase,
+            rc=127,
+            skipped=False,
+            error=f"could not resolve binary for phase {phase!r}",
+            elapsed_s=time.monotonic() - t0,
+        )
+
+    LOG.info("[%s] phase %s START", repo, phase)
+    env = _phase_env(cfg, loop_idx, trunk_sha, phase)
+    try:
+        completed = subprocess.run(
+            argv,
+            cwd=str(repo_dir),
+            env=env,
+            timeout=cfg.phase_timeout_s,
+            check=False,
+        )
+        rc = completed.returncode
+    except subprocess.TimeoutExpired as exc:
+        LOG.error("[%s] phase %s TIMEOUT after %.0fs", repo, phase, exc.timeout or 0.0)
+        return PhaseResult(
+            name=phase,
+            rc=124,
+            elapsed_s=time.monotonic() - t0,
+            error=f"timeout after {exc.timeout}s",
+        )
+    except OSError as exc:
+        LOG.error("[%s] phase %s OSError: %s", repo, phase, exc)
+        return PhaseResult(
+            name=phase,
+            rc=126,
+            elapsed_s=time.monotonic() - t0,
+            error=f"OSError: {exc}",
+        )
+    elapsed = time.monotonic() - t0
+    LOG.info("[%s] phase %s done in %.1fs (rc=%d)", repo, phase, elapsed, rc)
+    return PhaseResult(name=phase, rc=rc, elapsed_s=elapsed)
+
+
+# ---------------------------------------------------------------------------
+# Per-repo orchestration
+# ---------------------------------------------------------------------------
+
+
+def process_repo(
+    repo: str,
+    loop_idx: int,
+    cfg: LoopConfig,
+) -> RepoResult:
+    """Run the 6-phase pipeline for one repo. Never raises.
+
+    Any exception inside the function (filesystem error, gh API explosion,
+    unexpected programming bug) is caught and stashed in
+    ``RepoResult.runner_error`` so the outer loop never sees a thread
+    crash. Per-phase failures live in ``RepoResult.phases``.
+    """
+    result = RepoResult(repo=repo, loop_idx=loop_idx)
+    try:
+        return _process_repo_inner(repo, loop_idx, cfg, result)
+    except BaseException as exc:
+        tb = traceback.format_exc()
+        result.runner_error = f"{type(exc).__name__}: {exc}\n{tb}"
+        LOG.error("[%s] runner crashed: %s", repo, exc)
+        return result
+
+
+def _process_repo_inner(
+    repo: str,
+    loop_idx: int,
+    cfg: LoopConfig,
+    result: RepoResult,
+) -> RepoResult:
+    # Clones are done in an upfront sequential pass in main() — see
+    # _clone_missing_repos. process_repo runs concurrently across repos
+    # (--parallel-repos > 1), so doing the clone here would race two
+    # workers on the same gh-clone call when both target the same missing
+    # repo. Bash equivalent: scripts/run_automation_loop.sh:326-336.
+    repo_dir = _resolve_repo_dir(cfg.projects_dir, repo)
+    if not (repo_dir / ".git").exists():
+        result.runner_error = f"repo {repo} not cloned at {repo_dir}"
+        return result
+
+    LOG.info("── %s (loop %d) ──", repo, loop_idx)
+    trunk_sha = _rebase_main(repo, repo_dir)
+    LOG.info("[%s] trunk=%s", repo, trunk_sha)
+
+    # Open-issue discovery happens once per repo per loop. Phases 2/4/5/6
+    # need this list; the others auto-discover internally.
+    open_issues = _list_open_issue_numbers(cfg.org, repo)
+
+    for phase in ALL_PHASES:
+        if _shutdown_requested():
+            LOG.warning("[%s] phase %s SKIP (shutdown requested)", repo, phase)
+            result.phases.append(
+                PhaseResult(name=phase, skipped=True, skip_reason="shutdown requested")
+            )
+            continue
+
+        if phase not in cfg.phases:
+            LOG.info("[%s] phase %s SKIP (disabled by --phases)", repo, phase)
+            result.phases.append(
+                PhaseResult(name=phase, skipped=True, skip_reason="disabled by --phases")
+            )
+            continue
+
+        # drive-green only runs on the final loop. Mirrors bash behavior.
+        if phase == "drive-green" and loop_idx != cfg.loops:
+            LOG.info("[%s] phase %s SKIP (not final loop)", repo, phase)
+            result.phases.append(
+                PhaseResult(name=phase, skipped=True, skip_reason="not final loop")
+            )
+            continue
+
+        if phase in PHASES_REQUIRING_ISSUES and not open_issues:
+            LOG.info("[%s] phase %s SKIP (no open issues)", repo, phase)
+            result.phases.append(
+                PhaseResult(name=phase, skipped=True, skip_reason="no open issues")
+            )
+            continue
+
+        phase_result = run_phase(
+            repo=repo,
+            repo_dir=repo_dir,
+            phase=phase,
+            cfg=cfg,
+            loop_idx=loop_idx,
+            open_issues=open_issues,
+            trunk_sha=trunk_sha,
+        )
+        result.phases.append(phase_result)
+        if phase_result.failed:
+            LOG.warning(
+                "[%s] phase %s FAILED rc=%d — continuing to next phase",
+                repo,
+                phase,
+                phase_result.rc,
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Outer loop
+# ---------------------------------------------------------------------------
+
+
+def _preflight_token_scopes(org: str, probe_repo: str) -> None:
+    """Mirror the bash script's gh-token preflight."""
+    out = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-H",
+            "Accept: application/vnd.github+json",
+            f"/repos/{org}/{probe_repo}",
+            "--jq",
+            ".permissions",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        raise SystemExit(
+            f"ERROR: `gh` cannot read {org}/{probe_repo} with the current token.\n"
+            f"  {out.stderr.strip()}\n"
+            "  Required scopes: repo (classic) OR "
+            "Issues+PRs+Contents Read & Write (fine-grained).\n"
+            "  Check with: gh auth status"
+        )
+    if out.stdout.strip() in {"null", "{}"}:
+        LOG.warning(
+            "Token permissions on %s/%s are empty; PR/issue writes will fail.",
+            org,
+            probe_repo,
+        )
+
+
+def _rate_limit_remaining() -> tuple[int, int] | None:
+    """Return ``(remaining, reset_epoch)`` for the GraphQL budget, or None."""
+    out = subprocess.run(
+        ["gh", "api", "rate_limit"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode != 0:
+        return None
+    try:
+        data = json.loads(out.stdout)
+        gql = data["resources"]["graphql"]
+        return int(gql["remaining"]), int(gql["reset"])
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def _maybe_sleep_for_rate_budget(loop_idx: int, total_loops: int) -> None:
+    """Sleep until the upstream reset when GraphQL budget would be exhausted."""
+    if os.environ.get("HEPHAESTUS_RATE_GUARD", "1") == "0":
+        return
+    if loop_idx >= total_loops:
+        return
+    threshold = int(os.environ.get("HEPHAESTUS_RATE_GUARD_THRESHOLD", "200"))
+    rl = _rate_limit_remaining()
+    if rl is None:
+        return
+    remaining, reset_epoch = rl
+    if remaining >= threshold:
+        return
+    wait_s = max(0, reset_epoch - int(time.time()) + 5)
+    if wait_s <= 0:
+        return
+    LOG.info(
+        "Rate budget low (%d/%d GraphQL remaining); sleeping %ds until reset",
+        remaining,
+        threshold,
+        wait_s,
+    )
+    # Cooperatively cancellable sleep so SIGINT during the wait still works.
+    deadline = time.monotonic() + wait_s
+    while time.monotonic() < deadline:
+        if _shutdown_requested():
+            LOG.warning("Rate-budget sleep cancelled by shutdown request")
+            return
+        time.sleep(min(1.0, deadline - time.monotonic()))
+
+
+def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
+    """Drive ``cfg.loops`` iterations across ``repos``. Returns flat result list.
+
+    Any single thread raising is contained — ``process_repo`` already
+    swallows all exceptions, and ``Future.exception()`` is the second-line
+    safety net for the rare case where the work submission itself dies.
+    """
+    all_results: list[RepoResult] = []
+
+    for loop_idx in range(1, cfg.loops + 1):
+        if _shutdown_requested():
+            LOG.warning("Shutdown requested before loop %d — stopping", loop_idx)
+            break
+
+        LOG.info("━" * 60)
+        LOG.info("▶ LOOP %d / %d", loop_idx, cfg.loops)
+        LOG.info("━" * 60)
+
+        with ThreadPoolExecutor(
+            max_workers=max(1, cfg.parallel_repos),
+            thread_name_prefix="repo-",
+        ) as pool:
+            futures: dict[Future[RepoResult], str] = {
+                pool.submit(process_repo, repo, loop_idx, cfg): repo for repo in repos
+            }
+            for fut, repo in futures.items():
+                try:
+                    result = fut.result()
+                except BaseException as exc:
+                    LOG.error("[%s] future raised: %s", repo, exc)
+                    result = RepoResult(
+                        repo=repo,
+                        loop_idx=loop_idx,
+                        runner_error=f"future raised: {type(exc).__name__}: {exc}",
+                    )
+                all_results.append(result)
+                if result.any_failure:
+                    LOG.warning(
+                        "[%s] loop %d had failures (see phase rcs above)",
+                        repo,
+                        loop_idx,
+                    )
+
+        LOG.info("Loop %d complete.", loop_idx)
+        _maybe_sleep_for_rate_budget(loop_idx, cfg.loops)
+
+    LOG.info("✓ All %d loop(s) complete across %d repo(s).", cfg.loops, len(repos))
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def _setup_logging(verbose: bool) -> None:
+    from hephaestus.logging import setup_logging
+
+    setup_logging(level=logging.DEBUG if verbose else logging.INFO)
+
+
+def _resolve_org_and_repos(
+    args: argparse.Namespace,
+) -> tuple[str, list[str], str | None]:
+    """Resolve ``(org, repos, error_message)`` from CLI args + cwd detection.
+
+    Precedence:
+      1. ``--repos`` given → use it; org from cwd (preferred) or ``--org NAME``.
+      2. ``--org NAME`` (explicit) → enumerate non-fork repos in NAME.
+      3. ``--org`` (no arg) → detect org from cwd; enumerate non-fork repos.
+      4. (no flags) → use only the cwd repo + its org.
+
+    Returns ``("", [], "<reason>")`` on error so ``main()`` can log and exit.
+    """
+    # Branch 1: explicit --repos
+    if args.repos:
+        detected_org, _ = _detect_cwd_repo()
+        explicit_org = args.org if isinstance(args.org, str) else None
+        org = detected_org or explicit_org
+        if not org:
+            return (
+                "",
+                [],
+                "--repos requires being run inside a github.com repo or passing --org NAME.",
+            )
+        return (org, list(args.repos), None)
+
+    # Branches 2 + 3: --org variants
+    if args.org is not None:
+        if args.org is _ORG_AUTODETECT:
+            detected_org, _ = _detect_cwd_repo()
+            if not detected_org:
+                return (
+                    "",
+                    [],
+                    "--org with no argument requires being run inside a github.com repo.",
+                )
+            org = detected_org
+        else:
+            org = args.org
+        LOG.info("Discovering repos in %s ...", org)
+        candidates = _gh_list_repos(org)
+        if not candidates:
+            return (org, [], "No repos returned from gh repo list — possible rate limit.")
+        LOG.info("Sorting %d repos by open-issue count ...", len(candidates))
+        return (org, _sort_repos_by_open_count(org, candidates), None)
+
+    # Branch 4: no flags — default to cwd repo
+    detected_org, detected_repo = _detect_cwd_repo()
+    if not (detected_org and detected_repo):
+        return (
+            "",
+            [],
+            "No repo specified and cwd is not a github.com repo. "
+            "Pass --repos foo,bar or --org [NAME].",
+        )
+    LOG.info("Defaulting to current repo: %s/%s", detected_org, detected_repo)
+    return (detected_org, [detected_repo], None)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console-script entry point. Returns the process exit code."""
+    args = _parse_args(argv)
+    _setup_logging(args.verbose)
+
+    phases = _validate_phases(args.phases)
+
+    # Resolve org + repos using a 4-branch precedence ladder. Org is
+    # always set explicitly here — there is no silent fallback to a
+    # hardcoded default.
+    org, repos, err = _resolve_org_and_repos(args)
+    if err:
+        LOG.error("%s", err)
+        return 1
+
+    cfg = LoopConfig(
+        loops=args.loops,
+        max_workers=args.max_workers,
+        parallel_repos=args.parallel_repos,
+        phases=phases,
+        dry_run=args.dry_run,
+        allow_unsafe_phase_order=args.allow_unsafe_phase_order,
+        planner_model=args.planner_model,
+        reviewer_model=args.reviewer_model,
+        implementer_model=args.implementer_model,
+        org=org,
+        projects_dir=args.projects_dir,
+        phase_timeout_s=args.phase_timeout,
+    )
+
+    if not cfg.allow_unsafe_phase_order:
+        for w in _phase_order_warnings(cfg):
+            LOG.warning("%s (pass --allow-unsafe-phase-order to silence)", w)
+
+    signal.signal(signal.SIGINT, _request_shutdown)
+    signal.signal(signal.SIGTERM, _request_shutdown)
+    # SIGHUP missing on Windows; not the target platform but be tolerant.
+    with contextlib.suppress(AttributeError, ValueError):
+        signal.signal(signal.SIGHUP, _request_shutdown)
+
+    if not repos:
+        LOG.error("Repo list is empty; nothing to do.")
+        return 1
+
+    if not cfg.dry_run:
+        _preflight_token_scopes(cfg.org, repos[0])
+
+    _clone_missing_repos(cfg.org, repos, cfg.projects_dir)
+
+    LOG.info("Repos to process: %s", " ".join(repos))
+    LOG.info(
+        "Loops: %d | Max workers: %d | Parallel repos: %d | Dry run: %s",
+        cfg.loops,
+        cfg.max_workers,
+        cfg.parallel_repos,
+        cfg.dry_run,
+    )
+    LOG.info("Phases: %s", ",".join(cfg.phases))
+    LOG.info(
+        "Models: planner=%s reviewer=%s implementer=%s",
+        cfg.planner_model or "<default>",
+        cfg.reviewer_model or "<default>",
+        cfg.implementer_model or "<default>",
+    )
+
+    results = run_loop(cfg, repos)
+
+    failures = [r for r in results if r.any_failure]
+    if failures:
+        LOG.warning("%d/%d repo-loop results had failures", len(failures), len(results))
+        return 1
+    return 130 if _shutdown_requested() else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -32,6 +32,7 @@ import traceback
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
+from urllib.parse import urlparse
 
 LOG = logging.getLogger(__name__)
 
@@ -296,9 +297,22 @@ def _detect_cwd_repo() -> tuple[str | None, str | None]:
         ).stdout.strip()
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         url = ""
-    if "github.com" in url:
-        tail = url.split("github.com", 1)[1].lstrip(":/")
-        parts = tail.split("/", 1)
+
+    host = ""
+    path = ""
+    parsed = urlparse(url)
+    if parsed.scheme:
+        host = (parsed.hostname or "").rstrip(".").lower()
+        path = parsed.path.lstrip("/")
+    elif "@" in url and ":" in url:
+        # SCP-like git remote, e.g. git@github.com:org/repo.git
+        after_at = url.split("@", 1)[1]
+        host_part, path_part = after_at.split(":", 1)
+        host = host_part.rstrip(".").lower()
+        path = path_part.lstrip("/")
+
+    if host == "github.com":
+        parts = path.split("/", 1)
         if len(parts) == 2:
             org = parts[0] or None
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -888,7 +888,7 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
             for fut, repo in futures.items():
                 try:
                     result = fut.result()
-                except BaseException as exc:
+                except Exception as exc:
                     LOG.error("[%s] future raised: %s", repo, exc)
                     result = RepoResult(
                         repo=repo,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ all = [
 ]
 
 [project.scripts]
+hephaestus-automation-loop = "hephaestus.automation.loop_runner:main"
 hephaestus-plan-issues = "hephaestus.automation.planner:main"
 hephaestus-implement-issues = "hephaestus.automation.implementer:main"
 hephaestus-review-prs = "hephaestus.automation.pr_reviewer:main"

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -1,0 +1,718 @@
+"""Tests for hephaestus.automation.loop_runner.
+
+Focus: phase-isolation invariants. The whole reason for this module
+existing is that the previous bash version silently aborted between
+phases — these tests pin down that a Python phase failure (whether
+subprocess rc!=0, raised exception, or worker crash) does NOT prevent
+subsequent phases from being attempted.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation import loop_runner
+from hephaestus.automation.loop_runner import (
+    ALL_PHASES,
+    LoopConfig,
+    PhaseResult,
+    RepoResult,
+    _phase_order_warnings,
+    _validate_phases,
+    process_repo,
+    run_loop,
+    run_phase,
+)
+
+# ---------------------------------------------------------------------------
+# CLI / config validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_phases_accepts_full_list() -> None:
+    """Validate phases accepts full list."""
+    assert _validate_phases(",".join(ALL_PHASES)) == ALL_PHASES
+
+
+def test_validate_phases_accepts_subset() -> None:
+    """Validate phases accepts subset."""
+    assert _validate_phases("plan,implement") == ("plan", "implement")
+
+
+def test_validate_phases_rejects_typo() -> None:
+    """Validate phases rejects typo."""
+    with pytest.raises(SystemExit, match="Unknown phase"):
+        _validate_phases("plan,implmnt")
+
+
+def test_phase_order_warnings_implement_without_review_plans() -> None:
+    """Phase order warnings implement without review plans."""
+    cfg = LoopConfig(phases=("implement",))
+    warnings = _phase_order_warnings(cfg)
+    assert any("implement" in w and "review-plans" in w for w in warnings)
+
+
+def test_phase_order_warnings_address_review_without_review_prs() -> None:
+    """Phase order warnings address review without review prs."""
+    cfg = LoopConfig(phases=("address-review",))
+    warnings = _phase_order_warnings(cfg)
+    assert any("address-review" in w and "review-prs" in w for w in warnings)
+
+
+def test_phase_order_warnings_drive_green_without_implement() -> None:
+    """Phase order warnings drive green without implement."""
+    cfg = LoopConfig(phases=("drive-green",))
+    warnings = _phase_order_warnings(cfg)
+    assert any("drive-green" in w for w in warnings)
+
+
+def test_phase_order_warnings_silent_on_full_pipeline() -> None:
+    """Phase order warnings silent on full pipeline."""
+    cfg = LoopConfig(phases=ALL_PHASES)
+    assert _phase_order_warnings(cfg) == []
+
+
+# ---------------------------------------------------------------------------
+# run_phase — never raises, always returns PhaseResult
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_repo_dir(tmp_path: Path) -> Path:
+    """Create an empty fake repo dir with a .git/ marker."""
+    d = tmp_path / "repo"
+    d.mkdir()
+    (d / ".git").mkdir()
+    return d
+
+
+def test_run_phase_returns_rc_zero_on_success(fake_repo_dir: Path) -> None:
+    """Run phase returns rc zero on success."""
+    cfg = LoopConfig()
+    completed = MagicMock(returncode=0)
+    with (
+        patch.object(loop_runner, "_resolve_phase_bin", return_value=("/bin/true", [])),
+        patch("subprocess.run", return_value=completed) as run_mock,
+    ):
+        result = run_phase(
+            repo="r",
+            repo_dir=fake_repo_dir,
+            phase="plan",
+            cfg=cfg,
+            loop_idx=1,
+            open_issues=[],
+            trunk_sha="abc1234",
+        )
+    assert isinstance(result, PhaseResult)
+    assert result.rc == 0
+    assert not result.failed
+    assert result.name == "plan"
+    run_mock.assert_called_once()
+
+
+def test_run_phase_returns_rc_nonzero_does_not_raise(fake_repo_dir: Path) -> None:
+    """Run phase returns rc nonzero does not raise."""
+    cfg = LoopConfig()
+    completed = MagicMock(returncode=7)
+    with (
+        patch.object(loop_runner, "_resolve_phase_bin", return_value=("/bin/false", [])),
+        patch("subprocess.run", return_value=completed),
+    ):
+        result = run_phase(
+            repo="r",
+            repo_dir=fake_repo_dir,
+            phase="implement",
+            cfg=cfg,
+            loop_idx=1,
+            open_issues=[],
+            trunk_sha="abc1234",
+        )
+    assert result.rc == 7
+    assert result.failed
+
+
+def test_run_phase_handles_timeout(fake_repo_dir: Path) -> None:
+    """Run phase handles timeout."""
+    cfg = LoopConfig(phase_timeout_s=0.01)
+    with (
+        patch.object(loop_runner, "_resolve_phase_bin", return_value=("/bin/sleep", [])),
+        patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="x", timeout=0.01),
+        ),
+    ):
+        result = run_phase(
+            repo="r",
+            repo_dir=fake_repo_dir,
+            phase="plan",
+            cfg=cfg,
+            loop_idx=1,
+            open_issues=[],
+            trunk_sha="abc1234",
+        )
+    assert result.rc == 124
+    assert result.error is not None and "timeout" in result.error.lower()
+
+
+def test_run_phase_handles_oserror(fake_repo_dir: Path) -> None:
+    """Run phase handles oserror."""
+    cfg = LoopConfig()
+    with (
+        patch.object(loop_runner, "_resolve_phase_bin", return_value=("/nope", [])),
+        patch("subprocess.run", side_effect=OSError("no such file")),
+    ):
+        result = run_phase(
+            repo="r",
+            repo_dir=fake_repo_dir,
+            phase="plan",
+            cfg=cfg,
+            loop_idx=1,
+            open_issues=[],
+            trunk_sha="abc1234",
+        )
+    assert result.rc == 126
+    assert result.error is not None and "OSError" in result.error
+
+
+def test_run_phase_handles_unresolved_binary(fake_repo_dir: Path) -> None:
+    """Run phase handles unresolved binary."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=None):
+        result = run_phase(
+            repo="r",
+            repo_dir=fake_repo_dir,
+            phase="plan",
+            cfg=cfg,
+            loop_idx=1,
+            open_issues=[],
+            trunk_sha="abc1234",
+        )
+    assert result.rc == 127
+    assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# process_repo — phase isolation is the headline invariant
+# ---------------------------------------------------------------------------
+
+
+def _ok(name: str) -> PhaseResult:
+    return PhaseResult(name=name, rc=0, elapsed_s=0.1)
+
+
+def _fail(name: str, rc: int = 1) -> PhaseResult:
+    return PhaseResult(name=name, rc=rc, elapsed_s=0.1)
+
+
+@pytest.fixture
+def repo_inputs(tmp_path: Path) -> tuple[Path, LoopConfig]:
+    """Build a projects_dir + LoopConfig for process_repo tests."""
+    projects = tmp_path
+    (projects / "r" / ".git").mkdir(parents=True)
+    cfg = LoopConfig(loops=1, projects_dir=projects)
+    return projects, cfg
+
+
+def test_process_repo_runs_all_phases_when_all_succeed(
+    repo_inputs: tuple[Path, LoopConfig],
+) -> None:
+    """Process repo runs all phases when all succeed."""
+    _, cfg = repo_inputs
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1, 2]),
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+    ):
+        result = process_repo("r", loop_idx=1, cfg=cfg)
+    assert [p.name for p in result.phases] == list(ALL_PHASES)
+    assert not result.any_failure
+
+
+def test_process_repo_continues_after_phase_failure(repo_inputs: tuple[Path, LoopConfig]) -> None:
+    """The core regression test: phase 1 failing must NOT stop phases 2-6."""
+    _, cfg = repo_inputs
+    call_order: list[str] = []
+
+    def fake_run_phase(**kw: object) -> PhaseResult:
+        name = str(kw["phase"])
+        call_order.append(name)
+        rc = 1 if name == "plan" else 0
+        return PhaseResult(name=name, rc=rc, elapsed_s=0.1)
+
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        patch.object(loop_runner, "run_phase", side_effect=fake_run_phase),
+    ):
+        result = process_repo("r", loop_idx=1, cfg=cfg)
+
+    assert call_order == list(ALL_PHASES), "phase 1 failure must not skip subsequent phases"
+    assert result.phases[0].failed
+    assert not result.phases[1].failed
+    assert result.any_failure
+
+
+def test_process_repo_swallows_worker_exceptions(repo_inputs: tuple[Path, LoopConfig]) -> None:
+    """If process_repo itself blows up, it returns a RepoResult — never raises."""
+    _, cfg = repo_inputs
+    with patch.object(loop_runner, "_rebase_main", side_effect=RuntimeError("boom")):
+        result = process_repo("r", loop_idx=1, cfg=cfg)
+    assert isinstance(result, RepoResult)
+    assert result.runner_error is not None
+    assert "boom" in result.runner_error
+    assert result.any_failure
+
+
+def test_process_repo_skips_disabled_phases(repo_inputs: tuple[Path, LoopConfig]) -> None:
+    """Process repo skips disabled phases."""
+    _, cfg = repo_inputs
+    cfg = LoopConfig(loops=1, projects_dir=cfg.projects_dir, phases=("plan",))
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+    ):
+        result = process_repo("r", loop_idx=1, cfg=cfg)
+    by_name = {p.name: p for p in result.phases}
+    assert not by_name["plan"].skipped
+    for name in ALL_PHASES[1:]:
+        assert by_name[name].skipped
+        assert by_name[name].skip_reason == "disabled by --phases"
+
+
+def test_process_repo_skips_issue_phases_when_no_issues(
+    repo_inputs: tuple[Path, LoopConfig],
+) -> None:
+    """Process repo skips issue phases when no issues."""
+    _, cfg = repo_inputs
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+    ):
+        result = process_repo("r", loop_idx=1, cfg=cfg)
+    by_name = {p.name: p for p in result.phases}
+    for name in ("review-plans", "review-prs", "address-review", "drive-green"):
+        assert by_name[name].skipped
+        assert by_name[name].skip_reason == "no open issues"
+    # plan and implement auto-discover, so they still run
+    assert not by_name["plan"].skipped
+    assert not by_name["implement"].skipped
+
+
+def test_process_repo_skips_drive_green_on_non_final_loop(
+    repo_inputs: tuple[Path, LoopConfig],
+) -> None:
+    """Process repo skips drive green on non final loop."""
+    _, cfg = repo_inputs
+    cfg = LoopConfig(loops=3, projects_dir=cfg.projects_dir)
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+    ):
+        result_loop1 = process_repo("r", loop_idx=1, cfg=cfg)
+        result_loop3 = process_repo("r", loop_idx=3, cfg=cfg)
+    drive_green_loop1 = next(p for p in result_loop1.phases if p.name == "drive-green")
+    drive_green_loop3 = next(p for p in result_loop3.phases if p.name == "drive-green")
+    assert drive_green_loop1.skipped and drive_green_loop1.skip_reason == "not final loop"
+    assert not drive_green_loop3.skipped
+
+
+# ---------------------------------------------------------------------------
+# run_loop — outer driver swallows future exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_run_loop_swallows_future_exception(repo_inputs: tuple[Path, LoopConfig]) -> None:
+    """Swallow future exceptions so the outer loop survives.
+
+    If a future itself somehow raises (process_repo's safety net is bypassed),
+    run_loop still records a RepoResult with runner_error and continues.
+    """
+    _, cfg = repo_inputs
+
+    def crash(*_args: object, **_kw: object) -> RepoResult:
+        raise RuntimeError("simulated thread crash")
+
+    with patch.object(loop_runner, "process_repo", side_effect=crash):
+        results = run_loop(cfg, repos=["r1", "r2"])
+
+    assert len(results) == 2
+    assert all(r.runner_error is not None for r in results)
+    assert all("simulated thread crash" in (r.runner_error or "") for r in results)
+
+
+def test_run_loop_continues_when_one_repo_fails(repo_inputs: tuple[Path, LoopConfig]) -> None:
+    """Run loop continues when one repo fails."""
+    _, cfg = repo_inputs
+
+    def fake(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
+        rr = RepoResult(repo=repo, loop_idx=loop_idx)
+        if repo == "broken":
+            rr.runner_error = "boom"
+        else:
+            rr.phases.append(PhaseResult(name="plan", rc=0))
+        return rr
+
+    with patch.object(loop_runner, "process_repo", side_effect=fake):
+        results = run_loop(cfg, repos=["ok1", "broken", "ok2"])
+
+    by_repo = {r.repo: r for r in results}
+    assert by_repo["broken"].runner_error == "boom"
+    assert not by_repo["ok1"].any_failure
+    assert not by_repo["ok2"].any_failure
+
+
+# ---------------------------------------------------------------------------
+# Argv construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_phase_argv_plan_omits_issues() -> None:
+    """Build phase argv plan omits issues."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/plan", [])):
+        argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[1, 2])
+    assert argv is not None
+    assert "--issues" not in argv
+
+
+def test_build_phase_argv_review_plans_includes_issues() -> None:
+    """Build phase argv review plans includes issues."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
+        argv = loop_runner._build_phase_argv("review-plans", cfg, open_issues=[7, 8])
+    assert argv is not None
+    assert "--issues" in argv
+    assert "7" in argv and "8" in argv
+
+
+def test_build_phase_argv_passes_dry_run() -> None:
+    """Build phase argv passes dry run."""
+    cfg = LoopConfig(dry_run=True)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/plan", [])):
+        argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[])
+    assert argv is not None and "--dry-run" in argv
+
+
+def test_build_phase_argv_implement_has_single_max_workers() -> None:
+    """Regression: implement must not duplicate --max-workers."""
+    cfg = LoopConfig(max_workers=4)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/impl", [])):
+        argv = loop_runner._build_phase_argv("implement", cfg, open_issues=[])
+    assert argv is not None
+    assert argv.count("--max-workers") == 1
+
+
+def test_build_phase_argv_review_plans_omits_no_ui() -> None:
+    """Regression: review-plans does NOT receive --no-ui (bash never passed it)."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["s.py"])):
+        argv = loop_runner._build_phase_argv("review-plans", cfg, open_issues=[1])
+    assert argv is not None
+    assert "--no-ui" not in argv
+
+
+def test_build_phase_argv_implement_includes_no_ui() -> None:
+    """Implement DOES receive --no-ui."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/impl", [])):
+        argv = loop_runner._build_phase_argv("implement", cfg, open_issues=[])
+    assert argv is not None and "--no-ui" in argv
+
+
+def test_build_phase_argv_implement_no_follow_up_on_loop_3() -> None:
+    """Regression: implement gets --no-follow-up on loop >= 3 (bash FOLLOW_UP_FLAG)."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/impl", [])):
+        argv_loop2 = loop_runner._build_phase_argv("implement", cfg, [], loop_idx=2)
+        argv_loop3 = loop_runner._build_phase_argv("implement", cfg, [], loop_idx=3)
+        argv_loop5 = loop_runner._build_phase_argv("implement", cfg, [], loop_idx=5)
+    assert argv_loop2 is not None and "--no-follow-up" not in argv_loop2
+    assert argv_loop3 is not None and "--no-follow-up" in argv_loop3
+    assert argv_loop5 is not None and "--no-follow-up" in argv_loop5
+
+
+def test_build_phase_argv_plan_omits_max_workers() -> None:
+    """Plan phase does not accept --max-workers (auto-discovers internally)."""
+    cfg = LoopConfig(max_workers=4)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/plan", [])):
+        argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[])
+    assert argv is not None and "--max-workers" not in argv
+
+
+def test_phase_env_loop_index_only_for_drive_green() -> None:
+    """Regression: HEPH_LOOP_INDEX/HEPH_TOTAL_LOOPS scoped to drive-green only."""
+    cfg = LoopConfig(loops=5)
+    for phase in ("plan", "review-plans", "implement", "review-prs", "address-review"):
+        env = loop_runner._phase_env(cfg, loop_idx=3, trunk_sha="abc", phase=phase)
+        assert "HEPH_LOOP_INDEX" not in env, f"phase {phase} leaked HEPH_LOOP_INDEX"
+        assert "HEPH_TOTAL_LOOPS" not in env, f"phase {phase} leaked HEPH_TOTAL_LOOPS"
+    env_dg = loop_runner._phase_env(cfg, loop_idx=3, trunk_sha="abc", phase="drive-green")
+    assert env_dg["HEPH_LOOP_INDEX"] == "3"
+    assert env_dg["HEPH_TOTAL_LOOPS"] == "5"
+
+
+def test_phase_env_model_vars_only_when_non_empty() -> None:
+    """Model env vars only present when their cfg field is non-empty."""
+    cfg_empty = LoopConfig()
+    env = loop_runner._phase_env(cfg_empty, loop_idx=1, trunk_sha="abc", phase="plan")
+    assert "HEPH_PLANNER_MODEL" not in env
+    assert "HEPH_REVIEWER_MODEL" not in env
+    assert "HEPH_IMPLEMENTER_MODEL" not in env
+
+    cfg_set = LoopConfig(planner_model="opus", reviewer_model="sonnet", implementer_model="opus")
+    env_set = loop_runner._phase_env(cfg_set, loop_idx=1, trunk_sha="abc", phase="plan")
+    assert env_set["HEPH_PLANNER_MODEL"] == "opus"
+    assert env_set["HEPH_REVIEWER_MODEL"] == "sonnet"
+    assert env_set["HEPH_IMPLEMENTER_MODEL"] == "opus"
+
+
+def test_phase_env_trunk_sha_always_set() -> None:
+    """HEPH_TRUNK_GITHASH is always exported (session naming relies on it)."""
+    cfg = LoopConfig()
+    for phase in loop_runner.ALL_PHASES:
+        env = loop_runner._phase_env(cfg, loop_idx=1, trunk_sha="f936537", phase=phase)
+        assert env["HEPH_TRUNK_GITHASH"] == "f936537"
+
+
+# ---------------------------------------------------------------------------
+# CLI scope refinements: fork filter, comma-only --repos, cwd default, --org
+# ---------------------------------------------------------------------------
+
+
+def test_parse_repo_list_comma_only() -> None:
+    """Comma-separated input is parsed; whitespace is stripped."""
+    assert loop_runner._parse_repo_list("foo, bar,baz") == ["foo", "bar", "baz"]
+    assert loop_runner._parse_repo_list("") == []
+    assert loop_runner._parse_repo_list("solo") == ["solo"]
+
+
+def test_repos_argparse_rejects_space_separated() -> None:
+    """Argparse treats space-separated values as positional; raises SystemExit."""
+    with pytest.raises(SystemExit):
+        loop_runner._parse_args(["--repos", "foo", "bar"])
+
+
+def test_gh_list_repos_filters_forks_and_archived() -> None:
+    """``isFork: true`` and ``isArchived: true`` entries are excluded."""
+    payload = (
+        '[{"name":"keep","isFork":false,"isArchived":false},'
+        '{"name":"drop-fork","isFork":true,"isArchived":false},'
+        '{"name":"drop-archived","isFork":false,"isArchived":true},'
+        '{"name":"Odysseus","isFork":false,"isArchived":false}]'
+    )
+    with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=payload, stderr=""
+        )
+        names = loop_runner._gh_list_repos("MyOrg")
+    assert names == ["keep"]
+    invoked_argv = mock_run.call_args[0][0]
+    assert "--no-archived" in invoked_argv
+    assert "name,isArchived,isFork" in invoked_argv
+
+
+def test_list_open_issue_numbers_unions_author_and_assignee() -> None:
+    """Author + assignee queries are unioned (OR semantics) and sorted."""
+    calls = {"author": "10\n12\n", "assignee": "12\n7\n"}
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "--author" in argv:
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=calls["author"], stderr=""
+            )
+        if "--assignee" in argv:
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout=calls["assignee"], stderr=""
+            )
+        raise AssertionError(f"unexpected argv: {argv!r}")
+
+    with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run):
+        nums = loop_runner._list_open_issue_numbers("MyOrg", "MyRepo")
+    assert nums == [7, 10, 12]
+
+
+def test_list_open_issue_numbers_passes_at_me() -> None:
+    """``@me`` is passed for both ``--author`` and ``--assignee``."""
+    seen_filters: list[str] = []
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        for flag in ("--author", "--assignee"):
+            if flag in argv:
+                idx = argv.index(flag)
+                seen_filters.append(f"{flag}={argv[idx + 1]}")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run):
+        loop_runner._list_open_issue_numbers("Org", "Repo")
+    assert "--author=@me" in seen_filters
+    assert "--assignee=@me" in seen_filters
+
+
+def test_resolve_org_and_repos_cwd_default() -> None:
+    """No flags + cwd is a github repo → run for that single repo."""
+    args = loop_runner._parse_args([])
+    with patch(
+        "hephaestus.automation.loop_runner._detect_cwd_repo",
+        return_value=("MyOrg", "MyRepo"),
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is None
+    assert org == "MyOrg"
+    assert repos == ["MyRepo"]
+
+
+def test_resolve_org_and_repos_errors_when_no_scope_and_not_git() -> None:
+    """No flags + cwd is not a github repo → return error message."""
+    args = loop_runner._parse_args([])
+    with patch(
+        "hephaestus.automation.loop_runner._detect_cwd_repo",
+        return_value=(None, None),
+    ):
+        _, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is not None
+    assert "cwd is not a github.com repo" in err
+    assert repos == []
+
+
+def test_resolve_org_and_repos_org_no_arg_autodetects() -> None:
+    """``--org`` with no value → detect org from cwd, enumerate."""
+    args = loop_runner._parse_args(["--org"])
+    assert args.org is loop_runner._ORG_AUTODETECT
+    with (
+        patch(
+            "hephaestus.automation.loop_runner._detect_cwd_repo",
+            return_value=("DetectedOrg", "AnyRepo"),
+        ),
+        patch(
+            "hephaestus.automation.loop_runner._gh_list_repos",
+            return_value=["a", "b"],
+        ) as mock_list,
+        patch(
+            "hephaestus.automation.loop_runner._sort_repos_by_open_count",
+            side_effect=lambda _org, r: r,
+        ),
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is None
+    assert org == "DetectedOrg"
+    assert repos == ["a", "b"]
+    mock_list.assert_called_once_with("DetectedOrg")
+
+
+def test_resolve_org_and_repos_org_no_arg_errors_when_not_git() -> None:
+    """``--org`` with no value + cwd not a github repo → error."""
+    args = loop_runner._parse_args(["--org"])
+    with patch(
+        "hephaestus.automation.loop_runner._detect_cwd_repo",
+        return_value=(None, None),
+    ):
+        _, _, err = loop_runner._resolve_org_and_repos(args)
+    assert err is not None
+    assert "--org with no argument" in err
+
+
+def test_resolve_org_and_repos_org_named() -> None:
+    """``--org NAME`` enumerates the named org without cwd detection."""
+    args = loop_runner._parse_args(["--org", "ExplicitOrg"])
+    with (
+        patch(
+            "hephaestus.automation.loop_runner._detect_cwd_repo",
+        ) as mock_detect,
+        patch(
+            "hephaestus.automation.loop_runner._gh_list_repos",
+            return_value=["x"],
+        ),
+        patch(
+            "hephaestus.automation.loop_runner._sort_repos_by_open_count",
+            side_effect=lambda _org, r: r,
+        ),
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is None
+    assert org == "ExplicitOrg"
+    assert repos == ["x"]
+    mock_detect.assert_not_called()
+
+
+def test_resolve_org_and_repos_repos_flag_uses_cwd_org() -> None:
+    """``--repos foo,bar`` uses cwd-detected org without enumerating."""
+    args = loop_runner._parse_args(["--repos", "foo,bar"])
+    assert args.repos == ["foo", "bar"]
+    with (
+        patch(
+            "hephaestus.automation.loop_runner._detect_cwd_repo",
+            return_value=("CwdOrg", "Whatever"),
+        ),
+        patch("hephaestus.automation.loop_runner._gh_list_repos") as mock_list,
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is None
+    assert org == "CwdOrg"
+    assert repos == ["foo", "bar"]
+    mock_list.assert_not_called()
+
+
+def test_resolve_org_and_repos_repos_flag_falls_back_to_explicit_org() -> None:
+    """``--repos foo --org Bar`` (not in a git repo) uses ``Bar`` as the org."""
+    args = loop_runner._parse_args(["--repos", "foo", "--org", "Bar"])
+    with patch(
+        "hephaestus.automation.loop_runner._detect_cwd_repo",
+        return_value=(None, None),
+    ):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is None
+    assert org == "Bar"
+    assert repos == ["foo"]
+
+
+def test_detect_cwd_repo_parses_ssh_url() -> None:
+    """SSH origin ``git@github.com:Org/Repo.git`` yields ``Org``."""
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="/tmp/MyRepo\n", stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="git@github.com:MyOrg/MyRepo.git\n", stderr=""
+        )
+
+    with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run):
+        org, repo = loop_runner._detect_cwd_repo()
+    assert org == "MyOrg"
+    assert repo == "MyRepo"
+
+
+def test_detect_cwd_repo_parses_https_url() -> None:
+    """HTTPS origin ``https://github.com/Org/Repo`` yields ``Org``."""
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(
+                args=argv, returncode=0, stdout="/tmp/R\n", stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=argv, returncode=0, stdout="https://github.com/HOrg/R.git\n", stderr=""
+        )
+
+    with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run):
+        org, repo = loop_runner._detect_cwd_repo()
+    assert org == "HOrg"
+    assert repo == "R"
+
+
+def test_detect_cwd_repo_returns_none_when_not_git() -> None:
+    """``git rev-parse`` failure → ``(None, None)``."""
+    with patch(
+        "hephaestus.automation.loop_runner.subprocess.run",
+        side_effect=subprocess.CalledProcessError(128, ["git"]),
+    ):
+        org, repo = loop_runner._detect_cwd_repo()
+    assert (org, repo) == (None, None)


### PR DESCRIPTION
Lands the Python orchestrator that replaces `scripts/run_automation_loop.sh`, plus operator-facing refinements over the bash-equivalent CLI.

## What changes

- **Default scope = cwd repo.** No flags → detect `(org, repo)` from `git rev-parse --show-toplevel` + `git remote get-url origin` and run only for that one repo. Errors out clearly if cwd is not a github.com repo. No silent fallback to a hardcoded org.
- **`--org` is opt-in.** `--org NAME` enumerates that org; `--org` alone auto-detects org from cwd.
- **Skip forks and archived repos** in org enumeration (`gh repo list --json isFork --no-archived`).
- **`--repos` is comma-separated only** (`--repos foo,bar`). Space-separated is argparse-rejected.
- **Only automate `@me`-authored OR `@me`-assigned issues.** Two `gh issue list` queries unioned for OR semantics (gh ANDs filters natively).
- **PyPI-installable.** `hephaestus-automation-loop = "hephaestus.automation.loop_runner:main"` added to `[project.scripts]`; `pip install` produces the binary.

## Verification

- `pixi run ruff check` + `pixi run mypy` + `pixi run pytest tests/unit/automation/test_loop_runner.py` — all green (46 tests, 16 new for these refinements).
- README CLI table sync passes (`python3 scripts/check_cli_table_sync.py`).
- Smoke (from this repo): `hephaestus-automation-loop --dry-run --loops 1 --phases plan` → "Defaulting to current repo: HomericIntelligence/ProjectHephaestus" → runs only here.
- Smoke: `--org` alone → "Discovering repos in HomericIntelligence ..." (detected from origin) → 14 non-fork, non-archived repos enumerated.

Closes #590