### PR TITLE
fix(automation): accept MERGED issue state so merged-PR deps load

### DIFF
--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -92,7 +92,8 @@ class DependencyResolver:
 
         # Fetch each sub-issue and its dependencies
         for issue_num in sub_issues:
-            if self.skip_closed and cached_states.get(issue_num) == IssueState.CLOSED:
+            sub_state = cached_states.get(issue_num)
+            if self.skip_closed and sub_state is not None and sub_state.is_done:
                 logger.info("Skipping closed issue #%s", issue_num)
                 self.completed.add(issue_num)
                 continue
@@ -197,7 +198,8 @@ class DependencyResolver:
             if dep_num in self.graph.issues or dep_num in self.completed:
                 continue
 
-            if self.skip_closed and cached_states.get(dep_num) == IssueState.CLOSED:
+            dep_state = cached_states.get(dep_num)
+            if self.skip_closed and dep_state is not None and dep_state.is_done:
                 logger.info("Dependency #%s is closed, marking complete", dep_num)
                 self.completed.add(dep_num)
                 continue

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1111,11 +1111,13 @@ def is_issue_closed(issue_number: int, cached_states: dict[int, IssueState] | No
 
     """
     if cached_states and issue_number in cached_states:
-        return cached_states[issue_number] == IssueState.CLOSED
+        # A merged PR referenced as a dependency is terminal too, so treat
+        # MERGED as "closed" for skip purposes.
+        return cached_states[issue_number].is_done
 
     try:
         issue_data = gh_issue_json(issue_number)
-        return cast(bool, issue_data["state"] == "CLOSED")
+        return issue_data["state"] in ("CLOSED", "MERGED")
     except Exception as e:
         logger.warning("Failed to check if issue #%s is closed: %s", issue_number, e)
         return False

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -84,7 +84,6 @@ from .implementer_summary import ImplementationSummaryPrinter
 from .models import (
     ImplementationState,
     ImplementerOptions,
-    IssueState,
     WorkerResult,
 )
 from .pr_manager import commit_changes, create_pr
@@ -261,7 +260,8 @@ class IssueImplementer:
         cached_states = prefetch_issue_states(issue_numbers)
 
         for issue_num in issue_numbers:
-            if self.options.skip_closed and cached_states.get(issue_num) == IssueState.CLOSED:
+            issue_state = cached_states.get(issue_num)
+            if self.options.skip_closed and issue_state is not None and issue_state.is_done:
                 logger.info("Skipping closed issue #%s", issue_num)
                 self.resolver.completed.add(issue_num)
                 continue

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -22,10 +22,28 @@ PLAN_COMMENT_MARKER: str = "# Implementation Plan"
 
 
 class IssueState(str, Enum):
-    """GitHub issue state."""
+    """GitHub issue/PR state.
+
+    ``MERGED`` only ever applies to pull requests, but PRs share the issues
+    number-space, so a dependency reference (e.g. ``Depends on #123``) can point
+    at a merged PR. The GitHub API then reports ``"MERGED"`` for that node, which
+    must be a valid member or ``IssueState("MERGED")`` raises ``ValueError`` and
+    the dependency fails to load.
+    """
 
     OPEN = "OPEN"
     CLOSED = "CLOSED"
+    MERGED = "MERGED"
+
+    @property
+    def is_done(self) -> bool:
+        """True if the issue/PR is in a terminal state (closed or merged).
+
+        Skip-logic that previously gated on ``== IssueState.CLOSED`` should use
+        this so a merged-PR dependency is treated as complete rather than
+        re-queued for work.
+        """
+        return self in (IssueState.CLOSED, IssueState.MERGED)
 
 
 class IssueInfo(BaseModel):

--- a/tests/unit/automation/test_dependency_resolver.py
+++ b/tests/unit/automation/test_dependency_resolver.py
@@ -204,6 +204,27 @@ class TestLoadDependenciesIterative:
         # fetch_issue_info must NOT have been called for dep 1 (already in graph)
         mock_fetch.assert_not_called()
 
+    def test_merged_pr_dependency_is_skipped(self) -> None:
+        """A dependency that is a merged PR (state MERGED) is treated as done.
+
+        Regression: before MERGED was a valid IssueState, such a dependency was
+        fetched and crashed with ``'MERGED' is not a valid IssueState``. With
+        skip_closed=True it should be marked complete and never fetched.
+        """
+        from unittest.mock import patch
+
+        from hephaestus.automation.models import IssueState
+
+        resolver = DependencyResolver(skip_closed=True)
+        root = IssueInfo(number=10, title="Root", dependencies=[9])
+
+        with patch("hephaestus.automation.dependency_resolver.fetch_issue_info") as mock_fetch:
+            resolver._load_dependencies(root, {9: IssueState.MERGED})
+
+        mock_fetch.assert_not_called()
+        assert 9 in resolver.completed
+        assert 9 not in resolver.graph.issues
+
     def test_depth_cap_raises_runtime_error(self) -> None:
         """Exceeding _MAX_DEPENDENCY_DEPTH raises RuntimeError (A5-03)."""
         from unittest.mock import patch

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -15,6 +15,24 @@ from hephaestus.automation.models import (
 )
 
 
+class TestIssueState:
+    """Tests for the IssueState enum."""
+
+    def test_merged_is_a_valid_member(self) -> None:
+        """A merged-PR dependency yields ``"MERGED"``; it must parse without error.
+
+        Regression: ``dependency_resolver`` crashed with
+        ``'MERGED' is not a valid IssueState`` when a ``Depends on #N`` reference
+        pointed at a merged PR.
+        """
+        assert IssueState("MERGED") is IssueState.MERGED
+
+    def test_is_done_terminal_states(self) -> None:
+        assert IssueState.CLOSED.is_done is True
+        assert IssueState.MERGED.is_done is True
+        assert IssueState.OPEN.is_done is False
+
+
 class TestIssueInfo:
     """Tests for IssueInfo model."""
 


### PR DESCRIPTION
Add `MERGED` to `IssueState` (PRs share the issues number-space, so a `Depends on #N` reference can point at a merged PR reporting state `MERGED`). Previously `IssueState("MERGED")` raised `ValueError` and `dependency_resolver` dropped the edge.

Also adds an `IssueState.is_done` property (CLOSED or MERGED) and routes the four `== IssueState.CLOSED` skip-logic sites through it so a merged-PR dependency is treated as complete rather than re-queued.

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)