### PR TITLE
refactor(automation): extract CLI entry point into implementer_cli

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -9,7 +9,6 @@ Provides:
 
 from __future__ import annotations
 
-import argparse
 import logging
 import subprocess
 import sys
@@ -20,10 +19,8 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    add_agent_argument,
     is_codex,
 )
-from hephaestus.cli.utils import add_json_arg, emit_json_status
 
 # NOTE: Several symbols below are re-imported here purely so existing tests
 # can keep patching them at the ``hephaestus.automation.implementer.X`` path
@@ -38,13 +35,49 @@ from ._review_utils import find_pr_for_issue  # noqa: F401
 from .claude_invoke import invoke_claude_with_session  # noqa: F401
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
-from .git_utils import get_repo_root, get_repo_slug, run  # noqa: F401
-from .github_api import fetch_issue_info, gh_list_open_issues
+
+# ``get_repo_root`` is re-exported with an explicit ``as`` alias so that
+# ``implementer_cli.main`` (which resolves it via this module) and tests
+# patching ``implementer.get_repo_root`` share one lookup site.
+from .git_utils import (  # get_repo_slug/run kept for test-patch compat
+    get_repo_root as get_repo_root,
+)
+from .git_utils import (
+    get_repo_slug,  # noqa: F401
+    run,
+)
+
+# ``gh_list_open_issues`` is re-exported with an explicit ``as`` alias (not
+# called in this module's body any more — ``main`` lives in ``implementer_cli``)
+# so tests can keep patching it at
+# ``hephaestus.automation.implementer.gh_list_open_issues`` and have
+# ``implementer_cli.main`` (which looks it up here) observe the patch.
+from .github_api import fetch_issue_info
+from .github_api import (
+    gh_list_open_issues as gh_list_open_issues,
+)
 
 # MAX_REVIEW_ITERATIONS is re-exported so tests that import it via
 # ``hephaestus.automation.implementer`` see the same value the runtime loop
 # in :class:`ImplementationPhaseRunner` uses. There is a single source of
 # truth in implementer_phase_runner.
+#
+# The CLI entry point (argument parsing, logging setup, and ``main``) lives in
+# ``implementer_cli`` (extracted for SRP — see #468). Re-exported here with
+# explicit ``as`` aliases (required by mypy) so the ``hephaestus-implement-issues``
+# console script (``hephaestus.automation.implementer:main``) keeps resolving and
+# existing tests calling ``implementer.main()`` / ``implementer._parse_args()``
+# and patching ``implementer.<dep>`` continue to work unchanged. ``main`` imports
+# this module lazily (inside its body), so this top-level import is cycle-safe.
+from .implementer_cli import (
+    _parse_args as _parse_args,
+)
+from .implementer_cli import (
+    _setup_logging as _setup_logging,
+)
+from .implementer_cli import (
+    main as main,
+)
 from .implementer_phase_runner import MAX_REVIEW_ITERATIONS, ImplementationPhaseRunner
 from .implementer_state import ImplementationStateManager
 from .implementer_summary import ImplementationSummaryPrinter
@@ -663,209 +696,6 @@ class IssueImplementer:
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print implementation summary."""
         ImplementationSummaryPrinter(self.worktree_manager).print(results)
-
-
-def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
-    """Configure logging for the CLI.
-
-    Args:
-        verbose: Enable verbose (DEBUG) logging
-        log_dir: Optional directory to write log files
-
-    """
-    level = logging.DEBUG if verbose else logging.INFO
-    fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
-    datefmt = "%Y-%m-%d %H:%M:%S"
-    logging.basicConfig(level=level, format=fmt, datefmt=datefmt)
-
-    if log_dir:
-        log_dir.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(log_dir / "run.log", mode="a")
-        fh.setLevel(logging.DEBUG)
-        fh.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
-        logging.getLogger().addHandler(fh)
-
-
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the implementer CLI."""
-    parser = argparse.ArgumentParser(
-        description="Bulk implement GitHub issues using Claude Code",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  # Implement all open issues (no arguments needed)
-  %(prog)s
-
-  # Implement all issues in an epic
-  %(prog)s --epic 123
-
-  # Implement specific issues
-  %(prog)s --issues 595 596 597
-
-  # Analyze dependencies without implementing
-  %(prog)s --epic 123 --analyze
-
-  # Resume previous implementation
-  %(prog)s --epic 123 --resume
-
-  # Health check
-  %(prog)s --health-check
-
-  # Dry run
-  %(prog)s --issues 595 --dry-run
-        """,
-    )
-
-    parser.add_argument(
-        "--epic",
-        type=int,
-        help="Epic issue number containing sub-issues",
-    )
-    parser.add_argument(
-        "--issues",
-        type=int,
-        nargs="+",
-        help="Specific issue numbers to implement (alternative to --epic)",
-    )
-    add_agent_argument(parser)
-    parser.add_argument(
-        "--analyze",
-        action="store_true",
-        help="Analyze dependencies without implementing",
-    )
-    parser.add_argument(
-        "--health-check",
-        action="store_true",
-        help="Run health check of dependencies and environment",
-    )
-    parser.add_argument(
-        "--resume",
-        action="store_true",
-        help="Resume previous implementation from saved state",
-    )
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
-    parser.add_argument(
-        "--no-skip-closed",
-        action="store_true",
-        help="Implement closed issues (default: skip closed issues)",
-    )
-    parser.add_argument(
-        "--no-auto-merge",
-        action="store_true",
-        help="Don't enable auto-merge on created PRs",
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done without actually doing it",
-    )
-    parser.add_argument(
-        "--no-learn",
-        action="store_true",
-        help="Disable /learn after implementation (enabled by default)",
-    )
-    parser.add_argument(
-        "--no-follow-up",
-        action="store_true",
-        help="Disable automatic filing of follow-up issues (enabled by default)",
-    )
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
-    )
-    add_json_arg(parser)
-
-    args = parser.parse_args()
-
-    if args.epic and args.issues:
-        parser.error("Cannot specify both --epic and --issues")
-
-    return args
-
-
-def main() -> int:
-    """Execute the issue implementation workflow.
-
-    Returns:
-        Exit code: 0 on success, 1 on failure, 130 on keyboard interrupt
-
-    """
-    args = _parse_args()
-
-    state_dir = get_repo_root() / "build" / ".issue_implementer"
-    _setup_logging(args.verbose, log_dir=state_dir)
-
-    log = logging.getLogger(__name__)
-
-    # Auto-discover all open issues when neither --issues nor --epic is given
-    if not args.health_check and not args.epic and not args.issues:
-        discovered = gh_list_open_issues()
-        log.info(
-            "No --issues/--epic given; discovered %s open issues: %s", len(discovered), discovered
-        )
-        args.issues = discovered
-
-    options = ImplementerOptions(
-        epic_number=args.epic or 0,
-        issues=args.issues or [],
-        agent=args.agent,
-        analyze_only=args.analyze,
-        health_check=args.health_check,
-        resume=args.resume,
-        max_workers=args.max_workers,
-        skip_closed=not args.no_skip_closed,
-        auto_merge=not args.no_auto_merge,
-        dry_run=args.dry_run,
-        enable_learn=not args.no_learn,
-        enable_follow_up=not args.no_follow_up,
-        enable_ui=not args.no_ui and not args.json,
-    )
-
-    if args.health_check:
-        log.info("Running health check")
-    elif args.issues:
-        log.info("Starting implementation of issues: %s", args.issues)
-    else:
-        log.info("Starting implementation of epic #%s", args.epic)
-
-    from hephaestus.utils.terminal import terminal_guard
-
-    with terminal_guard():
-        try:
-            implementer = IssueImplementer(options)
-            results = implementer.run()
-
-            if not args.health_check and not args.analyze:
-                failed = [num for num, result in results.items() if not result.success]
-                if failed:
-                    log.error("Failed to implement %s issue(s): %s", len(failed), failed)
-                    if args.json:
-                        emit_json_status(1, issues=args.issues or [], failed=failed)
-                    return 1
-
-            log.info("Complete")
-            if args.json:
-                emit_json_status(0, issues=args.issues or [], epic=args.epic or 0)
-            return 0
-        except KeyboardInterrupt:
-            log.warning("Interrupted by user")
-            if args.json:
-                emit_json_status(130, message="interrupted")
-            return 130
 
 
 if __name__ == "__main__":

--- a/hephaestus/automation/implementer_cli.py
+++ b/hephaestus/automation/implementer_cli.py
@@ -1,0 +1,236 @@
+"""Command-line entry point for the bulk issue implementer.
+
+This module holds the argument-parsing, logging-setup, and ``main()`` entry
+point that were previously defined inline in :mod:`.implementer`. They were
+extracted to separate the CLI/entry-point concern from the
+:class:`~hephaestus.automation.implementer.IssueImplementer` orchestration
+class (SRP — see #468).
+
+``main`` deliberately resolves its patchable collaborators
+(``gh_list_open_issues``, ``get_repo_root``, ``CursesUI``, ``IssueImplementer``)
+through the :mod:`.implementer` module namespace rather than importing them
+directly. This preserves the existing test contract, where tests patch those
+names via ``patch.object(implementer, "...")`` and call ``implementer.main()``
+— the lookup must happen where those tests patch, not where the symbols are
+defined.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+
+from hephaestus.agents.runtime import add_agent_argument
+from hephaestus.cli.utils import add_json_arg, emit_json_status
+
+from .models import ImplementerOptions
+
+
+def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
+    """Configure logging for the CLI.
+
+    Args:
+        verbose: Enable verbose (DEBUG) logging
+        log_dir: Optional directory to write log files
+
+    """
+    level = logging.DEBUG if verbose else logging.INFO
+    fmt = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    logging.basicConfig(level=level, format=fmt, datefmt=datefmt)
+
+    if log_dir:
+        log_dir.mkdir(parents=True, exist_ok=True)
+        fh = logging.FileHandler(log_dir / "run.log", mode="a")
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(logging.Formatter(fmt, datefmt=datefmt))
+        logging.getLogger().addHandler(fh)
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the implementer CLI."""
+    parser = argparse.ArgumentParser(
+        description="Bulk implement GitHub issues using Claude Code",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Implement all open issues (no arguments needed)
+  %(prog)s
+
+  # Implement all issues in an epic
+  %(prog)s --epic 123
+
+  # Implement specific issues
+  %(prog)s --issues 595 596 597
+
+  # Analyze dependencies without implementing
+  %(prog)s --epic 123 --analyze
+
+  # Resume previous implementation
+  %(prog)s --epic 123 --resume
+
+  # Health check
+  %(prog)s --health-check
+
+  # Dry run
+  %(prog)s --issues 595 --dry-run
+        """,
+    )
+
+    parser.add_argument(
+        "--epic",
+        type=int,
+        help="Epic issue number containing sub-issues",
+    )
+    parser.add_argument(
+        "--issues",
+        type=int,
+        nargs="+",
+        help="Specific issue numbers to implement (alternative to --epic)",
+    )
+    add_agent_argument(parser)
+    parser.add_argument(
+        "--analyze",
+        action="store_true",
+        help="Analyze dependencies without implementing",
+    )
+    parser.add_argument(
+        "--health-check",
+        action="store_true",
+        help="Run health check of dependencies and environment",
+    )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume previous implementation from saved state",
+    )
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=3,
+        choices=range(1, 33),
+        metavar="N",
+        help="Maximum number of parallel workers, 1-32 (default: 3)",
+    )
+    parser.add_argument(
+        "--no-skip-closed",
+        action="store_true",
+        help="Implement closed issues (default: skip closed issues)",
+    )
+    parser.add_argument(
+        "--no-auto-merge",
+        action="store_true",
+        help="Don't enable auto-merge on created PRs",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without actually doing it",
+    )
+    parser.add_argument(
+        "--no-learn",
+        action="store_true",
+        help="Disable /learn after implementation (enabled by default)",
+    )
+    parser.add_argument(
+        "--no-follow-up",
+        action="store_true",
+        help="Disable automatic filing of follow-up issues (enabled by default)",
+    )
+    parser.add_argument(
+        "--no-ui",
+        action="store_true",
+        help="Disable curses UI (use plain logging instead)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    add_json_arg(parser)
+
+    args = parser.parse_args()
+
+    if args.epic and args.issues:
+        parser.error("Cannot specify both --epic and --issues")
+
+    return args
+
+
+def main() -> int:
+    """Execute the issue implementation workflow.
+
+    Returns:
+        Exit code: 0 on success, 1 on failure, 130 on keyboard interrupt
+
+    """
+    # Resolve patchable collaborators through the implementer module so that
+    # existing tests patching ``implementer.gh_list_open_issues`` /
+    # ``implementer.get_repo_root`` / ``implementer.CursesUI`` /
+    # ``implementer.IssueImplementer`` continue to intercept these lookups.
+    from . import implementer as _impl
+
+    args = _parse_args()
+
+    state_dir = _impl.get_repo_root() / "build" / ".issue_implementer"
+    _setup_logging(args.verbose, log_dir=state_dir)
+
+    log = logging.getLogger(__name__)
+
+    # Auto-discover all open issues when neither --issues nor --epic is given
+    if not args.health_check and not args.epic and not args.issues:
+        discovered = _impl.gh_list_open_issues()
+        log.info(
+            "No --issues/--epic given; discovered %s open issues: %s", len(discovered), discovered
+        )
+        args.issues = discovered
+
+    options = ImplementerOptions(
+        epic_number=args.epic or 0,
+        issues=args.issues or [],
+        agent=args.agent,
+        analyze_only=args.analyze,
+        health_check=args.health_check,
+        resume=args.resume,
+        max_workers=args.max_workers,
+        skip_closed=not args.no_skip_closed,
+        auto_merge=not args.no_auto_merge,
+        dry_run=args.dry_run,
+        enable_learn=not args.no_learn,
+        enable_follow_up=not args.no_follow_up,
+        enable_ui=not args.no_ui and not args.json,
+    )
+
+    if args.health_check:
+        log.info("Running health check")
+    elif args.issues:
+        log.info("Starting implementation of issues: %s", args.issues)
+    else:
+        log.info("Starting implementation of epic #%s", args.epic)
+
+    from hephaestus.utils.terminal import terminal_guard
+
+    with terminal_guard():
+        try:
+            implementer = _impl.IssueImplementer(options)
+            results = implementer.run()
+
+            if not args.health_check and not args.analyze:
+                failed = [num for num, result in results.items() if not result.success]
+                if failed:
+                    log.error("Failed to implement %s issue(s): %s", len(failed), failed)
+                    if args.json:
+                        emit_json_status(1, issues=args.issues or [], failed=failed)
+                    return 1
+
+            log.info("Complete")
+            if args.json:
+                emit_json_status(0, issues=args.issues or [], epic=args.epic or 0)
+            return 0
+        except KeyboardInterrupt:
+            log.warning("Interrupted by user")
+            if args.json:
+                emit_json_status(130, message="interrupted")
+            return 130

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,10 +211,13 @@ omit = [
     "*/__init__.py",
     # Full orchestration loops require a live claude/gh CLI — integration test territory.
     # Pure-function helpers in these modules are tested in tests/unit/automation/ instead.
-    # The allowlist of these 10 modules is frozen in tests/unit/validation/test_omit_allowlist.py
+    # The allowlist of these 11 modules is frozen in tests/unit/validation/test_omit_allowlist.py
     # to prevent silent growth of the omit list, and their importability is guarded by
     # tests/integration/test_orchestration_smoke.py.
     "hephaestus/automation/implementer.py",
+    # implementer_cli.py holds main()/CLI parsing extracted from implementer.py (#468);
+    # main() drives the live claude/gh orchestration loop, so it is integration-only.
+    "hephaestus/automation/implementer_cli.py",
     "hephaestus/automation/implementer_phase_runner.py",
     "hephaestus/automation/implementer_summary.py",
     "hephaestus/automation/planner.py",

--- a/tests/integration/test_orchestration_smoke.py
+++ b/tests/integration/test_orchestration_smoke.py
@@ -1,13 +1,14 @@
 """Smoke tests for omitted orchestration modules — integration backstop.
 
-These tests validate that the 10 automation modules omitted from coverage
+These tests validate that the 11 automation modules omitted from coverage
 (per pyproject.toml[tool.coverage.run].omit) remain importable and their
 console entry points work correctly.
 
 Module enumeration and entry-point discovery verified at plan time:
-- All 10 modules are importable (guards against import regressions)
+- All 11 modules are importable (guards against import regressions)
 - 4 modules have console scripts: implementer, planner, loop_runner, pr_reviewer
-- 2 modules are script-less but have main(): address_review, ci_driver
+- 3 modules are script-less but have main(): address_review, ci_driver,
+    implementer_cli (its main() backs the implementer console script via re-export)
 - 4 modules lack main() entirely: implementer_phase_runner, implementer_summary,
     curses_ui, github_api
 """
@@ -16,9 +17,10 @@ import subprocess
 
 import pytest
 
-# All 10 omitted orchestration modules
+# All 11 omitted orchestration modules
 OMITTED_MODULES = [
     "hephaestus.automation.implementer",
+    "hephaestus.automation.implementer_cli",
     "hephaestus.automation.implementer_phase_runner",
     "hephaestus.automation.implementer_summary",
     "hephaestus.automation.planner",
@@ -38,10 +40,14 @@ CONSOLE_SCRIPTS = [
     ("hephaestus-review-prs", "hephaestus.automation.pr_reviewer"),
 ]
 
-# Modules with main() but no console script
+# Modules with main() but no console script of their own.
+# implementer_cli.main() is exposed as the ``hephaestus-implement-issues`` script
+# via re-export from ``hephaestus.automation.implementer`` — it has no separate
+# entry point, so it is verified here for callability rather than via --help.
 MAIN_ONLY_MODULES = [
     "hephaestus.automation.address_review",
     "hephaestus.automation.ci_driver",
+    "hephaestus.automation.implementer_cli",
 ]
 
 

--- a/tests/unit/automation/test_implementer_cli.py
+++ b/tests/unit/automation/test_implementer_cli.py
@@ -1,0 +1,78 @@
+"""Tests for the extracted ``implementer_cli`` module (#468).
+
+The CLI entry point (``_parse_args`` / ``_setup_logging`` / ``main``) was moved
+out of ``implementer.py`` into ``implementer_cli.py`` for SRP. These tests lock
+the contract that makes that move safe:
+
+1. The three callables are re-exported from ``implementer`` and are the *same*
+   objects as in ``implementer_cli`` (console script + back-compat imports).
+2. ``main`` resolves its patchable collaborators through the ``implementer``
+   module, so ``patch.object(implementer, ...)`` still intercepts them — this is
+   what keeps the pre-existing ``test_implementer_main`` smoke tests valid.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.automation import implementer, implementer_cli
+
+
+class TestReExportIdentity:
+    """The re-exports must be the same objects, not copies."""
+
+    def test_main_reexported(self) -> None:
+        assert implementer.main is implementer_cli.main
+
+    def test_parse_args_reexported(self) -> None:
+        assert implementer._parse_args is implementer_cli._parse_args
+
+    def test_setup_logging_reexported(self) -> None:
+        assert implementer._setup_logging is implementer_cli._setup_logging
+
+
+class TestPatchRoutingThroughImplementer:
+    """``main`` must observe patches applied on the ``implementer`` module."""
+
+    def test_main_uses_patched_implementer_deps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Patched implementer deps must be honored by ``implementer_cli.main``.
+
+        Patching ``implementer.gh_list_open_issues`` / ``get_repo_root`` /
+        ``IssueImplementer`` must reach the lookups inside ``main``.
+        """
+        monkeypatch.setattr(sys, "argv", ["impl", "--dry-run", "--no-ui"])
+
+        with (
+            patch.object(implementer, "gh_list_open_issues", return_value=[]) as mock_list,
+            patch.object(implementer, "get_repo_root", return_value=tmp_path),
+        ):
+            rc = implementer_cli.main()
+
+        assert rc == 0
+        # Auto-discovery path with no --issues/--epic must consult the patched
+        # lookup on the implementer module.
+        mock_list.assert_called_once()
+
+
+class TestParseArgs:
+    """Argument parsing moved intact."""
+
+    def test_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["impl"])
+        args = implementer_cli._parse_args()
+        assert args.epic is None
+        assert args.issues is None
+        assert args.dry_run is False
+
+    def test_epic_and_issues_mutually_exclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["impl", "--epic", "1", "--issues", "2"])
+        with pytest.raises(SystemExit):
+            implementer_cli._parse_args()

--- a/tests/unit/validation/test_omit_allowlist.py
+++ b/tests/unit/validation/test_omit_allowlist.py
@@ -32,13 +32,14 @@ class TestOmitAllowlist:
 
         omit_list = pyproject.get("tool", {}).get("coverage", {}).get("run", {}).get("omit", [])
 
-        # Expected omit list: test globs + 10 automation modules
+        # Expected omit list: test globs + 11 automation modules
         expected_globs = {
             "*/tests/*",
             "*/__init__.py",
         }
         expected_modules = {
             "hephaestus/automation/implementer.py",
+            "hephaestus/automation/implementer_cli.py",
             "hephaestus/automation/implementer_phase_runner.py",
             "hephaestus/automation/implementer_summary.py",
             "hephaestus/automation/planner.py",


### PR DESCRIPTION
Extract \`_parse_args\`, \`_setup_logging\`, and \`main\` out of the 872-line \`implementer.py\` into a dedicated \`implementer_cli.py\`, separating the CLI/entry-point concern from the \`IssueImplementer\` orchestration class (SRP).

## What changed
- New \`hephaestus/automation/implementer_cli.py\` holds the three CLI callables.
- \`main\` resolves its patchable collaborators (\`gh_list_open_issues\`, \`get_repo_root\`, \`CursesUI\`, \`IssueImplementer\`) **through the \`implementer\` module**, so existing \`patch.object(implementer, ...)\` tests and the \`hephaestus-implement-issues\` console script keep working unchanged.
- The three callables are re-exported from \`implementer\` with explicit \`as\` aliases (mypy-clean re-export).
- \`implementer.py\` drops ~170 lines (872 to 702).
- New module added to the frozen coverage omit-allowlist (it drives the live claude/gh loop); allowlist + orchestration-smoke guards updated.

## Tests
- New \`test_implementer_cli.py\` locks re-export identity + patch-routing-through-implementer.
- All 45 pre-existing implementer tests pass unchanged (pure move-and-delegate, as their docstrings anticipated).
- 780 automation tests pass; import-cycle + entry-point smoke tests pass; ruff + mypy clean.

This is one slice of the multi-PR #468 decomposition; the remaining responsibilities were already extracted previously, so the umbrella stays open.

Closes #673
Refs #468