### PR TITLE
fix(automation): correct session_jsonl_path dot-encoding to match Claude CLI

### DIFF
--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -178,7 +178,21 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
         )
 
     if not should_resume:
-        return _run(create=True).stdout, sid
+        try:
+            return _run(create=True).stdout, sid
+        except subprocess.CalledProcessError as exc:
+            # Defense in depth (#822): the probe says no transcript exists
+            # but the CLI says the session is already registered. Encoding
+            # drift between hephaestus and the CLI can desync the probe;
+            # treat the rejection as proof the session exists and resume it.
+            stderr = (exc.stderr or "") + (exc.stdout or "")
+            if "already in use" in stderr.lower():
+                logger.warning(
+                    "claude --session-id %s rejected as already in use; resuming instead",
+                    sid,
+                )
+                return _run(create=False).stdout, sid
+            raise
 
     try:
         return _run(create=False).stdout, sid

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -173,9 +173,13 @@ def current_trunk_githash(repo_path: Path | None = None) -> str:
 def session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     """Return the path where Claude Code persists a session's transcript.
 
-    Claude encodes the cwd into the directory name by replacing each ``/``
-    with ``-``. Used to detect whether a session already exists (and thus
-    should be resumed) or needs to be created.
+    Claude encodes the cwd into the projects-directory name by replacing
+    BOTH ``/`` and ``.`` with ``-``. Probing only ``/`` (as a prior version
+    of this helper did) misses every cwd containing a dot-prefixed segment
+    like ``.worktrees``, ``.git``, or ``.venv``: ``transcript.exists()``
+    returns False even though the JSONL is on disk, the caller goes down
+    the ``--session-id`` create path, and the CLI rejects with ``Session ID
+    <uuid> is already in use``. (#822)
     """
-    encoded = str(cwd.resolve()).replace("/", "-")
+    encoded = str(cwd.resolve()).replace("/", "-").replace(".", "-")
     return Path.home() / ".claude" / "projects" / encoded / f"{uuid_str}.jsonl"

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -217,10 +217,10 @@ class TestSessionExpiredFallback:
         assert m.call_count == 1
 
     def test_create_already_in_use_falls_back_to_resume(self, fake_home: Path) -> None:
-        """When the CLI rejects --session-id with 'already in use', fall back to --resume. (#822)
+        """Fall back to --resume when --session-id is rejected as already-in-use.
 
         Defends against encoding drift between hephaestus's transcript probe
-        and the Claude CLI's actual session storage.
+        and the Claude CLI's actual session storage. (#822)
         """
         cwd = fake_home / "work"
         cwd.mkdir()

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -194,7 +194,7 @@ class TestSessionExpiredFallback:
         assert "--session-id" in _argv(m.call_args_list[1])
 
     def test_create_failure_propagates(self, fake_home: Path) -> None:
-        """A first-call (--session-id) failure is not retried."""
+        """A first-call (--session-id) failure for an unrelated reason is not retried."""
         cwd = fake_home / "work"
         cwd.mkdir()
         other = subprocess.CalledProcessError(
@@ -215,6 +215,43 @@ class TestSessionExpiredFallback:
                     cwd=cwd,
                 )
         assert m.call_count == 1
+
+    def test_create_already_in_use_falls_back_to_resume(self, fake_home: Path) -> None:
+        """When the CLI rejects --session-id with 'already in use', fall back to --resume. (#822)
+
+        Defends against encoding drift between hephaestus's transcript probe
+        and the Claude CLI's actual session storage.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        already = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude"],
+            output="",
+            stderr="Error: Session ID abc is already in use.",
+        )
+        ok = subprocess.CompletedProcess(
+            args=["claude"], returncode=0, stdout="resumed-ok", stderr=""
+        )
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[already, ok],
+        ) as m:
+            stdout, _ = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                githash="x",
+                prompt="hi",
+                model="sonnet",
+                cwd=cwd,
+            )
+        assert stdout == "resumed-ok"
+        assert m.call_count == 2
+        first_argv = m.call_args_list[0][0][0]
+        second_argv = m.call_args_list[1][0][0]
+        assert "--session-id" in first_argv
+        assert "--resume" in second_argv
 
 
 class TestArgvAssembly:

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -192,8 +192,9 @@ class TestSessionJsonlPath:
     def test_dot_prefixed_segment_encodes_dot_as_dash(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A `.worktrees` segment must yield `--worktrees-`, matching the
-        Claude CLI's actual on-disk encoding. (#822)
+        """Encode a `.worktrees` segment as `--worktrees-`, not `-.worktrees-`.
+
+        Matches the Claude CLI's actual on-disk encoding. (#822)
         """
         monkeypatch.setenv("HOME", str(tmp_path))
         target = tmp_path / "build" / ".worktrees" / "issue-5451"
@@ -216,8 +217,9 @@ class TestSessionJsonlPath:
     def test_mid_segment_dot_also_rewritten(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Mid-segment dots (e.g. `v1.2.3`) are rewritten too — matches the
-        CLI's flat `.` -> `-` rule. Documented edge case, not a bug.
+        """Rewrite mid-segment dots (e.g. `v1.2.3`) too.
+
+        Matches the CLI's flat `.` -> `-` rule. Documented edge case, not a bug.
         """
         monkeypatch.setenv("HOME", str(tmp_path))
         target = tmp_path / "release" / "v1.2.3" / "build"

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -176,13 +176,11 @@ class TestSessionJsonlPath:
 
     def test_path_encoding(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HOME", str(tmp_path))
-        # Path.home() reads $HOME at call time, so no reimport needed.
         target = tmp_path / "Projects" / "Foo"
         target.mkdir(parents=True)
         p = session_jsonl_path("abc-uuid", target)
         assert p.name == "abc-uuid.jsonl"
-        # The encoded segment is the resolved path with `/` -> `-`.
-        encoded = str(target.resolve()).replace("/", "-")
+        encoded = str(target.resolve()).replace("/", "-").replace(".", "-")
         assert encoded in str(p)
         assert p.parent.parent == tmp_path / ".claude" / "projects"
 
@@ -190,6 +188,43 @@ class TestSessionJsonlPath:
         sid = session_uuid("R", 1, AGENT_IMPLEMENTER, "abc1234")
         p = session_jsonl_path(sid, tmp_path)
         assert p.name == f"{sid}.jsonl"
+
+    def test_dot_prefixed_segment_encodes_dot_as_dash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A `.worktrees` segment must yield `--worktrees-`, matching the
+        Claude CLI's actual on-disk encoding. (#822)
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / "build" / ".worktrees" / "issue-5451"
+        target.mkdir(parents=True)
+        p = session_jsonl_path("u", target)
+        # `/.worktrees/` becomes `--worktrees-`, NOT `-.worktrees-`.
+        assert "--worktrees-issue-5451" in str(p)
+        assert "-.worktrees-" not in str(p)
+
+    def test_multiple_dot_segments_all_rewritten(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / ".venv" / ".tox" / "y"
+        target.mkdir(parents=True)
+        p = session_jsonl_path("u", target)
+        # Both leading dots get rewritten.
+        assert "." not in p.parent.name
+
+    def test_mid_segment_dot_also_rewritten(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mid-segment dots (e.g. `v1.2.3`) are rewritten too — matches the
+        CLI's flat `.` -> `-` rule. Documented edge case, not a bug.
+        """
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / "release" / "v1.2.3" / "build"
+        target.mkdir(parents=True)
+        p = session_jsonl_path("u", target)
+        assert "v1-2-3" in p.parent.name
+        assert "v1.2.3" not in p.parent.name
 
 
 class TestCurrentTrunkGithash:


### PR DESCRIPTION
## Summary

`session_jsonl_path` rewrote only `/` → `-` when computing the path to a Claude session's on-disk JSONL transcript. The Claude CLI rewrites BOTH `/` and `.` to `-`, so any cwd containing a dot-prefixed segment (`.worktrees`, `.git`, `.venv`) produced a probe path that differed from the actual on-disk location.

Result: `transcript.exists()` returned `False` for sessions whose JSONL was already on disk → callers went down the `--session-id` (create) path → Claude CLI rejected with `Error: Session ID <uuid> is already in use.` Bricked `drive_prs_green.py` for every issue in ProjectOdyssey because the worktree path contains `.worktrees`.

## Repro (verified before fix)

```python
>>> Path('/home/mvillmow/Projects/ProjectOdyssey/build/.worktrees/issue-5451').resolve()
PosixPath('/home/mvillmow/Projects/ProjectOdyssey/build/.worktrees/issue-5451')
>>> # Before: hephaestus probes
'-home-mvillmow-Projects-ProjectOdyssey-build-.worktrees-issue-5451'
>>> # After: matches Claude CLI's actual encoding
'-home-mvillmow-Projects-ProjectOdyssey-build--worktrees-issue-5451'
```

## Changes

- `hephaestus/automation/session_naming.py:173-181` — add `.replace(".", "-")` after the existing `/` → `-` step, document the rule and link issue #822 in the docstring.
- `hephaestus/automation/claude_invoke.py:180-201` — defense-in-depth fallback: when `--session-id` is rejected as "already in use," retry once via `--resume`. Guards against future encoding drift, races between probe and invoke, and CLI behavior changes.
- `tests/unit/automation/test_session_naming.py` — three new tests pinning the encoding contract.
- `tests/unit/automation/test_claude_invoke_session.py` — new test for the "already in use" fallback.

## Verification

```
$ pixi run pytest tests/unit/automation/test_session_naming.py tests/unit/automation/test_claude_invoke_session.py -q
45 passed in 2.00s

$ pixi run python -c "from pathlib import Path; from hephaestus.automation.session_naming import session_jsonl_path; p = session_jsonl_path('9ede78c6-262c-5931-b832-3897c3faf71f', Path('/home/mvillmow/Projects/ProjectOdyssey/build/.worktrees/issue-5451')); print(p.exists())"
True
```

Closes #822

## Test plan

- [x] New unit tests added and passing
- [x] End-to-end probe sanity check resolves to existing JSONL
- [ ] CI green
- [ ] Re-run `drive_prs_green.py` on a previously-driven issue — no "already in use" errors