### PR TITLE
fix(skills): validate skill frontmatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -116,7 +116,7 @@ repos:
     hooks:
       - id: hephaestus-check-skill-catalog
         name: hephaestus check skill catalog
-        description: Ensure docs/plugin-installation.md lists every shipped skill
+        description: Ensure docs/plugin-installation.md lists every shipped skill and skill frontmatter is valid
         # --environment default is explicit because the pre-commit CI job runs
         # in the lint env; the hephaestus-* console scripts live in default.
         entry: pixi run --environment default hephaestus-check-skill-catalog

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ with `--help` to see full usage.
 | `hephaestus-check-docstrings` | Check Python docstrings for genuine sentence fragments |
 | `hephaestus-check-python-version` | Check Python version consistency across project configuration files |
 | `hephaestus-check-readmes` | Markdown validation utilities for HomericIntelligence projects |
-| `hephaestus-check-skill-catalog` | Ensure `docs/plugin-installation.md` lists every skill shipped under `skills/` |
+| `hephaestus-check-skill-catalog` | Ensure `docs/plugin-installation.md` lists every skill shipped under `skills/` and validates skill frontmatter |
 | `hephaestus-check-stale-scripts` | Detect scripts in `scripts/` with no references in CI configs or other scripts |
 | `hephaestus-check-test-structure` | Validate unit test directory structure |
 | `hephaestus-check-tier-labels` | Enforce tier label consistency across all project Markdown files |

--- a/docs/plugin-installation.md
+++ b/docs/plugin-installation.md
@@ -15,7 +15,7 @@ ProjectHephaestus ships as a Claude Code plugin in addition to a Python package.
 
 The plugin ships **23 skills**. The table is kept in sync with the
 `skills/` directory by the `hephaestus-check-skill-catalog` pre-commit hook —
-adding or removing a skill without updating this table will fail CI.
+adding or removing a skill without updating this table, or shipping a skill without valid frontmatter, will fail CI.
 
 | Skill | Description |
 |-------|-------------|

--- a/hephaestus/validation/skill_catalog.py
+++ b/hephaestus/validation/skill_catalog.py
@@ -2,7 +2,9 @@ r"""Validate that docs/plugin-installation.md lists every shipped skill.
 
 Reads the markdown table under the "What the Plugin Provides" section and
 asserts each row matches a skill discovered by
-:func:`hephaestus.discovery.skills.discover_skills`.
+:func:`hephaestus.discovery.skills.discover_skills`. It also validates each
+shipped skill has loadable YAML frontmatter with a name matching its
+directory.
 
 The check is wired into pre-commit (see ``.pre-commit-config.yaml``) and runs
 whenever ``docs/plugin-installation.md`` or anything under ``skills/`` changes,
@@ -17,7 +19,7 @@ Usage::
 
 Exit codes:
     0: Table lists every shipped skill and no extras.
-    1: Mismatch — table is missing skills, lists removed skills, or both.
+    1: Mismatch — table is missing skills, lists removed skills, or a skill has invalid frontmatter.
 """
 
 from __future__ import annotations
@@ -27,6 +29,7 @@ import re
 import sys
 from pathlib import Path
 
+from hephaestus.agents.frontmatter import check_agent_file, extract_frontmatter_parsed
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 from hephaestus.discovery.skills import discover_skills
 from hephaestus.utils.helpers import get_repo_root
@@ -127,6 +130,54 @@ def check_skill_catalog(table_path: Path, skills_dir: Path) -> tuple[set[str], s
     return missing, extra
 
 
+def check_skill_frontmatter(skills_dir: Path) -> dict[str, list[str]]:
+    """Validate each shipped skill has loadable plugin metadata.
+
+    Args:
+        skills_dir: Path to the ``skills/`` directory.
+
+    Returns:
+        Mapping of skill directory name to validation errors. Empty means all
+        shipped skills have valid frontmatter.
+
+    """
+    if not skills_dir.exists():
+        return {}
+
+    errors_by_skill: dict[str, list[str]] = {}
+    required_fields: dict[str, type] = {"name": str, "description": str}
+    optional_fields: dict[str, type] = {"argument-hint": str, "allowed-tools": list}
+
+    for skill_file in sorted(skills_dir.glob("*/SKILL.md")):
+        skill_name = skill_file.parent.name
+        is_valid, errors = check_agent_file(
+            skill_file,
+            required_fields=required_fields,
+            optional_fields=optional_fields,
+        )
+        skill_errors = list(errors)
+
+        if is_valid:
+            parsed = extract_frontmatter_parsed(skill_file.read_text(encoding="utf-8"))
+            if parsed is None:
+                skill_errors.append("No parseable YAML frontmatter found")
+            else:
+                _raw, frontmatter = parsed
+                frontmatter_name = frontmatter.get("name")
+                if frontmatter_name != skill_name:
+                    skill_errors.append(
+                        f"Frontmatter name {frontmatter_name!r} must match directory {skill_name!r}"
+                    )
+                description = frontmatter.get("description", "")
+                if isinstance(description, str) and not description.strip():
+                    skill_errors.append("Field 'description' must not be empty")
+
+        if skill_errors:
+            errors_by_skill[skill_name] = skill_errors
+
+    return errors_by_skill
+
+
 def _format_diff(missing: set[str], extra: set[str]) -> str:
     """Format the missing/extra diff as a human-readable report."""
     lines: list[str] = []
@@ -140,6 +191,18 @@ def _format_diff(missing: set[str], extra: set[str]) -> str:
         lines.append("Extra in catalog (documented but not shipped):")
         for name in sorted(extra):
             lines.append(f"  - {name}")
+    return "\n".join(lines)
+
+
+def _format_frontmatter_errors(errors_by_skill: dict[str, list[str]]) -> str:
+    """Format skill frontmatter validation errors for text output."""
+    lines: list[str] = []
+    if errors_by_skill:
+        lines.append("Invalid skill frontmatter:")
+        for name in sorted(errors_by_skill):
+            lines.append(f"  - {name}:")
+            for error in errors_by_skill[name]:
+                lines.append(f"      - {error}")
     return "\n".join(lines)
 
 
@@ -183,7 +246,8 @@ def main(argv: list[str] | None = None) -> int:
     skills_dir: Path = args.skills_dir or (repo_root / "skills")
 
     missing, extra = check_skill_catalog(table_path, skills_dir)
-    ok = not missing and not extra
+    frontmatter_errors = check_skill_frontmatter(skills_dir)
+    ok = not missing and not extra and not frontmatter_errors
     exit_code = 0 if ok else 1
 
     if args.json:
@@ -192,6 +256,7 @@ def main(argv: list[str] | None = None) -> int:
             message=("skill catalog is in sync" if ok else "skill catalog is out of sync"),
             missing=sorted(missing),
             extra=sorted(extra),
+            frontmatter_errors=frontmatter_errors,
             table=str(table_path),
             skills_dir=str(skills_dir),
         )
@@ -202,9 +267,18 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print("ERROR: docs/plugin-installation.md is out of sync with skills/.")
         print()
-        print(_format_diff(missing, extra))
-        print()
-        print("Fix by updating the catalog table or by removing the deleted skill.")
+        diff = _format_diff(missing, extra)
+        frontmatter_report = _format_frontmatter_errors(frontmatter_errors)
+        if diff:
+            print(diff)
+            print()
+        if frontmatter_report:
+            print(frontmatter_report)
+            print()
+        print(
+            "Fix by updating the catalog table, removing the deleted skill, "
+            "or correcting skill frontmatter."
+        )
 
     return exit_code
 

--- a/skills/create-reusable-utilities/SKILL.md
+++ b/skills/create-reusable-utilities/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: create-reusable-utilities
+description: Port and generalize utility scripts from one project into ProjectHephaestus for cross-project reuse
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
+---
+
 # Create Reusable Utilities
 
 ## Overview

--- a/skills/finish-branch/SKILL.md
+++ b/skills/finish-branch/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: finish-branch
 description: Use when implementation is complete and all tests pass — guides branch completion by presenting structured options for merge, PR creation, or cleanup
-argument-hint: <optional: base branch name>
+argument-hint: "<optional: base branch name>"
 allowed-tools: [Bash, Read]
 ---
 

--- a/skills/github-actions-python-cicd/SKILL.md
+++ b/skills/github-actions-python-cicd/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: github-actions-python-cicd
+description: Set up a comprehensive GitHub Actions CI/CD pipeline for a Python project with multi-version testing
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
+---
+
 # GitHub Actions Python CI/CD Setup
 
 ## Overview

--- a/skills/python-repo-modernization/SKILL.md
+++ b/skills/python-repo-modernization/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: python-repo-modernization
+description: "Bring a partially modernized Python repo to production-grade quality: fix bugs, restructure tests, enhance CI/pre-commit, prepare for PyPI publishing"
+allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
+---
+
 # Python Repository Modernization
 
 ## Overview

--- a/skills/tidy/SKILL.md
+++ b/skills/tidy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tidy
 description: Tidy local branches in the CURRENT repo. Runs `gh tidy --rebase-all --trunk <default>` interactively, then dispatches a Myrmidon swarm to finish any rebases that gh-tidy could not complete. The swarm NEVER deletes branches — only gh-tidy can, via its own y/N prompts.
-argument-hint: <optional: --dry-run | --no-swarm | --trunk BRANCH | --max-concurrent N>
+argument-hint: "<optional: --dry-run | --no-swarm | --trunk BRANCH | --max-concurrent N>"
 allowed-tools: [Bash, Read]
 ---
 

--- a/skills/worktree-cleanup/SKILL.md
+++ b/skills/worktree-cleanup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktree-cleanup
-description: Audit every git worktree, ensure all state is committed, then prune worktrees cleanly. NEVER deletes branches — that's `gh tidy`'s job. Use when: (1) `git worktree list` shows many entries after a parallel session, (2) you suspect uncommitted work in worktrees, (3) you want to clean up before running `gh tidy`.
-argument-hint: <optional: --dry-run>
+description: "Audit every git worktree, ensure all state is committed, then prune worktrees cleanly. NEVER deletes branches — that's `gh tidy`'s job. Use when: (1) `git worktree list` shows many entries after a parallel session, (2) you suspect uncommitted work in worktrees, (3) you want to clean up before running `gh tidy`."
+argument-hint: "<optional: --dry-run>"
 allowed-tools: [Bash, Read]
 ---
 

--- a/tests/unit/validation/test_skill_catalog.py
+++ b/tests/unit/validation/test_skill_catalog.py
@@ -40,14 +40,23 @@ def make_table(tmp_path: Path, skill_names: list[str]) -> Path:
     return path
 
 
-def make_skills_dir(tmp_path: Path, skill_names: list[str]) -> Path:
+def make_skills_dir(
+    tmp_path: Path,
+    skill_names: list[str],
+    *,
+    with_frontmatter: bool = True,
+) -> Path:
     """Create a skills/ directory with one subdir per name (each has SKILL.md)."""
     skills_dir = tmp_path / "skills"
     skills_dir.mkdir()
     for name in skill_names:
         sub = skills_dir / name
         sub.mkdir()
-        (sub / "SKILL.md").write_text(f"# {name}\n")
+        if with_frontmatter:
+            content = f"---\nname: {name}\ndescription: Test skill {name}\n---\n\n# {name}\n"
+        else:
+            content = f"# {name}\n"
+        (sub / "SKILL.md").write_text(content)
     return skills_dir
 
 
@@ -193,6 +202,25 @@ class TestMainExitCodes:
         """Main exits 1 when the table lists a skill that is not shipped."""
         table = make_table(tmp_path, ["alpha", "removed"])
         skills_dir = make_skills_dir(tmp_path, ["alpha"])
+        result = main(["--table", str(table), "--skills-dir", str(skills_dir)])
+        assert result == 1
+
+    def test_returns_nonzero_when_skill_missing_frontmatter(self, tmp_path: Path) -> None:
+        """Main exits 1 when a shipped skill has no YAML frontmatter."""
+        table = make_table(tmp_path, ["alpha"])
+        skills_dir = make_skills_dir(tmp_path, ["alpha"], with_frontmatter=False)
+        result = main(["--table", str(table), "--skills-dir", str(skills_dir)])
+        assert result == 1
+
+    def test_returns_nonzero_when_skill_frontmatter_name_mismatches_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Main exits 1 when frontmatter name does not match the skill directory."""
+        table = make_table(tmp_path, ["alpha"])
+        skills_dir = make_skills_dir(tmp_path, ["alpha"])
+        (skills_dir / "alpha" / "SKILL.md").write_text(
+            "---\nname: beta\ndescription: Wrong skill name\n---\n\n# Alpha\n"
+        )
         result = main(["--table", str(table), "--skills-dir", str(skills_dir)])
         assert result == 1
 


### PR DESCRIPTION
Closes #722

## Summary
- add frontmatter validation to the skill catalog checker
- add missing frontmatter to legacy skill files
- quote existing colon-containing frontmatter values so every shipped skill parses as YAML

## Verification
- RED: env PYTEST_ADDOPTS=--no-cov python -m pytest tests/unit/validation/test_skill_catalog.py -k frontmatter -v failed before implementation
- env PYTEST_ADDOPTS=--no-cov python -m pytest tests/unit/validation/test_skill_catalog.py tests/unit/agents/test_frontmatter.py -v
- python -m hephaestus.validation.skill_catalog --repo-root /mnt/weka/home/micah.villmow/PerfHC/.hephaestus-patch
- python -m ruff check hephaestus/ tests/
- python -m ruff format --check hephaestus/ tests/
- python -m mypy hephaestus/

## Local limitations
- pixi/pre-commit are blocked locally because installed pixi is 0.68.1 while this repo requires >=0.69.0.
- python -m pytest tests/unit -v has unrelated local environment failures around /run/user/4618 GitHub/Claude session tests and existing markdown link-fixer absolute path cases; the patch-specific tests pass.