### PR TITLE
build(deps): replace pytest-watch with pytest-watcher

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ test-integration:
 test-shell:
     pixi run test-shell
 
-# Re-run unit tests on file change (uses pytest-watch). Cancel with Ctrl-C.
+# Re-run unit tests on file change (uses pytest-watcher). Cancel with Ctrl-C.
 watch:
     pixi run --environment default ptw {{ unit_test_dir }} -- --no-cov -q
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -106,14 +106,12 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/27/bb/6dfa7e6f4eeed22d3311af76256615da637f821d584cf7b7aab5f4cbffc5/pdoc-14.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/36/47/ab65fc1d682befc318c439940f81a0de1026048479f732e84fe714cd69c0/pytest-watch-4.2.0.tar.gz
       - pypi: https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/91/f7/ebf5003e1065fd00b4cbef53bf0a65c3d3e1b599b676d5383ccb7a8b88ba/pip_api-0.0.34-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/bf/7595e817906a29453ba4d99394e781b6fabe55d21f3c15d240f85dd06bb1/py_serializable-2.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
       - pypi: https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/2f/c7277b7615a93f51b5fbc1eacfc1b75e8103370e786fd8ce2abf6e5c04ab/packageurl_python-0.17.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
@@ -125,6 +123,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/ca/78d423b324b8d77900030fa59c4aa9054261ef0925631cd2501dd015b7b7/boolean_py-5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/fc/3f/172d73600ad2771774cda108efb813fc724fc345e5240a81a1085f1ade5d/pytest_watcher-0.6.3-py3-none-any.whl
   lint:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1504,15 +1503,6 @@ packages:
   name: sortedcontainers
   version: 2.4.0
   sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
-- pypi: https://files.pythonhosted.org/packages/36/47/ab65fc1d682befc318c439940f81a0de1026048479f732e84fe714cd69c0/pytest-watch-4.2.0.tar.gz
-  name: pytest-watch
-  version: 4.2.0
-  sha256: 06136f03d5b361718b8d0d234042f7b2f203910d8568f63df2f866b547b3d4b9
-  requires_dist:
-  - docopt>=0.4.0
-  - colorama>=0.3.3
-  - watchdog>=0.6.0
-  - pytest>=2.6.4
 - pypi: https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: markupsafe
   version: 3.0.3
@@ -1564,10 +1554,6 @@ packages:
   requires_dist:
   - defusedxml>=0.7.1,<0.8.0
   requires_python: '>=3.8,<4.0'
-- pypi: https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz
-  name: docopt
-  version: 0.6.2
-  sha256: 49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491
 - pypi: https://files.pythonhosted.org/packages/af/40/791891d4c0c4dab4c5e187c17261cedc26285fd41541577f900470a45a4d/license_expression-30.4.4-py3-none-any.whl
   name: license-expression
   version: 30.4.4
@@ -1733,3 +1719,11 @@ packages:
   version: 5.8.0
   sha256: 88eede9e66ca80e34085b9174e2327da2c61ac91f24f70e41c3ad76e4bb4872b
   requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fc/3f/172d73600ad2771774cda108efb813fc724fc345e5240a81a1085f1ade5d/pytest_watcher-0.6.3-py3-none-any.whl
+  name: pytest-watcher
+  version: 0.6.3
+  sha256: 83e7748c933087e8276edb6078663e6afa9926434b4fd8b85cf6b32b1d5bec89
+  requires_dist:
+  - tomli>=2.0.1 ; python_full_version < '3.11'
+  - watchdog>=2.0.0
+  requires_python: '>=3.9'

--- a/pixi.toml
+++ b/pixi.toml
@@ -68,9 +68,11 @@ bats-core = ">=1.11.0,<2"
 pip-audit = ">=2.7,<3"
 build = ">=1.0,<2"
 pdoc = ">=14.0,<15"
-# pytest-watch (ptw) powers `just watch` — runs unit tests on file change for
-# fast feedback during local development. Not on conda-forge; ships from PyPI.
-pytest-watch = ">=4.2,<5"
+# pytest-watcher (ptw) powers `just watch` — runs unit tests on file change for
+# fast feedback during local development. Actively maintained fork of the
+# unmaintained pytest-watch (last 2018 release; see issue #746). Not on
+# conda-forge; ships from PyPI.
+pytest-watcher = ">=0.4,<1"
 
 [feature.lint.dependencies]
 ruff = ">=0.1.0,<1"


### PR DESCRIPTION
Replace the unmaintained pytest-watch (last release 2018, pulls deprecated docopt 0.6.2) with pytest-watcher, the actively maintained modern fork.

## Changes

- Swap `pytest-watch` → `pytest-watcher` in `pixi.toml`
- Version pin: `>=0.4,<1` (stable line supporting pytest 9.x)
- `ptw` CLI entry point and justfile recipe unchanged
- Deprecated `docopt` 0.6.2 removed from dependency graph
- All 3170 unit tests pass under new environment

Closes #746