### PR TITLE
feat(nats): expose reconnect backoff via NATSConfig and env vars

### DIFF
--- a/hephaestus/nats/config.py
+++ b/hephaestus/nats/config.py
@@ -124,15 +124,15 @@ def load_nats_config(
             data["durable_name"] = env_durable
 
         env_initial = os.environ.get("NATS_INITIAL_BACKOFF_SECONDS")
-        if env_initial:
+        if env_initial is not None:
             data["initial_backoff_seconds"] = float(env_initial)
 
         env_max = os.environ.get("NATS_MAX_BACKOFF_SECONDS")
-        if env_max:
+        if env_max is not None:
             data["max_backoff_seconds"] = float(env_max)
 
         env_mult = os.environ.get("NATS_BACKOFF_MULTIPLIER")
-        if env_mult:
+        if env_mult is not None:
             data["backoff_multiplier"] = float(env_mult)
 
     return NATSConfig(**data)

--- a/hephaestus/nats/config.py
+++ b/hephaestus/nats/config.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Valid JetStream first-subscription deliver policies. These string values match
 # nats.js.api.DeliverPolicy's enum values, so the subscriber can build the enum
@@ -37,6 +37,9 @@ class NATSConfig(BaseModel):
         subjects: Subject patterns to subscribe to.
         durable_name: Durable consumer name for at-least-once delivery.
         deliver_policy: JetStream deliver policy for first-time subscription.
+        initial_backoff_seconds: Initial wait before the first reconnect attempt.
+        max_backoff_seconds: Upper bound for exponential reconnect backoff.
+        backoff_multiplier: Multiplier applied to backoff after each reconnect.
 
     """
 
@@ -55,6 +58,30 @@ class NATSConfig(BaseModel):
         default="new",
         description="JetStream deliver policy (new, all, last, etc.)",
     )
+    initial_backoff_seconds: float = Field(
+        default=1.0,
+        gt=0.0,
+        description="Initial wait (seconds) before the first reconnect attempt.",
+    )
+    max_backoff_seconds: float = Field(
+        default=60.0,
+        gt=0.0,
+        description="Upper bound (seconds) for exponential reconnect backoff.",
+    )
+    backoff_multiplier: float = Field(
+        default=2.0,
+        gt=1.0,
+        description="Multiplier applied to the current backoff after each failed reconnect.",
+    )
+
+    @model_validator(mode="after")
+    def _check_backoff_bounds(self) -> NATSConfig:
+        if self.max_backoff_seconds < self.initial_backoff_seconds:
+            raise ValueError(
+                "max_backoff_seconds must be >= initial_backoff_seconds "
+                f"(got max={self.max_backoff_seconds}, initial={self.initial_backoff_seconds})"
+            )
+        return self
 
 
 def load_nats_config(
@@ -69,6 +96,9 @@ def load_nats_config(
     - ``NATS_URL`` overrides ``url``
     - ``NATS_STREAM`` overrides ``stream``
     - ``NATS_DURABLE_NAME`` overrides ``durable_name``
+    - ``NATS_INITIAL_BACKOFF_SECONDS`` overrides ``initial_backoff_seconds``
+    - ``NATS_MAX_BACKOFF_SECONDS`` overrides ``max_backoff_seconds``
+    - ``NATS_BACKOFF_MULTIPLIER`` overrides ``backoff_multiplier``
 
     Args:
         yaml_config: Parsed YAML section for the NATS block.
@@ -92,5 +122,17 @@ def load_nats_config(
         env_durable = os.environ.get("NATS_DURABLE_NAME")
         if env_durable:
             data["durable_name"] = env_durable
+
+        env_initial = os.environ.get("NATS_INITIAL_BACKOFF_SECONDS")
+        if env_initial:
+            data["initial_backoff_seconds"] = float(env_initial)
+
+        env_max = os.environ.get("NATS_MAX_BACKOFF_SECONDS")
+        if env_max:
+            data["max_backoff_seconds"] = float(env_max)
+
+        env_mult = os.environ.get("NATS_BACKOFF_MULTIPLIER")
+        if env_mult:
+            data["backoff_multiplier"] = float(env_mult)
 
     return NATSConfig(**data)

--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -40,10 +40,6 @@ from hephaestus.nats.events import NATSEvent
 
 logger = logging.getLogger(__name__)
 
-_INITIAL_BACKOFF_SECONDS = 1.0
-_MAX_BACKOFF_SECONDS = 60.0
-_BACKOFF_MULTIPLIER = 2.0
-
 DEFAULT_JOIN_TIMEOUT: float = 5.0
 """Default join timeout (seconds) for :meth:`NATSSubscriberThread.stop`."""
 
@@ -234,7 +230,7 @@ class NATSSubscriberThread(threading.Thread):
             self._config.durable_name,
         )
 
-        backoff = _INITIAL_BACKOFF_SECONDS
+        backoff = self._config.initial_backoff_seconds
 
         try:
             while not self._stop_event.is_set():
@@ -244,7 +240,7 @@ class NATSSubscriberThread(threading.Thread):
                         loop.run_until_complete(self._subscribe_loop())
                     finally:
                         loop.close()
-                    backoff = _INITIAL_BACKOFF_SECONDS
+                    backoff = self._config.initial_backoff_seconds
                 except Exception as exc:
                     if self._stop_event.is_set():
                         break
@@ -254,7 +250,10 @@ class NATSSubscriberThread(threading.Thread):
                         backoff,
                     )
                     self._stop_event.wait(timeout=backoff)
-                    backoff = min(backoff * _BACKOFF_MULTIPLIER, _MAX_BACKOFF_SECONDS)
+                    backoff = min(
+                        backoff * self._config.backoff_multiplier,
+                        self._config.max_backoff_seconds,
+                    )
         except Exception as exc:
             with self._state_lock:
                 self._last_error = exc

--- a/tests/unit/nats/test_config.py
+++ b/tests/unit/nats/test_config.py
@@ -36,6 +36,28 @@ class TestNATSConfig:
         config = NATSConfig(enabled=True)
         assert config.enabled is True
 
+    def test_backoff_defaults_preserve_historical_constants(self) -> None:
+        config = NATSConfig()
+        assert config.initial_backoff_seconds == 1.0
+        assert config.max_backoff_seconds == 60.0
+        assert config.backoff_multiplier == 2.0
+
+    def test_initial_backoff_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            NATSConfig(initial_backoff_seconds=0.0)
+
+    def test_max_backoff_must_be_positive(self) -> None:
+        with pytest.raises(ValueError):
+            NATSConfig(max_backoff_seconds=-1.0)
+
+    def test_backoff_multiplier_must_exceed_one(self) -> None:
+        with pytest.raises(ValueError):
+            NATSConfig(backoff_multiplier=1.0)
+
+    def test_max_below_initial_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            NATSConfig(initial_backoff_seconds=10.0, max_backoff_seconds=5.0)
+
 
 class TestLoadNATSConfig:
     """Tests for load_nats_config()."""
@@ -69,3 +91,30 @@ class TestLoadNATSConfig:
         config = load_nats_config({})
         assert config.enabled is False
         assert config.durable_name == "hephaestus-subscriber"
+
+    def test_env_override_initial_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NATS_INITIAL_BACKOFF_SECONDS", "0.5")
+        config = load_nats_config({})
+        assert config.initial_backoff_seconds == 0.5
+
+    def test_env_override_max_backoff(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NATS_MAX_BACKOFF_SECONDS", "120.0")
+        config = load_nats_config({})
+        assert config.max_backoff_seconds == 120.0
+
+    def test_env_override_backoff_multiplier(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NATS_BACKOFF_MULTIPLIER", "3.0")
+        config = load_nats_config({})
+        assert config.backoff_multiplier == 3.0
+
+    def test_env_override_invalid_float_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NATS_INITIAL_BACKOFF_SECONDS", "not-a-number")
+        with pytest.raises(ValueError):
+            load_nats_config({})
+
+    def test_env_override_disabled_ignores_backoff_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("NATS_INITIAL_BACKOFF_SECONDS", "9.9")
+        config = load_nats_config({}, env_override=False)
+        assert config.initial_backoff_seconds == 1.0

--- a/tests/unit/nats/test_subscriber_backoff.py
+++ b/tests/unit/nats/test_subscriber_backoff.py
@@ -1,0 +1,77 @@
+"""Tests that NATSSubscriberThread reads backoff from NATSConfig, not module constants."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hephaestus.nats.config import NATSConfig
+from hephaestus.nats.subscriber import NATSSubscriberThread
+
+
+class TestSubscriberReadsBackoffFromConfig:
+    """Tests that subscriber reads backoff configuration from NATSConfig."""
+
+    def test_initial_backoff_taken_from_config(self) -> None:
+        config = NATSConfig(
+            enabled=True,
+            initial_backoff_seconds=0.25,
+            max_backoff_seconds=4.0,
+            backoff_multiplier=3.0,
+        )
+        thread = NATSSubscriberThread(config=config, handler=MagicMock())
+        # Force one iteration of the reconnect loop, then bail.
+        call_count = {"n": 0}
+
+        def _fake_run_until_complete(_coro: object) -> None:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("boom")
+            thread._stop_event.set()
+
+        waited: list[float] = []
+
+        def _fake_wait(timeout: float) -> bool:
+            waited.append(timeout)
+            return False
+
+        with (
+            patch("asyncio.new_event_loop") as new_loop,
+            patch.object(thread._stop_event, "wait", side_effect=_fake_wait),
+        ):
+            new_loop.return_value.run_until_complete.side_effect = _fake_run_until_complete
+            thread.run()
+
+        # First backoff must equal the config's initial value, not the old 1.0 constant.
+        assert waited and waited[0] == 0.25
+
+    def test_max_backoff_caps_growth(self) -> None:
+        config = NATSConfig(
+            enabled=True,
+            initial_backoff_seconds=1.0,
+            max_backoff_seconds=2.0,
+            backoff_multiplier=10.0,
+        )
+        thread = NATSSubscriberThread(config=config, handler=MagicMock())
+        iters = {"n": 0}
+
+        def _fake_run_until_complete(_coro: object) -> None:
+            iters["n"] += 1
+            if iters["n"] >= 3:
+                thread._stop_event.set()
+            raise RuntimeError("boom")
+
+        waited: list[float] = []
+
+        def _fake_wait(timeout: float) -> bool:
+            waited.append(timeout)
+            return False
+
+        with (
+            patch("asyncio.new_event_loop") as new_loop,
+            patch.object(thread._stop_event, "wait", side_effect=_fake_wait),
+        ):
+            new_loop.return_value.run_until_complete.side_effect = _fake_run_until_complete
+            thread.run()
+
+        # After multiplier=10, second wait would be 10.0; capped to max=2.0.
+        assert max(waited) == 2.0


### PR DESCRIPTION
## Summary
Expose hardcoded NATS reconnection backoff constants as configurable fields in NATSConfig with sensible defaults. Operators and chaos tests can now tune the reconnection cadence via environment variables without code changes.

## Changes
- Add three fields to NATSConfig: `initial_backoff_seconds`, `max_backoff_seconds`, `backoff_multiplier` with defaults (1.0, 60.0, 2.0)
- Implement field-level validation (`gt=0.0`, `gt=1.0`) and cross-field validator to ensure max >= initial
- Add environment variable overrides: `NATS_INITIAL_BACKOFF_SECONDS`, `NATS_MAX_BACKOFF_SECONDS`, `NATS_BACKOFF_MULTIPLIER`
- Update NATSSubscriberThread.run() to read backoff from config instead of module constants
- Add comprehensive test coverage for new fields and env-var overrides

## Test Plan
- [x] All 70 NATS unit tests pass
- [x] Backoff field validation tests pass (positive values, multiplier > 1, max >= initial)
- [x] Environment variable override tests pass
- [x] Subscriber reads backoff from config (verified with mock tests)
- [x] Defaults preserve historical behavior (1.0 / 60.0 / 2.0)
- [x] Code quality checks pass (ruff, formatting)

Closes #758