### PR TITLE
refactor(automation): split Planner into coordinator + 3 collaborators

### DIFF
--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -10,7 +10,6 @@ Provides:
 from __future__ import annotations
 
 import argparse
-import json
 import logging
 import shutil
 import subprocess
@@ -41,13 +40,12 @@ from .claude_timeouts import planner_claude_timeout
 from .git_utils import get_repo_root, get_repo_slug, issue_ref
 from .github_api import (
     GitHubRateLimitError,
-    _gh_call,
     gh_issue_comment,
     gh_issue_json,
     gh_list_open_issues,
-    prefetch_issue_states,
 )
-from .models import PLAN_COMMENT_MARKERS, PlannerOptions, PlanResult
+from .models import PlannerOptions, PlanResult
+from .planner_state import PlannerStateManager
 from .prompts import (
     get_advise_prompt,
     get_plan_loop_review_prompt,
@@ -87,6 +85,7 @@ class Planner:
         self.status_tracker = StatusTracker(options.parallel)
         self.results: dict[int, PlanResult] = {}
         self.lock = threading.Lock()
+        self.state_mgr = PlannerStateManager(options)
 
     def run(self) -> dict[int, PlanResult]:
         """Run the planner on all issues.
@@ -136,75 +135,12 @@ class Planner:
         return self.results
 
     def _filter_issues(self) -> list[int]:
-        """Filter issues based on options.
-
-        Only does the cheap, batched check here: skip closed issues using one
-        GraphQL call per 100 via :func:`prefetch_issue_states`. The
-        already-planned check happens per-issue inside :meth:`_plan_issue` so
-        it runs in parallel with the worker pool instead of blocking on N
-        sequential ``gh issue view --comments`` round-trips before any worker
-        starts (#548).
-
-        Returns:
-            List of issue numbers to plan
-
-        """
-        # Batch fetch issue states if we need to check for closed issues
-        cached_states = {}
-        if self.options.skip_closed:
-            cached_states = prefetch_issue_states(self.options.issues)
-
-        issues_to_plan = []
-        for issue_num in self.options.issues:
-            if self.options.skip_closed:
-                state = cached_states.get(issue_num)
-                if state and state.value == "CLOSED":
-                    logger.info("Issue #%s is closed, skipping", issue_num)
-                    continue
-
-            issues_to_plan.append(issue_num)
-
-        return issues_to_plan
+        """Filter issues based on options (delegates to state manager)."""
+        return self.state_mgr.filter()
 
     def _has_existing_plan(self, issue_number: int) -> bool:
-        """Check if an issue already has a plan in comments.
-
-        Args:
-            issue_number: Issue number to check
-
-        Returns:
-            True if plan exists
-
-        """
-        try:
-            result = _gh_call(
-                [
-                    "issue",
-                    "view",
-                    str(issue_number),
-                    "--comments",
-                    "--json",
-                    "comments",
-                ],
-            )
-
-            data = json.loads(result.stdout)
-            comments = data.get("comments", [])
-
-            # Look for plan markers in comments (shared with plan_reviewer)
-            for comment in comments:
-                body = comment.get("body", "")
-                if any(marker in body for marker in PLAN_COMMENT_MARKERS):
-                    logger.debug("Found existing plan for %s", issue_ref(issue_number))
-                    return True
-
-            return False
-
-        except Exception as e:
-            logger.warning(
-                "Failed to check for existing plan on %s: %s", issue_ref(issue_number), e
-            )
-            return False
+        """Check if an issue already has a plan (delegates to state manager)."""
+        return self.state_mgr.has_existing_plan(issue_number)
 
     def _plan_issue(self, issue_number: int) -> PlanResult:
         """Plan a single issue.

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -27,30 +27,23 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument, is_codex, run_codex_text
-from hephaestus.github.rate_limit import wait_until
+from hephaestus.agents.runtime import add_agent_argument
 
-from .claude_invoke import (
-    invoke_claude_with_session,
-    scan_quota_reset,
-)
 from .claude_models import advise_model
-from .git_utils import get_repo_root, get_repo_slug, issue_ref
+from .git_utils import get_repo_root, issue_ref
 from .github_api import (
     GitHubRateLimitError,
     gh_issue_comment,
     gh_list_open_issues,
 )
 from .models import PlannerOptions, PlanResult
+from .planner_claude import PlannerClaudeRunner
 from .planner_review_loop import MAX_REVIEW_ITERATIONS, PlanReviewLoop
 from .planner_state import PlannerStateManager
 from .prompts import (
     get_advise_prompt,
 )
-from .session_naming import (
-    AGENT_ADVISE,
-    current_trunk_githash,
-)
+from .session_naming import AGENT_ADVISE
 from .status_tracker import StatusTracker
 
 __all__ = ["MAX_REVIEW_ITERATIONS", "Planner", "main"]
@@ -79,6 +72,7 @@ class Planner:
         self.results: dict[int, PlanResult] = {}
         self.lock = threading.Lock()
         self.state_mgr = PlannerStateManager(options)
+        self.claude_runner = PlannerClaudeRunner(options)
         self.review_loop = PlanReviewLoop(self)
 
     def run(self) -> dict[int, PlanResult]:
@@ -230,88 +224,16 @@ class Planner:
         timeout: int = 300,
         extra_args: list[str] | None = None,
     ) -> str:
-        """Call Claude CLI on a deterministic session with rate-limit retry.
-
-        The session UUID is derived from ``(repo, issue_number, agent,
-        trunk_githash)`` via :func:`session_naming.session_uuid`. First call
-        for a tuple creates the session; every later call resumes it. Cross-
-        agent independence (planner vs reviewer) is preserved because the
-        ``agent`` string is part of the hash.
-
-        Args:
-            prompt: The prompt to send to Claude.
-            model: Claude model ID for ``--model`` (caller picks per phase).
-            agent: One of the ``AGENT_*`` constants from
-                :mod:`hephaestus.automation.session_naming`. Different agents
-                map to different session IDs.
-            issue_number: GitHub issue number; participates in the session ID.
-            max_retries: Maximum retry attempts for rate limits.
-            timeout: Subprocess timeout in seconds.
-            extra_args: Additional CLI arguments.
-
-        Returns:
-            Claude's response text (stdout, stripped).
-
-        Raises:
-            RuntimeError: If Claude call fails.
-
-        """
-        if is_codex(self.options.agent):
-            return self._call_codex(prompt, model=model, max_retries=max_retries, timeout=timeout)
-
-        repo_root = get_repo_root()
-        repo = get_repo_slug(repo_root)
-        githash = current_trunk_githash(repo_root)
-
-        try:
-            stdout, _ = invoke_claude_with_session(
-                repo=repo,
-                issue=issue_number,
-                agent=agent,
-                githash=githash,
-                prompt=prompt,
-                model=model,
-                cwd=repo_root,
-                timeout=timeout,
-                system_prompt_file=self.options.system_prompt_file,
-                extra_args=extra_args,
-            )
-            response = stdout.strip()
-            if not response:
-                raise RuntimeError("Claude returned empty response")
-            return response
-
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr or ""
-            stdout = e.stdout or ""
-
-            # Rate-limit messages may appear in either stream. The Claude CLI
-            # in particular returns its 429 ("You're out of extra usage ·
-            # resets ...") inside the stdout JSON payload as the ``result``
-            # field of an ``is_error: true`` response, not in stderr.
-            reset_epoch = scan_quota_reset(stderr, stdout)
-            if reset_epoch is not None and max_retries > 0:
-                if reset_epoch > 0:
-                    wait_until(reset_epoch)
-                else:
-                    import time
-
-                    time.sleep(5)
-                return self._call_claude(
-                    prompt,
-                    model=model,
-                    agent=agent,
-                    issue_number=issue_number,
-                    max_retries=max_retries - 1,
-                    timeout=timeout,
-                    extra_args=extra_args,
-                )
-
-            detail = stderr or stdout or "(no output)"
-            raise RuntimeError(f"Claude failed: {detail}") from e
-
-        except subprocess.TimeoutExpired as e:
-            raise RuntimeError(f"Claude timed out after {timeout}s") from e
+        """Call Claude (delegates to claude_runner)."""
+        return self.claude_runner.call_claude(
+            prompt,
+            model=model,
+            agent=agent,
+            issue_number=issue_number,
+            max_retries=max_retries,
+            timeout=timeout,
+            extra_args=extra_args,
+        )
 
     def _call_codex(
         self,
@@ -321,36 +243,10 @@ class Planner:
         max_retries: int = 3,
         timeout: int = 300,
     ) -> str:
-        """Call Codex CLI with retry logic for rate limits."""
-        try:
-            result = run_codex_text(
-                prompt,
-                cwd=get_repo_root(),
-                timeout=timeout,
-                sandbox="workspace-write",
-            )
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr or ""
-            stdout = e.stdout or ""
-            reset_epoch = scan_quota_reset(stderr, stdout)
-            if reset_epoch is not None and reset_epoch > 0 and max_retries > 0:
-                logger.warning("Codex usage cap hit; waiting for reset")
-                wait_until(reset_epoch)
-                return self._call_codex(
-                    prompt,
-                    model=model,
-                    max_retries=max_retries - 1,
-                    timeout=timeout,
-                )
-            detail = stderr or stdout or str(e)
-            raise RuntimeError(f"Codex failed: {detail}") from e
-        except subprocess.TimeoutExpired as e:
-            raise RuntimeError(f"Codex timed out after {timeout}s") from e
-
-        response = (result.stdout or "").strip()
-        if not response:
-            raise RuntimeError("Codex returned empty response")
-        return response
+        """Call Codex (delegates to claude_runner)."""
+        return self.claude_runner.call_codex(
+            prompt, model=model, max_retries=max_retries, timeout=timeout
+        )
 
     def _ensure_mnemosyne(self, mnemosyne_root: Path) -> bool:
         """Clone ProjectMnemosyne if it does not exist locally.

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -32,35 +32,28 @@ from hephaestus.github.rate_limit import wait_until
 
 from .claude_invoke import (
     invoke_claude_with_session,
-    parse_review_verdict,
     scan_quota_reset,
 )
-from .claude_models import advise_model, learn_model, planner_model, reviewer_model
-from .claude_timeouts import planner_claude_timeout
+from .claude_models import advise_model
 from .git_utils import get_repo_root, get_repo_slug, issue_ref
 from .github_api import (
     GitHubRateLimitError,
     gh_issue_comment,
-    gh_issue_json,
     gh_list_open_issues,
 )
 from .models import PlannerOptions, PlanResult
+from .planner_review_loop import MAX_REVIEW_ITERATIONS, PlanReviewLoop
 from .planner_state import PlannerStateManager
 from .prompts import (
     get_advise_prompt,
-    get_plan_loop_review_prompt,
-    get_plan_prompt,
 )
 from .session_naming import (
     AGENT_ADVISE,
-    AGENT_LEARNINGS,
-    AGENT_PLAN_REVIEWER,
-    AGENT_PLANNER,
     current_trunk_githash,
 )
 from .status_tracker import StatusTracker
 
-MAX_REVIEW_ITERATIONS = 3
+__all__ = ["MAX_REVIEW_ITERATIONS", "Planner", "main"]
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +79,7 @@ class Planner:
         self.results: dict[int, PlanResult] = {}
         self.lock = threading.Lock()
         self.state_mgr = PlannerStateManager(options)
+        self.review_loop = PlanReviewLoop(self)
 
     def run(self) -> dict[int, PlanResult]:
         """Run the planner on all issues.
@@ -521,88 +515,14 @@ class Planner:
         cached_advise: str | None = None,
         cached_issue_data: dict[str, Any] | None = None,
     ) -> str:
-        """Generate implementation plan using Claude Code.
-
-        Args:
-            issue_number: Issue number to plan
-            max_retries: Maximum retry attempts for rate limits
-            prior_review: When set, the previous review-loop iteration's NoGo
-                critique. Injected into the prompt so the planner can address
-                the findings on this iteration.
-            cached_advise: Pre-computed advise findings (avoids re-running advise
-                on every loop iteration). When ``None`` and advise is enabled,
-                advise runs once.
-            cached_issue_data: Pre-fetched issue JSON to avoid duplicate API calls.
-
-        Returns:
-            Generated plan text
-
-        Raises:
-            RuntimeError: If plan generation fails
-
-        """
-        # Fetch issue data
-        if cached_issue_data is not None:
-            issue_data = cached_issue_data
-        else:
-            issue_data = gh_issue_json(issue_number)
-        issue_title = issue_data.get("title", f"Issue #{issue_number}")
-        issue_body = issue_data.get("body", "")
-
-        # Run advise step if enabled (use cache if provided)
-        advise_findings = cached_advise if cached_advise is not None else ""
-        if cached_advise is None and self.options.enable_advise:
-            advise_findings = self._run_advise(issue_number, issue_title, issue_body)
-
-        # Build prompt
-        prompt = get_plan_prompt(issue_number)
-
-        # Add issue context
-        context_parts = [f"# Issue #{issue_number}: {issue_title}", "", issue_body]
-
-        # Inject advise findings if available
-        if advise_findings:
-            context_parts.extend(
-                [
-                    "",
-                    "---",
-                    "",
-                    "## Prior Learnings from Team Knowledge Base",
-                    "",
-                    advise_findings,
-                ]
-            )
-
-        # Inject prior review feedback if this is a re-plan
-        if prior_review:
-            context_parts.extend(
-                [
-                    "",
-                    "---",
-                    "",
-                    "## Prior reviewer critique — your previous plan got NOGO",
-                    "",
-                    "Address every concrete finding below in your revised plan:",
-                    "",
-                    prior_review,
-                ]
-            )
-
-        context_parts.extend(["", "---", "", prompt])
-
-        context = "\n".join(context_parts)
-
-        # Call Claude to generate plan. Plans are small but reasoning-heavy,
-        # so this is the right place to spend Opus.
-        plan = self._call_claude(
-            context,
-            model=planner_model(),
-            agent=AGENT_PLANNER,
-            issue_number=issue_number,
-            timeout=planner_claude_timeout(),
+        """Generate implementation plan (delegates to review loop)."""
+        return self.review_loop.generate_plan(
+            issue_number,
+            max_retries=max_retries,
+            prior_review=prior_review,
+            cached_advise=cached_advise,
+            cached_issue_data=cached_issue_data,
         )
-
-        return plan
 
     def _post_plan(
         self,
@@ -661,152 +581,18 @@ class Planner:
         logger.info("Posted plan to %s", issue_ref(issue_number))
 
     # ------------------------------------------------------------------
-    # Strict review loop — advise → loop[plan → learn → review] → post
+    # Strict review loop — delegations to PlanReviewLoop
     # ------------------------------------------------------------------
 
     def _run_plan_review_loop(
         self, issue_number: int, slot_id: int
     ) -> tuple[str, str | None, int, bool]:
-        """Run the bounded review loop for a single issue.
-
-        Pre-fetches the issue and runs advise once, then iterates:
-        plan → capture learnings → independent review (fresh session, with
-        pr-review-strict rubric) → check verdict. Terminates on the first
-        unambiguous GO or after :data:`MAX_REVIEW_ITERATIONS`.
-
-        Args:
-            issue_number: GitHub issue number.
-            slot_id: Worker slot id for status updates.
-
-        Returns:
-            Tuple of (final plan text, final review text or None, iterations run,
-            final_verdict_is_go). The fourth element is ``True`` only when the loop
-            terminated with an unambiguous GO verdict; ``False`` when the loop
-            exhausted all iterations without a GO (NOGO-exhausted).
-
-        """
-        # Pre-fetch issue once and cache for the whole loop
-        issue_data = gh_issue_json(issue_number)
-        issue_title = issue_data.get("title", f"Issue #{issue_number}")
-        issue_body = issue_data.get("body", "")
-
-        # Advise runs once before the loop — same findings inform every iteration
-        cached_advise = ""
-        if self.options.enable_advise:
-            cached_advise = self._run_advise(issue_number, issue_title, issue_body)
-
-        plan = ""
-        review_text: str | None = None
-        prior_review_for_plan: str | None = None
-        iterations_run = 0
-        final_verdict_is_go = False
-
-        for iteration in range(MAX_REVIEW_ITERATIONS):
-            iterations_run = iteration + 1
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: planning [R{iteration}]"
-            )
-
-            plan = self._generate_plan(
-                issue_number,
-                prior_review=prior_review_for_plan,
-                cached_advise=cached_advise,
-                cached_issue_data=issue_data,
-            )
-
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: capturing learnings [R{iteration}]"
-            )
-            learnings = self._capture_planner_learnings(issue_number, plan)
-
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: reviewing plan [R{iteration}]"
-            )
-            review_text = self._run_plan_review(
-                issue_number=issue_number,
-                issue_title=issue_title,
-                issue_body=issue_body,
-                plan_text=plan,
-                learnings=learnings,
-                iteration=iteration,
-                prior_review=review_text,
-            )
-
-            verdict = parse_review_verdict(review_text)
-            logger.info(
-                "%s R%s: Verdict=%s Grade=%s",
-                issue_ref(issue_number),
-                iteration,
-                verdict.verdict,
-                verdict.grade or "?",
-            )
-
-            if verdict.is_go:
-                logger.info(
-                    "%s: GO on iteration %s — loop terminated",
-                    issue_ref(issue_number),
-                    iteration,
-                )
-                final_verdict_is_go = True
-                break
-
-            # NoGo or AMBIGUOUS — feed this review back into next plan iteration
-            prior_review_for_plan = review_text
-
-        if not final_verdict_is_go:
-            logger.warning(
-                "%s: review loop exhausted %s iteration(s) without a GO verdict — "
-                "plan posted with NOGO-exhausted status",
-                issue_ref(issue_number),
-                iterations_run,
-            )
-
-        return plan, review_text, iterations_run, final_verdict_is_go
+        """Run the bounded review loop (delegates to review_loop)."""
+        return self.review_loop.run(issue_number, slot_id)
 
     def _capture_planner_learnings(self, issue_number: int, plan: str) -> str:
-        """Ask Claude to summarize what the planner just learned.
-
-        These learnings are passed to the reviewer alongside the plan, giving
-        the reviewer extra signal about which aspects the planner is most/least
-        confident in. Failure here is non-fatal — return empty string and let
-        the review proceed without learnings.
-
-        Uses ``learn_model()`` (Haiku by default) per the per-phase model
-        selection in :mod:`hephaestus.automation.claude_models`.
-
-        Args:
-            issue_number: GitHub issue number (used in prompt for grounding).
-            plan: The plan text the planner just produced.
-
-        Returns:
-            Bullet-point learnings text, or "" on any failure.
-
-        """
-        prompt = (
-            f"You just produced an implementation plan for GitHub issue "
-            f"#{issue_number}. Below is the plan you wrote.\n\n"
-            "List 3-5 brief bullets describing:\n"
-            "- The most uncertain assumptions in your plan\n"
-            "- Any external sources, files, or APIs you relied on without "
-            "directly verifying them\n"
-            "- Risks the reviewer should focus on\n\n"
-            "Output only the bullets — no preamble, no headers.\n\n"
-            "---\n\n"
-            f"{plan}"
-        )
-        try:
-            return self._call_claude(
-                prompt,
-                model=learn_model(),
-                agent=AGENT_LEARNINGS,
-                issue_number=issue_number,
-                timeout=120,
-            )
-        except Exception as e:
-            logger.warning(
-                "%s: planner-learnings capture failed (non-fatal): %s", issue_ref(issue_number), e
-            )
-            return ""
+        """Capture planner learnings (delegates to review_loop)."""
+        return self.review_loop.capture_planner_learnings(issue_number, plan)
 
     def _run_plan_review(
         self,
@@ -819,29 +605,8 @@ class Planner:
         iteration: int,
         prior_review: str | None,
     ) -> str:
-        """Run a reviewer pass on the current plan.
-
-        The reviewer's session is distinct from the planner's (different
-        ``agent`` string in the session UUID) so it stays unbiased by the
-        planner's internal state, but it resumes itself across review
-        iterations so successive critiques compound. Uses ``reviewer_model()``
-        (Sonnet by default).
-
-        Args:
-            issue_number: GitHub issue number.
-            issue_title: Issue title.
-            issue_body: Issue body.
-            plan_text: Plan to review.
-            learnings: Planner-captured learnings for this iteration.
-            iteration: Iteration index (0, 1, or 2).
-            prior_review: Previous iteration's review text, or ``None`` on iter 0.
-
-        Returns:
-            Review text. On reviewer-call failure, returns a synthetic NoGo
-            review so the loop can continue (failing safe — never silently GO).
-
-        """
-        prompt = get_plan_loop_review_prompt(
+        """Run reviewer pass (delegates to review_loop)."""
+        return self.review_loop.run_plan_review(
             issue_number=issue_number,
             issue_title=issue_title,
             issue_body=issue_body,
@@ -850,25 +615,6 @@ class Planner:
             iteration=iteration,
             prior_review=prior_review,
         )
-        try:
-            return self._call_claude(
-                prompt,
-                model=reviewer_model(),
-                agent=AGENT_PLAN_REVIEWER,
-                issue_number=issue_number,
-                timeout=planner_claude_timeout(),
-            )
-        except Exception as e:
-            logger.error(
-                "%s R%s: reviewer call failed: %s; treating as NOGO so the loop continues",
-                issue_ref(issue_number),
-                iteration,
-                e,
-            )
-            return (
-                f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
-                "Grade: F\nVerdict: NOGO\n"
-            )
 
     def _print_summary(self) -> None:
         """Print summary of planning results."""

--- a/hephaestus/automation/planner_claude.py
+++ b/hephaestus/automation/planner_claude.py
@@ -1,0 +1,176 @@
+"""Claude/Codex invocation helpers for :class:`Planner`.
+
+Wraps :func:`hephaestus.automation.claude_invoke.invoke_claude_with_session`
+(and the equivalent Codex CLI runner) with the rate-limit-retry policy that
+the planner has historically applied. Extracted from ``planner.py`` (#598)
+so the coordinator class stays focused on the worker-pool driver. No
+behavior change.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import TYPE_CHECKING
+
+from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.github.rate_limit import wait_until
+
+from .claude_invoke import invoke_claude_with_session, scan_quota_reset
+from .git_utils import get_repo_root, get_repo_slug
+from .session_naming import current_trunk_githash
+
+if TYPE_CHECKING:
+    from .models import PlannerOptions
+
+logger = logging.getLogger(__name__)
+
+
+class PlannerClaudeRunner:
+    """Run Claude or Codex on behalf of the planner.
+
+    Holds a reference to :class:`PlannerOptions` so it can pick the right
+    backend (Claude vs Codex) and forward the optional system-prompt file.
+    """
+
+    def __init__(self, options: PlannerOptions) -> None:
+        """Bind to the planner's options.
+
+        Args:
+            options: The shared :class:`PlannerOptions` instance.
+
+        """
+        self.options = options
+
+    def call_claude(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        agent: str,
+        issue_number: int | str,
+        max_retries: int = 3,
+        timeout: int = 300,
+        extra_args: list[str] | None = None,
+    ) -> str:
+        """Call Claude CLI on a deterministic session with rate-limit retry.
+
+        The session UUID is derived from ``(repo, issue_number, agent,
+        trunk_githash)`` via :func:`session_naming.session_uuid`. First call
+        for a tuple creates the session; every later call resumes it. Cross-
+        agent independence (planner vs reviewer) is preserved because the
+        ``agent`` string is part of the hash.
+
+        Args:
+            prompt: The prompt to send to Claude.
+            model: Claude model ID for ``--model`` (caller picks per phase).
+            agent: One of the ``AGENT_*`` constants from
+                :mod:`hephaestus.automation.session_naming`. Different agents
+                map to different session IDs.
+            issue_number: GitHub issue number; participates in the session ID.
+            max_retries: Maximum retry attempts for rate limits.
+            timeout: Subprocess timeout in seconds.
+            extra_args: Additional CLI arguments.
+
+        Returns:
+            Claude's response text (stdout, stripped).
+
+        Raises:
+            RuntimeError: If Claude call fails.
+
+        """
+        if is_codex(self.options.agent):
+            return self.call_codex(prompt, model=model, max_retries=max_retries, timeout=timeout)
+
+        repo_root = get_repo_root()
+        repo = get_repo_slug(repo_root)
+        githash = current_trunk_githash(repo_root)
+
+        try:
+            stdout, _ = invoke_claude_with_session(
+                repo=repo,
+                issue=issue_number,
+                agent=agent,
+                githash=githash,
+                prompt=prompt,
+                model=model,
+                cwd=repo_root,
+                timeout=timeout,
+                system_prompt_file=self.options.system_prompt_file,
+                extra_args=extra_args,
+            )
+            response = stdout.strip()
+            if not response:
+                raise RuntimeError("Claude returned empty response")
+            return response
+
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ""
+            stdout = e.stdout or ""
+
+            # Rate-limit messages may appear in either stream. The Claude CLI
+            # in particular returns its 429 ("You're out of extra usage ·
+            # resets ...") inside the stdout JSON payload as the ``result``
+            # field of an ``is_error: true`` response, not in stderr.
+            reset_epoch = scan_quota_reset(stderr, stdout)
+            if reset_epoch is not None and max_retries > 0:
+                if reset_epoch > 0:
+                    wait_until(reset_epoch)
+                else:
+                    import time
+
+                    time.sleep(5)
+                return self.call_claude(
+                    prompt,
+                    model=model,
+                    agent=agent,
+                    issue_number=issue_number,
+                    max_retries=max_retries - 1,
+                    timeout=timeout,
+                    extra_args=extra_args,
+                )
+
+            detail = stderr or stdout or "(no output)"
+            raise RuntimeError(f"Claude failed: {detail}") from e
+
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"Claude timed out after {timeout}s") from e
+
+    def call_codex(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_retries: int = 3,
+        timeout: int = 300,
+    ) -> str:
+        """Call Codex CLI with retry logic for rate limits."""
+        try:
+            result = run_codex_text(
+                prompt,
+                cwd=get_repo_root(),
+                timeout=timeout,
+                sandbox="workspace-write",
+            )
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ""
+            stdout = e.stdout or ""
+            reset_epoch = scan_quota_reset(stderr, stdout)
+            if reset_epoch is not None and reset_epoch > 0 and max_retries > 0:
+                logger.warning("Codex usage cap hit; waiting for reset")
+                wait_until(reset_epoch)
+                return self.call_codex(
+                    prompt,
+                    model=model,
+                    max_retries=max_retries - 1,
+                    timeout=timeout,
+                )
+            detail = stderr or stdout or str(e)
+            raise RuntimeError(f"Codex failed: {detail}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"Codex timed out after {timeout}s") from e
+
+        response = (result.stdout or "").strip()
+        if not response:
+            raise RuntimeError("Codex returned empty response")
+        return response

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -37,10 +37,13 @@ MAX_REVIEW_ITERATIONS = 3
 class PlanReviewLoop:
     """Bounded plan→learn→review iteration loop.
 
-    Holds a back-reference to the owning :class:`Planner` so the loop can
-    re-use the planner's ``_call_claude`` and ``_run_advise`` helpers without
-    duplicating their rate-limit retry logic. Once the Claude runner is
-    extracted (step 5), those calls will move off the back-reference.
+    Holds a back-reference to the owning :class:`Planner` and intentionally
+    routes per-issue work back through ``planner._generate_plan`` /
+    ``planner._capture_planner_learnings`` / ``planner._run_plan_review``
+    rather than calling :class:`PlannerClaudeRunner` directly. The indirection
+    preserves the existing ``patch.object(planner, "_generate_plan", ...)``
+    test seam: a patched method on the Planner instance still intercepts the
+    loop's inner calls.
     """
 
     def __init__(self, planner: Planner) -> None:

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -1,0 +1,356 @@
+"""Strict plan review loop for :class:`Planner`.
+
+Owns the bounded ``plan → capture learnings → review`` iteration cycle that
+runs per issue:
+
+1. Pre-fetch issue + run advise once before the loop.
+2. Up to :data:`MAX_REVIEW_ITERATIONS` iterations of
+   ``_generate_plan → _capture_planner_learnings → _run_plan_review``.
+3. Stop on the first unambiguous GO; otherwise feed the review back and
+   re-plan.
+
+Extracted from ``planner.py`` (#598) so the coordinator class stays focused
+on the worker-pool driver. No behavior change.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .claude_invoke import parse_review_verdict
+from .claude_models import learn_model, planner_model, reviewer_model
+from .claude_timeouts import planner_claude_timeout
+from .git_utils import issue_ref
+from .github_api import gh_issue_json
+from .prompts import get_plan_loop_review_prompt, get_plan_prompt
+from .session_naming import AGENT_LEARNINGS, AGENT_PLAN_REVIEWER, AGENT_PLANNER
+
+if TYPE_CHECKING:
+    from .planner import Planner
+
+logger = logging.getLogger(__name__)
+
+MAX_REVIEW_ITERATIONS = 3
+
+
+class PlanReviewLoop:
+    """Bounded plan→learn→review iteration loop.
+
+    Holds a back-reference to the owning :class:`Planner` so the loop can
+    re-use the planner's ``_call_claude`` and ``_run_advise`` helpers without
+    duplicating their rate-limit retry logic. Once the Claude runner is
+    extracted (step 5), those calls will move off the back-reference.
+    """
+
+    def __init__(self, planner: Planner) -> None:
+        """Bind the loop to its owning planner.
+
+        Args:
+            planner: The :class:`Planner` instance whose options,
+                status tracker, and Claude helpers this loop reuses.
+
+        """
+        self.planner = planner
+
+    @property
+    def options(self) -> Any:
+        """Shortcut to the planner's options."""
+        return self.planner.options
+
+    @property
+    def status_tracker(self) -> Any:
+        """Shortcut to the planner's status tracker."""
+        return self.planner.status_tracker
+
+    # ------------------------------------------------------------------
+    # Strict review loop — advise → loop[plan → learn → review] → post
+    # ------------------------------------------------------------------
+
+    def run(self, issue_number: int, slot_id: int) -> tuple[str, str | None, int, bool]:
+        """Run the bounded review loop for a single issue.
+
+        Pre-fetches the issue and runs advise once, then iterates:
+        plan → capture learnings → independent review (fresh session, with
+        pr-review-strict rubric) → check verdict. Terminates on the first
+        unambiguous GO or after :data:`MAX_REVIEW_ITERATIONS`.
+
+        Args:
+            issue_number: GitHub issue number.
+            slot_id: Worker slot id for status updates.
+
+        Returns:
+            Tuple of (final plan text, final review text or None, iterations run,
+            final_verdict_is_go). The fourth element is ``True`` only when the loop
+            terminated with an unambiguous GO verdict; ``False`` when the loop
+            exhausted all iterations without a GO (NOGO-exhausted).
+
+        """
+        issue_data = gh_issue_json(issue_number)
+        issue_title = issue_data.get("title", f"Issue #{issue_number}")
+        issue_body = issue_data.get("body", "")
+
+        cached_advise = ""
+        if self.options.enable_advise:
+            cached_advise = self.planner._run_advise(issue_number, issue_title, issue_body)
+
+        plan = ""
+        review_text: str | None = None
+        prior_review_for_plan: str | None = None
+        iterations_run = 0
+        final_verdict_is_go = False
+
+        for iteration in range(MAX_REVIEW_ITERATIONS):
+            iterations_run = iteration + 1
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: planning [R{iteration}]"
+            )
+
+            # Route through planner's delegation methods so test patches on
+            # Planner._generate_plan / _capture_planner_learnings / _run_plan_review
+            # continue to intercept the calls.
+            plan = self.planner._generate_plan(
+                issue_number,
+                prior_review=prior_review_for_plan,
+                cached_advise=cached_advise,
+                cached_issue_data=issue_data,
+            )
+
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: capturing learnings [R{iteration}]"
+            )
+            learnings = self.planner._capture_planner_learnings(issue_number, plan)
+
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: reviewing plan [R{iteration}]"
+            )
+            review_text = self.planner._run_plan_review(
+                issue_number=issue_number,
+                issue_title=issue_title,
+                issue_body=issue_body,
+                plan_text=plan,
+                learnings=learnings,
+                iteration=iteration,
+                prior_review=review_text,
+            )
+
+            verdict = parse_review_verdict(review_text)
+            logger.info(
+                "%s R%s: Verdict=%s Grade=%s",
+                issue_ref(issue_number),
+                iteration,
+                verdict.verdict,
+                verdict.grade or "?",
+            )
+
+            if verdict.is_go:
+                logger.info(
+                    "%s: GO on iteration %s — loop terminated",
+                    issue_ref(issue_number),
+                    iteration,
+                )
+                final_verdict_is_go = True
+                break
+
+            prior_review_for_plan = review_text
+
+        if not final_verdict_is_go:
+            logger.warning(
+                "%s: review loop exhausted %s iteration(s) without a GO verdict — "
+                "plan posted with NOGO-exhausted status",
+                issue_ref(issue_number),
+                iterations_run,
+            )
+
+        return plan, review_text, iterations_run, final_verdict_is_go
+
+    def generate_plan(
+        self,
+        issue_number: int,
+        max_retries: int = 3,
+        *,
+        prior_review: str | None = None,
+        cached_advise: str | None = None,
+        cached_issue_data: dict[str, Any] | None = None,
+    ) -> str:
+        """Generate implementation plan using Claude Code.
+
+        Args:
+            issue_number: Issue number to plan
+            max_retries: Maximum retry attempts for rate limits
+            prior_review: When set, the previous review-loop iteration's NoGo
+                critique. Injected into the prompt so the planner can address
+                the findings on this iteration.
+            cached_advise: Pre-computed advise findings (avoids re-running advise
+                on every loop iteration). When ``None`` and advise is enabled,
+                advise runs once.
+            cached_issue_data: Pre-fetched issue JSON to avoid duplicate API calls.
+
+        Returns:
+            Generated plan text
+
+        Raises:
+            RuntimeError: If plan generation fails
+
+        """
+        if cached_issue_data is not None:
+            issue_data = cached_issue_data
+        else:
+            issue_data = gh_issue_json(issue_number)
+        issue_title = issue_data.get("title", f"Issue #{issue_number}")
+        issue_body = issue_data.get("body", "")
+
+        advise_findings = cached_advise if cached_advise is not None else ""
+        if cached_advise is None and self.options.enable_advise:
+            advise_findings = self.planner._run_advise(issue_number, issue_title, issue_body)
+
+        prompt = get_plan_prompt(issue_number)
+
+        context_parts = [f"# Issue #{issue_number}: {issue_title}", "", issue_body]
+
+        if advise_findings:
+            context_parts.extend(
+                [
+                    "",
+                    "---",
+                    "",
+                    "## Prior Learnings from Team Knowledge Base",
+                    "",
+                    advise_findings,
+                ]
+            )
+
+        if prior_review:
+            context_parts.extend(
+                [
+                    "",
+                    "---",
+                    "",
+                    "## Prior reviewer critique — your previous plan got NOGO",
+                    "",
+                    "Address every concrete finding below in your revised plan:",
+                    "",
+                    prior_review,
+                ]
+            )
+
+        context_parts.extend(["", "---", "", prompt])
+
+        context = "\n".join(context_parts)
+
+        plan = self.planner._call_claude(
+            context,
+            model=planner_model(),
+            agent=AGENT_PLANNER,
+            issue_number=issue_number,
+            timeout=planner_claude_timeout(),
+        )
+
+        return plan
+
+    def capture_planner_learnings(self, issue_number: int, plan: str) -> str:
+        """Ask Claude to summarize what the planner just learned.
+
+        These learnings are passed to the reviewer alongside the plan, giving
+        the reviewer extra signal about which aspects the planner is most/least
+        confident in. Failure here is non-fatal — return empty string and let
+        the review proceed without learnings.
+
+        Uses ``learn_model()`` (Haiku by default) per the per-phase model
+        selection in :mod:`hephaestus.automation.claude_models`.
+
+        Args:
+            issue_number: GitHub issue number (used in prompt for grounding).
+            plan: The plan text the planner just produced.
+
+        Returns:
+            Bullet-point learnings text, or "" on any failure.
+
+        """
+        prompt = (
+            f"You just produced an implementation plan for GitHub issue "
+            f"#{issue_number}. Below is the plan you wrote.\n\n"
+            "List 3-5 brief bullets describing:\n"
+            "- The most uncertain assumptions in your plan\n"
+            "- Any external sources, files, or APIs you relied on without "
+            "directly verifying them\n"
+            "- Risks the reviewer should focus on\n\n"
+            "Output only the bullets — no preamble, no headers.\n\n"
+            "---\n\n"
+            f"{plan}"
+        )
+        try:
+            return self.planner._call_claude(
+                prompt,
+                model=learn_model(),
+                agent=AGENT_LEARNINGS,
+                issue_number=issue_number,
+                timeout=120,
+            )
+        except Exception as e:
+            logger.warning(
+                "%s: planner-learnings capture failed (non-fatal): %s", issue_ref(issue_number), e
+            )
+            return ""
+
+    def run_plan_review(
+        self,
+        *,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        plan_text: str,
+        learnings: str,
+        iteration: int,
+        prior_review: str | None,
+    ) -> str:
+        """Run a reviewer pass on the current plan.
+
+        The reviewer's session is distinct from the planner's (different
+        ``agent`` string in the session UUID) so it stays unbiased by the
+        planner's internal state, but it resumes itself across review
+        iterations so successive critiques compound. Uses ``reviewer_model()``
+        (Sonnet by default).
+
+        Args:
+            issue_number: GitHub issue number.
+            issue_title: Issue title.
+            issue_body: Issue body.
+            plan_text: Plan to review.
+            learnings: Planner-captured learnings for this iteration.
+            iteration: Iteration index (0, 1, or 2).
+            prior_review: Previous iteration's review text, or ``None`` on iter 0.
+
+        Returns:
+            Review text. On reviewer-call failure, returns a synthetic NoGo
+            review so the loop can continue (failing safe — never silently GO).
+
+        """
+        prompt = get_plan_loop_review_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            plan_text=plan_text,
+            learnings=learnings,
+            iteration=iteration,
+            prior_review=prior_review,
+        )
+        try:
+            return self.planner._call_claude(
+                prompt,
+                model=reviewer_model(),
+                agent=AGENT_PLAN_REVIEWER,
+                issue_number=issue_number,
+                timeout=planner_claude_timeout(),
+            )
+        except Exception as e:
+            logger.error(
+                "%s R%s: reviewer call failed: %s; treating as NOGO so the loop continues",
+                issue_ref(issue_number),
+                iteration,
+                e,
+            )
+            return (
+                f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
+                "Grade: F\nVerdict: NOGO\n"
+            )

--- a/hephaestus/automation/planner_state.py
+++ b/hephaestus/automation/planner_state.py
@@ -1,0 +1,114 @@
+"""State manager for :class:`hephaestus.automation.planner.Planner`.
+
+Owns the cheap, idempotent state queries the planner runs against GitHub:
+
+- ``filter()`` — drop closed issues from the working set (one batched GraphQL
+  call per 100 issues via :func:`prefetch_issue_states`).
+- ``has_existing_plan()`` — return ``True`` when an issue already carries one
+  of the canonical plan-comment markers.
+
+Extracted from ``planner.py`` (#598) so the coordinator class stays focused
+on the worker-pool driver. No behavior change.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from .git_utils import issue_ref
+from .github_api import _gh_call, prefetch_issue_states
+from .models import PLAN_COMMENT_MARKERS
+
+if TYPE_CHECKING:
+    from .models import PlannerOptions
+
+logger = logging.getLogger(__name__)
+
+
+class PlannerStateManager:
+    """Cheap GitHub state queries used by the planner.
+
+    Attributes:
+        options: The planner options driving filter behavior.
+
+    """
+
+    def __init__(self, options: PlannerOptions) -> None:
+        """Bind to the planner options driving filter behavior.
+
+        Args:
+            options: The shared :class:`PlannerOptions` instance.
+
+        """
+        self.options = options
+
+    def filter(self) -> list[int]:
+        """Filter issues based on options.
+
+        Only does the cheap, batched check here: skip closed issues using one
+        GraphQL call per 100 via :func:`prefetch_issue_states`. The
+        already-planned check happens per-issue inside
+        :meth:`Planner._plan_issue` so it runs in parallel with the worker
+        pool instead of blocking on N sequential ``gh issue view --comments``
+        round-trips before any worker starts (#548).
+
+        Returns:
+            List of issue numbers to plan
+
+        """
+        cached_states = {}
+        if self.options.skip_closed:
+            cached_states = prefetch_issue_states(self.options.issues)
+
+        issues_to_plan = []
+        for issue_num in self.options.issues:
+            if self.options.skip_closed:
+                state = cached_states.get(issue_num)
+                if state and state.value == "CLOSED":
+                    logger.info("Issue #%s is closed, skipping", issue_num)
+                    continue
+
+            issues_to_plan.append(issue_num)
+
+        return issues_to_plan
+
+    def has_existing_plan(self, issue_number: int) -> bool:
+        """Check if an issue already has a plan in comments.
+
+        Args:
+            issue_number: Issue number to check
+
+        Returns:
+            True if plan exists
+
+        """
+        try:
+            result = _gh_call(
+                [
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--comments",
+                    "--json",
+                    "comments",
+                ],
+            )
+
+            data = json.loads(result.stdout)
+            comments = data.get("comments", [])
+
+            for comment in comments:
+                body = comment.get("body", "")
+                if any(marker in body for marker in PLAN_COMMENT_MARKERS):
+                    logger.debug("Found existing plan for %s", issue_ref(issue_number))
+                    return True
+
+            return False
+
+        except Exception as e:
+            logger.warning(
+                "Failed to check for existing plan on %s: %s", issue_ref(issue_number), e
+            )
+            return False

--- a/tests/unit/automation/test_phase_agent_wiring.py
+++ b/tests/unit/automation/test_phase_agent_wiring.py
@@ -105,7 +105,12 @@ def test_planner_module_uses_its_expected_agents() -> None:
     AGENT_PLAN_REVIEWER — in-process plan-review call (separate from the
                           standalone plan_reviewer.py phase module)
     """
-    src = (AUTOMATION_DIR / "planner.py").read_text()
+    # The planner package was split (#598): the strict review loop lives in
+    # planner_review_loop.py. Scan both source files for AGENT_* wiring so the
+    # invariant survives the split.
+    src = (AUTOMATION_DIR / "planner.py").read_text() + (
+        AUTOMATION_DIR / "planner_review_loop.py"
+    ).read_text()
     found = set(re.findall(r"\bagent\s*=\s*(AGENT_[A-Z_]+)\b", src))
     expected = {
         "AGENT_PLANNER",
@@ -113,4 +118,4 @@ def test_planner_module_uses_its_expected_agents() -> None:
         "AGENT_LEARNINGS",
         "AGENT_PLAN_REVIEWER",
     }
-    assert found == expected, f"planner.py agent wiring drifted: found={found}, expected={expected}"
+    assert found == expected, f"planner agent wiring drifted: found={found}, expected={expected}"

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -53,10 +53,10 @@ class TestCallClaude:
 
         stack = ExitStack()
         stack.enter_context(
-            patch("hephaestus.automation.planner.get_repo_root", return_value=Path("/repo"))
+            patch("hephaestus.automation.planner_claude.get_repo_root", return_value=Path("/repo"))
         )
         stack.enter_context(
-            patch("hephaestus.automation.planner.get_repo_slug", return_value="TestRepo")
+            patch("hephaestus.automation.planner_claude.get_repo_slug", return_value="TestRepo")
         )
         return stack
 
@@ -136,7 +136,7 @@ class TestCallClaude:
         with (
             self._patch_repo(),
             patch("hephaestus.automation.claude_invoke.subprocess.run") as mock_run,
-            patch("hephaestus.automation.planner.scan_quota_reset") as mock_scan,
+            patch("hephaestus.automation.planner_claude.scan_quota_reset") as mock_scan,
         ):
             mock_run.side_effect = [
                 subprocess.CalledProcessError(1, "claude", stderr="rate limit exceeded"),
@@ -163,7 +163,7 @@ class TestCallClaude:
         with (
             self._patch_repo(),
             patch("hephaestus.automation.claude_invoke.subprocess.run") as mock_run,
-            patch("hephaestus.automation.planner.wait_until") as mock_wait,
+            patch("hephaestus.automation.planner_claude.wait_until") as mock_wait,
         ):
             mock_run.side_effect = [
                 subprocess.CalledProcessError(1, "claude", output=usage_json, stderr=""),

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -336,7 +336,7 @@ class TestGeneratePlan:
     def test_plan_with_advise_findings(self, planner: Any) -> None:
         """Test plan generation with advise findings injected."""
         with (
-            patch("hephaestus.automation.planner.gh_issue_json") as mock_gh,
+            patch("hephaestus.automation.planner_review_loop.gh_issue_json") as mock_gh,
             patch.object(
                 planner,
                 "_run_advise",
@@ -363,7 +363,7 @@ class TestGeneratePlan:
         planner = Planner(mock_options)
 
         with (
-            patch("hephaestus.automation.planner.gh_issue_json") as mock_gh,
+            patch("hephaestus.automation.planner_review_loop.gh_issue_json") as mock_gh,
             patch.object(planner, "_run_advise") as mock_advise,
             patch.object(planner, "_call_claude", return_value="# Implementation Plan\nStep 1"),
         ):

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -44,7 +44,7 @@ class TestRunPlanReviewLoop:
         """A GO on R0 must skip iterations 1 and 2."""
         with (
             patch(
-                "hephaestus.automation.planner.gh_issue_json",
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
                 return_value={"title": "T", "body": "B"},
             ),
             patch.object(planner, "_generate_plan", return_value="plan v0") as mock_plan,
@@ -64,7 +64,7 @@ class TestRunPlanReviewLoop:
         """When every review says NOGO, the loop runs exactly 3 iterations."""
         with (
             patch(
-                "hephaestus.automation.planner.gh_issue_json",
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
                 return_value={"title": "T", "body": "B"},
             ),
             patch.object(
@@ -91,7 +91,7 @@ class TestRunPlanReviewLoop:
     def test_terminates_on_go_at_iter1(self, planner: Planner) -> None:
         with (
             patch(
-                "hephaestus.automation.planner.gh_issue_json",
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
                 return_value={"title": "T", "body": "B"},
             ),
             patch.object(
@@ -117,7 +117,7 @@ class TestRunPlanReviewLoop:
         review_iter0 = _nogo_review("D")
         with (
             patch(
-                "hephaestus.automation.planner.gh_issue_json",
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
                 return_value={"title": "T", "body": "B"},
             ),
             patch.object(

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -317,7 +317,7 @@ class TestFilterIssues:
         with (
             patch.object(planner, "_has_existing_plan") as mock_check,
             patch(
-                "hephaestus.automation.planner.prefetch_issue_states",
+                "hephaestus.automation.planner_state.prefetch_issue_states",
                 return_value={},
             ),
         ):
@@ -331,7 +331,7 @@ class TestFilterIssues:
         from hephaestus.automation.models import IssueState
 
         with patch(
-            "hephaestus.automation.planner.prefetch_issue_states",
+            "hephaestus.automation.planner_state.prefetch_issue_states",
             return_value={123: IssueState.CLOSED},
         ):
             result = planner._filter_issues()
@@ -343,7 +343,7 @@ class TestFilterIssues:
         from hephaestus.automation.models import IssueState
 
         with patch(
-            "hephaestus.automation.planner.prefetch_issue_states",
+            "hephaestus.automation.planner_state.prefetch_issue_states",
             return_value={123: IssueState.OPEN},
         ):
             result = planner._filter_issues()

--- a/tests/unit/automation/test_planner_main.py
+++ b/tests/unit/automation/test_planner_main.py
@@ -1,0 +1,124 @@
+"""Smoke tests for ``Planner.run()`` and ``planner.main()``.
+
+Captures the current end-to-end behavior of the planner CLI entry point so
+the upcoming Planner-class decomposition (issue #598) can be verified as a
+pure move-and-delegate refactor. These tests intentionally exercise a
+narrow set of code paths through ``main()`` and ``Planner.run()`` and
+mock all external collaborators (GitHub API + Claude calls).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.automation import planner as planner_mod
+from hephaestus.automation.models import PlannerOptions, PlanResult
+
+
+@pytest.fixture(autouse=True)
+def _silence_logging(caplog: Any) -> None:
+    """Keep test output tidy regardless of basicConfig calls in main()."""
+    caplog.set_level("CRITICAL")
+
+
+def test_main_returns_zero_with_no_open_issues(monkeypatch: Any) -> None:
+    """``main()`` with no --issues and no discovered issues exits 0."""
+    monkeypatch.setattr("sys.argv", ["planner", "--dry-run"])
+    with patch(
+        "hephaestus.automation.planner.gh_list_open_issues",
+        return_value=[],
+    ):
+        rc = planner_mod.main()
+    assert rc == 0
+
+
+def test_main_returns_zero_when_rate_limited(monkeypatch: Any) -> None:
+    """If issue discovery is rate-limited, ``main()`` exits cleanly with 0."""
+    from hephaestus.automation.github_api import GitHubRateLimitError
+
+    monkeypatch.setattr("sys.argv", ["planner"])
+    with patch(
+        "hephaestus.automation.planner.gh_list_open_issues",
+        side_effect=GitHubRateLimitError("rate limit", reset_epoch=0),
+    ):
+        rc = planner_mod.main()
+    assert rc == 0
+
+
+def test_run_skips_issue_with_existing_plan() -> None:
+    """``Planner.run()`` short-circuits when the issue already has a plan.
+
+    The dry_run flag is irrelevant here: the existing-plan guard runs
+    BEFORE the dry-run branch, so neither a Claude call nor a GitHub post
+    should occur.
+    """
+    options = PlannerOptions(
+        issues=[123],
+        dry_run=False,
+        force=False,
+        parallel=1,
+        system_prompt_file=None,
+        skip_closed=False,
+        enable_advise=False,
+    )
+    planner = planner_mod.Planner(options)
+
+    with (
+        patch.object(planner, "_has_existing_plan", return_value=True) as mock_has,
+        patch.object(planner, "_call_claude") as mock_claude,
+        patch.object(planner, "_post_plan") as mock_post,
+    ):
+        results = planner.run()
+
+    assert results[123].success is True
+    assert results[123].plan_already_exists is True
+    mock_has.assert_called_once_with(123)
+    mock_claude.assert_not_called()
+    mock_post.assert_not_called()
+
+
+def test_run_dry_run_does_not_post_or_call_claude() -> None:
+    """``--dry-run`` path: when no existing plan, run skips Claude + posting."""
+    options = PlannerOptions(
+        issues=[456],
+        dry_run=True,
+        force=True,  # bypass the existing-plan check
+        parallel=1,
+        system_prompt_file=None,
+        skip_closed=False,
+        enable_advise=False,
+    )
+    planner = planner_mod.Planner(options)
+
+    with (
+        patch.object(planner, "_call_claude") as mock_claude,
+        patch.object(planner, "_post_plan") as mock_post,
+    ):
+        results = planner.run()
+
+    assert results[456] == PlanResult(issue_number=456, success=True)
+    mock_claude.assert_not_called()
+    mock_post.assert_not_called()
+
+
+def test_run_returns_empty_when_all_issues_filtered() -> None:
+    """``Planner.run()`` returns ``{}`` when every issue is filtered out."""
+    options = PlannerOptions(
+        issues=[1, 2],
+        dry_run=True,
+        force=False,
+        parallel=1,
+        system_prompt_file=None,
+        skip_closed=True,
+        enable_advise=False,
+    )
+    planner = planner_mod.Planner(options)
+
+    # Force _filter_issues to drop everything (simulates all-closed batch).
+    with patch.object(planner, "_filter_issues", return_value=[]):
+        results = planner.run()
+
+    assert results == {}


### PR DESCRIPTION
## Summary

Closes #598 (audit finding: Planner class mixed state persistence, GitHub I/O, Claude invocation, phase loop, plan review in 1,123 LOC).

Decomposes the class into a thin coordinator plus three focused collaborators:

- `PlannerStateManager` (new `hephaestus/automation/planner_state.py`) — owns issue filtering + the existing-plan check.
- `PlanReviewLoop` (new `hephaestus/automation/planner_review_loop.py`) — owns the plan-generation + plan-review iteration cycle.
- `PlannerClaudeRunner` (new `hephaestus/automation/planner_claude.py`) — owns the Claude/Codex invocation surface.

`Planner` itself is now a coordinator holding the parallel worker pool driver, GitHub posting, summary printing, and the mnemosyne-advise helpers.

## Behavior

No behavior change. This is move-and-delegate. Pre-refactor smoke tests on `main()` are committed first so the extraction commits prove behavior is preserved.

## Verification

- `pixi run pytest tests/unit/automation/ --no-cov` — 588 passed.
- `pixi run ruff check hephaestus/automation/` — All checks passed.
- `pixi run mypy` — Success: no issues found in 254 source files.
- `wc -l hephaestus/automation/planner.py` — 701 (down from 1,123; a -422 LOC delta). The original ≤350 LOC target wasn't achievable while keeping the mnemosyne-advise helpers (~150 LOC) and the argparse + main() CLI surface (~165 LOC) in the coordinator file, as required by the plan's hard-limit ("If full ≤350 LOC isn't achievable without violating move-only, commit safely and document the remainder").

Closes #598

Generated with Claude Code