### PR TITLE
chore(gitignore): ignore .claude/scheduled_tasks.lock runtime lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ htmlcov/
 # Claude Code agent prompt artifacts (accidentally-committed temporary files)
 /.claude-prompt-*.md
 /.claude-followup-*.md
+
+# Claude Code scheduled-task runtime lock (per-machine, per-process — not source)
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary

Adds `.claude/scheduled_tasks.lock` to `.gitignore`. This file is per-machine, per-process runtime state (sessionId + pid + procStart + acquiredAt) written by Claude Code's scheduled-task subsystem — not source.

While not ignored it shows up as untracked in `git status --porcelain`, which makes `hephaestus-tidy`'s `_working_tree_clean()` refuse to run on any host with a live Claude session. That blocks the entire tidy flow.

Closes #815

## Verification

```
$ git check-ignore -v .claude/scheduled_tasks.lock
.gitignore:84:.claude/scheduled_tasks.lock	.claude/scheduled_tasks.lock

$ git status --porcelain   # with lock file present
(empty)
```

## Test plan

- [x] `.claude/scheduled_tasks.lock` ignored by pattern (verified via `git check-ignore -v`)
- [x] `git status --porcelain` reports clean tree even with the lock file present
- [ ] CI green
- [ ] After merge: `pixi run hephaestus-tidy --dry-run` runs without the "Working tree has uncommitted changes" error