### PR TITLE
fix(deps): tighten urllib3 pin to >=2.7.0 to prevent CVE regression

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,11 @@ pip = "*"
 pydantic = ">=2.12.5,<3"
 pygments = ">=2.20.0"  # CVE-2026-4539
 pygithub = ">=2.9.1,<3"
+# Transitive via pygithub/requests. Pinned to prevent the lock from
+# downgrading below the fix version for CVE-2026-44431/44432 (fixed in
+# 2.7.0); without this, a future pixi update could silently reintroduce
+# the CVEs that were cleared in PR #992.
+urllib3 = ">=2.7.0"
 # Transitive via pygithub. Pinned to pull the security fix for
 # PYSEC-2026-175/177/178/179 (all fixed in 2.13.0); without this the locked
 # env resolves to 2.12.1 and pip-audit fails the dependency scan.


### PR DESCRIPTION
Closes #1000

## Summary

Add an explicit `urllib3 >=2.7.0` pin to `pixi.toml` to prevent the lock file from accidentally downgrading below the fix version for CVE-2026-44431 and CVE-2026-44432.

## Background

On PR #992, we removed CVE-2026-44431 and CVE-2026-44432 from the pip-audit suppression ledger after updating urllib3 from 2.6.3 to 2.7.0 via `pixi update`. Both CVEs are fixed in urllib3 >= 2.7.0.

However, urllib3 is a transitive dependency (via pygithub → requests), not explicitly pinned. Without an explicit pin, a future `pixi update` could silently downgrade urllib3 back below 2.7.0, reintroducing the CVEs.

## Change

Add `urllib3 = ">=2.7.0"` to the `[dependencies]` section of pixi.toml, following the same pattern as the existing `pyjwt >=2.13.0` security pin for transitive dependencies.