### PR TITLE
automation-loop: reduce log noise and add per-loop work summary

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -71,6 +71,9 @@ def get_repo_root(path: Path | None = None) -> Path:
     return _get_repo_root(path)
 
 
+_repo_info_cache: dict[Path | None, tuple[str, str]] = {}
+
+
 def get_repo_info(repo_root: Path | None = None) -> tuple[str, str]:
     """Get repository owner and name from git remote.
 
@@ -86,6 +89,11 @@ def get_repo_info(repo_root: Path | None = None) -> tuple[str, str]:
     """
     if repo_root is None:
         repo_root = get_repo_root()
+
+    key = repo_root.resolve() if repo_root is not None else None
+    cached = _repo_info_cache.get(key)
+    if cached is not None:
+        return cached
 
     try:
         result = run(
@@ -111,6 +119,7 @@ def get_repo_info(repo_root: Path | None = None) -> tuple[str, str]:
             raise RuntimeError(f"Unable to parse git remote URL: {remote_url}")
 
         logger.debug("Detected repo: %s/%s", owner, repo)
+        _repo_info_cache[key] = (owner, repo)
         return owner, repo
 
     except subprocess.CalledProcessError as e:
@@ -149,6 +158,12 @@ def get_repo_slug(repo_root: Path | None = None) -> str:
         repo = "repo"
     _repo_slug_cache[key] = repo
     return repo
+
+
+def clear_repo_caches() -> None:
+    """Clear both repo info and slug caches. For test isolation and long-lived processes."""
+    _repo_info_cache.clear()
+    _repo_slug_cache.clear()
 
 
 def issue_ref(issue_number: int | str) -> str:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -151,6 +151,44 @@ class RepoResult:
         return any(p.produced_work for p in self.phases if p.name in _CONVERGENCE_PHASES)
 
 
+def _summarize_loop(loop_results: list[RepoResult], loop_idx: int, elapsed_s: float) -> str:
+    """Generate a one-line summary of loop execution for logs.
+
+    Counts: planned (non-skipped plan phases), reviewed (review-plans +
+    review-prs non-skipped), skipped (all skipped phases).
+
+    Args:
+        loop_results: Results from all repos in this loop iteration.
+        loop_idx: Loop iteration number (1-indexed).
+        elapsed_s: Wall-clock seconds elapsed for the loop.
+
+    Returns:
+        A summary string like "loop 1: planned=5 reviewed=3 skipped=2 elapsed=45s".
+
+    """
+    total_planned = 0
+    total_reviewed = 0
+    total_skipped = 0
+
+    for result in loop_results:
+        for phase in result.phases:
+            if phase.skipped:
+                total_skipped += 1
+            else:
+                # Count non-skipped plan phase
+                if phase.name == "plan":
+                    total_planned += 1
+                # Count non-skipped review phases
+                elif phase.name in ("review-plans", "review-prs"):
+                    total_reviewed += 1
+
+    elapsed = f"{elapsed_s:.0f}s"
+    return (
+        f"loop {loop_idx}: planned={total_planned} reviewed={total_reviewed} "
+        f"skipped={total_skipped} elapsed={elapsed}"
+    )
+
+
 @dataclass
 class LoopConfig:
     """Top-level CLI-derived configuration."""
@@ -967,6 +1005,9 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
         LOG.info("▶ LOOP %d / %d", loop_idx, cfg.loops)
         LOG.info("━" * 60)
 
+        loop_t0 = time.monotonic()
+        loop_results: list[RepoResult] = []
+
         with ThreadPoolExecutor(
             max_workers=max(1, cfg.parallel_repos),
             thread_name_prefix="repo-",
@@ -984,6 +1025,7 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
                         loop_idx=loop_idx,
                         runner_error=f"future raised: {type(exc).__name__}: {exc}",
                     )
+                loop_results.append(result)
                 all_results.append(result)
                 if result.any_failure:
                     LOG.warning(
@@ -992,6 +1034,8 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
                         loop_idx,
                     )
 
+        elapsed_s = time.monotonic() - loop_t0
+        LOG.info("%s", _summarize_loop(loop_results, loop_idx, elapsed_s))
         LOG.info("Loop %d complete.", loop_idx)
 
         # Check for early exit: if this loop produced no work and had no

--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -93,13 +93,13 @@ def _extract_verdict_context(review_body: str) -> str:
         if "Verdict:" in line:
             preview = line.strip()
             if preview:
-                return preview[: _VERDICT_LOG_PREVIEW_CHARS]
+                return preview[:_VERDICT_LOG_PREVIEW_CHARS]
 
     # Fall back to first non-prefix content line
     for line in lines:
         stripped = line.strip()
         if stripped and not stripped.startswith(PLAN_REVIEW_PREFIX):
-            return stripped[: _VERDICT_LOG_PREVIEW_CHARS]
+            return stripped[:_VERDICT_LOG_PREVIEW_CHARS]
 
     return ""
 

--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -50,6 +50,9 @@ VERDICT_APPROVED = "APPROVED"
 VERDICT_REVISE = "REVISE"
 VERDICT_BLOCK = "BLOCK"
 
+# Maximum length for verdict context preview in logs (e.g., first verdict line or content).
+_VERDICT_LOG_PREVIEW_CHARS = 200
+
 
 def latest_verdict(review_body: str) -> str | None:
     """Return the LAST well-formed verdict token in ``review_body``.
@@ -66,6 +69,39 @@ def latest_verdict(review_body: str) -> str | None:
     """
     matches = VERDICT_LINE_RE.findall(review_body)
     return matches[-1] if matches else None
+
+
+def _extract_verdict_context(review_body: str) -> str:
+    """Extract a human-readable context line from a review body.
+
+    Returns the last line containing 'Verdict:' if present, else the first
+    non-empty line that doesn't start with PLAN_REVIEW_PREFIX. Truncated to
+    _VERDICT_LOG_PREVIEW_CHARS for logging. Useful for diagnosing missing or
+    unexpected verdicts by showing actual content rather than just the token.
+
+    Args:
+        review_body: Full text of a plan-review comment.
+
+    Returns:
+        A preview string (may be empty if body is empty or all-prefix).
+
+    """
+    lines = review_body.split("\n")
+
+    # Look for a line containing "Verdict:" (any case variation)
+    for line in reversed(lines):
+        if "Verdict:" in line:
+            preview = line.strip()
+            if preview:
+                return preview[: _VERDICT_LOG_PREVIEW_CHARS]
+
+    # Fall back to first non-prefix content line
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith(PLAN_REVIEW_PREFIX):
+            return stripped[: _VERDICT_LOG_PREVIEW_CHARS]
+
+    return ""
 
 
 def _fetch_issue_comments_graphql(issue_number: int) -> list[dict[str, Any]]:
@@ -94,7 +130,7 @@ def _fetch_issue_comments_graphql(issue_number: int) -> list[dict[str, Any]]:
         "  repository(owner:$owner,name:$name){"
         "    issue(number:$number){"
         "      comments(last: 100, orderBy: {field: UPDATED_AT, direction: DESC}){"
-        "        nodes{ body updatedAt }"
+        "        nodes{ body updatedAt url }"
         "      }"
         "    }"
         "  }"
@@ -165,10 +201,12 @@ def is_plan_review_approved(
         comments = _fetch_issue_comments_graphql(issue_number)
 
     latest_review_body: str | None = None
+    latest_review_url: str | None = None
     for comment in comments:
         body: str = comment.get("body", "")
         if body.startswith(PLAN_REVIEW_PREFIX):
             latest_review_body = body
+            latest_review_url = comment.get("url")
 
     if latest_review_body is None:
         logger.debug(
@@ -185,9 +223,13 @@ def is_plan_review_approved(
             issue_ref(issue_number),
         )
     else:
+        context = _extract_verdict_context(latest_review_body)
+        url_part = f" {latest_review_url}" if latest_review_url else " <no url>"
         logger.debug(
-            "Issue %s: latest plan review verdict is %s (not APPROVED)",
+            "Issue %s: latest plan review verdict is %s (not APPROVED) | %s%s",
             issue_ref(issue_number),
             verdict or "<missing>",
+            context,
+            url_part,
         )
     return is_approved

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -1,6 +1,7 @@
 """Tests for git utility functions."""
 
 import subprocess
+from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
@@ -19,7 +20,7 @@ from hephaestus.automation.git_utils import (
 
 
 @pytest.fixture(autouse=True)
-def _clear_caches() -> None:
+def _clear_caches() -> Generator[None, None, None]:
     """Clear repo caches before each test to avoid cross-test interference."""
     clear_repo_caches()
     yield
@@ -145,9 +146,7 @@ class TestGetRepoInfo:
 
     @patch("hephaestus.automation.git_utils.run")
     @patch("hephaestus.automation.git_utils.get_repo_root")
-    def test_clear_repo_caches_forces_re_detection(
-        self, mock_get_root: Any, mock_run: Any
-    ) -> None:
+    def test_clear_repo_caches_forces_re_detection(self, mock_get_root: Any, mock_run: Any) -> None:
         """Test that clear_repo_caches forces re-detection on next call."""
         repo_root = Path("/home/user/repo")
         mock_get_root.return_value = repo_root

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hephaestus.automation.git_utils import (
+    clear_repo_caches,
     get_current_branch,
     get_repo_info,
     get_repo_root,
@@ -15,6 +16,14 @@ from hephaestus.automation.git_utils import (
     run,
     safe_git_fetch,
 )
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches() -> None:
+    """Clear repo caches before each test to avoid cross-test interference."""
+    clear_repo_caches()
+    yield
+    clear_repo_caches()
 
 
 class TestRun:
@@ -109,6 +118,53 @@ class TestGetRepoInfo:
 
         with pytest.raises(RuntimeError, match="Unable to parse git remote URL"):
             get_repo_info()
+
+    @patch("hephaestus.automation.git_utils.run")
+    @patch("hephaestus.automation.git_utils.get_repo_root")
+    def test_result_caching_prevents_repeated_run_calls(
+        self, mock_get_root: Any, mock_run: Any
+    ) -> None:
+        """Test that repeated get_repo_info calls use cached result."""
+        repo_root = Path("/home/user/repo")
+        mock_get_root.return_value = repo_root
+        mock_result = Mock()
+        mock_result.stdout = "git@github.com:owner/repo.git\n"
+        mock_run.return_value = mock_result
+
+        # First call should invoke run() and cache the result
+        owner1, repo1 = get_repo_info(repo_root)
+        assert owner1 == "owner"
+        assert repo1 == "repo"
+        assert mock_run.call_count == 1
+
+        # Second call with same repo_root should return cached result without calling run()
+        owner2, repo2 = get_repo_info(repo_root)
+        assert owner2 == "owner"
+        assert repo2 == "repo"
+        assert mock_run.call_count == 1  # Should not increase
+
+    @patch("hephaestus.automation.git_utils.run")
+    @patch("hephaestus.automation.git_utils.get_repo_root")
+    def test_clear_repo_caches_forces_re_detection(
+        self, mock_get_root: Any, mock_run: Any
+    ) -> None:
+        """Test that clear_repo_caches forces re-detection on next call."""
+        repo_root = Path("/home/user/repo")
+        mock_get_root.return_value = repo_root
+        mock_result = Mock()
+        mock_result.stdout = "git@github.com:owner/repo.git\n"
+        mock_run.return_value = mock_result
+
+        # First call caches the result
+        get_repo_info(repo_root)
+        assert mock_run.call_count == 1
+
+        # Clear caches
+        clear_repo_caches()
+
+        # Next call should invoke run() again
+        get_repo_info(repo_root)
+        assert mock_run.call_count == 2
 
 
 class TestGetCurrentBranch:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -22,6 +22,7 @@ from hephaestus.automation.loop_runner import (
     PhaseResult,
     RepoResult,
     _phase_order_warnings,
+    _summarize_loop,
     _validate_phases,
     process_repo,
     run_loop,
@@ -716,3 +717,82 @@ def test_detect_cwd_repo_returns_none_when_not_git() -> None:
     ):
         org, repo = loop_runner._detect_cwd_repo()
     assert (org, repo) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _summarize_loop
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeLoop:
+    """Tests for loop summary generation."""
+
+    def test_empty_loop_results(self) -> None:
+        """Empty loop (no repos) produces zero counts."""
+        summary = _summarize_loop([], 1, 10.5)
+        assert summary == "loop 1: planned=0 reviewed=0 skipped=0 elapsed=10s"
+
+    def test_all_skipped_phases(self) -> None:
+        """All skipped phases counted in skipped column."""
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        repo_result.phases = [
+            PhaseResult("plan", skipped=True, skip_reason="no issues"),
+            PhaseResult("review-plans", skipped=True, skip_reason="no issues"),
+        ]
+        summary = _summarize_loop([repo_result], 2, 5.0)
+        assert "planned=0" in summary
+        assert "reviewed=0" in summary
+        assert "skipped=2" in summary
+        assert "loop 2" in summary
+
+    def test_counts_plan_phase(self) -> None:
+        """Non-skipped plan phase counted in planned."""
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        repo_result.phases = [PhaseResult("plan", rc=0)]
+        summary = _summarize_loop([repo_result], 1, 3.0)
+        assert "planned=1" in summary
+
+    def test_counts_review_phases(self) -> None:
+        """Non-skipped review-plans and review-prs counted in reviewed."""
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        repo_result.phases = [
+            PhaseResult("review-plans", rc=0),
+            PhaseResult("review-prs", rc=0),
+        ]
+        summary = _summarize_loop([repo_result], 1, 3.0)
+        assert "reviewed=2" in summary
+
+    def test_mixed_phases(self) -> None:
+        """Mix of skipped, planned, and reviewed phases."""
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        repo_result.phases = [
+            PhaseResult("plan", rc=0),
+            PhaseResult("review-plans", rc=0),
+            PhaseResult("implement", skipped=True, skip_reason="no issues"),
+            PhaseResult("review-prs", rc=1),  # failed but still counted as reviewed
+        ]
+        summary = _summarize_loop([repo_result], 3, 7.5)
+        assert "loop 3" in summary
+        assert "planned=1" in summary
+        assert "reviewed=2" in summary
+        assert "skipped=1" in summary
+
+    def test_elapsed_formatting(self) -> None:
+        """Elapsed time formatted with no decimal places."""
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        summary = _summarize_loop([repo_result], 1, 45.6)
+        assert "elapsed=46s" in summary
+
+    def test_multiple_repos_aggregated(self) -> None:
+        """Results from multiple repos aggregated together."""
+        repo1 = RepoResult(repo="Repo1", loop_idx=1)
+        repo1.phases = [PhaseResult("plan", rc=0)]
+        repo2 = RepoResult(repo="Repo2", loop_idx=1)
+        repo2.phases = [
+            PhaseResult("plan", skipped=True, skip_reason="no issues"),
+            PhaseResult("review-plans", rc=0),
+        ]
+        summary = _summarize_loop([repo1, repo2], 1, 10.0)
+        assert "planned=1" in summary
+        assert "reviewed=1" in summary
+        assert "skipped=1" in summary

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -19,6 +19,7 @@ from hephaestus.automation.review_state import (
     VERDICT_APPROVED,
     VERDICT_BLOCK,
     VERDICT_REVISE,
+    _extract_verdict_context,
     is_plan_review_approved,
     latest_verdict,
 )
@@ -72,16 +73,64 @@ class TestLatestVerdict:
 
 
 # ---------------------------------------------------------------------------
+# _extract_verdict_context
+# ---------------------------------------------------------------------------
+
+
+class TestExtractVerdictContext:
+    """Context extraction for not-APPROVED logs."""
+
+    def test_extracts_verdict_line_when_present(self) -> None:
+        body = f"{PLAN_REVIEW_PREFIX}\n\nReview text.\n\n**Verdict: REVISE**\n"
+        context = _extract_verdict_context(body)
+        assert "Verdict: REVISE" in context
+
+    def test_returns_first_non_prefix_line_when_no_verdict(self) -> None:
+        body = f"{PLAN_REVIEW_PREFIX}\n\nThis is the main content.\nMore details.\n"
+        context = _extract_verdict_context(body)
+        assert context == "This is the main content."
+
+    def test_prefers_verdict_line_over_first_content_line(self) -> None:
+        body = (
+            f"{PLAN_REVIEW_PREFIX}\n\nFirst line of content.\n"
+            "More details.\n**Verdict: BLOCK**\n"
+        )
+        context = _extract_verdict_context(body)
+        assert "Verdict: BLOCK" in context
+
+    def test_returns_empty_string_when_body_is_empty(self) -> None:
+        body = ""
+        context = _extract_verdict_context(body)
+        assert context == ""
+
+    def test_returns_empty_string_when_only_prefix_lines(self) -> None:
+        body = f"{PLAN_REVIEW_PREFIX}\n{PLAN_REVIEW_PREFIX}\n"
+        context = _extract_verdict_context(body)
+        assert context == ""
+
+    def test_truncates_to_verdict_log_preview_chars(self) -> None:
+        long_line = "x" * 500
+        body = f"{PLAN_REVIEW_PREFIX}\n\n{long_line}\n"
+        context = _extract_verdict_context(body)
+        assert len(context) <= 200
+
+
+# ---------------------------------------------------------------------------
 # is_plan_review_approved (with pre-supplied comments)
 # ---------------------------------------------------------------------------
 
 
-def _review_comment(verdict: str | None) -> dict[str, Any]:
+def _review_comment(
+    verdict: str | None, url: str | None = None
+) -> dict[str, Any]:
     if verdict is None:
         body = f"{PLAN_REVIEW_PREFIX}\n\nMalformed review with no verdict line.\n"
     else:
         body = f"{PLAN_REVIEW_PREFIX}\n\nBody.\n\n**Verdict: {verdict}**\n"
-    return {"body": body}
+    comment = {"body": body}
+    if url is not None:
+        comment["url"] = url
+    return comment
 
 
 def _plan_comment() -> dict[str, Any]:
@@ -133,6 +182,48 @@ class TestIsPlanReviewApprovedWithComments:
         # Review comment exists with the right prefix but no verdict line.
         comments = [_plan_comment(), _review_comment(None)]
         assert is_plan_review_approved(123, comments=comments) is False
+
+    def test_enriched_logging_includes_verdict_context_and_url(
+        self, caplog: Any
+    ) -> None:
+        """Not-APPROVED logs should include verdict context and URL."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        comments = [
+            _plan_comment(),
+            _review_comment(VERDICT_BLOCK, url="https://github.com/o/r/issues/123#comment-1"),
+        ]
+        is_plan_review_approved(123, comments=comments)
+        # Logs should include verdict context and URL when not-APPROVED
+        log_text = caplog.text
+        assert "BLOCK" in log_text
+        assert "https://github.com/o/r/issues/123#comment-1" in log_text
+
+    def test_enriched_logging_fallback_no_url(self, caplog: Any) -> None:
+        """Not-APPROVED logs should show <no url> when URL is missing."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        comments = [_plan_comment(), _review_comment(VERDICT_REVISE)]
+        is_plan_review_approved(123, comments=comments)
+        log_text = caplog.text
+        assert "REVISE" in log_text
+        assert "<no url>" in log_text
+
+    def test_enriched_logging_missing_verdict(self, caplog: Any) -> None:
+        """Not-APPROVED logs should show verdict context even for <missing> verdicts."""
+        import logging
+
+        caplog.set_level(logging.DEBUG)
+        comments = [
+            _plan_comment(),
+            _review_comment(None, url="https://github.com/o/r/issues/123#comment-2"),
+        ]
+        is_plan_review_approved(123, comments=comments)
+        log_text = caplog.text
+        assert "<missing>" in log_text
+        assert "https://github.com/o/r/issues/123#comment-2" in log_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -92,8 +92,7 @@ class TestExtractVerdictContext:
 
     def test_prefers_verdict_line_over_first_content_line(self) -> None:
         body = (
-            f"{PLAN_REVIEW_PREFIX}\n\nFirst line of content.\n"
-            "More details.\n**Verdict: BLOCK**\n"
+            f"{PLAN_REVIEW_PREFIX}\n\nFirst line of content.\nMore details.\n**Verdict: BLOCK**\n"
         )
         context = _extract_verdict_context(body)
         assert "Verdict: BLOCK" in context
@@ -120,9 +119,7 @@ class TestExtractVerdictContext:
 # ---------------------------------------------------------------------------
 
 
-def _review_comment(
-    verdict: str | None, url: str | None = None
-) -> dict[str, Any]:
+def _review_comment(verdict: str | None, url: str | None = None) -> dict[str, Any]:
     if verdict is None:
         body = f"{PLAN_REVIEW_PREFIX}\n\nMalformed review with no verdict line.\n"
     else:
@@ -183,9 +180,7 @@ class TestIsPlanReviewApprovedWithComments:
         comments = [_plan_comment(), _review_comment(None)]
         assert is_plan_review_approved(123, comments=comments) is False
 
-    def test_enriched_logging_includes_verdict_context_and_url(
-        self, caplog: Any
-    ) -> None:
+    def test_enriched_logging_includes_verdict_context_and_url(self, caplog: Any) -> None:
         """Not-APPROVED logs should include verdict context and URL."""
         import logging
 


### PR DESCRIPTION
## Summary

Reduces automation-loop diagnostic noise and improves visibility into loop execution:

1. **Silenced repo-detection noise** — both 68× `Detected repo` and 68× `Running command: git remote get-url origin` by caching `get_repo_info()` results per repo_root. Cache is invalidated between test runs via autouse fixture.
2. **Added per-loop summary** — emits `loop N: planned=X reviewed=Y skipped=Z elapsed=Ts` before each loop completes, so no-op loops (#614) are visible without reading every line.
3. **Enriched `<missing>` verdict logs** — when a plan-review verdict is not APPROVED, logs now include the first meaningful line of the review body + comment URL, making #613 root-causes actionable.

## Test Plan

- [x] All 676 automation tests pass (including 7 new `_summarize_loop` tests, 6 new `_extract_verdict_context` tests, 2 new caching tests, and 3 enriched logging tests)
- [x] Code passes ruff and mypy checks
- [x] Commit cryptographically signed
- [x] PR body includes `Closes #617`

## Files Changed

- `hephaestus/automation/git_utils.py`: Added `_repo_info_cache`, wrapped `get_repo_info()` with caching, added `clear_repo_caches()` helper.
- `hephaestus/automation/review_state.py`: Added `_VERDICT_LOG_PREVIEW_CHARS` constant, `_extract_verdict_context()` helper, GraphQL `url` field, enriched not-APPROVED logging.
- `hephaestus/automation/loop_runner.py`: Added `_summarize_loop()` helper, loop timing, per-loop summary emission.
- Test files extended with new test cases for all three changes.

Closes #617