### PR TITLE
fix(scripts): use portable shebang in setup_api_key.sh

### DIFF
--- a/scripts/shell/setup_api_key.sh
+++ b/scripts/shell/setup_api_key.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Helper script to export ANTHROPIC_API_KEY from Claude CLI credentials
 # This is necessary for container execution which needs the key in environment
 


### PR DESCRIPTION
Fix POLA violation in scripts/shell/setup_api_key.sh by changing shebang from `#!/bin/bash` to `#!/usr/bin/env bash` to match all sibling scripts in scripts/shell/.

This improves portability on systems where bash is not installed at `/bin/bash` (e.g., NixOS, some BSDs, Homebrew-installed bash on macOS).

Changes:
- scripts/shell/setup_api_key.sh:1 — shebang changed to use `/usr/bin/env bash`

Closes #770