### PR TITLE
fix(automation/github_api): treat 'no checks reported' as empty, not fatal

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1463,6 +1463,20 @@ def _map_pr_check(item: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+# ``gh pr checks`` exits non-zero with this stderr when the PR's head branch
+# has no check runs registered yet (a fresh PR before workflows have been
+# scheduled, or a repo with no CI configured for the branch). It is *not* a
+# real error — it is the empty result — so callers should see ``[]`` rather
+# than a hard failure that aborts the entire CI drive.
+_GH_PR_CHECKS_NO_CHECKS_FRAGMENT: str = "no checks reported"
+
+
+def _is_gh_pr_checks_no_checks_error(exc: subprocess.CalledProcessError) -> bool:
+    """Return True iff a failed ``gh pr checks`` is the no-checks-yet case."""
+    blob = (exc.stderr or "") + (exc.stdout or "")
+    return _GH_PR_CHECKS_NO_CHECKS_FRAGMENT in blob
+
+
 def gh_pr_checks(
     pr_number: int,
     dry_run: bool = False,
@@ -1475,7 +1489,8 @@ def gh_pr_checks(
 
     Returns:
         List of check dicts with keys: name (str), status (str), conclusion (str | None),
-        required (bool).
+        required (bool). Empty list if the PR has no check runs yet (``gh pr checks``
+        treats this as an error but the driver treats it as the empty case).
 
         ``gh pr checks --json`` does not expose ``status``/``conclusion``/``required`` — it
         exposes ``state`` (e.g. ``SUCCESS``/``FAILURE``/``PENDING``) and ``bucket``
@@ -1488,7 +1503,17 @@ def gh_pr_checks(
         logger.info("[dry_run] Would fetch CI checks for PR #%s", pr_number)
         return []
 
-    result = _gh_call(["pr", "checks", str(pr_number), "--json", "name,state,bucket,workflow"])
+    try:
+        result = _gh_call(["pr", "checks", str(pr_number), "--json", "name,state,bucket,workflow"])
+    except subprocess.CalledProcessError as exc:
+        if _is_gh_pr_checks_no_checks_error(exc):
+            logger.info(
+                "PR #%s has no check runs registered yet (gh: %s); treating as empty",
+                pr_number,
+                _GH_PR_CHECKS_NO_CHECKS_FRAGMENT,
+            )
+            return []
+        raise
     raw: list[dict[str, Any]] = json.loads(result.stdout)
 
     checks: list[dict[str, Any]] = [_map_pr_check(item) for item in raw]

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1469,6 +1469,41 @@ class TestGhPrChecks:
         assert check["status"] == "in_progress"
         assert check["conclusion"] is None
 
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_no_checks_reported_returns_empty(self, mock_gh_call: Any) -> None:
+        """Regression for #827: gh's 'no checks reported' stderr maps to ``[]``.
+
+        ``gh pr checks`` exits non-zero with stderr ``no checks reported on the
+        '<branch>' branch`` when the PR has no check runs registered yet (fresh
+        PR, no workflows configured, etc.). Previously this aborted the entire
+        CI drive with an unexpected-error log. The driver now treats it as the
+        empty-result case.
+        """
+        mock_gh_call.side_effect = subprocess.CalledProcessError(
+            1,
+            ["gh", "pr", "checks"],
+            output="",
+            stderr="no checks reported on the '45-ecosystem-health' branch\n",
+        )
+
+        assert gh_pr_checks(289) == []
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_other_called_process_error_still_raises(self, mock_gh_call: Any) -> None:
+        """Auth / network / unrelated gh failures still propagate."""
+        # We only swallow the exact "no checks reported" stderr — every other
+        # CalledProcessError still surfaces so genuine failures fail loud.
+        mock_gh_call.side_effect = subprocess.CalledProcessError(
+            128,
+            ["gh", "pr", "checks"],
+            output="",
+            stderr="HTTP 401: Bad credentials\n",
+        )
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            gh_pr_checks(289)
+        assert exc_info.value.returncode == 128
+
 
 class TestUpsertAndDeleteComment:
     """Idempotent plan/review comment lifecycle (one comment per role)."""


### PR DESCRIPTION
## Summary

`gh pr checks` exits non-zero with stderr `no checks reported on the '<branch>' branch` when the PR's head branch has no check runs registered yet (fresh PR before workflows are scheduled, repo with no CI configured for the branch, etc.). Previously `gh_pr_checks` let the `CalledProcessError` propagate, which the driver logged as an `unexpected error` and treated as a hard failure.

In the latest ecosystem run this is what made Odysseus issue #45 / PR #289 fail every retry — the retry-with-backoff layer was just amplifying the wrong-classification.

This fix catches `CalledProcessError` in `gh_pr_checks`, inspects combined stdout+stderr for the literal `no checks reported` substring, and returns `[]`. Every other `CalledProcessError` is re-raised so genuine failures (auth, network, etc.) still surface.

A new `_is_gh_pr_checks_no_checks_error(exc)` helper centralises the substring check so the magic string lives in exactly one place.

## Test plan

- [x] `pytest tests/unit/automation/test_github_api.py tests/unit/automation/test_ci_driver.py` (137 passed)
- [x] Added: `test_no_checks_reported_returns_empty` — gh fails with the canonical stderr, `gh_pr_checks` returns `[]`
- [x] Added: `test_other_called_process_error_still_raises` — auth/network failures still propagate
- [x] `pre-commit run` clean (ruff + mypy + bandit)

Closes #827