### PR TITLE
fix(ci): editable-install hephaestus in release test job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pixi-
 
+      - name: Editable install (scripts/ smoke tests spawn subprocesses that import hephaestus)
+        run: pixi run dev-install
+
       - name: Run tests
         run: pixi run pytest tests/unit
 


### PR DESCRIPTION
## Summary
- The `release.yml` `test` job ran `pixi run pytest tests/unit` with no editable install of `hephaestus`.
- `tests/unit/scripts/test_scripts_smoke.py::test_script_help_exits_zero` spawns subprocesses (`python scripts/<name>.py --help`) that `from hephaestus... import main`. Subprocesses don't inherit pytest's `pythonpath = [".", "scripts"]`, so all 15 `--help` tests failed with `ModuleNotFoundError: No module named 'hephaestus'`, blocking the v0.9.1 release.
- Fix: add `pixi run dev-install` before "Run tests" in the release `test` job, mirroring `pre-commit.yml`. `hephaestus` is intentionally not a pixi dep (#456); `dev-install` is the sanctioned editable-install task.

PR CI (`test.yml`) already passes because it runs `pip install -e ".[dev]"` first — this aligns the release workflow with it.

Closes #611

## Test plan
- [ ] `test.yml` stays green on this PR
- [ ] After merge, re-run release for v0.9.1; confirm release `test` + `type-check` green, PyPI publish succeeds, dist/* attached to the GitHub release