### PR TITLE
feat(automation): per-file sub-agents address review threads via /advise

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -652,7 +652,10 @@ class AddressReviewer(BaseReviewer):
                 timeout=address_review_claude_timeout(),
                 output_format="json",
                 permission_mode="dontAsk",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                # Task: the session acts as a coordinator that dispatches one
+                # sub-agent per file of review threads. Skill: each sub-agent
+                # runs /hephaestus:advise before fixing. See prompts/address_review.py.
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash,Task,Skill",
                 input_via_stdin=True,
             )
             log_file.write_text(stdout or "")

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -5,7 +5,8 @@ import secrets
 from ._shared import _UNTRUSTED_NOTICE, _fence_untrusted
 
 ADDRESS_REVIEW_PROMPT = """
-Address the review threads for PR #{pr_number} (issue #{issue_number}).
+You are the COORDINATOR for addressing the review threads on PR #{pr_number}
+(issue #{issue_number}).
 
 **Working Directory:** {worktree_path}
 
@@ -22,27 +23,58 @@ The block above is a JSON array where each element has:
 
 ---
 
-**Your task:**
-For each thread, read the file at `path` in the working directory and apply the necessary
-code fix. After fixing all addressable threads:
+**Your task (coordinator):**
 
-1. Run tests: `pixi run python -m pytest tests/ -v`
-2. Run pre-commit: `pre-commit run --all-files`
-3. Fix any issues found
-4. Commit all changes (do NOT push)
+1. Parse the review-threads JSON above and **group the threads by `path`** (one group
+   per distinct file). Threads with a null/empty `path` (PR-level / general comments)
+   form one extra group keyed as `__general__`.
+
+2. For EACH file group, dispatch ONE sub-agent using the Task tool
+   (`subagent_type: "general-purpose"`). Dispatch all groups, one sub-agent per file.
+   Each sub-agent OWNS exactly one file and must not touch any other file — this
+   prevents two agents editing the same file and causing merge/commit contention.
+
+   Give each sub-agent a self-contained prompt that instructs it to:
+   a. FIRST run the team-knowledge skill to pull prior learnings relevant to this fix:
+      `Skill(skill: "hephaestus:advise", args: "<short description of the review feedback>")`.
+      Use whatever it surfaces to inform the fix; do not skip this step.
+   b. Read the owned file at `path` in the working directory `{worktree_path}` and apply
+      the code fix for ALL of that file's review threads (you will pass it the thread
+      bodies + line numbers + thread_ids for its file only).
+   c. Report back, for each `thread_id` it handled, a one-line reply describing the fix —
+      or, if a thread is not addressable in code, say so and leave it out of the fixed set.
+
+   **Each sub-agent prompt MUST include these guardrails (critical):**
+   - "Do NOT background your work, do NOT exit early, and do NOT defer. Complete the fix
+     synchronously and return only when the file is fully edited."
+   - "You own ONLY the file `<path>`. Do not read-modify any other file. Do not commit,
+     push, or run git — the coordinator handles that."
+   - "Return your result as a compact list mapping each thread_id to a one-line reply."
+
+3. After ALL sub-agents have returned, you (the coordinator) integrate their results and
+   run the gates from the working directory:
+   - Run tests: `pixi run python -m pytest tests/ -v`
+   - Run pre-commit: `pre-commit run --all-files`
+   - Fix any issues found (you may edit files directly at this stage).
+   - Commit all changes (do NOT push).
+
+4. Trust but verify: only mark a thread `addressed` if the owning sub-agent actually
+   edited the file for it. If a sub-agent claimed a fix but the file is unchanged for that
+   thread, drop it from `addressed`.
 
 **Output format:**
-Write your fix notes in prose. At the very end of your response, emit a single fenced JSON block:
+Write your coordination notes in prose. At the very end of your response, emit a single
+fenced JSON block:
 
 ```json
 {{"addressed": ["<thread_id>", ...], "replies": {{"<thread_id>": "one-line reply"}}}}
 ```
 
-Rules for the JSON block:
-- `addressed`: array of thread_id strings for threads you actually fixed in code
+Rules for the JSON block (UNCHANGED — the pipeline parses exactly this):
+- `addressed`: array of thread_id strings for threads actually fixed in code
   (any thread_id not in the unresolved-set we presented is dropped silently)
-- `replies`: mapping of thread_id to a one-line reply describing what you changed
-- Only include threads you genuinely fixed. Leave unaddressable threads out of `addressed`.
+- `replies`: mapping of thread_id to a one-line reply describing what changed
+- Only include threads genuinely fixed. Leave unaddressable threads out of `addressed`.
 - Emit only one JSON block, at the very end of your response (the parser takes the LAST one).
 """
 

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -478,3 +478,62 @@ class TestImplLoopStrictRubric:
             out = self._build(iteration)
             assert "Grade: <A|B|C|D|F>" in out
             assert "Verdict: <GO|NOGO>" in out
+
+
+class TestAddressReviewPrompt:
+    """The address-review prompt is a coordinator that fans out per-file sub-agents."""
+
+    def _build(self) -> str:
+        return prompts.get_address_review_prompt(
+            pr_number=42,
+            issue_number=7,
+            worktree_path="/tmp/wt",
+            threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "fix"}]',
+        )
+
+    def test_substitutes_args(self) -> None:
+        out = self._build()
+        assert "42" in out
+        assert "7" in out
+        assert "/tmp/wt" in out
+
+    def test_instructs_per_file_subagent_fanout(self) -> None:
+        out = self._build()
+        # Coordinator groups by file and dispatches one sub-agent per file via Task.
+        assert "group the threads by `path`" in out or "group the threads by `path`" in out.lower()
+        assert "Task tool" in out
+        assert "ONE sub-agent" in out
+
+    def test_instructs_advise_skill(self) -> None:
+        """Each sub-agent must consult /hephaestus:advise before fixing."""
+        out = self._build()
+        assert "hephaestus:advise" in out
+
+    def test_has_no_early_exit_and_file_ownership_guardrails(self) -> None:
+        out = self._build()
+        assert "do NOT exit early" in out
+        assert "Do NOT background" in out
+        # File ownership: a sub-agent owns exactly one file.
+        assert "OWNS exactly one file" in out
+
+    def test_preserves_json_block_contract(self) -> None:
+        """The final JSON-block contract the pipeline parses must be intact."""
+        out = self._build()
+        assert '"addressed"' in out
+        assert '"replies"' in out
+
+    def test_threads_json_is_fenced_untrusted(self) -> None:
+        """Reviewer bodies stay fenced as untrusted input."""
+        out = self._build()
+        assert "BEGIN_" in out and "THREADS_JSON" in out
+        assert "UNTRUSTED" in out
+
+    def test_renders_with_brace_containing_body(self) -> None:
+        """A reviewer comment containing curly braces must not break .format()."""
+        out = prompts.get_address_review_prompt(
+            pr_number=1,
+            issue_number=1,
+            worktree_path="/tmp/wt",
+            threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "use {x: 1}"}]',
+        )
+        assert "use {x: 1}" in out


### PR DESCRIPTION
## Summary
- The `address-review` phase used ONE Claude session per issue for all review threads, and its `allowed_tools` lacked `Task` — so it could not fan out.
- The session is now a **coordinator**: it groups unresolved threads by file `path` and dispatches **one sub-agent per file** (file ownership prevents two agents editing the same file, per the verified-ci swarm dispatch learnings).
- Each sub-agent first runs `Skill(skill: "hephaestus:advise", ...)` to pull prior learnings, then fixes all of its file's threads. Guardrails baked in: no backgrounding, no early-exit, single-file ownership.
- Coordinator runs tests + pre-commit, commits (no push), and emits the **unchanged** final JSON-block contract (`{"addressed": [...], "replies": {...}}`).
- Thread reply/resolution stays in Python (`_resolve_addressed_threads` → `gh_pr_resolve_thread`), preserving the hallucinated-thread-id guard. `Task,Skill` added to the Claude path's `allowed_tools`.

## Test plan
- [x] `pixi run pytest tests/unit/automation/` — 671 passed (new `TestAddressReviewPrompt`: per-file fan-out, /advise, no-early-exit + file-ownership guardrails, preserved JSON contract, untrusted fencing, brace-safe rendering)
- [x] `pixi run ruff check` + `pixi run mypy` — clean

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)