### PR TITLE
[codex] Gate implementation PR auto-merge on review GO

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -42,11 +42,12 @@ Builds and publishes the package to PyPI on version tag push (`v*`).
 
 The consolidated required-status-check gate that runs on every pull request to
 `main` (and on push to `main`). It aggregates lint, markdownlint, `pixi-check`,
-shellcheck, the `pr-policy` gate (enforces `Closes #N`, auto-merge enabled, and
-signed commits), unit/integration/shell tests, wheel build, security scans
-(pip-audit, Gitleaks, bandit), workflow-schema validation, and version-sync. It
-also re-runs on `auto_merge_enabled` / `auto_merge_disabled` events so the
-`pr-policy` auto-merge check converges without timing races.
+shellcheck, the `pr-policy` gate (enforces `Closes #N`, signed commits, and
+the auto-merge state machine), unit/integration/shell tests, wheel build,
+security scans (pip-audit, Gitleaks, bandit), workflow-schema validation, and
+version-sync. It also re-runs on `auto_merge_enabled` / `auto_merge_disabled`
+and `labeled` / `unlabeled` events so the `pr-policy` auto-merge check
+converges without timing races.
 
 ### Auto-Tag Workflow (`workflows/auto-tag.yml`)
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -3,16 +3,19 @@ name: Required Checks
 on:
   pull_request:
     # Default types are [opened, synchronize, reopened], which do NOT fire when
-    # auto-merge is toggled after PR creation — so pr-policy's auto-merge check
-    # was stuck with its PR-open verdict until the next push (the race that #680
-    # papered over with `needs: lint`). Re-running on auto_merge_enabled /
-    # auto_merge_disabled (and ready_for_review) makes that gate converge on the
-    # true state with no timing reliance. See pr-policy below.
+    # auto-merge is toggled or labels are changed after PR creation — so
+    # pr-policy's auto-merge check was stuck with its PR-open verdict until the
+    # next push (the race that #680 papered over with `needs: lint`).
+    # Re-running on auto_merge_enabled / auto_merge_disabled, labeled /
+    # unlabeled, and ready_for_review makes that gate converge on the true
+    # state with no timing reliance. See pr-policy below.
     types:
       - opened
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
       - auto_merge_enabled
       - auto_merge_disabled
   push:
@@ -259,15 +262,17 @@ jobs:
     # Enforces repo PR policy on every PR. Three independent checks (each
     # gated by `if: always()` so one failure still surfaces the others):
     #   1. PR body contains `Closes #N` on its own line.
-    #   2. Auto-merge is enabled on the PR.
+    #   2. Auto-merge matches implementation-review state:
+    #      disabled before `state:implementation-go`, enabled after it.
     #   3. Every commit on the PR has a verified signature.
     # Push events are skipped because there is no PR to inspect.
     #
     # This gate intentionally has NO `needs:` — it runs immediately and
-    # re-runs whenever auto-merge is toggled (see the auto_merge_enabled /
-    # auto_merge_disabled trigger types in `on.pull_request` above), so the
-    # auto-merge check (#2) converges on the PR's true state without depending
-    # on another job's timing. The earlier `needs: lint` workaround (#680) only
+    # re-runs whenever auto-merge is toggled or labels change (see the
+    # auto_merge_enabled / auto_merge_disabled and labeled / unlabeled trigger
+    # types in `on.pull_request` above), so the auto-merge check (#2) converges
+    # on the PR's true state without depending on another job's timing.
+    # The earlier `needs: lint` workaround (#680) only
     # delayed the read and left a required-check-skipped-on-lint-failure wrinkle.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
@@ -286,13 +291,13 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
-          # `gh pr view --json body,autoMergeRequest` exposes body + auto-merge
-          # state but DOES NOT expose per-commit signatures; we use the GraphQL
-          # API for that. Two separate queries are fine here — the workflow
-          # runs at most once per PR event and the policy gate must be cheap
-          # to read and debug.
+          # `gh pr view --json body,autoMergeRequest,labels` exposes body,
+          # auto-merge state, and implementation-review labels but DOES NOT
+          # expose per-commit signatures; we use the GraphQL API for that. Two
+          # separate queries are fine here — the workflow runs at most once per
+          # PR event and the policy gate must be cheap to read and debug.
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json body,autoMergeRequest \
+            --json body,autoMergeRequest,labels \
             > pr.json
           gh api graphql \
             -f query='query($owner:String!,$name:String!,$pr:Int!) {
@@ -330,18 +335,30 @@ jobs:
             exit 1
           fi
 
-      - name: "Check 2: auto-merge enabled"
+      - name: "Check 2: auto-merge matches implementation-review state"
         if: always() && steps.fetch.outcome == 'success'
         run: |
           set -euo pipefail
           state=$(jq -r '.autoMergeRequest' pr.json)
-          if [ "$state" = "null" ] || [ -z "$state" ]; then
-            msg="::error::Auto-merge is not enabled on this PR."
-            msg+=" Run: gh pr merge $PR_NUMBER --auto --squash  (this repo is squash-only)."
-            echo "$msg"
-            exit 1
+          implementation_go=$(jq -r '[(.labels // [])[].name] | index("state:implementation-go") != null' pr.json)
+          if [ "$implementation_go" = "true" ]; then
+            if [ "$state" = "null" ] || [ -z "$state" ]; then
+              msg="::error::PR has state:implementation-go but auto-merge is not enabled."
+              msg+=" Run: gh pr merge $PR_NUMBER --auto --squash  (this repo is squash-only)."
+              echo "$msg"
+              exit 1
+            fi
+            echo "OK: implementation-GO PR has auto-merge enabled"
+          else
+            if [ "$state" != "null" ] && [ -n "$state" ]; then
+              msg="::error::Auto-merge is enabled before implementation review GO."
+              msg+=" Remove it with: gh pr merge $PR_NUMBER --disable-auto"
+              msg+="; re-enable only after state:implementation-go is applied."
+              echo "$msg"
+              exit 1
+            fi
+            echo "OK: auto-merge is deferred until implementation review GO"
           fi
-          echo "OK: auto-merge is enabled"
 
       - name: "Check 3: every commit is signed"
         if: always() && steps.fetch.outcome == 'success'

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -14,7 +14,7 @@ A piece of work is **done** when every item below is true.
 | 1 | Branch named `<issue-number>-<description>` | Convention (PR reviewer) |
 | 2 | PR body contains the literal line `Closes #<issue-number>` (capital C, no colon, on its own line) | CI gate `pr-policy` (`.github/workflows/_required.yml`) |
 | 3 | Every commit on the branch is cryptographically signed (`git commit -S`) | CI gate `pr-policy` |
-| 4 | Auto-merge is enabled with `--squash` (NOT `--rebase`; the repo disallows rebase merges) | CI gate `pr-policy` |
+| 4 | Auto-merge is disabled until `state:implementation-go`, then enabled with `--squash` (NOT `--rebase`; the repo disallows rebase merges) | CI gate `pr-policy` |
 | 5 | Commit messages follow Conventional Commits (`type(scope): description`) | PR reviewer (no automated gate) |
 | 6 | `pixi run ruff check hephaestus/ tests/` passes | CI job `lint` |
 | 7 | `pixi run ruff format --check hephaestus/ tests/` passes (no files would be reformatted) | CI job `lint` |

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -55,6 +55,7 @@ from .github_api import (
     gh_pr_list_unresolved_threads,
 )
 from .models import CIDriverOptions, WorkerResult
+from .pr_manager import pr_has_implementation_go_label
 from .prompts import get_advise_prompt_builder
 from .session_naming import AGENT_ADVISE, AGENT_CI_DRIVER
 from .status_tracker import StatusTracker
@@ -202,12 +203,10 @@ class CIDriver:
         # this is empty (#838). Stored on the driver so ``main()`` can check
         # it without changing ``run()``'s established return type.
         self.open_prs_remaining = [] if self.options.dry_run else self._list_open_prs_remaining()
-        # Arm auto-merge on EVERY un-armed open PR before the final report
-        # (#882). A PR the driver fixed-and-pushed, or one that arrived green
-        # from elsewhere, can end CLEAN but un-armed and then never merge
-        # (observed: ProjectHermes #645/#648). Arming is idempotent and a
-        # no-op for PRs GitHub won't let merge yet (conflicts / red CI / review
-        # gates), so a blanket pass is safe and drains the ready ones.
+        # Arm auto-merge on every implementation-GO un-armed open PR before
+        # the final report (#882). The implementation-GO label is the policy
+        # gate: PRs must not be queued for merge until in-loop implementation
+        # review has approved them.
         if self.open_prs_remaining and not self.options.dry_run:
             self.open_prs_remaining = self._arm_all_unarmed_open_prs(self.open_prs_remaining)
         if self.open_prs_remaining:
@@ -290,27 +289,28 @@ class CIDriver:
         # normalise to the gh-CLI shape consumers downstream already use.
         normalised: list[dict[str, Any]] = []
         for pr in raw_pulls:
+            labels = pr.get("labels") or []
             normalised.append(
                 {
                     "number": pr.get("number"),
                     "title": pr.get("title", ""),
                     "headRefName": (pr.get("head") or {}).get("ref", ""),
                     "autoMergeRequest": pr.get("auto_merge"),
+                    "labels": [
+                        label.get("name", "") for label in labels if isinstance(label, dict)
+                    ],
                     "isBot": (pr.get("user") or {}).get("type") == "Bot",
                 }
             )
         return normalised
 
     def _arm_all_unarmed_open_prs(self, open_prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Arm auto-merge on every un-armed open PR, then refresh their state (#882).
+        """Arm auto-merge on every implementation-GO un-armed open PR (#882).
 
         The per-issue drive only arms PRs it processed; a PR fixed-and-pushed by
         the driver (or one that arrived green from another actor) can end CLEAN
-        but un-armed and never merge. This blanket pass arms anything not yet
-        armed. ``_enable_auto_merge`` is idempotent and GitHub simply queues the
-        request for PRs it won't merge yet (conflicts / failing CI / required
-        review), so arming a not-yet-mergeable PR is a harmless no-op rather than
-        a force-merge.
+        but un-armed and never merge. This pass arms only PRs already marked
+        ``state:implementation-go`` so review approval remains the merge gate.
 
         Returns the open-PR list with ``autoMergeRequest`` refreshed for any PR
         that armed, so the caller's final gate reports the true state.
@@ -322,6 +322,12 @@ class CIDriver:
                 continue
             if pr.get("autoMergeRequest"):
                 continue  # already armed
+            if not pr_has_implementation_go_label(pr):
+                logger.info(
+                    "PR #%s lacks state:implementation-go; leaving auto-merge disabled",
+                    number,
+                )
+                continue
             if self._enable_auto_merge(number, is_bot_pr=bool(pr.get("isBot"))):
                 armed_now.append(number)
         if not armed_now:
@@ -613,6 +619,19 @@ class CIDriver:
             )
 
             if all_green:
+                if not self._pr_has_implementation_go(pr_number):
+                    logger.info(
+                        "Issue #%s: PR #%s is green but lacks state:implementation-go; "
+                        "leaving auto-merge disabled until implementation review approves it",
+                        issue_number,
+                        pr_number,
+                    )
+                    return WorkerResult(
+                        issue_number=issue_number,
+                        success=True,
+                        pr_number=pr_number,
+                    )
+
                 self.status_tracker.update_slot(
                     acquired_slot, f"{issue_ref(issue_number)}: enabling auto-merge"
                 )
@@ -937,6 +956,15 @@ class CIDriver:
         if not all(c.get("conclusion") in ("success", "skipped", "neutral") for c in required):
             # Still red after the fix — let the normal failure handling stand.
             return None
+
+        if not self._pr_has_implementation_go(pr_number):
+            logger.info(
+                "Issue #%s: PR #%s is green after fix but lacks state:implementation-go; "
+                "leaving auto-merge disabled until implementation review approves it",
+                issue_number,
+                pr_number,
+            )
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
         self.status_tracker.update_slot(
             acquired_slot, f"{issue_ref(issue_number)}: enabling auto-merge (post-fix)"
@@ -1337,6 +1365,22 @@ class CIDriver:
                 exc,
             )
             return None
+
+    def _pr_has_implementation_go(self, pr_number: int) -> bool:
+        """Return whether a PR has the implementation-review GO label."""
+        try:
+            result = _gh_call(
+                ["pr", "view", str(pr_number), "--json", "labels"],
+                check=False,
+            )
+            return pr_has_implementation_go_label(dict(json.loads(result.stdout or "{}")))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Could not fetch PR #%s labels for implementation-GO gate: %s",
+                pr_number,
+                exc,
+            )
+            return False
 
     def _wait_for_pr_terminal(self, issue_number: int, pr_number: int) -> str:
         """Block until an armed PR reaches a terminal state, or times out.

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -935,17 +935,19 @@ def gh_pr_create(
     branch: str,
     title: str,
     body: str,
-    auto_merge: bool = True,
+    auto_merge: bool = False,
     base: str = "main",
 ) -> int:
     """Create a pull request.
 
-    Enforces three policy properties at creation time:
+    Enforces PR body and signing policy at creation time:
 
     1. *body* must contain a literal ``Closes #N`` line.
     2. Every commit on *branch* (vs *base*) must be cryptographically signed.
-    3. Auto-merge MUST be enabled when ``auto_merge=True`` (the default); a
-       failure to enable auto-merge raises instead of warning.
+
+    When ``auto_merge=True`` the helper also arms auto-merge immediately. The
+    implementation pipeline deliberately passes ``False`` until the in-loop
+    implementation review marks the PR GO.
 
     The CI gate (``.github/workflows/_required.yml`` job ``pr-policy``) and the
     PR review prompt re-check the same three properties, so a slip past one
@@ -955,7 +957,7 @@ def gh_pr_create(
         branch: Branch name
         title: PR title
         body: PR description
-        auto_merge: Whether to enable auto-merge (default True; required by policy)
+        auto_merge: Whether to enable auto-merge immediately (default False)
         base: Base branch to compare against for signed-commit validation
 
     Returns:
@@ -963,8 +965,8 @@ def gh_pr_create(
 
     Raises:
         ValueError: If *body* lacks ``Closes #N`` or *branch* has unsigned commits.
-        RuntimeError: If the underlying ``gh`` CLI call fails, or auto-merge
-            cannot be enabled when ``auto_merge=True``.
+        RuntimeError: If the underlying ``gh`` CLI call fails, or immediate
+            auto-merge cannot be enabled when ``auto_merge=True``.
 
     """
     # Policy gate #1: PR body must reference the closing issue.
@@ -982,6 +984,8 @@ def gh_pr_create(
                     "create",
                     "--head",
                     branch,
+                    "--base",
+                    base,
                     "--title",
                     title,
                     "--body-file",
@@ -1000,19 +1004,16 @@ def gh_pr_create(
 
         logger.info("Created PR #%s", pr_number)
 
-        # Policy gate #3: auto-merge is mandatory when requested. A failure here
-        # used to log a warning; under the new policy it must raise so the
-        # operator sees the violation.
         if auto_merge:
             try:
-                _gh_call(["pr", "merge", str(pr_number), "--auto", "--rebase"])
+                _gh_call(["pr", "merge", str(pr_number), "--auto", "--squash"])
                 logger.info("Enabled auto-merge for PR #%s", pr_number)
             except Exception as e:
                 logger.error("Failed to enable auto-merge for PR #%s: %s", pr_number, e)
                 raise RuntimeError(
                     f"Auto-merge could not be enabled for PR #{pr_number}: {e}. "
-                    "Auto-merge is required by repo policy; resolve the underlying "
-                    "issue (e.g. branch protection, merge method) and re-run."
+                    "Resolve the underlying issue (e.g. branch protection, merge method) "
+                    "and re-run."
                 ) from e
 
         return pr_number

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -725,7 +725,7 @@ class IssueImplementer:
         return create_pr(
             issue_number,
             branch_name,
-            self.options.auto_merge,
+            auto_merge=False,
             agent=self.options.agent,
         )
 

--- a/hephaestus/automation/implementer_cli.py
+++ b/hephaestus/automation/implementer_cli.py
@@ -121,7 +121,7 @@ Examples:
     parser.add_argument(
         "--no-auto-merge",
         action="store_true",
-        help="Don't enable auto-merge on created PRs",
+        help="Don't enable auto-merge after implementation-review GO",
     )
     parser.add_argument(
         "--dry-run",

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -59,7 +59,14 @@ from .models import (
     ImplementationState,
     WorkerResult,
 )
-from .pr_manager import commit_changes, ensure_pr_created
+from .pr_manager import (
+    commit_changes,
+    enable_auto_merge_after_implementation_go,
+    ensure_pr_auto_merge_deferred,
+    ensure_pr_created,
+    mark_pr_implementation_go,
+    mark_pr_implementation_no_go,
+)
 from .pr_reviewer import gather_impl_review_context, review_pr_inline
 from .prompts import (
     get_advise_prompt_builder,
@@ -374,6 +381,7 @@ class ImplementationPhaseRunner:
             # created`` is a fallback that no-ops when the agent already opened
             # the PR.
             pr_number = impl._finalize_pr(issue_number, branch_name, worktree_path, state, slot_id)
+            ensure_pr_auto_merge_deferred(pr_number)
 
             # Strict review loop now absorbs the former ``review-prs`` and
             # ``address-review`` phases: each iteration runs a FRESH reviewer
@@ -401,6 +409,23 @@ class ImplementationPhaseRunner:
                 state.last_review_verdict = last_verdict
                 state.last_review_grade = last_grade
             impl._save_state(state)
+
+            if last_verdict == "GO":
+                mark_pr_implementation_go(pr_number)
+                if self.options.auto_merge:
+                    if slot_id is not None:
+                        self.status_tracker.update_slot(
+                            slot_id, f"{issue_ref(issue_number)}: enabling auto-merge"
+                        )
+                    enable_auto_merge_after_implementation_go(pr_number)
+            else:
+                mark_pr_implementation_no_go(pr_number)
+                impl._log(
+                    "warning",
+                    f"{issue_ref(issue_number)}: implementation review did not reach GO; "
+                    f"auto-merge remains disabled for {pr_ref(pr_number)}",
+                    thread_id,
+                )
 
             # impl-learnings + follow-up filing stay in Session 2 (#28 §B),
             # resuming AGENT_IMPLEMENTER AFTER the loop converges.

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -18,8 +18,19 @@ from hephaestus.agents.runtime import is_codex
 from ._secret_patterns import SECRET_FILE_EXTENSIONS, SECRET_FILE_NAMES
 from .claude_models import implementer_model
 from .git_utils import issue_ref, run
-from .github_api import _gh_call, fetch_issue_info, gh_pr_create
+from .github_api import (
+    _gh_call,
+    fetch_issue_info,
+    gh_issue_add_labels,
+    gh_issue_remove_labels,
+    gh_pr_create,
+)
 from .prompts import get_pr_description
+from .state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
+    is_implementation_go,
+)
 from .status_tracker import StatusTracker
 
 logger = logging.getLogger(__name__)
@@ -35,6 +46,72 @@ def _coauthor_for_agent(agent: str) -> tuple[str, str]:
     if is_codex(agent):
         return ("Codex", "noreply@openai.com")
     return (implementer_model(), "noreply@anthropic.com")
+
+
+def _detect_default_base_branch(worktree_path: Path) -> str:
+    """Return the repo default branch name for PR/signature ranges."""
+    result = run(
+        ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
+        cwd=worktree_path,
+        capture_output=True,
+        check=False,
+    )
+    ref = (result.stdout or "").strip()
+    if ref.startswith("origin/") and len(ref) > len("origin/"):
+        return ref.removeprefix("origin/")
+    return "main"
+
+
+def _pr_auto_merge_enabled(pr_number: int) -> bool:
+    """Return whether GitHub currently has auto-merge armed for a PR."""
+    result = _gh_call(["pr", "view", str(pr_number), "--json", "autoMergeRequest"])
+    data = json.loads(result.stdout or "{}")
+    return data.get("autoMergeRequest") is not None
+
+
+def ensure_pr_auto_merge_deferred(pr_number: int) -> None:
+    """Disable premature auto-merge before implementation review reaches GO."""
+    if not _pr_auto_merge_enabled(pr_number):
+        return
+    _gh_call(["pr", "merge", str(pr_number), "--disable-auto"])
+    logger.warning(
+        "Disabled premature auto-merge for PR #%s; implementation review has not reached GO yet",
+        pr_number,
+    )
+
+
+def mark_pr_implementation_go(pr_number: int) -> None:
+    """Mark a PR as implementation-review GO."""
+    gh_issue_add_labels(pr_number, [STATE_IMPLEMENTATION_GO])
+    gh_issue_remove_labels(pr_number, [STATE_IMPLEMENTATION_NO_GO])
+
+
+def mark_pr_implementation_no_go(pr_number: int) -> None:
+    """Mark a PR as implementation-review not-GO."""
+    gh_issue_add_labels(pr_number, [STATE_IMPLEMENTATION_NO_GO])
+    gh_issue_remove_labels(pr_number, [STATE_IMPLEMENTATION_GO])
+
+
+def pr_has_implementation_go_label(pr: dict[str, object]) -> bool:
+    """Return True when a PR dictionary carries the implementation-GO label."""
+    labels = pr.get("labels")
+    if not isinstance(labels, list):
+        return False
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return is_implementation_go(names)
+
+
+def enable_auto_merge_after_implementation_go(pr_number: int) -> None:
+    """Arm auto-merge after implementation review has labeled the PR GO."""
+    _gh_call(["pr", "merge", str(pr_number), "--auto", "--squash"])
+    logger.info("Enabled auto-merge for implementation-GO PR #%s", pr_number)
 
 
 def commit_changes(issue_number: int, worktree_path: Path, agent: str = "claude") -> None:
@@ -142,7 +219,8 @@ def ensure_pr_created(
         issue_number: Issue number
         branch_name: Git branch name
         worktree_path: Path to worktree
-        auto_merge: Whether to enable auto-merge on the PR
+        auto_merge: Whether the caller eventually wants auto-merge. The PR is
+            still created with auto-merge disabled until implementation review GO.
         status_tracker: StatusTracker instance for slot updates (optional)
         slot_id: Worker slot ID for status updates
         agent: Selected implementation agent for generated PR metadata.
@@ -204,7 +282,19 @@ def ensure_pr_created(
 
     # PR doesn't exist, create it
     logger.warning("No PR found for branch %s, creating one...", branch_name)
-    pr_number = create_pr(issue_number, branch_name, auto_merge, agent=agent)
+    if auto_merge:
+        logger.info(
+            "Deferring auto-merge for branch %s until implementation review marks the PR GO",
+            branch_name,
+        )
+    base_branch = _detect_default_base_branch(worktree_path)
+    pr_number = create_pr(
+        issue_number,
+        branch_name,
+        auto_merge=False,
+        agent=agent,
+        base=base_branch,
+    )
     logger.info("Created PR #%s", pr_number)
     return pr_number
 
@@ -214,6 +304,7 @@ def create_pr(
     branch_name: str,
     auto_merge: bool = False,
     agent: str = "claude",
+    base: str = "main",
 ) -> int:
     """Create pull request for issue.
 
@@ -243,4 +334,5 @@ def create_pr(
         title=pr_title,
         body=pr_body,
         auto_merge=auto_merge,
+        base=base,
     )

--- a/hephaestus/automation/prompts/_strict_rubric.py
+++ b/hephaestus/automation/prompts/_strict_rubric.py
@@ -92,9 +92,10 @@ _PR_STRICT_RUBRIC_DIMENSIONS = """
 concrete evidence from the artifacts above):**
 
 D1 — Policy compliance (HIGHEST PRIORITY / NOGO gate).
-    The three mandatory gates below (Closes #N / auto-merge / signed
-    commits) are graded as a single dimension. ANY violation forces an
-    overall NOGO verdict, regardless of every other dimension's grade.
+    The three mandatory gates below (Closes #N / auto-merge deferred until
+    implementation GO / signed commits) are graded as a single dimension. ANY
+    violation forces an overall NOGO verdict, regardless of every other
+    dimension's grade.
     Policy compliance is NEVER weighed against code quality — it is a
     hard precondition.
 

--- a/hephaestus/automation/prompts/implementation.py
+++ b/hephaestus/automation/prompts/implementation.py
@@ -89,16 +89,15 @@ After implementation is complete and tests pass:
    on its own line, with the literal keyword `Closes` (capital C). The
    variants `Fixes #N`, `Resolves #N`, `Closes: #N`, `closes #n` are NOT
    accepted by the policy check — even though GitHub recognizes them.
-4. IMMEDIATELY after PR creation, enable auto-merge:
-       gh pr merge <PR#> --auto --rebase
-   Fall back to `--squash` ONLY if rebase merging is disabled for the repo.
-5. Verify all three policy properties before declaring done. ``gh pr view``
-   exposes body + auto-merge state but NOT per-commit signatures, so the
-   verification uses two queries — the REST projection for body/auto-merge
-   and GraphQL for signing state:
-       # Body and auto-merge state:
+4. DO NOT enable auto-merge yet. Auto-merge is armed only after the
+   implementation-review loop marks the PR with `state:implementation-go`.
+5. Verify the creation-time policy properties before declaring done.
+   ``gh pr view`` exposes the body but NOT per-commit signatures, so the
+   verification uses two queries — the REST projection for body and GraphQL
+   for signing state:
+       # Body:
        gh pr view <PR#> --json body,autoMergeRequest \\
-         -q '.body | test("(?m)^Closes #\\\\d+\\\\s*$"), .autoMergeRequest != null'
+         -q '.body | test("(?m)^Closes #\\\\d+\\\\s*$"), .autoMergeRequest == null'
        # Per-commit signing state (GraphQL — replace OWNER/REPO/PR#):
        gh api graphql -f query='query($owner:String!,$name:String!,$pr:Int!){{
          repository(owner:$owner,name:$name){{
@@ -106,7 +105,7 @@ After implementation is complete and tests pass:
              commits(first:100){{ nodes{{ commit{{ oid signature{{ isValid }} }} }} }} }} }} }}' \\
          -F owner=OWNER -F name=REPO -F pr=<PR#> \\
          -q '[.data.repository.pullRequest.commits.nodes[].commit.signature.isValid] | all'
-   All three queries must return `true`. If any fails, fix it before
+   All three checks must return `true`. If any fails, fix it before
    reporting completion.
 
 A PR that fails any of these three checks will be BLOCKED at code review and

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -51,10 +51,11 @@ addition, but the NOGO verdict cannot be overridden by them.
    regex `^Closes #\\d+\\s*$` (case-sensitive `Closes`, hash + number, on its
    own line). `Fixes`, `Resolves`, `closes`, `Closes:` do NOT satisfy the
    policy. If absent, NOGO and quote the relevant lines of the description.
-2. **Auto-merge enabled:** the Auto-merge State block above contains a single
-   line. If it reads `auto_merge_enabled=true`, the check passes. If it reads
-   `auto_merge_enabled=false`, NOGO with a note explaining auto-merge must be
-   turned on via `gh pr merge <N> --auto --squash`.
+2. **Auto-merge deferred until implementation GO:** the Auto-merge State block
+   above contains a single line. During implementation review it MUST read
+   `auto_merge_enabled=false`. If it reads `auto_merge_enabled=true`, NOGO with
+   a note explaining auto-merge must stay disabled until this review returns GO
+   and the automation applies `state:implementation-go`.
 3. **Signed commits:** the Commit Signing State block above is a JSON array
    where each element is `{{"oid": "<sha>", "signature_valid": <bool>,
    "signer": "<login or null>"}}`. EVERY element must have
@@ -75,7 +76,7 @@ The review prose + inline comments explain *why*; the verdict line is a binary
 gate. Write your analysis in prose, then end your response with exactly one of
 the two verdict lines below (the parser takes the LAST matching line):
 
-Verdict: GO — Policy passes and code is acceptable.
+Verdict: GO — Policy passes, auto-merge is deferred, and code is acceptable.
 Verdict: NOGO — Policy violation OR fundamental code problem (explain in the review).
 
 After the verdict line, emit a single fenced JSON block:

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -60,6 +60,22 @@ _ALL_AGENTS = frozenset(
 # resuming the prior iteration's transcript. Implementer/planner/ci-driver
 # deliberately do NOT appear here — they resume one session across their stage.
 _PER_ITERATION_REVIEWERS = frozenset({AGENT_PLAN_REVIEWER, AGENT_PR_REVIEWER})
+_GIT_REPO_ENV_KEYS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+)
+
+
+def _repo_scoped_git_env() -> dict[str, str]:
+    """Return environment for explicit ``git -C`` calls, ignoring outer repos."""
+    env = os.environ.copy()
+    for key in _GIT_REPO_ENV_KEYS:
+        env.pop(key, None)
+    return env
 
 
 def reviewer_agent(base_agent: str, iteration: int) -> str:
@@ -153,6 +169,7 @@ def short_githash(repo_path: Path) -> str:
             ["git", "-C", str(repo_path), "rev-parse", "--short=7", "HEAD"],
             check=True,
             capture_output=True,
+            env=_repo_scoped_git_env(),
             text=True,
             timeout=5,
         )

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -43,6 +43,13 @@ STATE_PLAN_GO = "state:plan-go"
 #: present" / "remove all of these" operations.
 ALL_STATE_LABELS = (STATE_NEEDS_PLAN, STATE_PLAN_NO_GO, STATE_PLAN_GO)
 
+# PR-scoped implementation-review state labels. These deliberately live outside
+# ALL_STATE_LABELS so issue-level plan state remains independent from PR review
+# state.
+STATE_IMPLEMENTATION_NO_GO = "state:implementation-no-go"
+STATE_IMPLEMENTATION_GO = "state:implementation-go"
+ALL_IMPLEMENTATION_STATE_LABELS = (STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTATION_GO)
+
 #: Per-label colour (hex without leading ``#``) and short description. The
 #: provisioning script (``hephaestus-ensure-state-labels``) uses these when
 #: creating the labels on a repo so they have a consistent look across the org.
@@ -90,6 +97,11 @@ def is_plan_no_go(labels: Iterable[str]) -> bool:
     on the next loop.
     """
     return has_label(labels, STATE_PLAN_NO_GO)
+
+
+def is_implementation_go(labels: Iterable[str]) -> bool:
+    """Return ``True`` iff a PR carries the implementation-review GO label."""
+    return has_label(labels, STATE_IMPLEMENTATION_GO)
 
 
 def needs_plan(labels: Iterable[str]) -> bool:

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -41,6 +41,11 @@ def _make_check(
     }
 
 
+def _impl_go(driver: CIDriver) -> Any:
+    """Patch a PR as already approved by implementation review."""
+    return patch.object(driver, "_pr_has_implementation_go", return_value=True)
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -376,6 +381,7 @@ class TestOpenPrsRemaining:
                 "head": {"ref": "branch-1"},
                 "auto_merge": {"enabled_by": {"login": "bot"}},
                 "user": {"type": "User"},
+                "labels": [{"name": "state:implementation-go"}],
             },
             {
                 "number": 2,
@@ -398,6 +404,7 @@ class TestOpenPrsRemaining:
                 "headRefName": "branch-1",
                 "autoMergeRequest": {"enabled_by": {"login": "bot"}},
                 "isBot": False,
+                "labels": ["state:implementation-go"],
             },
             {
                 "number": 2,
@@ -405,6 +412,7 @@ class TestOpenPrsRemaining:
                 "headRefName": "branch-2",
                 "autoMergeRequest": None,
                 "isBot": True,
+                "labels": [],
             },
         ]
 
@@ -479,6 +487,7 @@ class TestAllRequiredGreen:
         ]
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge") as mock_merge,
             patch.object(driver, "_run_drive_green_learnings"),
             patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
@@ -487,6 +496,21 @@ class TestAllRequiredGreen:
 
         assert result.success is True
         mock_merge.assert_called_once_with(456, is_bot_pr=False)
+
+    def test_all_required_green_without_impl_go_does_not_arm(self, driver: CIDriver) -> None:
+        """Green CI is not enough; implementation review must mark the PR GO."""
+        checks = [_make_check("test", required=True)]
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            patch.object(driver, "_pr_has_implementation_go", return_value=False),
+            patch.object(driver, "_enable_auto_merge") as mock_merge,
+            patch.object(driver, "_wait_for_pr_terminal") as mock_wait,
+        ):
+            result = driver._drive_issue(123, 456, 0)
+
+        assert result.success is True
+        mock_merge.assert_not_called()
+        mock_wait.assert_not_called()
 
     def test_dry_run_no_auto_merge(self, mock_options: CIDriverOptions, tmp_path: Path) -> None:
         """dry_run=True, all green → gh pr merge not called."""
@@ -503,6 +527,7 @@ class TestAllRequiredGreen:
         checks = [_make_check("test", required=True)]
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            _impl_go(dry_driver),
             patch.object(dry_driver, "_enable_auto_merge") as mock_merge,
             patch("hephaestus.automation.ci_driver._gh_call") as mock_gh,
         ):
@@ -531,6 +556,7 @@ class TestRequiredVsNonRequired:
         ]
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge") as mock_merge,
             patch.object(driver, "_run_drive_green_learnings"),
             patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
@@ -550,6 +576,7 @@ class TestRequiredVsNonRequired:
         ]
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge") as mock_merge,
             patch.object(driver, "_run_drive_green_learnings"),
             patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
@@ -758,6 +785,7 @@ class TestEnableAutoMerge:
         checks = [_make_check("test", required=True)]
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge", return_value=False),
             patch.object(driver, "_run_drive_green_learnings") as mock_learn,
         ):
@@ -794,6 +822,7 @@ class TestDriveGreenLearnings:
         driver.shared_pr_issues = {456: [123]}
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge", return_value=True),
             patch.object(driver, "_get_pr_branch", return_value="123-impl"),
             patch.object(
@@ -1112,6 +1141,7 @@ class TestCIPollLoop:
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", side_effect=side_effect),
             patch("hephaestus.automation.ci_driver.time.sleep"),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge", return_value=True),
             patch.object(driver, "_run_drive_green_learnings"),
             patch.object(driver, "_wait_for_pr_terminal", return_value="MERGED"),
@@ -1179,6 +1209,7 @@ class TestRunCleanup:
         with (
             patch.object(d, "_discover_prs", return_value={1: 10}),
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=[green_check]),
+            _impl_go(d),
             patch.object(d, "_enable_auto_merge", return_value=True),
             patch.object(d, "_run_drive_green_learnings"),
             # Don't block the worker on the post-arm wait loop (#838).
@@ -1216,6 +1247,7 @@ class TestRunCleanup:
         with (
             patch.object(d, "_discover_prs", return_value={1: 10}),
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=[green_check]),
+            _impl_go(d),
             patch.object(d, "_enable_auto_merge", return_value=True),
             patch.object(d, "_run_drive_green_learnings"),
             # Don't block the worker on the post-arm wait loop (#838).
@@ -2128,6 +2160,7 @@ class TestRecheckAndArmAfterFix:
         green = [_make_check("test", required=True, conclusion="success")]
         with (
             patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=green),
+            _impl_go(driver),
             patch.object(driver, "_enable_auto_merge", return_value=True) as mock_arm,
             patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc"}),
             patch.object(driver, "_get_pr_branch", return_value="b"),
@@ -2250,13 +2283,28 @@ class TestEnableAutoMergeBotRetry:
 
 
 class TestArmAllUnarmedOpenPrs:
-    """The blanket arm-all pass marks every un-armed open PR auto-merge (#882)."""
+    """The arm-all pass marks implementation-GO un-armed PRs auto-merge (#882)."""
 
     def test_arms_only_unarmed_prs_and_passes_bot_flag(self, driver: CIDriver) -> None:
         open_prs: list[dict[str, Any]] = [
-            {"number": 10, "autoMergeRequest": {"x": 1}, "isBot": False},  # already armed
-            {"number": 11, "autoMergeRequest": None, "isBot": True},  # arm (bot)
-            {"number": 12, "autoMergeRequest": None, "isBot": False},  # arm (human)
+            {
+                "number": 10,
+                "autoMergeRequest": {"x": 1},
+                "labels": [{"name": "state:implementation-go"}],
+                "isBot": False,
+            },  # already armed
+            {
+                "number": 11,
+                "autoMergeRequest": None,
+                "labels": [{"name": "state:implementation-go"}],
+                "isBot": True,
+            },  # arm (bot)
+            {
+                "number": 12,
+                "autoMergeRequest": None,
+                "labels": [{"name": "state:implementation-go"}],
+                "isBot": False,
+            },  # arm (human)
         ]
         refreshed = [
             {"number": 10, "autoMergeRequest": {"x": 1}},
@@ -2274,6 +2322,19 @@ class TestArmAllUnarmedOpenPrs:
         assert called == {11: True, 12: False}
         # Returns the re-listed PRs so the gate sees fresh armed state.
         assert result == refreshed
+
+    def test_skips_unapproved_unarmed_prs(self, driver: CIDriver) -> None:
+        open_prs: list[dict[str, Any]] = [
+            {"number": 12, "autoMergeRequest": None, "labels": [], "isBot": False}
+        ]
+        with (
+            patch.object(driver, "_enable_auto_merge") as mock_arm,
+            patch.object(driver, "_list_open_prs_remaining") as mock_list,
+        ):
+            result = driver._arm_all_unarmed_open_prs(open_prs)
+        mock_arm.assert_not_called()
+        mock_list.assert_not_called()
+        assert result is open_prs
 
     def test_no_unarmed_prs_is_noop(self, driver: CIDriver) -> None:
         open_prs: list[dict[str, Any]] = [

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -986,22 +986,23 @@ class TestGhPrCreate:
 
     @patch("hephaestus.automation.github_api._assert_branch_commits_signed")
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_successful_pr_creation(self, mock_gh_call: Any, _mock_signed: Any) -> None:
+    def test_successful_pr_creation_defers_auto_merge(
+        self, mock_gh_call: Any, _mock_signed: Any
+    ) -> None:
         """Test successful PR creation."""
         mock_create_result = Mock()
         mock_create_result.stdout = "https://github.com/owner/repo/pull/456"
-        mock_merge_result = Mock()
-        mock_gh_call.side_effect = [mock_create_result, mock_merge_result]
+        mock_gh_call.return_value = mock_create_result
 
         pr_number = gh_pr_create(
             branch="feature-branch",
             title="Test PR",
             body=_POLICY_BODY,
-            auto_merge=True,
         )
 
         assert pr_number == 456
-        assert mock_gh_call.call_count == 2  # create + auto-merge
+        assert mock_gh_call.call_count == 1
+        assert "--base" in mock_gh_call.call_args.args[0]
 
     @patch("hephaestus.automation.github_api._assert_branch_commits_signed")
     @patch("hephaestus.automation.github_api._gh_call")
@@ -1044,7 +1045,7 @@ class TestGhPrCreate:
     def test_pr_creation_auto_merge_failure_raises(
         self, mock_gh_call: Any, _mock_signed: Any
     ) -> None:
-        """Auto-merge is mandatory; a failure must raise, not warn."""
+        """Immediate auto-merge remains available for non-implementation callers."""
         mock_create_result = Mock()
         mock_create_result.stdout = "https://github.com/owner/repo/pull/456"
 
@@ -1149,9 +1150,9 @@ class TestGhPrCreate:
             branch="feature-branch",
             title="Test PR",
             body=_POLICY_BODY,
-            auto_merge=True,
         )
         assert pr_number == 42
+        assert mock_gh_call.call_count == 1
 
 
 class TestWriteSecure:

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -288,6 +288,12 @@ class TestPlanReviewVerdictGate:
             ),
             patch.object(impl, "_finalize_pr", return_value=999),
             patch.object(impl, "_run_post_pr_followup"),
+            patch("hephaestus.automation.implementer_phase_runner.ensure_pr_auto_merge_deferred"),
+            patch("hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"),
+            patch(
+                "hephaestus.automation.implementer_phase_runner."
+                "enable_auto_merge_after_implementation_go"
+            ),
             patch(
                 "hephaestus.automation.implementer.fetch_issue_info",
                 return_value=MagicMock(title="t", body="b"),
@@ -465,6 +471,12 @@ class TestExistingPrSkipsImplementation:
             patch.object(impl, "_run_claude_code", return_value="sess-1"),
             patch.object(impl, "_run_impl_review_loop", return_value=(1, "GO", "A")),
             patch.object(impl, "_finalize_pr", return_value=999),
+            patch("hephaestus.automation.implementer_phase_runner.ensure_pr_auto_merge_deferred"),
+            patch("hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"),
+            patch(
+                "hephaestus.automation.implementer_phase_runner."
+                "enable_auto_merge_after_implementation_go"
+            ),
             patch.object(impl, "_run_post_pr_followup"),
             patch(
                 "hephaestus.automation.implementer.fetch_issue_info",

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -517,12 +518,87 @@ class TestReviewIterationStatePersistence:
         prior_file = implementer.state_dir / "review-prior-42.txt"
         assert iter_file.exists(), "review-iter-42.json not created"
         assert prior_file.exists(), "review-prior-42.txt not created"
-
-        import json
-
         data = json.loads(iter_file.read_text())
         assert data["iterations_run"] == 2
         assert prior_file.read_text() == "prior text"
+
+
+class TestImplementationAutoMergeGate:
+    """Implementation PR auto-merge must wait for implementation-review GO."""
+
+    def _drive(
+        self,
+        implementer: IssueImplementer,
+        tmp_path: Path,
+        *,
+        review_verdict: str,
+        auto_merge: bool,
+    ) -> None:
+        implementer.options.auto_merge = auto_merge
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.ensure_pr_auto_merge_deferred"
+            ) as mock_defer,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"
+            ) as mock_go,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_no_go"
+            ) as mock_nogo,
+            patch(
+                "hephaestus.automation.implementer_phase_runner."
+                "enable_auto_merge_after_implementation_go"
+            ) as mock_arm,
+            patch.object(
+                implementer.worktree_manager, "create_worktree", return_value=worktree_path
+            ),
+            patch.object(implementer, "_has_plan", return_value=True),
+            patch.object(implementer, "_save_state"),
+            patch("hephaestus.automation.implementer.find_pr_for_issue", return_value=None),
+            patch("hephaestus.automation.implementer.is_plan_review_go", return_value=True),
+            patch.object(implementer, "_run_advise", return_value=""),
+            patch.object(implementer, "_run_claude_code", return_value="session-1"),
+            patch.object(implementer, "_finalize_pr", return_value=456),
+            patch.object(
+                implementer, "_run_impl_review_loop", return_value=(1, review_verdict, "A")
+            ),
+            patch.object(implementer, "_run_post_pr_followup"),
+            patch("hephaestus.automation.implementer.fetch_issue_info") as mock_issue,
+        ):
+            mock_issue.return_value.title = "title"
+            mock_issue.return_value.body = "body"
+
+            result = implementer._implement_issue(1)
+
+        assert result.success is True
+        mock_defer.assert_called_once_with(456)
+        if review_verdict == "GO":
+            mock_go.assert_called_once_with(456)
+            mock_nogo.assert_not_called()
+        else:
+            mock_go.assert_not_called()
+            mock_nogo.assert_called_once_with(456)
+        if review_verdict == "GO" and auto_merge:
+            mock_arm.assert_called_once_with(456)
+        else:
+            mock_arm.assert_not_called()
+
+    def test_go_review_labels_pr_then_arms_auto_merge(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        self._drive(implementer, tmp_path, review_verdict="GO", auto_merge=True)
+
+    def test_nogo_review_leaves_auto_merge_disabled(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        self._drive(implementer, tmp_path, review_verdict="NOGO", auto_merge=True)
+
+    def test_go_review_respects_no_auto_merge_option(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        self._drive(implementer, tmp_path, review_verdict="GO", auto_merge=False)
 
     def test_load_review_iteration_state_round_trips(self, implementer: IssueImplementer) -> None:
         """Round-trip: save then load must return the same values."""

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -97,6 +97,7 @@ class TestEnsurePRCreated:
                 _status("abc1234 commit msg"),  # git log
                 _status(""),  # ls-remote (not pushed)
                 _status(""),  # git push
+                _status("origin/master"),  # default base branch
             ]
         )
         gh_mock = _status("[]")
@@ -106,13 +107,16 @@ class TestEnsurePRCreated:
             patch.object(pr_manager, "create_pr", return_value=42) as create_mock,
         ):
             assert pr_manager.ensure_pr_created(1, "branch", Path("/tmp/wt")) == 42
-            create_mock.assert_called_once_with(1, "branch", False, agent="claude")
+            create_mock.assert_called_once_with(
+                1, "branch", auto_merge=False, agent="claude", base="master"
+            )
 
     def test_creates_pr_with_selected_agent_metadata(self) -> None:
         run_mock = MagicMock(
             side_effect=[
                 _status("abc1234 commit msg"),
                 _status("refs/heads/branch"),
+                _status("origin/master"),
             ]
         )
         gh_mock = _status("[]")
@@ -122,7 +126,9 @@ class TestEnsurePRCreated:
             patch.object(pr_manager, "create_pr", return_value=42) as create_mock,
         ):
             assert pr_manager.ensure_pr_created(1, "branch", Path("/tmp/wt"), agent="codex") == 42
-            create_mock.assert_called_once_with(1, "branch", False, agent="codex")
+            create_mock.assert_called_once_with(
+                1, "branch", auto_merge=False, agent="codex", base="master"
+            )
 
 
 class TestCreatePR:
@@ -139,6 +145,7 @@ class TestCreatePR:
         assert kwargs["branch"] == "branch"
         assert "Add feature X" in kwargs["title"]
         assert kwargs["auto_merge"] is True
+        assert kwargs["base"] == "main"
         assert "Closes #5" in kwargs["body"]
         assert "Automated implementation via Codex" in kwargs["body"]
         assert "Claude Code" not in kwargs["body"]

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -34,15 +34,17 @@ class TestImplementationPrompt:
         assert "1" in out
 
     def test_enforces_pr_policy(self) -> None:
-        """Implementer prompt must require Closes #N, auto-merge, and signed commits."""
+        """Implementer prompt must require Closes #N, deferred auto-merge, and signatures."""
         out = prompts.get_implementation_prompt(issue_number=42)
         # All three policy properties must be named in the prompt.
         assert "Closes #42" in out
         assert "MANDATORY" in out
         assert "git commit -S" in out
-        assert "--auto --rebase" in out
+        assert "DO NOT enable auto-merge yet" in out
+        assert "state:implementation-go" in out
         # Verification command must include all three fields.
         assert "autoMergeRequest" in out
+        assert ".autoMergeRequest == null" in out
         assert "isValid" in out
         # The agent must be told to abort on failure (no "best-effort" wording).
         assert "abort" in out.lower() or "non-negotiable" in out.lower()
@@ -72,6 +74,8 @@ class TestPRReviewAnalysisPrompt:
         # Each of the three policy checks must be explicitly enumerated.
         assert "Closes #N" in out or "Closes #\\d" in out
         assert "auto_merge_enabled" in out
+        assert "MUST read" in out
+        assert "auto_merge_enabled=false" in out
         assert "signature_valid" in out
         # The NOGO / POLICY VIOLATION sentinels must be present.
         assert "POLICY VIOLATION" in out

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -26,6 +26,28 @@ from hephaestus.automation.session_naming import (
     short_githash,
 )
 
+_GIT_REPO_ENV_KEYS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+)
+
+
+def _git_test_env() -> dict[str, str]:
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    for key in _GIT_REPO_ENV_KEYS:
+        env.pop(key, None)
+    return env
+
 
 class TestReviewerAgent:
     """Per-iteration reviewer session tokens (fresh session each loop round)."""
@@ -154,13 +176,7 @@ class TestShortGithash:
     """``git rev-parse --short=7 HEAD`` wrapper with graceful failure."""
 
     def test_real_repo(self, tmp_path: Path) -> None:
-        env = {
-            **os.environ,
-            "GIT_AUTHOR_NAME": "t",
-            "GIT_AUTHOR_EMAIL": "t@t",
-            "GIT_COMMITTER_NAME": "t",
-            "GIT_COMMITTER_EMAIL": "t@t",
-        }
+        env = _git_test_env()
         subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, env=env)
         subprocess.run(
             [
@@ -182,6 +198,12 @@ class TestShortGithash:
         assert all(c in "0123456789abcdef" for c in h)
 
     def test_missing_repo_returns_unknown(self, tmp_path: Path) -> None:
+        assert short_githash(tmp_path) == "unknown"
+
+    def test_ignores_outer_git_dir_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GIT_DIR", str(Path.cwd() / ".git"))
         assert short_githash(tmp_path) == "unknown"
 
 
@@ -256,13 +278,7 @@ class TestCurrentTrunkGithash:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("HEPH_TRUNK_GITHASH", raising=False)
-        env = {
-            **os.environ,
-            "GIT_AUTHOR_NAME": "t",
-            "GIT_AUTHOR_EMAIL": "t@t",
-            "GIT_COMMITTER_NAME": "t",
-            "GIT_COMMITTER_EMAIL": "t@t",
-        }
+        env = _git_test_env()
         subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True, env=env)
         subprocess.run(
             [


### PR DESCRIPTION
## Summary

- gate implementation PR auto-merge behind `state:implementation-go`
- defer auto-merge at PR creation and disable premature agent-enabled auto-merge before review
- make `pr-policy` enforce the state machine and rerun on label/auto-merge changes
- harden git hash lookup against hook-provided `GIT_DIR`/worktree variables

## Validation

- `python3.13 -m pytest tests/unit/automation -q --no-cov`
- `python3.13 -m pytest -q --no-cov`
- pre-push hook: `pytest -q` (`3157 passed, 6 skipped`, coverage 85.04%)
- ruff checks and workflow YAML parsing

Closes #898
