### PR TITLE
fix(deps): align mypy upper-cap to <2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,10 @@ dev = [
     "pytest-cov>=7.0,<8",
     "pre-commit>=3.0,<5",
     "ruff>=0.1.0,<1",
-    "mypy>=1.8.0,<3",
+    # Upper-cap kept in lockstep with pixi.toml [feature.dev]/[feature.lint] —
+    # mypy 1.x and 2.x have different error semantics; CI tests only 1.x.
+    # Enforced by tests/unit/scripts/test_dependency_floor_consistency.py.
+    "mypy>=1.8.0,<2",
     "build>=1.0,<2",
     "pip-audit>=2.7,<3",
     "tomli>=2.0,<3;python_version<'3.11'",

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -38,6 +38,28 @@ def _floor(spec: str) -> str:
     return version
 
 
+def _upper_cap(spec: str) -> str:
+    """Extract the upper-cap version (<X[.Y[.Z]]) from a PEP 508 / pixi spec.
+
+    Args:
+        spec: A constraint string like "mypy>=1.8.0,<2" or ">=1.8.0,<2".
+
+    Returns:
+        The upper-cap version (e.g., "2").
+
+    Raises:
+        AssertionError: If no "<" cap clause is present in the spec.
+
+    """
+    # Split off any name prefix (PEP 508) so we only scan the version range.
+    range_part = spec.split(">=", 1)[1] if ">=" in spec else spec
+    for clause in range_part.split(","):
+        clause = clause.strip()
+        if clause.startswith("<") and not clause.startswith("<="):
+            return clause[1:].strip()
+    raise AssertionError(f"No '<' upper-cap found in constraint spec: {spec}")
+
+
 @pytest.fixture
 def repo_root() -> Path:
     """Return the repository root directory."""
@@ -134,4 +156,77 @@ class TestDependencyFloorConsistency:
 
         assert major_version >= 2, (
             f"PyGithub floor must be 2.x or higher for API compatibility; found {floor}"
+        )
+
+
+class TestMypyUpperCapConsistency:
+    """Tests for mypy upper-cap consistency across pyproject.toml and pixi.toml.
+
+    mypy 1.x and 2.x have different error semantics; the pixi-driven CI
+    (`pixi run mypy`) only ever resolves the cap declared in pixi.toml, so
+    a pip-install user on `.[dev]` must see the same cap or they land on
+    an untested major. Tracks issue #748.
+    """
+
+    def test_mypy_upper_cap_matches_across_manifests(self, repo_root: Path) -> None:
+        """Mypy upper-cap in pyproject.toml dev extra must equal both pixi features."""
+        pyproject_path = repo_root / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+
+        dev_deps = pyproject["project"]["optional-dependencies"]["dev"]
+        pyproject_spec = next(
+            (dep for dep in dev_deps if dep.startswith("mypy")),
+            None,
+        )
+        assert pyproject_spec is not None, "mypy not found in [project.optional-dependencies.dev]"
+
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        pixi_dev_spec = pixi["feature"]["dev"]["dependencies"]["mypy"]
+        pixi_lint_spec = pixi["feature"]["lint"]["dependencies"]["mypy"]
+
+        pyproject_cap = _upper_cap(pyproject_spec)
+        pixi_dev_cap = _upper_cap(pixi_dev_spec)
+        pixi_lint_cap = _upper_cap(pixi_lint_spec)
+
+        assert pyproject_cap == pixi_dev_cap == pixi_lint_cap, (
+            "mypy upper-cap skew: "
+            f"pyproject.toml dev={pyproject_cap} vs "
+            f"pixi.toml [feature.dev]={pixi_dev_cap} vs "
+            f"[feature.lint]={pixi_lint_cap}. "
+            "Update all three together — see issue #748."
+        )
+
+    def test_mypy_floor_matches_across_manifests(self, repo_root: Path) -> None:
+        """Mypy floor in pyproject.toml dev extra must equal both pixi features."""
+        pyproject_path = repo_root / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+
+        dev_deps = pyproject["project"]["optional-dependencies"]["dev"]
+        pyproject_spec = next(
+            (dep for dep in dev_deps if dep.startswith("mypy")),
+            None,
+        )
+        assert pyproject_spec is not None
+
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        pixi_dev_spec = pixi["feature"]["dev"]["dependencies"]["mypy"]
+        pixi_lint_spec = pixi["feature"]["lint"]["dependencies"]["mypy"]
+
+        pyproject_floor = _floor(pyproject_spec)
+        pixi_dev_floor = _floor(pixi_dev_spec)
+        pixi_lint_floor = _floor(pixi_lint_spec)
+
+        assert pyproject_floor == pixi_dev_floor == pixi_lint_floor, (
+            "mypy floor skew: "
+            f"pyproject.toml dev={pyproject_floor} vs "
+            f"pixi.toml [feature.dev]={pixi_dev_floor} vs "
+            f"[feature.lint]={pixi_lint_floor}."
         )


### PR DESCRIPTION
## Summary

Align mypy upper-cap constraint from `<3` to `<2` across all manifests. mypy 1.x and 2.x have different error semantics; the pixi-driven CI only tests version 1.x, so a pip install `.[dev]` user must see the same cap as what's verified by continuous integration.

## Changes

- **pyproject.toml**: Update mypy constraint from `>=1.8.0,<3` to `>=1.8.0,<2` with clarifying comment
- **tests/unit/scripts/test_dependency_floor_consistency.py**: Add `TestMypyUpperCapConsistency` regression tests to enforce alignment across pyproject.toml and both pixi.toml features

## Test Plan

✅ `pixi run pytest tests/unit/scripts/test_dependency_floor_consistency.py::TestMypyUpperCapConsistency -v`  
✅ Mypy consistency verified: pyproject.toml = pixi.toml [feature.dev] = pixi.toml [feature.lint] = `<2`  
✅ Type checking passes: `pixi run mypy`  
✅ All existing tests pass  
✅ Code quality checks: ruff format + ruff check

Closes #748

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>