### PR TITLE
docs(readme): point non-Linux users to wheel install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,48 @@ codex plugin add hephaestus@project-hephaestus
 
 The Codex manifest lives in [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json), and the marketplace entry lives in [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
 
+### Installing in Another Project
+
+ProjectHephaestus is published to PyPI as `homericintelligence-hephaestus`.
+The wheel is pure-Python and installs on Linux, macOS, and Windows
+(see `requires-python` in [`pyproject.toml`](pyproject.toml)). This is
+the supported install path for non-Linux platforms.
+
+**Using pip:**
+
+```bash
+pip install homericintelligence-hephaestus
+```
+
+**Using Pixi:**
+
+Add to `pyproject.toml`:
+
+```toml
+[project]
+dependencies = [
+    "homericintelligence-hephaestus>=0.9,<1",
+]
+```
+
+Or add a PyPI entry to `pixi.toml`:
+
+```toml
+[pypi-dependencies]
+homericintelligence-hephaestus = ">=0.9,<1"
+```
+
+Then run `pixi install` to resolve the dependency.
+
+After 1.0 ships, bump these constraints to `>=1.0,<2`.
+
+**For local development (path dependency):**
+
+```toml
+[pypi-dependencies]
+homericintelligence-hephaestus = { path = "../ProjectHephaestus", editable = true }
+```
+
 ## Key Features
 
 ### General Utilities (`hephaestus.utils`)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ ProjectHephaestus/
 
 This project uses [Pixi](https://pixi.sh) for environment management, which automatically handles dependencies and creates isolated environments.
 
+> **Platform note:** The pixi developer environment is **Linux-64 only** (see
+> `platforms` in [`pixi.toml`](pixi.toml)). On macOS or Windows, install the
+> published wheel into a plain virtualenv instead — see
+> [From PyPI](#from-pypi) above. The
+> full comparison table (install paths, supported platforms, Python versions)
+> lives in [CONTRIBUTING.md#platform-support](CONTRIBUTING.md#platform-support).
+
 ### Prerequisites
 
 Install Pixi by following the [official installation guide](https://pixi.sh/install/).

--- a/tests/unit/validation/test_readme_platform_support.py
+++ b/tests/unit/validation/test_readme_platform_support.py
@@ -1,0 +1,46 @@
+"""Regression test for README ↔ CONTRIBUTING platform-support cross-reference.
+
+Issue #767: install/upgrade docs for non-Linux platforms must point readers
+from the README (the first-landed surface) to the canonical comparison table
+in CONTRIBUTING.md. This test guards both halves of that link.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+README = REPO_ROOT / "README.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+# Markdown anchor GitHub generates for "### Platform Support".
+PLATFORM_SUPPORT_ANCHOR = "CONTRIBUTING.md#platform-support"
+
+
+def test_contributing_has_platform_support_heading() -> None:
+    """The canonical Platform Support table must exist in CONTRIBUTING.md."""
+    text = CONTRIBUTING.read_text(encoding="utf-8")
+    assert "### Platform Support" in text, (
+        "CONTRIBUTING.md must contain a '### Platform Support' heading; README links to its anchor."
+    )
+
+
+def test_readme_links_to_platform_support_section() -> None:
+    """README must cross-link to the CONTRIBUTING Platform Support anchor."""
+    text = README.read_text(encoding="utf-8")
+    assert PLATFORM_SUPPORT_ANCHOR in text, (
+        f"README.md must link to {PLATFORM_SUPPORT_ANCHOR} so macOS/Windows "
+        "readers find the supported install path before running `pixi install`."
+    )
+
+
+def test_readme_flags_pixi_as_linux_only() -> None:
+    """README must warn that the pixi dev env is Linux-only before `pixi install`."""
+    text = README.read_text(encoding="utf-8")
+    pixi_section_start = text.index("## Getting Started with Pixi")
+    pixi_install_pos = text.index("pixi install", pixi_section_start)
+    preface = text[pixi_section_start:pixi_install_pos]
+    assert "linux-64" in preface.lower() or "linux only" in preface.lower(), (
+        "README must mention the linux-64 restriction before the first "
+        "`pixi install` command so off-Linux users do not hit a hard failure."
+    )

--- a/tests/unit/validation/test_readme_platform_support.py
+++ b/tests/unit/validation/test_readme_platform_support.py
@@ -37,7 +37,10 @@ def test_readme_links_to_platform_support_section() -> None:
 def test_readme_flags_pixi_as_linux_only() -> None:
     """README must warn that the pixi dev env is Linux-only before `pixi install`."""
     text = README.read_text(encoding="utf-8")
-    pixi_section_start = text.index("## Getting Started with Pixi")
+    pixi_section_start = text.find("## Getting Started with Pixi")
+    assert pixi_section_start != -1, (
+        "README must contain a '## Getting Started with Pixi' section heading"
+    )
     pixi_install_pos = text.find("pixi install", pixi_section_start)
     assert pixi_install_pos != -1, (
         "README must contain 'pixi install' command in the Getting Started section"

--- a/tests/unit/validation/test_readme_platform_support.py
+++ b/tests/unit/validation/test_readme_platform_support.py
@@ -38,7 +38,10 @@ def test_readme_flags_pixi_as_linux_only() -> None:
     """README must warn that the pixi dev env is Linux-only before `pixi install`."""
     text = README.read_text(encoding="utf-8")
     pixi_section_start = text.index("## Getting Started with Pixi")
-    pixi_install_pos = text.index("pixi install", pixi_section_start)
+    pixi_install_pos = text.find("pixi install", pixi_section_start)
+    assert pixi_install_pos != -1, (
+        "README must contain 'pixi install' command in the Getting Started section"
+    )
     preface = text[pixi_section_start:pixi_install_pos]
     assert "linux-64" in preface.lower() or "linux only" in preface.lower(), (
         "README must mention the linux-64 restriction before the first "


### PR DESCRIPTION
## Summary

Add explicit platform support guidance to README: pixi dev environment is Linux-64 only, while the published wheel supports macOS/Windows via pip. Cross-reference the canonical platform comparison table in CONTRIBUTING.md (from PR #932). Add regression test to prevent anchor drift between README and CONTRIBUTING.

Closes #767

## Test plan

- [x] Run regression tests: `pixi run pytest tests/unit/validation/test_readme_platform_support.py -v` (all 3 pass)
- [x] Run full validation suite: `pixi run pytest tests/unit/validation -v` (649 passed)
- [x] Pre-commit hooks pass: `pre-commit run --files README.md tests/unit/validation/test_readme_platform_support.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)