### PR TITLE
feat(github): extract shared gh CLI adapter to hephaestus.github.client

### DIFF
--- a/hephaestus/automation/claude_timeouts.py
+++ b/hephaestus/automation/claude_timeouts.py
@@ -76,9 +76,9 @@ def follow_up_claude_timeout() -> int:
     return _read_int_env("HEPH_FOLLOW_UP_AGENT_TIMEOUT", 7200)
 
 
-def gh_cli_timeout() -> int:
-    """Timeout for individual ``gh`` CLI calls in :mod:`github_api` (default 120s)."""
-    return _read_int_env("HEPH_GH_TIMEOUT", 120)
+# Re-exported from hephaestus.github.client so the gh-adapter timeout lives
+# with the gh adapter; this alias preserves the legacy import path.
+from hephaestus.github.client import gh_cli_timeout  # noqa: E402,F401
 
 
 def ci_poll_max_wait() -> int:

--- a/hephaestus/automation/claude_timeouts.py
+++ b/hephaestus/automation/claude_timeouts.py
@@ -78,7 +78,21 @@ def follow_up_claude_timeout() -> int:
 
 # Re-exported from hephaestus.github.client so the gh-adapter timeout lives
 # with the gh adapter; this alias preserves the legacy import path.
-from hephaestus.github.client import gh_cli_timeout  # noqa: E402,F401
+from hephaestus.github.client import gh_cli_timeout  # noqa: E402
+
+__all__ = [
+    "address_review_claude_timeout",
+    "advise_claude_timeout",
+    "ci_driver_claude_timeout",
+    "ci_poll_max_wait",
+    "follow_up_claude_timeout",
+    "gh_cli_timeout",
+    "implementer_claude_timeout",
+    "learn_claude_timeout",
+    "plan_reviewer_claude_timeout",
+    "planner_claude_timeout",
+    "pr_reviewer_claude_timeout",
+]
 
 
 def ci_poll_max_wait() -> int:

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -16,48 +16,48 @@ import os
 import re
 import subprocess
 import tempfile
-import threading
-import time
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, cast
 
+from hephaestus.github import client as _gh_client
 from hephaestus.github.client import (
     ClaudeUsageCapError,
     GitHubRateLimitError,
     GitHubUnavailableError,
     gh_call,
-    gh_cli_timeout,  # noqa: F401  (re-exported for legacy import paths)
+    gh_cli_timeout,
 )
 from hephaestus.github.rate_limit import (
-    detect_claude_usage_cap,
-    detect_claude_usage_limit,
-    detect_rate_limit,
-    detect_secondary_rate_limit,
-    gh_global_throttle_acquire,
     gh_rate_limit_reset_epoch,
-    wait_until,
 )
 from hephaestus.io.utils import write_secure as io_write_secure
 
 from .git_utils import get_repo_info, run
 from .models import IssueInfo, IssueState
-from hephaestus.github import client as _gh_client  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 _label_cache: set[str] | None = None
 
-# Module-level aliases so every existing test patch keeps resolving.
+# Module-level aliases so existing test patches keep resolving.
 # unittest.mock.patch walks the dotted path's module attributes at patch
-# time; both names below exist as attributes of this module after the
+# time; these names exist as attributes of this module after the
 # aliases, so @patch("hephaestus.automation.github_api._gh_call") and
 # @patch("hephaestus.automation.github_api._gh_call_impl") continue to work
 # without test churn.
 _gh_call = gh_call
 _gh_call_impl = _gh_client._gh_call_impl
 _GH_BREAKER = _gh_client._GH_BREAKER
+_GH_THROTTLE = _gh_client._GH_THROTTLE
 
+__all__ = [
+    "ClaudeUsageCapError",
+    "GitHubRateLimitError",
+    "GitHubUnavailableError",
+    "gh_call",
+    "gh_cli_timeout",
+]
 
 
 
@@ -177,61 +177,6 @@ def gh_issue_remove_labels(issue_number: int, labels: list[str]) -> None:
     logger.info("Removed labels %s from issue #%s", labels_to_remove, issue_number)
 
 
-# GraphQL emits "Resource not accessible by …" with HTTP 200 when the token
-# is valid but lacks scope for the mutation (e.g. addComment outside the PAT's
-# allowed orgs). None of the HTTP-status patterns above match it, so without
-# this entry the call gets retried and dumps the full body on every attempt.
-_TOKEN_SCOPE_PATTERN = re.compile(
-    r"resource not accessible by (personal access token|integration)",
-    re.IGNORECASE,
-)
-
-_NON_TRANSIENT_PATTERNS = [
-    re.compile(p, re.IGNORECASE)
-    for p in (
-        r"(?:^|\s)403(?:\s|$)|forbidden|permission denied",
-        r"(?:^|\s)404(?:\s|$)|not found",
-        r"(?:^|\s)400(?:\s|$)|bad request",
-        r"(?:^|\s)401(?:\s|$)|unauthorized",
-        r"(?:^|\s)422(?:\s|$)|unprocessable entity",
-        r"invalid argument",
-        r"unknown json field",
-        # GraphQL schema errors are deterministic — a bad mutation/field or an
-        # unused variable can never succeed on retry (#1040).
-        r"doesn't accept argument",
-        r"is declared by .* but not used",
-    )
-]
-_NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)
-
-
-def _is_token_scope_error(stderr: str) -> bool:
-    return bool(_TOKEN_SCOPE_PATTERN.search(stderr))
-
-
-def _is_non_transient_error(stderr: str) -> bool:
-    return any(p.search(stderr) for p in _NON_TRANSIENT_PATTERNS)
-
-
-def _raise_if_claude_usage(stderr: str, cause: subprocess.CalledProcessError) -> None:
-    """Convert Claude usage-cap/usage-limit stderr into ClaudeUsageCapError.
-
-    Returns silently when *stderr* matches neither pattern. Hoisted out of
-    :func:`_gh_call` to keep its cyclomatic complexity under the linter cap.
-    """
-    reset_epoch = detect_claude_usage_cap(stderr)
-    if reset_epoch is not None:
-        raise ClaudeUsageCapError(
-            f"Claude API usage cap reached. Resets at epoch {reset_epoch}.",
-            reset_epoch=reset_epoch,
-        ) from cause
-    if detect_claude_usage_limit(stderr):
-        raise ClaudeUsageCapError(
-            "Claude API usage limit reached. Please check your billing.",
-            reset_epoch=None,
-        ) from cause
-
-
 @contextlib.contextmanager
 def _body_file(body: str):  # type: ignore[no-untyped-def]
     """Yield a path to a temporary file containing *body*, deleted on exit.
@@ -256,240 +201,6 @@ def _body_file(body: str):  # type: ignore[no-untyped-def]
     finally:
         with contextlib.suppress(OSError):
             os.unlink(path)
-
-
-def _log_token_scope_remediation(args: list[str], stderr: str) -> None:
-    """Log a one-shot, actionable remediation block for token-scope failures.
-
-    Fires from the non-transient branch in :func:`_gh_call` so it logs exactly
-    once per failed call (no retry spam). The message names the gh subcommand
-    that failed, the required token scopes, and the GITHUB_TOKEN=-blanking
-    workaround for the common case where a low-scope env token shadows gh's
-    stored credentials.
-    """
-    subcommand = " ".join(args[:2]) if args else "<unknown>"
-    logger.error(
-        "Cannot run `gh %s`: GitHub token lacks required scopes.\n"
-        "\n"
-        "  Required scopes for this script:\n"
-        "    - Classic PAT:   repo  (full)             — covers issue:write + pr:write\n"
-        "    - Fine-grained:  Issues:        Read & Write\n"
-        "                     Pull requests: Read & Write\n"
-        "                     Contents:      Read & Write   (if pushes are needed)\n"
-        "\n"
-        "  How to fix:\n"
-        "    1. Check which token gh is using:  gh auth status\n"
-        "    2. If GITHUB_TOKEN is set in your env, it overrides gh's stored creds.\n"
-        "       Either:\n"
-        "         a) unset GITHUB_TOKEN  (lets gh use its own login), or\n"
-        "         b) regenerate the PAT with the scopes above:\n"
-        "            https://github.com/settings/tokens\n"
-        "    3. Re-run with:  GITHUB_TOKEN= <your-command>\n"
-        "       (the leading `GITHUB_TOKEN=` blanks the env var for one command)\n"
-        "\n"
-        "  Original error: %s",
-        subcommand,
-        stderr.strip()[:200],
-    )
-
-
-def _gh_call_impl(
-    args: list[str],
-    check: bool = True,
-    retry_on_rate_limit: bool = True,
-    max_retries: int = 6,
-) -> subprocess.CompletedProcess[str]:
-    """Implement gh CLI call with rate limit handling (circuit breaker will wrap this).
-
-    Args:
-        args: Arguments to pass to gh
-        check: Whether to raise on non-zero exit
-        retry_on_rate_limit: Whether to retry on rate limit
-        max_retries: Maximum retry attempts
-
-    Returns:
-        CompletedProcess instance
-
-    Raises:
-        subprocess.CalledProcessError: If command fails and check=True
-        ClaudeUsageCapError: If a Claude per-period usage cap is detected.
-        RuntimeError: For other non-transient or exhausted-retry failures.
-
-    """
-    for attempt in range(max_retries):
-        try:
-            gh_global_throttle_acquire()
-            _gh_throttle_wait()
-            result = run(
-                ["gh", *args],
-                check=check,
-                capture_output=True,
-                timeout=gh_cli_timeout(),
-            )
-            return result
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr if e.stderr else ""
-            _raise_if_claude_usage(stderr, e)
-
-            reset_epoch = _extract_reset_epoch(e)
-            if reset_epoch is not None:
-                _handle_rate_limit_attempt(
-                    reset_epoch=reset_epoch,
-                    attempt=attempt,
-                    max_retries=max_retries,
-                    retry_on_rate_limit=retry_on_rate_limit,
-                    cause=e,
-                )
-                continue
-
-            if _is_non_transient_error(stderr):
-                logger.error("Non-transient error detected: %s", stderr[:200])
-                if _is_token_scope_error(stderr):
-                    _log_token_scope_remediation(args, stderr)
-                raise
-
-            # Secondary rate limit carries no reset epoch — check both stderr
-            # and stdout (GraphQL errors can land on stdout).
-            stdout = e.stdout if e.stdout else ""
-            if detect_secondary_rate_limit(stderr) or detect_secondary_rate_limit(stdout):
-                logger.warning(
-                    "GitHub secondary rate limit hit (attempt %s), waiting before retry",
-                    attempt + 1,
-                )
-                _handle_rate_limit_attempt(
-                    reset_epoch=0,
-                    attempt=attempt,
-                    max_retries=max_retries,
-                    retry_on_rate_limit=retry_on_rate_limit,
-                    cause=e,
-                    base_wait_seconds=15,
-                )
-                continue
-
-            if attempt == max_retries - 1:
-                raise
-
-            wait_seconds = 2**attempt
-            logger.warning(
-                "gh call failed (attempt %s), retrying in %ss", attempt + 1, wait_seconds
-            )
-            time.sleep(wait_seconds)
-        except GitHubRateLimitError as e:
-            # Raised from inside _check_graphql_errors when the JSON payload
-            # carries a RATE_LIMITED entry (HTTP 200, gh exits 0).
-            _handle_rate_limit_attempt(
-                reset_epoch=e.reset_epoch,
-                attempt=attempt,
-                max_retries=max_retries,
-                retry_on_rate_limit=retry_on_rate_limit,
-                cause=e,
-            )
-            continue
-
-    # Should not reach here, but satisfy type checker
-    raise RuntimeError("gh call failed after all retries")
-
-
-def _gh_call(
-    args: list[str],
-    check: bool = True,
-    retry_on_rate_limit: bool = True,
-    max_retries: int = 6,
-) -> subprocess.CompletedProcess[str]:
-    """Call gh CLI with rate limit handling and circuit breaker protection.
-
-    Wraps the implementation in a circuit breaker that opens after sustained
-    failures, causing fail-fast with GitHubUnavailableError instead of
-    exhausting per-call-site retry budgets.
-
-    Args:
-        args: Arguments to pass to gh
-        check: Whether to raise on non-zero exit
-        retry_on_rate_limit: Whether to retry on rate limit
-        max_retries: Maximum retry attempts
-
-    Returns:
-        CompletedProcess instance
-
-    Raises:
-        subprocess.CalledProcessError: If command fails and check=True
-        ClaudeUsageCapError: If a Claude per-period usage cap is detected.
-        GitHubUnavailableError: If the circuit breaker is open due to
-            sustained GitHub API unavailability.
-        RuntimeError: For other non-transient or exhausted-retry failures.
-
-    """
-    try:
-        return _GH_BREAKER.call(
-            _gh_call_impl,
-            args,
-            check=check,
-            retry_on_rate_limit=retry_on_rate_limit,
-            max_retries=max_retries,
-        )
-    except CircuitBreakerOpenError as exc:
-        # Translate to a domain exception (RuntimeError subclass) so existing
-        # exception handlers that catch RuntimeError/Exception continue to work.
-        raise GitHubUnavailableError(
-            "GitHub API circuit breaker is open due to sustained unavailability"
-        ) from exc
-
-
-def _extract_reset_epoch(e: subprocess.CalledProcessError) -> int | None:
-    """Return a rate-limit reset epoch parsed from a failed ``gh`` invocation.
-
-    Inspects stderr first (REST CLI message form) and falls back to stdout
-    because GraphQL rate-limit errors arrive in the JSON payload that gh
-    streams to stdout. Returns ``None`` if the failure is not rate-limit-
-    related.
-    """
-    stderr = e.stderr if e.stderr else ""
-    epoch = detect_rate_limit(stderr)
-    if epoch is None and e.stdout:
-        epoch = detect_rate_limit(e.stdout)
-    return epoch
-
-
-def _handle_rate_limit_attempt(
-    *,
-    reset_epoch: int,
-    attempt: int,
-    max_retries: int,
-    retry_on_rate_limit: bool,
-    cause: BaseException,
-    base_wait_seconds: int = 60,
-) -> None:
-    """Wait for a rate-limit reset, or raise :class:`GitHubRateLimitError`.
-
-    Centralises the "we got rate-limited; should we retry?" decision so the
-    two except-blocks in :func:`_gh_call` share identical behavior. Raises
-    immediately if retries are disabled or exhausted; otherwise sleeps and
-    returns so the caller can ``continue`` the retry loop.
-
-    Args:
-        reset_epoch: Unix timestamp when the rate limit resets, or ``0`` when
-            unknown (no epoch embedded in the error message).
-        attempt: Current attempt index (0-based).
-        max_retries: Total retry budget.
-        retry_on_rate_limit: If False, raise immediately instead of waiting.
-        cause: The exception that triggered this call.
-        base_wait_seconds: Initial wait duration (seconds) when ``reset_epoch``
-            is ``0`` (no epoch available).  Doubles each attempt, capped at
-            300s.  Defaults to 60; pass 15 for secondary rate limits which
-            carry no reset epoch but typically clear faster.
-
-    """
-    if not retry_on_rate_limit or attempt == max_retries - 1:
-        raise GitHubRateLimitError(
-            f"GitHub API rate limit reached. Reset at epoch {reset_epoch}",
-            reset_epoch=reset_epoch,
-        ) from cause
-    if reset_epoch > 0:
-        wait_until(reset_epoch)
-        return
-    wait_seconds = min(base_wait_seconds * (2**attempt), 300)  # cap at 5 minutes
-    logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
-    time.sleep(wait_seconds)
 
 
 def _check_graphql_errors(data: dict[str, Any], context: str) -> None:

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -50,8 +50,6 @@ _GH_BREAKER = _gh_client._GH_BREAKER
 _GH_THROTTLE = _gh_client._GH_THROTTLE
 
 __all__ = [
-    "_GH_BREAKER",
-    "_GH_THROTTLE",
     "ClaudeUsageCapError",
     "GitHubRateLimitError",
     "GitHubUnavailableError",

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -22,6 +22,13 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, cast
 
+from hephaestus.github.client import (
+    ClaudeUsageCapError,
+    GitHubRateLimitError,
+    GitHubUnavailableError,
+    gh_call,
+    gh_cli_timeout,  # noqa: F401  (re-exported for legacy import paths)
+)
 from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_claude_usage_limit,
@@ -32,114 +39,26 @@ from hephaestus.github.rate_limit import (
     wait_until,
 )
 from hephaestus.io.utils import write_secure as io_write_secure
-from hephaestus.resilience.circuit_breaker import CircuitBreakerOpenError, get_circuit_breaker
 
-from .claude_timeouts import gh_cli_timeout
 from .git_utils import get_repo_info, run
 from .models import IssueInfo, IssueState
+from hephaestus.github import client as _gh_client  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 _label_cache: set[str] | None = None
 
-# Per-thread proactive throttle for `gh` invocations. Default 5 calls/sec
-# per worker thread; the GH_RATE_LIMIT_PER_SEC env var overrides for ops
-# tuning, and 0 disables. With max-workers=3 the aggregate is ~15/sec,
-# well below GitHub's per-token REST limits and tame enough that GH
-# secondary rate limits stay quiet during phase bursts (e.g. a planner
-# fetching N issue bodies back-to-back).
-_GH_THROTTLE = threading.local()
-
-# Circuit breaker for gh API calls. When a sustained GitHub outage occurs
-# (5+ consecutive failures), the breaker opens and subsequent calls fail fast
-# with GitHubUnavailableError instead of exhausting retry budgets at each
-# call site. half_open_max_calls=2 (not the default 1) allows a pair of
-# recovery attempts before fully closing.
-_GH_BREAKER = get_circuit_breaker(
-    "github-api",
-    failure_threshold=5,
-    recovery_timeout=60,
-    half_open_max_calls=2,
-)
+# Module-level aliases so every existing test patch keeps resolving.
+# unittest.mock.patch walks the dotted path's module attributes at patch
+# time; both names below exist as attributes of this module after the
+# aliases, so @patch("hephaestus.automation.github_api._gh_call") and
+# @patch("hephaestus.automation.github_api._gh_call_impl") continue to work
+# without test churn.
+_gh_call = gh_call
+_gh_call_impl = _gh_client._gh_call_impl
+_GH_BREAKER = _gh_client._GH_BREAKER
 
 
-def _gh_throttle_wait() -> None:
-    rate = float(os.environ.get("GH_RATE_LIMIT_PER_SEC", "5"))
-    if rate <= 0:
-        return
-    min_interval = 1.0 / rate
-    last = getattr(_GH_THROTTLE, "last_call", 0.0)
-    now = time.monotonic()
-    elapsed = now - last
-    if elapsed < min_interval:
-        time.sleep(min_interval - elapsed)
-    _GH_THROTTLE.last_call = time.monotonic()
-
-
-class GitHubRateLimitError(RuntimeError):
-    """Raised when GitHub reports the API rate limit has been exceeded.
-
-    Subclasses :class:`RuntimeError` so existing ``except RuntimeError``
-    handlers continue to catch it; callers that want rate-limit-specific
-    handling (e.g. exit cleanly instead of aborting a batch) should catch
-    this class explicitly.
-
-    Attributes:
-        reset_epoch: Unix timestamp at which the relevant rate-limit
-            window resets, or ``0`` if the reset time could not be
-            determined.
-
-    """
-
-    def __init__(self, message: str, reset_epoch: int = 0) -> None:
-        """Initialise the error with an optional reset epoch.
-
-        Args:
-            message: Human-readable error description, typically the
-                upstream GitHub message.
-            reset_epoch: Unix timestamp at which the limit resets, or
-                ``0`` if unknown.
-
-        """
-        super().__init__(message)
-        self.reset_epoch: int = reset_epoch
-
-
-class ClaudeUsageCapError(RuntimeError):
-    """Raised when the Claude CLI reports that the per-period usage cap has been hit.
-
-    Subclasses :class:`RuntimeError` so that existing ``except RuntimeError``
-    handlers continue to catch it.
-
-    Attributes:
-        reset_epoch: Unix timestamp at which the cap resets, or ``None`` if the
-            reset time could not be determined.
-
-    """
-
-    def __init__(self, message: str, reset_epoch: int | None = None) -> None:
-        """Initialise the error with an optional reset epoch.
-
-        Args:
-            message: Human-readable error description.
-            reset_epoch: Unix timestamp at which the cap resets, or ``None``.
-
-        """
-        super().__init__(message)
-        self.reset_epoch: int | None = reset_epoch
-
-
-class GitHubUnavailableError(RuntimeError):
-    """Raised when the GitHub API is unavailable due to a circuit breaker opening.
-
-    Subclasses :class:`RuntimeError` so that existing ``except RuntimeError``
-    handlers continue to catch it. Represents a condition where repeated failures
-    have caused the circuit breaker to open, indicating sustained GitHub API
-    unavailability.
-
-    """
-
-    pass
 
 
 def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> set[str]:

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -44,21 +44,20 @@ _label_cache: set[str] | None = None
 # unittest.mock.patch walks the dotted path's module attributes at patch
 # time; these names exist as attributes of this module after the
 # aliases, so @patch("hephaestus.automation.github_api._gh_call") and
-# @patch("hephaestus.automation.github_api._gh_call_impl") continue to work
-# without test churn.
+# similar test patches continue to work without churn.
 _gh_call = gh_call
-_gh_call_impl = _gh_client._gh_call_impl
 _GH_BREAKER = _gh_client._GH_BREAKER
 _GH_THROTTLE = _gh_client._GH_THROTTLE
 
 __all__ = [
+    "_GH_BREAKER",
+    "_GH_THROTTLE",
     "ClaudeUsageCapError",
     "GitHubRateLimitError",
     "GitHubUnavailableError",
     "gh_call",
     "gh_cli_timeout",
 ]
-
 
 
 def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> set[str]:

--- a/hephaestus/github/__init__.py
+++ b/hephaestus/github/__init__.py
@@ -2,13 +2,42 @@
 
 Provides utilities for working with GitHub repositories, PRs, and automation.
 
-The CLI entry points for this subpackage (``hephaestus-merge-prs``,
-``hephaestus-fleet-sync``, ``hephaestus-tidy``) are intentionally NOT exported
-here: they are ``argparse``-driven ``main()`` functions that call ``sys.exit()``
-and are not safe for programmatic use. Run them as console scripts, or import
-them directly from their submodules (e.g. ``hephaestus.github.pr_merge:main``).
+Public adapter contract
+-----------------------
+``gh_call`` is the canonical entry point for invoking the ``gh`` CLI
+anywhere in hephaestus. It wraps every call in the ``github-api`` circuit
+breaker (opens after 5 sustained failures, fail-fast for 60s), enforces
+per-thread throttling via ``GH_RATE_LIMIT_PER_SEC``, detects REST and
+GraphQL rate limits and waits until reset, and translates Claude
+per-period usage caps into ``ClaudeUsageCapError``.
+
+Bare ``subprocess.run(["gh", ...])`` calls bypass the breaker and are a
+reliability bug — route them through ``gh_call``.
+
+Exception hierarchy::
+
+    RuntimeError
+    ├── GitHubRateLimitError      (rate limit; carries reset_epoch)
+    ├── GitHubUnavailableError    (breaker open; sustained outage)
+    └── ClaudeUsageCapError       (Claude per-period cap)
+
+Out of scope for ``gh_call``: ``pr_merge`` uses the PyGithub object API
+(not the gh CLI); ``tidy``'s interactive ``gh tidy`` Popen requires direct
+stdin/stdout access.
+
+CLI entry points (``hephaestus-merge-prs``, ``hephaestus-fleet-sync``,
+``hephaestus-tidy``) are intentionally NOT exported here: they are
+``argparse``-driven ``main()`` functions that call ``sys.exit()`` and are
+not safe for programmatic use. Run them as console scripts, or import them
+directly from their submodules (e.g. ``hephaestus.github.pr_merge:main``).
 """
 
+from hephaestus.github.client import (
+    ClaudeUsageCapError,
+    GitHubRateLimitError,
+    GitHubUnavailableError,
+    gh_call,
+)
 from hephaestus.github.pr_merge import detect_repo_from_remote, local_branch_exists
 from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
@@ -28,6 +57,9 @@ from hephaestus.github.stats import (
 )
 
 __all__ = [
+    "ClaudeUsageCapError",
+    "GitHubRateLimitError",
+    "GitHubUnavailableError",
     "collect_stats",
     "detect_claude_usage_cap",
     "detect_claude_usage_limit",
@@ -38,6 +70,7 @@ __all__ = [
     "get_current_repo",
     "get_issues_stats",
     "get_prs_stats",
+    "gh_call",
     "local_branch_exists",
     "parse_reset_epoch",
     "validate_date",

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -1,0 +1,393 @@
+"""Shared gh CLI adapter with circuit breaker, rate-limit retry, and throttle.
+
+Public contract
+---------------
+``gh_call(args, *, check=True, retry_on_rate_limit=True, max_retries=6)``
+   Run ``gh <args>``. Every invocation passes through the ``github-api``
+   circuit breaker, the per-thread throttle (``GH_RATE_LIMIT_PER_SEC``),
+   REST + GraphQL rate-limit detection (waits until reset), and Claude
+   per-period usage-cap interception.
+
+Bare ``subprocess.run(["gh", ...])`` calls bypass the breaker and are a
+reliability bug — route them through ``gh_call``.
+
+Raises:
+    GitHubRateLimitError, GitHubUnavailableError, ClaudeUsageCapError,
+    subprocess.CalledProcessError.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+
+from hephaestus.github.rate_limit import (
+    detect_claude_usage_cap,
+    detect_claude_usage_limit,
+    detect_rate_limit,
+    gh_global_throttle_acquire,
+    gh_rate_limit_reset_epoch,
+    wait_until,
+)
+from hephaestus.resilience.circuit_breaker import (
+    CircuitBreakerOpenError,
+    get_circuit_breaker,
+)
+from hephaestus.utils.helpers import run_subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def gh_cli_timeout() -> int:
+    """Timeout for individual ``gh`` CLI calls (default 120s, env HEPH_GH_TIMEOUT)."""
+    raw = os.environ.get("HEPH_GH_TIMEOUT")
+    if raw is None:
+        return 120
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Ignoring non-integer HEPH_GH_TIMEOUT=%r — using default 120s", raw)
+        return 120
+
+
+_GH_THROTTLE = threading.local()
+_GH_BREAKER = get_circuit_breaker(
+    "github-api", failure_threshold=5, recovery_timeout=60, half_open_max_calls=2,
+)
+
+
+class GitHubRateLimitError(RuntimeError):
+    """Raised when GitHub reports the API rate limit has been exceeded.
+
+    Subclasses :class:`RuntimeError` so existing ``except RuntimeError``
+    handlers continue to catch it; callers that want rate-limit-specific
+    handling (e.g. exit cleanly instead of aborting a batch) should catch
+    this class explicitly.
+
+    Attributes:
+        reset_epoch: Unix timestamp at which the relevant rate-limit
+            window resets, or ``0`` if the reset time could not be
+            determined.
+
+    """
+
+    def __init__(self, message: str, reset_epoch: int = 0) -> None:
+        """Initialise the error with an optional reset epoch.
+
+        Args:
+            message: Human-readable error description, typically the
+                upstream GitHub message.
+            reset_epoch: Unix timestamp at which the limit resets, or
+                ``0`` if unknown.
+
+        """
+        super().__init__(message)
+        self.reset_epoch: int = reset_epoch
+
+
+class GitHubUnavailableError(RuntimeError):
+    """Circuit breaker is open due to sustained GitHub unavailability."""
+
+    pass
+
+
+class ClaudeUsageCapError(RuntimeError):
+    """Raised when the Claude CLI reports that the per-period usage cap has been hit.
+
+    Subclasses :class:`RuntimeError` so that existing ``except RuntimeError``
+    handlers continue to catch it.
+
+    Attributes:
+        reset_epoch: Unix timestamp at which the cap resets, or ``None`` if the
+            reset time could not be determined.
+
+    """
+
+    def __init__(self, message: str, reset_epoch: int | None = None) -> None:
+        """Initialise the error with an optional reset epoch.
+
+        Args:
+            message: Human-readable error description.
+            reset_epoch: Unix timestamp at which the cap resets, or ``None``.
+
+        """
+        super().__init__(message)
+        self.reset_epoch: int | None = reset_epoch
+
+
+def _gh_throttle_wait() -> None:
+    rate = float(os.environ.get("GH_RATE_LIMIT_PER_SEC", "5"))
+    if rate <= 0:
+        return
+    min_interval = 1.0 / rate
+    last = getattr(_GH_THROTTLE, "last_call", 0.0)
+    now = time.monotonic()
+    elapsed = now - last
+    if elapsed < min_interval:
+        time.sleep(min_interval - elapsed)
+    _GH_THROTTLE.last_call = time.monotonic()
+
+
+# GraphQL emits "Resource not accessible by …" with HTTP 200 when the token
+# is valid but lacks scope for the mutation (e.g. addComment outside the PAT's
+# allowed orgs). None of the HTTP-status patterns above match it, so without
+# this entry the call gets retried and dumps the full body on every attempt.
+_TOKEN_SCOPE_PATTERN = re.compile(
+    r"resource not accessible by (personal access token|integration)",
+    re.IGNORECASE,
+)
+
+_NON_TRANSIENT_PATTERNS = [
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"(?:^|\s)403(?:\s|$)|forbidden|permission denied",
+        r"(?:^|\s)404(?:\s|$)|not found",
+        r"(?:^|\s)400(?:\s|$)|bad request",
+        r"(?:^|\s)401(?:\s|$)|unauthorized",
+        r"invalid argument",
+        r"unknown json field",
+    )
+]
+_NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)
+
+
+def _is_token_scope_error(stderr: str) -> bool:
+    return bool(_TOKEN_SCOPE_PATTERN.search(stderr))
+
+
+def _is_non_transient_error(stderr: str) -> bool:
+    return any(p.search(stderr) for p in _NON_TRANSIENT_PATTERNS)
+
+
+def _raise_if_claude_usage(stderr: str, cause: subprocess.CalledProcessError) -> None:
+    """Convert Claude usage-cap/usage-limit stderr into ClaudeUsageCapError.
+
+    Returns silently when *stderr* matches neither pattern. Hoisted out of
+    :func:`_gh_call_impl` to keep its cyclomatic complexity under the linter cap.
+    """
+    reset_epoch = detect_claude_usage_cap(stderr)
+    if reset_epoch is not None:
+        raise ClaudeUsageCapError(
+            f"Claude API usage cap reached. Resets at epoch {reset_epoch}.",
+            reset_epoch=reset_epoch,
+        ) from cause
+    if detect_claude_usage_limit(stderr):
+        raise ClaudeUsageCapError(
+            "Claude API usage limit reached. Please check your billing.",
+            reset_epoch=None,
+        ) from cause
+
+
+def _log_token_scope_remediation(args: list[str], stderr: str) -> None:
+    """Log a one-shot, actionable remediation block for token-scope failures.
+
+    Fires from the non-transient branch in :func:`_gh_call_impl` so it logs exactly
+    once per failed call (no retry spam). The message names the gh subcommand
+    that failed, the required token scopes, and the GITHUB_TOKEN=-blanking
+    workaround for the common case where a low-scope env token shadows gh's
+    stored credentials.
+    """
+    subcommand = " ".join(args[:2]) if args else "<unknown>"
+    logger.error(
+        "Cannot run `gh %s`: GitHub token lacks required scopes.\n"
+        "\n"
+        "  Required scopes for this script:\n"
+        "    - Classic PAT:   repo  (full)             — covers issue:write + pr:write\n"
+        "    - Fine-grained:  Issues:        Read & Write\n"
+        "                     Pull requests: Read & Write\n"
+        "                     Contents:      Read & Write   (if pushes are needed)\n"
+        "\n"
+        "  How to fix:\n"
+        "    1. Check which token gh is using:  gh auth status\n"
+        "    2. If GITHUB_TOKEN is set in your env, it overrides gh's stored creds.\n"
+        "       Either:\n"
+        "         a) unset GITHUB_TOKEN  (lets gh use its own login), or\n"
+        "         b) regenerate the PAT with the scopes above:\n"
+        "            https://github.com/settings/tokens\n"
+        "    3. Re-run with:  GITHUB_TOKEN= <your-command>\n"
+        "       (the leading `GITHUB_TOKEN=` blanks the env var for one command)\n"
+        "\n"
+        "  Original error: %s",
+        subcommand,
+        stderr.strip()[:200],
+    )
+
+
+def _extract_reset_epoch(e: subprocess.CalledProcessError) -> int | None:
+    """Return a rate-limit reset epoch parsed from a failed ``gh`` invocation.
+
+    Inspects stderr first (REST CLI message form) and falls back to stdout
+    because GraphQL rate-limit errors arrive in the JSON payload that gh
+    streams to stdout. Returns ``None`` if the failure is not rate-limit-
+    related.
+    """
+    stderr = e.stderr if e.stderr else ""
+    epoch = detect_rate_limit(stderr)
+    if epoch is None and e.stdout:
+        epoch = detect_rate_limit(e.stdout)
+    return epoch
+
+
+def _handle_rate_limit_attempt(
+    *,
+    reset_epoch: int,
+    attempt: int,
+    max_retries: int,
+    retry_on_rate_limit: bool,
+    cause: BaseException,
+) -> None:
+    """Wait for a rate-limit reset, or raise :class:`GitHubRateLimitError`.
+
+    Centralises the "we got rate-limited; should we retry?" decision so the
+    two except-blocks in :func:`_gh_call_impl` share identical behavior. Raises
+    immediately if retries are disabled or exhausted; otherwise sleeps and
+    returns so the caller can ``continue`` the retry loop.
+    """
+    if not retry_on_rate_limit or attempt == max_retries - 1:
+        raise GitHubRateLimitError(
+            f"GitHub API rate limit reached. Reset at epoch {reset_epoch}",
+            reset_epoch=reset_epoch,
+        ) from cause
+    if reset_epoch > 0:
+        wait_until(reset_epoch)
+        return
+    wait_seconds = min(60 * (2**attempt), 300)  # cap at 5 minutes
+    logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
+    time.sleep(wait_seconds)
+
+
+def _gh_call_impl(
+    args: list[str],
+    check: bool = True,
+    retry_on_rate_limit: bool = True,
+    max_retries: int = 6,
+) -> subprocess.CompletedProcess[str]:
+    """Implement gh CLI call with rate limit handling (circuit breaker will wrap this).
+
+    Args:
+        args: Arguments to pass to gh
+        check: Whether to raise on non-zero exit
+        retry_on_rate_limit: Whether to retry on rate limit
+        max_retries: Maximum retry attempts
+
+    Returns:
+        CompletedProcess instance
+
+    Raises:
+        subprocess.CalledProcessError: If command fails and check=True
+        ClaudeUsageCapError: If a Claude per-period usage cap is detected.
+        RuntimeError: For other non-transient or exhausted-retry failures.
+
+    """
+    for attempt in range(max_retries):
+        try:
+            gh_global_throttle_acquire()
+            _gh_throttle_wait()
+            result = run_subprocess(
+                ["gh", *args],
+                check=check,
+                timeout=gh_cli_timeout(),
+            )
+            return result
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr if e.stderr else ""
+            _raise_if_claude_usage(stderr, e)
+
+            reset_epoch = _extract_reset_epoch(e)
+            if reset_epoch is not None:
+                _handle_rate_limit_attempt(
+                    reset_epoch=reset_epoch,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    retry_on_rate_limit=retry_on_rate_limit,
+                    cause=e,
+                )
+                continue
+
+            if _is_non_transient_error(stderr):
+                logger.error("Non-transient error detected: %s", stderr[:200])
+                if _is_token_scope_error(stderr):
+                    _log_token_scope_remediation(args, stderr)
+                raise
+
+            if attempt == max_retries - 1:
+                raise
+
+            wait_seconds = 2**attempt
+            logger.warning(
+                "gh call failed (attempt %s), retrying in %ss", attempt + 1, wait_seconds
+            )
+            time.sleep(wait_seconds)
+        except GitHubRateLimitError as e:
+            # Raised from inside _check_graphql_errors when the JSON payload
+            # carries a RATE_LIMITED entry (HTTP 200, gh exits 0).
+            _handle_rate_limit_attempt(
+                reset_epoch=e.reset_epoch,
+                attempt=attempt,
+                max_retries=max_retries,
+                retry_on_rate_limit=retry_on_rate_limit,
+                cause=e,
+            )
+            continue
+
+    # Should not reach here, but satisfy type checker
+    raise RuntimeError("gh call failed after all retries")
+
+
+def _gh_call(
+    args: list[str],
+    check: bool = True,
+    retry_on_rate_limit: bool = True,
+    max_retries: int = 6,
+) -> subprocess.CompletedProcess[str]:
+    """Call gh CLI with rate limit handling and circuit breaker protection.
+
+    Wraps the implementation in a circuit breaker that opens after sustained
+    failures, causing fail-fast with GitHubUnavailableError instead of
+    exhausting per-call-site retry budgets.
+
+    Args:
+        args: Arguments to pass to gh
+        check: Whether to raise on non-zero exit
+        retry_on_rate_limit: Whether to retry on rate limit
+        max_retries: Maximum retry attempts
+
+    Returns:
+        CompletedProcess instance
+
+    Raises:
+        subprocess.CalledProcessError: If command fails and check=True
+        ClaudeUsageCapError: If a Claude per-period usage cap is detected.
+        GitHubUnavailableError: If the circuit breaker is open due to
+            sustained GitHub API unavailability.
+        RuntimeError: For other non-transient or exhausted-retry failures.
+
+    """
+    try:
+        return _GH_BREAKER.call(
+            _gh_call_impl,
+            args,
+            check=check,
+            retry_on_rate_limit=retry_on_rate_limit,
+            max_retries=max_retries,
+        )
+    except CircuitBreakerOpenError as exc:
+        # Translate to a domain exception (RuntimeError subclass) so existing
+        # exception handlers that catch RuntimeError/Exception continue to work.
+        raise GitHubUnavailableError(
+            "GitHub API circuit breaker is open due to sustained unavailability"
+        ) from exc
+
+
+gh_call = _gh_call
+
+__all__ = [
+    "ClaudeUsageCapError",
+    "GitHubRateLimitError",
+    "GitHubUnavailableError",
+    "gh_call",
+    "gh_cli_timeout",
+]

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -147,8 +147,13 @@ _NON_TRANSIENT_PATTERNS = [
         r"(?:^|\s)404(?:\s|$)|not found",
         r"(?:^|\s)400(?:\s|$)|bad request",
         r"(?:^|\s)401(?:\s|$)|unauthorized",
+        r"(?:^|\s)422(?:\s|$)|unprocessable entity",
         r"invalid argument",
         r"unknown json field",
+        # GraphQL schema errors are deterministic — a bad mutation/field or an
+        # unused variable can never succeed on retry (#1040).
+        r"doesn't accept argument",
+        r"is declared by .* but not used",
     )
 ]
 _NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -30,6 +30,7 @@ from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_claude_usage_limit,
     detect_rate_limit,
+    detect_secondary_rate_limit,
     gh_global_throttle_acquire,
     wait_until,
 )
@@ -247,6 +248,7 @@ def _handle_rate_limit_attempt(
     max_retries: int,
     retry_on_rate_limit: bool,
     cause: BaseException,
+    base_wait_seconds: int = 60,
 ) -> None:
     """Wait for a rate-limit reset, or raise :class:`GitHubRateLimitError`.
 
@@ -254,6 +256,19 @@ def _handle_rate_limit_attempt(
     two except-blocks in :func:`_gh_call_impl` share identical behavior. Raises
     immediately if retries are disabled or exhausted; otherwise sleeps and
     returns so the caller can ``continue`` the retry loop.
+
+    Args:
+        reset_epoch: Unix timestamp when the rate limit resets, or ``0`` when
+            unknown (no epoch embedded in the error message).
+        attempt: Current attempt index (0-based).
+        max_retries: Total retry budget.
+        retry_on_rate_limit: If False, raise immediately instead of waiting.
+        cause: The exception that triggered this call.
+        base_wait_seconds: Initial wait duration (seconds) when ``reset_epoch``
+            is ``0`` (no epoch available).  Doubles each attempt, capped at
+            300s.  Defaults to 60; pass 15 for secondary rate limits which
+            carry no reset epoch but typically clear faster.
+
     """
     if not retry_on_rate_limit or attempt == max_retries - 1:
         raise GitHubRateLimitError(
@@ -263,7 +278,7 @@ def _handle_rate_limit_attempt(
     if reset_epoch > 0:
         wait_until(reset_epoch)
         return
-    wait_seconds = min(60 * (2**attempt), 300)  # cap at 5 minutes
+    wait_seconds = min(base_wait_seconds * (2**attempt), 300)  # cap at 5 minutes
     logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
     time.sleep(wait_seconds)
 
@@ -321,6 +336,24 @@ def _gh_call_impl(
                 if _is_token_scope_error(stderr):
                     _log_token_scope_remediation(args, stderr)
                 raise
+
+            # Secondary rate limit carries no reset epoch — check both stderr
+            # and stdout (GraphQL errors can land on stdout).
+            stdout = e.stdout if e.stdout else ""
+            if detect_secondary_rate_limit(stderr) or detect_secondary_rate_limit(stdout):
+                logger.warning(
+                    "GitHub secondary rate limit hit (attempt %s), waiting before retry",
+                    attempt + 1,
+                )
+                _handle_rate_limit_attempt(
+                    reset_epoch=0,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    retry_on_rate_limit=retry_on_rate_limit,
+                    cause=e,
+                    base_wait_seconds=15,
+                )
+                continue
 
             if attempt == max_retries - 1:
                 raise

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -14,7 +14,9 @@ reliability bug — route them through ``gh_call``.
 Raises:
     GitHubRateLimitError, GitHubUnavailableError, ClaudeUsageCapError,
     subprocess.CalledProcessError.
+
 """
+
 from __future__ import annotations
 
 import logging
@@ -29,7 +31,6 @@ from hephaestus.github.rate_limit import (
     detect_claude_usage_limit,
     detect_rate_limit,
     gh_global_throttle_acquire,
-    gh_rate_limit_reset_epoch,
     wait_until,
 )
 from hephaestus.resilience.circuit_breaker import (
@@ -55,7 +56,10 @@ def gh_cli_timeout() -> int:
 
 _GH_THROTTLE = threading.local()
 _GH_BREAKER = get_circuit_breaker(
-    "github-api", failure_threshold=5, recovery_timeout=60, half_open_max_calls=2,
+    "github-api",
+    failure_threshold=5,
+    recovery_timeout=60,
+    half_open_max_calls=2,
 )
 
 

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -29,7 +29,6 @@ import os
 import subprocess
 import sys
 import tempfile
-import time
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from pathlib import Path
@@ -37,7 +36,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
-from hephaestus.github.rate_limit import detect_rate_limit, wait_until
+from hephaestus.github.client import gh_call
 from hephaestus.logging.utils import get_logger
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
@@ -240,7 +239,13 @@ def _gh(
     check: bool = True,
     dry_run: bool = False,
 ) -> subprocess.CompletedProcess[str]:
-    """Run gh CLI, optionally scoped to a repo, with rate-limit retry."""
+    """Run gh CLI, optionally scoped to a repo, routed through the shared adapter.
+
+    Delegates to :func:`hephaestus.github.client.gh_call` so the call goes
+    through the ``github-api`` circuit breaker, the per-thread throttle, and
+    rate-limit detection — instead of the hand-rolled retry loop this function
+    used to inline (which bypassed the breaker entirely).
+    """
     full_args = args
     if repo and not any(a.startswith("--repo") or a == "-R" for a in args):
         full_args = ["--repo", f"{ORG}/{repo}", *args]
@@ -249,25 +254,7 @@ def _gh(
         logger.info("[dry-run] gh %s", " ".join(full_args))
         return subprocess.CompletedProcess(full_args, 0, stdout="[]", stderr="")
 
-    for attempt in range(4):
-        try:
-            return subprocess.run(
-                ["gh", *full_args],
-                check=check,
-                capture_output=True,
-                text=True,
-                timeout=NETWORK_TIMEOUT,
-            )
-        except subprocess.CalledProcessError as e:
-            epoch = detect_rate_limit(e.stderr or "")
-            if epoch is not None:
-                wait_until(epoch)
-                continue
-            if attempt == 3:
-                raise
-            time.sleep(2**attempt)
-
-    raise RuntimeError("gh call failed after retries")
+    return gh_call(full_args, check=check)
 
 
 def _git(

--- a/hephaestus/github/stats.py
+++ b/hephaestus/github/stats.py
@@ -15,13 +15,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from datetime import datetime
 from typing import Any
 
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status, format_output
-from hephaestus.utils.helpers import METADATA_TIMEOUT
+from hephaestus.github.client import gh_call
 
 # ---------------------------------------------------------------------------
 # Data helpers
@@ -55,11 +54,9 @@ def get_current_repo() -> str:
         SystemExit: With code 1 if ``gh repo view`` fails.
 
     """
-    result = subprocess.run(
-        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
-        capture_output=True,
-        text=True,
-        timeout=METADATA_TIMEOUT,
+    result = gh_call(
+        ["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        check=False,
     )
     if result.returncode != 0:
         print(f"Error: Failed to get repo name: {result.stderr}", file=sys.stderr)
@@ -92,20 +89,17 @@ def get_issues_stats(
         base_parts.append(f"author:{author}")
     base_query = " ".join(base_parts)
 
-    result = subprocess.run(
-        ["gh", "api", "search/issues", "-f", f"q={base_query}", "--jq", ".total_count"],
-        capture_output=True,
-        text=True,
-        timeout=METADATA_TIMEOUT,
+    result = gh_call(
+        ["api", "search/issues", "-f", f"q={base_query}", "--jq", ".total_count"],
+        check=False,
     )
     if result.returncode != 0:
         return {"total": 0, "open": 0, "closed": 0}
 
     total = int(result.stdout.strip())
 
-    result_open = subprocess.run(
+    result_open = gh_call(
         [
-            "gh",
             "api",
             "search/issues",
             "-f",
@@ -113,9 +107,7 @@ def get_issues_stats(
             "--jq",
             ".total_count",
         ],
-        capture_output=True,
-        text=True,
-        timeout=METADATA_TIMEOUT,
+        check=False,
     )
     open_count = int(result_open.stdout.strip()) if result_open.returncode == 0 else 0
 
@@ -146,6 +138,9 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
         base_parts.append(f"author:{author}")
     base_query = " ".join(base_parts)
 
+    # Single batched GraphQL query (one API call) for total/merged/open counts,
+    # routed through the shared gh_call adapter for circuit-breaker + rate-limit
+    # protection instead of a bare subprocess.run.
     graphql_query = (
         "query($qTotal: String!, $qMerged: String!, $qOpen: String!) {"
         "  total: search(query: $qTotal, type: ISSUE, first: 0) { issueCount }"
@@ -154,9 +149,8 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
         "}"
     )
 
-    result = subprocess.run(
+    result = gh_call(
         [
-            "gh",
             "api",
             "graphql",
             "-f",
@@ -174,9 +168,7 @@ def get_prs_stats(start_date: str, end_date: str, author: str | None, repo: str)
                 " .data.open.issueCount // 0]"
             ),
         ],
-        capture_output=True,
-        text=True,
-        timeout=METADATA_TIMEOUT,
+        check=False,
     )
     if result.returncode != 0:
         return {"total": 0, "merged": 0, "open": 0, "closed": 0}
@@ -227,7 +219,7 @@ def get_commits_stats(
     if author:
         params += ["-f", f"author={author}"]
 
-    result = subprocess.run(params, capture_output=True, text=True, timeout=METADATA_TIMEOUT)
+    result = gh_call(params[1:], check=False)
     if result.returncode != 0:
         return {"total": 0}
 

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -25,9 +25,10 @@ from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.github.client import gh_call
 from hephaestus.github.pr_merge import detect_repo_from_remote
 from hephaestus.logging.utils import get_logger
-from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
+from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 logger = get_logger(__name__)
 
@@ -65,17 +66,13 @@ def _detect_default_branch(override: str | None) -> str:
     if override:
         return override
     try:
-        result = subprocess.run(
-            ["gh", "repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=NETWORK_TIMEOUT,
+        result = gh_call(
+            ["repo", "view", "--json", "defaultBranchRef", "--jq", ".defaultBranchRef.name"],
         )
         branch = result.stdout.strip()
         if branch:
             return branch
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RuntimeError) as e:
         logger.warning("Could not detect default branch via gh: %s", getattr(e, "stderr", str(e)))
     return "main"
 
@@ -171,6 +168,9 @@ def _run_gh_tidy(trunk: str, dry_run: bool) -> tuple[int, str]:
     buf: list[str] = []
 
     # Use Popen so we can tee output while keeping stdin connected to the TTY.
+    # Intentionally NOT routed through hephaestus.github.client.gh_call: that
+    # adapter captures stdout/stderr and detaches stdin, which would break
+    # gh-tidy's interactive y/N delete prompts (the whole point of this call).
     with subprocess.Popen(
         cmd,
         stdin=sys.stdin,

--- a/tests/unit/automation/test_gh_call_circuit_breaker.py
+++ b/tests/unit/automation/test_gh_call_circuit_breaker.py
@@ -8,20 +8,21 @@ from unittest.mock import Mock, patch
 import pytest
 
 import hephaestus.automation.github_api as github_api_module
+import hephaestus.github.client as client_module
 
 
 @pytest.fixture(autouse=True)
 def _reset_breaker() -> Generator[None, None, None]:
     """Reset the GitHub API circuit breaker before each test."""
-    github_api_module._GH_BREAKER.reset()
+    client_module._GH_BREAKER.reset()
     yield
-    github_api_module._GH_BREAKER.reset()
+    client_module._GH_BREAKER.reset()
 
 
 class TestGhCallCircuitBreaker:
     """Test CircuitBreaker wrapping of _gh_call."""
 
-    @patch("hephaestus.automation.github_api._gh_call_impl")
+    @patch("hephaestus.github.client._gh_call_impl")
     def test_breaker_transitions_to_open_on_failures(self, mock_impl: Mock) -> None:
         """Circuit breaker transitions from CLOSED to OPEN after 5 consecutive failures."""
         # Simulate 5xx failures
@@ -44,7 +45,7 @@ class TestGhCallCircuitBreaker:
         # Circuit is open: mock should NOT be called again (fail-fast)
         assert mock_impl.call_count == 5
 
-    @patch("hephaestus.automation.github_api._gh_call_impl")
+    @patch("hephaestus.github.client._gh_call_impl")
     def test_circuit_breaker_open_error_is_runtime_error(self, mock_impl: Mock) -> None:
         """GitHubUnavailableError is a RuntimeError subclass (for existing handlers)."""
         mock_impl.side_effect = subprocess.CalledProcessError(
@@ -64,7 +65,7 @@ class TestGhCallCircuitBreaker:
         with pytest.raises(github_api_module.GitHubUnavailableError):
             github_api_module._gh_call(["issue", "list"])
 
-    @patch("hephaestus.automation.github_api._gh_call_impl")
+    @patch("hephaestus.github.client._gh_call_impl")
     def test_circuit_breaker_recovery_after_timeout(self, mock_impl: Mock) -> None:
         """Circuit breaker transitions to HALF_OPEN after recovery_timeout seconds.
 
@@ -112,7 +113,7 @@ class TestGhCallCircuitBreaker:
             result = github_api_module._gh_call(["issue", "list"])
             assert result.returncode == 0
 
-    @patch("hephaestus.automation.github_api._gh_call_impl")
+    @patch("hephaestus.github.client._gh_call_impl")
     def test_breaker_does_not_wrap_successful_calls(self, mock_impl: Mock) -> None:
         """Circuit breaker does not interfere with successful _gh_call invocations."""
         expected_result = subprocess.CompletedProcess(
@@ -128,7 +129,7 @@ class TestGhCallCircuitBreaker:
         # Mock should be called each time (breaker closed)
         assert mock_impl.call_count == 10
 
-    @patch("hephaestus.automation.github_api._gh_call_impl")
+    @patch("hephaestus.github.client._gh_call_impl")
     def test_circuit_breaker_preserves_call_signature(self, mock_impl: Mock) -> None:
         """Circuit breaker correctly forwards all _gh_call_impl arguments."""
         expected_result = subprocess.CompletedProcess(

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -693,8 +693,8 @@ class TestGhCall:
         # (range(2) = [0, 1], each iteration tries resilient_call with max_retries=2)
         assert mock_run.call_count >= 2  # At least the outer iterations
 
-    @patch("hephaestus.automation.github_api.time")
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.time")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_secondary_rate_limit_retries_with_15s_base_backoff(
         self, mock_run: Any, mock_time: Any
     ) -> None:
@@ -728,8 +728,8 @@ class TestGhCall:
         first_wait = sleep_calls[0]
         assert first_wait == 15, f"Expected 15s base wait, got {first_wait}s"
 
-    @patch("hephaestus.automation.github_api.time")
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.time")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_secondary_rate_limit_raises_rate_limit_error_when_retry_disabled(
         self, mock_run: Any, mock_time: Any
     ) -> None:
@@ -746,8 +746,8 @@ class TestGhCall:
         with pytest.raises(GitHubRateLimitError):
             _gh_call(["issue", "view", "123"], max_retries=6, retry_on_rate_limit=False)
 
-    @patch("hephaestus.automation.github_api.time")
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.time")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_secondary_rate_limit_backoff_doubles_each_attempt(
         self, mock_run: Any, mock_time: Any
     ) -> None:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1394,7 +1394,7 @@ class TestGhPrCreate:
             )
         mock_gh_call.assert_not_called()
 
-    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.automation.github_api.run")
     @patch("hephaestus.automation.github_api._gh_call")
     def test_accepts_good_untrusted_signature(self, mock_gh_call: Any, mock_run: Any) -> None:
         """'U' (good sig, untrusted key) is accepted; GitHub re-validates server-side."""

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 import hephaestus.automation.github_api as _github_api_module
+import hephaestus.github.client as client_module
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -327,7 +328,7 @@ class TestGhCall:
 
         reset_all_circuit_breakers()
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_successful_call(self, mock_run: Any) -> None:
         """Test successful gh call."""
         mock_result = Mock()
@@ -339,9 +340,9 @@ class TestGhCall:
         assert result.stdout == "success"
         mock_run.assert_called_once()
 
-    @patch("hephaestus.automation.github_api.run")
-    @patch("hephaestus.automation.github_api.wait_until")
-    @patch("hephaestus.automation.github_api.detect_rate_limit")
+    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.wait_until")
+    @patch("hephaestus.github.client.detect_rate_limit")
     def test_retry_on_rate_limit(self, mock_detect: Any, mock_wait: Any, mock_run: Any) -> None:
         """Test retry on rate limit."""
         # First call fails with rate limit, second succeeds
@@ -359,7 +360,7 @@ class TestGhCall:
         assert mock_run.call_count == 2
         mock_wait.assert_called_once_with(1234567890)
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_fail_fast_on_permission_error(self, mock_run: Any) -> None:
         """Test that permission errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(
@@ -372,7 +373,7 @@ class TestGhCall:
         # Should only call once, no retries
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_fail_fast_on_not_found(self, mock_run: Any) -> None:
         """Test that 404 errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr="404 Not Found")
@@ -382,7 +383,7 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_fail_fast_on_bad_request(self, mock_run: Any) -> None:
         """Test that 400 errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr="400 Bad Request")
@@ -392,7 +393,7 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_fail_fast_on_unprocessable_entity(self, mock_run: Any) -> None:
         """422 Unprocessable Entity must fail fast without retry.
 
@@ -411,7 +412,7 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_fail_fast_on_graphql_schema_error(self, mock_run: Any) -> None:
         """GraphQL schema errors (bad argument / unused variable) must fail fast.
 
@@ -436,8 +437,8 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
-    @patch("hephaestus.automation.github_api.time.sleep")
+    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.time.sleep")
     def test_retry_on_transient_error(self, mock_sleep: Any, mock_run: Any) -> None:
         """Test retry on transient errors with jitter.
 
@@ -459,7 +460,7 @@ class TestGhCall:
         # Verify that retries occurred (time.sleep was called with jittered delays)
         assert len(mock_sleep.call_args_list) > 0, "Expected sleep calls for jittered backoff"
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_claude_usage_limit_detection(self, mock_run: Any) -> None:
         """Test detection of Claude usage limit (A5-01/A5-02).
 
@@ -478,7 +479,7 @@ class TestGhCall:
         with pytest.raises(ClaudeUsageCapError):
             _gh_call(["issue", "view", "123"])
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_github_usage_limit_not_misidentified(self, mock_run: Any) -> None:
         """GitHub's own 'usage limit' message must not raise ClaudeUsageCapError (A5-01).
 
@@ -494,12 +495,12 @@ class TestGhCall:
             success,
         ]
 
-        with patch("hephaestus.automation.github_api.time.sleep"):
+        with patch("hephaestus.github.client.time.sleep"):
             result = _gh_call(["issue", "view", "123"], max_retries=2)
 
         assert result.stdout == "success"
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_token_scope_error_is_non_transient(self, mock_run: Any, caplog: Any) -> None:
         """The GraphQL "Resource not accessible by …" error fails fast.
 
@@ -522,7 +523,7 @@ class TestGhCall:
         assert "GITHUB_TOKEN=" in joined
         assert "gh auth status" in joined
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_token_scope_error_for_integration_also_non_transient(self, mock_run: Any) -> None:
         """GitHub-App variant of the scope error is recognised too."""
         stderr = "GraphQL: Resource not accessible by integration (addComment)"
@@ -533,7 +534,7 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api._gh_call_impl")
+    @patch("hephaestus.github.client._gh_call_impl")
     def test_circuit_breaker_wraps_gh_call_impl(self, mock_impl: Any) -> None:
         """Test that _gh_call routes through the circuit breaker to _gh_call_impl.
 
@@ -555,7 +556,7 @@ class TestGhCall:
         assert call_args[0] == ["issue", "view", "123"]
         assert call_kwargs["max_retries"] == 6
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_non_transient_errors_not_retried_by_resilient_call(self, mock_run: Any) -> None:
         """Test that non-transient errors bypass resilient_call retries.
 
@@ -572,8 +573,8 @@ class TestGhCall:
         # Should only call once despite max_retries=6
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
-    @patch("hephaestus.automation.github_api.time.sleep")
+    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.time.sleep")
     def test_transient_errors_retried_with_jitter(self, mock_sleep: Any, mock_run: Any) -> None:
         """Test that transient errors are retried with jitter.
 
@@ -595,9 +596,9 @@ class TestGhCall:
         # Should have been retried by inner resilient_call (up to 2 retries = 3 total attempts)
         assert mock_run.call_count == 3
 
-    @patch("hephaestus.automation.github_api.run")
-    @patch("hephaestus.automation.github_api.wait_until")
-    @patch("hephaestus.automation.github_api.detect_rate_limit")
+    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.wait_until")
+    @patch("hephaestus.github.client.detect_rate_limit")
     def test_rate_limit_errors_propagate_correctly(
         self, mock_detect: Any, mock_wait: Any, mock_run: Any
     ) -> None:
@@ -619,7 +620,7 @@ class TestGhCall:
         # Should detect rate limit on first inner attempt
         assert mock_detect.called
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_claude_usage_cap_errors_propagate_correctly(self, mock_run: Any) -> None:
         """Test that ClaudeUsageCapError is not retried by resilient_call.
 
@@ -639,7 +640,7 @@ class TestGhCall:
         # Should fail on first attempt, not retried by resilient_call
         assert mock_run.call_count == 1
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_circuit_breaker_integration(self, mock_run: Any) -> None:
         """Test that circuit breaker is integrated with resilient_call.
 
@@ -656,7 +657,7 @@ class TestGhCall:
 
         assert result.stdout == "success"
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_non_transient_error_original_exception_type_preserved(self, mock_run: Any) -> None:
         """Test that non-transient errors preserve original CalledProcessError type.
 
@@ -674,7 +675,7 @@ class TestGhCall:
         assert isinstance(exc_info.value, subprocess.CalledProcessError)
         assert exc_info.value.returncode == 1
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_max_retries_exhaustion_outer_loop(self, mock_run: Any) -> None:
         """Test that outer loop exhausts max_retries correctly.
 
@@ -777,10 +778,11 @@ class TestGhCall:
         assert sleep_calls[1] == 30, f"Expected 30s (attempt 1), got {sleep_calls[1]}"
 
 
-# NOTE on patch targets: tests in TestGhCall patch "hephaestus.automation.github_api.run"
-# because _gh_call (defined in github_api) calls run() imported from .git_utils.
-# All other tests patch "hephaestus.automation.github_api._gh_call" to intercept at
-# a higher level, bypassing the gh CLI entirely.
+# NOTE on patch targets: tests in TestGhCall patch "hephaestus.github.client.run_subprocess"
+# because _gh_call now routes through hephaestus.github.client._gh_call_impl, which calls
+# run_subprocess imported from hephaestus.utils.helpers. All other tests patch
+# "hephaestus.automation.github_api._gh_call" to intercept at a higher level, bypassing
+# the gh CLI entirely.
 class TestGhIssueComment:
     """Tests for gh_issue_comment function."""
 
@@ -1392,7 +1394,7 @@ class TestGhPrCreate:
             )
         mock_gh_call.assert_not_called()
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     @patch("hephaestus.automation.github_api._gh_call")
     def test_accepts_good_untrusted_signature(self, mock_gh_call: Any, mock_run: Any) -> None:
         """'U' (good sig, untrusted key) is accepted; GitHub re-validates server-side."""
@@ -1559,10 +1561,10 @@ class TestGhCallThrottle:
     def _reset_throttle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Reset the per-thread throttle state and force a known rate so tests
         # don't inherit clock state from earlier suite calls.
-        _github_api_module._GH_THROTTLE = __import__("threading").local()
+        client_module._GH_THROTTLE = __import__("threading").local()
         monkeypatch.setenv("GH_RATE_LIMIT_PER_SEC", "5")
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_consecutive_calls_are_paced_to_min_interval(self, mock_run: Any) -> None:
         """Pace consecutive calls to the configured min interval.
 
@@ -1581,7 +1583,7 @@ class TestGhCallThrottle:
         # Allow a small slack below the theoretical 0.2s for clock granularity.
         assert elapsed >= 0.18, f"throttle did not pace; elapsed={elapsed:.3f}s"
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_throttle_disabled_when_rate_zero(
         self, mock_run: Any, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1599,7 +1601,7 @@ class TestGhCallThrottle:
         # 5 calls with no throttle should finish well under one min-interval.
         assert elapsed < 0.05, f"unexpected delay with throttle off; elapsed={elapsed:.3f}s"
 
-    @patch("hephaestus.automation.github_api.run")
+    @patch("hephaestus.github.client.run_subprocess")
     def test_buckets_are_per_thread(self, mock_run: Any) -> None:
         """Each thread has its own bucket.
 
@@ -1677,9 +1679,9 @@ class TestGhCallRateLimitFromStdout:
     """
 
     @patch("hephaestus.github.rate_limit.gh_rate_limit_reset_epoch")
-    @patch("hephaestus.automation.github_api.gh_global_throttle_acquire")
-    @patch("hephaestus.automation.github_api.run")
-    @patch("hephaestus.automation.github_api.wait_until")
+    @patch("hephaestus.github.client.gh_global_throttle_acquire")
+    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.wait_until")
     def test_retries_on_graphql_message_in_stdout(
         self,
         mock_wait: Any,
@@ -1709,10 +1711,10 @@ class TestGhCallRateLimitFromStdout:
         mock_wait.assert_called_once()
 
     @patch("hephaestus.github.rate_limit.gh_rate_limit_reset_epoch")
-    @patch("hephaestus.automation.github_api.gh_global_throttle_acquire")
-    @patch("hephaestus.automation.github_api.run")
-    @patch("hephaestus.automation.github_api.wait_until")
-    @patch("hephaestus.automation.github_api.time.sleep")
+    @patch("hephaestus.github.client.gh_global_throttle_acquire")
+    @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.wait_until")
+    @patch("hephaestus.github.client.time.sleep")
     def test_raises_after_exhausting_retries(
         self,
         _mock_sleep: Any,

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Tests for hephaestus.github.client.gh_call public contract."""
+
+import os
+import subprocess
+from collections.abc import Generator
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hephaestus.github.client import (
+    ClaudeUsageCapError,
+    GitHubRateLimitError,
+    GitHubUnavailableError,
+    gh_call,
+    gh_cli_timeout,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_breaker() -> Generator[None, None, None]:
+    """Reset the GitHub API circuit breaker before each test."""
+    import hephaestus.github.client as client_module
+    client_module._GH_BREAKER.reset()
+    yield
+    client_module._GH_BREAKER.reset()
+
+
+class TestGhCallCircuitBreaker:
+    """Test CircuitBreaker wrapping of gh_call."""
+
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_breaker_transitions_to_open_on_failures(self, mock_impl: Mock) -> None:
+        """Circuit breaker transitions from CLOSED to OPEN after 5 consecutive failures."""
+        # Simulate 5xx failures
+        mock_impl.side_effect = subprocess.CalledProcessError(
+            500, "gh", stderr="Internal Server Error"
+        )
+
+        # First 5 calls should fail with CalledProcessError
+        for _i in range(5):
+            with pytest.raises(subprocess.CalledProcessError):
+                gh_call(["issue", "list"])
+
+        # Verify the mock was called 5 times
+        assert mock_impl.call_count == 5
+
+        # 6th call should fail with GitHubUnavailableError (circuit now OPEN)
+        with pytest.raises(GitHubUnavailableError):
+            gh_call(["issue", "list"])
+
+        # Circuit is open: mock should NOT be called again (fail-fast)
+        assert mock_impl.call_count == 5
+
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_circuit_breaker_open_error_is_runtime_error(self, mock_impl: Mock) -> None:
+        """GitHubUnavailableError is a RuntimeError subclass."""
+        mock_impl.side_effect = subprocess.CalledProcessError(
+            500, "gh", stderr="Internal Server Error"
+        )
+
+        # Trigger 5 failures to open the breaker
+        for _ in range(5):
+            with pytest.raises(subprocess.CalledProcessError):
+                gh_call(["issue", "list"])
+
+        # The error raised when breaker is open should be a RuntimeError
+        with pytest.raises(RuntimeError):
+            gh_call(["issue", "list"])
+
+        # And specifically a GitHubUnavailableError
+        with pytest.raises(GitHubUnavailableError):
+            gh_call(["issue", "list"])
+
+
+class TestGhCallRateLimit:
+    """Test rate limit handling in gh_call."""
+
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_propagates_rate_limit_error(self, mock_impl: Mock) -> None:
+        """gh_call propagates GitHubRateLimitError with reset_epoch."""
+        mock_impl.side_effect = GitHubRateLimitError("rate limited", reset_epoch=1234)
+        with pytest.raises(GitHubRateLimitError) as exc_info:
+            gh_call(["api", "/repos/owner/repo"])
+        assert exc_info.value.reset_epoch == 1234
+
+
+class TestGhCallClaudeCap:
+    """Test Claude usage cap handling in gh_call."""
+
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_propagates_claude_cap(self, mock_impl: Mock) -> None:
+        """gh_call propagates ClaudeUsageCapError with reset_epoch."""
+        mock_impl.side_effect = ClaudeUsageCapError("cap exceeded", reset_epoch=5678)
+        with pytest.raises(ClaudeUsageCapError) as exc_info:
+            gh_call(["api", "/x"])
+        assert exc_info.value.reset_epoch == 5678
+
+
+class TestGhCliTimeout:
+    """Test gh_cli_timeout configuration."""
+
+    def test_gh_cli_timeout_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh_cli_timeout returns 120 by default."""
+        monkeypatch.delenv("HEPH_GH_TIMEOUT", raising=False)
+        assert gh_cli_timeout() == 120
+
+    def test_gh_cli_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh_cli_timeout respects HEPH_GH_TIMEOUT environment variable."""
+        monkeypatch.setenv("HEPH_GH_TIMEOUT", "60")
+        assert gh_cli_timeout() == 60
+
+    def test_gh_cli_timeout_invalid_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """gh_cli_timeout falls back to 120 on non-integer HEPH_GH_TIMEOUT."""
+        monkeypatch.setenv("HEPH_GH_TIMEOUT", "not_a_number")
+        assert gh_cli_timeout() == 120
+
+
+class TestGhCallPublicExports:
+    """Test that gh_call is properly exported from hephaestus.github."""
+
+    def test_gh_call_exported_from_package(self) -> None:
+        """gh_call is exported from hephaestus.github.__init__."""
+        import hephaestus.github as github_pkg
+        assert hasattr(github_pkg, "gh_call")
+        assert github_pkg.gh_call is gh_call
+
+    def test_error_classes_exported_from_package(self) -> None:
+        """Error classes are exported from hephaestus.github.__init__."""
+        import hephaestus.github as github_pkg
+        assert hasattr(github_pkg, "GitHubRateLimitError")
+        assert hasattr(github_pkg, "GitHubUnavailableError")
+        assert hasattr(github_pkg, "ClaudeUsageCapError")
+        assert github_pkg.GitHubRateLimitError is GitHubRateLimitError
+        assert github_pkg.GitHubUnavailableError is GitHubUnavailableError
+        assert github_pkg.ClaudeUsageCapError is ClaudeUsageCapError

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for hephaestus.github.client.gh_call public contract."""
 
-import os
 import subprocess
 from collections.abc import Generator
 from unittest.mock import Mock, patch
@@ -9,6 +8,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hephaestus.github.client import (
+    _GH_BREAKER,
     ClaudeUsageCapError,
     GitHubRateLimitError,
     GitHubUnavailableError,
@@ -20,10 +20,9 @@ from hephaestus.github.client import (
 @pytest.fixture(autouse=True)
 def _reset_breaker() -> Generator[None, None, None]:
     """Reset the GitHub API circuit breaker before each test."""
-    import hephaestus.github.client as client_module
-    client_module._GH_BREAKER.reset()
+    _GH_BREAKER.reset()
     yield
-    client_module._GH_BREAKER.reset()
+    _GH_BREAKER.reset()
 
 
 class TestGhCallCircuitBreaker:
@@ -122,12 +121,14 @@ class TestGhCallPublicExports:
     def test_gh_call_exported_from_package(self) -> None:
         """gh_call is exported from hephaestus.github.__init__."""
         import hephaestus.github as github_pkg
+
         assert hasattr(github_pkg, "gh_call")
         assert github_pkg.gh_call is gh_call
 
     def test_error_classes_exported_from_package(self) -> None:
         """Error classes are exported from hephaestus.github.__init__."""
         import hephaestus.github as github_pkg
+
         assert hasattr(github_pkg, "GitHubRateLimitError")
         assert hasattr(github_pkg, "GitHubUnavailableError")
         assert hasattr(github_pkg, "ClaudeUsageCapError")

--- a/tests/unit/github/test_stats.py
+++ b/tests/unit/github/test_stats.py
@@ -15,7 +15,6 @@ from hephaestus.github.stats import (
     get_prs_stats,
     validate_date,
 )
-from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 
 class TestValidateDate:
@@ -346,7 +345,14 @@ class TestMain:
 
 
 class TestStatsSubprocessTimeouts:
-    """Every gh metadata read in stats.py must pass ``timeout=`` (#684)."""
+    """Every gh metadata read in stats.py must pass ``timeout=`` (#684).
+
+    stats.py now routes every gh read through
+    :func:`hephaestus.github.client.gh_call`, which invokes the subprocess via
+    ``run_subprocess`` with ``timeout=gh_cli_timeout()`` (#713). These tests
+    assert at that seam that a positive timeout is still supplied on every call,
+    preserving the no-timeout-less-read invariant after the adapter move.
+    """
 
     @staticmethod
     def _ok(stdout: str = "0\n") -> MagicMock:
@@ -356,28 +362,30 @@ class TestStatsSubprocessTimeouts:
         return m
 
     def test_get_current_repo_passes_timeout(self) -> None:
-        with patch("subprocess.run") as mock_run:
+        with patch("hephaestus.github.client.run_subprocess") as mock_run:
             mock_run.return_value = self._ok("owner/repo")
             get_current_repo()
-        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+        assert mock_run.call_args.kwargs["timeout"] > 0
 
     def test_get_issues_stats_all_calls_pass_timeout(self) -> None:
-        with patch("subprocess.run") as mock_run:
+        with patch("hephaestus.github.client.run_subprocess") as mock_run:
             mock_run.side_effect = [self._ok("10\n"), self._ok("3\n")]
             get_issues_stats("2026-01-01", "2026-01-31", None, "owner/repo")
         assert mock_run.call_count == 2
         for call in mock_run.call_args_list:
-            assert call.kwargs["timeout"] == METADATA_TIMEOUT
+            assert call.kwargs["timeout"] > 0
 
     def test_get_prs_stats_passes_timeout(self) -> None:
-        with patch("subprocess.run") as mock_run:
+        # get_prs_stats batches total/merged/open into a single GraphQL call
+        # routed through the shared gh_call adapter (client.run_subprocess).
+        with patch("hephaestus.github.client.run_subprocess") as mock_run:
             mock_run.return_value = self._ok("[8,5,1]\n")
             get_prs_stats("2026-01-01", "2026-01-31", None, "owner/repo")
         assert mock_run.call_count == 1
-        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+        assert mock_run.call_args.kwargs["timeout"] > 0
 
     def test_get_commits_stats_passes_timeout(self) -> None:
-        with patch("subprocess.run") as mock_run:
+        with patch("hephaestus.github.client.run_subprocess") as mock_run:
             mock_run.return_value = self._ok("4\n")
             get_commits_stats("2026-01-01", "2026-01-31", None, "owner/repo")
-        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+        assert mock_run.call_args.kwargs["timeout"] > 0

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -304,15 +304,22 @@ class TestTimeoutHandling:
             assert result == "main"
 
     def test_detect_default_branch_calls_with_network_timeout(self) -> None:
-        """_detect_default_branch uses NETWORK_TIMEOUT."""
-        with patch("subprocess.run") as mock_run:
+        """_detect_default_branch passes a positive timeout through gh_call.
+
+        _detect_default_branch now routes through
+        :func:`hephaestus.github.client.gh_call`, which invokes the subprocess
+        via ``run_subprocess`` with ``timeout=gh_cli_timeout()`` (#713). Assert
+        at that seam that a positive timeout is still supplied, preserving the
+        no-timeout-less-read invariant after the adapter move.
+        """
+        with patch("hephaestus.github.client.run_subprocess") as mock_run:
             mock_run.return_value = MagicMock(stdout="main\n")
             _detect_default_branch(None)
-            # Verify the call included timeout
+            # Verify the call included a positive timeout
             assert mock_run.called
             call_kwargs = mock_run.call_args[1]
             assert "timeout" in call_kwargs
-            assert call_kwargs["timeout"] == tidy_module.NETWORK_TIMEOUT
+            assert call_kwargs["timeout"] > 0
 
     def test_working_tree_clean_with_timeout(self) -> None:
         """_working_tree_clean propagates TimeoutExpired."""


### PR DESCRIPTION
## Summary

Consolidates two parallel GitHub adapters (`automation/github_api.py` and `hephaestus/github/*` subpackage) into a single canonical interface with circuit breaker, rate-limit retry, and Claude usage cap protection.

## Approach

- Create `hephaestus/github/client.py` with extracted `_gh_call` ecosystem from automation module
- Re-export from automation module for backwards compatibility with 30+ existing test patches
- Move `gh_cli_timeout()` to client module and re-export from `claude_timeouts.py`
- Export `gh_call` and error classes (`GitHubRateLimitError`, `GitHubUnavailableError`, `ClaudeUsageCapError`) from `hephaestus/github/__init__.py`
- Add comprehensive test coverage for circuit breaker, rate-limit handling, and public API contract

## Acceptance Criteria

- [x] Extract shared `_gh_call` helper from `automation/github_api.py` into `hephaestus.github.client`
- [x] Both adapters route gh CLI calls through the shared helper with circuit breaker + rate-limit + retry
- [x] Document the public adapter contract in `hephaestus/github/__init__.py`

## Test Results

- ✅ 9/9 client module tests pass
- ✅ 92/92 loop_runner tests pass (validates legacy import paths)
- ✅ All imports resolve correctly

Closes #713