### PR TITLE
fix(automation/ci_driver): dedupe shared PRs at discovery to avoid worktree collisions

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -166,23 +166,62 @@ class CIDriver:
         return results
 
     def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:
-        """Pre-discover open PRs for all issues.
+        """Pre-discover open PRs for all issues, deduped by PR.
+
+        When a single PR closes multiple issues (a legitimate ``pr-policy``
+        configuration — audit rollups, dependency bumps that cover several
+        CVEs, etc.), every one of those issues resolves to the same PR. The
+        downstream worker loop would then race N threads to check the same
+        branch out into N different worktree paths, and ``git worktree add``
+        rejects all but the first because a branch can only be checked out
+        once. The losers were marked CI-failed even though the PR was being
+        driven correctly by the first issue (#834).
+
+        We dedupe at discovery time: keep one canonical issue per PR (the
+        lowest-numbered, for deterministic ordering and stable logs), and
+        defer the others.
 
         Args:
             issue_numbers: Issue numbers to check
 
         Returns:
-            Mapping of issue_number -> pr_number for issues that have an open PR
+            Mapping of canonical_issue_number -> pr_number, with at most one
+            entry per PR.
 
         """
-        pr_map: dict[int, int] = {}
+        # Per-issue lookup first; preserve insertion order so the "lowest
+        # numbered issue wins" tie-break is stable across runs given the same
+        # input list.
+        raw_map: dict[int, int] = {}
         for issue_num in issue_numbers:
             pr_number = self._find_pr_for_issue(issue_num)
             if pr_number is not None:
-                pr_map[issue_num] = pr_number
+                raw_map[issue_num] = pr_number
             else:
                 logger.info("Issue #%s: no open PR found, skipping", issue_num)
-        return pr_map
+
+        # Group by PR, then pick a canonical issue per PR (the smallest one)
+        # and log the deferred siblings so operators can see the dedupe.
+        pr_to_issues: dict[int, list[int]] = {}
+        for issue_num, pr_num in raw_map.items():
+            pr_to_issues.setdefault(pr_num, []).append(issue_num)
+
+        deduped: dict[int, int] = {}
+        for pr_num, issues in pr_to_issues.items():
+            canonical = min(issues)
+            deduped[canonical] = pr_num
+            if len(issues) > 1:
+                deferred = sorted(i for i in issues if i != canonical)
+                logger.info(
+                    "PR #%s closes multiple issues %s; driving via issue #%s, "
+                    "deferring %s (single PR cannot be checked out into multiple "
+                    "worktrees concurrently)",
+                    pr_num,
+                    sorted(issues),
+                    canonical,
+                    deferred,
+                )
+        return deduped
 
     def _drive_issue(  # noqa: C901  # poll loop + required-check classification + fix path
         self, issue_number: int, pr_number: int, slot_id: int

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -199,6 +199,53 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
 
 
 # ---------------------------------------------------------------------------
+# _discover_prs: dedupe shared-PR
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPrsDedupe:
+    """Tests for #834: PRs that close multiple issues are processed once."""
+
+    def test_single_issue_per_pr_unchanged(self, driver: CIDriver) -> None:
+        """The 1:1 mapping case is unchanged: every input issue resolves to a PR."""
+        with patch.object(driver, "_find_pr_for_issue", side_effect=[100, 101, 102]):
+            result = driver._discover_prs([1, 2, 3])
+        assert result == {1: 100, 2: 101, 3: 102}
+
+    def test_multiple_issues_one_pr_collapses_to_lowest(self, driver: CIDriver) -> None:
+        """Nine issues → same PR → result has one entry keyed by the lowest issue (#834)."""
+        # Reproduces the ProjectNestor failure: PR #103 closes nine issues.
+        # Without dedupe the driver would race nine workers against the same
+        # branch and the eight losers would fail `git worktree add`.
+        with patch.object(
+            driver,
+            "_find_pr_for_issue",
+            side_effect=[103] * 9,
+        ):
+            result = driver._discover_prs([64, 59, 39, 37, 29, 28, 23, 22, 12])
+
+        assert result == {12: 103}
+
+    def test_mixed_shared_and_unique_prs(self, driver: CIDriver) -> None:
+        """Mix of shared and unique PRs: each PR appears once, shared via lowest issue."""
+        # 1,2 → PR 100 (shared); 3 → PR 200 (unique); 4,5 → PR 300 (shared)
+        with patch.object(
+            driver,
+            "_find_pr_for_issue",
+            side_effect=[100, 100, 200, 300, 300],
+        ):
+            result = driver._discover_prs([1, 2, 3, 4, 5])
+        assert result == {1: 100, 3: 200, 4: 300}
+
+    def test_no_pr_skipped_separately_from_shared(self, driver: CIDriver) -> None:
+        """Issues with no PR are dropped; remaining issues still get deduped."""
+        # 1 → PR 100; 2 → no PR; 3 → PR 100 (shared with 1)
+        with patch.object(driver, "_find_pr_for_issue", side_effect=[100, None, 100]):
+            result = driver._discover_prs([1, 2, 3])
+        assert result == {1: 100}
+
+
+# ---------------------------------------------------------------------------
 # _drive_issue: no PR found
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

When a single PR closes multiple issues (a perfectly valid `pr-policy` config — audit rollup PRs, dependency bumps that cover several CVEs, etc.), every one of those issues resolves to the same PR. The downstream worker loop then races N threads to check the PR's head branch out into N different worktree paths, and `git worktree add` rejects all-but-the-first because a branch can only be checked out once. The losers were marked CI-failed even though the PR was being driven correctly by the first issue.

In ecosystem run `20260531T085744Z` against ProjectNestor, PR #103 closed nine issues. The driver attempted `git worktree add` for branch `12-impl` nine times in parallel and eight failed with:

```
fatal: '12-impl' is already used by worktree at '.../issue-65'
```

The ProjectNestor repo was marked failed despite #18 (and others) succeeding cleanly on their own PRs.

## Fix

`_discover_prs` now groups by PR, picks the lowest-numbered issue as canonical (deterministic ordering / stable logs), and logs the deferred siblings. The downstream loop is unchanged — it just sees one entry per PR instead of N.

## Test plan

- [x] `pytest tests/unit/automation/test_ci_driver.py` (41 passed)
- [x] New `TestDiscoverPrsDedupe`: 4 cases
  - `test_single_issue_per_pr_unchanged` — happy path preserved
  - `test_multiple_issues_one_pr_collapses_to_lowest` — repro of the ProjectNestor scenario (9 issues → 1 entry keyed by lowest issue)
  - `test_mixed_shared_and_unique_prs` — interleaved sharing
  - `test_no_pr_skipped_separately_from_shared` — `None` returns from `_find_pr_for_issue` still drop the issue cleanly
- [x] `pre-commit run` clean (ruff + mypy + bandit)

Closes #834