### PR TITLE
fix(automation): validate incompatible agent flags to prevent silent no-ops

### DIFF
--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -138,6 +138,40 @@ def run_codex(
     return 0
 
 
+# Flag values that silently no-op when --agent=claude is selected.
+# - `approval` is not a parameter of run_claude_text at all, so any
+#   non-default value (i.e. != "never") is a no-op.
+# - `sandbox="read-only"` IS honored (run_claude_text:125 gates
+#   --permission-mode on it), so only `danger-full-access` is a no-op.
+# See issue #773.
+_CLAUDE_NOOP_VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
+    ("approval", "--approval", frozenset({"untrusted", "on-request"})),
+    ("sandbox", "--sandbox", frozenset({"danger-full-access"})),
+)
+
+
+def validate_agent_flags(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """Reject flag values that the selected agent does not honor.
+
+    Only fires when the operator EXPLICITLY passed ``--agent=claude``. When
+    ``--agent`` is omitted, ``resolve_agent`` will auto-detect at run time and
+    that path keeps its existing semantics. See issue #773.
+    """
+    if args.agent != "claude":
+        return
+    offending: list[str] = []
+    for attr, flag, noop_values in _CLAUDE_NOOP_VALUES:
+        value = getattr(args, attr)
+        if value in noop_values:
+            offending.append(f"{flag}={value}")
+    if offending:
+        parser.error(
+            "--agent=claude does not honor "
+            + ", ".join(offending)
+            + " (these flag values only apply to --agent=codex)"
+        )
+
+
 def run_agent(args: argparse.Namespace) -> int:
     """Run one provider-selected automation stage and persist its output/log files."""
     repo_root = Path(args.repo_root).expanduser().resolve()
@@ -163,7 +197,9 @@ def run_agent(args: argparse.Namespace) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     """Run the agent stage command-line interface."""
-    args = build_parser().parse_args(argv)
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    validate_agent_flags(parser, args)
     exit_code = run_agent(args)
     if args.json:
         emit_json_status(exit_code, stage=args.stage, agent=args.agent)

--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -168,7 +168,7 @@ def validate_agent_flags(parser: argparse.ArgumentParser, args: argparse.Namespa
         parser.error(
             "--agent=claude does not honor "
             + ", ".join(offending)
-            + " (these flag values only apply to --agent=codex)"
+            + " (these flag values are not supported by the claude agent)"
         )
 
 

--- a/tests/unit/automation/test_agent_stage.py
+++ b/tests/unit/automation/test_agent_stage.py
@@ -91,3 +91,148 @@ def test_run_agent_rejects_unsupported_direct_agent_value(tmp_path: Path) -> Non
 
     with pytest.raises(ValueError, match="Unsupported agent: bogus"):
         agent_stage.run_agent(args)
+
+
+def test_main_rejects_approval_flag_with_claude_agent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--approval is Codex-only; passing it with --agent=claude must error (issue #773)."""
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "claude",
+        "--approval",
+        "on-request",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        agent_stage.main(argv)
+    assert exc.value.code == 2
+    assert "--approval=on-request" in capsys.readouterr().err
+
+
+def test_main_rejects_danger_full_access_sandbox_with_claude_agent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """--sandbox=danger-full-access silently no-ops on claude; must error (issue #773)."""
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "claude",
+        "--sandbox",
+        "danger-full-access",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        agent_stage.main(argv)
+    assert exc.value.code == 2
+    assert "--sandbox=danger-full-access" in capsys.readouterr().err
+
+
+def test_main_allows_read_only_sandbox_with_claude_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--sandbox=read-only IS honored by run_claude_text and must NOT be rejected.
+
+    Regression guard for the over-restriction caught in plan review of issue #773.
+    """
+
+    def fake_run_claude_text(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["claude"], 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(agent_stage, "run_claude_text", fake_run_claude_text)
+    monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "claude")
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "claude",
+        "--sandbox",
+        "read-only",
+    ]
+    assert agent_stage.main(argv) == 0
+
+
+def test_main_allows_default_flags_with_claude_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defaults must pass validation; only explicit no-op values are rejected."""
+
+    def fake_run_claude_text(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["claude"], 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(agent_stage, "run_claude_text", fake_run_claude_text)
+    monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "claude")
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "claude",
+    ]
+    assert agent_stage.main(argv) == 0
+
+
+def test_main_allows_approval_with_codex_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex honors --approval, so validation must not fire."""
+
+    def fake_run_codex_session(*a: object, **kw: object) -> AgentRunResult:
+        return AgentRunResult(stdout="ok", stderr="", session_id=None)
+
+    monkeypatch.setattr(agent_stage, "run_codex_session", fake_run_codex_session)
+    monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "codex")
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "codex",
+        "--approval",
+        "on-request",
+    ]
+    assert agent_stage.main(argv) == 0


### PR DESCRIPTION
## Summary

Reject --approval and certain --sandbox values when --agent=claude is selected, as these flags are only honored by --agent=codex. Operators no longer have flag values silently ignored.

## Changes

- Added `validate_agent_flags()` to check for flag-agent incompatibilities at parse time
- `--approval` with non-default values is rejected (only applies to codex)
- `--sandbox=danger-full-access` is rejected (only applies to codex)
- `--sandbox=read-only` is explicitly allowed (it IS honored by run_claude_text)

## Test Plan

- ✅ `test_main_rejects_approval_flag_with_claude_agent` — confirms --approval rejection
- ✅ `test_main_rejects_danger_full_access_sandbox_with_claude_agent` — confirms sandbox rejection
- ✅ `test_main_allows_read_only_sandbox_with_claude_agent` — regression guard for allowed sandbox value
- ✅ `test_main_allows_default_flags_with_claude_agent` — defaults still work
- ✅ `test_main_allows_approval_with_codex_agent` — codex path unaffected
- ✅ All existing tests still pass

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)