### PR TITLE
fix(automation): guard planner output against changelog-shaped plans

### DIFF
--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -32,6 +32,47 @@ logger = logging.getLogger(__name__)
 
 MAX_REVIEW_ITERATIONS = 3
 
+# Section headers a genuine plan is expected to contain at least one of. A body
+# that contains NONE of these is a meta-narrative / changelog, not a plan — the
+# planner agent occasionally returns such text (#693/#695 NOGO-exhaustion: the
+# agent posted a "I fixed the comment" changelog instead of the plan, which the
+# reviewer then correctly NOGO'd). We detect that shape and post a visible
+# warning rather than letting a contentless body masquerade as the plan.
+_PLAN_SECTION_HEADERS = (
+    "objective",
+    "approach",
+    "files to create",
+    "files to modify",
+    "implementation order",
+    "implementation steps",
+    "verification",
+    "skills used",
+    "changes from review",
+)
+
+# Visible marker prepended (after the plan marker) when the body has no plan
+# sections. Operators and the reviewer can grep for it; it is intentionally
+# loud and machine-greppable.
+_PLAN_CONTENT_MISSING_BANNER = (
+    "> [!CAUTION]\n"
+    "> **PLAN-CONTENT-MISSING** — The planner returned text containing no "
+    "recognised plan sections (it looks like a changelog or status note, not a "
+    "plan). This is posted verbatim for diagnosis but **must not be implemented**; "
+    "the planner should re-plan with a full plan body (Objective, Approach, Files "
+    "to Modify, Verification, etc.).\n\n"
+)
+
+
+def _plan_body_has_sections(body: str) -> bool:
+    """Return True if ``body`` contains at least one recognised plan section header.
+
+    Case-insensitive substring match on the known section names. A plan as
+    terse as a single ``## Objective`` section passes; a pure narrative or
+    changelog with none of the headers does not.
+    """
+    haystack = body.lower()
+    return any(header in haystack for header in _PLAN_SECTION_HEADERS)
+
 
 class PlannerHost(Protocol):
     """Minimal Planner surface the review loop depends on.
@@ -286,6 +327,22 @@ class PlanReviewLoop:
             if plan.lstrip().startswith(PLAN_COMMENT_MARKER)
             else f"{PLAN_COMMENT_MARKER}\n\n{plan}"
         )
+        # Guard (#695): if the model returned a contentless narrative/changelog
+        # with no recognised plan sections, prepend a visible warning so the
+        # reviewer and operators do not mistake it for a plan. We still post it
+        # (for diagnosis) rather than dropping it silently.
+        if not _plan_body_has_sections(body):
+            logger.warning(
+                "%s: planner output contains no recognised plan sections "
+                "(possible changelog/meta-narrative); flagging with a "
+                "PLAN-CONTENT-MISSING banner",
+                issue_ref(issue_number),
+            )
+            # ``body`` is already marker-prefixed (normalised just above); insert
+            # the banner immediately after the marker line without duplicating
+            # the marker.
+            after_marker = body[len(PLAN_COMMENT_MARKER) :].lstrip("\n")
+            body = f"{PLAN_COMMENT_MARKER}\n\n{_PLAN_CONTENT_MISSING_BANNER}{after_marker}"
         if re_planned and "\n## Changes from review" not in f"\n{body}":
             body = (
                 f"{body.rstrip()}\n\n## Changes from review\n\n"

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -31,8 +31,17 @@ Create an implementation plan for GitHub issue #{issue_number}.
   when present). When a prior review is present you are RE-PLANNING to
   address it, not starting fresh.
 
-You produce/refresh exactly ONE `# Implementation Plan` comment on the issue
-(it is upserted in place — do not write a second plan comment).
+**Output contract — read carefully:**
+Your FINAL message must BE the complete plan, as markdown, starting with the
+`# Implementation Plan` heading and containing every section below in full.
+The pipeline posts your output to the issue for you — you MUST NOT run `gh`,
+`gh api`, `git`, or any command that creates, edits, or PATCHes an issue
+comment yourself. Do NOT post a status note, changelog, or "I updated the
+comment" summary as your output: whatever you return IS the plan body that
+gets posted and reviewed, so returning anything other than the full plan
+(e.g. a meta-narrative about what you did) will fail review. When re-planning
+after a NOGO, output the FULL revised plan again — not a diff or a description
+of your edits.
 
 **Your plan should include:**
 1. **Objective** - Brief description of what needs to be done

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -390,6 +390,74 @@ class TestLoopUpsertsPlanAndReview:
         assert verdict_is_go is True
 
 
+class TestPlanBodyContentGuard:
+    """Stage 2 (#695): a changelog-shaped 'plan' must not be posted as a plan.
+
+    Root cause of the #693 NOGO-exhaustion: the planner agent returned a
+    meta-narrative/changelog instead of a plan body, which the loop then
+    upserted verbatim and handed to the reviewer — who (correctly) NOGO'd a
+    plan that contained no implementation content. The guard flags any plan
+    body that lacks every expected section header with a visible operator
+    warning, rather than silently posting the changelog as the plan.
+    """
+
+    def _plan_calls(self, mock_upsert: Any) -> list[Any]:
+        return [c for c in mock_upsert.call_args_list if c.args[1] == PLAN_COMMENT_MARKER]
+
+    def test_changelog_shaped_plan_gets_content_warning(
+        self, planner: Planner, _patch_loop_upsert: Any
+    ) -> None:
+        """A 'plan' that is pure narrative (no section headers) is flagged, not posted clean."""
+        changelog = (
+            "Fixed and verified. The R1 reviewer was correct in substance: my prior "
+            "`gh api PATCH` had accidentally overwritten the issue comment with only the "
+            "chat-summary changelog, so the full plan was absent. The comment now contains "
+            "the complete plan."
+        )
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
+                return_value={"title": "T", "body": "B"},
+            ),
+            patch.object(planner, "_generate_plan", return_value=changelog),
+            patch.object(planner, "_capture_planner_learnings", return_value=""),
+            patch.object(planner, "_run_plan_review", return_value=_nogo_review()),
+        ):
+            planner._run_plan_review_loop(123, slot_id=0)
+
+        plan_calls = self._plan_calls(_patch_loop_upsert)
+        assert plan_calls, "expected a PLAN upsert"
+        body = plan_calls[0].args[2]
+        # Still carries the marker (so the upsert keys correctly)...
+        assert body.startswith(PLAN_COMMENT_MARKER)
+        # ...but a visible warning marks it as not-a-real-plan so neither the
+        # reviewer nor an operator mistakes the changelog for a plan.
+        assert "PLAN-CONTENT-MISSING" in body
+
+    def test_terse_but_valid_plan_passes_through_without_warning(
+        self, planner: Planner, _patch_loop_upsert: Any
+    ) -> None:
+        """A short plan that DOES contain a recognised section header is not flagged."""
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
+                return_value={"title": "T", "body": "B"},
+            ),
+            patch.object(
+                planner,
+                "_generate_plan",
+                return_value="## Objective\nFix X.\n\n## Verification\nRun the suite.",
+            ),
+            patch.object(planner, "_capture_planner_learnings", return_value=""),
+            patch.object(planner, "_run_plan_review", return_value=_go_review()),
+        ):
+            planner._run_plan_review_loop(123, slot_id=0)
+
+        body = self._plan_calls(_patch_loop_upsert)[0].args[2]
+        assert "PLAN-CONTENT-MISSING" not in body
+        assert "## Objective" in body
+
+
 class TestCapturePlannerLearnings:
     """Learnings capture must fail safely (return '') without raising."""
 


### PR DESCRIPTION
## Summary

Fixes the planner review loop NOGO-exhausting an issue when the planner *agent* returns a changelog/status-note instead of the plan body (observed live on #693: NOGO C/C/D over 3 iterations, then the implementer correctly deferred).

- **prompts/planning.py** — the agent's final message must BE the full plan; it is explicitly forbidden from running `gh`/`gh api`/`git` or posting/editing comments itself (the pipeline owns posting via `_upsert_plan_comment`). Re-plans must output the full revised plan, not a diff/summary.
- **planner_review_loop._upsert_plan_comment** — new `_plan_body_has_sections()` guard prepends a visible, greppable `PLAN-CONTENT-MISSING` `[!CAUTION]` banner when the body contains no recognised plan section, so a changelog can no longer masquerade as a plan (posted for diagnosis, not dropped).

## Test plan

- [x] New `tests/unit/automation/test_planner_loop.py::TestPlanBodyContentGuard`: changelog-shaped plan gets the banner; terse-but-valid plan (has a section header) passes through clean (no false-positive).
- [x] Existing `TestLoopUpsertsPlanAndReview` still green (marker not duplicated).
- [x] Full unit suite green (2911 passed), ruff + mypy clean.

Closes #695