### PR TITLE
feat(cli): standardize --dry-run help text across all CLIs

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -25,6 +25,7 @@ import threading
 from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument
+from hephaestus.cli.utils import add_dry_run_arg
 
 from .github_api import _gh_call
 
@@ -117,11 +118,7 @@ def build_review_parser(
     )
     add_agent_argument(parser)
     add_max_workers_arg(parser)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help=dry_run_help,
-    )
+    add_dry_run_arg(parser, prefix=dry_run_help)
     parser.add_argument(
         "--no-ui",
         action="store_true",

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -1060,8 +1060,8 @@ class AddressReviewer(BaseReviewer):
                     logger.info("  #%s: %s", issue_num, result.error)
 
 
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the address review CLI."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for address review CLI."""
     parser = build_review_parser(
         description=(
             "Find PRs with unresolved review threads and use Claude Code or Codex to fix the "
@@ -1079,10 +1079,15 @@ Examples:
   %(prog)s --issues 595 596 597 --max-workers 5
         """,
         issues_help="Issue numbers whose linked PRs should have review threads addressed",
-        dry_run_help=("Show what would be done without actually resolving threads or pushing code"),
+        dry_run_help="Show what would be done without actually resolving threads or pushing code.",
     )
     add_json_arg(parser)
-    return parser.parse_args()
+    return parser
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the address review CLI."""
+    return _build_parser().parse_args(argv)
 
 
 def main() -> int:

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -30,7 +30,7 @@ from hephaestus.agents.runtime import (
     run_codex_session,
     session_agent_matches,
 )
-from hephaestus.cli.utils import add_json_arg, emit_json_status
+from hephaestus.cli.utils import add_dry_run_arg, add_json_arg, emit_json_status
 
 from ._review_utils import add_max_workers_arg, find_pr_for_issue
 from .advise_runner import run_advise
@@ -3068,8 +3068,8 @@ def _setup_logging(verbose: bool = False) -> None:
     )
 
 
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the CI driver CLI."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for the CI-driver CLI."""
     parser = argparse.ArgumentParser(
         description="Drive PRs to green CI: fix failures and enable auto-merge",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -3121,10 +3121,9 @@ Examples:
     )
     add_agent_argument(parser)
     add_max_workers_arg(parser)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done without any GitHub writes or git pushes",
+    add_dry_run_arg(
+        parser,
+        prefix="Suppress GitHub writes and git pushes (no comments, no merges, no pushes).",
     )
     parser.add_argument(
         "--no-ui",
@@ -3169,8 +3168,12 @@ Examples:
         ),
     )
     add_json_arg(parser)
+    return parser
 
-    return parser.parse_args()
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the CI driver CLI."""
+    return _build_parser().parse_args(argv)
 
 
 def _evaluate_run_result(

--- a/hephaestus/automation/implementer_cli.py
+++ b/hephaestus/automation/implementer_cli.py
@@ -23,7 +23,12 @@ from pathlib import Path
 
 from hephaestus.agents.runtime import add_agent_argument, resolve_agent
 from hephaestus.automation._review_utils import add_max_workers_arg
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import (
+    add_dry_run_arg,
+    add_json_arg,
+    add_version_arg,
+    emit_json_status,
+)
 
 from .models import ImplementerOptions
 
@@ -49,8 +54,8 @@ def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
         logging.getLogger().addHandler(fh)
 
 
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the implementer CLI."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for the implementer CLI."""
     parser = argparse.ArgumentParser(
         description="Bulk implement GitHub issues using Claude Code or Codex",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -117,10 +122,9 @@ Examples:
         action="store_true",
         help="Don't enable auto-merge after implementation-review GO",
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be done without actually doing it",
+    add_dry_run_arg(
+        parser,
+        prefix="Suppress GitHub mutations and git pushes (no PR creation, no commits).",
     )
     parser.add_argument(
         "--no-learn",
@@ -155,8 +159,13 @@ Examples:
     )
     add_json_arg(parser)
     add_version_arg(parser)
+    return parser
 
-    args = parser.parse_args()
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the implementer CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
 
     if args.epic and args.issues:
         parser.error("Cannot specify both --epic and --issues")

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -41,7 +41,12 @@ from hephaestus.agents.runtime import add_agent_argument, resolve_agent
 from hephaestus.automation._review_utils import add_max_workers_arg
 from hephaestus.automation.ci_driver import _pr_is_failing
 from hephaestus.automation.claude_timeouts import gh_cli_timeout
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import (
+    add_dry_run_arg,
+    add_json_arg,
+    add_version_arg,
+    emit_json_status,
+)
 from hephaestus.config.paths import DEFAULT_PROJECTS_DIR, resolve_projects_dir
 from hephaestus.constants import scripts_dir as _scripts_dir
 from hephaestus.resilience.subprocess_resilience import resilient_call
@@ -333,12 +338,16 @@ def _read_work_report(path: str) -> int | None:
 # ---------------------------------------------------------------------------
 
 
-def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for the loop runner."""
     p = argparse.ArgumentParser(
         prog="hephaestus-automation-loop",
         description="Run the 3-stage automation pipeline across HomericIntelligence repos.",
     )
-    p.add_argument("--dry-run", action="store_true", help="Pass --dry-run to every phase")
+    add_dry_run_arg(
+        p,
+        prefix="Forward --dry-run to every phase (suppresses GitHub mutations and git pushes).",
+    )
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
     add_max_workers_arg(
         p,
@@ -444,7 +453,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("-v", "--verbose", action="store_true", help="Enable DEBUG logging")
     add_json_arg(p)
     add_version_arg(p)
-    return p.parse_args(argv)
+    return p
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the loop runner."""
+    return _build_parser().parse_args(argv)
 
 
 def _validate_phases(phases_csv: str) -> tuple[str, ...]:

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
 from hephaestus.automation._review_utils import add_max_workers_arg
-from hephaestus.cli.utils import add_json_arg, emit_json_status
+from hephaestus.cli.utils import add_dry_run_arg, add_json_arg, emit_json_status
 from hephaestus.github.rate_limit import wait_until
 
 from .claude_invoke import invoke_claude_with_session, parse_review_verdict, scan_quota_reset
@@ -619,8 +619,8 @@ def _setup_logging(verbose: bool = False) -> None:
     )
 
 
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the plan reviewer CLI."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for plan_reviewer CLI."""
     parser = argparse.ArgumentParser(
         description="Review implementation plans posted to GitHub issues using Claude",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -649,14 +649,9 @@ Examples:
     )
     add_agent_argument(parser)
     add_max_workers_arg(parser)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help=(
-            "Suppress GitHub mutations (no review comments posted). NOTE: Claude "
-            "is still invoked to analyse plans — dry-run still incurs full "
-            "Claude token cost. It is for correctness rehearsal, not cost preview."
-        ),
+    add_dry_run_arg(
+        parser,
+        prefix="Suppress GitHub mutations (no review comments posted).",
     )
     parser.add_argument(
         "--no-ui",
@@ -670,8 +665,12 @@ Examples:
         help="Enable verbose logging",
     )
     add_json_arg(parser)
+    return parser
 
-    return parser.parse_args()
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the plan reviewer CLI."""
+    return _build_parser().parse_args(argv)
 
 
 def main() -> int:

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -17,7 +17,12 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument, resolve_agent
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import (
+    add_dry_run_arg,
+    add_json_arg,
+    add_version_arg,
+    emit_json_status,
+)
 
 from .advise_runner import advise_skipped, ensure_mnemosyne, run_advise
 from .claude_models import advise_model
@@ -469,8 +474,11 @@ def _setup_logging(verbose: bool = False) -> None:
     )
 
 
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the planner CLI."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for the planner CLI.
+
+    Extracted so tests can inspect help text without invoking parse_args.
+    """
     from pathlib import Path
 
     parser = argparse.ArgumentParser(
@@ -505,13 +513,9 @@ Examples:
         help="Issue numbers to plan (default: all open issues)",
     )
     add_agent_argument(parser)
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help=(
-            "Suppress GitHub mutations and agent calls (no issue comments posted). "
-            "This is for wiring and discovery rehearsal, not plan generation."
-        ),
+    add_dry_run_arg(
+        parser,
+        prefix="Suppress GitHub mutations and agent calls (no issue comments posted).",
     )
     parser.add_argument(
         "--force",
@@ -549,8 +553,12 @@ Examples:
     )
     add_json_arg(parser)
     add_version_arg(parser)
+    return parser
 
-    return parser.parse_args()
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the planner CLI."""
+    return _build_parser().parse_args(argv)
 
 
 def main() -> int:

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -878,8 +878,8 @@ class PRReviewer(BaseReviewer):
                     logger.info("  #%s: %s", issue_num, result.error)
 
 
-def _parse_args() -> argparse.Namespace:
-    """Parse command line arguments for the reviewer CLI."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for PR reviewer CLI."""
     parser = build_review_parser(
         description=(
             "Analyze open PRs linked to GitHub issues using Claude Code or Codex "
@@ -897,11 +897,16 @@ Examples:
   %(prog)s --issues 595 596 --max-workers 5
         """,
         issues_help="Issue numbers whose linked PRs should be reviewed",
-        dry_run_help="Show what would be done without actually posting any review comments",
+        dry_run_help="Show what would be done without actually posting any review comments.",
     )
     add_json_arg(parser)
     add_version_arg(parser)
-    return parser.parse_args()
+    return parser
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the reviewer CLI."""
+    return _build_parser().parse_args(argv)
 
 
 def main() -> int:

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -22,7 +22,9 @@ __version__ = get_version()
 
 __all__ = [
     "COMMAND_REGISTRY",
+    "DRY_RUN_HELP_CAVEAT",
     "CommandRegistry",
+    "add_dry_run_arg",
     "add_json_arg",
     "add_logging_args",
     "add_version_arg",
@@ -139,6 +141,45 @@ def add_json_arg(parser: argparse.ArgumentParser) -> None:
         "--json",
         action="store_true",
         help="Emit machine-readable JSON output instead of human-readable text",
+    )
+
+
+DRY_RUN_HELP_CAVEAT = (
+    "NOTE: Claude is still invoked, so --dry-run still incurs full "
+    "Claude API token cost. It is for correctness rehearsal, not cost preview."
+)
+
+
+def add_dry_run_arg(parser: argparse.ArgumentParser, *, prefix: str | None = None) -> None:
+    """Add the standard ``--dry-run`` flag with the canonical help-text contract.
+
+    Every ProjectHephaestus CLI that invokes Claude must surface the same
+    contract: GitHub/git mutations are suppressed, but Claude is still called
+    and tokens are still spent.
+
+    ``prefix`` is an optional CLI-specific lead-in that names the side-effects
+    this particular CLI suppresses (e.g. ``"No review comments posted."``).
+    It is placed BEFORE the canonical caveat. If ``prefix`` does not end in
+    sentence-terminating punctuation, a period and space are appended so the
+    concatenation reads cleanly. The canonical caveat is always appended last
+    so it cannot be silently dropped (#772).
+
+    Args:
+        parser: ArgumentParser instance to add the flag to
+        prefix: Optional CLI-specific description of suppressed side-effects
+
+    """
+    if prefix:
+        trimmed = prefix.rstrip()
+        if trimmed and trimmed[-1] not in ".!?":
+            trimmed = trimmed + "."
+        help_text = f"{trimmed} {DRY_RUN_HELP_CAVEAT}"
+    else:
+        help_text = DRY_RUN_HELP_CAVEAT
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=help_text,
     )
 
 

--- a/tests/unit/cli/test_dry_run_help.py
+++ b/tests/unit/cli/test_dry_run_help.py
@@ -1,0 +1,76 @@
+"""Tests for the shared --dry-run help-text contract (#772)."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+
+import pytest
+
+from hephaestus.cli.utils import DRY_RUN_HELP_CAVEAT, add_dry_run_arg
+
+TOKEN_COST_SENTENCE = "still incurs full Claude API token cost"  # noqa: S105
+
+CLI_PARSER_BUILDERS = [
+    "hephaestus.automation.planner",
+    "hephaestus.automation.plan_reviewer",
+    "hephaestus.automation.pr_reviewer",
+    "hephaestus.automation.address_review",
+    "hephaestus.automation.implementer_cli",
+    "hephaestus.automation.ci_driver",
+    "hephaestus.automation.loop_runner",
+]
+
+
+def _dry_run_help(parser: argparse.ArgumentParser) -> str:
+    for action in parser._actions:
+        if "--dry-run" in action.option_strings:
+            return action.help or ""
+    raise AssertionError("--dry-run not found on parser")
+
+
+def test_canonical_caveat_mentions_token_cost() -> None:
+    """Test that canonical caveat mentions token cost."""
+    assert TOKEN_COST_SENTENCE in DRY_RUN_HELP_CAVEAT
+
+
+def test_add_dry_run_arg_appends_flag_with_caveat() -> None:
+    """Test that add_dry_run_arg appends the flag with canonical caveat."""
+    p = argparse.ArgumentParser()
+    add_dry_run_arg(p)
+    help_text = _dry_run_help(p)
+    assert TOKEN_COST_SENTENCE in help_text
+    # When no prefix is supplied, the caveat is the whole help string.
+    assert help_text == DRY_RUN_HELP_CAVEAT
+
+
+def test_add_dry_run_arg_prefix_precedes_caveat() -> None:
+    """Test that prefix text precedes the canonical caveat."""
+    p = argparse.ArgumentParser()
+    add_dry_run_arg(p, prefix="No review comments posted.")
+    help_text = _dry_run_help(p)
+    assert help_text.startswith("No review comments posted.")
+    assert help_text.endswith(DRY_RUN_HELP_CAVEAT)
+    assert TOKEN_COST_SENTENCE in help_text
+
+
+def test_add_dry_run_arg_prefix_without_terminal_punctuation_gets_period() -> None:
+    """Guards against the 'Suppress mutations NOTE: Claude…' concatenation bug."""
+    p = argparse.ArgumentParser()
+    add_dry_run_arg(p, prefix="Suppress mutations")
+    help_text = _dry_run_help(p)
+    assert "Suppress mutations. " in help_text
+    assert help_text.endswith(DRY_RUN_HELP_CAVEAT)
+
+
+@pytest.mark.parametrize("module_path", CLI_PARSER_BUILDERS)
+def test_every_cli_parser_carries_canonical_caveat(module_path: str) -> None:
+    """Test that every CLI parser carries the canonical caveat."""
+    mod = importlib.import_module(module_path)
+    parser = mod._build_parser()
+    assert isinstance(parser, argparse.ArgumentParser)
+    help_text = _dry_run_help(parser)
+    assert TOKEN_COST_SENTENCE in help_text, (
+        f"{module_path}._build_parser() produced --dry-run help without "
+        f"the canonical caveat: {help_text!r}"
+    )


### PR DESCRIPTION
## Summary

Standardized help text for the `--dry-run` flag across all ProjectHephaestus CLIs that invoke Claude. The canonical contract is now clear to users: GitHub/git side-effects are suppressed, but Claude is still invoked and tokens are spent.

## Changes

- Add `DRY_RUN_HELP_CAVEAT` constant to `hephaestus/cli/utils.py`
- Add `add_dry_run_arg()` helper to standardize `--dry-run` across all CLIs
- Extract `_build_parser()` from each CLI's `_parse_args()` for test accessibility
- Refactored: planner, plan_reviewer, pr_reviewer, address_review, implementer_cli, ci_driver, loop_runner
- Route `_review_utils.py`'s `--dry-run` through the new helper
- Added test suite (test_dry_run_help.py) to verify canonical caveat presence

## Test plan

- [x] All 11 new tests pass (test_dry_run_help.py)
- [x] All 20 existing regression tests pass (review_utils + implementer_cli)
- [x] ruff check and format all modified files
- [x] mypy passes on full codebase
- [x] Verify user-visible help output shows token cost caveat for all CLIs

Closes #772

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>