### PR TITLE
fix(automation/ci_driver): retry diverged pushes via fetch + force-with-lease

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -35,7 +35,13 @@ from .advise_runner import run_advise
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import advise_model, implementer_model, learn_model
 from .claude_timeouts import ci_driver_claude_timeout, learn_claude_timeout
-from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref, run
+from .git_utils import (
+    get_repo_root,
+    get_repo_slug,
+    issue_ref,
+    pr_ref,
+    push_current_branch_with_lease_on_divergence,
+)
 from .github_api import _gh_call, gh_issue_json, gh_pr_checks
 from .models import CIDriverOptions, WorkerResult
 from .prompts import get_advise_prompt
@@ -699,7 +705,7 @@ class CIDriver:
                     return False
 
                 try:
-                    run(["git", "push", "origin", "HEAD"], cwd=worktree_path)
+                    push_current_branch_with_lease_on_divergence(worktree_path)
                     logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
                     return True
                 except Exception as push_err:
@@ -743,7 +749,7 @@ class CIDriver:
             if claude_result.returncode == 0:
                 # Push the fixes
                 try:
-                    run(["git", "push", "origin", "HEAD"], cwd=worktree_path)
+                    push_current_branch_with_lease_on_divergence(worktree_path)
                     logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
                     return True
                 except Exception as push_err:

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -284,6 +284,98 @@ def get_current_branch(repo_root: Path | None = None) -> str:
         raise RuntimeError(f"Failed to get current branch: {e}") from e
 
 
+# When the remote branch has advanced (someone else — or a parallel ci_driver
+# worker — pushed in the meantime), ``git push`` reports one of these two
+# stderr fragments. We catch them to trigger a fetch + force-with-lease retry
+# rather than abandoning the CI fix after a single attempt.
+_PUSH_REJECTED_FRAGMENTS: tuple[str, ...] = (
+    "non-fast-forward",
+    "fetch first",
+)
+
+
+def _is_push_rejected_diverged(exc: subprocess.CalledProcessError) -> bool:
+    """Return True iff ``git push`` failed because the remote branch diverged."""
+    blob = (exc.stderr or "") + (exc.stdout or "")
+    return any(fragment in blob for fragment in _PUSH_REJECTED_FRAGMENTS)
+
+
+def push_current_branch_with_lease_on_divergence(
+    cwd: Path,
+    *,
+    branch: str | None = None,
+    remote: str = "origin",
+) -> subprocess.CompletedProcess[str]:
+    """Push ``HEAD`` to ``<remote>``; on divergence, fetch + force-with-lease retry.
+
+    The first attempt is a plain ``git push <remote> HEAD``. If that fails with a
+    non-fast-forward / fetch-first rejection — the exact symptom seen when a
+    second CI-fix iteration runs before the bot's previous push has been mirrored
+    locally, or when a human commits to the bot's branch — we then:
+
+    1. ``git fetch <remote> <branch>`` to update the remote-tracking ref.
+    2. ``git push --force-with-lease=<branch> <remote> HEAD:<branch>`` so the
+       push refuses if a *new* commit landed between step 1 and now (the safety
+       guarantee `--force-with-lease` provides over a bare `--force`).
+
+    Any other error from the first push (auth failure, network, etc.) is
+    re-raised unchanged. The second push's failure is also re-raised — callers
+    log it and treat the issue as failed.
+
+    Args:
+        cwd: Worktree path to run the git commands in.
+        branch: Branch name. If omitted, derived from ``git rev-parse
+            --abbrev-ref HEAD`` in ``cwd``.
+        remote: Remote name (default ``origin``).
+
+    Returns:
+        The successful push's ``CompletedProcess``.
+
+    Raises:
+        subprocess.CalledProcessError: If both the initial push and the
+            lease-retry push fail. The exception is the *retry* failure if the
+            initial push was a recognized divergence, otherwise the *initial*
+            failure.
+
+    """
+    try:
+        return run(
+            [
+                "git",
+                "push",
+                remote,
+                "HEAD",
+            ],
+            cwd=cwd,
+        )
+    except subprocess.CalledProcessError as exc:
+        if not _is_push_rejected_diverged(exc):
+            raise
+        # Resolve the branch name lazily — most callers know it, but we don't
+        # want to require it on every caller.
+        if branch is None:
+            branch = get_current_branch(cwd)
+        logger.warning(
+            "git push to %s/%s rejected as diverged; fetching + force-with-lease retry",
+            remote,
+            branch,
+        )
+        # Fetch the canonical tip so the lease check has something current to
+        # compare against. If this fetch fails, raise — we cannot safely
+        # lease-push without an up-to-date remote-tracking ref.
+        run(["git", "fetch", remote, branch], cwd=cwd)
+        return run(
+            [
+                "git",
+                "push",
+                f"--force-with-lease={branch}",
+                remote,
+                f"HEAD:{branch}",
+            ],
+            cwd=cwd,
+        )
+
+
 def is_clean_working_tree(repo_root: Path | None = None) -> bool:
     """Check if the working tree is clean (no uncommitted changes).
 

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -174,7 +174,9 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
             "hephaestus.automation.ci_driver.run_codex_session",
             return_value=fresh_result,
         ) as mock_fresh,
-        patch("hephaestus.automation.ci_driver.run") as mock_run,
+        patch(
+            "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+        ) as mock_push,
     ):
         result = driver._run_ci_fix_session(
             issue_number=123,
@@ -186,7 +188,7 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
 
     assert result is True
     mock_fresh.assert_called_once()
-    mock_run.assert_called_once_with(["git", "push", "origin", "HEAD"], cwd=tmp_path)
+    mock_push.assert_called_once_with(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -14,6 +14,7 @@ from hephaestus.automation.git_utils import (
     get_repo_info,
     get_repo_root,
     is_clean_working_tree,
+    push_current_branch_with_lease_on_divergence,
     run,
     safe_git_fetch,
 )
@@ -269,3 +270,137 @@ class TestSafeGitFetch:
         assert result is False
         # With retry_with_backoff(max_retries=2), it runs initial + 2 retries = 3
         assert mock_run.call_count == 3
+
+
+class TestPushCurrentBranchWithLeaseOnDivergence:
+    """Tests for push_current_branch_with_lease_on_divergence."""
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_happy_path_plain_push(self, mock_run: Any) -> None:
+        """Successful initial push: no fetch, no force, single git invocation."""
+        mock_run.return_value = Mock(returncode=0)
+        worktree = Path("/tmp/worktree-xyz")
+
+        result = push_current_branch_with_lease_on_divergence(worktree)
+
+        assert result is mock_run.return_value
+        assert mock_run.call_count == 1
+        args, _kwargs = mock_run.call_args
+        assert args[0] == ["git", "push", "origin", "HEAD"]
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_non_fast_forward_triggers_fetch_and_lease(self, mock_run: Any) -> None:
+        """non-fast-forward rejection → fetch + force-with-lease retry succeeds."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "origin", "HEAD"],
+            output="",
+            stderr=" ! [rejected]   HEAD -> 511-impl (non-fast-forward)\n",
+        )
+        # Sequence: push fails, get_current_branch, fetch, lease push (all succeed).
+        mock_run.side_effect = [
+            push_err,
+            Mock(returncode=0, stdout="511-impl\n"),  # get_current_branch
+            Mock(returncode=0),  # fetch
+            Mock(returncode=0),  # lease push
+        ]
+
+        result = push_current_branch_with_lease_on_divergence(worktree)
+
+        assert result.returncode == 0
+        assert mock_run.call_count == 4
+        # 3rd call must be a fetch of the diverged branch.
+        fetch_args, _ = mock_run.call_args_list[2]
+        assert fetch_args[0] == ["git", "fetch", "origin", "511-impl"]
+        # 4th call must be the lease-protected push.
+        lease_args, _ = mock_run.call_args_list[3]
+        assert lease_args[0] == [
+            "git",
+            "push",
+            "--force-with-lease=511-impl",
+            "origin",
+            "HEAD:511-impl",
+        ]
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_fetch_first_also_triggers_lease(self, mock_run: Any) -> None:
+        """'fetch first' rejection text triggers the same retry path."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "origin", "HEAD"],
+            output="",
+            stderr=" ! [rejected]   HEAD -> 43-impl (fetch first)\n",
+        )
+        mock_run.side_effect = [
+            push_err,
+            Mock(returncode=0, stdout="43-impl\n"),
+            Mock(returncode=0),
+            Mock(returncode=0),
+        ]
+
+        push_current_branch_with_lease_on_divergence(worktree)
+        # Confirm the retry path executed (4 git invocations).
+        assert mock_run.call_count == 4
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_branch_arg_skips_get_current_branch(self, mock_run: Any) -> None:
+        """If caller passes branch=, no rev-parse call is needed for lease retry."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "origin", "HEAD"],
+            output="",
+            stderr="non-fast-forward\n",
+        )
+        # Only 3 calls now: failed push, fetch, lease push.
+        mock_run.side_effect = [push_err, Mock(returncode=0), Mock(returncode=0)]
+
+        push_current_branch_with_lease_on_divergence(worktree, branch="577-nomad-vessel-groups")
+
+        assert mock_run.call_count == 3
+        fetch_args, _ = mock_run.call_args_list[1]
+        assert fetch_args[0] == ["git", "fetch", "origin", "577-nomad-vessel-groups"]
+        lease_args, _ = mock_run.call_args_list[2]
+        assert "--force-with-lease=577-nomad-vessel-groups" in lease_args[0]
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_unrelated_push_failure_raises(self, mock_run: Any) -> None:
+        """Auth/network failures (not divergence) propagate without retry."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            128,
+            ["git", "push", "origin", "HEAD"],
+            output="",
+            stderr="fatal: could not read Username for 'https://github.com'\n",
+        )
+        mock_run.side_effect = [push_err]
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            push_current_branch_with_lease_on_divergence(worktree)
+        # The original (non-divergence) error is re-raised — not silently swallowed.
+        assert exc_info.value.returncode == 128
+        assert mock_run.call_count == 1
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_lease_push_failure_propagates(self, mock_run: Any) -> None:
+        """If the lease-protected retry also fails, the caller sees that error."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "origin", "HEAD"],
+            output="",
+            stderr="non-fast-forward\n",
+        )
+        lease_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "--force-with-lease=511-impl", "origin", "HEAD:511-impl"],
+            output="",
+            stderr="stale info\n",
+        )
+        mock_run.side_effect = [push_err, Mock(returncode=0), lease_err]
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            push_current_branch_with_lease_on_divergence(worktree, branch="511-impl")
+        assert exc_info.value.stderr == "stale info\n"


### PR DESCRIPTION
## Summary

When `ci_driver` pushes a CI fix it currently runs a bare `git push origin HEAD`. If the remote branch has advanced (parallel ci_driver workers, an earlier fix that already landed, or any other writer) the push is rejected as `non-fast-forward` / `fetch first` and the driver gives up after a single attempt — even though the fix itself is sound. This pattern surfaced repeatedly in the latest ecosystem run (see issue body for log paths).

This adds `push_current_branch_with_lease_on_divergence(cwd, *, branch=None)` in `hephaestus/automation/git_utils.py`:

1. Tries `git push origin HEAD` first (happy-path behavior is identical).
2. On a divergence rejection only, runs `git fetch origin <branch>` then `git push --force-with-lease=<branch> origin HEAD:<branch>`.
3. Any other push error (auth, network, missing remote, …) is re-raised unchanged so the driver still fails fast.

`ci_driver._run_ci_fix_session` calls the new helper at both push sites (codex agent path + Claude agent path), so behaviour is symmetric between agents.

`--force-with-lease` (without `--force-if-includes`) is the right safety level here: the bot owns these per-issue branches, but if a *new* tip lands between our fetch and our push we want the lease to refuse — better to fail loud than to clobber an unobserved commit.

## Test plan

- [x] `pytest tests/unit/automation/test_git_utils.py tests/unit/automation/test_ci_driver.py` (62 passed)
- [x] New `TestPushCurrentBranchWithLeaseOnDivergence` covers: happy path (plain push), non-fast-forward → lease retry, fetch-first → lease retry, caller-provided branch (skips rev-parse), unrelated push error propagates, lease retry failure propagates
- [x] Updated `test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure` to patch the new helper
- [x] `pre-commit run` clean on all changed files (ruff + mypy + bandit)

Closes #825