### PR TITLE
[Feat] CI driver: wait for armed PRs to merge; drain dependabot backlog

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -582,7 +582,9 @@ class CIDriver:
                     return WorkerResult(
                         issue_number=issue_number, success=True, pr_number=pr_number
                     )
-                merge_ok = self._enable_auto_merge(pr_number)
+                merge_ok = self._enable_auto_merge(
+                    pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number)
+                )
                 if merge_ok:
                     # PR is green and auto-merge is enabled — but do NOT
                     # capture /learn here (#840). Auto-merge-armed is not
@@ -598,6 +600,24 @@ class CIDriver:
                     pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
                     pr_head_branch = self._get_pr_branch(pr_number)
                     self._arm_drive_green(pr_number, pr_head_branch, pr_head_sha)
+
+                    # Block until the armed PR actually finishes instead of
+                    # returning the instant auto-merge is enabled (#838). If CI
+                    # goes red after arming, drop into the fix path; otherwise
+                    # MERGED/CLOSED/TIMEOUT are all "nothing more to drive here".
+                    outcome = self._wait_for_pr_terminal(issue_number, pr_number)
+                    if outcome == "FAILING":
+                        fix_result = self._attempt_ci_fixes(issue_number, pr_number, acquired_slot)
+                        if fix_result is not None:
+                            return fix_result
+                        return WorkerResult(
+                            issue_number=issue_number,
+                            success=False,
+                            pr_number=pr_number,
+                            error=(
+                                f"CI fix failed after {self.options.max_fix_iterations} attempt(s)"
+                            ),
+                        )
                 return WorkerResult(
                     issue_number=issue_number,
                     success=merge_ok,
@@ -1114,6 +1134,83 @@ class CIDriver:
             )
             return None
 
+    def _wait_for_pr_terminal(self, issue_number: int, pr_number: int) -> str:
+        """Block until an armed PR reaches a terminal state, or times out.
+
+        Once a PR's auto-merge is armed, the driver historically observed the
+        OPEN state once and returned success — declaring the repo "not done"
+        on PRs that were seconds away from merging (#838 false-failure class).
+        Instead, poll the PR until it actually finishes so the driver can react
+        to the real outcome (merge, abandonment, or freshly-red CI).
+
+        Polls ``_gh_pr_state`` with exponential backoff (``min(2**n, 60)`` cap,
+        matching the CI-pending poll loop in ``_drive_issue``), bounded by
+        ``HEPH_PR_MERGE_MAX_WAIT`` seconds (default 1800). On each OPEN poll we
+        also inspect required checks: a required check concluding ``failure``
+        returns ``FAILING`` straight away rather than waiting out the timeout.
+
+        Args:
+            issue_number: GitHub issue number (for status/log lines).
+            pr_number: PR whose merge we are waiting on.
+
+        Returns:
+            One of ``"MERGED"``, ``"CLOSED"``, ``"FAILING"``, or ``"TIMEOUT"``.
+
+        """
+        if self.options.dry_run:
+            return "TIMEOUT"
+
+        max_wait = int(os.environ.get("HEPH_PR_MERGE_MAX_WAIT", "1800"))
+        elapsed = 0
+        attempt = 0
+        iref = issue_ref(issue_number)
+
+        while True:
+            gh_state = self._gh_pr_state(pr_number)
+            state = ((gh_state or {}).get("state") or "").upper()
+
+            if state == "MERGED":
+                logger.info("Issue #%s: PR #%s merged", issue_number, pr_number)
+                return "MERGED"
+            if state == "CLOSED":
+                logger.info(
+                    "Issue #%s: PR #%s closed without merging while waiting",
+                    issue_number,
+                    pr_number,
+                )
+                return "CLOSED"
+
+            # Still OPEN (or unknown). If a required check has gone red since
+            # arming, stop waiting and let the caller drive a fix.
+            failing = self._failing_required_check_names(pr_number)
+            if failing:
+                logger.warning(
+                    "Issue #%s: PR #%s went red while awaiting merge (failing: %s)",
+                    issue_number,
+                    pr_number,
+                    ", ".join(failing),
+                )
+                return "FAILING"
+
+            sleep_secs = min(2**attempt, 60)
+            if elapsed + sleep_secs > max_wait:
+                logger.warning(
+                    "Issue #%s: PR #%s still OPEN after %ss (limit %ss); leaving armed and pending",
+                    issue_number,
+                    pr_number,
+                    elapsed,
+                    max_wait,
+                )
+                return "TIMEOUT"
+
+            self.status_tracker.update_slot(
+                0,
+                f"{iref}: PR #{pr_number} awaiting merge ({elapsed}s elapsed)",
+            )
+            time.sleep(sleep_secs)
+            elapsed += sleep_secs
+            attempt += 1
+
     def _sweep_orphaned_arming_records(self) -> None:  # noqa: C901  # one record loop with three state branches; splitting it just hides the contract
         """Drop CLOSED records and capture missed ``/learn`` for MERGED orphans (#848).
 
@@ -1260,12 +1357,33 @@ class CIDriver:
             return None
 
         # Still in flight at the same arming SHA — auto-merge is presumably
-        # still waiting on CI / branch protection. Nothing more to do.
+        # still waiting on CI / branch protection. Block until it finishes
+        # (#838) rather than returning success on a PR that may still go red.
         logger.info(
             "Issue #%s: PR #%s still OPEN at the armed SHA; waiting for merge",
             issue_number,
             pr_number,
         )
+        outcome = self._wait_for_pr_terminal(issue_number, pr_number)
+        if outcome == "MERGED":
+            # Fire the post-merge /learn exactly once, mirroring the MERGED
+            # branch above so we don't lose the capture by exiting early.
+            self.status_tracker.update_slot(
+                0, f"{issue_ref(issue_number)}: capturing post-merge /learn"
+            )
+            self._run_drive_green_learnings(issue_number, pr_number)
+            record["learn_captured_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            self._save_arming_state(issue_number, record)
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        if outcome == "CLOSED":
+            self._clear_arming_state(issue_number)
+            return None
+        if outcome == "FAILING":
+            # PR went red after arming — clear the stale arming and fall
+            # through so the normal drive path can fix it.
+            self._clear_arming_state(issue_number)
+            return None
+        # TIMEOUT — still pending; leave armed for a later pass to resolve.
         return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
     def _load_impl_session_id(self, issue_number: int) -> str | None:
@@ -1470,8 +1588,17 @@ class CIDriver:
         pr_head_branch: str,
         pre_agent_sha: str,
         session_id: str | None,
+        max_retries: int = 2,
     ) -> bool:
-        """Re-invoke the same agent session once when the first turn produced no commit (#846).
+        """Re-invoke the agent up to ``max_retries`` times after a no-commit turn (#846).
+
+        A single no-op agent turn used to be terminal: with
+        ``max_fix_iterations=1`` the whole issue failed the instant the first
+        force-engagement retry also returned no commit. That cost real PRs
+        (AchaeanFleet #691/#683, Hermes #643). We now re-engage up to
+        ``max_retries`` times before recording the forensics marker, re-checking
+        between attempts so a PR that goes green (or where a commit lands)
+        short-circuits immediately.
 
         Only fires when the PR still has failing required checks — a green PR
         that arrived via concurrent activity should NOT be perturbed. Stays on
@@ -1496,51 +1623,62 @@ class CIDriver:
             marker to ``state_dir``.
 
         """
-        failing = self._failing_required_check_names(pr_number)
-        if not failing:
-            logger.info(
-                "Issue #%s: no-commit turn but PR #%s has no failing required checks; "
-                "skipping force-engagement retry",
-                issue_number,
-                pr_number,
+        failing: list[str] = []
+        for retry in range(1, max_retries + 1):
+            failing = self._failing_required_check_names(pr_number)
+            if not failing:
+                logger.info(
+                    "Issue #%s: no-commit turn but PR #%s has no failing required "
+                    "checks; skipping force-engagement retry",
+                    issue_number,
+                    pr_number,
+                )
+                return False
+
+            review_threads_block = self._format_review_threads_block(pr_number)
+            retry_prompt = self._force_engagement_prompt(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                worktree_path=worktree_path,
+                pr_head_branch=pr_head_branch,
+                failing_check_names=failing,
+                review_threads_block=review_threads_block,
             )
-            return False
 
-        review_threads_block = self._format_review_threads_block(pr_number)
-        retry_prompt = self._force_engagement_prompt(
-            issue_number=issue_number,
-            pr_number=pr_number,
-            worktree_path=worktree_path,
-            pr_head_branch=pr_head_branch,
-            failing_check_names=failing,
-            review_threads_block=review_threads_block,
-        )
+            logger.warning(
+                "Issue #%s: no-commit on CI fix turn; re-invoking with "
+                "force-engagement prompt (retry %s/%s, failing: %s)",
+                issue_number,
+                retry,
+                max_retries,
+                ", ".join(failing) or "<unknown>",
+            )
 
-        logger.warning(
-            "Issue #%s: no-commit on first CI fix turn; re-invoking with "
-            "force-engagement prompt (failing: %s)",
-            issue_number,
-            ", ".join(failing) or "<unknown>",
-        )
-
-        try:
-            if is_codex(self.options.agent):
-                if session_id:
-                    try:
-                        resume_codex_session(
-                            session_id,
-                            retry_prompt,
-                            cwd=worktree_path,
-                            timeout=ci_driver_claude_timeout(),
-                        )
-                    except subprocess.CalledProcessError as exc:
-                        logger.warning(
-                            "Issue #%s: Codex retry resume failed for PR #%s; "
-                            "falling back to fresh session: %s",
-                            issue_number,
-                            pr_number,
-                            (exc.stderr or exc.stdout or "")[:300],
-                        )
+            try:
+                if is_codex(self.options.agent):
+                    if session_id:
+                        try:
+                            resume_codex_session(
+                                session_id,
+                                retry_prompt,
+                                cwd=worktree_path,
+                                timeout=ci_driver_claude_timeout(),
+                            )
+                        except subprocess.CalledProcessError as exc:
+                            logger.warning(
+                                "Issue #%s: Codex retry resume failed for PR #%s; "
+                                "falling back to fresh session: %s",
+                                issue_number,
+                                pr_number,
+                                (exc.stderr or exc.stdout or "")[:300],
+                            )
+                            run_codex_session(
+                                retry_prompt,
+                                cwd=worktree_path,
+                                timeout=ci_driver_claude_timeout(),
+                                sandbox="workspace-write",
+                            )
+                    else:
                         run_codex_session(
                             retry_prompt,
                             cwd=worktree_path,
@@ -1548,51 +1686,53 @@ class CIDriver:
                             sandbox="workspace-write",
                         )
                 else:
-                    run_codex_session(
-                        retry_prompt,
+                    repo_slug = get_repo_slug(self.repo_root)
+                    invoke_claude_with_session(
+                        repo=repo_slug,
+                        issue=issue_number,
+                        agent=AGENT_CI_DRIVER,
+                        prompt=retry_prompt,
+                        model=implementer_model(),
                         cwd=worktree_path,
                         timeout=ci_driver_claude_timeout(),
-                        sandbox="workspace-write",
+                        output_format="json",
+                        allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                        extra_args=["--dangerously-skip-permissions"],
+                        input_via_stdin=True,
                     )
-            else:
-                repo_slug = get_repo_slug(self.repo_root)
-                invoke_claude_with_session(
-                    repo=repo_slug,
-                    issue=issue_number,
-                    agent=AGENT_CI_DRIVER,
-                    prompt=retry_prompt,
-                    model=implementer_model(),
-                    cwd=worktree_path,
-                    timeout=ci_driver_claude_timeout(),
-                    output_format="json",
-                    allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                    extra_args=["--dangerously-skip-permissions"],
-                    input_via_stdin=True,
+            except subprocess.CalledProcessError as exc:
+                logger.error(
+                    "Issue #%s: no-commit retry session failed for PR #%s: %s",
+                    issue_number,
+                    pr_number,
+                    (exc.stderr or exc.stdout or "")[:300],
                 )
-        except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Issue #%s: no-commit retry session failed for PR #%s: %s",
-                issue_number,
-                pr_number,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return False
-        except subprocess.TimeoutExpired:
-            logger.error(
-                "Issue #%s: no-commit retry session timed out for PR #%s",
-                issue_number,
-                pr_number,
-            )
-            return False
+                return False
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    "Issue #%s: no-commit retry session timed out for PR #%s",
+                    issue_number,
+                    pr_number,
+                )
+                return False
 
-        if self._head_advanced(worktree_path, pre_agent_sha, issue_number):
-            return True
+            if self._head_advanced(worktree_path, pre_agent_sha, issue_number):
+                return True
+
+            logger.warning(
+                "Issue #%s: still no commit on PR #%s after force-engagement retry %s/%s",
+                issue_number,
+                pr_number,
+                retry,
+                max_retries,
+            )
 
         logger.error(
-            "Issue #%s: REPEATED no-commit on PR #%s after force-engagement retry; "
-            "marking and moving on",
+            "Issue #%s: REPEATED no-commit on PR #%s after %s force-engagement "
+            "retries; marking and moving on",
             issue_number,
             pr_number,
+            max_retries,
         )
         self._record_repeated_no_commit(
             issue_number=issue_number,
@@ -1893,7 +2033,7 @@ class CIDriver:
             )
             return False
 
-    def _enable_auto_merge(self, pr_number: int) -> bool:
+    def _enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:
         """Enable auto-merge for the given PR using squash strategy.
 
         First attempts ``gh pr merge --auto --squash``. This repo is
@@ -1903,8 +2043,16 @@ class CIDriver:
         squash merge (``gh pr merge --squash --delete-branch``). If both
         strategies fail, logs an ERROR and returns False.
 
+        For bot-authored PRs (Dependabot etc., #848) a green PR left ``NOT
+        armed`` accumulates forever and keeps the repo perpetually "not done".
+        Those PRs are low-risk dependency bumps, so before giving up we make a
+        strategy-agnostic ``gh pr merge --auto`` attempt (no ``--squash``),
+        letting whatever merge method the repo actually allows take effect.
+
         Args:
             pr_number: GitHub PR number.
+            is_bot_pr: True when this is a bot-authored PR, enabling the
+                strategy-agnostic arming retry described above.
 
         Returns:
             True if auto-merge was enabled (or fallback merge succeeded),
@@ -1922,6 +2070,21 @@ class CIDriver:
                 pr_number,
                 e,
             )
+
+        # Bot PRs: try arming without forcing a strategy before stronger
+        # fallbacks. A repo that disallows squash (rebase/merge-only) would
+        # otherwise strand every Dependabot PR as NOT armed.
+        if is_bot_pr:
+            try:
+                _gh_call(["pr", "merge", str(pr_number), "--auto"])
+                logger.info("Enabled auto-merge (strategy-agnostic) for bot PR #%s", pr_number)
+                return True
+            except subprocess.CalledProcessError as bot_err:
+                logger.warning(
+                    "Could not enable strategy-agnostic auto-merge for bot PR #%s: %s",
+                    pr_number,
+                    bot_err,
+                )
 
         if not self.options.force_merge_on_stall:
             logger.error(
@@ -2222,6 +2385,70 @@ def _final_loop_gate_passes(force: bool) -> tuple[bool, str]:
     return True, f"final loop {idx}/{total}"
 
 
+def _evaluate_run_result(
+    results: dict[int, WorkerResult],
+    open_prs_remaining: list[dict[str, Any]],
+    *,
+    issues: list[int],
+    as_json: bool,
+) -> int:
+    """Map a completed drive into a process exit code (#838).
+
+    The repo is "done" when no PR still needs human action. After the
+    wait-for-merge change the driver blocks on armed PRs until they merge or go
+    red, so a PR that is STILL armed-and-pending at exit is just slow CI we
+    already waited on — it must not red-flag the repo. We partition the
+    remaining open PRs into ``armed_pending`` (auto-merge armed, merging on its
+    own) vs ``needs_action`` (un-armed, genuinely stuck) and only fail on the
+    latter (or on per-issue failures).
+
+    Args:
+        results: Per-issue worker results from ``CIDriver.run()``.
+        open_prs_remaining: Open PRs left on the repo (each carries
+            ``number`` and ``autoMergeRequest``).
+        issues: The input issue list (echoed into JSON status).
+        as_json: Whether to emit a machine-readable status line.
+
+    Returns:
+        ``0`` if clean (possibly with armed-pending PRs still merging),
+        ``1`` if any issue failed or any PR needs manual action.
+
+    """
+    log = logging.getLogger(__name__)
+    failed = [num for num, result in results.items() if not result.success]
+    armed_pending = [pr.get("number") for pr in open_prs_remaining if pr.get("autoMergeRequest")]
+    needs_action = [pr.get("number") for pr in open_prs_remaining if not pr.get("autoMergeRequest")]
+    if armed_pending:
+        log.warning(
+            "%s PR(s) armed and still merging (waited; not a failure): %s",
+            len(armed_pending),
+            armed_pending,
+        )
+    if failed or needs_action:
+        if failed:
+            log.error("CI drive failed for %s issue(s): %s", len(failed), failed)
+        if needs_action:
+            log.error(
+                "Repo not done: %s open PR(s) need manual action: %s",
+                len(needs_action),
+                needs_action,
+            )
+        if as_json:
+            emit_json_status(
+                1,
+                issues=issues,
+                failed=failed,
+                needs_action=needs_action,
+                armed_pending=armed_pending,
+            )
+        return 1
+
+    log.info("CI driver complete")
+    if as_json:
+        emit_json_status(0, issues=issues, failed=[], needs_action=[], armed_pending=armed_pending)
+    return 0
+
+
 def main() -> int:
     """Execute the CI driver workflow.
 
@@ -2262,35 +2489,9 @@ def main() -> int:
 
         driver = CIDriver(options)
         results = driver.run()
-
-        failed = [num for num, result in results.items() if not result.success]
-        # The repo is "done" only when there are zero open PRs left — even
-        # an empty ``failed`` list is not sufficient because auto-merge may
-        # still be pending, PRs from outside the input set may remain, etc.
-        # (#838). ``driver.open_prs_remaining`` is populated by ``run()``.
-        remaining_pr_numbers = [pr.get("number") for pr in driver.open_prs_remaining]
-        if failed or remaining_pr_numbers:
-            if failed:
-                log.error("CI drive failed for %s issue(s): %s", len(failed), failed)
-            if remaining_pr_numbers:
-                log.error(
-                    "Repo not done: %s open PR(s) remain: %s",
-                    len(remaining_pr_numbers),
-                    remaining_pr_numbers,
-                )
-            if args.json:
-                emit_json_status(
-                    1,
-                    issues=args.issues,
-                    failed=failed,
-                    open_prs_remaining=remaining_pr_numbers,
-                )
-            return 1
-
-        log.info("CI driver complete")
-        if args.json:
-            emit_json_status(0, issues=args.issues, failed=[], open_prs_remaining=[])
-        return 0
+        return _evaluate_run_result(
+            results, driver.open_prs_remaining, issues=args.issues, as_json=args.json
+        )
 
     except KeyboardInterrupt:
         log.warning("Interrupted by user")

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.agents.runtime import AgentRunResult
-from hephaestus.automation.ci_driver import CIDriver
-from hephaestus.automation.models import CIDriverOptions
+from hephaestus.automation.ci_driver import CIDriver, _evaluate_run_result
+from hephaestus.automation.models import CIDriverOptions, WorkerResult
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -451,11 +451,12 @@ class TestAllRequiredGreen:
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
             patch.object(driver, "_enable_auto_merge") as mock_merge,
             patch.object(driver, "_run_drive_green_learnings"),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
         assert result.success is True
-        mock_merge.assert_called_once_with(456)
+        mock_merge.assert_called_once_with(456, is_bot_pr=False)
 
     def test_dry_run_no_auto_merge(self, mock_options: CIDriverOptions, tmp_path: Path) -> None:
         """dry_run=True, all green → gh pr merge not called."""
@@ -502,12 +503,13 @@ class TestRequiredVsNonRequired:
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
             patch.object(driver, "_enable_auto_merge") as mock_merge,
             patch.object(driver, "_run_drive_green_learnings"),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
         # All non-required treated as required → all green → auto-merge
         assert result.success is True
-        mock_merge.assert_called_once_with(456)
+        mock_merge.assert_called_once_with(456, is_bot_pr=False)
 
     def test_required_vs_nonrequired_only_required_gates_green(self, driver: CIDriver) -> None:
         """Mix of required/non-required; only required=True ones gate green."""
@@ -520,11 +522,12 @@ class TestRequiredVsNonRequired:
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
             patch.object(driver, "_enable_auto_merge") as mock_merge,
             patch.object(driver, "_run_drive_green_learnings"),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
         assert result.success is True
-        mock_merge.assert_called_once_with(456)
+        mock_merge.assert_called_once_with(456, is_bot_pr=False)
 
     def test_failing_required_runs_fix_session(self, driver: CIDriver) -> None:
         """Required check failed → _run_ci_fix_session called."""
@@ -772,6 +775,9 @@ class TestDriveGreenLearnings:
                 "hephaestus.automation.ci_driver.invoke_claude_with_session",
                 return_value=("ok", "sid"),
             ) as mock_invoke,
+            # Don't block on the post-arm wait loop; we only assert the
+            # arming record is written here, not the merge outcome.
+            patch.object(driver, "_wait_for_pr_terminal", return_value="TIMEOUT"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
@@ -884,8 +890,8 @@ class TestDriveGreenLearnings:
         mock_learn.assert_not_called()
         mock_state.assert_not_called()
 
-    def test_check_armed_pr_open_at_same_sha_short_circuits(self, driver: CIDriver) -> None:
-        """OPEN at the armed SHA → success, /learn not fired, record kept."""
+    def test_check_armed_pr_open_at_same_sha_waits_then_pending(self, driver: CIDriver) -> None:
+        """OPEN at the armed SHA → wait; still pending (TIMEOUT) keeps the record."""
         driver._save_arming_state(
             42,
             {
@@ -903,6 +909,8 @@ class TestDriveGreenLearnings:
                 return_value={"state": "OPEN", "headRefOid": "abc1234"},
             ),
             patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+            # The PR never resolves within the budget → TIMEOUT (still pending).
+            patch.object(driver, "_wait_for_pr_terminal", return_value="TIMEOUT"),
         ):
             result = driver._check_arming_on_drive_start(42, 500)
 
@@ -911,6 +919,37 @@ class TestDriveGreenLearnings:
         mock_learn.assert_not_called()
         # Record preserved for the next run.
         assert driver._load_arming_state(42) is not None
+
+    def test_check_armed_pr_merges_during_wait_fires_learn(self, driver: CIDriver) -> None:
+        """OPEN at armed SHA that merges during the wait → /learn fires once."""
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_captured_at": None,
+            },
+        )
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "headRefOid": "abc1234"},
+            ),
+            patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+            patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        assert result is not None
+        assert result.success is True
+        mock_learn.assert_called_once_with(42, 500)
+        # Record marked captured so /learn never re-fires.
+        record = driver._load_arming_state(42)
+        assert record is not None
+        assert record["learn_captured_at"] is not None
 
     def test_check_armed_pr_head_advanced_clears_record_and_falls_through(
         self, driver: CIDriver
@@ -1045,6 +1084,7 @@ class TestCIPollLoop:
             patch("hephaestus.automation.ci_driver.time.sleep"),
             patch.object(driver, "_enable_auto_merge", return_value=True),
             patch.object(driver, "_run_drive_green_learnings"),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
         ):
             result = driver._drive_issue(123, 456, 0)
 
@@ -1472,8 +1512,9 @@ class TestNoCommitRetry:
                 session_id=None,
             )
         assert result is False
-        # Exactly ONE retry — must not loop forever.
-        mock_invoke.assert_called_once()
+        # Bounded retries — re-engages up to max_retries (default 2) before
+        # giving up, so a single no-op turn is no longer terminal (#846).
+        assert mock_invoke.call_count == 2
         # Forensics marker is written next to the arming-state files.
         marker = driver.state_dir / "repeated-no-commit-2.json"
         assert marker.exists()
@@ -1968,3 +2009,114 @@ class TestMechanicalRebase:
         # With the flag off the method is simply never called; here we assert the
         # option is wired so the guard evaluates False.
         assert driver.options.enable_mechanical_rebase is False
+
+
+# ---------------------------------------------------------------------------
+# #838: wait-for-merge + final-gate honesty
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForPrTerminal:
+    """``_wait_for_pr_terminal`` blocks until a real terminal state (#838)."""
+
+    def test_merged_returns_merged(self, driver: CIDriver) -> None:
+        with patch.object(driver, "_gh_pr_state", return_value={"state": "MERGED"}):
+            assert driver._wait_for_pr_terminal(1, 2) == "MERGED"
+
+    def test_closed_returns_closed(self, driver: CIDriver) -> None:
+        with patch.object(driver, "_gh_pr_state", return_value={"state": "CLOSED"}):
+            assert driver._wait_for_pr_terminal(1, 2) == "CLOSED"
+
+    def test_open_with_red_required_check_returns_failing(self, driver: CIDriver) -> None:
+        # OPEN but a required check is red → react immediately, don't wait it out.
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"state": "OPEN"}),
+            patch.object(driver, "_failing_required_check_names", return_value=["lint"]),
+        ):
+            assert driver._wait_for_pr_terminal(1, 2) == "FAILING"
+
+    def test_open_and_green_times_out(
+        self, driver: CIDriver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # OPEN, no failing checks, never merges → bounded by HEPH_PR_MERGE_MAX_WAIT.
+        monkeypatch.setenv("HEPH_PR_MERGE_MAX_WAIT", "0")
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"state": "OPEN"}),
+            patch.object(driver, "_failing_required_check_names", return_value=[]),
+            patch("hephaestus.automation.ci_driver.time.sleep") as mock_sleep,
+        ):
+            assert driver._wait_for_pr_terminal(1, 2) == "TIMEOUT"
+        # With a 0s budget the very first sleep would overrun → no sleep at all.
+        mock_sleep.assert_not_called()
+
+    def test_dry_run_short_circuits_to_timeout(
+        self, mock_options: CIDriverOptions, tmp_path: Path
+    ) -> None:
+        mock_options.dry_run = True
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_root", return_value=tmp_path),
+            patch("hephaestus.automation.ci_driver.WorktreeManager"),
+            patch("hephaestus.automation.ci_driver.StatusTracker"),
+        ):
+            d = CIDriver(mock_options)
+            d.state_dir = tmp_path
+        # Must not touch the network in dry-run.
+        with patch.object(d, "_gh_pr_state") as mock_state:
+            assert d._wait_for_pr_terminal(1, 2) == "TIMEOUT"
+        mock_state.assert_not_called()
+
+
+class TestEnableAutoMergeBotRetry:
+    """Bot PRs get a strategy-agnostic ``--auto`` retry before giving up (#848)."""
+
+    def test_bot_pr_falls_back_to_strategy_agnostic_auto(self, driver: CIDriver) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh(args: list[str]) -> MagicMock:
+            calls.append(args)
+            # First call (--auto --squash) fails; second (--auto) succeeds.
+            if "--squash" in args:
+                raise subprocess.CalledProcessError(1, args, stderr="squash disabled")
+            return MagicMock(stdout="")
+
+        with patch("hephaestus.automation.ci_driver._gh_call", side_effect=fake_gh):
+            ok = driver._enable_auto_merge(2, is_bot_pr=True)
+        assert ok is True
+        # Exactly two arming attempts: --squash then strategy-agnostic --auto.
+        assert ["pr", "merge", "2", "--auto", "--squash"] in calls
+        assert ["pr", "merge", "2", "--auto"] in calls
+
+    def test_non_bot_pr_does_not_get_extra_retry(self, driver: CIDriver) -> None:
+        # force_merge_on_stall is False by default → no fallback for human PRs.
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call",
+            side_effect=subprocess.CalledProcessError(1, ["gh"], stderr="nope"),
+        ) as mock_gh:
+            ok = driver._enable_auto_merge(2, is_bot_pr=False)
+        assert ok is False
+        # Only the primary --squash attempt; no strategy-agnostic retry.
+        assert mock_gh.call_count == 1
+
+
+class TestEvaluateRunResult:
+    """The final gate separates armed-pending PRs from genuinely-stuck ones (#838)."""
+
+    def test_clean_repo_is_zero(self) -> None:
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        assert _evaluate_run_result(results, [], issues=[1], as_json=False) == 0
+
+    def test_armed_pending_only_is_zero(self) -> None:
+        # A PR still merging on its own must NOT red-flag the repo.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining = [{"number": 10, "autoMergeRequest": {"enabledAt": "now"}}]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
+
+    def test_needs_action_pr_is_one(self) -> None:
+        # An un-armed PR genuinely needs manual action → failure.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining = [{"number": 11, "autoMergeRequest": None}]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 1
+
+    def test_failed_issue_is_one(self) -> None:
+        results = {1: WorkerResult(issue_number=1, success=False, pr_number=10)}
+        assert _evaluate_run_result(results, [], issues=[1], as_json=False) == 1

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1151,6 +1151,8 @@ class TestRunCleanup:
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=[green_check]),
             patch.object(d, "_enable_auto_merge", return_value=True),
             patch.object(d, "_run_drive_green_learnings"),
+            # Don't block the worker on the post-arm wait loop (#838).
+            patch.object(d, "_wait_for_pr_terminal", return_value="MERGED"),
         ):
             d.run()
 
@@ -1186,6 +1188,8 @@ class TestRunCleanup:
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=[green_check]),
             patch.object(d, "_enable_auto_merge", return_value=True),
             patch.object(d, "_run_drive_green_learnings"),
+            # Don't block the worker on the post-arm wait loop (#838).
+            patch.object(d, "_wait_for_pr_terminal", return_value="MERGED"),
             caplog.at_level(logging.INFO, logger="hephaestus.automation.ci_driver"),
         ):
             d.run()


### PR DESCRIPTION
Closes #877

## Objective

A `drive_prs_green` ecosystem run reported **7 repos as FAILED** that were not actually broken. Root-cause analysis showed the driver's observe-and-return design exits non-zero whenever *any* open PR remains — even when every PR was processed successfully and is auto-merge-armed, merging on its own. This PR makes the driver wait for real outcomes and stops false failures.

## Changes

**1. Wait-for-merge** — new `_wait_for_pr_terminal` blocks on an armed PR until it `MERGED` / `CLOSED` / `FAILING` (a required check turns red after arming) / `TIMEOUT` (`HEPH_PR_MERGE_MAX_WAIT`, default 1800s). Wired into `_drive_issue` (post-arm) and the "still OPEN at armed SHA" branch of `_check_arming_on_drive_start`. On `FAILING` we drive a fix instead of declaring success; on `MERGED` the post-merge `/learn` fires once.

**2. Robust dependabot arming** — `_enable_auto_merge` now takes `is_bot_pr`; for bot PRs it makes a strategy-agnostic `--auto` retry (no `--squash`) before giving up, so repos that disallow squash stop stranding every Dependabot PR as `NOT armed`.

**3. Final-gate honesty** — extracted `_evaluate_run_result`, which partitions remaining open PRs into `armed_pending` (still merging → warn, not fail) vs `needs_action` (un-armed, genuinely stuck → fail). JSON status reports both buckets distinctly.

**4. Harden no-commit path** — `_retry_no_commit_once` re-engages up to `max_retries` (default 2) times instead of once before recording the forensics marker, so a single no-op agent turn is no longer terminal (cost real PRs in AchaeanFleet/Hermes).

## Success Criteria

- [x] New tests for `_wait_for_pr_terminal` states + timeout, bot arming retry, gate partitioning, bounded no-commit retry
- [x] Green-path `_drive_issue` tests patch the new wait so they don't block
- [x] Full module: **107 passed**
- [x] `pre-commit run` clean (ruff, mypy, bandit, C901)

## Notes

Companion fix in HomericIntelligence/AchaeanFleet#693 repairs the broken-on-main CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)