### PR TITLE
fix(github): include cwd in run_git_cmd log line

### DIFF
--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -71,7 +71,10 @@ def run_git_cmd(cmd: list[str], dry_run: bool = False, cwd: str | None = None) -
         cwd: Working directory
 
     """
-    logger.info("$ %s", " ".join(cmd))
+    if cwd is not None:
+        logger.info("$ %s (cwd=%s)", " ".join(cmd), cwd)
+    else:
+        logger.info("$ %s", " ".join(cmd))
     run_subprocess(cmd, cwd=cwd, dry_run=dry_run)
 
 

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -84,6 +84,20 @@ class TestRunGitCmd:
         run_git_cmd(["git", "log"], cwd="/some/path")
         mock_run.assert_called_once_with(["git", "log"], cwd="/some/path", dry_run=False)
 
+    @patch("hephaestus.github.pr_merge.logger")
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_log_includes_cwd_when_provided(self, _mock_run, mock_logger) -> None:
+        """Log line includes (cwd=...) when cwd is passed."""
+        run_git_cmd(["git", "log"], cwd="/some/path")
+        mock_logger.info.assert_called_once_with("$ %s (cwd=%s)", "git log", "/some/path")
+
+    @patch("hephaestus.github.pr_merge.logger")
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_log_omits_cwd_when_not_provided(self, _mock_run, mock_logger) -> None:
+        """Log line omits cwd suffix when cwd is None (no noise added to existing traces)."""
+        run_git_cmd(["git", "status"])
+        mock_logger.info.assert_called_once_with("$ %s", "git status")
+
 
 class TestChecksSuccessAndPrint:
     """Tests for checks_success_and_log."""


### PR DESCRIPTION
## Summary

Include working directory context in the log line for `run_git_cmd` when called with a non-None cwd parameter. This eliminates ambiguity in multi-worktree or multi-repo scenarios.

The log format is conditional:
- When `cwd=None` (default): existing format is preserved to avoid noise
- When `cwd` is provided: format becomes `$ <cmd> (cwd=<path>)`

## Test Plan

- All 48 existing tests in `test_pr_merge.py` pass
- Two new tests verify the conditional logging behavior:
  - `test_log_includes_cwd_when_provided`: verifies cwd appears when provided
  - `test_log_omits_cwd_when_not_provided`: verifies no noise in default case
- All linting and type checks pass

Closes #771