### PR TITLE
fix(dx): include dev-install in justfile bootstrap recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -19,6 +19,7 @@ default:
 # Install dependencies and set up pre-commit hooks (one-command bootstrap)
 bootstrap:
     pixi install
+    pixi run dev-install
     pixi run pre-commit install
 
 # Run all tests (unit + integration)


### PR DESCRIPTION
## Summary

`just bootstrap` previously omitted `pixi run dev-install`, so the dev env produced by the recipe could not actually import `hephaestus`. The omission was already flagged in pixi.toml's own comment block ("Run once after pixi install: pixi run dev-install"). One-line fix to the bootstrap recipe restores the one-command-setup promise.

Closes #592

## Test plan

- [x] `just bootstrap` succeeds and produces an importable env
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)