### PR TITLE
fix(cli): pr_merge main() returns int, not sys.exit()

### DIFF
--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -196,7 +196,7 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
         logger.error("  Failed to merge PR #%d. API message: %s", pr_number, message)
 
 
-def main() -> None:  # noqa: C901
+def main() -> int:  # noqa: C901
     """Serve as the main entry point for PR merge automation."""
     parser = argparse.ArgumentParser(
         description="Merge open PRs with successful CI/CD into main (rebase via PR API)"
@@ -223,7 +223,7 @@ def main() -> None:  # noqa: C901
         logger.error(
             "Please set GITHUB_TOKEN environment variable with a token that has 'repo' scope."
         )
-        sys.exit(1)
+        return 1
 
     # Detect or use provided repo name
     repo_name = args.repo or detect_repo_from_remote()
@@ -232,7 +232,7 @@ def main() -> None:  # noqa: C901
             "Could not detect repository name. Please provide --repo OWNER/REPO or "
             "ensure you're in a git repository with a GitHub remote."
         )
-        sys.exit(1)
+        return 1
 
     logger.info("Working with repository: %s", repo_name)
 
@@ -244,7 +244,7 @@ def main() -> None:  # noqa: C901
             "PyGithub not installed. Install with: pip install PyGithub\n"
             "Or install hephaestus with github extras: pip install hephaestus[github]"
         )
-        sys.exit(1)
+        return 1
 
     # Connect to GitHub
     gh = Github(token)
@@ -252,7 +252,7 @@ def main() -> None:  # noqa: C901
         repo = gh.get_repo(repo_name)
     except Exception as e:  # broad catch intentional: PyGithub raises many exception subtypes
         logger.error("Error accessing repo %s: %s", repo_name, e)
-        sys.exit(1)
+        return 1
 
     # Update local main
     logger.info("Updating local 'main'...")
@@ -303,7 +303,8 @@ def main() -> None:  # noqa: C901
             logger.warning("  CI/CD checks not successful for PR #%d. Skipping merge.", pr.number)
 
     logger.info("\nDone processing all open PRs.")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -300,36 +300,39 @@ class TestMain:
 
     @patch("hephaestus.github.pr_merge.run_git_cmd")
     @patch("hephaestus.github.pr_merge.detect_repo_from_remote")
-    def test_exits_1_when_no_token(self, mock_detect, mock_git) -> None:
-        """main() exits 1 when GITHUB_TOKEN is not set."""
+    def test_returns_1_when_no_token(self, mock_detect, mock_git) -> None:
+        """main() returns 1 when GITHUB_TOKEN is not set."""
         with patch.dict("os.environ", {}, clear=True):
             with patch("os.getenv", return_value=None):
                 with patch("sys.argv", ["prog"]):
-                    with pytest.raises(SystemExit) as exc_info:
-                        from hephaestus.github.pr_merge import main
+                    from hephaestus.github.pr_merge import main
 
-                        main()
-        assert exc_info.value.code == 1
+                    assert main() == 1
 
     @patch("hephaestus.github.pr_merge.run_git_cmd")
-    def test_exits_1_when_no_repo_detected(self, mock_git) -> None:
-        """main() exits 1 when repo can't be detected."""
+    def test_returns_1_when_no_repo_detected(self, mock_git) -> None:
+        """main() returns 1 when repo can't be detected."""
         with patch("os.getenv", return_value="fake-token"):
             with patch("hephaestus.github.pr_merge.detect_repo_from_remote", return_value=None):
                 with patch("sys.argv", ["prog"]):
-                    with pytest.raises(SystemExit) as exc_info:
-                        from hephaestus.github.pr_merge import main
+                    from hephaestus.github.pr_merge import main
 
-                        main()
-        assert exc_info.value.code == 1
+                    assert main() == 1
 
     @pytest.mark.skipif(
         not importlib.util.find_spec("github"),
         reason="PyGithub not installed — cannot mock its absence when it is genuinely absent",
     )
     @patch("hephaestus.github.pr_merge.run_git_cmd")
-    def test_exits_1_when_pygithub_not_installed(self, mock_git) -> None:
-        """main() exits 1 when PyGithub is not importable."""
+    def test_returns_1_when_pygithub_not_installed(self, mock_git) -> None:
+        """main() returns 1 when PyGithub is not importable."""
+        # A blanket builtins.__import__ patch also fires for argparse's
+        # transitive `import locale`, so main() may not reach the github import
+        # at all. Accept either outcome (return 1 from the clean path, or
+        # ImportError propagating from incidental machinery) — both signal that
+        # PyGithub's absence is fatal, which is what we are asserting.
+        from hephaestus.github.pr_merge import main
+
         with patch("os.getenv", return_value="fake-token"):
             with patch(
                 "hephaestus.github.pr_merge.detect_repo_from_remote", return_value="owner/repo"
@@ -338,14 +341,15 @@ class TestMain:
                     "builtins.__import__", side_effect=ImportError("No module named 'github'")
                 ):
                     with patch("sys.argv", ["prog"]):
-                        with pytest.raises((SystemExit, ImportError)):
-                            from hephaestus.github.pr_merge import main
-
-                            main()
+                        try:
+                            result = main()
+                        except ImportError:
+                            return  # acceptable failure mode
+                        assert result == 1
 
     @patch("hephaestus.github.pr_merge.run_git_cmd")
-    def test_exits_1_when_repo_access_fails(self, mock_git) -> None:
-        """main() exits 1 when GitHub repo access raises."""
+    def test_returns_1_when_repo_access_fails(self, mock_git) -> None:
+        """main() returns 1 when GitHub repo access raises."""
         mock_gh = MagicMock()
         mock_gh.get_repo.side_effect = Exception("Not found")
         mock_github_module = MagicMock()
@@ -357,11 +361,9 @@ class TestMain:
             ):
                 with patch.dict(sys.modules, {"github": mock_github_module}):
                     with patch("sys.argv", ["prog"]):
-                        with pytest.raises(SystemExit) as exc_info:
-                            from hephaestus.github.pr_merge import main
+                        from hephaestus.github.pr_merge import main
 
-                            main()
-        assert exc_info.value.code == 1
+                        assert main() == 1
 
     @patch("hephaestus.github.pr_merge.try_push_head_branch")
     @patch("hephaestus.github.pr_merge.run_git_cmd")


### PR DESCRIPTION
## Summary

`hephaestus/github/pr_merge.py` had `def main() -> None` with 4× `sys.exit(1)`, inconsistent with the rest of the CLI surface (e.g. `implementer.py` returns int). This PR aligns it with the convention so `rc = main()` returns a meaningful exit code.

- Signature: `def main() -> None` → `def main() -> int`
- 4× `sys.exit(1)` → `return 1`
- Added `return 0` on success
- `if __name__ == "__main__": main()` → `sys.exit(main())`
- 4 test assertions updated from `pytest.raises(SystemExit)` to `assert main() == 1`

## Verification

- [x] `pixi run pytest tests/unit/github/test_pr_merge.py` — 39/39 pass
- [x] `pixi run ruff check` — clean
- [x] `pixi run mypy` — clean (251 files)

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)