### PR TITLE
fix(github): pr_merge uses squash, not rebase, on squash-only repos

### DIFF
--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -194,7 +194,7 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
         message = str(result)
 
     if merged:
-        logger.info("  PR #%d merged into %s via rebase. sha=%s", pr_number, base_branch, sha)
+        logger.info("  PR #%d merged into %s via squash. sha=%s", pr_number, base_branch, sha)
     else:
         logger.error("  Failed to merge PR #%d. API message: %s", pr_number, message)
 
@@ -202,7 +202,7 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
 def main() -> int:  # noqa: C901
     """Serve as the main entry point for PR merge automation."""
     parser = argparse.ArgumentParser(
-        description="Merge open PRs with successful CI/CD into main (rebase via PR API)"
+        description="Merge open PRs with successful CI/CD into main (squash via PR API)"
     )
     parser.add_argument(
         "--dry-run",
@@ -303,10 +303,14 @@ def main() -> int:  # noqa: C901
                 try_push_head_branch(head_branch, args.dry_run)
 
             if args.dry_run:
-                logger.info("[DRY-RUN] Would merge PR #%d via rebase", pr.number)
+                logger.info("[DRY-RUN] Would merge PR #%d via squash", pr.number)
             else:
                 try:
-                    result = pr.merge(merge_method="rebase")
+                    # Squash-only: the HomericIntelligence repos disable rebase
+                    # merges in branch protection (a rebase merge fails with
+                    # "Rebase merges are not allowed on this repository").
+                    # Matches `gh pr merge --auto --squash`.
+                    result = pr.merge(merge_method="squash")
                     handle_merge_result(result, pr.number, base_branch)
                 # broad catch intentional: PyGithub raises many exception subtypes
                 except Exception as e:

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -410,7 +410,7 @@ class TestMain:
 
                         main()
 
-        pr.merge.assert_called_once_with(merge_method="rebase")
+        pr.merge.assert_called_once_with(merge_method="squash")
 
     @patch("hephaestus.github.pr_merge.try_push_head_branch")
     @patch("hephaestus.github.pr_merge.run_git_cmd")
@@ -510,7 +510,7 @@ class TestMain:
 
                         main()
 
-        pr.merge.assert_called_once_with(merge_method="rebase")
+        pr.merge.assert_called_once_with(merge_method="squash")
 
     @patch("hephaestus.github.pr_merge.try_push_head_branch")
     @patch("hephaestus.github.pr_merge.run_git_cmd")
@@ -689,3 +689,21 @@ class TestMainJson:
                         assert main() == 1
         payload = json.loads(capsys.readouterr().out)
         assert payload["status"] == "error"
+
+
+class TestSquashOnlyInvariant:
+    """The HomericIntelligence repos disable rebase merges in branch protection.
+
+    `pr.merge(merge_method="rebase")` fails with "Rebase merges are not allowed
+    on this repository". Lock the squash-only contract at the source level so a
+    future edit cannot silently reintroduce a rebase merge path.
+    """
+
+    def test_no_rebase_merge_method_in_source(self) -> None:
+        import inspect
+
+        from hephaestus.github import pr_merge
+
+        source = inspect.getsource(pr_merge)
+        assert 'merge_method="rebase"' not in source
+        assert 'merge_method="squash"' in source


### PR DESCRIPTION
Switch `pr_merge.main()` from `pr.merge(merge_method="rebase")` to `merge_method="squash"`. The HomericIntelligence repos disable rebase merges in branch protection, so the rebase path failed with "Rebase merges are not allowed on this repository" (~27 such errors in a recent automation run). Updates the success log + argparse description to match.

This completes the last open acceptance criterion of #718 (the `github_api.py` site was already fixed; this was the remaining `merge_method="rebase"` callsite). Adds a source-invariant regression test and updates the two existing merge-path tests from rebase to squash.

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)