### PR TITLE
fix(nats): remove redundant asyncio.wait_for around next_msg

### DIFF
--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -315,11 +315,8 @@ class NATSSubscriberThread(threading.Thread):
             while not self._stop_event.is_set():
                 for sub in subscriptions:
                     try:
-                        msg = await asyncio.wait_for(
-                            sub.next_msg(timeout=0.5),
-                            timeout=1.0,
-                        )
-                    except (asyncio.TimeoutError, TimeoutError):
+                        msg = await sub.next_msg(timeout=0.5)
+                    except TimeoutError:
                         continue
 
                     try:

--- a/tests/unit/nats/test_subscriber_polling.py
+++ b/tests/unit/nats/test_subscriber_polling.py
@@ -1,0 +1,37 @@
+"""Tests for the inner polling timeout behavior of _subscribe_loop (#753)."""
+from __future__ import annotations
+
+import inspect
+
+from hephaestus.nats import subscriber
+
+
+def test_polling_loop_source_code_does_not_use_asyncio_wait_for() -> None:
+    """Regression: source code must not contain asyncio.wait_for around next_msg (#753)."""
+    source = inspect.getsource(subscriber.NATSSubscriberThread._subscribe_loop)
+    assert (
+        "asyncio.wait_for" not in source
+    ), "asyncio.wait_for must not be used to wrap next_msg (issue #753)"
+
+
+def test_polling_loop_uses_only_next_msg_timeout() -> None:
+    """The inner timeout=0.5 on next_msg is the only timeout mechanism."""
+    source = inspect.getsource(subscriber.NATSSubscriberThread._subscribe_loop)
+    # Check that next_msg is called with timeout=0.5
+    assert (
+        "next_msg(timeout=0.5)" in source
+    ), "next_msg must be called with timeout=0.5"
+    # Check the except clause catches TimeoutError only
+    assert "except TimeoutError:" in source, "except clause must catch TimeoutError"
+
+
+def test_except_clause_not_redundant() -> None:
+    """The except clause should not catch both asyncio.TimeoutError and TimeoutError."""
+    source = inspect.getsource(subscriber.NATSSubscriberThread._subscribe_loop)
+    # On Python 3.10+, catching both is redundant
+    assert (
+        "except (asyncio.TimeoutError, TimeoutError):" not in source
+    ), "except clause must not catch both asyncio.TimeoutError and TimeoutError"
+    assert (
+        "except TimeoutError:" in source
+    ), "except clause should catch TimeoutError only"


### PR DESCRIPTION
## Summary

Removes the redundant outer `asyncio.wait_for(timeout=1.0)` wrapper around `sub.next_msg(timeout=0.5)` in the NATS polling loop. The inner 0.5s timeout always fires first, making the outer wrapper dead code per issue #753.

Also simplifies the except clause from `(asyncio.TimeoutError, TimeoutError)` to `TimeoutError` since they are equivalent on Python 3.10+ (the project's minimum version).

## Changes

- Removed `asyncio.wait_for()` wrapper from `hephaestus/nats/subscriber.py:318-321`
- Simplified except clause to catch only `TimeoutError`
- Added regression tests in `tests/unit/nats/test_subscriber_polling.py` to prevent re-introduction

## Test Plan

✅ All 61 existing NATS tests pass
✅ 3 new regression tests confirm:
  - `asyncio.wait_for` is not used
  - `next_msg(timeout=0.5)` is called directly
  - Except clause catches only `TimeoutError`
✅ Type checking: Success (305 source files)
✅ Lint: All checks passed

Closes #753

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>