### PR TITLE
docs(ci): document Linux-only test matrix rationale

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@
 #
 # macOS and Windows support is tracked separately in #539 and is currently
 # out of scope. The published wheels remain pure-Python and importable on
-# other platforms (see CONTRIBUTING.md "Platform asymmetry"), but CI does
+# other platforms (see CONTRIBUTING.md "Platform Support"), but CI does
 # not exercise them there.
 #
 # When #539 lands, expand `matrix.os` here and remove this header.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,17 @@
+# Platform scope: Linux-only.
+#
+# This workflow intentionally runs only on `ubuntu-latest`. The project's pixi
+# environment targets `linux-64` exclusively (see `pixi.toml` `[workspace]`
+# platforms), so the CI test matrix mirrors the supported development surface.
+#
+# macOS and Windows support is tracked separately in #539 and is currently
+# out of scope. The published wheels remain pure-Python and importable on
+# other platforms (see CONTRIBUTING.md "Platform asymmetry"), but CI does
+# not exercise them there.
+#
+# When #539 lands, expand `matrix.os` here and remove this header.
+# Tracking: #794, #539.
+
 name: Test
 
 # Cross-Python compatibility matrix.


### PR DESCRIPTION
## Summary

Document the rationale for the Linux-only test matrix in `.github/workflows/test.yml` to honestly reflect the project's current platform support scope.

The workflow intentionally runs only on ubuntu-latest. Platform scope is limited to Linux (pixi targets linux-64 exclusively per pixi.toml), so the CI test matrix mirrors the supported development surface.

macOS and Windows support is tracked separately in #539 and remains out of scope. Published wheels remain pure-Python and importable on other platforms, but CI does not exercise them there.

Closes #794