### PR TITLE
fix(automation): normalize plan body so leading whitespace can't corrupt marker

### DIFF
--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -322,10 +322,16 @@ class PlanReviewLoop:
                 requires the ``## Changes from review`` section.
 
         """
+        # Normalise so ``body`` ALWAYS begins exactly at the marker (index 0).
+        # ``plan.lstrip()`` in the passthrough is load-bearing: a plan that
+        # arrives with leading whitespace (e.g. "\n\n# Implementation Plan…")
+        # would otherwise keep the whitespace, breaking both ``startswith`` and
+        # the banner-insert slice below (#700).
+        stripped = plan.lstrip()
         body = (
-            plan
-            if plan.lstrip().startswith(PLAN_COMMENT_MARKER)
-            else f"{PLAN_COMMENT_MARKER}\n\n{plan}"
+            stripped
+            if stripped.startswith(PLAN_COMMENT_MARKER)
+            else f"{PLAN_COMMENT_MARKER}\n\n{stripped}"
         )
         # Guard (#695): if the model returned a contentless narrative/changelog
         # with no recognised plan sections, prepend a visible warning so the

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -457,6 +457,56 @@ class TestPlanBodyContentGuard:
         assert "PLAN-CONTENT-MISSING" not in body
         assert "## Objective" in body
 
+    def test_leading_whitespace_marker_not_corrupted_by_banner(
+        self, planner: Planner, _patch_loop_upsert: Any
+    ) -> None:
+        """A leading-whitespace marker must not be sliced mid-token by the banner insert.
+
+        Regression (#700): when the plan arrives with leading whitespace before
+        the marker, the passthrough branch kept the whitespace, so the banner
+        insert's ``body[len(MARKER):]`` slice cut into the whitespace+marker and
+        produced a corrupted/duplicated marker. The body must still begin with
+        exactly one intact ``# Implementation Plan`` marker after flagging.
+        """
+        changelog = "\n\n# Implementation Plan\n\nFixed and verified. The comment now has the plan."
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
+                return_value={"title": "T", "body": "B"},
+            ),
+            patch.object(planner, "_generate_plan", return_value=changelog),
+            patch.object(planner, "_capture_planner_learnings", return_value=""),
+            patch.object(planner, "_run_plan_review", return_value=_nogo_review()),
+        ):
+            planner._run_plan_review_loop(123, slot_id=0)
+
+        body = self._plan_calls(_patch_loop_upsert)[0].args[2]
+        assert body.startswith(PLAN_COMMENT_MARKER)
+        assert body.count(PLAN_COMMENT_MARKER) == 1
+        assert "PLAN-CONTENT-MISSING" in body
+
+    def test_leading_whitespace_valid_plan_passes_clean(
+        self, planner: Planner, _patch_loop_upsert: Any
+    ) -> None:
+        """A valid plan with leading whitespace + marker is unflagged and uncorrupted."""
+        plan = "\n# Implementation Plan\n\n## Objective\nDo X."
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
+                return_value={"title": "T", "body": "B"},
+            ),
+            patch.object(planner, "_generate_plan", return_value=plan),
+            patch.object(planner, "_capture_planner_learnings", return_value=""),
+            patch.object(planner, "_run_plan_review", return_value=_go_review()),
+        ):
+            planner._run_plan_review_loop(123, slot_id=0)
+
+        body = self._plan_calls(_patch_loop_upsert)[0].args[2]
+        assert body.startswith(PLAN_COMMENT_MARKER)
+        assert body.count(PLAN_COMMENT_MARKER) == 1
+        assert "PLAN-CONTENT-MISSING" not in body
+        assert "## Objective" in body
+
 
 class TestCapturePlannerLearnings:
     """Learnings capture must fail safely (return '') without raising."""


### PR DESCRIPTION
## Summary

Follow-up to the #695 content guard. When the planner returns a plan with leading whitespace before the `# Implementation Plan` marker (e.g. `"\n\n# Implementation Plan…"`), the guard's banner-insert slice `body[len(MARKER):]` cut into the whitespace+marker (corrupting/duplicating it) and the body no longer began with the canonical marker.

Fix: strip once and key both the `startswith` check and the body off the stripped text, so `body` always begins exactly at the marker.

## Test plan

- [x] New `TestPlanBodyContentGuard::test_leading_whitespace_marker_not_corrupted_by_banner` (changelog + leading ws → banner, exactly one intact marker).
- [x] New `test_leading_whitespace_valid_plan_passes_clean` (valid plan + leading ws → unflagged, one marker, section retained).
- [x] Planner loop suite (35) + automation suite (867) green; ruff + mypy clean.

Closes #700