### PR TITLE
fix: scope warnings filter to lazy import via catch_warnings

### DIFF
--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -38,14 +38,6 @@ from typing import Any
 from hephaestus.nats.config import NATSConfig
 from hephaestus.nats.events import NATSEvent
 
-# Suppress nats-py DeprecationWarning for asyncio.iscoroutinefunction (Python 3.11+)
-warnings.filterwarnings(
-    "ignore",
-    message=".*asyncio.iscoroutinefunction.*",
-    category=DeprecationWarning,
-    module="nats",
-)
-
 logger = logging.getLogger(__name__)
 
 _INITIAL_BACKOFF_SECONDS = 1.0
@@ -276,7 +268,18 @@ class NATSSubscriberThread(threading.Thread):
     async def _subscribe_loop(self) -> None:
         """Connect to NATS JetStream and process messages until stop is requested."""
         try:
-            import nats as nats_client
+            # nats-py calls asyncio.iscoroutinefunction, which raises a
+            # DeprecationWarning on Python 3.12+. Scope the suppression to just
+            # the import so we do not mutate the process-wide warnings filter
+            # chain (issue #798).
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*asyncio.iscoroutinefunction.*",
+                    category=DeprecationWarning,
+                    module="nats",
+                )
+                import nats as nats_client
         except ImportError:
             logger.error(
                 "nats-py is not installed. "

--- a/tests/unit/nats/test_subscriber.py
+++ b/tests/unit/nats/test_subscriber.py
@@ -315,3 +315,80 @@ class TestConfigurableJoinTimeout:
         thread._stop_event.set()
         # Thread was never started — stop() should not raise.
         thread.stop()
+
+
+def test_importing_subscriber_does_not_mutate_global_warnings_filters() -> None:
+    """Regression for #798: module-level warnings.filterwarnings was global mutation.
+
+    Spawns a fresh Python process so test-collection import state cannot mask
+    the leak. The subprocess snapshots warnings.filters, imports the module,
+    and asserts no row was added.
+    """
+    import subprocess
+    import sys
+
+    code = (
+        "import warnings, json, sys;"
+        "before = list(warnings.filters);"
+        "import hephaestus.nats.subscriber;"  # triggers module body
+        "after = list(warnings.filters);"
+        "sys.exit(0 if after == before else 1)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        "Importing hephaestus.nats.subscriber added a row to warnings.filters; "
+        "suppression should be scoped via warnings.catch_warnings() inside "
+        "_subscribe_loop instead of running at module scope. "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+
+def test_subscribe_loop_lazy_import_suppresses_deprecation_warning() -> None:
+    """Regression for #798: catch_warnings() suppresses nats-py DeprecationWarning.
+
+    The catch_warnings() block must actually suppress the nats-py
+    DeprecationWarning when _subscribe_loop runs its lazy import.
+
+    Runs in a subprocess with -W error::DeprecationWarning so that if the
+    suppression block fails to scope correctly, the import re-raises as an
+    error and the subprocess exits non-zero. The NATS connect that follows
+    the import is expected to fail (no broker); we only care that the import
+    inside the catch_warnings block completed cleanly.
+    """
+    import subprocess
+    import sys
+
+    code = """
+import asyncio
+from hephaestus.nats.config import NATSConfig
+from hephaestus.nats.subscriber import NATSSubscriberThread
+
+cfg = NATSConfig(enabled=True, url='nats://127.0.0.1:1', subjects=['x.>'])
+t = NATSSubscriberThread(config=cfg, handler=lambda e: None)
+
+try:
+    asyncio.run(t._subscribe_loop())
+except DeprecationWarning:
+    raise SystemExit(2)
+except Exception:
+    pass
+
+raise SystemExit(0)
+"""
+    result = subprocess.run(
+        [sys.executable, "-W", "error::DeprecationWarning", "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        "Lazy import of nats-py inside _subscribe_loop leaked a "
+        "DeprecationWarning past the catch_warnings() block. "
+        f"returncode={result.returncode} stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Summary

Replace module-level `warnings.filterwarnings` with a `warnings.catch_warnings()` block around the lazy nats import inside `_subscribe_loop`. This prevents process-wide mutation of the warnings filter chain and confines the DeprecationWarning suppression to the only place it is needed (issue #798).

## Changes

1. **hephaestus/nats/subscriber.py**: Removed module-level `warnings.filterwarnings()` call (lines 41-47) and wrapped the lazy `import nats as nats_client` at line 279 inside `_subscribe_loop` with a `warnings.catch_warnings()` context manager.

2. **tests/unit/nats/test_subscriber.py**: Added two regression tests:
   - `test_importing_subscriber_does_not_mutate_global_warnings_filters`: Subprocess-isolated test that verifies importing the module does not add rows to `warnings.filters`.
   - `test_subscribe_loop_lazy_import_suppresses_deprecation_warning`: Tests that the `catch_warnings()` block suppresses the DeprecationWarning during the actual lazy import inside `_subscribe_loop`.

## Verification

All 60 nats unit tests pass, including the two new regression tests. Lint and type checking pass.

Closes #798

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>