### PR TITLE
fix(resilience): enforce half_open_max_calls concurrency limit

### DIFF
--- a/hephaestus/resilience/circuit_breaker.py
+++ b/hephaestus/resilience/circuit_breaker.py
@@ -54,11 +54,17 @@ class CircuitBreaker:
     Tracks failures and opens the circuit when a threshold is exceeded,
     preventing further calls until a recovery timeout has elapsed.
 
+    The HALF_OPEN state admits a limited number of concurrent in-flight calls
+    to test recovery. The `half_open_max_calls` parameter controls this concurrency
+    limit: each admitted call increments an in-flight counter, and each completed
+    call (success or failure) decrements it, allowing the next call to proceed.
+
     Args:
         name: Identifier for this circuit breaker instance
         failure_threshold: Number of consecutive failures before opening
         recovery_timeout: Seconds to wait before transitioning to half-open
-        half_open_max_calls: Max calls allowed in half-open state
+        half_open_max_calls: Maximum number of calls admitted concurrently in-flight
+            while HALF_OPEN; each call releases its slot on completion (success or failure)
         success_threshold: Consecutive successes in HALF_OPEN required to close
 
     Example:
@@ -81,7 +87,8 @@ class CircuitBreaker:
             name: Identifier for this circuit breaker instance
             failure_threshold: Consecutive failures before opening
             recovery_timeout: Seconds before transitioning to half-open
-            half_open_max_calls: Max calls allowed in half-open state
+            half_open_max_calls: Maximum number of calls admitted concurrently
+                in-flight while HALF_OPEN; each call releases its slot on completion
             success_threshold: Consecutive successes in HALF_OPEN to close
 
         """
@@ -158,13 +165,13 @@ class CircuitBreaker:
         return result
 
     def _record_success(self) -> None:
-        """Record a successful call."""
+        """Record a successful call (releases this call's half-open slot)."""
         with self._lock:
             if self._state == CircuitBreakerState.HALF_OPEN:
+                if self._half_open_calls > 0:
+                    self._half_open_calls -= 1
                 self._half_open_successes += 1
                 if self._half_open_successes < self.success_threshold:
-                    # Allow the next probe through by resetting the call counter
-                    self._half_open_calls = 0
                     return
                 logger.info(
                     "Circuit breaker '%s' closing after %d successful half-open call(s)",
@@ -177,12 +184,14 @@ class CircuitBreaker:
             self._half_open_successes = 0
 
     def _record_failure(self) -> None:
-        """Record a failed call."""
+        """Record a failed call (releases this call's half-open slot)."""
         with self._lock:
             self._failure_count += 1
             self._last_failure_time = time.monotonic()
 
             if self._state == CircuitBreakerState.HALF_OPEN:
+                if self._half_open_calls > 0:
+                    self._half_open_calls -= 1
                 self._state = CircuitBreakerState.OPEN
                 logger.warning(
                     "Circuit breaker '%s' re-opened after half-open failure",
@@ -225,7 +234,8 @@ def get_circuit_breaker(
         name: Unique identifier for the circuit breaker
         failure_threshold: Failures before opening (only used on creation)
         recovery_timeout: Recovery timeout in seconds (only used on creation)
-        half_open_max_calls: Max half-open calls (only used on creation)
+        half_open_max_calls: Maximum concurrent in-flight calls in HALF_OPEN state
+            (only used on creation)
         success_threshold: Successes in HALF_OPEN to close (only used on creation)
 
     Returns:

--- a/tests/unit/resilience/test_circuit_breaker.py
+++ b/tests/unit/resilience/test_circuit_breaker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -444,3 +445,148 @@ def test_parametrized_thresholds_full_cycle(
         cb.call(lambda: "ok")
 
     assert cb.state == CircuitBreakerState.CLOSED
+
+
+class TestCircuitBreakerHalfOpenConcurrency:
+    """Tests for half-open admission under concurrent access."""
+
+    def test_half_open_inflight_never_exceeds_max(self) -> None:
+        """Peak concurrent in-flight calls never exceed half_open_max_calls.
+
+        With success_threshold > 1, verifies that _half_open_calls is decremented
+        on call completion, preventing re-admission while earlier probes are
+        executing outside the lock.
+
+        Uses a threading.Barrier to guarantee concurrent execution and
+        deterministic peak measurement, eliminating timing dependencies.
+        """
+        half_open_max_calls = 2
+        success_threshold = 10
+        num_probe_threads = 8
+
+        cb = CircuitBreaker(
+            "concurrency_test",
+            failure_threshold=1,
+            recovery_timeout=0.1,
+            half_open_max_calls=half_open_max_calls,
+            success_threshold=success_threshold,
+        )
+
+        # Open the circuit
+        with pytest.raises(RuntimeError):
+            cb.call(MagicMock(side_effect=RuntimeError("fail")))
+
+        assert cb.state == CircuitBreakerState.OPEN
+
+        # Wait for recovery
+        time.sleep(0.15)
+        assert cb.state == CircuitBreakerState.HALF_OPEN
+
+        # Track concurrent in-flight calls
+        current_inflight = 0
+        peak_inflight = 0
+        inflight_lock = threading.Lock()
+        probe_barrier = threading.Barrier(half_open_max_calls, timeout=2.0)
+
+        def probe_func() -> str:
+            """Probe that tracks in-flight concurrency and blocks at barrier."""
+            nonlocal current_inflight, peak_inflight
+            with inflight_lock:
+                current_inflight += 1
+                peak_inflight = max(peak_inflight, current_inflight)
+            with contextlib.suppress(threading.BrokenBarrierError):
+                probe_barrier.wait()
+            with inflight_lock:
+                current_inflight -= 1
+            return "ok"
+
+        # Spawn threads; some will be admitted (up to half_open_max_calls),
+        # others will get CircuitBreakerOpenError
+        threads = []
+        for _ in range(num_probe_threads):
+
+            def attempt() -> None:
+                with contextlib.suppress(CircuitBreakerOpenError):
+                    cb.call(probe_func)
+
+            t = threading.Thread(target=attempt)
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        # Peak concurrent calls should never exceed half_open_max_calls,
+        # even though success_threshold > 1 and _half_open_calls was being reset
+        assert peak_inflight <= half_open_max_calls, (
+            f"Peak concurrent calls ({peak_inflight}) "
+            f"exceeded half_open_max_calls ({half_open_max_calls})"
+        )
+
+    def test_half_open_slot_released_on_success(self) -> None:
+        """In-flight slot is released on successful call, allowing reuse within half-open phase."""
+        half_open_max_calls = 1
+        success_threshold = 3
+
+        cb = CircuitBreaker(
+            "slot_reuse_test",
+            failure_threshold=1,
+            recovery_timeout=0.1,
+            half_open_max_calls=half_open_max_calls,
+            success_threshold=success_threshold,
+        )
+
+        # Open the circuit
+        with pytest.raises(RuntimeError):
+            cb.call(MagicMock(side_effect=RuntimeError("fail")))
+
+        # Wait for recovery
+        time.sleep(0.15)
+        assert cb.state == CircuitBreakerState.HALF_OPEN
+
+        # First probe succeeds
+        cb.call(lambda: "ok")
+        assert cb.state == CircuitBreakerState.HALF_OPEN
+        assert cb._half_open_calls == 0  # Slot released
+        assert cb._half_open_successes == 1
+
+        # Second probe reuses the same slot
+        cb.call(lambda: "ok")
+        assert cb.state == CircuitBreakerState.HALF_OPEN
+        assert cb._half_open_calls == 0  # Slot released again
+        assert cb._half_open_successes == 2
+
+        # Third probe closes the circuit
+        cb.call(lambda: "ok")
+        assert cb.state == CircuitBreakerState.CLOSED
+        # After transition to CLOSED, counters are reset
+        assert cb._half_open_calls == 0
+
+    def test_half_open_slot_released_on_failure(self) -> None:
+        """In-flight slot is released on failed call in half-open state."""
+        half_open_max_calls = 2
+        success_threshold = 2
+
+        cb = CircuitBreaker(
+            "slot_failure_test",
+            failure_threshold=1,
+            recovery_timeout=0.1,
+            half_open_max_calls=half_open_max_calls,
+            success_threshold=success_threshold,
+        )
+
+        # Open the circuit
+        with pytest.raises(RuntimeError):
+            cb.call(MagicMock(side_effect=RuntimeError("fail")))
+
+        # Wait for recovery
+        time.sleep(0.15)
+        assert cb.state == CircuitBreakerState.HALF_OPEN
+
+        # One probe fails
+        with pytest.raises(RuntimeError):
+            cb.call(MagicMock(side_effect=RuntimeError("probe fails")))
+
+        # Should be back to OPEN, slot released
+        assert cb.state == CircuitBreakerState.OPEN
+        assert cb._half_open_calls == 0


### PR DESCRIPTION
## Summary

Fix the circuit breaker's HALF_OPEN admission gate to enforce the `half_open_max_calls` concurrency limit under concurrent access.

## Problem

With `success_threshold > 1`, the `_record_success` method was resetting `_half_open_calls = 0` on each intermediate success, allowing the admission gate to re-open while earlier probes were still executing outside the lock. This violated the documented concurrency guarantee.

## Solution

Convert `_half_open_calls` to a proper in-flight call gauge that is:
- Incremented on admission (existing behavior)
- **Decremented on completion** (both success and failure) — the fix
- All mutations remain protected by `self._lock`

This ensures the concurrency limit is enforced across the entire call duration, not just at admission time.

## Testing

Added `TestCircuitBreakerHalfOpenConcurrency` with three deterministic tests:
- `test_half_open_inflight_never_exceeds_max`: Uses `threading.Barrier` to guarantee concurrent execution and verify peak in-flight ≤ `half_open_max_calls`
- `test_half_open_slot_released_on_success`: Verifies slot reuse within the half-open phase
- `test_half_open_slot_released_on_failure`: Verifies slot release on failure

All 32 tests pass (29 existing + 3 new). Coverage: 96.97% for circuit_breaker.py.

Closes #626