### PR TITLE
docs(code-of-conduct): bulleted pledge list (#777)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,24 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of:
+
+- age
+- body size
+- visible or invisible disability
+- ethnicity
+- sex characteristics
+- gender identity and expression
+- level of experience
+- education
+- socio-economic status
+- nationality
+- personal appearance
+- race
+- caste
+- color
+- religion
+- sexual identity and orientation
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 


### PR DESCRIPTION
Reformats the Our Pledge demographics list as a bulleted list to match Contributor Covenant 2.1 source rendering. Wording is unchanged.

Closes #777