### PR TITLE
feat(automation): add audit reviewer for batch PR analysis with sub-agent dispatch

### DIFF
--- a/LEARNINGS_ISSUE_768.md
+++ b/LEARNINGS_ISSUE_768.md
@@ -1,8 +1,8 @@
 # Issue #768 Implementation Learnings
 
-**Date**: 2026-06-05  
-**Issue**: Remove emoji from `scripts/compare_benchmarks.py` stderr output  
-**Status**: COMPLETE - PR #962 created with correct GPG signature  
+**Date**: 2026-06-05
+**Issue**: Remove emoji from `scripts/compare_benchmarks.py` stderr output
+**Status**: COMPLETE - PR #962 created with correct GPG signature
 
 ## Key Learnings
 
@@ -12,7 +12,8 @@
 
 **Result**: GitHub pr-policy check failed with "Check 3: every commit is signed" → `reason: "no_user"` via REST API.
 
-**Solution**: 
+**Solution**:
+
 ```bash
 # Set local config to key's registered email
 git config user.email "4211002+mvillmow@users.noreply.github.com"
@@ -28,13 +29,13 @@ gh api repos/OWNER/REPO/commits/HASH --jq '.commit.verification | {verified, rea
 
 ### 2. Fresh Commits on New Branch > Amendment + Force Push
 
-**Attempted Approach 1**: Amended commit multiple times locally using `git commit --amend -S --reset-author`  
+**Attempted Approach 1**: Amended commit multiple times locally using `git commit --amend -S --reset-author`
 → Result: Confusing commit history, local/remote divergence, unclear which amendment fixed the issue
 
-**Attempted Approach 2**: Force-pushed amended commits  
+**Attempted Approach 2**: Force-pushed amended commits
 → Result: System blocked force-push for safety (reasonable policy)
 
-**Successful Approach**: Created fresh branch from main, re-applied changes with correct config, committed once  
+**Successful Approach**: Created fresh branch from main, re-applied changes with correct config, committed once
 → Result: Clean, auditable history; no force-push needed; clear evidence of correct signature
 
 **Lesson**: For email/signature fixes, start fresh on a new branch rather than fighting with amendments. Cleaner history, easier to debug, and respects system safety policies.
@@ -44,31 +45,29 @@ gh api repos/OWNER/REPO/commits/HASH --jq '.commit.verification | {verified, rea
 ### 3. Subprocess-Based Tests Robustly Guard Against Regression
 
 **Pattern Used**: Created `tests/unit/scripts/test_compare_benchmarks_no_emoji.py` that:
+
 - Runs the actual script as a subprocess (not mocked)
 - Provides minimal JSON fixtures with specific timings
 - Captures stderr and checks for absence of emoji byte prefixes
 - Verifies correct ASCII strings appear in output
 
 **Test Structure**:
+
 ```python
 def test_pass_path_emits_no_emoji_on_stderr(tmp_path):
     """Verify no emoji bytes appear when no critical regressions found."""
     # Write minimal fixtures
     _write_results(current, 1.0)  # No regression
     _write_results(baseline, 1.0)
-    
+
     # Run actual script
     result = _run(current, baseline)
-    
-    # Guard against emoji byte prefixes
-    for prefix in (b"\xf0\x9f", b"\xe2\x9d\x8c", b"\xe2\x9c\x85"):
-        assert prefix not in result.stderr
-    
-    # Verify correct text appears
-    assert b"PASS" in result.stderr
+
+    # Guard against emoji byte prefixes    for prefix in (b"\xf0\x9f", b"\xe2\x9d\x8c", b"\xe2\x9c\x85"):        assert prefix not in result.stderr    # Verify correct text appears    assert b"PASS" in result.stderr
 ```
 
 **Benefits**:
+
 - Tests real script behavior, not mock behavior
 - Catches subtle issues (emoji encoding, output format)
 - Fixtures are minimal and clear
@@ -86,10 +85,12 @@ def test_pass_path_emits_no_emoji_on_stderr(tmp_path):
 **Answer**: No. The rule applies to **user-facing output (stderr)**, not intentional visual indicators in **rendered Markdown reports**.
 
 **Evidence from Plan Review**:
+
 - Emoji in `scripts/compare_benchmarks.py` stderr (lines 131, 134) → **violates rule** (command-line output)
 - Emoji in `hephaestus/benchmarks/compare.py` Markdown report tables → **out of scope** (visual severity indicators in report)
 
 **Key Distinction**:
+
 - stderr/stdout/console output: Plain ASCII only (portability across CI systems)
 - Markdown/report output: Emoji allowed (intentional visual design for humans reading reports)
 
@@ -100,6 +101,7 @@ def test_pass_path_emits_no_emoji_on_stderr(tmp_path):
 ## Implementation Details
 
 ### Files Changed
+
 1. **scripts/compare_benchmarks.py** lines 131, 134:
    - Changed `❌ FAILED:` → `FAIL:`
    - Changed `✅ No critical regressions detected` → `PASS: No critical regressions detected`
@@ -110,6 +112,7 @@ def test_pass_path_emits_no_emoji_on_stderr(tmp_path):
    - Runs actual script with minimal fixtures
 
 ### Verification Status
+
 - ✅ Local tests pass (all 2 emoji guard tests + 16 benchmark tests)
 - ✅ Ruff linting and formatting pass
 - ✅ Commit signature verified via REST API (`verified: true, reason: "valid"`)
@@ -120,8 +123,8 @@ def test_pass_path_emits_no_emoji_on_stderr(tmp_path):
 
 ## What Would Go Into ProjectMnemosyne Skill
 
-**Skill Name**: `gpg-signing-email-pr-policy-validation`  
-**Category**: `ci-cd`  
+**Skill Name**: `gpg-signing-email-pr-policy-validation`
+**Category**: `ci-cd`
 **Verification**: `verified-local` (signature verified, pr-policy pending in CI)
 
 This captures the pr-policy signing failure and the correct workflow for fixing it.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ config = merge_with_env({}, convert_bools=True)
 <!-- CLI table generated from pyproject.toml [project.scripts]. Keep in sync via
      `python3 scripts/check_cli_table_sync.py` (also enforced in pre-commit). -->
 
-44 console scripts are installed when you install the package.  Run any command
+45 console scripts are installed when you install the package.  Run any command
 with `--help` to see full usage.
 
 ### Automation
@@ -242,6 +242,7 @@ with `--help` to see full usage.
 | `hephaestus-plan-issues` | Bulk issue planning using Claude Code or Codex |
 | `hephaestus-implement-issues` | Bulk issue implementation using Claude Code or Codex in parallel worktrees |
 | `hephaestus-review-prs` | Read-only PR review automation using Claude Code or Codex in parallel worktrees |
+| `hephaestus-audit-prs` | Batch audit of ALL open PRs using a coordinator that fans out one sub-agent per PR |
 | `hephaestus-agent-stage` | Run one Claude or Codex automation stage with prompt and skill context |
 | `hephaestus-ensure-state-labels` | Idempotently provision `state:needs-plan` / `state:plan-no-go` / `state:plan-go` labels on one or more repos |
 

--- a/docs/audit-reviewer.md
+++ b/docs/audit-reviewer.md
@@ -1,0 +1,315 @@
+# Audit Reviewer (`hephaestus-audit-prs`)
+
+Batch audit review of **all open pull requests** using a coordinator + sub-agent
+dispatch pattern.  One command reviews every open PR at once — the coordinator
+agent fans out one sub-agent per PR, collects their findings, and posts inline
+review comments back to each PR.
+
+## Overview
+
+The audit reviewer solves the problem of reviewing many open PRs efficiently.
+Instead of running a separate agent session per PR, a single **coordinator**
+agent parses the open PR list, dispatches one sub-agent per PR (via the Task
+tool), aggregates results, and returns a structured JSON payload.  The Python
+automation then posts each sub-agent's inline comments to the corresponding PR
+and writes a persistent audit report.
+
+```
+┌─────────────┐
+│ gh pr list  │  enumerate all open PRs
+└──────┬──────┘
+       ▼
+┌─────────────────┐
+│  Coordinator    │  dispatch one sub-agent per PR (batches of ≤10)
+│  (Claude/Codex) │
+└──────┬──────────┘
+       ▼
+┌─────────────────┐
+│  Sub-agent #1   │  gh pr diff, gh pr view, analyse, return JSON
+│  Sub-agent #2   │  gh pr diff, gh pr view, analyse, return JSON
+│  ...            │
+│  Sub-agent #N   │
+└──────┬──────────┘
+       ▼
+┌─────────────────┐
+│  Post reviews   │  gh api POST /repos/{owner}/{repo}/pulls/{n}/reviews
+│  Write report   │  build/.audit/audit-report-{timestamp}.json
+│  Print summary  │  per-PR verdict table (✓/✗, comment count, verdict)
+└─────────────────┘
+```
+
+## CLI Usage
+
+```bash
+# Review all open PRs (up to 100)
+hephaestus-audit-prs
+
+# Review with a dry run (no posts, reports intent only)
+hephaestus-audit-prs --dry-run
+
+# Review specific PRs only
+hephaestus-audit-prs --pr-numbers 595 596 597
+
+# Cap the number of PRs fetched
+hephaestus-audit-prs --limit 20
+
+# Use Codex as the coordinator agent
+hephaestus-audit-prs --agent codex
+
+# Verbose logging
+hephaestus-audit-prs -v
+
+# Machine-readable output
+hephaestus-audit-prs --json
+```
+
+### CLI Flags
+
+| Flag | Default | Description |
+|---|---|---|
+| `--agent {claude,codex}` | `claude` (auto-detected if omitted) | Coordinator agent provider |
+| `--dry-run` | `false` | Show what would be done without posting reviews |
+| `--limit N` | `100` | Maximum number of open PRs to fetch |
+| `--pr-numbers N...` | (none) | Explicit PR numbers to review; overrides `--limit` and the open-PR list |
+| `-v`, `--verbose` | `false` | Enable DEBUG-level logging |
+| `--json` | `false` | Emit machine-readable JSON status on exit |
+
+### Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success — all reviews posted without failures |
+| `1` | Partial failure — at least one posting failed, or coordinator returned no results |
+| `130` | Interrupted by user (Ctrl-C) |
+
+## Programmatic API
+
+The `AuditReviewer` class can be used directly from Python for scripting or
+integration into larger automation workflows.
+
+```python
+from hephaestus.automation.audit_reviewer import AuditReviewer
+
+# Review all open PRs (Claude, dry run)
+reviewer = AuditReviewer(agent="claude", dry_run=True, limit=50)
+exit_code = reviewer.run()  # 0 on success, 1 on failure
+
+# Review specific PRs
+reviewer = AuditReviewer(pr_numbers=[595, 596, 597])
+exit_code = reviewer.run()
+```
+
+### `AuditReviewer` Constructor
+
+```python
+AuditReviewer(
+    *,
+    agent: str = "claude",
+    dry_run: bool = False,
+    limit: int = 100,
+    pr_numbers: list[int] | None = None,
+)
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `agent` | `"claude"` | `"claude"` or `"codex"` — coordinator agent provider |
+| `dry_run` | `False` | Log intent without invoking agents or posting reviews |
+| `limit` | `100` | Maximum open PRs to fetch (ignored when `pr_numbers` is set) |
+| `pr_numbers` | `None` | Explicit PR numbers to review; bypasses the open-PR list |
+
+### `AuditReviewer.run()` → `int`
+
+Executes the full 4-stage workflow:
+
+1. **Enumerate PRs** — calls `gh_pr_list_open()` (or `_fetch_prs_by_number()` for
+   explicit PRs).  Returns early with exit 0 if no open PRs are found.
+2. **Run coordinator** — builds the audit prompt with the full PR list, invokes
+   the selected agent, and parses the aggregated JSON results.
+3. **Post inline reviews** — posts each sub-agent's `comments` array to the
+   corresponding PR via `gh_pr_review_post()`.
+4. **Write report + print summary** — persists a timestamped JSON report to
+   `build/.audit/` and prints a human-readable summary to the logger.
+
+Returns `0` on success, `1` if any posting failed or coordinator returned no results.
+
+### Lower-Level Functions
+
+For finer-grained control, the individual stages are exposed as standalone functions:
+
+```python
+from hephaestus.automation.audit_reviewer import (
+    run_audit_coordinator,
+    post_audit_results,
+    write_audit_report,
+    print_audit_summary,
+    _parse_coordinator_results,
+)
+```
+
+| Function | Purpose |
+|---|---|
+| `run_audit_coordinator(*, pr_list, worktree_path, agent, state_dir, dry_run)` | Build prompt, invoke agent, parse results |
+| `post_audit_results(results, *, dry_run)` | Post per-PR inline reviews; returns `dict[int, bool]` |
+| `write_audit_report(results, posted, state_dir)` | Write timestamped JSON report to `state_dir` |
+| `print_audit_summary(results, posted)` | Print human-readable per-PR verdict table |
+| `_parse_coordinator_results(text)` | Extract the last `\`\`\`json` block from coordinator output |
+
+## Report Format
+
+The audit report is written to `build/.audit/audit-report-{timestamp}.json`:
+
+```json
+{
+  "timestamp": "20260605T120000Z",
+  "total_prs": 5,
+  "posted": 4,
+  "failed": 1,
+  "results": [
+    {
+      "pr_number": 595,
+      "summary": "LGTM — clean refactor, all tests pass",
+      "comment_count": 0,
+      "posted": true
+    },
+    {
+      "pr_number": 596,
+      "summary": "Missing test for new error path in _derive_ci_status",
+      "comment_count": 2,
+      "posted": true
+    },
+    {
+      "pr_number": 597,
+      "summary": "Potential race in worktree cleanup — see inline comments",
+      "comment_count": 3,
+      "posted": false
+    }
+  ]
+}
+```
+
+## Coordinator Prompt
+
+The coordinator receives a JSON list of open PRs (fetched via `gh pr list --json`)
+and is instructed to:
+
+1. Parse the PR list.
+2. Dispatch one sub-agent per PR in **batches of at most 10** (to avoid API
+   rate limits).
+3. Each sub-agent runs `gh pr diff {number}` and `gh pr view {number} --json`
+   to fetch the diff and metadata.
+4. Each sub-agent returns a JSON object with `comments` (inline review array)
+   and `summary` (verdict text).
+5. The coordinator collects all results and emits a single `\`\`\`json` block
+   with a `results` array.
+
+The prompt is built by `get_audit_coordinator_prompt()` in
+[`hephaestus/automation/prompts/audit.py`](../hephaestus/automation/prompts/audit.py),
+which applies untrusted-content fencing (random nonces) to all PR metadata —
+the same safety contract used by the plan reviewer and PR reviewer prompts.
+
+### Sub-Agent Guardrails
+
+Every sub-agent prompt includes these critical guardrails:
+
+- **No backgrounding**: "Do NOT background your work, do NOT exit early, and do
+  NOT defer.  Complete the analysis synchronously."
+- **Scope isolation**: "You own ONLY PR #N.  Do not read or touch any other PR's data."
+- **Strict output format**: The exact JSON schema is specified with `\`\`\`json`
+  fencing; `line` must be an integer that exists in the diff; `side` must be `RIGHT`.
+- **LGTM shortcut**: If the PR has no issues, return `{"comments": [], "summary": "LGTM"}`.
+
+## Session State
+
+Each audit run creates a Claude/Codex session in `build/.audit/`:
+
+| File | Content |
+|---|---|
+| `audit-coordinator.log` | Raw coordinator agent output (stdout + stderr) |
+| `audit-report-{timestamp}.json` | Parsed results + posting outcomes |
+
+The coordinator session uses a timestamp-derived `issue` number (rather than a
+real GitHub issue number) so each audit run gets a **fresh** Claude session —
+avoiding resumption of stale transcripts from prior audits.
+
+## Integration with the Automation Pipeline
+
+The audit reviewer complements the existing 3-stage pipeline
+(plan → implement → drive-green) by providing **batch review** of *all* open PRs:
+
+| Tool | Scope | Agent count |
+|---|---|---|
+| `hephaestus-review-prs` | One PR per invocation (read-only review) | 1 agent |
+| `hephaestus-audit-prs` | **All** open PRs in one invocation | 1 coordinator + N sub-agents |
+
+The audit reviewer is particularly useful for:
+
+- **Pre-release sweeps** — review every open PR before a release cut.
+- **Stale PR detection** — identify PRs that have been open too long without
+  activity.
+- **Cross-PR consistency** — spot conflicts or duplication across multiple
+  in-flight PRs.
+
+## Error Handling
+
+| Failure mode | Behaviour |
+|---|---|
+| No open PRs | Logs info, exits 0 |
+| Coordinator returns no JSON block | Logs warning, exits 1 |
+| Coordinator process crashes (`CalledProcessError`) | Raises `RuntimeError` with stderr |
+| Coordinator times out (`TimeoutExpired`) | Raises `RuntimeError` with "timed out" |
+| Individual PR fetch fails | Logs warning, skips that PR |
+| Individual PR posting fails | Logs warning, marks `posted: false` for that PR; exits 1 |
+| Keyboard interrupt | Logs warning, exits 130 |
+
+## Environment Variables
+
+The coordinator session timeout is controlled by the same environment variables
+used by the PR reviewer:
+
+| Variable | Default | Description |
+|---|---|---|
+| `HEPH_PR_REVIEWER_CLAUDE_TIMEOUT` | `1800` | Coordinator session timeout in seconds (30 min) |
+
+See [`hephaestus/automation/claude_timeouts.py`](../hephaestus/automation/claude_timeouts.py)
+for the full timeout resolution logic.
+
+## Examples
+
+### Pre-Release Sweep
+
+```bash
+# Dry-run to see what would be reviewed
+hephaestus-audit-prs --dry-run
+
+# Review all open PRs before cutting a release
+hephaestus-audit-prs --limit 100
+
+# Check the report
+cat build/.audit/audit-report-*.json | python -m json.tool
+```
+
+### Review Specific PRs
+
+```bash
+# Review only PRs 595, 596, and 597 using Codex
+hephaestus-audit-prs --agent codex --pr-numbers 595 596 597 -v
+```
+
+### Scripted Integration
+
+```python
+import json
+from pathlib import Path
+from hephaestus.automation.audit_reviewer import AuditReviewer
+
+# Review with a low limit for quick feedback
+reviewer = AuditReviewer(agent="claude", dry_run=False, limit=5)
+exit_code = reviewer.run()
+
+# Read the report programmatically
+reports = sorted(Path("build/.audit").glob("audit-report-*.json"))
+if reports:
+    report = json.loads(reports[-1].read_text())
+    print(f"{report['posted']}/{report['total_prs']} reviews posted")
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ just docs        # outputs to docs/api/
 ```
 
 The generated `docs/api/` directory is git-ignored; run the command locally to browse
-full function signatures, docstrings, and type annotations for all 44 CLI entry points.
+full function signatures, docstrings, and type annotations for all 45 CLI entry points.
 
 ## Setup
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ full function signatures, docstrings, and type annotations for all 45 CLI entry 
 See the [README](../README.md) for installation and development setup instructions.
 
 - [Plugin Installation Guide](plugin-installation.md) — Install the Claude Code or Codex plugin and enable skills in your project
+- [Audit Reviewer](audit-reviewer.md) — Batch audit review of all open PRs using coordinator + sub-agent dispatch
 
 ## Contributing
 

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -1,0 +1,522 @@
+"""Batch audit review of all open PRs using a coordinator + sub-agent dispatch.
+
+Lists all open PRs via ``gh pr list``, builds a coordinator prompt that
+dispatches one sub-agent per PR (using the Task tool), then parses the
+aggregated results and posts each sub-agent's inline review comments back
+to the corresponding PR via :func:`gh_pr_review_post`.
+
+Provides:
+- ``hephaestus-audit-prs`` console script that reviews every open PR at once.
+- ``AuditReviewer`` class for programmatic use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
+from hephaestus.cli.utils import add_json_arg, emit_json_status
+
+from .claude_invoke import invoke_claude_with_session
+from .claude_models import reviewer_model
+from .claude_timeouts import pr_reviewer_claude_timeout
+from .github_api import _derive_ci_status, _gh_call, gh_pr_list_open, gh_pr_review_post, write_secure
+from .git_utils import get_repo_root, get_repo_slug, pr_ref
+from .session_naming import AGENT_AUDIT_REVIEWER
+
+logger = logging.getLogger(__name__)
+
+_AUDIT_STATE_DIR = Path("build") / ".audit"
+
+
+def _parse_coordinator_results(text: str) -> list[dict[str, Any]]:
+    """Extract the last ```json``` block from the coordinator response.
+
+    Args:
+        text: Raw coordinator agent output.
+
+    Returns:
+        Parsed ``"results"`` list from the JSON block, or an empty list on
+        failure.
+
+    """
+    matches = re.findall(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if not matches:
+        logger.warning("No JSON block found in coordinator response")
+        return []
+    try:
+        data = json.loads(matches[-1])
+        results = data.get("results", [])
+        if not isinstance(results, list):
+            logger.warning("Coordinator JSON 'results' is not a list")
+            return []
+        return results
+    except json.JSONDecodeError as exc:
+        logger.warning("Failed to parse coordinator JSON: %s", exc)
+        return []
+
+
+def run_audit_coordinator(
+    *,
+    pr_list: list[dict[str, Any]],
+    worktree_path: Path,
+    agent: str,
+    state_dir: Path,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    """Run the coordinator agent and return parsed per-PR results.
+
+    Builds the coordinator prompt with the full PR list, invokes the selected
+    agent, and returns the parsed ``"results"`` array.
+
+    Args:
+        pr_list: PR metadata list from :func:`gh_pr_list_open`.
+        worktree_path: Working directory for the coordinator session.
+        agent: ``"claude"`` or ``"codex"``.
+        state_dir: Directory for session log files.
+        dry_run: When True, skip agent invocation and return empty list.
+
+    Returns:
+        List of per-PR result dicts with keys ``pr_number``, ``comments``,
+        ``summary``.
+
+    """
+    if dry_run:
+        logger.info("[DRY RUN] Would run audit coordinator for %s PR(s)", len(pr_list))
+        return []
+
+    from .prompts.audit import get_audit_coordinator_prompt
+
+    prompt = get_audit_coordinator_prompt(pr_list)
+
+    log_file = state_dir / "audit-coordinator.log"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        if is_codex(agent):
+            result = run_codex_text(
+                prompt,
+                cwd=worktree_path,
+                timeout=pr_reviewer_claude_timeout(),
+                sandbox="workspace-write",
+            )
+            log_file.write_text(result.stdout or "")
+            return _parse_coordinator_results(result.stdout or "")
+
+        repo_root = get_repo_root()
+        repo_slug = get_repo_slug(repo_root)
+        # Use a timestamp-derived issue number so each audit run gets a fresh
+        # Claude session — avoids resuming stale transcripts from prior audits.
+        issue = int(time.time())
+        stdout, _ = invoke_claude_with_session(
+            repo=repo_slug,
+            issue=issue,  # unique per run, not tied to a single issue
+            agent=AGENT_AUDIT_REVIEWER,
+            prompt=prompt,
+            model=reviewer_model(),
+            cwd=worktree_path,
+            timeout=pr_reviewer_claude_timeout(),
+            output_format="json",
+            permission_mode="dontAsk",
+            allowed_tools="Read,Glob,Grep,Bash,Task",
+            input_via_stdin=True,
+        )
+        log_file.write_text(stdout or "")
+
+        try:
+            data = json.loads(stdout or "{}")
+            response_text: str = data.get("result", stdout or "")
+        except (json.JSONDecodeError, AttributeError):
+            response_text = stdout or ""
+
+        return _parse_coordinator_results(response_text)
+
+    except subprocess.CalledProcessError as e:
+        stdout = e.stdout or ""
+        stderr = e.stderr or ""
+        log_file.write_text(
+            f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
+        )
+        raise RuntimeError(
+            f"Audit coordinator failed: {e.stderr or e.stdout}"
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+        raise RuntimeError("Audit coordinator timed out") from e
+
+
+def post_audit_results(
+    results: list[dict[str, Any]],
+    *,
+    dry_run: bool = False,
+) -> dict[int, bool]:
+    """Post each per-PR result as an inline PR review.
+
+    Args:
+        results: Parsed results from the coordinator (list of
+            ``{pr_number, comments, summary}`` dicts).
+        dry_run: When True, log intent without posting.
+
+    Returns:
+        Mapping of ``pr_number`` → ``True`` if posted successfully, ``False``
+        if posting failed or was skipped.
+
+    """
+    posted: dict[int, bool] = {}
+    for entry in results:
+        pr_number = int(entry.get("pr_number", 0))
+        if not pr_number:
+            logger.warning("Skipping result with missing pr_number: %r", entry)
+            continue
+        comments = entry.get("comments", [])
+        summary = entry.get("summary", "Audit review")
+
+        if not isinstance(comments, list):
+            comments = []
+
+        if dry_run:
+            logger.info(
+                "[dry_run] Would post audit review on PR %s", pr_ref(pr_number)
+            )
+            posted[pr_number] = False
+            continue
+
+        try:
+            gh_pr_review_post(
+                pr_number=pr_number,
+                comments=comments,
+                summary=summary,
+                dry_run=dry_run,
+            )
+            posted[pr_number] = True
+            logger.info("Posted audit review on PR %s", pr_ref(pr_number))
+        except Exception as exc:
+            logger.warning("Failed to post audit review on PR #%s: %s", pr_number, exc)
+            posted[pr_number] = False
+
+    return posted
+
+
+def write_audit_report(
+    results: list[dict[str, Any]],
+    posted: dict[int, bool],
+    state_dir: Path,
+) -> Path:
+    """Write a persistent audit report to ``state_dir``.
+
+    Args:
+        results: Parsed coordinator results.
+        posted: Posting outcome map from :func:`post_audit_results`.
+        state_dir: Directory for the report.
+
+    Returns:
+        Path to the written report file.
+
+    """
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    report_path = state_dir / f"audit-report-{timestamp}.json"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    report = {
+        "timestamp": timestamp,
+        "total_prs": len(results),
+        "posted": sum(1 for ok in posted.values() if ok),
+        "failed": sum(1 for ok in posted.values() if not ok),
+        "results": [
+            {
+                "pr_number": int(e.get("pr_number", 0)),
+                "summary": e.get("summary", ""),
+                "comment_count": len(e.get("comments", [])),
+                "posted": posted.get(int(e.get("pr_number", 0)), False),
+            }
+            for e in results
+        ],
+    }
+
+    write_secure(report_path, json.dumps(report, indent=2) + "\n")
+    logger.info("Audit report written to %s", report_path)
+    return report_path
+
+
+def print_audit_summary(
+    results: list[dict[str, Any]],
+    posted: dict[int, bool],
+) -> None:
+    """Print a human-readable audit summary to the logger.
+
+    Args:
+        results: Parsed coordinator results.
+        posted: Posting outcome map.
+
+    """
+    total = len(results)
+    posted_count = sum(1 for ok in posted.values() if ok)
+    failed_count = sum(1 for ok in posted.values() if not ok)
+    total_comments = sum(len(e.get("comments", [])) for e in results)
+
+    logger.info("=" * 60)
+    logger.info("PR Audit Review Summary")
+    logger.info("=" * 60)
+    logger.info("Total PRs analysed:  %s", total)
+    logger.info("Reviews posted:      %s", posted_count)
+    logger.info("Post failures:        %s", failed_count)
+    logger.info("Total inline comments:%s", total_comments)
+
+    # Show per-PR verdicts
+    for entry in results:
+        pr_number = int(entry.get("pr_number", 0))
+        summary = entry.get("summary", "?")
+        comment_count = len(entry.get("comments", []))
+        status = "\u2713" if posted.get(pr_number) else "\u2717"
+        logger.info(
+            "  %s PR #%s \u2014 %s (%s comment(s))",
+            status,
+            pr_number,
+            summary[:80],
+            comment_count,
+        )
+
+
+class AuditReviewer:
+    """Batch review all open PRs using a coordinator + sub-agent dispatch.
+
+    The reviewer:
+    1. Lists all open PRs via :func:`gh_pr_list_open`.
+    2. Runs a coordinator agent that fans out one sub-agent per PR.
+    3. Posts each sub-agent's inline review comments to its PR.
+    4. Writes a persistent audit report.
+
+    Example::
+
+        reviewer = AuditReviewer(agent="claude", dry_run=False, limit=50)
+        reviewer.run()
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: str = "claude",
+        dry_run: bool = False,
+        limit: int = 100,
+        pr_numbers: list[int] | None = None,
+    ) -> None:
+        """Initialise the audit reviewer.
+
+        Args:
+            agent: ``"claude"`` or ``"codex"``.
+            dry_run: When True, log intent without posting.
+            limit: Maximum PRs to fetch (default 100).
+            pr_numbers: Optional explicit list of PR numbers to review
+                (overrides ``limit`` and ``gh_pr_list_open``).
+
+        """
+        self.agent = agent
+        self.dry_run = dry_run
+        self.limit = limit
+        self.pr_numbers = pr_numbers
+        self.repo_root = Path(get_repo_root())
+        self.state_dir = self.repo_root / _AUDIT_STATE_DIR
+
+    def run(self) -> int:
+        """Execute the audit workflow.
+
+        Returns:
+            Exit code: 0 on success, 1 if any posting failures occurred.
+
+        """
+        logger.info("Starting PR audit review (agent=%s)", self.agent)
+
+        # Step 1: enumerate open PRs
+        if self.pr_numbers:
+            pr_list = self._fetch_prs_by_number(self.pr_numbers)
+        else:
+            pr_list = gh_pr_list_open(limit=self.limit, dry_run=self.dry_run)
+
+        if not pr_list:
+            logger.info("No open PRs found — nothing to review")
+            return 0
+
+        logger.info("Found %s open PR(s) to review", len(pr_list))
+
+        # Step 2: run coordinator
+        worktree_path = self.repo_root
+        results = run_audit_coordinator(
+            pr_list=pr_list,
+            worktree_path=worktree_path,
+            agent=self.agent,
+            state_dir=self.state_dir,
+            dry_run=self.dry_run,
+        )
+
+        if not results:
+            logger.warning("Coordinator returned no results")
+            return 1
+
+        logger.info("Coordinator returned %s PR result(s)", len(results))
+
+        # Step 3: post inline reviews
+        posted = post_audit_results(results, dry_run=self.dry_run)
+
+        # Step 4: write report + print summary
+        write_audit_report(results, posted, self.state_dir)
+        print_audit_summary(results, posted)
+
+        failures = sum(1 for ok in posted.values() if not ok)
+        return 1 if failures > 0 else 0
+
+    @staticmethod
+    def _fetch_prs_by_number(pr_numbers: list[int]) -> list[dict[str, Any]]:
+        """Fetch PR metadata for explicit PR numbers via ``gh pr view``.
+
+        Args:
+            pr_numbers: List of PR numbers to fetch.
+
+        Returns:
+            List of PR metadata dicts in the same shape as
+            :func:`gh_pr_list_open`.
+
+        """
+        pr_list: list[dict[str, Any]] = []
+        for pr_num in pr_numbers:
+            try:
+                result = _gh_call(
+                    [
+                        "pr",
+                        "view",
+                        str(pr_num),
+                        "--json",
+                        "number,title,author,headRefName,baseRefName,"
+                        "mergeable,mergeStateStatus,statusCheckRollup",
+                    ],
+                    check=False,
+                )
+                data = json.loads(result.stdout or "{}")
+                if not data:
+                    continue
+                author_data = data.get("author") or {}
+                checks = data.get("statusCheckRollup") or []
+
+                pr_list.append(
+                    {
+                        "number": data["number"],
+                        "title": data.get("title", ""),
+                        "author": author_data.get("login", "unknown"),
+                        "headRefName": data.get("headRefName", ""),
+                        "baseRefName": data.get("baseRefName", ""),
+                        "mergeable": data.get("mergeable", "UNKNOWN"),
+                        "mergeStateStatus": data.get("mergeStateStatus", "UNKNOWN"),
+                        "ci_status": _derive_ci_status(checks),
+                    }
+                )
+            except Exception as exc:
+                logger.warning("Failed to fetch PR #%s: %s", pr_num, exc)
+        pr_list.sort(key=lambda p: p["number"])
+        return pr_list
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments for the audit reviewer CLI."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Review ALL open PRs in the repository using a single coordinator "
+            "agent that fans out one sub-agent per PR."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  # Review all open PRs (up to 100)
+  %(prog)s
+
+  # Review with dry run (no posts)
+  %(prog)s --dry-run
+
+  # Review specific PRs only
+  %(prog)s --pr-numbers 595 596 597
+
+  # Cap the number of PRs fetched
+  %(prog)s --limit 20
+""",
+    )
+    add_agent_argument(parser)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be done without posting any review comments",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Maximum number of open PRs to fetch (default: 100)",
+    )
+    parser.add_argument(
+        "--pr-numbers",
+        type=int,
+        nargs="+",
+        metavar="N",
+        help="Explicit PR numbers to review (overrides --limit and gh pr list)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    add_json_arg(parser)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point for ``hephaestus-audit-prs``.
+
+    Returns:
+        Exit code: 0 on success, 1 on failure, 130 on keyboard interrupt.
+
+    """
+    args = _parse_args()
+    agent = resolve_agent(args.agent)
+
+    level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    logger.info("Starting audit review (agent=%s, dry_run=%s)", agent, args.dry_run)
+
+    from hephaestus.utils.terminal import terminal_guard
+
+    reviewer = AuditReviewer(
+        agent=agent,
+        dry_run=args.dry_run,
+        limit=args.limit,
+        pr_numbers=args.pr_numbers,
+    )
+
+    with terminal_guard():
+        try:
+            exit_code = reviewer.run()
+            if args.json:
+                emit_json_status(exit_code)
+            return exit_code
+        except KeyboardInterrupt:
+            logger.warning("Interrupted by user")
+            if args.json:
+                emit_json_status(130, message="interrupted")
+            return 130
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -28,8 +28,14 @@ from hephaestus.cli.utils import add_json_arg, emit_json_status
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
-from .github_api import _derive_ci_status, _gh_call, gh_pr_list_open, gh_pr_review_post, write_secure
 from .git_utils import get_repo_root, get_repo_slug, pr_ref
+from .github_api import (
+    _derive_ci_status,
+    _gh_call,
+    gh_pr_list_open,
+    gh_pr_review_post,
+    write_secure,
+)
 from .session_naming import AGENT_AUDIT_REVIEWER
 
 logger = logging.getLogger(__name__)

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -148,12 +148,8 @@ def run_audit_coordinator(
     except subprocess.CalledProcessError as e:
         stdout = e.stdout or ""
         stderr = e.stderr or ""
-        log_file.write_text(
-            f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-        )
-        raise RuntimeError(
-            f"Audit coordinator failed: {e.stderr or e.stdout}"
-        ) from e
+        log_file.write_text(f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}")
+        raise RuntimeError(f"Audit coordinator failed: {e.stderr or e.stdout}") from e
     except subprocess.TimeoutExpired as e:
         log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
         raise RuntimeError("Audit coordinator timed out") from e
@@ -189,9 +185,7 @@ def post_audit_results(
             comments = []
 
         if dry_run:
-            logger.info(
-                "[dry_run] Would post audit review on PR %s", pr_ref(pr_number)
-            )
+            logger.info("[dry_run] Would post audit review on PR %s", pr_ref(pr_number))
             posted[pr_number] = False
             continue
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1608,3 +1608,101 @@ def gh_pr_checks(
 
     logger.debug("Fetched %s CI check(s) for PR #%s", len(checks), pr_number)
     return checks
+
+
+# Common conclusions that indicate a failing CI check across gh pr list and gh pr view.
+_BAD_CI_CONCLUSIONS: frozenset[str] = frozenset(
+    {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "ERROR"}
+)
+_PENDING_CI_CONCLUSIONS: frozenset[str] = frozenset(
+    {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING"}
+)
+
+
+def _derive_ci_status(checks: list[dict[str, Any]]) -> str:
+    """Reduce a ``statusCheckRollup`` list to a single CI status string.
+
+    Args:
+        checks: Raw check objects from ``gh pr list --json statusCheckRollup``
+            or ``gh pr view --json statusCheckRollup``.
+
+    Returns:
+        ``"SUCCESS"``, ``"FAILURE"``, ``"PENDING"``, or ``"UNKNOWN"``.
+
+    """
+    if not checks:
+        return "UNKNOWN"
+    conclusions = {c.get("conclusion") or c.get("state", "PENDING") for c in checks}
+    if conclusions & _BAD_CI_CONCLUSIONS:
+        return "FAILURE"
+    if conclusions & _PENDING_CI_CONCLUSIONS:
+        return "PENDING"
+    return "SUCCESS"
+
+
+def gh_pr_list_open(
+    limit: int = 100,
+    *,
+    dry_run: bool = False,
+) -> list[dict[str, Any]]:
+    """Return a list of open PRs with metadata from ``gh pr list``.
+
+    Each returned dict has keys:
+    - ``number``, ``title``, ``author`` (login), ``headRefName``, ``baseRefName``
+    - ``mergeable``, ``mergeStateStatus``
+    - ``ci_status``: string derived from ``statusCheckRollup`` — one of
+      ``"SUCCESS"``, ``"FAILURE"``, ``"PENDING"``, or ``"UNKNOWN"``.
+
+    Args:
+        limit: Maximum number of PRs to fetch (default 100).
+        dry_run: If True, return an empty list.
+
+    Returns:
+        List of PR metadata dicts, sorted by number ascending.
+
+    Raises:
+        RuntimeError: If the ``gh`` call or JSON parsing fails.
+
+    """
+    if dry_run:
+        logger.info("[dry_run] Would list open PRs")
+        return []
+
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--json",
+                "number,title,author,headRefName,baseRefName,"
+                "mergeable,mergeStateStatus,statusCheckRollup",
+                "--limit",
+                str(limit),
+            ]
+        )
+        raw = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        raise RuntimeError(f"Failed to list open PRs: {e}") from e
+
+    out: list[dict[str, Any]] = []
+    for pr in raw:
+        author_data = pr.get("author") or {}
+        checks = pr.get("statusCheckRollup") or []
+        out.append(
+            {
+                "number": pr["number"],
+                "title": pr.get("title", ""),
+                "author": author_data.get("login", "unknown"),
+                "headRefName": pr.get("headRefName", ""),
+                "baseRefName": pr.get("baseRefName", ""),
+                "mergeable": pr.get("mergeable", "UNKNOWN"),
+                "mergeStateStatus": pr.get("mergeStateStatus", "UNKNOWN"),
+                "ci_status": _derive_ci_status(checks),
+            }
+        )
+
+    out.sort(key=lambda p: p["number"])
+    logger.info("Listed %s open PR(s)", len(out))
+    return out

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1614,9 +1614,7 @@ def gh_pr_checks(
 _BAD_CI_CONCLUSIONS: frozenset[str] = frozenset(
     {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "ERROR"}
 )
-_PENDING_CI_CONCLUSIONS: frozenset[str] = frozenset(
-    {"PENDING", "IN_PROGRESS", "QUEUED", "WAITING"}
-)
+_PENDING_CI_CONCLUSIONS: frozenset[str] = frozenset({"PENDING", "IN_PROGRESS", "QUEUED", "WAITING"})
 
 
 def _derive_ci_status(checks: list[dict[str, Any]]) -> str:

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -43,16 +43,16 @@ from ._strict_rubric import _STRICT_GRADING_AND_ANTI_INFLATION as _STRICT_GRADIN
 from ._strict_rubric import _STRICT_REVIEW_OUTPUT_FORMAT as _STRICT_REVIEW_OUTPUT_FORMAT
 from ._strict_rubric import _STRICT_REVIEW_RUBRIC as _STRICT_REVIEW_RUBRIC
 from .address_review import ADDRESS_REVIEW_PROMPT, get_address_review_prompt
-from .audit import (
-    AUDIT_COORDINATOR_PROMPT,
-    get_audit_coordinator_prompt,
-)
 from .advise import (
     ADVISE_PROMPT,
     CODEX_ADVISE_PROMPT,
     get_advise_prompt,
     get_advise_prompt_builder,
     get_codex_advise_prompt,
+)
+from .audit import (
+    AUDIT_COORDINATOR_PROMPT,
+    get_audit_coordinator_prompt,
 )
 from .follow_up import FOLLOW_UP_PROMPT, get_follow_up_prompt
 from .implementation import (
@@ -80,6 +80,7 @@ from .pr_review import (
 __all__ = [
     "ADDRESS_REVIEW_PROMPT",
     "ADVISE_PROMPT",
+    "AUDIT_COORDINATOR_PROMPT",
     "CODEX_ADVISE_PROMPT",
     "FOLLOW_UP_PROMPT",
     "IMPLEMENTATION_PROMPT",
@@ -92,6 +93,7 @@ __all__ = [
     "get_address_review_prompt",
     "get_advise_prompt",
     "get_advise_prompt_builder",
+    "get_audit_coordinator_prompt",
     "get_codex_advise_prompt",
     "get_follow_up_prompt",
     "get_impl_loop_review_prompt",
@@ -102,6 +104,4 @@ __all__ = [
     "get_plan_review_prompt",
     "get_pr_description",
     "get_pr_review_analysis_prompt",
-    "AUDIT_COORDINATOR_PROMPT",
-    "get_audit_coordinator_prompt",
 ]

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -43,6 +43,10 @@ from ._strict_rubric import _STRICT_GRADING_AND_ANTI_INFLATION as _STRICT_GRADIN
 from ._strict_rubric import _STRICT_REVIEW_OUTPUT_FORMAT as _STRICT_REVIEW_OUTPUT_FORMAT
 from ._strict_rubric import _STRICT_REVIEW_RUBRIC as _STRICT_REVIEW_RUBRIC
 from .address_review import ADDRESS_REVIEW_PROMPT, get_address_review_prompt
+from .audit import (
+    AUDIT_COORDINATOR_PROMPT,
+    get_audit_coordinator_prompt,
+)
 from .advise import (
     ADVISE_PROMPT,
     CODEX_ADVISE_PROMPT,
@@ -98,4 +102,6 @@ __all__ = [
     "get_plan_review_prompt",
     "get_pr_description",
     "get_pr_review_analysis_prompt",
+    "AUDIT_COORDINATOR_PROMPT",
+    "get_audit_coordinator_prompt",
 ]

--- a/hephaestus/automation/prompts/audit.py
+++ b/hephaestus/automation/prompts/audit.py
@@ -1,0 +1,118 @@
+"""Audit-review prompts: coordinator dispatches sub-agents per PR for batch review.
+
+The coordinator receives a JSON list of open PR metadata and dispatches one
+sub-agent per PR.  Each sub-agent analyses a single PR (diff, CI, description)
+and returns inline review comments + a summary verdict.  The coordinator
+collects all results and emits a final aggregated JSON block that the Python
+caller parses and posts as inline reviews via :func:`gh_pr_review_post`.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from typing import Any
+
+from ._shared import _UNTRUSTED_NOTICE, _fence_untrusted
+
+AUDIT_COORDINATOR_PROMPT = """\
+You are the COORDINATOR for a batch code-review audit of all open pull requests
+in this repository.
+
+Your job is to dispatch one sub-agent per PR, collect their findings, and
+produce a single aggregated JSON result.  The Python automation will then post
+each sub-agent's inline comments to the corresponding PR.
+
+{untrusted_notice}
+
+**Open PRs (untrusted):**
+{pr_list_block}
+
+The block above is a JSON array where each element has:
+- `number`: PR number (integer)
+- `title`: PR title
+- `author`: author login
+- `headRefName`: source branch name
+- `baseRefName`: target branch name
+- `mergeable`: `"MERGEABLE"` / `"CONFLICTING"` / `"UNKNOWN"`
+- `mergeStateStatus`: `"CLEAN"` / `"BEHIND"` / `"DIRTY"` / `"BLOCKED"` / `"UNKNOWN"`
+- `ci_status`: `"SUCCESS"` / `"FAILURE"` / `"PENDING"` / `"UNKNOWN"`
+
+---
+
+**Your task (coordinator):**
+
+1. Parse the PR list above.  Dispatch one sub-agent per PR using the Task
+   tool (`subagent_type: "general-purpose"`).  **Dispatch in batches of at most
+   10 PRs at a time** — wait for a batch to complete before dispatching the
+   next.  This prevents overwhelming the system and hitting API limits.
+
+   Give each sub-agent a self-contained prompt that instructs it to:
+   a. Fetch the PR diff: `gh pr diff {{number}}`
+   b. Fetch the PR description + review comments:
+      `gh pr view {{number}} --json body,reviews,comments`
+   c. Analyse the diff for code quality, correctness, obvious bugs, missing
+      tests, and style/convention violations.  Focus on issues that a human
+      reviewer would flag — don't nitpick formatting that a linter would catch.
+   d. Report findings as a JSON object with `comments` (array of inline review
+      objects) and `summary` (short verdict text).
+
+   **Each sub-agent prompt MUST include these guardrails (critical):**
+   - "Do NOT background your work, do NOT exit early, and do NOT defer.
+      Complete the analysis synchronously and return only when done."
+   - "You own ONLY PR #{{number}}.  Do not read or touch any other PR's data."
+   - "Return your result as valid JSON in this exact format:
+      ```json
+      {{"comments": [{{"path": "...", "line": N, "side": "RIGHT", "body": "..."}}], "summary": "..."}}
+      ```"
+   - "`line` must be an integer that exists in the diff.  `side` must be `RIGHT`."
+   - "If the PR looks fine with no issues to flag, return
+      `{{"comments": [], "summary": "LGTM"}}`."
+
+2. After ALL sub-agents have returned, collect their results into a single
+   JSON block.  Drop any sub-agent result that is not valid JSON.
+
+**Output format:**
+Write your coordination notes in prose.  At the very end of your response,
+emit a single fenced JSON block:
+
+```json
+{{
+  "results": [
+    {{
+      "pr_number": <int>,
+      "comments": [{{"path": "...", "line": <int>, "side": "RIGHT", "body": "..."}}],
+      "summary": "<verdict text>"
+    }},
+    ...
+  ]
+}}
+```
+
+Rules for the JSON block:
+- `results`: array of per-PR results.  One entry per successfully-analysed PR.
+- `pr_number`: the PR number the sub-agent was tasked with.
+- `comments`: the inline-comment array from the sub-agent (may be empty).
+- `summary`: the verdict text from the sub-agent.
+- Emit only one JSON block, at the very end of your response.
+"""
+
+
+def get_audit_coordinator_prompt(
+    pr_list: list[dict[str, Any]],
+) -> str:
+    """Build the coordinator prompt that dispatches sub-agents per PR.
+
+    Args:
+        pr_list: List of PR metadata dicts from :func:`gh_pr_list_open`.
+
+    Returns:
+        Formatted coordinator prompt string.
+
+    """
+    nonce = secrets.token_hex(8).upper()
+    pr_list_json = json.dumps(pr_list)
+    return AUDIT_COORDINATOR_PROMPT.format(
+        pr_list_block=_fence_untrusted("PR_LIST", pr_list_json, nonce),
+        untrusted_notice=_UNTRUSTED_NOTICE,
+    )

--- a/hephaestus/automation/prompts/audit.py
+++ b/hephaestus/automation/prompts/audit.py
@@ -63,7 +63,8 @@ The block above is a JSON array where each element has:
    - "You own ONLY PR #{{number}}.  Do not read or touch any other PR's data."
    - "Return your result as valid JSON in this exact format:
       ```json
-      {{"comments": [{{"path": "...", "line": N, "side": "RIGHT", "body": "..."}}], "summary": "..."}}
+      {{"comments": [{{"path": "...", "line": N, "side": "RIGHT", \
+"body": "..."}}], "summary": "..."}}
       ```"
    - "`line` must be an integer that exists in the diff.  `side` must be `RIGHT`."
    - "If the PR looks fine with no issues to flag, return

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -40,6 +40,7 @@ AGENT_IMPLEMENTER = "implementer"
 AGENT_PR_REVIEWER = "pr-reviewer"
 AGENT_ADDRESS_REVIEW = "address-review"
 AGENT_CI_DRIVER = "ci-driver"
+AGENT_AUDIT_REVIEWER = "audit-reviewer"
 
 _ALL_AGENTS = frozenset(
     {
@@ -51,6 +52,7 @@ _ALL_AGENTS = frozenset(
         AGENT_PR_REVIEWER,
         AGENT_ADDRESS_REVIEW,
         AGENT_CI_DRIVER,
+        AGENT_AUDIT_REVIEWER,
     }
 )
 

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -246,13 +246,13 @@ def format_output(data: Any, format_type: str = "text") -> str:
         import json
 
         return json.dumps(data, indent=2)
-    elif format_type == "table" and isinstance(data, (list, tuple)):
+    elif format_type == "table" and isinstance(data, list | tuple):
         if data and isinstance(data[0], dict):
             # Dict rows to table
             headers = list(data[0].keys()) if data else []
             rows = [[str(row.get(h, "")) for h in headers] for row in data]
             return format_table(rows, headers)
-        elif data and isinstance(data[0], (list, tuple)):
+        elif data and isinstance(data[0], list | tuple):
             # Already in row format
             return format_table(data)
         else:
@@ -260,7 +260,7 @@ def format_output(data: Any, format_type: str = "text") -> str:
             return "\n".join(str(item) for item in data)
     else:
         # Default text format
-        if isinstance(data, (list, tuple)):
+        if isinstance(data, list | tuple):
             return "\n".join(str(item) for item in data)
         elif isinstance(data, dict):
             lines = []

--- a/hephaestus/resilience/subprocess_resilience.py
+++ b/hephaestus/resilience/subprocess_resilience.py
@@ -70,7 +70,7 @@ def is_transient_subprocess_error(error: BaseException) -> bool:
 
     if isinstance(error, TRANSIENT_SUBPROCESS_ERRORS):
         # For generic OSError/SubprocessError, check for transient patterns
-        if isinstance(error, (OSError, subprocess.SubprocessError)):
+        if isinstance(error, OSError | subprocess.SubprocessError):
             # Build searchable text from all available error info
             parts = [str(error).lower()]
             if isinstance(error, subprocess.CalledProcessError):

--- a/hephaestus/validation/audit.py
+++ b/hephaestus/validation/audit.py
@@ -72,7 +72,7 @@ def extract_cvss_score(severity_list: list[dict[str, Any]]) -> float | None:
     scores: list[float] = []
     for entry in severity_list:
         score_str = entry.get("score", "")
-        if isinstance(score_str, (int, float)):
+        if isinstance(score_str, int | float):
             scores.append(float(score_str))
         elif isinstance(score_str, str) and CVSS_PATTERN.match(score_str):
             pass

--- a/hephaestus/validation/config_lint.py
+++ b/hephaestus/validation/config_lint.py
@@ -223,7 +223,7 @@ class ConfigLinter:
         # Check for duplicate values (may indicate copy-paste errors)
         seen_values: dict[Any, str] = {}
         for key, value in values:
-            if isinstance(value, (int, float, str)) and value != "":
+            if isinstance(value, int | float | str) and value != "":
                 if value in seen_values:
                     self.suggestions.append(
                         f"{filepath} - Duplicate value '{value}' "
@@ -243,7 +243,7 @@ class ConfigLinter:
         for param, (min_val, max_val) in self.perf_thresholds.items():
             if param in config:
                 value = config[param]
-                if isinstance(value, (int, float)) and (value < min_val or value > max_val):
+                if isinstance(value, int | float) and (value < min_val or value > max_val):
                     self.warnings.append(
                         f"{filepath} - '{param}' value {value} "
                         f"outside recommended range ({min_val}-{max_val})"

--- a/hephaestus/validation/docstrings.py
+++ b/hephaestus/validation/docstrings.py
@@ -161,7 +161,7 @@ def _context_label(node: ast.AST) -> str:
         return "module"
     if isinstance(node, ast.ClassDef):
         return f"class {node.name}"
-    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+    if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
         return f"def {node.name}"
     return "unknown"
 
@@ -170,7 +170,7 @@ def _docstring_nodes(tree: ast.Module) -> list[tuple[ast.AST, str, int]]:
     """Extract ``(node, docstring_text, line_number)`` for all docstring-bearing nodes."""
     results: list[tuple[ast.AST, str, int]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+        if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
             continue
         body = getattr(node, "body", [])
         if not body:

--- a/pixi.lock
+++ b/pixi.lock
@@ -95,7 +95,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.3.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
@@ -209,7 +209,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.3.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
@@ -1341,9 +1341,9 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
-- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-  sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
-  md5: 9272daa869e03efe68833e3dc7a02130
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+  md5: cbb88288f74dbe6ada1c6c7d0a97223e
   depends:
   - backports.zstd >=1.0.0
   - brotli-python >=1.2.0
@@ -1354,8 +1354,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/urllib3?source=hash-mapping
-  size: 103172
-  timestamp: 1767817860341
+  size: 103560
+  timestamp: 1778188657149
 - conda: https://conda.anaconda.org/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
   sha256: 8dbe1085b6dbc0beaaa45514a983bc91c2c306079a257c936566b727f5e82fb8
   md5: d3874a78e238013db5106c8e31f1ae58

--- a/pixi.lock
+++ b/pixi.lock
@@ -68,7 +68,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
@@ -184,7 +184,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
@@ -984,17 +984,17 @@ packages:
   - pkg:pypi/pathspec?source=compressed-mapping
   size: 56559
   timestamp: 1777271601895
-- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
-  sha256: 00acccc6f69568ddc56d4d5cc031fdb27eb6a1588a80b1f3a5233bd2a6f944f0
-  md5: 2e7e59a063366f1fc4f45ac86bd9485f
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
+  sha256: 9e673d3c6003f416df11670a14b026a04e3a45ebec55357987e15b860f138f2a
+  md5: 733cc07ed34162ac50b936464b163366
   depends:
   - python >=3.13.0a0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/pip?source=compressed-mapping
-  size: 1199678
-  timestamp: 1777924078252
+  size: 1202377
+  timestamp: 1780262809860
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937

--- a/pixi.toml
+++ b/pixi.toml
@@ -92,23 +92,13 @@ bandit = ">=1.9.4,<2"
 # a re-review trigger so a suppression is never silently permanent. Re-review
 # the whole list every dependency bump (or quarterly, whichever comes first).
 #
-# CVE-2026-3219 (pip): unfixable — the flaw is in a library pip vendors and there
-#   is no released pip we can pin that drops the vulnerable copy. pip is bundled
-#   by the runner's Python; we never declare it as a dependency.
-#   Re-review: drop when a fixed pip ships and the runner Python carries it.
-# CVE-2026-44431 (urllib3): not-yet-packaged — fixed in urllib3 2.7.0; that
-#   release is not on conda-forge yet, so the locked env cannot reach it.
-#   Re-review: drop when conda-forge publishes urllib3 >= 2.7.0.
-# CVE-2026-44432 (urllib3): not-yet-packaged — same urllib3 2.6.3 → 2.7.0 fix and
-#   same conda-forge availability gap as CVE-2026-44431; tracked together.
-#   Re-review: drop alongside CVE-2026-44431 when urllib3 >= 2.7.0 lands.
 # PYSEC-2025-183 (CVE-2025-45768): affects every pyjwt release (0.1.1-2.12.1) with
 #   no fixed version, and is disputed by the pyjwt maintainers — it concerns the key
 #   length chosen by the calling application, not a library defect. pyjwt is only a
 #   transitive dependency of pygithub (we never import it directly), so there is no
 #   version bump or code change that resolves it. Ignored as unfixable + disputed.
 #   Re-review: drop if pyjwt publishes a fixed release or pygithub drops the dep.
-pip-audit = "pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-44431 --ignore-vuln CVE-2026-44432 --ignore-vuln PYSEC-2025-183"
+pip-audit = "pip-audit --ignore-vuln PYSEC-2025-183"
 sast = "bandit -c pyproject.toml -r hephaestus scripts --severity-level medium"
 
 [environments]

--- a/pixi.toml
+++ b/pixi.toml
@@ -96,10 +96,6 @@ bandit = ">=1.9.4,<2"
 #   is no released pip we can pin that drops the vulnerable copy. pip is bundled
 #   by the runner's Python; we never declare it as a dependency.
 #   Re-review: drop when a fixed pip ships and the runner Python carries it.
-# CVE-2026-6357 (pip): not-yet-packaged — fixed in pip 26.1 (we run 26.0.1), but
-#   pip is supplied by the runner Python and our deps don't pin it, so we cannot
-#   force the bump ourselves.
-#   Re-review: drop when the runner Python ships pip >= 26.1.
 # CVE-2026-44431 (urllib3): not-yet-packaged — fixed in urllib3 2.7.0; that
 #   release is not on conda-forge yet, so the locked env cannot reach it.
 #   Re-review: drop when conda-forge publishes urllib3 >= 2.7.0.
@@ -112,7 +108,7 @@ bandit = ">=1.9.4,<2"
 #   transitive dependency of pygithub (we never import it directly), so there is no
 #   version bump or code change that resolves it. Ignored as unfixable + disputed.
 #   Re-review: drop if pyjwt publishes a fixed release or pygithub drops the dep.
-pip-audit = "pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357 --ignore-vuln CVE-2026-44431 --ignore-vuln CVE-2026-44432 --ignore-vuln PYSEC-2025-183"
+pip-audit = "pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-44431 --ignore-vuln CVE-2026-44432 --ignore-vuln PYSEC-2025-183"
 sast = "bandit -c pyproject.toml -r hephaestus scripts --severity-level medium"
 
 [environments]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ hephaestus-validate-workflow-checkout = "hephaestus.ci.workflows:validate_workfl
 hephaestus-github-stats = "hephaestus.github.stats:main"
 hephaestus-agent-stats = "hephaestus.agents.stats:main"
 hephaestus-validate-agents = "hephaestus.agents.frontmatter:validate_agents_main"
+hephaestus-audit-prs = "hephaestus.automation.audit_reviewer:main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"
@@ -242,6 +243,8 @@ omit = [
     "hephaestus/automation/github_api.py",
     # pr_reviewer.py drives a full Claude session against a live PR; integration-only
     "hephaestus/automation/pr_reviewer.py",
+    # audit_reviewer.py drives a full Claude session against live PRs; integration-only
+    "hephaestus/automation/audit_reviewer.py",
 ]
 
 [tool.coverage.report]

--- a/tests/integration/test_audit_reviewer_smoke.py
+++ b/tests/integration/test_audit_reviewer_smoke.py
@@ -1,0 +1,262 @@
+"""Integration smoke tests for the audit reviewer module.
+
+Validates that the audit-reviewer module works correctly end-to-end without
+requiring live GitHub or agent access.
+
+These tests complement the auto-discovered CLI entry-point checks in
+``test_cli_entry_points.py`` (which cover ``--help``, ``--json``, and
+importability for every ``[project.scripts]`` entry) with functional
+smoke tests of the core parsing, reporting, and class-construction paths.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Module importability
+# ---------------------------------------------------------------------------
+
+class TestAuditReviewerImportable:
+    """The audit reviewer module must be importable without errors."""
+
+    def test_module_importable(self) -> None:
+        """Verify the module can be imported."""
+        try:
+            import hephaestus.automation.audit_reviewer  # noqa: F401
+        except ImportError as e:
+            pytest.fail(f"audit_reviewer module failed to import: {e}")
+
+    def test_key_symbols_exported(self) -> None:
+        """Verify all public API symbols are accessible."""
+        from hephaestus.automation import audit_reviewer
+
+        expected = [
+            "AuditReviewer",
+            "run_audit_coordinator",
+            "post_audit_results",
+            "write_audit_report",
+            "print_audit_summary",
+            "_parse_coordinator_results",
+        ]
+        for name in expected:
+            assert hasattr(audit_reviewer, name), (
+                f"audit_reviewer.{name} not found"
+            )
+
+
+# ---------------------------------------------------------------------------
+# _parse_coordinator_results — integration-level smoke
+# ---------------------------------------------------------------------------
+
+class TestParseCoordinatorResultsIntegration:
+    """End-to-end parsing of realistic coordinator output."""
+
+    @staticmethod
+    def _coordinator_text(results: list[dict]) -> str:
+        """Build a realistic coordinator response with prose + JSON block."""
+        prose = (
+            "I've dispatched sub-agents for all 3 PRs.\n\n"
+            "PR #100: Clean refactor, LGTM.\n"
+            "PR #101: Found a potential issue.\n"
+            "PR #102: Looks good with minor nits.\n"
+        )
+        block = "```json\n" + json.dumps({"results": results}) + "\n```"
+        return prose + "\n" + block
+
+    def test_parse_realistic_output(self) -> None:
+        """Parse a realistic coordinator response with prose + JSON block."""
+        from hephaestus.automation.audit_reviewer import (
+            _parse_coordinator_results,
+        )
+
+        text = self._coordinator_text(
+            [
+                {
+                    "pr_number": 100,
+                    "comments": [],
+                    "summary": "LGTM — clean refactor",
+                },
+                {
+                    "pr_number": 101,
+                    "comments": [
+                        {
+                            "path": "src/foo.py",
+                            "line": 42,
+                            "side": "RIGHT",
+                            "body": "Possible race condition here",
+                        }
+                    ],
+                    "summary": "Needs attention — race condition",
+                },
+            ]
+        )
+
+        results = _parse_coordinator_results(text)
+        assert len(results) == 2
+        assert results[0]["pr_number"] == 100
+        assert results[0]["summary"] == "LGTM — clean refactor"
+        assert results[1]["pr_number"] == 101
+        assert len(results[1]["comments"]) == 1
+
+    def test_parse_multiple_json_blocks_uses_last(self) -> None:
+        """Only the last ```json``` block is parsed."""
+        from hephaestus.automation.audit_reviewer import (
+            _parse_coordinator_results,
+        )
+
+        text = (
+            "```json\n"
+            + json.dumps({"results": [{"pr_number": 1, "comments": [], "summary": "old"}]})
+            + "\n```\n"
+            "Some more prose...\n"
+            "```json\n"
+            + json.dumps({"results": [{"pr_number": 2, "comments": [], "summary": "new"}]})
+            + "\n```"
+        )
+
+        results = _parse_coordinator_results(text)
+        assert len(results) == 1
+        assert results[0]["pr_number"] == 2
+        assert results[0]["summary"] == "new"
+
+
+# ---------------------------------------------------------------------------
+# write_audit_report — integration-level smoke
+# ---------------------------------------------------------------------------
+
+class TestWriteAuditReportIntegration:
+    """End-to-end audit report writing."""
+
+    def test_writes_valid_json_report(self, tmp_path: Path) -> None:
+        """Report file must be valid JSON with expected top-level keys."""
+        from hephaestus.automation.audit_reviewer import write_audit_report
+
+        results = [
+            {
+                "pr_number": 100,
+                "comments": [
+                    {"path": "a.py", "line": 1, "side": "RIGHT", "body": "nit"}
+                ],
+                "summary": "One nit",
+            }
+        ]
+        posted = {100: True}
+
+        report_path = write_audit_report(results, posted, tmp_path)
+        assert report_path.exists()
+        assert report_path.suffix == ".json"
+
+        data = json.loads(report_path.read_text())
+        assert data["total_prs"] == 1
+        assert data["posted"] == 1
+        assert data["failed"] == 0
+        assert data["results"][0]["pr_number"] == 100
+        assert data["results"][0]["comment_count"] == 1
+        assert data["results"][0]["posted"] is True
+
+    def test_report_with_posting_failures(self, tmp_path: Path) -> None:
+        """Failed postings must be reflected in the report."""
+        from hephaestus.automation.audit_reviewer import write_audit_report
+
+        results = [
+            {"pr_number": 100, "comments": [], "summary": "ok"},
+            {"pr_number": 101, "comments": [], "summary": "ok"},
+        ]
+        posted = {100: True, 101: False}
+
+        report_path = write_audit_report(results, posted, tmp_path)
+        data = json.loads(report_path.read_text())
+
+        assert data["total_prs"] == 2
+        assert data["posted"] == 1
+        assert data["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# print_audit_summary — integration-level smoke
+# ---------------------------------------------------------------------------
+
+class TestPrintAuditSummaryIntegration:
+    """End-to-end summary printing."""
+
+    def test_prints_summary_without_errors(self, caplog) -> None:
+        """print_audit_summary must log the summary including per-PR lines."""
+        from hephaestus.automation.audit_reviewer import print_audit_summary
+
+        results = [
+            {"pr_number": 100, "comments": [], "summary": "LGTM"},
+            {
+                "pr_number": 101,
+                "comments": [
+                    {"path": "x.py", "line": 1, "side": "RIGHT", "body": "bug"}
+                ],
+                "summary": "Has issues",
+            },
+        ]
+        posted = {100: True, 101: False}
+
+        with caplog.at_level(logging.INFO):
+            print_audit_summary(results, posted)
+
+        log_text = "\n".join(caplog.messages)
+        assert "PR Audit Review Summary" in log_text
+        assert "Total PRs analysed" in log_text
+        assert "Reviews posted" in log_text
+        assert "Post failures" in log_text
+        # Per-PR verdict lines must appear with PR number, verdict, and counts
+        assert "PR #100" in log_text
+        assert "LGTM" in log_text
+        assert "PR #101" in log_text
+        assert "Has issues" in log_text
+        assert "0 comment" in log_text  # PR #100
+        assert "1 comment" in log_text  # PR #101
+
+
+# ---------------------------------------------------------------------------
+# AuditReviewer construction
+# ---------------------------------------------------------------------------
+
+class TestAuditReviewerConstruction:
+    """AuditReviewer must be constructable with various parameter combinations."""
+
+    def test_default_construction(self) -> None:
+        """Default parameters produce a valid instance."""
+        from hephaestus.automation.audit_reviewer import AuditReviewer
+
+        reviewer = AuditReviewer()
+        assert reviewer.agent == "claude"
+        assert reviewer.dry_run is False
+        assert reviewer.limit == 100
+        assert reviewer.pr_numbers is None
+        assert isinstance(reviewer.repo_root, Path)
+
+    def test_codex_construction(self) -> None:
+        """Codex agent parameter is accepted."""
+        from hephaestus.automation.audit_reviewer import AuditReviewer
+
+        reviewer = AuditReviewer(agent="codex", dry_run=True, limit=10)
+        assert reviewer.agent == "codex"
+        assert reviewer.dry_run is True
+        assert reviewer.limit == 10
+
+    def test_pr_numbers_construction(self) -> None:
+        """Explicit PR numbers parameter is accepted."""
+        from hephaestus.automation.audit_reviewer import AuditReviewer
+
+        reviewer = AuditReviewer(pr_numbers=[595, 596])
+        assert reviewer.pr_numbers == [595, 596]
+
+    def test_state_dir_is_under_build(self) -> None:
+        """State directory must end with ``build/.audit`` under the repo root."""
+        from hephaestus.automation.audit_reviewer import AuditReviewer
+
+        reviewer = AuditReviewer()
+        assert str(reviewer.state_dir).endswith("build/.audit")

--- a/tests/integration/test_audit_reviewer_smoke.py
+++ b/tests/integration/test_audit_reviewer_smoke.py
@@ -24,6 +24,7 @@ pytestmark = pytest.mark.integration
 # Module importability
 # ---------------------------------------------------------------------------
 
+
 class TestAuditReviewerImportable:
     """The audit reviewer module must be importable without errors."""
 
@@ -47,14 +48,13 @@ class TestAuditReviewerImportable:
             "_parse_coordinator_results",
         ]
         for name in expected:
-            assert hasattr(audit_reviewer, name), (
-                f"audit_reviewer.{name} not found"
-            )
+            assert hasattr(audit_reviewer, name), f"audit_reviewer.{name} not found"
 
 
 # ---------------------------------------------------------------------------
 # _parse_coordinator_results — integration-level smoke
 # ---------------------------------------------------------------------------
+
 
 class TestParseCoordinatorResultsIntegration:
     """End-to-end parsing of realistic coordinator output."""
@@ -132,6 +132,7 @@ class TestParseCoordinatorResultsIntegration:
 # write_audit_report — integration-level smoke
 # ---------------------------------------------------------------------------
 
+
 class TestWriteAuditReportIntegration:
     """End-to-end audit report writing."""
 
@@ -142,9 +143,7 @@ class TestWriteAuditReportIntegration:
         results = [
             {
                 "pr_number": 100,
-                "comments": [
-                    {"path": "a.py", "line": 1, "side": "RIGHT", "body": "nit"}
-                ],
+                "comments": [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "nit"}],
                 "summary": "One nit",
             }
         ]
@@ -184,6 +183,7 @@ class TestWriteAuditReportIntegration:
 # print_audit_summary — integration-level smoke
 # ---------------------------------------------------------------------------
 
+
 class TestPrintAuditSummaryIntegration:
     """End-to-end summary printing."""
 
@@ -195,9 +195,7 @@ class TestPrintAuditSummaryIntegration:
             {"pr_number": 100, "comments": [], "summary": "LGTM"},
             {
                 "pr_number": 101,
-                "comments": [
-                    {"path": "x.py", "line": 1, "side": "RIGHT", "body": "bug"}
-                ],
+                "comments": [{"path": "x.py", "line": 1, "side": "RIGHT", "body": "bug"}],
                 "summary": "Has issues",
             },
         ]
@@ -223,6 +221,7 @@ class TestPrintAuditSummaryIntegration:
 # ---------------------------------------------------------------------------
 # AuditReviewer construction
 # ---------------------------------------------------------------------------
+
 
 class TestAuditReviewerConstruction:
     """AuditReviewer must be constructable with various parameter combinations."""

--- a/tests/integration/test_orchestration_smoke.py
+++ b/tests/integration/test_orchestration_smoke.py
@@ -30,6 +30,7 @@ OMITTED_MODULES = [
     "hephaestus.automation.curses_ui",
     "hephaestus.automation.github_api",
     "hephaestus.automation.pr_reviewer",
+    "hephaestus.automation.audit_reviewer",
 ]
 
 # Modules with console scripts (run --help to verify entry point works)
@@ -38,6 +39,7 @@ CONSOLE_SCRIPTS = [
     ("hephaestus-plan-issues", "hephaestus.automation.planner"),
     ("hephaestus-automation-loop", "hephaestus.automation.loop_runner"),
     ("hephaestus-review-prs", "hephaestus.automation.pr_reviewer"),
+    ("hephaestus-audit-prs", "hephaestus.automation.audit_reviewer"),
 ]
 
 # Modules with main() but no console script of their own.

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -1,0 +1,322 @@
+"""Tests for hephaestus.automation.audit_reviewer.
+
+Covers _parse_coordinator_results, post_audit_results, write_audit_report,
+print_audit_summary, and the CLI main() smoke tests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from hephaestus.automation import audit_reviewer
+
+
+class TestParseCoordinatorResults:
+    """Tests for _parse_coordinator_results."""
+
+    def test_extracts_last_json_block(self) -> None:
+        text = 'some prose\n```json\n{"results": [{"pr_number": 1}]}\n```\ntrailing'
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert results == [{"pr_number": 1}]
+
+    def test_returns_last_json_block_when_multiple(self) -> None:
+        text = (
+            '```json\n{"results": [{"pr_number": 1}]}\n```\n'
+            'more text\n'
+            '```json\n{"results": [{"pr_number": 2}, {"pr_number": 3}]}\n```'
+        )
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert len(results) == 2
+        assert results[0]["pr_number"] == 2
+        assert results[1]["pr_number"] == 3
+
+    def test_returns_empty_list_when_no_json_block(self) -> None:
+        results = audit_reviewer._parse_coordinator_results("no json here")
+        assert results == []
+
+    def test_returns_empty_list_when_results_not_a_list(self) -> None:
+        text = '```json\n{"results": "not a list"}\n```'
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert results == []
+
+    def test_returns_empty_list_when_invalid_json(self) -> None:
+        text = "```json\n{invalid json}\n```"
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert results == []
+
+    def test_returns_empty_list_when_no_results_key(self) -> None:
+        text = '```json\n{"other": "data"}\n```'
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert results == []
+
+    def test_handles_json_without_fence_gracefully(self) -> None:
+        """Missing ``` markers should return empty."""
+        text = '{"results": [{"pr_number": 1}]}'
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert results == []
+
+
+class TestPostAuditResults:
+    """Tests for post_audit_results."""
+
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
+    def test_posts_all_results(self, mock_post: Any) -> None:
+        results: list[dict[str, Any]] = [
+            {
+                "pr_number": 1,
+                "comments": [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "fix"}],
+                "summary": "needs work",
+            },
+            {
+                "pr_number": 2,
+                "comments": [],
+                "summary": "LGTM",
+            },
+        ]
+        posted = audit_reviewer.post_audit_results(results)
+        assert mock_post.call_count == 2
+        assert posted == {1: True, 2: True}
+
+    def test_dry_run_does_nothing(self) -> None:
+        results: list[dict[str, Any]] = [
+            {"pr_number": 1, "comments": [], "summary": "test"}
+        ]
+        posted = audit_reviewer.post_audit_results(results, dry_run=True)
+        assert posted == {1: False}
+
+    def test_skips_missing_pr_number(self) -> None:
+        results: list[dict[str, Any]] = [
+            {"comments": [], "summary": "no pr_number key"}
+        ]
+        posted = audit_reviewer.post_audit_results(results)
+        assert posted == {}
+
+    def test_handles_non_list_comments(self) -> None:
+        results: list[dict[str, Any]] = [
+            {"pr_number": 1, "comments": "not-a-list", "summary": "test"}
+        ]
+        # Should coerce "not-a-list" to [] and still post
+        with patch("hephaestus.automation.audit_reviewer.gh_pr_review_post") as mock_post:
+            posted = audit_reviewer.post_audit_results(results)
+            assert posted == {1: True}
+            # comments arg should be [] after coercion
+            assert mock_post.call_args.kwargs["comments"] == []
+
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
+    def test_posting_failure_is_recorded(self, mock_post: Any) -> None:
+        mock_post.side_effect = RuntimeError("API down")
+        results: list[dict[str, Any]] = [
+            {"pr_number": 1, "comments": [], "summary": "test"}
+        ]
+        posted = audit_reviewer.post_audit_results(results)
+        assert posted == {1: False}
+
+
+class TestWriteAuditReport:
+    """Tests for write_audit_report."""
+
+    def test_writes_report_file(self, tmp_path: Path) -> None:
+        results: list[dict[str, Any]] = [
+            {"pr_number": 1, "comments": [{}], "summary": "ok"},
+            {"pr_number": 2, "comments": [], "summary": "LGTM"},
+        ]
+        posted = {1: True, 2: True}
+        state_dir = tmp_path / "audit"
+
+        path = audit_reviewer.write_audit_report(results, posted, state_dir)
+
+        assert path.exists()
+        report = json.loads(path.read_text())
+        assert report["total_prs"] == 2
+        assert report["posted"] == 2
+        assert report["failed"] == 0
+        assert len(report["results"]) == 2
+
+        # Check PR 1: 1 comment, posted true
+        assert report["results"][0]["pr_number"] == 1
+        assert report["results"][0]["comment_count"] == 1
+        assert report["results"][0]["posted"] is True
+
+        # Check PR 2: 0 comments, posted true
+        assert report["results"][1]["pr_number"] == 2
+        assert report["results"][1]["comment_count"] == 0
+        assert report["results"][1]["posted"] is True
+
+    def test_report_counts_failures(self, tmp_path: Path) -> None:
+        results: list[dict[str, Any]] = [
+            {"pr_number": 1, "comments": [], "summary": "ok"},
+        ]
+        posted = {1: False}
+        state_dir = tmp_path / "audit"
+
+        path = audit_reviewer.write_audit_report(results, posted, state_dir)
+
+        report = json.loads(path.read_text())
+        assert report["posted"] == 0
+        assert report["failed"] == 1
+
+    def test_creates_state_dir_if_missing(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "deeply" / "nested" / "audit"
+        results: list[dict[str, Any]] = []
+        posted: dict[int, bool] = {}
+
+        path = audit_reviewer.write_audit_report(results, posted, state_dir)
+
+        assert path.exists()
+        assert path.parent == state_dir
+
+
+class TestPrintAuditSummary:
+    """Tests for print_audit_summary (best-effort logging verification)."""
+
+    def test_prints_summary_lines(self, caplog: Any) -> None:
+        import logging
+
+        caplog.set_level(logging.INFO, logger="hephaestus.automation.audit_reviewer")
+        results: list[dict[str, Any]] = [
+            {"pr_number": 1, "comments": [{"path": "a.py", "line": 1, "body": "fix"}], "summary": "needs work"},
+        ]
+        posted = {1: True}
+
+        audit_reviewer.print_audit_summary(results, posted)
+
+        assert "Total PRs analysed" in caplog.text
+        assert "Reviews posted" in caplog.text
+        assert "needs work" in caplog.text
+
+
+class TestAuditReviewerFetchPrsByNumber:
+    """Tests for AuditReviewer._fetch_prs_by_number static method."""
+
+    @patch("hephaestus.automation.audit_reviewer._gh_call")
+    def test_fetches_and_parses_prs(self, mock_gh_call: Any) -> None:
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {
+                "number": 42,
+                "title": "Test PR",
+                "author": {"login": "alice"},
+                "headRefName": "feat",
+                "baseRefName": "main",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+            }
+        )
+        mock_gh_call.return_value = mock_result
+
+        prs = audit_reviewer.AuditReviewer._fetch_prs_by_number([42])
+
+        assert len(prs) == 1
+        assert prs[0]["number"] == 42
+        assert prs[0]["author"] == "alice"
+        assert prs[0]["ci_status"] == "SUCCESS"
+
+    @patch("hephaestus.automation.audit_reviewer._gh_call")
+    def test_returns_sorted_by_number(self, mock_gh_call: Any) -> None:
+        """Even when fetching by explicit numbers, results are sorted by PR number."""
+
+        def side_effect(args: list[str], **__: Any) -> Any:
+            num = [a for a in args if a.isdigit()][0]
+            result = Mock()
+            result.stdout = json.dumps(
+                {
+                    "number": int(num),
+                    "title": f"PR {num}",
+                    "author": {"login": "user"},
+                    "headRefName": "feat",
+                    "baseRefName": "main",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [],
+                }
+            )
+            return result
+
+        mock_gh_call.side_effect = side_effect
+
+        prs = audit_reviewer.AuditReviewer._fetch_prs_by_number([3, 1, 2])
+
+        assert [p["number"] for p in prs] == [1, 2, 3]
+
+    @patch("hephaestus.automation.audit_reviewer._gh_call")
+    def test_skip_failed_fetches(self, mock_gh_call: Any) -> None:
+        """Failed fetches are logged and skipped, not propagated."""
+        mock_gh_call.side_effect = RuntimeError("gh offline")
+
+        prs = audit_reviewer.AuditReviewer._fetch_prs_by_number([42])
+
+        assert prs == []
+
+
+class TestAuditReviewerMain:
+    """Smoke tests for audit_reviewer.main() CLI entry point."""
+
+    def test_main_success(self, monkeypatch: Any) -> None:
+        """When run() returns 0, main() exits 0."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["audit_reviewer", "--dry-run", "--agent", "claude"],
+        )
+        with (
+            patch.object(audit_reviewer.AuditReviewer, "__init__", return_value=None),
+            patch.object(audit_reviewer.AuditReviewer, "run", return_value=0),
+        ):
+            assert audit_reviewer.main() == 0
+
+    def test_main_failure(self, monkeypatch: Any) -> None:
+        """When run() returns 1, main() exits 1."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["audit_reviewer", "--dry-run", "--agent", "claude"],
+        )
+        with (
+            patch.object(audit_reviewer.AuditReviewer, "__init__", return_value=None),
+            patch.object(audit_reviewer.AuditReviewer, "run", return_value=1),
+        ):
+            assert audit_reviewer.main() == 1
+
+    def test_main_keyboard_interrupt(self, monkeypatch: Any) -> None:
+        """KeyboardInterrupt during run() returns 130."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["audit_reviewer", "--dry-run", "--agent", "claude"],
+        )
+        with (
+            patch.object(audit_reviewer.AuditReviewer, "__init__", return_value=None),
+            patch.object(audit_reviewer.AuditReviewer, "run", MagicMock(side_effect=KeyboardInterrupt())),
+        ):
+            assert audit_reviewer.main() == 130
+
+    def test_main_with_pr_numbers(self, monkeypatch: Any) -> None:
+        """The --pr-numbers flag is passed through to AuditReviewer."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["audit_reviewer", "--pr-numbers", "595", "596", "--dry-run", "--agent", "claude"],
+        )
+        init_mock = MagicMock(return_value=None)
+        with (
+            patch.object(audit_reviewer.AuditReviewer, "__init__", init_mock),
+            patch.object(audit_reviewer.AuditReviewer, "run", return_value=0),
+        ):
+            audit_reviewer.main()
+            assert init_mock.call_args.kwargs["pr_numbers"] == [595, 596]
+
+    def test_main_with_limit(self, monkeypatch: Any) -> None:
+        """The --limit flag is passed through to AuditReviewer."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["audit_reviewer", "--limit", "20", "--dry-run", "--agent", "claude"],
+        )
+        init_mock = MagicMock(return_value=None)
+        with (
+            patch.object(audit_reviewer.AuditReviewer, "__init__", init_mock),
+            patch.object(audit_reviewer.AuditReviewer, "run", return_value=0),
+        ):
+            audit_reviewer.main()
+            assert init_mock.call_args.kwargs["limit"] == 20

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -1,12 +1,14 @@
 """Tests for hephaestus.automation.audit_reviewer.
 
 Covers _parse_coordinator_results, post_audit_results, write_audit_report,
-print_audit_summary, and the CLI main() smoke tests.
+print_audit_summary, run_audit_coordinator, AuditReviewer.run(),
+AuditReviewer._fetch_prs_by_number, and the CLI main() smoke tests.
 """
 
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -14,6 +16,23 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from hephaestus.automation import audit_reviewer
+
+
+def _make_pr_list(count: int = 2) -> list[dict[str, Any]]:
+    """Build a minimal PR list for test inputs."""
+    return [
+        {
+            "number": i,
+            "title": f"PR {i}",
+            "author": "testuser",
+            "headRefName": f"feat-{i}",
+            "baseRefName": "main",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "ci_status": "SUCCESS",
+        }
+        for i in range(1, count + 1)
+    ]
 
 
 class TestParseCoordinatorResults:
@@ -57,6 +76,45 @@ class TestParseCoordinatorResults:
     def test_handles_json_without_fence_gracefully(self) -> None:
         """Missing ``` markers should return empty."""
         text = '{"results": [{"pr_number": 1}]}'
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert results == []
+
+    def test_handles_empty_string(self) -> None:
+        """Empty string returns empty list."""
+        results = audit_reviewer._parse_coordinator_results("")
+        assert results == []
+
+    def test_handles_whitespace_only_text(self) -> None:
+        """Whitespace-only text with no JSON returns empty list."""
+        results = audit_reviewer._parse_coordinator_results("   \n  \n  ")
+        assert results == []
+
+    def test_extracts_from_text_with_prose_before_and_after(self) -> None:
+        """Coordinator prose before and after the JSON block is ignored."""
+        text = (
+            "I have reviewed all PRs. Here are the results:\n\n"
+            '```json\n{"results": [{"pr_number": 42, "comments": [], "summary": "LGTM"}]}\n```\n\n'
+            "All PRs have been analysed."
+        )
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert len(results) == 1
+        assert results[0]["pr_number"] == 42
+
+    def test_extracts_results_with_extra_fields(self) -> None:
+        """Results dict may carry extra fields beyond pr_number/comments/summary."""
+        text = (
+            '```json\n'
+            '{"results": [{"pr_number": 1, "comments": [], "summary": "ok",'
+            ' "extra_field": "ignored"}]}\n'
+            '```'
+        )
+        results = audit_reviewer._parse_coordinator_results(text)
+        assert len(results) == 1
+        assert results[0]["pr_number"] == 1
+
+    def test_returns_empty_list_for_malformed_fence(self) -> None:
+        """Unclosed fence block returns empty (regex requires closing ```)."""
+        text = '```json\n{"results": [{"pr_number": 1}]}'
         results = audit_reviewer._parse_coordinator_results(text)
         assert results == []
 
@@ -179,7 +237,11 @@ class TestPrintAuditSummary:
 
         caplog.set_level(logging.INFO, logger="hephaestus.automation.audit_reviewer")
         results: list[dict[str, Any]] = [
-            {"pr_number": 1, "comments": [{"path": "a.py", "line": 1, "body": "fix"}], "summary": "needs work"},
+            {
+                "pr_number": 1,
+                "comments": [{"path": "a.py", "line": 1, "body": "fix"}],
+                "summary": "needs work",
+            },
         ]
         posted = {1: True}
 
@@ -192,6 +254,11 @@ class TestPrintAuditSummary:
 
 class TestAuditReviewerFetchPrsByNumber:
     """Tests for AuditReviewer._fetch_prs_by_number static method."""
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Fetching with an empty list returns an empty list."""
+        prs = audit_reviewer.AuditReviewer._fetch_prs_by_number([])
+        assert prs == []
 
     @patch("hephaestus.automation.audit_reviewer._gh_call")
     def test_fetches_and_parses_prs(self, mock_gh_call: Any) -> None:
@@ -222,7 +289,7 @@ class TestAuditReviewerFetchPrsByNumber:
         """Even when fetching by explicit numbers, results are sorted by PR number."""
 
         def side_effect(args: list[str], **__: Any) -> Any:
-            num = [a for a in args if a.isdigit()][0]
+            num = next(a for a in args if a.isdigit())
             result = Mock()
             result.stdout = json.dumps(
                 {
@@ -252,6 +319,362 @@ class TestAuditReviewerFetchPrsByNumber:
         prs = audit_reviewer.AuditReviewer._fetch_prs_by_number([42])
 
         assert prs == []
+
+
+class TestRunAuditCoordinator:
+    """Tests for run_audit_coordinator."""
+
+    def test_dry_run_returns_empty(self, tmp_path: Path) -> None:
+        """dry_run=True skips agent invocation and returns empty list."""
+        pr_list = _make_pr_list()
+        results = audit_reviewer.run_audit_coordinator(
+            pr_list=pr_list,
+            worktree_path=tmp_path,
+            agent="claude",
+            state_dir=tmp_path / "audit",
+            dry_run=True,
+        )
+        assert results == []
+
+    @patch("hephaestus.automation.audit_reviewer.is_codex", return_value=True)
+    @patch("hephaestus.automation.audit_reviewer.run_codex_text")
+    def test_codex_path_parses_results(
+        self, mock_run_codex: Any, mock_is_codex: Any, tmp_path: Path
+    ) -> None:
+        """Codex path: runs run_codex_text and parses its JSON output."""
+        pr_list = _make_pr_list()
+        mock_result = Mock()
+        mock_result.stdout = (
+            '```json\n{"results": [{"pr_number": 1, "comments": [],'
+            ' "summary": "LGTM"}, {"pr_number": 2, "comments": [],'
+            ' "summary": "LGTM"}]}\n```'
+        )
+        mock_run_codex.return_value = mock_result
+
+        results = audit_reviewer.run_audit_coordinator(
+            pr_list=pr_list,
+            worktree_path=tmp_path,
+            agent="codex",
+            state_dir=tmp_path / "audit",
+        )
+
+        assert len(results) == 2
+        assert results[0]["pr_number"] == 1
+        assert results[1]["pr_number"] == 2
+        mock_run_codex.assert_called_once()
+
+    @patch("hephaestus.automation.audit_reviewer.is_codex", return_value=True)
+    @patch("hephaestus.automation.audit_reviewer.run_codex_text")
+    def test_codex_path_handles_empty_stdout(
+        self, mock_run_codex: Any, mock_is_codex: Any, tmp_path: Path
+    ) -> None:
+        """Codex path: empty/NULL stdout returns empty list gracefully."""
+        pr_list = _make_pr_list()
+        mock_result = Mock()
+        mock_result.stdout = None
+        mock_run_codex.return_value = mock_result
+
+        results = audit_reviewer.run_audit_coordinator(
+            pr_list=pr_list,
+            worktree_path=tmp_path,
+            agent="codex",
+            state_dir=tmp_path / "audit",
+        )
+
+        assert results == []
+
+    @patch("hephaestus.automation.audit_reviewer.is_codex", return_value=False)
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_slug")
+    @patch("hephaestus.automation.audit_reviewer.invoke_claude_with_session")
+    def test_claude_path_parses_results(
+        self,
+        mock_invoke: Any,
+        mock_repo_slug: Any,
+        mock_repo_root: Any,
+        mock_is_codex: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Claude path: runs invoke_claude_with_session and parses JSON output."""
+        pr_list = _make_pr_list()
+        mock_repo_root.return_value = tmp_path
+        mock_repo_slug.return_value = "test-repo"
+        mock_invoke.return_value = (
+            '```json\n{"results": [{"pr_number": 1, "comments": [],'
+            ' "summary": "LGTM"}]}\n```',
+            "session-sid",
+        )
+
+        results = audit_reviewer.run_audit_coordinator(
+            pr_list=pr_list,
+            worktree_path=tmp_path,
+            agent="claude",
+            state_dir=tmp_path / "audit",
+        )
+
+        assert len(results) == 1
+        assert results[0]["pr_number"] == 1
+        mock_invoke.assert_called_once()
+
+    @patch("hephaestus.automation.audit_reviewer.is_codex", return_value=False)
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_slug")
+    @patch("hephaestus.automation.audit_reviewer.invoke_claude_with_session")
+    def test_claude_path_handles_json_output_format(
+        self,
+        mock_invoke: Any,
+        mock_repo_slug: Any,
+        mock_repo_root: Any,
+        mock_is_codex: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Claude path with json output_format: extracts result from JSON wrapper."""
+        pr_list = _make_pr_list()
+        mock_repo_root.return_value = tmp_path
+        mock_repo_slug.return_value = "test-repo"
+        # When output_format="json", stdout is a JSON dict with "result" key
+        wrapped_json = json.dumps({
+            "result": (
+                '```json\n{"results": [{"pr_number": 1, "comments": [],'
+                ' "summary": "LGTM"}]}\n```'
+            )
+        })
+        mock_invoke.return_value = (wrapped_json, "session-sid")
+
+        results = audit_reviewer.run_audit_coordinator(
+            pr_list=pr_list,
+            worktree_path=tmp_path,
+            agent="claude",
+            state_dir=tmp_path / "audit",
+        )
+
+        assert len(results) == 1
+
+    @patch("hephaestus.automation.audit_reviewer.is_codex", return_value=False)
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_slug")
+    @patch("hephaestus.automation.audit_reviewer.invoke_claude_with_session")
+    def test_claude_path_raises_on_called_process_error(
+        self,
+        mock_invoke: Any,
+        mock_repo_slug: Any,
+        mock_repo_root: Any,
+        mock_is_codex: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Claude path: CalledProcessError raises RuntimeError with stderr."""
+        pr_list = _make_pr_list()
+        mock_repo_root.return_value = tmp_path
+        mock_repo_slug.return_value = "test-repo"
+        mock_invoke.side_effect = subprocess.CalledProcessError(
+            1, "claude", output="", stderr="fatal error"
+        )
+
+        with pytest.raises(RuntimeError, match="fatal error"):
+            audit_reviewer.run_audit_coordinator(
+                pr_list=pr_list,
+                worktree_path=tmp_path,
+                agent="claude",
+                state_dir=tmp_path / "audit",
+            )
+
+    @patch("hephaestus.automation.audit_reviewer.is_codex", return_value=False)
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_slug")
+    @patch("hephaestus.automation.audit_reviewer.invoke_claude_with_session")
+    def test_claude_path_raises_on_timeout(
+        self,
+        mock_invoke: Any,
+        mock_repo_slug: Any,
+        mock_repo_root: Any,
+        mock_is_codex: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Claude path: TimeoutExpired raises RuntimeError."""
+        pr_list = _make_pr_list()
+        mock_repo_root.return_value = tmp_path
+        mock_repo_slug.return_value = "test-repo"
+        mock_invoke.side_effect = subprocess.TimeoutExpired("claude", 300, output="")
+
+        with pytest.raises(RuntimeError, match="timed out"):
+            audit_reviewer.run_audit_coordinator(
+                pr_list=pr_list,
+                worktree_path=tmp_path,
+                agent="claude",
+                state_dir=tmp_path / "audit",
+            )
+
+
+class TestAuditReviewerRun:
+    """Tests for AuditReviewer.run() orchestration method."""
+
+    @patch("hephaestus.automation.audit_reviewer.write_audit_report")
+    @patch("hephaestus.automation.audit_reviewer.print_audit_summary")
+    @patch("hephaestus.automation.audit_reviewer.post_audit_results")
+    @patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_list_open")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    def test_run_happy_path(
+        self,
+        mock_get_root: Any,
+        mock_list_open: Any,
+        mock_run_coord: Any,
+        mock_post: Any,
+        mock_print: Any,
+        mock_write: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Full happy path: list PRs → run coordinator → post → write → print."""
+        pr_list = _make_pr_list()
+        mock_get_root.return_value = str(tmp_path)
+        mock_list_open.return_value = pr_list
+        mock_run_coord.return_value = [
+            {"pr_number": 1, "comments": [], "summary": "LGTM"},
+            {"pr_number": 2, "comments": [], "summary": "LGTM"},
+        ]
+        mock_post.return_value = {1: True, 2: True}
+
+        reviewer = audit_reviewer.AuditReviewer(agent="claude")
+        exit_code = reviewer.run()
+
+        assert exit_code == 0
+        mock_list_open.assert_called_once()
+        mock_run_coord.assert_called_once()
+        assert mock_run_coord.call_args.kwargs["dry_run"] is False
+        mock_post.assert_called_once()
+        mock_write.assert_called_once()
+        mock_print.assert_called_once()
+
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_list_open")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    def test_run_no_open_prs(
+        self,
+        mock_get_root: Any,
+        mock_list_open: Any,
+        tmp_path: Path,
+    ) -> None:
+        """When no open PRs exist, returns 0 early without running coordinator."""
+        mock_get_root.return_value = str(tmp_path)
+        mock_list_open.return_value = []
+
+        reviewer = audit_reviewer.AuditReviewer(agent="claude")
+        exit_code = reviewer.run()
+
+        assert exit_code == 0
+        mock_list_open.assert_called_once()
+
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_list_open")
+    @patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    def test_run_coordinator_returns_empty(
+        self,
+        mock_get_root: Any,
+        mock_run_coord: Any,
+        mock_list_open: Any,
+        tmp_path: Path,
+    ) -> None:
+        """When coordinator returns no results, returns 1."""
+        pr_list = _make_pr_list()
+        mock_get_root.return_value = str(tmp_path)
+        mock_list_open.return_value = pr_list
+        mock_run_coord.return_value = []
+
+        reviewer = audit_reviewer.AuditReviewer(agent="claude")
+        exit_code = reviewer.run()
+
+        assert exit_code == 1
+
+    @patch("hephaestus.automation.audit_reviewer.write_audit_report")
+    @patch("hephaestus.automation.audit_reviewer.print_audit_summary")
+    @patch("hephaestus.automation.audit_reviewer.post_audit_results")
+    @patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_list_open")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    def test_run_with_posting_failure(
+        self,
+        mock_get_root: Any,
+        mock_list_open: Any,
+        mock_run_coord: Any,
+        mock_post: Any,
+        mock_print: Any,
+        mock_write: Any,
+        tmp_path: Path,
+    ) -> None:
+        """When posting fails for some PRs, returns 1."""
+        pr_list = _make_pr_list()
+        mock_get_root.return_value = str(tmp_path)
+        mock_list_open.return_value = pr_list
+        mock_run_coord.return_value = [
+            {"pr_number": 1, "comments": [], "summary": "LGTM"},
+        ]
+        mock_post.return_value = {1: False}
+
+        reviewer = audit_reviewer.AuditReviewer(agent="claude")
+        exit_code = reviewer.run()
+
+        assert exit_code == 1
+
+    @patch("hephaestus.automation.audit_reviewer.write_audit_report")
+    @patch("hephaestus.automation.audit_reviewer.print_audit_summary")
+    @patch("hephaestus.automation.audit_reviewer.post_audit_results")
+    @patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    def test_run_with_pr_numbers(
+        self,
+        mock_get_root: Any,
+        mock_run_coord: Any,
+        mock_post: Any,
+        mock_print: Any,
+        mock_write: Any,
+        tmp_path: Path,
+    ) -> None:
+        """When pr_numbers are provided, uses _fetch_prs_by_number instead of gh_pr_list_open."""
+        mock_get_root.return_value = str(tmp_path)
+        mock_run_coord.return_value = [
+            {"pr_number": 42, "comments": [], "summary": "LGTM"},
+        ]
+        mock_post.return_value = {42: True}
+
+        with patch.object(
+            audit_reviewer.AuditReviewer, "_fetch_prs_by_number"
+        ) as mock_fetch:
+            mock_fetch.return_value = [
+                {
+                    "number": 42,
+                    "title": "Test",
+                    "author": "alice",
+                    "headRefName": "feat",
+                    "baseRefName": "main",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "ci_status": "SUCCESS",
+                },
+            ]
+            reviewer = audit_reviewer.AuditReviewer(
+                agent="claude", pr_numbers=[42]
+            )
+            exit_code = reviewer.run()
+
+        assert exit_code == 0
+        mock_fetch.assert_called_once_with([42])
+
+    @patch("hephaestus.automation.audit_reviewer.gh_pr_list_open")
+    @patch("hephaestus.automation.audit_reviewer.get_repo_root")
+    def test_run_dry_run_early_exit(
+        self,
+        mock_get_root: Any,
+        mock_list_open: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Dry run: gh_pr_list_open returns empty → early exit 0."""
+        mock_get_root.return_value = str(tmp_path)
+        mock_list_open.return_value = []
+
+        reviewer = audit_reviewer.AuditReviewer(agent="claude", dry_run=True)
+        exit_code = reviewer.run()
+
+        assert exit_code == 0
+        mock_list_open.assert_called_once()
 
 
 class TestAuditReviewerMain:
@@ -289,7 +712,11 @@ class TestAuditReviewerMain:
         )
         with (
             patch.object(audit_reviewer.AuditReviewer, "__init__", return_value=None),
-            patch.object(audit_reviewer.AuditReviewer, "run", MagicMock(side_effect=KeyboardInterrupt())),
+            patch.object(
+                audit_reviewer.AuditReviewer,
+                "run",
+                MagicMock(side_effect=KeyboardInterrupt()),
+            ),
         ):
             assert audit_reviewer.main() == 130
 

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -46,7 +46,7 @@ class TestParseCoordinatorResults:
     def test_returns_last_json_block_when_multiple(self) -> None:
         text = (
             '```json\n{"results": [{"pr_number": 1}]}\n```\n'
-            'more text\n'
+            "more text\n"
             '```json\n{"results": [{"pr_number": 2}, {"pr_number": 3}]}\n```'
         )
         results = audit_reviewer._parse_coordinator_results(text)
@@ -103,10 +103,10 @@ class TestParseCoordinatorResults:
     def test_extracts_results_with_extra_fields(self) -> None:
         """Results dict may carry extra fields beyond pr_number/comments/summary."""
         text = (
-            '```json\n'
+            "```json\n"
             '{"results": [{"pr_number": 1, "comments": [], "summary": "ok",'
             ' "extra_field": "ignored"}]}\n'
-            '```'
+            "```"
         )
         results = audit_reviewer._parse_coordinator_results(text)
         assert len(results) == 1
@@ -141,16 +141,12 @@ class TestPostAuditResults:
         assert posted == {1: True, 2: True}
 
     def test_dry_run_does_nothing(self) -> None:
-        results: list[dict[str, Any]] = [
-            {"pr_number": 1, "comments": [], "summary": "test"}
-        ]
+        results: list[dict[str, Any]] = [{"pr_number": 1, "comments": [], "summary": "test"}]
         posted = audit_reviewer.post_audit_results(results, dry_run=True)
         assert posted == {1: False}
 
     def test_skips_missing_pr_number(self) -> None:
-        results: list[dict[str, Any]] = [
-            {"comments": [], "summary": "no pr_number key"}
-        ]
+        results: list[dict[str, Any]] = [{"comments": [], "summary": "no pr_number key"}]
         posted = audit_reviewer.post_audit_results(results)
         assert posted == {}
 
@@ -168,9 +164,7 @@ class TestPostAuditResults:
     @patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
     def test_posting_failure_is_recorded(self, mock_post: Any) -> None:
         mock_post.side_effect = RuntimeError("API down")
-        results: list[dict[str, Any]] = [
-            {"pr_number": 1, "comments": [], "summary": "test"}
-        ]
+        results: list[dict[str, Any]] = [{"pr_number": 1, "comments": [], "summary": "test"}]
         posted = audit_reviewer.post_audit_results(results)
         assert posted == {1: False}
 
@@ -400,8 +394,7 @@ class TestRunAuditCoordinator:
         mock_repo_root.return_value = tmp_path
         mock_repo_slug.return_value = "test-repo"
         mock_invoke.return_value = (
-            '```json\n{"results": [{"pr_number": 1, "comments": [],'
-            ' "summary": "LGTM"}]}\n```',
+            '```json\n{"results": [{"pr_number": 1, "comments": [], "summary": "LGTM"}]}\n```',
             "session-sid",
         )
 
@@ -433,12 +426,14 @@ class TestRunAuditCoordinator:
         mock_repo_root.return_value = tmp_path
         mock_repo_slug.return_value = "test-repo"
         # When output_format="json", stdout is a JSON dict with "result" key
-        wrapped_json = json.dumps({
-            "result": (
-                '```json\n{"results": [{"pr_number": 1, "comments": [],'
-                ' "summary": "LGTM"}]}\n```'
-            )
-        })
+        wrapped_json = json.dumps(
+            {
+                "result": (
+                    '```json\n{"results": [{"pr_number": 1, "comments": [],'
+                    ' "summary": "LGTM"}]}\n```'
+                )
+            }
+        )
         mock_invoke.return_value = (wrapped_json, "session-sid")
 
         results = audit_reviewer.run_audit_coordinator(
@@ -635,9 +630,7 @@ class TestAuditReviewerRun:
         ]
         mock_post.return_value = {42: True}
 
-        with patch.object(
-            audit_reviewer.AuditReviewer, "_fetch_prs_by_number"
-        ) as mock_fetch:
+        with patch.object(audit_reviewer.AuditReviewer, "_fetch_prs_by_number") as mock_fetch:
             mock_fetch.return_value = [
                 {
                     "number": 42,
@@ -650,9 +643,7 @@ class TestAuditReviewerRun:
                     "ci_status": "SUCCESS",
                 },
             ]
-            reviewer = audit_reviewer.AuditReviewer(
-                agent="claude", pr_numbers=[42]
-            )
+            reviewer = audit_reviewer.AuditReviewer(agent="claude", pr_numbers=[42])
             exit_code = reviewer.run()
 
         assert exit_code == 0

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -11,6 +11,7 @@ import hephaestus.automation.github_api as _github_api_module
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
+    _derive_ci_status,
     _gh_call,
     fetch_issue_info,
     gh_create_label,
@@ -25,6 +26,7 @@ from hephaestus.automation.github_api import (
     gh_list_open_issues,
     gh_pr_checks,
     gh_pr_create,
+    gh_pr_list_open,
     gh_pr_review_post,
     is_issue_closed,
     parse_issue_dependencies,
@@ -1638,6 +1640,163 @@ class TestUpsertAndDeleteComment:
         (args,) = mock_gh_call.call_args.args
         assert "DELETE" in args
         assert "/repos/o/r/issues/comments/42" in args
+
+
+class TestDeriveCiStatus:
+    """Tests for _derive_ci_status helper."""
+
+    def test_empty_checks_returns_unknown(self) -> None:
+        assert _derive_ci_status([]) == "UNKNOWN"
+
+    def test_all_success_returns_success(self) -> None:
+        checks = [
+            {"conclusion": "SUCCESS"},
+            {"conclusion": "SUCCESS"},
+            {"conclusion": "NEUTRAL"},
+        ]
+        assert _derive_ci_status(checks) == "SUCCESS"
+
+    def test_any_failure_returns_failure(self) -> None:
+        checks = [
+            {"conclusion": "SUCCESS"},
+            {"conclusion": "FAILURE"},
+        ]
+        assert _derive_ci_status(checks) == "FAILURE"
+
+    def test_timed_out_is_failure(self) -> None:
+        checks = [{"conclusion": "TIMED_OUT"}]
+        assert _derive_ci_status(checks) == "FAILURE"
+
+    def test_cancelled_is_failure(self) -> None:
+        checks = [{"conclusion": "CANCELLED"}]
+        assert _derive_ci_status(checks) == "FAILURE"
+
+    def test_action_required_is_failure(self) -> None:
+        checks = [{"conclusion": "ACTION_REQUIRED"}]
+        assert _derive_ci_status(checks) == "FAILURE"
+
+    def test_error_is_failure(self) -> None:
+        checks = [{"conclusion": "ERROR"}]
+        assert _derive_ci_status(checks) == "FAILURE"
+
+    def test_pending_returns_pending(self) -> None:
+        checks = [{"conclusion": "PENDING"}]
+        assert _derive_ci_status(checks) == "PENDING"
+
+    def test_in_progress_returns_pending(self) -> None:
+        checks = [{"conclusion": "IN_PROGRESS"}]
+        assert _derive_ci_status(checks) == "PENDING"
+
+    def test_queued_returns_pending(self) -> None:
+        checks = [{"conclusion": "QUEUED"}]
+        assert _derive_ci_status(checks) == "PENDING"
+
+    def test_waiting_returns_pending(self) -> None:
+        checks = [{"conclusion": "WAITING"}]
+        assert _derive_ci_status(checks) == "PENDING"
+
+    def test_mixed_pending_and_success_returns_pending(self) -> None:
+        checks = [
+            {"conclusion": "SUCCESS"},
+            {"conclusion": "PENDING"},
+        ]
+        assert _derive_ci_status(checks) == "PENDING"
+
+    def test_fallback_to_state_field(self) -> None:
+        """When 'conclusion' is missing, fall back to 'state' field."""
+        checks = [{"state": "FAILURE"}]
+        assert _derive_ci_status(checks) == "FAILURE"
+
+    def test_missing_both_fields_defaults_to_pending(self) -> None:
+        """When neither 'conclusion' nor 'state' is present, default to PENDING."""
+        checks = [{"name": "some-check"}]
+        assert _derive_ci_status(checks) == "PENDING"
+
+
+class TestGhPrListOpen:
+    """Tests for gh_pr_list_open function."""
+
+    def test_dry_run_returns_empty(self) -> None:
+        assert gh_pr_list_open(dry_run=True) == []
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_returns_sorted_pr_list(self, mock_gh_call: Any) -> None:
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            [
+                {
+                    "number": 5,
+                    "title": "PR five",
+                    "author": {"login": "alice"},
+                    "headRefName": "feat-5",
+                    "baseRefName": "main",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [{"conclusion": "SUCCESS"}],
+                },
+                {
+                    "number": 1,
+                    "title": "PR one",
+                    "author": {"login": "bob"},
+                    "headRefName": "feat-1",
+                    "baseRefName": "main",
+                    "mergeable": "CONFLICTING",
+                    "mergeStateStatus": "DIRTY",
+                    "statusCheckRollup": [],
+                },
+            ]
+        )
+        mock_gh_call.return_value = mock_result
+
+        prs = gh_pr_list_open()
+
+        assert len(prs) == 2
+        assert prs[0]["number"] == 1
+        assert prs[1]["number"] == 5
+        assert prs[0]["author"] == "bob"
+        assert prs[0]["mergeable"] == "CONFLICTING"
+        assert prs[0]["ci_status"] == "UNKNOWN"
+        assert prs[1]["author"] == "alice"
+        assert prs[1]["ci_status"] == "SUCCESS"
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_handles_missing_author(self, mock_gh_call: Any) -> None:
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "PR one",
+                    "author": None,
+                    "headRefName": "feat-1",
+                    "baseRefName": "main",
+                    "mergeable": "UNKNOWN",
+                    "mergeStateStatus": "UNKNOWN",
+                    "statusCheckRollup": [],
+                }
+            ]
+        )
+        mock_gh_call.return_value = mock_result
+
+        prs = gh_pr_list_open()
+
+        assert prs[0]["author"] == "unknown"
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_failure_raises_runtime_error(self, mock_gh_call: Any) -> None:
+        mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
+
+        with pytest.raises(RuntimeError, match="Failed to list open PRs"):
+            gh_pr_list_open()
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_json_decode_error_raises_runtime_error(self, mock_gh_call: Any) -> None:
+        mock_result = Mock()
+        mock_result.stdout = "not json"
+        mock_gh_call.return_value = mock_result
+
+        with pytest.raises(RuntimeError, match="Failed to list open PRs"):
+            gh_pr_list_open()
 
 
 class TestGhPrReviewPost:

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 
 from hephaestus.automation import prompts
+from hephaestus.automation.prompts.audit import get_audit_coordinator_prompt
 
 
 class TestImplementationPrompt:
@@ -637,6 +638,75 @@ class TestImplLoopStrictRubric:
         assert "CONTRACT VIOLATION" in out
         assert "Verdict: GO" in out
         assert "Verdict: NOGO" in out
+
+
+class TestAuditCoordinatorPrompt:
+    """Tests for the audit coordinator prompt."""
+
+    def test_renders_with_minimal_pr_list(self) -> None:
+        pr_list: list[dict[str, object]] = [
+            {
+                "number": 42,
+                "title": "Fix bug",
+                "author": "alice",
+                "headRefName": "fix-42",
+                "baseRefName": "main",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "ci_status": "SUCCESS",
+            }
+        ]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert "42" in out
+        assert "alice" in out
+        assert "MERGEABLE" in out
+
+    def test_fences_pr_list_as_untrusted(self) -> None:
+        """The PR list must be fenced with nonce delimiters and carry the untrusted notice."""
+        pr_list: list[dict[str, object]] = [{"number": 1, "title": "test"}]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert "BEGIN_" in out and "PR_LIST" in out
+        assert "UNTRUSTED" in out
+
+    def test_renders_with_multiple_prs(self) -> None:
+        pr_list: list[dict[str, object]] = [
+            {"number": 1, "title": "PR 1", "ci_status": "SUCCESS"},
+            {"number": 2, "title": "PR 2", "ci_status": "FAILURE"},
+            {"number": 3, "title": "PR 3", "ci_status": "PENDING"},
+        ]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert "PR 1" in out
+        assert "PR 2" in out
+        assert "PR 3" in out
+
+    def test_concurrency_batching_guidance_present(self) -> None:
+        """The prompt must instruct batching at most 10 PRs at a time."""
+        pr_list: list[dict[str, object]] = [{"number": 1, "title": "test"}]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert "at most 10" in out or "batches" in out.lower()
+
+    def test_coordinator_output_format_is_present(self) -> None:
+        """The JSON output block contract must be in the prompt."""
+        pr_list: list[dict[str, object]] = [{"number": 1, "title": "test"}]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert '"results"' in out
+        assert '"pr_number"' in out
+        assert '"comments"' in out
+        assert '"summary"' in out
+
+    def test_subagent_guardrails_present(self) -> None:
+        """Critical guardrails must appear in the prompt."""
+        pr_list: list[dict[str, object]] = [{"number": 1, "title": "test"}]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert "Do NOT background" in out
+        assert "do NOT exit early" in out
+        assert "own ONLY PR" in out
+
+    def test_allowed_tools_include_task(self) -> None:
+        """The coordinator's allowed_tools in the caller includes Task for sub-agent dispatch."""
+        pr_list: list[dict[str, object]] = [{"number": 1, "title": "test"}]
+        out = get_audit_coordinator_prompt(pr_list)
+        assert "Task" in out
 
 
 class TestAddressReviewPrompt:

--- a/tests/unit/validation/test_omit_allowlist.py
+++ b/tests/unit/validation/test_omit_allowlist.py
@@ -32,7 +32,7 @@ class TestOmitAllowlist:
 
         omit_list = pyproject.get("tool", {}).get("coverage", {}).get("run", {}).get("omit", [])
 
-        # Expected omit list: test globs + 11 automation modules
+        # Expected omit list: test globs + 12 automation modules
         expected_globs = {
             "*/tests/*",
             "*/__init__.py",
@@ -49,6 +49,7 @@ class TestOmitAllowlist:
             "hephaestus/automation/curses_ui.py",
             "hephaestus/automation/github_api.py",
             "hephaestus/automation/pr_reviewer.py",
+            "hephaestus/automation/audit_reviewer.py",
         }
 
         actual_set = set(omit_list)


### PR DESCRIPTION
## Summary

Adds `AuditReviewer` class and `hephaestus-audit-prs` CLI that reviews ALL open PRs using a coordinator+sub-agent dispatch pattern (one sub-agent per PR via the Task tool), mirroring the existing `address_review` mechanism.

Each sub-agent analyses a PR's diff, CI status, and description, then returns inline review comments posted via `gh_pr_review_post`.

## New modules

- **`hephaestus/automation/audit_reviewer.py`** — AuditReviewer class + CLI entry point
- **`hephaestus/automation/prompts/audit.py`** — Coordinator prompt (batches 10 PRs at a time, fences untrusted content)

## Modified modules

- **`github_api.py`** — Added `gh_pr_list_open()` and `_derive_ci_status()` helper
- **`session_naming.py`** — Added `AGENT_AUDIT_REVIEWER` constant
- **`prompts/__init__.py`** — Re-exports audit prompt symbols
- **`pyproject.toml`** — Added console script + coverage omit
- **`README.md` + `docs/index.md`** — Documented new console script + linked audit reviewer docs
- **`tests/integration/test_orchestration_smoke.py`** — Added audit_reviewer to OMITTED_MODULES and CONSOLE_SCRIPTS

## Documentation

- **`docs/audit-reviewer.md`** — Comprehensive documentation covering architecture, CLI usage, programmatic API, report format, coordinator prompt, error handling, environment variables, and examples

## Tests

- 13 tests for `_derive_ci_status`
- 4 tests for `gh_pr_list_open`
- 7 tests for audit coordinator prompt
- 43 tests for audit_reviewer module (unit: parsing, posting, reporting, CLI, coordinator, run orchestration, edge cases)
- 11 integration smoke tests for audit_reviewer (importability, key symbols, parsing integration, report writing, summary printing, construction)

Closes #994
