### PR TITLE
test(config): add integration tests to default pytest discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,24 @@ pixi shell
 ### Running Tests
 
 ```bash
-# Run tests using the test feature
-pixi run test
-
-# Or run tests directly with pytest
+# Run all tests (unit + integration)
+just test
 pixi run pytest
+
+# Run only unit tests (coverage-gated in CI)
+just test-unit
+pytest -m unit
+
+# Run only integration tests
+just test-integration
+pytest -m integration
+
+# Run all tests except integration
+pytest -m "not integration"
 ```
+
+All integration tests carry `pytest.mark.integration` (module-level `pytestmark`),
+so marker-based selection is reliable.
 
 ### Development Commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ max-complexity = 10
 "scripts/**" = ["C901", "S101", "D102", "D107", "D401"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests/unit"]
+testpaths = ["tests/unit", "tests/integration"]
 pythonpath = [".", "scripts"]
 addopts = [
     "-v",

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -26,6 +26,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover — only on Python 3.10

--- a/tests/integration/test_gh_trace_id_propagation.py
+++ b/tests/integration/test_gh_trace_id_propagation.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 from hephaestus.logging.utils import correlation_id_scope, get_current_correlation_id
 from hephaestus.utils.helpers import run_subprocess
 

--- a/tests/integration/test_gh_trace_id_propagation.py
+++ b/tests/integration/test_gh_trace_id_propagation.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.integration
-
 from hephaestus.logging.utils import correlation_id_scope, get_current_correlation_id
 from hephaestus.utils.helpers import run_subprocess
+
+pytestmark = pytest.mark.integration
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_package_import.py
+++ b/tests/integration/test_package_import.py
@@ -5,6 +5,8 @@ import importlib
 
 import pytest
 
+pytestmark = pytest.mark.integration
+
 # All top-level symbols from hephaestus.__all__
 TOP_LEVEL_SYMBOLS = [
     "COMMAND_REGISTRY",


### PR DESCRIPTION
Resolves the issue where integration tests in `tests/integration/` are not picked up by the default pytest invocation. A developer running bare `pytest`, `pixi run pytest`, or `just test` now discovers both unit and integration suites.

## Changes

1. Expanded `pyproject.toml [tool.pytest.ini_options] testpaths` to include both `tests/unit` and `tests/integration`
2. Added `pytestmark = pytest.mark.integration` to three previously-unmarked integration test files:
   - `tests/integration/test_cli_entry_points.py`
   - `tests/integration/test_gh_trace_id_propagation.py`
   - `tests/integration/test_package_import.py`
3. Updated README with marker-based test selection documentation

## Verification

- Default `pytest --collect-only` now discovers 3406 tests (3188 unit + 218 integration)
- `pytest -m unit` excludes all integration tests cleanly
- `pytest -m integration` excludes all unit tests cleanly
- CI workflows remain unaffected (they use explicit paths with `--override-ini`)

Closes #740