### PR TITLE
[Feat] ci_driver: arm auto-merge on all un-armed open PRs

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -201,6 +201,14 @@ class CIDriver:
         # this is empty (#838). Stored on the driver so ``main()`` can check
         # it without changing ``run()``'s established return type.
         self.open_prs_remaining = [] if self.options.dry_run else self._list_open_prs_remaining()
+        # Arm auto-merge on EVERY un-armed open PR before the final report
+        # (#882). A PR the driver fixed-and-pushed, or one that arrived green
+        # from elsewhere, can end CLEAN but un-armed and then never merge
+        # (observed: ProjectHermes #645/#648). Arming is idempotent and a
+        # no-op for PRs GitHub won't let merge yet (conflicts / red CI / review
+        # gates), so a blanket pass is safe and drains the ready ones.
+        if self.open_prs_remaining and not self.options.dry_run:
+            self.open_prs_remaining = self._arm_all_unarmed_open_prs(self.open_prs_remaining)
         if self.open_prs_remaining:
             logger.warning(
                 "%d open PR(s) remain on the repo — not done:",
@@ -287,9 +295,44 @@ class CIDriver:
                     "title": pr.get("title", ""),
                     "headRefName": (pr.get("head") or {}).get("ref", ""),
                     "autoMergeRequest": pr.get("auto_merge"),
+                    "isBot": (pr.get("user") or {}).get("type") == "Bot",
                 }
             )
         return normalised
+
+    def _arm_all_unarmed_open_prs(self, open_prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Arm auto-merge on every un-armed open PR, then refresh their state (#882).
+
+        The per-issue drive only arms PRs it processed; a PR fixed-and-pushed by
+        the driver (or one that arrived green from another actor) can end CLEAN
+        but un-armed and never merge. This blanket pass arms anything not yet
+        armed. ``_enable_auto_merge`` is idempotent and GitHub simply queues the
+        request for PRs it won't merge yet (conflicts / failing CI / required
+        review), so arming a not-yet-mergeable PR is a harmless no-op rather than
+        a force-merge.
+
+        Returns the open-PR list with ``autoMergeRequest`` refreshed for any PR
+        that armed, so the caller's final gate reports the true state.
+        """
+        armed_now: list[int] = []
+        for pr in open_prs:
+            number = pr.get("number")
+            if not isinstance(number, int) or number < 0:
+                continue
+            if pr.get("autoMergeRequest"):
+                continue  # already armed
+            if self._enable_auto_merge(number, is_bot_pr=bool(pr.get("isBot"))):
+                armed_now.append(number)
+        if not armed_now:
+            return open_prs
+        logger.info(
+            "Armed auto-merge on %d previously-unarmed open PR(s): %s",
+            len(armed_now),
+            sorted(armed_now),
+        )
+        # Re-list so the final gate sees the freshly-armed PRs as armed_pending
+        # rather than needs_action.
+        return self._list_open_prs_remaining()
 
     def _discover_bot_prs(self) -> dict[int, int]:
         """Enumerate every open ``is_bot=true`` PR on the repo (#848).

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -349,12 +349,14 @@ class TestOpenPrsRemaining:
                 "title": "first",
                 "head": {"ref": "branch-1"},
                 "auto_merge": {"enabled_by": {"login": "bot"}},
+                "user": {"type": "User"},
             },
             {
                 "number": 2,
                 "title": "second",
                 "head": {"ref": "branch-2"},
                 "auto_merge": None,
+                "user": {"type": "Bot"},
             },
         ]
         result_mock = MagicMock(stdout=json.dumps(rest_pulls))
@@ -369,12 +371,14 @@ class TestOpenPrsRemaining:
                 "title": "first",
                 "headRefName": "branch-1",
                 "autoMergeRequest": {"enabled_by": {"login": "bot"}},
+                "isBot": False,
             },
             {
                 "number": 2,
                 "title": "second",
                 "headRefName": "branch-2",
                 "autoMergeRequest": None,
+                "isBot": True,
             },
         ]
 
@@ -2100,6 +2104,56 @@ class TestEnableAutoMergeBotRetry:
         assert ok is False
         # Only the primary --squash attempt; no strategy-agnostic retry.
         assert mock_gh.call_count == 1
+
+
+class TestArmAllUnarmedOpenPrs:
+    """The blanket arm-all pass marks every un-armed open PR auto-merge (#882)."""
+
+    def test_arms_only_unarmed_prs_and_passes_bot_flag(self, driver: CIDriver) -> None:
+        open_prs: list[dict[str, Any]] = [
+            {"number": 10, "autoMergeRequest": {"x": 1}, "isBot": False},  # already armed
+            {"number": 11, "autoMergeRequest": None, "isBot": True},  # arm (bot)
+            {"number": 12, "autoMergeRequest": None, "isBot": False},  # arm (human)
+        ]
+        refreshed = [
+            {"number": 10, "autoMergeRequest": {"x": 1}},
+            {"number": 11, "autoMergeRequest": {"x": 1}},
+            {"number": 12, "autoMergeRequest": {"x": 1}},
+        ]
+        with (
+            patch.object(driver, "_enable_auto_merge", return_value=True) as mock_arm,
+            patch.object(driver, "_list_open_prs_remaining", return_value=refreshed),
+        ):
+            result = driver._arm_all_unarmed_open_prs(open_prs)
+        # Already-armed #10 is skipped; #11 and #12 are armed.
+        assert mock_arm.call_count == 2
+        called = {c.args[0]: c.kwargs.get("is_bot_pr") for c in mock_arm.call_args_list}
+        assert called == {11: True, 12: False}
+        # Returns the re-listed PRs so the gate sees fresh armed state.
+        assert result == refreshed
+
+    def test_no_unarmed_prs_is_noop(self, driver: CIDriver) -> None:
+        open_prs: list[dict[str, Any]] = [
+            {"number": 10, "autoMergeRequest": {"x": 1}, "isBot": False}
+        ]
+        with (
+            patch.object(driver, "_enable_auto_merge") as mock_arm,
+            patch.object(driver, "_list_open_prs_remaining") as mock_list,
+        ):
+            result = driver._arm_all_unarmed_open_prs(open_prs)
+        mock_arm.assert_not_called()
+        mock_list.assert_not_called()  # no re-list when nothing armed
+        assert result is open_prs
+
+    def test_skips_sentinel_unknown_pr(self, driver: CIDriver) -> None:
+        # _list_open_prs_remaining returns [{"number": -1, ...}] on lookup failure.
+        open_prs: list[dict[str, Any]] = [
+            {"number": -1, "title": "(unknown)", "autoMergeRequest": None}
+        ]
+        with patch.object(driver, "_enable_auto_merge") as mock_arm:
+            result = driver._arm_all_unarmed_open_prs(open_prs)
+        mock_arm.assert_not_called()
+        assert result is open_prs
 
 
 class TestEvaluateRunResult:


### PR DESCRIPTION
Closes #882

## Objective

"Make sure the hephaestus script also marks all PRs as auto-merge." The driver only armed PRs it actively drove green; a PR it fixed-and-pushed (or one that arrived green from elsewhere) could end **CLEAN but un-armed** and never merge — observed: ProjectHermes #645/#648, both CLEAN, un-armed, merged instantly once armed by hand.

## Change

`run()` now makes a blanket arming pass after enumerating open PRs: `_arm_all_unarmed_open_prs()` arms every PR whose `autoMergeRequest` is None (via the existing `_enable_auto_merge`, passing `is_bot_pr` from a new `isBot` field on the open-PR listing), then re-lists so the final gate reports freshly-armed PRs as `armed_pending` not `needs_action`.

**Safety:** arming is idempotent; GitHub queues it as a no-op for PRs it won't merge yet (conflicts / failing CI / required review) — it does **not** force-merge. `force_merge_on_stall` stays off.

## Verification

- [x] Tests: arms only un-armed PRs, passes the bot flag, skips already-armed + the `-1` sentinel, re-lists only when something armed
- [x] Full automation suite: **1006 passed, no hang**
- [x] `pre-commit run` clean (ruff, mypy, bandit, C901)

## Notes

Follow-up to the ci_driver fixes in #879. Minor textual overlap with #879 near `run()` — will rebase if #879 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)