### PR TITLE
fix(validation/doc_policy): require gh pr merge --auto --squash

### DIFF
--- a/hephaestus/validation/doc_policy.py
+++ b/hephaestus/validation/doc_policy.py
@@ -10,7 +10,8 @@ Policies enforced:
 
 - ``gh pr create`` must NOT include ``--label``
 - ``git commit`` must NOT use ``--no-verify``
-- ``gh pr merge`` must use ``--auto --rebase`` (not ``--merge`` or ``--squash``)
+- ``gh pr merge`` must use ``--auto --squash`` (not ``--merge`` or ``--rebase``;
+  rebase merges are disabled on this repo — squash-only per CLAUDE.md)
 - ``git push`` must NOT push directly to ``main``/``master``
 
 Excluded paths (archived / test-fixture content that is not authoritative):
@@ -111,8 +112,26 @@ _RAW_RULES: list[tuple[str, Severity, str, str]] = [
     (
         "wrong-merge-strategy",
         Severity.CRITICAL,
-        "gh pr merge must use --auto --rebase, not --merge or --squash",
-        r"gh\s+pr\s+merge\b(?!.*--auto\s+--rebase\b)(?!.*--rebase\s+--auto\b).*(?:--merge\b|--squash\b)",
+        (
+            "gh pr merge must use --auto --squash (squash-only; rebase merges "
+            "are disabled on this repo per CLAUDE.md). --merge and --rebase "
+            "are rejected as merge-strategy flags."
+        ),
+        # Flag any ``gh pr merge`` invocation that does NOT carry both
+        # ``--auto`` AND ``--squash`` (in either order), OR that carries one
+        # of the rejected merge-strategy flags ``--merge`` / ``--rebase``.
+        #
+        # Implementation: this regex matches when the line contains
+        # ``gh pr merge`` and either lacks the required ``--auto --squash``
+        # combination, or includes a rejected strategy flag.
+        r"gh\s+pr\s+merge\b"
+        r"(?:"
+        # rejected merge-strategy flags
+        r"(?=.*--merge\b)"
+        r"|(?=.*--rebase\b)"
+        # OR missing the required --auto / --squash combination
+        r"|(?!.*--auto\s+--squash\b)(?!.*--squash\s+--auto\b)"
+        r")",
     ),
     (
         "push-direct-to-main",

--- a/tests/unit/validation/test_doc_policy.py
+++ b/tests/unit/validation/test_doc_policy.py
@@ -127,8 +127,8 @@ class TestScanFileDetectsViolations:
         findings = scan_file(md, tmp_path)
         assert any(f.rule == "no-verify-in-commit" for f in findings)
 
-    def test_detects_squash_merge_strategy(self, tmp_path: Path) -> None:
-        """Should flag gh pr merge that uses --squash."""
+    def test_detects_rebase_merge_strategy(self, tmp_path: Path) -> None:
+        """Should flag gh pr merge that uses --rebase (rebase merges disabled)."""
         md = make_md(
             tmp_path,
             "bad.md",
@@ -136,7 +136,7 @@ class TestScanFileDetectsViolations:
             # Doc
 
             ```bash
-            gh pr merge --squash
+            gh pr merge --auto --rebase
             ```
             """,
         )
@@ -152,7 +152,39 @@ class TestScanFileDetectsViolations:
             # Doc
 
             ```bash
-            gh pr merge --merge
+            gh pr merge --auto --merge
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "wrong-merge-strategy" for f in findings)
+
+    def test_detects_missing_auto_flag(self, tmp_path: Path) -> None:
+        """Should flag gh pr merge --squash when --auto is missing."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge --squash
+            ```
+            """,
+        )
+        findings = scan_file(md, tmp_path)
+        assert any(f.rule == "wrong-merge-strategy" for f in findings)
+
+    def test_detects_missing_squash_flag(self, tmp_path: Path) -> None:
+        """Should flag gh pr merge --auto when --squash is missing."""
+        md = make_md(
+            tmp_path,
+            "bad.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge --auto
             ```
             """,
         )
@@ -215,8 +247,8 @@ class TestScanFilePassesCleanExamples:
         )
         assert scan_file(md, tmp_path) == []
 
-    def test_passes_rebase_merge_strategy(self, tmp_path: Path) -> None:
-        """Gh pr merge --auto --rebase should produce no findings."""
+    def test_passes_squash_merge_strategy(self, tmp_path: Path) -> None:
+        """Gh pr merge --auto --squash should produce no findings."""
         md = make_md(
             tmp_path,
             "good.md",
@@ -224,14 +256,14 @@ class TestScanFilePassesCleanExamples:
             # Doc
 
             ```bash
-            gh pr merge --auto --rebase
+            gh pr merge --auto --squash
             ```
             """,
         )
         assert scan_file(md, tmp_path) == []
 
-    def test_passes_rebase_merge_strategy_with_pr_number(self, tmp_path: Path) -> None:
-        """Gh pr merge with PR number and --auto --rebase should produce no findings."""
+    def test_passes_squash_merge_strategy_with_pr_number(self, tmp_path: Path) -> None:
+        """Gh pr merge with PR number and --auto --squash should produce no findings."""
         md = make_md(
             tmp_path,
             "good.md",
@@ -239,7 +271,22 @@ class TestScanFilePassesCleanExamples:
             # Doc
 
             ```bash
-            gh pr merge 42 --auto --rebase
+            gh pr merge 42 --auto --squash
+            ```
+            """,
+        )
+        assert scan_file(md, tmp_path) == []
+
+    def test_passes_squash_merge_strategy_reversed_order(self, tmp_path: Path) -> None:
+        """Gh pr merge --squash --auto (flags reversed) should produce no findings."""
+        md = make_md(
+            tmp_path,
+            "good.md",
+            """\
+            # Doc
+
+            ```bash
+            gh pr merge --squash --auto
             ```
             """,
         )


### PR DESCRIPTION
Inverts the linter to require --squash (the actual repo policy) instead of --rebase. Updates tests accordingly.

Unblocks #851, #852, #854.

Closes #850