### PR TITLE
fix(automation/ci_driver): /learn on detected merge with per-issue arming state

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -85,6 +85,12 @@ class CIDriver:
         # after the per-issue drive completes. The repo is only "done" when
         # this is empty (#838).
         self.open_prs_remaining: list[dict[str, Any]] = []
+        # Populated by _discover_prs: maps pr_number -> ALL issues that
+        # resolved to that PR. Used when arming /learn for the success path
+        # so every sibling issue covered by a multi-issue PR gets its own
+        # arming record (and therefore its own /learn capture once the PR
+        # actually merges in a subsequent run). #840 +on top of #834.
+        self.shared_pr_issues: dict[int, list[int]] = {}
 
     def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # thread pool + finally + preserve report
         """Run the CI driver on all configured issues.
@@ -306,6 +312,13 @@ class CIDriver:
         for issue_num, pr_num in raw_map.items():
             pr_to_issues.setdefault(pr_num, []).append(issue_num)
 
+        # Stash the full PR→[issues] map so the success path (#840) can write
+        # an arming record for *every* sibling issue when a shared-PR group
+        # auto-merge-arms. Without this, only the canonical issue would ever
+        # get its post-merge ``/learn`` capture; the other N-1 deferred
+        # issues would silently lose their lessons.
+        self.shared_pr_issues = {pr: sorted(issues) for pr, issues in pr_to_issues.items()}
+
         deduped: dict[int, int] = {}
         for pr_num, issues in pr_to_issues.items():
             canonical = min(issues)
@@ -352,6 +365,16 @@ class CIDriver:
         _ci_poll_max_wait: int = int(os.environ.get("HEPH_CI_POLL_MAX_WAIT", "600"))
 
         try:
+            # Detected-merge / armed-state short-circuit (#840). If a prior
+            # run armed this issue's PR and GitHub now reports it MERGED,
+            # capture /learn once and return. If it's still OPEN at the
+            # armed SHA, no further drive work is needed. Falls through to
+            # the normal drive only when there's no record, the arming is
+            # stale, or the PR was abandoned without merging.
+            armed_result = self._check_arming_on_drive_start(issue_number, pr_number)
+            if armed_result is not None:
+                return armed_result
+
             self.status_tracker.update_slot(
                 acquired_slot, f"{issue_ref(issue_number)}: fetching checks"
             )
@@ -442,13 +465,20 @@ class CIDriver:
                     )
                 merge_ok = self._enable_auto_merge(pr_number)
                 if merge_ok:
-                    # PR is green and auto-merge is enabled — capture drive-green
-                    # learnings under AGENT_CI_DRIVER (Session 3). Non-fatal:
-                    # a failed learnings step must not flip the drive to failure.
+                    # PR is green and auto-merge is enabled — but do NOT
+                    # capture /learn here (#840). Auto-merge-armed is not
+                    # the same as merged: CI flake, branch-protection block,
+                    # human cancellation can still keep the PR open. Instead
+                    # write an arming record per sibling issue (#834) and
+                    # let the NEXT run's _check_arming_on_drive_start fire
+                    # /learn once GitHub reports the PR as MERGED.
                     self.status_tracker.update_slot(
-                        acquired_slot, f"{issue_ref(issue_number)}: capturing learnings"
+                        acquired_slot, f"{issue_ref(issue_number)}: arming for post-merge /learn"
                     )
-                    self._run_drive_green_learnings(issue_number, pr_number)
+                    gh_state = self._gh_pr_state(pr_number)
+                    pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
+                    pr_head_branch = self._get_pr_branch(pr_number)
+                    self._arm_drive_green(pr_number, pr_head_branch, pr_head_sha)
                 return WorkerResult(
                     issue_number=issue_number,
                     success=merge_ok,
@@ -731,6 +761,201 @@ class CIDriver:
         except Exception as e:
             logger.warning("Could not fetch CI logs for PR #%s: %s", pr_number, e)
             return ""
+
+    # ------------------------------------------------------------------
+    # Drive-green arming records (#840)
+    #
+    # Each issue whose PR auto-merge-armed gets a small JSON record at
+    # ``state_dir / "drive-green-armed-<issue>.json"`` so the NEXT run can
+    # detect "the PR finally merged" and fire ``/learn`` exactly once — even
+    # for the N-1 deferred siblings from the #834 shared-PR dedupe. Firing
+    # ``/learn`` on auto-merge-armed (the prior behavior) polluted
+    # ProjectMnemosyne with lessons from PRs that never actually shipped.
+    # ------------------------------------------------------------------
+
+    def _arming_state_path(self, issue_number: int) -> Path:
+        return self.state_dir / f"drive-green-armed-{issue_number}.json"
+
+    def _load_arming_state(self, issue_number: int) -> dict[str, Any] | None:
+        """Return the parsed arming record for ``issue_number`` or ``None``."""
+        path = self._arming_state_path(issue_number)
+        if not path.exists():
+            return None
+        try:
+            return dict(json.loads(path.read_text()))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "Could not read arming record for issue #%s: %s; ignoring",
+                issue_number,
+                exc,
+            )
+            return None
+
+    def _save_arming_state(self, issue_number: int, record: dict[str, Any]) -> None:
+        """Persist the arming record. Best-effort; logs and swallows IO errors."""
+        path = self._arming_state_path(issue_number)
+        try:
+            path.write_text(json.dumps(record, indent=2, sort_keys=True))
+        except OSError as exc:
+            logger.warning(
+                "Could not write arming record for issue #%s: %s",
+                issue_number,
+                exc,
+            )
+
+    def _clear_arming_state(self, issue_number: int) -> None:
+        path = self._arming_state_path(issue_number)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Could not delete arming record for issue #%s: %s",
+                issue_number,
+                exc,
+            )
+
+    def _arm_drive_green(self, pr_number: int, pr_head_branch: str, pr_head_sha: str) -> None:
+        """Record arming for every issue that resolved to ``pr_number``.
+
+        Called on the auto-merge-armed success path in the same run. For a
+        shared-PR group (#834), this writes one arming record per sibling
+        issue so each one gets its own ``/learn`` capture once the PR merges
+        in a subsequent run. The canonical issue and all deferred siblings
+        share the same ``pr_number`` and ``pr_head_branch`` — they differ
+        only in the issue id encoded in the filename.
+        """
+        siblings = self.shared_pr_issues.get(pr_number, [])
+        if not siblings:
+            # Defensive: the PR map should always know the issue, but if not
+            # we still want SOMETHING to fire /learn on the next run.
+            return
+        armed_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        for issue_num in siblings:
+            existing = self._load_arming_state(issue_num) or {}
+            if existing.get("learn_captured_at"):
+                # Already captured — don't overwrite the captured timestamp.
+                continue
+            record = {
+                "pr_number": pr_number,
+                "pr_head_branch": pr_head_branch,
+                "head_sha_at_arming": pr_head_sha,
+                "armed_at": armed_at,
+                "learn_captured_at": None,
+            }
+            self._save_arming_state(issue_num, record)
+            logger.info(
+                "Issue #%s: armed for /learn on merge of PR #%s (head=%s @ %s)",
+                issue_num,
+                pr_number,
+                pr_head_branch,
+                pr_head_sha[:8] if pr_head_sha else "?",
+            )
+
+    def _gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+        """Return ``{state, headRefOid, mergedAt}`` for ``pr_number`` or ``None``.
+
+        Used by the on-drive-start check (#840) to detect post-merge so the
+        ``/learn`` capture can fire exactly once per issue.
+        """
+        try:
+            result = _gh_call(
+                ["pr", "view", str(pr_number), "--json", "state,headRefOid,mergedAt"],
+                check=False,
+            )
+            return dict(json.loads(result.stdout or "{}"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Could not fetch PR #%s state for arming check: %s",
+                pr_number,
+                exc,
+            )
+            return None
+
+    def _check_arming_on_drive_start(
+        self, issue_number: int, pr_number: int
+    ) -> WorkerResult | None:
+        """Fire ``/learn`` if a prior run armed and the PR has since merged.
+
+        Called at the top of ``_drive_issue``. Returns:
+
+        - ``WorkerResult(success=True, ...)`` if the arming record handled
+          the issue (merge detected + ``/learn`` fired, OR still in flight,
+          OR already-captured). Caller returns this directly without doing
+          any further drive work.
+        - ``None`` if the issue should fall through to the normal drive
+          path (no arming record, arming stale, or PR abandoned).
+        """
+        record = self._load_arming_state(issue_number)
+        if record is None:
+            return None
+        if record.get("learn_captured_at"):
+            logger.info(
+                "Issue #%s: /learn already captured at %s; skipping further drive",
+                issue_number,
+                record["learn_captured_at"],
+            )
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+        gh_state = self._gh_pr_state(pr_number)
+        if gh_state is None:
+            # Treat unknown state as "still in flight" — don't redo the drive.
+            # The next run will retry the check.
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+        state = (gh_state.get("state") or "").upper()
+        current_sha = gh_state.get("headRefOid") or ""
+
+        if state == "MERGED":
+            logger.info(
+                "Issue #%s: PR #%s detected as MERGED; capturing /learn",
+                issue_number,
+                pr_number,
+            )
+            self.status_tracker.update_slot(
+                0, f"{issue_ref(issue_number)}: capturing post-merge /learn"
+            )
+            self._run_drive_green_learnings(issue_number, pr_number)
+            # Mark captured even if /learn failed — it's best-effort and
+            # retrying it on every subsequent run would churn API calls.
+            record["learn_captured_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            self._save_arming_state(issue_number, record)
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+        if state == "CLOSED":
+            # PR closed without merging. Lessons are not load-bearing if
+            # nothing shipped. Drop the record and fall through so the
+            # normal flow can decide what to do (likely "no open PR").
+            logger.info(
+                "Issue #%s: PR #%s was CLOSED without merging; dropping arming record",
+                issue_number,
+                pr_number,
+            )
+            self._clear_arming_state(issue_number)
+            return None
+
+        # OPEN
+        armed_sha = record.get("head_sha_at_arming") or ""
+        if current_sha and armed_sha and current_sha != armed_sha:
+            # The PR was force-pushed (or rebased) after arming. The arming
+            # is stale — re-enter the drive so it can re-arm at the new tip.
+            logger.info(
+                "Issue #%s: PR #%s head advanced from %s to %s since arming; re-entering drive",
+                issue_number,
+                pr_number,
+                armed_sha[:8],
+                current_sha[:8],
+            )
+            self._clear_arming_state(issue_number)
+            return None
+
+        # Still in flight at the same arming SHA — auto-merge is presumably
+        # still waiting on CI / branch protection. Nothing more to do.
+        logger.info(
+            "Issue #%s: PR #%s still OPEN at the armed SHA; waiting for merge",
+            issue_number,
+            pr_number,
+        )
+        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
     def _load_impl_session_id(self, issue_number: int) -> str | None:
         """Load the Claude session ID from the implementer's saved state.
@@ -1116,10 +1341,23 @@ class CIDriver:
         try:
             githash = current_trunk_githash(self.repo_root)
             repo_slug = get_repo_slug(self.repo_root)
-            # Resume from the SAME worktree the fix session used: the Session 3
-            # transcript is probed by cwd (session_jsonl_path), so a different
-            # cwd would silently start a cold session instead of resuming.
-            worktree_path = self._get_worktree_path(issue_number, pr_number)
+            # Best-effort: try to resume in the original worktree (so the
+            # AGENT_CI_DRIVER transcript is found by ``session_jsonl_path``).
+            # In the post-merge code path (#840) the PR's head branch may be
+            # gone from the remote, so ``_get_worktree_path`` could fail. In
+            # that case fall back to ``repo_root`` cwd — the prompt is
+            # self-contained, and a fresh ``--session-id`` create still
+            # captures the lesson.
+            try:
+                cwd = self._get_worktree_path(issue_number, pr_number)
+            except Exception as wt_err:
+                logger.info(
+                    "Issue #%s: no worktree available for /learn (%s); "
+                    "falling back to repo root for a fresh session",
+                    issue_number,
+                    wt_err,
+                )
+                cwd = self.repo_root
             invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,
@@ -1127,7 +1365,7 @@ class CIDriver:
                 githash=githash,
                 prompt=prompt,
                 model=learn_model(),
-                cwd=worktree_path,
+                cwd=cwd,
                 timeout=learn_claude_timeout(),
                 output_format="text",
                 allowed_tools="Read,Write,Edit,Glob,Grep,Bash",

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -291,6 +291,19 @@ class TestDiscoverPrsDedupe:
             result = driver._discover_prs([1, 2, 3])
         assert result == {1: 100}
 
+    def test_shared_pr_issues_populated_for_arming_fanout(self, driver: CIDriver) -> None:
+        """_discover_prs must record EVERY sibling per PR for the #840 fan-out."""
+        # The arming flow in #840 walks driver.shared_pr_issues[pr_num] to
+        # write one arming record per issue covered by a multi-issue PR. If
+        # the dedupe forgets the siblings, only the canonical issue gets a
+        # /learn on merge and the other 8 lose their lessons.
+        siblings_for_103 = [12, 22, 23, 28, 29, 37, 39, 59, 64]
+        side_effect = [103] * len(siblings_for_103) + [200]
+        with patch.object(driver, "_find_pr_for_issue", side_effect=side_effect):
+            driver._discover_prs([*siblings_for_103, 99])
+        assert driver.shared_pr_issues[103] == siblings_for_103
+        assert driver.shared_pr_issues[200] == [99]
+
 
 # ---------------------------------------------------------------------------
 # #838: repo done-state — open PR count must be zero
@@ -714,57 +727,271 @@ class TestEnableAutoMerge:
 
 
 class TestDriveGreenLearnings:
-    """Tests for the post-green learnings capture under AGENT_CI_DRIVER."""
+    """Tests for the post-merge /learn capture under AGENT_CI_DRIVER (#840).
 
-    def test_learnings_runs_on_success_under_ci_driver_agent(
+    /learn no longer fires when auto-merge is *armed* — it fires when GitHub
+    reports the PR as MERGED on a subsequent run. The drive success path
+    writes one arming record per sibling issue (covering the #834 shared-PR
+    fan-out); ``_check_arming_on_drive_start`` is what triggers /learn next
+    time. Each arming record is idempotent and self-clears on
+    abandoned-PR or head-SHA-advanced states.
+    """
+
+    def test_auto_merge_armed_writes_arming_record_but_no_learn(
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
-        """All required green + auto-merge ok → learnings resumes Session 3."""
-        from hephaestus.automation.session_naming import AGENT_CI_DRIVER
-
-        wt = tmp_path / "wt-123"
+        """All-green + auto-merge ok → arming record written, /learn NOT called."""
         checks = [_make_check("test", required=True)]
+        # The dedupe map normally drives shared_pr_issues; for this test
+        # set it up directly with a single-issue PR.
+        driver.shared_pr_issues = {456: [123]}
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
             patch.object(driver, "_enable_auto_merge", return_value=True),
-            patch.object(driver, "_get_worktree_path", return_value=wt),
+            patch.object(driver, "_get_pr_branch", return_value="123-impl"),
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "headRefOid": "abc1234"},
+            ),
             patch(
                 "hephaestus.automation.ci_driver.invoke_claude_with_session",
                 return_value=("ok", "sid"),
             ) as mock_invoke,
-            patch("hephaestus.automation.ci_driver.get_repo_slug", return_value="ProjectX"),
-            patch("hephaestus.automation.ci_driver.current_trunk_githash", return_value="abc1234"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
         assert result.success is True
-        mock_invoke.assert_called_once()
-        assert mock_invoke.call_args.kwargs["agent"] == AGENT_CI_DRIVER
-        assert mock_invoke.call_args.kwargs["issue"] == 123
-        # Must resume from the worktree so the Session 3 transcript is found.
-        assert mock_invoke.call_args.kwargs["cwd"] == wt
+        # No /learn yet — only an arming record on disk.
+        mock_invoke.assert_not_called()
+        record = driver._load_arming_state(123)
+        assert record is not None
+        assert record["pr_number"] == 456
+        assert record["pr_head_branch"] == "123-impl"
+        assert record["head_sha_at_arming"] == "abc1234"
+        assert record["learn_captured_at"] is None
 
-    def test_learnings_failure_is_non_fatal(self, driver: CIDriver, tmp_path: Path) -> None:
-        """A raising learnings session must not flip a successful drive to failure."""
-        checks = [_make_check("test", required=True)]
+    def test_arming_fans_out_across_shared_pr_group(self, driver: CIDriver) -> None:
+        """A PR closing 9 issues → 9 arming records (so 9 /learns fire on merge)."""
+        # Reproduces the ProjectNestor scenario from #834: PR #103 closes nine
+        # issues. The canonical issue drives it, but every sibling needs its
+        # own arming record so each one gets its own /learn capture once the
+        # PR finally merges in a subsequent run (#840).
+        siblings = [12, 22, 23, 28, 29, 37, 39, 59, 64]
+        driver.shared_pr_issues = {103: siblings}
+
+        driver._arm_drive_green(pr_number=103, pr_head_branch="12-impl", pr_head_sha="abc")
+
+        for issue in siblings:
+            record = driver._load_arming_state(issue)
+            assert record is not None, f"missing arming record for issue #{issue}"
+            assert record["pr_number"] == 103
+            assert record["learn_captured_at"] is None
+
+    def test_arming_skips_already_captured_record(self, driver: CIDriver) -> None:
+        """An issue with learn_captured_at set must not be re-armed."""
+        # Idempotency guard: re-running the drive should not clobber a record
+        # whose /learn already fired.
+        driver.shared_pr_issues = {500: [42]}
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "old-branch",
+                "head_sha_at_arming": "deadbee",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": "2026-01-02T00:00:00Z",
+            },
+        )
+
+        driver._arm_drive_green(pr_number=500, pr_head_branch="new-branch", pr_head_sha="cafef00d")
+
+        record = driver._load_arming_state(42)
+        assert record is not None
+        # The pre-existing captured timestamp survives — no overwrite.
+        assert record["learn_captured_at"] == "2026-01-02T00:00:00Z"
+        assert record["pr_head_branch"] == "old-branch"
+
+    def test_check_armed_pr_merged_fires_learn_once(self, driver: CIDriver) -> None:
+        """An armed issue whose PR is now MERGED triggers /learn exactly once."""
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": None,
+            },
+        )
         with (
-            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
-            patch.object(driver, "_enable_auto_merge", return_value=True),
-            patch.object(driver, "_get_worktree_path", return_value=tmp_path),
-            patch(
-                "hephaestus.automation.ci_driver.invoke_claude_with_session",
-                side_effect=RuntimeError("boom"),
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={
+                    "state": "MERGED",
+                    "headRefOid": "abc1234",
+                    "mergedAt": "2026-01-02T00:00:00Z",
+                },
             ),
-            patch("hephaestus.automation.ci_driver.get_repo_slug", return_value="ProjectX"),
-            patch("hephaestus.automation.ci_driver.current_trunk_githash", return_value="abc1234"),
+            patch.object(driver, "_run_drive_green_learnings", return_value=True) as mock_learn,
         ):
-            result = driver._drive_issue(123, 456, 0)
+            result = driver._check_arming_on_drive_start(42, 500)
 
-        # Drive still succeeds even though learnings raised.
+        assert result is not None
         assert result.success is True
+        mock_learn.assert_called_once_with(42, 500)
+        # Captured timestamp is now set so subsequent runs short-circuit.
+        record = driver._load_arming_state(42)
+        assert record is not None
+        assert record["learn_captured_at"] is not None
+
+    def test_check_armed_pr_merged_skips_when_already_captured(self, driver: CIDriver) -> None:
+        """learn_captured_at != None → return success without re-firing /learn."""
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": "2026-01-02T00:00:00Z",
+            },
+        )
+        with (
+            patch.object(driver, "_gh_pr_state") as mock_state,
+            patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        assert result is not None
+        assert result.success is True
+        # Already captured — no /learn re-fire, no state query needed.
+        mock_learn.assert_not_called()
+        mock_state.assert_not_called()
+
+    def test_check_armed_pr_open_at_same_sha_short_circuits(self, driver: CIDriver) -> None:
+        """OPEN at the armed SHA → success, /learn not fired, record kept."""
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": None,
+            },
+        )
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "headRefOid": "abc1234"},
+            ),
+            patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        assert result is not None
+        assert result.success is True
+        mock_learn.assert_not_called()
+        # Record preserved for the next run.
+        assert driver._load_arming_state(42) is not None
+
+    def test_check_armed_pr_head_advanced_clears_record_and_falls_through(
+        self, driver: CIDriver
+    ) -> None:
+        """OPEN with a different head SHA → drop record, return None (re-enter drive)."""
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": None,
+            },
+        )
+        with patch.object(
+            driver,
+            "_gh_pr_state",
+            return_value={"state": "OPEN", "headRefOid": "fffffff"},
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        # None → caller will re-enter the normal drive path.
+        assert result is None
+        # Record cleared so the next /enable_auto_merge can re-arm fresh.
+        assert driver._load_arming_state(42) is None
+
+    def test_check_armed_pr_closed_without_merge_clears_record(self, driver: CIDriver) -> None:
+        """CLOSED-without-merge → drop record, return None, /learn NOT fired."""
+        # Lessons aren't load-bearing if nothing shipped; capturing /learn
+        # for an abandoned PR would pollute Mnemosyne with false-positives.
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": None,
+            },
+        )
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "CLOSED", "headRefOid": "abc1234"},
+            ),
+            patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        assert result is None
+        mock_learn.assert_not_called()
+        assert driver._load_arming_state(42) is None
+
+    def test_check_with_no_arming_record_returns_none(self, driver: CIDriver) -> None:
+        """No prior arming → return None (fall through to the normal drive)."""
+        result = driver._check_arming_on_drive_start(42, 500)
+        assert result is None
+
+    def test_learn_failure_marks_captured_to_avoid_loop(self, driver: CIDriver) -> None:
+        """A failing /learn still flips learn_captured_at so we don't loop forever."""
+        # If /learn fails (model quota, network, etc.) and we retried it on
+        # every subsequent run, we'd churn API calls for the same issue
+        # indefinitely. Best-effort: mark captured, log the failure, move on.
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": None,
+            },
+        )
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "MERGED", "headRefOid": "abc1234"},
+            ),
+            patch.object(driver, "_run_drive_green_learnings", return_value=False),
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        assert result is not None
+        assert result.success is True
+        record = driver._load_arming_state(42)
+        assert record is not None
+        assert record["learn_captured_at"] is not None
 
     def test_learnings_skipped_for_codex(self, driver: CIDriver) -> None:
         """Codex has no persisted drive-green session, so learnings is skipped."""
+        # Direct test of _run_drive_green_learnings — the codex path is
+        # untouched by the #840 arming rework.
         driver.options.agent = "codex"
         with patch("hephaestus.automation.ci_driver.invoke_claude_with_session") as mock_invoke:
             result = driver._run_drive_green_learnings(123, 456)


### PR DESCRIPTION
## Summary

The drive-green `/learn` step fired in `_drive_issue` immediately after auto-merge was enabled. Two problems:

1. **Auto-merge armed ≠ PR merged.** Many auto-merge-armed PRs get blocked by a CI flake, a branch-protection check, or a manual cancellation. Capturing learnings at the auto-merge-armed moment polluted ProjectMnemosyne with lessons from PRs that never actually shipped.
2. **#834's shared-PR dedupe** meant one PR closing 9 issues had the canonical issue drive it and the other 8 silently skipped. Even if the canonical issue's `/learn` fired, the deferred siblings never got their own lessons — so a single PR ⇒ one `/learn` instead of the nine the user expected.

## Fix

Replace auto-merge-armed `/learn` trigger with a **per-issue arming-record state machine driven by detected-merge**.

### Arming on success

When CI is green and auto-merge enables, write `state_dir/drive-green-armed-<issue>.json` for **every** issue in the shared-PR group (canonical + all deferred siblings from #834). Each record carries `pr_number`, `pr_head_branch`, `head_sha_at_arming`, `armed_at`, and `learn_captured_at = null`.

### Detection on every subsequent drive

`_check_arming_on_drive_start` at the top of `_drive_issue` queries `gh pr view` for `state` + `headRefOid` + `mergedAt`:

| GH state | Action |
|---|---|
| `learn_captured_at != null` | success, no work |
| MERGED | fire `/learn` once, set `learn_captured_at`, success |
| OPEN + same head SHA | success, no `/learn` yet (still in flight) |
| OPEN + different head SHA | drop record, re-enter drive (PR was force-pushed) |
| CLOSED (not merged) | drop record, re-enter drive (PR was abandoned) |

### Fan-out for shared-PR groups

`_discover_prs` now populates `self.shared_pr_issues: dict[pr → list[issue]]` so `_arm_drive_green` writes a record for every sibling. A PR closing 9 issues now produces 9 arming records and, on the next run after merge, **9 distinct `/learn` captures** — exactly the user's ask.

### Idempotency / robustness

- A failing `/learn` still flips `learn_captured_at` so we don't churn API calls on every subsequent run.
- `_run_drive_green_learnings` falls back to `repo_root` cwd when `_get_worktree_path` fails (post-merge: the PR's head branch may be gone from the remote). Prompt is self-contained so a fresh `--session-id` still captures the lesson.

## Test plan

- [x] `pytest tests/unit/automation` (948 passed)
- [x] `TestDiscoverPrsDedupe::test_shared_pr_issues_populated_for_arming_fanout` — verifies the fan-out map
- [x] `TestDriveGreenLearnings` (10 new cases):
  - `test_auto_merge_armed_writes_arming_record_but_no_learn`
  - `test_arming_fans_out_across_shared_pr_group` (the 9-issue ProjectNestor scenario)
  - `test_arming_skips_already_captured_record` (idempotency)
  - `test_check_armed_pr_merged_fires_learn_once`
  - `test_check_armed_pr_merged_skips_when_already_captured`
  - `test_check_armed_pr_open_at_same_sha_short_circuits`
  - `test_check_armed_pr_head_advanced_clears_record_and_falls_through`
  - `test_check_armed_pr_closed_without_merge_clears_record`
  - `test_check_with_no_arming_record_returns_none`
  - `test_learn_failure_marks_captured_to_avoid_loop`
- [x] `pre-commit run` clean (ruff format + ruff check after one RUF005 fix)

Closes #840