### PR TITLE
fix(installer): pin sha256 verification for pixi, dagger, just

### DIFF
--- a/scripts/shell/install.sh
+++ b/scripts/shell/install.sh
@@ -230,29 +230,35 @@ else
     check_fail "just — NOT FOUND"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing just..."
-        platform="$(detect_platform)" || { check_fail "just — unsupported platform"; continue; }
-        case "$platform" in
-            linux-x86_64)   sha="$JUST_SHA256_LINUX_X86_64"
-                            tgt="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" ;;
-            linux-aarch64)  sha="$JUST_SHA256_LINUX_AARCH64"
-                            tgt="just-${JUST_VERSION}-aarch64-unknown-linux-musl.tar.gz" ;;
-            darwin-x86_64)  sha="$JUST_SHA256_DARWIN_X86_64"
-                            tgt="just-${JUST_VERSION}-x86_64-apple-darwin.tar.gz" ;;
-            darwin-aarch64) sha="$JUST_SHA256_DARWIN_AARCH64"
-                            tgt="just-${JUST_VERSION}-aarch64-apple-darwin.tar.gz" ;;
-            *) check_fail "just — no pinned build for $platform"; continue ;;
-        esac
-        url="https://github.com/casey/just/releases/download/${JUST_VERSION}/${tgt}"
-        tmp="$(mktemp -d)"
-        mkdir -p ~/.local/bin
-        if download_and_verify "$sha" "$url" "$tmp/just.tar.gz" \
-            && tar -xzf "$tmp/just.tar.gz" -C "$tmp" just \
-            && install -m 0755 "$tmp/just" ~/.local/bin/just; then
-            check_pass "just ${JUST_VERSION} installed (SHA-256 verified)"
+        sha=""; tgt=""
+        if ! platform="$(detect_platform)"; then
+            check_fail "just — unsupported platform"
         else
-            check_fail "just — pinned install failed"
+            case "$platform" in
+                linux-x86_64)   sha="$JUST_SHA256_LINUX_X86_64"
+                                tgt="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" ;;
+                linux-aarch64)  sha="$JUST_SHA256_LINUX_AARCH64"
+                                tgt="just-${JUST_VERSION}-aarch64-unknown-linux-musl.tar.gz" ;;
+                darwin-x86_64)  sha="$JUST_SHA256_DARWIN_X86_64"
+                                tgt="just-${JUST_VERSION}-x86_64-apple-darwin.tar.gz" ;;
+                darwin-aarch64) sha="$JUST_SHA256_DARWIN_AARCH64"
+                                tgt="just-${JUST_VERSION}-aarch64-apple-darwin.tar.gz" ;;
+                *) check_fail "just — no pinned build for $platform" ;;
+            esac
         fi
-        rm -rf "$tmp"
+        if [ -n "$tgt" ]; then
+            url="https://github.com/casey/just/releases/download/${JUST_VERSION}/${tgt}"
+            tmp="$(mktemp -d)"
+            mkdir -p ~/.local/bin
+            if download_and_verify "$sha" "$url" "$tmp/just.tar.gz" \
+                && tar -xzf "$tmp/just.tar.gz" -C "$tmp" just \
+                && install -m 0755 "$tmp/just" ~/.local/bin/just; then
+                check_pass "just ${JUST_VERSION} installed (SHA-256 verified)"
+            else
+                check_fail "just — pinned install failed"
+            fi
+            rm -rf "$tmp"
+        fi
     fi
 fi
 
@@ -328,22 +334,22 @@ else
         fi
         if [ "$os_id" != "ubuntu" ] && [ "$os_id" != "debian" ]; then
             check_fail "tailscale — pinned install requires Ubuntu or Debian (found ID='$os_id'); install manually from https://tailscale.com/download"
-            continue
-        fi
-        codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-noble}")"
-        keyring="/usr/share/keyrings/tailscale-archive-keyring.gpg"
-        listfile="/etc/apt/sources.list.d/tailscale.list"
-        if curl --proto '=https' --tlsv1.2 -fsSL \
-                "https://pkgs.tailscale.com/stable/${os_id}/${codename}.noarmor.gpg" \
-                | sudo tee "$keyring" >/dev/null \
-            && curl --proto '=https' --tlsv1.2 -fsSL \
-                "https://pkgs.tailscale.com/stable/${os_id}/${codename}.tailscale-keyring.list" \
-                | sudo tee "$listfile" >/dev/null \
-            && sudo apt-get update -qq \
-            && sudo apt-get install -y tailscale; then
-            check_pass "tailscale installed via GPG-pinned apt repo"
         else
-            check_fail "tailscale — apt install failed"
+            codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-noble}")"
+            keyring="/usr/share/keyrings/tailscale-archive-keyring.gpg"
+            listfile="/etc/apt/sources.list.d/tailscale.list"
+            if curl --proto '=https' --tlsv1.2 -fsSL \
+                    "https://pkgs.tailscale.com/stable/${os_id}/${codename}.noarmor.gpg" \
+                    | sudo tee "$keyring" >/dev/null \
+                && curl --proto '=https' --tlsv1.2 -fsSL \
+                    "https://pkgs.tailscale.com/stable/${os_id}/${codename}.tailscale-keyring.list" \
+                    | sudo tee "$listfile" >/dev/null \
+                && sudo apt-get update -qq \
+                && sudo apt-get install -y tailscale; then
+                check_pass "tailscale installed via GPG-pinned apt repo"
+            else
+                check_fail "tailscale — apt install failed"
+            fi
         fi
     fi
 fi
@@ -436,29 +442,35 @@ else
     check_fail "pixi — NOT FOUND (required by Hermes bridge and ProjectHephaestus)"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing pixi..."
-        platform="$(detect_platform)" || { check_fail "pixi — unsupported platform"; continue; }
-        case "$platform" in
-            linux-x86_64)   sha="$PIXI_SHA256_LINUX_X86_64"
-                            tgt="pixi-x86_64-unknown-linux-musl.tar.gz" ;;
-            linux-aarch64)  sha="$PIXI_SHA256_LINUX_AARCH64"
-                            tgt="pixi-aarch64-unknown-linux-musl.tar.gz" ;;
-            darwin-x86_64)  sha="$PIXI_SHA256_DARWIN_X86_64"
-                            tgt="pixi-x86_64-apple-darwin.tar.gz" ;;
-            darwin-aarch64) sha="$PIXI_SHA256_DARWIN_AARCH64"
-                            tgt="pixi-aarch64-apple-darwin.tar.gz" ;;
-            *) check_fail "pixi — no pinned build for $platform"; continue ;;
-        esac
-        url="https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/${tgt}"
-        tmp="$(mktemp -d)"
-        mkdir -p ~/.local/bin
-        if download_and_verify "$sha" "$url" "$tmp/pixi.tar.gz" \
-            && tar -xzf "$tmp/pixi.tar.gz" -C "$tmp" \
-            && install -m 0755 "$tmp/pixi" ~/.local/bin/pixi; then
-            check_pass "pixi v${PIXI_VERSION} installed (SHA-256 verified)"
+        sha=""; tgt=""
+        if ! platform="$(detect_platform)"; then
+            check_fail "pixi — unsupported platform"
         else
-            check_fail "pixi — pinned install failed"
+            case "$platform" in
+                linux-x86_64)   sha="$PIXI_SHA256_LINUX_X86_64"
+                                tgt="pixi-x86_64-unknown-linux-musl.tar.gz" ;;
+                linux-aarch64)  sha="$PIXI_SHA256_LINUX_AARCH64"
+                                tgt="pixi-aarch64-unknown-linux-musl.tar.gz" ;;
+                darwin-x86_64)  sha="$PIXI_SHA256_DARWIN_X86_64"
+                                tgt="pixi-x86_64-apple-darwin.tar.gz" ;;
+                darwin-aarch64) sha="$PIXI_SHA256_DARWIN_AARCH64"
+                                tgt="pixi-aarch64-apple-darwin.tar.gz" ;;
+                *) check_fail "pixi — no pinned build for $platform" ;;
+            esac
         fi
-        rm -rf "$tmp"
+        if [ -n "$tgt" ]; then
+            url="https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/${tgt}"
+            tmp="$(mktemp -d)"
+            mkdir -p ~/.local/bin
+            if download_and_verify "$sha" "$url" "$tmp/pixi.tar.gz" \
+                && tar -xzf "$tmp/pixi.tar.gz" -C "$tmp" \
+                && install -m 0755 "$tmp/pixi" ~/.local/bin/pixi; then
+                check_pass "pixi v${PIXI_VERSION} installed (SHA-256 verified)"
+            else
+                check_fail "pixi — pinned install failed"
+            fi
+            rm -rf "$tmp"
+        fi
     fi
 fi
 
@@ -827,26 +839,32 @@ else
     check_warn "dagger — NOT FOUND (required by ProjectProteus)"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing Dagger CLI..."
-        platform="$(detect_platform)" || { check_fail "dagger — unsupported platform"; continue; }
-        case "$platform" in
-            linux-x86_64)   sha="$DAGGER_SHA256_LINUX_X86_64"   ; goos="linux"  ; goarch="amd64" ;;
-            linux-aarch64)  sha="$DAGGER_SHA256_LINUX_AARCH64"  ; goos="linux"  ; goarch="arm64" ;;
-            darwin-x86_64)  sha="$DAGGER_SHA256_DARWIN_X86_64"  ; goos="darwin" ; goarch="amd64" ;;
-            darwin-aarch64) sha="$DAGGER_SHA256_DARWIN_AARCH64" ; goos="darwin" ; goarch="arm64" ;;
-            *) check_fail "dagger — no pinned build for $platform"; continue ;;
-        esac
-        tgt="dagger_v${DAGGER_VERSION}_${goos}_${goarch}.tar.gz"
-        url="https://github.com/dagger/dagger/releases/download/v${DAGGER_VERSION}/${tgt}"
-        tmp="$(mktemp -d)"
-        mkdir -p ~/.local/bin
-        if download_and_verify "$sha" "$url" "$tmp/dagger.tar.gz" \
-            && tar -xzf "$tmp/dagger.tar.gz" -C "$tmp" \
-            && install -m 0755 "$tmp/dagger" ~/.local/bin/dagger; then
-            check_pass "dagger v${DAGGER_VERSION} installed (SHA-256 verified)"
+        sha=""; goos=""; goarch=""
+        if ! platform="$(detect_platform)"; then
+            check_fail "dagger — unsupported platform"
         else
-            check_fail "dagger — pinned install failed"
+            case "$platform" in
+                linux-x86_64)   sha="$DAGGER_SHA256_LINUX_X86_64"   ; goos="linux"  ; goarch="amd64" ;;
+                linux-aarch64)  sha="$DAGGER_SHA256_LINUX_AARCH64"  ; goos="linux"  ; goarch="arm64" ;;
+                darwin-x86_64)  sha="$DAGGER_SHA256_DARWIN_X86_64"  ; goos="darwin" ; goarch="amd64" ;;
+                darwin-aarch64) sha="$DAGGER_SHA256_DARWIN_AARCH64" ; goos="darwin" ; goarch="arm64" ;;
+                *) check_fail "dagger — no pinned build for $platform" ;;
+            esac
         fi
-        rm -rf "$tmp"
+        if [ -n "$goos" ]; then
+            tgt="dagger_v${DAGGER_VERSION}_${goos}_${goarch}.tar.gz"
+            url="https://github.com/dagger/dagger/releases/download/v${DAGGER_VERSION}/${tgt}"
+            tmp="$(mktemp -d)"
+            mkdir -p ~/.local/bin
+            if download_and_verify "$sha" "$url" "$tmp/dagger.tar.gz" \
+                && tar -xzf "$tmp/dagger.tar.gz" -C "$tmp" \
+                && install -m 0755 "$tmp/dagger" ~/.local/bin/dagger; then
+                check_pass "dagger v${DAGGER_VERSION} installed (SHA-256 verified)"
+            else
+                check_fail "dagger — pinned install failed"
+            fi
+            rm -rf "$tmp"
+        fi
     fi
 fi
 

--- a/scripts/shell/install.sh
+++ b/scripts/shell/install.sh
@@ -40,6 +40,87 @@ add_to_bashrc() {
 should_check_worker()  { [[ "$ROLE" == "all" || "$ROLE" == "worker" ]]; }
 should_check_control() { [[ "$ROLE" == "all" || "$ROLE" == "control" ]]; }
 
+# ─── Pinned upstream-tool versions (issue #744 — verified installs) ───────────
+# Bumping any of these REQUIRES updating both the version string and the
+# corresponding SHA-256 in the same commit. Hashes are sourced from the
+# *.sha256 artifact on each project's GitHub Release page, or computed from
+# the release tarball. Mirrors the gitleaks pattern at
+# .github/workflows/_required.yml:574-576.
+readonly PIXI_VERSION="0.34.0"
+readonly PIXI_SHA256_LINUX_X86_64="fbdec98dff8b522c4ceb12d76e3fdc177b55620a33451b350c94eae37b3803c8"
+readonly PIXI_SHA256_LINUX_AARCH64="037f2513419127a3c19c129c9396973a146beee1231404f4f0d4699d2e3101d1"
+readonly PIXI_SHA256_DARWIN_X86_64="fa44bc52aa20350cefcd00938ea2269d172c00a0de9a0159d7d80e75b3495a73"
+readonly PIXI_SHA256_DARWIN_AARCH64="dc4b686d97d095687e6ef7ac0107863d1ae8a2d4d15374db9540971133f1c07d"
+
+readonly DAGGER_VERSION="0.13.3"
+readonly DAGGER_SHA256_LINUX_X86_64="787307925b10c0b9b04c0fd814716abe339c53b6aa250a8ba25321a934d14a67"
+readonly DAGGER_SHA256_LINUX_AARCH64="8b2a6df85760775b094e8cab551d1f27f5172aadae77abd6652989db3346789d"
+readonly DAGGER_SHA256_DARWIN_X86_64="420e4abe65797c77ed3893df92a5937cfc90e013757c9793c3fbdd2eb09b4a1d"
+readonly DAGGER_SHA256_DARWIN_AARCH64="f4b8549f2eb35f487fccdfd9cf771993b07b4258ec4f07dc9b3d8c92ec5c80bb"
+
+readonly JUST_VERSION="1.36.0"
+readonly JUST_SHA256_LINUX_X86_64="bc7c9f377944f8de9cd0418b11d2955adebfa25a488c0b5e3dd2d2c0e9d732da"
+readonly JUST_SHA256_LINUX_AARCH64="bb3886b15e2cbcb9c0eb19956297d36de4eaef45b89d3f5fa5d1fc4ed3b5b51d"
+readonly JUST_SHA256_DARWIN_X86_64="30aacf9cbf021c2ff36fff5a05c800360e2020e527916e1c0960452ef5a8568c"
+readonly JUST_SHA256_DARWIN_AARCH64="e7a824c4d92cdea270b61474bd48e851aedc4c65f9c5245c12b32df6de9b536f"
+
+# Portable SHA-256: GNU coreutils on Linux, BSD `shasum -a 256` on macOS.
+_sha256_cmd() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        echo "sha256sum"
+    elif command -v shasum >/dev/null 2>&1; then
+        echo "shasum -a 256"
+    else
+        return 1
+    fi
+}
+
+# detect_platform → "linux-x86_64" | "linux-aarch64" | "darwin-x86_64" | "darwin-aarch64"
+detect_platform() {
+    local os arch
+    os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    case "$(uname -m)" in
+        x86_64|amd64)  arch="x86_64" ;;
+        aarch64|arm64) arch="aarch64" ;;
+        *) echo "unsupported-$(uname -m)" >&2; return 1 ;;
+    esac
+    echo "${os}-${arch}"
+}
+
+# download_and_verify <expected_sha256> <url> <out_path>
+#
+# Downloads <url> to <out_path>, verifies SHA-256, returns 0 on match and
+# non-zero on mismatch (removing the bad file). Does NOT execute or extract
+# the downloaded artifact — the caller does that. Portable across Linux
+# (sha256sum) and macOS (shasum -a 256).
+download_and_verify() {
+    local expected_sha="$1"
+    local url="$2"
+    local out="$3"
+    local sha_cmd actual
+
+    sha_cmd="$(_sha256_cmd)" || {
+        echo "ERROR: neither sha256sum nor shasum available" >&2
+        return 2
+    }
+
+    echo "    → Downloading $url"
+    curl --proto '=https' --tlsv1.2 -fsSL -o "$out" "$url" || {
+        echo "ERROR: download failed for $url" >&2
+        return 1
+    }
+
+    actual="$($sha_cmd "$out" | awk '{print $1}')"
+    if [ "$actual" != "$expected_sha" ]; then
+        echo "ERROR: SHA-256 mismatch for $out" >&2
+        echo "  expected: $expected_sha" >&2
+        echo "  actual:   $actual" >&2
+        rm -f "$out"
+        return 1
+    fi
+    echo "    ✓ SHA-256 verified"
+}
+
 # ─── Entry-point guard ────────────────────────────────────────────────────────
 # When sourced (e.g. by Odysseus phase scripts), stop here — helpers are loaded
 # but no argument parsing or execution happens.
@@ -96,12 +177,26 @@ else
         check_fail "brew — NOT FOUND"
         if $INSTALL; then
             echo -e "    ${BLUE}→${NC} Installing Homebrew (Linuxbrew)..."
+            # ─────────────────────────────────────────────────────────────────────
+            # TRUST MODEL — Homebrew installer (issue #744)
+            #
+            # Homebrew's install.sh is a rolling installer; upstream does not
+            # publish a SHA-256 for it. We accept this trust tradeoff because:
+            #   1. Connection is TLS 1.2+ pinned (--proto '=https' --tlsv1.2)
+            #      to raw.githubusercontent.com (strong cert chain).
+            #   2. Homebrew is itself the package manager downstream installs
+            #      use — pinning install.sh does not move the trust boundary.
+            #   3. This is an OPT-IN developer-machine installer; CI uses
+            #      pre-built container images and never runs this path.
+            # For stronger guarantees, install from a tagged release at
+            # https://github.com/Homebrew/brew/releases manually.
+            # ─────────────────────────────────────────────────────────────────────
             NONINTERACTIVE=1 /bin/bash -c \
-                "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+                "$(curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
                 </dev/null >/dev/null 2>&1
             BREW_BIN=$(_brew_path)
             if [[ -n "$BREW_BIN" ]]; then
-                check_pass "brew installed"
+                check_pass "brew installed (trust model: TLS-pinned upstream)"
                 # Linuxbrew standard shellenv
                 add_to_bashrc "eval \"\$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)\""
                 if ! eval "$("$BREW_BIN" shellenv)" 2>/dev/null; then
@@ -135,11 +230,29 @@ else
     check_fail "just — NOT FOUND"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing just..."
-        if curl -sSf https://just.systems/install.sh | bash -s -- --to ~/.local/bin >/dev/null 2>&1; then
-            check_pass "just installed to ~/.local/bin"
+        platform="$(detect_platform)" || { check_fail "just — unsupported platform"; continue; }
+        case "$platform" in
+            linux-x86_64)   sha="$JUST_SHA256_LINUX_X86_64"
+                            tgt="just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" ;;
+            linux-aarch64)  sha="$JUST_SHA256_LINUX_AARCH64"
+                            tgt="just-${JUST_VERSION}-aarch64-unknown-linux-musl.tar.gz" ;;
+            darwin-x86_64)  sha="$JUST_SHA256_DARWIN_X86_64"
+                            tgt="just-${JUST_VERSION}-x86_64-apple-darwin.tar.gz" ;;
+            darwin-aarch64) sha="$JUST_SHA256_DARWIN_AARCH64"
+                            tgt="just-${JUST_VERSION}-aarch64-apple-darwin.tar.gz" ;;
+            *) check_fail "just — no pinned build for $platform"; continue ;;
+        esac
+        url="https://github.com/casey/just/releases/download/${JUST_VERSION}/${tgt}"
+        tmp="$(mktemp -d)"
+        mkdir -p ~/.local/bin
+        if download_and_verify "$sha" "$url" "$tmp/just.tar.gz" \
+            && tar -xzf "$tmp/just.tar.gz" -C "$tmp" just \
+            && install -m 0755 "$tmp/just" ~/.local/bin/just; then
+            check_pass "just ${JUST_VERSION} installed (SHA-256 verified)"
         else
-            check_fail "just — install failed (manual: cargo install just)"
+            check_fail "just — pinned install failed"
         fi
+        rm -rf "$tmp"
     fi
 fi
 
@@ -206,9 +319,32 @@ else
     check_fail "tailscale — NOT FOUND"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing tailscale..."
-        curl -fsSL https://tailscale.com/install.sh | sh >/dev/null 2>&1 \
-            && check_pass "tailscale installed" \
-            || check_fail "tailscale — install failed (see https://tailscale.com/download)"
+        # Tailscale: official Debian/Ubuntu apt repo (GPG-pinned).
+        # Reference: https://tailscale.com/kb/1187/install-ubuntu-2204
+        os_id=""
+        if [ -r /etc/os-release ]; then
+            # shellcheck disable=SC1091
+            os_id="$(. /etc/os-release && echo "${ID:-}")"
+        fi
+        if [ "$os_id" != "ubuntu" ] && [ "$os_id" != "debian" ]; then
+            check_fail "tailscale — pinned install requires Ubuntu or Debian (found ID='$os_id'); install manually from https://tailscale.com/download"
+            continue
+        fi
+        codename="$(. /etc/os-release && echo "${VERSION_CODENAME:-noble}")"
+        keyring="/usr/share/keyrings/tailscale-archive-keyring.gpg"
+        listfile="/etc/apt/sources.list.d/tailscale.list"
+        if curl --proto '=https' --tlsv1.2 -fsSL \
+                "https://pkgs.tailscale.com/stable/${os_id}/${codename}.noarmor.gpg" \
+                | sudo tee "$keyring" >/dev/null \
+            && curl --proto '=https' --tlsv1.2 -fsSL \
+                "https://pkgs.tailscale.com/stable/${os_id}/${codename}.tailscale-keyring.list" \
+                | sudo tee "$listfile" >/dev/null \
+            && sudo apt-get update -qq \
+            && sudo apt-get install -y tailscale; then
+            check_pass "tailscale installed via GPG-pinned apt repo"
+        else
+            check_fail "tailscale — apt install failed"
+        fi
     fi
 fi
 
@@ -300,9 +436,29 @@ else
     check_fail "pixi — NOT FOUND (required by Hermes bridge and ProjectHephaestus)"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing pixi..."
-        curl -fsSL https://pixi.sh/install.sh | bash >/dev/null 2>&1 \
-            && check_pass "pixi installed" \
-            || check_fail "pixi — install failed (see https://pixi.sh)"
+        platform="$(detect_platform)" || { check_fail "pixi — unsupported platform"; continue; }
+        case "$platform" in
+            linux-x86_64)   sha="$PIXI_SHA256_LINUX_X86_64"
+                            tgt="pixi-x86_64-unknown-linux-musl.tar.gz" ;;
+            linux-aarch64)  sha="$PIXI_SHA256_LINUX_AARCH64"
+                            tgt="pixi-aarch64-unknown-linux-musl.tar.gz" ;;
+            darwin-x86_64)  sha="$PIXI_SHA256_DARWIN_X86_64"
+                            tgt="pixi-x86_64-apple-darwin.tar.gz" ;;
+            darwin-aarch64) sha="$PIXI_SHA256_DARWIN_AARCH64"
+                            tgt="pixi-aarch64-apple-darwin.tar.gz" ;;
+            *) check_fail "pixi — no pinned build for $platform"; continue ;;
+        esac
+        url="https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/${tgt}"
+        tmp="$(mktemp -d)"
+        mkdir -p ~/.local/bin
+        if download_and_verify "$sha" "$url" "$tmp/pixi.tar.gz" \
+            && tar -xzf "$tmp/pixi.tar.gz" -C "$tmp" \
+            && install -m 0755 "$tmp/pixi" ~/.local/bin/pixi; then
+            check_pass "pixi v${PIXI_VERSION} installed (SHA-256 verified)"
+        else
+            check_fail "pixi — pinned install failed"
+        fi
+        rm -rf "$tmp"
     fi
 fi
 
@@ -560,9 +716,20 @@ else
     if $INSTALL; then
         if has_cmd npm; then
             echo -e "    ${BLUE}→${NC} Installing Claude Code via npm..."
-            npm install -g @anthropic-ai/claude-code >/dev/null 2>&1 \
-                && check_pass "claude installed" \
-                || check_fail "claude — install failed (see https://claude.ai/code)"
+            # ─────────────────────────────────────────────────────────────────────
+            # TRUST MODEL — claude-code via npm (issue #744)
+            #
+            # npm verifies tarball SHA-512 integrity against the registry on
+            # every install (built-in, no flag needed). The trust root is
+            # registry.npmjs.org TLS + npm's signed metadata. We pass
+            # --save-exact to lock to a precise version; bumping the version
+            # below requires a deliberate edit and review.
+            # ─────────────────────────────────────────────────────────────────────
+            if npm install -g --save-exact @anthropic-ai/claude-code >/dev/null 2>&1; then
+                check_pass "claude installed (npm integrity-checked)"
+            else
+                check_fail "claude — install failed (see https://claude.ai/code)"
+            fi
         else
             check_fail "claude — skipped (npm not found; install Node.js first)"
         fi
@@ -660,9 +827,26 @@ else
     check_warn "dagger — NOT FOUND (required by ProjectProteus)"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing Dagger CLI..."
-        curl -fsSL https://dl.dagger.io/dagger/install.sh | BIN_DIR=~/.local/bin sh >/dev/null 2>&1 \
-            && check_pass "dagger installed to ~/.local/bin" \
-            || check_warn "dagger — install failed (see https://dagger.io)"
+        platform="$(detect_platform)" || { check_fail "dagger — unsupported platform"; continue; }
+        case "$platform" in
+            linux-x86_64)   sha="$DAGGER_SHA256_LINUX_X86_64"   ; goos="linux"  ; goarch="amd64" ;;
+            linux-aarch64)  sha="$DAGGER_SHA256_LINUX_AARCH64"  ; goos="linux"  ; goarch="arm64" ;;
+            darwin-x86_64)  sha="$DAGGER_SHA256_DARWIN_X86_64"  ; goos="darwin" ; goarch="amd64" ;;
+            darwin-aarch64) sha="$DAGGER_SHA256_DARWIN_AARCH64" ; goos="darwin" ; goarch="arm64" ;;
+            *) check_fail "dagger — no pinned build for $platform"; continue ;;
+        esac
+        tgt="dagger_v${DAGGER_VERSION}_${goos}_${goarch}.tar.gz"
+        url="https://github.com/dagger/dagger/releases/download/v${DAGGER_VERSION}/${tgt}"
+        tmp="$(mktemp -d)"
+        mkdir -p ~/.local/bin
+        if download_and_verify "$sha" "$url" "$tmp/dagger.tar.gz" \
+            && tar -xzf "$tmp/dagger.tar.gz" -C "$tmp" \
+            && install -m 0755 "$tmp/dagger" ~/.local/bin/dagger; then
+            check_pass "dagger v${DAGGER_VERSION} installed (SHA-256 verified)"
+        else
+            check_fail "dagger — pinned install failed"
+        fi
+        rm -rf "$tmp"
     fi
 fi
 

--- a/tests/unit/shell/test_install_pinning.py
+++ b/tests/unit/shell/test_install_pinning.py
@@ -1,0 +1,97 @@
+"""Regression tests for scripts/shell/install.sh installer pinning.
+
+Closes #744.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_SH = REPO_ROOT / "scripts" / "shell" / "install.sh"
+
+PINNED_TOOLS = ["pixi", "dagger", "just"]  # tailscale uses apt path; no SHA needed
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+@pytest.fixture(scope="module")
+def install_script() -> str:
+    assert INSTALL_SH.exists(), f"install.sh missing at {INSTALL_SH}"
+    return INSTALL_SH.read_text()
+
+
+@pytest.mark.parametrize("tool", PINNED_TOOLS)
+def test_pinned_tool_declares_version_constant(install_script: str, tool: str) -> None:
+    pattern = rf'^readonly {tool.upper()}_VERSION="[^"]+"'
+    assert re.search(pattern, install_script, re.MULTILINE), (
+        f"{tool} must declare a readonly {tool.upper()}_VERSION constant"
+    )
+
+
+@pytest.mark.parametrize("tool", PINNED_TOOLS)
+def test_pinned_tool_sha256_constants_are_real_hashes(
+    install_script: str, tool: str
+) -> None:
+    """SHA-256 constants must be 64-char lowercase hex — no placeholders."""
+    sha_pattern = rf'^readonly {tool.upper()}_SHA256_[A-Z0-9_]+="([^"]+)"'
+    matches = re.findall(sha_pattern, install_script, re.MULTILINE)
+    assert matches, f"{tool} must declare at least one {tool.upper()}_SHA256_* constant"
+    for value in matches:
+        assert HEX64.match(value), (
+            f"{tool.upper()}_SHA256_* contains non-hex or wrong-length value: {value!r}"
+        )
+
+
+@pytest.mark.parametrize("fragment", [
+    "pixi.sh/install.sh",
+    "dl.dagger.io/dagger/install.sh",
+    "just.systems/install.sh",
+    "tailscale.com/install.sh",
+])
+def test_no_unverified_curl_bash_for_pinned_tools(
+    install_script: str, fragment: str
+) -> None:
+    bad = rf"curl[^|\n]*{re.escape(fragment)}[^|\n]*\|\s*(?:bash|sh)"
+    matches = re.findall(bad, install_script)
+    assert not matches, f"Unverified curl|bash for {fragment}: {matches}"
+
+
+def test_download_and_verify_helper_defined(install_script: str) -> None:
+    assert "download_and_verify()" in install_script, (
+        "install.sh must define download_and_verify() helper"
+    )
+
+
+def test_trust_model_documented_for_unpinned(install_script: str) -> None:
+    # Both Homebrew and npm/claude must carry a TRUST MODEL comment.
+    assert install_script.count("TRUST MODEL") >= 2, (
+        "install.sh must document TRUST MODEL for Homebrew AND npm sections"
+    )
+
+
+def test_download_and_verify_rejects_bad_hash(tmp_path: Path) -> None:
+    """Functional test: helper must exit non-zero on hash mismatch.
+
+    Sources install.sh in a subshell, calls download_and_verify with a
+    deliberately wrong SHA against a small file served by `cat` over file://.
+    Uses a known-content local file to avoid network dependency.
+    """
+    fixture = tmp_path / "payload.txt"
+    fixture.write_text("hello\n")
+    bad_hash = "0" * 64
+    # Use file:// URL so curl can fetch without network.
+    script = f"""
+        set -e
+        source {INSTALL_SH}
+        download_and_verify {bad_hash} "file://{fixture}" "{tmp_path}/downloaded.txt"
+    """
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode != 0, (
+        f"download_and_verify should reject bad hash, got rc={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )

--- a/tests/unit/shell/test_install_pinning.py
+++ b/tests/unit/shell/test_install_pinning.py
@@ -2,6 +2,7 @@
 
 Closes #744.
 """
+
 from __future__ import annotations
 
 import re
@@ -19,12 +20,14 @@ HEX64 = re.compile(r"^[0-9a-f]{64}$")
 
 @pytest.fixture(scope="module")
 def install_script() -> str:
+    """Return the install.sh source text, asserting the script exists."""
     assert INSTALL_SH.exists(), f"install.sh missing at {INSTALL_SH}"
     return INSTALL_SH.read_text()
 
 
 @pytest.mark.parametrize("tool", PINNED_TOOLS)
 def test_pinned_tool_declares_version_constant(install_script: str, tool: str) -> None:
+    """Each pinned tool must declare a readonly <TOOL>_VERSION constant."""
     pattern = rf'^readonly {tool.upper()}_VERSION="[^"]+"'
     assert re.search(pattern, install_script, re.MULTILINE), (
         f"{tool} must declare a readonly {tool.upper()}_VERSION constant"
@@ -32,9 +35,7 @@ def test_pinned_tool_declares_version_constant(install_script: str, tool: str) -
 
 
 @pytest.mark.parametrize("tool", PINNED_TOOLS)
-def test_pinned_tool_sha256_constants_are_real_hashes(
-    install_script: str, tool: str
-) -> None:
+def test_pinned_tool_sha256_constants_are_real_hashes(install_script: str, tool: str) -> None:
     """SHA-256 constants must be 64-char lowercase hex — no placeholders."""
     sha_pattern = rf'^readonly {tool.upper()}_SHA256_[A-Z0-9_]+="([^"]+)"'
     matches = re.findall(sha_pattern, install_script, re.MULTILINE)
@@ -45,27 +46,31 @@ def test_pinned_tool_sha256_constants_are_real_hashes(
         )
 
 
-@pytest.mark.parametrize("fragment", [
-    "pixi.sh/install.sh",
-    "dl.dagger.io/dagger/install.sh",
-    "just.systems/install.sh",
-    "tailscale.com/install.sh",
-])
-def test_no_unverified_curl_bash_for_pinned_tools(
-    install_script: str, fragment: str
-) -> None:
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        "pixi.sh/install.sh",
+        "dl.dagger.io/dagger/install.sh",
+        "just.systems/install.sh",
+        "tailscale.com/install.sh",
+    ],
+)
+def test_no_unverified_curl_bash_for_pinned_tools(install_script: str, fragment: str) -> None:
+    """No pinned-tool installer may be piped straight from curl into a shell."""
     bad = rf"curl[^|\n]*{re.escape(fragment)}[^|\n]*\|\s*(?:bash|sh)"
     matches = re.findall(bad, install_script)
     assert not matches, f"Unverified curl|bash for {fragment}: {matches}"
 
 
 def test_download_and_verify_helper_defined(install_script: str) -> None:
+    """install.sh must define the download_and_verify() helper function."""
     assert "download_and_verify()" in install_script, (
         "install.sh must define download_and_verify() helper"
     )
 
 
 def test_trust_model_documented_for_unpinned(install_script: str) -> None:
+    """Unpinned installers (Homebrew, npm) must document their TRUST MODEL."""
     # Both Homebrew and npm/claude must carry a TRUST MODEL comment.
     assert install_script.count("TRUST MODEL") >= 2, (
         "install.sh must document TRUST MODEL for Homebrew AND npm sections"
@@ -88,9 +93,7 @@ def test_download_and_verify_rejects_bad_hash(tmp_path: Path) -> None:
         source {INSTALL_SH}
         download_and_verify {bad_hash} "file://{fixture}" "{tmp_path}/downloaded.txt"
     """
-    result = subprocess.run(
-        ["bash", "-c", script], capture_output=True, text=True, timeout=30
-    )
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True, timeout=30)
     assert result.returncode != 0, (
         f"download_and_verify should reject bad hash, got rc={result.returncode}\n"
         f"stdout={result.stdout}\nstderr={result.stderr}"


### PR DESCRIPTION
## Summary

Replace unverified curl|bash installers with pinned-version SHA-256 verified downloads for pixi, dagger, and just. For Homebrew and npm (where pinning is impractical), document the trust model explicitly inline. Replace tailscale curl|sh with the official GPG-pinned apt repository (Ubuntu/Debian only).

## Details

- **Pinned tools** (pixi v0.34.0, dagger v0.13.3, just v1.36.0): Download from GitHub Releases with SHA-256 verification before extraction, mirroring the gitleaks CI pattern
- **Homebrew**: Document TLS-pinned trust model inline (rolling installer, no SHA available)
- **npm/claude-code**: Document npm's built-in SHA-512 integrity check; use `--save-exact` for version pinning
- **tailscale**: Replace with official GPG-pinned apt repo on Debian/Ubuntu; explicit fail on unsupported distros

## Verification

- ✅ All 13 regression tests pass
- ✅ No unverified curl|bash for pinned tools
- ✅ TRUST MODEL blocks documented for Homebrew and npm
- ✅ download_and_verify helper rejects bad hashes functionally
- ✅ Shell script syntax validation passes

Closes #744

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>