### PR TITLE
fix(agents): select authenticated default agent

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -15,6 +15,11 @@ from typing import Any, Literal
 AgentName = Literal["claude", "codex"]
 AGENT_CHOICES: tuple[AgentName, ...] = ("claude", "codex")
 DEFAULT_AGENT: AgentName = "claude"
+AGENT_AUTH_STATUS_TIMEOUT = 10
+AGENT_AUTH_STATUS_COMMANDS: dict[AgentName, tuple[tuple[str, ...], ...]] = {
+    "claude": (("claude", "auth", "status"),),
+    "codex": (("codex", "login", "status"),),
+}
 
 
 @dataclass(frozen=True)
@@ -34,28 +39,59 @@ def add_agent_argument(parser: argparse.ArgumentParser) -> None:
         default=None,
         help=(
             "Agent backend to invoke for model-driven steps "
-            "(default: auto-detect, preferring claude when available)"
+            "(default: auto-detect authenticated backend, preferring claude when authenticated)"
         ),
     )
+
+
+def is_agent_authenticated(agent: AgentName) -> bool:
+    """Return True when the provider CLI is installed and reports logged-in auth."""
+    if shutil.which(agent) is None:
+        return False
+
+    for cmd in AGENT_AUTH_STATUS_COMMANDS[agent]:
+        try:
+            result = subprocess.run(
+                list(cmd),
+                text=True,
+                capture_output=True,
+                timeout=AGENT_AUTH_STATUS_TIMEOUT,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0:
+            return True
+    return False
 
 
 def resolve_agent(agent: str | None) -> AgentName:
     """Resolve an optional provider selection into a concrete backend.
 
-    When the operator omits ``--agent``, prefer Claude if both provider CLIs
-    are present. Codex is the fallback when Claude is absent.
+    When the operator omits ``--agent``, choose an installed provider that also
+    reports authenticated status. Claude still wins ties when both providers are
+    authenticated.
     """
     if agent is not None:
         if agent not in AGENT_CHOICES:
             raise ValueError(f"Unsupported agent: {agent}")
         return agent
-    if shutil.which("claude"):
-        return "claude"
-    if shutil.which("codex"):
-        return "codex"
+
+    installed_agents = tuple(agent_name for agent_name in AGENT_CHOICES if shutil.which(agent_name))
+    if not installed_agents:
+        raise RuntimeError(
+            "No supported agent backend found on PATH. Install `claude` or `codex`, "
+            "or pass --agent after installing the selected backend."
+        )
+
+    for agent_name in installed_agents:
+        if is_agent_authenticated(agent_name):
+            return agent_name
+
     raise RuntimeError(
-        "No supported agent backend found on PATH. Install `claude` or `codex`, "
-        "or pass --agent after installing the selected backend."
+        "Supported agent backends are installed but none are authenticated. "
+        "Run `claude auth status` or `codex login status`, then log in to the "
+        "provider you want automation to use."
     )
 
 

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -187,22 +187,53 @@ def test_run_claude_text_read_only_omits_write_permissions(tmp_path: Path) -> No
     assert "--allowedTools" not in captured_cmd
 
 
-def test_resolve_agent_prefers_claude_when_both_exist() -> None:
-    """Omitted --agent auto-detects, preferring Claude when both CLIs exist."""
+def test_resolve_agent_prefers_claude_when_both_are_authenticated() -> None:
+    """Omitted --agent prefers Claude only when both CLIs are authenticated."""
     with patch("hephaestus.agents.runtime.shutil.which") as mock_which:
         mock_which.side_effect = lambda name: (
             f"/bin/{name}" if name in {"claude", "codex"} else None
         )
 
-        assert agent_runtime.resolve_agent(None) == "claude"
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                ["auth", "status"], 0, stdout="logged in", stderr=""
+            )
+
+            assert agent_runtime.resolve_agent(None) == "claude"
 
 
-def test_resolve_agent_uses_codex_when_claude_absent() -> None:
-    """Codex is the fallback when Claude is not installed."""
+def test_resolve_agent_uses_authenticated_codex_when_claude_absent() -> None:
+    """Codex is the fallback when Claude is not installed and Codex is authenticated."""
     with patch("hephaestus.agents.runtime.shutil.which") as mock_which:
         mock_which.side_effect = lambda name: "/bin/codex" if name == "codex" else None
 
-        assert agent_runtime.resolve_agent(None) == "codex"
+        with patch(
+            "subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["codex", "login", "status"], 0, stdout="Logged in using ChatGPT", stderr=""
+            ),
+        ):
+            assert agent_runtime.resolve_agent(None) == "codex"
+
+
+def test_resolve_agent_uses_codex_when_only_codex_is_authenticated() -> None:
+    """An installed but unauthenticated Claude CLI should not beat authenticated Codex."""
+    with patch("hephaestus.agents.runtime.shutil.which") as mock_which:
+        mock_which.side_effect = lambda name: (
+            f"/bin/{name}" if name in {"claude", "codex"} else None
+        )
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            if cmd == ["claude", "auth", "status"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="Not logged in")
+            if cmd == ["codex", "login", "status"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout="Logged in using ChatGPT", stderr=""
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert agent_runtime.resolve_agent(None) == "codex"
 
 
 def test_resolve_agent_explicit_codex_overrides_claude() -> None:
@@ -216,6 +247,23 @@ def test_resolve_agent_errors_when_no_provider_exists() -> None:
     with patch("hephaestus.agents.runtime.shutil.which", return_value=None):
         with pytest.raises(RuntimeError, match="No supported agent backend"):
             agent_runtime.resolve_agent(None)
+
+
+def test_resolve_agent_errors_when_no_provider_is_authenticated() -> None:
+    """Installed providers must prove authentication before auto-selection."""
+    with patch("hephaestus.agents.runtime.shutil.which") as mock_which:
+        mock_which.side_effect = lambda name: (
+            f"/bin/{name}" if name in {"claude", "codex"} else None
+        )
+
+        with patch(
+            "subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["auth", "status"], 1, stdout="", stderr="Not logged in"
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="none are authenticated"):
+                agent_runtime.resolve_agent(None)
 
 
 def test_add_agent_argument_defaults_to_auto_detect() -> None:


### PR DESCRIPTION
## Summary

- choose the default automation agent from installed CLIs that report authenticated status
- keep Claude as the tie-break only when it is authenticated
- select Codex when Claude is missing or unauthenticated and Codex is authenticated

## Test Plan

- python3 -m ruff check hephaestus/agents/runtime.py tests/unit/agents/test_runtime.py
- python3 -m pytest tests/unit/agents/test_runtime.py -q --no-cov
- /private/tmp/hephaestus-radiance-venv/bin/hephaestus-automation-loop --loops 1 --dry-run --no-advise --json from /Users/mvillmow/Projects/Radiance

Closes #886