### PR TITLE
security: add int() cast for GraphQL issue numbers

### DIFF
--- a/.claude-followup-629.md
+++ b/.claude-followup-629.md
@@ -1,0 +1,10 @@
+{
+  "follow_ups": [
+    {
+      "category": "security",
+      "title": "Add int() cast for PR number in GraphQL query",
+      "body": "gh_pr_list_unresolved_threads at hephaestus/automation/github_api.py:1100 interpolates pr_number directly into GraphQL query without int() cast. owner/repo are regex-guarded (lines 1093-1094) but pr_number is not. Same pattern as #629. Fix: cast {int(pr_number)} in the f-string at line 1100."
+    }
+  ],
+  "rejected": []
+}

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -787,7 +787,7 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
 
     """
     fragments = [
-        f"issue{idx}: issue(number: {num}) {{ number state }}" for idx, num in enumerate(batch)
+        f"issue{idx}: issue(number: {int(num)}) {{ number state }}" for idx, num in enumerate(batch)
     ]
     query = f"""
         query {{

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -247,7 +247,9 @@ class TestPrefetchIssueStates:
 
     @patch("hephaestus.automation.github_api._gh_call")
     @patch("hephaestus.automation.github_api.get_repo_info")
-    def test_non_numeric_issue_number_raises_error(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+    def test_non_numeric_issue_number_raises_error(
+        self, mock_repo_info: Any, mock_gh_call: Any
+    ) -> None:
         """Test that non-numeric issue numbers raise ValueError during int() casting."""
         mock_repo_info.return_value = ("owner", "repo")
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -215,6 +215,48 @@ class TestPrefetchIssueStates:
 
         assert states == {}
 
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_int_validation_in_graphql_query(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        """Test that issue numbers are cast to int in GraphQL query to prevent injection."""
+        mock_repo_info.return_value = ("owner", "repo")
+
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "issue0": {"number": 123, "state": "OPEN"},
+                    }
+                }
+            }
+        )
+        mock_gh_call.return_value = mock_result
+
+        # Call with issue numbers
+        states = prefetch_issue_states([123])
+
+        # Verify the GraphQL query was called with int-casted numbers
+        mock_gh_call.assert_called()
+        call_args = mock_gh_call.call_args
+        # The query should contain the int-casted number
+        query_arg = call_args[0][0]
+        assert any("issue(number: 123)" in arg for arg in query_arg)
+
+        assert states[123] == IssueState.OPEN
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_non_numeric_issue_number_raises_error(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        """Test that non-numeric issue numbers raise ValueError during int() casting."""
+        mock_repo_info.return_value = ("owner", "repo")
+
+        # Try to pass a non-numeric string (type-hint violation)
+        # This should raise a ValueError when int() is called on it
+        with pytest.raises(ValueError):
+            # Using "abc" as string will fail the int() cast
+            prefetch_issue_states(["abc"])  # type: ignore
+
 
 class TestGhCall:
     """Tests for _gh_call function."""


### PR DESCRIPTION
## Summary
Added runtime int() validation for GraphQL issue numbers to prevent injection attacks, matching existing regex-guarding of owner/repo fields.

## Changes
- Cast issue numbers to int() in _fetch_batch_states GraphQL query fragment
- Added tests for int validation and non-numeric input error handling

Closes #629