### PR TITLE
[Fix] ci_driver: re-arm after fix, session races, DIRTY PRs, lint-safe blocker

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -946,8 +946,12 @@ class CIDriver:
         try:
             result = _gh_call(["pr", "view", str(pr_number), "--json", "baseRefName"], check=False)
             base_branch = dict(json.loads(result.stdout or "{}")).get("baseRefName") or "main"
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
-            pass
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.debug(
+                "Failed to determine PR base branch for #%s; defaulting to 'main': %s",
+                pr_number,
+                exc,
+            )
         conflict_context = (
             f"This PR has a MERGE CONFLICT with `origin/{base_branch}` "
             f"(mergeStateStatus=DIRTY) — it cannot merge until the conflict is "

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -608,6 +608,11 @@ class CIDriver:
                     outcome = self._wait_for_pr_terminal(issue_number, pr_number)
                     if outcome == "FAILING":
                         fix_result = self._attempt_ci_fixes(issue_number, pr_number, acquired_slot)
+                        if fix_result is not None and fix_result.success:
+                            rearmed = self._recheck_and_arm_after_fix(
+                                issue_number, pr_number, acquired_slot
+                            )
+                            return rearmed if rearmed is not None else fix_result
                         if fix_result is not None:
                             return fix_result
                         return WorkerResult(
@@ -618,6 +623,8 @@ class CIDriver:
                                 f"CI fix failed after {self.options.max_fix_iterations} attempt(s)"
                             ),
                         )
+                    if outcome == "DIRTY":
+                        return self._resolve_dirty_pr(issue_number, pr_number, acquired_slot)
                 return WorkerResult(
                     issue_number=issue_number,
                     success=merge_ok,
@@ -640,6 +647,15 @@ class CIDriver:
 
             # 6. Attempt fix iterations
             fix_result = self._attempt_ci_fixes(issue_number, pr_number, acquired_slot)
+            if fix_result is not None and fix_result.success:
+                # A fix was pushed, which re-triggers CI. The old code returned
+                # success here and walked away, leaving a now-green PR NOT armed
+                # (it never re-polled or enabled auto-merge). Re-enter the
+                # check→arm→wait flow ONCE so the fixed PR actually arms.
+                rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+                if rearmed is not None:
+                    return rearmed
+                return fix_result
             if fix_result is not None:
                 return fix_result
 
@@ -827,11 +843,138 @@ class CIDriver:
             build_prompt=get_advise_prompt,
         )
 
+    def _recheck_and_arm_after_fix(
+        self, issue_number: int, pr_number: int, acquired_slot: int
+    ) -> WorkerResult | None:
+        """After a CI fix is pushed, re-poll checks and arm if now green.
+
+        The fix push re-triggers CI. Historically ``_attempt_ci_fixes`` returned
+        success the instant a fix landed and never came back to arm the PR, so a
+        now-green PR sat ``NOT armed`` forever (observed: ProjectHermes #645,
+        which ended ``CLEAN`` but un-armed). This re-enters the
+        check→arm→wait flow ONCE.
+
+        Returns:
+            A terminal ``WorkerResult`` if the PR armed (and we waited on it), or
+            ``None`` if CI is still pending / not green yet — in which case the
+            caller keeps the fix's success result and a later run arms it.
+
+        """
+        if self.options.dry_run:
+            return None
+
+        # Bounded poll for the freshly-pushed run to conclude. Reuse the same
+        # backoff/cap pattern as the main poll loop.
+        max_wait = int(os.environ.get("HEPH_CI_POLL_MAX_WAIT", "600"))
+        elapsed = 0
+        attempt = 0
+        while True:
+            checks = gh_pr_checks(pr_number, dry_run=self.options.dry_run)
+            required = [c for c in checks if c.get("required", False)] or checks
+            if required and all(c.get("status") == "completed" for c in required):
+                break
+            sleep_secs = min(2**attempt, 60)
+            if elapsed + sleep_secs > max_wait:
+                logger.info(
+                    "Issue #%s: post-fix CI still pending after %ss; leaving for next run",
+                    issue_number,
+                    elapsed,
+                )
+                return None
+            self.status_tracker.update_slot(
+                acquired_slot,
+                f"{issue_ref(issue_number)}: awaiting post-fix CI ({elapsed}s)",
+            )
+            time.sleep(sleep_secs)
+            elapsed += sleep_secs
+            attempt += 1
+
+        required = [c for c in checks if c.get("required", False)] or checks
+        if not all(c.get("conclusion") in ("success", "skipped", "neutral") for c in required):
+            # Still red after the fix — let the normal failure handling stand.
+            return None
+
+        self.status_tracker.update_slot(
+            acquired_slot, f"{issue_ref(issue_number)}: enabling auto-merge (post-fix)"
+        )
+        merge_ok = self._enable_auto_merge(
+            pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number)
+        )
+        if not merge_ok:
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                pr_number=pr_number,
+                error=f"auto-merge failed for PR {pr_ref(pr_number)}",
+            )
+        gh_state = self._gh_pr_state(pr_number)
+        pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
+        pr_head_branch = self._get_pr_branch(pr_number)
+        self._arm_drive_green(pr_number, pr_head_branch, pr_head_sha)
+        self._wait_for_pr_terminal(issue_number, pr_number)
+        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+    def _resolve_dirty_pr(
+        self, issue_number: int, pr_number: int, acquired_slot: int
+    ) -> WorkerResult:
+        """Resolve an armed-but-DIRTY (merge-conflict) PR (#838 follow-up).
+
+        ``_wait_for_pr_terminal`` returns ``"DIRTY"`` for an armed PR with a
+        merge conflict — it can never merge while armed, and waiting out the
+        1800s timeout makes no progress. First try the cheap mechanical rebase;
+        if that lands cleanly the push re-triggers CI and we re-arm. If the
+        rebase still conflicts, hand it to the agent with explicit
+        conflict-resolution instructions (the normal fix path only fires on
+        failing *checks*, and a conflicted PR has none — so the agent would
+        otherwise get no guidance).
+
+        Returns a terminal ``WorkerResult``.
+        """
+        if self.options.dry_run:
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+        # 1. Cheap path: mechanical rebase. Returns True only on a clean
+        #    rebase+push, in which case re-poll and arm the rebased head.
+        if self._attempt_mechanical_rebase(issue_number, pr_number, acquired_slot):
+            rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+            if rearmed is not None:
+                return rearmed
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+        # 2. Rebase still conflicts → agent resolves the conflict explicitly.
+        base_branch = "main"
+        try:
+            result = _gh_call(["pr", "view", str(pr_number), "--json", "baseRefName"], check=False)
+            base_branch = dict(json.loads(result.stdout or "{}")).get("baseRefName") or "main"
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            pass
+        conflict_context = (
+            f"This PR has a MERGE CONFLICT with `origin/{base_branch}` "
+            f"(mergeStateStatus=DIRTY) — it cannot merge until the conflict is "
+            f"resolved. Rebase the PR head branch onto `origin/{base_branch}` and "
+            f"resolve every conflict, keeping both the PR's intent and the latest "
+            f"base changes. Then commit the resolution (signed). There may be NO "
+            f"failing CI checks — the conflict itself is the blocker."
+        )
+        fix_result = self._attempt_ci_fixes(
+            issue_number, pr_number, acquired_slot, extra_context=conflict_context
+        )
+        if fix_result is not None and fix_result.success:
+            rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+            return rearmed if rearmed is not None else fix_result
+        return WorkerResult(
+            issue_number=issue_number,
+            success=False,
+            pr_number=pr_number,
+            error=f"PR {pr_ref(pr_number)} has an unresolved merge conflict",
+        )
+
     def _attempt_ci_fixes(
         self,
         issue_number: int,
         pr_number: int,
         acquired_slot: int,
+        extra_context: str = "",
     ) -> WorkerResult | None:
         """Attempt CI fix iterations for a failing PR.
 
@@ -839,6 +982,9 @@ class CIDriver:
             issue_number: GitHub issue number.
             pr_number: GitHub PR number.
             acquired_slot: Worker slot ID for status tracking.
+            extra_context: Optional text prepended to the CI failure logs in the
+                fix-session prompt — e.g. merge-conflict resolution instructions
+                for a DIRTY PR, where ``_get_failing_ci_logs`` alone is empty.
 
         Returns:
             WorkerResult on success or dry-run, None if all iterations failed.
@@ -861,6 +1007,8 @@ class CIDriver:
                 f"{issue_ref(issue_number)}: fetching CI logs (attempt {iteration + 1})",
             )
             ci_logs = self._get_failing_ci_logs(pr_number)
+            if extra_context:
+                ci_logs = f"{extra_context}\n\n{ci_logs}".strip()
             session_id = self._load_impl_session_id(issue_number)
             worktree_path = self._get_worktree_path(issue_number, pr_number)
             # Resolve the PR's actual head-branch name once per iteration. The
@@ -1115,14 +1263,22 @@ class CIDriver:
             )
 
     def _gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
-        """Return ``{state, headRefOid, mergedAt}`` for ``pr_number`` or ``None``.
+        """Return ``{state, headRefOid, mergedAt, mergeStateStatus}`` or ``None``.
 
         Used by the on-drive-start check (#840) to detect post-merge so the
-        ``/learn`` capture can fire exactly once per issue.
+        ``/learn`` capture can fire exactly once per issue, and by
+        ``_wait_for_pr_terminal`` to detect a ``DIRTY`` (merge-conflict) PR that
+        would otherwise sit armed-but-unmergeable until the timeout.
         """
         try:
             result = _gh_call(
-                ["pr", "view", str(pr_number), "--json", "state,headRefOid,mergedAt"],
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "state,headRefOid,mergedAt,mergeStateStatus",
+                ],
                 check=False,
             )
             return dict(json.loads(result.stdout or "{}"))
@@ -1154,7 +1310,9 @@ class CIDriver:
             pr_number: PR whose merge we are waiting on.
 
         Returns:
-            One of ``"MERGED"``, ``"CLOSED"``, ``"FAILING"``, or ``"TIMEOUT"``.
+            One of ``"MERGED"``, ``"CLOSED"``, ``"FAILING"``, ``"DIRTY"`` (the
+            PR has a merge conflict and will never merge while armed — caller
+            should rebase/resolve), or ``"TIMEOUT"``.
 
         """
         if self.options.dry_run:
@@ -1191,6 +1349,20 @@ class CIDriver:
                     ", ".join(failing),
                 )
                 return "FAILING"
+
+            # An armed PR that is DIRTY/CONFLICTING has a merge conflict with
+            # the base branch — it can never merge while armed, so waiting out
+            # the full timeout is pointless. Stop and let the caller rebase /
+            # hand it to the agent to resolve the conflict.
+            merge_status = ((gh_state or {}).get("mergeStateStatus") or "").upper()
+            if merge_status in ("DIRTY", "CONFLICTING"):
+                logger.warning(
+                    "Issue #%s: PR #%s is %s (merge conflict) while armed; needs rebase/resolution",
+                    issue_number,
+                    pr_number,
+                    merge_status,
+                )
+                return "DIRTY"
 
             sleep_secs = min(2**attempt, 60)
             if elapsed + sleep_secs > max_wait:
@@ -1378,9 +1550,10 @@ class CIDriver:
         if outcome == "CLOSED":
             self._clear_arming_state(issue_number)
             return None
-        if outcome == "FAILING":
-            # PR went red after arming — clear the stale arming and fall
-            # through so the normal drive path can fix it.
+        if outcome in ("FAILING", "DIRTY"):
+            # PR went red (FAILING) or now conflicts (DIRTY) after arming —
+            # clear the stale arming and fall through so the normal drive path
+            # re-arms and routes to the fix / _resolve_dirty_pr handling.
             self._clear_arming_state(issue_number)
             return None
         # TIMEOUT — still pending; leave armed for a later pass to resolve.
@@ -1519,9 +1692,12 @@ class CIDriver:
             f"failing on the remote:\n\n"
             f"{failing_block}\n\n"
             f"Returning no commit when required checks are still red is itself a "
-            f"bug — either fix the code so the failing checks pass, or, if no fix "
-            f"is possible, write a commit that documents the blocker in the PR "
-            f"description and references the upstream cause.\n\n"
+            f"bug — fix the code so the failing checks pass. If no code fix is "
+            f"possible, DO NOT commit a 'blocker' file: a new Markdown/docs file "
+            f"will itself fail the repo's lint gates (e.g. markdownlint) and turn "
+            f"one red check into two. Instead leave the tree unchanged and report "
+            f"the blocker via the `BLOCKED:` line below — do NOT commit any file to "
+            f"document it.\n\n"
             f"Working directory: {worktree_path}\n"
             f"Current branch (DO NOT change, DO NOT create a new branch): "
             f"{pr_head_branch}\n\n"
@@ -1529,13 +1705,17 @@ class CIDriver:
             f"1. Re-read the failing check logs for the names listed above.\n"
             f"2. Make the minimal change that addresses each failure.\n"
             f"3. Run `pixi run python -m pytest tests/ -v` and "
-            f"`pre-commit run --all-files` locally to verify before committing.\n"
+            f"`pre-commit run --all-files` locally to verify before committing. "
+            f"This MUST include any markdown/lint hooks — every file you add or "
+            f"edit has to pass the repo's own linters, with no rule disabled.\n"
             f"4. **Every commit MUST be cryptographically signed (`git commit -S`).** "
             f"NEVER use `--no-verify`. The repository's CI gate rejects unsigned "
             f"commits and any commit that bypassed pre-commit hooks.\n"
             f"5. Do NOT run `git checkout -b`, `git switch -c`, or any command "
             f"that creates or switches branches — the fix has to land on "
-            f"`{pr_head_branch}`.\n\n"
+            f"`{pr_head_branch}`.\n"
+            f"6. Do NOT add a new top-level `CI_BLOCKER.md` or similar doc file to "
+            f"record the blocker — use the `BLOCKED:` line instead.\n\n"
             f"If after the steps above you still cannot produce a commit, reply "
             f"with a single line `BLOCKED: <one-sentence reason>` and stop."
         )

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import subprocess
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -143,11 +144,17 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
     if not input_via_stdin:
         base_tail.append(prompt)
 
-    def _build(create: bool) -> list[str]:
-        mode = ["--session-id", sid, "--name", display_name] if create else ["--resume", sid]
+    def _build(
+        create: bool, sid_override: str | None = None, name_override: str | None = None
+    ) -> list[str]:
+        use_sid = sid_override or sid
+        use_name = name_override or display_name
+        mode = ["--session-id", use_sid, "--name", use_name] if create else ["--resume", use_sid]
         return ["claude", *mode, *base_tail]
 
-    def _run(create: bool) -> subprocess.CompletedProcess[str]:
+    def _run(
+        create: bool, sid_override: str | None = None, name_override: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         # CLAUDECODE is set by an outer Claude Code process to refuse nested
         # invocations; clear it so the automation subprocess can launch.
@@ -158,12 +165,12 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
         cid = get_current_correlation_id()
         if cid:
             env["GH_TRACE_ID"] = cid
-        cmd = _build(create)
+        cmd = _build(create, sid_override=sid_override, name_override=name_override)
         logger.debug(
             "claude invoke: agent=%s issue=%s sid=%s mode=%s",
             agent,
             issue,
-            sid,
+            sid_override or sid,
             "create" if create else "resume",
         )
         return subprocess.run(
@@ -187,13 +194,44 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
             # drift between hephaestus and the CLI can desync the probe;
             # treat the rejection as proof the session exists and resume it.
             stderr = (exc.stderr or "") + (exc.stdout or "")
-            if "already in use" in stderr.lower():
-                logger.warning(
-                    "claude --session-id %s rejected as already in use; resuming instead",
-                    sid,
-                )
-                return _run(create=False).stdout, sid
-            raise
+            if "already in use" not in stderr.lower():
+                raise
+            # Under concurrency (3 parallel CI-fix workers) two workers can race
+            # on the same deterministic UUIDv5 session before the transcript is
+            # on disk; the loser hits "already in use" (observed: ProjectHermes
+            # #647). The session may still be initializing in the sibling worker,
+            # so resume can ALSO fail. Retry resume with backoff; if it never
+            # frees, fall back to a FRESH unique session so the drive proceeds
+            # instead of aborting the PR.
+            logger.warning(
+                "claude --session-id %s rejected as already in use; resuming instead",
+                sid,
+            )
+            for resume_attempt in range(3):
+                try:
+                    return _run(create=False).stdout, sid
+                except subprocess.CalledProcessError as resume_exc:
+                    logger.warning(
+                        "claude --resume %s failed (attempt %s/3): %s",
+                        sid,
+                        resume_attempt + 1,
+                        ((resume_exc.stderr or "") + (resume_exc.stdout or ""))[:200],
+                    )
+                    time.sleep(2 * (resume_attempt + 1))
+            # Resume never succeeded — derive a fresh, unique session so this
+            # worker is not coupled to the contended id. uuid4 guarantees no
+            # collision with the deterministic id or another worker's fresh one.
+            fresh_sid = str(uuid.uuid4())
+            fresh_name = f"{display_name}-{fresh_sid[:8]}"
+            logger.warning(
+                "claude session %s unrecoverable; creating fresh session %s",
+                sid,
+                fresh_sid,
+            )
+            return (
+                _run(create=True, sid_override=fresh_sid, name_override=fresh_name).stdout,
+                fresh_sid,
+            )
 
     try:
         return _run(create=False).stdout, sid

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1393,6 +1393,14 @@ class TestForceEngagementPrompt:
         # Signed-commits and no --no-verify re-stated (user requirement).
         assert "git commit -S" in prompt
         assert "--no-verify" in prompt
+        # Bug 4: the agent must NOT be told to commit a blocker file (a new
+        # Markdown file fails the repo's markdownlint and turns 1 red check into
+        # 2). It should use the BLOCKED: line and never disable a lint rule.
+        assert "CI_BLOCKER.md" in prompt  # explicitly named as forbidden
+        assert "BLOCKED:" in prompt
+        assert "no rule disabled" in prompt
+        # The old "write a commit that documents the blocker" instruction is gone.
+        assert "write a commit that documents the blocker" not in prompt
 
     def test_review_threads_block_prepended_when_nonempty(
         self, driver: CIDriver, tmp_path: Path
@@ -2039,6 +2047,19 @@ class TestWaitForPrTerminal:
         ):
             assert driver._wait_for_pr_terminal(1, 2) == "FAILING"
 
+    def test_open_dirty_returns_dirty(self, driver: CIDriver) -> None:
+        # OPEN, checks green, but mergeStateStatus DIRTY (conflict) → DIRTY,
+        # don't wait out the full timeout on an unmergeable armed PR (#838).
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "mergeStateStatus": "DIRTY"},
+            ),
+            patch.object(driver, "_failing_required_check_names", return_value=[]),
+        ):
+            assert driver._wait_for_pr_terminal(1, 2) == "DIRTY"
+
     def test_open_and_green_times_out(
         self, driver: CIDriver, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -2068,6 +2089,102 @@ class TestWaitForPrTerminal:
         with patch.object(d, "_gh_pr_state") as mock_state:
             assert d._wait_for_pr_terminal(1, 2) == "TIMEOUT"
         mock_state.assert_not_called()
+
+
+class TestRecheckAndArmAfterFix:
+    """A pushed CI fix must re-poll + arm; never leave a now-green PR un-armed."""
+
+    def test_green_after_fix_arms_and_waits(self, driver: CIDriver) -> None:
+        green = [_make_check("test", required=True, conclusion="success")]
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=green),
+            patch.object(driver, "_enable_auto_merge", return_value=True) as mock_arm,
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc"}),
+            patch.object(driver, "_get_pr_branch", return_value="b"),
+            patch.object(driver, "_arm_drive_green") as mock_record,
+            patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED") as mock_wait,
+        ):
+            result = driver._recheck_and_arm_after_fix(1, 2, 0)
+        assert result is not None and result.success is True
+        mock_arm.assert_called_once()
+        mock_record.assert_called_once()
+        mock_wait.assert_called_once()
+
+    def test_still_pending_after_fix_returns_none(
+        self, driver: CIDriver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # CI hasn't concluded yet after the push → None (caller keeps fix success;
+        # a later run arms it). Bounded by HEPH_CI_POLL_MAX_WAIT.
+        monkeypatch.setenv("HEPH_CI_POLL_MAX_WAIT", "0")
+        pending = [_make_check("test", status="in_progress", conclusion="", required=True)]
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=pending),
+            patch("hephaestus.automation.ci_driver.time.sleep"),
+            patch.object(driver, "_enable_auto_merge") as mock_arm,
+        ):
+            assert driver._recheck_and_arm_after_fix(1, 2, 0) is None
+        mock_arm.assert_not_called()
+
+    def test_still_red_after_fix_returns_none(self, driver: CIDriver) -> None:
+        red = [_make_check("test", required=True, conclusion="failure")]
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=red),
+            patch.object(driver, "_enable_auto_merge") as mock_arm,
+        ):
+            assert driver._recheck_and_arm_after_fix(1, 2, 0) is None
+        mock_arm.assert_not_called()
+
+
+class TestResolveDirtyPr:
+    """An armed-but-DIRTY PR is rebased, then handed to the agent if still conflicting."""
+
+    def test_clean_mechanical_rebase_then_arm(self, driver: CIDriver) -> None:
+        with (
+            patch.object(driver, "_attempt_mechanical_rebase", return_value=True) as mock_rb,
+            patch.object(
+                driver,
+                "_recheck_and_arm_after_fix",
+                return_value=WorkerResult(issue_number=1, success=True, pr_number=2),
+            ) as mock_rearm,
+        ):
+            result = driver._resolve_dirty_pr(1, 2, 0)
+        assert result.success is True
+        mock_rb.assert_called_once()
+        mock_rearm.assert_called_once()
+
+    def test_conflict_routes_to_agent_with_context(self, driver: CIDriver) -> None:
+        with (
+            patch.object(driver, "_attempt_mechanical_rebase", return_value=False),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout='{"baseRefName":"main"}'),
+            ),
+            patch.object(
+                driver,
+                "_attempt_ci_fixes",
+                return_value=WorkerResult(issue_number=1, success=True, pr_number=2),
+            ) as mock_fix,
+            patch.object(
+                driver,
+                "_recheck_and_arm_after_fix",
+                return_value=WorkerResult(issue_number=1, success=True, pr_number=2),
+            ),
+        ):
+            result = driver._resolve_dirty_pr(1, 2, 0)
+        assert result.success is True
+        # The agent must get explicit conflict-resolution context.
+        ctx = mock_fix.call_args.kwargs.get("extra_context", "")
+        assert "MERGE CONFLICT" in ctx
+
+    def test_unresolved_conflict_returns_failure(self, driver: CIDriver) -> None:
+        with (
+            patch.object(driver, "_attempt_mechanical_rebase", return_value=False),
+            patch("hephaestus.automation.ci_driver._gh_call", return_value=MagicMock(stdout="{}")),
+            patch.object(driver, "_attempt_ci_fixes", return_value=None),
+        ):
+            result = driver._resolve_dirty_pr(1, 2, 0)
+        assert result.success is False
+        assert "conflict" in (result.error or "").lower()
 
 
 class TestEnableAutoMergeBotRetry:

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -245,6 +245,56 @@ class TestSessionExpiredFallback:
         assert "--session-id" in first_argv
         assert "--resume" in second_argv
 
+    def test_in_use_then_resume_fails_creates_fresh_session(self, fake_home: Path) -> None:
+        """Create in-use → resume keeps failing → fall back to a FRESH session.
+
+        Under 3 parallel CI-fix workers, two can race on the same deterministic
+        session UUID; the loser hits "already in use" and resume can also fail
+        while the sibling is still initializing. Rather than aborting the PR
+        (observed: ProjectHermes #647), derive a fresh unique session.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        already = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude"],
+            output="",
+            stderr="Error: Session ID abc is already in use.",
+        )
+        resume_fail = subprocess.CalledProcessError(
+            returncode=1, cmd=["claude"], output="", stderr="cannot resume: locked"
+        )
+        fresh_ok = subprocess.CompletedProcess(
+            args=["claude"], returncode=0, stdout="fresh-ok", stderr=""
+        )
+        # create(in-use) → resume×3 fail → fresh create ok
+        with (
+            patch(
+                "hephaestus.automation.claude_invoke.subprocess.run",
+                side_effect=[already, resume_fail, resume_fail, resume_fail, fresh_ok],
+            ) as m,
+            patch("hephaestus.automation.claude_invoke.time.sleep"),
+        ):
+            stdout, returned_sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="sonnet",
+                cwd=cwd,
+            )
+        assert stdout == "fresh-ok"
+        # 1 create + 3 resume + 1 fresh create
+        assert m.call_count == 5
+        # The final call is a fresh --session-id create with a DIFFERENT id.
+        final_argv = m.call_args_list[-1][0][0]
+        assert "--session-id" in final_argv
+        fresh_sid = final_argv[final_argv.index("--session-id") + 1]
+        assert returned_sid == fresh_sid
+        # The deterministic id and the fresh id must differ.
+        orig_sid = m.call_args_list[0][0][0][m.call_args_list[0][0][0].index("--session-id") + 1]
+        assert fresh_sid != orig_sid
+
 
 class TestArgvAssembly:
     """Optional flags appear in argv at the right positions."""


### PR DESCRIPTION
Closes #878

## Objective

A second `drive_prs_green` ecosystem run (after #876) surfaced **four real `ci_driver` bugs** that strand PRs. This fixes all four + tests.

## Bugs fixed

**1. Re-arm after a successful CI fix** — `_attempt_ci_fixes` returned success the instant a fix landed and never re-polled or armed, so a now-green PR sat `NOT armed` forever (ProjectHermes #645 ended `CLEAN` + un-armed). New `_recheck_and_arm_after_fix` re-enters check→arm→wait once after a fix.

**2. Session-id "already in use" under concurrency** — the deterministic UUIDv5 session collides when parallel workers race before the transcript is on disk; the loser's resume fallback was unguarded, so a failed resume killed the drive (ProjectHermes #647). Now retries resume 3× with backoff, then falls back to a fresh `uuid4` session.

**3. DIRTY (merge-conflict) PRs never resolved** — `_gh_pr_state` now fetches `mergeStateStatus`; `_wait_for_pr_terminal` returns a new `"DIRTY"` outcome instead of waiting out the 1800s timeout on an unmergeable armed PR (ProjectOdyssey #5487/#5485/#5471). New `_resolve_dirty_pr` tries a mechanical rebase, then hands the agent an explicit conflict-resolution prompt.

**4. Blocker-doc breaks markdownlint** — the force-engagement prompt told the agent to "write a commit that documents the blocker", and the agent created a `CI_BLOCKER.md` that fails the repo's `markdownlint` (MD013/MD032), turning one red check into two. The prompt now **forbids committing a blocker file** (use the `BLOCKED:` line), requires every added/edited file to pass the repo's own linters **with no rule disabled**, and names `CI_BLOCKER.md` as forbidden.

## Success Criteria

- [x] Unit tests for each bug (re-arm green/pending/red; DIRTY detection; resolve-dirty clean/agent/unresolved; session fresh-fallback; prompt no-blocker-file)
- [x] Full `pytest tests/unit/automation`: **1011 passed**, no hang
- [x] `pre-commit run` clean (ruff, mypy, bandit, C901)

## Notes

Root-caused from `drive-prs-green-logs/20260602T043807Z`. Follow-up to #876/#877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)