### PR TITLE
feat: add timeout= to unbounded short-lived subprocess calls

### DIFF
--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status, format_output
+from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 # Header written at the top of every auto-generated requirements file.
 _GENERATED_HEADER = """\
@@ -294,11 +295,19 @@ def get_pixi_packages() -> dict[str, str]:
         SystemExit: With code 1 if ``pixi list`` fails.
 
     """
-    result = subprocess.run(
-        ["pixi", "list", "--json"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["pixi", "list", "--json"],
+            capture_output=True,
+            text=True,
+            timeout=METADATA_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        print(
+            "ERROR: pixi list --json timed out",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     if result.returncode != 0:
         print(
             f"ERROR: pixi list --json failed: {result.stderr}",

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -39,6 +39,7 @@ from hephaestus.agents.runtime import add_agent_argument, is_codex, run_codex_te
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 from hephaestus.github.rate_limit import detect_rate_limit, wait_until
 from hephaestus.logging.utils import get_logger
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 logger = get_logger(__name__)
 
@@ -62,15 +63,19 @@ def get_resign_email() -> str:
     if env:
         return env
     for args in (["--global"], []):
-        result = subprocess.run(
-            ["git", "config", *args, "--get", "user.email"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        email = result.stdout.strip()
-        if result.returncode == 0 and email:
-            return email
+        try:
+            result = subprocess.run(
+                ["git", "config", *args, "--get", "user.email"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=METADATA_TIMEOUT,
+            )
+            email = result.stdout.strip()
+            if result.returncode == 0 and email:
+                return email
+        except subprocess.TimeoutExpired:
+            continue
     raise RuntimeError(
         "fleet_sync: no resign email configured. Set FLEET_GIT_EMAIL=<address> "
         "or `git config --global user.email <address>` before running."
@@ -154,7 +159,7 @@ def _gh(
                 check=check,
                 capture_output=True,
                 text=True,
-                timeout=120,
+                timeout=NETWORK_TIMEOUT,
             )
         except subprocess.CalledProcessError as e:
             epoch = detect_rate_limit(e.stderr or "")
@@ -174,7 +179,10 @@ def _git(
     dry_run: bool = False,
     check: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a git command in a working directory."""
+    """Run a git command in a working directory.
+
+    Uses NETWORK_TIMEOUT for operations involving network I/O (clone, fetch, push).
+    """
     if dry_run:
         logger.info("[dry-run] git %s (in %s)", " ".join(args), cwd)
         return subprocess.CompletedProcess(["git", *args], 0, stdout="", stderr="")
@@ -184,6 +192,7 @@ def _git(
         capture_output=True,
         text=True,
         check=check,
+        timeout=NETWORK_TIMEOUT,
     )
 
 
@@ -312,7 +321,7 @@ def rebase_and_resign(pr: PRInfo, clone_dir: Path, dry_run: bool = False) -> boo
         logger.info("  ✓ Rebased and re-signed PR #%d", pr.number)
         return True
 
-    except subprocess.CalledProcessError as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         logger.error("  Rebase/push failed for PR #%d: %s", pr.number, e.stderr or str(e))
         return False
 
@@ -382,6 +391,7 @@ def resolve_conflict_with_agent(
             capture_output=True,
             text=True,
             check=False,
+            timeout=NETWORK_TIMEOUT,
         )
 
         # Identify conflicted files
@@ -391,6 +401,7 @@ def resolve_conflict_with_agent(
             capture_output=True,
             text=True,
             check=True,
+            timeout=METADATA_TIMEOUT,
         )
         conflict_files = [f.strip() for f in status_result.stdout.splitlines() if f.strip()]
 
@@ -415,6 +426,7 @@ def resolve_conflict_with_agent(
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=METADATA_TIMEOUT,
             )
             commit_count = commit_count_result.stdout.strip()
             resign_email = get_resign_email()
@@ -464,6 +476,7 @@ Rules:
             capture_output=True,
             text=True,
             check=False,
+            timeout=NETWORK_TIMEOUT,
         )
         if branch in verify.stdout:
             logger.info("  ✓ Conflict resolved and pushed for PR #%d", pr.number)

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -27,6 +27,7 @@ from hephaestus.agents.runtime import add_agent_argument, is_codex, run_codex_te
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 from hephaestus.github.pr_merge import detect_repo_from_remote
 from hephaestus.logging.utils import get_logger
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 logger = get_logger(__name__)
 
@@ -62,45 +63,63 @@ def _detect_default_branch(override: str | None) -> str:
             capture_output=True,
             text=True,
             check=True,
+            timeout=NETWORK_TIMEOUT,
         )
         branch = result.stdout.strip()
         if branch:
             return branch
-    except subprocess.CalledProcessError as e:
-        logger.warning("Could not detect default branch via gh: %s", e.stderr.strip())
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        logger.warning("Could not detect default branch via gh: %s", getattr(e, "stderr", str(e)))
     return "main"
 
 
 def _working_tree_clean() -> bool:
     """Return True if the git working tree has no uncommitted changes."""
-    result = subprocess.run(
-        ["git", "status", "--porcelain"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return result.returncode == 0 and result.stdout.strip() == ""
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=METADATA_TIMEOUT,
+        )
+        return result.returncode == 0 and result.stdout.strip() == ""
+    except subprocess.TimeoutExpired as e:
+        logger.error("git status timed out: %s", e)
+        raise
 
 
 def _in_git_repo() -> bool:
     """Return True if cwd is inside a git repository."""
-    return (
-        subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
-            capture_output=True,
-            check=False,
-        ).returncode
-        == 0
-    )
+    try:
+        return (
+            subprocess.run(
+                ["git", "rev-parse", "--git-dir"],
+                capture_output=True,
+                check=False,
+                timeout=METADATA_TIMEOUT,
+            ).returncode
+            == 0
+        )
+    except subprocess.TimeoutExpired as e:
+        logger.error("git rev-parse --git-dir timed out: %s", e)
+        raise
 
 
 def _repo_root() -> Path:
-    """Return the root directory of the current git repository."""
+    """Return the root directory of the current git repository.
+
+    Note: TimeoutExpired propagates to the sole caller (_validate_environment),
+    which invokes this bare without a try/except. This is consistent with the
+    CalledProcessError path: both failures propagate as unhandled exceptions to
+    the CLI entrypoint.
+    """
     result = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
         capture_output=True,
         text=True,
         check=True,
+        timeout=METADATA_TIMEOUT,
     )
     return Path(result.stdout.strip())
 

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -17,6 +17,13 @@ from hephaestus.logging.utils import get_logger
 
 logger = get_logger(__name__)
 
+# Subprocess timeouts for different operation types.
+# METADATA_TIMEOUT: local, non-network queries (git status, git config, pixi list)
+# NETWORK_TIMEOUT: operations touching the network (gh calls, git clone/fetch/push)
+# Both support env-var overrides for CI tuning.
+METADATA_TIMEOUT: int = int(os.environ.get("HEPHAESTUS_SUBPROCESS_METADATA_TIMEOUT", "10"))
+NETWORK_TIMEOUT: int = int(os.environ.get("HEPHAESTUS_SUBPROCESS_NETWORK_TIMEOUT", "120"))
+
 
 def slugify(text: str) -> str:
     """Convert text to a URL-friendly slug.

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-import subprocess
 
 import pytest
 
@@ -563,8 +563,9 @@ class TestTimeoutHandling:
         """get_pixi_packages uses METADATA_TIMEOUT."""
         from hephaestus.utils.helpers import METADATA_TIMEOUT
 
+        pixi_out = '[{"name": "pkg", "version": "1.0"}]'
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout='[{"name": "pkg", "version": "1.0"}]')
+            mock_run.return_value = MagicMock(returncode=0, stdout=pixi_out)
             get_pixi_packages()
             assert mock_run.called
             call_kwargs = mock_run.call_args[1]

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+import subprocess
 
 import pytest
 
@@ -17,6 +18,7 @@ from hephaestus.config.dep_sync import (
     check_requirements_against_pixi,
     check_requirements_up_to_date,
     generate_requirements_content,
+    get_pixi_packages,
     parse_pixi_toml,
     parse_requirements,
     sync_requirements,
@@ -542,3 +544,29 @@ class TestParsePixiTomlFeatureEnvs:
         (tmp_path / "requirements-dev.txt").write_text("pytest==9.0.3\n")
         errors = check_dep_sync(tmp_path)
         assert errors == []
+
+
+class TestTimeoutHandling:
+    """Tests for subprocess timeout handling in dep_sync."""
+
+    def test_get_pixi_packages_with_timeout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """get_pixi_packages exits with code 1 on timeout."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(["pixi"], 10)
+            with pytest.raises(SystemExit) as exc_info:
+                get_pixi_packages()
+            assert exc_info.value.code == 1
+            captured = capsys.readouterr()
+            assert "timed out" in captured.err
+
+    def test_get_pixi_packages_uses_metadata_timeout(self) -> None:
+        """get_pixi_packages uses METADATA_TIMEOUT."""
+        from hephaestus.utils.helpers import METADATA_TIMEOUT
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout='[{"name": "pkg", "version": "1.0"}]')
+            get_pixi_packages()
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == METADATA_TIMEOUT

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -1,8 +1,17 @@
-"""Unit tests for hephaestus.github.fleet_sync — pure logic functions."""
+"""Unit tests for hephaestus.github.fleet_sync — pure logic functions and timeouts."""
 
 from __future__ import annotations
 
-from hephaestus.github.fleet_sync import PRInfo, PRStatus, _ci_state
+import importlib
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.github.fleet_sync import PRInfo, PRStatus, _ci_state, get_resign_email
+
+fleet_sync_module = importlib.import_module("hephaestus.github.fleet_sync")
 
 
 class TestCiState:
@@ -294,3 +303,62 @@ class TestMain:
         )
         assert fleet_sync.main() == 0
         assert calls == ["owner/a", "owner/b"]
+
+
+class TestTimeoutHandling:
+    """Tests for subprocess timeout handling in fleet_sync."""
+
+    def test_get_resign_email_with_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_resign_email handles TimeoutExpired by trying next config source."""
+        monkeypatch.delenv("FLEET_GIT_EMAIL", raising=False)
+
+        call_count = [0]
+
+        def failing_run(*args, **kwargs):
+            call_count[0] += 1
+            # First call times out, second returns a result
+            if call_count[0] == 1:
+                raise subprocess.TimeoutExpired(["git"], 10)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "alice@example.com\n"
+            return result
+
+        monkeypatch.setattr("hephaestus.github.fleet_sync.subprocess.run", failing_run)
+        # Should get email from second attempt (after timeout)
+        assert get_resign_email() == "alice@example.com"
+
+    def test_get_resign_email_uses_metadata_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """get_resign_email uses METADATA_TIMEOUT."""
+        monkeypatch.delenv("FLEET_GIT_EMAIL", raising=False)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="test@example.com\n")
+            get_resign_email()
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == fleet_sync_module.METADATA_TIMEOUT
+
+    def test_gh_uses_network_timeout(self) -> None:
+        """_gh function uses NETWORK_TIMEOUT."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="[]")
+            fleet_sync_module._gh(["pr", "list"], repo="TestRepo")
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == fleet_sync_module.NETWORK_TIMEOUT
+
+    def test_git_uses_network_timeout(self) -> None:
+        """_git function uses NETWORK_TIMEOUT."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="")
+            work_dir = Path("/tmp/test")
+            fleet_sync_module._git(["clone", "url", "."], cwd=work_dir)
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == fleet_sync_module.NETWORK_TIMEOUT

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -328,9 +328,7 @@ class TestTimeoutHandling:
         # Should get email from second attempt (after timeout)
         assert get_resign_email() == "alice@example.com"
 
-    def test_get_resign_email_uses_metadata_timeout(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_get_resign_email_uses_metadata_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """get_resign_email uses METADATA_TIMEOUT."""
         monkeypatch.delenv("FLEET_GIT_EMAIL", raising=False)
 

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -1,12 +1,20 @@
-"""Unit tests for hephaestus.github.tidy — focusing on parse_problem_branches."""
+"""Unit tests for hephaestus.github.tidy — focusing on parse_problem_branches and timeouts."""
 
 import asyncio
 import importlib
+import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.github.tidy import parse_problem_branches
+from hephaestus.github.tidy import (
+    _detect_default_branch,
+    _in_git_repo,
+    _repo_root,
+    _working_tree_clean,
+    parse_problem_branches,
+)
 
 tidy_module = importlib.import_module("hephaestus.github.tidy")
 
@@ -264,3 +272,69 @@ class TestMain:
         monkeypatch.setattr(tidy_module, "_validate_environment", lambda: None)
         monkeypatch.setattr("sys.argv", ["hephaestus-tidy"])
         assert tidy_module.main() == 1
+
+
+class TestTimeoutHandling:
+    """Tests for subprocess timeout handling in tidy helpers."""
+
+    def test_detect_default_branch_with_timeout(self) -> None:
+        """_detect_default_branch falls back to 'main' on timeout."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(["gh"], 120)
+            result = _detect_default_branch(None)
+            assert result == "main"
+
+    def test_detect_default_branch_calls_with_network_timeout(self) -> None:
+        """_detect_default_branch uses NETWORK_TIMEOUT."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="main\n")
+            _detect_default_branch(None)
+            # Verify the call included timeout
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == tidy_module.NETWORK_TIMEOUT
+
+    def test_working_tree_clean_with_timeout(self) -> None:
+        """_working_tree_clean propagates TimeoutExpired."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(["git"], 10)
+            with pytest.raises(subprocess.TimeoutExpired):
+                _working_tree_clean()
+
+    def test_working_tree_clean_uses_metadata_timeout(self) -> None:
+        """_working_tree_clean uses METADATA_TIMEOUT."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            _working_tree_clean()
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == tidy_module.METADATA_TIMEOUT
+
+    def test_in_git_repo_with_timeout(self) -> None:
+        """_in_git_repo propagates TimeoutExpired."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(["git"], 10)
+            with pytest.raises(subprocess.TimeoutExpired):
+                _in_git_repo()
+
+    def test_in_git_repo_uses_metadata_timeout(self) -> None:
+        """_in_git_repo uses METADATA_TIMEOUT."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            _in_git_repo()
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == tidy_module.METADATA_TIMEOUT
+
+    def test_repo_root_uses_metadata_timeout(self) -> None:
+        """_repo_root uses METADATA_TIMEOUT."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="/path/to/repo\n")
+            _repo_root()
+            assert mock_run.called
+            call_kwargs = mock_run.call_args[1]
+            assert "timeout" in call_kwargs
+            assert call_kwargs["timeout"] == tidy_module.METADATA_TIMEOUT

--- a/tests/unit/utils/test_constants.py
+++ b/tests/unit/utils/test_constants.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """Tests for the shared constants module."""
 
+import importlib
 import logging
+import os
+from unittest.mock import patch
 
 import pytest
 
 from hephaestus.constants import DEFAULT_EXCLUDE_DIRS, LOG_FORMAT
+from hephaestus.utils import helpers
 
 
 class TestDefaultExcludeDirs:
@@ -78,3 +82,55 @@ class TestLogFormat:
         assert "%(name)s" in LOG_FORMAT
         assert "%(levelname)s" in LOG_FORMAT
         assert "%(message)s" in LOG_FORMAT
+
+
+class TestSubprocessTimeouts:
+    """Tests for subprocess timeout constants."""
+
+    def test_metadata_timeout_exists(self) -> None:
+        """METADATA_TIMEOUT constant is defined."""
+        assert hasattr(helpers, "METADATA_TIMEOUT")
+        assert isinstance(helpers.METADATA_TIMEOUT, int)
+        assert helpers.METADATA_TIMEOUT > 0
+
+    def test_network_timeout_exists(self) -> None:
+        """NETWORK_TIMEOUT constant is defined."""
+        assert hasattr(helpers, "NETWORK_TIMEOUT")
+        assert isinstance(helpers.NETWORK_TIMEOUT, int)
+        assert helpers.NETWORK_TIMEOUT > 0
+
+    def test_network_timeout_longer_than_metadata(self) -> None:
+        """NETWORK_TIMEOUT should be longer than METADATA_TIMEOUT."""
+        assert helpers.NETWORK_TIMEOUT >= helpers.METADATA_TIMEOUT
+
+    def test_default_metadata_timeout_is_10(self) -> None:
+        """Default METADATA_TIMEOUT is 10 seconds."""
+        if "HEPHAESTUS_SUBPROCESS_METADATA_TIMEOUT" not in os.environ:
+            assert helpers.METADATA_TIMEOUT == 10
+
+    def test_default_network_timeout_is_120(self) -> None:
+        """Default NETWORK_TIMEOUT is 120 seconds."""
+        if "HEPHAESTUS_SUBPROCESS_NETWORK_TIMEOUT" not in os.environ:
+            assert helpers.NETWORK_TIMEOUT == 120
+
+    def test_metadata_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """METADATA_TIMEOUT respects HEPHAESTUS_SUBPROCESS_METADATA_TIMEOUT env var."""
+        monkeypatch.setenv("HEPHAESTUS_SUBPROCESS_METADATA_TIMEOUT", "5")
+        # Reimport to pick up the new env var
+        importlib.reload(helpers)
+        try:
+            assert helpers.METADATA_TIMEOUT == 5
+        finally:
+            # Restore original values
+            importlib.reload(helpers)
+
+    def test_network_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """NETWORK_TIMEOUT respects HEPHAESTUS_SUBPROCESS_NETWORK_TIMEOUT env var."""
+        monkeypatch.setenv("HEPHAESTUS_SUBPROCESS_NETWORK_TIMEOUT", "300")
+        # Reimport to pick up the new env var
+        importlib.reload(helpers)
+        try:
+            assert helpers.NETWORK_TIMEOUT == 300
+        finally:
+            # Restore original values
+            importlib.reload(helpers)

--- a/tests/unit/utils/test_constants.py
+++ b/tests/unit/utils/test_constants.py
@@ -4,7 +4,6 @@
 import importlib
 import logging
 import os
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -14,7 +14,6 @@ from hephaestus.utils.helpers import (
     get_repo_root,
     human_readable_size,
     install_package,
-    logger,
     run_subprocess,
     slugify,
 )
@@ -179,7 +178,7 @@ class TestRunSubprocess:
 
     def test_log_on_error_false_suppresses_error_log(self):
         """When log_on_error=False, failure does not call logger.error."""
-        with patch.object(logger, "error") as mock_error:
+        with patch("hephaestus.utils.helpers.logger.error") as mock_error:
             with pytest.raises(subprocess.CalledProcessError):
                 run_subprocess(["false"], log_on_error=False)
 
@@ -187,7 +186,7 @@ class TestRunSubprocess:
 
     def test_log_on_error_true_emits_error_log(self):
         """When log_on_error=True (default), failure calls logger.error."""
-        with patch.object(logger, "error") as mock_error:
+        with patch("hephaestus.utils.helpers.logger.error") as mock_error:
             with pytest.raises(subprocess.CalledProcessError):
                 run_subprocess(["false"], log_on_error=True)
 
@@ -201,7 +200,7 @@ class TestRunSubprocess:
         """
         long_arg = "x" * 10_000
 
-        with patch.object(logger, "error") as mock_error:
+        with patch("hephaestus.utils.helpers.logger.error") as mock_error:
             with pytest.raises(subprocess.CalledProcessError):
                 run_subprocess(["false", long_arg])
 
@@ -370,7 +369,7 @@ class TestRunSubprocessTimeoutLogging:
         exc = subprocess.TimeoutExpired(cmd=["sleep", "99"], timeout=1)
         with (
             patch("subprocess.run", side_effect=exc),
-            patch.object(logger, "error") as mock_error,
+            patch("hephaestus.utils.helpers.logger.error") as mock_error,
         ):
             with pytest.raises(subprocess.TimeoutExpired):
                 run_subprocess(["sleep", "99"], timeout=1)


### PR DESCRIPTION
## Summary

Add `timeout=` arguments to all unbounded short-lived subprocess calls in three modules, eliminating indefinite-hang paths.

**Key changes:**
- Add METADATA_TIMEOUT (10s) and NETWORK_TIMEOUT (120s) to helpers.py
- Apply to tidy.py (_detect_default_branch, _working_tree_clean, _in_git_repo, _repo_root)
- Apply to fleet_sync.py (get_resign_email, _gh, _git, resolve_conflict_with_agent calls, rebase_and_resign)
- Apply to dep_sync.py (get_pixi_packages)
- Uniform TimeoutExpired handling: timeouts are failures, routed to existing exception paths

**Test plan**
- Unit tests verify timeout constants exist and respect env-var overrides
- Per-call-site timeout tier validation (network vs metadata timeouts)
- TimeoutExpired exception handling and propagation
- All 138 tests pass; mypy and ruff checks pass

Closes #624

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>