### PR TITLE
fix(security): update urllib3 to 2.7.0, tighten pin, remove 4 stale CVE suppressions

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -68,7 +68,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
@@ -95,7 +95,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.3.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
@@ -184,7 +184,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.6.0-pyha770c72_0.conda
@@ -209,7 +209,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.3.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamllint-1.38.0-pyhcf101f3_1.conda
@@ -984,17 +984,17 @@ packages:
   - pkg:pypi/pathspec?source=compressed-mapping
   size: 56559
   timestamp: 1777271601895
-- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.1-pyh145f28c_0.conda
-  sha256: 00acccc6f69568ddc56d4d5cc031fdb27eb6a1588a80b1f3a5233bd2a6f944f0
-  md5: 2e7e59a063366f1fc4f45ac86bd9485f
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
+  sha256: 9e673d3c6003f416df11670a14b026a04e3a45ebec55357987e15b860f138f2a
+  md5: 733cc07ed34162ac50b936464b163366
   depends:
   - python >=3.13.0a0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/pip?source=compressed-mapping
-  size: 1199678
-  timestamp: 1777924078252
+  size: 1202377
+  timestamp: 1780262809860
 - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
   sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
   md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
@@ -1341,9 +1341,9 @@ packages:
   purls: []
   size: 119135
   timestamp: 1767016325805
-- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
-  sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
-  md5: 9272daa869e03efe68833e3dc7a02130
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+  sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+  md5: cbb88288f74dbe6ada1c6c7d0a97223e
   depends:
   - backports.zstd >=1.0.0
   - brotli-python >=1.2.0
@@ -1354,8 +1354,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/urllib3?source=hash-mapping
-  size: 103172
-  timestamp: 1767817860341
+  size: 103560
+  timestamp: 1778188657149
 - conda: https://conda.anaconda.org/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
   sha256: 8dbe1085b6dbc0beaaa45514a983bc91c2c306079a257c936566b727f5e82fb8
   md5: d3874a78e238013db5106c8e31f1ae58

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,11 @@ pip = "*"
 pydantic = ">=2.12.5,<3"
 pygments = ">=2.20.0"  # CVE-2026-4539
 pygithub = ">=2.9.1,<3"
+# Transitive via pygithub/requests. Pinned to prevent the lock from
+# downgrading below the fix version for CVE-2026-44431/44432 (fixed in
+# 2.7.0); without this, a future pixi update could silently reintroduce
+# the CVEs. Closes #1004.
+urllib3 = ">=2.7.0"
 # Transitive via pygithub. Pinned to pull the security fix for
 # PYSEC-2026-175/177/178/179 (all fixed in 2.13.0); without this the locked
 # env resolves to 2.12.1 and pip-audit fails the dependency scan.
@@ -92,27 +97,13 @@ bandit = ">=1.9.4,<2"
 # a re-review trigger so a suppression is never silently permanent. Re-review
 # the whole list every dependency bump (or quarterly, whichever comes first).
 #
-# CVE-2026-3219 (pip): unfixable — the flaw is in a library pip vendors and there
-#   is no released pip we can pin that drops the vulnerable copy. pip is bundled
-#   by the runner's Python; we never declare it as a dependency.
-#   Re-review: drop when a fixed pip ships and the runner Python carries it.
-# CVE-2026-6357 (pip): not-yet-packaged — fixed in pip 26.1 (we run 26.0.1), but
-#   pip is supplied by the runner Python and our deps don't pin it, so we cannot
-#   force the bump ourselves.
-#   Re-review: drop when the runner Python ships pip >= 26.1.
-# CVE-2026-44431 (urllib3): not-yet-packaged — fixed in urllib3 2.7.0; that
-#   release is not on conda-forge yet, so the locked env cannot reach it.
-#   Re-review: drop when conda-forge publishes urllib3 >= 2.7.0.
-# CVE-2026-44432 (urllib3): not-yet-packaged — same urllib3 2.6.3 → 2.7.0 fix and
-#   same conda-forge availability gap as CVE-2026-44431; tracked together.
-#   Re-review: drop alongside CVE-2026-44431 when urllib3 >= 2.7.0 lands.
 # PYSEC-2025-183 (CVE-2025-45768): affects every pyjwt release (0.1.1-2.12.1) with
 #   no fixed version, and is disputed by the pyjwt maintainers — it concerns the key
 #   length chosen by the calling application, not a library defect. pyjwt is only a
 #   transitive dependency of pygithub (we never import it directly), so there is no
 #   version bump or code change that resolves it. Ignored as unfixable + disputed.
 #   Re-review: drop if pyjwt publishes a fixed release or pygithub drops the dep.
-pip-audit = "pip-audit --ignore-vuln CVE-2026-3219 --ignore-vuln CVE-2026-6357 --ignore-vuln CVE-2026-44431 --ignore-vuln CVE-2026-44432 --ignore-vuln PYSEC-2025-183"
+pip-audit = "pip-audit --ignore-vuln PYSEC-2025-183"
 sast = "bandit -c pyproject.toml -r hephaestus scripts --severity-level medium"
 
 [environments]


### PR DESCRIPTION
Closes #1003
Closes #1004
Closes #1002

## Summary

Consolidated security fix that updates two dependencies and removes **all 4 stale suppressions** from the pip-audit ledger, reducing the suppression list from 5 entries to 1.

## Changes

**Dependency updates (pixi.lock):**
- urllib3 2.6.3 → 2.7.0 (fixes CVE-2026-44431, CVE-2026-44432)
- pip 26.1.1 → 26.1.2 (fixes PYSEC-2026-196, confirms CVE-2026-3219/6357 already fixed)

**pixi.toml:**
- Added `urllib3 >=2.7.0` pin to `[dependencies]` to prevent regression (Closes #1004)
- Removed stale CVE-2026-3219 suppression (fixed since pip >= 26.1.0)
- Removed stale CVE-2026-6357 suppression (fixed since pip >= 26.1.0)
- Removed stale CVE-2026-44431 suppression (fixed in urllib3 2.7.0, now on conda-forge)
- Removed stale CVE-2026-44432 suppression (same urllib3 2.7.0 fix)

## Suppression ledger: 5 → 1

Only PYSEC-2025-183 (pyjwt) remains — truly unfixable, all releases affected, disputed by maintainers.

## Verification

`pixi run --environment lint pip-audit` reports 0 known vulnerabilities.

## Note

Supersedes PR #1005 (pip-only fix) — this PR includes those changes plus the urllib3 update and pin.