### PR TITLE
fix(automation): Use stable human name in Co-Authored-By trailer

### DIFF
--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -42,10 +42,26 @@ def _agent_display_name(agent: str) -> str:
 
 
 def _coauthor_for_agent(agent: str) -> tuple[str, str]:
-    """Return the co-author identity for fallback commits made by automation."""
+    """Return the co-author identity for fallback commits made by automation.
+
+    Returns a stable, human-shaped (name, email) pair suitable for the
+    ``Co-Authored-By:`` git trailer. Model identifiers are intentionally NOT
+    placed in the name slot — see ``_provenance_for_agent`` for that.
+    """
     if is_codex(agent):
         return ("Codex", "noreply@openai.com")
-    return (implementer_model(), "noreply@anthropic.com")
+    return ("Claude Code", "noreply@anthropic.com")
+
+
+def _provenance_for_agent(agent: str) -> str:
+    """Return the value for an ``Implemented-By:`` trailer.
+
+    For Claude agents this is the resolved model id (honoring
+    ``HEPH_IMPLEMENTER_MODEL``); for Codex it is the literal ``"Codex"``.
+    """
+    if is_codex(agent):
+        return "Codex"
+    return implementer_model()
 
 
 def _detect_default_base_branch(worktree_path: Path) -> str:
@@ -213,12 +229,14 @@ def commit_changes(issue_number: int, worktree_path: Path, agent: str = "claude"
     # Generate commit message
     issue = fetch_issue_info(issue_number)
     coauthor_name, coauthor_email = _coauthor_for_agent(agent)
+    provenance = _provenance_for_agent(agent)
     commit_msg = f"""feat: Implement #{issue_number}
 
 {issue.title}
 
 Closes #{issue_number}
 
+Implemented-By: {provenance}
 Co-Authored-By: {coauthor_name} <{coauthor_email}>
 """
 

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -7,6 +7,7 @@ and GitHub-API calls.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -178,15 +179,17 @@ class TestCreatePR:
 
 
 # ---------------------------------------------------------------------------
-# #382/A4-08: Co-Authored-By uses implementer_model() not hardcoded string
+# #717: Co-Authored-By uses a human-shaped name; model id moves to Implemented-By
 # ---------------------------------------------------------------------------
 
 
-class TestCoAuthorLine:
-    """Tests that commit_changes uses implementer_model() for Co-Authored-By (#382/A4-08)."""
+_COAUTHOR_HUMAN_NAME_RE = re.compile(r"^Co-Authored-By: [A-Za-z].* <.*@.*>$")
 
-    def test_coauthor_uses_implementer_model(self) -> None:
-        """Co-Authored-By line reflects whatever implementer_model() returns."""
+
+class TestCoAuthorLine:
+    """commit_changes emits a human Co-Authored-By and a separate Implemented-By trailer (#717)."""
+
+    def test_claude_coauthor_is_human_name_not_model_id(self) -> None:
         porcelain = " M src/feature.py\n"
         run_mock = MagicMock(
             side_effect=[
@@ -200,29 +203,48 @@ class TestCoAuthorLine:
         with (
             patch.object(pr_manager, "run", run_mock),
             patch.object(pr_manager, "fetch_issue_info", return_value=issue),
-            patch.object(
-                pr_manager, "implementer_model", return_value="claude-test-model-9"
-            ) as mock_model,
+            patch.object(pr_manager, "implementer_model", return_value="claude-test-model-9"),
         ):
             pr_manager.commit_changes(10, Path("/tmp/wt"))
 
-        # The commit call must include the dynamic model name, not a hardcoded string
-        commit_call = run_mock.call_args_list[2].args[0]
-        commit_msg = commit_call[-1]  # last arg is the -m message
-        assert "claude-test-model-9" in commit_msg
-        assert "Claude Sonnet 4.6" not in commit_msg  # old hardcoded value must be gone
-        mock_model.assert_called_once()
+        commit_msg = run_mock.call_args_list[2].args[0][-1]
+        coauthor_line = next(
+            line for line in commit_msg.splitlines() if line.startswith("Co-Authored-By:")
+        )
+        assert coauthor_line == "Co-Authored-By: Claude Code <noreply@anthropic.com>"
+        assert _COAUTHOR_HUMAN_NAME_RE.match(coauthor_line)
+        # Model id must NOT appear in the name slot of Co-Authored-By (#717).
+        assert "claude-test-model-9" not in coauthor_line
 
-    def test_coauthor_reflects_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When HEPH_IMPLEMENTER_MODEL is set, commit uses that model name."""
+    def test_claude_implemented_by_carries_model_id(self) -> None:
+        porcelain = " M src/feature.py\n"
+        run_mock = MagicMock(
+            side_effect=[
+                _status(porcelain),  # git status
+                _status(""),  # git add
+                _status(""),  # git commit
+            ]
+        )
+        issue = MagicMock(title="Add feature")
+
+        with (
+            patch.object(pr_manager, "run", run_mock),
+            patch.object(pr_manager, "fetch_issue_info", return_value=issue),
+            patch.object(pr_manager, "implementer_model", return_value="claude-test-model-9"),
+        ):
+            pr_manager.commit_changes(11, Path("/tmp/wt"))
+
+        commit_msg = run_mock.call_args_list[2].args[0][-1]
+        assert "Implemented-By: claude-test-model-9" in commit_msg
+
+    def test_implemented_by_reflects_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HEPH_IMPLEMENTER_MODEL", "claude-env-override-5")
-
         porcelain = " M foo.py\n"
         run_mock = MagicMock(
             side_effect=[
-                _status(porcelain),
-                _status(""),
-                _status(""),
+                _status(porcelain),  # git status
+                _status(""),  # git add
+                _status(""),  # git commit
             ]
         )
         issue = MagicMock(title="env override test")
@@ -233,17 +255,22 @@ class TestCoAuthorLine:
         ):
             pr_manager.commit_changes(20, Path("/tmp/wt"))
 
-        commit_call = run_mock.call_args_list[2].args[0]
-        commit_msg = commit_call[-1]
-        assert "claude-env-override-5" in commit_msg
+        commit_msg = run_mock.call_args_list[2].args[0][-1]
+        # Env override flows into Implemented-By, not Co-Authored-By.
+        assert "Implemented-By: claude-env-override-5" in commit_msg
+        coauthor_line = next(
+            line for line in commit_msg.splitlines() if line.startswith("Co-Authored-By:")
+        )
+        assert "claude-env-override-5" not in coauthor_line
+        assert coauthor_line == "Co-Authored-By: Claude Code <noreply@anthropic.com>"
 
-    def test_codex_coauthor_does_not_use_claude_model(self) -> None:
+    def test_codex_coauthor_is_codex_human_name(self) -> None:
         porcelain = " M foo.py\n"
         run_mock = MagicMock(
             side_effect=[
-                _status(porcelain),
-                _status(""),
-                _status(""),
+                _status(porcelain),  # git status
+                _status(""),  # git add
+                _status(""),  # git commit
             ]
         )
         issue = MagicMock(title="codex fallback commit")
@@ -255,7 +282,11 @@ class TestCoAuthorLine:
         ):
             pr_manager.commit_changes(30, Path("/tmp/wt"), agent="codex")
 
-        commit_call = run_mock.call_args_list[2].args[0]
-        commit_msg = commit_call[-1]
-        assert "Co-Authored-By: Codex <noreply@openai.com>" in commit_msg
+        commit_msg = run_mock.call_args_list[2].args[0][-1]
+        coauthor_line = next(
+            line for line in commit_msg.splitlines() if line.startswith("Co-Authored-By:")
+        )
+        assert coauthor_line == "Co-Authored-By: Codex <noreply@openai.com>"
+        assert _COAUTHOR_HUMAN_NAME_RE.match(coauthor_line)
+        assert "Implemented-By: Codex" in commit_msg
         mock_model.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes the Co-Authored-By git trailer to use a stable human-shaped name instead of the raw model identifier. This resolves contribution tracking issues and ensures mailmap/shortlog compatibility.

- Claude commits now emit `Co-Authored-By: Claude Code <noreply@anthropic.com>`
- Codex commits now emit `Co-Authored-By: Codex <noreply@openai.com>`
- Model provenance (e.g., `claude-haiku-4-5`) moves to a separate `Implemented-By:` trailer

## Acceptance Criteria

- [x] Use stable human-shaped name in Co-Authored-By (Claude Code / Codex)
- [x] Move model identifier to Implemented-By trailer
- [x] Add regression test for RFC-compliant pattern

## Test Plan

- Run: `pixi run pytest tests/unit/automation/test_pr_manager.py::TestCoAuthorLine -v`
- All 4 new tests pass:
  - `test_claude_coauthor_is_human_name_not_model_id` — verifies "Claude Code" in trailer
  - `test_claude_implemented_by_carries_model_id` — verifies model in Implemented-By
  - `test_implemented_by_reflects_env_override` — verifies HEPH_IMPLEMENTER_MODEL honored
  - `test_codex_coauthor_is_codex_human_name` — verifies Codex branch compliance
- All 14 existing tests still pass
- Lint: `pixi run ruff check` passes
- Type: `pixi run mypy` passes

Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)