### PR TITLE
refactor(nats): remove YAGNI default verb stub handlers

### DIFF
--- a/hephaestus/nats/__init__.py
+++ b/hephaestus/nats/__init__.py
@@ -28,7 +28,6 @@ from hephaestus.nats.events import NATSEvent as NATSEvent
 from hephaestus.nats.events import SubjectParts as SubjectParts
 from hephaestus.nats.events import parse_subject as parse_subject
 from hephaestus.nats.handlers import EventRouter as EventRouter
-from hephaestus.nats.handlers import create_default_router as create_default_router
 from hephaestus.nats.subscriber import DEFAULT_JOIN_TIMEOUT as DEFAULT_JOIN_TIMEOUT
 from hephaestus.nats.subscriber import NATSSubscriberThread as NATSSubscriberThread
 from hephaestus.nats.subscriber import SubscriberState as SubscriberState
@@ -41,7 +40,6 @@ __all__ = [
     "NATSSubscriberThread",
     "SubjectParts",
     "SubscriberState",
-    "create_default_router",
     "load_nats_config",
     "parse_subject",
 ]

--- a/hephaestus/nats/handlers.py
+++ b/hephaestus/nats/handlers.py
@@ -77,35 +77,3 @@ class EventRouter:
                 parts.verb,
                 event.sequence,
             )
-
-
-def _handle_task_created(event: NATSEvent) -> None:
-    """Log a task creation event."""
-    logger.info("Task created: %s (seq=%d)", event.subject, event.sequence)
-
-
-def _handle_task_updated(event: NATSEvent) -> None:
-    """Log a task update event."""
-    logger.info("Task updated: %s (seq=%d)", event.subject, event.sequence)
-
-
-def _handle_task_completed(event: NATSEvent) -> None:
-    """Log a task completion event."""
-    logger.info("Task completed: %s (seq=%d)", event.subject, event.sequence)
-
-
-def create_default_router() -> EventRouter:
-    """Create an :class:`EventRouter` pre-loaded with default stub handlers.
-
-    The default handlers log creation, update, and completion events.
-    Register your own handlers to override them.
-
-    Returns:
-        :class:`EventRouter` with created/updated/completed handlers registered.
-
-    """
-    router = EventRouter()
-    router.register("created", _handle_task_created)
-    router.register("updated", _handle_task_updated)
-    router.register("completed", _handle_task_completed)
-    return router

--- a/tests/unit/nats/test_handlers.py
+++ b/tests/unit/nats/test_handlers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from hephaestus.nats.events import NATSEvent
-from hephaestus.nats.handlers import EventRouter, create_default_router
+from hephaestus.nats.handlers import EventRouter
 
 
 def _event(subject: str) -> NATSEvent:
@@ -51,24 +51,3 @@ class TestEventRouter:
         router.dispatch(_event("hi.tasks.team.123.created"))
         first.assert_not_called()
         second.assert_called_once()
-
-
-class TestCreateDefaultRouter:
-    """Tests for create_default_router()."""
-
-    def test_returns_event_router(self) -> None:
-        router = create_default_router()
-        assert isinstance(router, EventRouter)
-
-    def test_has_created_handler(self) -> None:
-        router = create_default_router()
-        # Should dispatch without error
-        router.dispatch(_event("hi.tasks.team.123.created"))
-
-    def test_has_updated_handler(self) -> None:
-        router = create_default_router()
-        router.dispatch(_event("hi.tasks.team.123.updated"))
-
-    def test_has_completed_handler(self) -> None:
-        router = create_default_router()
-        router.dispatch(_event("hi.tasks.team.123.completed"))


### PR DESCRIPTION
## Summary

Deleted the YAGNI default verb stub handlers (`_handle_task_created`, `_handle_task_updated`, `_handle_task_completed`) and the `create_default_router()` factory from `hephaestus/nats/handlers.py`. These were convenience scaffolding with no real consumers in this repo or any sibling repo.

Callers must now register their own handlers with `EventRouter` directly, which is already the documented and expected pattern.

## Changes

- Removed three stub handler functions and the `create_default_router()` factory
- Removed re-export from `hephaestus/nats/__init__.py`
- Removed `__all__` entry
- Deleted `TestCreateDefaultRouter` test class
- All 5 remaining `TestEventRouter` tests pass

## Verification

All seven acceptance criteria from the approved plan pass:
1. ✓ Stubs and factory deleted from module
2. ✓ No leftover references in shipped code or tests
3. ✓ No consumers in sibling repos
4. ✓ `__all__` alphabetised, symbol absent
5. ✓ Test suite passes
6. ✓ Broader NATS suite unaffected (54 tests pass)
7. ✓ Lint and type-check clean

Closes #796

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>