### PR TITLE
Preserve final loop phases in automation loop

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -82,6 +82,8 @@ ALL_PHASES: tuple[str, ...] = (
     "drive-green",
 )
 
+FINAL_LOOP_ONLY_PHASES: frozenset[str] = frozenset({"drive-green"})
+
 # DEFAULT_PROJECTS_DIR is re-exported from hephaestus.config.paths so existing
 # tests that patch this module-level name continue to work. See #704: the
 # projects root is now resolved at runtime via resolve_projects_dir() so that
@@ -440,12 +442,22 @@ def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
     """
     warnings: list[str] = []
     selected = set(cfg.phases)
+    if "plan" in selected and "implement" not in selected:
+        warnings.append(
+            "--phases includes 'plan' but not 'implement'; this is planning-only "
+            "and will not create implementation PRs"
+        )
     if "drive-green" in selected and "implement" not in selected:
         warnings.append(
             "--phases includes 'drive-green' but not 'implement'; "
             "drive-green will run against PRs not touched this invocation"
         )
     return warnings
+
+
+def _has_pending_final_loop_phase(cfg: LoopConfig, loop_idx: int) -> bool:
+    """Return true when early-exit would skip a selected final-loop-only phase."""
+    return loop_idx < cfg.loops and any(phase in cfg.phases for phase in FINAL_LOOP_ONLY_PHASES)
 
 
 # ---------------------------------------------------------------------------
@@ -1010,8 +1022,8 @@ def _process_repo_inner(
             )
             continue
 
-        # drive-green only runs on the final loop. Mirrors bash behavior.
-        if phase == "drive-green" and loop_idx != cfg.loops:
+        # Some phases only run on the configured final loop. Mirrors bash behavior.
+        if phase in FINAL_LOOP_ONLY_PHASES and loop_idx != cfg.loops:
             LOG.info("[%s] phase %s SKIP (not final loop)", repo, phase)
             result.phases.append(
                 PhaseResult(name=phase, skipped=True, skip_reason="not final loop")
@@ -1202,13 +1214,14 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
         # (#614)
         if (
             loop_idx < cfg.loops
+            and not _has_pending_final_loop_phase(cfg, loop_idx)
             and not any(r.any_failure for r in loop_results)
             and not any(r.produced_work for r in loop_results)
         ):
             LOG.info(
                 "Early exit after loop %d/%d: full pass produced 0 new plans"
                 " and 0 non-skipped reviews across all %d repo(s)."
-                " Remaining loops skipped — use --loops to override upper bound.",
+                " Remaining loops skipped.",
                 loop_idx,
                 cfg.loops,
                 len(repos),

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -109,6 +109,13 @@ def test_phase_order_warnings_drive_green_without_implement_warns() -> None:
     assert any("drive-green" in w and "implement" in w for w in warnings)
 
 
+def test_phase_order_warnings_plan_without_implement_warns() -> None:
+    """Plan selected without implement makes the invocation planning-only."""
+    cfg = LoopConfig(phases=("plan",))
+    warnings = _phase_order_warnings(cfg)
+    assert any("planning-only" in w and "implementation PRs" in w for w in warnings)
+
+
 def test_phase_order_warnings_drive_green_with_implement_silent() -> None:
     """drive-green selected alongside implement produces no warning."""
     cfg = LoopConfig(phases=("implement", "drive-green"))

--- a/tests/unit/automation/test_loop_runner_early_exit.py
+++ b/tests/unit/automation/test_loop_runner_early_exit.py
@@ -432,13 +432,14 @@ class TestRunLoopEarlyExit:
     """Tests for early-exit logic in run_loop (#614)."""
 
     def test_early_exit_fires_on_zero_work_pass(self, tmp_path: Path) -> None:
-        """When a full pass across all repos produces 0 new plans and 0 reviews, break early.
+        """When a non-final pass produces 0 new plans and 0 reviews, break early.
 
-        A 5-loop config should stop after loop 1 when no repo reports any work.
+        A 5-loop config with no final-loop-only phases should stop after loop 1
+        when no repo reports any work.
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=5, projects_dir=projects)
+        cfg = LoopConfig(loops=5, projects_dir=projects, phases=("plan", "implement"))
 
         call_count = 0
 
@@ -453,6 +454,25 @@ class TestRunLoopEarlyExit:
         # Only loop 1 should have run — early-exit fires immediately.
         assert max(r.loop_idx for r in results) == 1
         assert call_count == 1
+
+    def test_early_exit_does_not_skip_selected_final_loop_phase(self, tmp_path: Path) -> None:
+        """A selected final-loop-only phase prevents early-exit before its loop."""
+        projects = tmp_path
+        (projects / "r1" / ".git").mkdir(parents=True)
+        cfg = LoopConfig(loops=3, projects_dir=projects)
+
+        call_count = 0
+
+        def fake_process(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
+            nonlocal call_count
+            call_count += 1
+            return _zero_work_result(repo, loop_idx)
+
+        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
+            results = run_loop(cfg, repos=["r1"])
+
+        assert max(r.loop_idx for r in results) == 3
+        assert call_count == 3
 
     def test_loops_caps_when_work_continues_every_loop(self, tmp_path: Path) -> None:
         """--loops is still respected as an upper bound when work is produced each loop.


### PR DESCRIPTION
## Summary

- Preserve selected final-loop-only phases, currently `drive-green`, by blocking early-exit before their configured final loop.
- Reuse a shared `FINAL_LOOP_ONLY_PHASES` definition for both phase skipping and early-exit decisions.
- Warn when `--phases plan` excludes `implement`, since that mode is planning-only and will not create implementation PRs.
- Update loop-runner tests for plan-only warnings and final-loop early-exit behavior.

## Why

The Radiance run used `--phases plan`, so implementation was disabled by CLI selection. There was also a separate loop-runner bug: with all phases selected, early-exit could still stop before the configured final loop, preventing `drive-green` from ever running.

## Validation

- `python3 -m pytest tests/unit/automation/test_loop_runner.py tests/unit/automation/test_loop_runner_early_exit.py -q --no-cov`
- `python3 -m ruff check hephaestus/automation/loop_runner.py tests/unit/automation/test_loop_runner.py tests/unit/automation/test_loop_runner_early_exit.py`
- `python3 -m ruff format --check hephaestus/automation/loop_runner.py tests/unit/automation/test_loop_runner.py tests/unit/automation/test_loop_runner_early_exit.py`
- `python3 -m pytest -q`
- pre-push hook: `pytest -q`
- `git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=/Users/mvillmow/.ssh/allowed_signers log --show-signature -1 --format=fuller`

Closes #894
