### PR TITLE
docs(license): use inception-year copyright to stop silent aging

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024-2026, Micah Villmow
+Copyright (c) 2024, Micah Villmow
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ProjectHephaestus
-Copyright (c) 2024-2026, Micah Villmow
+Copyright (c) 2024, Micah Villmow
 
 This product is distributed under the BSD 3-Clause License (see LICENSE).
 


### PR DESCRIPTION
Update LICENSE and NOTICE copyright strings to use inception year only (2024), eliminating silent aging of date ranges.

Closes #784