### PR TITLE
fix(forensics): validate GDB_CMD_PREFIX against argv injection

### DIFF
--- a/hephaestus/forensics/gdb_runner.py
+++ b/hephaestus/forensics/gdb_runner.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run any command under ``gdb`` to capture crashes a runtime would swallow.
+r"""Run any command under ``gdb`` to capture crashes a runtime would swallow.
 
 Some runtimes — JIT compilers, sanitizer runtimes, language VMs — install
 their own ``SIGABRT``/``SIGSEGV``/``SIGILL`` handlers that catch a fatal
@@ -22,6 +22,17 @@ Environment variables:
 * ``GDB_CMD_PREFIX`` — optional command prefix inserted before ``gdb``, e.g.
   ``"pixi run --"``, so gdb and its inferior inherit an activated environment.
 
+Security:
+
+* ``GDB_CMD_PREFIX`` is an intentional escape hatch and its tokens are spliced
+  into the ``gdb`` argv, so unvalidated input would allow argv injection (e.g.
+  ``--init-eval-command``). Each whitespace-separated token MUST either be the
+  bare argv terminator ``--`` or fully match ``[A-Za-z0-9_./:=,@+~\\-]+`` AND
+  NOT start with ``-``. Anything else is rejected: the library entry point
+  raises ``ValueError`` and the CLI prints ``[run-under-gdb] ERROR: …`` to
+  stderr and exits with code ``2``. The supported shape is a sub-runner like
+  ``"pixi run --"`` that ends in its own argument terminator.
+
 Exit code:
 
 * ``0`` / ``N`` — normal exit with the inferior's own exit code ``N``.
@@ -33,6 +44,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -41,6 +53,50 @@ import time
 from pathlib import Path
 
 from hephaestus.cli.utils import add_json_arg, emit_json_status
+
+_GDB_PREFIX_TOKEN_RE = re.compile(r"[A-Za-z0-9_./:=,@+~\-]+")
+
+
+def _validate_gdb_cmd_prefix(raw: str | None) -> list[str]:
+    """Whitelist-validate ``GDB_CMD_PREFIX`` into argv tokens.
+
+    Returns ``[]`` for ``None``/empty/whitespace-only input. Otherwise splits
+    on whitespace; each token must either be the bare argv terminator ``--``
+    or fully match the safe character class AND not begin with ``-`` (which
+    would let a caller inject gdb flags such as ``--init-eval-command``).
+
+    Args:
+        raw: The raw env-var / kwarg value.
+
+    Returns:
+        The validated argv tokens, ready to splice before ``gdb``.
+
+    Raises:
+        ValueError: If any token contains disallowed characters or is a
+            ``-``-leading flag-like token other than the bare ``--``. The
+            message names the offending token.
+
+    """
+    if not raw or not raw.strip():
+        return []
+    tokens = raw.split()
+    for tok in tokens:
+        if tok == "--":
+            continue
+        if tok.startswith("-"):
+            raise ValueError(
+                f"GDB_CMD_PREFIX token {tok!r} is a flag-like token; only the "
+                "bare argv terminator '--' is permitted among '-'-leading "
+                "tokens, to prevent gdb argv injection"
+            )
+        if not _GDB_PREFIX_TOKEN_RE.fullmatch(tok):
+            raise ValueError(
+                f"GDB_CMD_PREFIX token {tok!r} contains characters outside the "
+                r"allowed set [A-Za-z0-9_./:=,@+~\-]; refusing to splice into "
+                "gdb argv"
+            )
+    return tokens
+
 
 #: gdb batch script template. Uses Python event hooks rather than a plain
 #: gdb-script ``if`` because ``handle SIG* stop`` + a ``hook-stop`` block
@@ -162,15 +218,24 @@ def run_under_gdb(
         command: The program to run. Resolved via ``PATH`` if not a path.
         command_args: Arguments passed to ``command`` verbatim.
         gdb_cmd_prefix: Optional whitespace-separated command prefix inserted
-            before ``gdb`` (e.g. ``"pixi run --"``) so gdb and its inferior
-            inherit an activated environment.
+            before ``gdb`` (e.g. ``"pixi run --"``). Each token must either
+            be the bare ``--`` terminator or match
+            ``[A-Za-z0-9_./:=,@+~-]+`` and not start with ``-``; otherwise a
+            ``ValueError`` is raised (see module ``Security:`` note).
 
     Returns:
         ``0``/``N`` for a normal exit with code ``N``; ``128 + signo`` if the
         inferior was stopped by a caught signal; ``127`` if ``command`` cannot
         be resolved on ``PATH`` (the POSIX "command not found" convention).
 
+    Raises:
+        ValueError: If ``gdb_cmd_prefix`` (or the ``GDB_CMD_PREFIX`` env var
+            that feeds it) contains an unsafe token. See the module
+            ``Security:`` note for the whitelist.
+
     """
+    prefix = _validate_gdb_cmd_prefix(gdb_cmd_prefix)  # fail fast
+
     core_path = Path(core_dir)
     core_path.mkdir(parents=True, exist_ok=True)
 
@@ -200,7 +265,6 @@ def run_under_gdb(
         print(f"[run-under-gdb] binary   : {command_bin}", file=sys.stderr)
         print(f"[run-under-gdb] args     : {' '.join(command_args)}", file=sys.stderr)
 
-        prefix = gdb_cmd_prefix.split() if gdb_cmd_prefix else []
         gdb_cmd = [
             *prefix,
             "gdb",
@@ -278,12 +342,18 @@ def main(argv: list[str] | None = None) -> int:
             emit_json_status(rc, message="ran command directly (RUN_UNDER_GDB=0)")
         return rc
 
-    rc = run_under_gdb(
-        core_dir=args.core_dir,
-        command=args.command,
-        command_args=args.command_args,
-        gdb_cmd_prefix=os.environ.get("GDB_CMD_PREFIX"),
-    )
+    try:
+        rc = run_under_gdb(
+            core_dir=args.core_dir,
+            command=args.command,
+            command_args=args.command_args,
+            gdb_cmd_prefix=os.environ.get("GDB_CMD_PREFIX"),
+        )
+    except ValueError as exc:
+        print(f"[run-under-gdb] ERROR: {exc}", file=sys.stderr)
+        if args.json:
+            emit_json_status(2, message=f"invalid GDB_CMD_PREFIX: {exc}")
+        return 2
     if args.json:
         emit_json_status(rc, message="ran command under gdb")
     return rc

--- a/tests/unit/forensics/test_gdb_runner.py
+++ b/tests/unit/forensics/test_gdb_runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from hephaestus.forensics.gdb_runner import (
+    _validate_gdb_cmd_prefix,
     build_gdb_script,
     main,
     resolve_command,
@@ -164,3 +165,111 @@ class TestMain:
         monkeypatch.setattr(gdb_runner, "run_under_gdb", lambda **kw: 42)
         rc = main([str(tmp_path), "sh"])
         assert rc == 42
+
+
+class TestValidateGdbCmdPrefix:
+    """Tests for GDB_CMD_PREFIX whitelist validation."""
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "\t\n  "])
+    def test_empty_input_returns_empty_list(self, raw: str | None) -> None:
+        """Empty, None, or whitespace-only input returns an empty list."""
+        assert _validate_gdb_cmd_prefix(raw) == []
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("pixi run --", ["pixi", "run", "--"]),
+            ("/usr/bin/env", ["/usr/bin/env"]),
+            ("env FOO=bar baz", ["env", "FOO=bar", "baz"]),
+            ("nice", ["nice"]),
+            ("direnv exec . --", ["direnv", "exec", ".", "--"]),
+        ],
+    )
+    def test_accepts_safe_prefixes(self, raw: str, expected: list[str]) -> None:
+        """Safe prefixes are validated and returned as token lists."""
+        assert _validate_gdb_cmd_prefix(raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "--init-eval-command=run",
+            "-ex",
+            "pixi --bad",
+            "rm; rm -rf /",
+            "foo|bar",
+            "foo&bar",
+            "foo&&bar",
+            "$(echo hi)",
+            "`id`",
+            "foo>out",
+            "foo<in",
+            "foo*",
+            "foo?",
+            "foo'bar",
+            'foo"bar',
+            "foo\\bar",
+        ],
+    )
+    def test_rejects_unsafe_prefixes(self, raw: str) -> None:
+        """Unsafe prefixes raise ValueError with a descriptive message."""
+        with pytest.raises(ValueError, match="GDB_CMD_PREFIX"):
+            _validate_gdb_cmd_prefix(raw)
+
+
+class TestRunUnderGdbPrefixValidation:
+    """run_under_gdb surfaces the prefix-validation error to callers."""
+
+    def test_unsafe_prefix_raises_before_subprocess(self, tmp_path: Path) -> None:
+        """Hoisted validation fires before resolve_command for unsafe prefix."""
+        with pytest.raises(ValueError, match="GDB_CMD_PREFIX"):
+            run_under_gdb(
+                str(tmp_path / "cores"),
+                _UNRESOLVABLE_CMD,
+                [],
+                gdb_cmd_prefix="--init-eval-command=run",
+            )
+
+    def test_safe_prefix_does_not_raise(self, tmp_path: Path) -> None:
+        """Safe prefix passes validation; unresolvable command still returns 127."""
+        rc = run_under_gdb(
+            str(tmp_path / "cores"),
+            _UNRESOLVABLE_CMD,
+            [],
+            gdb_cmd_prefix="pixi run --",
+        )
+        assert rc == 127
+
+
+class TestMainPrefixValidation:
+    """main() converts validation errors into a clean CLI error + exit 2."""
+
+    def test_main_returns_2_on_unsafe_env_var(self, monkeypatch, capsys, tmp_path: Path) -> None:
+        """main() returns 2 and prints ERROR to stderr for invalid GDB_CMD_PREFIX."""
+        monkeypatch.delenv("RUN_UNDER_GDB", raising=False)
+        monkeypatch.setenv("GDB_CMD_PREFIX", "--init-eval-command=run")
+        rc = main([str(tmp_path / "cores"), _UNRESOLVABLE_CMD])
+        captured = capsys.readouterr()
+        assert rc == 2
+        assert "[run-under-gdb] ERROR:" in captured.err
+        assert "GDB_CMD_PREFIX" in captured.err
+
+    def test_main_json_envelope_on_unsafe_env_var(
+        self, monkeypatch, capsys, tmp_path: Path
+    ) -> None:
+        """main() emits a JSON status envelope with status != ok on invalid prefix."""
+        import json
+
+        monkeypatch.delenv("RUN_UNDER_GDB", raising=False)
+        monkeypatch.setenv("GDB_CMD_PREFIX", "--init-eval-command=run")
+        rc = main(["--json", str(tmp_path / "cores"), _UNRESOLVABLE_CMD])
+        assert rc == 2
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] != "ok"
+        assert "GDB_CMD_PREFIX" in payload["message"]
+
+    def test_main_safe_env_var_unchanged(self, monkeypatch, tmp_path: Path) -> None:
+        """Safe prefix + unresolvable command: validation passes, returns 127."""
+        monkeypatch.delenv("RUN_UNDER_GDB", raising=False)
+        monkeypatch.setenv("GDB_CMD_PREFIX", "pixi run --")
+        rc = main([str(tmp_path / "cores"), _UNRESOLVABLE_CMD])
+        assert rc == 127


### PR DESCRIPTION
## Summary

Harden `hephaestus/forensics/gdb_runner.py` against arbitrary-argument injection through the `GDB_CMD_PREFIX` environment variable.

- Add whitelist validation that restricts tokens to `[A-Za-z0-9_./:=,@+~\-]` and rejects flag-like tokens (except the bare `--`)
- Library callers receive `ValueError` on invalid input
- CLI emits `[run-under-gdb] ERROR: …` to stderr and exits with code 2
- Document security implications and supported sub-runner patterns in module docstring
- Comprehensive test coverage for validation, library error handling, and CLI behavior

Closes #751