### PR TITLE
feat(resilience): wrap _gh_call in CircuitBreaker + propagate correlation_id

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -74,6 +74,12 @@ def run_claude_text(
 
     env = os.environ.copy()
     env["CLAUDECODE"] = ""
+    # Propagate correlation ID to subprocess if set (for gh tracing).
+    from hephaestus.logging.utils import get_current_correlation_id
+
+    cid = get_current_correlation_id()
+    if cid:
+        env["GH_TRACE_ID"] = cid
     return subprocess.run(
         cmd,
         input=prompt,

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -151,6 +151,12 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
         # CLAUDECODE is set by an outer Claude Code process to refuse nested
         # invocations; clear it so the automation subprocess can launch.
         env["CLAUDECODE"] = ""
+        # Propagate correlation ID to subprocess if set (for gh tracing).
+        from hephaestus.logging.utils import get_current_correlation_id
+
+        cid = get_current_correlation_id()
+        if cid:
+            env["GH_TRACE_ID"] = cid
         cmd = _build(create)
         logger.debug(
             "claude invoke: agent=%s issue=%s sid=%s mode=%s",

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -25,6 +25,7 @@ def run(
     check: bool = True,
     timeout: int | None = None,
     log_errors: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run a subprocess command with consistent error handling.
 
@@ -36,6 +37,8 @@ def run(
         timeout: Optional timeout in seconds
         log_errors: If False, suppress ERROR logging on failure. Use when
             the caller expects and handles the failure itself.
+        env: Optional environment dict to pass to subprocess.run().
+            If provided, replaces the current process environment.
 
     Returns:
         CompletedProcess instance
@@ -52,6 +55,7 @@ def run(
         timeout=timeout,
         check=check,
         log_on_error=log_errors,
+        env=env,
     )
 
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -30,7 +30,7 @@ from hephaestus.github.rate_limit import (
     wait_until,
 )
 from hephaestus.io.utils import write_secure as io_write_secure
-from hephaestus.resilience import resilient_call
+from hephaestus.resilience.circuit_breaker import CircuitBreakerOpenError, get_circuit_breaker
 
 from .claude_timeouts import gh_cli_timeout
 from .git_utils import get_repo_info, run
@@ -47,6 +47,18 @@ _label_cache: set[str] | None = None
 # secondary rate limits stay quiet during phase bursts (e.g. a planner
 # fetching N issue bodies back-to-back).
 _GH_THROTTLE = threading.local()
+
+# Circuit breaker for gh API calls. When a sustained GitHub outage occurs
+# (5+ consecutive failures), the breaker opens and subsequent calls fail fast
+# with GitHubUnavailableError instead of exhausting retry budgets at each
+# call site. half_open_max_calls=2 (not the default 1) allows a pair of
+# recovery attempts before fully closing.
+_GH_BREAKER = get_circuit_breaker(
+    "github-api",
+    failure_threshold=5,
+    recovery_timeout=60,
+    half_open_max_calls=2,
+)
 
 
 def _gh_throttle_wait() -> None:
@@ -115,16 +127,17 @@ class ClaudeUsageCapError(RuntimeError):
         self.reset_epoch: int | None = reset_epoch
 
 
-class _NonTransientGhError(Exception):
-    """Wraps a CalledProcessError that must NOT be retried by resilient_call.
+class GitHubUnavailableError(RuntimeError):
+    """Raised when the GitHub API is unavailable due to a circuit breaker opening.
 
-    Carries the original CalledProcessError as ``__cause__`` so the outer
-    _gh_call layer can re-raise the original error and preserve subprocess
-    semantics for callers that ``except subprocess.CalledProcessError``.
+    Subclasses :class:`RuntimeError` so that existing ``except RuntimeError``
+    handlers continue to catch it. Represents a condition where repeated failures
+    have caused the circuit breaker to open, indicating sustained GitHub API
+    unavailability.
+
     """
 
-
-_GH_CB_NAME = "gh_cli"
+    pass
 
 
 def gh_list_labels(refresh: bool = False) -> set[str]:
@@ -279,79 +292,19 @@ def _log_token_scope_remediation(args: list[str], stderr: str) -> None:
     )
 
 
-def _gh_invoke_once(
-    args: list[str],
-    *,
-    check: bool = True,
-) -> subprocess.CompletedProcess[str]:
-    """Single gh invocation with error classification.
-
-    Pre-classifies errors before returning to resilient_call so that
-    non-transient failures are wrapped in _NonTransientGhError (which is
-    not in TRANSIENT_SUBPROCESS_ERRORS) and bypass the retry loop.
-
-    Args:
-        args: Arguments to pass to gh
-        check: Whether to raise on non-zero exit
-
-    Returns:
-        CompletedProcess instance
-
-    Raises:
-        subprocess.CalledProcessError: transient failures (retried by resilient_call)
-        _NonTransientGhError: non-transient failures (NOT retried)
-        GitHubRateLimitError: rate-limit hit (NOT retried by resilient_call)
-        ClaudeUsageCapError: Claude usage cap (NOT retried)
-
-    """
-    gh_global_throttle_acquire()
-    _gh_throttle_wait()
-    try:
-        return run(
-            ["gh", *args],
-            check=check,
-            capture_output=True,
-            timeout=gh_cli_timeout(),
-        )
-    except subprocess.CalledProcessError as e:
-        stderr = e.stderr if e.stderr else ""
-
-        _raise_if_claude_usage(stderr, e)
-
-        reset_epoch = _extract_reset_epoch(e)
-        if reset_epoch is not None:
-            raise GitHubRateLimitError(
-                f"GitHub API rate limit reached. Reset at epoch {reset_epoch}",
-                reset_epoch=reset_epoch,
-            ) from e
-
-        if _is_non_transient_error(stderr):
-            if _is_token_scope_error(stderr):
-                _log_token_scope_remediation(args, stderr)
-            logger.error("Non-transient error detected: %s", stderr[:200])
-            raise _NonTransientGhError(str(e)) from e
-
-        raise
-
-
-def _gh_call(
+def _gh_call_impl(
     args: list[str],
     check: bool = True,
     retry_on_rate_limit: bool = True,
     max_retries: int = 6,
 ) -> subprocess.CompletedProcess[str]:
-    """Call gh CLI with rate limit handling and resilient retries.
-
-    Combines resilient_call (for transient retries with jitter and circuit breaker)
-    with an outer loop for rate-limit waits. Non-transient errors are caught by
-    _gh_invoke_once and wrapped in _NonTransientGhError so resilient_call does
-    not retry them.
+    """Implement gh CLI call with rate limit handling (circuit breaker will wrap this).
 
     Args:
         args: Arguments to pass to gh
         check: Whether to raise on non-zero exit
         retry_on_rate_limit: Whether to retry on rate limit
-        max_retries: Maximum outer retry attempts
+        max_retries: Maximum retry attempts
 
     Returns:
         CompletedProcess instance
@@ -359,27 +312,52 @@ def _gh_call(
     Raises:
         subprocess.CalledProcessError: If command fails and check=True
         ClaudeUsageCapError: If a Claude per-period usage cap is detected.
-        GitHubRateLimitError: If rate limit is hit and not retried.
         RuntimeError: For other non-transient or exhausted-retry failures.
 
     """
     for attempt in range(max_retries):
         try:
-            return cast(
-                subprocess.CompletedProcess[str],
-                resilient_call(
-                    _gh_invoke_once,
-                    args,
-                    circuit_breaker_name=_GH_CB_NAME,
-                    max_retries=2,
-                    initial_delay=2.0,
-                    max_delay=30.0,
-                    check=check,
-                ),
+            gh_global_throttle_acquire()
+            _gh_throttle_wait()
+            result = run(
+                ["gh", *args],
+                check=check,
+                capture_output=True,
+                timeout=gh_cli_timeout(),
             )
-        except _NonTransientGhError as e:
-            raise cast(subprocess.CalledProcessError, e.__cause__) from None
+            return result
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr if e.stderr else ""
+            _raise_if_claude_usage(stderr, e)
+
+            reset_epoch = _extract_reset_epoch(e)
+            if reset_epoch is not None:
+                _handle_rate_limit_attempt(
+                    reset_epoch=reset_epoch,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    retry_on_rate_limit=retry_on_rate_limit,
+                    cause=e,
+                )
+                continue
+
+            if _is_non_transient_error(stderr):
+                logger.error("Non-transient error detected: %s", stderr[:200])
+                if _is_token_scope_error(stderr):
+                    _log_token_scope_remediation(args, stderr)
+                raise
+
+            if attempt == max_retries - 1:
+                raise
+
+            wait_seconds = 2**attempt
+            logger.warning(
+                "gh call failed (attempt %s), retrying in %ss", attempt + 1, wait_seconds
+            )
+            time.sleep(wait_seconds)
         except GitHubRateLimitError as e:
+            # Raised from inside _check_graphql_errors when the JSON payload
+            # carries a RATE_LIMITED entry (HTTP 200, gh exits 0).
             _handle_rate_limit_attempt(
                 reset_epoch=e.reset_epoch,
                 attempt=attempt,
@@ -389,7 +367,53 @@ def _gh_call(
             )
             continue
 
+    # Should not reach here, but satisfy type checker
     raise RuntimeError("gh call failed after all retries")
+
+
+def _gh_call(
+    args: list[str],
+    check: bool = True,
+    retry_on_rate_limit: bool = True,
+    max_retries: int = 6,
+) -> subprocess.CompletedProcess[str]:
+    """Call gh CLI with rate limit handling and circuit breaker protection.
+
+    Wraps the implementation in a circuit breaker that opens after sustained
+    failures, causing fail-fast with GitHubUnavailableError instead of
+    exhausting per-call-site retry budgets.
+
+    Args:
+        args: Arguments to pass to gh
+        check: Whether to raise on non-zero exit
+        retry_on_rate_limit: Whether to retry on rate limit
+        max_retries: Maximum retry attempts
+
+    Returns:
+        CompletedProcess instance
+
+    Raises:
+        subprocess.CalledProcessError: If command fails and check=True
+        ClaudeUsageCapError: If a Claude per-period usage cap is detected.
+        GitHubUnavailableError: If the circuit breaker is open due to
+            sustained GitHub API unavailability.
+        RuntimeError: For other non-transient or exhausted-retry failures.
+
+    """
+    try:
+        return _GH_BREAKER.call(
+            _gh_call_impl,
+            args,
+            check=check,
+            retry_on_rate_limit=retry_on_rate_limit,
+            max_retries=max_retries,
+        )
+    except CircuitBreakerOpenError as exc:
+        # Translate to a domain exception (RuntimeError subclass) so existing
+        # exception handlers that catch RuntimeError/Exception continue to work.
+        raise GitHubUnavailableError(
+            "GitHub API circuit breaker is open due to sustained unavailability"
+        ) from exc
 
 
 def _extract_reset_epoch(e: subprocess.CalledProcessError) -> int | None:

--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -12,11 +12,14 @@ Usage:
     logger.info("This is an info message")
 """
 
+import contextvars
 import logging
 import os
 import sys
 import threading
 import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +32,11 @@ _handler_setup_lock = threading.Lock()
 # Honour HEPHAESTUS_LOG_FORMAT=json so logging format can be configured at
 # deployment time without code changes (12-factor pattern).
 _ENV_JSON_FORMAT: bool = os.environ.get("HEPHAESTUS_LOG_FORMAT", "").lower() == "json"
+
+# Context variable for correlation ID propagation to subprocesses (thread- and async-safe)
+_correlation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "correlation_id", default=None
+)
 
 
 class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
@@ -76,6 +84,62 @@ class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
         """
         cid = correlation_id if correlation_id is not None else str(uuid.uuid4())
         return self.bind(correlation_id=cid)
+
+
+def set_correlation_id(correlation_id: str) -> contextvars.Token[str | None]:
+    """Set the ambient correlation ID for subprocess propagation.
+
+    Thread- and async-safe via contextvars. Intended for callers who manage
+    their own cleanup via _correlation_id_var.reset(token). Most callers
+    should use the correlation_id_scope() context manager instead.
+
+    Args:
+        correlation_id: Correlation ID string to set.
+
+    Returns:
+        A Token that can be used to restore the previous value.
+
+    """
+    return _correlation_id_var.set(correlation_id)
+
+
+def get_current_correlation_id() -> str | None:
+    """Get the current ambient correlation ID, if set.
+
+    Thread- and async-safe via contextvars. Returns None if no correlation
+    ID is currently bound.
+
+    Returns:
+        The current correlation ID string, or None.
+
+    """
+    return _correlation_id_var.get()
+
+
+@contextmanager
+def correlation_id_scope(correlation_id: str) -> Generator[None, None, None]:
+    """Context manager to set an ambient correlation ID for subprocess propagation.
+
+    The correlation ID is set on entry and restored on exit (thread- and
+    async-safe via contextvars). This is the primary API for subprocess
+    correlation ID propagation.
+
+    Args:
+        correlation_id: Correlation ID string to set for the scope.
+
+    Yields:
+        None.
+
+    Example:
+        with correlation_id_scope("request-abc-123"):
+            _gh_call(["issue", "create"])  # gh process sees GH_TRACE_ID=request-abc-123
+
+    """
+    token = set_correlation_id(correlation_id)
+    try:
+        yield
+    finally:
+        _correlation_id_var.reset(token)
 
 
 def get_logger(

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -146,6 +146,7 @@ def run_subprocess(
     check: bool = True,
     dry_run: bool = False,
     log_on_error: bool = True,
+    env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run subprocess command with proper error handling.
 
@@ -157,6 +158,8 @@ def run_subprocess(
         dry_run: If True, log the command but do not execute it
         log_on_error: If False, suppress ERROR logging when the command fails.
             Use when failure is expected and already handled by the caller.
+        env: Optional environment dict to pass to subprocess.run().
+            If provided, replaces the current process environment.
 
     Returns:
         Completed process object
@@ -168,6 +171,16 @@ def run_subprocess(
     if dry_run:
         logger.info("[DRY-RUN] $ %s", " ".join(cmd))
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    # Inject correlation ID into subprocess environment if set.
+    # Function-local import to keep module import graph clean.
+    effective_env = env if env is not None else os.environ.copy()
+    from hephaestus.logging.utils import get_current_correlation_id
+
+    cid = get_current_correlation_id()
+    if cid:
+        effective_env["GH_TRACE_ID"] = cid
+
     try:
         result = subprocess.run(
             cmd,
@@ -177,6 +190,7 @@ def run_subprocess(
             text=True,
             check=check,
             timeout=timeout,
+            env=effective_env,
         )
         return result
     except subprocess.TimeoutExpired:

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -174,7 +174,7 @@ def run_subprocess(
 
     # Inject correlation ID into subprocess environment if set.
     # Function-local import to keep module import graph clean.
-    effective_env = env if env is not None else os.environ.copy()
+    effective_env = env.copy() if env is not None else os.environ.copy()
     from hephaestus.logging.utils import get_current_correlation_id
 
     cid = get_current_correlation_id()

--- a/tests/integration/test_gh_trace_id_propagation.py
+++ b/tests/integration/test_gh_trace_id_propagation.py
@@ -4,20 +4,20 @@
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation.git_utils import run as git_run
 from hephaestus.logging.utils import correlation_id_scope, get_current_correlation_id
+from hephaestus.utils.helpers import run_subprocess
 
 
 @pytest.fixture(autouse=True)
 def _fake_binary_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Add a temporary directory with fake 'gh' and 'git' binaries to PATH.
 
-    These fake binaries echo their environment so tests can verify GH_TRACE_ID.
+    These fake binaries output GH_TRACE_ID if set, else NO_GH_TRACE_ID.
     """
     fake_bin_dir = tmp_path / "bin"
     fake_bin_dir.mkdir()
@@ -25,7 +25,7 @@ def _fake_binary_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     # Create a fake 'gh' script that outputs environment
     fake_gh = fake_bin_dir / "gh"
     fake_gh.write_text(
-        "#!/bin/sh\nenv | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'\n",
+        "#!/bin/sh\n(env | grep -q '^GH_TRACE_ID=' && env | grep '^GH_TRACE_ID=') || echo 'NO_GH_TRACE_ID'\n",
         encoding="utf-8",
     )
     fake_gh.chmod(0o755)
@@ -33,7 +33,7 @@ def _fake_binary_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     # Create a fake 'git' script that outputs environment
     fake_git = fake_bin_dir / "git"
     fake_git.write_text(
-        "#!/bin/sh\nenv | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'\n",
+        "#!/bin/sh\n(env | grep -q '^GH_TRACE_ID=' && env | grep '^GH_TRACE_ID=') || echo 'NO_GH_TRACE_ID'\n",
         encoding="utf-8",
     )
     fake_git.chmod(0o755)
@@ -50,66 +50,42 @@ class TestGhTraceIdPropagation:
         """Verify that get_current_correlation_id() returns None by default."""
         assert get_current_correlation_id() is None
 
-    def test_gh_trace_id_present_in_scope(self, tmp_path: Path) -> None:
-        """GH_TRACE_ID should be present in subprocess when in correlation_id_scope."""
-        result = subprocess.run(
-            ["gh", "issue", "list"],
-            capture_output=True,
-            text=True,
+    def test_gh_trace_id_injected_via_run_subprocess(self) -> None:
+        """GH_TRACE_ID should be injected into the subprocess environment via run_subprocess."""
+        # Outside scope: no GH_TRACE_ID should be set
+        result = run_subprocess(
+            ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
             check=False,
-            env=None,  # Use current environment (won't have GH_TRACE_ID)
         )
-        # Outside scope: no GH_TRACE_ID
-        assert "NO_GH_TRACE_ID" in result.stdout or "GH_TRACE_ID" not in result.stdout
+        assert "NO_GH_TRACE_ID" in result.stdout
 
         # Inside scope: GH_TRACE_ID should be present
         with correlation_id_scope("test-trace-id-123"):
-            # Use git_run (which calls run_subprocess) to verify the injection
-            result = git_run(
-                ["--version"],
-                cwd=Path(os.getcwd()),
+            result = run_subprocess(
+                ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
                 check=False,
             )
             assert "GH_TRACE_ID=test-trace-id-123" in result.stdout
 
-    def test_gh_trace_id_absent_outside_scope(self) -> None:
-        """GH_TRACE_ID should not be set outside of correlation_id_scope."""
-        assert get_current_correlation_id() is None
-
-        result = subprocess.run(
-            ["gh", "issue", "list"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        # Outside scope: no GH_TRACE_ID
-        assert "NO_GH_TRACE_ID" in result.stdout
-
-    def test_nested_correlation_id_scopes(self) -> None:
+    def test_correlation_id_preserved_across_scopes(self) -> None:
         """Nested correlation_id_scope should propagate the innermost ID."""
         with correlation_id_scope("outer-id"):
-            result_outer = subprocess.run(
-                ["gh", "issue", "list"],
-                capture_output=True,
-                text=True,
+            result_outer = run_subprocess(
+                ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
                 check=False,
             )
             assert "GH_TRACE_ID=outer-id" in result_outer.stdout
 
             with correlation_id_scope("inner-id"):
-                result_inner = subprocess.run(
-                    ["gh", "issue", "list"],
-                    capture_output=True,
-                    text=True,
+                result_inner = run_subprocess(
+                    ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
                     check=False,
                 )
                 assert "GH_TRACE_ID=inner-id" in result_inner.stdout
 
             # After exiting inner scope, outer ID should be restored
-            result_back = subprocess.run(
-                ["gh", "issue", "list"],
-                capture_output=True,
-                text=True,
+            result_back = run_subprocess(
+                ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
                 check=False,
             )
             assert "GH_TRACE_ID=outer-id" in result_back.stdout
@@ -118,10 +94,8 @@ class TestGhTraceIdPropagation:
         """Correlation ID should be cleaned up even if an exception occurs in the scope."""
         try:
             with correlation_id_scope("error-scope-id"):
-                result = subprocess.run(
-                    ["gh", "issue", "list"],
-                    capture_output=True,
-                    text=True,
+                result = run_subprocess(
+                    ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
                     check=False,
                 )
                 assert "GH_TRACE_ID=error-scope-id" in result.stdout
@@ -131,10 +105,27 @@ class TestGhTraceIdPropagation:
 
         # After exception: correlation ID should be cleared
         assert get_current_correlation_id() is None
-        result = subprocess.run(
-            ["gh", "issue", "list"],
-            capture_output=True,
-            text=True,
+        result = run_subprocess(
+            ["sh", "-c", "env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'"],
             check=False,
         )
         assert "NO_GH_TRACE_ID" in result.stdout
+
+    def test_custom_env_dict_preserved(self) -> None:
+        """When a custom env dict is passed to run_subprocess, GH_TRACE_ID should be injected into it."""
+        custom_env = {"CUSTOM_VAR": "custom_value"}
+
+        with correlation_id_scope("custom-trace-id"):
+            result = run_subprocess(
+                [
+                    "sh",
+                    "-c",
+                    "echo CUSTOM_VAR=$CUSTOM_VAR; env | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'",
+                ],
+                env=custom_env,
+                check=False,
+            )
+            # Custom var should still be present
+            assert "CUSTOM_VAR=custom_value" in result.stdout
+            # GH_TRACE_ID should be injected
+            assert "GH_TRACE_ID=custom-trace-id" in result.stdout

--- a/tests/integration/test_gh_trace_id_propagation.py
+++ b/tests/integration/test_gh_trace_id_propagation.py
@@ -2,10 +2,7 @@
 """Integration test for GH_TRACE_ID environment variable propagation."""
 
 import os
-import subprocess
-import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -25,7 +22,8 @@ def _fake_binary_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     # Create a fake 'gh' script that outputs environment
     fake_gh = fake_bin_dir / "gh"
     fake_gh.write_text(
-        "#!/bin/sh\n(env | grep -q '^GH_TRACE_ID=' && env | grep '^GH_TRACE_ID=') || echo 'NO_GH_TRACE_ID'\n",
+        "#!/bin/sh\n"
+        "(env | grep -q '^GH_TRACE_ID=' && env | grep '^GH_TRACE_ID=') || echo 'NO_GH_TRACE_ID'\n",
         encoding="utf-8",
     )
     fake_gh.chmod(0o755)
@@ -33,7 +31,8 @@ def _fake_binary_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     # Create a fake 'git' script that outputs environment
     fake_git = fake_bin_dir / "git"
     fake_git.write_text(
-        "#!/bin/sh\n(env | grep -q '^GH_TRACE_ID=' && env | grep '^GH_TRACE_ID=') || echo 'NO_GH_TRACE_ID'\n",
+        "#!/bin/sh\n"
+        "(env | grep -q '^GH_TRACE_ID=' && env | grep '^GH_TRACE_ID=') || echo 'NO_GH_TRACE_ID'\n",
         encoding="utf-8",
     )
     fake_git.chmod(0o755)
@@ -112,7 +111,7 @@ class TestGhTraceIdPropagation:
         assert "NO_GH_TRACE_ID" in result.stdout
 
     def test_custom_env_dict_preserved(self) -> None:
-        """When a custom env dict is passed to run_subprocess, GH_TRACE_ID should be injected into it."""
+        """Verify GH_TRACE_ID is injected into a custom env dict passed to run_subprocess."""
         custom_env = {"CUSTOM_VAR": "custom_value"}
 
         with correlation_id_scope("custom-trace-id"):

--- a/tests/integration/test_gh_trace_id_propagation.py
+++ b/tests/integration/test_gh_trace_id_propagation.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Integration test for GH_TRACE_ID environment variable propagation."""
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from hephaestus.automation.git_utils import run as git_run
+from hephaestus.logging.utils import correlation_id_scope, get_current_correlation_id
+
+
+@pytest.fixture(autouse=True)
+def _fake_binary_on_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Add a temporary directory with fake 'gh' and 'git' binaries to PATH.
+
+    These fake binaries echo their environment so tests can verify GH_TRACE_ID.
+    """
+    fake_bin_dir = tmp_path / "bin"
+    fake_bin_dir.mkdir()
+
+    # Create a fake 'gh' script that outputs environment
+    fake_gh = fake_bin_dir / "gh"
+    fake_gh.write_text(
+        "#!/bin/sh\nenv | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    # Create a fake 'git' script that outputs environment
+    fake_git = fake_bin_dir / "git"
+    fake_git.write_text(
+        "#!/bin/sh\nenv | grep GH_TRACE_ID || echo 'NO_GH_TRACE_ID'\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+
+    # Prepend the fake bin directory to PATH so our fake binaries are found first
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", str(fake_bin_dir) + ":" + original_path)
+
+
+class TestGhTraceIdPropagation:
+    """Test that GH_TRACE_ID is propagated to subprocesses via correlation_id_scope."""
+
+    def test_correlation_id_not_set_by_default(self) -> None:
+        """Verify that get_current_correlation_id() returns None by default."""
+        assert get_current_correlation_id() is None
+
+    def test_gh_trace_id_present_in_scope(self, tmp_path: Path) -> None:
+        """GH_TRACE_ID should be present in subprocess when in correlation_id_scope."""
+        result = subprocess.run(
+            ["gh", "issue", "list"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=None,  # Use current environment (won't have GH_TRACE_ID)
+        )
+        # Outside scope: no GH_TRACE_ID
+        assert "NO_GH_TRACE_ID" in result.stdout or "GH_TRACE_ID" not in result.stdout
+
+        # Inside scope: GH_TRACE_ID should be present
+        with correlation_id_scope("test-trace-id-123"):
+            # Use git_run (which calls run_subprocess) to verify the injection
+            result = git_run(
+                ["--version"],
+                cwd=Path(os.getcwd()),
+                check=False,
+            )
+            assert "GH_TRACE_ID=test-trace-id-123" in result.stdout
+
+    def test_gh_trace_id_absent_outside_scope(self) -> None:
+        """GH_TRACE_ID should not be set outside of correlation_id_scope."""
+        assert get_current_correlation_id() is None
+
+        result = subprocess.run(
+            ["gh", "issue", "list"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # Outside scope: no GH_TRACE_ID
+        assert "NO_GH_TRACE_ID" in result.stdout
+
+    def test_nested_correlation_id_scopes(self) -> None:
+        """Nested correlation_id_scope should propagate the innermost ID."""
+        with correlation_id_scope("outer-id"):
+            result_outer = subprocess.run(
+                ["gh", "issue", "list"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert "GH_TRACE_ID=outer-id" in result_outer.stdout
+
+            with correlation_id_scope("inner-id"):
+                result_inner = subprocess.run(
+                    ["gh", "issue", "list"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert "GH_TRACE_ID=inner-id" in result_inner.stdout
+
+            # After exiting inner scope, outer ID should be restored
+            result_back = subprocess.run(
+                ["gh", "issue", "list"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            assert "GH_TRACE_ID=outer-id" in result_back.stdout
+
+    def test_correlation_id_cleanup_after_exception(self) -> None:
+        """Correlation ID should be cleaned up even if an exception occurs in the scope."""
+        try:
+            with correlation_id_scope("error-scope-id"):
+                result = subprocess.run(
+                    ["gh", "issue", "list"],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                assert "GH_TRACE_ID=error-scope-id" in result.stdout
+                raise ValueError("Test exception")
+        except ValueError:
+            pass
+
+        # After exception: correlation ID should be cleared
+        assert get_current_correlation_id() is None
+        result = subprocess.run(
+            ["gh", "issue", "list"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert "NO_GH_TRACE_ID" in result.stdout

--- a/tests/unit/automation/test_gh_call_circuit_breaker.py
+++ b/tests/unit/automation/test_gh_call_circuit_breaker.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for CircuitBreaker wrapping of _gh_call."""
+
+import subprocess
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hephaestus.automation.github_api import GitHubUnavailableError, _gh_call
+from hephaestus.resilience.circuit_breaker import reset_all_circuit_breakers
+
+
+@pytest.fixture(autouse=True)
+def _reset_breaker() -> None:
+    """Reset the GitHub API circuit breaker before each test."""
+    # Import and reset the module's _GH_BREAKER directly
+    import hephaestus.automation.github_api as github_api_module
+    github_api_module._GH_BREAKER.reset()
+    yield
+    github_api_module._GH_BREAKER.reset()
+
+
+class TestGhCallCircuitBreaker:
+    """Test CircuitBreaker wrapping of _gh_call."""
+
+    @patch("hephaestus.automation.github_api._gh_call_impl")
+    def test_breaker_transitions_to_open_on_failures(self, mock_impl: Mock) -> None:
+        """Circuit breaker transitions from CLOSED to OPEN after 5 consecutive failures."""
+        # Simulate 5xx failures
+        mock_impl.side_effect = subprocess.CalledProcessError(
+            500, "gh", stderr="Internal Server Error"
+        )
+
+        # First 5 calls should fail with CalledProcessError (not caught by breaker)
+        for i in range(5):
+            with pytest.raises(subprocess.CalledProcessError):
+                _gh_call(["issue", "list"])
+
+        # Verify the mock was called 5 times
+        assert mock_impl.call_count == 5
+
+        # 6th call should fail with GitHubUnavailableError (circuit now OPEN)
+        with pytest.raises(GitHubUnavailableError):
+            _gh_call(["issue", "list"])
+
+        # Circuit is open: mock should NOT be called again (fail-fast)
+        assert mock_impl.call_count == 5
+
+    @patch("hephaestus.automation.github_api._gh_call_impl")
+    def test_circuit_breaker_open_error_is_runtime_error(self, mock_impl: Mock) -> None:
+        """GitHubUnavailableError is a RuntimeError subclass (for existing handlers)."""
+        mock_impl.side_effect = subprocess.CalledProcessError(
+            500, "gh", stderr="Internal Server Error"
+        )
+
+        # Trigger 5 failures to open the breaker
+        for _ in range(5):
+            with pytest.raises(subprocess.CalledProcessError):
+                _gh_call(["issue", "list"])
+
+        # The error raised when breaker is open should be a RuntimeError
+        with pytest.raises(RuntimeError):
+            _gh_call(["issue", "list"])
+
+        # And specifically a GitHubUnavailableError
+        with pytest.raises(GitHubUnavailableError):
+            _gh_call(["issue", "list"])
+
+    @patch("hephaestus.automation.github_api._gh_call_impl")
+    def test_circuit_breaker_recovery_after_timeout(self, mock_impl: Mock) -> None:
+        """Circuit breaker transitions to HALF_OPEN after recovery_timeout seconds.
+
+        Note: This test uses time mocking to avoid a 60-second sleep.
+        """
+        import time
+        from unittest.mock import MagicMock
+
+        # Simulate failure
+        mock_impl.side_effect = subprocess.CalledProcessError(
+            500, "gh", stderr="Internal Server Error"
+        )
+
+        # Trigger 5 failures to open the breaker
+        for _ in range(5):
+            with pytest.raises(subprocess.CalledProcessError):
+                _gh_call(["issue", "list"])
+
+        # Verify breaker is open
+        with pytest.raises(GitHubUnavailableError):
+            _gh_call(["issue", "list"])
+
+        # Now simulate recovery by mocking the breaker's internal time check.
+        # We need to access the actual breaker instance to manipulate its state.
+        from hephaestus.automation.github_api import _GH_BREAKER
+
+        # Mock time.monotonic to simulate timeout passage
+        original_monotonic = time.monotonic
+        elapsed_time = 0.0
+
+        def mock_monotonic() -> float:
+            return original_monotonic() + elapsed_time
+
+        with patch("time.monotonic", side_effect=mock_monotonic):
+            # Advance time past recovery_timeout (60 seconds)
+            elapsed_time = 61.0
+
+            # Change mock to succeed
+            mock_impl.side_effect = None
+            mock_impl.return_value = subprocess.CompletedProcess(
+                ["gh", "issue", "list"], returncode=0, stdout="[]", stderr=""
+            )
+
+            # Call should succeed (breaker in HALF_OPEN allows 2 calls)
+            result = _gh_call(["issue", "list"])
+            assert result.returncode == 0
+
+            # Another call should also succeed and fully close the breaker
+            result = _gh_call(["issue", "list"])
+            assert result.returncode == 0
+
+    @patch("hephaestus.automation.github_api._gh_call_impl")
+    def test_breaker_does_not_wrap_successful_calls(self, mock_impl: Mock) -> None:
+        """Circuit breaker does not interfere with successful _gh_call invocations."""
+        expected_result = subprocess.CompletedProcess(
+            ["gh", "issue", "list"], returncode=0, stdout="[]", stderr=""
+        )
+        mock_impl.return_value = expected_result
+
+        # Multiple successful calls should work fine
+        for _ in range(10):
+            result = _gh_call(["issue", "list"])
+            assert result == expected_result
+
+        # Mock should be called each time (breaker closed)
+        assert mock_impl.call_count == 10
+
+    @patch("hephaestus.automation.github_api._gh_call_impl")
+    def test_circuit_breaker_preserves_call_signature(self, mock_impl: Mock) -> None:
+        """Circuit breaker correctly forwards all _gh_call_impl arguments."""
+        expected_result = subprocess.CompletedProcess(
+            ["gh", "issue", "list"], returncode=0, stdout="[]", stderr=""
+        )
+        mock_impl.return_value = expected_result
+
+        # Call with custom arguments
+        result = _gh_call(
+            ["issue", "list"],
+            check=False,
+            retry_on_rate_limit=False,
+            max_retries=3,
+        )
+
+        assert result == expected_result
+
+        # Verify the mock was called with correct arguments
+        mock_impl.assert_called_once_with(
+            ["issue", "list"],
+            check=False,
+            retry_on_rate_limit=False,
+            max_retries=3,
+        )

--- a/tests/unit/automation/test_gh_call_circuit_breaker.py
+++ b/tests/unit/automation/test_gh_call_circuit_breaker.py
@@ -11,7 +11,7 @@ from hephaestus.resilience.circuit_breaker import reset_all_circuit_breakers
 
 
 @pytest.fixture(autouse=True)
-def _reset_breaker() -> None:
+def _reset_breaker() -> None:  # type: ignore[misc]
     """Reset the GitHub API circuit breaker before each test."""
     # Import and reset the module's _GH_BREAKER directly
     import hephaestus.automation.github_api as github_api_module

--- a/tests/unit/automation/test_gh_call_circuit_breaker.py
+++ b/tests/unit/automation/test_gh_call_circuit_breaker.py
@@ -2,19 +2,17 @@
 """Tests for CircuitBreaker wrapping of _gh_call."""
 
 import subprocess
+from collections.abc import Generator
 from unittest.mock import Mock, patch
 
 import pytest
 
-from hephaestus.automation.github_api import GitHubUnavailableError, _gh_call
-from hephaestus.resilience.circuit_breaker import reset_all_circuit_breakers
+import hephaestus.automation.github_api as github_api_module
 
 
 @pytest.fixture(autouse=True)
-def _reset_breaker() -> None:  # type: ignore[misc]
+def _reset_breaker() -> Generator[None, None, None]:
     """Reset the GitHub API circuit breaker before each test."""
-    # Import and reset the module's _GH_BREAKER directly
-    import hephaestus.automation.github_api as github_api_module
     github_api_module._GH_BREAKER.reset()
     yield
     github_api_module._GH_BREAKER.reset()
@@ -32,16 +30,16 @@ class TestGhCallCircuitBreaker:
         )
 
         # First 5 calls should fail with CalledProcessError (not caught by breaker)
-        for i in range(5):
+        for _i in range(5):
             with pytest.raises(subprocess.CalledProcessError):
-                _gh_call(["issue", "list"])
+                github_api_module._gh_call(["issue", "list"])
 
         # Verify the mock was called 5 times
         assert mock_impl.call_count == 5
 
         # 6th call should fail with GitHubUnavailableError (circuit now OPEN)
-        with pytest.raises(GitHubUnavailableError):
-            _gh_call(["issue", "list"])
+        with pytest.raises(github_api_module.GitHubUnavailableError):
+            github_api_module._gh_call(["issue", "list"])
 
         # Circuit is open: mock should NOT be called again (fail-fast)
         assert mock_impl.call_count == 5
@@ -56,15 +54,15 @@ class TestGhCallCircuitBreaker:
         # Trigger 5 failures to open the breaker
         for _ in range(5):
             with pytest.raises(subprocess.CalledProcessError):
-                _gh_call(["issue", "list"])
+                github_api_module._gh_call(["issue", "list"])
 
         # The error raised when breaker is open should be a RuntimeError
         with pytest.raises(RuntimeError):
-            _gh_call(["issue", "list"])
+            github_api_module._gh_call(["issue", "list"])
 
         # And specifically a GitHubUnavailableError
-        with pytest.raises(GitHubUnavailableError):
-            _gh_call(["issue", "list"])
+        with pytest.raises(github_api_module.GitHubUnavailableError):
+            github_api_module._gh_call(["issue", "list"])
 
     @patch("hephaestus.automation.github_api._gh_call_impl")
     def test_circuit_breaker_recovery_after_timeout(self, mock_impl: Mock) -> None:
@@ -73,7 +71,6 @@ class TestGhCallCircuitBreaker:
         Note: This test uses time mocking to avoid a 60-second sleep.
         """
         import time
-        from unittest.mock import MagicMock
 
         # Simulate failure
         mock_impl.side_effect = subprocess.CalledProcessError(
@@ -83,16 +80,13 @@ class TestGhCallCircuitBreaker:
         # Trigger 5 failures to open the breaker
         for _ in range(5):
             with pytest.raises(subprocess.CalledProcessError):
-                _gh_call(["issue", "list"])
+                github_api_module._gh_call(["issue", "list"])
 
         # Verify breaker is open
-        with pytest.raises(GitHubUnavailableError):
-            _gh_call(["issue", "list"])
+        with pytest.raises(github_api_module.GitHubUnavailableError):
+            github_api_module._gh_call(["issue", "list"])
 
         # Now simulate recovery by mocking the breaker's internal time check.
-        # We need to access the actual breaker instance to manipulate its state.
-        from hephaestus.automation.github_api import _GH_BREAKER
-
         # Mock time.monotonic to simulate timeout passage
         original_monotonic = time.monotonic
         elapsed_time = 0.0
@@ -111,11 +105,11 @@ class TestGhCallCircuitBreaker:
             )
 
             # Call should succeed (breaker in HALF_OPEN allows 2 calls)
-            result = _gh_call(["issue", "list"])
+            result = github_api_module._gh_call(["issue", "list"])
             assert result.returncode == 0
 
             # Another call should also succeed and fully close the breaker
-            result = _gh_call(["issue", "list"])
+            result = github_api_module._gh_call(["issue", "list"])
             assert result.returncode == 0
 
     @patch("hephaestus.automation.github_api._gh_call_impl")
@@ -128,7 +122,7 @@ class TestGhCallCircuitBreaker:
 
         # Multiple successful calls should work fine
         for _ in range(10):
-            result = _gh_call(["issue", "list"])
+            result = github_api_module._gh_call(["issue", "list"])
             assert result == expected_result
 
         # Mock should be called each time (breaker closed)
@@ -143,7 +137,7 @@ class TestGhCallCircuitBreaker:
         mock_impl.return_value = expected_result
 
         # Call with custom arguments
-        result = _gh_call(
+        result = github_api_module._gh_call(
             ["issue", "list"],
             check=False,
             retry_on_rate_limit=False,

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -26,6 +26,13 @@ from hephaestus.automation.github_api import (
     write_secure,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.resilience.circuit_breaker import reset_all_circuit_breakers
+
+
+@pytest.fixture(autouse=True)
+def _reset_circuit_breakers() -> None:
+    """Reset all circuit breakers before each test to prevent cross-test contamination."""
+    reset_all_circuit_breakers()
 
 
 class TestGhIssueJson:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -438,28 +438,27 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.resilient_call")
-    def test_resilient_call_invoked_with_correct_parameters(self, mock_resilient: Any) -> None:
-        """Test that _gh_call invokes resilient_call with correct parameters.
+    @patch("hephaestus.automation.github_api._gh_call_impl")
+    def test_circuit_breaker_wraps_gh_call_impl(self, mock_impl: Any) -> None:
+        """Test that _gh_call routes through the circuit breaker to _gh_call_impl.
 
-        Verifies that the circuit breaker name, max_retries, and other
-        parameters are passed correctly to resilient_call.
+        Verifies that the circuit breaker calls _gh_call_impl with the
+        correct arguments forwarded from _gh_call.
         """
+        _github_api_module._GH_BREAKER.reset()
         mock_result = Mock(spec=subprocess.CompletedProcess)
         mock_result.stdout = "success"
-        mock_resilient.return_value = mock_result
+        mock_impl.return_value = mock_result
 
         result = _gh_call(["issue", "view", "123"], max_retries=6)
 
         assert result.stdout == "success"
-        # resilient_call should be called on outer loop
-        assert mock_resilient.call_count == 1
-        # Check that circuit_breaker_name was passed
-        call_kwargs = mock_resilient.call_args[1]
-        assert "circuit_breaker_name" in call_kwargs
-        assert call_kwargs["circuit_breaker_name"] == "gh_cli"
-        assert call_kwargs["max_retries"] == 2  # inner retries
-        assert call_kwargs["initial_delay"] == 2.0
+        # _gh_call_impl should be called once via the circuit breaker
+        assert mock_impl.call_count == 1
+        # Check that args and kwargs are forwarded correctly
+        call_args, call_kwargs = mock_impl.call_args
+        assert call_args[0] == ["issue", "view", "123"]
+        assert call_kwargs["max_retries"] == 6
 
     @patch("hephaestus.automation.github_api.run")
     def test_non_transient_errors_not_retried_by_resilient_call(self, mock_run: Any) -> None:

--- a/tests/unit/logging/test_correlation_id_context.py
+++ b/tests/unit/logging/test_correlation_id_context.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Unit tests for correlation ID context variable functionality."""
 
-import threading
+from collections.abc import Generator
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -15,7 +15,7 @@ from hephaestus.logging.utils import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_correlation_id() -> None:
+def _reset_correlation_id() -> Generator[None, None, None]:
     """Reset correlation ID to None before each test."""
     token = _correlation_id_var.set(None)
     try:
@@ -140,6 +140,7 @@ class TestCorrelationIdThreadIsolation:
             try:
                 # Sleep to ensure threads overlap
                 import time
+
                 time.sleep(0.01)
                 results[thread_id] = get_current_correlation_id()
             finally:
@@ -159,6 +160,7 @@ class TestCorrelationIdThreadIsolation:
         outer_token = set_correlation_id("outer-id")
 
         try:
+
             def set_in_thread() -> str | None:
                 inner_token = set_correlation_id("inner-id")
                 try:

--- a/tests/unit/logging/test_correlation_id_context.py
+++ b/tests/unit/logging/test_correlation_id_context.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for correlation ID context variable functionality."""
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from hephaestus.logging.utils import (
+    _correlation_id_var,
+    correlation_id_scope,
+    get_current_correlation_id,
+    set_correlation_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_correlation_id() -> None:
+    """Reset correlation ID to None before each test."""
+    token = _correlation_id_var.set(None)
+    try:
+        yield
+    finally:
+        _correlation_id_var.reset(token)
+
+
+class TestSetAndGetCorrelationId:
+    """Test set_correlation_id() and get_current_correlation_id()."""
+
+    def test_get_correlation_id_none_by_default(self) -> None:
+        """get_current_correlation_id() returns None when not set."""
+        assert get_current_correlation_id() is None
+
+    def test_set_correlation_id(self) -> None:
+        """set_correlation_id() sets the correlation ID."""
+        token = set_correlation_id("test-id-123")
+        try:
+            assert get_current_correlation_id() == "test-id-123"
+        finally:
+            _correlation_id_var.reset(token)
+        assert get_current_correlation_id() is None
+
+    def test_set_correlation_id_token_reset(self) -> None:
+        """Token.reset() restores the previous value."""
+        # Initial value: None
+        assert get_current_correlation_id() is None
+
+        # Set first ID
+        token1 = set_correlation_id("id-1")
+        assert get_current_correlation_id() == "id-1"
+
+        # Set second ID (nested)
+        token2 = set_correlation_id("id-2")
+        assert get_current_correlation_id() == "id-2"
+
+        # Reset second ID (restore id-1)
+        _correlation_id_var.reset(token2)
+        assert get_current_correlation_id() == "id-1"
+
+        # Reset first ID (restore None)
+        _correlation_id_var.reset(token1)
+        assert get_current_correlation_id() is None
+
+    def test_set_multiple_times(self) -> None:
+        """Setting correlation ID multiple times (without nesting) overwrites."""
+        token1 = set_correlation_id("id-1")
+        assert get_current_correlation_id() == "id-1"
+
+        token2 = set_correlation_id("id-2")
+        assert get_current_correlation_id() == "id-2"
+
+        # Reset token2
+        _correlation_id_var.reset(token2)
+        # After resetting token2, we're back to id-1 (the context before token2)
+        assert get_current_correlation_id() == "id-1"
+
+        _correlation_id_var.reset(token1)
+        assert get_current_correlation_id() is None
+
+
+class TestCorrelationIdScope:
+    """Test correlation_id_scope() context manager."""
+
+    def test_scope_sets_and_restores(self) -> None:
+        """correlation_id_scope() sets ID on entry, restores on exit."""
+        assert get_current_correlation_id() is None
+
+        with correlation_id_scope("scope-id-123"):
+            assert get_current_correlation_id() == "scope-id-123"
+
+        assert get_current_correlation_id() is None
+
+    def test_scope_nested(self) -> None:
+        """Nested correlation_id_scope() contexts work correctly."""
+        assert get_current_correlation_id() is None
+
+        with correlation_id_scope("outer"):
+            assert get_current_correlation_id() == "outer"
+
+            with correlation_id_scope("inner"):
+                assert get_current_correlation_id() == "inner"
+
+            assert get_current_correlation_id() == "outer"
+
+        assert get_current_correlation_id() is None
+
+    def test_scope_exception_cleanup(self) -> None:
+        """correlation_id_scope() cleans up even if an exception is raised."""
+        assert get_current_correlation_id() is None
+
+        with pytest.raises(ValueError):
+            with correlation_id_scope("error-scope"):
+                assert get_current_correlation_id() == "error-scope"
+                raise ValueError("test error")
+
+        # Even after exception, context is restored
+        assert get_current_correlation_id() is None
+
+    def test_scope_preserves_existing(self) -> None:
+        """correlation_id_scope() preserves ID from outer scope."""
+        with correlation_id_scope("outer"):
+            assert get_current_correlation_id() == "outer"
+
+            with correlation_id_scope("inner"):
+                assert get_current_correlation_id() == "inner"
+
+            assert get_current_correlation_id() == "outer"
+
+
+class TestCorrelationIdThreadIsolation:
+    """Test that correlation IDs are thread-isolated via contextvars."""
+
+    def test_different_threads_have_different_values(self) -> None:
+        """Each thread has its own correlation ID value."""
+        results: dict[int, str | None] = {}
+
+        def get_id_in_thread(thread_id: int) -> None:
+            # Set a thread-specific ID
+            token = set_correlation_id(f"thread-{thread_id}")
+            try:
+                # Sleep to ensure threads overlap
+                import time
+                time.sleep(0.01)
+                results[thread_id] = get_current_correlation_id()
+            finally:
+                _correlation_id_var.reset(token)
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = [executor.submit(get_id_in_thread, i) for i in range(3)]
+            for future in futures:
+                future.result()
+
+        # Each thread saw its own value
+        assert results == {0: "thread-0", 1: "thread-1", 2: "thread-2"}
+
+    def test_outer_thread_unaffected_by_inner_threads(self) -> None:
+        """Setting correlation ID in a thread doesn't affect the outer thread."""
+        outer_before = get_current_correlation_id()
+        outer_token = set_correlation_id("outer-id")
+
+        try:
+            def set_in_thread() -> str | None:
+                inner_token = set_correlation_id("inner-id")
+                try:
+                    return get_current_correlation_id()
+                finally:
+                    _correlation_id_var.reset(inner_token)
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                inner_result = executor.submit(set_in_thread).result()
+
+            # Inner thread had its own value
+            assert inner_result == "inner-id"
+
+            # Outer thread is unaffected
+            assert get_current_correlation_id() == "outer-id"
+        finally:
+            _correlation_id_var.reset(outer_token)
+            assert get_current_correlation_id() == outer_before


### PR DESCRIPTION
## Summary

Two independent resilience improvements at the gh CLI chokepoint:

- **Half 1:** Wrap `_gh_call` in `CircuitBreaker` so sustained GitHub outages fail fast with `GitHubUnavailableError` instead of every call site exhausting its retry budget.
- **Half 2:** Propagate correlation ID from Python logging context to `gh` (and `git`/`claude`/`runtime`) subprocesses via `GH_TRACE_ID` env var, so operators can correlate Python logs with child-process stderr.

## Implementation Details

### CircuitBreaker (Half 1)
- Extract `_gh_call` body → `_gh_call_impl` (signature unchanged)
- Wrap via `get_circuit_breaker()` with failure_threshold=5, recovery_timeout=60, half_open_max_calls=2
- Translate `CircuitBreakerOpenError` → new `GitHubUnavailableError(RuntimeError)` at boundary
- Existing exception handlers (`except RuntimeError`/`except Exception`) continue to catch it

### Correlation ID Propagation (Half 2)
- Add `contextvars`-based ambient API in `logging/utils.py`:
  - `set_correlation_id(cid)` — set ambient correlation ID (returns Token for manual cleanup)
  - `get_current_correlation_id()` — read ambient correlation ID
  - `correlation_id_scope(cid)` — context manager for scoped correlation ID
- Inject `GH_TRACE_ID` at four subprocess sites:
  - `run_subprocess()` (for `_gh_call` via `gh` invocation)
  - `git_utils.run()`
  - `claude_invoke._run()`
  - `runtime.py` (agent runtime)
- Thread- and async-safe via `contextvars`; POLA-compliant (`with_correlation_id` unchanged)

## Test Plan

- [x] Unit tests: correlation_id context var semantics + thread isolation
- [x] Unit tests: circuit breaker state transitions (CLOSED → OPEN → HALF_OPEN)
- [x] Unit tests: `GitHubUnavailableError` catchable as `RuntimeError`
- [x] Integration test: `GH_TRACE_ID` present in subprocess when in `correlation_id_scope`
- [x] All existing tests pass with breaker reset fixture

Closes #609

🤖 Generated with [Claude Code](https://claude.ai/code)