### PR TITLE
refactor(validation): delete hand-rolled YAML pre-parser; use yaml.safe_load

### DIFF
--- a/hephaestus/validation/config_lint.py
+++ b/hephaestus/validation/config_lint.py
@@ -90,7 +90,6 @@ class ConfigLinter:
 
         return len(self.errors) == 0
 
-
     def _check_formatting(self, content: str, filepath: Path) -> None:
         """Check formatting issues.
 
@@ -143,9 +142,7 @@ class ConfigLinter:
             problem = getattr(e, "problem", None) or str(e)
             mark = getattr(e, "problem_mark", None)
             if mark is not None:
-                self.errors.append(
-                    f"{filepath}:{mark.line + 1} - YAML syntax error: {problem}"
-                )
+                self.errors.append(f"{filepath}:{mark.line + 1} - YAML syntax error: {problem}")
             else:
                 self.errors.append(f"{filepath} - YAML syntax error: {problem}")
             return None

--- a/hephaestus/validation/config_lint.py
+++ b/hephaestus/validation/config_lint.py
@@ -4,7 +4,6 @@
 Validates YAML configuration files for syntax, formatting, and common issues.
 """
 
-import re
 from pathlib import Path
 from typing import Any
 
@@ -74,15 +73,12 @@ class ConfigLinter:
             self.errors.append(f"Failed to read file: {e}")
             return False
 
-        # Check YAML syntax
-        if not self._check_yaml_syntax(content, filepath):
-            return False
-
-        # Check formatting
+        # Pure-text formatting checks (tabs / trailing whitespace / odd indent).
         self._check_formatting(content, filepath)
 
-        # Parse configuration
-        config = self._parse_yaml(content)
+        # Parse YAML. _parse_yaml records any syntax error in self.errors
+        # (with filepath:line from PyYAML's problem_mark) and returns None.
+        config = self._parse_yaml(content, filepath)
         if config is None:
             return False
 
@@ -94,195 +90,6 @@ class ConfigLinter:
 
         return len(self.errors) == 0
 
-    @staticmethod
-    def _strip_inline_comment(line: str) -> str:
-        r"""Strip inline YAML comments while preserving # inside quoted strings.
-
-        Per YAML spec, # is a comment delimiter only when:
-        - It is preceded by whitespace (or is the first character)
-        - It is NOT inside a single-quoted or double-quoted scalar
-
-        Double-quoted scalars support backslash escapes (e.g. ``\"`` is a
-        literal quote, not a closing delimiter).  Single-quoted scalars do not
-        support backslash escapes (``''`` is the only escape sequence).
-
-        Args:
-            line: A single line of YAML text
-
-        Returns:
-            The line with any inline comment removed
-
-        """
-        in_single_quote = False
-        in_double_quote = False
-        i = 0
-
-        while i < len(line):
-            char = line[i]
-            # Skip over backslash escapes inside double-quoted scalars.
-            if in_double_quote and char == "\\":
-                i += 2  # skip the escaped character
-                continue
-            if char == "'" and not in_double_quote:
-                in_single_quote = not in_single_quote
-            elif char == '"' and not in_single_quote:
-                in_double_quote = not in_double_quote
-            elif (
-                char == "#"
-                and not in_single_quote
-                and not in_double_quote
-                and (i == 0 or line[i - 1] in (" ", "\t"))
-            ):
-                return line[:i]
-            i += 1
-
-        return line
-
-    @staticmethod
-    def _count_unquoted(text: str, open_char: str, close_char: str) -> int:
-        """Count net occurrences of open_char/close_char outside quoted regions.
-
-        Skips characters inside single-quoted or double-quoted scalars.
-        Handles backslash escapes inside double-quoted scalars.
-
-        Args:
-            text: Text to scan (comment already stripped).
-            open_char: The opening delimiter to count (e.g. ``{``).
-            close_char: The closing delimiter to count (e.g. ``}``).
-
-        Returns:
-            Net count: number of open_char minus number of close_char found
-            outside any quoted region.
-
-        """
-        count = 0
-        in_single_quote = False
-        in_double_quote = False
-        i = 0
-        while i < len(text):
-            char = text[i]
-            if in_double_quote and char == "\\":
-                i += 2
-                continue
-            if char == "'" and not in_double_quote:
-                in_single_quote = not in_single_quote
-            elif char == '"' and not in_single_quote:
-                in_double_quote = not in_double_quote
-            elif not in_single_quote and not in_double_quote:
-                if char == open_char:
-                    count += 1
-                elif char == close_char:
-                    count -= 1
-            i += 1
-        return count
-
-    @staticmethod
-    def _is_valid_yaml_key_line(line: str) -> bool:
-        """Check whether a line with a colon matches a valid YAML construct.
-
-        Args:
-            line: The line (after stripping inline comments).
-
-        Returns:
-            True if the line looks like a valid YAML key or construct.
-
-        """
-        s = line.strip()
-        return bool(
-            not s
-            or "://" in line
-            or re.match(r"^\s*[\w\-]+:", line)
-            or re.match(r'^\s*["\'][^"\']+["\']:', line)
-            or re.match(r"^\s*\{", line)
-            or re.match(r"^\s*-\s", line)
-            or re.match(r"^\s*---", line)
-            or re.match(r"^\s*\.\.\.", line)
-        )
-
-    @staticmethod
-    def _is_block_scalar_continuation(line: str, stripped: str, block_scalar_indent: int) -> bool:
-        """Check if a line is a continuation of a block scalar.
-
-        Args:
-            line: Raw line (for indentation measurement).
-            stripped: The stripped line content.
-            block_scalar_indent: Indent level of the block scalar's parent key.
-
-        Returns:
-            True if the line continues the block scalar.
-
-        """
-        if stripped == "":
-            return True
-        current_indent = len(line) - len(line.lstrip())
-        return current_indent > block_scalar_indent
-
-    def _check_yaml_syntax(self, content: str, filepath: Path) -> bool:
-        """Check if YAML syntax is valid.
-
-        Args:
-            content: File content
-            filepath: Path to file
-
-        Returns:
-            True if syntax is valid
-
-        """
-        try:
-            lines = content.split("\n")
-            brace_count = 0
-            bracket_count = 0
-            in_block_scalar = False
-            block_scalar_indent = 0
-
-            for i, line in enumerate(lines):
-                stripped = line.strip()
-
-                # Track block scalar context (| and > multi-line strings)
-                if in_block_scalar:
-                    if self._is_block_scalar_continuation(line, stripped, block_scalar_indent):
-                        continue
-                    in_block_scalar = False
-
-                # Skip comment-only lines
-                if stripped.startswith("#"):
-                    continue
-
-                # Strip inline comments, preserving # inside quoted strings
-                comment_stripped = self._strip_inline_comment(line)
-
-                # Count braces and brackets outside of quoted regions.
-                # Using the same quote-tracking approach as _strip_inline_comment
-                # avoids false positives for braces/brackets in string values
-                # (e.g. ``key: "{not a brace}"``).
-                brace_count += self._count_unquoted(comment_stripped, "{", "}")
-                bracket_count += self._count_unquoted(comment_stripped, "[", "]")
-
-                # Detect block scalar start: key: |  key: >  key: |+  key: |-
-                # key: |2  key: >+  key: >-2  etc.  (YAML chomping/indent indicators)
-                if re.match(r"^\s*[\w\"\'\-][^:]*:\s*[|>][-+]?\d*\s*$", stripped):
-                    in_block_scalar = True
-                    block_scalar_indent = len(line) - len(line.lstrip())
-                    continue
-
-                # Malformed key check — only warn when a colon is present
-                # but the line doesn't match any valid YAML construct
-                if ":" in comment_stripped and not self._is_valid_yaml_key_line(comment_stripped):
-                    self.warnings.append(f"{filepath}:{i + 1} - Possible malformed key")
-
-            if brace_count != 0:
-                self.errors.append(f"{filepath} - Unmatched braces")
-                return False
-
-            if bracket_count != 0:
-                self.errors.append(f"{filepath} - Unmatched brackets")
-                return False
-
-            return True
-
-        except (ValueError, TypeError) as e:
-            self.errors.append(f"Syntax check failed: {e}")
-            return False
 
     def _check_formatting(self, content: str, filepath: Path) -> None:
         """Check formatting issues.
@@ -311,27 +118,39 @@ class ConfigLinter:
                         f"{filepath}:{i + 1} - Inconsistent indentation (use 2 spaces)"
                     )
 
-    def _parse_yaml(self, content: str) -> dict[str, Any] | None:
-        """Parse YAML content.
+    def _parse_yaml(self, content: str, filepath: Path) -> dict[str, Any] | None:
+        """Parse YAML content via :func:`yaml.safe_load`.
+
+        On a YAML syntax error, appends ``"{filepath}:{line} - YAML syntax
+        error: {problem}"`` to ``self.errors`` and returns ``None``. When
+        PyYAML does not provide a ``problem_mark`` the filepath is reported
+        without a line number.
 
         Args:
-            content: YAML content string
+            content: YAML content string.
+            filepath: Source file path (used in error messages only).
 
         Returns:
-            Parsed configuration dict or None if parsing fails
+            Parsed configuration dict, an empty dict for non-mapping documents,
+            or ``None`` if parsing failed.
 
         """
-        try:
-            import yaml
+        import yaml
 
+        try:
             result = yaml.safe_load(content)
-            return result if isinstance(result, dict) else {}
-        except ImportError:
-            logger.warning("PyYAML not installed, skipping YAML parsing checks")
-            return {}
-        except Exception as e:  # broad catch intentional: yaml has undocumented exception subtypes
-            self.errors.append(f"YAML parsing failed: {e}")
+        except yaml.YAMLError as e:
+            problem = getattr(e, "problem", None) or str(e)
+            mark = getattr(e, "problem_mark", None)
+            if mark is not None:
+                self.errors.append(
+                    f"{filepath}:{mark.line + 1} - YAML syntax error: {problem}"
+                )
+            else:
+                self.errors.append(f"{filepath} - YAML syntax error: {problem}")
             return None
+
+        return result if isinstance(result, dict) else {}
 
     def _check_deprecated_keys(self, config: dict[str, Any], filepath: Path) -> None:
         """Check for deprecated configuration keys.

--- a/tests/unit/config/test_config_lint.py
+++ b/tests/unit/config/test_config_lint.py
@@ -168,12 +168,11 @@ class TestYamlSyntaxFalsePositives:
         linter: ConfigLinter,
         yaml_file: Any,
     ) -> None:
-        """A genuinely suspicious line should still produce a warning."""
-        # A line like "  @weird:stuff" has a colon but doesn't match any valid pattern
+        """A line PyYAML cannot tokenize is reported as a syntax error."""
         path = yaml_file("key: value\n@weird:stuff\n")
-        linter.lint_file(path)
-        malformed_warnings = [w for w in linter.warnings if "malformed key" in w.lower()]
-        assert len(malformed_warnings) == 1
+        result = linter.lint_file(path)
+        assert result is False
+        assert any("YAML syntax error" in e for e in linter.errors)
 
     def test_block_scalar_skips_inner_lines(
         self,
@@ -234,7 +233,7 @@ class TestBlockScalarBraceCounting:
         yaml_content = f"key: value\ndescription: {scalar_type}\n  {content}\nnext_key: value\n"
         path = yaml_file(yaml_content)
         result = linter.lint_file(path)
-        brace_errors = [e for e in linter.errors if "Unmatched braces" in e]
+        brace_errors = [e for e in linter.errors if "YAML syntax error" in e]
         assert brace_errors == [], f"False brace error for {scalar_type} with '{content}'"
         assert result is True
 
@@ -272,7 +271,7 @@ class TestBlockScalarBraceCounting:
         yaml_content = f"key: value\nitems: {scalar_type}\n  {content}\nnext_key: value\n"
         path = yaml_file(yaml_content)
         result = linter.lint_file(path)
-        bracket_errors = [e for e in linter.errors if "Unmatched brackets" in e]
+        bracket_errors = [e for e in linter.errors if "YAML syntax error" in e]
         assert bracket_errors == [], f"False bracket error for {scalar_type} with '{content}'"
         assert result is True
 
@@ -293,8 +292,8 @@ class TestBlockScalarBraceCounting:
         )
         path = yaml_file(content)
         result = linter.lint_file(path)
-        brace_errors = [e for e in linter.errors if "Unmatched braces" in e]
-        bracket_errors = [e for e in linter.errors if "Unmatched brackets" in e]
+        brace_errors = [e for e in linter.errors if "YAML syntax error" in e]
+        bracket_errors = [e for e in linter.errors if "YAML syntax error" in e]
         assert brace_errors == []
         assert bracket_errors == []
         assert result is True
@@ -308,7 +307,7 @@ class TestBlockScalarBraceCounting:
         path = yaml_file("key: { unclosed\n")
         result = linter.lint_file(path)
         assert result is False
-        assert any("Unmatched braces" in e for e in linter.errors)
+        assert any("YAML syntax error" in e for e in linter.errors)
 
     def test_brackets_outside_block_scalar_still_detected(
         self,
@@ -319,7 +318,7 @@ class TestBlockScalarBraceCounting:
         path = yaml_file("key: [ unclosed\n")
         result = linter.lint_file(path)
         assert result is False
-        assert any("Unmatched brackets" in e for e in linter.errors)
+        assert any("YAML syntax error" in e for e in linter.errors)
 
     def test_braces_after_block_scalar_ends_still_counted(
         self,
@@ -331,47 +330,7 @@ class TestBlockScalarBraceCounting:
         path = yaml_file(content)
         result = linter.lint_file(path)
         assert result is False
-        assert any("Unmatched braces" in e for e in linter.errors)
-
-
-class TestStripInlineComment:
-    """Tests for ConfigLinter._strip_inline_comment."""
-
-    @pytest.mark.parametrize(
-        ("line", "expected"),
-        [
-            ('color: "#FF0000"', 'color: "#FF0000"'),
-            ("color: '#FF0000'", "color: '#FF0000'"),
-            ('desc: "text with # in middle"', 'desc: "text with # in middle"'),
-            ("value: plain text # comment", "value: plain text "),
-            (
-                'value: "quoted # not comment" # real',
-                'value: "quoted # not comment" ',
-            ),
-            ("# full line comment", ""),
-            ("value: plain text", "value: plain text"),
-            ("value: no#space", "value: no#space"),
-            ("", ""),
-            ("  # indented comment", "  "),
-            ("key: 'single # hash' # comment", "key: 'single # hash' "),
-        ],
-        ids=[
-            "hex-color-double-quotes",
-            "hex-color-single-quotes",
-            "hash-mid-double-string",
-            "legitimate-inline-comment",
-            "quoted-hash-and-real-comment",
-            "full-line-comment",
-            "no-hash",
-            "hash-without-preceding-space",
-            "empty-line",
-            "indented-comment",
-            "single-quoted-hash-and-comment",
-        ],
-    )
-    def test_strip_inline_comment(self, line: str, expected: str) -> None:
-        """_strip_inline_comment handles various quote/comment scenarios."""
-        assert ConfigLinter._strip_inline_comment(line) == expected
+        assert any("YAML syntax error" in e for e in linter.errors)
 
 
 class TestLintFileQuotedHash:

--- a/tests/unit/validation/test_config_lint.py
+++ b/tests/unit/validation/test_config_lint.py
@@ -6,160 +6,47 @@ from pathlib import Path
 from hephaestus.validation.config_lint import ConfigLinter
 
 
-class TestStripInlineComment:
-    """Tests for ConfigLinter._strip_inline_comment."""
+class TestLintFileSyntaxErrors:
+    """Syntax-error detection now flows through yaml.safe_load."""
 
-    def test_plain_comment_stripped(self):
-        """Hash preceded by space is stripped."""
-        assert ConfigLinter._strip_inline_comment("key: value # comment") == "key: value "
-
-    def test_hash_in_single_quotes_preserved(self):
-        """Hash inside single-quoted value is NOT stripped."""
-        assert (
-            ConfigLinter._strip_inline_comment("key: 'val # not comment'")
-            == "key: 'val # not comment'"
-        )
-
-    def test_hash_in_double_quotes_preserved(self):
-        """Hash inside double-quoted value is NOT stripped."""
-        assert (
-            ConfigLinter._strip_inline_comment('key: "val # not comment"')
-            == 'key: "val # not comment"'
-        )
-
-    def test_comment_after_double_quoted_value(self):
-        """Comment after closing double-quote is stripped."""
-        result = ConfigLinter._strip_inline_comment('key: "value" # comment')
-        assert result == 'key: "value" '
-
-    def test_backslash_escaped_quote_in_double_quoted(self):
-        """Backslash-escaped quote does not close the double-quoted region."""
-        line = r'key: "she said \"hi\" # not a comment" # real comment'
-        result = ConfigLinter._strip_inline_comment(line)
-        assert "# real comment" not in result
-        assert '"hi"' in result or r"\"hi\"" in result
-
-    def test_no_comment(self):
-        """Lines without comment are returned unchanged."""
-        assert ConfigLinter._strip_inline_comment("key: value") == "key: value"
-
-    def test_empty_line(self):
-        """Empty line is returned unchanged."""
-        assert ConfigLinter._strip_inline_comment("") == ""
-
-    def test_hash_without_preceding_space_not_stripped(self):
-        """Hash not preceded by whitespace is not treated as comment delimiter."""
-        assert (
-            ConfigLinter._strip_inline_comment("key: value#not_comment") == "key: value#not_comment"
-        )
-
-    def test_trailing_backslash_at_end_of_double_quote(self):
-        """Backslash at end of double-quoted string does not cause index error."""
-        line = 'key: "value\\\\"'
-        result = ConfigLinter._strip_inline_comment(line)
-        assert result == line
-
-
-class TestCountUnquoted:
-    """Tests for ConfigLinter._count_unquoted."""
-
-    def test_simple_balanced_braces(self):
-        """Balanced braces return 0."""
-        assert ConfigLinter._count_unquoted("{}", "{", "}") == 0
-
-    def test_unmatched_open_brace(self):
-        """Unmatched open brace returns positive."""
-        assert ConfigLinter._count_unquoted("{key: val", "{", "}") == 1
-
-    def test_brace_inside_double_quotes_ignored(self):
-        """Brace inside double-quoted string is not counted."""
-        assert ConfigLinter._count_unquoted('key: "{not a brace}"', "{", "}") == 0
-
-    def test_brace_inside_single_quotes_ignored(self):
-        """Brace inside single-quoted string is not counted."""
-        assert ConfigLinter._count_unquoted("key: '{not a brace}'", "{", "}") == 0
-
-    def test_unmatched_open_bracket(self):
-        """Unmatched open bracket returns positive."""
-        assert ConfigLinter._count_unquoted("[1, 2", "[", "]") == 1
-
-    def test_bracket_inside_quotes_ignored(self):
-        """Bracket inside quotes is not counted."""
-        assert ConfigLinter._count_unquoted('key: "[not a bracket]"', "[", "]") == 0
-
-    def test_backslash_escaped_quote_not_closing(self):
-        r"""Escaped \" inside double-quoted value is not treated as close."""
-        assert ConfigLinter._count_unquoted(r'key: "val \"not closed\" more"', "{", "}") == 0
-
-
-class TestCheckYamlSyntax:
-    """Tests for ConfigLinter._check_yaml_syntax (via lint_file)."""
-
-    def _lint(self, content: str) -> ConfigLinter:
-        """Lint *content* via _check_yaml_syntax and return the linter for assertions."""
+    def test_unmatched_braces_detected(self, tmp_path: Path):
+        f = tmp_path / "c.yaml"
+        f.write_text("key: {value\n")
         linter = ConfigLinter()
-        linter._check_yaml_syntax(content, Path("test.yaml"))
-        return linter
+        assert linter.lint_file(f) is False
+        assert any("YAML syntax error" in e for e in linter.errors)
 
-    def test_valid_yaml_passes(self):
-        """Simple valid YAML passes syntax check."""
-        linter = self._lint("key: value\nother: 123\n")
-        assert not linter.errors
+    def test_unmatched_brackets_detected(self, tmp_path: Path):
+        f = tmp_path / "c.yaml"
+        f.write_text("key: [1, 2\n")
+        linter = ConfigLinter()
+        assert linter.lint_file(f) is False
+        assert any("YAML syntax error" in e for e in linter.errors)
 
-    def test_unmatched_braces_detected(self):
-        """Unmatched opening brace produces an error."""
-        linter = self._lint("key: {value\n")
-        assert any("Unmatched braces" in e for e in linter.errors)
+    def test_braces_in_string_not_false_positive(self, tmp_path: Path):
+        f = tmp_path / "c.yaml"
+        f.write_text('key: "{unclosed brace inside string"\n')
+        linter = ConfigLinter()
+        assert linter.lint_file(f) is True
 
-    def test_unmatched_brackets_detected(self):
-        """Unmatched opening bracket produces an error."""
-        linter = self._lint("key: [1, 2\n")
-        assert any("Unmatched brackets" in e for e in linter.errors)
+    def test_block_scalar_pipe_allows_braces(self, tmp_path: Path):
+        f = tmp_path / "c.yaml"
+        f.write_text("key: |\n  {unclosed brace in block scalar\n")
+        linter = ConfigLinter()
+        assert linter.lint_file(f) is True
 
-    def test_braces_in_string_not_false_positive(self):
-        """Braces inside a quoted string do not trigger an error."""
-        linter = self._lint('key: "{unclosed brace inside string"\n')
-        assert not any("Unmatched braces" in e for e in linter.errors)
+    def test_block_scalar_folded_allows_brackets(self, tmp_path: Path):
+        f = tmp_path / "c.yaml"
+        f.write_text("key: >\n  [unclosed bracket in block scalar\n")
+        linter = ConfigLinter()
+        assert linter.lint_file(f) is True
 
-    def test_block_scalar_pipe(self):
-        """Block scalar with | is detected; contents not scanned for braces."""
-        linter = self._lint("key: |\n  {unclosed brace in block scalar\n")
-        assert not any("Unmatched braces" in e for e in linter.errors)
-
-    def test_block_scalar_greater_than(self):
-        """Block scalar with > is detected."""
-        linter = self._lint("key: >\n  [unclosed bracket in block scalar\n")
-        assert not any("Unmatched brackets" in e for e in linter.errors)
-
-    def test_block_scalar_with_chomp_strip(self):
-        """Block scalar with |- (strip chomping) is recognized."""
-        linter = self._lint("key: |-\n  {unclosed brace in block scalar\n")
-        assert not any("Unmatched braces" in e for e in linter.errors)
-
-    def test_block_scalar_with_chomp_keep(self):
-        """Block scalar with |+ (keep chomping) is recognized."""
-        linter = self._lint("key: |+\n  {unclosed brace in block scalar\n")
-        assert not any("Unmatched braces" in e for e in linter.errors)
-
-    def test_block_scalar_with_indent_indicator(self):
-        """Block scalar with |2 (explicit indent) is recognized."""
-        linter = self._lint("key: |2\n  {unclosed brace in block scalar\n")
-        assert not any("Unmatched braces" in e for e in linter.errors)
-
-    def test_block_scalar_folded_with_indicators(self):
-        """Block scalar with >- (fold+strip) is recognized."""
-        linter = self._lint("key: >-\n  [unclosed bracket in block scalar\n")
-        assert not any("Unmatched brackets" in e for e in linter.errors)
-
-    def test_balanced_inline_dict(self):
-        """Balanced inline dict is valid."""
-        linter = self._lint("key: {a: 1, b: 2}\n")
-        assert not linter.errors
-
-    def test_balanced_inline_list(self):
-        """Balanced inline list is valid."""
-        linter = self._lint("key: [1, 2, 3]\n")
-        assert not linter.errors
+    def test_error_includes_line_number(self, tmp_path: Path):
+        f = tmp_path / "c.yaml"
+        f.write_text("good: line\nbad: : : :\n")
+        linter = ConfigLinter()
+        linter.lint_file(f)
+        assert any(":2" in e for e in linter.errors)
 
 
 class TestLintFile:


### PR DESCRIPTION
## Summary

Replace the 65-line `_check_yaml_syntax` method and its four private helpers with direct calls to `yaml.safe_load()`. This eliminates ~190 lines of duplicate parsing logic that reimplemented YAML syntax checking already provided by PyYAML.

**Why**: The hand-rolled YAML pre-parser duplicates work already done by `yaml.safe_load()`, introduces maintenance burden, and can drift from upstream PyYAML. The issue identified this as a KISS/DRY violation (finding S04 from `/hephaestus:repo-analyze-strict-full`).

**Result**: All YAML syntax errors now flow through PyYAML's battle-tested parser, with error messages that include precise line/column information from `problem_mark`. File size reduced from 454 → 273 lines.

## Changes
- Delete `_check_yaml_syntax` and helpers: `_strip_inline_comment`, `_count_unquoted`, `_is_valid_yaml_key_line`, `_is_block_scalar_continuation`
- Rewrite `_parse_yaml` to accept `filepath` and format `yaml.YAMLError` exceptions with line numbers from `problem_mark`
- Update `lint_file` call site to pass `filepath` to `_parse_yaml`
- Delete `import re` (no longer used)
- Update test suites: delete unit tests for deleted helpers, migrate to public-API integration tests

## Testing
- All 803 existing tests pass ✓
- New `TestLintFileSyntaxErrors` suite confirms syntax error detection via PyYAML with line numbers ✓
- Block scalar tolerance for braces/brackets preserved ✓
- Hex color and quoted `#` handling preserved ✓

Closes #733