### PR TITLE
fix(packaging): include NOTICE and COMPATIBILITY.md in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,8 @@ only-include = [
     "hephaestus",
     "README.md",
     "LICENSE",
+    "NOTICE",
+    "COMPATIBILITY.md",
     "pyproject.toml",
 ]
 

--- a/tests/integration/test_sdist_contents.py
+++ b/tests/integration/test_sdist_contents.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Integration test: sdist ships required top-level metadata files."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_TOP_LEVEL_FILES = {
+    "README.md",
+    "LICENSE",
+    "NOTICE",
+    "COMPATIBILITY.md",
+    "pyproject.toml",
+}
+
+
+@pytest.mark.integration
+def test_sdist_includes_notice_and_compatibility(tmp_path: Path) -> None:
+    """Building the sdist must include NOTICE and COMPATIBILITY.md (issue #765)."""
+    subprocess.run(
+        [sys.executable, "-m", "build", "--sdist", "--outdir", str(tmp_path)],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    sdists = list(tmp_path.glob("*.tar.gz"))
+    assert len(sdists) == 1, f"expected one sdist, got {sdists}"
+
+    with tarfile.open(sdists[0], "r:gz") as tf:
+        # sdist members are prefixed with "<name>-<version>/"; strip the prefix.
+        top_level = {
+            Path(m.name).parts[1]
+            for m in tf.getmembers()
+            if len(Path(m.name).parts) == 2 and m.isfile()
+        }
+
+    missing = REQUIRED_TOP_LEVEL_FILES - top_level
+    assert not missing, f"sdist is missing required files: {sorted(missing)}"
+    assert len(top_level) > 3, f"suspiciously few top-level files: {top_level}"


### PR DESCRIPTION
## Summary

Add NOTICE and COMPATIBILITY.md to [tool.hatch.build.targets.sdist] only-include so PyPI sdist consumers receive the third-party-license NOTICE file (referenced by README at line 400) and the project's compatibility policy.

## Test Plan

- [x] New integration test `tests/integration/test_sdist_contents.py` validates required files are shipped
- [x] Direct tar inspection confirms files are present in built sdist
- [x] Full integration test suite passes
- [x] All unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, markdown lint, yaml lint, bandit, etc.)
- [x] No unwanted directories (.claude, tests, scripts, .github) leaked into sdist

Closes #765