### PR TITLE
fix(automation): subprocess timeouts + adopt resilient_call

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -36,9 +36,37 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlparse
 
+from hephaestus.automation.claude_timeouts import gh_cli_timeout
 from hephaestus.cli.utils import add_json_arg, emit_json_status
+from hephaestus.resilience.subprocess_resilience import resilient_call
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 LOG = logging.getLogger(__name__)
+
+
+def _default_phase_timeout_s() -> float:
+    """Return the default per-phase timeout in seconds.
+
+    A phase that shells out to ``claude`` can stall indefinitely on a network
+    hang; a non-``None`` default ensures the worker thread is always bounded
+    even when the operator does not pass ``--phase-timeout``. Overridable via
+    ``HEPH_PHASE_TIMEOUT`` (seconds). Mirrors the graceful-fallback contract of
+    :mod:`hephaestus.automation.claude_timeouts`: a malformed env value logs a
+    warning and falls back to the default rather than crashing at startup.
+
+    The 3600s (1h) default comfortably exceeds the longest in-phase Claude
+    timeout (the implementer's 1800s) so a healthy phase never trips it.
+    """
+    default = 3600
+    raw = os.environ.get("HEPH_PHASE_TIMEOUT")
+    if raw is None:
+        return float(default)
+    try:
+        return float(raw)
+    except ValueError:
+        LOG.warning("Ignoring non-numeric HEPH_PHASE_TIMEOUT=%r — using default %ds", raw, default)
+        return float(default)
+
 
 # Canonical phase ordering. The pipeline collapsed from 6 phases to 3
 # session-stable stages (#455/#468/#484): the former standalone review-plans,
@@ -207,9 +235,11 @@ class LoopConfig:
     # hardcoded fallback. Always set by main() before ``run_loop``.
     org: str = ""
     projects_dir: Path = DEFAULT_PROJECTS_DIR
-    # Per-phase timeout in seconds. ``None`` disables (the planner /
-    # implementer naturally bound themselves via their own batch caps).
-    phase_timeout_s: float | None = None
+    # Per-phase timeout in seconds. Defaults to an env-overridable bound
+    # (``HEPH_PHASE_TIMEOUT``) so a stalled subprocess can never hang a worker
+    # thread indefinitely (#684). Passing ``--phase-timeout`` overrides it;
+    # ``None`` explicitly disables the bound.
+    phase_timeout_s: float | None = field(default_factory=_default_phase_timeout_s)
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +351,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument(
         "--phase-timeout",
         type=float,
-        default=None,
-        help="Per-phase timeout in seconds (default: no timeout)",
+        default=_default_phase_timeout_s(),
+        help=(
+            "Per-phase timeout in seconds (default: HEPH_PHASE_TIMEOUT or "
+            f"{int(_default_phase_timeout_s())}s). Pass 0 or a negative value to disable."
+        ),
     )
     p.add_argument(
         "--repos",
@@ -425,22 +458,26 @@ def _detect_cwd_repo() -> tuple[str | None, str | None]:
 
 def _gh_list_repos(org: str) -> list[str]:
     """Return non-archived, non-fork, non-Odysseus repos for ``org``."""
-    out = subprocess.run(
-        [
-            "gh",
-            "repo",
-            "list",
-            org,
-            "--no-archived",
-            "--json",
-            "name,isArchived,isFork",
-            "--limit",
-            "200",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "repo",
+                "list",
+                org,
+                "--no-archived",
+                "--json",
+                "name,isArchived,isFork",
+                "--limit",
+                "200",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=gh_cli_timeout(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(f"gh repo list {org} timed out after {exc.timeout}s") from exc
     if out.returncode != 0:
         raise SystemExit(f"gh repo list {org} failed (rc={out.returncode}): {out.stderr.strip()}")
     try:
@@ -464,28 +501,32 @@ def _gh_issue_numbers_for(org: str, repo: str, filter_flag: str) -> set[int]:
     any failure (rate limit, auth error, etc.) so callers can fall back
     safely.
     """
-    out = subprocess.run(
-        [
-            "gh",
-            "issue",
-            "list",
-            "--repo",
-            f"{org}/{repo}",
-            "--state",
-            "open",
-            filter_flag,
-            "@me",
-            "--limit",
-            "200",
-            "--json",
-            "number",
-            "--jq",
-            ".[].number",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--repo",
+                f"{org}/{repo}",
+                "--state",
+                "open",
+                filter_flag,
+                "@me",
+                "--limit",
+                "200",
+                "--json",
+                "number",
+                "--jq",
+                ".[].number",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=gh_cli_timeout(),
+        )
+    except subprocess.TimeoutExpired:
+        return set()
     if out.returncode != 0:
         return set()
     return {int(x) for x in out.stdout.split() if x.strip().isdigit()}
@@ -528,10 +569,16 @@ def _ensure_clone(org: str, repo: str, dest: Path) -> None:
         return
     LOG.info("Cloning %s/%s -> %s", org, repo, dest)
     dest.parent.mkdir(parents=True, exist_ok=True)
-    rc = subprocess.run(
+    # Route the clone through resilient_call: a network blip retries with
+    # backoff, while a true hang is bounded by NETWORK_TIMEOUT (#684).
+    completed = resilient_call(
+        subprocess.run,
         ["gh", "repo", "clone", f"{org}/{repo}", str(dest)],
         check=False,
-    ).returncode
+        timeout=NETWORK_TIMEOUT,
+        circuit_breaker_name="gh-repo-clone",
+    )
+    rc = completed.returncode  # type: ignore[attr-defined]
     if rc != 0:
         raise RuntimeError(f"gh repo clone {org}/{repo} failed (rc={rc})")
 
@@ -558,15 +605,26 @@ def _clone_missing_repos(org: str, repos: list[str], projects_dir: Path) -> None
 
 def _rebase_main(repo: str, repo_dir: Path) -> str:
     """Fetch + rebase main; return short trunk SHA (or 'unknown')."""
-    subprocess.run(
-        ["git", "-C", str(repo_dir), "fetch", "origin", "--quiet"],
-        check=False,
-    )
+    # The fetch touches the network, so route it through resilient_call:
+    # transient failures retry with backoff and a genuine stall is capped by
+    # NETWORK_TIMEOUT (#684). A timeout after retries is non-fatal here — the
+    # subsequent rebase against a stale origin/main is still safe.
+    try:
+        resilient_call(
+            subprocess.run,
+            ["git", "-C", str(repo_dir), "fetch", "origin", "--quiet"],
+            check=False,
+            timeout=NETWORK_TIMEOUT,
+            circuit_breaker_name="git-fetch",
+        )
+    except subprocess.TimeoutExpired:
+        LOG.warning("[%s] git fetch timed out; rebasing against stale origin/main", repo)
     rb = subprocess.run(
         ["git", "-C", str(repo_dir), "rebase", "origin/main", "--quiet"],
         capture_output=True,
         text=True,
         check=False,
+        timeout=METADATA_TIMEOUT,
     )
     if rb.returncode != 0:
         # Mid-rebase state; fall back to a hard reset so the loop can continue.
@@ -576,17 +634,20 @@ def _rebase_main(repo: str, repo_dir: Path) -> str:
             ["git", "-C", str(repo_dir), "rebase", "--abort"],
             capture_output=True,
             check=False,
+            timeout=METADATA_TIMEOUT,
         )
         subprocess.run(
             ["git", "-C", str(repo_dir), "reset", "--hard", "origin/main", "--quiet"],
             capture_output=True,
             check=False,
+            timeout=METADATA_TIMEOUT,
         )
     sha = subprocess.run(
         ["git", "-C", str(repo_dir), "rev-parse", "--short=7", "HEAD"],
         capture_output=True,
         text=True,
         check=False,
+        timeout=METADATA_TIMEOUT,
     )
     return sha.stdout.strip() or "unknown"
 
@@ -888,20 +949,26 @@ def _process_repo_inner(
 
 def _preflight_token_scopes(org: str, probe_repo: str) -> None:
     """Mirror the bash script's gh-token preflight."""
-    out = subprocess.run(
-        [
-            "gh",
-            "api",
-            "-H",
-            "Accept: application/vnd.github+json",
-            f"/repos/{org}/{probe_repo}",
-            "--jq",
-            ".permissions",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        out = subprocess.run(
+            [
+                "gh",
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                f"/repos/{org}/{probe_repo}",
+                "--jq",
+                ".permissions",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=gh_cli_timeout(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SystemExit(
+            f"ERROR: `gh` token preflight for {org}/{probe_repo} timed out after {exc.timeout}s."
+        ) from exc
     if out.returncode != 0:
         raise SystemExit(
             f"ERROR: `gh` cannot read {org}/{probe_repo} with the current token.\n"
@@ -920,12 +987,16 @@ def _preflight_token_scopes(org: str, probe_repo: str) -> None:
 
 def _rate_limit_remaining() -> tuple[int, int] | None:
     """Return ``(remaining, reset_epoch)`` for the GraphQL budget, or None."""
-    out = subprocess.run(
-        ["gh", "api", "rate_limit"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        out = subprocess.run(
+            ["gh", "api", "rate_limit"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=gh_cli_timeout(),
+        )
+    except subprocess.TimeoutExpired:
+        return None
     if out.returncode != 0:
         return None
     try:
@@ -1152,7 +1223,11 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         implementer_model=args.implementer_model,
         org=org,
         projects_dir=args.projects_dir,
-        phase_timeout_s=args.phase_timeout,
+        # A non-positive --phase-timeout explicitly disables the bound; any
+        # positive value (including the env-overridable default) applies it.
+        phase_timeout_s=(
+            args.phase_timeout if args.phase_timeout and args.phase_timeout > 0 else None
+        ),
     )
 
     if not cfg.allow_unsafe_phase_order:

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 from hephaestus.logging.utils import get_logger
-from hephaestus.utils.helpers import run_subprocess
+from hephaestus.utils.helpers import METADATA_TIMEOUT, run_subprocess
 
 logger = get_logger(__name__)
 
@@ -142,10 +142,12 @@ def local_branch_exists(branch_name: str) -> bool:
     """
     try:
         out = subprocess.check_output(
-            ["git", "branch", "--list", branch_name], stderr=subprocess.DEVNULL
+            ["git", "branch", "--list", branch_name],
+            stderr=subprocess.DEVNULL,
+            timeout=METADATA_TIMEOUT,
         )
         return bool(out.strip())
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return False
 
 

--- a/hephaestus/github/stats.py
+++ b/hephaestus/github/stats.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from typing import Any
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status, format_output
+from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 # ---------------------------------------------------------------------------
 # Data helpers
@@ -57,6 +58,7 @@ def get_current_repo() -> str:
         ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
         capture_output=True,
         text=True,
+        timeout=METADATA_TIMEOUT,
     )
     if result.returncode != 0:
         print(f"Error: Failed to get repo name: {result.stderr}", file=sys.stderr)
@@ -93,6 +95,7 @@ def get_issues_stats(
         ["gh", "api", "search/issues", "-f", f"q={base_query}", "--jq", ".total_count"],
         capture_output=True,
         text=True,
+        timeout=METADATA_TIMEOUT,
     )
     if result.returncode != 0:
         return {"total": 0, "open": 0, "closed": 0}
@@ -111,6 +114,7 @@ def get_issues_stats(
         ],
         capture_output=True,
         text=True,
+        timeout=METADATA_TIMEOUT,
     )
     open_count = int(result_open.stdout.strip()) if result_open.returncode == 0 else 0
 
@@ -139,6 +143,7 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
         ["gh", "api", "search/issues", "-f", f"q={base_query}", "--jq", ".total_count"],
         capture_output=True,
         text=True,
+        timeout=METADATA_TIMEOUT,
     )
     if result.returncode != 0:
         return {"total": 0, "merged": 0, "open": 0, "closed": 0}
@@ -157,6 +162,7 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
         ],
         capture_output=True,
         text=True,
+        timeout=METADATA_TIMEOUT,
     )
     merged = int(result_merged.stdout.strip()) if result_merged.returncode == 0 else 0
 
@@ -172,6 +178,7 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
         ],
         capture_output=True,
         text=True,
+        timeout=METADATA_TIMEOUT,
     )
     open_count = int(result_open.stdout.strip()) if result_open.returncode == 0 else 0
 
@@ -215,7 +222,7 @@ def get_commits_stats(
     if author:
         params += ["-f", f"author={author}"]
 
-    result = subprocess.run(params, capture_output=True, text=True)
+    result = subprocess.run(params, capture_output=True, text=True, timeout=METADATA_TIMEOUT)
     if result.returncode != 0:
         return {"total": 0}
 

--- a/hephaestus/validation/complexity.py
+++ b/hephaestus/validation/complexity.py
@@ -18,7 +18,7 @@ import sys
 from pathlib import Path
 
 from hephaestus.cli.utils import add_json_arg, format_output
-from hephaestus.utils.helpers import get_repo_root
+from hephaestus.utils.helpers import NETWORK_TIMEOUT, get_repo_root
 
 
 def run_ruff_complexity_check(
@@ -52,6 +52,7 @@ def run_ruff_complexity_check(
         capture_output=True,
         text=True,
         cwd=repo_root,
+        timeout=NETWORK_TIMEOUT,
     )
 
     if not result.stdout.strip():

--- a/hephaestus/validation/doc_config.py
+++ b/hephaestus/validation/doc_config.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from hephaestus.cli.utils import add_json_arg, format_output
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 _tomllib = None
 for _mod_name in ("tomllib", "tomli"):
@@ -260,8 +261,9 @@ def collect_actual_test_count(repo_root: Path) -> int | None:
             cwd=repo_root,
             capture_output=True,
             text=True,
+            timeout=NETWORK_TIMEOUT,
         )
-    except (FileNotFoundError, OSError):
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
 
     output = result.stdout + result.stderr

--- a/hephaestus/validation/mypy_per_file.py
+++ b/hephaestus/validation/mypy_per_file.py
@@ -25,6 +25,7 @@ import sys
 from pathlib import Path
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 # mypy flags that consume the next argument as their value.
 _FLAGS_WITH_VALUE: frozenset[str] = frozenset(
@@ -95,9 +96,19 @@ def run_mypy_per_file(
     overall_rc = 0
     for filepath in files:
         cmd = [executable, "-m", "mypy", *extra_flags, filepath]
-        result = subprocess.run(cmd, capture_output=False)
-        if result.returncode != 0:
-            overall_rc = result.returncode
+        try:
+            result = subprocess.run(cmd, capture_output=False, timeout=NETWORK_TIMEOUT)
+            rc = result.returncode
+        except subprocess.TimeoutExpired as exc:
+            # A hung mypy run must not stall the whole check; treat it as a
+            # failure for this file so the aggregate rc is non-zero (#684).
+            print(
+                f"mypy-each-file: {filepath} timed out after {exc.timeout}s",
+                file=sys.stderr,
+            )
+            rc = 124
+        if rc != 0:
+            overall_rc = rc
 
     return overall_rc
 

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -16,19 +16,28 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation import loop_runner
+from hephaestus.automation.claude_timeouts import gh_cli_timeout
 from hephaestus.automation.loop_runner import (
     ALL_PHASES,
     LoopConfig,
     PhaseResult,
     RepoResult,
+    _default_phase_timeout_s,
+    _ensure_clone,
+    _gh_issue_numbers_for,
     _phase_order_warnings,
+    _preflight_token_scopes,
+    _rate_limit_remaining,
+    _rebase_main,
     _resolve_phase_bin,
     _summarize_loop,
     _validate_phases,
+    main,
     process_repo,
     run_loop,
     run_phase,
 )
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 # ---------------------------------------------------------------------------
 # Phase topology — the 6→3 stage collapse (#455/#468/#484)
@@ -830,3 +839,223 @@ class TestSummarizeLoop:
         assert "planned=1" in summary
         assert "implemented=1" in summary
         assert "skipped=1" in summary
+
+
+# ---------------------------------------------------------------------------
+# Subprocess timeout discipline (#684)
+# ---------------------------------------------------------------------------
+
+
+def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedProcess[str]:
+    """Build a CompletedProcess stand-in for mocked subprocess.run calls."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+class TestSubprocessTimeouts:
+    """Every unbounded gh/git call in the loop must now pass ``timeout=``."""
+
+    def test_gh_list_repos_passes_timeout(self) -> None:
+        """``gh repo list`` is a network op bounded by gh_cli_timeout()."""
+        with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="[]")
+            loop_runner._gh_list_repos("MyOrg")
+        assert mock_run.call_args.kwargs["timeout"] == gh_cli_timeout()
+
+    def test_gh_issue_numbers_passes_timeout(self) -> None:
+        """``gh issue list`` is bounded by gh_cli_timeout()."""
+        with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout="1\n2\n")
+            _gh_issue_numbers_for("Org", "Repo", "--author")
+        assert mock_run.call_args.kwargs["timeout"] == gh_cli_timeout()
+
+    def test_preflight_token_scopes_passes_timeout(self) -> None:
+        """The token preflight ``gh api`` call is bounded by gh_cli_timeout()."""
+        with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout='{"push": true}')
+            _preflight_token_scopes("Org", "Repo")
+        assert mock_run.call_args.kwargs["timeout"] == gh_cli_timeout()
+
+    def test_rate_limit_remaining_passes_timeout(self) -> None:
+        """``gh api rate_limit`` is bounded by gh_cli_timeout()."""
+        payload = '{"resources":{"graphql":{"remaining":5000,"reset":0}}}'
+        with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+            mock_run.return_value = _completed(stdout=payload)
+            _rate_limit_remaining()
+        assert mock_run.call_args.kwargs["timeout"] == gh_cli_timeout()
+
+    def test_rebase_main_git_ops_pass_metadata_timeout(self, tmp_path: Path) -> None:
+        """The local git ops in _rebase_main carry METADATA_TIMEOUT."""
+        with (
+            patch("hephaestus.automation.loop_runner.resilient_call") as mock_resilient,
+            patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run,
+        ):
+            mock_resilient.return_value = _completed()
+            mock_run.return_value = _completed(stdout="abc1234")
+            _rebase_main("Repo", tmp_path)
+        # Every direct subprocess.run (rebase / rev-parse) is bounded.
+        assert mock_run.call_count >= 2
+        for call in mock_run.call_args_list:
+            assert call.kwargs["timeout"] == METADATA_TIMEOUT
+
+    def test_gh_list_repos_timeout_raises_systemexit(self) -> None:
+        """A timed-out ``gh repo list`` surfaces as a clean SystemExit."""
+        with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=120)
+            with pytest.raises(SystemExit, match="timed out"):
+                loop_runner._gh_list_repos("MyOrg")
+
+    def test_gh_issue_numbers_timeout_returns_empty_set(self) -> None:
+        """A timed-out issue query degrades to an empty set, not a crash."""
+        with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=120)
+            assert _gh_issue_numbers_for("Org", "Repo", "--author") == set()
+
+
+class TestResilientCallAdoption:
+    """The hang-prone clone/fetch calls route through resilient_call (#684)."""
+
+    def test_ensure_clone_uses_resilient_call_with_network_timeout(self, tmp_path: Path) -> None:
+        """``_ensure_clone`` delegates the clone to resilient_call."""
+        dest = tmp_path / "Repo"
+        with patch("hephaestus.automation.loop_runner.resilient_call") as mock_resilient:
+            mock_resilient.return_value = _completed(returncode=0)
+            _ensure_clone("Org", "Repo", dest)
+        assert mock_resilient.call_count == 1
+        # The wrapped callable is subprocess.run; the clone is NETWORK_TIMEOUT-bounded.
+        assert mock_resilient.call_args.args[0] is subprocess.run
+        assert mock_resilient.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+        assert mock_resilient.call_args.kwargs["circuit_breaker_name"] == "gh-repo-clone"
+
+    def test_rebase_main_fetch_uses_resilient_call(self, tmp_path: Path) -> None:
+        """``_rebase_main`` routes the network fetch through resilient_call."""
+        with (
+            patch("hephaestus.automation.loop_runner.resilient_call") as mock_resilient,
+            patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run,
+        ):
+            mock_resilient.return_value = _completed()
+            mock_run.return_value = _completed(stdout="abc1234")
+            _rebase_main("Repo", tmp_path)
+        assert mock_resilient.call_count == 1
+        # The wrapped callable is the module's subprocess.run (here the patched mock).
+        assert mock_resilient.call_args.args[0] is mock_run
+        assert mock_resilient.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+        assert mock_resilient.call_args.kwargs["circuit_breaker_name"] == "git-fetch"
+
+    def test_resilient_call_terminates_hung_clone(self, tmp_path: Path) -> None:
+        """A subprocess that never returns is killed: TimeoutExpired propagates.
+
+        ``resilient_call`` does not retry intentional timeouts (it is not in the
+        transient set), so the TimeoutExpired surfaces and ``_ensure_clone``
+        converts the failed clone into a RuntimeError rather than hanging.
+        """
+        dest = tmp_path / "Repo"
+
+        def _hang(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd="gh repo clone", timeout=120)
+
+        with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=_hang):
+            with pytest.raises(subprocess.TimeoutExpired):
+                _ensure_clone("Org", "Repo", dest)
+
+    def test_rebase_main_fetch_timeout_is_non_fatal(self, tmp_path: Path) -> None:
+        """A timed-out fetch is logged and the rebase proceeds against stale main."""
+
+        def _hang(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.TimeoutExpired(cmd="git fetch", timeout=120)
+
+        with (
+            patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run,
+            patch(
+                "hephaestus.automation.loop_runner.resilient_call",
+                side_effect=_hang,
+            ),
+        ):
+            mock_run.return_value = _completed(stdout="def5678")
+            sha = _rebase_main("Repo", tmp_path)
+        assert sha == "def5678"
+
+
+class TestDefaultPhaseTimeout:
+    """run_phase must apply a default timeout when --phase-timeout is absent (#684)."""
+
+    def test_default_phase_timeout_is_non_none(self) -> None:
+        """A fresh LoopConfig has a positive default phase timeout."""
+        cfg = LoopConfig()
+        assert cfg.phase_timeout_s is not None
+        assert cfg.phase_timeout_s == _default_phase_timeout_s()
+        assert cfg.phase_timeout_s > 0
+
+    def test_run_phase_passes_default_timeout_to_subprocess(self, fake_repo_dir: Path) -> None:
+        """When no override is given, run_phase forwards the default timeout."""
+        cfg = LoopConfig()
+        completed = MagicMock(returncode=0)
+        with (
+            patch.object(loop_runner, "_resolve_phase_bin", return_value=("/bin/true", [])),
+            patch("subprocess.run", return_value=completed) as run_mock,
+        ):
+            run_phase(
+                repo="r",
+                repo_dir=fake_repo_dir,
+                phase="plan",
+                cfg=cfg,
+                loop_idx=1,
+                open_issues=[],
+                trunk_sha="abc1234",
+            )
+        assert run_mock.call_args.kwargs["timeout"] == _default_phase_timeout_s()
+
+    def test_default_phase_timeout_reads_env_override(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``HEPH_PHASE_TIMEOUT`` overrides the built-in default."""
+        monkeypatch.setenv("HEPH_PHASE_TIMEOUT", "42")
+        assert _default_phase_timeout_s() == 42.0
+
+    def test_default_phase_timeout_ignores_malformed_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-numeric override falls back to the default instead of crashing."""
+        monkeypatch.setenv("HEPH_PHASE_TIMEOUT", "not-a-number")
+        assert _default_phase_timeout_s() == 3600.0
+
+    def test_main_applies_default_phase_timeout_when_flag_absent(self) -> None:
+        """``main`` builds a LoopConfig with the default timeout when --phase-timeout is omitted."""
+        captured: dict[str, LoopConfig] = {}
+
+        def _capture(cfg: LoopConfig, _repos: list[str]) -> list[RepoResult]:
+            captured["cfg"] = cfg
+            return []
+
+        with (
+            patch.object(
+                loop_runner,
+                "_resolve_org_and_repos",
+                return_value=("Org", ["Repo"], None),
+            ),
+            patch.object(loop_runner, "_preflight_token_scopes"),
+            patch.object(loop_runner, "_clone_missing_repos"),
+            patch.object(loop_runner, "run_loop", side_effect=_capture),
+        ):
+            main(["--repos", "Repo", "--dry-run", "--loops", "1"])
+        assert captured["cfg"].phase_timeout_s == _default_phase_timeout_s()
+
+    def test_main_disables_phase_timeout_when_zero(self) -> None:
+        """``--phase-timeout 0`` explicitly disables the bound (None)."""
+        captured: dict[str, LoopConfig] = {}
+
+        def _capture(cfg: LoopConfig, _repos: list[str]) -> list[RepoResult]:
+            captured["cfg"] = cfg
+            return []
+
+        with (
+            patch.object(
+                loop_runner,
+                "_resolve_org_and_repos",
+                return_value=("Org", ["Repo"], None),
+            ),
+            patch.object(loop_runner, "_preflight_token_scopes"),
+            patch.object(loop_runner, "_clone_missing_repos"),
+            patch.object(loop_runner, "run_loop", side_effect=_capture),
+        ):
+            main(["--repos", "Repo", "--phase-timeout", "0", "--loops", "1"])
+        assert captured["cfg"].phase_timeout_s is None

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -17,6 +17,7 @@ from hephaestus.github.pr_merge import (
     run_git_cmd,
     try_push_head_branch,
 )
+from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 
 class TestDetectRepoFromRemote:
@@ -235,6 +236,19 @@ class TestLocalBranchExists:
     def test_returns_false_on_subprocess_error(self, mock_check) -> None:
         """Returns False when subprocess raises CalledProcessError."""
         mock_check.side_effect = subprocess.CalledProcessError(1, "git")
+        assert local_branch_exists("branch") is False
+
+    @patch("hephaestus.github.pr_merge.subprocess.check_output")
+    def test_passes_timeout(self, mock_check) -> None:
+        """The git branch lookup is bounded by METADATA_TIMEOUT (#684)."""
+        mock_check.return_value = b"  my-feature\n"
+        local_branch_exists("my-feature")
+        assert mock_check.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+
+    @patch("hephaestus.github.pr_merge.subprocess.check_output")
+    def test_returns_false_on_timeout(self, mock_check) -> None:
+        """A hung ``git branch --list`` degrades to False instead of hanging (#684)."""
+        mock_check.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
         assert local_branch_exists("branch") is False
 
 

--- a/tests/unit/github/test_stats.py
+++ b/tests/unit/github/test_stats.py
@@ -10,10 +10,12 @@ from hephaestus.github.stats import (
     collect_stats,
     format_stats_table,
     get_commits_stats,
+    get_current_repo,
     get_issues_stats,
     get_prs_stats,
     validate_date,
 )
+from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 
 class TestValidateDate:
@@ -301,3 +303,42 @@ class TestMain:
         mock_repo.assert_called_once()
         payload = json.loads(capsys.readouterr().out)
         assert payload["repo"] == "owner/auto"
+
+
+class TestStatsSubprocessTimeouts:
+    """Every gh metadata read in stats.py must pass ``timeout=`` (#684)."""
+
+    @staticmethod
+    def _ok(stdout: str = "0\n") -> MagicMock:
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = stdout
+        return m
+
+    def test_get_current_repo_passes_timeout(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._ok("owner/repo")
+            get_current_repo()
+        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+
+    def test_get_issues_stats_all_calls_pass_timeout(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [self._ok("10\n"), self._ok("3\n")]
+            get_issues_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert mock_run.call_count == 2
+        for call in mock_run.call_args_list:
+            assert call.kwargs["timeout"] == METADATA_TIMEOUT
+
+    def test_get_prs_stats_all_calls_pass_timeout(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = [self._ok("8\n"), self._ok("5\n"), self._ok("1\n")]
+            get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert mock_run.call_count == 3
+        for call in mock_run.call_args_list:
+            assert call.kwargs["timeout"] == METADATA_TIMEOUT
+
+    def test_get_commits_stats_passes_timeout(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = self._ok("4\n")
+            get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
+        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT

--- a/tests/unit/validation/test_complexity.py
+++ b/tests/unit/validation/test_complexity.py
@@ -1,7 +1,9 @@
 """Tests for hephaestus.validation.complexity."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
 from hephaestus.validation.complexity import (
     check_max_complexity,
     main,
@@ -107,3 +109,14 @@ class TestMain:
             ],
         )
         assert main() == 1
+
+
+class TestComplexitySubprocessTimeout:
+    """``run_ruff_complexity_check`` must bound the external ruff call (#684)."""
+
+    def test_ruff_invocation_passes_timeout(self, tmp_path: Path) -> None:
+        """The ruff subprocess is bounded so a hung tool cannot stall the check."""
+        with patch("hephaestus.validation.complexity.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            run_ruff_complexity_check("hephaestus/", 10, tmp_path)
+        assert mock_run.call_args.kwargs["timeout"] == NETWORK_TIMEOUT

--- a/tests/unit/validation/test_doc_config.py
+++ b/tests/unit/validation/test_doc_config.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
 from hephaestus.validation.doc_config import (
     check_addopts_cov_fail_under,
     check_claude_md_threshold,
@@ -224,6 +227,21 @@ class TestCollectActualTestCount:
         # No tests/ directory — subprocess will likely return nothing parseable
         result = collect_actual_test_count(tmp_path)
         assert result is None or isinstance(result, int)
+
+    def test_pytest_collection_passes_timeout(self, tmp_path: Path) -> None:
+        """The pytest --collect-only subprocess is bounded (#684)."""
+        with patch("hephaestus.validation.doc_config.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="5 tests collected\n", stderr="")
+            collect_actual_test_count(tmp_path)
+        assert mock_run.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        """A hung pytest collection degrades to None instead of hanging (#684)."""
+        with patch(
+            "hephaestus.validation.doc_config.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="pytest", timeout=120),
+        ):
+            assert collect_actual_test_count(tmp_path) is None
 
 
 class TestCheckDocConfigConsistency:

--- a/tests/unit/validation/test_mypy_per_file.py
+++ b/tests/unit/validation/test_mypy_per_file.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
 from hephaestus.validation.mypy_per_file import (
     check_mypy_per_file,
     main,
@@ -119,6 +121,26 @@ class TestRunMypyPerFile:
             run_mypy_per_file(files, flags=["--ignore-missing-imports"])
 
         assert call_count == 3
+
+    def test_passes_timeout_per_invocation(self, tmp_path: Path) -> None:
+        """Each per-file mypy run is bounded by NETWORK_TIMEOUT (#684)."""
+        files = [str(tmp_path / "f.py")]
+        Path(files[0]).write_text("x = 1\n")
+        with patch("hephaestus.validation.mypy_per_file.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            run_mypy_per_file(files, flags=[])
+        assert mock_run.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+
+    def test_timeout_yields_nonzero_rc(self, tmp_path: Path) -> None:
+        """A hung mypy run is treated as a failure (rc 124), not a crash (#684)."""
+        files = [str(tmp_path / "f.py")]
+        Path(files[0]).write_text("x = 1\n")
+        with patch(
+            "hephaestus.validation.mypy_per_file.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="mypy", timeout=120),
+        ):
+            rc = run_mypy_per_file(files, flags=[])
+        assert rc == 124
 
 
 class TestCheckMypyPerFile:


### PR DESCRIPTION
Adds timeout= to unbounded gh/git subprocess calls in the automation loop, gives run_phase a default phase timeout, and routes the hang-prone clone/fetch through resilient_call (resolving its YAGNI/dead-code status).

Closes #684