### PR TITLE
Use Codex advise skill trigger in automation

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -1,17 +1,16 @@
-"""Shared ``/advise`` runner for every pipeline stage.
+"""Shared advise runner for every pipeline stage.
 
 Each of the three session-stable stages (plan, implement, drive-green) begins
-with an ``/advise`` step that searches ProjectMnemosyne for relevant prior
+with an advise step that searches ProjectMnemosyne for relevant prior
 learnings before doing any work. The Mnemosyne clone/refresh, prompt
 construction, and skip-marker conventions are identical across stages, so they
 live here once (DRY) rather than being copied into ``planner.py``,
 ``implementer_phase_runner.py``, and ``ci_driver.py``.
 
-The only thing that differs per stage is *how* Claude is invoked (the planner
-routes through ``Planner._call_claude``; the implementer and CI driver use
-``invoke_claude_with_session``). Callers therefore pass an ``invoke`` callable
-that takes the advise prompt and returns Claude's text output; this module owns
-everything around it. The advise call always runs under
+The only thing that differs per stage is *how* the selected agent is invoked.
+Callers therefore pass an ``invoke`` callable that takes the advise prompt and
+returns the agent's text output; this module owns everything around it. The
+advise call always runs under
 :data:`~hephaestus.automation.session_naming.AGENT_ADVISE` — a distinct, cheap,
 read-only session — so it never pollutes the stage's main transcript.
 """
@@ -173,10 +172,10 @@ def run_advise(
     invoke: Callable[[str], str],
     build_prompt: Callable[..., str],
 ) -> str:
-    """Run the ``/advise`` step and return findings (or a skip marker).
+    """Run the advise step and return findings (or a skip marker).
 
     Locates ProjectMnemosyne (cloning/refreshing as needed), builds the advise
-    prompt, and invokes Claude via the stage-supplied ``invoke`` callable. Any
+    prompt, and invokes the selected agent via the stage-supplied ``invoke`` callable. Any
     failure degrades to an :func:`advise_skipped` marker so a stage never aborts
     just because advice could not be gathered.
 
@@ -185,7 +184,7 @@ def run_advise(
         issue_title: Issue title.
         issue_body: Issue body/description.
         invoke: Stage-specific callable that runs the advise prompt under
-            ``AGENT_ADVISE`` and returns Claude's text output.
+            ``AGENT_ADVISE`` and returns the agent's text output.
         build_prompt: The advise prompt builder (``prompts.get_advise_prompt``),
             injected so this module need not import the prompts package.
 

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -55,7 +55,7 @@ from .github_api import (
     gh_pr_list_unresolved_threads,
 )
 from .models import CIDriverOptions, WorkerResult
-from .prompts import get_advise_prompt
+from .prompts import get_advise_prompt_builder
 from .session_naming import AGENT_ADVISE, AGENT_CI_DRIVER
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
@@ -884,7 +884,7 @@ class CIDriver:
             issue_title=issue_title,
             issue_body=issue_body,
             invoke=_invoke,
-            build_prompt=get_advise_prompt,
+            build_prompt=get_advise_prompt_builder(self.options.agent),
         )
 
     def _recheck_and_arm_after_fix(

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -62,7 +62,7 @@ from .models import (
 from .pr_manager import commit_changes, ensure_pr_created
 from .pr_reviewer import gather_impl_review_context, review_pr_inline
 from .prompts import (
-    get_advise_prompt,
+    get_advise_prompt_builder,
     get_impl_loop_review_prompt,
     get_impl_resume_feedback_prompt,
     get_implementation_prompt,
@@ -844,7 +844,7 @@ class ImplementationPhaseRunner:
             issue_title=issue_title,
             issue_body=issue_body,
             invoke=_invoke,
-            build_prompt=get_advise_prompt,
+            build_prompt=get_advise_prompt_builder(self.options.agent),
         )
 
     # ------------------------------------------------------------------

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -32,9 +32,7 @@ from .models import PLAN_COMMENT_MARKER, PlannerOptions, PlanResult
 from .planner_claude import PlannerClaudeRunner
 from .planner_review_loop import MAX_REVIEW_ITERATIONS, PlanReviewLoop
 from .planner_state import PlannerStateManager
-from .prompts import (
-    get_advise_prompt,
-)
+from .prompts import get_advise_prompt_builder
 from .review_state import is_plan_review_go
 from .session_naming import AGENT_ADVISE
 from .status_tracker import StatusTracker
@@ -300,7 +298,7 @@ class Planner:
             issue_title=issue_title,
             issue_body=issue_body,
             invoke=_invoke,
-            build_prompt=get_advise_prompt,
+            build_prompt=get_advise_prompt_builder(self.options.agent),
         )
 
     @staticmethod

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -43,7 +43,13 @@ from ._strict_rubric import _STRICT_GRADING_AND_ANTI_INFLATION as _STRICT_GRADIN
 from ._strict_rubric import _STRICT_REVIEW_OUTPUT_FORMAT as _STRICT_REVIEW_OUTPUT_FORMAT
 from ._strict_rubric import _STRICT_REVIEW_RUBRIC as _STRICT_REVIEW_RUBRIC
 from .address_review import ADDRESS_REVIEW_PROMPT, get_address_review_prompt
-from .advise import ADVISE_PROMPT, get_advise_prompt
+from .advise import (
+    ADVISE_PROMPT,
+    CODEX_ADVISE_PROMPT,
+    get_advise_prompt,
+    get_advise_prompt_builder,
+    get_codex_advise_prompt,
+)
 from .follow_up import FOLLOW_UP_PROMPT, get_follow_up_prompt
 from .implementation import (
     IMPL_LOOP_REVIEW_PROMPT,
@@ -70,6 +76,7 @@ from .pr_review import (
 __all__ = [
     "ADDRESS_REVIEW_PROMPT",
     "ADVISE_PROMPT",
+    "CODEX_ADVISE_PROMPT",
     "FOLLOW_UP_PROMPT",
     "IMPLEMENTATION_PROMPT",
     "IMPL_LOOP_REVIEW_PROMPT",
@@ -80,6 +87,8 @@ __all__ = [
     "PR_REVIEW_ANALYSIS_PROMPT",
     "get_address_review_prompt",
     "get_advise_prompt",
+    "get_advise_prompt_builder",
+    "get_codex_advise_prompt",
     "get_follow_up_prompt",
     "get_impl_loop_review_prompt",
     "get_impl_resume_feedback_prompt",

--- a/hephaestus/automation/prompts/advise.py
+++ b/hephaestus/automation/prompts/advise.py
@@ -1,5 +1,9 @@
 """Advise-phase prompt: search the team knowledge base before planning."""
 
+from collections.abc import Callable
+
+from hephaestus.agents.runtime import is_codex
+
 from ._shared import _relativize_path
 
 ADVISE_PROMPT = """
@@ -48,6 +52,16 @@ None found
 **Important:** Only return findings from the actual marketplace. Do not speculate or invent skills.
 """
 
+CODEX_ADVISE_PROMPT = """$advise Search team knowledge before planning this issue.
+
+Issue #{issue_number}: {issue_title}
+
+Body:
+{issue_body}
+
+Return the advise findings only, in markdown. Do not implement or modify files.
+"""
+
 
 def get_advise_prompt(
     issue_number: int,
@@ -78,3 +92,32 @@ def get_advise_prompt(
         issue_body=issue_body,
         marketplace_path=safe_marketplace_path,
     )
+
+
+def get_codex_advise_prompt(
+    issue_number: int,
+    issue_title: str,
+    issue_body: str,
+    marketplace_path: str,
+    repo_root: str | None = None,
+) -> str:
+    """Get the Codex advise prompt using Codex's ``$advise`` skill trigger.
+
+    Codex skills are invoked with ``$skill-name`` rather than Claude slash
+    commands. The marketplace path is accepted for the shared runner call
+    signature but intentionally not interpolated: the installed Codex advise
+    skill owns Mnemosyne clone/update and marketplace discovery.
+    """
+    del marketplace_path, repo_root
+    return CODEX_ADVISE_PROMPT.format(
+        issue_number=issue_number,
+        issue_title=issue_title,
+        issue_body=issue_body,
+    )
+
+
+def get_advise_prompt_builder(agent: str) -> Callable[..., str]:
+    """Return the provider-specific advise prompt builder."""
+    if is_codex(agent):
+        return get_codex_advise_prompt
+    return get_advise_prompt

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -268,6 +268,23 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
     mock_push.assert_not_called()
 
 
+def test_codex_ci_advise_uses_codex_prompt_builder(driver: CIDriver) -> None:
+    """Codex CI repair runs should trigger the Codex `$advise` skill prompt."""
+    driver.options.agent = "codex"
+
+    with (
+        patch(
+            "hephaestus.automation.ci_driver.gh_issue_json",
+            return_value={"title": "Test Issue", "body": "Issue body"},
+        ),
+        patch("hephaestus.automation.ci_driver.run_advise", return_value="findings") as run,
+    ):
+        result = driver._run_advise(123)
+
+    assert result == "findings"
+    assert run.call_args.kwargs["build_prompt"].__name__ == "get_codex_advise_prompt"
+
+
 # ---------------------------------------------------------------------------
 # _discover_prs: dedupe shared-PR
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -39,6 +39,21 @@ def _nogo(grade: str = "D") -> str:
     return f"Findings.\n\nGrade: {grade}\nVerdict: NOGO\n"
 
 
+def test_codex_implementer_advise_uses_codex_prompt_builder(
+    implementer: IssueImplementer,
+) -> None:
+    """Codex implementer runs should trigger the Codex `$advise` skill prompt."""
+    implementer.options.agent = "codex"
+
+    with patch(
+        "hephaestus.automation.implementer_phase_runner.run_advise", return_value="findings"
+    ) as run:
+        result = implementer._run_advise(123, "Test Issue", "Issue body")
+
+    assert result == "findings"
+    assert run.call_args.kwargs["build_prompt"].__name__ == "get_codex_advise_prompt"
+
+
 class TestRunImplReviewLoop:
     """Integration tests for the Stage 2 in-loop review + address cycle (#28).
 

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -231,6 +231,17 @@ class TestRunAdvise:
                 assert "Related Skills" in result
                 assert "Found 3 skills" in result
 
+    def test_codex_advise_uses_codex_prompt_builder(self, mock_options: Any) -> None:
+        """Codex runs should trigger the Codex `$advise` skill prompt."""
+        mock_options.agent = "codex"
+        planner = Planner(mock_options)
+
+        with patch("hephaestus.automation.planner.run_advise", return_value="findings") as run:
+            result = planner._run_advise(123, "Test Issue", "Issue body")
+
+        assert result == "findings"
+        assert run.call_args.kwargs["build_prompt"].__name__ == "get_codex_advise_prompt"
+
     def test_graceful_failure_on_error(self, planner: Any) -> None:
         """When advise errors, return a sentinel-comment (not silent ``""``).
 

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -295,6 +295,25 @@ class TestAdvisePrompt:
         assert "7" in out
         assert "/mp.json" in out
 
+    def test_codex_prompt_uses_dollar_advise_skill_trigger(self) -> None:
+        """Codex automation should invoke the installed skill, not manual slash syntax."""
+        out = prompts.get_codex_advise_prompt(
+            issue_number=7,
+            issue_title="t",
+            issue_body="b",
+            marketplace_path="/mp.json",
+        )
+
+        assert out.startswith("$advise ")
+        assert "/advise" not in out
+        assert "Issue #7: t" in out
+        assert "b" in out
+
+    def test_advise_prompt_builder_selects_codex_prompt(self) -> None:
+        """Provider-specific advise prompt selection keeps stage callers simple."""
+        assert prompts.get_advise_prompt_builder("codex") is prompts.get_codex_advise_prompt
+        assert prompts.get_advise_prompt_builder("claude") is prompts.get_advise_prompt
+
 
 class TestFollowUpPrompt:
     """Tests for follow up prompt."""


### PR DESCRIPTION
## Summary

- Add a Codex-specific advise prompt that invokes the installed Codex skill with
  $advise instead of sending the legacy marketplace prompt.
- Route planner, implementer, and CI-driver advise calls through a shared
  provider-specific prompt selector.
- Add regression coverage for planner, implementer, CI, and prompt selection.

## Validation

- python3 -m ruff check hephaestus/automation/advise_runner.py hephaestus/automation/prompts/advise.py hephaestus/automation/prompts/__init__.py hephaestus/automation/planner.py hephaestus/automation/implementer_phase_runner.py hephaestus/automation/ci_driver.py tests/unit/automation/test_prompts.py tests/unit/automation/test_planner.py tests/unit/automation/test_implementer_loop.py tests/unit/automation/test_ci_driver.py
- python3 -m pytest tests/unit/automation/test_advise_runner.py tests/unit/automation/test_prompts.py tests/unit/automation/test_planner.py tests/unit/automation/test_implementer_loop.py tests/unit/automation/test_ci_driver.py -q --no-cov
- Live non-mutating Codex smoke resolved the installed advise skill and returned findings.
- Non-mutating Radiance Planner._run_advise smoke completed with Codex and returned ProjectMnemosyne findings before the advise timeout.

## Notes

Full local pre-push pytest ran 3,142 tests and failed only because the base
interpreter lacks defusedxml and mypy. The touched-file suite passed locally;
CI should run in the project dependency environment.

Closes #888
