### PR TITLE
refactor: consolidate duplicated version/toml parsers

### DIFF
--- a/hephaestus/ci/precommit.py
+++ b/hephaestus/ci/precommit.py
@@ -20,7 +20,6 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import importlib
 import os
 import re
 import sys
@@ -28,17 +27,14 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status, format_output
+from hephaestus.config.pixi import is_deps_section
+from hephaestus.io.toml import import_tomllib
+from hephaestus.version.parsing import parse_version_tuple
 
 # ---------------------------------------------------------------------------
 # TOML loading (tomllib on 3.11+, tomli on 3.10, manual fallback)
 # ---------------------------------------------------------------------------
-_tomllib = None
-for _mod_name in ("tomllib", "tomli"):
-    try:
-        _tomllib = importlib.import_module(_mod_name)
-        break
-    except ModuleNotFoundError:
-        continue
+_tomllib = import_tomllib()
 
 try:
     import yaml as _yaml
@@ -226,11 +222,7 @@ def _is_deps_section_header(stripped: str) -> bool:
         True if this section contains conda/pip package→version entries.
 
     """
-    inner = stripped.lstrip("[").split("]")[0].split("#")[0].strip()
-    if inner == "dependencies":
-        return True
-    parts = inner.split(".")
-    return len(parts) == 3 and parts[0] == "feature" and parts[2] == "dependencies"
+    return is_deps_section(stripped, include_pypi=False)
 
 
 def _parse_pixi_dependencies_fallback(pixi_path: Path) -> dict[str, str]:
@@ -311,6 +303,9 @@ def load_pixi_versions(pixi_path: Path) -> dict[str, str]:
 def _version_tuple(version: str) -> tuple[int, ...]:
     """Convert a version string to a comparable tuple of integers.
 
+    Splits on ``.`` and coerces any non-integer segment to ``0`` so a noisy
+    suffix like ``"1.2.rc1"`` parses to ``(1, 2, 0)``.
+
     Args:
         version: Version string, e.g. ``"1.19.1"``.
 
@@ -318,13 +313,7 @@ def _version_tuple(version: str) -> tuple[int, ...]:
         Tuple of ints, e.g. ``(1, 19, 1)``.
 
     """
-    parts = []
-    for part in version.split("."):
-        try:
-            parts.append(int(part))
-        except ValueError:
-            parts.append(0)
-    return tuple(parts)
+    return parse_version_tuple(version, on_non_numeric="zero")
 
 
 def check_version_drift(

--- a/hephaestus/config/dep_sync.py
+++ b/hephaestus/config/dep_sync.py
@@ -39,7 +39,9 @@ from pathlib import Path
 from typing import NamedTuple
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status, format_output
+from hephaestus.config.pixi import is_deps_section
 from hephaestus.utils.helpers import METADATA_TIMEOUT
+from hephaestus.version.parsing import parse_version_tuple
 
 # Header written at the top of every auto-generated requirements file.
 _GENERATED_HEADER = """\
@@ -64,6 +66,9 @@ class VersionRange(NamedTuple):
 def _parse_version(v: str) -> tuple[int, ...]:
     """Parse a dotted version string into a tuple of ints.
 
+    Splits on ``.`` and ``-`` and drops any non-numeric segment, so a
+    pre-release suffix like ``"1.2.3rc1"`` parses to ``(1, 2)``.
+
     Args:
         v: Version string like ``"1.2.3"``.
 
@@ -71,7 +76,7 @@ def _parse_version(v: str) -> tuple[int, ...]:
         Tuple of integers, e.g. ``(1, 2, 3)``.
 
     """
-    return tuple(int(x) for x in re.split(r"[.\-]", v) if x.isdigit())
+    return parse_version_tuple(v, split_pattern=r"[.\-]", on_non_numeric="drop")
 
 
 def _parse_constraints(spec: str) -> list[VersionRange]:
@@ -145,17 +150,7 @@ def _is_deps_section(header: str) -> bool:
         True if the section contains package→version entries we care about.
 
     """
-    # Strip brackets and optional inline comment
-    inner = header.strip().lstrip("[").split("]")[0].split("#")[0].strip()
-    if inner in ("dependencies", "pypi-dependencies"):
-        return True
-    # feature.<name>.dependencies or feature.<name>.pypi-dependencies
-    parts = inner.split(".")
-    return (
-        len(parts) == 3
-        and parts[0] == "feature"
-        and parts[2] in ("dependencies", "pypi-dependencies")
-    )
+    return is_deps_section(header, include_pypi=True)
 
 
 def parse_pixi_toml(path: Path) -> dict[str, str]:

--- a/hephaestus/config/pixi.py
+++ b/hephaestus/config/pixi.py
@@ -1,0 +1,43 @@
+"""Shared helpers for the line-by-line ``pixi.toml`` dependency-section parser.
+
+Both :mod:`hephaestus.config.dep_sync` and :mod:`hephaestus.ci.precommit` walk
+``pixi.toml`` line by line (to avoid requiring a TOML parser on Python 3.10) and
+need to recognise dependency section headers. They differ in one respect:
+``dep_sync`` also treats ``pypi-dependencies`` sections as dependency sections,
+whereas ``precommit`` only cares about conda ``dependencies``. That single
+difference is expressed via the ``include_pypi`` flag.
+
+Recognised patterns (with ``include_pypi=True``):
+
+- ``[dependencies]``
+- ``[pypi-dependencies]``
+- ``[feature.<name>.dependencies]``
+- ``[feature.<name>.pypi-dependencies]``
+
+With ``include_pypi=False`` only the two ``dependencies`` forms match.
+"""
+
+from __future__ import annotations
+
+
+def is_deps_section(header: str, *, include_pypi: bool = True) -> bool:
+    """Return True if *header* is a pixi.toml dependency section header.
+
+    Args:
+        header: A TOML section header line including the brackets. Surrounding
+            whitespace and a trailing inline comment are tolerated.
+        include_pypi: If True (default), ``pypi-dependencies`` sections count as
+            dependency sections. If False, only conda ``dependencies`` match.
+
+    Returns:
+        True if the section holds package→version entries we care about.
+
+    """
+    # Strip brackets and optional inline comment.
+    inner = header.strip().lstrip("[").split("]")[0].split("#")[0].strip()
+    section_names = ("dependencies", "pypi-dependencies") if include_pypi else ("dependencies",)
+    if inner in section_names:
+        return True
+    # feature.<name>.dependencies (and pypi-dependencies when include_pypi).
+    parts = inner.split(".")
+    return len(parts) == 3 and parts[0] == "feature" and parts[2] in section_names

--- a/hephaestus/io/toml.py
+++ b/hephaestus/io/toml.py
@@ -1,0 +1,46 @@
+"""Shared TOML-module resolution for the ``tomllib`` / ``tomli`` fallback.
+
+``tomllib`` ships in the standard library on Python 3.11+. On Python 3.10 it is
+absent, and callers fall back to the ``tomli`` backport. Several modules across
+the package reimplemented the identical import-fallback loop; this module
+provides a single resolver so that logic lives in one place.
+
+The resolver returns the imported module (so callers keep using
+``module.load(fh)`` exactly as before) or ``None`` when neither package is
+installed — preserving each caller's existing ``if module is None`` fallback
+behaviour.
+
+Usage::
+
+    from hephaestus.io.toml import import_tomllib
+
+    _tomllib = import_tomllib()
+    if _tomllib is not None:
+        with path.open("rb") as fh:
+            data = _tomllib.load(fh)
+"""
+
+from __future__ import annotations
+
+import importlib
+import types
+
+
+def import_tomllib() -> types.ModuleType | None:
+    """Return the ``tomllib`` module, the ``tomli`` backport, or ``None``.
+
+    Tries ``tomllib`` (stdlib on Python 3.11+) first, then the ``tomli``
+    backport (used on Python 3.10). Returns ``None`` if neither is importable so
+    that callers can fall back to a regex/manual parser or a default config.
+
+    Returns:
+        The resolved TOML module exposing ``load`` / ``loads``, or ``None`` if
+        no TOML parser is available.
+
+    """
+    for mod_name in ("tomllib", "tomli"):
+        try:
+            return importlib.import_module(mod_name)
+        except ModuleNotFoundError:
+            continue
+    return None

--- a/hephaestus/validation/coverage.py
+++ b/hephaestus/validation/coverage.py
@@ -14,24 +14,18 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import importlib
 import logging
 import sys
 from pathlib import Path
 from typing import Any, cast
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status, format_output
+from hephaestus.io.toml import import_tomllib
 from hephaestus.utils.helpers import get_repo_root
 
 logger = logging.getLogger(__name__)
 
-tomllib = None
-for _mod_name in ("tomllib", "tomli"):
-    try:
-        tomllib = importlib.import_module(_mod_name)
-        break
-    except ModuleNotFoundError:
-        continue
+tomllib = import_tomllib()
 
 
 def load_coverage_config(config_file: Path | None = None) -> dict[str, Any]:

--- a/hephaestus/validation/doc_config.py
+++ b/hephaestus/validation/doc_config.py
@@ -23,7 +23,6 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import importlib
 import re
 import subprocess
 import sys
@@ -31,15 +30,10 @@ from pathlib import Path
 from typing import Any, cast
 
 from hephaestus.cli.utils import add_json_arg, format_output
+from hephaestus.io.toml import import_tomllib
 from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
-_tomllib = None
-for _mod_name in ("tomllib", "tomli"):
-    try:
-        _tomllib = importlib.import_module(_mod_name)
-        break
-    except ModuleNotFoundError:
-        continue
+_tomllib = import_tomllib()
 
 
 def _load_pyproject(repo_root: Path) -> dict[str, Any]:

--- a/hephaestus/validation/python_version.py
+++ b/hephaestus/validation/python_version.py
@@ -14,21 +14,15 @@ Usage::
 from __future__ import annotations
 
 import argparse
-import importlib
 import re
 import sys
 from pathlib import Path
 
 from hephaestus.cli.utils import add_json_arg, format_output
+from hephaestus.io.toml import import_tomllib
 from hephaestus.utils.helpers import get_repo_root
 
-tomllib = None
-for _mod_name in ("tomllib", "tomli"):
-    try:
-        tomllib = importlib.import_module(_mod_name)
-        break
-    except ModuleNotFoundError:
-        continue
+tomllib = import_tomllib()
 
 _CLASSIFIER_VERSION_RE = re.compile(r"Programming Language :: Python :: (\d+\.\d+)$")
 _DOCKERFILE_FROM_RE = re.compile(r"^\s*FROM\s+python:(\d+\.\d+)", re.IGNORECASE | re.MULTILINE)

--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -24,30 +24,24 @@ Usage:
 """
 
 import argparse
-import importlib
 import re
 import subprocess
 import sys
-import types
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _dist_version
 from pathlib import Path
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status, format_output
+from hephaestus.io.toml import import_tomllib
 from hephaestus.utils.helpers import get_repo_root
 from hephaestus.version.manager import VersionManager, parse_version
+from hephaestus.version.parsing import parse_version_tuple
 
 # PyPI distribution name used for the importlib.metadata fallback.
 _DIST_NAME = "HomericIntelligence-Hephaestus"
 
 # tomllib ships with Python 3.11+; fall back to the tomli backport on 3.10.
-_tomllib: types.ModuleType | None = None
-for _mod_name in ("tomllib", "tomli"):
-    try:
-        _tomllib = importlib.import_module(_mod_name)
-        break
-    except ImportError:
-        continue
+_tomllib = import_tomllib()
 
 # ---------------------------------------------------------------------------
 # Internal helpers
@@ -64,6 +58,9 @@ _INLINE_CODE_RE = re.compile(r"``[^`]+``|`[^`]+`")
 def _parse_version_tuple(version_str: str) -> tuple[int, ...]:
     """Parse ``"X.Y.Z"`` into a comparable tuple of ints.
 
+    Splits on ``.`` and requires every segment to be an integer; raises on any
+    non-numeric segment. Inputs here are always pre-validated ``X.Y.Z`` strings.
+
     Args:
         version_str: A semver string like ``"1.2.3"``.
 
@@ -71,7 +68,7 @@ def _parse_version_tuple(version_str: str) -> tuple[int, ...]:
         A tuple such as ``(1, 2, 3)``.
 
     """
-    return tuple(int(p) for p in version_str.split("."))
+    return parse_version_tuple(version_str, on_non_numeric="raise")
 
 
 def _version_from_git_tag(repo_root: Path) -> str | None:

--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 from hephaestus.logging.utils import get_logger
 from hephaestus.utils.helpers import get_repo_root
+from hephaestus.version.parsing import parse_version_tuple
 
 logger = get_logger(__name__)
 
@@ -46,10 +47,9 @@ def parse_version(version: str) -> tuple[int, int, int]:
             f"Invalid version format: {version}. Expected format: MAJOR.MINOR.PATCH (e.g., 0.1.0)"
         )
 
-    major = int(match.group(1))
-    minor = int(match.group(2))
-    patch = int(match.group(3))
-
+    # The regex guarantees exactly three all-digit groups; delegate the numeric
+    # conversion to the shared core, then narrow to the fixed 3-tuple contract.
+    major, minor, patch = parse_version_tuple(version, on_non_numeric="raise")
     return (major, minor, patch)
 
 

--- a/hephaestus/version/parsing.py
+++ b/hephaestus/version/parsing.py
@@ -1,0 +1,70 @@
+"""Shared version-string parsing core.
+
+Several modules parsed dotted version strings into comparable integer tuples,
+each with subtly different handling of non-numeric segments:
+
+- ``config.dep_sync._parse_version`` splits on ``.`` and ``-`` and **drops** any
+  segment that is not all-digits (e.g. ``"1.2.3rc1"`` → ``(1, 2)``).
+- ``ci.precommit._version_tuple`` splits on ``.`` and **coerces** any
+  non-integer segment to ``0`` (e.g. ``"1.2.rc1"`` → ``(1, 2, 0)``).
+- ``version.consistency._parse_version_tuple`` splits on ``.`` and **raises** on
+  any non-integer segment (it is only ever fed pre-validated ``X.Y.Z`` strings).
+
+This module exposes one configurable core, :func:`parse_version_tuple`, plus
+thin convenience wrappers that reproduce each call site's exact behaviour. The
+strict 3-component semver validator lives in
+:func:`hephaestus.version.manager.parse_version`, which delegates its integer
+conversion here after its own regex validation.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+#: Strategy for handling a segment that is not a base-10 integer.
+#:
+#: - ``"drop"``: silently skip the segment.
+#: - ``"zero"``: replace it with ``0``.
+#: - ``"raise"``: let ``int()`` raise :class:`ValueError`.
+NonNumeric = Literal["drop", "zero", "raise"]
+
+
+def parse_version_tuple(
+    version: str,
+    *,
+    split_pattern: str = r"\.",
+    on_non_numeric: NonNumeric = "raise",
+) -> tuple[int, ...]:
+    r"""Parse a dotted version string into a tuple of ints.
+
+    Args:
+        version: Version string such as ``"1.2.3"``.
+        split_pattern: Regex used to split the string into segments. Defaults to
+            a literal dot; pass ``r"[.\\-]"`` to also split on dashes.
+        on_non_numeric: How to handle a segment that is not a base-10 integer:
+            ``"drop"`` skips it, ``"zero"`` substitutes ``0``, and ``"raise"``
+            propagates the :class:`ValueError` from ``int()``.
+
+    Returns:
+        Tuple of integers, e.g. ``(1, 2, 3)``.
+
+    Raises:
+        ValueError: If ``on_non_numeric`` is ``"raise"`` and a segment is not a
+            valid integer.
+
+    """
+    parts: list[int] = []
+    for segment in re.split(split_pattern, version):
+        if on_non_numeric == "drop":
+            if segment.isdigit():
+                parts.append(int(segment))
+            continue
+        try:
+            parts.append(int(segment))
+        except ValueError:
+            if on_non_numeric == "zero":
+                parts.append(0)
+            else:  # "raise"
+                raise
+    return tuple(parts)

--- a/tests/unit/config/test_dep_sync.py
+++ b/tests/unit/config/test_dep_sync.py
@@ -47,6 +47,16 @@ class TestParseVersion:
     def test_four_components(self) -> None:
         assert _parse_version("1.2.3.4") == (1, 2, 3, 4)
 
+    def test_prerelease_suffix_dropped(self) -> None:
+        # "3rc1" is not all-digits, so the whole segment is dropped
+        assert _parse_version("1.2.3rc1") == (1, 2)
+
+    def test_dev_suffix_segment_dropped(self) -> None:
+        assert _parse_version("2.0.0.dev1") == (2, 0, 0)
+
+    def test_empty_string(self) -> None:
+        assert _parse_version("") == ()
+
 
 class TestParseConstraints:
     """Tests for _parse_constraints()."""

--- a/tests/unit/config/test_pixi.py
+++ b/tests/unit/config/test_pixi.py
@@ -1,0 +1,100 @@
+"""Tests for hephaestus.config.pixi shared dependency-section detector.
+
+Pins both consumers' behaviour so the DRY consolidation stays
+behaviour-preserving:
+
+- ``include_pypi=True`` reproduces ``config.dep_sync._is_deps_section``.
+- ``include_pypi=False`` reproduces ``ci.precommit._is_deps_section_header``.
+"""
+
+from __future__ import annotations
+
+from hephaestus.config.pixi import is_deps_section
+
+
+class TestIncludePypi:
+    """``include_pypi=True`` — dep_sync semantics (accepts pypi-dependencies)."""
+
+    def test_dependencies(self) -> None:
+        assert is_deps_section("[dependencies]", include_pypi=True) is True
+
+    def test_pypi_dependencies(self) -> None:
+        assert is_deps_section("[pypi-dependencies]", include_pypi=True) is True
+
+    def test_feature_dependencies(self) -> None:
+        assert is_deps_section("[feature.dev.dependencies]", include_pypi=True) is True
+
+    def test_feature_pypi_dependencies(self) -> None:
+        assert is_deps_section("[feature.dev.pypi-dependencies]", include_pypi=True) is True
+
+    def test_feature_hyphenated_name(self) -> None:
+        assert is_deps_section("[feature.test-tools.dependencies]", include_pypi=True) is True
+
+    def test_project_rejected(self) -> None:
+        assert is_deps_section("[project]", include_pypi=True) is False
+
+    def test_bare_feature_rejected(self) -> None:
+        assert is_deps_section("[feature.dev]", include_pypi=True) is False
+
+    def test_tasks_rejected(self) -> None:
+        assert is_deps_section("[tasks]", include_pypi=True) is False
+
+    def test_surrounding_whitespace_tolerated(self) -> None:
+        assert is_deps_section("  [dependencies]  ", include_pypi=True) is True
+
+    def test_inline_comment_tolerated(self) -> None:
+        assert is_deps_section("[dependencies] # conda deps", include_pypi=True) is True
+
+    def test_nested_feature_table_rejected(self) -> None:
+        # Four-part header is not feature.<name>.dependencies
+        assert is_deps_section("[feature.a.b.dependencies]", include_pypi=True) is False
+
+
+class TestExcludePypi:
+    """``include_pypi=False`` — precommit semantics (conda dependencies only)."""
+
+    def test_dependencies(self) -> None:
+        assert is_deps_section("[dependencies]", include_pypi=False) is True
+
+    def test_feature_dependencies(self) -> None:
+        assert is_deps_section("[feature.dev.dependencies]", include_pypi=False) is True
+
+    def test_pypi_dependencies_rejected(self) -> None:
+        assert is_deps_section("[pypi-dependencies]", include_pypi=False) is False
+
+    def test_feature_pypi_dependencies_rejected(self) -> None:
+        assert is_deps_section("[feature.dev.pypi-dependencies]", include_pypi=False) is False
+
+    def test_project_rejected(self) -> None:
+        assert is_deps_section("[project]", include_pypi=False) is False
+
+
+class TestDelegationParity:
+    """The live wrappers must equal the shared helper for matching options."""
+
+    HEADERS = (
+        "[dependencies]",
+        "[pypi-dependencies]",
+        "[feature.dev.dependencies]",
+        "[feature.dev.pypi-dependencies]",
+        "[feature.test-tools.dependencies]",
+        "[project]",
+        "[feature.dev]",
+        "[tasks]",
+    )
+
+    def test_dep_sync_delegates(self) -> None:
+        from hephaestus.config.dep_sync import _is_deps_section
+
+        for h in self.HEADERS:
+            assert _is_deps_section(h) == is_deps_section(h, include_pypi=True)
+
+    def test_precommit_delegates(self) -> None:
+        from hephaestus.ci.precommit import _is_deps_section_header
+
+        # precommit's caller pre-strips the line; mirror that here.
+        for h in self.HEADERS:
+            stripped = h.strip()
+            assert _is_deps_section_header(stripped) == is_deps_section(
+                stripped, include_pypi=False
+            )

--- a/tests/unit/io/test_toml.py
+++ b/tests/unit/io/test_toml.py
@@ -1,0 +1,75 @@
+"""Tests for hephaestus.io.toml shared tomllib/tomli resolver."""
+
+from __future__ import annotations
+
+import importlib
+import types
+
+import pytest
+
+from hephaestus.io.toml import import_tomllib
+
+
+def test_returns_a_toml_module() -> None:
+    """On a supported interpreter a module exposing ``load`` is returned."""
+    module = import_tomllib()
+    assert module is not None
+    assert hasattr(module, "load")
+    assert hasattr(module, "loads")
+
+
+def test_prefers_tomllib_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``tomllib`` is tried before the ``tomli`` backport."""
+    requested: list[str] = []
+    sentinel = types.ModuleType("fake_tomllib")
+
+    def fake_import(name: str) -> types.ModuleType:
+        requested.append(name)
+        return sentinel
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert import_tomllib() is sentinel
+    assert requested == ["tomllib"]
+
+
+def test_falls_back_to_tomli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``tomllib`` is absent the ``tomli`` backport is used."""
+    requested: list[str] = []
+    tomli_stub = types.ModuleType("fake_tomli")
+
+    def fake_import(name: str) -> types.ModuleType:
+        requested.append(name)
+        if name == "tomllib":
+            raise ModuleNotFoundError("no tomllib")
+        return tomli_stub
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert import_tomllib() is tomli_stub
+    assert requested == ["tomllib", "tomli"]
+
+
+def test_returns_none_when_neither_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When neither package imports, ``None`` is returned (3.10 no-tomli case)."""
+
+    def fake_import(name: str) -> types.ModuleType:
+        raise ModuleNotFoundError(f"no {name}")
+
+    monkeypatch.setattr(importlib, "import_module", fake_import)
+    assert import_tomllib() is None
+
+
+def test_real_module_can_parse() -> None:
+    """The resolved module round-trips a trivial TOML document."""
+    module = import_tomllib()
+    assert module is not None
+    data = module.loads('[tool]\nname = "x"\n')
+    assert data == {"tool": {"name": "x"}}
+
+
+def test_resolver_matches_direct_tomllib_import() -> None:
+    """Resolver returns the same module a direct import would yield (3.11+)."""
+    try:
+        direct = importlib.import_module("tomllib")
+    except ModuleNotFoundError:
+        pytest.skip("tomllib not present on this interpreter")
+    assert import_tomllib() is direct

--- a/tests/unit/version/test_parsing.py
+++ b/tests/unit/version/test_parsing.py
@@ -1,0 +1,126 @@
+"""Tests for hephaestus.version.parsing shared version-tuple core.
+
+These tests pin the three behaviours the shared core must reproduce so the DRY
+consolidation of the four version parsers stays behaviour-preserving:
+
+- ``on_non_numeric="drop"`` reproduces ``config.dep_sync._parse_version``.
+- ``on_non_numeric="zero"`` reproduces ``ci.precommit._version_tuple``.
+- ``on_non_numeric="raise"`` reproduces ``version.consistency._parse_version_tuple``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hephaestus.version.parsing import parse_version_tuple
+
+
+class TestDropMode:
+    """``on_non_numeric='drop'`` — dep_sync semantics (split on '.' and '-')."""
+
+    def _parse(self, v: str) -> tuple[int, ...]:
+        return parse_version_tuple(v, split_pattern=r"[.\-]", on_non_numeric="drop")
+
+    def test_simple_version(self) -> None:
+        assert self._parse("1.2.3") == (1, 2, 3)
+
+    def test_single_component(self) -> None:
+        assert self._parse("2") == (2,)
+
+    def test_two_components(self) -> None:
+        assert self._parse("1.0") == (1, 0)
+
+    def test_splits_on_dash(self) -> None:
+        assert self._parse("1.2-3") == (1, 2, 3)
+
+    def test_drops_non_digit_segment(self) -> None:
+        assert self._parse("1.a.3") == (1, 3)
+
+    def test_four_components(self) -> None:
+        assert self._parse("1.2.3.4") == (1, 2, 3, 4)
+
+    def test_prerelease_suffix_dropped(self) -> None:
+        # "3rc1" is not all-digits -> dropped entirely
+        assert self._parse("1.2.3rc1") == (1, 2)
+
+    def test_dev_suffix_segment_kept(self) -> None:
+        # "0" segments survive; "dev1" dropped
+        assert self._parse("2.0.0.dev1") == (2, 0, 0)
+
+    def test_empty_string(self) -> None:
+        assert self._parse("") == ()
+
+    def test_all_non_numeric(self) -> None:
+        assert self._parse("a.b.c") == ()
+
+
+class TestZeroMode:
+    """``on_non_numeric='zero'`` — precommit semantics (split on '.', coerce)."""
+
+    def _parse(self, v: str) -> tuple[int, ...]:
+        return parse_version_tuple(v, on_non_numeric="zero")
+
+    def test_simple_version(self) -> None:
+        assert self._parse("1.19.1") == (1, 19, 1)
+
+    def test_non_integer_segment_becomes_zero(self) -> None:
+        assert self._parse("1.2.rc1") == (1, 2, 0)
+
+    def test_does_not_split_on_dash(self) -> None:
+        # No dash splitting -> "2-3" is one non-int segment -> 0
+        assert self._parse("1.2-3") == (1, 0)
+
+    def test_empty_segment_becomes_zero(self) -> None:
+        assert self._parse("1..2") == (1, 0, 2)
+
+    def test_empty_string(self) -> None:
+        assert self._parse("") == (0,)
+
+
+class TestRaiseMode:
+    """``on_non_numeric='raise'`` — consistency semantics (strict, split on '.')."""
+
+    def _parse(self, v: str) -> tuple[int, ...]:
+        return parse_version_tuple(v, on_non_numeric="raise")
+
+    def test_simple_version(self) -> None:
+        assert self._parse("1.2.3") == (1, 2, 3)
+
+    def test_two_components(self) -> None:
+        assert self._parse("1.2") == (1, 2)
+
+    def test_raises_on_non_numeric(self) -> None:
+        with pytest.raises(ValueError):
+            self._parse("1.a.3")
+
+    def test_raises_on_prerelease(self) -> None:
+        with pytest.raises(ValueError):
+            self._parse("1.2.3rc1")
+
+    def test_raises_on_empty_string(self) -> None:
+        with pytest.raises(ValueError):
+            self._parse("")
+
+
+class TestDelegationParity:
+    """The live call sites must equal the shared core for the same options."""
+
+    def test_dep_sync_delegates(self) -> None:
+        from hephaestus.config.dep_sync import _parse_version
+
+        for v in ("1.2.3", "2", "1.0", "1.2-3", "1.a.3", "1.2.3.4", "1.2.3rc1", "", "2.0.0.dev1"):
+            assert _parse_version(v) == parse_version_tuple(
+                v, split_pattern=r"[.\-]", on_non_numeric="drop"
+            )
+
+    def test_precommit_delegates(self) -> None:
+        from hephaestus.ci.precommit import _version_tuple
+
+        for v in ("1.19.1", "1.2.rc1", "1.2-3", "1..2", "", "0.26.1"):
+            assert _version_tuple(v) == parse_version_tuple(v, on_non_numeric="zero")
+
+    def test_consistency_delegates(self) -> None:
+        from hephaestus.version.consistency import _parse_version_tuple
+
+        for v in ("1.2.3", "0.0.1", "10.20.30", "1.2"):
+            assert _parse_version_tuple(v) == parse_version_tuple(v, on_non_numeric="raise")


### PR DESCRIPTION
Consolidates 4 version-string parsers, the duplicated pixi-deps-section detector, and the tomllib/tomli import-fallback (5 copies) into shared helpers. Behavior-preserving; adds edge-case tests.

Closes #692