### PR TITLE
fix(docs): correct CLI count in README + docs/index and enforce it

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ config = merge_with_env({}, convert_bools=True)
 <!-- CLI table generated from pyproject.toml [project.scripts]. Keep in sync via
      `python3 scripts/check_cli_table_sync.py` (also enforced in pre-commit). -->
 
-42 console scripts are installed when you install the package.  Run any command
+44 console scripts are installed when you install the package.  Run any command
 with `--help` to see full usage.
 
 ### Automation

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ just docs        # outputs to docs/api/
 ```
 
 The generated `docs/api/` directory is git-ignored; run the command locally to browse
-full function signatures, docstrings, and type annotations for all 37+ CLI entry points.
+full function signatures, docstrings, and type annotations for all 44 CLI entry points.
 
 ## Setup
 

--- a/scripts/check_cli_table_sync.py
+++ b/scripts/check_cli_table_sync.py
@@ -6,12 +6,21 @@ whenever README.md or pyproject.toml changes.  It succeeds silently when the
 README mentions every command declared in [project.scripts] and exits non-zero
 with a clear diff otherwise.
 
+Beyond verifying that every command name appears in README.md, the script also
+verifies the prose counts in ``README.md`` (e.g. "44 console scripts") and in
+``docs/index.md`` (e.g. "44 CLI entry points") agree with the actual length of
+``[project.scripts]``.  This prevents documentation drift like #857, where
+README.md claimed 42 and docs/index.md claimed 37+ even though the real count
+was 44.
+
 Usage:
     python3 scripts/check_cli_table_sync.py
 
 Exit codes:
-    0  All pyproject.toml scripts are documented in README.md.
-    1  One or more scripts are missing from the README CLI section.
+    0  All pyproject.toml scripts are documented in README.md AND the prose
+       counts in README.md / docs/index.md match the actual count.
+    1  One or more scripts are missing from the README CLI section OR a prose
+       count is wrong.
 """
 
 from __future__ import annotations
@@ -35,22 +44,97 @@ except ModuleNotFoundError:  # pragma: no cover — only on Python 3.10
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 README = REPO_ROOT / "README.md"
+DOCS_INDEX = REPO_ROOT / "docs" / "index.md"
 
 # Regex that matches a backtick-quoted command name anywhere in the README.
 _BACKTICK_CMD_RE = re.compile(r"`(hephaestus-[a-z0-9-]+)`")
 
+# Regex that matches the README prose "<N> console scripts".
+_README_PROSE_RE = re.compile(r"(\d+)\s+console scripts")
 
-def _load_scripts() -> set[str]:
+# Regex that matches the docs/index.md prose "<N>+? CLI entry points".  The
+# optional ``+`` is intentionally allowed in the pattern so legacy text like
+# "37+" parses cleanly, but the check below treats the bare integer as
+# authoritative.
+_DOCS_INDEX_PROSE_RE = re.compile(r"(\d+)\+?\s+CLI entry points")
+
+
+def _load_scripts(repo_root: Path | None = None) -> set[str]:
     """Return the set of command names from pyproject.toml [project.scripts]."""
-    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    pyproject = (repo_root / "pyproject.toml") if repo_root is not None else PYPROJECT
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
     scripts: dict[str, str] = data.get("project", {}).get("scripts", {})
     return set(scripts.keys())
 
 
-def _readme_documented_commands() -> set[str]:
+def _readme_documented_commands(repo_root: Path | None = None) -> set[str]:
     """Return all ``hephaestus-*`` commands mentioned in README.md."""
-    readme_text = README.read_text(encoding="utf-8")
+    readme = (repo_root / "README.md") if repo_root is not None else README
+    readme_text = readme.read_text(encoding="utf-8")
     return set(_BACKTICK_CMD_RE.findall(readme_text))
+
+
+def check_prose_counts(repo_root: Path, expected_count: int) -> tuple[bool, list[str]]:
+    """Verify the prose counts in README.md and docs/index.md match expected_count.
+
+    The check runs the regex against the full file text and treats a missing
+    match as a mismatch — silently dropping the prose sentence would erode the
+    guard rail that this checker exists to provide.
+
+    Args:
+        repo_root: Repository root to search under.  Used so tests can point at
+            a temporary scratch directory.
+        expected_count: The authoritative count of ``[project.scripts]`` keys.
+
+    Returns:
+        ``(ok, mismatches)``.  ``ok`` is ``True`` iff every prose count matches
+        ``expected_count``.  ``mismatches`` is a list of human-readable strings,
+        one per offending file, that explain what was found vs. what was
+        expected.  An empty list means everything passed.
+
+    """
+    mismatches: list[str] = []
+
+    readme = repo_root / "README.md"
+    docs_index = repo_root / "docs" / "index.md"
+
+    if not readme.is_file():
+        mismatches.append(f"README.md not found at {readme}")
+    else:
+        readme_text = readme.read_text(encoding="utf-8")
+        match = _README_PROSE_RE.search(readme_text)
+        if match is None:
+            mismatches.append(
+                "README.md: missing prose sentence matching "
+                "r'(\\d+)\\s+console scripts' — has the wording changed?"
+            )
+        else:
+            actual = int(match.group(1))
+            if actual != expected_count:
+                mismatches.append(
+                    f"README.md: prose says '{actual} console scripts' but "
+                    f"pyproject.toml [project.scripts] has {expected_count} entries"
+                )
+
+    if not docs_index.is_file():
+        mismatches.append(f"docs/index.md not found at {docs_index}")
+    else:
+        docs_text = docs_index.read_text(encoding="utf-8")
+        match = _DOCS_INDEX_PROSE_RE.search(docs_text)
+        if match is None:
+            mismatches.append(
+                "docs/index.md: missing prose sentence matching "
+                "r'(\\d+)\\+?\\s+CLI entry points' — has the wording changed?"
+            )
+        else:
+            actual = int(match.group(1))
+            if actual != expected_count:
+                mismatches.append(
+                    f"docs/index.md: prose says '{actual} CLI entry points' but "
+                    f"pyproject.toml [project.scripts] has {expected_count} entries"
+                )
+
+    return (len(mismatches) == 0, mismatches)
 
 
 def main() -> int:
@@ -86,8 +170,19 @@ def main() -> int:
             print(f"  - {cmd}")
         print()
 
+    prose_ok, prose_mismatches = check_prose_counts(REPO_ROOT, len(declared))
+    if not prose_ok:
+        ok = False
+        print("ERROR: Prose counts disagree with pyproject.toml [project.scripts]:\n")
+        for line in prose_mismatches:
+            print(f"  - {line}")
+        print()
+
     if ok:
-        print(f"OK: all {len(declared)} pyproject.toml scripts are documented in README.md.")
+        print(
+            f"OK: all {len(declared)} pyproject.toml scripts are documented in README.md, "
+            "and prose counts in README.md and docs/index.md agree."
+        )
         return 0
 
     return 1

--- a/tests/unit/scripts/test_check_cli_table_sync.py
+++ b/tests/unit/scripts/test_check_cli_table_sync.py
@@ -1,0 +1,145 @@
+"""Tests for scripts/check_cli_table_sync.py.
+
+The script verifies two invariants:
+
+1. Every command listed in ``pyproject.toml [project.scripts]`` is mentioned
+   somewhere in ``README.md`` (the original purpose of the script).
+2. The human-readable prose counts in ``README.md`` and ``docs/index.md``
+   agree with the actual ``[project.scripts]`` length.  This second check was
+   added by #857 after the README, the docs, and the table disagreed (42 vs.
+   37+ vs. 44).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to sys.path so we can import the checker directly, mirroring the
+# pattern used by tests/unit/scripts/test_check_version_single_source.py.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from check_cli_table_sync import check_prose_counts
+
+
+class TestCheckProseCounts:
+    """Tests for ``check_prose_counts``."""
+
+    def _make_repo(
+        self,
+        tmp_path: Path,
+        *,
+        readme_count: str | int | None,
+        docs_count: str | int | None,
+    ) -> Path:
+        """Build a scratch repo with the requested prose counts.
+
+        Passing ``None`` for either ``readme_count`` or ``docs_count`` omits
+        the relevant prose sentence entirely so the checker can be exercised
+        against missing-sentence cases.
+        """
+        readme = tmp_path / "README.md"
+        if readme_count is None:
+            readme.write_text("# Project\n\nNo CLI mention here.\n")
+        else:
+            readme.write_text(
+                f"# Project\n\n{readme_count} console scripts are installed when "
+                "you install the package.\n"
+            )
+
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        docs_index = docs / "index.md"
+        if docs_count is None:
+            docs_index.write_text("# Docs\n\nNo CLI mention here.\n")
+        else:
+            docs_index.write_text(
+                f"# Docs\n\nFull function signatures for all {docs_count} CLI entry points.\n"
+            )
+
+        return tmp_path
+
+    def test_returns_true_when_both_counts_match(self, tmp_path: Path) -> None:
+        """Matching prose counts in README and docs/index return ok=True."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=44)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is True
+        assert mismatches == []
+
+    def test_returns_false_on_readme_mismatch(self, tmp_path: Path) -> None:
+        """A wrong README count produces a clear mismatch message."""
+        repo = self._make_repo(tmp_path, readme_count=42, docs_count=44)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("README.md" in m and "42" in m and "44" in m for m in mismatches), mismatches
+
+    def test_returns_false_on_docs_index_mismatch(self, tmp_path: Path) -> None:
+        """A wrong docs/index.md count produces a clear mismatch message."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=37)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("docs/index.md" in m and "37" in m and "44" in m for m in mismatches), mismatches
+
+    def test_legacy_plus_suffix_still_parsed(self, tmp_path: Path) -> None:
+        """The docs/index pattern strips a trailing ``+`` like '37+' before comparing.
+
+        The original drift this guard exists to catch was ``37+ CLI entry
+        points`` vs. the real count of 44, so the ``+`` must still be parsed
+        as a mismatch rather than silently skipped.
+        """
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count="37+")
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("docs/index.md" in m and "37" in m for m in mismatches), mismatches
+
+    def test_missing_readme_prose_is_a_mismatch(self, tmp_path: Path) -> None:
+        """If the README prose sentence is missing, that is treated as a mismatch.
+
+        Silently passing when the wording disappears would defeat the entire
+        purpose of the guard rail.
+        """
+        repo = self._make_repo(tmp_path, readme_count=None, docs_count=44)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("README.md" in m and "missing prose" in m for m in mismatches), mismatches
+
+    def test_missing_docs_index_prose_is_a_mismatch(self, tmp_path: Path) -> None:
+        """If the docs/index.md prose sentence is missing, that is a mismatch."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=None)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("docs/index.md" in m and "missing prose" in m for m in mismatches), mismatches
+
+    def test_missing_readme_file_is_a_mismatch(self, tmp_path: Path) -> None:
+        """If README.md does not exist at all, that is reported as a mismatch."""
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        (docs / "index.md").write_text("Full function signatures for all 44 CLI entry points.\n")
+        ok, mismatches = check_prose_counts(tmp_path, expected_count=44)
+        assert ok is False
+        assert any("README.md not found" in m for m in mismatches), mismatches
+
+    def test_missing_docs_index_file_is_a_mismatch(self, tmp_path: Path) -> None:
+        """If docs/index.md does not exist at all, that is reported."""
+        (tmp_path / "README.md").write_text("44 console scripts are installed.\n")
+        ok, mismatches = check_prose_counts(tmp_path, expected_count=44)
+        assert ok is False
+        assert any("docs/index.md not found" in m for m in mismatches), mismatches
+
+
+class TestMain:
+    """End-to-end tests for ``main`` against the real repository."""
+
+    def test_returns_0_against_real_repo(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The checker must PASS on the actual repository configuration.
+
+        This catches drift the moment a contributor lands a new console script
+        without bumping the README/docs prose.
+        """
+        import check_cli_table_sync as mod
+
+        assert mod.main() == 0
+        out = capsys.readouterr().out
+        assert "OK" in out


### PR DESCRIPTION
Three different numbers were claimed (README=42, docs/index=37+, table=44). Aligns them with the actual count of 44 and extends check_cli_table_sync.py to fail CI on future prose-count drift.

Sequenced after #856 (which landed the skill-catalog hook bumping the count to 44).

Closes #857