### PR TITLE
ci(pr-policy): gate on lint to remove the auto-merge race

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -244,6 +244,13 @@ jobs:
     #   2. Auto-merge is enabled on the PR.
     #   3. Every commit on the PR has a verified signature.
     # Push events are skipped because there is no PR to inspect.
+    #
+    # `needs: lint` defers this gate until lint passes. Besides matching how
+    # every other downstream job here is gated, it removes a race: pr-policy is
+    # a ~3s check that, run on PR-open, used to evaluate the auto-merge check
+    # (#2) before `gh pr merge --auto` had registered, reporting a spurious
+    # failure. Waiting on lint gives auto-merge time to land before #2 reads it.
+    needs: lint
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 5


### PR DESCRIPTION
## Summary

Adds `needs: lint` to the `pr-policy` job in `.github/workflows/_required.yml`.

`pr-policy` ran on PR-open with no dependency, so it fired ~3s in — before `gh pr merge --auto` had registered — and its auto-merge check (#2) read a stale snapshot, reporting a **spurious failure** on freshly-opened PRs (observed on #677 and #679; it passes on re-run once auto-merge lands). Gating on `lint` defers the check until lint passes (~1+ min), by which point auto-merge is reliably enabled. This also matches how every other downstream job here is already gated (`markdownlint`, `pixi-check`, `justfile-check`, `symlink-check`, `shellcheck`).

The three policy checks themselves (Closes #N, auto-merge, signed commits) are unchanged.

## Test plan

- [x] Workflow YAML parses; `pr-policy needs: lint`, target exists, no missing/cyclic `needs`
- [x] `yamllint -c .yamllint.yaml .github/workflows/_required.yml` exits 0 (only pre-existing line-length warnings, untouched lines)
- [x] No `run:` interpolation of untrusted input added (only a `needs:` key + comment); the job already uses safe `jq -r`/`gh api -F` patterns
- [ ] This PR is itself the first to exercise the gated `pr-policy` — auto-merge should land cleanly without a transient pr-policy red

Closes #680