### PR TITLE
fix(automation): post PR reviews via REST so in-loop reviewer stops spurious NOGO

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1233,12 +1233,20 @@ def gh_pr_review_post(
 
     owner, repo = get_repo_info()
 
-    # Fetch the PR node ID via REST
-    pr_info = _gh_call(["api", f"repos/{owner}/{repo}/pulls/{pr_number}", "--jq", ".node_id"])
-    pr_node_id = pr_info.stdout.strip()
-
-    # Build threads list for the mutation
-    thread_items = [
+    # Build the inline-comment list. The REST reviews endpoint natively accepts
+    # ``{path, line, side, body}`` — unlike the GraphQL
+    # ``DraftPullRequestReviewComment`` input type, which only exposes
+    # ``path``/``position``/``body`` and has NO ``line``/``side`` fields. The
+    # previous GraphQL mutation therefore failed twice over:
+    #   1. ``-f comments=<json-string>`` sent the array as a STRING, so GitHub
+    #      rejected every post ("Variable $comments ... was provided invalid
+    #      value"; even ``[]`` failed with 'Expected "[]" to be a key-value
+    #      object'), and the loop treated every PR as a spurious NOGO.
+    #   2. Even passed as a typed array, ``line``/``side`` are undefined on
+    #      ``DraftPullRequestReviewComment``.
+    # POST /pulls/{n}/reviews is the correct surface for ``line``/``side``
+    # comments and for summary-only (empty ``comments``) reviews alike.
+    review_comments = [
         {
             "path": c["path"],
             "line": c["line"],
@@ -1248,59 +1256,36 @@ def gh_pr_review_post(
         for c in comments
     ]
 
-    # The mutation only returns the new review's node id. We deliberately do
-    # NOT try to read the review's threads off the comment nodes: a
-    # ``PullRequestReviewComment`` has no ``pullRequestReviewThread`` field, so
-    # the old query (added for the #375 "foreign thread" fix) failed at the
-    # GraphQL layer on *every* call ("Field 'pullRequestReviewThread' doesn't
-    # exist on type 'PullRequestReviewComment'"), meaning no review ever
-    # posted. Instead we capture the review id here and resolve *this* review's
-    # threads in a follow-up ``pullRequest.reviewThreads`` query
-    # (:func:`_review_threads_for_review`), matching on the review id so we
-    # still exclude pre-existing human-reviewer threads.
-    mutation = """
-mutation AddReview(
-  $prId: ID!, $body: String!,
-  $event: PullRequestReviewEvent!,
-  $comments: [DraftPullRequestReviewComment!]
-) {
-  addPullRequestReview(
-    input: {pullRequestId: $prId, body: $body, event: $event, comments: $comments}
-  ) {
-    pullRequestReview {
-      id
-    }
-  }
-}
-"""
+    request_body = json.dumps({"body": summary, "event": event, "comments": review_comments})
+    fd, input_path = tempfile.mkstemp(prefix="gh-review-", suffix=".json")
+    try:
+        os.close(fd)
+        io_write_secure(Path(input_path), request_body)
+        result = _gh_call(
+            [
+                "api",
+                "-X",
+                "POST",
+                f"repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+                "--input",
+                input_path,
+            ]
+        )
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(input_path)
 
-    threads_json = json.dumps(thread_items)
-    result = _gh_call(
-        [
-            "api",
-            "graphql",
-            "-f",
-            f"query={mutation}",
-            "-f",
-            f"prId={pr_node_id}",
-            "-f",
-            f"body={summary}",
-            "-f",
-            f"event={event}",
-            "-f",
-            f"comments={threads_json}",
-        ]
-    )
-
-    data = json.loads(result.stdout)
-    _check_graphql_errors(data, f"gh_pr_review_post(pr={pr_number})")
-    review_data = data.get("data", {}).get("addPullRequestReview", {}).get("pullRequestReview", {})
-    review_id = review_data.get("id")
-    if not review_id:
-        logger.warning("Posted PR review on #%s but no review id returned", pr_number)
+    review = json.loads(result.stdout)
+    # The REST payload returns both the numeric ``id`` and the GraphQL global
+    # ``node_id``. The thread-resolution follow-up matches on the GraphQL review
+    # node id, so pass that through (preserving the #375 guarantee that only
+    # threads created by *this* review are returned).
+    review_node_id = review.get("node_id")
+    if not review_node_id:
+        logger.warning("Posted PR review on #%s but no review node id returned", pr_number)
         return []
 
-    thread_ids = _review_threads_for_review(pr_number, review_id)
+    thread_ids = _review_threads_for_review(pr_number, review_node_id)
     logger.info("Posted PR review on #%s; created %s thread(s)", pr_number, len(thread_ids))
     return thread_ids
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1599,22 +1599,21 @@ class TestGhPrReviewPost:
 
     @staticmethod
     def _gh_call_side_effect(review_id: str, threads: list[dict[str, Any]]) -> Any:
-        """Build a side_effect covering the three _gh_call invocations.
+        """Build a side_effect covering the two _gh_call invocations.
 
-        1. REST fetch of the PR node id (``--jq .node_id``)
-        2. ``addPullRequestReview`` mutation → ``pullRequestReview { id }``
-        3. ``reviewThreads`` follow-up query
+        1. ``POST /pulls/{n}/reviews`` (REST) → ``{id, node_id}``. The review
+           body is delivered via ``--input <file>`` and natively supports
+           ``line``/``side`` inline comments and empty comment lists.
+        2. ``reviewThreads`` follow-up GraphQL query, matched on the returned
+           review node id.
         """
 
         def _side_effect(args: list[str], *_: Any, **__: Any) -> Any:
             joined = " ".join(args)
             result = Mock()
-            if "--jq" in args:
-                result.stdout = "PR_node_123"
-            elif "addPullRequestReview" in joined:
-                result.stdout = json.dumps(
-                    {"data": {"addPullRequestReview": {"pullRequestReview": {"id": review_id}}}}
-                )
+            if "/reviews" in joined:
+                # REST review POST returns numeric id + GraphQL node_id.
+                result.stdout = json.dumps({"id": 999, "node_id": review_id})
             elif "reviewThreads" in joined:
                 result.stdout = json.dumps(
                     {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": threads}}}}}
@@ -1688,3 +1687,69 @@ class TestGhPrReviewPost:
         thread_ids = gh_pr_review_post(pr_number=7, comments=[], summary="x", dry_run=True)
         assert thread_ids == []
         mock_gh_call.assert_not_called()
+
+    @staticmethod
+    def _review_post_call(mock_gh_call: Any) -> Any:
+        """Return the _gh_call invocation that POSTed the review via REST.
+
+        The review body is delivered via ``gh api -X POST .../reviews --input
+        <file>``; ``--input`` files are unlinked after the call, so the body must
+        be inspected from inside the side_effect, not here.
+        """
+        for call in mock_gh_call.call_args_list:
+            sent_args = call.args[0] if call.args else call.kwargs.get("args", [])
+            if any(isinstance(a, str) and a.endswith("/reviews") for a in sent_args):
+                return call
+        raise AssertionError("review POST was never sent")
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_comments_sent_as_typed_json_body_not_stringified_field(
+        self, mock_gh_call: Any, _mock_repo: Any
+    ) -> None:
+        """Inline comments must reach gh as a typed JSON body, never as a stringified ``-f`` field.
+
+        Regression: ``gh api graphql -f comments='[{...}]'`` sent the array as a
+        *string*, so GitHub rejected every review post ("Variable $comments ...
+        was provided invalid value") and the loop saw a spurious NOGO. The review
+        is now POSTed to ``/pulls/{n}/reviews`` with the body delivered via
+        ``--input`` (a typed JSON body), and ``line``/``side`` are sent verbatim.
+        """
+        mock_gh_call.side_effect = self._gh_call_side_effect("REVIEW_1", [])
+
+        gh_pr_review_post(
+            pr_number=7,
+            comments=[{"path": "a.py", "line": 1, "side": "RIGHT", "body": "fix"}],
+            summary="Findings",
+        )
+
+        sent_args = self._review_post_call(mock_gh_call).args[0]
+        # No stringified comments field anywhere in argv.
+        assert not any(isinstance(a, str) and a.startswith("comments=") for a in sent_args), (
+            "comments must not be passed as a stringified field"
+        )
+        assert not any(
+            isinstance(a, str) and a.startswith("-f") and "comments" in a for a in sent_args
+        )
+        # The typed body is delivered via --input to the REST reviews endpoint.
+        assert "--input" in sent_args, "review body must be sent via --input"
+        assert any(isinstance(a, str) and a.endswith("/reviews") for a in sent_args)
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_empty_comments_still_posts_summary_review(
+        self, mock_gh_call: Any, _mock_repo: Any
+    ) -> None:
+        """An empty ``comments`` list must post a summary-only review, not crash.
+
+        Regression: even ``comments=[]`` failed under the stringified GraphQL form
+        (``Expected "[]" to be a key-value object``), so summary-only NOGO reviews
+        could never post and the loop always saw a spurious failure.
+        """
+        mock_gh_call.side_effect = self._gh_call_side_effect("REVIEW_1", [])
+
+        # Must not raise.
+        gh_pr_review_post(pr_number=7, comments=[], summary="Summary only")
+
+        # The review POST was still sent.
+        self._review_post_call(mock_gh_call)


### PR DESCRIPTION
## Summary

The bulk implementer's in-loop PR reviewer crashed on every call, marking every PR `state:implementation-no-go` and never arming auto-merge — even clean, green PRs (observed live: 19 PRs from one batch, 0 reached GO).

**Root cause:** `gh_pr_review_post` posted the review via a GraphQL `addPullRequestReview` mutation, passing the typed `$comments` array as a stringified `-f comments=` field. `gh -f` sends strings, so GitHub rejected every call (`Variable $comments ... was provided invalid value`); even `[]` failed (`Expected "[]" to be a key-value object`). The reviewer caught the error and treated it as NOGO. `DraftPullRequestReviewComment` also lacks `line`/`side` fields, so inline comments were doubly invalid.

**Fix:** Post via REST `POST /pulls/{n}/reviews`, body delivered through `gh api --input <file>` (typed JSON). REST natively accepts `{path, line, side, body}` and empty comment lists, and returns the GraphQL `node_id` the existing thread-resolution follow-up needs (preserves the #375 guarantee).

## Verification

- New regression tests in `TestGhPrReviewPost`: body sent via `--input` (never a stringified field); empty comments still posts a summary review.
- `pixi run pytest tests/unit/automation/` → 1077 passed.
- `ruff check` / `ruff format --check` / `mypy` clean.
- End-to-end against the live GitHub API: summary-only review posts cleanly on a real PR.

Closes #938