### PR TITLE
fix(docs): correct README install pin and SECURITY supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Add to `pyproject.toml`:
 ```toml
 [project]
 dependencies = [
-    "homericintelligence-hephaestus>=1.0,<2",
+    "homericintelligence-hephaestus>=0.9,<1",
 ]
 ```
 
@@ -147,10 +147,12 @@ Or add a PyPI entry to `pixi.toml`:
 
 ```toml
 [pypi-dependencies]
-homericintelligence-hephaestus = ">=1.0,<2"
+homericintelligence-hephaestus = ">=0.9,<1"
 ```
 
 Then run `pixi install` to resolve the dependency.
+
+After 1.0 ships, bump these constraints to `>=1.0,<2`.
 
 **For local development (path dependency):**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,6 @@ As of 2026-05-24. Python >= 3.10 required.
 
 | Version | Supported       |
 |---------|-----------------|
-| 1.x     | ✅ Supported    |
 | 0.9.x   | ✅ Supported    |
 | < 0.9   | ❌ End of life  |
 


### PR DESCRIPTION
Two CRITICAL audit findings — README pin and SECURITY policy both reference a nonexistent 1.x release line.

- README.md:142,150 → switch >=1.0,<2 to >=0.9,<1
- SECURITY.md table → remove the false 1.x row

Closes #853