### PR TITLE
feat: [NITPICK] prompts/_strict_rubric.py:13-44 embeds absolute home-dir path

### DIFF
--- a/hephaestus/automation/prompts/_strict_rubric.py
+++ b/hephaestus/automation/prompts/_strict_rubric.py
@@ -7,16 +7,48 @@ the seven graded software-engineering principles. Per-stage rubrics
 shared blocks.
 """
 
-# Rubric block embedded into every loop-review prompt. Mirrors the philosophy
-# of the `review-pr-strict` skill at:
-#   ~/.claude/plugins/marketplaces/ProjectHephaestus/skills/review-pr-strict/SKILL.md
-# Embedded inline so the spawned reviewer process does not depend on the plugin
-# being autoloaded — works in any environment that has `claude --print`.
-_STRICT_REVIEW_RUBRIC = """
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Plugin-skill reference path is resolved at runtime — never hardcoded.
+# Override via HEPHAESTUS_PLUGIN_SKILLS_DIR for non-default deployments
+# (CI, containers, alternate $HOME). Falls back to the standard Claude
+# Code plugin layout under the current user's home directory.
+_DEFAULT_PLUGIN_SKILLS_SUBPATH = Path(".claude/plugins/marketplaces/ProjectHephaestus/skills")
+_STRICT_SKILL_NAME = "review-pr-strict"
+
+
+def _skill_reference() -> str:
+    """Resolve the absolute path to the review-pr-strict SKILL.md if it exists.
+
+    Returns the resolved path as a string when the file is present, or an empty
+    string when it is not (graceful degradation — the rubric is self-contained
+    and the path is only a reference). Honors the HEPHAESTUS_PLUGIN_SKILLS_DIR
+    env var; otherwise falls back to ``~/.claude/plugins/marketplaces/...``
+    resolved via :func:`pathlib.Path.home`.
+    """
+    override = os.environ.get("HEPHAESTUS_PLUGIN_SKILLS_DIR")
+    skills_dir = Path(override) if override else Path.home() / _DEFAULT_PLUGIN_SKILLS_SUBPATH
+    candidate = skills_dir / _STRICT_SKILL_NAME / "SKILL.md"
+    return str(candidate) if candidate.is_file() else ""
+
+
+def build_strict_review_rubric() -> str:
+    """Build the strict-review rubric prompt with a runtime-resolved skill reference."""
+    skill_ref = _skill_reference()
+    if skill_ref:
+        skill_line = (
+            f"`review-pr-strict` skill (rubric summarized below — refer to the full skill at\n"
+            f"`{skill_ref}`\n"
+            f"if available):"
+        )
+    else:
+        skill_line = "`review-pr-strict` skill (rubric summarized below):"
+    return f"""
 You are a ruthlessly thorough technical reviewer. Apply this rubric per the
-`review-pr-strict` skill (rubric summarized below — refer to the full skill at
-`~/.claude/plugins/marketplaces/ProjectHephaestus/skills/review-pr-strict/SKILL.md`
-if available):
+{skill_line}
 
 GRADING (every dimension starts at F; A must be EARNED with concrete evidence):
 - A  (93-100%) Exemplary, RARE
@@ -42,6 +74,13 @@ EVALUATE THESE DIMENSIONS:
 5. Scope discipline — KISS / YAGNI; no speculative work
 6. Verification plan — concrete steps the reviewer can run to confirm
 """
+
+
+# Module-level constant preserved for backward-compatibility with the
+# ``hephaestus.automation.prompts`` re-export. Resolved once at import time;
+# tests that need per-call resolution call ``build_strict_review_rubric()``
+# directly.
+_STRICT_REVIEW_RUBRIC = build_strict_review_rubric()
 
 # Verdict contract for the strict loop reviewers (plan-loop + impl-loop). The
 # fenced ``Grade:`` / ``Verdict: <GO|NOGO>`` block below is parsed by

--- a/tests/unit/automation/test_strict_rubric.py
+++ b/tests/unit/automation/test_strict_rubric.py
@@ -1,0 +1,51 @@
+"""Unit tests for the strict-rubric skill-path parameterization (issue #800)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.automation.prompts import _strict_rubric as sr
+
+
+def test_skill_reference_uses_env_var_when_set(tmp_path, monkeypatch):
+    """When HEPHAESTUS_PLUGIN_SKILLS_DIR is set, _skill_reference() uses it."""
+    skill_dir = tmp_path / "skills"
+    skill_path = skill_dir / "review-pr-strict" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("stub")
+    monkeypatch.setenv("HEPHAESTUS_PLUGIN_SKILLS_DIR", str(skill_dir))
+    assert str(skill_path) in sr._skill_reference()
+
+
+def test_skill_reference_default_graceful_degradation(monkeypatch, tmp_path):
+    """When SKILL.md is absent, _skill_reference() returns empty string."""
+    monkeypatch.delenv("HEPHAESTUS_PLUGIN_SKILLS_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    assert sr._skill_reference() == ""
+
+
+def test_rubric_contains_no_hardcoded_home_path(monkeypatch, tmp_path):
+    """Rubric prompt must not embed hardcoded ~/... or /home/... paths."""
+    monkeypatch.delenv("HEPHAESTUS_PLUGIN_SKILLS_DIR", raising=False)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    rubric = sr.build_strict_review_rubric()
+    assert "~/.claude/plugins" not in rubric
+    assert "/home/" not in rubric
+
+
+def test_rubric_includes_skill_path_when_file_exists(tmp_path, monkeypatch):
+    """When SKILL.md exists, rubric prompt includes the resolved path."""
+    skill_dir = tmp_path / "skills"
+    skill_md = skill_dir / "review-pr-strict" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("stub")
+    monkeypatch.setenv("HEPHAESTUS_PLUGIN_SKILLS_DIR", str(skill_dir))
+    rubric = sr.build_strict_review_rubric()
+    assert str(skill_md) in rubric
+
+
+def test_module_level_constant_still_exported():
+    """Backward-compat: _STRICT_REVIEW_RUBRIC symbol still resolves."""
+    from hephaestus.automation.prompts import _STRICT_REVIEW_RUBRIC
+
+    assert "ruthlessly thorough technical reviewer" in _STRICT_REVIEW_RUBRIC


### PR DESCRIPTION
## Summary
Implements #800

## Changes
- Automated implementation via Claude Code

## Testing
- Automated tests included

## Closes
Closes #800

Generated by Claude Code via ProjectHephaestus automation.
