### PR TITLE
fix(automation/ci_driver): pin CI-fix push to PR head branch; sync worktree first

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -41,6 +41,7 @@ from .git_utils import (
     issue_ref,
     pr_ref,
     push_current_branch_with_lease_on_divergence,
+    sync_worktree_to_remote_branch,
 )
 from .github_api import _gh_call, gh_issue_json, gh_pr_checks
 from .models import CIDriverOptions, WorkerResult
@@ -430,6 +431,10 @@ class CIDriver:
             ci_logs = self._get_failing_ci_logs(pr_number)
             session_id = self._load_impl_session_id(issue_number)
             worktree_path = self._get_worktree_path(issue_number, pr_number)
+            # Resolve the PR's actual head-branch name once per iteration. The
+            # CI fix push must target THIS remote ref even if Claude switches
+            # branches locally during the session (#832).
+            pr_head_branch = self._get_pr_branch(pr_number)
 
             if self.options.dry_run:
                 logger.info(
@@ -445,7 +450,13 @@ class CIDriver:
                 f"{issue_ref(issue_number)}: running CI fix session (attempt {iteration + 1})",
             )
             fixed = self._run_ci_fix_session(
-                issue_number, pr_number, worktree_path, ci_logs, session_id, advise_findings
+                issue_number,
+                pr_number,
+                worktree_path,
+                ci_logs,
+                session_id,
+                advise_findings,
+                pr_head_branch=pr_head_branch,
             )
             if fixed:
                 logger.info(
@@ -625,6 +636,8 @@ class CIDriver:
         ci_logs: str,
         session_id: str | None,
         advise_findings: str = "",
+        *,
+        pr_head_branch: str,
     ) -> bool:
         """Invoke Claude to fix CI failures, then push the result.
 
@@ -636,11 +649,31 @@ class CIDriver:
             session_id: Optional Claude session ID to resume.
             advise_findings: Prior learnings from the advise step, prepended to
                 the prompt as context. Empty or a skip marker contributes nothing.
+            pr_head_branch: The PR's head-branch name on the remote. The push
+                uses this as the destination refspec so the fix lands on the
+                actual PR branch even if the agent switched branches locally
+                during the session (#832).
 
         Returns:
             True if the fix session succeeded and the branch was pushed.
 
         """
+        # Sync the worktree to the PR's actual remote head BEFORE the agent
+        # runs. WorktreeManager may have reused a stale local branch ref that
+        # pointed at an old ``main`` tip — without this reset the agent would
+        # commit on top of the wrong base and the force-with-lease push would
+        # either no-op or regress the PR (#832).
+        try:
+            sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: failed to sync worktree to origin/%s before CI fix: %s",
+                issue_number,
+                pr_head_branch,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return False
+
         advise_block = ""
         findings = advise_findings.strip()
         if findings and not findings.startswith("<!-- advise step skipped"):
@@ -648,12 +681,15 @@ class CIDriver:
         prompt = (
             f"{advise_block}"
             f"Fix the CI failures for PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}).\n\n"
-            f"Working directory: {worktree_path}\n\n"
+            f"Working directory: {worktree_path}\n"
+            f"Current branch (DO NOT change): {pr_head_branch}\n\n"
             f"CI failure logs:\n{ci_logs}\n\n"
             "Fix the code to make the CI checks pass. After fixing:\n"
             "1. Run: pixi run python -m pytest tests/ -v\n"
             "2. Run: pre-commit run --all-files\n"
-            "3. Commit changes (do NOT push)\n\n"
+            "3. Commit changes (do NOT push) on the current branch — DO NOT run "
+            "`git checkout -b`, `git switch -c`, or any other command that creates "
+            "or switches to a different branch\n\n"
             f"Commit message: fix: Address CI failures for PR {pr_ref(pr_number)}\n"
         )
 
@@ -705,7 +741,11 @@ class CIDriver:
                     return False
 
                 try:
-                    push_current_branch_with_lease_on_divergence(worktree_path)
+                    push_current_branch_with_lease_on_divergence(
+                        worktree_path,
+                        branch=pr_head_branch,
+                        push_ref=f"HEAD:{pr_head_branch}",
+                    )
                     logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
                     return True
                 except Exception as push_err:
@@ -749,7 +789,11 @@ class CIDriver:
             if claude_result.returncode == 0:
                 # Push the fixes
                 try:
-                    push_current_branch_with_lease_on_divergence(worktree_path)
+                    push_current_branch_with_lease_on_divergence(
+                        worktree_path,
+                        branch=pr_head_branch,
+                        push_ref=f"HEAD:{pr_head_branch}",
+                    )
                     logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
                     return True
                 except Exception as push_err:

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -305,18 +305,19 @@ def push_current_branch_with_lease_on_divergence(
     *,
     branch: str | None = None,
     remote: str = "origin",
+    push_ref: str = "HEAD",
 ) -> subprocess.CompletedProcess[str]:
     """Push ``HEAD`` to ``<remote>``; on divergence, fetch + force-with-lease retry.
 
-    The first attempt is a plain ``git push <remote> HEAD``. If that fails with a
+    The first attempt is ``git push <remote> <push_ref>``. If that fails with a
     non-fast-forward / fetch-first rejection — the exact symptom seen when a
     second CI-fix iteration runs before the bot's previous push has been mirrored
     locally, or when a human commits to the bot's branch — we then:
 
     1. ``git fetch <remote> <branch>`` to update the remote-tracking ref.
-    2. ``git push --force-with-lease=<branch> <remote> HEAD:<branch>`` so the
-       push refuses if a *new* commit landed between step 1 and now (the safety
-       guarantee `--force-with-lease` provides over a bare `--force`).
+    2. ``git push --force-with-lease=<branch> <remote> <push_ref_or_default>`` so
+       the push refuses if a *new* commit landed between step 1 and now (the
+       safety guarantee ``--force-with-lease`` provides over a bare ``--force``).
 
     Any other error from the first push (auth failure, network, etc.) is
     re-raised unchanged. The second push's failure is also re-raised — callers
@@ -324,9 +325,15 @@ def push_current_branch_with_lease_on_divergence(
 
     Args:
         cwd: Worktree path to run the git commands in.
-        branch: Branch name. If omitted, derived from ``git rev-parse
-            --abbrev-ref HEAD`` in ``cwd``.
+        branch: Branch name on the remote. If omitted, derived from ``git
+            rev-parse --abbrev-ref HEAD`` in ``cwd``.
         remote: Remote name (default ``origin``).
+        push_ref: Refspec to push. Defaults to ``"HEAD"`` (push the current
+            branch to whatever the remote tracks). When the local HEAD may
+            have been moved off the target branch by an agent (#832), callers
+            should pass an explicit refspec like ``f"HEAD:{branch}"`` to force
+            the push to land on the named remote branch regardless of local
+            branch state.
 
     Returns:
         The successful push's ``CompletedProcess``.
@@ -344,7 +351,7 @@ def push_current_branch_with_lease_on_divergence(
                 "git",
                 "push",
                 remote,
-                "HEAD",
+                push_ref,
             ],
             cwd=cwd,
         )
@@ -364,16 +371,63 @@ def push_current_branch_with_lease_on_divergence(
         # compare against. If this fetch fails, raise — we cannot safely
         # lease-push without an up-to-date remote-tracking ref.
         run(["git", "fetch", remote, branch], cwd=cwd)
+        # The lease retry preserves any explicit ``push_ref`` the caller passed
+        # so HEAD lands on the right *remote* branch even if the local HEAD has
+        # drifted (#832). The default ``"HEAD"`` is rewritten to
+        # ``HEAD:<branch>`` so the lease push and the initial push behave
+        # consistently when no explicit refspec is given.
+        lease_push_ref = push_ref if push_ref != "HEAD" else f"HEAD:{branch}"
         return run(
             [
                 "git",
                 "push",
                 f"--force-with-lease={branch}",
                 remote,
-                f"HEAD:{branch}",
+                lease_push_ref,
             ],
             cwd=cwd,
         )
+
+
+def sync_worktree_to_remote_branch(
+    cwd: Path,
+    branch: str,
+    *,
+    remote: str = "origin",
+) -> None:
+    """Reset ``cwd`` to ``<remote>/<branch>`` so the agent starts from the PR head.
+
+    The worktree may have been created from a stale local branch (e.g.
+    ``WorktreeManager`` reused an existing local ref that pointed at the repo's
+    old ``main`` tip from a previous run, never noticing that ``origin/<branch>``
+    has advanced). Before any agent runs in this worktree, we want HEAD to
+    match the PR's actual head on the remote so the agent's commit is built on
+    top of the real PR history.
+
+    This runs in two steps in ``cwd``:
+
+    1. ``git fetch <remote> <branch>`` — updates the remote-tracking ref so the
+       reset has a current target.
+    2. ``git reset --hard <remote>/<branch>`` — moves HEAD to the PR's actual
+       head, discarding any divergent local commits or working-tree edits.
+
+    The worktree is throwaway (the driver removes it after each issue), so
+    ``reset --hard`` is safe here: there is no human work to preserve.
+
+    Args:
+        cwd: Worktree path.
+        branch: Remote branch name (the PR's head).
+        remote: Remote name (default ``origin``).
+
+    Raises:
+        subprocess.CalledProcessError: If either git command fails. Callers
+            should treat this as a hard error — without a synced HEAD the
+            subsequent CI-fix push would land on the wrong base.
+
+    """
+    logger.info("Syncing worktree at %s to %s/%s before agent run", cwd, remote, branch)
+    run(["git", "fetch", remote, branch], cwd=cwd)
+    run(["git", "reset", "--hard", f"{remote}/{branch}"], cwd=cwd)
 
 
 def is_clean_working_tree(repo_root: Path | None = None) -> bool:

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -177,6 +177,7 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
         patch(
             "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
         ) as mock_push,
+        patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch") as mock_sync,
     ):
         result = driver._run_ci_fix_session(
             issue_number=123,
@@ -184,11 +185,17 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
             worktree_path=tmp_path,
             ci_logs="failed",
             session_id="old-session",
+            pr_head_branch="456-pr-head",
         )
 
     assert result is True
     mock_fresh.assert_called_once()
-    mock_push.assert_called_once_with(tmp_path)
+    # Worktree must be reset to the PR's remote head *before* the agent runs
+    # so the fix is committed on top of the real PR history (#832).
+    mock_sync.assert_called_once_with(tmp_path, "456-pr-head")
+    # And the push must target the PR's head branch explicitly — not bare HEAD —
+    # so a Claude-side branch switch cannot route the fix to a stray branch (#832).
+    mock_push.assert_called_once_with(tmp_path, branch="456-pr-head", push_ref="HEAD:456-pr-head")
 
 
 # ---------------------------------------------------------------------------
@@ -771,6 +778,7 @@ class TestNoDeadTempfile:
                 worktree_path=tmp_path,
                 ci_logs="",
                 session_id=None,
+                pr_head_branch="some-branch",
             )
 
         txt_files = list(tmp_path.glob("*.txt"))

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -17,6 +17,7 @@ from hephaestus.automation.git_utils import (
     push_current_branch_with_lease_on_divergence,
     run,
     safe_git_fetch,
+    sync_worktree_to_remote_branch,
 )
 
 
@@ -404,3 +405,80 @@ class TestPushCurrentBranchWithLeaseOnDivergence:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             push_current_branch_with_lease_on_divergence(worktree, branch="511-impl")
         assert exc_info.value.stderr == "stale info\n"
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_explicit_push_ref_used_on_initial_push(self, mock_run: Any) -> None:
+        """When push_ref is set, the initial push uses it as the refspec (#832)."""
+        # Without this, a Claude-side branch switch would route the push to a
+        # stray branch instead of the PR's head.
+        mock_run.return_value = Mock(returncode=0)
+        worktree = Path("/tmp/worktree-xyz")
+
+        push_current_branch_with_lease_on_divergence(
+            worktree, branch="5391-auto-impl", push_ref="HEAD:5391-auto-impl"
+        )
+
+        args, _ = mock_run.call_args
+        assert args[0] == ["git", "push", "origin", "HEAD:5391-auto-impl"]
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_explicit_push_ref_preserved_in_lease_retry(self, mock_run: Any) -> None:
+        """The lease-retry path must use the same explicit push_ref (#832)."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "origin", "HEAD:5391-auto-impl"],
+            output="",
+            stderr="non-fast-forward\n",
+        )
+        mock_run.side_effect = [push_err, Mock(returncode=0), Mock(returncode=0)]
+
+        push_current_branch_with_lease_on_divergence(
+            worktree, branch="5391-auto-impl", push_ref="HEAD:5391-auto-impl"
+        )
+
+        # 3rd call must be the lease push using the explicit refspec.
+        lease_args, _ = mock_run.call_args_list[2]
+        assert lease_args[0] == [
+            "git",
+            "push",
+            "--force-with-lease=5391-auto-impl",
+            "origin",
+            "HEAD:5391-auto-impl",
+        ]
+
+
+class TestSyncWorktreeToRemoteBranch:
+    """Tests for sync_worktree_to_remote_branch (#832 — reset before agent)."""
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_fetches_then_resets_to_remote_head(self, mock_run: Any) -> None:
+        """Runs ``git fetch origin <branch>`` then ``git reset --hard origin/<branch>``."""
+        mock_run.return_value = Mock(returncode=0)
+        worktree = Path("/tmp/worktree-xyz")
+
+        sync_worktree_to_remote_branch(worktree, "5450-auto-impl")
+
+        assert mock_run.call_count == 2
+        fetch_args, fetch_kwargs = mock_run.call_args_list[0]
+        assert fetch_args[0] == ["git", "fetch", "origin", "5450-auto-impl"]
+        assert fetch_kwargs["cwd"] == worktree
+        reset_args, reset_kwargs = mock_run.call_args_list[1]
+        assert reset_args[0] == ["git", "reset", "--hard", "origin/5450-auto-impl"]
+        assert reset_kwargs["cwd"] == worktree
+
+    @patch("hephaestus.automation.git_utils.run")
+    def test_fetch_failure_propagates(self, mock_run: Any) -> None:
+        """If fetch fails, raise — we cannot safely reset to a stale ref."""
+        fetch_err = subprocess.CalledProcessError(
+            128,
+            ["git", "fetch"],
+            output="",
+            stderr="fatal: unable to access remote\n",
+        )
+        mock_run.side_effect = [fetch_err]
+
+        with pytest.raises(subprocess.CalledProcessError):
+            sync_worktree_to_remote_branch(Path("/tmp/worktree-xyz"), "any-branch")
+        # Reset must NOT have run after a fetch failure.
+        assert mock_run.call_count == 1


### PR DESCRIPTION
## Summary

The CI-fix push was using a bare `git push origin HEAD` and silently sending fixes to the wrong remote branch. In yesterday's ecosystem run the driver logged \"pushed CI fixes for PR #5483\" while PR #5483 was never updated on GitHub — a stray `5391-fix-ci` branch was created instead of `5391-auto-impl` (the PR's actual head). Same pattern repeated for at least 11 PRs across ProjectOdyssey/ProjectKeystone/Odysseus.

Two compounding bugs:

1. **Agent switched branches locally.** The CI-fix prompt told the agent to commit, but did not pin it to the worktree's branch. The agent followed `CLAUDE.md`'s general \"git checkout -b <issue-number>-description\" workflow, switched to a new branch, and committed there. `git push origin HEAD` then went to that new branch name.

2. **Worktree was on the wrong base.** `WorktreeManager` reuses any matching local branch ref. That local ref often pointed at the repo's old `main` tip and was many commits behind `origin/<pr-head>`. Even with the agent on the right branch, its fix was committed on top of the wrong base.

## Fix

Programmatic, two layers (the user explicitly asked for the worktree to be put on the correct ref BEFORE launching Claude):

- **Before the agent runs** — new helper `sync_worktree_to_remote_branch(worktree, branch)` does `git fetch origin <branch>` then `git reset --hard origin/<branch>`. Safe because the worktree is throwaway. Called as the first step of `_run_ci_fix_session`.
- **When the agent's session returns** — push with an explicit refspec `HEAD:<pr-head-branch>` so the push lands on the named remote branch regardless of where HEAD points locally. `push_current_branch_with_lease_on_divergence` gets a new `push_ref` parameter; the lease-retry path preserves the explicit refspec.

The prompt also gains an explicit \"Current branch (DO NOT change): <branch>\" line and forbids `git checkout -b` / `git switch -c` — belt-and-suspenders, since the explicit refspec is the load-bearing fix.

## Test plan

- [x] `pytest tests/unit/automation` (930 passed)
- [x] `pytest tests/unit/automation/test_git_utils.py tests/unit/automation/test_ci_driver.py` (66 passed)
- [x] New `TestSyncWorktreeToRemoteBranch`: fetch + reset --hard sequence, fetch-failure propagates without reset
- [x] New `test_explicit_push_ref_used_on_initial_push`: initial push uses `HEAD:<branch>` when `push_ref` is set
- [x] New `test_explicit_push_ref_preserved_in_lease_retry`: lease retry uses the same explicit refspec
- [x] Updated `test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure` to assert sync and explicit-refspec push
- [x] `ruff check` clean, `pre-commit run` clean (auto-format applied; re-tested green)

Closes #832