### PR TITLE
docs(notice): formalize LGPL-3.0 rationale for PyGithub extra

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -27,10 +27,19 @@ These packages are installed only when the corresponding extra is requested
 
   github extra
     PyGithub    LGPL-3.0-only
-                LGPL-3.0 is compatible with BSD-3-Clause distribution when the
-                LGPL library is dynamically linked (as Python imports do). This
-                project does not modify PyGithub; consumers can replace it via
-                their own pip resolution.
+                SPDX: https://spdx.org/licenses/LGPL-3.0-only.html
+
+                ProjectHephaestus declares PyGithub as an optional pip
+                dependency under the `[github]` extra. We do not vendor,
+                modify, redistribute, or statically embed PyGithub's
+                source; the wheel we publish contains zero PyGithub code.
+                Users who install the extra obtain PyGithub directly from
+                PyPI under its own LGPL-3.0-only terms, and may substitute
+                a different version (e.g. `pip install <fork>`) without
+                rebuilding ProjectHephaestus. The authoritative analysis
+                of LGPL-3.0 obligations on combining works is in the
+                LGPLv3 license text itself, which PyPI distributes with
+                every PyGithub release.
 
   nats extra
     nats-py     Apache-2.0


### PR DESCRIPTION
Formalizes the LGPL-3.0 compatibility statement in NOTICE to address the informal "dynamically linked" language and provide verifiable authoritative sources instead.

## Changes

Replaced the informal 4-line compatibility justification with a more formal 9-line statement that:

1. **Links to SPDX:** Provides the authoritative SPDX identifier page
2. **States verifiable facts:** Documents what this project does (declares a pip dependency, does not vendor/modify/redistribute PyGithub source)
3. **Points to authoritative source:** References the LGPLv3 license text itself as the source for detailed obligations analysis

## Verification

- ✓ NOTICE passes all pre-commit checks
- ✓ SPDX URL verified and present
- ✓ No unverified FSF FAQ links present
- ✓ All adjacent sections unchanged
- ✓ Commit cryptographically signed

Closes #783