### PR TITLE
refactor(automation): use json.JSONDecoder.raw_decode for follow_up JSON extraction

### DIFF
--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -81,57 +81,24 @@ class FollowUpResponse:
     rejected: list[RejectedItem] = field(default_factory=list)
 
 
-def _extract_outer_json_object(text: str) -> str | None:
-    """Find and return the outermost JSON object ``{...}`` in *text*.
-
-    Uses a balanced-brace scan so prose containing additional ``{`` or
-    nested objects does not confuse the boundary detection. Carries the
-    A5-07 lesson (originally applied to the array variant in the prior
-    schema): a greedy regex over-consumes, a non-greedy regex stops too
-    early inside nested structures.
-    """
-    start = text.find("{")
-    if start == -1:
-        return None
-    depth = 0
-    in_string = False
-    escape_next = False
-    for i in range(start, len(text)):
-        ch = text[i]
-        if escape_next:
-            escape_next = False
-            continue
-        if ch == "\\" and in_string:
-            escape_next = True
-            continue
-        if ch == '"':
-            in_string = not in_string
-            continue
-        if in_string:
-            continue
-        if ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth -= 1
-            if depth == 0:
-                return text[start : i + 1]
-    return None
-
-
 def _extract_json_object(text: str) -> dict[str, Any] | None:
     """Extract the first JSON object from ``text``.
 
-    Looks for a fenced ```json ... ``` block first, then falls back to a
-    balanced-brace scan over the bare text. Returns ``None`` if nothing
-    parseable is found.
+    Looks for a fenced ```json ... ``` block first, then falls back to
+    ``json.JSONDecoder.raw_decode`` over the bare text starting at the
+    first ``{``. Returns ``None`` if nothing parseable is found.
     """
     fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-    candidate = fenced.group(1) if fenced else _extract_outer_json_object(text)
-    if candidate is None:
-        return None
+    if fenced is not None:
+        candidate = fenced.group(1)
+    else:
+        start = text.find("{")
+        if start == -1:
+            return None
+        candidate = text[start:]
 
     try:
-        parsed = json.loads(candidate)
+        parsed, _ = json.JSONDecoder().raw_decode(candidate)
     except json.JSONDecodeError:
         return None
     if not isinstance(parsed, dict):

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -60,6 +60,51 @@ class TestParseFollowUpResponse:
         response = parse_follow_up_response("{not valid")
         assert response.follow_ups == []
 
+    def test_parses_fenced_json_with_nested_object(self) -> None:
+        r"""Regression: the fenced regex must not truncate on inner ``}``.
+
+        Locks in that ``r"```(?:json)?\s*(\{.*?\})\s*```"`` correctly
+        spans nested objects because ``.*?`` is anchored by the trailing
+        fence literal.
+        """
+        text = (
+            "```json\n"
+            '{"follow_ups": [{"category": "core", "title": "T",'
+            ' "body": "B", "extra": {"nested": "val"}}],'
+            ' "rejected": []}\n'
+            "```"
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].title == "T"
+
+    def test_parses_bare_json_with_trailing_text(self) -> None:
+        """``raw_decode`` must stop at the closing ``}`` of the first object.
+
+        Mirrors the prior balancer's behavior of returning early once
+        the outer brace closes, ignoring any garbage that follows.
+        """
+        text = (
+            '{"follow_ups": [{"category": "core", "title": "T",'
+            ' "body": "B"}], "rejected": []}'
+            "\nsome trailing log line that is not JSON"
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].title == "T"
+
+    def test_parses_bare_json_with_leading_whitespace_before_brace(self) -> None:
+        """Prose followed by blank lines before the JSON must still parse."""
+        text = (
+            "Some prose explaining the response.\n"
+            "\n   \n"
+            '{"follow_ups": [{"category": "security", "title": "T",'
+            ' "body": "B"}], "rejected": []}'
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].category == "security"
+
     def test_caps_at_three_items(self) -> None:
         items = [{"category": "core", "title": f"T{i}", "body": f"B{i}"} for i in range(10)]
         text = json.dumps({"follow_ups": items, "rejected": []})


### PR DESCRIPTION
## Summary

Replaced the hand-written balanced-brace parser `_extract_outer_json_object` with `json.JSONDecoder().raw_decode()`, the canonical stdlib way to find the first JSON object in a string. This eliminates duplicated parsing logic (discovered via `/hephaestus:repo-analyze-strict-full` audit finding) and ensures the implementation inherits stdlib correctness and security fixes automatically.

## Changes

- **Deleted `_extract_outer_json_object` (35 lines)**: The private helper function that manually scanned for balanced braces is no longer needed.
- **Simplified `_extract_json_object`**: Now uses `json.JSONDecoder().raw_decode()` directly, collapsing the two-stage decode chain (substring extraction + `json.loads`) into a single stdlib call.
- **Added three regression tests**: New tests in `TestParseFollowUpResponse` verify behavior on edge cases: fenced JSON with nested objects, bare JSON with trailing text, and leading whitespace before the opening brace.

## Test Results

All 31 tests pass, including the 3 new regression tests:
- `test_parses_fenced_json_with_nested_object` ✓
- `test_parses_bare_json_with_trailing_text` ✓
- `test_parses_bare_json_with_leading_whitespace_before_brace` ✓

The module now has 90.03% test coverage.

Closes #736