### PR TITLE
fix(skills/learn): align gh pr merge with ProjectMnemosyne policy

### DIFF
--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -419,7 +419,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
     # Enable auto-merge so the PR merges automatically once CI passes
     # Note: gh pr merge requires a PR number when using --repo
     PR_NUMBER=$(gh pr list --repo HomericIntelligence/ProjectMnemosyne --head "skill/<name>" --json number --jq '.[0].number')
-    gh pr merge "$PR_NUMBER" --auto --rebase --repo HomericIntelligence/ProjectMnemosyne
+    gh pr merge "$PR_NUMBER" --auto --squash --repo HomericIntelligence/ProjectMnemosyne
     ```
 
 10. **Cleanup worktree** (always clean up after PR creation):


### PR DESCRIPTION
Verified ProjectMnemosyne's allowed merge methods and updated the skill accordingly.

```
$ gh api repos/HomericIntelligence/ProjectMnemosyne --jq '{rebase: .allow_rebase_merge, squash: .allow_squash_merge, merge: .allow_merge_commit}'
{"merge":true,"rebase":false,"squash":true}
```

Since `allow_rebase_merge=false`, the previous `--rebase` instruction in
`skills/learn/SKILL.md:422` would always fail when a `/learn` agent ran
it. Switched to `--squash`, which ProjectMnemosyne allows. This also
clears the doc-policy linter that PR #863 tightened to reject `--rebase`
in fenced shell blocks.

Unblocked by #850 (merged via #863).

Closes #852