### PR TITLE
docs: add --squash to gh pr merge in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ that violates any of them is blocked:
 2. **Reference the issue**: the PR body must contain the literal line `Closes #<n>`
    (capital `C`, no colon, on its own line). `Fixes`, `Resolves`, `closes`, and
    `Closes:` are **not** accepted.
-3. **Enable auto-merge**: `gh pr merge --auto`.
+3. **Enable auto-merge**: `gh pr merge --auto --squash`.
 
 Also: ensure tests pass locally (`pixi run test`), keep commits to logical units with
 [conventional commit](https://www.conventionalcommits.org/) messages, and never bypass

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ three rules — a PR that violates any of them is blocked:
 3. Push the branch (`git push -u origin 123-amazing-feature`).
 4. Open a pull request whose body contains the literal line `Closes #123`
    (capital `C`, no colon, on its own line — `Fixes`/`Resolves` are **not** accepted).
-5. Enable auto-merge: `gh pr merge --auto`.
+5. Enable auto-merge: `gh pr merge --auto --squash`.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process.
 


### PR DESCRIPTION
Aligns newcomer-facing docs with the squash-only policy in CLAUDE.md. Unblocked by #850 (linter) and sequenced after #853.

Closes #854