### PR TITLE
[Fix] Bump pyjwt to >=2.13.0 (PYSEC-2026-175/177/178/179)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -76,7 +76,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -193,7 +193,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygithub-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.3.0-pyhcf101f3_0.conda
@@ -1094,9 +1094,9 @@ packages:
   - pkg:pypi/pygments?source=compressed-mapping
   size: 893031
   timestamp: 1774796815820
-- conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.12.1-pyhcf101f3_0.conda
-  sha256: 4279ee4cf2533fd17910ae7373159d9bee2492d8c50932ddc74dd27a70b15de4
-  md5: b27a9f4eca2925036e43542488d3a804
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
+  sha256: 58cda7489477fecb859ec95bf73cba7e4634db1a517e29e0d3086d7ec71733ae
+  md5: edb808d7f7396478ab6e457e697b8ec5
   depends:
   - python >=3.10
   - typing_extensions >=4.0
@@ -1107,8 +1107,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyjwt?source=hash-mapping
-  size: 32247
-  timestamp: 1773482160904
+  size: 33417
+  timestamp: 1779400286454
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,10 @@ pip = "*"
 pydantic = ">=2.12.5,<3"
 pygments = ">=2.20.0"  # CVE-2026-4539
 pygithub = ">=2.9.1,<3"
+# Transitive via pygithub. Pinned to pull the security fix for
+# PYSEC-2026-175/177/178/179 (all fixed in 2.13.0); without this the locked
+# env resolves to 2.12.1 and pip-audit fails the dependency scan.
+pyjwt = ">=2.13.0"
 # Build backend for the `dev-install` editable install.
 hatchling = ">=1.27.0,<2"
 hatch-vcs = ">=0.4.0,<1"


### PR DESCRIPTION
Closes #880

## Objective

The `Dependency vulnerability scan` is red on every PR. pyjwt 2.12.1 (transitive via pygithub) has 4 advisories — **PYSEC-2026-175/177/178/179** — all fixed in **2.13.0** (available on conda-forge).

## Fix

Pin `pyjwt >=2.13.0` in `[dependencies]` (mirrors the existing pygments CVE pin) and regenerate `pixi.lock`. Local `pixi run -e lint pip-audit` now reports **"No known vulnerabilities found, 2 ignored"**.

## Verification

- [x] `pip-audit` clean locally with the new lock
- [x] `pre-commit` pixi-lock check passes

## Notes

Unblocks all Hephaestus PRs (including the ci_driver fixes in #879). Surfaced while landing #878/#879.

🤖 Generated with [Claude Code](https://claude.com/claude-code)