### PR TITLE
refactor(automation): dedupe pr_reviewer + address_review via BaseReviewer

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -7,18 +7,144 @@ Provides:
 - ``parse_json_block``: Extract the last ```json``` block from Claude output.
 - ``find_pr_for_issue``: Locate the open PR for a GitHub issue (two or three
   lookup strategies depending on the caller's needs).
+- ``setup_review_logging``: Standard logging configuration for the reviewer
+  CLIs (#599 dedupe).
+- ``build_review_parser``: Argparse parser builder shared by ``pr_reviewer``
+  and ``address_review`` (#599 dedupe).
+- ``instance_log``: Shared body of the per-instance ``_log`` helper used by
+  the reviewer classes (#599 dedupe).
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import re
+import threading
 from typing import Any
+
+from hephaestus.agents.runtime import add_agent_argument
 
 from .github_api import _gh_call
 
 logger = logging.getLogger(__name__)
+
+
+def setup_review_logging(verbose: bool = False) -> None:
+    """Configure root logging for the reviewer CLIs.
+
+    Identical to the previously-duplicated ``_setup_logging`` helpers in
+    ``pr_reviewer.py`` and ``address_review.py``.
+
+    Args:
+        verbose: Enable DEBUG-level logging (otherwise INFO).
+
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def build_review_parser(
+    description: str,
+    epilog: str | None = None,
+    *,
+    issues_help: str,
+    dry_run_help: str,
+) -> argparse.ArgumentParser:
+    """Build the argparse parser shared by ``pr_reviewer`` and ``address_review``.
+
+    The two CLIs differ only in their ``description``/``epilog`` text and in
+    the help strings for ``--issues`` / ``--dry-run``. Every other option
+    (``--agent``, ``--max-workers``, ``--no-ui``, ``-v/--verbose``) is
+    identical.
+
+    Args:
+        description: Parser description text.
+        epilog: Parser epilog text (typically an Examples block).
+        issues_help: Help text for the ``--issues`` argument.
+        dry_run_help: Help text for the ``--dry-run`` argument.
+
+    Returns:
+        Configured ``argparse.ArgumentParser`` — caller invokes ``parse_args``.
+
+    """
+    parser = argparse.ArgumentParser(
+        description=description,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=epilog,
+    )
+
+    parser.add_argument(
+        "--issues",
+        type=int,
+        nargs="+",
+        required=True,
+        help=issues_help,
+    )
+    add_agent_argument(parser)
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=3,
+        choices=range(1, 33),
+        metavar="N",
+        help="Maximum number of parallel workers, 1-32 (default: 3)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=dry_run_help,
+    )
+    parser.add_argument(
+        "--no-ui",
+        action="store_true",
+        help="Disable curses UI (use plain logging instead)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser
+
+
+def instance_log(
+    log_manager: Any,
+    level: str,
+    msg: str,
+    thread_id: int | None = None,
+    *,
+    caller_logger: logging.Logger | None = None,
+) -> None:
+    """Log to both the caller's module logger and the per-thread UI buffer.
+
+    Shared body of the previously-duplicated ``PRReviewer._log`` and
+    ``AddressReviewer._log`` instance methods. ``caller_logger`` defaults
+    to this module's logger so callers that don't care about provenance
+    can omit it, but the reviewer classes pass their own module logger to
+    preserve the pre-refactor log-record source.
+
+    Args:
+        log_manager: A ``ThreadLogManager`` exposing ``.log(thread_id, msg)``.
+        level: Log level name — ``"error"``, ``"warning"``, or ``"info"``.
+        msg: Message to log.
+        thread_id: Thread ID for the UI buffer (defaults to current thread).
+        caller_logger: Logger used for the stdlib log record. Defaults to
+            this module's logger.
+
+    """
+    target_logger = caller_logger if caller_logger is not None else logger
+    getattr(target_logger, level)(msg)
+    tid = thread_id or threading.get_ident()
+    prefix = {"error": "ERROR", "warning": "WARN", "info": ""}.get(level, "")
+    ui_msg = f"{prefix}: {msg}" if prefix else msg
+    log_manager.log(tid, ui_msg)
 
 
 def parse_json_block(text: str) -> dict[str, Any]:

--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -28,6 +28,9 @@ from .worktree_manager import WorktreeManager
 logger = logging.getLogger(__name__)
 
 
+_MISSING = object()
+
+
 def _resolve_from_subclass_module(cls: type, name: str) -> Any:
     """Look up ``name`` from the module that defines ``cls``.
 
@@ -36,9 +39,24 @@ def _resolve_from_subclass_module(cls: type, name: str) -> Any:
     with ``patch("hephaestus.automation.<module>.<Name>")``. Looking these
     up dynamically here preserves that test seam — patching the subclass
     module still wins.
+
+    Raises:
+        TypeError: If the subclass module does not re-export ``name``. The
+            error names the offending subclass and module so a future author
+            of a third ``BaseReviewer`` subclass gets an actionable message
+            instead of a bare ``AttributeError``.
+
     """
     module = importlib.import_module(cls.__module__)
-    return getattr(module, name)
+    obj = getattr(module, name, _MISSING)
+    if obj is _MISSING:
+        raise TypeError(
+            f"{cls.__qualname__} must re-export {name!r} in its own module "
+            f"({cls.__module__}) for BaseReviewer test-patch compatibility. "
+            f"Add `from .{name.lower()}_module import {name}  # noqa: F401` "
+            f"or equivalent to {cls.__module__}."
+        )
+    return obj
 
 
 class BaseReviewer:
@@ -154,7 +172,11 @@ class BaseReviewer:
         try:
             return ReviewState.model_validate_json(state_file.read_text())
         except Exception as exc:
-            logger.warning(
+            # Log under the subclass module's logger so observability tooling
+            # that filters on logger name attributes this to pr_reviewer /
+            # address_review (same behavior as before the BaseReviewer split).
+            subclass_logger = logging.getLogger(type(self).__module__)
+            subclass_logger.warning(
                 "Malformed review state for issue #%d (%s)", issue_number, exc
             )
             return None

--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -159,6 +159,3 @@ class BaseReviewer:
             )
             return None
 
-    def _state_file(self, issue_number: int) -> Path:
-        """Return the on-disk review-state file path for ``issue_number``."""
-        return self.state_dir / f"review-{issue_number}.json"

--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -1,0 +1,164 @@
+"""Shared scaffolding for the PR reviewer + address-review CLIs.
+
+Issue #599: ``PRReviewer`` and ``AddressReviewer`` previously duplicated
+their ``__init__``, ``_log``, ``_fail`` / ``_fail_review``, and review-state
+loading logic. This module hosts the common pieces as ``BaseReviewer``,
+which both concrete classes now subclass.
+
+Subclasses own only the work-specific methods (``_review_pr`` for
+``PRReviewer``; ``_address_issue`` for ``AddressReviewer``).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import threading
+from pathlib import Path
+from typing import Any
+
+from ._review_utils import instance_log
+from .curses_ui import CursesUI, ThreadLogManager
+from .git_utils import issue_ref
+from .github_api import write_secure
+from .models import ReviewPhase, ReviewState, WorkerResult
+from .status_tracker import StatusTracker
+from .worktree_manager import WorktreeManager
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_from_subclass_module(cls: type, name: str) -> Any:
+    """Look up ``name`` from the module that defines ``cls``.
+
+    The reviewer subclasses re-export ``WorktreeManager``, ``StatusTracker``,
+    and ``ThreadLogManager`` from their own modules so tests can patch them
+    with ``patch("hephaestus.automation.<module>.<Name>")``. Looking these
+    up dynamically here preserves that test seam — patching the subclass
+    module still wins.
+    """
+    module = importlib.import_module(cls.__module__)
+    return getattr(module, name)
+
+
+class BaseReviewer:
+    """Shared scaffolding for the reviewer CLIs.
+
+    Owns:
+        - ``options``: subclass-specific options model (duck-typed; must expose
+          ``max_workers``).
+        - ``repo_root`` + ``state_dir``: filesystem layout.
+        - ``worktree_manager``: shared ``WorktreeManager``.
+        - ``status_tracker``: parallel-worker slot tracker.
+        - ``log_manager``: per-thread UI log buffer.
+        - ``states``: in-memory ``ReviewState`` cache keyed by issue number.
+        - ``state_lock``: serializes mutation of ``states``.
+        - ``ui``: optional ``CursesUI`` (set by subclass ``run()``).
+
+    Concrete subclasses override the work-specific methods only.
+    """
+
+    def __init__(self, options: Any) -> None:
+        """Initialize the shared reviewer scaffolding.
+
+        Args:
+            options: A subclass-specific options model. Must expose
+                ``max_workers`` (other attributes are read by subclasses).
+
+        """
+        self.options = options
+        # Resolve from the subclass's module so tests can patch them via
+        # ``patch("hephaestus.automation.<module>.<Name>")``.
+        get_repo_root_fn = _resolve_from_subclass_module(type(self), "get_repo_root")
+        self.repo_root: Path = Path(get_repo_root_fn())
+        self.state_dir: Path = self.repo_root / "build" / ".issue_implementer"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        worktree_manager_cls = _resolve_from_subclass_module(type(self), "WorktreeManager")
+        status_tracker_cls = _resolve_from_subclass_module(type(self), "StatusTracker")
+        thread_log_manager_cls = _resolve_from_subclass_module(type(self), "ThreadLogManager")
+
+        self.worktree_manager: WorktreeManager = worktree_manager_cls()
+        self.status_tracker: StatusTracker = status_tracker_cls(options.max_workers)
+        self.log_manager: ThreadLogManager = thread_log_manager_cls()
+
+        self.states: dict[int, ReviewState] = {}
+        self.state_lock = threading.Lock()
+
+        self.ui: CursesUI | None = None
+
+    def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
+        """Log to both module logger and per-thread UI buffer.
+
+        Subclasses may override to substitute their own module logger so that
+        the log record's ``name`` matches the subclass module.
+        """
+        instance_log(self.log_manager, level, msg, thread_id, caller_logger=logger)
+
+    def _save_state(self, state: ReviewState) -> None:
+        """Persist a ``ReviewState`` to ``review-<issue_number>.json``.
+
+        Both reviewer CLIs use this same filename layout.
+
+        Args:
+            state: The ``ReviewState`` to persist.
+
+        """
+        state_file = self.state_dir / f"review-{state.issue_number}.json"
+        write_secure(state_file, state.model_dump_json(indent=2))
+
+    def _fail(
+        self,
+        issue_number: int,
+        error_msg: str,
+        slot_id: int,
+    ) -> WorkerResult:
+        """Record a worker failure and return a failed ``WorkerResult``.
+
+        Updates the status tracker, marks any in-memory state ``FAILED``,
+        persists it, and returns a ``WorkerResult(success=False)``.
+
+        Args:
+            issue_number: GitHub issue number.
+            error_msg: Human-readable error description.
+            slot_id: Worker slot ID for status updates.
+
+        Returns:
+            ``WorkerResult`` with ``success=False`` and ``error=error_msg``.
+
+        """
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
+        )
+        err_state = self.states.get(issue_number)
+        if err_state:
+            with self.state_lock:
+                err_state.phase = ReviewPhase.FAILED
+                err_state.error = error_msg
+            self._save_state(err_state)
+        return WorkerResult(issue_number=issue_number, success=False, error=error_msg)
+
+    def _load_review_state_from_disk(self, issue_number: int) -> ReviewState | None:
+        """Load a ``ReviewState`` from disk, or return ``None`` if absent / invalid.
+
+        Args:
+            issue_number: GitHub issue number.
+
+        Returns:
+            ``ReviewState`` if the file exists and parses, else ``None``.
+
+        """
+        state_file = self.state_dir / f"review-{issue_number}.json"
+        if not state_file.exists():
+            return None
+        try:
+            return ReviewState.model_validate_json(state_file.read_text())
+        except Exception as exc:
+            logger.warning(
+                "Malformed review state for issue #%d (%s)", issue_number, exc
+            )
+            return None
+
+    def _state_file(self, issue_number: int) -> Path:
+        """Return the on-disk review-state file path for ``issue_number``."""
+        return self.state_dir / f"review-{issue_number}.json"

--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -176,8 +176,5 @@ class BaseReviewer:
             # that filters on logger name attributes this to pr_reviewer /
             # address_review (same behavior as before the BaseReviewer split).
             subclass_logger = logging.getLogger(type(self).__module__)
-            subclass_logger.warning(
-                "Malformed review state for issue #%d (%s)", issue_number, exc
-            )
+            subclass_logger.warning("Malformed review state for issue #%d (%s)", issue_number, exc)
             return None
-

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -893,9 +893,7 @@ Examples:
   %(prog)s --issues 595 596 597 --max-workers 5
         """,
         issues_help="Issue numbers whose linked PRs should have review threads addressed",
-        dry_run_help=(
-            "Show what would be done without actually resolving threads or pushing code"
-        ),
+        dry_run_help=("Show what would be done without actually resolving threads or pushing code"),
     )
     return parser.parse_args()
 

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -38,26 +38,32 @@ from ._review_utils import (
     instance_log,
     setup_review_logging,
 )
+from ._reviewer_base import BaseReviewer
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
 from .claude_timeouts import address_review_claude_timeout
-from .curses_ui import CursesUI, ThreadLogManager
-from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref, run
+from .curses_ui import CursesUI, ThreadLogManager  # noqa: F401  (ThreadLogManager re-exported)
+from .git_utils import (  # noqa: F401  (get_repo_root re-exported)
+    get_repo_root,
+    get_repo_slug,
+    issue_ref,
+    pr_ref,
+    run,
+)
 from .github_api import (
     gh_pr_list_unresolved_threads,
     gh_pr_resolve_thread,
-    write_secure,
 )
 from .models import AddressReviewOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_address_review_prompt
 from .session_naming import AGENT_IMPLEMENTER, current_trunk_githash
-from .status_tracker import StatusTracker
-from .worktree_manager import WorktreeManager
+from .status_tracker import StatusTracker  # noqa: F401 — re-exported for test patching
+from .worktree_manager import WorktreeManager  # noqa: F401 — re-exported for test patching
 
 logger = logging.getLogger(__name__)
 
 
-class AddressReviewer:
+class AddressReviewer(BaseReviewer):
     """Addresses unresolved PR review threads using Claude Code.
 
     Features:
@@ -66,7 +72,12 @@ class AddressReviewer:
     - Selective thread resolution (only resolves threads Claude explicitly fixed)
     - State persistence for observability
     - Real-time curses UI for status monitoring
+
+    Inherits shared scaffolding (``__init__``, ``_log``, ``_fail``,
+    ``_save_state``) from :class:`BaseReviewer`.
     """
+
+    options: AddressReviewOptions
 
     def __init__(self, options: AddressReviewOptions) -> None:
         """Initialize address reviewer.
@@ -75,30 +86,13 @@ class AddressReviewer:
             options: Reviewer configuration options
 
         """
-        self.options = options
-        self.repo_root = get_repo_root()
-        self.state_dir = self.repo_root / "build" / ".issue_implementer"
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-
-        self.worktree_manager = WorktreeManager()
-        self.status_tracker = StatusTracker(options.max_workers)
-        self.log_manager = ThreadLogManager()
-
-        self.states: dict[int, ReviewState] = {}
-        self.state_lock = threading.Lock()
-
-        self.ui: CursesUI | None = None
+        super().__init__(options)
 
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.
 
-        Delegates to :func:`_review_utils.instance_log` (#599 dedupe).
-
-        Args:
-            level: Log level ("error", "warning", or "info")
-            msg: Message to log
-            thread_id: Thread ID (defaults to current thread)
-
+        Overrides :meth:`BaseReviewer._log` so the stdlib log record
+        attributes to this module rather than ``_reviewer_base``.
         """
         instance_log(self.log_manager, level, msg, thread_id, caller_logger=logger)
 
@@ -487,6 +481,9 @@ class AddressReviewer:
     def _load_review_state(self, issue_number: int) -> ReviewState | None:
         """Load review state from disk.
 
+        Thin wrapper around :meth:`BaseReviewer._load_review_state_from_disk`
+        kept for backward compatibility with internal callers and tests.
+
         Args:
             issue_number: GitHub issue number
 
@@ -494,25 +491,19 @@ class AddressReviewer:
             ReviewState if state file exists and is valid, None otherwise
 
         """
-        state_file = self.state_dir / f"review-{issue_number}.json"
-        if not state_file.exists():
-            return None
-        try:
-            data = json.loads(state_file.read_text())
-            return ReviewState.model_validate(data)
-        except Exception as e:
-            logger.warning("Could not load review state for #%s: %s", issue_number, e)
-            return None
+        return self._load_review_state_from_disk(issue_number)
 
     def _save_review_state(self, state: ReviewState) -> None:
         """Save review state to disk.
+
+        Thin wrapper around :meth:`BaseReviewer._save_state` kept for
+        backward compatibility with internal callers.
 
         Args:
             state: ReviewState to persist
 
         """
-        state_file = self.state_dir / f"review-{state.issue_number}.json"
-        write_secure(state_file, state.model_dump_json(indent=2))
+        self._save_state(state)
 
     def _get_or_create_worktree(
         self,
@@ -857,34 +848,6 @@ class AddressReviewer:
             logger.info("Pushed branch %s to origin", branch_name)
         except subprocess.CalledProcessError as e:
             raise RuntimeError(f"Failed to push branch {branch_name}: {e}") from e
-
-    def _fail(
-        self,
-        issue_number: int,
-        error_msg: str,
-        slot_id: int,
-    ) -> WorkerResult:
-        """Record a failure, update state and tracker, and return a failed WorkerResult.
-
-        Args:
-            issue_number: GitHub issue number
-            error_msg: Human-readable error description
-            slot_id: Worker slot ID for status updates
-
-        Returns:
-            WorkerResult with success=False
-
-        """
-        self.status_tracker.update_slot(
-            slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
-        )
-        err_state = self.states.get(issue_number)
-        if err_state:
-            with self.state_lock:
-                err_state.phase = ReviewPhase.FAILED
-                err_state.error = error_msg
-            self._save_review_state(err_state)
-        return WorkerResult(issue_number=issue_number, success=False, error=error_msg)
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print address review summary.

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -26,14 +26,18 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    add_agent_argument,
     is_codex,
     resume_codex_session,
     run_codex_session,
     session_agent_matches,
 )
 
-from ._review_utils import find_pr_for_issue
+from ._review_utils import (
+    build_review_parser,
+    find_pr_for_issue,
+    instance_log,
+    setup_review_logging,
+)
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
 from .claude_timeouts import address_review_claude_timeout
@@ -88,17 +92,15 @@ class AddressReviewer:
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.
 
+        Delegates to :func:`_review_utils.instance_log` (#599 dedupe).
+
         Args:
             level: Log level ("error", "warning", or "info")
             msg: Message to log
             thread_id: Thread ID (defaults to current thread)
 
         """
-        getattr(logger, level)(msg)
-        tid = thread_id or threading.get_ident()
-        prefix = {"error": "ERROR", "warning": "WARN", "info": ""}.get(level, "")
-        ui_msg = f"{prefix}: {msg}" if prefix else msg
-        self.log_manager.log(tid, ui_msg)
+        instance_log(self.log_manager, level, msg, thread_id, caller_logger=logger)
 
     def run(self) -> dict[int, WorkerResult]:
         """Run the address review workflow.
@@ -909,29 +911,13 @@ class AddressReviewer:
                     logger.info("  #%s: %s", issue_num, result.error)
 
 
-def _setup_logging(verbose: bool = False) -> None:
-    """Configure logging for the CLI.
-
-    Args:
-        verbose: Enable verbose (DEBUG) logging
-
-    """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
-
 def _parse_args() -> argparse.Namespace:
     """Parse command line arguments for the address review CLI."""
-    parser = argparse.ArgumentParser(
+    parser = build_review_parser(
         description=(
             "Find PRs with unresolved review threads and use Claude Code to fix the code, "
             "then resolve only the threads Claude explicitly addresses."
         ),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   # Address review threads for specific issues
@@ -943,41 +929,11 @@ Examples:
   # Use more parallel workers
   %(prog)s --issues 595 596 597 --max-workers 5
         """,
+        issues_help="Issue numbers whose linked PRs should have review threads addressed",
+        dry_run_help=(
+            "Show what would be done without actually resolving threads or pushing code"
+        ),
     )
-
-    parser.add_argument(
-        "--issues",
-        type=int,
-        nargs="+",
-        required=True,
-        help="Issue numbers whose linked PRs should have review threads addressed",
-    )
-    add_agent_argument(parser)
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done without actually resolving threads or pushing code",
-    )
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
-    )
-
     return parser.parse_args()
 
 
@@ -989,7 +945,7 @@ def main() -> int:
 
     """
     args = _parse_args()
-    _setup_logging(args.verbose)
+    setup_review_logging(args.verbose)
 
     log = logging.getLogger(__name__)
     log.info("Starting address review for issues: %s", args.issues)

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -24,9 +24,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument, is_codex, run_codex_text
+from hephaestus.agents.runtime import is_codex, run_codex_text
 
-from ._review_utils import find_pr_for_issue, parse_json_block
+from ._review_utils import (
+    build_review_parser,
+    find_pr_for_issue,
+    instance_log,
+    parse_json_block,
+    setup_review_logging,
+)
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
@@ -167,17 +173,15 @@ class PRReviewer:
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.
 
+        Delegates to :func:`_review_utils.instance_log` (#599 dedupe).
+
         Args:
             level: Log level ("error", "warning", or "info")
             msg: Message to log
             thread_id: Thread ID (defaults to current thread)
 
         """
-        getattr(logger, level)(msg)
-        tid = thread_id or threading.get_ident()
-        prefix = {"error": "ERROR", "warning": "WARN", "info": ""}.get(level, "")
-        ui_msg = f"{prefix}: {msg}" if prefix else msg
-        self.log_manager.log(tid, ui_msg)
+        instance_log(self.log_manager, level, msg, thread_id, caller_logger=logger)
 
     def run(self) -> dict[int, WorkerResult]:
         """Run the PR reviewer.
@@ -801,29 +805,13 @@ class PRReviewer:
                     logger.info("  #%s: %s", issue_num, result.error)
 
 
-def _setup_logging(verbose: bool = False) -> None:
-    """Configure logging for the CLI.
-
-    Args:
-        verbose: Enable verbose (DEBUG) logging
-
-    """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-
-
 def _parse_args() -> argparse.Namespace:
     """Parse command line arguments for the reviewer CLI."""
-    parser = argparse.ArgumentParser(
+    parser = build_review_parser(
         description=(
             "Analyze open PRs linked to GitHub issues using Claude Code "
             "and post inline review comments (read-only — does not fix code)"
         ),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   # Review PRs for specific issues
@@ -835,41 +823,9 @@ Examples:
   # Review with more workers
   %(prog)s --issues 595 596 --max-workers 5
         """,
+        issues_help="Issue numbers whose linked PRs should be reviewed",
+        dry_run_help="Show what would be done without actually posting any review comments",
     )
-
-    parser.add_argument(
-        "--issues",
-        type=int,
-        nargs="+",
-        required=True,
-        help="Issue numbers whose linked PRs should be reviewed",
-    )
-    add_agent_argument(parser)
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done without actually posting any review comments",
-    )
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
-    )
-
     return parser.parse_args()
 
 
@@ -881,7 +837,7 @@ def main() -> int:
 
     """
     args = _parse_args()
-    _setup_logging(args.verbose)
+    setup_review_logging(args.verbose)
 
     log = logging.getLogger(__name__)
     log.info("Starting PR review for issues: %s", args.issues)

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -33,17 +33,18 @@ from ._review_utils import (
     parse_json_block,
     setup_review_logging,
 )
+from ._reviewer_base import BaseReviewer
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
-from .curses_ui import CursesUI, ThreadLogManager
+from .curses_ui import CursesUI, ThreadLogManager  # noqa: F401  (ThreadLogManager re-exported)
 from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref, pr_ref
-from .github_api import _gh_call, fetch_issue_info, gh_pr_review_post, write_secure
+from .github_api import _gh_call, fetch_issue_info, gh_pr_review_post
 from .models import ReviewerOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_pr_review_analysis_prompt
 from .session_naming import AGENT_PR_REVIEWER, current_trunk_githash
-from .status_tracker import StatusTracker
-from .worktree_manager import WorktreeManager
+from .status_tracker import StatusTracker  # noqa: F401 — re-exported for test patching
+from .worktree_manager import WorktreeManager  # noqa: F401 — re-exported for test patching
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +138,7 @@ def _parse_json_block(text: str) -> dict[str, Any]:
     return parse_json_block(text)
 
 
-class PRReviewer:
+class PRReviewer(BaseReviewer):
     """Posts inline review comments on open PRs linked to specified issues.
 
     Features:
@@ -147,7 +148,12 @@ class PRReviewer:
     - Real-time curses UI for status monitoring
 
     This class does NOT commit, push, or fix code.
+
+    Inherits shared scaffolding (``__init__``, ``_log``, ``_fail``,
+    ``_save_state``) from :class:`BaseReviewer`.
     """
+
+    options: ReviewerOptions
 
     def __init__(self, options: ReviewerOptions):
         """Initialize PR reviewer.
@@ -156,30 +162,13 @@ class PRReviewer:
             options: Reviewer configuration options
 
         """
-        self.options = options
-        self.repo_root = get_repo_root()
-        self.state_dir = self.repo_root / "build" / ".issue_implementer"
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-
-        self.worktree_manager = WorktreeManager()
-        self.status_tracker = StatusTracker(options.max_workers)
-        self.log_manager = ThreadLogManager()
-
-        self.states: dict[int, ReviewState] = {}
-        self.state_lock = threading.Lock()
-
-        self.ui: CursesUI | None = None
+        super().__init__(options)
 
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.
 
-        Delegates to :func:`_review_utils.instance_log` (#599 dedupe).
-
-        Args:
-            level: Log level ("error", "warning", or "info")
-            msg: Message to log
-            thread_id: Thread ID (defaults to current thread)
-
+        Overrides :meth:`BaseReviewer._log` so the stdlib log record
+        attributes to this module rather than ``_reviewer_base``.
         """
         instance_log(self.log_manager, level, msg, thread_id, caller_logger=logger)
 
@@ -490,16 +479,6 @@ class PRReviewer:
             with contextlib.suppress(Exception):
                 prompt_file.unlink()
 
-    def _save_state(self, state: ReviewState) -> None:
-        """Save review state to disk.
-
-        Args:
-            state: ReviewState to persist
-
-        """
-        state_file = self.state_dir / f"review-{state.issue_number}.json"
-        write_secure(state_file, state.model_dump_json(indent=2))
-
     def _get_or_create_state(self, issue_number: int, pr_number: int) -> ReviewState:
         """Get or create review state for an issue.
 
@@ -521,62 +500,20 @@ class PRReviewer:
         """
         with self.state_lock:
             if issue_number not in self.states:
-                # Try to load from disk before creating a fresh state
-                state_file = self.state_dir / f"review-{issue_number}.json"
-                if state_file.exists():
-                    try:
-                        self.states[issue_number] = ReviewState.model_validate_json(
-                            state_file.read_text()
-                        )
-                        logger.debug(
-                            "Loaded review state for issue #%d from disk (phase=%s)",
-                            issue_number,
-                            self.states[issue_number].phase,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            "Malformed review state file for issue #%d (%s); starting fresh",
-                            issue_number,
-                            exc,
-                        )
-                        self.states[issue_number] = ReviewState(
-                            issue_number=issue_number,
-                            pr_number=pr_number,
-                        )
+                loaded = self._load_review_state_from_disk(issue_number)
+                if loaded is not None:
+                    self.states[issue_number] = loaded
+                    logger.debug(
+                        "Loaded review state for issue #%d from disk (phase=%s)",
+                        issue_number,
+                        loaded.phase,
+                    )
                 else:
                     self.states[issue_number] = ReviewState(
                         issue_number=issue_number,
                         pr_number=pr_number,
                     )
             return self.states[issue_number]
-
-    def _fail_review(
-        self,
-        issue_number: int,
-        error_msg: str,
-        slot_id: int,
-    ) -> WorkerResult:
-        """Record a review failure, update state and tracker, and return a failed WorkerResult.
-
-        Args:
-            issue_number: GitHub issue number
-            error_msg: Human-readable error description
-            slot_id: Worker slot ID for status updates
-
-        Returns:
-            WorkerResult with success=False
-
-        """
-        self.status_tracker.update_slot(
-            slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
-        )
-        err_state = self.states.get(issue_number)
-        if err_state:
-            with self.state_lock:
-                err_state.phase = ReviewPhase.FAILED
-                err_state.error = error_msg
-            self._save_state(err_state)
-        return WorkerResult(issue_number=issue_number, success=False, error=error_msg)
 
     def _review_pr(self, issue_number: int, pr_number: int) -> WorkerResult:
         """Analyze and post inline review comments for a single PR.
@@ -712,22 +649,22 @@ class PRReviewer:
         except subprocess.TimeoutExpired as e:
             error_msg = f"Timeout: {' '.join(str(c) for c in e.cmd[:3])} exceeded {e.timeout}s"
             self._log("error", error_msg, thread_id)
-            return self._fail_review(issue_number, error_msg, slot_id)
+            return self._fail(issue_number, error_msg, slot_id)
 
         except subprocess.CalledProcessError as e:
             error_msg = (
                 f"Command failed (exit {e.returncode}): {' '.join(str(c) for c in e.cmd[:3])}"
             )
             self._log("error", error_msg, thread_id)
-            return self._fail_review(issue_number, error_msg, slot_id)
+            return self._fail(issue_number, error_msg, slot_id)
 
         except RuntimeError as e:
             self._log("error", f"Runtime error: {e}", thread_id)
-            return self._fail_review(issue_number, str(e)[:80], slot_id)
+            return self._fail(issue_number, str(e)[:80], slot_id)
 
         except Exception as e:
             self._log("error", f"Unexpected {type(e).__name__}: {e}", thread_id)
-            return self._fail_review(issue_number, str(e)[:80], slot_id)
+            return self._fail(issue_number, str(e)[:80], slot_id)
 
         finally:
             time.sleep(1)

--- a/tests/unit/automation/test_address_review_main.py
+++ b/tests/unit/automation/test_address_review_main.py
@@ -1,0 +1,63 @@
+"""Smoke tests for address_review.main() to lock in current CLI behavior.
+
+These tests capture the current behavior of ``address_review.main()`` so
+the upcoming dedupe of helpers shared with ``pr_reviewer.py`` (issue #599)
+can be verified as a pure move-and-delegate refactor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hephaestus.automation import address_review
+from hephaestus.automation.models import WorkerResult
+
+
+def _patched_run(return_value: dict[int, WorkerResult]):
+    """Return a context-manager-friendly patch of AddressReviewer.run."""
+    return patch.object(address_review.AddressReviewer, "run", return_value=return_value)
+
+
+def test_main_returns_0_when_no_unresolved_threads(monkeypatch) -> None:
+    """When run() returns an empty dict, main() exits 0."""
+    monkeypatch.setattr("sys.argv", ["address_review", "--issues", "1", "--no-ui", "--dry-run"])
+    with (
+        patch.object(address_review.AddressReviewer, "__init__", return_value=None),
+        _patched_run({}),
+    ):
+        assert address_review.main() == 0
+
+
+def test_main_returns_0_on_all_success(monkeypatch) -> None:
+    """When every WorkerResult.success is True, main() exits 0."""
+    monkeypatch.setattr("sys.argv", ["address_review", "--issues", "1", "--no-ui", "--dry-run"])
+    results = {1: WorkerResult(issue_number=1, success=True, pr_number=42)}
+    with (
+        patch.object(address_review.AddressReviewer, "__init__", return_value=None),
+        _patched_run(results),
+    ):
+        assert address_review.main() == 0
+
+
+def test_main_returns_1_on_any_failure(monkeypatch) -> None:
+    """When any WorkerResult.success is False, main() exits 1."""
+    monkeypatch.setattr("sys.argv", ["address_review", "--issues", "1", "--no-ui", "--dry-run"])
+    results = {1: WorkerResult(issue_number=1, success=False, error="boom")}
+    with (
+        patch.object(address_review.AddressReviewer, "__init__", return_value=None),
+        _patched_run(results),
+    ):
+        assert address_review.main() == 1
+
+
+def test_main_returns_130_on_keyboard_interrupt(monkeypatch) -> None:
+    """A KeyboardInterrupt during run() is caught and returns 130."""
+    monkeypatch.setattr(
+        "sys.argv", ["address_review", "--issues", "1", "--no-ui", "--dry-run"]
+    )
+    boom = MagicMock(side_effect=KeyboardInterrupt())
+    with (
+        patch.object(address_review.AddressReviewer, "__init__", return_value=None),
+        patch.object(address_review.AddressReviewer, "run", boom),
+    ):
+        assert address_review.main() == 130

--- a/tests/unit/automation/test_address_review_main.py
+++ b/tests/unit/automation/test_address_review_main.py
@@ -52,9 +52,7 @@ def test_main_returns_1_on_any_failure(monkeypatch) -> None:
 
 def test_main_returns_130_on_keyboard_interrupt(monkeypatch) -> None:
     """A KeyboardInterrupt during run() is caught and returns 130."""
-    monkeypatch.setattr(
-        "sys.argv", ["address_review", "--issues", "1", "--no-ui", "--dry-run"]
-    )
+    monkeypatch.setattr("sys.argv", ["address_review", "--issues", "1", "--no-ui", "--dry-run"])
     boom = MagicMock(side_effect=KeyboardInterrupt())
     with (
         patch.object(address_review.AddressReviewer, "__init__", return_value=None),

--- a/tests/unit/automation/test_pr_reviewer_main.py
+++ b/tests/unit/automation/test_pr_reviewer_main.py
@@ -1,0 +1,61 @@
+"""Smoke tests for pr_reviewer.main() to lock in current CLI behavior.
+
+These tests capture the current behavior of ``pr_reviewer.main()`` so the
+upcoming dedupe of helpers shared with ``address_review.py`` (issue #599)
+can be verified as a pure move-and-delegate refactor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hephaestus.automation import pr_reviewer
+from hephaestus.automation.models import WorkerResult
+
+
+def _patched_run(return_value: dict[int, WorkerResult]):
+    """Return a context-manager-friendly patch of PRReviewer.run."""
+    return patch.object(pr_reviewer.PRReviewer, "run", return_value=return_value)
+
+
+def test_main_returns_0_when_no_prs_discovered(monkeypatch) -> None:
+    """When run() returns an empty dict, main() exits 0."""
+    monkeypatch.setattr("sys.argv", ["pr_reviewer", "--issues", "1", "--no-ui", "--dry-run"])
+    with (
+        patch.object(pr_reviewer.PRReviewer, "__init__", return_value=None),
+        _patched_run({}),
+    ):
+        assert pr_reviewer.main() == 0
+
+
+def test_main_returns_0_on_all_success(monkeypatch) -> None:
+    """When every WorkerResult.success is True, main() exits 0."""
+    monkeypatch.setattr("sys.argv", ["pr_reviewer", "--issues", "1", "--no-ui", "--dry-run"])
+    results = {1: WorkerResult(issue_number=1, success=True, pr_number=42)}
+    with (
+        patch.object(pr_reviewer.PRReviewer, "__init__", return_value=None),
+        _patched_run(results),
+    ):
+        assert pr_reviewer.main() == 0
+
+
+def test_main_returns_1_on_any_failure(monkeypatch) -> None:
+    """When any WorkerResult.success is False, main() exits 1."""
+    monkeypatch.setattr("sys.argv", ["pr_reviewer", "--issues", "1", "--no-ui", "--dry-run"])
+    results = {1: WorkerResult(issue_number=1, success=False, error="boom")}
+    with (
+        patch.object(pr_reviewer.PRReviewer, "__init__", return_value=None),
+        _patched_run(results),
+    ):
+        assert pr_reviewer.main() == 1
+
+
+def test_main_returns_130_on_keyboard_interrupt(monkeypatch) -> None:
+    """A KeyboardInterrupt during run() is caught and returns 130."""
+    monkeypatch.setattr("sys.argv", ["pr_reviewer", "--issues", "1", "--no-ui", "--dry-run"])
+    boom = MagicMock(side_effect=KeyboardInterrupt())
+    with (
+        patch.object(pr_reviewer.PRReviewer, "__init__", return_value=None),
+        patch.object(pr_reviewer.PRReviewer, "run", boom),
+    ):
+        assert pr_reviewer.main() == 130


### PR DESCRIPTION
## Summary

Closes #599 (audit finding: `pr_reviewer.py` and `address_review.py` shared ~300 LOC of structurally near-identical code).

The six duplicate pairs identified in the audit are now hosted in two shared modules:

- `hephaestus/automation/_review_utils.py` (existing, expanded):
  - `setup_review_logging()` — replaces both `_setup_logging`.
  - `build_review_parser()` — replaces the 95%-identical `_parse_args` bodies, parameterized by description / epilog / help strings.
  - `instance_log()` — replaces both `_log` instance-method bodies (accepts a `caller_logger` kwarg so log records still attribute to the subclass module).

- `hephaestus/automation/_reviewer_base.py` (new) — `BaseReviewer` class:
  - Common `__init__` (worktree manager + status tracker + log manager + states dict + lock + ui).
  - Unified `_fail()` (replaces `_fail_review` in pr_reviewer and `_fail` in address_review).
  - Unified `_save_state()` (replaces `_save_state` and `_save_review_state`).
  - `_load_review_state_from_disk()` — replaces the inline state-load idiom on both classes.

`PRReviewer` and `AddressReviewer` are now `BaseReviewer` subclasses. They override only the work-specific methods (`_review_pr` and `_address_issue` respectively) plus `_log` so the stdlib log record still names the subclass module.

To preserve the existing test-patching seam, `BaseReviewer.__init__` resolves `WorktreeManager` / `StatusTracker` / `ThreadLogManager` / `get_repo_root` from the *subclass*'s module via `importlib.import_module(cls.__module__)` — so all existing `patch("hephaestus.automation.pr_reviewer.WorktreeManager")` calls in the test suite still intercept construction.

## Behavior

No behavior change. Identical CLI surface, identical exit codes, identical Claude prompts. Pre-refactor smoke tests on both `main()` functions are committed first (4 tests per CLI) to lock in the existing 0 / 1 / 130 exit-code contract.

## Verification

- `pixi run pytest tests/unit/automation/ --no-cov` — 591 passed (was 591).
- `pixi run ruff check hephaestus/` — clean.
- `pixi run mypy` — Success.
- `wc -l hephaestus/automation/{pr_reviewer,address_review}.py`:
  - `pr_reviewer.py`: 920 -> 810 LOC (-110).
  - `address_review.py`: 1028 -> 945 LOC (-83).
  - Plus 164 LOC in new `_reviewer_base.py` and +126 LOC added to `_review_utils.py`, but the dedup is genuine because each shared helper now has exactly one home.

## Commits

Four signed, bisectable commits:

1. `test(automation): add reviewer main() smoke tests` — captures current behavior before the refactor.
2. `refactor(automation): extract shared reviewer CLI helpers into _review_utils` — `setup_review_logging`, `build_review_parser`, `instance_log`.
3. `refactor(automation): extract BaseReviewer for PRReviewer + AddressReviewer` — `__init__`, `_log`, `_fail`, `_save_state`, state-load helper.
4. `refactor(automation): drop unused _state_file helper` — YAGNI.

Closes #599

Generated with [Claude Code](https://claude.com/claude-code)