### PR TITLE
fix(automation/ci_driver): don't claim success when agent makes no commit

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -41,6 +41,7 @@ from .git_utils import (
     issue_ref,
     pr_ref,
     push_current_branch_with_lease_on_divergence,
+    run,
     sync_worktree_to_remote_branch,
 )
 from .github_api import _gh_call, gh_issue_json, gh_pr_checks
@@ -628,6 +629,50 @@ class CIDriver:
             logger.warning("Could not load session_id for issue #%s: %s", issue_number, e)
             return None
 
+    def _head_advanced(
+        self,
+        worktree_path: Path,
+        pre_agent_sha: str,
+        issue_number: int,
+    ) -> bool:
+        """Return True iff HEAD has moved past ``pre_agent_sha`` after the agent ran.
+
+        Called between the agent session and the push to detect the
+        no-commit-made case (#836). When ``pre_agent_sha`` still matches HEAD
+        the agent did not commit anything, so a force-with-lease push of
+        HEAD:<branch> would be a silent 0-exit no-op and the driver would
+        falsely log "pushed CI fixes". We instead log a warning and return
+        False so the iteration counts as failed.
+
+        Args:
+            worktree_path: Worktree to inspect.
+            pre_agent_sha: HEAD SHA captured right after the pre-agent sync.
+            issue_number: For log context.
+
+        Returns:
+            True if HEAD moved (something to push); False if it did not (or
+            if reading HEAD failed — we treat that as "don't push" too).
+
+        """
+        try:
+            post_agent_sha = run(["git", "rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: failed to read HEAD after CI fix session: %s",
+                issue_number,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return False
+        if post_agent_sha == pre_agent_sha:
+            logger.warning(
+                "Issue #%s: agent session produced no new commit (HEAD unchanged "
+                "at %s); skipping push and treating iteration as failed",
+                issue_number,
+                pre_agent_sha[:8],
+            )
+            return False
+        return True
+
     def _run_ci_fix_session(  # noqa: C901  # provider resume/fallback paths are intentionally coupled
         self,
         issue_number: int,
@@ -670,6 +715,21 @@ class CIDriver:
                 "Issue #%s: failed to sync worktree to origin/%s before CI fix: %s",
                 issue_number,
                 pr_head_branch,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return False
+
+        # Snapshot HEAD immediately after the sync. The push helper exits 0
+        # silently when HEAD == origin/<branch> (nothing to push), so without
+        # this guard we logged "pushed CI fixes" for sessions that returned
+        # without committing — the remote was unchanged but the driver
+        # claimed success (#836). The post-agent HEAD is compared below.
+        try:
+            pre_agent_sha = run(["git", "rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: failed to snapshot HEAD before CI fix session: %s",
+                issue_number,
                 (exc.stderr or exc.stdout or "")[:300],
             )
             return False
@@ -740,6 +800,8 @@ class CIDriver:
                     )
                     return False
 
+                if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):
+                    return False
                 try:
                     push_current_branch_with_lease_on_divergence(
                         worktree_path,
@@ -788,6 +850,8 @@ class CIDriver:
 
             if claude_result.returncode == 0:
                 # Push the fixes
+                if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):
+                    return False
                 try:
                     push_current_branch_with_lease_on_divergence(
                         worktree_path,

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -167,6 +167,12 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
         stderr="session not found",
     )
     fresh_result = AgentRunResult(stdout="fixed", stderr="", session_id="fresh-session")
+    # rev-parse HEAD returns SHA_PRE first (snapshot before agent) then SHA_POST
+    # (after agent) — a non-zero SHA delta proves the agent committed.
+    pre_post_sequence = [
+        MagicMock(stdout="aaaa1111\n"),
+        MagicMock(stdout="bbbb2222\n"),
+    ]
 
     with (
         patch("hephaestus.automation.ci_driver.resume_codex_session", side_effect=resume_error),
@@ -178,6 +184,7 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
             "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
         ) as mock_push,
         patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch") as mock_sync,
+        patch("hephaestus.automation.ci_driver.run", side_effect=pre_post_sequence),
     ):
         result = driver._run_ci_fix_session(
             issue_number=123,
@@ -196,6 +203,46 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
     # And the push must target the PR's head branch explicitly — not bare HEAD —
     # so a Claude-side branch switch cannot route the fix to a stray branch (#832).
     mock_push.assert_called_once_with(tmp_path, branch="456-pr-head", push_ref="HEAD:456-pr-head")
+
+
+def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
+    driver: CIDriver,
+    tmp_path: Path,
+) -> None:
+    """Agent returned without committing → no push, no false success log (#836)."""
+    driver.options.agent = "codex"
+    fresh_result = AgentRunResult(stdout="no changes needed", stderr="", session_id="x")
+    # Pre and post snapshots return the SAME SHA → agent made no commit.
+    unchanged_sha = MagicMock(stdout="cafef00d\n")
+
+    with (
+        patch(
+            "hephaestus.automation.ci_driver.run_codex_session",
+            return_value=fresh_result,
+        ),
+        patch(
+            "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+        ) as mock_push,
+        patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch"),
+        patch(
+            "hephaestus.automation.ci_driver.run",
+            side_effect=[unchanged_sha, unchanged_sha],
+        ),
+    ):
+        result = driver._run_ci_fix_session(
+            issue_number=789,
+            pr_number=101,
+            worktree_path=tmp_path,
+            ci_logs="failed",
+            session_id=None,
+            pr_head_branch="789-impl",
+        )
+
+    # The iteration must report failure rather than a bogus success.
+    assert result is False
+    # And we must NOT have attempted a push — the prior bug was that a silent
+    # no-op push exited 0 and the driver logged "pushed CI fixes" anyway.
+    mock_push.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After the pre-sync added in #832 the worktree's HEAD matches `origin/<branch>`. If the agent returns without committing — session resumed an old transcript that already \"fixed\" the PR, model decided nothing was wrong, session timed out before committing, etc. — HEAD remains equal to `origin/<branch>`. The subsequent `git push --force-with-lease=<branch> origin HEAD:<branch>` is a **silent 0-exit no-op**, and the driver was logging `pushed CI fixes for PR #N / CI fix applied successfully` while the remote PR was unchanged.

In ecosystem run `20260531T085744Z` against ProjectOdyssey the driver claimed to push fixes for 11 PRs but every remote branch tip stayed at yesterday's SHA. The success path was vacuous.

## Fix

Snapshot HEAD immediately after the sync. After the agent returns, compare HEAD again before pushing. If HEAD did not advance:

- Log: `agent session produced no new commit (HEAD unchanged at <sha>); skipping push and treating iteration as failed`
- Return `False` from `_run_ci_fix_session` — the iteration counts as failed, no push is attempted, no success line is logged.

A new `_head_advanced(worktree, pre_agent_sha, issue_number)` helper centralises the post-agent comparison so the codex and Claude branches behave identically.

The push helper itself is unchanged; the guard sits entirely in the driver.

## Test plan

- [x] `pytest tests/unit/automation` (931 passed)
- [x] New `test_codex_ci_fix_session_skips_push_when_head_did_not_advance` — HEAD pre/post SHAs equal → returns `False`, push NOT called
- [x] Updated `test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure` to mock `run` returning a moving SHA (so push IS called as before)
- [x] `pre-commit run` clean

Closes #836