### PR TITLE
ci: enable auto-merge on implementation GO

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -49,6 +49,13 @@ version-sync. It also re-runs on `auto_merge_enabled` / `auto_merge_disabled`
 and `labeled` / `unlabeled` events so the `pr-policy` auto-merge check
 converges without timing races.
 
+### Enable Auto-Merge on Implementation GO Workflow (`workflows/enable-auto-merge-on-implementation-go.yml`)
+
+Privileged label-event workflow that runs when `state:implementation-go` is
+added to an open pull request. It does not checkout PR code; it only reads PR
+metadata, verifies the GO label is still present, and enables squash auto-merge
+with `gh pr merge --auto --squash` when auto-merge is not already armed.
+
 ### Auto-Tag Workflow (`workflows/auto-tag.yml`)
 
 Manually dispatched (`workflow_dispatch`) release-tagging helper. Computes the

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -342,6 +342,25 @@ jobs:
           state=$(jq -r '.autoMergeRequest' pr.json)
           implementation_go=$(jq -r '[(.labels // [])[].name] | index("state:implementation-go") != null' pr.json)
           if [ "$implementation_go" = "true" ]; then
+            for attempt in 1 2 3 4 5 6; do
+              if [ "$state" != "null" ] && [ -n "$state" ]; then
+                echo "OK: implementation-GO PR has auto-merge enabled"
+                exit 0
+              fi
+              if [ "$attempt" -lt 6 ]; then
+                echo "Waiting for label-triggered auto-merge workflow to arm PR #$PR_NUMBER..."
+                sleep 10
+                gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                  --json autoMergeRequest,labels \
+                  > pr.json
+                state=$(jq -r '.autoMergeRequest' pr.json)
+                implementation_go=$(jq -r '[(.labels // [])[].name] | index("state:implementation-go") != null' pr.json)
+                if [ "$implementation_go" != "true" ]; then
+                  break
+                fi
+              fi
+            done
+
             if [ "$state" = "null" ] || [ -z "$state" ]; then
               msg="::error::PR has state:implementation-go but auto-merge is not enabled."
               msg+=" Run: gh pr merge $PR_NUMBER --auto --squash  (this repo is squash-only)."

--- a/.github/workflows/enable-auto-merge-on-implementation-go.yml
+++ b/.github/workflows/enable-auto-merge-on-implementation-go.yml
@@ -1,0 +1,69 @@
+name: Enable auto-merge on implementation GO
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: implementation-go-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  enable-auto-merge:
+    name: enable-auto-merge
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    if: >
+      github.event.label.name == 'state:implementation-go' &&
+      github.event.pull_request.state == 'open' &&
+      !github.event.pull_request.draft
+    steps:
+      - name: Enable squash auto-merge
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          case "$PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "::error::Unexpected PR_NUMBER value (not a positive integer)"
+              exit 1
+              ;;
+          esac
+
+          gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json autoMergeRequest,isDraft,labels,state \
+            > pr.json
+
+          state=$(jq -r '.state // ""' pr.json)
+          if [ "$state" != "OPEN" ]; then
+            echo "PR #$PR_NUMBER is not open; no auto-merge changes needed."
+            exit 0
+          fi
+
+          is_draft=$(jq -r '.isDraft' pr.json)
+          if [ "$is_draft" = "true" ]; then
+            echo "PR #$PR_NUMBER is draft; auto-merge remains disabled."
+            exit 0
+          fi
+
+          implementation_go=$(jq -r '[(.labels // [])[].name] | index("state:implementation-go") != null' pr.json)
+          if [ "$implementation_go" != "true" ]; then
+            echo "PR #$PR_NUMBER no longer has state:implementation-go; auto-merge remains disabled."
+            exit 0
+          fi
+
+          auto_merge=$(jq -r '.autoMergeRequest' pr.json)
+          if [ "$auto_merge" != "null" ] && [ -n "$auto_merge" ]; then
+            echo "PR #$PR_NUMBER already has auto-merge enabled."
+            exit 0
+          fi
+
+          gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash
+          echo "Enabled squash auto-merge for implementation-GO PR #$PR_NUMBER."

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -17,6 +17,12 @@ from hephaestus.ci.workflows import (
     validate_workflow,
 )
 
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AUTO_MERGE_ON_GO_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "enable-auto-merge-on-implementation-go.yml"
+)
+REQUIRED_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_required.yml"
+
 
 class TestCollectYmlFiles:
     """Tests for collect_yml_files()."""
@@ -183,6 +189,47 @@ jobs:
         wf = tmp_path / "big.yml"
         wf.write_bytes(b"x" * (1_048_576 + 1))
         assert validate_workflow(wf) == []
+
+
+class TestEnableAutoMergeOnImplementationGoWorkflow:
+    """Regression tests for the implementation-GO auto-merge workflow."""
+
+    def _workflow_text(self) -> str:
+        return AUTO_MERGE_ON_GO_WORKFLOW.read_text(encoding="utf-8")
+
+    def test_runs_only_on_pull_request_target_label_events(self) -> None:
+        """Privileged workflow is limited to PR label events."""
+        text = self._workflow_text()
+        assert "pull_request_target:" in text
+        assert "types: [labeled]" in text
+        assert "state:implementation-go" in text
+
+    def test_does_not_checkout_pr_controlled_code(self) -> None:
+        """pull_request_target workflow must not execute code from the PR."""
+        text = self._workflow_text()
+        assert "actions/checkout" not in text
+        assert "github.event.pull_request.head" not in text
+        assert validate_workflow(AUTO_MERGE_ON_GO_WORKFLOW) == []
+
+    def test_enables_squash_auto_merge_with_numeric_pr_guard(self) -> None:
+        """The workflow validates PR_NUMBER and uses repo-required squash auto-merge."""
+        text = self._workflow_text()
+        assert "''|*[!0-9]*)" in text
+        assert 'gh pr merge "$PR_NUMBER" --repo "$REPO" --auto --squash' in text
+
+    def test_skips_if_auto_merge_is_already_armed(self) -> None:
+        """Re-labeling an already armed PR is a no-op."""
+        text = self._workflow_text()
+        assert "autoMergeRequest" in text
+        assert 'if [ "$auto_merge" != "null" ] && [ -n "$auto_merge" ]; then' in text
+        assert "already has auto-merge enabled" in text
+
+    def test_pr_policy_waits_for_label_workflow_to_converge(self) -> None:
+        """pr-policy must not race the label-triggered auto-merge workflow."""
+        text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+        assert "Waiting for label-triggered auto-merge workflow" in text
+        assert 'gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"' in text
+        assert "sleep 10" in text
 
 
 class TestCollectWorkflowFiles:


### PR DESCRIPTION
## Summary
- Add a pull_request_target workflow that reacts to state:implementation-go labels.
- Enable squash auto-merge only after verifying the PR is open, non-draft, still labeled GO, and not already armed.
- Document the workflow and add regression tests for the privileged workflow shape.

## Test Plan
- python -m ruff check tests/unit/ci/test_workflows.py
- python -m pytest -q tests/unit/ci/test_precommit.py tests/unit/ci/test_workflows.py tests/unit/validation/test_doc_policy.py --no-cov
- python -m pytest -q tests/unit/ci/test_workflows.py --no-cov
- git push pre-push hook: 3180 passed, 6 skipped, coverage 84.98%

Closes #914