### PR TITLE
fix(scripts): replace hardcoded version with dynamic hephaestus.__version__

### DIFF
--- a/scripts/example_usage.py
+++ b/scripts/example_usage.py
@@ -8,6 +8,7 @@ in ProjectHephaestus.
 import tempfile
 from pathlib import Path
 
+import hephaestus
 from hephaestus.cli.utils import add_logging_args, create_parser
 
 # Import our utilities
@@ -46,7 +47,7 @@ def main():
         # Write data
         sample_data = {
             "name": "ProjectHephaestus",
-            "version": "0.1.0",
+            "version": hephaestus.__version__,
             "modules": ["config", "logging", "io", "utils", "cli"],
         }
 


### PR DESCRIPTION
## Summary
Replace hardcoded version string in sample data with the live installed package version.

This eliminates documentation drift vs. hatch-vcs dynamic versioning and keeps the demo script in sync with releases. The package already exposes `hephaestus.__version__` via importlib.metadata, which is the canonical source of truth.

Closes #787