### PR TITLE
fix(security): update pip to 26.1.2 and remove stale CVE suppressions

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -68,7 +68,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
@@ -184,7 +184,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
@@ -984,17 +984,17 @@ packages:
   - pkg:pypi/pathspec?source=compressed-mapping
   size: 56559
   timestamp: 1777271601895
-- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
-  sha256: 00acccc6f69568ddc56d4d5cc031fdb27eb6a1588a80b1f3a5233bd2a6f944f0
-  md5: 2e7e59a063366f1fc4f45ac86bd9485f
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
+  sha256: 9e673d3c6003f416df11670a14b026a04e3a45ebec55357987e15b860f138f2a
+  md5: 733cc07ed34162ac50b936464b163366
   depends:
   - python >=3.13.0a0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/pip?source=compressed-mapping
-  size: 1199678
-  timestamp: 1777924078252
+  size: 1202377
+  timestamp: 1780262809860
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937

--- a/pixi.toml
+++ b/pixi.toml
@@ -92,14 +92,6 @@ bandit = ">=1.9.4,<2"
 # a re-review trigger so a suppression is never silently permanent. Re-review
 # the whole list every dependency bump (or quarterly, whichever comes first).
 #
-# CVE-2026-3219 (pip): unfixable — the flaw is in a library pip vendors and there
-#   is no released pip we can pin that drops the vulnerable copy. pip is bundled
-#   by the runner's Python; we never declare it as a dependency.
-#   Re-review: drop when a fixed pip ships and the runner Python carries it.
-# CVE-2026-6357 (pip): not-yet-packaged — fixed in pip 26.1 (we run 26.0.1), but
-#   pip is supplied by the runner Python and our deps don't pin it, so we cannot
-#   force the bump ourselves.
-#   Re-review: drop when the runner Python ships pip >= 26.1.
 # CVE-2026-44431 (urllib3): not-yet-packaged — fixed in urllib3 2.7.0; that
 #   release is not on conda-forge yet, so the locked env cannot reach it.
 #   Re-review: drop when conda-forge publishes urllib3 >= 2.7.0.
@@ -112,7 +104,7 @@ bandit = ">=1.9.4,<2"
 #   transitive dependency of pygithub (we never import it directly), so there is no
 #   version bump or code change that resolves it. Ignored as unfixable + disputed.
 #   Re-review: drop if pyjwt publishes a fixed release or pygithub drops the dep.
-pip-audit = "pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357 --ignore-vuln CVE-2026-44431 --ignore-vuln CVE-2026-44432 --ignore-vuln PYSEC-2025-183"
+pip-audit = "pip-audit --ignore-vuln CVE-2026-44431 --ignore-vuln CVE-2026-44432 --ignore-vuln PYSEC-2025-183"
 sast = "bandit -c pyproject.toml -r hephaestus scripts --severity-level medium"
 
 [environments]


### PR DESCRIPTION
Closes #1002

## Summary

Update pip from 26.1.1 to 26.1.2 via `pixi update pip`, fixing `PYSEC-2026-196`. Remove two stale suppressions from the pip-audit ledger that were already fixed by the pip upgrade.

## Changes

- `pixi update pip` → 26.1.2 (from 26.1.1)
- Remove `--ignore-vuln CVE-2026-3219` (fixed since pip ≥ 26.1.0)
- Remove `--ignore-vuln CVE-2026-6357` (fixed since pip ≥ 26.1.0)
- `pixi.lock` updated automatically

## Verification

`pixi run --environment lint pip-audit` reports 0 active vulnerabilities (3 suppressed: CVE-2026-44431/44432 urllib3, PYSEC-2025-183 pyjwt).