### PR TITLE
[Fix] Use addPullRequestReviewThreadReply to resolve PR review threads

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1513,10 +1513,13 @@ def gh_pr_resolve_thread(
         logger.info("[dry_run] Would resolve thread %r with reply: %r", thread_id, reply_body)
         return
 
-    # Step 1: post a reply to the thread via GraphQL addPullRequestReviewComment
+    # Step 1: post a reply to the thread via GraphQL addPullRequestReviewThreadReply.
+    # NOT addPullRequestReviewComment — its input type (AddPullRequestReviewCommentInput)
+    # has no pullRequestReviewThreadId field, so that mutation fails on every call
+    # (verified against the live GitHub schema via introspection).
     reply_mutation = """
 mutation AddReply($threadId: ID!, $body: String!) {
-  addPullRequestReviewComment(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
+  addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
     comment { id }
   }
 }

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -25,6 +25,7 @@ from hephaestus.automation.github_api import (
     gh_list_open_issues,
     gh_pr_checks,
     gh_pr_create,
+    gh_pr_resolve_thread,
     gh_pr_review_post,
     is_issue_closed,
     parse_issue_dependencies,
@@ -1874,3 +1875,65 @@ class TestGhPrReviewPost:
 
         # The review POST was still sent.
         self._review_post_call(mock_gh_call)
+
+
+class TestGhPrResolveThread:
+    """Direct tests for ``gh_pr_resolve_thread``.
+
+    Higher-level callers (``address_review``) mock this function out, so the
+    raw GraphQL it builds had no direct coverage — which let a broken mutation
+    (``addPullRequestReviewComment``, whose input type has no
+    ``pullRequestReviewThreadId`` field) ship and fail on every call. These
+    tests pin the mutation names and call args so the regression cannot recur.
+    """
+
+    @staticmethod
+    def _ok_call() -> Any:
+        """Return a ``_gh_call`` Mock whose stdout is empty (no GraphQL errors)."""
+        result = Mock()
+        result.stdout = "{}"
+        return result
+
+    @staticmethod
+    def _query_arg(call_args: list[str]) -> str:
+        """Return the GraphQL ``query=...`` argument from a ``_gh_call`` argv."""
+        return next(a for a in call_args if isinstance(a, str) and a.startswith("query="))
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_reply_uses_thread_reply_mutation(self, mock_gh_call: Any) -> None:
+        """Step 1 must call ``addPullRequestReviewThreadReply`` with the thread id.
+
+        Regression guard: ``addPullRequestReviewComment`` does NOT accept
+        ``pullRequestReviewThreadId`` and fails on every call.
+        """
+        mock_gh_call.return_value = self._ok_call()
+
+        gh_pr_resolve_thread("THREAD_ID_1", "Done — addressed.")
+
+        reply_args = mock_gh_call.call_args_list[0][0][0]
+        query = self._query_arg(reply_args)
+        assert "addPullRequestReviewThreadReply" in query
+        assert "addPullRequestReviewComment" not in query
+        # The thread id and body are forwarded as GraphQL variables.
+        assert "threadId=THREAD_ID_1" in reply_args
+        assert "body=Done — addressed." in reply_args
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_second_call_resolves_thread(self, mock_gh_call: Any) -> None:
+        """Step 2 must call ``resolveReviewThread`` for the same thread id."""
+        mock_gh_call.return_value = self._ok_call()
+
+        gh_pr_resolve_thread("THREAD_ID_2", "Reply body")
+
+        assert mock_gh_call.call_count == 2
+        resolve_args = mock_gh_call.call_args_list[1][0][0]
+        query = self._query_arg(resolve_args)
+        assert "resolveReviewThread" in query
+        assert "threadId=THREAD_ID_2" in resolve_args
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_dry_run_makes_no_calls(self, mock_gh_call: Any) -> None:
+        """``dry_run=True`` must not invoke ``_gh_call`` at all."""
+        gh_pr_resolve_thread("THREAD_ID_3", "Reply body", dry_run=True)
+
+        mock_gh_call.assert_not_called()


### PR DESCRIPTION
## Summary

`gh_pr_resolve_thread()` (`hephaestus/automation/github_api.py`) posted its reply via the GraphQL mutation `addPullRequestReviewComment(input: {pullRequestReviewThreadId: ...})`. That input type (`AddPullRequestReviewCommentInput`) has **no** `pullRequestReviewThreadId` field, so the mutation failed on **every** call and exhausted all 3 retries — PR review threads were never replied-to or resolved.

Surfaced in a `loop_runner` run as repeated:

```
gh: InputObject 'AddPullRequestReviewCommentInput' doesn't accept argument 'pullRequestReviewThreadId'
```

## Root cause (verified against the live GitHub schema)

Introspection confirms:

- `AddPullRequestReviewCommentInput` → no `pullRequestReviewThreadId`.
- `AddPullRequestReviewThreadReplyInput` → **does** accept `pullRequestReviewThreadId` + `body`; its payload exposes `comment`.

The function had **no direct unit test** (callers mock it at the `address_review` boundary), so the broken query shipped silently — the same failure mode as the prior verified-ci fix for the analogous `addPullRequestReview` field bug.

## Changes

- **`github_api.py`**: reply mutation now uses `addPullRequestReviewThreadReply`. The Step-2 `resolveReviewThread` mutation was already correct and is unchanged.
- **`test_github_api.py`**: new `TestGhPrResolveThread` pins the mutation names (`addPullRequestReviewThreadReply`, not `addPullRequestReviewComment`), the forwarded `threadId`/`body` args, the `resolveReviewThread` second call, and the `dry_run` no-op.
- **`nats/subscriber.py`**: coerce `NATSConfig.deliver_policy` (a `str`) to the nats `DeliverPolicy` enum at the `js.subscribe` call site — fixes a **pre-existing** tree-wide mypy error (`subscriber.py:307`) that blocked the pre-commit mypy hook.

## Verification

- `pixi run mypy` → `Success: no issues found in 315 source files`
- `pixi run ruff check` / `ruff format` → clean on all changed files
- `pixi run pytest tests/unit/automation/test_github_api.py` → 112 passed (incl. 3 new)
- Live schema introspection confirms `AddPullRequestReviewThreadReplyInput` lists `pullRequestReviewThreadId` + `body`.

Note: `test_subscribe_loop_lazy_import_suppresses_deprecation_warning` fails identically on `main` (a pre-existing subprocess connection-timeout flake, unrelated to this change).

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)