### PR TITLE
Drop legacy Claude timeout overrides

### DIFF
--- a/hephaestus/automation/claude_timeouts.py
+++ b/hephaestus/automation/claude_timeouts.py
@@ -4,8 +4,7 @@ Each phase that shells out to an agent CLI or ``gh`` has historically
 hard-coded its own timeout. Centralising them here parallels
 :mod:`claude_models` and gives operators a way to tune slow repos / network
 conditions without code changes via ``HEPH_<PHASE>_AGENT_TIMEOUT`` environment
-variables (values in seconds). Legacy ``HEPH_<PHASE>_CLAUDE_TIMEOUT`` names are
-still accepted for compatibility.
+variables (values in seconds).
 
 If an env var is set but not an integer, the default is used and a warning is
 logged on first read; we never crash on a malformed timeout because the cost
@@ -20,101 +19,61 @@ import os
 logger = logging.getLogger(__name__)
 
 
-def _read_int_env(name: str, default: int, *, legacy_name: str | None = None) -> int:
+def _read_int_env(name: str, default: int) -> int:
     """Return ``int(os.environ[name])`` or ``default`` if unset/invalid."""
     raw = os.environ.get(name)
-    source = name
-    if raw is None and legacy_name is not None:
-        raw = os.environ.get(legacy_name)
-        source = legacy_name
     if raw is None:
         return default
     try:
         return int(raw)
     except ValueError:
-        logger.warning("Ignoring non-integer %s=%r — using default %ds", source, raw, default)
+        logger.warning("Ignoring non-integer %s=%r — using default %ds", name, raw, default)
         return default
 
 
 def planner_claude_timeout() -> int:
     """Timeout for agent calls inside the planner (default 600s)."""
-    return _read_int_env(
-        "HEPH_PLANNER_AGENT_TIMEOUT",
-        600,
-        legacy_name="HEPH_PLANNER_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_PLANNER_AGENT_TIMEOUT", 600)
 
 
 def plan_reviewer_claude_timeout() -> int:
     """Timeout for agent calls inside the plan reviewer (default 300s)."""
-    return _read_int_env(
-        "HEPH_PLAN_REVIEWER_AGENT_TIMEOUT",
-        300,
-        legacy_name="HEPH_PLAN_REVIEWER_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_PLAN_REVIEWER_AGENT_TIMEOUT", 300)
 
 
 def implementer_claude_timeout() -> int:
     """Timeout for the implementer's agent invocation (default 1800s)."""
-    return _read_int_env(
-        "HEPH_IMPLEMENTER_AGENT_TIMEOUT",
-        1800,
-        legacy_name="HEPH_IMPLEMENTER_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_IMPLEMENTER_AGENT_TIMEOUT", 1800)
 
 
 def advise_claude_timeout() -> int:
     """Timeout for lightweight advise agent calls (default 360s)."""
-    return _read_int_env(
-        "HEPH_ADVISE_AGENT_TIMEOUT",
-        360,
-        legacy_name="HEPH_ADVISE_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_ADVISE_AGENT_TIMEOUT", 360)
 
 
 def pr_reviewer_claude_timeout() -> int:
     """Timeout for the PR reviewer's agent analysis (default 1200s)."""
-    return _read_int_env(
-        "HEPH_PR_REVIEWER_AGENT_TIMEOUT",
-        1200,
-        legacy_name="HEPH_PR_REVIEWER_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_PR_REVIEWER_AGENT_TIMEOUT", 1200)
 
 
 def address_review_claude_timeout() -> int:
     """Timeout for the address-review fix session (default 1800s)."""
-    return _read_int_env(
-        "HEPH_ADDRESS_REVIEW_AGENT_TIMEOUT",
-        1800,
-        legacy_name="HEPH_ADDRESS_REVIEW_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_ADDRESS_REVIEW_AGENT_TIMEOUT", 1800)
 
 
 def ci_driver_claude_timeout() -> int:
     """Timeout for the CI-driver fix session (default 1800s)."""
-    return _read_int_env(
-        "HEPH_CI_DRIVER_AGENT_TIMEOUT",
-        1800,
-        legacy_name="HEPH_CI_DRIVER_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_CI_DRIVER_AGENT_TIMEOUT", 1800)
 
 
 def learn_claude_timeout() -> int:
     """Timeout for the post-impl ``/learn`` agent call (default 600s)."""
-    return _read_int_env(
-        "HEPH_LEARN_AGENT_TIMEOUT",
-        600,
-        legacy_name="HEPH_LEARN_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_LEARN_AGENT_TIMEOUT", 600)
 
 
 def follow_up_claude_timeout() -> int:
     """Timeout for the follow-up-issue agent session (default 600s)."""
-    return _read_int_env(
-        "HEPH_FOLLOW_UP_AGENT_TIMEOUT",
-        600,
-        legacy_name="HEPH_FOLLOW_UP_CLAUDE_TIMEOUT",
-    )
+    return _read_int_env("HEPH_FOLLOW_UP_AGENT_TIMEOUT", 600)
 
 
 def gh_cli_timeout() -> int:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -104,8 +104,7 @@ __all__ = [
 ]
 
 # Default implementation timeout in seconds. Actual runtime value is read from
-# ``HEPH_IMPLEMENTER_AGENT_TIMEOUT`` (or legacy
-# ``HEPH_IMPLEMENTER_CLAUDE_TIMEOUT``) by
+# ``HEPH_IMPLEMENTER_AGENT_TIMEOUT`` by
 # :func:`.claude_timeouts.implementer_claude_timeout`; this constant serves as
 # the documented default and can be used in tests.
 _CLAUDE_IMPL_TIMEOUT: int = 1800

--- a/tests/unit/automation/test_claude_timeouts.py
+++ b/tests/unit/automation/test_claude_timeouts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 
 import pytest
 
@@ -21,16 +22,81 @@ def test_planner_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     assert claude_timeouts.planner_claude_timeout() == 600
 
 
-def test_planner_timeout_legacy_env_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Legacy Claude-named timeout env vars remain supported."""
-    _clear_planner_timeout_env(monkeypatch)
-    monkeypatch.setenv("HEPH_PLANNER_CLAUDE_TIMEOUT", "444")
+@pytest.mark.parametrize(
+    ("generic_env", "legacy_env", "timeout_fn", "default"),
+    [
+        (
+            "HEPH_PLANNER_AGENT_TIMEOUT",
+            "HEPH_PLANNER_CLAUDE_TIMEOUT",
+            claude_timeouts.planner_claude_timeout,
+            600,
+        ),
+        (
+            "HEPH_PLAN_REVIEWER_AGENT_TIMEOUT",
+            "HEPH_PLAN_REVIEWER_CLAUDE_TIMEOUT",
+            claude_timeouts.plan_reviewer_claude_timeout,
+            300,
+        ),
+        (
+            "HEPH_IMPLEMENTER_AGENT_TIMEOUT",
+            "HEPH_IMPLEMENTER_CLAUDE_TIMEOUT",
+            claude_timeouts.implementer_claude_timeout,
+            1800,
+        ),
+        (
+            "HEPH_ADVISE_AGENT_TIMEOUT",
+            "HEPH_ADVISE_CLAUDE_TIMEOUT",
+            claude_timeouts.advise_claude_timeout,
+            360,
+        ),
+        (
+            "HEPH_PR_REVIEWER_AGENT_TIMEOUT",
+            "HEPH_PR_REVIEWER_CLAUDE_TIMEOUT",
+            claude_timeouts.pr_reviewer_claude_timeout,
+            1200,
+        ),
+        (
+            "HEPH_ADDRESS_REVIEW_AGENT_TIMEOUT",
+            "HEPH_ADDRESS_REVIEW_CLAUDE_TIMEOUT",
+            claude_timeouts.address_review_claude_timeout,
+            1800,
+        ),
+        (
+            "HEPH_CI_DRIVER_AGENT_TIMEOUT",
+            "HEPH_CI_DRIVER_CLAUDE_TIMEOUT",
+            claude_timeouts.ci_driver_claude_timeout,
+            1800,
+        ),
+        (
+            "HEPH_LEARN_AGENT_TIMEOUT",
+            "HEPH_LEARN_CLAUDE_TIMEOUT",
+            claude_timeouts.learn_claude_timeout,
+            600,
+        ),
+        (
+            "HEPH_FOLLOW_UP_AGENT_TIMEOUT",
+            "HEPH_FOLLOW_UP_CLAUDE_TIMEOUT",
+            claude_timeouts.follow_up_claude_timeout,
+            600,
+        ),
+    ],
+)
+def test_legacy_claude_timeout_envs_are_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+    generic_env: str,
+    legacy_env: str,
+    timeout_fn: Callable[[], int],
+    default: int,
+) -> None:
+    """Legacy Claude-named timeout env vars are no longer supported."""
+    monkeypatch.delenv(generic_env, raising=False)
+    monkeypatch.setenv(legacy_env, "444")
 
-    assert claude_timeouts.planner_claude_timeout() == 444
+    assert timeout_fn() == default
 
 
-def test_planner_timeout_agent_env_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Generic agent timeout env vars override legacy names."""
+def test_planner_timeout_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Generic agent timeout env vars tune planner calls."""
     _clear_planner_timeout_env(monkeypatch)
     monkeypatch.setenv("HEPH_PLANNER_CLAUDE_TIMEOUT", "444")
     monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "555")
@@ -55,7 +121,6 @@ def test_planner_timeout_invalid_agent_env_logs_and_defaults(
 def test_advise_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Advise timeout keeps its short default unless explicitly tuned."""
     monkeypatch.delenv("HEPH_ADVISE_AGENT_TIMEOUT", raising=False)
-    monkeypatch.delenv("HEPH_ADVISE_CLAUDE_TIMEOUT", raising=False)
 
     assert claude_timeouts.advise_claude_timeout() == 360
 


### PR DESCRIPTION
## Summary

- Remove legacy `HEPH_*_CLAUDE_TIMEOUT` fallback support from automation timeout configuration.
- Keep the generic `HEPH_*_AGENT_TIMEOUT` variables and `HEPH_GH_TIMEOUT` behavior unchanged.
- Update timeout tests to assert every former Claude timeout alias is ignored.
- Remove stale implementer comment text that documented the legacy alias.

## Validation

- `python3 -m pytest tests/unit/automation/test_claude_timeouts.py -q --no-cov`
- `python3 -m ruff check hephaestus/automation/claude_timeouts.py tests/unit/automation/test_claude_timeouts.py hephaestus/automation/implementer.py`
- `python3 -m ruff format --check hephaestus/automation/claude_timeouts.py tests/unit/automation/test_claude_timeouts.py hephaestus/automation/implementer.py`
- `python3 -m pytest -q`
- pre-push hook: `pytest -q`
- `git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=/Users/mvillmow/.ssh/allowed_signers log --show-signature -1 --format=fuller`

Closes #892
