### PR TITLE
Double planner and advise automation timeouts

### DIFF
--- a/hephaestus/automation/claude_timeouts.py
+++ b/hephaestus/automation/claude_timeouts.py
@@ -37,10 +37,10 @@ def _read_int_env(name: str, default: int, *, legacy_name: str | None = None) ->
 
 
 def planner_claude_timeout() -> int:
-    """Timeout for agent calls inside the planner (default 300s)."""
+    """Timeout for agent calls inside the planner (default 600s)."""
     return _read_int_env(
         "HEPH_PLANNER_AGENT_TIMEOUT",
-        300,
+        600,
         legacy_name="HEPH_PLANNER_CLAUDE_TIMEOUT",
     )
 
@@ -64,10 +64,10 @@ def implementer_claude_timeout() -> int:
 
 
 def advise_claude_timeout() -> int:
-    """Timeout for lightweight advise agent calls (default 180s)."""
+    """Timeout for lightweight advise agent calls (default 360s)."""
     return _read_int_env(
         "HEPH_ADVISE_AGENT_TIMEOUT",
-        180,
+        360,
         legacy_name="HEPH_ADVISE_CLAUDE_TIMEOUT",
     )
 

--- a/tests/unit/automation/test_claude_timeouts.py
+++ b/tests/unit/automation/test_claude_timeouts.py
@@ -18,7 +18,7 @@ def test_planner_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Planner timeout uses the documented default when unset."""
     _clear_planner_timeout_env(monkeypatch)
 
-    assert claude_timeouts.planner_claude_timeout() == 300
+    assert claude_timeouts.planner_claude_timeout() == 600
 
 
 def test_planner_timeout_legacy_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -47,7 +47,7 @@ def test_planner_timeout_invalid_agent_env_logs_and_defaults(
     monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "slow")
 
     with caplog.at_level(logging.WARNING, logger="hephaestus.automation.claude_timeouts"):
-        assert claude_timeouts.planner_claude_timeout() == 300
+        assert claude_timeouts.planner_claude_timeout() == 600
 
     assert any("HEPH_PLANNER_AGENT_TIMEOUT" in record.message for record in caplog.records)
 
@@ -57,7 +57,7 @@ def test_advise_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HEPH_ADVISE_AGENT_TIMEOUT", raising=False)
     monkeypatch.delenv("HEPH_ADVISE_CLAUDE_TIMEOUT", raising=False)
 
-    assert claude_timeouts.advise_claude_timeout() == 180
+    assert claude_timeouts.advise_claude_timeout() == 360
 
 
 def test_advise_timeout_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Double the planner agent timeout default from 300s to 600s.
- Double the advise agent timeout default from 180s to 360s.
- Keep existing `HEPH_*_AGENT_TIMEOUT` and legacy `HEPH_*_CLAUDE_TIMEOUT` override behavior unchanged.

## Validation

- `python3 -m pytest -q`
- `python3 -m pytest tests/unit/automation/test_claude_timeouts.py -q --no-cov`
- `python3 -m ruff check hephaestus/automation/claude_timeouts.py tests/unit/automation/test_claude_timeouts.py`
- `git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=/Users/mvillmow/.ssh/allowed_signers log --show-signature -1 --format=fuller`

## Notes

- A 3-loop Radiance planning run was started from the local repo. Loop 1 passed the old 180s advise timeout failure point and updated the plan/review comments before the run was stopped so this PR could be created.

Closes #890
