### PR TITLE
docs: pipeline/version/CI-matrix currency fixes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -11,7 +11,7 @@ Continuous Integration pipeline that runs on every push and pull request to `mai
 **Matrix:**
 
 - OS: `ubuntu-latest`
-- Python: `3.12`
+- Python: `3.10` / `3.11` / `3.12` / `3.13`
 - Test types: `unit`, `integration`
 
 **Jobs:**
@@ -23,7 +23,7 @@ Continuous Integration pipeline that runs on every push and pull request to `mai
 **Status Badge:**
 
 ```markdown
-![Test](https://github.com/mvillmow/ProjectHephaestus/actions/workflows/test.yml/badge.svg)
+![Test](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml/badge.svg)
 ```
 
 ### Pre-commit Workflow (`workflows/pre-commit.yml`)
@@ -37,6 +37,23 @@ Scheduled and on-demand pip-audit scan for dependency vulnerabilities.
 ### Release Workflow (`workflows/release.yml`)
 
 Builds and publishes the package to PyPI on version tag push (`v*`).
+
+### Required Checks Workflow (`workflows/_required.yml`)
+
+The consolidated required-status-check gate that runs on every pull request to
+`main` (and on push to `main`). It aggregates lint, markdownlint, `pixi-check`,
+shellcheck, the `pr-policy` gate (enforces `Closes #N`, auto-merge enabled, and
+signed commits), unit/integration/shell tests, wheel build, security scans
+(pip-audit, Gitleaks, bandit), workflow-schema validation, and version-sync. It
+also re-runs on `auto_merge_enabled` / `auto_merge_disabled` events so the
+`pr-policy` auto-merge check converges without timing races.
+
+### Auto-Tag Workflow (`workflows/auto-tag.yml`)
+
+Manually dispatched (`workflow_dispatch`) release-tagging helper. Computes the
+next `vX.Y.Z` tag by bumping the requested component (`patch` / `minor` /
+`major`) from the highest existing tag, then pushes it — which in turn triggers
+`release.yml`.
 
 ## Maintenance
 

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -36,8 +36,15 @@ jobs:
           # Find the highest existing vX.Y.Z tag and increment the requested component
           LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
           if [ -z "${LATEST_TAG}" ]; then
-            # No tags yet — start at v0.7.0 base
-            LATEST="0.7.0"
+            # No vX.Y.Z tags found. This repo is tag-driven and already has a
+            # published history (13+ tags as of v0.9.2), so an empty result here
+            # means the tags were not fetched (missing fetch-depth/fetch-tags) or
+            # a fresh repo with no release line — NOT a request to seed a version.
+            # Fail loudly rather than silently inventing a stale base tag, which
+            # would push a wrong release tag and trigger release.yml.
+            echo "::error::No vX.Y.Z tags found. Refusing to seed a version automatically." >&2
+            echo "::error::Ensure tags are fetched (fetch-depth: 0, fetch-tags: true) or create the initial tag manually." >&2
+            exit 1
           else
             LATEST="${LATEST_TAG#v}"
           fi

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,6 +8,28 @@ ProjectHephaestus follows [Semantic Versioning](https://semver.org/).
 
 Upgrading across a major version? See the [migration guide](docs/MIGRATION.md).
 
+## Supported Python Versions
+
+ProjectHephaestus supports **Python 3.10+** (`requires-python = ">=3.10"` in
+`pyproject.toml`). CI exercises the package on 3.10, 3.11, 3.12, and 3.13. Dropping
+support for a Python minor version is treated as a backwards-incompatible change and
+follows the deprecation policy below.
+
+## Versioning: Python Package vs Claude Code Plugin
+
+ProjectHephaestus ships **two independently versioned artifacts**:
+
+- **The Python package** (`homericintelligence-hephaestus`) — version is **tag-driven**
+  via hatch-vcs (derived from the latest `vX.Y.Z` git tag; currently `0.9.2`). This is
+  the version the Semantic Versioning guarantees in this document apply to.
+- **The Claude Code plugin** (`hephaestus`, declared in `.claude-plugin/`) — carries its
+  own `version` field (currently `3.0.0`) that tracks the skill/command surface, not the
+  Python API.
+
+These two version numbers are **not** coupled and will not match. The plugin version
+says nothing about the Python package version and vice versa. See
+[`docs/plugin-installation.md`](docs/plugin-installation.md) for plugin installation.
+
 ## Stability Tiers
 
 ProjectHephaestus ships 19 subpackages with different maturity levels. Only the
@@ -38,7 +60,7 @@ may change incompatibly in a minor release.
 | Subpackage | Why provisional |
 |------------|-----------------|
 | `hephaestus.agents` | Agent metadata schema still evolving |
-| `hephaestus.automation` | Actively-evolving 6-phase issue/PR pipeline; large refactor pending (#468) |
+| `hephaestus.automation` | Actively-evolving 3-stage issue/PR pipeline (collapsed from the prior 6-phase design in #677/#679); internals still evolving |
 | `hephaestus.benchmarks` | Comparison API is exploratory |
 | `hephaestus.ci` | CI helpers are project-specific glue, not a general API |
 | `hephaestus.datasets` | Downloader URLs and on-disk layout are not contracted |

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,17 +1,27 @@
 # Migration Guide
 
-## 0.x → 1.0
+> **Status (as of 2026-05-28):** The latest released version is **0.9.2** (tag-driven
+> via hatch-vcs). **1.0 has not been released yet** — the section below is the
+> *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
+> prepare. There are currently **no breaking changes between 0.9.x releases**: upgrading
+> within the 0.9.x line requires no code changes for code that uses only the documented
+> public API in [`COMPATIBILITY.md`](../COMPATIBILITY.md). The `Development Status ::
+> 5 - Production/Stable` classifier in `pyproject.toml` reflects the maturity of the
+> stable public API surface, not a 1.0 tag; the package remains tag-driven and is
+> currently on the 0.9.x series.
+
+## 0.x → 1.0 (forthcoming — not yet released)
 
 ### Summary
 
-**Version 1.0 introduces no breaking changes to the documented public API.**
+**Version 1.0 will introduce no breaking changes to the documented public API.**
 
-The 1.0 release does not change the public API — it *commits* to it. Every symbol
+The 1.0 release will not change the public API — it will *commit* to it. Every symbol
 listed in [`COMPATIBILITY.md`](../COMPATIBILITY.md) keeps the same name, signature,
 and behavior it had in the 0.x series. Code that uses only the documented public API
-needs **no changes** to move from a recent 0.x release to 1.0.
+will need **no changes** to move from a recent 0.x release to 1.0.
 
-What 1.0 means for consumers:
+What 1.0 will mean for consumers:
 
 - The public API surface in `COMPATIBILITY.md` is now covered by the
   [Semantic Versioning](https://semver.org/) guarantees and the deprecation policy —

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,9 +6,9 @@ ProjectHephaestus is the foundational utilities and tooling repository of the Ho
 
 ## Current Focus (Q2 2026)
 
-The project is currently focused on addressing findings from the strict 2026-04-28 repository audit (Epic #310). This ongoing work spans:
+The strict 2026-04-28 repository audit (Epic #310) is now **closed**. The active work is remediating findings from the follow-up strict 2026-05-28 audit, tracked as individual `audit-finding` issues. This ongoing work spans:
 
-1. **Strict Audit Remediation** — Addressing 29 major, minor, and nitpick findings across 15 audit dimensions. Focus areas include improving automation module test coverage, fixing f-string logging anti-patterns, and hardening the 6-phase review-PR pipeline.
+1. **Audit Remediation** — Addressing the open `audit-finding` issues across the 15 audit dimensions. Focus areas include documentation currency, automation module test coverage, fixing f-string logging anti-patterns, and continued hardening of the 3-stage review-PR pipeline (collapsed from the prior 6-phase design in #677/#679).
 
 2. **Automation Package Stabilization** — Refactoring and hardening the automation modules (PR review, CI driver, issue implementation) to improve single responsibility, observability, and idempotency. This includes fixing critical bugs in the CI state machine and worktree management.
 
@@ -44,7 +44,7 @@ Conservative, directional items:
 
 ProjectHephaestus uses an Epic-and-children issue pattern for project planning. Major initiatives are tracked as Epic issues (labeled `epic`), with breakdown into concrete child issues tagged by audit section and severity.
 
-**Exemplar:** Epic #310 (Strict audit 2026-04-28) contains 29 child issues spanning all 15 audit dimensions, with clear scoping and evidence-based requirements.
+**Exemplar:** Epic #310 (Strict audit 2026-04-28, now closed) contained 29 child issues spanning all 15 audit dimensions, with clear scoping and evidence-based requirements.
 
 We also capture session learnings in ProjectMnemosyne via the `/learn` skill, preserving team knowledge about patterns, anti-patterns, and decisions across the ecosystem.
 
@@ -52,4 +52,4 @@ We also capture session learnings in ProjectMnemosyne via the `/learn` skill, pr
 
 This roadmap is reviewed and updated at the end of each release cycle (typically monthly). As new Epics are created or project priorities shift, the roadmap is refreshed to reflect current focus areas. To propose changes, open an issue and reference this document.
 
-Last updated: 2026-05-09
+Last updated: 2026-05-28

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -2,6 +2,13 @@
 
 ProjectHephaestus ships as a Claude Code plugin in addition to a Python package. Installing the plugin gives any repository in your ecosystem access to the `hephaestus` skill set.
 
+> **Note on versions:** The plugin version (currently `3.0.0`, declared in
+> `.claude-plugin/`) and the Python package version (currently `0.9.2`, tag-driven via
+> hatch-vcs) are **separate artifacts** with independent version numbers — they are not
+> coupled and will not match. See
+> [`COMPATIBILITY.md`](../COMPATIBILITY.md#versioning-python-package-vs-claude-code-plugin)
+> for details.
+
 ## What the Plugin Provides
 
 | Skill | Invocation | Description |

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1,4 +1,4 @@
-"""Per-issue 6-phase pipeline runner for :class:`IssueImplementer`.
+"""Per-issue 3-stage pipeline runner for :class:`IssueImplementer`.
 
 Extracted from :mod:`hephaestus.automation.implementer` as part of the #597
 decomposition. The runner owns the body of ``_implement_issue`` and all of


### PR DESCRIPTION
Removes stale 6-phase pipeline references (collapsed to 3 stages in #677/#679), reconciles the version narrative, adds supported-Python to COMPATIBILITY, and fixes the .github/README CI matrix + badge URL.

Closes #685