### PR TITLE
refactor: consolidate __version__ resolution into _version_lookup

### DIFF
--- a/hephaestus/__init__.py
+++ b/hephaestus/__init__.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from typing import Any
 
-try:
-    # The PyPI distribution name is "HomericIntelligence-Hephaestus", which
-    # importlib.metadata does NOT normalize to the import name "hephaestus".
-    __version__ = _pkg_version("HomericIntelligence-Hephaestus")
-except PackageNotFoundError:
-    __version__ = "unknown"
+from hephaestus._version_lookup import get_version
+
+__version__ = get_version()
 
 __author__ = "Micah Villmow"
 

--- a/hephaestus/_version_lookup.py
+++ b/hephaestus/_version_lookup.py
@@ -1,0 +1,32 @@
+"""Internal helper: resolve the installed distribution version.
+
+Single source of truth for the `__version__` lookup used by both
+`hephaestus/__init__.py` and `hephaestus/cli/utils.py`. Kept as a private
+leaf module so importers do not need to evaluate `hephaestus/__init__.py`.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+# The PyPI distribution name is "HomericIntelligence-Hephaestus", which
+# importlib.metadata does NOT normalize to the import name "hephaestus".
+_DIST_NAME = "HomericIntelligence-Hephaestus"
+
+__all__ = ["get_version"]
+
+
+def get_version() -> str:
+    """Return the installed distribution version, or ``"unknown"`` if absent.
+
+    Returns:
+        The version string from package metadata, or the literal ``"unknown"``
+        when the distribution is not installed (e.g. running from a source
+        checkout without an editable install).
+
+    """
+    try:
+        return _pkg_version(_DIST_NAME)
+    except PackageNotFoundError:
+        return "unknown"

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -13,16 +13,11 @@ Follows development principles:
 import argparse
 import sys
 from collections.abc import Callable, Sequence
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _pkg_version
 from typing import Any
 
-try:
-    # The PyPI distribution name is "HomericIntelligence-Hephaestus", which
-    # importlib.metadata does NOT normalize to the import name "hephaestus".
-    __version__ = _pkg_version("HomericIntelligence-Hephaestus")
-except PackageNotFoundError:
-    __version__ = "unknown"
+from hephaestus._version_lookup import get_version
+
+__version__ = get_version()
 
 __all__ = [
     "COMMAND_REGISTRY",

--- a/tests/unit/version/test_version_lookup.py
+++ b/tests/unit/version/test_version_lookup.py
@@ -1,0 +1,30 @@
+"""Unit tests for hephaestus._version_lookup."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError
+from unittest.mock import patch
+
+from hephaestus._version_lookup import get_version
+
+
+def test_get_version_returns_installed_version() -> None:
+    """When the distribution is installed, get_version returns its metadata value."""
+    with patch("hephaestus._version_lookup._pkg_version", return_value="1.2.3"):
+        assert get_version() == "1.2.3"
+
+
+def test_get_version_falls_back_to_unknown() -> None:
+    """When the distribution is not installed, get_version returns 'unknown'."""
+    with patch(
+        "hephaestus._version_lookup._pkg_version",
+        side_effect=PackageNotFoundError("HomericIntelligence-Hephaestus"),
+    ):
+        assert get_version() == "unknown"
+
+
+def test_get_version_returns_str() -> None:
+    """Resolved value is always a string (live call against installed dist)."""
+    result = get_version()
+    assert isinstance(result, str)
+    assert result  # non-empty


### PR DESCRIPTION
## Summary

Extract the duplicated `importlib.metadata.version()` resolution block into a single private helper module. Both `hephaestus/__init__.py` and `hephaestus/cli/utils.py` previously contained identical error-handling logic; this refactoring consolidates that into `hephaestus._version_lookup.get_version()`.

## Changes

- **New module**: `hephaestus/_version_lookup.py` — private helper with single source of truth for version resolution
- **Updated**: `hephaestus/__init__.py` — now calls `get_version()` instead of inlined try/except
- **Updated**: `hephaestus/cli/utils.py` — now calls `get_version()` instead of inlined try/except
- **New tests**: `tests/unit/version/test_version_lookup.py` — full coverage of resolved and fallback paths

## Testing

- ✅ All new unit tests pass (3 tests, 100% coverage of helper)
- ✅ All existing integration tests pass (no regressions)
- ✅ All CLI tests pass (version flag still works)
- ✅ Pre-commit hooks pass (format, lint, structure)

Closes #739

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>