### PR TITLE
ci: pin secondary workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   auto-tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:
@@ -46,7 +46,7 @@ jobs:
         run: pixi run pytest tests/unit
 
   type-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:
@@ -75,7 +75,7 @@ jobs:
         run: pixi run mypy
 
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [test, type-check]
     environment: pypi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   pip-audit:
     name: Dependency vulnerability scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary

Pins seven `runs-on: ubuntu-latest` job declarations to `ubuntu-24.04` so all workflows are as deterministic as `_required.yml` (which was already pinned). Prevents silent drift when GitHub updates the `ubuntu-latest` alias.

Files touched:
- `.github/workflows/auto-tag.yml`
- `.github/workflows/test.yml`
- `.github/workflows/release.yml` (3 jobs)
- `.github/workflows/security.yml`
- `.github/workflows/pre-commit.yml`

Closes #593

## Test plan

- [ ] CI green on this PR (workflows still resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)