### PR TITLE
fix(automation): skip PR creation when branch has no commits vs base

### DIFF
--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -62,6 +62,31 @@ def _detect_default_base_branch(worktree_path: Path) -> str:
     return "main"
 
 
+def _branch_has_commits_vs_base(branch_name: str, base: str, worktree_path: Path) -> bool:
+    """Return True if *branch_name* has at least one commit not on *base*.
+
+    ``git log -1`` only proves a commit exists somewhere on the branch; it stays
+    green when the agent's commits are identical to (or already merged into)
+    base, in which case ``gh pr create`` fails with the opaque
+    ``No commits between main and <branch>`` GraphQL error — six times, since the
+    caller retries. Counting ``origin/<base>..<branch>`` (falling back to a local
+    ``<base>..<branch>`` range when ``origin/<base>`` is unknown) lets us detect
+    the empty-diff case up front and report it cleanly instead.
+    """
+    for ref in (f"origin/{base}..{branch_name}", f"{base}..{branch_name}"):
+        result = run(
+            ["git", "rev-list", "--count", ref],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return int((result.stdout or "0").strip() or "0") > 0
+    # Could not evaluate either range (e.g. base ref missing locally). Be
+    # permissive: let PR creation proceed rather than block on a check failure.
+    return True
+
+
 def _pr_auto_merge_enabled(pr_number: int) -> bool:
     """Return whether GitHub currently has auto-merge armed for a PR."""
     result = _gh_call(["pr", "view", str(pr_number), "--json", "autoMergeRequest"])
@@ -252,6 +277,19 @@ def ensure_pr_created(
 
     logger.info("Commit exists: %s", result.stdout.strip()[:80])
 
+    # Guard against an empty diff vs base. A commit existing on the branch does
+    # not mean it differs from base (the agent may have produced no net change,
+    # or its work already landed). Opening a PR in that case fails with
+    # "No commits between <base> and <branch>" and the caller retries six times.
+    # Detect it here and fail with an actionable message instead.
+    base_branch = _detect_default_base_branch(worktree_path)
+    if not _branch_has_commits_vs_base(branch_name, base_branch, worktree_path):
+        raise RuntimeError(
+            f"No changes produced for issue {issue_ref(issue_number)}: branch "
+            f"{branch_name!r} has no commits vs {base_branch!r}. Skipping PR "
+            "creation (the implementation session made no net change)."
+        )
+
     # Check if branch was pushed, if not push it
     _update_slot(f"{issue_ref(issue_number)}: Pushing branch")
     result = run(
@@ -287,7 +325,6 @@ def ensure_pr_created(
             "Deferring auto-merge for branch %s until implementation review marks the PR GO",
             branch_name,
         )
-    base_branch = _detect_default_base_branch(worktree_path)
     pr_number = create_pr(
         issue_number,
         branch_name,

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -77,10 +77,34 @@ class TestEnsurePRCreated:
             with pytest.raises(RuntimeError, match="No commit found"):
                 pr_manager.ensure_pr_created(1, "branch", Path("/tmp/wt"))
 
+    def test_empty_diff_vs_base_raises_before_pr_create(self) -> None:
+        """A commit exists but the branch has no commits vs base → no PR created.
+
+        Regression for the opaque, retried "No commits between main and
+        <branch>" failure: detect the empty-diff branch up front and raise a
+        clear message instead of letting `gh pr create` fail.
+        """
+        run_mock = MagicMock(
+            side_effect=[
+                _status("abc1234 commit msg"),  # git log (a commit exists)
+                _status("origin/master"),  # default base branch (guard)
+                _status("0"),  # rev-list count vs base → no net change
+            ]
+        )
+        with (
+            patch.object(pr_manager, "run", run_mock),
+            patch.object(pr_manager, "create_pr") as create_mock,
+        ):
+            with pytest.raises(RuntimeError, match="No changes produced"):
+                pr_manager.ensure_pr_created(1, "branch", Path("/tmp/wt"))
+        create_mock.assert_not_called()
+
     def test_returns_existing_pr(self) -> None:
         run_mock = MagicMock(
             side_effect=[
                 _status("abc1234 commit msg"),  # git log
+                _status("origin/master"),  # default base branch (guard)
+                _status("2"),  # rev-list count vs base (has commits)
                 _status("refs/heads/branch"),  # ls-remote (already pushed)
             ]
         )
@@ -95,9 +119,10 @@ class TestEnsurePRCreated:
         run_mock = MagicMock(
             side_effect=[
                 _status("abc1234 commit msg"),  # git log
+                _status("origin/master"),  # default base branch (guard)
+                _status("3"),  # rev-list count vs base (has commits)
                 _status(""),  # ls-remote (not pushed)
                 _status(""),  # git push
-                _status("origin/master"),  # default base branch
             ]
         )
         gh_mock = _status("[]")
@@ -114,9 +139,10 @@ class TestEnsurePRCreated:
     def test_creates_pr_with_selected_agent_metadata(self) -> None:
         run_mock = MagicMock(
             side_effect=[
-                _status("abc1234 commit msg"),
-                _status("refs/heads/branch"),
-                _status("origin/master"),
+                _status("abc1234 commit msg"),  # git log
+                _status("origin/master"),  # default base branch (guard)
+                _status("1"),  # rev-list count vs base (has commits)
+                _status("refs/heads/branch"),  # ls-remote (already pushed)
             ]
         )
         gh_mock = _status("[]")


### PR DESCRIPTION
Add a no-commit-vs-base guard to `ensure_pr_created`. Previously only `git log -1` was checked (a commit exists), which stays green for an empty-diff branch; `gh pr create` then failed with the opaque "No commits between main and <branch>" error and the caller retried it six times (~30 such failures in one run).

Now `_branch_has_commits_vs_base` counts `origin/<base>..<branch>` (with a local-range fallback) and raises an actionable "No changes produced" error before pushing/creating the PR. The base-branch detection is hoisted so it runs once.

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)