### PR TITLE
fix(automation/session_naming): drop githash from automation-loop sessions

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -58,7 +58,7 @@ from .github_api import (
 )
 from .models import AddressReviewOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_address_review_prompt
-from .session_naming import AGENT_IMPLEMENTER, current_trunk_githash
+from .session_naming import AGENT_IMPLEMENTER
 from .status_tracker import StatusTracker  # noqa: F401 — re-exported for test patching
 from .worktree_manager import WorktreeManager  # noqa: F401 — re-exported for test patching
 
@@ -176,13 +176,11 @@ def run_address_fix_session(
             )
             return parsed
 
-        githash = current_trunk_githash(repo_root)
         repo_slug = get_repo_slug(repo_root)
         stdout, _ = invoke_claude_with_session(
             repo=repo_slug,
             issue=issue_number,
             agent=AGENT_IMPLEMENTER,
-            githash=githash,
             prompt=prompt,
             model=implementer_model(),
             cwd=worktree_path,

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -48,7 +48,7 @@ from .git_utils import (
 from .github_api import _gh_call, gh_issue_json, gh_pr_checks
 from .models import CIDriverOptions, WorkerResult
 from .prompts import get_advise_prompt
-from .session_naming import AGENT_ADVISE, AGENT_CI_DRIVER, current_trunk_githash
+from .session_naming import AGENT_ADVISE, AGENT_CI_DRIVER
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
@@ -514,13 +514,11 @@ class CIDriver:
                     sandbox="read-only",
                 )
                 return (result.stdout or "").strip()
-            githash = current_trunk_githash(self.repo_root)
             repo_slug = get_repo_slug(self.repo_root)
             stdout, _ = invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,
                 agent=AGENT_ADVISE,
-                githash=githash,
                 prompt=prompt,
                 model=advise_model(),
                 cwd=self.repo_root,
@@ -958,14 +956,12 @@ class CIDriver:
             # independent of the implementer's transcript. The first fix call
             # creates it via --session-id; later calls resume it. The codex
             # path above instead resumes the raw ``session_id`` it was handed.
-            githash = current_trunk_githash(self.repo_root)
             repo_slug = get_repo_slug(self.repo_root)
             try:
                 stdout, _ = invoke_claude_with_session(
                     repo=repo_slug,
                     issue=issue_number,
                     agent=AGENT_CI_DRIVER,
-                    githash=githash,
                     prompt=prompt,
                     model=implementer_model(),
                     cwd=worktree_path,
@@ -1114,7 +1110,6 @@ class CIDriver:
             "Do NOT create files under .claude-plugin/ in this repo."
         )
         try:
-            githash = current_trunk_githash(self.repo_root)
             repo_slug = get_repo_slug(self.repo_root)
             # Resume from the SAME worktree the fix session used: the Session 3
             # transcript is probed by cwd (session_jsonl_path), so a different
@@ -1124,7 +1119,6 @@ class CIDriver:
                 repo=repo_slug,
                 issue=issue_number,
                 agent=AGENT_CI_DRIVER,
-                githash=githash,
                 prompt=prompt,
                 model=learn_model(),
                 cwd=worktree_path,

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -57,7 +57,6 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
     repo: str,
     issue: int | str,
     agent: str,
-    githash: str,
     prompt: str,
     model: str,
     cwd: Path,
@@ -72,14 +71,17 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
 ) -> tuple[str, str]:
     """Invoke Claude with a deterministic session.
 
-    First call for the ``(repo, issue, agent, githash)`` tuple uses
+    First call for the ``(repo, issue, agent)`` tuple uses
     ``--session-id <uuid>`` to create the session. Every later call uses
-    ``--resume <uuid>``. By default any ``--resume`` failure retries once
-    with ``--session-id`` to recreate; quota-cap detection happens one
-    layer up. Pass ``recreate_on_resume_failure=False`` to propagate the
-    ``CalledProcessError`` instead — needed by callers that must apply
-    their own session-expired classification (e.g. the impl review-loop
-    feedback path stops iterating on expiry rather than restarting).
+    ``--resume <uuid>``. The session is scoped to the artifact (issue/PR),
+    not to a commit SHA, so the transcript persists across main-bumps for
+    the entire lifetime of the issue (#841). By default any ``--resume``
+    failure retries once with ``--session-id`` to recreate; quota-cap
+    detection happens one layer up. Pass ``recreate_on_resume_failure=False``
+    to propagate the ``CalledProcessError`` instead — needed by callers
+    that must apply their own session-expired classification (e.g. the
+    impl review-loop feedback path stops iterating on expiry rather than
+    restarting).
 
     Args:
         repo: Repository slug (e.g. ``"ProjectScylla"``).
@@ -87,7 +89,6 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
             :func:`session_naming.session_name`.
         agent: One of the ``AGENT_*`` constants in
             :mod:`hephaestus.automation.session_naming`.
-        githash: Short trunk SHA for the loop iteration.
         prompt: Prompt text. Passed as a positional argv unless
             ``input_via_stdin`` is True.
         model: ``--model`` value (use ``planner_model()`` /
@@ -124,7 +125,7 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
         subprocess.TimeoutExpired: If the call exceeds ``timeout``.
 
     """
-    display_name = session_name(repo, issue, agent, githash)
+    display_name = session_name(repo, issue, agent)
     sid = str(uuid.uuid5(uuid.NAMESPACE_DNS, display_name))
     transcript = session_jsonl_path(sid, cwd)
     should_resume = transcript.exists()

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -826,13 +826,11 @@ class ImplementationPhaseRunner:
                     sandbox="read-only",
                 )
                 return (result.stdout or "").strip()
-            githash = _impl_mod.current_trunk_githash(self.repo_root)
             repo_slug = _impl_mod.get_repo_slug(self.repo_root)
             stdout, _ = _impl_mod.invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,
                 agent=_impl_mod.AGENT_ADVISE,
-                githash=githash,
                 prompt=prompt,
                 model=advise_model(),
                 cwd=self.repo_root,
@@ -1277,14 +1275,12 @@ class ImplementationPhaseRunner:
         # ``recreate_on_resume_failure=False`` propagates the underlying error
         # so we can preserve the "stop iterating on expiry" contract.
         _impl_mod = self._impl_module
-        githash = _impl_mod.current_trunk_githash(self.repo_root)
         repo_slug = _impl_mod.get_repo_slug(self.repo_root)
         try:
             _impl_mod.invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,
                 agent=_impl_mod.AGENT_IMPLEMENTER,
-                githash=githash,
                 prompt=prompt,
                 model=implementer_model(),
                 cwd=worktree_path,
@@ -1553,7 +1549,6 @@ class ImplementationPhaseRunner:
         prompt_file.write_text(prompt)
 
         _impl_mod = self._impl_module
-        githash = _impl_mod.current_trunk_githash(self.repo_root)
         repo_slug = _impl_mod.get_repo_slug(self.repo_root)
 
         try:
@@ -1561,7 +1556,6 @@ class ImplementationPhaseRunner:
                 repo=repo_slug,
                 issue=issue_number,
                 agent=_impl_mod.AGENT_IMPLEMENTER,
-                githash=githash,
                 prompt=prompt,
                 model=implementer_model(),
                 cwd=worktree_path,

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -36,7 +36,7 @@ from .review_state import (
 from .review_state import (
     is_plan_review_go,
 )
-from .session_naming import AGENT_PLAN_REVIEWER, current_trunk_githash
+from .session_naming import AGENT_PLAN_REVIEWER
 from .status_tracker import StatusTracker
 from .work_report import write_work_report
 
@@ -438,14 +438,12 @@ class PlanReviewer:
 
         repo_root = get_repo_root()
         repo = get_repo_slug(repo_root)
-        githash = current_trunk_githash(repo_root)
 
         try:
             stdout, _ = invoke_claude_with_session(
                 repo=repo,
                 issue=issue_number,
                 agent=AGENT_PLAN_REVIEWER,
-                githash=githash,
                 prompt=prompt,
                 model=reviewer_model(),
                 cwd=repo_root,

--- a/hephaestus/automation/planner_claude.py
+++ b/hephaestus/automation/planner_claude.py
@@ -18,7 +18,6 @@ from hephaestus.github.rate_limit import wait_until
 
 from .claude_invoke import invoke_claude_with_session, scan_quota_reset
 from .git_utils import get_repo_root, get_repo_slug
-from .session_naming import current_trunk_githash
 
 if TYPE_CHECKING:
     from .models import PlannerOptions
@@ -84,14 +83,12 @@ class PlannerClaudeRunner:
 
         repo_root = get_repo_root()
         repo = get_repo_slug(repo_root)
-        githash = current_trunk_githash(repo_root)
 
         try:
             stdout, _ = invoke_claude_with_session(
                 repo=repo,
                 issue=issue_number,
                 agent=agent,
-                githash=githash,
                 prompt=prompt,
                 model=model,
                 cwd=repo_root,

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -46,7 +46,7 @@ from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref, p
 from .github_api import _gh_call, fetch_issue_info, gh_pr_review_post
 from .models import ReviewerOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_pr_review_analysis_prompt
-from .session_naming import AGENT_PR_REVIEWER, current_trunk_githash, reviewer_agent
+from .session_naming import AGENT_PR_REVIEWER, reviewer_agent
 from .status_tracker import StatusTracker  # noqa: F401 — re-exported for test patching
 from .worktree_manager import WorktreeManager  # noqa: F401 — re-exported for test patching
 
@@ -218,13 +218,11 @@ def run_pr_review_analysis(
             return parsed
 
         repo_root = get_repo_root()
-        githash = current_trunk_githash(repo_root)
         repo_slug = get_repo_slug(repo_root)
         stdout, _ = invoke_claude_with_session(
             repo=repo_slug,
             issue=issue_number,
             agent=review_agent,
-            githash=githash,
             prompt=prompt,
             model=reviewer_model(),
             cwd=worktree_path,

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -1,13 +1,15 @@
 """Deterministic Claude-session naming for the automation pipeline.
 
-Within a given trunk git SHA, every Claude invocation for the same
-``(repo, issue, agent)`` tuple lands on the SAME Claude CLI session — first
-call creates it via ``--session-id``, every later call resumes it via
-``--resume``. This restores prompt-cache reuse across loop iterations.
+Every Claude invocation for the same ``(repo, issue, agent)`` tuple lands on
+the SAME Claude CLI session — first call creates it via ``--session-id``,
+every later call resumes it via ``--resume``. This restores prompt-cache
+reuse across loop iterations *and* across main-bumps (#841): the artifact
+being worked on is the issue/PR, not the commit at which the loop started,
+so the session must persist as long as the issue does.
 
 Names
 -----
-Human-readable: ``<repo>_<issue>_<agent>_<githash>``
+Human-readable: ``<repo>_<issue>_<agent>``
 
 Session ID (what ``claude --session-id`` accepts):
 ``str(uuid.uuid5(NAMESPACE_DNS, <human-readable>))``
@@ -99,14 +101,19 @@ def _is_valid_agent(agent: str) -> bool:
     return bool(sep) and base in _PER_ITERATION_REVIEWERS and suffix.isdigit()
 
 
-def session_name(repo: str, issue: int | str, agent: str, githash: str) -> str:
+def session_name(repo: str, issue: int | str, agent: str) -> str:
     """Return the human-readable session name.
+
+    The tuple is intentionally **(repo, issue, agent) only** — no githash.
+    The Claude transcript persists across main-bumps so a long-running
+    drive (CI fix loop, planner, implementer) resumes its context whenever
+    the same artifact (issue/PR) is touched again, instead of being
+    discarded every time main advances (#841).
 
     Args:
         repo: Repository slug without owner (e.g. ``"ProjectScylla"``).
         issue: Issue number; leading ``#`` is stripped.
         agent: One of the ``AGENT_*`` constants in this module.
-        githash: Short SHA of the trunk HEAD captured at loop start.
 
     Returns:
         Underscore-joined name suitable for ``claude --name``.
@@ -121,18 +128,17 @@ def session_name(repo: str, issue: int | str, agent: str, githash: str) -> str:
             f"or a per-iteration reviewer token (e.g. 'plan-reviewer-r0')"
         )
     repo_s = repo.strip()
-    githash_s = githash.strip()
-    if not repo_s or not githash_s:
-        raise ValueError("repo and githash must be non-empty")
+    if not repo_s:
+        raise ValueError("repo must be non-empty")
     issue_s = str(issue).lstrip("#").strip()
     if not issue_s:
         raise ValueError("issue must be non-empty")
-    return f"{repo_s}_{issue_s}_{agent}_{githash_s}"
+    return f"{repo_s}_{issue_s}_{agent}"
 
 
-def session_uuid(repo: str, issue: int | str, agent: str, githash: str) -> str:
+def session_uuid(repo: str, issue: int | str, agent: str) -> str:
     """Return the deterministic UUIDv5 session ID for the tuple."""
-    name = session_name(repo, issue, agent, githash)
+    name = session_name(repo, issue, agent)
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
 
 

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -509,10 +509,6 @@ class TestRunAddressFixSessionModuleLevel:
         with (
             patch("hephaestus.automation.address_review.get_repo_slug", return_value="Repo"),
             patch(
-                "hephaestus.automation.address_review.current_trunk_githash",
-                return_value="abc1234",
-            ),
-            patch(
                 "hephaestus.automation.address_review.invoke_claude_with_session",
                 side_effect=_fake_invoke,
             ),

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -733,7 +733,6 @@ class TestDriveGreenLearnings:
                 return_value=("ok", "sid"),
             ) as mock_invoke,
             patch("hephaestus.automation.ci_driver.get_repo_slug", return_value="ProjectX"),
-            patch("hephaestus.automation.ci_driver.current_trunk_githash", return_value="abc1234"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
@@ -756,7 +755,6 @@ class TestDriveGreenLearnings:
                 side_effect=RuntimeError("boom"),
             ),
             patch("hephaestus.automation.ci_driver.get_repo_slug", return_value="ProjectX"),
-            patch("hephaestus.automation.ci_driver.current_trunk_githash", return_value="abc1234"),
         ):
             result = driver._drive_issue(123, 456, 0)
 

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -62,7 +62,6 @@ class TestCreateVsResume:
             repo="R",
             issue=1,
             agent=AGENT_PLANNER,
-            githash="x",
             prompt="hi",
             model="sonnet",
             cwd=cwd,
@@ -72,19 +71,18 @@ class TestCreateVsResume:
         assert "--name" in argv
         assert "--resume" not in argv
         assert out == "ok"
-        assert sid == session_uuid("R", 1, AGENT_PLANNER, "x")
+        assert sid == session_uuid("R", 1, AGENT_PLANNER)
 
     def test_subsequent_call_uses_resume(self, stub_run: MagicMock, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER, "x")
+        sid = session_uuid("R", 1, AGENT_PLANNER)
         _make_existing_jsonl(fake_home, cwd, sid)
 
         invoke_claude_with_session(
             repo="R",
             issue=1,
             agent=AGENT_PLANNER,
-            githash="x",
             prompt="hi",
             model="sonnet",
             cwd=cwd,
@@ -104,7 +102,6 @@ class TestCreateVsResume:
             repo="R",
             issue=1,
             agent=AGENT_PLANNER,
-            githash="x",
             prompt="hi",
             model="sonnet",
             cwd=cwd,
@@ -113,7 +110,6 @@ class TestCreateVsResume:
             repo="R",
             issue=1,
             agent=AGENT_PLAN_REVIEWER,
-            githash="x",
             prompt="hi",
             model="sonnet",
             cwd=cwd,
@@ -127,7 +123,7 @@ class TestSessionExpiredFallback:
     def test_expired_resume_falls_back_to_create(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER, "x")
+        sid = session_uuid("R", 1, AGENT_PLANNER)
         _make_existing_jsonl(fake_home, cwd, sid)
 
         expired_exc = subprocess.CalledProcessError(
@@ -145,7 +141,6 @@ class TestSessionExpiredFallback:
                 repo="R",
                 issue=1,
                 agent=AGENT_PLANNER,
-                githash="x",
                 prompt="hi",
                 model="sonnet",
                 cwd=cwd,
@@ -169,7 +164,7 @@ class TestSessionExpiredFallback:
         """
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER, "x")
+        sid = session_uuid("R", 1, AGENT_PLANNER)
         _make_existing_jsonl(fake_home, cwd, sid)
 
         transient = subprocess.CalledProcessError(
@@ -184,7 +179,6 @@ class TestSessionExpiredFallback:
                 repo="R",
                 issue=1,
                 agent=AGENT_PLANNER,
-                githash="x",
                 prompt="hi",
                 model="sonnet",
                 cwd=cwd,
@@ -209,7 +203,6 @@ class TestSessionExpiredFallback:
                     repo="R",
                     issue=1,
                     agent=AGENT_PLANNER,
-                    githash="x",
                     prompt="hi",
                     model="sonnet",
                     cwd=cwd,
@@ -241,7 +234,6 @@ class TestSessionExpiredFallback:
                 repo="R",
                 issue=1,
                 agent=AGENT_PLANNER,
-                githash="x",
                 prompt="hi",
                 model="sonnet",
                 cwd=cwd,
@@ -266,7 +258,6 @@ class TestArgvAssembly:
             repo="R",
             issue=1,
             agent=AGENT_PLANNER,
-            githash="x",
             prompt="hi",
             model="sonnet",
             cwd=cwd,
@@ -299,7 +290,6 @@ class TestArgvAssembly:
             repo="R",
             issue=1,
             agent=AGENT_PLANNER,
-            githash="x",
             prompt="the-prompt",
             model="sonnet",
             cwd=cwd,
@@ -322,7 +312,6 @@ class TestArgvAssembly:
             repo="R",
             issue=1,
             agent=AGENT_PLANNER,
-            githash="x",
             prompt="hi",
             model="sonnet",
             cwd=cwd,
@@ -337,7 +326,7 @@ class TestRecreateOnResumeFailureToggle:
     def test_propagates_called_process_error(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER, "x")
+        sid = session_uuid("R", 1, AGENT_PLANNER)
         _make_existing_jsonl(fake_home, cwd, sid)
 
         boom = subprocess.CalledProcessError(
@@ -349,7 +338,6 @@ class TestRecreateOnResumeFailureToggle:
                     repo="R",
                     issue=1,
                     agent=AGENT_PLANNER,
-                    githash="x",
                     prompt="hi",
                     model="sonnet",
                     cwd=cwd,
@@ -371,7 +359,7 @@ class TestEndToEndSessionResume:
     def test_create_then_resume_lands_on_same_uuid(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        expected_sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "abc1234")
+        expected_sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
 
         # The first call's mock must write the JSONL on disk to simulate
         # what the real ``claude --session-id`` invocation does.
@@ -390,7 +378,6 @@ class TestEndToEndSessionResume:
                 repo="ProjectScylla",
                 issue=1944,
                 agent=AGENT_PLANNER,
-                githash="abc1234",
                 prompt="iter 0",
                 model="sonnet",
                 cwd=cwd,
@@ -399,7 +386,6 @@ class TestEndToEndSessionResume:
                 repo="ProjectScylla",
                 issue=1944,
                 agent=AGENT_PLANNER,
-                githash="abc1234",
                 prompt="iter 1",
                 model="sonnet",
                 cwd=cwd,
@@ -423,13 +409,20 @@ class TestEndToEndSessionResume:
         assert first_argv[-1] == "iter 0"
         assert second_argv[-1] == "iter 1"
 
-    def test_different_githash_starts_fresh_family(self, fake_home: Path) -> None:
-        """A new trunk SHA must produce a different UUID (fresh session family)."""
+    def test_session_id_is_githash_invariant(self, fake_home: Path) -> None:
+        """The session UUID depends only on (repo, issue, agent) — #841.
+
+        Regression for #841: the prior behavior fed ``current_trunk_githash``
+        into the session-naming tuple, so every main-bump forked a new
+        session family. The whole loop is now PR/issue-scoped: the same
+        (repo, issue, agent) tuple must always resume the same transcript.
+        """
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid_old = session_uuid("R", 1, AGENT_PLANNER, "abc1234")
-        sid_new = session_uuid("R", 1, AGENT_PLANNER, "def5678")
-        _make_existing_jsonl(fake_home, cwd, sid_old)
+        sid_first_call = session_uuid("R", 1, AGENT_PLANNER)
+
+        # Pre-populate the transcript so the call resumes rather than creates.
+        _make_existing_jsonl(fake_home, cwd, sid_first_call)
 
         with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
             m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
@@ -437,16 +430,14 @@ class TestEndToEndSessionResume:
                 repo="R",
                 issue=1,
                 agent=AGENT_PLANNER,
-                githash="def5678",  # new trunk SHA
                 prompt="hi",
                 model="sonnet",
                 cwd=cwd,
             )
 
-        assert returned_sid == sid_new
-        assert returned_sid != sid_old
+        assert returned_sid == sid_first_call
         argv = _argv(m.call_args)
-        # No prior JSONL exists for the new SHA → must --session-id (create), not --resume.
-        assert "--session-id" in argv
-        assert sid_new in argv
-        assert "--resume" not in argv
+        # Existing transcript → resume the same session, never create a new one.
+        assert "--resume" in argv
+        assert sid_first_call in argv
+        assert "--session-id" not in argv

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -532,10 +532,6 @@ class TestRunPrReviewAnalysis:
             patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
             patch("hephaestus.automation.pr_reviewer.get_repo_slug", return_value="Repo"),
             patch(
-                "hephaestus.automation.pr_reviewer.current_trunk_githash",
-                return_value="abc1234",
-            ),
-            patch(
                 "hephaestus.automation.pr_reviewer.invoke_claude_with_session",
                 side_effect=_fake_invoke,
             ),

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -35,14 +35,14 @@ class TestReviewerAgent:
         assert reviewer_agent(AGENT_PR_REVIEWER, 2) == "pr-reviewer-r2"
 
     def test_per_iteration_uuids_differ(self) -> None:
-        u0 = session_uuid("R", 5, reviewer_agent(AGENT_PLAN_REVIEWER, 0), "abc1234")
-        u1 = session_uuid("R", 5, reviewer_agent(AGENT_PLAN_REVIEWER, 1), "abc1234")
+        u0 = session_uuid("R", 5, reviewer_agent(AGENT_PLAN_REVIEWER, 0))
+        u1 = session_uuid("R", 5, reviewer_agent(AGENT_PLAN_REVIEWER, 1))
         assert u0 != u1
 
     def test_suffixed_reviewer_token_is_valid_session_agent(self) -> None:
         # session_name must accept the reviewer_agent() form.
-        name = session_name("R", 5, reviewer_agent(AGENT_PR_REVIEWER, 3), "x")
-        assert name == "R_5_pr-reviewer-r3_x"
+        name = session_name("R", 5, reviewer_agent(AGENT_PR_REVIEWER, 3))
+        assert name == "R_5_pr-reviewer-r3"
 
     def test_rejects_non_reviewer_base(self) -> None:
         with pytest.raises(ValueError, match="reviewer_agent expects"):
@@ -54,72 +54,65 @@ class TestReviewerAgent:
 
     def test_unsuffixed_unknown_still_rejected(self) -> None:
         with pytest.raises(ValueError, match="unknown agent"):
-            session_name("R", 5, "totally-bogus", "x")
+            session_name("R", 5, "totally-bogus")
 
 
 class TestSessionName:
-    """Human-readable session name construction."""
+    """Human-readable session name construction.
+
+    Per #841 the tuple is (repo, issue, agent) — no githash. The transcript
+    persists across main-bumps so resume keeps working as a long-lived
+    artifact is touched again.
+    """
 
     def test_basic(self) -> None:
-        assert (
-            session_name("ProjectScylla", 1944, AGENT_PLANNER, "abc1234")
-            == "ProjectScylla_1944_planner_abc1234"
-        )
+        assert session_name("ProjectScylla", 1944, AGENT_PLANNER) == "ProjectScylla_1944_planner"
 
     def test_strips_hash_prefix_from_issue(self) -> None:
-        assert session_name("R", "#42", AGENT_PLANNER, "x") == "R_42_planner_x"
+        assert session_name("R", "#42", AGENT_PLANNER) == "R_42_planner"
 
     def test_int_and_str_issue_equivalent(self) -> None:
-        assert session_name("R", 42, AGENT_PLANNER, "x") == session_name(
-            "R", "42", AGENT_PLANNER, "x"
-        )
+        assert session_name("R", 42, AGENT_PLANNER) == session_name("R", "42", AGENT_PLANNER)
 
     def test_unknown_agent_raises(self) -> None:
         with pytest.raises(ValueError, match="unknown agent"):
-            session_name("R", 1, "wizard", "x")
+            session_name("R", 1, "wizard")
 
     @pytest.mark.parametrize(
-        ("repo", "issue", "gh"),
-        [("", 1, "x"), ("R", 1, ""), ("R", "", "x")],
+        ("repo", "issue"),
+        [("", 1), ("R", "")],
     )
-    def test_empty_components_raise(self, repo: str, issue: int | str, gh: str) -> None:
+    def test_empty_components_raise(self, repo: str, issue: int | str) -> None:
         with pytest.raises(ValueError):
-            session_name(repo, issue, AGENT_PLANNER, gh)
+            session_name(repo, issue, AGENT_PLANNER)
 
     def test_whitespace_stripped(self) -> None:
-        assert session_name("  R  ", 1, AGENT_PLANNER, "  abc  ") == "R_1_planner_abc"
+        assert session_name("  R  ", 1, AGENT_PLANNER) == "R_1_planner"
 
 
 class TestSessionUUID:
-    """Deterministic UUIDv5 derivation from (repo, issue, agent, githash)."""
+    """Deterministic UUIDv5 derivation from (repo, issue, agent)."""
 
     def test_deterministic(self) -> None:
-        a = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "abc1234")
-        b = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "abc1234")
+        a = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
+        b = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
         assert a == b
 
     def test_returns_valid_uuid(self) -> None:
-        sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "abc1234")
+        sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
         # uuid.UUID raises ValueError on invalid input.
         uuid.UUID(sid)
 
     def test_different_agent_different_uuid(self) -> None:
-        a = session_uuid("R", 1, AGENT_PLANNER, "x")
-        b = session_uuid("R", 1, AGENT_PLAN_REVIEWER, "x")
+        a = session_uuid("R", 1, AGENT_PLANNER)
+        b = session_uuid("R", 1, AGENT_PLAN_REVIEWER)
         assert a != b
 
     def test_different_repo_different_uuid(self) -> None:
-        assert session_uuid("R1", 1, AGENT_PLANNER, "x") != session_uuid(
-            "R2", 1, AGENT_PLANNER, "x"
-        )
+        assert session_uuid("R1", 1, AGENT_PLANNER) != session_uuid("R2", 1, AGENT_PLANNER)
 
     def test_different_issue_different_uuid(self) -> None:
-        assert session_uuid("R", 1, AGENT_PLANNER, "x") != session_uuid("R", 2, AGENT_PLANNER, "x")
-
-    def test_different_githash_different_uuid(self) -> None:
-        assert session_uuid("R", 1, AGENT_PLANNER, "abc1234") != session_uuid(
-            "R", 1, AGENT_PLANNER, "def5678"
-        )
+        assert session_uuid("R", 1, AGENT_PLANNER) != session_uuid("R", 2, AGENT_PLANNER)
 
     def test_each_agent_constant_yields_distinct_uuid(self) -> None:
         agents = [
@@ -132,8 +125,23 @@ class TestSessionUUID:
             AGENT_ADDRESS_REVIEW,
             AGENT_CI_DRIVER,
         ]
-        uuids = {session_uuid("R", 1, a, "x") for a in agents}
+        uuids = {session_uuid("R", 1, a) for a in agents}
         assert len(uuids) == len(agents)
+
+    def test_signature_does_not_accept_githash_kw(self) -> None:
+        """Regression for #841: passing a githash kwarg must be a TypeError.
+
+        The whole point of #841 is that the session id is a function of the
+        artifact (repo, issue, agent) only — never a commit. If a caller
+        sneaks ``githash=`` back into ``invoke_claude_with_session``, that
+        kwarg would silently end up here and produce a different UUID per
+        main-bump. Making the function refuse the kwarg outright keeps the
+        invariant load-bearing rather than aspirational.
+        """
+        with pytest.raises(TypeError):
+            session_uuid("R", 1, AGENT_PLANNER, githash="abc1234")  # type: ignore[call-arg]
+        with pytest.raises(TypeError):
+            session_name("R", 1, AGENT_PLANNER, githash="abc1234")  # type: ignore[call-arg]
 
 
 class TestShortGithash:
@@ -185,7 +193,7 @@ class TestSessionJsonlPath:
         assert p.parent.parent == tmp_path / ".claude" / "projects"
 
     def test_uuid_in_filename(self, tmp_path: Path) -> None:
-        sid = session_uuid("R", 1, AGENT_IMPLEMENTER, "abc1234")
+        sid = session_uuid("R", 1, AGENT_IMPLEMENTER)
         p = session_jsonl_path(sid, tmp_path)
         assert p.name == f"{sid}.jsonl"
 


### PR DESCRIPTION
## Summary

Every agent in the pipeline (planner, plan_reviewer, implementer, address_review, pr_reviewer, ci_driver) fed the live `current_trunk_githash` into the session-naming tuple. The deterministic UUID changed whenever `main` advanced, so each main-bump forked a fresh session family and ``invoke_claude_with_session`` fell back to a ``--session-id`` create rather than ``--resume``-ing the prior session.

For the whole automation loop this is the wrong scope: the long-lived artifact is the issue/PR, not the commit at which the loop happened to start. The same (repo, issue, agent) tuple should resolve to the same session id across every iteration, every run, and every main-bump for as long as the artifact exists.

## Changes

- ``session_name`` and ``session_uuid`` in ``session_naming.py``: ``githash`` parameter removed.
- ``invoke_claude_with_session`` in ``claude_invoke.py``: ``githash`` parameter removed.
- All 8 call sites updated: ``planner_claude``, ``plan_reviewer``, ``pr_reviewer``, ``address_review``, ``implementer_phase_runner`` (3 sites), ``ci_driver`` (3 sites).
- Unused ``current_trunk_githash`` imports removed from those modules. The helper itself is kept for callers that still need a trunk-SHA observation for non-session purposes (logging, state files).
- A new regression test (`test_signature_does_not_accept_githash_kw`) makes ``githash=`` a hard ``TypeError`` so the invariant cannot silently regress via a future caller.

## Risk and mitigations

Three already-landed fixes bound the staleness risk:

- **#823 (dot-encoding fix)**: made ``--resume`` reliable in the first place.
- **#832 (worktree pre-sync)**: every iteration starts from the PR's actual remote head so the workspace state always matches live.
- **#836 (no-commit guard)**: confused-resume produces an honest failure instead of a silent no-op push.

Together these turn the staleness concern into "the session has more context than the current state, occasionally" — which is the desired property, since the alternative was "the session has zero context every time main moves".

## Test plan

- [x] `pytest tests/unit/automation` (938 passed)
- [x] Updated `test_session_naming.py` to drop the githash positional, kept all distinctness assertions, added the kwarg-rejection regression test.
- [x] Updated `test_claude_invoke_session.py`: replaced `test_different_githash_starts_fresh_family` with `test_session_id_is_githash_invariant` (the inverse assertion).
- [x] Updated `test_pr_reviewer_posting.py` and `test_address_review.py` to drop now-irrelevant `current_trunk_githash` patches.
- [x] Updated `test_ci_driver.py` to drop two `current_trunk_githash` patches that referenced the removed import.
- [x] `pre-commit run` clean (ruff format auto-applied; re-tested green).

Closes #841