### PR TITLE
fix(github_api): Parameterise GraphQL queries to prevent injection

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1040,15 +1040,13 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
     # never user data. This was smoke-tested against the live GitHub endpoint.
     var_decls = ",".join(f"$n{idx}:Int!" for idx in range(len(batch)))
     fragments = " ".join(
-        f"issue{idx}: issue(number:$n{idx}){{ number state }}"
-        for idx in range(len(batch))
+        f"issue{idx}: issue(number:$n{idx}){{ number state }}" for idx in range(len(batch))
     )
     query = (
         f"query($owner:String!,$name:String!,{var_decls})"
         f"{{repository(owner:$owner,name:$name){{{fragments}}}}}"
     )
-    args = ["api", "graphql", "-f", f"query={query}",
-            "-F", f"owner={owner}", "-F", f"name={repo}"]
+    args = ["api", "graphql", "-f", f"query={query}", "-F", f"owner={owner}", "-F", f"name={repo}"]
     for idx, num in enumerate(batch):
         args.extend(["-F", f"n{idx}={int(num)}"])
 
@@ -1344,13 +1342,20 @@ def _review_threads_for_review(pr_number: int, review_id: str) -> list[str]:
         "}"
     )
     try:
-        result = _gh_call([
-            "api", "graphql",
-            "-f", f"query={query}",
-            "-F", f"owner={owner}",
-            "-F", f"name={repo}",
-            "-F", f"number={int(pr_number)}",
-        ])
+        result = _gh_call(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={repo}",
+                "-F",
+                f"number={int(pr_number)}",
+            ]
+        )
         data = json.loads(result.stdout)
         _check_graphql_errors(data, f"_review_threads_for_review(pr={pr_number})")
     except (subprocess.CalledProcessError, json.JSONDecodeError, RuntimeError) as exc:
@@ -1421,13 +1426,20 @@ def gh_pr_list_unresolved_threads(
         "}"
     )
 
-    result = _gh_call([
-        "api", "graphql",
-        "-f", f"query={query}",
-        "-F", f"owner={owner}",
-        "-F", f"name={repo}",
-        "-F", f"number={int(pr_number)}",
-    ])
+    result = _gh_call(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"name={repo}",
+            "-F",
+            f"number={int(pr_number)}",
+        ]
+    )
     data = json.loads(result.stdout)
     _check_graphql_errors(data, f"gh_pr_list_unresolved_threads(pr={pr_number})")
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1034,19 +1034,27 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
         Mapping of issue number to IssueState for the batch.
 
     """
-    fragments = [
-        f"issue{idx}: issue(number: {int(num)}) {{ number state }}" for idx, num in enumerate(batch)
-    ]
-    query = f"""
-        query {{
-            repository(owner: "{owner}", name: "{repo}") {{
-                {" ".join(fragments)}
-            }}
-        }}
-        """
+    # GraphQL cannot index a list variable to build per-element aliases, so we
+    # declare one $nN:Int! per issue and bind each via -F nN=<int>. The f-string
+    # interpolates only range(len(batch))-derived fragment indices (query structure),
+    # never user data. This was smoke-tested against the live GitHub endpoint.
+    var_decls = ",".join(f"$n{idx}:Int!" for idx in range(len(batch)))
+    fragments = " ".join(
+        f"issue{idx}: issue(number:$n{idx}){{ number state }}"
+        for idx in range(len(batch))
+    )
+    query = (
+        f"query($owner:String!,$name:String!,{var_decls})"
+        f"{{repository(owner:$owner,name:$name){{{fragments}}}}}"
+    )
+    args = ["api", "graphql", "-f", f"query={query}",
+            "-F", f"owner={owner}", "-F", f"name={repo}"]
+    for idx, num in enumerate(batch):
+        args.extend(["-F", f"n{idx}={int(num)}"])
+
     states: dict[int, IssueState] = {}
     try:
-        result = _gh_call(["api", "graphql", "-f", f"query={query}"])
+        result = _gh_call(args)
         data = json.loads(result.stdout)
         _check_graphql_errors(data, "prefetch_issue_states")
         repo_data = data.get("data", {}).get("repository", {})
@@ -1324,27 +1332,25 @@ def _review_threads_for_review(pr_number: int, review_id: str) -> list[str]:
         logger.error("Invalid owner/repo format: %s/%s", owner, repo)
         return []
 
-    query = f"""
-query GetReviewThreads {{
-  repository(owner: "{owner}", name: "{repo}") {{
-    pullRequest(number: {pr_number}) {{
-      reviewThreads(first: 100) {{
-        nodes {{
-          id
-          isResolved
-          comments(first: 1) {{
-            nodes {{
-              pullRequestReview {{ id }}
-            }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}
-"""
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "  repository(owner:$owner,name:$name){"
+        "    pullRequest(number:$number){"
+        "      reviewThreads(first:100){"
+        "        nodes{ id isResolved comments(first:1){ nodes{ pullRequestReview{ id } } } }"
+        "      }"
+        "    }"
+        "  }"
+        "}"
+    )
     try:
-        result = _gh_call(["api", "graphql", "-f", f"query={query}"])
+        result = _gh_call([
+            "api", "graphql",
+            "-f", f"query={query}",
+            "-F", f"owner={owner}",
+            "-F", f"name={repo}",
+            "-F", f"number={int(pr_number)}",
+        ])
         data = json.loads(result.stdout)
         _check_graphql_errors(data, f"_review_threads_for_review(pr={pr_number})")
     except (subprocess.CalledProcessError, json.JSONDecodeError, RuntimeError) as exc:
@@ -1403,27 +1409,25 @@ def gh_pr_list_unresolved_threads(
         logger.error("Invalid owner/repo format: %s/%s", owner, repo)
         return []
 
-    query = f"""
-query GetThreads {{
-  repository(owner: "{owner}", name: "{repo}") {{
-    pullRequest(number: {pr_number}) {{
-      reviewThreads(first: 100) {{
-        nodes {{
-          id
-          isResolved
-          path
-          line
-          comments(first: 1) {{
-            nodes {{ body }}
-          }}
-        }}
-      }}
-    }}
-  }}
-}}
-"""
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "  repository(owner:$owner,name:$name){"
+        "    pullRequest(number:$number){"
+        "      reviewThreads(first:100){"
+        "        nodes{ id isResolved path line comments(first:1){ nodes{ body } } }"
+        "      }"
+        "    }"
+        "  }"
+        "}"
+    )
 
-    result = _gh_call(["api", "graphql", "-f", f"query={query}"])
+    result = _gh_call([
+        "api", "graphql",
+        "-f", f"query={query}",
+        "-F", f"owner={owner}",
+        "-F", f"name={repo}",
+        "-F", f"number={int(pr_number)}",
+    ])
     data = json.loads(result.stdout)
     _check_graphql_errors(data, f"gh_pr_list_unresolved_threads(pr={pr_number})")
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -228,31 +228,27 @@ class TestPrefetchIssueStates:
     @patch("hephaestus.automation.github_api._gh_call")
     @patch("hephaestus.automation.github_api.get_repo_info")
     def test_int_validation_in_graphql_query(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
-        """Test that issue numbers are cast to int in GraphQL query to prevent injection."""
+        """Issue numbers must flow through `-F nN=<int>` flags, not interpolation (#738)."""
         mock_repo_info.return_value = ("owner", "repo")
-
         mock_result = Mock()
         mock_result.stdout = json.dumps(
-            {
-                "data": {
-                    "repository": {
-                        "issue0": {"number": 123, "state": "OPEN"},
-                    }
-                }
-            }
+            {"data": {"repository": {"issue0": {"number": 123, "state": "OPEN"}}}}
         )
         mock_gh_call.return_value = mock_result
 
-        # Call with issue numbers
         states = prefetch_issue_states([123])
 
-        # Verify the GraphQL query was called with int-casted numbers
         mock_gh_call.assert_called()
-        call_args = mock_gh_call.call_args
-        # The query should contain the int-casted number
-        query_arg = call_args[0][0]
-        assert any("issue(number: 123)" in arg for arg in query_arg)
-
+        argv = mock_gh_call.call_args[0][0]
+        query = next(a for a in argv if a.startswith("query="))
+        assert "$n0:Int!" in query
+        assert "issue(number:$n0)" in query
+        assert "issue(number: 123)" not in query  # regression guard for #738
+        assert "n0=123" in argv
+        # owner/repo also parameterised (no f-string interpolation)
+        assert 'repository(owner:$owner,name:$name)' in query
+        assert 'owner: "owner"' not in query
+        assert "owner=owner" in argv and "name=repo" in argv
         assert states[123] == IssueState.OPEN
 
     @patch("hephaestus.automation.github_api._gh_call")
@@ -268,6 +264,52 @@ class TestPrefetchIssueStates:
         with pytest.raises(ValueError):
             # Using "abc" as string will fail the int() cast
             prefetch_issue_states(["abc"])  # type: ignore
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_batch_uses_one_variable_per_issue(
+        self, mock_repo_info: Any, mock_gh_call: Any
+    ) -> None:
+        """Each batch element gets its own $nN scalar + -F nN flag (#738)."""
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {"data": {"repository": {
+                "issue0": {"number": 11, "state": "OPEN"},
+                "issue1": {"number": 22, "state": "CLOSED"},
+                "issue2": {"number": 33, "state": "OPEN"},
+            }}}
+        )
+        mock_gh_call.return_value = mock_result
+
+        prefetch_issue_states([11, 22, 33])
+
+        argv = mock_gh_call.call_args[0][0]
+        query = next(a for a in argv if a.startswith("query="))
+        for idx, num in enumerate([11, 22, 33]):
+            assert f"$n{idx}:Int!" in query
+            assert f"issue{idx}: issue(number:$n{idx})" in query
+            assert f"n{idx}={num}" in argv
+
+    @patch("hephaestus.automation.github_api.gh_issue_json")
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_batch_failure_falls_back_to_individual_fetch(
+        self, mock_repo_info: Any, mock_gh_call: Any, mock_issue_json: Any
+    ) -> None:
+        """When batch GraphQL fails, _fetch_batch_states falls back to gh_issue_json."""
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
+        mock_issue_json.side_effect = [
+            {"number": 11, "state": "OPEN"},
+            {"number": 22, "state": "CLOSED"},
+        ]
+
+        states = prefetch_issue_states([11, 22])
+
+        assert mock_issue_json.call_count == 2
+        assert states[11] == IssueState.OPEN
+        assert states[22] == IssueState.CLOSED
 
 
 class TestGhCall:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -246,7 +246,7 @@ class TestPrefetchIssueStates:
         assert "issue(number: 123)" not in query  # regression guard for #738
         assert "n0=123" in argv
         # owner/repo also parameterised (no f-string interpolation)
-        assert 'repository(owner:$owner,name:$name)' in query
+        assert "repository(owner:$owner,name:$name)" in query
         assert 'owner: "owner"' not in query
         assert "owner=owner" in argv and "name=repo" in argv
         assert states[123] == IssueState.OPEN
@@ -274,11 +274,15 @@ class TestPrefetchIssueStates:
         mock_repo_info.return_value = ("owner", "repo")
         mock_result = Mock()
         mock_result.stdout = json.dumps(
-            {"data": {"repository": {
-                "issue0": {"number": 11, "state": "OPEN"},
-                "issue1": {"number": 22, "state": "CLOSED"},
-                "issue2": {"number": 33, "state": "OPEN"},
-            }}}
+            {
+                "data": {
+                    "repository": {
+                        "issue0": {"number": 11, "state": "OPEN"},
+                        "issue1": {"number": 22, "state": "CLOSED"},
+                        "issue2": {"number": 33, "state": "OPEN"},
+                    }
+                }
+            }
         )
         mock_gh_call.return_value = mock_result
 

--- a/tests/unit/automation/test_github_api_review_threads.py
+++ b/tests/unit/automation/test_github_api_review_threads.py
@@ -1,4 +1,5 @@
 """Tests for GraphQL parameterisation in PR review-thread helpers (#738)."""
+
 from __future__ import annotations
 
 import json
@@ -56,8 +57,4 @@ class TestListUnresolvedThreadsParameterisation:
         assert "pullRequest(number:$number)" in query
         assert "pullRequest(number: 42)" not in query  # regression guard
         assert 'owner: "owner"' not in query
-        assert (
-            "owner=owner" in argv
-            and "name=repo" in argv
-            and "number=42" in argv
-        )
+        assert "owner=owner" in argv and "name=repo" in argv and "number=42" in argv

--- a/tests/unit/automation/test_github_api_review_threads.py
+++ b/tests/unit/automation/test_github_api_review_threads.py
@@ -1,0 +1,63 @@
+"""Tests for GraphQL parameterisation in PR review-thread helpers (#738)."""
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import Mock, patch
+
+from hephaestus.automation.github_api import (
+    _review_threads_for_review,
+    gh_pr_list_unresolved_threads,
+)
+
+
+class TestReviewThreadsForReviewParameterisation:
+    """Tests for _review_threads_for_review parameterisation."""
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_uses_parameterised_query(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+        )
+        mock_gh_call.return_value = mock_result
+
+        _review_threads_for_review(42, "RV_kw1")
+
+        argv = mock_gh_call.call_args[0][0]
+        query = next(a for a in argv if a.startswith("query="))
+        assert "$number:Int!" in query
+        assert "pullRequest(number:$number)" in query
+        assert "pullRequest(number: 42)" not in query  # regression guard
+        assert 'owner: "owner"' not in query
+        assert "owner=owner" in argv and "name=repo" in argv and "number=42" in argv
+
+
+class TestListUnresolvedThreadsParameterisation:
+    """Tests for gh_pr_list_unresolved_threads parameterisation."""
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_uses_parameterised_query(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": []}}}}}
+        )
+        mock_gh_call.return_value = mock_result
+
+        gh_pr_list_unresolved_threads(42)
+
+        argv = mock_gh_call.call_args[0][0]
+        query = next(a for a in argv if a.startswith("query="))
+        assert "$number:Int!" in query
+        assert "pullRequest(number:$number)" in query
+        assert "pullRequest(number: 42)" not in query  # regression guard
+        assert 'owner: "owner"' not in query
+        assert (
+            "owner=owner" in argv
+            and "name=repo" in argv
+            and "number=42" in argv
+        )


### PR DESCRIPTION
## Summary

Parameterise GraphQL queries in three functions to prevent injection:
- `_fetch_batch_states`: Use one `$nN:Int!` variable per batch element with corresponding `-F nN=<int>` flags
- `_review_threads_for_review`: Use `$owner`, `$name`, `$number` variables
- `gh_pr_list_unresolved_threads`: Use `$owner`, `$name`, `$number` variables

Owner/repo remain regex-sanitised for defense-in-depth. Batch fetch uses named scalars because GraphQL aliases cannot index lists.

## Tests

- Updated `test_int_validation_in_graphql_query` to assert new parameterised query shape
- Added `test_batch_uses_one_variable_per_issue` for multi-element batch verification
- Added `test_batch_failure_falls_back_to_individual_fetch` for fallback codepath coverage
- New file `test_github_api_review_threads.py` with tests for both review-thread helpers

All 215 dependent module tests pass (planner_loop, ci_driver, address_review, implementer_loop).

Closes #738