### PR TITLE
fix(ci): Replace emoji status icons with ASCII markers

### DIFF
--- a/hephaestus/ci/precommit.py
+++ b/hephaestus/ci/precommit.py
@@ -65,7 +65,7 @@ def format_summary_table(elapsed_s: int, file_count: int, hook_status: str) -> s
         Markdown-formatted table string including a trailing newline.
 
     """
-    status_icon = "✅" if hook_status == "passed" else "❌"
+    status_icon = "[PASS]" if hook_status == "passed" else "[FAIL]"
     return (
         "## Pre-commit Hook Benchmark\n\n"
         "| Metric | Value |\n"


### PR DESCRIPTION
## Summary

Replaces non-ASCII emoji status icons (✅/❌) with ASCII-friendly markers ([PASS]/[FAIL]) in the pre-commit benchmark output to improve cross-platform compatibility and align with project conventions.

## Changes

- Updated `format_summary_table()` in `hephaestus/ci/precommit.py` to use `[PASS]` and `[FAIL]` instead of emoji
- All existing tests pass without modification

## Testing

- Verified all 43 existing tests pass
- Tested output manually to ensure formatting is correct

Closes #793