### PR TITLE
fix: correct watch recipe to use default environment

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ test-shell:
 
 # Re-run unit tests on file change (uses pytest-watch). Cancel with Ctrl-C.
 watch:
-    pixi run --environment dev ptw {{ unit_test_dir }} -- --no-cov -q
+    pixi run --environment default ptw {{ unit_test_dir }} -- --no-cov -q
 
 # Run linter
 lint:


### PR DESCRIPTION
Fix the just watch recipe which references a nonexistent pixi environment 'dev'. The dev feature is included in the default environment, so the recipe should use --environment default.

Closes #621