### PR TITLE
fix(forensics): use shlex.split() for GDB_CMD_PREFIX parsing

### DIFF
--- a/hephaestus/forensics/gdb_runner.py
+++ b/hephaestus/forensics/gdb_runner.py
@@ -20,7 +20,9 @@ Environment variables:
 * ``RUN_UNDER_GDB=0`` — skip gdb entirely and exec the command directly
   (local-dev escape hatch; gdb adds overhead).
 * ``GDB_CMD_PREFIX`` — optional command prefix inserted before ``gdb``, e.g.
-  ``"pixi run --"``, so gdb and its inferior inherit an activated environment.
+  ``"pixi run --"``. Parsed with ``shlex.split`` so values containing
+  shell-quoted whitespace (e.g. ``"'/path with space/pixi' run --"``) are
+  tokenized correctly.
 
 Exit code:
 
@@ -33,6 +35,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -161,9 +164,10 @@ def run_under_gdb(
         core_dir: Directory for cores and gdb logs (created if absent).
         command: The program to run. Resolved via ``PATH`` if not a path.
         command_args: Arguments passed to ``command`` verbatim.
-        gdb_cmd_prefix: Optional whitespace-separated command prefix inserted
-            before ``gdb`` (e.g. ``"pixi run --"``) so gdb and its inferior
-            inherit an activated environment.
+        gdb_cmd_prefix: Optional command prefix inserted before ``gdb`` (e.g.
+            ``"pixi run --"``) so gdb and its inferior inherit an activated
+            environment. Parsed with :func:`shlex.split` to honor shell quoting
+            rules, so paths with embedded whitespace can be quoted.
 
     Returns:
         ``0``/``N`` for a normal exit with code ``N``; ``128 + signo`` if the
@@ -200,7 +204,7 @@ def run_under_gdb(
         print(f"[run-under-gdb] binary   : {command_bin}", file=sys.stderr)
         print(f"[run-under-gdb] args     : {' '.join(command_args)}", file=sys.stderr)
 
-        prefix = gdb_cmd_prefix.split() if gdb_cmd_prefix else []
+        prefix = shlex.split(gdb_cmd_prefix) if gdb_cmd_prefix else []
         gdb_cmd = [
             *prefix,
             "gdb",
@@ -260,7 +264,8 @@ def main(argv: list[str] | None = None) -> int:
     Reads two environment variables:
 
     * ``RUN_UNDER_GDB=0`` — bypass gdb and exec the command directly.
-    * ``GDB_CMD_PREFIX`` — optional prefix word list inserted before ``gdb``.
+    * ``GDB_CMD_PREFIX`` — optional prefix inserted before ``gdb``; parsed with
+      ``shlex.split`` so shell-quoted whitespace in paths is preserved.
 
     Args:
         argv: Argument vector (defaults to ``sys.argv[1:]``).

--- a/tests/unit/forensics/test_gdb_runner.py
+++ b/tests/unit/forensics/test_gdb_runner.py
@@ -116,6 +116,83 @@ class TestRunUnderGdb:
         assert rc == 5
 
 
+class TestGdbCmdPrefixParsing:
+    """Regression tests for GDB_CMD_PREFIX shell-quote parsing (issue #756)."""
+
+    @staticmethod
+    def _capture_argv(monkeypatch) -> list[list[str]]:
+        captured: list[list[str]] = []
+
+        def fake_run(argv, check=False):
+            captured.append(list(argv))
+
+            class _R:
+                returncode = 0
+
+            return _R()
+
+        monkeypatch.setattr("hephaestus.forensics.gdb_runner.subprocess.run", fake_run)
+        return captured
+
+    def test_prefix_none_yields_no_prefix_tokens(self, monkeypatch, tmp_path) -> None:
+        captured = self._capture_argv(monkeypatch)
+        run_under_gdb(str(tmp_path / "cores"), "sh", ["-c", "true"], gdb_cmd_prefix=None)
+        assert captured, "subprocess.run was not invoked"
+        assert captured[0][0] == "gdb"
+
+    def test_prefix_empty_string_yields_no_prefix_tokens(self, monkeypatch, tmp_path) -> None:
+        captured = self._capture_argv(monkeypatch)
+        run_under_gdb(str(tmp_path / "cores"), "sh", ["-c", "true"], gdb_cmd_prefix="")
+        assert captured[0][0] == "gdb"
+
+    def test_unquoted_prefix_splits_on_whitespace(self, monkeypatch, tmp_path) -> None:
+        captured = self._capture_argv(monkeypatch)
+        run_under_gdb(
+            str(tmp_path / "cores"),
+            "sh",
+            ["-c", "true"],
+            gdb_cmd_prefix="pixi run --",
+        )
+        argv = captured[0]
+        assert argv[:3] == ["pixi", "run", "--"]
+        assert argv[3] == "gdb"
+
+    def test_single_quoted_path_with_spaces_stays_one_token(self, monkeypatch, tmp_path) -> None:
+        """Regression for issue #756: '/path with space/pixi' must be ONE token."""
+        captured = self._capture_argv(monkeypatch)
+        run_under_gdb(
+            str(tmp_path / "cores"),
+            "sh",
+            ["-c", "true"],
+            gdb_cmd_prefix="'/path with space/pixi' run --",
+        )
+        argv = captured[0]
+        assert argv[:3] == ["/path with space/pixi", "run", "--"]
+        assert argv[3] == "gdb"
+
+    def test_double_quoted_path_with_spaces_stays_one_token(self, monkeypatch, tmp_path) -> None:
+        captured = self._capture_argv(monkeypatch)
+        run_under_gdb(
+            str(tmp_path / "cores"),
+            "sh",
+            ["-c", "true"],
+            gdb_cmd_prefix='"/abs path/to/pixi" run --',
+        )
+        argv = captured[0]
+        assert argv[:3] == ["/abs path/to/pixi", "run", "--"]
+
+    def test_malformed_quoting_raises_valueerror(self, monkeypatch, tmp_path) -> None:
+        """Unclosed quotes surface as ValueError, not as silently broken argv."""
+        self._capture_argv(monkeypatch)
+        with pytest.raises(ValueError):
+            run_under_gdb(
+                str(tmp_path / "cores"),
+                "sh",
+                ["-c", "true"],
+                gdb_cmd_prefix="'unterminated",
+            )
+
+
 class TestMain:
     """Tests for the CLI entry point."""
 


### PR DESCRIPTION
## Summary

Replace naive whitespace `.split()` with `shlex.split()` so that `GDB_CMD_PREFIX` values containing quoted whitespace (e.g., `"'/path with space/pixi' run --"`) tokenize correctly instead of silently fragmenting.

## Changes

- Update `gdb_runner.py:203` to use `shlex.split()` instead of `.split()`
- Add import `shlex` at the top of the module (alphabetically placed)
- Update docstrings at three sites to document shell-quoting behavior:
  - Module-level env var documentation (lines 22-25)
  - `run_under_gdb()` parameter docstring (lines 164-170)
  - `main()` docstring (lines 266-268)
- Add regression test class `TestGdbCmdPrefixParsing` with 6 test cases covering:
  - None and empty-string prefix (no tokenization)
  - Unquoted whitespace-separated prefix
  - Single-quoted and double-quoted paths with embedded spaces
  - Malformed quoting (unclosed quotes raise ValueError)

## Test Results

All tests pass:
- 20 passed, 2 skipped (gdb not installed in test environment, expected)
- New regression tests all pass
- No regressions in existing tests
- Code passes ruff linting and formatting checks

Closes #756

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>