### PR TITLE
fix(automation): recover from session-id collision on the resume path

### DIFF
--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -24,6 +24,7 @@ import re
 import subprocess
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -51,6 +52,40 @@ def _session_expired(stderr: str, stdout: str) -> bool:
     """Return True if either stream indicates the resume target is gone."""
     blob = (stderr + "\n" + stdout).lower()
     return any(phrase in blob for phrase in SESSION_EXPIRED_PHRASES)
+
+
+def _run_fresh_session(
+    run_session: Callable[..., subprocess.CompletedProcess[str]],
+    display_name: str,
+    contended_sid: str,
+) -> tuple[str, str]:
+    """Create and run a brand-new uuid4 session, decoupled from a contended id.
+
+    Both the create path and the resume path fall back here when the
+    deterministic uuid5 session id is unrecoverable (another worker holds it).
+    uuid4 guarantees no collision with the deterministic id or another worker's
+    fresh one, so the call proceeds instead of aborting.
+
+    Args:
+        run_session: The ``_run`` closure from :func:`invoke_claude_with_session`.
+        display_name: Base session name; the fresh id's prefix is appended.
+        contended_sid: The deterministic id that could not be used (for logs).
+
+    Returns:
+        ``(stdout, fresh_sid)`` from the fresh session.
+
+    """
+    fresh_sid = str(uuid.uuid4())
+    fresh_name = f"{display_name}-{fresh_sid[:8]}"
+    logger.warning(
+        "claude session %s unrecoverable; creating fresh session %s",
+        contended_sid,
+        fresh_sid,
+    )
+    return (
+        run_session(create=True, sid_override=fresh_sid, name_override=fresh_name).stdout,
+        fresh_sid,
+    )
 
 
 def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + create vs resume + expired fallback toggle
@@ -219,19 +254,8 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
                     )
                     time.sleep(2 * (resume_attempt + 1))
             # Resume never succeeded — derive a fresh, unique session so this
-            # worker is not coupled to the contended id. uuid4 guarantees no
-            # collision with the deterministic id or another worker's fresh one.
-            fresh_sid = str(uuid.uuid4())
-            fresh_name = f"{display_name}-{fresh_sid[:8]}"
-            logger.warning(
-                "claude session %s unrecoverable; creating fresh session %s",
-                sid,
-                fresh_sid,
-            )
-            return (
-                _run(create=True, sid_override=fresh_sid, name_override=fresh_name).stdout,
-                fresh_sid,
-            )
+            # worker is not coupled to the contended id.
+            return _run_fresh_session(_run, display_name, sid)
 
     try:
         return _run(create=False).stdout, sid
@@ -251,7 +275,19 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
             exc.returncode,
             expired,
         )
-        return _run(create=True).stdout, sid
+        try:
+            return _run(create=True).stdout, sid
+        except subprocess.CalledProcessError as recreate_exc:
+            # The recreate reuses the deterministic sid, so under concurrency a
+            # sibling worker that just created this session makes the recreate
+            # collide with "already in use" too (observed: planner ProjectHermes).
+            # Without this guard the error propagated as "Session ID … is already
+            # in use" and aborted the call. Fall back to a fresh unique session,
+            # mirroring the should_resume=False path above.
+            recreate_err = (recreate_exc.stderr or "") + (recreate_exc.stdout or "")
+            if "already in use" not in recreate_err.lower():
+                raise
+            return _run_fresh_session(_run, display_name, sid)
 
 
 def scan_quota_reset(*texts: str) -> int | None:

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -187,6 +187,53 @@ class TestSessionExpiredFallback:
         assert m.call_count == 2
         assert "--session-id" in _argv(m.call_args_list[1])
 
+    def test_resume_then_recreate_collision_falls_back_to_fresh_session(
+        self, fake_home: Path
+    ) -> None:
+        """Resume fails, recreate collides 'already in use' → fresh uuid4 session.
+
+        Regression: the resume path recreated with the SAME deterministic sid,
+        so under concurrency a sibling worker holding that session made the
+        recreate collide too, and the error propagated as "Session ID … is
+        already in use" (observed: planner ProjectHermes). It must instead fall
+        back to a brand-new unique session, like the no-transcript path.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        sid = session_uuid("R", 1, AGENT_PLANNER)
+        _make_existing_jsonl(fake_home, cwd, sid)
+
+        resume_fail = subprocess.CalledProcessError(
+            returncode=1, cmd=["claude"], output="", stderr="transient resume error"
+        )
+        recreate_collision = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude"],
+            output="",
+            stderr="Error: Session ID is already in use.",
+        )
+        ok = MagicMock(stdout="fresh-ok", stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[resume_fail, recreate_collision, ok],
+        ) as m:
+            out, returned_sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="sonnet",
+                cwd=cwd,
+            )
+        assert out == "fresh-ok"
+        # A brand-new uuid4 session, not the contended deterministic one.
+        assert returned_sid != sid
+        assert m.call_count == 3
+        # The final call creates the fresh session with that new id.
+        final_argv = _argv(m.call_args_list[2])
+        assert "--session-id" in final_argv
+        assert returned_sid in final_argv
+
     def test_create_failure_propagates(self, fake_home: Path) -> None:
         """A first-call (--session-id) failure for an unrelated reason is not retried."""
         cwd = fake_home / "work"


### PR DESCRIPTION
The deterministic uuid5 session id can collide under concurrency. The no-transcript path already falls back to a fresh uuid4 session, but the resume path recreated with the SAME id, so a sibling worker holding that session made the recreate collide too and the error propagated as "Session ID … is already in use" (planner ProjectHermes).

Extract the fallback into `_run_fresh_session()` and use it from both paths; on the resume path, fall back to a fresh unique session when the recreate collides instead of propagating.

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)