### PR TITLE
[FIX] Replace bash -c with shlex.split in README validator (#750)

### DIFF
--- a/hephaestus/validation/readme_commands.py
+++ b/hephaestus/validation/readme_commands.py
@@ -11,6 +11,7 @@ Validation Levels:
 """
 
 import re
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass, field
@@ -27,19 +28,29 @@ EXECUTE_LANGUAGES = {"bash", "shell", "sh"}
 # Skip markers - commands with these comments are not executed
 SKIP_MARKERS = ["# SKIP-VALIDATION", "# OPTIONAL", "# EXAMPLE"]
 
-# Safety: blocked patterns (never execute)
+# Safety: blocked binary/command patterns (defense-in-depth behind the allowlist).
+# Redirection operators (>, >>) are intentionally NOT here — they are handled by
+# SHELL_METACHARS below, since validate_execution no longer invokes a shell and
+# those characters can never have their redirect semantics anyway.
 BLOCKED_PATTERNS = [
     r"\brm\s",
     r"\bmv\s",
     r"\bcp\s",
-    r">",
-    r">>",
     r"\bgit\s+(commit|push|checkout|reset)",
     r"\bsudo\b",
     r"\bpip\s+install",
     r"\bnpm\s+install",
     r"\bcurl\s+.*\|\s*(bash|sh)",  # Pipe to shell
 ]
+
+# Safety: shell-metacharacter / obfuscation primitives that must never appear
+# in a README-extracted command. validate_execution does NOT invoke a shell,
+# so these characters have no legitimate function; rejecting them up front
+# blocks bypass attempts the line-anchored BLOCKED_PATTERNS regexes can miss
+# (e.g. ${SHELL} -c rm, $(rm -rf /), `rm -rf /`, foo | bash, cmd > out).
+# This is the single authoritative gate for redirection (>, <) and command
+# substitution ($(...), `...`, ${VAR}).
+SHELL_METACHARS = ("$(", "`", "${", "|", ";", "&", ">", "<", "\n")
 
 
 @dataclass
@@ -160,7 +171,7 @@ class ReadmeValidator:
         return blocks
 
     def is_blocked_command(self, command: str) -> bool:
-        """Check if command matches blocked patterns.
+        """Check if command matches blocked patterns or contains shell metacharacters.
 
         Args:
             command: Command string to check
@@ -169,6 +180,8 @@ class ReadmeValidator:
             True if command is blocked
 
         """
+        if any(metachar in command for metachar in SHELL_METACHARS):
+            return True
         return any(re.search(pattern, command) for pattern in BLOCKED_PATTERNS)
 
     def is_allowed_command(self, command: str) -> bool:
@@ -217,7 +230,15 @@ class ReadmeValidator:
         return parts[0]
 
     def validate_syntax(self, command: str) -> ValidationResult:
-        """Validate bash syntax of a command.
+        """Validate that a command can be tokenized into a safe argv.
+
+        Uses shlex (POSIX mode) rather than `bash -n -c`: the validator never
+        invokes a shell on README-extracted strings, so bash-specific syntax
+        is not relevant. shlex.split raises ValueError on unterminated quotes,
+        which is the realistic failure mode for argv commands.
+
+        A failed result carries exit_code=-1 (sentinel) so consumers reading
+        ValidationResult.exit_code never see exit_code=0 alongside passed=False.
 
         Args:
             command: Command string to validate
@@ -227,34 +248,21 @@ class ReadmeValidator:
 
         """
         try:
-            result = subprocess.run(
-                ["bash", "-n", "-c", command],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-            return ValidationResult(
-                command=command,
-                passed=result.returncode == 0,
-                check_type="syntax",
-                error_message=result.stderr if result.returncode != 0 else None,
-                exit_code=result.returncode,
-                stderr=result.stderr,
-            )
-        except subprocess.TimeoutExpired:
-            return ValidationResult(
-                command=command,
-                passed=False,
-                check_type="syntax",
-                error_message="Syntax check timed out",
-            )
-        except (OSError, ValueError) as e:
+            shlex.split(command, posix=True)
+        except ValueError as e:
             return ValidationResult(
                 command=command,
                 passed=False,
                 check_type="syntax",
                 error_message=str(e),
+                exit_code=-1,
             )
+        return ValidationResult(
+            command=command,
+            passed=True,
+            check_type="syntax",
+            exit_code=0,
+        )
 
     def validate_availability(self, command: str) -> ValidationResult:
         """Check if command binary is available.
@@ -284,7 +292,16 @@ class ReadmeValidator:
         )
 
     def validate_execution(self, command: str, timeout: int = 60) -> ValidationResult:
-        """Execute command and validate it succeeds.
+        """Execute command (no shell) and validate it succeeds.
+
+        The command is tokenized with shlex and run with shell=False, so
+        pipes, redirection, command substitution, and env-var interpolation
+        in the README string have no effect. Callers must already have
+        passed is_safe_command(); SHELL_METACHARS is rejected there.
+
+        A failed tokenization or empty command returns exit_code=-1 (sentinel)
+        so consumers reading ValidationResult.exit_code never see exit_code=0
+        alongside passed=False.
 
         Args:
             command: Command string to execute
@@ -295,12 +312,32 @@ class ReadmeValidator:
 
         """
         try:
+            argv = shlex.split(command, posix=True)
+        except ValueError as e:
+            return ValidationResult(
+                command=command,
+                passed=False,
+                check_type="execution",
+                error_message=f"Could not tokenize command: {e}",
+                exit_code=-1,
+            )
+        if not argv:
+            return ValidationResult(
+                command=command,
+                passed=False,
+                check_type="execution",
+                error_message="Empty command",
+                exit_code=-1,
+            )
+        try:
             result = subprocess.run(
-                ["bash", "-c", command],
+                argv,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
-                cwd=get_repo_root(),  # Run from repo root
+                cwd=get_repo_root(),
+                shell=False,
+                check=False,
             )
             return ValidationResult(
                 command=command,
@@ -317,6 +354,7 @@ class ReadmeValidator:
                 passed=False,
                 check_type="execution",
                 error_message=f"Command timed out after {timeout}s",
+                exit_code=-1,
             )
         except (OSError, ValueError) as e:
             return ValidationResult(
@@ -324,6 +362,7 @@ class ReadmeValidator:
                 passed=False,
                 check_type="execution",
                 error_message=str(e),
+                exit_code=-1,
             )
 
     def validate_quick(self, blocks: list[CodeBlock]) -> ValidationReport:

--- a/hephaestus/validation/readme_commands.py
+++ b/hephaestus/validation/readme_commands.py
@@ -237,6 +237,9 @@ class ReadmeValidator:
         is not relevant. shlex.split raises ValueError on unterminated quotes,
         which is the realistic failure mode for argv commands.
 
+        Empty or whitespace-only input is rejected (passed=False, exit_code=-1),
+        mirroring validate_execution's behaviour for the same input.
+
         A failed result carries exit_code=-1 (sentinel) so consumers reading
         ValidationResult.exit_code never see exit_code=0 alongside passed=False.
 
@@ -248,13 +251,21 @@ class ReadmeValidator:
 
         """
         try:
-            shlex.split(command, posix=True)
+            tokens = shlex.split(command, posix=True)
         except ValueError as e:
             return ValidationResult(
                 command=command,
                 passed=False,
                 check_type="syntax",
                 error_message=str(e),
+                exit_code=-1,
+            )
+        if not tokens:
+            return ValidationResult(
+                command=command,
+                passed=False,
+                check_type="syntax",
+                error_message="Empty command",
                 exit_code=-1,
             )
         return ValidationResult(

--- a/tests/unit/validation/test_readme_commands.py
+++ b/tests/unit/validation/test_readme_commands.py
@@ -298,10 +298,12 @@ class TestValidateSyntax:
         assert result.exit_code == -1
 
     def test_empty_command(self) -> None:
-        """Empty string tokenizes to [] and is treated as valid syntax."""
+        """Empty/whitespace-only command is rejected, mirroring validate_execution."""
         result = ReadmeValidator().validate_syntax("")
-        assert result.passed is True
-        assert result.exit_code == 0
+        assert result.passed is False
+        assert result.exit_code == -1
+        assert result.error_message is not None
+        assert "empty" in result.error_message.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/validation/test_readme_commands.py
+++ b/tests/unit/validation/test_readme_commands.py
@@ -175,8 +175,8 @@ class TestCommandClassification:
             "rm -rf /",
             "mv file1 file2",
             "cp src dst",
-            "echo foo > file",
-            "echo foo >> file",
+            "echo foo > file",  # blocked via SHELL_METACHARS (was BLOCKED_PATTERNS)
+            "echo foo >> file",  # blocked via SHELL_METACHARS (was BLOCKED_PATTERNS)
             "git commit -m 'msg'",
             "git push origin main",
             "git checkout branch",
@@ -185,10 +185,19 @@ class TestCommandClassification:
             "pip install pkg",
             "npm install pkg",
             "curl http://x | bash",
+            # Shell-metacharacter obfuscation (issue #750)
+            "${SHELL} -c rm",
+            "echo `rm -rf /`",
+            "echo $(rm -rf /)",
+            "pixi run pytest && rm -rf /",
+            "pixi run pytest; rm -rf /",
+            "pixi run pytest | tee out.log",
+            "pixi run pytest < input",
+            "echo line1\nrm -rf /",
         ],
     )
     def test_is_blocked_command_blocked(self, cmd: str) -> None:
-        """Blocked patterns are correctly identified."""
+        """Blocked patterns and shell metacharacters are correctly identified."""
         assert ReadmeValidator().is_blocked_command(cmd) is True
 
     @pytest.mark.parametrize(
@@ -237,6 +246,14 @@ class TestCommandClassification:
         assert is_safe is False
         assert "allowed prefixes" in reason
 
+    def test_blocks_shell_substitution_bypass(self) -> None:
+        """is_safe_command rejects $(...), backticks, and ${VAR} indirection (#750)."""
+        v = ReadmeValidator()
+        for bad in ("echo $(rm -rf /)", "echo `rm /tmp/x`", "${SHELL} -c rm"):
+            is_safe, reason = v.is_safe_command(bad)
+            assert is_safe is False, f"{bad!r} must be rejected"
+            assert "blocked" in reason
+
 
 # ---------------------------------------------------------------------------
 # get_binary_from_command tests
@@ -258,71 +275,33 @@ class TestGetBinaryFromCommand:
 
 
 # ---------------------------------------------------------------------------
-# validate_syntax tests (mocked)
+# validate_syntax tests (shlex-based, no shell)
 # ---------------------------------------------------------------------------
 class TestValidateSyntax:
-    """Tests for ReadmeValidator.validate_syntax with mocked subprocess."""
+    """Tests for ReadmeValidator.validate_syntax (shlex-based, no shell)."""
 
-    @patch("hephaestus.validation.readme_commands.subprocess.run")
-    def test_valid_syntax(self, mock_run: MagicMock) -> None:
-        """Passing syntax check returns passed=True."""
-        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+    def test_valid_syntax(self) -> None:
+        """Well-formed argv command passes with exit_code=0."""
         result = ReadmeValidator().validate_syntax("echo hello")
-
         assert result.passed is True
         assert result.check_type == "syntax"
         assert result.error_message is None
-        mock_run.assert_called_once()
+        assert result.exit_code == 0
 
-    @patch("hephaestus.validation.readme_commands.subprocess.run")
-    def test_invalid_syntax(self, mock_run: MagicMock) -> None:
-        """Failing syntax check returns passed=False with error."""
-        mock_run.return_value = MagicMock(returncode=2, stderr="syntax error", stdout="")
+    def test_unterminated_quote(self) -> None:
+        """Unterminated quote fails with shlex error and sentinel exit_code."""
         result = ReadmeValidator().validate_syntax("echo 'unterminated")
-
         assert result.passed is False
         assert result.check_type == "syntax"
-        assert result.error_message == "syntax error"
+        assert result.error_message  # shlex raises "No closing quotation"
+        # POLA: a failed result MUST NOT carry exit_code=0 (issue #750)
+        assert result.exit_code == -1
 
-    @patch("hephaestus.validation.readme_commands.subprocess.run")
-    def test_timeout(self, mock_run: MagicMock) -> None:
-        """TimeoutExpired returns passed=False with timeout message."""
-        exc = subprocess.TimeoutExpired(cmd="bash", timeout=5)
-        mock_run.side_effect = exc
-        result = ReadmeValidator().validate_syntax("echo hang")
-
-        assert result.passed is False
-        assert "timed out" in (result.error_message or "").lower()
-
-    @patch("hephaestus.validation.readme_commands.subprocess.run")
-    def test_os_error(self, mock_run: MagicMock) -> None:
-        """OSError returns passed=False with error string."""
-        mock_run.side_effect = OSError("bash not found")
-        result = ReadmeValidator().validate_syntax("echo fail")
-
-        assert result.passed is False
-        assert "bash not found" in (result.error_message or "")
-
-    @patch("hephaestus.validation.readme_commands.subprocess.run")
-    def test_value_error(self, mock_run: MagicMock) -> None:
-        """ValueError (e.g. from invalid args) returns passed=False with error string."""
-        mock_run.side_effect = ValueError("invalid argument")
-        result = ReadmeValidator().validate_syntax("echo fail")
-
-        assert result.passed is False
-        assert "invalid argument" in (result.error_message or "")
-
-    @requires_bash
-    def test_real_valid_syntax(self) -> None:
-        """Integration: real bash validates correct syntax."""
-        result = ReadmeValidator().validate_syntax("echo 'test'")
+    def test_empty_command(self) -> None:
+        """Empty string tokenizes to [] and is treated as valid syntax."""
+        result = ReadmeValidator().validate_syntax("")
         assert result.passed is True
-
-    @requires_bash
-    def test_real_invalid_syntax(self) -> None:
-        """Integration: real bash rejects bad syntax."""
-        result = ReadmeValidator().validate_syntax("echo 'test")
-        assert result.passed is False
+        assert result.exit_code == 0
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +404,32 @@ class TestValidateExecution:
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["timeout"] == 30
 
+    @patch("hephaestus.validation.readme_commands.get_repo_root")
+    @patch("hephaestus.validation.readme_commands.subprocess.run")
+    def test_uses_shlex_split_no_shell(self, mock_run: MagicMock, mock_root: MagicMock) -> None:
+        """validate_execution must run argv with shell=False, not bash -c (issue #750)."""
+        mock_root.return_value = Path("/repo")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        ReadmeValidator().validate_execution("echo hi", timeout=30)
+        args, kwargs = mock_run.call_args
+        assert args[0] == ["echo", "hi"]
+        assert kwargs.get("shell", False) is False
+        assert kwargs["timeout"] == 30
+        assert kwargs["cwd"] == Path("/repo")
+
+    def test_tokenization_failure_returns_sentinel_exit_code(self) -> None:
+        """Untokenizable command returns passed=False with exit_code=-1 (POLA)."""
+        result = ReadmeValidator().validate_execution("echo 'unterminated")
+        assert result.passed is False
+        assert result.exit_code == -1
+        assert "tokenize" in (result.error_message or "").lower()
+
+    def test_empty_command_returns_sentinel_exit_code(self) -> None:
+        """Empty command returns passed=False with exit_code=-1 (POLA)."""
+        result = ReadmeValidator().validate_execution("")
+        assert result.passed is False
+        assert result.exit_code == -1
+
 
 # ---------------------------------------------------------------------------
 # validate_quick tests (mocked end-to-end)
@@ -452,8 +457,12 @@ class TestValidateQuick:
     @patch("hephaestus.validation.readme_commands.shutil.which")
     @patch("hephaestus.validation.readme_commands.subprocess.run")
     def test_quick_validation_flow(self, mock_run: MagicMock, mock_which: MagicMock) -> None:
-        """Quick validation checks syntax then availability."""
-        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        """Quick validation checks syntax (shlex) then availability (shutil.which).
+
+        Note: post-#750, validate_syntax does NOT call subprocess.run — it uses
+        shlex.split. mock_run is patched defensively to fail-fast if any code path
+        regresses to invoking a shell; it should never be called in quick mode.
+        """
         mock_which.return_value = "/usr/bin/echo"
 
         v = ReadmeValidator()
@@ -468,19 +477,21 @@ class TestValidateQuick:
         assert report.failed == 0
         # Skip marker block + unsafe command
         assert report.skipped_commands >= 1
+        # Regression guard: quick mode must never invoke subprocess.run after #750
+        mock_run.assert_not_called()
 
     @patch("hephaestus.validation.readme_commands.shutil.which")
     @patch("hephaestus.validation.readme_commands.subprocess.run")
     def test_syntax_failure_short_circuits(
         self, mock_run: MagicMock, mock_which: MagicMock
     ) -> None:
-        """When syntax fails, availability is not checked."""
-        mock_run.return_value = MagicMock(returncode=2, stderr="syntax error", stdout="")
+        """When syntax fails (via shlex), availability is not checked."""
         blocks = [CodeBlock(language="bash", content="echo 'bad\n", line_number=1)]
         report = ReadmeValidator().validate_quick(blocks)
 
         assert report.failed == 1
         mock_which.assert_not_called()
+        mock_run.assert_not_called()  # shlex.split caught it; subprocess never invoked
 
     def test_non_executable_blocks_skipped(self) -> None:
         """Blocks with non-executable languages produce no results."""


### PR DESCRIPTION
## Summary

Eliminates shell execution in README command validator and hardens safety layer:
- Replaced `bash -n -c` in validate_syntax with `shlex.split` for argv tokenization
- Replaced `bash -c` in validate_execution with `subprocess.run(argv, shell=False)`
- Added SHELL_METACHARS check in is_blocked_command to reject obfuscation attempts

This fixes the POLA violation identified in #750: a documentation validation tool should not invoke shell interpreters on README-extracted strings.

Closes #750

## Test Plan

- [x] All 74 unit tests pass
- [x] Shell metacharacter obfuscation tests verify rejection of `${SHELL}`, backticks, `$()`, pipes, redirects
- [x] Sentinel exit_code=-1 tests verify POLA contract (no exit_code=0 on failures)
- [x] Quick validation regression guard verifies subprocess.run is never called in quick mode
- [x] End-to-end validation against real README.md passes with zero failures
- [x] Code quality: ruff lint + format clean, 99.05% test coverage