### PR TITLE
fix(resilience): wire is_transient_subprocess_error into resilient_call

### DIFF
--- a/hephaestus/resilience/subprocess_resilience.py
+++ b/hephaestus/resilience/subprocess_resilience.py
@@ -45,11 +45,17 @@ TRANSIENT_ERROR_PATTERNS: list[str] = [
 ]
 
 
-def is_transient_subprocess_error(error: Exception) -> bool:
+def is_transient_subprocess_error(error: BaseException) -> bool:
     """Check if a subprocess error is transient and should be retried.
 
     Checks both the exception type and any stderr content in the error
     message for known transient patterns.
+
+    Accepts ``BaseException`` so the function is directly usable as a
+    ``retry_predicate`` for :func:`hephaestus.utils.retry.retry_with_backoff`
+    (which calls predicates with the broadest exception type). Non-Exception
+    base exceptions (e.g. ``KeyboardInterrupt``) fall through the type checks
+    and return ``False``.
 
     Args:
         error: Exception to check
@@ -94,6 +100,12 @@ def resilient_call(
     Rate limit errors are NOT retried — they propagate immediately for
     the caller to handle.
 
+    Only *transient* errors are retried: the broad ``TRANSIENT_SUBPROCESS_ERRORS``
+    tuple is paired with :func:`is_transient_subprocess_error` as a predicate
+    so that, e.g., a ``PermissionError`` (``OSError``) does not waste three
+    retries on a clearly non-transient failure, and ``subprocess.TimeoutExpired``
+    propagates immediately because timeouts are intentional, not flakes.
+
     Args:
         func: Function to call
         *args: Positional arguments for func
@@ -121,6 +133,7 @@ def resilient_call(
         backoff_factor=2,
         max_delay=max_delay,
         retry_on=TRANSIENT_SUBPROCESS_ERRORS,
+        retry_predicate=is_transient_subprocess_error,
         logger=logger.warning,
         jitter=True,
     )

--- a/hephaestus/utils/retry.py
+++ b/hephaestus/utils/retry.py
@@ -49,6 +49,35 @@ def is_network_error(error: BaseException) -> bool:
     return any(keyword in error_str for keyword in NETWORK_ERROR_KEYWORDS)
 
 
+def _compute_backoff_delay(
+    attempt: int,
+    initial_delay: float,
+    backoff_factor: int,
+    max_delay: float | None,
+    jitter: bool,
+) -> float:
+    """Compute the sleep delay for the given retry attempt.
+
+    Args:
+        attempt: Zero-based attempt index (0 for the first retry).
+        initial_delay: Initial delay in seconds before first retry.
+        backoff_factor: Multiplier for delay between retries.
+        max_delay: Optional cap (applied *before* jitter so the actual sleep
+            value can reach max_delay * 1.25 at most when jitter=True).
+        jitter: If True, perturb the delay by ±25 %.
+
+    Returns:
+        Sleep duration in seconds (always >= 0.1).
+
+    """
+    delay: float = initial_delay * (backoff_factor**attempt)
+    if max_delay is not None:
+        delay = min(delay, max_delay)
+    if jitter:
+        delay = float(delay + random.uniform(-0.25 * delay, 0.25 * delay))
+    return max(0.1, delay)
+
+
 def retry_with_backoff(
     max_retries: int = 3,
     initial_delay: float = 1.0,
@@ -57,6 +86,7 @@ def retry_with_backoff(
     retry_on: tuple[type[BaseException], ...] = (Exception,),
     logger: Callable[[str], None] | None = None,
     max_delay: float | None = None,
+    retry_predicate: Callable[[BaseException], bool] | None = None,
 ) -> Callable[[F], F]:
     """Retry a function with exponential backoff.
 
@@ -68,6 +98,11 @@ def retry_with_backoff(
         retry_on: Tuple of exception types to retry on (default: all exceptions)
         logger: Optional logging function for retry attempts
         max_delay: Maximum delay cap in seconds (default: None, no cap)
+        retry_predicate: Optional callable applied *after* the ``retry_on``
+            isinstance check. If provided and the predicate returns ``False``
+            for the raised exception, the exception is re-raised immediately
+            without retrying. Lets callers filter beyond exception type — for
+            example, retry only ``OSError``s whose message looks transient.
 
     Returns:
         Decorated function with retry logic
@@ -84,6 +119,14 @@ def retry_with_backoff(
             # Only retry on specific exceptions
             return requests.get("https://api.example.com")
 
+        @retry_with_backoff(
+            retry_on=(OSError,),
+            retry_predicate=lambda e: "connection reset" in str(e).lower(),
+        )
+        def transient_only():
+            # Retries OSErrors only when their message looks transient
+            ...
+
     """
 
     def decorator(func: F) -> F:
@@ -97,24 +140,19 @@ def retry_with_backoff(
                 except retry_on as e:
                     last_exception = e
 
+                    # Honor a caller-supplied filter that runs *after* the
+                    # isinstance check. If it rejects the exception, propagate
+                    # immediately so non-transient failures don't waste retries.
+                    if retry_predicate is not None and not retry_predicate(e):
+                        raise
+
                     # Don't retry on last attempt
                     if attempt == max_retries:
                         break
 
-                    # Calculate delay with exponential backoff
-                    delay = initial_delay * (backoff_factor**attempt)
-
-                    # Cap delay if max_delay is specified
-                    if max_delay is not None:
-                        delay = min(delay, max_delay)
-
-                    # Add jitter if requested (±25%)
-                    if jitter:
-                        jitter_amount = random.uniform(-0.25 * delay, 0.25 * delay)
-                        delay += jitter_amount
-
-                    # Ensure delay is positive
-                    delay = max(0.1, delay)
+                    delay = _compute_backoff_delay(
+                        attempt, initial_delay, backoff_factor, max_delay, jitter
+                    )
 
                     # Log retry attempt
                     if logger:

--- a/tests/unit/resilience/test_subprocess_resilience.py
+++ b/tests/unit/resilience/test_subprocess_resilience.py
@@ -146,3 +146,86 @@ class TestResilientCall:
                 initial_delay=0.01,
                 max_delay=0.1,
             )
+
+
+class TestRetryPredicateWiring:
+    """Tests that resilient_call actually invokes is_transient_subprocess_error.
+
+    Before this wire-up, resilient_call only matched on the
+    TRANSIENT_SUBPROCESS_ERRORS exception tuple, so non-transient OSErrors
+    (e.g. permission denied) and intentional TimeoutExpired errors burned
+    three pointless retries. The predicate gates retries on stderr-pattern
+    content as well as exception type.
+    """
+
+    @patch("time.sleep")
+    def test_non_transient_oserror_does_not_retry(self, mock_sleep) -> None:
+        """OSError without a transient pattern is raised after a single call."""
+        call_count = 0
+
+        def permission_denied() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise OSError(13, "Permission denied")
+
+        with pytest.raises(OSError, match="Permission denied"):
+            resilient_call(
+                permission_denied,
+                max_retries=3,
+                initial_delay=0.01,
+                max_delay=0.1,
+            )
+
+        # Predicate rejects → propagate immediately, no retries, no sleeps.
+        assert call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("time.sleep")
+    def test_transient_stderr_pattern_retries(self, mock_sleep) -> None:
+        """CalledProcessError with transient stderr is retried until success."""
+        call_count = 0
+
+        def flaky_subprocess() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise subprocess.CalledProcessError(
+                    returncode=1,
+                    cmd="git fetch",
+                    stderr="fatal: Connection reset by peer",
+                )
+            return "ok"
+
+        result = resilient_call(
+            flaky_subprocess,
+            max_retries=3,
+            initial_delay=0.01,
+            max_delay=0.1,
+        )
+
+        assert result == "ok"
+        assert call_count == 3
+        # Two retries before success → two sleeps.
+        assert mock_sleep.call_count == 2
+
+    @patch("time.sleep")
+    def test_timeout_expired_does_not_retry(self, mock_sleep) -> None:
+        """subprocess.TimeoutExpired is intentional and bypasses retry."""
+        call_count = 0
+
+        def times_out() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise subprocess.TimeoutExpired(cmd="long-job", timeout=30)
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            resilient_call(
+                times_out,
+                max_retries=3,
+                initial_delay=0.01,
+                max_delay=0.1,
+            )
+
+        # Predicate returns False for TimeoutExpired → no retries, no sleeps.
+        assert call_count == 1
+        mock_sleep.assert_not_called()


### PR DESCRIPTION
Behavioral change: a dead predicate function is now actually used. Non-transient errors no longer incur three pointless retries.

Extends `retry_with_backoff` with an optional `retry_predicate` parameter applied AFTER the isinstance check. `resilient_call` now passes `is_transient_subprocess_error` as that predicate.

Adds 3 new tests pinning the wire-up: non-transient OSError, transient CalledProcessError stderr pattern, and TimeoutExpired. The only behavioral change in the audit-remediation batch.

Closes #859