### PR TITLE
fix(version): eradicate hardcoded version strings; gate manager on hatch-vcs

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -20,11 +20,13 @@ follows the deprecation policy below.
 ProjectHephaestus ships **two independently versioned artifacts**:
 
 - **The Python package** (`homericintelligence-hephaestus`) — version is **tag-driven**
-  via hatch-vcs (derived from the latest `vX.Y.Z` git tag; currently `0.9.2`). This is
-  the version the Semantic Versioning guarantees in this document apply to.
+  via hatch-vcs (derived from the latest `vX.Y.Z` git tag; see
+  [latest release](https://github.com/HomericIntelligence/ProjectHephaestus/releases/latest)).
+  This is the version the Semantic Versioning guarantees in this document apply to.
 - **The Claude Code plugin** (`hephaestus`, declared in `.claude-plugin/`) — carries its
-  own `version` field (currently `3.0.0`) that tracks the skill/command surface, not the
-  Python API.
+  own `version` field (declared in
+  [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)) that tracks the
+  skill/command surface, not the Python API.
 
 These two version numbers are **not** coupled and will not match. The plugin version
 says nothing about the Python package version and vice versa. See

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -2,10 +2,12 @@
 
 ProjectHephaestus ships as a Claude Code plugin in addition to a Python package. Installing the plugin gives any repository in your ecosystem access to the `hephaestus` skill set.
 
-> **Note on versions:** The plugin version (currently `3.0.0`, declared in
-> `.claude-plugin/`) and the Python package version (currently `0.9.2`, tag-driven via
-> hatch-vcs) are **separate artifacts** with independent version numbers — they are not
-> coupled and will not match. See
+> **Note on versions:** The plugin version (declared in
+> [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json)) and the Python package
+> version (tag-driven via hatch-vcs; see
+> [latest release](https://github.com/HomericIntelligence/ProjectHephaestus/releases/latest))
+> are **separate artifacts** with independent version numbers — they are not coupled and
+> will not match. See
 > [`COMPATIBILITY.md`](../COMPATIBILITY.md#versioning-python-package-vs-claude-code-plugin)
 > for details.
 

--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -2,13 +2,22 @@
 
 """Version management utilities for updating and verifying version files.
 
-The authoritative project version lives in pyproject.toml under [project].version.
-This module keeps secondary version files in sync:
+This module supports two version-source models:
+
+1. **Static pyproject** — ``[project].version = "x.y.z"`` is the source of truth.
+   ``update_pyproject_file()`` rewrites that field; ``verify()`` reads it.
+2. **hatch-vcs dynamic** — ``pyproject.toml`` declares ``dynamic = ["version"]``
+   with ``[tool.hatch.version] source = "vcs"`` and the version is derived from
+   the latest ``vX.Y.Z`` git tag. There is **no** static ``[project].version``.
+   On such projects, ``update_pyproject_file()`` no-ops with a warning (writing
+   would reintroduce the field that the project's ``check-version-single-source``
+   pre-commit hook explicitly rejects).
+
+This module keeps secondary version files in sync regardless of model:
 - VERSION (root file)
 - __init__.py (__version__ attribute)
 
-Note: pixi.toml intentionally has no version field. The package version is
-provided to pixi via the editable install from pyproject.toml.
+Note: pixi.toml intentionally has no version field.
 """
 
 import re
@@ -26,6 +35,21 @@ class _UnsetType:
 
 
 _UNSET = _UnsetType()  # sentinel: use default pyproject_file path
+
+
+_HATCH_VCS_DYNAMIC_RE = re.compile(r'^\s*dynamic\s*=\s*\[\s*[^]]*"version"[^]]*\]', re.MULTILINE)
+
+
+def _is_hatch_vcs_project(pyproject_content: str) -> bool:
+    """Return True if pyproject.toml declares a dynamic version via hatch-vcs.
+
+    Detection is intentionally lenient: any ``dynamic = [..., "version", ...]``
+    declaration is sufficient. The narrower form
+    ``[tool.hatch.version] source = "vcs"`` is a stronger signal but the dynamic
+    declaration alone is enough to mean ``[project].version`` should not exist
+    and therefore should not be written.
+    """
+    return bool(_HATCH_VCS_DYNAMIC_RE.search(pyproject_content))
 
 
 def parse_version(version: str) -> tuple[int, int, int]:
@@ -111,6 +135,12 @@ class VersionManager:
     ) -> None:
         """Update version in pyproject.toml [project].version.
 
+        On hatch-vcs projects (``dynamic = ["version"]`` declared), this is a
+        no-op with an explanatory warning: the version is derived from git tags
+        and rewriting ``[project].version`` would either silently fail (no field
+        to match) or, on a misconfigured repo, reintroduce a static field that
+        the ``check-version-single-source`` pre-commit hook rejects.
+
         Args:
             pyproject_file: Path to pyproject.toml
             version: New version string
@@ -122,10 +152,21 @@ class VersionManager:
                 logger.warning("  %s not found, skipping", pyproject_file)
             return
 
+        content = pyproject_file.read_text()
+
+        if _is_hatch_vcs_project(content):
+            if verbose:
+                logger.warning(
+                    "  %s declares dynamic version via hatch-vcs; "
+                    "skipping [project].version rewrite "
+                    "(tag the release with `git tag -s v%s` instead)",
+                    pyproject_file,
+                    version,
+                )
+            return
+
         if verbose:
             logger.info("Updating %s...", pyproject_file)
-
-        content = pyproject_file.read_text()
 
         # Replace version = "x.y.z" only within the [project] section.
         # The negative lookahead (?!\[) stops the section match at the next header.

--- a/tests/unit/version/test_manager.py
+++ b/tests/unit/version/test_manager.py
@@ -315,6 +315,66 @@ def test_version_manager_update_pyproject_no_version_section(tmp_path):
     assert pyproject.read_text() == original
 
 
+def test_version_manager_update_pyproject_skips_hatch_vcs_dynamic(tmp_path):
+    """update_pyproject_file() no-ops on hatch-vcs projects (dynamic version)."""
+    import logging
+
+    pyproject = tmp_path / "pyproject.toml"
+    original = (
+        '[project]\nname = "mypkg"\ndynamic = ["version"]\n\n[tool.hatch.version]\nsource = "vcs"\n'
+    )
+    pyproject.write_text(original)
+
+    # Attach a list-handler directly to the module logger because the project's
+    # custom get_logger() sets propagate=False, which makes pytest's caplog
+    # (rooted at the root logger) miss the records.
+    module_logger = logging.getLogger("hephaestus.version.manager")
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _ListHandler(level=logging.WARNING)
+    module_logger.addHandler(handler)
+    try:
+        manager = VersionManager(
+            repo_root=tmp_path,
+            version_files=[],
+            init_files=[],
+            pyproject_file=pyproject,
+        )
+        manager.update_pyproject_file(pyproject, "1.2.3", verbose=True)
+    finally:
+        module_logger.removeHandler(handler)
+
+    # File content must be untouched — writing [project].version on a hatch-vcs
+    # project would either silently fail or, on a misconfigured repo, trip the
+    # check-version-single-source pre-commit hook.
+    assert pyproject.read_text() == original
+    # A warning must be logged so callers (e.g. release scripts) see the no-op.
+    messages = [rec.getMessage() for rec in records]
+    assert any("hatch-vcs" in m for m in messages)
+    assert any("git tag -s v1.2.3" in m for m in messages)
+
+
+def test_version_manager_update_pyproject_still_writes_static_project(tmp_path):
+    """update_pyproject_file() still writes on plain static-[project].version projects."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "mypkg"\nversion = "0.1.0"\n')
+
+    manager = VersionManager(
+        repo_root=tmp_path,
+        version_files=[],
+        init_files=[],
+        pyproject_file=pyproject,
+    )
+
+    manager.update_pyproject_file(pyproject, "2.0.0", verbose=False)
+
+    assert 'version = "2.0.0"' in pyproject.read_text()
+
+
 def test_version_manager_update_pyproject_missing_file(tmp_path):
     """update_pyproject_file() handles missing pyproject.toml gracefully."""
     missing = tmp_path / "pyproject.toml"


### PR DESCRIPTION
## Summary

Pre-release sweep before tagging v0.9.4. Removes all hardcoded version strings from tracked markdown and hardens `VersionManager.update_pyproject_file()` against the hatch-vcs single-source invariant.

## Changes

- **`COMPATIBILITY.md`** — replaces "currently `0.9.2`" and "currently `3.0.0`" with links to the GitHub latest release and the plugin.json file. The doc no longer drifts on every release.
- **`docs/plugin-installation.md`** — same fix for the duplicate version notes.
- **`hephaestus/version/manager.py`** — `update_pyproject_file()` now detects `dynamic = ["version"]` and no-ops with a clear `WARNING` (previously silently rewrote `[project].version` regardless of project model, contradicting the `check-version-single-source` pre-commit invariant).
- **`tests/unit/version/test_manager.py`** — two new regression tests: one asserts the no-op + warning on hatch-vcs, the other asserts static-`[project].version` projects still update correctly.

## Test plan

- [x] `pixi run pytest tests/unit/version/test_manager.py -v` — new tests pass; pre-existing `test_version_manager_auto_detect_*` failures are unchanged from main (they exist on `main` HEAD too — not my regression)
- [x] `pixi run ruff check hephaestus/ tests/`
- [x] `pixi run ruff format --check hephaestus/ tests/`
- [x] `pixi run mypy hephaestus/version/manager.py`
- [x] `grep -rn "currently \`0\.9\.2\`\|currently \`3\.0\.0\`" --include='*.md'` against tracked files returns no matches

## Why this is the v0.9.4 pre-tag

User directive: "before tagging v0.9.4, lets make sure all static version issues are fixed". This PR is that fix. After it lands on main, the next step is `git tag -s v0.9.4` against the merge commit.

Closes #812
Closes #709
Closes #731
Closes #732