### PR TITLE
fix(automation): self-heal stale plan-review comments via has_usable_plan

### DIFF
--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -117,8 +117,15 @@ class Planner:
         return self.state_mgr.filter()
 
     def _has_existing_plan(self, issue_number: int) -> bool:
-        """Check if an issue already has a plan (delegates to state manager)."""
-        return self.state_mgr.has_existing_plan(issue_number)
+        """Check if an issue has a plan whose latest review is parseable.
+
+        Delegates to :meth:`PlannerStateManager.has_usable_plan` (#702): an
+        issue counts as "already planned" only when its latest plan-review
+        comment carries a parseable ``Verdict: GO/NOGO`` line. Issues with a
+        plan but an unparseable (pre-contract) review are re-planned so the
+        loop self-heals stale reviews without manual cleanup.
+        """
+        return self.state_mgr.has_usable_plan(issue_number)
 
     def _plan_issue(self, issue_number: int) -> PlanResult:
         """Plan a single issue.

--- a/hephaestus/automation/planner_state.py
+++ b/hephaestus/automation/planner_state.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 from .git_utils import issue_ref
 from .github_api import _gh_call, prefetch_issue_states
 from .models import PLAN_COMMENT_MARKER
-from .review_state import PLAN_REVIEW_PREFIX, fetch_all_issue_comments_graphql
+from .review_state import PLAN_REVIEW_PREFIX, fetch_all_issue_comments_graphql, latest_verdict
 
 if TYPE_CHECKING:
     from .models import PlannerOptions
@@ -194,3 +194,47 @@ class PlannerStateManager:
                 "Failed to check for existing plan on %s: %s", issue_ref(issue_number), e
             )
             return False
+
+    def has_usable_plan(self, issue_number: int) -> bool:
+        """Return True iff the issue has a plan AND a parseable plan-review.
+
+        Self-heal gate (#702). The planner skips an issue when it already has
+        a plan comment, but the implementer also needs the latest plan-review
+        to carry a parseable ``Verdict: GO/NOGO`` line; otherwise the GO-gate
+        stays False forever and the issue is stuck. By returning ``False`` for
+        "plan exists but the latest review is unparseable," the planner
+        re-plans (and re-reviews) the issue on the next loop, which self-heals
+        the stale-review case without manual cleanup.
+
+        Semantics:
+
+        - No plan comment → ``False`` (delegates to existing plan-existence check).
+        - Plan but no review yet → ``True`` (review will run in this loop).
+        - Plan + latest review carries a parseable verdict (GO or NOGO) → ``True``.
+          A parseable NOGO is a real reviewer signal, not a stale comment;
+          the implementer's existing NOGO-defer logic handles it downstream.
+        - Plan + latest review is unparseable (no ``Verdict:`` line) → ``False``,
+          flagging re-plan needed.
+
+        Args:
+            issue_number: Issue number to check.
+
+        Returns:
+            ``True`` when the planner may skip; ``False`` when re-planning is needed.
+
+        """
+        if not self.has_existing_plan(issue_number):
+            return False
+        cached = self.get_cached_comments(issue_number)
+        if cached is None:
+            # Without the cache the cheapest signal is "plan present" — preserve
+            # the prior behaviour rather than make a second uncached gh round-trip.
+            return True
+        latest_review_body: str | None = None
+        for comment in cached:
+            body = str(comment.get("body", ""))
+            if body.startswith(PLAN_REVIEW_PREFIX):
+                latest_review_body = body
+        if latest_review_body is None:
+            return True
+        return latest_verdict(latest_review_body) is not None

--- a/tests/unit/automation/test_planner_state.py
+++ b/tests/unit/automation/test_planner_state.py
@@ -40,6 +40,20 @@ def _other_body() -> str:
     return "Just a regular comment with no plan marker.\n"
 
 
+def _review_body(verdict: str = "GO") -> str:
+    """Build a parseable plan-review body carrying a verdict line."""
+    return f"## 🔍 Plan Review\n\nLooks good.\n\nGrade: A\nVerdict: {verdict}\n"
+
+
+def _unparseable_review_body() -> str:
+    """Build a plan-review-prefixed body with no parseable ``Verdict:`` line.
+
+    Mirrors the pre-verdict-contract review comments observed across the org
+    (320 ``no parseable Verdict`` warnings during the 2026-05-29 org run).
+    """
+    return "## 🔍 Plan Review\n\nThe plan looks fine — implement it.\n"
+
+
 # ---------------------------------------------------------------------------
 # prefetch_comments / get_cached_comments
 # ---------------------------------------------------------------------------
@@ -183,3 +197,102 @@ class TestHasExistingPlanFallback:
             side_effect=RuntimeError("network error"),
         ):
             assert mgr.has_existing_plan(43) is False
+
+
+# ---------------------------------------------------------------------------
+# has_usable_plan — self-heals stale unparseable plan-review comments (#702)
+# ---------------------------------------------------------------------------
+
+
+class TestHasUsablePlan:
+    """has_usable_plan = plan comment present AND latest plan-review parseable.
+
+    Background (#702): the org-wide 2026-05-29 loop run logged 320
+    "no parseable Verdict" warnings. Those issues had a plan comment AND a
+    plan-review comment, but the review predated the Verdict: GO/NOGO contract
+    so the implementer's GO-gate stayed False forever — the loop never
+    re-planned them because ``has_existing_plan`` only checked for the plan
+    comment, not whether its review was usable.
+
+    ``has_usable_plan`` returns True iff BOTH the plan comment exists AND the
+    latest plan-review comment carries a parseable verdict. When the review
+    is unparseable, the next loop will re-plan (and re-review) the issue,
+    self-healing without manual cleanup.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _patch_repo(self) -> Any:
+        with (
+            patch(
+                "hephaestus.automation.review_state.get_repo_root",
+                return_value="/tmp/repo",
+            ),
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("owner", "repo"),
+            ),
+        ):
+            yield
+
+    def _mgr_with_cache(self, cache: dict[int, list[dict[str, Any]]]) -> PlannerStateManager:
+        mgr = PlannerStateManager(_make_options(issues=list(cache.keys())))
+        with patch(
+            "hephaestus.automation.planner_state.fetch_all_issue_comments_graphql",
+            return_value=cache,
+        ):
+            mgr.prefetch_comments(list(cache.keys()))
+        return mgr
+
+    def test_returns_true_when_plan_and_parseable_go_review_present(self) -> None:
+        """Healthy state: plan + GO-verdict review → usable."""
+        mgr = self._mgr_with_cache(
+            {51: [{"body": _plan_body()}, {"body": _review_body("GO")}]}
+        )
+        assert mgr.has_usable_plan(51) is True
+
+    def test_returns_true_when_plan_and_parseable_nogo_review_present(self) -> None:
+        """A parseable NOGO is still 'usable' for the gate — the implementer reads it.
+
+        The intent of has_usable_plan is purely "is the review parseable?" — a
+        NOGO is a real reviewer signal, not a stale-comment defect. The
+        implementer's existing NOGO-defer logic handles it downstream.
+        """
+        mgr = self._mgr_with_cache(
+            {52: [{"body": _plan_body()}, {"body": _review_body("NOGO")}]}
+        )
+        assert mgr.has_usable_plan(52) is True
+
+    def test_returns_false_when_plan_present_but_review_unparseable(self) -> None:
+        """The #702 case: plan + verdict-less review → NOT usable → re-plan next loop."""
+        mgr = self._mgr_with_cache(
+            {53: [{"body": _plan_body()}, {"body": _unparseable_review_body()}]}
+        )
+        assert mgr.has_usable_plan(53) is False
+
+    def test_returns_false_when_no_plan_comment(self) -> None:
+        """No plan at all → not usable (delegates to existing existence semantics)."""
+        mgr = self._mgr_with_cache({54: [{"body": _other_body()}]})
+        assert mgr.has_usable_plan(54) is False
+
+    def test_returns_true_when_plan_present_and_no_review_yet(self) -> None:
+        """A plan with no review yet is 'usable' — the review will run this loop.
+
+        This preserves the prior has_existing_plan semantics for the
+        no-review-yet case so the loop's normal "plan posted, awaiting review"
+        flow is unaffected.
+        """
+        mgr = self._mgr_with_cache({55: [{"body": _plan_body()}]})
+        assert mgr.has_usable_plan(55) is True
+
+    def test_latest_review_wins_when_multiple_reviews_present(self) -> None:
+        """Most-recent review's parseability decides — older unparseable review is ignored."""
+        mgr = self._mgr_with_cache(
+            {
+                56: [
+                    {"body": _plan_body()},
+                    {"body": _unparseable_review_body()},   # older, stale
+                    {"body": _review_body("GO")},            # newer, valid
+                ]
+            }
+        )
+        assert mgr.has_usable_plan(56) is True


### PR DESCRIPTION
## Summary

The 2026-05-29 org-wide loop run logged **320 `no parseable Verdict` warnings** on issues whose only `## 🔍 Plan Review` comment predates the verdict contract. Those issues are stuck forever: the planner skips them (plan comment exists → reuse), the implementer defers (review unparseable → can't gate to GO). No PRs land for them.

Add `PlannerStateManager.has_usable_plan(issue_number)`:
- No plan comment → `False`.
- Plan, no review yet → `True` (preserves current behavior).
- Plan + parseable GO/NOGO review → `True` (no regression).
- Plan + **unparseable** review → `False` → planner re-plans next loop, regenerating a valid verdict.

Rewires `Planner._has_existing_plan` to delegate to it. The old `has_existing_plan` stays as the existence-only primitive (still used for clarity + stats counting).

## Test plan

- [x] New `tests/unit/automation/test_planner_state.py::TestHasUsablePlan` — 6 tests covering all four semantics plus the "latest review wins when multiple reviews present" edge case.
- [x] Planner + state + loop suites (77 tests) green; full automation suite (876) green; ruff + mypy clean.

Closes #702