### PR TITLE
refactor(automation): split IssueImplementer into coordinator + 3 collaborators

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -50,6 +50,7 @@ from .follow_up import parse_follow_up_items, run_follow_up_issues
 from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref, run
 from .github_api import fetch_issue_info, gh_list_open_issues
 from .implementer_state import ImplementationStateManager
+from .implementer_summary import ImplementationSummaryPrinter
 from .learn import learn_needs_rerun, run_learn
 from .models import (
     ImplementationPhase,
@@ -1733,46 +1734,7 @@ class IssueImplementer:
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print implementation summary."""
-        total = len(results)
-        deferred = sum(1 for r in results.values() if r.plan_review_not_approved)
-        successful = sum(
-            1 for r in results.values() if r.success and not r.plan_review_not_approved
-        )
-        failed = total - successful - deferred
-
-        logger.info("=" * 60)
-        logger.info("Implementation Summary")
-        logger.info("=" * 60)
-        logger.info("Total issues: %s", total)
-        logger.info("Successful: %s", successful)
-        logger.info("Deferred (awaiting APPROVED plan-review): %s", deferred)
-        logger.info("Failed: %s", failed)
-
-        if successful > 0:
-            logger.info("\nSuccessful PRs:")
-            for issue_num, result in results.items():
-                if result.success and result.pr_number:
-                    logger.info("  #%s: PR #%s", issue_num, result.pr_number)
-
-        if failed > 0:
-            logger.info("\nFailed issues:")
-            for issue_num, result in results.items():
-                if not result.success:
-                    logger.info("  #%s: %s", issue_num, result.error)
-
-        preserved = self.worktree_manager.preserved
-        if preserved:
-            issue_nums = [n for n, _ in preserved]
-            script = sys.argv[0]
-            issues_arg = " ".join(str(n) for n in issue_nums)
-            logger.info("\nPreserved worktrees (contain uncommitted changes):")
-            for issue_num, path in preserved:
-                logger.info("  #%s: %s", issue_num, path)
-            logger.info("\nRerun these issues after inspecting/cleaning the worktrees:")
-            logger.info("  %s --issues %s --resume", script, issues_arg)
-            logger.info("To discard them instead:")
-            for _, path in preserved:
-                logger.info("  git worktree remove --force %s", path)
+        ImplementationSummaryPrinter(self.worktree_manager).print(results)
 
 
 def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -10,63 +10,50 @@ Provides:
 from __future__ import annotations
 
 import argparse
-import contextlib
-import json
 import logging
-import os
 import subprocess
 import sys
 import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from hephaestus.agents.runtime import (
     add_agent_argument,
     is_codex,
-    resume_codex_session,
-    run_codex_session,
-    run_codex_text,
-    session_agent_matches,
 )
 from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_rate_limit,
-    wait_until,
 )
 
-from .claude_invoke import (
-    SESSION_EXPIRED_PHRASES,
-    invoke_claude_with_session,
-    parse_review_verdict,
+# NOTE: Several symbols below are re-imported here purely so existing tests
+# can keep patching them at the ``hephaestus.automation.implementer.X`` path
+# (e.g. ``patch("hephaestus.automation.implementer.is_plan_review_approved")``).
+# :mod:`.implementer_phase_runner` deliberately routes its call sites through
+# this module — see :meth:`.implementer_phase_runner.ImplementationPhaseRunner._impl_module`
+# — so a patch here intercepts both call sites.
+from . import (  # noqa: F401  # re-export for test-patch compatibility
+    review_state,
 )
-from .claude_models import implementer_model, reviewer_model
-from .claude_timeouts import implementer_claude_timeout
+from .claude_invoke import invoke_claude_with_session  # noqa: F401
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
-from .follow_up import parse_follow_up_items, run_follow_up_issues
-from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref, run
+from .git_utils import get_repo_root, get_repo_slug, run  # noqa: F401
 from .github_api import fetch_issue_info, gh_list_open_issues
+from .implementer_phase_runner import ImplementationPhaseRunner
 from .implementer_state import ImplementationStateManager
 from .implementer_summary import ImplementationSummaryPrinter
-from .learn import learn_needs_rerun, run_learn
 from .models import (
-    ImplementationPhase,
     ImplementationState,
     ImplementerOptions,
     IssueState,
     WorkerResult,
 )
-from .pr_manager import commit_changes, create_pr, ensure_pr_created
-from .prompts import (
-    get_impl_loop_review_prompt,
-    get_impl_resume_feedback_prompt,
-    get_implementation_prompt,
-)
-from .review_state import is_plan_review_approved
-from .session_naming import AGENT_IMPLEMENTER, current_trunk_githash
+from .pr_manager import commit_changes, create_pr
+from .review_state import is_plan_review_approved  # noqa: F401
+from .session_naming import AGENT_IMPLEMENTER, current_trunk_githash  # noqa: F401
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
@@ -138,6 +125,7 @@ class IssueImplementer:
         self.log_manager = ThreadLogManager()
 
         self.state_mgr = ImplementationStateManager(self.state_dir)
+        self.phase_runner = ImplementationPhaseRunner(self)
 
         self.ui: CursesUI | None = None
 
@@ -250,7 +238,7 @@ class IssueImplementer:
             issue_numbers: List of issue numbers to load
 
         """
-        from .github_api import fetch_issue_info, prefetch_issue_states
+        from .github_api import prefetch_issue_states
 
         # Prefetch states for efficiency
         cached_states = prefetch_issue_states(issue_numbers)
@@ -445,6 +433,14 @@ class IssueImplementer:
         self._print_summary(results)
         return results
 
+    # ------------------------------------------------------------------
+    # Per-issue phase runner — bodies live in implementer_phase_runner.py.
+    # Each shim here forwards to the runner; the runner dispatches all
+    # cross-method calls back through ``self.impl._xxx`` so test idioms
+    # like ``patch.object(impl, "_has_plan", ...)`` keep intercepting
+    # every call site, including the ones inside ``_implement_issue``.
+    # ------------------------------------------------------------------
+
     def _finalize_pr(
         self,
         issue_number: int,
@@ -453,46 +449,10 @@ class IssueImplementer:
         state: ImplementationState,
         slot_id: int | None,
     ) -> int:
-        """Ensure commit is pushed and PR is created, then persist the PR number.
-
-        Extracted from :meth:`_implement_issue` to satisfy SRP: this unit owns
-        only the "gate the work behind a merged PR" concern, independently of
-        the learn/follow-up post-processing that follows.
-
-        Args:
-            issue_number: GitHub issue number.
-            branch_name: Implementation branch name.
-            worktree_path: Path to the git worktree.
-            state: Mutable implementation state (pr_number updated in-place).
-            slot_id: Worker slot id for status updates.
-
-        Returns:
-            PR number created or located by :func:`ensure_pr_created`.
-
-        """
-        with self.state_lock:
-            state.phase = ImplementationPhase.CREATING_PR
-        self._save_state(state)
-
-        # A2-004: optional pre-PR test gate (opt-in via run_pre_pr_tests=True).
-        if self.options.run_pre_pr_tests:
-            if slot_id is not None:
-                self.status_tracker.update_slot(
-                    slot_id, f"{issue_ref(issue_number)}: Running pre-PR tests"
-                )
-            tests_passed = self._run_tests_in_worktree(worktree_path, issue_number)
-            if not tests_passed:
-                logger.warning(
-                    "#%d: pre-PR tests failed; PR will still be created but "
-                    "manual review is required before merging",
-                    issue_number,
-                )
-
-        pr_number = self._ensure_pr_created(issue_number, branch_name, worktree_path, slot_id)
-        with self.state_lock:
-            state.pr_number = pr_number
-        self._save_state(state)
-        return pr_number
+        """Ensure commit is pushed and PR is created, then persist the PR number."""
+        return self.phase_runner._finalize_pr(
+            issue_number, branch_name, worktree_path, state, slot_id
+        )
 
     def _run_post_pr_followup(
         self,
@@ -501,418 +461,28 @@ class IssueImplementer:
         state: ImplementationState,
         slot_id: int | None,
     ) -> None:
-        """Run /learn and file follow-up issues after the PR is created.
+        """Run /learn and file follow-up issues after the PR is created."""
+        self.phase_runner._run_post_pr_followup(issue_number, worktree_path, state, slot_id)
 
-        Extracted from :meth:`_implement_issue` to satisfy SRP: this unit owns
-        only the knowledge-capture and issue-hygiene concerns that follow a
-        successful PR, independently of the PR-creation logic.
-
-        Marks ``state.phase = COMPLETED`` and sets ``state.completed_at``
-        regardless of whether the optional learn/follow-up steps succeed, so
-        the issue is never left stuck in a non-terminal phase.
-
-        Args:
-            issue_number: GitHub issue number.
-            worktree_path: Path to the git worktree.
-            state: Mutable implementation state (updated in-place).
-            slot_id: Worker slot id for status updates.
-
-        """
-        # Learn phase (after CREATING_PR, before COMPLETED)
-        can_resume_session = self._can_resume_state_session(state)
-        if self.options.enable_learn and can_resume_session and state.session_id:
-            if slot_id is not None:
-                self.status_tracker.update_slot(
-                    slot_id, f"{issue_ref(issue_number)}: Running learn"
-                )
-            with self.state_lock:
-                state.phase = ImplementationPhase.LEARN
-            self._save_state(state)
-            retro_success = self._run_learn(
-                state.session_id,
-                worktree_path,
-                issue_number,
-                slot_id,
-                session_agent=state.session_agent,
-            )
-            with self.state_lock:
-                state.learn_completed = retro_success
-            self._save_state(state)
-
-        # Follow-up issues phase (after LEARN, before COMPLETED)
-        if self.options.enable_follow_up and can_resume_session and state.session_id:
-            if slot_id is not None:
-                self.status_tracker.update_slot(
-                    slot_id, f"{issue_ref(issue_number)}: Identifying follow-ups"
-                )
-            with self.state_lock:
-                state.phase = ImplementationPhase.FOLLOW_UP_ISSUES
-            self._save_state(state)
-            self._run_follow_up_issues(
-                state.session_id,
-                worktree_path,
-                issue_number,
-                slot_id,
-                session_agent=state.session_agent,
-            )
-
-        # Mark as completed
-        with self.state_lock:
-            state.phase = ImplementationPhase.COMPLETED
-            state.completed_at = datetime.now(timezone.utc)
-        self._save_state(state)
-
-    def _implement_issue(self, issue_number: int) -> WorkerResult:  # noqa: C901  # orchestration with many retry/outcome paths
-        """Implement a single issue.
-
-        Args:
-            issue_number: Issue number to implement
-
-        Returns:
-            WorkerResult
-
-        """
-        slot_id = self.status_tracker.acquire_slot()
-        if slot_id is None:
-            return WorkerResult(
-                issue_number=issue_number,
-                success=False,
-                error="Failed to acquire worker slot",
-            )
-
-        thread_id = threading.get_ident()
-
-        try:
-            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Starting")
-            self._log("info", f"Starting issue {issue_ref(issue_number)}", thread_id)
-
-            # Initialize state
-            state = self._get_or_create_state(issue_number)
-
-            branch_name = f"{issue_number}-auto-impl"
-
-            # In dry-run mode skip all real side-effects (worktree creation,
-            # Claude calls, PR creation).  This guard must come BEFORE
-            # create_worktree() so --dry-run never leaves real build/.worktrees/
-            # directories or branches behind (#371).
-            if self.options.dry_run:
-                self._log(
-                    "info",
-                    f"[DRY RUN] Would create worktree, run {self.options.agent}, review, "
-                    f"create PR for #{issue_number}",
-                    thread_id,
-                )
-                return WorkerResult(
-                    issue_number=issue_number,
-                    success=True,
-                    branch_name=branch_name,
-                    worktree_path=None,
-                )
-
-            # Create worktree (only in non-dry-run mode)
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: Creating worktree"
-            )
-            worktree_path = self.worktree_manager.create_worktree(issue_number, branch_name)
-
-            with self.state_lock:
-                state.worktree_path = str(worktree_path)
-                state.branch_name = branch_name
-            self._save_state(state)
-
-            # Check for existing plan
-            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Checking plan")
-            if not self._has_plan(issue_number):
-                self.status_tracker.update_slot(
-                    slot_id, f"{issue_ref(issue_number)}: Generating plan"
-                )
-                self._log("info", f"Issue #{issue_number} has no plan, generating...", thread_id)
-                with self.state_lock:
-                    state.phase = ImplementationPhase.PLANNING
-                self._save_state(state)
-                self._generate_plan(issue_number)
-
-            # Gate on APPROVED plan-review verdict (#551). The legacy
-            # ``_has_plan`` check above only verifies a plan comment EXISTS;
-            # it does not look at the plan-reviewer's verdict, so a BLOCK
-            # or REVISE plan (or a NOGO-exhausted plan that still starts
-            # with "# Implementation Plan", see planner.py:692-700) used to
-            # be implemented just like an APPROVED one. We now defer the
-            # issue when the latest plan-review is anything other than
-            # APPROVED, so the next loop's plan-review phase can re-evaluate
-            # after the planner amends.
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: Checking plan-review verdict"
-            )
-            if not is_plan_review_approved(issue_number):
-                self._log(
-                    "info",
-                    f"Issue #{issue_number}: latest plan-review verdict is not "
-                    f"APPROVED — deferring implementation until next loop",
-                    thread_id,
-                )
-                with self.state_lock:
-                    state.phase = ImplementationPhase.WAITING_FOR_PLAN_REVIEW
-                self._save_state(state)
-                self.status_tracker.update_slot(
-                    slot_id,
-                    f"{issue_ref(issue_number)}: Waiting for APPROVED plan-review",
-                )
-                return WorkerResult(
-                    issue_number=issue_number,
-                    success=True,
-                    branch_name=branch_name,
-                    worktree_path=str(worktree_path),
-                    plan_review_not_approved=True,
-                )
-
-            # Fetch issue info for context
-            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Fetching issue")
-            with self.state_lock:
-                state.phase = ImplementationPhase.IMPLEMENTING
-            self._save_state(state)
-
-            # Run the selected implementation agent
-            issue = fetch_issue_info(issue_number)
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}"
-            )
-            session_id = self._run_claude_code(
-                issue_number,
-                worktree_path,
-                get_implementation_prompt(
-                    issue_number=issue_number,
-                    issue_title=issue.title,
-                    issue_body=issue.body,
-                    branch_name=branch_name,
-                    worktree_path=str(worktree_path),
-                    repo_root=str(self.repo_root),
-                ),
-                slot_id=slot_id,
-            )
-            with self.state_lock:
-                state.session_id = session_id
-                state.session_agent = self.options.agent if session_id else None
-            self._save_state(state)
-
-            # Strict review loop re-uses the selected agent session when a
-            # session id was captured. Reviewer calls are always fresh so
-            # their judgment is unbiased.
-            with self.state_lock:
-                state.phase = ImplementationPhase.REVIEWING
-            self._save_state(state)
-            iterations, last_verdict, last_grade = self._run_impl_review_loop(
-                issue_number=issue_number,
-                worktree_path=worktree_path,
-                branch_name=branch_name,
-                issue_title=issue.title,
-                issue_body=issue.body,
-                session_id=session_id,
-                slot_id=slot_id,
-                thread_id=thread_id,
-                state=state,
-            )
-            with self.state_lock:
-                state.review_iterations = iterations
-                state.last_review_verdict = last_verdict
-                state.last_review_grade = last_grade
-            self._save_state(state)
-
-            # Verify commit, push, PR creation; then run /learn and follow-ups.
-            pr_number = self._finalize_pr(issue_number, branch_name, worktree_path, state, slot_id)
-            self._run_post_pr_followup(issue_number, worktree_path, state, slot_id)
-
-            self._log("info", f"Issue #{issue_number} completed: PR {pr_ref(pr_number)}", thread_id)
-
-            return WorkerResult(
-                issue_number=issue_number,
-                success=True,
-                pr_number=pr_number,
-                branch_name=branch_name,
-                worktree_path=str(worktree_path),
-            )
-
-        except subprocess.TimeoutExpired as e:
-            error_msg = f"Timeout: {' '.join(e.cmd[:3])} exceeded {e.timeout}s"
-            self._log("error", error_msg, thread_id)
-
-            # Show failure in UI before releasing slot
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
-            )
-
-            err_state = self._get_state(issue_number)
-            if err_state:
-                with self.state_lock:
-                    err_state.phase = ImplementationPhase.FAILED
-                    err_state.error = error_msg
-                    err_state.attempts += 1
-                self._save_state(err_state)
-
-            return WorkerResult(
-                issue_number=issue_number,
-                success=False,
-                error=error_msg,
-            )
-
-        except subprocess.CalledProcessError as e:
-            error_msg = f"Command failed (exit {e.returncode}): {' '.join(e.cmd[:3])}"
-            self._log("error", error_msg, thread_id)
-            if e.stderr:
-                self._log("error", f"stderr: {e.stderr[:300]}", thread_id)
-
-            # Show failure in UI before releasing slot
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
-            )
-
-            err_state = self._get_state(issue_number)
-            if err_state:
-                with self.state_lock:
-                    err_state.phase = ImplementationPhase.FAILED
-                    err_state.error = str(e)
-                    err_state.attempts += 1
-                self._save_state(err_state)
-
-            return WorkerResult(
-                issue_number=issue_number,
-                success=False,
-                error=str(e),
-            )
-
-        except RuntimeError as e:
-            self._log("error", f"Runtime error: {e}", thread_id)
-
-            # Show failure in UI before releasing slot
-            error_msg = str(e)[:80]
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
-            )
-
-            err_state = self._get_state(issue_number)
-            if err_state:
-                with self.state_lock:
-                    err_state.phase = ImplementationPhase.FAILED
-                    err_state.error = str(e)
-                    err_state.attempts += 1
-                self._save_state(err_state)
-
-            return WorkerResult(
-                issue_number=issue_number,
-                success=False,
-                error=str(e),
-            )
-
-        except Exception as e:  # broad catch: top-level worker boundary, must not crash thread pool
-            self._log("error", f"Unexpected {type(e).__name__}: {e}", thread_id)
-
-            # Show failure in UI before releasing slot
-            error_msg = str(e)[:80]
-            self.status_tracker.update_slot(
-                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
-            )
-
-            err_state = self._get_state(issue_number)
-            if err_state:
-                with self.state_lock:
-                    err_state.phase = ImplementationPhase.FAILED
-                    err_state.error = str(e)
-                    err_state.attempts += 1
-                self._save_state(err_state)
-
-            return WorkerResult(
-                issue_number=issue_number,
-                success=False,
-                error=str(e),
-            )
-        finally:
-            self.status_tracker.release_slot(slot_id)
+    def _implement_issue(self, issue_number: int) -> WorkerResult:
+        """Implement a single issue."""
+        return self.phase_runner._implement_issue(issue_number)
 
     def _has_plan(self, issue_number: int) -> bool:
         """Check if issue has an implementation plan."""
-        try:
-            result = run(
-                ["gh", "issue", "view", str(issue_number), "--comments", "--json", "comments"],
-                capture_output=True,
-            )
-            data = json.loads(result.stdout)
-            comments = data.get("comments", [])
-
-            for comment in comments:
-                body = comment.get("body", "")
-                if "Implementation Plan" in body or "## Plan" in body:
-                    return True
-
-            return False
-        except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
-            return False
+        return self.phase_runner._has_plan(issue_number)
 
     def _generate_plan(self, issue_number: int) -> None:
-        """Generate plan for an issue using hephaestus-plan-issues.
-
-        Prefers the installed entry point, falls back to a local
-        scripts/plan_issues.py if present (legacy ProjectScylla layout).
-        """
-        import shutil
-
-        # Prefer the installed entry point (works in any repo)
-        entry_point = shutil.which("hephaestus-plan-issues")
-        if entry_point:
-            run(
-                [entry_point, "--issues", str(issue_number), "--agent", self.options.agent],
-                timeout=600,
-            )
-            return
-
-        # Fall back to python -m invocation (works when PYTHONPATH is set).
-        # On failure, fall through to the legacy scripts/plan_issues.py path.
-        with contextlib.suppress(subprocess.SubprocessError, OSError):
-            run(
-                [
-                    sys.executable,
-                    "-m",
-                    "hephaestus.automation.planner",
-                    "--issues",
-                    str(issue_number),
-                    "--agent",
-                    self.options.agent,
-                ],
-                timeout=600,
-            )
-            return
-
-        # Legacy fallback: local scripts/plan_issues.py (ProjectScylla layout)
-        plan_script = self.repo_root / "scripts" / "plan_issues.py"
-        if plan_script.exists():
-            run(
-                [sys.executable, str(plan_script), "--issues", str(issue_number)],
-                timeout=600,
-            )
-            return
-
-        raise RuntimeError(
-            "Could not find hephaestus-plan-issues entry point, "
-            "hephaestus.automation.planner module, or "
-            f"scripts/plan_issues.py in {self.repo_root}"
-        )
+        """Generate plan for an issue using hephaestus-plan-issues."""
+        self.phase_runner._generate_plan(issue_number)
 
     def _parse_follow_up_items(self, text: str) -> list[dict[str, Any]]:
         """Parse follow-up items from Claude's JSON response."""
-        return parse_follow_up_items(text)
+        return self.phase_runner._parse_follow_up_items(text)
 
     def _can_resume_state_session(self, state: ImplementationState) -> bool:
         """Return True when the saved session can be resumed by the selected agent."""
-        if not state.session_id:
-            return False
-        if session_agent_matches(state.session_agent, self.options.agent):
-            return True
-        logger.info(
-            "Skipping session resume for issue #%s: session belongs to %s, selected agent is %s",
-            state.issue_number,
-            state.session_agent or "claude",
-            self.options.agent,
-        )
-        return False
+        return self.phase_runner._can_resume_state_session(state)
 
     def _run_follow_up_issues(
         self,
@@ -924,85 +494,21 @@ class IssueImplementer:
         session_agent: str | None = None,
     ) -> None:
         """Resume the selected agent session to identify and file follow-up issues."""
-        run_follow_up_issues(
+        self.phase_runner._run_follow_up_issues(
             session_id,
             worktree_path,
             issue_number,
-            self.state_dir,
-            self.status_tracker,
             slot_id,
-            dry_run=self.options.dry_run,
-            agent=self.options.agent,
             session_agent=session_agent,
         )
 
     def _learn_needs_rerun(self, issue_number: int) -> bool:
         """Check if learn log indicates failure."""
-        return learn_needs_rerun(issue_number, self.state_dir)
+        return self.phase_runner._learn_needs_rerun(issue_number)
 
     def _rerun_failed_learns(self) -> dict[int, bool]:
-        """Re-run failed learns for completed issues.
-
-        Returns:
-            Dictionary mapping issue number to success status
-
-        """
-        results: dict[int, bool] = {}
-
-        for issue_number, state in self.states.items():
-            # Only re-run for completed issues with failed learns
-            if (
-                state.phase != ImplementationPhase.COMPLETED
-                or state.learn_completed
-                or not self._can_resume_state_session(state)
-            ):
-                continue
-
-            # Check if log indicates failure
-            if not self._learn_needs_rerun(issue_number):
-                continue
-
-            # Verify worktree exists
-            if not state.worktree_path:
-                logger.warning("Skipping learn re-run for #%s: no worktree_path", issue_number)
-                continue
-
-            session_id = state.session_id
-            if session_id is None:
-                continue
-
-            worktree_path = Path(state.worktree_path)
-            if not worktree_path.exists():
-                logger.warning("Skipping learn re-run for #%s: worktree not found", issue_number)
-                continue
-
-            # Re-run learn
-            logger.info("Re-running failed learn for issue #%s", issue_number)
-            success = self._run_learn(
-                session_id,
-                worktree_path,
-                issue_number,
-                slot_id=None,
-                session_agent=state.session_agent,
-            )
-
-            # Update and save state
-            with self.state_lock:
-                state.learn_completed = success
-            self._save_state(state)
-
-            results[issue_number] = success
-
-        if results:
-            success_count = sum(1 for s in results.values() if s)
-            logger.info(
-                "Re-ran %s learn(s): %s succeeded, %s failed",
-                len(results),
-                success_count,
-                len(results) - success_count,
-            )
-
-        return results
+        """Re-run failed learns for completed issues."""
+        return self.phase_runner._rerun_failed_learns()
 
     def _run_learn(
         self,
@@ -1014,19 +520,13 @@ class IssueImplementer:
         session_agent: str | None = None,
     ) -> bool:
         """Resume the selected agent session to run /learn."""
-        return run_learn(
+        return self.phase_runner._run_learn(
             session_id,
             worktree_path,
             issue_number,
-            self.state_dir,
             slot_id,
-            agent=self.options.agent,
             session_agent=session_agent,
         )
-
-    # ------------------------------------------------------------------
-    # Strict review loop for implementer sessions
-    # ------------------------------------------------------------------
 
     def _run_impl_review_loop(
         self,
@@ -1041,137 +541,18 @@ class IssueImplementer:
         thread_id: int | None,
         state: ImplementationState | None = None,
     ) -> tuple[int, str | None, str | None]:
-        """Run the bounded review loop for an implementation.
-
-        Agent sessions are re-used across iterations. Claude uses
-        ``claude --resume <session_id>``; Codex uses
-        ``codex exec resume <session_id>`` with the session UUID captured from
-        the JSONL ``session_meta`` event. The reviewer is a separate, fresh
-        session each iteration so its judgment is unbiased.
-
-        Iteration 0 reviews the just-completed initial run. Iterations 1 and 2
-        first resume the impl session with feedback, then re-review the
-        resulting diff.
-
-        Args:
-            issue_number: GitHub issue number.
-            worktree_path: Path to the git worktree (for diff and resume CWD).
-            branch_name: Implementation branch name (for diff base resolution).
-            issue_title: Issue title (review prompt context).
-            issue_body: Issue body (review prompt context).
-            session_id: Implementer's agent session id. ``None`` if capture
-                failed — the loop runs a single review (iteration 0) and stops,
-                since we cannot re-iterate without a session to resume.
-            slot_id: Worker slot id for status updates.
-            thread_id: Thread id for log routing.
-
-        Returns:
-            Tuple of (iterations executed, last verdict string, last grade letter).
-
-        """
-        last_verdict: str | None = None
-        last_grade: str | None = None
-        prior_review: str | None = None
-        iterations_run = 0
-
-        for iteration in range(MAX_REVIEW_ITERATIONS):
-            # Iterations 1+ resume the impl session with the prior reviewer's
-            # critique, so the implementer can fix the flagged issues before
-            # the next review.
-            if iteration > 0:
-                if session_id is None:
-                    ref = issue_ref(issue_number)
-                    self._log(
-                        "warning",
-                        f"{ref}: cannot iterate (no session_id from initial run); "
-                        "stopping review loop",
-                        thread_id,
-                    )
-                    break
-                if slot_id is not None:
-                    self.status_tracker.update_slot(
-                        slot_id, f"{issue_ref(issue_number)}: addressing review [R{iteration}]"
-                    )
-                resumed = self._resume_impl_with_feedback(
-                    session_id=session_id,
-                    worktree_path=worktree_path,
-                    issue_number=issue_number,
-                    review_text=prior_review or "",
-                    prev_iteration=iteration - 1,
-                    verdict=last_verdict or "NOGO",
-                    state=state,
-                )
-                if not resumed:
-                    ref = issue_ref(issue_number)
-                    self._log(
-                        "warning",
-                        f"{ref}: resume failed at R{iteration}; stopping review loop",
-                        thread_id,
-                    )
-                    break
-
-            # Compute the diff and changed-files list for the reviewer.
-            if slot_id is not None:
-                self.status_tracker.update_slot(
-                    slot_id, f"{issue_ref(issue_number)}: reviewing impl [R{iteration}]"
-                )
-            diff_text = self._collect_diff(worktree_path, branch_name)
-            files_changed = self._collect_changed_files(worktree_path, branch_name)
-
-            review_text = self._run_impl_review(
-                issue_number=issue_number,
-                issue_title=issue_title,
-                issue_body=issue_body,
-                diff_text=diff_text,
-                files_changed=files_changed,
-                iteration=iteration,
-                prior_review=prior_review,
-            )
-            self._save_review_log(issue_number, iteration, review_text)
-            iterations_run = iteration + 1
-
-            verdict = parse_review_verdict(review_text)
-            last_verdict = verdict.verdict
-            last_grade = verdict.grade
-            self._log(
-                "info",
-                f"{issue_ref(issue_number)} R{iteration}: Verdict={verdict.verdict} "
-                f"Grade={verdict.grade or '?'}",
-                thread_id,
-            )
-
-            # A2-005: Persist review iteration progress so --resume can skip
-            # already-completed iterations.  Persist BEFORE breaking out so
-            # the final iteration's data is always on disk.
-            self._save_review_iteration_state(issue_number, iterations_run, review_text)
-
-            if verdict.is_go:
-                ref = issue_ref(issue_number)
-                self._log(
-                    "info",
-                    f"{ref}: GO on iteration {iteration} — review loop terminated",
-                    thread_id,
-                )
-                break
-
-            # Save this review for next iteration's context
-            prior_review = review_text
-
-        # A2-003: Surface AMBIGUOUS verdict distinctly so operators can triage
-        # without inspecting raw log files.
-        if last_verdict == "AMBIGUOUS" or (
-            iterations_run == MAX_REVIEW_ITERATIONS and last_verdict not in (None, "GO")
-        ):
-            logger.warning(
-                "#%d: review loop ended without clear GO — "
-                "final verdict=%r after %d iteration(s); "
-                "PR created but manual review is recommended",
-                issue_number,
-                last_verdict,
-                iterations_run,
-            )
-
-        return iterations_run, last_verdict, last_grade
+        """Run the bounded review loop for an implementation."""
+        return self.phase_runner._run_impl_review_loop(
+            issue_number=issue_number,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            session_id=session_id,
+            slot_id=slot_id,
+            thread_id=thread_id,
+            state=state,
+        )
 
     def _resume_impl_with_feedback(
         self,
@@ -1184,131 +565,16 @@ class IssueImplementer:
         verdict: str,
         state: ImplementationState | None = None,
     ) -> bool:
-        """Resume the impl session and feed reviewer feedback as the next prompt.
-
-        Claude resumes with ``claude --resume <session_id>`` and Codex resumes
-        with ``codex exec resume <session_id>``. On Claude ``CalledProcessError``
-        the method distinguishes two cases (#372):
-
-        * **Session-expired** — the ``--resume`` target no longer exists in
-          the Claude CLI's session store. Detected by checking ``e.stderr`` /
-          ``e.stdout`` against :data:`SESSION_EXPIRED_PHRASES`. When detected
-          sets ``state.error = "session_expired:<session_id>"`` (if *state* is
-          provided) and returns ``False`` so the loop stops gracefully.
-          Partial work in the worktree is preserved for later inspection.
-
-        * **Transient / other failure** — logs at ERROR with the full stderr so
-          operators see useful diagnostics rather than a bare warning.
-
-        Args:
-            session_id: Agent session id to resume.
-            worktree_path: CWD for the claude invocation.
-            issue_number: For log messages.
-            review_text: Reviewer critique to feed back to the implementer.
-            prev_iteration: Zero-based index of the review that produced the
-                critique (used in the prompt and log messages).
-            verdict: Last verdict string (``"NOGO"`` / ``"AMBIGUOUS"``).
-            state: Optional mutable implementation state; updated in-place
-                when session expiry is detected.
-
-        Returns:
-            ``True`` if the resume completed successfully, ``False`` otherwise.
-
-        """
-        prompt = get_impl_resume_feedback_prompt(
+        """Resume the impl session and feed reviewer feedback as the next prompt."""
+        return self.phase_runner._resume_impl_with_feedback(
+            session_id=session_id,
+            worktree_path=worktree_path,
             issue_number=issue_number,
+            review_text=review_text,
             prev_iteration=prev_iteration,
             verdict=verdict,
-            review_text=review_text,
+            state=state,
         )
-        if is_codex(self.options.agent):
-            try:
-                result = resume_codex_session(
-                    session_id,
-                    prompt,
-                    cwd=worktree_path,
-                    timeout=implementer_claude_timeout(),
-                )
-                log_file = (
-                    self.state_dir / f"codex-feedback-{issue_number}-r{prev_iteration + 1}.log"
-                )
-                log_file.write_text(result.stdout or "")
-                return True
-            except subprocess.CalledProcessError as e:
-                logger.error(
-                    "#%d: Codex failed to address R%d feedback (exit=%d): %s",
-                    issue_number,
-                    prev_iteration + 1,
-                    e.returncode,
-                    (e.stderr or e.stdout or "")[:500],
-                )
-                return False
-            except subprocess.TimeoutExpired:
-                logger.error(
-                    "#%d: Codex timed out addressing R%d feedback",
-                    issue_number,
-                    prev_iteration + 1,
-                )
-                return False
-
-        # Route through the centralized helper so create/resume semantics and
-        # the SESSION_EXPIRED phrase list stay in one place. The deterministic
-        # UUID matches what the initial impl session was created with, so the
-        # passed-in ``session_id`` (legacy ``state.session_id``) is ignored on
-        # the Claude path — it's still consumed by the codex branch above.
-        # ``recreate_on_resume_failure=False`` propagates the underlying error
-        # so we can preserve the "stop iterating on expiry" contract.
-        githash = current_trunk_githash(self.repo_root)
-        repo_slug = get_repo_slug(self.repo_root)
-        try:
-            invoke_claude_with_session(
-                repo=repo_slug,
-                issue=issue_number,
-                agent=AGENT_IMPLEMENTER,
-                githash=githash,
-                prompt=prompt,
-                model=implementer_model(),
-                cwd=worktree_path,
-                timeout=implementer_claude_timeout(),
-                permission_mode="dontAsk",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                recreate_on_resume_failure=False,
-            )
-            return True
-        except subprocess.CalledProcessError as e:
-            combined = ((e.stderr or "") + (e.stdout or "")).lower()
-            if any(phrase in combined for phrase in SESSION_EXPIRED_PHRASES):
-                # Session pruned — partial work may still be committable;
-                # don't treat this as an unrecoverable failure.
-                error_tag = f"session_expired:{session_id}"
-                logger.warning(
-                    "#%d: impl session %r expired before R%d; "
-                    "stopping review loop (partial work preserved)",
-                    issue_number,
-                    session_id,
-                    prev_iteration + 1,
-                )
-                if state is not None:
-                    with self.state_lock:
-                        state.error = error_tag
-                    self._save_state(state)
-            else:
-                logger.error(
-                    "#%d: failed to resume impl session for R%d (exit=%d): %s",
-                    issue_number,
-                    prev_iteration + 1,
-                    e.returncode,
-                    (e.stderr or e.stdout or "")[:500],
-                )
-            return False
-        except Exception as e:  # broad: resume is best-effort, never crash the loop
-            logger.error(
-                "#%d: unexpected error resuming impl session for R%d: %s",
-                issue_number,
-                prev_iteration + 1,
-                e,
-            )
-            return False
 
     def _run_impl_review(
         self,
@@ -1321,13 +587,8 @@ class IssueImplementer:
         iteration: int,
         prior_review: str | None,
     ) -> str:
-        """Run a fresh-session reviewer against the current impl diff.
-
-        Uses ``reviewer_model()`` (Sonnet by default) per the per-phase model
-        selection in :mod:`hephaestus.automation.claude_models`. On reviewer
-        call failure, returns a synthetic NoGo so the loop fails safe.
-        """
-        prompt = get_impl_loop_review_prompt(
+        """Run a fresh-session reviewer against the current impl diff."""
+        return self.phase_runner._run_impl_review(
             issue_number=issue_number,
             issue_title=issue_title,
             issue_body=issue_body,
@@ -1336,360 +597,50 @@ class IssueImplementer:
             iteration=iteration,
             prior_review=prior_review,
         )
-        try:
-            if is_codex(self.options.agent):
-                result = run_codex_text(
-                    prompt,
-                    cwd=self.repo_root,
-                    timeout=600,
-                    sandbox="read-only",
-                )
-                output = (result.stdout or "").strip()
-                if not output:
-                    raise RuntimeError("reviewer returned empty output")
-                return output
-
-            env = os.environ.copy()
-            env["CLAUDECODE"] = ""
-            result = subprocess.run(
-                [
-                    "claude",
-                    "--print",
-                    "--model",
-                    reviewer_model(),
-                    "--output-format",
-                    "text",
-                ],
-                input=prompt,
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=600,
-                env=env,
-            )
-            output = (result.stdout or "").strip()
-            if not output:
-                raise RuntimeError("reviewer returned empty output")
-            return output
-        except Exception as e:
-            logger.error(
-                "#%s R%s: impl reviewer call failed: %s; treating as NOGO so the loop continues",
-                issue_number,
-                iteration,
-                e,
-            )
-            return (
-                f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
-                "Grade: F\nVerdict: NOGO\n"
-            )
 
     def _collect_diff(self, worktree_path: Path, branch_name: str) -> str:
-        """Return the cumulative diff of *branch_name* against ``origin/main``.
-
-        Falls back to ``HEAD~1..HEAD`` if origin/main is unavailable. Truncates
-        to ~200KB to keep the reviewer prompt manageable.
-        """
-        try:
-            result = run(
-                ["git", "diff", "origin/main...HEAD"],
-                cwd=worktree_path,
-                capture_output=True,
-                check=False,
-                timeout=60,
-            )
-            diff = result.stdout or ""
-            if not diff.strip():
-                fb = run(
-                    ["git", "diff", "HEAD~1..HEAD"],
-                    cwd=worktree_path,
-                    capture_output=True,
-                    check=False,
-                    timeout=60,
-                )
-                diff = fb.stdout or ""
-        except Exception as e:
-            logger.warning("diff collection failed for %s: %s", branch_name, e)
-            return ""
-
-        max_chars = 200_000
-        if len(diff) > max_chars:
-            diff = diff[:max_chars] + f"\n\n[... diff truncated at {max_chars} chars ...]\n"
-        return diff
+        """Return the cumulative diff of *branch_name* against ``origin/main``."""
+        return self.phase_runner._collect_diff(worktree_path, branch_name)
 
     def _collect_changed_files(self, worktree_path: Path, branch_name: str) -> str:
         """Return a newline-separated list of changed files vs ``origin/main``."""
-        try:
-            result = run(
-                ["git", "diff", "--name-only", "origin/main...HEAD"],
-                cwd=worktree_path,
-                capture_output=True,
-                check=False,
-                timeout=30,
-            )
-            files = (result.stdout or "").strip()
-            if files:
-                return files
-            fb = run(
-                ["git", "diff", "--name-only", "HEAD~1..HEAD"],
-                cwd=worktree_path,
-                capture_output=True,
-                check=False,
-                timeout=30,
-            )
-            return (fb.stdout or "").strip()
-        except Exception as e:
-            logger.warning("changed-files collection failed for %s: %s", branch_name, e)
-            return ""
+        return self.phase_runner._collect_changed_files(worktree_path, branch_name)
 
     def _save_review_log(self, issue_number: int, iteration: int, review_text: str) -> None:
         """Persist a per-iteration review log for later inspection."""
-        try:
-            log_file = self.state_dir / f"review-{issue_number}-r{iteration}.log"
-            log_file.write_text(review_text)
-        except Exception as e:
-            logger.warning("#%s: failed to save review log r%s: %s", issue_number, iteration, e)
+        self.phase_runner._save_review_log(issue_number, iteration, review_text)
 
     def _save_review_iteration_state(
         self, issue_number: int, iterations_run: int, prior_review: str
     ) -> None:
-        """Persist review loop progress for ``--resume`` continuity (A2-005).
-
-        Writes two files per issue:
-
-        * ``review-iter-{N}.json`` — JSON with ``iterations_run`` so resume
-          can skip already-completed iterations.
-        * ``review-prior-{N}.txt`` — the last reviewer critique so it can be
-          reloaded as ``prior_review`` on resume.
-
-        Failures are logged and swallowed — persistence is best-effort.
-        """
-        try:
-            iter_file = self.state_dir / f"review-iter-{issue_number}.json"
-            iter_file.write_text(json.dumps({"iterations_run": iterations_run}))
-        except Exception as e:
-            logger.warning("#%d: failed to persist review iteration count: %s", issue_number, e)
-        try:
-            prior_file = self.state_dir / f"review-prior-{issue_number}.txt"
-            prior_file.write_text(prior_review)
-        except Exception as e:
-            logger.warning("#%d: failed to persist prior review text: %s", issue_number, e)
+        """Persist review loop progress for ``--resume`` continuity (A2-005)."""
+        self.phase_runner._save_review_iteration_state(issue_number, iterations_run, prior_review)
 
     def _load_review_iteration_state(self, issue_number: int) -> tuple[int, str | None]:
-        """Load persisted review iteration progress for ``--resume`` (A2-005).
-
-        Returns:
-            Tuple of ``(iterations_run, prior_review_text)`` loaded from disk.
-            Returns ``(0, None)`` if no persisted state exists.
-
-        """
-        iterations_run = 0
-        prior_review: str | None = None
-        try:
-            iter_file = self.state_dir / f"review-iter-{issue_number}.json"
-            if iter_file.exists():
-                data = json.loads(iter_file.read_text())
-                iterations_run = int(data.get("iterations_run", 0))
-        except Exception as e:
-            logger.warning(
-                "#%d: failed to load persisted review iteration count: %s", issue_number, e
-            )
-        try:
-            prior_file = self.state_dir / f"review-prior-{issue_number}.txt"
-            if prior_file.exists():
-                prior_review = prior_file.read_text()
-        except Exception as e:
-            logger.warning("#%d: failed to load persisted prior review text: %s", issue_number, e)
-        return iterations_run, prior_review
+        """Load persisted review iteration progress for ``--resume`` (A2-005)."""
+        return self.phase_runner._load_review_iteration_state(issue_number)
 
     def _run_tests_in_worktree(self, worktree_path: Path, issue_number: int) -> bool:
-        """Run the unit test suite inside the worktree as a pre-PR gate (A2-004).
-
-        Invokes ``pixi run pytest tests/unit -q --tb=short`` with a generous
-        timeout. On non-zero exit, logs a warning and returns ``False`` so the
-        caller can decide whether to block the PR or log-and-continue.
-
-        Args:
-            worktree_path: Path to the git worktree where the tests are run.
-            issue_number: For log messages.
-
-        Returns:
-            ``True`` if all tests pass, ``False`` on failure or timeout.
-
-        """
-        try:
-            result = subprocess.run(
-                ["pixi", "run", "pytest", "tests/unit", "-q", "--tb=short"],
-                cwd=worktree_path,
-                capture_output=True,
-                text=True,
-                timeout=600,
-            )
-            if result.returncode == 0:
-                logger.info("#%d: pre-PR tests passed", issue_number)
-                return True
-            logger.warning(
-                "#%d: pre-PR tests FAILED (exit %d):\n%s",
-                issue_number,
-                result.returncode,
-                (result.stdout + result.stderr)[-2000:],
-            )
-            return False
-        except subprocess.TimeoutExpired:
-            logger.warning("#%d: pre-PR tests timed out after 600s", issue_number)
-            return False
-        except Exception as e:
-            logger.warning("#%d: pre-PR tests could not run: %s", issue_number, e)
-            return False
+        """Run the unit test suite inside the worktree as a pre-PR gate (A2-004)."""
+        return self.phase_runner._run_tests_in_worktree(worktree_path, issue_number)
 
     def _run_claude_code(
         self, issue_number: int, worktree_path: Path, prompt: str, slot_id: int | None = None
     ) -> str | None:
-        """Run the selected implementation agent in a worktree.
-
-        Args:
-            issue_number: Issue number
-            worktree_path: Path to worktree
-            prompt: Implementation prompt
-            slot_id: Worker slot ID for status updates
-
-        Returns:
-            Session ID if captured, None otherwise
-
-        """
-        if self.options.dry_run:
-            logger.info("[DRY RUN] Would run %s for issue #%s", self.options.agent, issue_number)
-            return None
-
-        self.state_dir.mkdir(parents=True, exist_ok=True)
-
-        if is_codex(self.options.agent):
-            return self._run_codex_code(issue_number, worktree_path, prompt)
-
-        return self._run_claude_impl_session(issue_number, worktree_path, prompt)
+        """Run the selected implementation agent in a worktree."""
+        return self.phase_runner._run_claude_code(issue_number, worktree_path, prompt, slot_id)
 
     def _run_claude_impl_session(
         self, issue_number: int, worktree_path: Path, prompt: str
     ) -> str | None:
         """Run Claude implementation prompt and return its session id."""
-        prompt_file = worktree_path / f".claude-prompt-{issue_number}.md"
-        prompt_file.write_text(prompt)
+        return self.phase_runner._run_claude_impl_session(issue_number, worktree_path, prompt)
 
-        githash = current_trunk_githash(self.repo_root)
-        repo_slug = get_repo_slug(self.repo_root)
-
-        try:
-            stdout, _ = invoke_claude_with_session(
-                repo=repo_slug,
-                issue=issue_number,
-                agent=AGENT_IMPLEMENTER,
-                githash=githash,
-                prompt=prompt,
-                model=implementer_model(),
-                cwd=worktree_path,
-                timeout=implementer_claude_timeout(),
-                output_format="json",
-                permission_mode="dontAsk",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-            )
-            result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
-            # Parse session_id from JSON output
-            try:
-                data = json.loads(result.stdout)
-
-                # The CLI sometimes returns exit 0 with ``is_error: true`` in
-                # JSON (e.g. usage caps in some channels). Treat that as a
-                # failure so the orchestrator can wait/retry instead of
-                # silently logging a useless session_id.
-                if isinstance(data, dict) and data.get("is_error"):
-                    err_text = str(data.get("result") or "")
-                    log_file = self.state_dir / f"claude-{issue_number}.log"
-                    log_file.write_text(result.stdout or "")
-                    reset_epoch = _claude_quota_reset_epoch(err_text)
-                    if reset_epoch is not None and reset_epoch > 0:
-                        logger.warning(
-                            "Claude usage cap hit for issue #%s; waiting for reset", issue_number
-                        )
-                        wait_until(reset_epoch)
-                    raise RuntimeError(f"Claude Code failed: {err_text or 'is_error=true'}")
-
-                session_id = data.get("session_id")
-
-                # Save successful output to log file
-                log_file = self.state_dir / f"claude-{issue_number}.log"
-                log_file.write_text(result.stdout or "")
-
-                return cast(str | None, session_id)
-            except (json.JSONDecodeError, AttributeError):
-                logger.warning("Could not parse session_id for issue #%s", issue_number)
-                logger.debug("Claude stdout: %s", result.stdout[:500])
-
-                # Save output even if JSON parsing failed
-                log_file = self.state_dir / f"claude-{issue_number}.log"
-                log_file.write_text(result.stdout or "")
-
-                return None
-        except subprocess.CalledProcessError as e:
-            logger.error("Claude Code failed for issue #%s", issue_number)
-            logger.error("Exit code: %s", e.returncode)
-            if e.stdout:
-                logger.error("Stdout: %s", e.stdout[:1000])
-            if e.stderr:
-                logger.error("Stderr: %s", e.stderr[:1000])
-
-            # Save failure output to log file
-            log_file = self.state_dir / f"claude-{issue_number}.log"
-            stdout = e.stdout or ""
-            stderr = e.stderr or ""
-            output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-            log_file.write_text(output)
-
-            # If the failure was a quota cap, block until reset rather than
-            # letting the orchestrator burn through every remaining issue in
-            # seconds. The Claude CLI puts its 429 message in stdout JSON.
-            reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
-            if reset_epoch is not None and reset_epoch > 0:
-                logger.warning(
-                    "Claude usage cap hit for issue #%s; waiting for reset", issue_number
-                )
-                wait_until(reset_epoch)
-
-            raise RuntimeError(f"Claude Code failed: {e.stderr or e.stdout}") from e
-        except subprocess.TimeoutExpired as e:
-            # Save timeout info to log file
-            log_file = self.state_dir / f"claude-{issue_number}.log"
-            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
-
-            raise RuntimeError("Claude Code timed out") from e
-        finally:
-            # Clean up temp file
-            with contextlib.suppress(Exception):
-                prompt_file.unlink()
-
-    def _run_codex_code(self, issue_number: int, worktree_path: Path, prompt: str) -> str | None:
+    def _run_codex_code(
+        self, issue_number: int, worktree_path: Path, prompt: str
+    ) -> str | None:
         """Run Codex implementation prompt in a worktree."""
-        log_file = self.state_dir / f"codex-{issue_number}.log"
-        try:
-            result = run_codex_session(
-                prompt,
-                cwd=worktree_path,
-                timeout=implementer_claude_timeout(),
-                sandbox="workspace-write",
-            )
-            log_file.write_text(result.stdout or "")
-            return result.session_id
-        except subprocess.CalledProcessError as e:
-            stdout = e.stdout or ""
-            stderr = e.stderr or ""
-            output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-            log_file.write_text(output)
-            reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
-            if reset_epoch is not None and reset_epoch > 0:
-                logger.warning("Codex usage cap hit for issue #%s; waiting for reset", issue_number)
-                wait_until(reset_epoch)
-            raise RuntimeError(f"Codex failed: {stderr or stdout}") from e
-        except subprocess.TimeoutExpired as e:
-            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
-            raise RuntimeError("Codex timed out") from e
+        return self.phase_runner._run_codex_code(issue_number, worktree_path, prompt)
 
     def _commit_changes(self, issue_number: int, worktree_path: Path) -> None:
         """Commit changes in worktree."""
@@ -1703,13 +654,8 @@ class IssueImplementer:
         slot_id: int | None = None,
     ) -> int:
         """Ensure commit is pushed and PR is created (fallback if Claude didn't do it)."""
-        return ensure_pr_created(
-            issue_number,
-            branch_name,
-            worktree_path,
-            self.options.auto_merge,
-            self.status_tracker,
-            slot_id,
+        return self.phase_runner._ensure_pr_created(
+            issue_number, branch_name, worktree_path, slot_id
         )
 
     def _create_pr(self, issue_number: int, branch_name: str) -> int:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -49,6 +49,7 @@ from .dependency_resolver import CyclicDependencyError, DependencyResolver
 from .follow_up import parse_follow_up_items, run_follow_up_issues
 from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref, run
 from .github_api import fetch_issue_info, gh_list_open_issues
+from .implementer_state import ImplementationStateManager
 from .learn import learn_needs_rerun, run_learn
 from .models import (
     ImplementationPhase,
@@ -135,10 +136,26 @@ class IssueImplementer:
         self.status_tracker = StatusTracker(options.max_workers)
         self.log_manager = ThreadLogManager()
 
-        self.states: dict[int, ImplementationState] = {}
-        self.state_lock = threading.Lock()
+        self.state_mgr = ImplementationStateManager(self.state_dir)
 
         self.ui: CursesUI | None = None
+
+    # ------------------------------------------------------------------
+    # Compatibility shims: callers that pre-date the #597 state-manager
+    # extraction reach into ``self.states`` / ``self.state_lock`` directly.
+    # Expose them as read-only views onto the manager so behavior is
+    # identical.
+    # ------------------------------------------------------------------
+
+    @property
+    def states(self) -> dict[int, ImplementationState]:
+        """Return the in-memory state dict owned by :attr:`state_mgr`."""
+        return self.state_mgr.states
+
+    @property
+    def state_lock(self) -> threading.Lock:
+        """Return the lock guarding :attr:`states`."""
+        return self.state_mgr.lock
 
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.
@@ -1700,35 +1717,19 @@ class IssueImplementer:
 
     def _get_or_create_state(self, issue_number: int) -> ImplementationState:
         """Get or create implementation state for an issue."""
-        with self.state_lock:
-            if issue_number not in self.states:
-                self.states[issue_number] = ImplementationState(issue_number=issue_number)
-            return self.states[issue_number]
+        return self.state_mgr.get_or_create(issue_number)
 
     def _get_state(self, issue_number: int) -> ImplementationState | None:
         """Get implementation state for an issue."""
-        with self.state_lock:
-            return self.states.get(issue_number)
+        return self.state_mgr.get(issue_number)
 
     def _save_state(self, state: ImplementationState) -> None:
         """Save implementation state to disk."""
-        from .github_api import write_secure
-
-        state_file = self.state_dir / f"issue-{state.issue_number}.json"
-        # Use write_secure for atomic writes
-        write_secure(state_file, state.model_dump_json(indent=2))
+        self.state_mgr.save(state)
 
     def _load_state(self) -> None:
         """Load all implementation states from disk."""
-        for state_file in self.state_dir.glob("issue-*.json"):
-            try:
-                with open(state_file) as f:
-                    state = ImplementationState.model_validate_json(f.read())
-                    with self.state_lock:
-                        self.states[state.issue_number] = state
-                logger.info("Loaded state for issue #%s", state.issue_number)
-            except (json.JSONDecodeError, ValueError, OSError) as e:
-                logger.error("Failed to load state from %s: %s", state_file, e)
+        self.state_mgr.load_all()
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print implementation summary."""

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -161,7 +161,7 @@ class IssueImplementer:
         ui_msg = f"{prefix}: {msg}" if prefix else msg
         self.log_manager.log(tid, ui_msg)
 
-    def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # one-extra-branch for #574 early-exit; orchestration body is intentionally linear
+    def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # branchy orchestration body is intentionally linear
         """Run the implementer.
 
         Returns:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -23,10 +23,6 @@ from hephaestus.agents.runtime import (
     add_agent_argument,
     is_codex,
 )
-from hephaestus.github.rate_limit import (
-    detect_claude_usage_cap,
-    detect_rate_limit,
-)
 
 # NOTE: Several symbols below are re-imported here purely so existing tests
 # can keep patching them at the ``hephaestus.automation.implementer.X`` path
@@ -42,7 +38,12 @@ from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
 from .git_utils import get_repo_root, get_repo_slug, run  # noqa: F401
 from .github_api import fetch_issue_info, gh_list_open_issues
-from .implementer_phase_runner import ImplementationPhaseRunner
+
+# MAX_REVIEW_ITERATIONS is re-exported so tests that import it via
+# ``hephaestus.automation.implementer`` see the same value the runtime loop
+# in :class:`ImplementationPhaseRunner` uses. There is a single source of
+# truth in implementer_phase_runner.
+from .implementer_phase_runner import MAX_REVIEW_ITERATIONS, ImplementationPhaseRunner
 from .implementer_state import ImplementationStateManager
 from .implementer_summary import ImplementationSummaryPrinter
 from .models import (
@@ -67,8 +68,6 @@ __all__ = [
     "main",
 ]
 
-MAX_REVIEW_ITERATIONS = 3
-
 # Default Claude implementation timeout in seconds. Actual runtime value is
 # read from the ``HEPH_IMPLEMENTER_CLAUDE_TIMEOUT`` env-var by
 # :func:`.claude_timeouts.implementer_claude_timeout`; this constant serves
@@ -77,23 +76,6 @@ _CLAUDE_IMPL_TIMEOUT: int = 1800
 
 
 logger = logging.getLogger(__name__)
-
-
-def _claude_quota_reset_epoch(*texts: str) -> int | None:
-    """Find a quota-reset epoch across one or more output streams.
-
-    Inspects each text for either form of rate-limit message — the GitHub-CLI
-    "Limit reached ..." form or the Claude-CLI "out of extra usage ·
-    resets ..." form. Uses ``is not None`` chaining so an epoch of ``0``
-    (rate-limited, reset time unknown) is preserved instead of being
-    mistaken for "no rate limit".
-    """
-    for text in texts:
-        for detect in (detect_rate_limit, detect_claude_usage_cap):
-            epoch = detect(text)
-            if epoch is not None:
-                return epoch
-    return None
 
 
 class IssueImplementer:
@@ -636,9 +618,7 @@ class IssueImplementer:
         """Run Claude implementation prompt and return its session id."""
         return self.phase_runner._run_claude_impl_session(issue_number, worktree_path, prompt)
 
-    def _run_codex_code(
-        self, issue_number: int, worktree_path: Path, prompt: str
-    ) -> str | None:
+    def _run_codex_code(self, issue_number: int, worktree_path: Path, prompt: str) -> str | None:
         """Run Codex implementation prompt in a worktree."""
         return self.phase_runner._run_codex_code(issue_number, worktree_path, prompt)
 

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1,0 +1,1329 @@
+"""Per-issue 6-phase pipeline runner for :class:`IssueImplementer`.
+
+Extracted from :mod:`hephaestus.automation.implementer` as part of the #597
+decomposition. The runner owns the body of ``_implement_issue`` and all of
+its phase helpers (plan / impl / review-loop / test / PR / follow-up /
+learn). It does NOT own:
+
+* the ``states`` dict + lock — that lives on
+  :class:`~hephaestus.automation.implementer_state.ImplementationStateManager`.
+* the end-of-run summary — that lives on
+  :class:`~hephaestus.automation.implementer_summary.ImplementationSummaryPrinter`.
+
+The runner keeps a back-reference to the parent ``IssueImplementer`` so
+that cross-method dispatch can flow back through the coordinator's
+thin shims. That preserves the test-patch contract:
+``patch.object(impl, "_has_plan", ...)`` still intercepts every callsite,
+including the ones inside ``_implement_issue`` that were moved here.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from hephaestus.agents.runtime import (
+    is_codex,
+    resume_codex_session,
+    run_codex_session,
+    run_codex_text,
+    session_agent_matches,
+)
+from hephaestus.github.rate_limit import wait_until
+
+from .claude_invoke import (
+    SESSION_EXPIRED_PHRASES,
+    parse_review_verdict,
+)
+from .claude_models import implementer_model, reviewer_model
+from .claude_timeouts import implementer_claude_timeout
+from .follow_up import parse_follow_up_items, run_follow_up_issues
+from .git_utils import issue_ref, pr_ref, run
+from .learn import learn_needs_rerun, run_learn
+from .models import (
+    ImplementationPhase,
+    ImplementationState,
+    WorkerResult,
+)
+from .pr_manager import ensure_pr_created
+from .prompts import (
+    get_impl_loop_review_prompt,
+    get_impl_resume_feedback_prompt,
+    get_implementation_prompt,
+)
+
+# NOTE: ``is_plan_review_approved``, ``fetch_issue_info``,
+# ``invoke_claude_with_session``, ``get_repo_slug``, ``current_trunk_githash``,
+# and ``AGENT_IMPLEMENTER`` are deliberately NOT imported here. Existing tests
+# patch them at ``hephaestus.automation.implementer.X`` so the call sites
+# below look them up dynamically through that module via
+# :meth:`._impl_module`. This preserves the test-patch contract after the
+# #597 extraction.
+
+if TYPE_CHECKING:
+    from .implementer import IssueImplementer
+
+logger = logging.getLogger(__name__)
+
+MAX_REVIEW_ITERATIONS = 3
+
+
+def _claude_quota_reset_epoch(*texts: str) -> int | None:
+    """Find a quota-reset epoch across one or more output streams.
+
+    Mirrors the helper in :mod:`hephaestus.automation.implementer`. Kept
+    local to the runner so the agent-call paths don't import back through
+    the coordinator module.
+    """
+    from hephaestus.github.rate_limit import detect_claude_usage_cap, detect_rate_limit
+
+    for text in texts:
+        if not text:
+            continue
+        epoch = detect_rate_limit(text)
+        if epoch is not None:
+            return epoch
+        epoch = detect_claude_usage_cap(text)
+        if epoch is not None:
+            return epoch
+    return None
+
+
+class ImplementationPhaseRunner:
+    """Runs the per-issue implementation pipeline for one ``IssueImplementer``.
+
+    The runner is constructed by :class:`IssueImplementer` and keeps a
+    back-reference to it so cross-method dispatch (``_has_plan``,
+    ``_save_state``, ``_run_claude_code``, …) can flow back through the
+    coordinator. That keeps existing ``patch.object(impl, "_method")``
+    test idioms working unchanged.
+    """
+
+    def __init__(self, impl: IssueImplementer) -> None:
+        """Initialize the runner.
+
+        Args:
+            impl: Parent ``IssueImplementer``. Held by reference; the
+                runner reads ``impl.options``, ``impl.state_dir``,
+                ``impl.repo_root``, ``impl.worktree_manager``,
+                ``impl.status_tracker``, ``impl.state_mgr``, and the
+                ``_log`` / ``_get_state`` / ``_get_or_create_state`` /
+                ``_save_state`` helper methods from it.
+
+        """
+        self.impl = impl
+
+    # ------------------------------------------------------------------
+    # Convenience accessors — keep method bodies readable without
+    # rewriting them.
+    # ------------------------------------------------------------------
+
+    @property
+    def options(self) -> Any:
+        """Return the parent ImplementerOptions."""
+        return self.impl.options
+
+    @property
+    def state_dir(self) -> Path:
+        """Return the state directory used for on-disk artifacts."""
+        return self.impl.state_dir
+
+    @property
+    def repo_root(self) -> Path:
+        """Return the repository root used as default CWD."""
+        return self.impl.repo_root
+
+    @property
+    def status_tracker(self) -> Any:
+        """Return the shared :class:`StatusTracker`."""
+        return self.impl.status_tracker
+
+    @property
+    def worktree_manager(self) -> Any:
+        """Return the shared :class:`WorktreeManager`."""
+        return self.impl.worktree_manager
+
+    @property
+    def state_lock(self) -> threading.Lock:
+        """Return the lock guarding the state manager's in-memory dict."""
+        return self.impl.state_mgr.lock
+
+    @property
+    def _impl_module(self) -> Any:
+        """Return the ``hephaestus.automation.implementer`` module.
+
+        Used for dynamic lookup of patchable symbols (``is_plan_review_approved``,
+        ``fetch_issue_info``, ``invoke_claude_with_session``, ``get_repo_slug``,
+        ``current_trunk_githash``, ``AGENT_IMPLEMENTER``) so that tests which
+        ``patch("hephaestus.automation.implementer.X", ...)`` keep working
+        after the #597 extraction moved the call sites out to this module.
+        """
+        from . import implementer as _impl_mod
+
+        return _impl_mod
+
+    # ------------------------------------------------------------------
+    # Top-level per-issue pipeline
+    # ------------------------------------------------------------------
+
+    def _implement_issue(self, issue_number: int) -> WorkerResult:  # noqa: C901  # orchestration with many retry/outcome paths
+        """Implement a single issue.
+
+        Args:
+            issue_number: Issue number to implement
+
+        Returns:
+            WorkerResult
+
+        """
+        impl = self.impl
+        slot_id = self.status_tracker.acquire_slot()
+        if slot_id is None:
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error="Failed to acquire worker slot",
+            )
+
+        thread_id = threading.get_ident()
+
+        try:
+            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Starting")
+            impl._log("info", f"Starting issue {issue_ref(issue_number)}", thread_id)
+
+            # Initialize state
+            state = impl._get_or_create_state(issue_number)
+
+            branch_name = f"{issue_number}-auto-impl"
+
+            # In dry-run mode skip all real side-effects (worktree creation,
+            # Claude calls, PR creation).  This guard must come BEFORE
+            # create_worktree() so --dry-run never leaves real build/.worktrees/
+            # directories or branches behind (#371).
+            if self.options.dry_run:
+                impl._log(
+                    "info",
+                    f"[DRY RUN] Would create worktree, run {self.options.agent}, review, "
+                    f"create PR for #{issue_number}",
+                    thread_id,
+                )
+                return WorkerResult(
+                    issue_number=issue_number,
+                    success=True,
+                    branch_name=branch_name,
+                    worktree_path=None,
+                )
+
+            # Create worktree (only in non-dry-run mode)
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: Creating worktree"
+            )
+            worktree_path = self.worktree_manager.create_worktree(issue_number, branch_name)
+
+            with self.state_lock:
+                state.worktree_path = str(worktree_path)
+                state.branch_name = branch_name
+            impl._save_state(state)
+
+            # Check for existing plan
+            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Checking plan")
+            if not impl._has_plan(issue_number):
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: Generating plan"
+                )
+                impl._log("info", f"Issue #{issue_number} has no plan, generating...", thread_id)
+                with self.state_lock:
+                    state.phase = ImplementationPhase.PLANNING
+                impl._save_state(state)
+                impl._generate_plan(issue_number)
+
+            # Gate on APPROVED plan-review verdict (#551). The legacy
+            # ``_has_plan`` check above only verifies a plan comment EXISTS;
+            # it does not look at the plan-reviewer's verdict, so a BLOCK
+            # or REVISE plan (or a NOGO-exhausted plan that still starts
+            # with "# Implementation Plan", see planner.py:692-700) used to
+            # be implemented just like an APPROVED one. We now defer the
+            # issue when the latest plan-review is anything other than
+            # APPROVED, so the next loop's plan-review phase can re-evaluate
+            # after the planner amends.
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: Checking plan-review verdict"
+            )
+            if not self._impl_module.is_plan_review_approved(issue_number):
+                impl._log(
+                    "info",
+                    f"Issue #{issue_number}: latest plan-review verdict is not "
+                    f"APPROVED — deferring implementation until next loop",
+                    thread_id,
+                )
+                with self.state_lock:
+                    state.phase = ImplementationPhase.WAITING_FOR_PLAN_REVIEW
+                impl._save_state(state)
+                self.status_tracker.update_slot(
+                    slot_id,
+                    f"{issue_ref(issue_number)}: Waiting for APPROVED plan-review",
+                )
+                return WorkerResult(
+                    issue_number=issue_number,
+                    success=True,
+                    branch_name=branch_name,
+                    worktree_path=str(worktree_path),
+                    plan_review_not_approved=True,
+                )
+
+            # Fetch issue info for context
+            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Fetching issue")
+            with self.state_lock:
+                state.phase = ImplementationPhase.IMPLEMENTING
+            impl._save_state(state)
+
+            # Run the selected implementation agent
+            issue = self._impl_module.fetch_issue_info(issue_number)
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}"
+            )
+            session_id = impl._run_claude_code(
+                issue_number,
+                worktree_path,
+                get_implementation_prompt(
+                    issue_number=issue_number,
+                    issue_title=issue.title,
+                    issue_body=issue.body,
+                    branch_name=branch_name,
+                    worktree_path=str(worktree_path),
+                    repo_root=str(self.repo_root),
+                ),
+                slot_id=slot_id,
+            )
+            with self.state_lock:
+                state.session_id = session_id
+                state.session_agent = self.options.agent if session_id else None
+            impl._save_state(state)
+
+            # Strict review loop re-uses the selected agent session when a
+            # session id was captured. Reviewer calls are always fresh so
+            # their judgment is unbiased.
+            with self.state_lock:
+                state.phase = ImplementationPhase.REVIEWING
+            impl._save_state(state)
+            iterations, last_verdict, last_grade = impl._run_impl_review_loop(
+                issue_number=issue_number,
+                worktree_path=worktree_path,
+                branch_name=branch_name,
+                issue_title=issue.title,
+                issue_body=issue.body,
+                session_id=session_id,
+                slot_id=slot_id,
+                thread_id=thread_id,
+                state=state,
+            )
+            with self.state_lock:
+                state.review_iterations = iterations
+                state.last_review_verdict = last_verdict
+                state.last_review_grade = last_grade
+            impl._save_state(state)
+
+            # Verify commit, push, PR creation; then run /learn and follow-ups.
+            pr_number = impl._finalize_pr(issue_number, branch_name, worktree_path, state, slot_id)
+            impl._run_post_pr_followup(issue_number, worktree_path, state, slot_id)
+
+            impl._log("info", f"Issue #{issue_number} completed: PR {pr_ref(pr_number)}", thread_id)
+
+            return WorkerResult(
+                issue_number=issue_number,
+                success=True,
+                pr_number=pr_number,
+                branch_name=branch_name,
+                worktree_path=str(worktree_path),
+            )
+
+        except subprocess.TimeoutExpired as e:
+            error_msg = f"Timeout: {' '.join(e.cmd[:3])} exceeded {e.timeout}s"
+            impl._log("error", error_msg, thread_id)
+
+            # Show failure in UI before releasing slot
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
+            )
+
+            err_state = impl._get_state(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ImplementationPhase.FAILED
+                    err_state.error = error_msg
+                    err_state.attempts += 1
+                impl._save_state(err_state)
+
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error=error_msg,
+            )
+
+        except subprocess.CalledProcessError as e:
+            error_msg = f"Command failed (exit {e.returncode}): {' '.join(e.cmd[:3])}"
+            impl._log("error", error_msg, thread_id)
+            if e.stderr:
+                impl._log("error", f"stderr: {e.stderr[:300]}", thread_id)
+
+            # Show failure in UI before releasing slot
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
+            )
+
+            err_state = impl._get_state(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ImplementationPhase.FAILED
+                    err_state.error = str(e)
+                    err_state.attempts += 1
+                impl._save_state(err_state)
+
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error=str(e),
+            )
+
+        except RuntimeError as e:
+            impl._log("error", f"Runtime error: {e}", thread_id)
+
+            # Show failure in UI before releasing slot
+            error_msg = str(e)[:80]
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
+            )
+
+            err_state = impl._get_state(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ImplementationPhase.FAILED
+                    err_state.error = str(e)
+                    err_state.attempts += 1
+                impl._save_state(err_state)
+
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error=str(e),
+            )
+
+        except Exception as e:  # broad catch: top-level worker boundary, must not crash thread pool
+            impl._log("error", f"Unexpected {type(e).__name__}: {e}", thread_id)
+
+            # Show failure in UI before releasing slot
+            error_msg = str(e)[:80]
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: FAILED - {error_msg[:50]}"
+            )
+
+            err_state = impl._get_state(issue_number)
+            if err_state:
+                with self.state_lock:
+                    err_state.phase = ImplementationPhase.FAILED
+                    err_state.error = str(e)
+                    err_state.attempts += 1
+                impl._save_state(err_state)
+
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                error=str(e),
+            )
+        finally:
+            self.status_tracker.release_slot(slot_id)
+
+    # ------------------------------------------------------------------
+    # PR finalization + post-PR followup (extracted from _implement_issue
+    # for SRP; preserved here verbatim).
+    # ------------------------------------------------------------------
+
+    def _finalize_pr(
+        self,
+        issue_number: int,
+        branch_name: str,
+        worktree_path: Path,
+        state: ImplementationState,
+        slot_id: int | None,
+    ) -> int:
+        """Ensure commit is pushed and PR is created, then persist the PR number."""
+        impl = self.impl
+        with self.state_lock:
+            state.phase = ImplementationPhase.CREATING_PR
+        impl._save_state(state)
+
+        # A2-004: optional pre-PR test gate (opt-in via run_pre_pr_tests=True).
+        if self.options.run_pre_pr_tests:
+            if slot_id is not None:
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: Running pre-PR tests"
+                )
+            tests_passed = impl._run_tests_in_worktree(worktree_path, issue_number)
+            if not tests_passed:
+                logger.warning(
+                    "#%d: pre-PR tests failed; PR will still be created but "
+                    "manual review is required before merging",
+                    issue_number,
+                )
+
+        pr_number = impl._ensure_pr_created(issue_number, branch_name, worktree_path, slot_id)
+        with self.state_lock:
+            state.pr_number = pr_number
+        impl._save_state(state)
+        return pr_number
+
+    def _run_post_pr_followup(
+        self,
+        issue_number: int,
+        worktree_path: Path,
+        state: ImplementationState,
+        slot_id: int | None,
+    ) -> None:
+        """Run /learn and file follow-up issues after the PR is created."""
+        impl = self.impl
+        # Learn phase (after CREATING_PR, before COMPLETED)
+        can_resume_session = self._can_resume_state_session(state)
+        if self.options.enable_learn and can_resume_session and state.session_id:
+            if slot_id is not None:
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: Running learn"
+                )
+            with self.state_lock:
+                state.phase = ImplementationPhase.LEARN
+            impl._save_state(state)
+            retro_success = self._run_learn(
+                state.session_id,
+                worktree_path,
+                issue_number,
+                slot_id,
+                session_agent=state.session_agent,
+            )
+            with self.state_lock:
+                state.learn_completed = retro_success
+            impl._save_state(state)
+
+        # Follow-up issues phase (after LEARN, before COMPLETED)
+        if self.options.enable_follow_up and can_resume_session and state.session_id:
+            if slot_id is not None:
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: Identifying follow-ups"
+                )
+            with self.state_lock:
+                state.phase = ImplementationPhase.FOLLOW_UP_ISSUES
+            impl._save_state(state)
+            self._run_follow_up_issues(
+                state.session_id,
+                worktree_path,
+                issue_number,
+                slot_id,
+                session_agent=state.session_agent,
+            )
+
+        # Mark as completed
+        with self.state_lock:
+            state.phase = ImplementationPhase.COMPLETED
+            state.completed_at = datetime.now(timezone.utc)
+        impl._save_state(state)
+
+    # ------------------------------------------------------------------
+    # Plan-presence and plan-generation
+    # ------------------------------------------------------------------
+
+    def _has_plan(self, issue_number: int) -> bool:
+        """Check if issue has an implementation plan."""
+        try:
+            result = run(
+                ["gh", "issue", "view", str(issue_number), "--comments", "--json", "comments"],
+                capture_output=True,
+            )
+            data = json.loads(result.stdout)
+            comments = data.get("comments", [])
+
+            for comment in comments:
+                body = comment.get("body", "")
+                if "Implementation Plan" in body or "## Plan" in body:
+                    return True
+
+            return False
+        except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
+            return False
+
+    def _generate_plan(self, issue_number: int) -> None:
+        """Generate plan for an issue using hephaestus-plan-issues."""
+        import shutil
+
+        # Prefer the installed entry point (works in any repo)
+        entry_point = shutil.which("hephaestus-plan-issues")
+        if entry_point:
+            run(
+                [entry_point, "--issues", str(issue_number), "--agent", self.options.agent],
+                timeout=600,
+            )
+            return
+
+        # Fall back to python -m invocation (works when PYTHONPATH is set).
+        # On failure, fall through to the legacy scripts/plan_issues.py path.
+        with contextlib.suppress(subprocess.SubprocessError, OSError):
+            run(
+                [
+                    sys.executable,
+                    "-m",
+                    "hephaestus.automation.planner",
+                    "--issues",
+                    str(issue_number),
+                    "--agent",
+                    self.options.agent,
+                ],
+                timeout=600,
+            )
+            return
+
+        # Legacy fallback: local scripts/plan_issues.py (ProjectScylla layout)
+        plan_script = self.repo_root / "scripts" / "plan_issues.py"
+        if plan_script.exists():
+            run(
+                [sys.executable, str(plan_script), "--issues", str(issue_number)],
+                timeout=600,
+            )
+            return
+
+        raise RuntimeError(
+            "Could not find hephaestus-plan-issues entry point, "
+            "hephaestus.automation.planner module, or "
+            f"scripts/plan_issues.py in {self.repo_root}"
+        )
+
+    # ------------------------------------------------------------------
+    # Follow-up / learn helpers
+    # ------------------------------------------------------------------
+
+    def _parse_follow_up_items(self, text: str) -> list[dict[str, Any]]:
+        """Parse follow-up items from Claude's JSON response."""
+        return parse_follow_up_items(text)
+
+    def _can_resume_state_session(self, state: ImplementationState) -> bool:
+        """Return True when the saved session can be resumed by the selected agent."""
+        if not state.session_id:
+            return False
+        if session_agent_matches(state.session_agent, self.options.agent):
+            return True
+        logger.info(
+            "Skipping session resume for issue #%s: session belongs to %s, selected agent is %s",
+            state.issue_number,
+            state.session_agent or "claude",
+            self.options.agent,
+        )
+        return False
+
+    def _run_follow_up_issues(
+        self,
+        session_id: str,
+        worktree_path: Path,
+        issue_number: int,
+        slot_id: int | None = None,
+        *,
+        session_agent: str | None = None,
+    ) -> None:
+        """Resume the selected agent session to identify and file follow-up issues."""
+        run_follow_up_issues(
+            session_id,
+            worktree_path,
+            issue_number,
+            self.state_dir,
+            self.status_tracker,
+            slot_id,
+            dry_run=self.options.dry_run,
+            agent=self.options.agent,
+            session_agent=session_agent,
+        )
+
+    def _learn_needs_rerun(self, issue_number: int) -> bool:
+        """Check if learn log indicates failure."""
+        return learn_needs_rerun(issue_number, self.state_dir)
+
+    def _rerun_failed_learns(self) -> dict[int, bool]:
+        """Re-run failed learns for completed issues.
+
+        Returns:
+            Dictionary mapping issue number to success status
+
+        """
+        impl = self.impl
+        results: dict[int, bool] = {}
+
+        for issue_number, state in self.impl.state_mgr.states.items():
+            # Only re-run for completed issues with failed learns
+            if (
+                state.phase != ImplementationPhase.COMPLETED
+                or state.learn_completed
+                or not self._can_resume_state_session(state)
+            ):
+                continue
+
+            # Check if log indicates failure
+            if not impl._learn_needs_rerun(issue_number):
+                continue
+
+            # Verify worktree exists
+            if not state.worktree_path:
+                logger.warning("Skipping learn re-run for #%s: no worktree_path", issue_number)
+                continue
+
+            session_id = state.session_id
+            if session_id is None:
+                continue
+
+            worktree_path = Path(state.worktree_path)
+            if not worktree_path.exists():
+                logger.warning("Skipping learn re-run for #%s: worktree not found", issue_number)
+                continue
+
+            # Re-run learn
+            logger.info("Re-running failed learn for issue #%s", issue_number)
+            success = impl._run_learn(
+                session_id,
+                worktree_path,
+                issue_number,
+                slot_id=None,
+                session_agent=state.session_agent,
+            )
+
+            # Update and save state
+            with self.state_lock:
+                state.learn_completed = success
+            impl._save_state(state)
+
+            results[issue_number] = success
+
+        if results:
+            success_count = sum(1 for s in results.values() if s)
+            logger.info(
+                "Re-ran %s learn(s): %s succeeded, %s failed",
+                len(results),
+                success_count,
+                len(results) - success_count,
+            )
+
+        return results
+
+    def _run_learn(
+        self,
+        session_id: str,
+        worktree_path: Path,
+        issue_number: int,
+        slot_id: int | None = None,
+        *,
+        session_agent: str | None = None,
+    ) -> bool:
+        """Resume the selected agent session to run /learn."""
+        return run_learn(
+            session_id,
+            worktree_path,
+            issue_number,
+            self.state_dir,
+            slot_id,
+            agent=self.options.agent,
+            session_agent=session_agent,
+        )
+
+    # ------------------------------------------------------------------
+    # Strict review loop for implementer sessions
+    # ------------------------------------------------------------------
+
+    def _run_impl_review_loop(
+        self,
+        *,
+        issue_number: int,
+        worktree_path: Path,
+        branch_name: str,
+        issue_title: str,
+        issue_body: str,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        state: ImplementationState | None = None,
+    ) -> tuple[int, str | None, str | None]:
+        """Run the bounded review loop for an implementation."""
+        impl = self.impl
+        last_verdict: str | None = None
+        last_grade: str | None = None
+        prior_review: str | None = None
+        iterations_run = 0
+
+        for iteration in range(MAX_REVIEW_ITERATIONS):
+            # Iterations 1+ resume the impl session with the prior reviewer's
+            # critique, so the implementer can fix the flagged issues before
+            # the next review.
+            if iteration > 0:
+                if session_id is None:
+                    ref = issue_ref(issue_number)
+                    impl._log(
+                        "warning",
+                        f"{ref}: cannot iterate (no session_id from initial run); "
+                        "stopping review loop",
+                        thread_id,
+                    )
+                    break
+                if slot_id is not None:
+                    self.status_tracker.update_slot(
+                        slot_id, f"{issue_ref(issue_number)}: addressing review [R{iteration}]"
+                    )
+                resumed = impl._resume_impl_with_feedback(
+                    session_id=session_id,
+                    worktree_path=worktree_path,
+                    issue_number=issue_number,
+                    review_text=prior_review or "",
+                    prev_iteration=iteration - 1,
+                    verdict=last_verdict or "NOGO",
+                    state=state,
+                )
+                if not resumed:
+                    ref = issue_ref(issue_number)
+                    impl._log(
+                        "warning",
+                        f"{ref}: resume failed at R{iteration}; stopping review loop",
+                        thread_id,
+                    )
+                    break
+
+            # Compute the diff and changed-files list for the reviewer.
+            if slot_id is not None:
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: reviewing impl [R{iteration}]"
+                )
+            diff_text = impl._collect_diff(worktree_path, branch_name)
+            files_changed = impl._collect_changed_files(worktree_path, branch_name)
+
+            review_text = impl._run_impl_review(
+                issue_number=issue_number,
+                issue_title=issue_title,
+                issue_body=issue_body,
+                diff_text=diff_text,
+                files_changed=files_changed,
+                iteration=iteration,
+                prior_review=prior_review,
+            )
+            impl._save_review_log(issue_number, iteration, review_text)
+            iterations_run = iteration + 1
+
+            verdict = parse_review_verdict(review_text)
+            last_verdict = verdict.verdict
+            last_grade = verdict.grade
+            impl._log(
+                "info",
+                f"{issue_ref(issue_number)} R{iteration}: Verdict={verdict.verdict} "
+                f"Grade={verdict.grade or '?'}",
+                thread_id,
+            )
+
+            # A2-005: Persist review iteration progress so --resume can skip
+            # already-completed iterations.  Persist BEFORE breaking out so
+            # the final iteration's data is always on disk.
+            impl._save_review_iteration_state(issue_number, iterations_run, review_text)
+
+            if verdict.is_go:
+                ref = issue_ref(issue_number)
+                impl._log(
+                    "info",
+                    f"{ref}: GO on iteration {iteration} — review loop terminated",
+                    thread_id,
+                )
+                break
+
+            # Save this review for next iteration's context
+            prior_review = review_text
+
+        # A2-003: Surface AMBIGUOUS verdict distinctly so operators can triage
+        # without inspecting raw log files.
+        if last_verdict == "AMBIGUOUS" or (
+            iterations_run == MAX_REVIEW_ITERATIONS and last_verdict not in (None, "GO")
+        ):
+            logger.warning(
+                "#%d: review loop ended without clear GO — "
+                "final verdict=%r after %d iteration(s); "
+                "PR created but manual review is recommended",
+                issue_number,
+                last_verdict,
+                iterations_run,
+            )
+
+        return iterations_run, last_verdict, last_grade
+
+    def _resume_impl_with_feedback(
+        self,
+        *,
+        session_id: str,
+        worktree_path: Path,
+        issue_number: int,
+        review_text: str,
+        prev_iteration: int,
+        verdict: str,
+        state: ImplementationState | None = None,
+    ) -> bool:
+        """Resume the impl session and feed reviewer feedback as the next prompt."""
+        impl = self.impl
+        prompt = get_impl_resume_feedback_prompt(
+            issue_number=issue_number,
+            prev_iteration=prev_iteration,
+            verdict=verdict,
+            review_text=review_text,
+        )
+        if is_codex(self.options.agent):
+            try:
+                result = resume_codex_session(
+                    session_id,
+                    prompt,
+                    cwd=worktree_path,
+                    timeout=implementer_claude_timeout(),
+                )
+                log_file = (
+                    self.state_dir / f"codex-feedback-{issue_number}-r{prev_iteration + 1}.log"
+                )
+                log_file.write_text(result.stdout or "")
+                return True
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    "#%d: Codex failed to address R%d feedback (exit=%d): %s",
+                    issue_number,
+                    prev_iteration + 1,
+                    e.returncode,
+                    (e.stderr or e.stdout or "")[:500],
+                )
+                return False
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    "#%d: Codex timed out addressing R%d feedback",
+                    issue_number,
+                    prev_iteration + 1,
+                )
+                return False
+
+        # Route through the centralized helper so create/resume semantics and
+        # the SESSION_EXPIRED phrase list stay in one place. The deterministic
+        # UUID matches what the initial impl session was created with, so the
+        # passed-in ``session_id`` (legacy ``state.session_id``) is ignored on
+        # the Claude path — it's still consumed by the codex branch above.
+        # ``recreate_on_resume_failure=False`` propagates the underlying error
+        # so we can preserve the "stop iterating on expiry" contract.
+        _impl_mod = self._impl_module
+        githash = _impl_mod.current_trunk_githash(self.repo_root)
+        repo_slug = _impl_mod.get_repo_slug(self.repo_root)
+        try:
+            _impl_mod.invoke_claude_with_session(
+                repo=repo_slug,
+                issue=issue_number,
+                agent=_impl_mod.AGENT_IMPLEMENTER,
+                githash=githash,
+                prompt=prompt,
+                model=implementer_model(),
+                cwd=worktree_path,
+                timeout=implementer_claude_timeout(),
+                permission_mode="dontAsk",
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                recreate_on_resume_failure=False,
+            )
+            return True
+        except subprocess.CalledProcessError as e:
+            combined = ((e.stderr or "") + (e.stdout or "")).lower()
+            if any(phrase in combined for phrase in SESSION_EXPIRED_PHRASES):
+                # Session pruned — partial work may still be committable;
+                # don't treat this as an unrecoverable failure.
+                error_tag = f"session_expired:{session_id}"
+                logger.warning(
+                    "#%d: impl session %r expired before R%d; "
+                    "stopping review loop (partial work preserved)",
+                    issue_number,
+                    session_id,
+                    prev_iteration + 1,
+                )
+                if state is not None:
+                    with self.state_lock:
+                        state.error = error_tag
+                    impl._save_state(state)
+            else:
+                logger.error(
+                    "#%d: failed to resume impl session for R%d (exit=%d): %s",
+                    issue_number,
+                    prev_iteration + 1,
+                    e.returncode,
+                    (e.stderr or e.stdout or "")[:500],
+                )
+            return False
+        except Exception as e:  # broad: resume is best-effort, never crash the loop
+            logger.error(
+                "#%d: unexpected error resuming impl session for R%d: %s",
+                issue_number,
+                prev_iteration + 1,
+                e,
+            )
+            return False
+
+    def _run_impl_review(
+        self,
+        *,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        diff_text: str,
+        files_changed: str,
+        iteration: int,
+        prior_review: str | None,
+    ) -> str:
+        """Run a fresh-session reviewer against the current impl diff."""
+        prompt = get_impl_loop_review_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            diff_text=diff_text,
+            files_changed=files_changed,
+            iteration=iteration,
+            prior_review=prior_review,
+        )
+        try:
+            if is_codex(self.options.agent):
+                result = run_codex_text(
+                    prompt,
+                    cwd=self.repo_root,
+                    timeout=600,
+                    sandbox="read-only",
+                )
+                output = (result.stdout or "").strip()
+                if not output:
+                    raise RuntimeError("reviewer returned empty output")
+                return output
+
+            env = os.environ.copy()
+            env["CLAUDECODE"] = ""
+            result = subprocess.run(
+                [
+                    "claude",
+                    "--print",
+                    "--model",
+                    reviewer_model(),
+                    "--output-format",
+                    "text",
+                ],
+                input=prompt,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=600,
+                env=env,
+            )
+            output = (result.stdout or "").strip()
+            if not output:
+                raise RuntimeError("reviewer returned empty output")
+            return output
+        except Exception as e:
+            logger.error(
+                "#%s R%s: impl reviewer call failed: %s; treating as NOGO so the loop continues",
+                issue_number,
+                iteration,
+                e,
+            )
+            return (
+                f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
+                "Grade: F\nVerdict: NOGO\n"
+            )
+
+    def _collect_diff(self, worktree_path: Path, branch_name: str) -> str:
+        """Return the cumulative diff of *branch_name* against ``origin/main``."""
+        try:
+            result = run(
+                ["git", "diff", "origin/main...HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                check=False,
+                timeout=60,
+            )
+            diff = result.stdout or ""
+            if not diff.strip():
+                fb = run(
+                    ["git", "diff", "HEAD~1..HEAD"],
+                    cwd=worktree_path,
+                    capture_output=True,
+                    check=False,
+                    timeout=60,
+                )
+                diff = fb.stdout or ""
+        except Exception as e:
+            logger.warning("diff collection failed for %s: %s", branch_name, e)
+            return ""
+
+        max_chars = 200_000
+        if len(diff) > max_chars:
+            diff = diff[:max_chars] + f"\n\n[... diff truncated at {max_chars} chars ...]\n"
+        return diff
+
+    def _collect_changed_files(self, worktree_path: Path, branch_name: str) -> str:
+        """Return a newline-separated list of changed files vs ``origin/main``."""
+        try:
+            result = run(
+                ["git", "diff", "--name-only", "origin/main...HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+            files = (result.stdout or "").strip()
+            if files:
+                return files
+            fb = run(
+                ["git", "diff", "--name-only", "HEAD~1..HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                check=False,
+                timeout=30,
+            )
+            return (fb.stdout or "").strip()
+        except Exception as e:
+            logger.warning("changed-files collection failed for %s: %s", branch_name, e)
+            return ""
+
+    def _save_review_log(self, issue_number: int, iteration: int, review_text: str) -> None:
+        """Persist a per-iteration review log for later inspection."""
+        try:
+            log_file = self.state_dir / f"review-{issue_number}-r{iteration}.log"
+            log_file.write_text(review_text)
+        except Exception as e:
+            logger.warning("#%s: failed to save review log r%s: %s", issue_number, iteration, e)
+
+    def _save_review_iteration_state(
+        self, issue_number: int, iterations_run: int, prior_review: str
+    ) -> None:
+        """Persist review loop progress for ``--resume`` continuity (A2-005)."""
+        try:
+            iter_file = self.state_dir / f"review-iter-{issue_number}.json"
+            iter_file.write_text(json.dumps({"iterations_run": iterations_run}))
+        except Exception as e:
+            logger.warning("#%d: failed to persist review iteration count: %s", issue_number, e)
+        try:
+            prior_file = self.state_dir / f"review-prior-{issue_number}.txt"
+            prior_file.write_text(prior_review)
+        except Exception as e:
+            logger.warning("#%d: failed to persist prior review text: %s", issue_number, e)
+
+    def _load_review_iteration_state(self, issue_number: int) -> tuple[int, str | None]:
+        """Load persisted review iteration progress for ``--resume`` (A2-005)."""
+        iterations_run = 0
+        prior_review: str | None = None
+        try:
+            iter_file = self.state_dir / f"review-iter-{issue_number}.json"
+            if iter_file.exists():
+                data = json.loads(iter_file.read_text())
+                iterations_run = int(data.get("iterations_run", 0))
+        except Exception as e:
+            logger.warning(
+                "#%d: failed to load persisted review iteration count: %s", issue_number, e
+            )
+        try:
+            prior_file = self.state_dir / f"review-prior-{issue_number}.txt"
+            if prior_file.exists():
+                prior_review = prior_file.read_text()
+        except Exception as e:
+            logger.warning("#%d: failed to load persisted prior review text: %s", issue_number, e)
+        return iterations_run, prior_review
+
+    # ------------------------------------------------------------------
+    # Pre-PR test gate
+    # ------------------------------------------------------------------
+
+    def _run_tests_in_worktree(self, worktree_path: Path, issue_number: int) -> bool:
+        """Run the unit test suite inside the worktree as a pre-PR gate (A2-004)."""
+        try:
+            result = subprocess.run(
+                ["pixi", "run", "pytest", "tests/unit", "-q", "--tb=short"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            if result.returncode == 0:
+                logger.info("#%d: pre-PR tests passed", issue_number)
+                return True
+            logger.warning(
+                "#%d: pre-PR tests FAILED (exit %d):\n%s",
+                issue_number,
+                result.returncode,
+                (result.stdout + result.stderr)[-2000:],
+            )
+            return False
+        except subprocess.TimeoutExpired:
+            logger.warning("#%d: pre-PR tests timed out after 600s", issue_number)
+            return False
+        except Exception as e:
+            logger.warning("#%d: pre-PR tests could not run: %s", issue_number, e)
+            return False
+
+    # ------------------------------------------------------------------
+    # Agent invocation
+    # ------------------------------------------------------------------
+
+    def _run_claude_code(
+        self, issue_number: int, worktree_path: Path, prompt: str, slot_id: int | None = None
+    ) -> str | None:
+        """Run the selected implementation agent in a worktree."""
+        if self.options.dry_run:
+            logger.info("[DRY RUN] Would run %s for issue #%s", self.options.agent, issue_number)
+            return None
+
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+        if is_codex(self.options.agent):
+            return self.impl._run_codex_code(issue_number, worktree_path, prompt)
+
+        return self.impl._run_claude_impl_session(issue_number, worktree_path, prompt)
+
+    def _run_claude_impl_session(
+        self, issue_number: int, worktree_path: Path, prompt: str
+    ) -> str | None:
+        """Run Claude implementation prompt and return its session id."""
+        prompt_file = worktree_path / f".claude-prompt-{issue_number}.md"
+        prompt_file.write_text(prompt)
+
+        _impl_mod = self._impl_module
+        githash = _impl_mod.current_trunk_githash(self.repo_root)
+        repo_slug = _impl_mod.get_repo_slug(self.repo_root)
+
+        try:
+            stdout, _ = _impl_mod.invoke_claude_with_session(
+                repo=repo_slug,
+                issue=issue_number,
+                agent=_impl_mod.AGENT_IMPLEMENTER,
+                githash=githash,
+                prompt=prompt,
+                model=implementer_model(),
+                cwd=worktree_path,
+                timeout=implementer_claude_timeout(),
+                output_format="json",
+                permission_mode="dontAsk",
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+            )
+            result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+            # Parse session_id from JSON output
+            try:
+                data = json.loads(result.stdout)
+
+                # The CLI sometimes returns exit 0 with ``is_error: true`` in
+                # JSON (e.g. usage caps in some channels). Treat that as a
+                # failure so the orchestrator can wait/retry instead of
+                # silently logging a useless session_id.
+                if isinstance(data, dict) and data.get("is_error"):
+                    err_text = str(data.get("result") or "")
+                    log_file = self.state_dir / f"claude-{issue_number}.log"
+                    log_file.write_text(result.stdout or "")
+                    reset_epoch = _claude_quota_reset_epoch(err_text)
+                    if reset_epoch is not None and reset_epoch > 0:
+                        logger.warning(
+                            "Claude usage cap hit for issue #%s; waiting for reset", issue_number
+                        )
+                        wait_until(reset_epoch)
+                    raise RuntimeError(f"Claude Code failed: {err_text or 'is_error=true'}")
+
+                session_id = data.get("session_id")
+
+                # Save successful output to log file
+                log_file = self.state_dir / f"claude-{issue_number}.log"
+                log_file.write_text(result.stdout or "")
+
+                return cast(str | None, session_id)
+            except (json.JSONDecodeError, AttributeError):
+                logger.warning("Could not parse session_id for issue #%s", issue_number)
+                logger.debug("Claude stdout: %s", result.stdout[:500])
+
+                # Save output even if JSON parsing failed
+                log_file = self.state_dir / f"claude-{issue_number}.log"
+                log_file.write_text(result.stdout or "")
+
+                return None
+        except subprocess.CalledProcessError as e:
+            logger.error("Claude Code failed for issue #%s", issue_number)
+            logger.error("Exit code: %s", e.returncode)
+            if e.stdout:
+                logger.error("Stdout: %s", e.stdout[:1000])
+            if e.stderr:
+                logger.error("Stderr: %s", e.stderr[:1000])
+
+            # Save failure output to log file
+            log_file = self.state_dir / f"claude-{issue_number}.log"
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+            output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+            log_file.write_text(output)
+
+            # If the failure was a quota cap, block until reset rather than
+            # letting the orchestrator burn through every remaining issue in
+            # seconds. The Claude CLI puts its 429 message in stdout JSON.
+            reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
+            if reset_epoch is not None and reset_epoch > 0:
+                logger.warning(
+                    "Claude usage cap hit for issue #%s; waiting for reset", issue_number
+                )
+                wait_until(reset_epoch)
+
+            raise RuntimeError(f"Claude Code failed: {e.stderr or e.stdout}") from e
+        except subprocess.TimeoutExpired as e:
+            # Save timeout info to log file
+            log_file = self.state_dir / f"claude-{issue_number}.log"
+            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+
+            raise RuntimeError("Claude Code timed out") from e
+        finally:
+            # Clean up temp file
+            with contextlib.suppress(Exception):
+                prompt_file.unlink()
+
+    def _run_codex_code(self, issue_number: int, worktree_path: Path, prompt: str) -> str | None:
+        """Run Codex implementation prompt in a worktree."""
+        log_file = self.state_dir / f"codex-{issue_number}.log"
+        try:
+            result = run_codex_session(
+                prompt,
+                cwd=worktree_path,
+                timeout=implementer_claude_timeout(),
+                sandbox="workspace-write",
+            )
+            log_file.write_text(result.stdout or "")
+            return result.session_id
+        except subprocess.CalledProcessError as e:
+            stdout = e.stdout or ""
+            stderr = e.stderr or ""
+            output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+            log_file.write_text(output)
+            reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
+            if reset_epoch is not None and reset_epoch > 0:
+                logger.warning("Codex usage cap hit for issue #%s; waiting for reset", issue_number)
+                wait_until(reset_epoch)
+            raise RuntimeError(f"Codex failed: {stderr or stdout}") from e
+        except subprocess.TimeoutExpired as e:
+            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+            raise RuntimeError("Codex timed out") from e
+
+    # ------------------------------------------------------------------
+    # PR creation (thin wrappers preserved for back-compat)
+    # ------------------------------------------------------------------
+
+    def _ensure_pr_created(
+        self,
+        issue_number: int,
+        branch_name: str,
+        worktree_path: Path,
+        slot_id: int | None = None,
+    ) -> int:
+        """Ensure commit is pushed and PR is created (fallback if Claude didn't do it)."""
+        return ensure_pr_created(
+            issue_number,
+            branch_name,
+            worktree_path,
+            self.options.auto_merge,
+            self.status_tracker,
+            slot_id,
+        )

--- a/hephaestus/automation/implementer_state.py
+++ b/hephaestus/automation/implementer_state.py
@@ -1,0 +1,97 @@
+"""Per-issue implementation state persistence.
+
+Owns the ``states`` dict, the lock guarding it, and the on-disk
+``issue-<n>.json`` files under ``state_dir``. Extracted from
+:mod:`hephaestus.automation.implementer` as part of the #597 decomposition.
+
+The class deliberately mirrors the inline methods that lived on
+``IssueImplementer`` (``_get_or_create_state``, ``_get_state``,
+``_save_state``, ``_load_state``) so the coordinator can delegate
+without changing call sites.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from pathlib import Path
+
+from .models import ImplementationState
+
+logger = logging.getLogger(__name__)
+
+
+class ImplementationStateManager:
+    """Manages per-issue ``ImplementationState`` with thread-safe access.
+
+    The manager keeps an in-memory dict keyed by issue number and persists
+    each state object to ``<state_dir>/issue-<n>.json`` via the secure
+    atomic-write helper used by the rest of the automation pipeline.
+
+    Attributes:
+        state_dir: Directory holding the on-disk state files.
+        states: In-memory state dict (issue number -> state).
+
+    """
+
+    def __init__(self, state_dir: Path) -> None:
+        """Initialize the manager.
+
+        Args:
+            state_dir: Directory to read/write issue-*.json files. The
+                directory is NOT created here — callers (i.e. the
+                coordinator) are responsible for ``mkdir(parents=True,
+                exist_ok=True)`` so the state file paths remain identical
+                to the pre-refactor layout.
+
+        """
+        self.state_dir = state_dir
+        self.states: dict[int, ImplementationState] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def lock(self) -> threading.Lock:
+        """Expose the internal lock so callers needing compound updates can use it.
+
+        Mirrors the legacy ``IssueImplementer.state_lock`` attribute so
+        in-class call sites that wrap ``state.foo = bar`` in
+        ``with self.state_lock:`` keep working verbatim.
+        """
+        return self._lock
+
+    def get_or_create(self, issue_number: int) -> ImplementationState:
+        """Return the state for *issue_number*, creating a new one if absent."""
+        with self._lock:
+            if issue_number not in self.states:
+                self.states[issue_number] = ImplementationState(issue_number=issue_number)
+            return self.states[issue_number]
+
+    def get(self, issue_number: int) -> ImplementationState | None:
+        """Return the state for *issue_number*, or ``None`` if not yet created."""
+        with self._lock:
+            return self.states.get(issue_number)
+
+    def save(self, state: ImplementationState) -> None:
+        """Atomically persist *state* to ``issue-<n>.json`` under ``state_dir``."""
+        # Imported lazily to avoid widening the module import graph at load.
+        from .github_api import write_secure
+
+        state_file = self.state_dir / f"issue-{state.issue_number}.json"
+        write_secure(state_file, state.model_dump_json(indent=2))
+
+    def load_all(self) -> None:
+        """Load every ``issue-*.json`` file under ``state_dir`` into memory.
+
+        Per-file decode failures are logged and skipped so a single corrupt
+        state file cannot prevent the rest of the automation from resuming.
+        """
+        for state_file in self.state_dir.glob("issue-*.json"):
+            try:
+                with open(state_file) as f:
+                    state = ImplementationState.model_validate_json(f.read())
+                    with self._lock:
+                        self.states[state.issue_number] = state
+                logger.info("Loaded state for issue #%s", state.issue_number)
+            except (json.JSONDecodeError, ValueError, OSError) as e:
+                logger.error("Failed to load state from %s: %s", state_file, e)

--- a/hephaestus/automation/implementer_summary.py
+++ b/hephaestus/automation/implementer_summary.py
@@ -1,0 +1,85 @@
+"""End-of-run summary printer for :mod:`hephaestus.automation.implementer`.
+
+Extracted from :class:`IssueImplementer` as part of the #597 decomposition.
+The printer owns the "render final results to ``logger.info``" concern and
+nothing else — it does not consult the state manager, mutate any state, or
+touch the filesystem.
+
+The printer reads the list of *preserved* worktrees off the
+``WorktreeManager`` it is constructed with, which mirrors the legacy
+inline behavior exactly.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from .models import WorkerResult
+from .worktree_manager import WorktreeManager
+
+logger = logging.getLogger(__name__)
+
+
+class ImplementationSummaryPrinter:
+    """Render the end-of-run summary to ``logger.info``.
+
+    Attributes:
+        worktree_manager: Source of preserved-worktree entries. Held by
+            reference so the summary sees the same list the orchestrator
+            populated during the run.
+
+    """
+
+    def __init__(self, worktree_manager: WorktreeManager) -> None:
+        """Initialize the printer.
+
+        Args:
+            worktree_manager: Worktree manager whose ``preserved`` list will
+                be appended to the summary footer.
+
+        """
+        self.worktree_manager = worktree_manager
+
+    def print(self, results: dict[int, WorkerResult]) -> None:
+        """Print the implementation summary for *results*."""
+        total = len(results)
+        deferred = sum(1 for r in results.values() if r.plan_review_not_approved)
+        successful = sum(
+            1 for r in results.values() if r.success and not r.plan_review_not_approved
+        )
+        failed = total - successful - deferred
+
+        logger.info("=" * 60)
+        logger.info("Implementation Summary")
+        logger.info("=" * 60)
+        logger.info("Total issues: %s", total)
+        logger.info("Successful: %s", successful)
+        logger.info("Deferred (awaiting APPROVED plan-review): %s", deferred)
+        logger.info("Failed: %s", failed)
+
+        if successful > 0:
+            logger.info("\nSuccessful PRs:")
+            for issue_num, result in results.items():
+                if result.success and result.pr_number:
+                    logger.info("  #%s: PR #%s", issue_num, result.pr_number)
+
+        if failed > 0:
+            logger.info("\nFailed issues:")
+            for issue_num, result in results.items():
+                if not result.success:
+                    logger.info("  #%s: %s", issue_num, result.error)
+
+        preserved = self.worktree_manager.preserved
+        if preserved:
+            issue_nums = [n for n, _ in preserved]
+            script = sys.argv[0]
+            issues_arg = " ".join(str(n) for n in issue_nums)
+            logger.info("\nPreserved worktrees (contain uncommitted changes):")
+            for issue_num, path in preserved:
+                logger.info("  #%s: %s", issue_num, path)
+            logger.info("\nRerun these issues after inspecting/cleaning the worktrees:")
+            logger.info("  %s --issues %s --resume", script, issues_arg)
+            logger.info("To discard them instead:")
+            for _, path in preserved:
+                logger.info("  git worktree remove --force %s", path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,8 @@ omit = [
     # Full orchestration loops require a live claude/gh CLI — integration test territory.
     # Pure-function helpers in these modules are tested in tests/unit/automation/ instead.
     "hephaestus/automation/implementer.py",
+    "hephaestus/automation/implementer_phase_runner.py",
+    "hephaestus/automation/implementer_summary.py",
     "hephaestus/automation/planner.py",
     "hephaestus/automation/address_review.py",
     "hephaestus/automation/ci_driver.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ omit = [
     "hephaestus/automation/planner.py",
     "hephaestus/automation/address_review.py",
     "hephaestus/automation/ci_driver.py",
+    "hephaestus/automation/loop_runner.py",
     # curses_ui.py uses a live terminal; cannot be unit-tested without a real TTY
     "hephaestus/automation/curses_ui.py",
     # github_api.py shells out to gh CLI for every call; fully integration-only

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -1,0 +1,93 @@
+"""Smoke tests for ``IssueImplementer.run()`` and ``implementer.main()``.
+
+These tests pin the current behavior of the top-level entry points so that
+the upcoming class split (state manager / summary printer / phase runner)
+can be verified as a pure move-and-delegate. Three paths are covered:
+
+1. ``main()`` with no discoverable issues returns 0 without raising.
+2. ``main(--health-check)`` returns 0 (health check is best-effort and
+   never marks the run as failed in current code).
+3. ``--no-ui`` causes ``CursesUI`` to never be instantiated.
+
+Tests intentionally exercise the real ``ImplementerOptions``/``IssueImplementer``
+plumbing (no patching of the class under test) so they catch any behavioral
+regression introduced by the refactor.
+
+See #597.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def test_main_returns_zero_when_no_open_issues(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Auto-discovery path with zero open issues must exit 0, not crash.
+
+    Mirrors the #574 short-circuit: when ``gh_list_open_issues()`` returns
+    ``[]``, ``IssueImplementer.run()`` returns ``{}`` and ``main()`` reports
+    success.
+    """
+    from hephaestus.automation import implementer
+
+    monkeypatch.setattr(sys, "argv", ["impl", "--dry-run", "--no-ui"])
+
+    with (
+        patch.object(implementer, "gh_list_open_issues", return_value=[]),
+        patch.object(implementer, "get_repo_root", return_value=tmp_path),
+    ):
+        rc = implementer.main()
+
+    assert rc == 0
+
+
+def test_main_health_check_returns_zero(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``--health-check`` must exit 0 even if individual probes log errors.
+
+    Current ``_health_check()`` logs subprocess failures but always returns
+    an empty results dict, and ``main()`` skips the failure-detection branch
+    for health-check mode — so the documented exit code is 0.
+    """
+    from hephaestus.automation import implementer
+
+    monkeypatch.setattr(sys, "argv", ["impl", "--health-check", "--no-ui"])
+
+    with patch.object(implementer, "get_repo_root", return_value=tmp_path):
+        rc = implementer.main()
+
+    assert rc == 0
+
+
+def test_no_ui_flag_skips_curses(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``--no-ui`` must prevent ``CursesUI`` from ever being instantiated.
+
+    The curses UI is only constructed inside ``run()`` when
+    ``options.enable_ui`` is True; ``--no-ui`` flips that flag off in
+    ``main()``. We assert the class constructor is never reached.
+    """
+    from hephaestus.automation import implementer
+
+    monkeypatch.setattr(sys, "argv", ["impl", "--dry-run", "--no-ui"])
+
+    with (
+        patch.object(implementer, "gh_list_open_issues", return_value=[]),
+        patch.object(implementer, "get_repo_root", return_value=tmp_path),
+        patch.object(implementer, "CursesUI") as mock_curses,
+    ):
+        rc = implementer.main()
+
+    assert rc == 0
+    mock_curses.assert_not_called()

--- a/tests/unit/automation/test_phase_agent_wiring.py
+++ b/tests/unit/automation/test_phase_agent_wiring.py
@@ -31,10 +31,20 @@ AUTOMATION_DIR = Path(automation_pkg.__file__).parent
 
 
 # Self-agent phases: module owns a unique session identity.
-SELF_AGENT_PHASES: list[tuple[str, str]] = [
-    ("plan_reviewer.py", "AGENT_PLAN_REVIEWER"),
-    ("pr_reviewer.py", "AGENT_PR_REVIEWER"),
-    ("implementer.py", "AGENT_IMPLEMENTER"),
+#
+# Each entry is ``(module_file, expected_agent_constant, companion_files)``,
+# where ``companion_files`` is an optional tuple of sibling modules that
+# share the same self-agent identity. For ``implementer.py`` the
+# per-issue phase runner was extracted into ``implementer_phase_runner.py``
+# in #597 — both files participate in the implementer's session and must
+# be inspected together. ``invoke_claude_with_session`` is called inside
+# the runner; the ``AGENT_IMPLEMENTER`` constant is referenced through
+# the implementer module's namespace (``_impl_mod.AGENT_IMPLEMENTER``)
+# so test patches at ``implementer.AGENT_IMPLEMENTER`` still take effect.
+SELF_AGENT_PHASES: list[tuple[str, str, tuple[str, ...]]] = [
+    ("plan_reviewer.py", "AGENT_PLAN_REVIEWER", ()),
+    ("pr_reviewer.py", "AGENT_PR_REVIEWER", ()),
+    ("implementer.py", "AGENT_IMPLEMENTER", ("implementer_phase_runner.py",)),
 ]
 
 
@@ -46,36 +56,63 @@ CONTINUATION_PHASES: list[str] = [
 ]
 
 
-@pytest.mark.parametrize("module_file, expected_agent", SELF_AGENT_PHASES)
-def test_self_agent_phase_imports_expected_agent(module_file: str, expected_agent: str) -> None:
-    """Each self-agent phase imports its dedicated AGENT_* constant."""
-    src = (AUTOMATION_DIR / module_file).read_text()
+def _read_phase_sources(module_file: str, companions: tuple[str, ...]) -> str:
+    """Return the concatenated source of *module_file* and any companions."""
+    parts = [(AUTOMATION_DIR / module_file).read_text()]
+    parts.extend((AUTOMATION_DIR / c).read_text() for c in companions)
+    return "\n".join(parts)
+
+
+@pytest.mark.parametrize("module_file, expected_agent, companions", SELF_AGENT_PHASES)
+def test_self_agent_phase_imports_expected_agent(
+    module_file: str, expected_agent: str, companions: tuple[str, ...]
+) -> None:
+    """Each self-agent phase imports its dedicated AGENT_* constant.
+
+    Imports may live in ``module_file`` itself or in any of its
+    ``companions`` (e.g. ``implementer_phase_runner.py`` was extracted from
+    ``implementer.py`` in #597 but still participates in the implementer's
+    session identity).
+    """
+    src = _read_phase_sources(module_file, companions)
     import_pattern = re.compile(rf"from\s+\.session_naming\s+import\s+[^\n]*\b{expected_agent}\b")
     assert import_pattern.search(src), (
-        f"{module_file} must import {expected_agent} from .session_naming"
+        f"{module_file} (and companions {companions}) must import {expected_agent} "
+        f"from .session_naming"
     )
 
 
-@pytest.mark.parametrize("module_file, expected_agent", SELF_AGENT_PHASES)
+@pytest.mark.parametrize("module_file, expected_agent, companions", SELF_AGENT_PHASES)
 def test_self_agent_phase_passes_expected_agent_kwarg(
-    module_file: str, expected_agent: str
+    module_file: str, expected_agent: str, companions: tuple[str, ...]
 ) -> None:
-    """Each self-agent phase passes its AGENT_* constant via ``agent=``."""
-    src = (AUTOMATION_DIR / module_file).read_text()
-    kwarg_pattern = re.compile(rf"\bagent\s*=\s*{expected_agent}\b")
+    """Each self-agent phase passes its AGENT_* constant via ``agent=``.
+
+    The implementer module dispatches the actual call through
+    ``implementer_phase_runner`` and references the constant as
+    ``_impl_mod.AGENT_IMPLEMENTER`` so test patches at
+    ``hephaestus.automation.implementer.AGENT_IMPLEMENTER`` continue to
+    work. The pattern below accepts both the bare ``AGENT_IMPLEMENTER``
+    form and the namespaced ``X.AGENT_IMPLEMENTER`` form.
+    """
+    src = _read_phase_sources(module_file, companions)
+    kwarg_pattern = re.compile(rf"\bagent\s*=\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)?{expected_agent}\b")
     assert kwarg_pattern.search(src), (
-        f"{module_file} must pass agent={expected_agent} to invoke_claude_with_session"
+        f"{module_file} (and companions {companions}) must pass agent={expected_agent} "
+        "to invoke_claude_with_session"
     )
 
 
-@pytest.mark.parametrize("module_file, expected_agent", SELF_AGENT_PHASES)
-def test_self_agent_phase_does_not_use_foreign_agent(module_file: str, expected_agent: str) -> None:
+@pytest.mark.parametrize("module_file, expected_agent, companions", SELF_AGENT_PHASES)
+def test_self_agent_phase_does_not_use_foreign_agent(
+    module_file: str, expected_agent: str, companions: tuple[str, ...]
+) -> None:
     """A self-agent phase must not pass any other AGENT_* constant."""
-    src = (AUTOMATION_DIR / module_file).read_text()
-    found = set(re.findall(r"\bagent\s*=\s*(AGENT_[A-Z_]+)\b", src))
+    src = _read_phase_sources(module_file, companions)
+    found = set(re.findall(r"\bagent\s*=\s*(?:[A-Za-z_][A-Za-z0-9_]*\.)?(AGENT_[A-Z_]+)\b", src))
     assert found <= {expected_agent}, (
-        f"{module_file} uses unexpected AGENT_* constants: "
-        f"{found - {expected_agent}}; expected only {expected_agent}"
+        f"{module_file} (and companions {companions}) uses unexpected AGENT_* "
+        f"constants: {found - {expected_agent}}; expected only {expected_agent}"
     )
 
 


### PR DESCRIPTION
## Summary

Decomposes the 1,974-LOC `IssueImplementer` (audit finding: mixed state persistence, worktree management, curses UI, CLI parsing, and per-phase orchestration in a single class) into a thin coordinator plus three focused collaborators:

- `ImplementationStateManager` (new `hephaestus/automation/implementer_state.py`) -- owns the per-issue `states` dict + lock + save/load.
- `ImplementationSummaryPrinter` (new `hephaestus/automation/implementer_summary.py`) -- owns the end-of-run summary rendering.
- `ImplementationPhaseRunner` (new `hephaestus/automation/implementer_phase_runner.py`) -- owns the per-issue 6-phase pipeline (plan -> impl -> review-loop -> test -> PR -> follow-up -> learn) and 20+ phase helpers.

`IssueImplementer` is now a thin coordinator holding `__init__`, `run`, `_log`, `_load_issues`, `_health_check`, `_analyze_dependencies`, `_implement_all`, and one-line delegations.

## Behavior

No behavior change. This is a move-and-delegate refactor: identical exit codes, identical stdout/stderr, identical state file paths. Pre-refactor smoke tests on `main()` are committed first (commit 1) so the extraction commits prove they preserve behavior.

The phase runner keeps a back-reference to the parent `IssueImplementer` so cross-method dispatch (`_has_plan`, `_save_state`, `_run_claude_code`, etc.) flows back through the coordinator's thin shims. This preserves the existing test-patch contract -- `patch.object(impl, "_has_plan", ...)` continues to intercept every call site, including the ones inside `_implement_issue` that were moved.

Patchable module-level symbols (`is_plan_review_approved`, `fetch_issue_info`, `invoke_claude_with_session`, `get_repo_slug`, `current_trunk_githash`, `AGENT_IMPLEMENTER`) are re-exported by `implementer.py` and looked up via the runner's `_impl_module` helper, so existing `patch("hephaestus.automation.implementer.X")` test idioms work unchanged.

## LOC delta

| File | Before | After |
| --- | --- | --- |
| `hephaestus/automation/implementer.py` | 1,974 | 883 |

Net 55% reduction on the coordinator. The originally-targeted 500 LOC was not achievable while preserving "pure move-and-delegate" semantics -- the per-issue helpers (`_run_impl_review_loop`, `_resume_impl_with_feedback`, `_run_impl_review`, etc.) are called directly by tests on the `IssueImplementer` instance, so each keeps an instance-level delegation shim. Removing them would require modifying ~30 test call sites, which the plan explicitly disallows.

## Verification

- `pixi run pytest tests/unit --no-cov` -- 2418 passed, 11 skipped.
- `pixi run ruff check hephaestus/ tests/` -- clean.
- `pixi run mypy` -- Success: no issues found in 255 source files.

## Commits

1. `test(automation): add IssueImplementer.run() smoke tests` -- three smoke tests pinning `main()` behavior so the extraction can be proved move-only.
2. `refactor(automation): extract ImplementationStateManager from implementer`
3. `refactor(automation): extract ImplementationSummaryPrinter`
4. `refactor(automation): extract ImplementationPhaseRunner` (the big one)
5. `refactor(automation): tidy IssueImplementer noqa after extraction`

Closes #597