### PR TITLE
docs: fix stale merge guidance + add permission boundary

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,24 @@
   "enabledPlugins": {
     "hephaestus@ProjectHephaestus": true,
     "safety-net@cc-marketplace": true
+  },
+  "permissions": {
+    "deny": [
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf ~)",
+      "Bash(rm -rf $HOME*)",
+      "Bash(sudo:*)",
+      "Bash(curl * | sh)",
+      "Bash(curl * | bash)",
+      "Bash(git push --force*)",
+      "Bash(git push -f*)",
+      "Bash(git reset --hard origin/main)",
+      "Bash(git push * --no-verify*)",
+      "Bash(git commit * --no-verify*)",
+      "Bash(gh pr merge * --admin*)",
+      "Write(~/.ssh/**)",
+      "Write(~/.aws/**)",
+      "Write(~/.gnupg/**)"
+    ]
   }
 }

--- a/.claude/workflows/development.md
+++ b/.claude/workflows/development.md
@@ -16,7 +16,7 @@ This file describes the typical development workflow for ProjectHephaestus.
 1. **Automated Checks**: All PRs must pass pre-commit hooks
 2. **Peer Review**: At least one other developer review required
 3. **Security Review**: Security-sensitive changes require special attention
-4. **Merge**: Use rebase merge strategy with auto-merge enabled
+4. **Merge**: Use squash merge strategy with auto-merge enabled (`gh pr merge --auto --squash`)
 
 ## Testing Workflow
 


### PR DESCRIPTION
## Summary

Addresses two stale/missing configurations in project guidance:

- Fixed `.claude/workflows/development.md:19` to correctly document squash merge strategy (aligns with actual repo configuration: rebase merge disabled, squash enabled)
- Added `permissions.deny` boundary to `.claude/settings.json` with defense-in-depth security entries matching ecosystem convention (ProjectHermes/ProjectArgus pattern)

## Changes

1. **development.md:19** — Updated merge strategy guidance from "rebase merge strategy" to "squash merge strategy" with concrete command (`gh pr merge --auto --squash`)
2. **.claude/settings.json** — Added `permissions.deny` block with 15 entries covering:
   - Destructive operations: `rm -rf`, `sudo`, credential file writes
   - Signing bypass: `--no-verify` flags
   - Force push and admin merge bypass
   - Shell injection patterns: `curl | sh`, `curl | bash`

All entries copied verbatim from ProjectHermes (proven ecosystem convention, no novel glob semantics).

## Test Plan

- [x] JSON valid (`python -m json.tool .claude/settings.json`)
- [x] Tests passing (`pytest tests/unit/validation/test_doc_policy.py` — 37/37)
- [x] Pre-commit passing (markdown lint, trailing whitespace, file endings)
- [x] Doc policy audit clean (no new violations from prose change)

Closes #628