### PR TITLE
ci: allow terminal pr-policy auto-merge states

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -297,7 +297,7 @@ jobs:
           # separate queries are fine here — the workflow runs at most once per
           # PR event and the policy gate must be cheap to read and debug.
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json body,autoMergeRequest,labels \
+            --json body,autoMergeRequest,labels,state \
             > pr.json
           gh api graphql \
             -f query='query($owner:String!,$name:String!,$pr:Int!) {
@@ -339,6 +339,12 @@ jobs:
         if: always() && steps.fetch.outcome == 'success'
         run: |
           set -euo pipefail
+          pr_state=$(jq -r '.state // ""' pr.json)
+          if [ "$pr_state" != "OPEN" ]; then
+            echo "OK: PR state is $pr_state; auto-merge policy is terminal"
+            exit 0
+          fi
+
           state=$(jq -r '.autoMergeRequest' pr.json)
           implementation_go=$(jq -r '[(.labels // [])[].name] | index("state:implementation-go") != null' pr.json)
           if [ "$implementation_go" = "true" ]; then
@@ -351,8 +357,13 @@ jobs:
                 echo "Waiting for label-triggered auto-merge workflow to arm PR #$PR_NUMBER..."
                 sleep 10
                 gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                  --json autoMergeRequest,labels \
+                  --json autoMergeRequest,labels,state \
                   > pr.json
+                pr_state=$(jq -r '.state // ""' pr.json)
+                if [ "$pr_state" != "OPEN" ]; then
+                  echo "OK: PR state is $pr_state; auto-merge policy is terminal"
+                  exit 0
+                fi
                 state=$(jq -r '.autoMergeRequest' pr.json)
                 implementation_go=$(jq -r '[(.labels // [])[].name] | index("state:implementation-go") != null' pr.json)
                 if [ "$implementation_go" != "true" ]; then

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -229,7 +229,15 @@ class TestEnableAutoMergeOnImplementationGoWorkflow:
         text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
         assert "Waiting for label-triggered auto-merge workflow" in text
         assert 'gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"' in text
+        assert "--json autoMergeRequest,labels,state" in text
         assert "sleep 10" in text
+
+    def test_pr_policy_treats_merged_prs_as_terminal(self) -> None:
+        """GitHub clears autoMergeRequest after merge, so merged PRs must pass."""
+        text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+        assert "--json body,autoMergeRequest,labels,state" in text
+        assert "pr_state=$(jq -r '.state // \"\"' pr.json)" in text
+        assert "auto-merge policy is terminal" in text
 
 
 class TestCollectWorkflowFiles:


### PR DESCRIPTION
## Summary
- Fetch PR state in pr-policy metadata.
- Treat merged or closed PRs as terminal for the auto-merge policy check.
- Add regression coverage for GitHub clearing autoMergeRequest after merge.

## Test Plan
- python -m ruff check tests/unit/ci/test_workflows.py
- python -m ruff format --check tests/unit/ci/test_workflows.py
- python -m pytest -q tests/unit/ci/test_workflows.py tests/unit/validation/test_doc_policy.py --no-cov
- python workflow validator for .github/workflows/_required.yml
- Full pre-push suite: 3182 passed, 6 skipped; coverage 84.98%

Closes #916