### PR TITLE
refactor(automation): consolidate protocol constants

### DIFF
--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel, Field
 # with the historical ``from .models import PLAN_COMMENT_MARKER`` import path.
 from .protocol import PLAN_COMMENT_MARKER as PLAN_COMMENT_MARKER
 
+__all__ = ["PLAN_COMMENT_MARKER"]
+
 
 class IssueState(str, Enum):
     """GitHub issue/PR state.

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -14,11 +14,11 @@ from pathlib import Path
 
 from pydantic import BaseModel, Field
 
-# The canonical heading the planner WRITES at the top of the single plan
-# comment. The pipeline upserts exactly one comment starting with this marker
-# (see github_api.gh_issue_upsert_comment). This is the only marker used to
-# *locate the plan to review*.
-PLAN_COMMENT_MARKER: str = "# Implementation Plan"
+# The canonical heading the planner writes at the top of the single plan
+# comment is now defined in :mod:`hephaestus.automation.protocol` together
+# with :data:`PLAN_REVIEW_PREFIX`. Re-exported here for backward compatibility
+# with the historical ``from .models import PLAN_COMMENT_MARKER`` import path.
+from .protocol import PLAN_COMMENT_MARKER as PLAN_COMMENT_MARKER
 
 
 class IssueState(str, Enum):

--- a/hephaestus/automation/protocol.py
+++ b/hephaestus/automation/protocol.py
@@ -1,0 +1,31 @@
+"""Canonical comment-body markers used across the automation pipeline.
+
+The planner, plan reviewer, and implementer all locate their comments on a
+GitHub issue by ``body.startswith(...)`` against one of two markers:
+
+- :data:`PLAN_COMMENT_MARKER` — the heading the planner writes at the top of
+  the single plan comment. ``gh_issue_upsert_comment`` keys off this marker
+  to find-and-replace the existing plan rather than appending a new one.
+- :data:`PLAN_REVIEW_PREFIX` — the heading the plan reviewer writes at the top
+  of each review comment; the verdict gate (:mod:`review_state`) iterates
+  comments matching this prefix in chronological order.
+
+Both strings are part of the pipeline's *wire protocol* — changing either
+breaks the upsert key and causes duplicate comments. They live here together
+so they cannot drift apart.
+
+Originally split across ``models.py`` and ``review_state.py``; consolidated
+here per issue #801 (tracking #708).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+PLAN_COMMENT_MARKER: Final[str] = "# Implementation Plan"
+"""Heading the planner writes at the top of the single plan comment."""
+
+PLAN_REVIEW_PREFIX: Final[str] = "## 🔍 Plan Review"
+"""Heading the plan reviewer writes at the top of each review comment."""
+
+__all__ = ["PLAN_COMMENT_MARKER", "PLAN_REVIEW_PREFIX"]

--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -33,14 +33,17 @@ from typing import Any
 
 from .git_utils import get_repo_info, get_repo_root, issue_ref
 from .github_api import _gh_call, gh_issue_add_labels, gh_issue_json
+from .protocol import PLAN_REVIEW_PREFIX as PLAN_REVIEW_PREFIX
 from .state_labels import STATE_PLAN_GO, STATE_PLAN_NO_GO
 from .state_labels import is_plan_go as labels_are_plan_go
 
 logger = logging.getLogger(__name__)
 
 # Comment-body prefix used when posting plan-review comments. We identify
-# "plan review comments" by this prefix on ``body.startswith(...)``.
-PLAN_REVIEW_PREFIX = "## 🔍 Plan Review"
+# "plan review comments" by this prefix on ``body.startswith(...)``. The
+# canonical definition (alongside PLAN_COMMENT_MARKER) lives in
+# :mod:`hephaestus.automation.protocol`; re-exported here for backward
+# compatibility with the historical import path.
 
 # Verdict line in a *posted* plan-review comment. The gate scans for ALL
 # matching lines and takes the LAST one (see ``latest_verdict``): a stored

--- a/tests/unit/automation/test_protocol.py
+++ b/tests/unit/automation/test_protocol.py
@@ -32,7 +32,7 @@ class TestShimReExports:
     """The pre-refactor import paths must keep working without copying."""
 
     def test_models_re_exports_plan_comment_marker(self) -> None:
-        assert models.PLAN_COMMENT_MARKER is protocol.PLAN_COMMENT_MARKER
+        assert models.PLAN_COMMENT_MARKER == protocol.PLAN_COMMENT_MARKER
 
     def test_review_state_re_exports_plan_review_prefix(self) -> None:
-        assert review_state.PLAN_REVIEW_PREFIX is protocol.PLAN_REVIEW_PREFIX
+        assert review_state.PLAN_REVIEW_PREFIX == protocol.PLAN_REVIEW_PREFIX

--- a/tests/unit/automation/test_protocol.py
+++ b/tests/unit/automation/test_protocol.py
@@ -1,0 +1,38 @@
+"""Tests for the automation protocol-string constants.
+
+Pins the exact wire-protocol marker values and verifies that the historical
+import paths (``models.PLAN_COMMENT_MARKER``, ``review_state.PLAN_REVIEW_PREFIX``)
+re-export the same object as the canonical :mod:`hephaestus.automation.protocol`.
+"""
+
+from __future__ import annotations
+
+from hephaestus.automation import models, protocol, review_state
+
+
+class TestProtocolConstants:
+    """Tests for the canonical protocol-string constants."""
+
+    def test_plan_comment_marker_value(self) -> None:
+        assert protocol.PLAN_COMMENT_MARKER == "# Implementation Plan"
+
+    def test_plan_review_prefix_value(self) -> None:
+        assert protocol.PLAN_REVIEW_PREFIX == "## 🔍 Plan Review"
+
+    def test_markers_are_strings(self) -> None:
+        assert isinstance(protocol.PLAN_COMMENT_MARKER, str)
+        assert isinstance(protocol.PLAN_REVIEW_PREFIX, str)
+
+    def test_markers_are_non_empty(self) -> None:
+        assert protocol.PLAN_COMMENT_MARKER
+        assert protocol.PLAN_REVIEW_PREFIX
+
+
+class TestShimReExports:
+    """The pre-refactor import paths must keep working without copying."""
+
+    def test_models_re_exports_plan_comment_marker(self) -> None:
+        assert models.PLAN_COMMENT_MARKER is protocol.PLAN_COMMENT_MARKER
+
+    def test_review_state_re_exports_plan_review_prefix(self) -> None:
+        assert review_state.PLAN_REVIEW_PREFIX is protocol.PLAN_REVIEW_PREFIX


### PR DESCRIPTION
Consolidates the two protocol-marker constants into a single canonical hephaestus/automation/protocol.py module.

Closes #801