### PR TITLE
fix(automation): pipe PR-review prompt via stdin to avoid ARG_MAX overflow

### DIFF
--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -230,6 +230,11 @@ def run_pr_review_analysis(
             output_format="json",
             permission_mode="dontAsk",
             allowed_tools="Read,Glob,Grep",
+            # Pipe the prompt via stdin, not argv: the PR-review prompt embeds the
+            # full diff and can be tens of KB, which overflows ARG_MAX and raises
+            # `[Errno 7] Argument list too long` when passed as a positional arg.
+            # Matches the plan reviewer / address-review / ci_driver invocations.
+            input_via_stdin=True,
         )
         log_file.write_text(stdout or "")
 

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -548,6 +548,42 @@ class TestRunPrReviewAnalysis:
             )
         assert captured["agent"] == "pr-reviewer-r1"
 
+    def test_prompt_passed_via_stdin_not_argv(self, tmp_path: Path) -> None:
+        """The reviewer prompt is piped via stdin, never embedded in argv.
+
+        Regression for `[Errno 7] Argument list too long: 'claude'`: the
+        PR-review prompt embeds the full diff and overflows ARG_MAX when passed
+        as a positional argument, so the wrapper must be called with
+        ``input_via_stdin=True``.
+        """
+        captured: dict[str, object] = {}
+
+        def _fake_invoke(**kwargs: object) -> tuple[str, str]:
+            captured.update(kwargs)
+            return (
+                '{"result": "```json\\n{\\"comments\\": [], \\"summary\\": \\"ok\\"}\\n```"}',
+                "",
+            )
+
+        with (
+            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
+            patch("hephaestus.automation.pr_reviewer.get_repo_slug", return_value="Repo"),
+            patch(
+                "hephaestus.automation.pr_reviewer.invoke_claude_with_session",
+                side_effect=_fake_invoke,
+            ),
+        ):
+            run_pr_review_analysis(
+                pr_number=1,
+                issue_number=1,
+                worktree_path=tmp_path,
+                context={"pr_diff": "x" * 200_000},
+                agent="claude",
+                state_dir=tmp_path,
+                dry_run=False,
+            )
+        assert captured["input_via_stdin"] is True
+
 
 class TestReviewPrInline:
     """review_pr_inline runs a FRESH per-iteration reviewer and posts inline threads."""


### PR DESCRIPTION
Pass `input_via_stdin=True` in `run_pr_review_analysis` so the PR-review prompt (PR diff + context, often tens of KB) is piped via stdin instead of being embedded in the `claude` subprocess argv. Fixes the `[Errno 7] Argument list too long` failure that forced every large-diff in-loop review to NOGO.

Matches the safe pattern already used by `plan_reviewer`, `address_review`, and `ci_driver`. Adds a regression test exercising a 200 KB diff.

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)