### PR TITLE
fix(scripts): downgrade noisy WARNING to INFO in happy path

### DIFF
--- a/hephaestus/scripts_lib/check_python_version_consistency.py
+++ b/hephaestus/scripts_lib/check_python_version_consistency.py
@@ -161,13 +161,13 @@ def check_ci_matrix_coverage(repo_root: Path) -> bool:
 
     ci_workflow = repo_root / ".github" / "workflows" / "test.yml"
     if not ci_workflow.exists():
-        print(f"WARNING: CI workflow not found at {ci_workflow} — skipping matrix check")
+        print(f"INFO: CI workflow not found at {ci_workflow} — skipping matrix check")
         return True
 
     matrix_versions = extract_ci_matrix_python_versions(ci_workflow.read_text())
 
     if not matrix_versions:
-        print(f"WARNING: No python-version matrix found in {ci_workflow} — skipping matrix check")
+        print(f"INFO: No python-version matrix found in {ci_workflow} — skipping matrix check")
         return True
 
     missing = sorted(set(classifier_versions) - set(matrix_versions))

--- a/tests/unit/scripts_lib/test_check_python_version_consistency.py
+++ b/tests/unit/scripts_lib/test_check_python_version_consistency.py
@@ -251,11 +251,30 @@ class TestCheckCiMatrixCoverage:
         pyproject.write_text('[project]\nname = "mypkg"\n')
         assert check_ci_matrix_coverage(tmp_path) is True
 
-    def test_returns_true_when_no_ci_workflow(self, tmp_path: Path) -> None:
-        """Returns True (with warning) when CI workflow file does not exist."""
+    def test_returns_true_when_no_ci_workflow(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Returns True with INFO (not WARNING) when CI workflow file does not exist."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('"Programming Language :: Python :: 3.10",\n')
         assert check_ci_matrix_coverage(tmp_path) is True
+        captured = capsys.readouterr().out
+        assert "INFO:" in captured
+        assert "WARNING:" not in captured
+
+    def test_returns_true_when_no_matrix_in_workflow(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Returns True with INFO (not WARNING) when workflow has no python-version matrix."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('"Programming Language :: Python :: 3.10",\n')
+        workflow_dir = tmp_path / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "test.yml").write_text("jobs:\n  test:\n    runs-on: ubuntu-latest\n")
+        assert check_ci_matrix_coverage(tmp_path) is True
+        captured = capsys.readouterr().out
+        assert "INFO:" in captured
+        assert "WARNING:" not in captured
 
     def test_returns_true_when_matrix_has_extra_versions(self, tmp_path: Path) -> None:
         """Returns True when CI matrix has versions beyond what classifiers list."""


### PR DESCRIPTION
Downgrade two `WARNING:` lines in `check_ci_matrix_coverage()` to `INFO:` level. These messages fire when optional infrastructure (CI workflow file or its python-version matrix) is absent — both are acceptable skip-the-check paths that return `True` (success). INFO level correctly signals "expected state, no action needed" while preserving observability for debugging.

**Changes:**
- Line 164: `WARNING: CI workflow not found...` → `INFO: CI workflow not found...`
- Line 170: `WARNING: No python-version matrix found...` → `INFO: No python-version matrix found...`

**Tests:**
- Updated `test_returns_true_when_no_ci_workflow` to capture stdout and assert `INFO:` prefix (not `WARNING:`)
- Added `test_returns_true_when_no_matrix_in_workflow` with same assertion pattern
- All 34 tests in the module pass ✅

Closes #789