### PR TITLE
feat(config): make projects root configurable via $PROJECTS_ROOT

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -38,6 +38,7 @@ from urllib.parse import urlparse
 
 from hephaestus.automation.claude_timeouts import gh_cli_timeout
 from hephaestus.cli.utils import add_json_arg, emit_json_status
+from hephaestus.config.paths import DEFAULT_PROJECTS_DIR, resolve_projects_dir
 from hephaestus.resilience.subprocess_resilience import resilient_call
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
@@ -79,7 +80,11 @@ ALL_PHASES: tuple[str, ...] = (
     "drive-green",
 )
 
-DEFAULT_PROJECTS_DIR = Path.home() / "Projects"
+# DEFAULT_PROJECTS_DIR is re-exported from hephaestus.config.paths so existing
+# tests that patch this module-level name continue to work. See #704: the
+# projects root is now resolved at runtime via resolve_projects_dir() so that
+# the ``PROJECTS_ROOT`` env var can override the historical ``~/Projects``
+# default without code changes here.
 
 # Sentinel for ``--org`` invoked with no argument (auto-detect from cwd).
 # Module-level identity guarantees ``args.org is _ORG_AUTODETECT`` is the
@@ -344,9 +349,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p.add_argument(
         "--projects-dir",
-        type=Path,
-        default=DEFAULT_PROJECTS_DIR,
-        help=f"Local directory containing repo clones (default: {DEFAULT_PROJECTS_DIR})",
+        type=str,
+        default=None,
+        help=(
+            "Local directory containing repo clones. When omitted, resolved from "
+            "the ``PROJECTS_ROOT`` env var (if set and existing), otherwise "
+            f"falls back to ``{DEFAULT_PROJECTS_DIR}``."
+        ),
     )
     p.add_argument(
         "--phase-timeout",
@@ -1222,7 +1231,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         reviewer_model=args.reviewer_model,
         implementer_model=args.implementer_model,
         org=org,
-        projects_dir=args.projects_dir,
+        projects_dir=resolve_projects_dir(args.projects_dir),
         # A non-positive --phase-timeout explicitly disables the bound; any
         # positive value (including the env-overridable default) applies it.
         phase_timeout_s=(

--- a/hephaestus/config/paths.py
+++ b/hephaestus/config/paths.py
@@ -1,0 +1,77 @@
+"""Path resolution helpers for ProjectHephaestus utilities.
+
+This module centralizes lookup of the "projects root" directory — the
+parent directory under which sibling HomericIntelligence repositories
+are checked out. Historically this was hardcoded to ``~/Projects``;
+callers now resolve it via :func:`resolve_projects_dir`, which honors
+an explicit override, the ``PROJECTS_ROOT`` environment variable, or
+falls back to the historical default with a warning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROJECTS_DIR: Path = Path.home() / "Projects"
+
+# Module-level guard so the warning fires at most once per
+# (override, env) tuple per process. Tests can clear this to re-trigger.
+_warned_keys: set[tuple[str | None, str | None]] = set()
+
+
+def resolve_projects_dir(override: str | None = None) -> Path:
+    """Resolve the projects root directory.
+
+    Priority:
+      1. explicit ``override`` argument (e.g. from a CLI flag)
+      2. ``$PROJECTS_ROOT`` environment variable, IFF that directory exists
+      3. :data:`DEFAULT_PROJECTS_DIR` (``~/Projects``)
+
+    A warning is emitted when the fallback path is taken because neither
+    an override nor a usable ``PROJECTS_ROOT`` was supplied. A distinct
+    warning fires when ``PROJECTS_ROOT`` is set but its directory does
+    not exist. Warnings are de-duplicated per process per
+    ``(override, env)`` tuple.
+
+    Args:
+        override: Optional explicit path (e.g. from a ``--projects-dir`` CLI
+            flag). When provided, the env var and default are skipped and no
+            warning is emitted.
+
+    Returns:
+        The resolved projects-root directory as a :class:`pathlib.Path`.
+
+    """
+    if override is not None:
+        return Path(override)
+
+    env = os.environ.get("PROJECTS_ROOT")
+    key: tuple[str | None, str | None] = (override, env)
+
+    if env:
+        env_path = Path(env)
+        if env_path.is_dir():
+            return env_path
+        if key not in _warned_keys:
+            logger.warning(
+                "PROJECTS_ROOT=%s does not exist; falling back to %s",
+                env,
+                DEFAULT_PROJECTS_DIR,
+            )
+            _warned_keys.add(key)
+        return DEFAULT_PROJECTS_DIR
+
+    if key not in _warned_keys:
+        logger.warning(
+            "PROJECTS_ROOT not set and no --projects-dir given; falling back to default: %s",
+            DEFAULT_PROJECTS_DIR,
+        )
+        _warned_keys.add(key)
+    return DEFAULT_PROJECTS_DIR
+
+
+__all__ = ["DEFAULT_PROJECTS_DIR", "resolve_projects_dir"]

--- a/scripts/run_automation_loop.sh
+++ b/scripts/run_automation_loop.sh
@@ -122,7 +122,19 @@ DRY_RUN=0
 LOOPS=5
 MAX_WORKERS=3
 PARALLEL_REPOS=1
-PROJECTS_DIR="$HOME/Projects"
+# Resolve projects root: explicit PROJECTS_ROOT env var (if it points to a real
+# directory) wins; otherwise fall back to ~/Projects with a warning. Mirrors
+# hephaestus.config.paths.resolve_projects_dir() for the bash entry point. (#704)
+if [ -n "${PROJECTS_ROOT:-}" ] && [ -d "$PROJECTS_ROOT" ]; then
+  PROJECTS_DIR="$PROJECTS_ROOT"
+else
+  if [ -n "${PROJECTS_ROOT:-}" ]; then
+    echo "WARNING: PROJECTS_ROOT=$PROJECTS_ROOT does not exist; falling back to $HOME/Projects" >&2
+  else
+    echo "WARNING: PROJECTS_ROOT not set; falling back to $HOME/Projects" >&2
+  fi
+  PROJECTS_DIR="$HOME/Projects"
+fi
 ORG="HomericIntelligence"
 
 ALL_PHASES="plan,implement,drive-green"

--- a/tests/unit/automation/test_planner_state.py
+++ b/tests/unit/automation/test_planner_state.py
@@ -245,9 +245,7 @@ class TestHasUsablePlan:
 
     def test_returns_true_when_plan_and_parseable_go_review_present(self) -> None:
         """Healthy state: plan + GO-verdict review → usable."""
-        mgr = self._mgr_with_cache(
-            {51: [{"body": _plan_body()}, {"body": _review_body("GO")}]}
-        )
+        mgr = self._mgr_with_cache({51: [{"body": _plan_body()}, {"body": _review_body("GO")}]})
         assert mgr.has_usable_plan(51) is True
 
     def test_returns_true_when_plan_and_parseable_nogo_review_present(self) -> None:
@@ -257,9 +255,7 @@ class TestHasUsablePlan:
         NOGO is a real reviewer signal, not a stale-comment defect. The
         implementer's existing NOGO-defer logic handles it downstream.
         """
-        mgr = self._mgr_with_cache(
-            {52: [{"body": _plan_body()}, {"body": _review_body("NOGO")}]}
-        )
+        mgr = self._mgr_with_cache({52: [{"body": _plan_body()}, {"body": _review_body("NOGO")}]})
         assert mgr.has_usable_plan(52) is True
 
     def test_returns_false_when_plan_present_but_review_unparseable(self) -> None:
@@ -290,8 +286,8 @@ class TestHasUsablePlan:
             {
                 56: [
                     {"body": _plan_body()},
-                    {"body": _unparseable_review_body()},   # older, stale
-                    {"body": _review_body("GO")},            # newer, valid
+                    {"body": _unparseable_review_body()},  # older, stale
+                    {"body": _review_body("GO")},  # newer, valid
                 ]
             }
         )

--- a/tests/unit/config/test_paths.py
+++ b/tests/unit/config/test_paths.py
@@ -8,6 +8,7 @@ per-process de-duplication guard.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,7 @@ from hephaestus.config.paths import DEFAULT_PROJECTS_DIR, resolve_projects_dir
 
 
 @pytest.fixture(autouse=True)
-def _reset_warned_keys() -> None:
+def _reset_warned_keys() -> Iterator[None]:
     """Clear the per-process warning-dedup guard before & after each test.
 
     Without this, tests would leak state into each other and the

--- a/tests/unit/config/test_paths.py
+++ b/tests/unit/config/test_paths.py
@@ -1,0 +1,92 @@
+"""Unit tests for ``hephaestus.config.paths.resolve_projects_dir``.
+
+Covers the priority order (override > env > default), the warning emitted
+on fallback (distinct for unset vs. nonexistent ``PROJECTS_ROOT``), and the
+per-process de-duplication guard.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from hephaestus.config import paths as paths_mod
+from hephaestus.config.paths import DEFAULT_PROJECTS_DIR, resolve_projects_dir
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_keys() -> None:
+    """Clear the per-process warning-dedup guard before & after each test.
+
+    Without this, tests would leak state into each other and the
+    de-duplication test would race other cases that share the
+    ``(None, None)`` key.
+    """
+    paths_mod._warned_keys.clear()
+    yield
+    paths_mod._warned_keys.clear()
+
+
+def test_override_takes_priority_no_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """An explicit override wins over both env and default; no warning fires."""
+    monkeypatch.setenv("PROJECTS_ROOT", str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+        result = resolve_projects_dir("/some/explicit/path")
+    assert result == Path("/some/explicit/path")
+    assert caplog.records == []
+
+
+def test_env_var_used_when_dir_exists_no_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """PROJECTS_ROOT pointing at a real directory is honored silently."""
+    monkeypatch.setenv("PROJECTS_ROOT", str(tmp_path))
+    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+        result = resolve_projects_dir()
+    assert result == tmp_path
+    assert caplog.records == []
+
+
+def test_env_var_dir_missing_warns_and_falls_back(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """A nonexistent PROJECTS_ROOT triggers a 'does not exist' warning + default."""
+    nonexistent = tmp_path / "does-not-exist"
+    monkeypatch.setenv("PROJECTS_ROOT", str(nonexistent))
+    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+        result = resolve_projects_dir()
+    assert result == DEFAULT_PROJECTS_DIR
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert "does not exist" in caplog.records[0].getMessage()
+    assert str(nonexistent) in caplog.records[0].getMessage()
+
+
+def test_no_override_no_env_warns_and_uses_default(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Unset PROJECTS_ROOT + no override emits the 'not set' warning + default."""
+    monkeypatch.delenv("PROJECTS_ROOT", raising=False)
+    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+        result = resolve_projects_dir()
+    assert result == DEFAULT_PROJECTS_DIR
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert "PROJECTS_ROOT not set" in caplog.records[0].getMessage()
+
+
+def test_warning_deduplicated_within_process(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Calling resolve twice with the same (override, env) key warns only once."""
+    monkeypatch.delenv("PROJECTS_ROOT", raising=False)
+    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+        first = resolve_projects_dir()
+        second = resolve_projects_dir()
+    assert first == DEFAULT_PROJECTS_DIR
+    assert second == DEFAULT_PROJECTS_DIR
+    assert len(caplog.records) == 1


### PR DESCRIPTION
## Summary

- Adds `hephaestus/config/paths.py` with `resolve_projects_dir()`, honoring (in priority order) an explicit override, the `$PROJECTS_ROOT` env var (when its directory exists), and a `~/Projects` fallback.
- Logs a clear `WARNING` whenever the fallback fires — distinct messages for unset vs. nonexistent `$PROJECTS_ROOT`. De-duplicated per process per `(override, env)` tuple.
- Re-exports `DEFAULT_PROJECTS_DIR` from `loop_runner.py` for backward compat; wires `--projects-dir` through `resolve_projects_dir()` so the CLI flag becomes an override and the env var is consulted when the flag is absent.
- Mirrors the same semantics in `scripts/run_automation_loop.sh`.
- New unit tests in `tests/unit/config/test_paths.py` cover override, env-var-present, env-var-missing-dir, neither, and warning de-duplication.

## Test Plan

- [x] `pytest tests/unit/config tests/unit/automation/test_loop_runner_early_exit.py -v` — 43 passed
- [x] `pytest tests/unit/automation/test_loop_runner.py` — 79 passed
- [x] `ruff check hephaestus/ tests/ scripts/` — clean
- [x] `ruff format --check` on changed files — clean

Closes #704