### PR TITLE
refactor(automation): inject PlannerHost protocol, eliminate planner coupling

### DIFF
--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -16,7 +16,7 @@ on the worker-pool driver. No behavior change.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any, Protocol
 
 from .claude_invoke import parse_review_verdict
 from .claude_models import learn_model, planner_model, reviewer_model
@@ -26,32 +26,101 @@ from .github_api import gh_issue_json
 from .prompts import get_plan_loop_review_prompt, get_plan_prompt
 from .session_naming import AGENT_LEARNINGS, AGENT_PLAN_REVIEWER, AGENT_PLANNER
 
-if TYPE_CHECKING:
-    from .planner import Planner
-
 logger = logging.getLogger(__name__)
 
 MAX_REVIEW_ITERATIONS = 3
 
 
+class PlannerHost(Protocol):
+    """Minimal Planner surface the review loop depends on.
+
+    Declares only the methods and attributes PlanReviewLoop calls, allowing
+    the loop to depend on this interface rather than the concrete Planner's
+    full private surface (Dependency Inversion Principle). Implements
+    structural substitutability — any object with these members satisfies
+    the protocol.
+
+    Method names retain their underscore prefix because they are the existing
+    call surface. This is deliberate: the test seam (e.g.,
+    ``patch.object(planner, "_generate_plan", ...)``) targets these private
+    names, and renaming them is out of scope. The docstring here makes the
+    contract explicit and documented.
+    """
+
+    options: Any
+    status_tracker: Any
+
+    def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
+        """Search team knowledge base for relevant prior learnings."""
+        ...
+
+    def _generate_plan(
+        self,
+        issue_number: int,
+        max_retries: int = 3,
+        *,
+        prior_review: str | None = None,
+        cached_advise: str | None = None,
+        cached_issue_data: dict[str, Any] | None = None,
+    ) -> str:
+        """Generate implementation plan using Claude Code."""
+        ...
+
+    def _capture_planner_learnings(self, issue_number: int, plan: str) -> str:
+        """Capture learnings from the generated plan."""
+        ...
+
+    def _run_plan_review(
+        self,
+        *,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        plan_text: str,
+        learnings: str,
+        iteration: int,
+        prior_review: str | None,
+    ) -> str:
+        """Run a reviewer pass on the current plan."""
+        ...
+
+    def _call_claude(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        agent: str,
+        issue_number: int | str,
+        max_retries: int = 3,
+        timeout: int = 300,
+        extra_args: list[str] | None = None,
+    ) -> str:
+        """Call Claude with the given prompt."""
+        ...
+
+
 class PlanReviewLoop:
     """Bounded plan→learn→review iteration loop.
 
-    Holds a back-reference to the owning :class:`Planner` and intentionally
-    routes per-issue work back through ``planner._generate_plan`` /
+    Holds a back-reference to a :class:`PlannerHost` and intentionally routes
+    per-issue work back through ``planner._generate_plan`` /
     ``planner._capture_planner_learnings`` / ``planner._run_plan_review``
     rather than calling :class:`PlannerClaudeRunner` directly. The indirection
     preserves the existing ``patch.object(planner, "_generate_plan", ...)``
-    test seam: a patched method on the Planner instance still intercepts the
+    test seam: a patched method on the host instance still intercepts the
     loop's inner calls.
+
+    Depends on the minimal :class:`PlannerHost` protocol rather than the
+    concrete Planner class, making the loop substitutable for testing and
+    allowing implementation flexibility.
     """
 
-    def __init__(self, planner: Planner) -> None:
-        """Bind the loop to its owning planner.
+    def __init__(self, planner: PlannerHost) -> None:
+        """Bind the loop to its owning planner host.
 
         Args:
-            planner: The :class:`Planner` instance whose options,
-                status tracker, and Claude helpers this loop reuses.
+            planner: A :class:`PlannerHost` instance (typically a Planner)
+                whose options, status tracker, and Claude helpers this loop reuses.
 
         """
         self.planner = planner

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -52,7 +52,7 @@ class PlannerHost(Protocol):
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
         """Search team knowledge base for relevant prior learnings."""
-        ...
+        pass
 
     def _generate_plan(
         self,
@@ -64,11 +64,11 @@ class PlannerHost(Protocol):
         cached_issue_data: dict[str, Any] | None = None,
     ) -> str:
         """Generate implementation plan using Claude Code."""
-        ...
+        pass
 
     def _capture_planner_learnings(self, issue_number: int, plan: str) -> str:
         """Capture learnings from the generated plan."""
-        ...
+        pass
 
     def _run_plan_review(
         self,
@@ -82,7 +82,7 @@ class PlannerHost(Protocol):
         prior_review: str | None,
     ) -> str:
         """Run a reviewer pass on the current plan."""
-        ...
+        pass
 
     def _call_claude(
         self,
@@ -96,7 +96,7 @@ class PlannerHost(Protocol):
         extra_args: list[str] | None = None,
     ) -> str:
         """Call Claude with the given prompt."""
-        ...
+        pass
 
 
 class PlanReviewLoop:

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -349,3 +349,51 @@ class TestFilterIssues:
             result = planner._filter_issues()
 
         assert result == [123]
+
+
+class TestPlanReviewLoopProtocolSubstitutability:
+    """Verify PlanReviewLoop depends on PlannerHost protocol, not concrete Planner.
+
+    This ensures the loop is genuinely substitutable — it can be instantiated
+    with any object that implements the PlannerHost protocol, not just a
+    Planner instance.
+    """
+
+    def test_loop_runs_with_protocol_host(self) -> None:
+        """PlanReviewLoop must work with a minimal fake host (not a real Planner).
+
+        This is the core proof that the Protocol injection works: the loop
+        doesn't depend on the concrete Planner class, only the interface.
+        """
+        from unittest.mock import MagicMock
+
+        from hephaestus.automation.planner_review_loop import PlanReviewLoop
+
+        # Create a minimal fake host that satisfies PlannerHost protocol
+        fake_host = MagicMock()
+        fake_host.options = MagicMock()
+        fake_host.options.enable_advise = False
+        fake_host.status_tracker = MagicMock()
+        fake_host._run_advise = MagicMock(return_value="advise")
+        fake_host._generate_plan = MagicMock(return_value="plan")
+        fake_host._capture_planner_learnings = MagicMock(return_value="learnings")
+        fake_host._run_plan_review = MagicMock(return_value=_go_review())
+        fake_host._call_claude = MagicMock(return_value="result")
+
+        # Instantiate PlanReviewLoop with the fake host (not a Planner)
+        loop = PlanReviewLoop(fake_host)
+
+        # Verify the loop can run without error
+        with patch(
+            "hephaestus.automation.planner_review_loop.gh_issue_json",
+            return_value={"title": "Test", "body": "Description"},
+        ):
+            plan, review, iterations, verdict_is_go = loop.run(123, slot_id=0)
+
+        # Verify the loop called the host's methods
+        assert fake_host._generate_plan.called
+        assert fake_host._capture_planner_learnings.called
+        assert fake_host._run_plan_review.called
+        assert plan == "plan"
+        assert iterations == 1
+        assert verdict_is_go is True

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -388,7 +388,7 @@ class TestPlanReviewLoopProtocolSubstitutability:
             "hephaestus.automation.planner_review_loop.gh_issue_json",
             return_value={"title": "Test", "body": "Description"},
         ):
-            plan, review, iterations, verdict_is_go = loop.run(123, slot_id=0)
+            plan, _review, iterations, verdict_is_go = loop.run(123, slot_id=0)
 
         # Verify the loop called the host's methods
         assert fake_host._generate_plan.called


### PR DESCRIPTION
## Summary

PlanReviewLoop was constructed with the entire Planner object and reached into ~8 private methods, violating Dependency Inversion Principle and modularity. This PR replaces the concrete dependency with a `PlannerHost` Protocol declaring only the interface the loop actually uses.

## Changes

- Define `PlannerHost(Protocol)` with the 5 methods and 2 attributes `PlanReviewLoop` consumes
- Change `PlanReviewLoop.__init__(planner: PlannerHost)` signature
- `Planner` structurally satisfies the protocol, so all call sites work unchanged
- Test seam (`patch.object(planner, "_generate_plan", ...)`) preserved via late-binding through the host instance
- Add substitutability test verifying loop works with minimal fake host

## Test plan

- [x] All 19 existing planner loop tests pass
- [x] All 24 planner tests pass
- [x] New substitutability test verifies loop accepts minimal PlannerHost implementation
- [x] mypy confirms structural conformance
- [x] ruff lint and format checks pass
- [x] No runtime behavior change — purely type-layer refactoring

Closes #620