### PR TITLE
Avoid automation phase preload warnings

### DIFF
--- a/hephaestus/automation/__init__.py
+++ b/hephaestus/automation/__init__.py
@@ -1,15 +1,21 @@
 """Automation utilities for GitHub issue planning and implementation."""
 
-from hephaestus.automation.dependency_resolver import DependencyResolver
-from hephaestus.automation.implementer import IssueImplementer
-from hephaestus.automation.models import (
-    ImplementerOptions,
-    IssueInfo,
-    PlannerOptions,
-    ReviewerOptions,
-)
-from hephaestus.automation.planner import Planner
-from hephaestus.automation.pr_reviewer import PRReviewer
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from hephaestus.automation.dependency_resolver import DependencyResolver
+    from hephaestus.automation.implementer import IssueImplementer
+    from hephaestus.automation.models import (
+        ImplementerOptions,
+        IssueInfo,
+        PlannerOptions,
+        ReviewerOptions,
+    )
+    from hephaestus.automation.planner import Planner
+    from hephaestus.automation.pr_reviewer import PRReviewer
 
 __all__ = [
     "DependencyResolver",
@@ -21,3 +27,31 @@ __all__ = [
     "PlannerOptions",
     "ReviewerOptions",
 ]
+
+_LAZY_EXPORTS: dict[str, str] = {
+    "DependencyResolver": "hephaestus.automation.dependency_resolver",
+    "ImplementerOptions": "hephaestus.automation.models",
+    "IssueImplementer": "hephaestus.automation.implementer",
+    "IssueInfo": "hephaestus.automation.models",
+    "Planner": "hephaestus.automation.planner",
+    "PlannerOptions": "hephaestus.automation.models",
+    "PRReviewer": "hephaestus.automation.pr_reviewer",
+    "ReviewerOptions": "hephaestus.automation.models",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load package-level exports without preloading phase entrypoints."""
+    try:
+        module_name = _LAZY_EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include lazy exports in interactive introspection."""
+    return sorted(set(globals()) | set(__all__))

--- a/tests/unit/automation/test_package_imports.py
+++ b/tests/unit/automation/test_package_imports.py
@@ -1,0 +1,67 @@
+"""Regression tests for automation package import side effects."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+_PHASE_ENTRYPOINTS = (
+    "hephaestus.automation.planner",
+    "hephaestus.automation.implementer",
+    "hephaestus.automation.pr_reviewer",
+)
+
+
+def _run_python(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_package_import_does_not_preload_phase_entrypoints() -> None:
+    """Parent package import must not preload modules executed via ``python -m``."""
+    result = _run_python(
+        f"""
+import sys
+import hephaestus.automation
+
+loaded = [name for name in {_PHASE_ENTRYPOINTS!r} if name in sys.modules]
+if loaded:
+    raise SystemExit("preloaded phase entrypoints: " + ", ".join(loaded))
+"""
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+def test_package_lazy_exports_remain_importable() -> None:
+    """Existing package-level class imports should keep working."""
+    result = _run_python(
+        """
+import hephaestus.automation as automation
+
+for name in automation.__all__:
+    assert getattr(automation, name).__name__ == name
+"""
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+
+
+@pytest.mark.parametrize("module_name", _PHASE_ENTRYPOINTS)
+def test_phase_entrypoint_help_has_no_runpy_preload_warning(module_name: str) -> None:
+    """Phase modules should run through ``python -m`` without preload warnings."""
+    result = subprocess.run(
+        [sys.executable, "-W", "error::RuntimeWarning", "-m", module_name, "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "found in sys.modules after import of package" not in result.stderr


### PR DESCRIPTION
## Summary

- avoid eager automation package imports of runnable phase modules
- preserve package-level public exports through lazy `__getattr__`
- add regression coverage for package import side effects and `python -m` phase execution

## Validation

- `python3 -m pytest tests/unit/automation/test_package_imports.py -q --no-cov`
- `python3 -m ruff check hephaestus/automation/__init__.py tests/unit/automation/test_package_imports.py`
- `python3 -m ruff format --check hephaestus/automation/__init__.py tests/unit/automation/test_package_imports.py`
- `python3 -W error::RuntimeWarning -m hephaestus.automation.implementer --help`
- `python3 -W error::RuntimeWarning -m hephaestus.automation.planner --help`
- `python3 -W error::RuntimeWarning -m hephaestus.automation.pr_reviewer --help`
- `python3 -m pytest -q`
- pre-push hook: `pytest -q`

Closes #896
