### PR TITLE
docs(extras): document that [all] excludes [dev]

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ print(hephaestus.__version__)
 
 > **Note on naming.** `pip install hephaestus` and `pip install project-hephaestus` will **not** find this package — both names are unowned on PyPI. The `HomericIntelligence-<Project>` prefix is the deliberate naming convention shared across the HomericIntelligence ecosystem (ProjectKeystone, ProjectOdyssey, etc.) to avoid PyPI namespace collisions. Wheel filenames are PEP 625 normalized to lowercase, so you will see `homericintelligence_hephaestus-<version>-py3-none-any.whl` on disk and in release assets.
 
+### Optional dependencies
+
+`pyproject.toml` defines several extras groups. `[all]` is a **runtime** aggregator
+and intentionally excludes `[dev]` (which carries test/lint tooling such as
+pytest, ruff, and mypy):
+
+- `pip install HomericIntelligence-Hephaestus[all]` — installs all runtime
+  extras: `github`, `nats`, `toml`, `xml`, `schema`.
+- `pip install HomericIntelligence-Hephaestus[dev]` — installs development and
+  testing dependencies. Use this for contributors and CI.
+- `pip install "HomericIntelligence-Hephaestus[all,dev]"` — both, for a full
+  development environment via pip (Pixi users get this automatically via
+  `pixi install`).
+- Individual extras (e.g. `[github]`, `[schema]`) are available for users who
+  only need one integration.
+
 ### Development setup
 
 For local development, use [Pixi](https://pixi.sh) to manage the environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ dependencies = [
     "tzdata; platform_system == 'Windows'",
 ]
 
+# Optional-dependency groups. The `all` aggregator below intentionally lists
+# only runtime extras (github, nats, toml, xml, schema) — `dev` is kept separate
+# so production installs of `[all]` do not pull pytest/ruff/mypy. If you change
+# this convention, update the "Optional dependencies" section in README.md.
 [project.optional-dependencies]
 dev = [
     # pytest 9.x and pytest-cov 7.x are the latest majors; tight floors are


### PR DESCRIPTION
## Summary

Documents the existing convention in `pyproject.toml` where the `[all]` extras
group aggregates only runtime dependencies (`github`, `nats`, `toml`, `xml`,
`schema`) and intentionally excludes `[dev]` (test/lint tooling). This prevents
users installing `pip install hephaestus[all]` from expecting test dependencies
to be included.

## Changes

1. **README.md**: Added "Optional dependencies" subsection (lines 168–185) explaining the `[all]` vs `[dev]` distinction with usage examples
2. **pyproject.toml**: Added 4-line intent comment (lines 37–40) documenting the convention for future editors

No behavior changes — documentation-only fix for a NITPICK audit finding.

## Testing

- ✓ Pre-commit hooks pass (markdown lint, TOML syntax, version checks)
- ✓ 624 unit validation tests pass
- ✓ Sanity check confirms `[all]` does not include `[dev]` and all 5 runtime extras present

Closes #786

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>