### PR TITLE
fix(automation): replace substring match with prefix-match in _has_plan

### DIFF
--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -66,9 +66,9 @@ from .github_api import (
 )
 from .learn import compact_session, learn_needs_rerun, run_learn
 from .models import (
+    PLAN_COMMENT_MARKER,
     ImplementationPhase,
     ImplementationState,
-    PLAN_COMMENT_MARKER,
     WorkerResult,
 )
 from .planner_state import _comments_contain_plan

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -68,8 +68,10 @@ from .learn import compact_session, learn_needs_rerun, run_learn
 from .models import (
     ImplementationPhase,
     ImplementationState,
+    PLAN_COMMENT_MARKER,
     WorkerResult,
 )
+from .planner_state import _comments_contain_plan
 from .pr_manager import (
     commit_changes,
     enable_auto_merge_after_implementation_go,
@@ -712,7 +714,18 @@ class ImplementationPhaseRunner:
     # ------------------------------------------------------------------
 
     def _has_plan(self, issue_number: int) -> bool:
-        """Check if issue has an implementation plan."""
+        """Check if issue has an implementation plan.
+
+        Delegates to :func:`planner_state._comments_contain_plan` so the
+        prefix-anchored check stays in sync with the planner. Substring
+        matching here previously caused the implementer to mistake a
+        ``## 🔍 Plan Review`` comment (which quotes the plan body) for the
+        plan itself — the same bug class fixed in #455/#468/#484 (#715).
+
+        Note: ``_comments_contain_plan`` is a private helper but is the
+        canonical implementation per its own docstring; cross-module reuse
+        here is intentional to avoid a third copy of the same prefix logic.
+        """
         try:
             result = run(
                 ["gh", "issue", "view", str(issue_number), "--comments", "--json", "comments"],
@@ -720,13 +733,7 @@ class ImplementationPhaseRunner:
             )
             data = json.loads(result.stdout)
             comments = data.get("comments", [])
-
-            for comment in comments:
-                body = comment.get("body", "")
-                if "Implementation Plan" in body or "## Plan" in body:
-                    return True
-
-            return False
+            return _comments_contain_plan(comments)
         except (subprocess.SubprocessError, json.JSONDecodeError, OSError):
             return False
 
@@ -2098,11 +2105,14 @@ class ImplementationPhaseRunner:
     def _fetch_plan_and_review(self, issue_number: int) -> tuple[str, str]:
         """Return ``(plan_text, plan_review_text)`` for the reviewer context.
 
-        The PLAN comment is identified the same way :meth:`_has_plan` does
-        ("Implementation Plan" / "## Plan"); the PLAN_REVIEW comment is the one
-        whose body starts with ``review_state.PLAN_REVIEW_PREFIX``. Best-effort:
-        any fetch failure yields empty strings (looked up via ``_impl_module``
-        so tests can patch ``hephaestus.automation.implementer.review_state``).
+        The PLAN comment is identified the same way
+        :func:`planner_state._comments_contain_plan` does — prefix-anchored on
+        :data:`PLAN_COMMENT_MARKER`, skipping comments whose body starts with
+        :data:`review_state.PLAN_REVIEW_PREFIX`. The PLAN_REVIEW comment is
+        the one whose body starts with ``review_state.PLAN_REVIEW_PREFIX``.
+        Best-effort: any fetch failure yields empty strings (looked up via
+        ``_impl_module`` so tests can patch
+        ``hephaestus.automation.implementer.review_state``).
         """
         plan_text = ""
         plan_review_text = ""
@@ -2111,9 +2121,10 @@ class ImplementationPhaseRunner:
             comments = review_state._fetch_issue_comments_graphql(issue_number)
             for comment in comments:
                 body = comment.get("body", "")
-                if body.startswith(review_state.PLAN_REVIEW_PREFIX):
+                stripped = body.lstrip()
+                if stripped.startswith(review_state.PLAN_REVIEW_PREFIX):
                     plan_review_text = body
-                elif "Implementation Plan" in body or "## Plan" in body:
+                elif stripped.startswith(PLAN_COMMENT_MARKER):
                     plan_text = body
         except Exception as e:
             logger.warning("#%s: failed to fetch PLAN/PLAN_REVIEW context: %s", issue_number, e)

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -1014,16 +1014,28 @@ class TestHasPlanPrefixMatch:
         with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
             return IssueImplementer(options)
 
-    def test_plan_review_quoting_plan_heading_is_not_a_plan(self, impl: IssueImplementer) -> None:
-        """_has_plan does not match substring in a Plan Review comment.
+    @staticmethod
+    def _mock_gh_view(comments: list[dict[str, Any]]) -> Any:
+        def mock_gh_view(*args: Any, **kwargs: Any) -> MagicMock:
+            result = MagicMock()
+            result.stdout = json.dumps({"comments": comments}).encode("utf-8")
+            return result
 
-        Regression for #455/#468/#484: a ``## 🔍 Plan Review`` body contains
-        ``## Implementation Plan`` as substring when it quotes the plan, and
+        return mock_gh_view
+
+    def test_plan_review_quoting_plan_heading_is_not_a_plan(self, impl: IssueImplementer) -> None:
+        """_has_plan does not match a Plan Review comment that merely quotes the plan.
+
+        Regression for #455/#468/#484/#715: a ``## 🔍 Plan Review`` body contains
+        ``# Implementation Plan`` as substring when it quotes the plan, and
         substring matching caused the false positive. Prefix-matching (only at
         the start of the body) must be used instead.
+
+        The fixture intentionally contains ONLY the Plan-Review comment (no
+        genuine plan), so the OLD substring code would return ``True`` here —
+        this test fails against the pre-fix code and guards the bug.
         """
         comments = [
-            {"body": "# Implementation Plan\n\nStep 1: Do something"},
             {
                 "body": (
                     "## 🔍 Plan Review\n\n"
@@ -1033,14 +1045,24 @@ class TestHasPlanPrefixMatch:
             },
         ]
 
-        def mock_gh_view(*args: Any, **kwargs: Any) -> MagicMock:
-            result = MagicMock()
-            result.stdout = json.dumps({"comments": comments}).encode("utf-8")
-            return result
+        with patch(
+            "hephaestus.automation.implementer_phase_runner.run",
+            side_effect=self._mock_gh_view(comments),
+        ):
+            assert impl.phase_runner._has_plan(1) is False
+
+    def test_real_plan_comment_is_detected(self, impl: IssueImplementer) -> None:
+        """_has_plan returns True for a comment whose body starts with the marker.
+
+        Covers the positive branch of the prefix check (#715): a body beginning
+        with ``# Implementation Plan`` is a genuine plan.
+        """
+        comments = [
+            {"body": "# Implementation Plan\n\nStep 1: Do something"},
+        ]
 
         with patch(
             "hephaestus.automation.implementer_phase_runner.run",
-            side_effect=mock_gh_view,
+            side_effect=self._mock_gh_view(comments),
         ):
-            # The first comment is the plan; the second quotes it but is NOT the plan
             assert impl.phase_runner._has_plan(1) is True

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -12,6 +12,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1013,9 +1014,7 @@ class TestHasPlanPrefixMatch:
         with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
             return IssueImplementer(options)
 
-    def test_plan_review_quoting_plan_heading_is_not_a_plan(
-        self, impl: IssueImplementer
-    ) -> None:
+    def test_plan_review_quoting_plan_heading_is_not_a_plan(self, impl: IssueImplementer) -> None:
         """_has_plan does not match substring in a Plan Review comment.
 
         Regression for #455/#468/#484: a ``## 🔍 Plan Review`` body contains
@@ -1034,7 +1033,7 @@ class TestHasPlanPrefixMatch:
             },
         ]
 
-        def mock_gh_view(*args, **kwargs) -> MagicMock:  # type: ignore[no-untyped-def]
+        def mock_gh_view(*args: Any, **kwargs: Any) -> MagicMock:
             result = MagicMock()
             result.stdout = json.dumps({"comments": comments}).encode("utf-8")
             return result

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -8,6 +8,7 @@ the public CLI contract that other repos shell out to.
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -981,3 +982,66 @@ class TestAdviseAsImplementerTurn:
         assert call_kw["model"] == implementer_model(), (
             f"Expected implementer_model() but got {call_kw['model']!r}"
         )
+
+
+# #715 — _has_plan and _fetch_plan_and_review must use prefix-match not substring
+# ---------------------------------------------------------------------------------
+
+
+class TestHasPlanPrefixMatch:
+    """Regression coverage for #715 — _has_plan must NOT substring-match.
+
+    A ``## 🔍 Plan Review`` comment quotes the plan and therefore contains
+    ``## Implementation Plan`` and ``## Plan`` as substrings. The pre-#715
+    implementation returned True on those, causing the implementer to
+    treat its own prior plan-review as "the plan" (#455/#468/#484 bug
+    class).
+    """
+
+    @pytest.fixture
+    def impl(self, tmp_path: Path) -> IssueImplementer:
+        # Mirror TestPlanReviewVerdictGate.impl (line 241-251): the fixture
+        # is class-scoped throughout this module, never module-level, so this
+        # class declares its own to stay self-contained.
+        options = ImplementerOptions(
+            issues=[1],
+            dry_run=False,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            return IssueImplementer(options)
+
+    def test_plan_review_quoting_plan_heading_is_not_a_plan(
+        self, impl: IssueImplementer
+    ) -> None:
+        """_has_plan does not match substring in a Plan Review comment.
+
+        Regression for #455/#468/#484: a ``## 🔍 Plan Review`` body contains
+        ``## Implementation Plan`` as substring when it quotes the plan, and
+        substring matching caused the false positive. Prefix-matching (only at
+        the start of the body) must be used instead.
+        """
+        comments = [
+            {"body": "# Implementation Plan\n\nStep 1: Do something"},
+            {
+                "body": (
+                    "## 🔍 Plan Review\n\n"
+                    "The plan's # Implementation Plan section looks good.\n\n"
+                    "Verdict: GO"
+                )
+            },
+        ]
+
+        def mock_gh_view(*args, **kwargs) -> MagicMock:  # type: ignore[no-untyped-def]
+            result = MagicMock()
+            result.stdout = json.dumps({"comments": comments}).encode("utf-8")
+            return result
+
+        with patch(
+            "hephaestus.automation.implementer_phase_runner.run",
+            side_effect=mock_gh_view,
+        ):
+            # The first comment is the plan; the second quotes it but is NOT the plan
+            assert impl.phase_runner._has_plan(1) is True


### PR DESCRIPTION
## Summary

Fixes the substring-match anti-pattern in `implementer_phase_runner.py` that reintroduces the bug class fixed in #455/#468/#484.

A `## 🔍 Plan Review` comment quotes the plan body (containing plan headings as substrings) and was falsely triggering as "has a plan" under the old substring matching logic.

## Changes

- Import `_comments_contain_plan` from `planner_state` (canonical prefix-anchored helper)
- Import `PLAN_COMMENT_MARKER` from `models`
- Replace `_has_plan` substring matching with delegation to `_comments_contain_plan`
- Replace `_fetch_plan_and_review` substring matching with prefix-anchored check using the same constant
- Add regression test verifying Plan Review comments are not counted as plans

Closes #715