### PR TITLE
docs(scripts): remove stale run_automation_loop.sh reference

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,10 +42,6 @@ module — most users invoke the `hephaestus-*` console scripts instead.
   implementation in parallel worktrees; absorbs PR-review +
   thread-addressing in-loop).
 - **`drive_prs_green.py`** → drive open PRs to green CI.
-- **`run_automation_loop.sh`** — Legacy bash glue script, superseded by the
-  `hephaestus-automation-loop` console script
-  (`hephaestus.automation.loop_runner`). Drives the 3-stage pipeline
-  (plan → implement → drive-green).
 
 ### GitHub
 
@@ -73,9 +69,6 @@ python3 scripts/check_cli_table_sync.py
 
 # Markdown link fixer
 python3 scripts/fix_invalid_links.py .
-
-# Automation pipeline (shell glue)
-scripts/run_automation_loop.sh
 
 # Symlink check
 scripts/check-symlinks.sh


### PR DESCRIPTION
## Summary

Remove stale documentation references to `scripts/run_automation_loop.sh`, which was deleted in PR #922 (commit b81df80) as a YAGNI cleanup. The file no longer exists, and the Python replacement (`hephaestus-automation-loop`) is the canonical implementation.

This resolves the underlying concern of issue #790 (brittle sed-based parsing in the deleted script) by completing the documentation cleanup.

Closes #790