### PR TITLE
fix(skills/myrmidon-swarm): use --squash for gh pr merge

### DIFF
--- a/skills/myrmidon-swarm/SKILL.md
+++ b/skills/myrmidon-swarm/SKILL.md
@@ -315,7 +315,7 @@ Sub-agents that create PRs must follow:
 3. `git commit -m "type(scope): description"`
 4. `git push -u origin <branch>`
 5. `gh pr create --title "..." --body "..."`
-6. `gh pr merge --auto --rebase`
+6. `gh pr merge --auto --squash`
 </constraints>
 
 <agent_prompt_template>


### PR DESCRIPTION
Switches --rebase to --squash to match repo policy. Unblocked by #850 (linter fix).

Closes #851