### PR TITLE
refactor(automation): foundation for 3-stage pipeline (session naming, comment upsert, anchored plan marker)

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -526,6 +526,154 @@ def gh_issue_comment(issue_number: int, body: str) -> None:
         raise RuntimeError(f"Failed to post comment to issue #{issue_number}: {e}") from e
 
 
+def _fetch_issue_comment_ids(issue_number: int) -> list[dict[str, Any]]:
+    """Return up to 100 most-recent issue comments as ``{databaseId, body}`` dicts.
+
+    Unlike :func:`_fetch_issue_comments_graphql` in ``review_state`` (which
+    fetches ``body``/``url`` for verdict parsing), this also requests
+    ``databaseId`` — the integer id required by the REST update/delete
+    endpoints (``/repos/{o}/{r}/issues/comments/{id}``). Newest-first from
+    GraphQL is reversed to chronological order so "last match wins" matches
+    the rest of the pipeline.
+
+    Returns an empty list on any failure (callers then fall back to create).
+    """
+    owner, name = get_repo_info()
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "  repository(owner:$owner,name:$name){"
+        "    issue(number:$number){"
+        "      comments(last: 100, orderBy: {field: UPDATED_AT, direction: DESC}){"
+        "        nodes{ databaseId body }"
+        "      }"
+        "    }"
+        "  }"
+        "}"
+    )
+    try:
+        result = _gh_call(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={issue_number}",
+            ],
+        )
+        data = json.loads(result.stdout)
+        nodes = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("issue", {})
+            .get("comments", {})
+            .get("nodes", [])
+        )
+        return list(reversed(nodes))
+    except Exception as exc:
+        logger.warning("Failed to fetch comment ids for issue #%s: %s", issue_number, exc)
+        return []
+
+
+def gh_issue_delete_comment(comment_id: int) -> None:
+    """Delete a single issue comment by its REST database id.
+
+    Args:
+        comment_id: The integer ``databaseId`` of the issue comment.
+
+    Raises:
+        RuntimeError: If the delete call fails.
+
+    """
+    owner, name = get_repo_info()
+    try:
+        _gh_call(
+            [
+                "api",
+                "--method",
+                "DELETE",
+                f"/repos/{owner}/{name}/issues/comments/{comment_id}",
+            ],
+        )
+        logger.info("Deleted issue comment %s", comment_id)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Failed to delete issue comment {comment_id}: {e}") from e
+
+
+def gh_issue_upsert_comment(issue_number: int, marker_prefix: str, body: str) -> int | None:
+    """Create-or-update the single issue comment whose body starts with ``marker_prefix``.
+
+    Enforces the "one comment per role" invariant: the pipeline must keep at
+    most one PLAN comment (``# Implementation Plan``) and one REVIEW comment
+    (``## 🔍 Plan Review``) per issue, updated in place rather than appended.
+
+    Behaviour:
+    - Find every existing comment whose body ``startswith(marker_prefix)``.
+    - If none: create a new comment.
+    - If one or more: PATCH the newest matching comment with ``body`` and
+      DELETE the older duplicates (one-time convergence for issues that
+      already accumulated multiple plan/review comments).
+
+    Args:
+        issue_number: GitHub issue number.
+        marker_prefix: The role marker the comment body must start with.
+        body: The full new comment body (should itself start with the marker).
+
+    Returns:
+        The ``databaseId`` of the upserted comment, or ``None`` if a fresh
+        comment was created via ``gh issue comment`` (whose id we do not parse).
+
+    Raises:
+        RuntimeError: If a create/update/delete call fails.
+
+    """
+    comments = _fetch_issue_comment_ids(issue_number)
+    matching = [
+        c
+        for c in comments
+        if str(c.get("body", "")).startswith(marker_prefix) and c.get("databaseId") is not None
+    ]
+
+    if not matching:
+        # No existing comment with this marker — create a fresh one.
+        gh_issue_comment(issue_number, body)
+        return None
+
+    # Newest matching comment wins (list is chronological → last element).
+    target = matching[-1]
+    target_id = int(target["databaseId"])
+    owner, name = get_repo_info()
+
+    # Delete older duplicates so only one comment with this marker remains.
+    for dup in matching[:-1]:
+        dup_id = dup.get("databaseId")
+        if dup_id is not None:
+            gh_issue_delete_comment(int(dup_id))
+
+    try:
+        with _body_file(body) as path:
+            _gh_call(
+                [
+                    "api",
+                    "--method",
+                    "PATCH",
+                    f"/repos/{owner}/{name}/issues/comments/{target_id}",
+                    "-F",
+                    f"body=@{path}",
+                ],
+            )
+        logger.info("Updated issue comment %s (marker %r)", target_id, marker_prefix)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"Failed to update issue comment {target_id} on #{issue_number}: {e}"
+        ) from e
+    return target_id
+
+
 def _parse_issue_number(output: str) -> int:
     """Extract issue number from gh issue create output (URL or bare number)."""
     match = re.search(r"/issues/(\d+)", output)

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -14,10 +14,19 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-# Markers that identify a plan comment posted by the planner. Used by both
-# the planner (to skip already-posted plans) and plan_reviewer (to locate
-# the plan to review). Single source of truth — adding a new heading style
-# only requires one edit.
+# The canonical heading the planner WRITES at the top of the single plan
+# comment. The pipeline upserts exactly one comment starting with this marker
+# (see github_api.gh_issue_upsert_comment). This is the only marker used to
+# *locate the plan to review*.
+PLAN_COMMENT_MARKER: str = "# Implementation Plan"
+
+# Broader set of headings that may identify a *legacy* plan comment authored
+# before the single-comment model. Used ONLY for backward-compatible detection
+# of "does this issue already have a plan?" — NOT for selecting the plan body
+# to feed the reviewer. Critically this set must never be used as a substring
+# match against arbitrary comment bodies: a "## 🔍 Plan Review" comment legitimately
+# contains "## Objective"/"## Plan" when it quotes the plan, and matching those
+# caused the reviewer to review its own prior review (issues #455/#468/#484).
 PLAN_COMMENT_MARKERS: tuple[str, ...] = (
     "# Implementation Plan",
     "## Implementation Plan",

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -20,21 +20,6 @@ from pydantic import BaseModel, Field
 # *locate the plan to review*.
 PLAN_COMMENT_MARKER: str = "# Implementation Plan"
 
-# Broader set of headings that may identify a *legacy* plan comment authored
-# before the single-comment model. Used ONLY for backward-compatible detection
-# of "does this issue already have a plan?" — NOT for selecting the plan body
-# to feed the reviewer. Critically this set must never be used as a substring
-# match against arbitrary comment bodies: a "## 🔍 Plan Review" comment legitimately
-# contains "## Objective"/"## Plan" when it quotes the plan, and matching those
-# caused the reviewer to review its own prior review (issues #455/#468/#484).
-PLAN_COMMENT_MARKERS: tuple[str, ...] = (
-    "# Implementation Plan",
-    "## Implementation Plan",
-    "# Plan",
-    "## Plan",
-    "## Objective",
-)
-
 
 class IssueState(str, Enum):
     """GitHub issue state."""

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -3,7 +3,7 @@
 Provides:
 - Parallel plan review across multiple issues
 - Duplicate review detection (skips already-reviewed issues)
-- Plan detection using the same markers as the planner
+- Plan detection using the same canonical marker as the planner
 - Dry-run support with early return before any GitHub writes
 """
 
@@ -28,7 +28,7 @@ from .claude_models import reviewer_model
 from .claude_timeouts import plan_reviewer_claude_timeout
 from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref
 from .github_api import _gh_call, gh_issue_comment, gh_issue_json
-from .models import PLAN_COMMENT_MARKER, PLAN_COMMENT_MARKERS, PlanReviewerOptions, WorkerResult
+from .models import PLAN_COMMENT_MARKER, PlanReviewerOptions, WorkerResult
 from .prompts import get_plan_review_prompt
 from .review_state import (
     PLAN_REVIEW_PREFIX as _REVIEW_PREFIX_SHARED,
@@ -42,10 +42,6 @@ from .work_report import write_work_report
 
 logger = logging.getLogger(__name__)
 
-# Plan-comment markers live in models.PLAN_COMMENT_MARKERS — re-exported here
-# under the existing private name so test files that imported it still work.
-_PLAN_MARKERS = PLAN_COMMENT_MARKERS
-
 # Prefix used by this reviewer when posting review comments.
 #
 # IMPORTANT: byte-exact case-sensitive match assumption. Idempotency rests on
@@ -57,8 +53,8 @@ _PLAN_MARKERS = PLAN_COMMENT_MARKERS
 # will post a duplicate review every loop. If that becomes a concern,
 # NFC-normalize both sides via ``unicodedata.normalize("NFC", ...)`` before
 # comparison. See issue #565.
-# Re-exported from review_state for back-compat. Both reviewer and
-# implementer now share one source of truth for the plan-review gate
+# Aliased from review_state so both reviewer and implementer share one
+# source of truth for the plan-review gate
 # (see :mod:`hephaestus.automation.review_state` and issue #551).
 _REVIEW_PREFIX = _REVIEW_PREFIX_SHARED
 
@@ -374,11 +370,9 @@ class PlanReviewer:
             stripped = body.lstrip()
             if stripped.startswith(_REVIEW_PREFIX):
                 continue  # never treat a review comment as the plan
-            # Canonical marker first; fall back to legacy markers but ONLY at
-            # the start of the body (anchored), never as a free substring.
-            if stripped.startswith(PLAN_COMMENT_MARKER) or any(
-                stripped.startswith(marker) for marker in _PLAN_MARKERS
-            ):
+            # Match the single canonical marker ONLY at the start of the body
+            # (anchored), never as a free substring.
+            if stripped.startswith(PLAN_COMMENT_MARKER):
                 logger.debug("Found plan comment for issue #%s", issue_number)
                 return body
 

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -28,7 +28,7 @@ from .claude_models import reviewer_model
 from .claude_timeouts import plan_reviewer_claude_timeout
 from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref
 from .github_api import _gh_call, gh_issue_comment, gh_issue_json
-from .models import PLAN_COMMENT_MARKERS, PlanReviewerOptions, WorkerResult
+from .models import PLAN_COMMENT_MARKER, PLAN_COMMENT_MARKERS, PlanReviewerOptions, WorkerResult
 from .prompts import get_plan_review_prompt
 from .review_state import (
     PLAN_REVIEW_PREFIX as _REVIEW_PREFIX_SHARED,
@@ -346,10 +346,18 @@ class PlanReviewer:
         return comments
 
     def _get_latest_plan(self, issue_number: int) -> str | None:
-        """Return the body of the last comment that looks like a plan.
+        """Return the body of the last comment that is the PLAN.
 
         Uses :meth:`_fetch_issue_comments` so the API call is shared with
         :meth:`_latest_review_is_final`.
+
+        Selection rules (fixes the self-review bug of #455/#468/#484):
+        - A plan comment must *start with* a plan heading, not merely contain
+          one. A ``## 🔍 Plan Review`` body that quotes the plan contains
+          ``## Objective``/``## Plan`` as substrings — matching those caused
+          the reviewer to pick its own prior review as "the plan".
+        - Review comments (``body.startswith(_REVIEW_PREFIX)``) are excluded
+          outright, belt-and-suspenders.
 
         Args:
             issue_number: GitHub issue number.
@@ -360,10 +368,17 @@ class PlanReviewer:
         """
         comments = self._fetch_issue_comments(issue_number)
 
-        # Walk in reverse to find the *last* plan comment
+        # Walk in reverse to find the *last* genuine plan comment.
         for comment in reversed(comments):
             body: str = comment.get("body", "")
-            if any(marker in body for marker in _PLAN_MARKERS):
+            stripped = body.lstrip()
+            if stripped.startswith(_REVIEW_PREFIX):
+                continue  # never treat a review comment as the plan
+            # Canonical marker first; fall back to legacy markers but ONLY at
+            # the start of the body (anchored), never as a free substring.
+            if stripped.startswith(PLAN_COMMENT_MARKER) or any(
+                stripped.startswith(marker) for marker in _PLAN_MARKERS
+            ):
                 logger.debug("Found plan comment for issue #%s", issue_number)
                 return body
 

--- a/hephaestus/automation/planner_state.py
+++ b/hephaestus/automation/planner_state.py
@@ -6,8 +6,8 @@ Owns the cheap, idempotent state queries the planner runs against GitHub:
   call per 100 issues via :func:`prefetch_issue_states`).
 - ``prefetch_comments()`` — batch-fetch all issue comments in one aliased
   GraphQL call and store them in an internal cache (#616).
-- ``has_existing_plan()`` — return ``True`` when an issue already carries one
-  of the canonical plan-comment markers (uses the cache when available).
+- ``has_existing_plan()`` — return ``True`` when an issue already carries the
+  canonical plan-comment marker (uses the cache when available).
 
 Extracted from ``planner.py`` (#598) so the coordinator class stays focused
 on the worker-pool driver. No behavior change.
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from .git_utils import issue_ref
 from .github_api import _gh_call, prefetch_issue_states
-from .models import PLAN_COMMENT_MARKER, PLAN_COMMENT_MARKERS
+from .models import PLAN_COMMENT_MARKER
 from .review_state import PLAN_REVIEW_PREFIX, fetch_all_issue_comments_graphql
 
 if TYPE_CHECKING:
@@ -43,9 +43,7 @@ def _comments_contain_plan(comments: list[dict[str, Any]]) -> bool:
         stripped = comment.get("body", "").lstrip()
         if stripped.startswith(PLAN_REVIEW_PREFIX):
             continue
-        if stripped.startswith(PLAN_COMMENT_MARKER) or any(
-            stripped.startswith(marker) for marker in PLAN_COMMENT_MARKERS
-        ):
+        if stripped.startswith(PLAN_COMMENT_MARKER):
             return True
     return False
 

--- a/hephaestus/automation/planner_state.py
+++ b/hephaestus/automation/planner_state.py
@@ -21,13 +21,33 @@ from typing import TYPE_CHECKING, Any
 
 from .git_utils import issue_ref
 from .github_api import _gh_call, prefetch_issue_states
-from .models import PLAN_COMMENT_MARKERS
-from .review_state import fetch_all_issue_comments_graphql
+from .models import PLAN_COMMENT_MARKER, PLAN_COMMENT_MARKERS
+from .review_state import PLAN_REVIEW_PREFIX, fetch_all_issue_comments_graphql
 
 if TYPE_CHECKING:
     from .models import PlannerOptions
 
 logger = logging.getLogger(__name__)
+
+
+def _comments_contain_plan(comments: list[dict[str, Any]]) -> bool:
+    """Return True if any comment is a plan comment (not a review).
+
+    Matches plan markers only at the START of a comment body, never as a free
+    substring: a ``## 🔍 Plan Review`` comment quotes the plan (so it contains
+    plan headings as substrings) and must NOT count as "has a plan" — that
+    substring confusion caused the reviewer to review its own prior review
+    (#455/#468/#484). Mirrors ``plan_reviewer._get_latest_plan``.
+    """
+    for comment in comments:
+        stripped = comment.get("body", "").lstrip()
+        if stripped.startswith(PLAN_REVIEW_PREFIX):
+            continue
+        if stripped.startswith(PLAN_COMMENT_MARKER) or any(
+            stripped.startswith(marker) for marker in PLAN_COMMENT_MARKERS
+        ):
+            return True
+    return False
 
 
 class PlannerStateManager:
@@ -144,11 +164,9 @@ class PlannerStateManager:
         # Fast path: use cached comments when available (#616).
         cached = self.get_cached_comments(issue_number)
         if cached is not None:
-            for comment in cached:
-                body = comment.get("body", "")
-                if any(marker in body for marker in PLAN_COMMENT_MARKERS):
-                    logger.debug("Found existing plan for %s (cached)", issue_ref(issue_number))
-                    return True
+            if _comments_contain_plan(cached):
+                logger.debug("Found existing plan for %s (cached)", issue_ref(issue_number))
+                return True
             return False
 
         # Slow path: individual fetch (pre-#616 behaviour, kept as fallback).
@@ -167,11 +185,9 @@ class PlannerStateManager:
             data = json.loads(result.stdout)
             comments = data.get("comments", [])
 
-            for comment in comments:
-                body = comment.get("body", "")
-                if any(marker in body for marker in PLAN_COMMENT_MARKERS):
-                    logger.debug("Found existing plan for %s", issue_ref(issue_number))
-                    return True
+            if _comments_contain_plan(comments):
+                logger.debug("Found existing plan for %s", issue_ref(issue_number))
+                return True
 
             return False
 

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -52,6 +52,52 @@ _ALL_AGENTS = frozenset(
     }
 )
 
+# Reviewer agents that get a *fresh* session per loop iteration (see
+# reviewer_agent). The plan/impl reviewers must stay unbiased across the
+# review loop, so each iteration uses a distinct session UUID rather than
+# resuming the prior iteration's transcript. Implementer/planner/ci-driver
+# deliberately do NOT appear here — they resume one session across their stage.
+_PER_ITERATION_REVIEWERS = frozenset({AGENT_PLAN_REVIEWER, AGENT_PR_REVIEWER})
+
+
+def reviewer_agent(base_agent: str, iteration: int) -> str:
+    """Return a per-iteration reviewer agent token.
+
+    The two review loops (plan review, PR/impl review) must run as a *fresh*
+    Claude session every iteration so the reviewer never inherits its own
+    previous verdict. Because the session UUID is derived from the agent
+    string (see :func:`session_uuid`), appending the iteration index yields a
+    new session per round while keeping the family human-readable.
+
+    Args:
+        base_agent: ``AGENT_PLAN_REVIEWER`` or ``AGENT_PR_REVIEWER``.
+        iteration: Zero-based review-loop iteration index.
+
+    Returns:
+        ``f"{base_agent}-r{iteration}"`` (e.g. ``"plan-reviewer-r0"``).
+
+    Raises:
+        ValueError: If ``base_agent`` is not a per-iteration reviewer or
+            ``iteration`` is negative.
+
+    """
+    if base_agent not in _PER_ITERATION_REVIEWERS:
+        raise ValueError(
+            f"reviewer_agent expects one of {sorted(_PER_ITERATION_REVIEWERS)}, got {base_agent!r}"
+        )
+    if iteration < 0:
+        raise ValueError(f"iteration must be >= 0, got {iteration}")
+    return f"{base_agent}-r{iteration}"
+
+
+def _is_valid_agent(agent: str) -> bool:
+    """Return True for a known base agent or a per-iteration reviewer token."""
+    if agent in _ALL_AGENTS:
+        return True
+    # Accept the reviewer_agent() form: "<base>-r<N>".
+    base, sep, suffix = agent.rpartition("-r")
+    return bool(sep) and base in _PER_ITERATION_REVIEWERS and suffix.isdigit()
+
 
 def session_name(repo: str, issue: int | str, agent: str, githash: str) -> str:
     """Return the human-readable session name.
@@ -69,8 +115,11 @@ def session_name(repo: str, issue: int | str, agent: str, githash: str) -> str:
         ValueError: If any component is empty or ``agent`` is unknown.
 
     """
-    if agent not in _ALL_AGENTS:
-        raise ValueError(f"unknown agent {agent!r}; must be one of {sorted(_ALL_AGENTS)}")
+    if not _is_valid_agent(agent):
+        raise ValueError(
+            f"unknown agent {agent!r}; must be one of {sorted(_ALL_AGENTS)} "
+            f"or a per-iteration reviewer token (e.g. 'plan-reviewer-r0')"
+        )
     repo_s = repo.strip()
     githash_s = githash.strip()
     if not repo_s or not githash_s:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -16,7 +16,9 @@ from hephaestus.automation.github_api import (
     gh_create_label,
     gh_issue_comment,
     gh_issue_create,
+    gh_issue_delete_comment,
     gh_issue_json,
+    gh_issue_upsert_comment,
     gh_list_labels,
     gh_list_open_issues,
     gh_pr_checks,
@@ -1386,3 +1388,67 @@ class TestGhPrChecks:
         (check,) = gh_pr_checks(789)
         assert check["status"] == "in_progress"
         assert check["conclusion"] is None
+
+
+class TestUpsertAndDeleteComment:
+    """Idempotent plan/review comment lifecycle (one comment per role)."""
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("o", "r"))
+    @patch("hephaestus.automation.github_api._fetch_issue_comment_ids", return_value=[])
+    @patch("hephaestus.automation.github_api.gh_issue_comment")
+    def test_upsert_creates_when_absent(
+        self, mock_create: Any, _mock_fetch: Any, _mock_repo: Any
+    ) -> None:
+        rv = gh_issue_upsert_comment(5, "# Implementation Plan", "# Implementation Plan\nbody")
+        mock_create.assert_called_once_with(5, "# Implementation Plan\nbody")
+        assert rv is None  # fresh create: id not parsed
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("o", "r"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.gh_issue_comment")
+    def test_upsert_patches_existing(
+        self, mock_create: Any, mock_gh_call: Any, _mock_repo: Any
+    ) -> None:
+        with patch(
+            "hephaestus.automation.github_api._fetch_issue_comment_ids",
+            return_value=[{"databaseId": 99, "body": "# Implementation Plan\nold"}],
+        ):
+            rv = gh_issue_upsert_comment(5, "# Implementation Plan", "# Implementation Plan\nnew")
+        # No fresh comment created; a PATCH call was issued for id 99.
+        mock_create.assert_not_called()
+        assert rv == 99
+        patched = any(
+            "PATCH" in str(c) and "issues/comments/99" in str(c)
+            for c in mock_gh_call.call_args_list
+        )
+        assert patched, mock_gh_call.call_args_list
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("o", "r"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.gh_issue_comment")
+    def test_upsert_deletes_older_duplicates(
+        self, _mock_create: Any, mock_gh_call: Any, _mock_repo: Any
+    ) -> None:
+        # Three legacy plan comments → newest (id 3) patched, 1 and 2 deleted.
+        with patch(
+            "hephaestus.automation.github_api._fetch_issue_comment_ids",
+            return_value=[
+                {"databaseId": 1, "body": "# Implementation Plan\na"},
+                {"databaseId": 2, "body": "# Implementation Plan\nb"},
+                {"databaseId": 3, "body": "# Implementation Plan\nc"},
+            ],
+        ):
+            rv = gh_issue_upsert_comment(5, "# Implementation Plan", "# Implementation Plan\nnew")
+        assert rv == 3
+        calls = [str(c) for c in mock_gh_call.call_args_list]
+        assert any("DELETE" in c and "comments/1" in c for c in calls), calls
+        assert any("DELETE" in c and "comments/2" in c for c in calls), calls
+        assert any("PATCH" in c and "comments/3" in c for c in calls), calls
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("o", "r"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_delete_comment_calls_rest_delete(self, mock_gh_call: Any, _mock_repo: Any) -> None:
+        gh_issue_delete_comment(42)
+        (args,) = mock_gh_call.call_args.args
+        assert "DELETE" in args
+        assert "/repos/o/r/issues/comments/42" in args

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -127,6 +127,43 @@ class TestGetLatestPlan:
 
         assert result is None
 
+    def test_get_latest_plan_ignores_review_comment(self, reviewer: PlanReviewer) -> None:
+        """A review comment that quotes the plan must never be picked as the plan.
+
+        Regression for #455/#468/#484: a ``## 🔍 Plan Review`` body contains
+        ``## Objective``/``## Plan`` as substrings when it quotes the plan, and
+        matching those caused the reviewer to review its own prior review.
+        """
+        comments = [
+            {"body": "# Implementation Plan\n\n## Objective\nDo the thing."},
+            # A later review comment quoting the plan's headings:
+            {
+                "body": (
+                    "## 🔍 Plan Review\n\nThe plan's ## Objective and ## Plan "
+                    "sections look fine.\n\n**Verdict: REVISE**"
+                )
+            },
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            result = reviewer._get_latest_plan(123)
+
+        assert result is not None
+        # Must be the actual plan, NOT the review comment.
+        assert result.lstrip().startswith("# Implementation Plan")
+        assert "🔍 Plan Review" not in result
+
+    def test_get_latest_plan_review_only_issue_returns_none(self, reviewer: PlanReviewer) -> None:
+        """An issue with ONLY a review comment (no real plan) → None, not the review."""
+        comments = [
+            {"body": "## 🔍 Plan Review\n\nDiscusses a ## Plan.\n\n**Verdict: REVISE**"},
+        ]
+        with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
+            mock_gh.return_value = _make_gh_result({"comments": comments})
+            result = reviewer._get_latest_plan(123)
+
+        assert result is None
+
 
 class TestLatestReviewIsFinal:
     """Tests for the FINAL/APPROVED short-circuit gate.

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -85,7 +85,7 @@ class TestGetLatestPlan:
         """_get_latest_plan returns plan text from matching comment."""
         comments = [
             {"body": "Some other comment"},
-            {"body": "## Implementation Plan\n\nStep 1: Do something\nStep 2: Do more"},
+            {"body": "# Implementation Plan\n\nStep 1: Do something\nStep 2: Do more"},
         ]
         with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
             mock_gh.return_value = _make_gh_result({"comments": comments})
@@ -97,8 +97,8 @@ class TestGetLatestPlan:
     def test_get_latest_plan_returns_last_plan(self, reviewer: PlanReviewer) -> None:
         """_get_latest_plan returns the LAST plan comment when multiple exist."""
         comments = [
-            {"body": "## Implementation Plan\n\nFirst plan"},
-            {"body": "## Implementation Plan\n\nSecond plan (updated)"},
+            {"body": "# Implementation Plan\n\nFirst plan"},
+            {"body": "# Implementation Plan\n\nSecond plan (updated)"},
         ]
         with patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh:
             mock_gh.return_value = _make_gh_result({"comments": comments})

--- a/tests/unit/automation/test_planner_state.py
+++ b/tests/unit/automation/test_planner_state.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation.models import PLAN_COMMENT_MARKERS, PlannerOptions
+from hephaestus.automation.models import PLAN_COMMENT_MARKER, PlannerOptions
 from hephaestus.automation.planner_state import PlannerStateManager
 
 # ---------------------------------------------------------------------------
@@ -33,7 +33,7 @@ def _make_options(issues: list[int] | None = None) -> PlannerOptions:
 
 
 def _plan_body() -> str:
-    return f"{PLAN_COMMENT_MARKERS[0]}\n\nStep 1: do the thing.\n"
+    return f"{PLAN_COMMENT_MARKER}\n\nStep 1: do the thing.\n"
 
 
 def _other_body() -> str:

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -19,11 +19,42 @@ from hephaestus.automation.session_naming import (
     AGENT_PLANNER,
     AGENT_PR_REVIEWER,
     current_trunk_githash,
+    reviewer_agent,
     session_jsonl_path,
     session_name,
     session_uuid,
     short_githash,
 )
+
+
+class TestReviewerAgent:
+    """Per-iteration reviewer session tokens (fresh session each loop round)."""
+
+    def test_plan_reviewer_iteration_token(self) -> None:
+        assert reviewer_agent(AGENT_PLAN_REVIEWER, 0) == "plan-reviewer-r0"
+        assert reviewer_agent(AGENT_PR_REVIEWER, 2) == "pr-reviewer-r2"
+
+    def test_per_iteration_uuids_differ(self) -> None:
+        u0 = session_uuid("R", 5, reviewer_agent(AGENT_PLAN_REVIEWER, 0), "abc1234")
+        u1 = session_uuid("R", 5, reviewer_agent(AGENT_PLAN_REVIEWER, 1), "abc1234")
+        assert u0 != u1
+
+    def test_suffixed_reviewer_token_is_valid_session_agent(self) -> None:
+        # session_name must accept the reviewer_agent() form.
+        name = session_name("R", 5, reviewer_agent(AGENT_PR_REVIEWER, 3), "x")
+        assert name == "R_5_pr-reviewer-r3_x"
+
+    def test_rejects_non_reviewer_base(self) -> None:
+        with pytest.raises(ValueError, match="reviewer_agent expects"):
+            reviewer_agent(AGENT_IMPLEMENTER, 0)
+
+    def test_rejects_negative_iteration(self) -> None:
+        with pytest.raises(ValueError, match="iteration must be"):
+            reviewer_agent(AGENT_PLAN_REVIEWER, -1)
+
+    def test_unsuffixed_unknown_still_rejected(self) -> None:
+        with pytest.raises(ValueError, match="unknown agent"):
+            session_name("R", 5, "totally-bogus", "x")
 
 
 class TestSessionName:


### PR DESCRIPTION
**Foundation increment for the 3-stage pipeline restructure.** Self-contained: ships the session-identity, comment-lifecycle, and anchored-marker primitives the full collapse depends on, and fixes the #455/#468/#484 re-review bug at its root. The phase collapse itself lands in a follow-up PR.

## Summary
Lays the groundwork for collapsing `hephaestus-automation-loop` from 6 phases into 3 session-stable stages, and independently fixes the root cause of the re-review bug.

### What this PR lands
- `session_naming.reviewer_agent(base, iter)` — fresh reviewer session per loop iteration; planner/implementer/ci-driver resume one session per stage.
- `github_api.gh_issue_upsert_comment` / `gh_issue_delete_comment` — keep at most ONE plan + ONE review comment per issue, updated in place (PATCH), legacy duplicates deleted.
- `models.PLAN_COMMENT_MARKER` (single canonical marker; legacy `PLAN_COMMENT_MARKERS` tuple removed) + anchored plan detection in `plan_reviewer._get_latest_plan` and `planner_state.has_existing_plan` — **fixes the bug where a `## 🔍 Plan Review` comment quoting the plan was selected AS the plan** (the reviewer reviewing its own review). Both the cached and uncached `has_existing_plan` paths route through one anchored helper so the bug cannot reappear via the #616 comment cache.
- Tests for all of the above incl. the #455/#468/#484 self-review regression.

### Follow-up work (tracked in #671, separate PR)
- Stage 1: single planner session owns plan-learnings; sole reviewer upserts the REVIEW comment; `## Changes from review` on re-plan.
- Stage 2: impl loop absorbs review-prs + address-review (per-file sub-agents from #661); retire those phases.
- Stage 3: drive-green own session (AGENT_CI_DRIVER) + learnings.
- Advise-first for all three stages; prompt/template rewrites; phase-list collapse to (plan, implement, drive-green).

## Test plan
- [x] `pixi run pytest tests/unit/automation/` — 774 passed (rebased onto #670/#669)
- [x] `pixi run ruff check` + `pixi run ruff format --check` + `pixi run mypy` — clean

Closes #671