### PR TITLE
feat(github): decouple fleet_sync from hardcoded ORG and ALL_REPOS

### DIFF
--- a/.fleet.yml
+++ b/.fleet.yml
@@ -1,0 +1,19 @@
+# Fleet configuration consumed by hephaestus-fleet-sync.
+# Override per-invocation with --org / --repos or FLEET_ORG / FLEET_REPOS.
+org: HomericIntelligence
+repos:
+  - Odysseus
+  - AchaeanFleet
+  - ProjectArgus
+  - ProjectHermes
+  - ProjectTelemachy
+  - ProjectKeystone
+  - Myrmidons
+  - ProjectProteus
+  - ProjectOdyssey
+  - ProjectScylla
+  - ProjectMnemosyne
+  - ProjectHephaestus
+  - ProjectAgamemnon
+  - ProjectNestor
+  - ProjectCharybdis

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -208,6 +208,29 @@ def get_resign_exec() -> str:
     return f"git -c user.email={get_resign_email()} commit --amend --no-edit -S --reset-author"
 
 
+def _parse_env_repos(env_repos_raw: str | None) -> list[str] | None:
+    """Parse comma-separated FLEET_REPOS and validate non-empty.
+
+    Args:
+        env_repos_raw: Raw FLEET_REPOS value from environment
+
+    Returns:
+        List of repo names with whitespace trimmed, or None if input is None
+
+    Raises:
+        RuntimeError: If repos are set but all empty after trimming
+
+    """
+    if env_repos_raw is None:
+        return None
+    env_repos = [r.strip() for r in env_repos_raw.split(",") if r.strip()]
+    if not env_repos:
+        raise RuntimeError(
+            "FLEET_REPOS is set but contains no valid repos after splitting on commas"
+        )
+    return env_repos
+
+
 def _find_default_config() -> Path | None:
     """Return the first existing .fleet.yml in CWD or repo-root, else None."""
     cwd_path = Path.cwd() / DEFAULT_FLEET_CONFIG_FILENAME
@@ -248,7 +271,7 @@ def _load_fleet_config(config_path: str | None) -> tuple[str | None, list[str] |
                 file_repos_raw = cfg.get("repos")
                 if isinstance(file_repos_raw, list):
                     file_repos = file_repos_raw
-            except Exception as e:
+            except (FileNotFoundError, ValueError) as e:
                 raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
 
     return file_org, file_repos
@@ -287,11 +310,7 @@ def resolve_fleet_config(
     env_repos_raw = os.environ.get("FLEET_REPOS")
 
     if env_org and env_repos_raw is not None:
-        env_repos = [r.strip() for r in env_repos_raw.split(",") if r.strip()]
-        if not env_repos:
-            raise RuntimeError(
-                "FLEET_REPOS is set but contains no valid repos after splitting on commas"
-            )
+        env_repos = _parse_env_repos(env_repos_raw)
         return env_org, env_repos
 
     # Step 3: Try config file
@@ -304,9 +323,7 @@ def resolve_fleet_config(
             "no fleet org configured. Set --org, FLEET_ORG, or org: in .fleet.yml"
         )
 
-    final_repos = cli_repos or (
-        [r.strip() for r in env_repos_raw.split(",") if r.strip()] if env_repos_raw else None
-    ) or file_repos
+    final_repos = cli_repos or _parse_env_repos(env_repos_raw) or file_repos
 
     if not final_repos:
         raise RuntimeError(
@@ -359,7 +376,9 @@ def _gh(
     """
     full_args = args
     if repo and not any(a.startswith("--repo") or a == "-R" for a in args):
-        repo_arg = f"{org}/{repo}" if org else repo
+        if not org:
+            raise ValueError("org must be provided when repo is specified")
+        repo_arg = f"{org}/{repo}"
         full_args = ["--repo", repo_arg, *args]
 
     if dry_run:

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -309,6 +309,16 @@ def resolve_fleet_config(
     if not final_org:
         raise RuntimeError("no fleet org configured. Set --org, FLEET_ORG, or org: in .fleet.yml")
 
+    # Distinguish "FLEET_REPOS set but empty after comma-split" from "unset" so
+    # operators can tell a typo'd value (e.g. " , , " or "") apart from simply
+    # not having configured the env var. Only fires when no higher-priority CLI
+    # value overrides it.
+    if not cli_repos and env_repos_raw is not None and env_repos is None:
+        raise RuntimeError(
+            f"FLEET_REPOS is set but contains no valid entries after comma-split "
+            f"(got {env_repos_raw!r})"
+        )
+
     final_repos = cli_repos or env_repos or file_repos
 
     if not final_repos:

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python3
-"""Sync all PRs across the HomericIntelligence fleet.
+r"""Sync all PRs across a configurable GitHub org's fleet of repos.
 
 For every open PR in every configured repo:
   - Ready (CI green, no conflicts) → merge via merge commit (GitHub signs it)
@@ -11,12 +10,19 @@ Signing uses the local GPG key configured in git's ``user.signingkey``.
 All commits produced by this script are signed with ``git commit -S``.
 
 Usage:
-    hephaestus-fleet-sync [--dry-run] [--repos REPO ...] [--skip-conflict-resolution]
+    hephaestus-fleet-sync [--dry-run] [--org ORG] [--repos REPO ...] \
+                          [--config PATH] [--skip-conflict-resolution]
 
-Options:
-    --dry-run                    Print actions without executing
-    --repos REPO [REPO ...]      Restrict to specific repos (default: all 15)
-    --skip-conflict-resolution   Skip agent conflict resolution for conflicted PRs
+Config resolution (highest priority first):
+    1. ``--org`` / ``--repos`` CLI flags
+    2. ``FLEET_ORG`` / ``FLEET_REPOS`` env vars
+       (``FLEET_REPOS`` is comma-separated; whitespace is trimmed;
+        values are always treated as strings — no int/float coercion)
+    3. ``.fleet.yml`` at ``--config PATH`` if given, else ``./.fleet.yml``,
+       else repo-root ``.fleet.yml``
+
+For ProjectHephaestus's own fleet, a bundled ``.fleet.yml`` lives at the
+repo root, so no configuration is required for the default operator flow.
 """
 
 from __future__ import annotations
@@ -36,6 +42,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.config.utils import load_config
 from hephaestus.github.client import gh_call
 from hephaestus.logging.utils import get_logger
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
@@ -56,7 +63,7 @@ class Symbols:
 UNICODE_SYMBOLS = Symbols(banner="══", check="✓", arrow="→", dash="—")
 ASCII_SYMBOLS = Symbols(banner="==", check="*", arrow="->", dash="--")
 
-ORG = "HomericIntelligence"
+DEFAULT_FLEET_CONFIG_FILENAME = ".fleet.yml"
 
 
 def _signing_key_uid_emails() -> list[str] | None:
@@ -201,23 +208,112 @@ def get_resign_exec() -> str:
     return f"git -c user.email={get_resign_email()} commit --amend --no-edit -S --reset-author"
 
 
-ALL_REPOS: list[str] = [
-    "Odysseus",
-    "AchaeanFleet",
-    "ProjectArgus",
-    "ProjectHermes",
-    "ProjectTelemachy",
-    "ProjectKeystone",
-    "Myrmidons",
-    "ProjectProteus",
-    "ProjectOdyssey",
-    "ProjectScylla",
-    "ProjectMnemosyne",
-    "ProjectHephaestus",
-    "ProjectAgamemnon",
-    "ProjectNestor",
-    "ProjectCharybdis",
-]
+def _find_default_config() -> Path | None:
+    """Return the first existing .fleet.yml in CWD or repo-root, else None."""
+    cwd_path = Path.cwd() / DEFAULT_FLEET_CONFIG_FILENAME
+    if cwd_path.exists():
+        return cwd_path
+
+    repo_root_path = Path(__file__).resolve().parent.parent.parent / DEFAULT_FLEET_CONFIG_FILENAME
+    if repo_root_path.exists():
+        return repo_root_path
+
+    return None
+
+
+def _load_fleet_config(config_path: str | None) -> tuple[str | None, list[str] | None]:
+    """Load org and repos from config file, auto-discovering if needed.
+
+    Args:
+        config_path: Explicit path to .fleet.yml, or None for auto-discovery
+
+    Returns:
+        Tuple of (org, repos) where either may be None if not found
+
+    """
+    if config_path is None:
+        found_config = _find_default_config()
+        if found_config is not None:
+            config_path = str(found_config)
+
+    file_org = None
+    file_repos = None
+
+    if config_path is not None:
+        config_path_obj = Path(config_path)
+        if config_path_obj.exists():
+            try:
+                cfg = load_config(config_path_obj)
+                file_org = cfg.get("org")
+                file_repos_raw = cfg.get("repos")
+                if isinstance(file_repos_raw, list):
+                    file_repos = file_repos_raw
+            except Exception as e:
+                raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
+
+    return file_org, file_repos
+
+
+def resolve_fleet_config(
+    cli_org: str | None = None,
+    cli_repos: list[str] | None = None,
+    config_path: str | None = None,
+) -> tuple[str, list[str]]:
+    """Resolve fleet organization and repo list with layered config sources.
+
+    Resolution order (highest to lowest priority):
+    1. CLI flags (cli_org, cli_repos)
+    2. Environment variables (FLEET_ORG, FLEET_REPOS)
+    3. Config file (.fleet.yml at config_path, or auto-discovered)
+
+    Args:
+        cli_org: Organization name from --org flag
+        cli_repos: Repo names from --repos flag
+        config_path: Explicit path to .fleet.yml, or None for auto-discovery
+
+    Returns:
+        Tuple of (org, repos) where repos is a list of bare repo names
+
+    Raises:
+        RuntimeError: If org or repos cannot be resolved from any source
+
+    """
+    # Step 1: Try CLI flags
+    if cli_org is not None and cli_repos is not None:
+        return cli_org, cli_repos
+
+    # Step 2: Try environment variables (as strings, bypassing merge_with_env type coercion)
+    env_org = os.environ.get("FLEET_ORG", "").strip()
+    env_repos_raw = os.environ.get("FLEET_REPOS")
+
+    if env_org and env_repos_raw is not None:
+        env_repos = [r.strip() for r in env_repos_raw.split(",") if r.strip()]
+        if not env_repos:
+            raise RuntimeError(
+                "FLEET_REPOS is set but contains no valid repos after splitting on commas"
+            )
+        return env_org, env_repos
+
+    # Step 3: Try config file
+    file_org, file_repos = _load_fleet_config(config_path)
+
+    # Merge results with fallback to environment or file values
+    final_org = cli_org or env_org or file_org
+    if not final_org:
+        raise RuntimeError(
+            "no fleet org configured. Set --org, FLEET_ORG, or org: in .fleet.yml"
+        )
+
+    final_repos = cli_repos or (
+        [r.strip() for r in env_repos_raw.split(",") if r.strip()] if env_repos_raw else None
+    ) or file_repos
+
+    if not final_repos:
+        raise RuntimeError(
+            "no fleet repos configured. Set --repos, FLEET_REPOS, or repos: in .fleet.yml"
+        )
+
+    return final_org, final_repos
 
 
 class PRStatus(Enum):
@@ -250,6 +346,7 @@ class PRInfo:
 def _gh(
     args: list[str],
     repo: str | None = None,
+    org: str | None = None,
     check: bool = True,
     dry_run: bool = False,
 ) -> subprocess.CompletedProcess[str]:
@@ -262,7 +359,8 @@ def _gh(
     """
     full_args = args
     if repo and not any(a.startswith("--repo") or a == "-R" for a in args):
-        full_args = ["--repo", f"{ORG}/{repo}", *args]
+        repo_arg = f"{org}/{repo}" if org else repo
+        full_args = ["--repo", repo_arg, *args]
 
     if dry_run:
         logger.info("[dry-run] gh %s", " ".join(full_args))
@@ -310,7 +408,7 @@ def _ci_state(checks: list[dict[str, Any]]) -> str:
     return "SUCCESS"
 
 
-def _fetch_pr_ci_state(repo: str, number: int) -> str:
+def _fetch_pr_ci_state(repo: str, number: int, org: str | None = None) -> str:
     """Fetch a single PR's statusCheckRollup and reduce it to a CI state.
 
     Fetched per-PR rather than in the bulk list: requesting statusCheckRollup for
@@ -324,6 +422,7 @@ def _fetch_pr_ci_state(repo: str, number: int) -> str:
         result = _gh(
             ["pr", "view", str(number), "--json", "statusCheckRollup"],
             repo=repo,
+            org=org,
         )
         data = json.loads(result.stdout)
     except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as e:
@@ -332,7 +431,7 @@ def _fetch_pr_ci_state(repo: str, number: int) -> str:
     return _ci_state(data.get("statusCheckRollup") or [])
 
 
-def list_prs(repo: str) -> list[PRInfo]:
+def list_prs(repo: str, org: str) -> list[PRInfo]:
     """List all open PRs in a repo with their readiness status.
 
     The bulk ``gh pr list`` deliberately omits ``statusCheckRollup`` — requesting
@@ -366,6 +465,7 @@ def list_prs(repo: str) -> list[PRInfo]:
                 "100",
             ],
             repo=repo,
+            org=org,
         )
         prs_raw: list[dict[str, Any]] = json.loads(result.stdout)
     except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as e:
@@ -377,7 +477,7 @@ def list_prs(repo: str) -> list[PRInfo]:
     out: list[PRInfo] = []
 
     for p in prs_raw:
-        ci = _fetch_pr_ci_state(repo, p["number"])
+        ci = _fetch_pr_ci_state(repo, p["number"], org)
         mergeable = p.get("mergeable", "UNKNOWN")
         merge_state = p.get("mergeStateStatus", "UNKNOWN")
 
@@ -420,7 +520,7 @@ def list_prs(repo: str) -> list[PRInfo]:
     return out
 
 
-def ensure_repo_clone(repo: str, clone_dir: Path, dry_run: bool = False) -> Path:
+def ensure_repo_clone(repo: str, org: str, clone_dir: Path, dry_run: bool = False) -> Path:
     """Return a single reusable clone of ``repo``, cloning once or fetching if present.
 
     fleet_sync used to ``git clone`` the whole repo afresh for every PR (#1044).
@@ -429,7 +529,8 @@ def ensure_repo_clone(repo: str, clone_dir: Path, dry_run: bool = False) -> Path
     Per-PR work then happens in cheap ``git worktree`` checkouts off this clone.
 
     Args:
-        repo: Repository name (under ``ORG``).
+        repo: Repository name (under ``org``).
+        org: GitHub organization owning ``repo``.
         clone_dir: Directory that holds per-repo clones for this run.
         dry_run: If True, log intent without running git.
 
@@ -437,7 +538,7 @@ def ensure_repo_clone(repo: str, clone_dir: Path, dry_run: bool = False) -> Path
         Path to the reusable repo clone (``clone_dir/<repo>``).
 
     """
-    repo_url = f"https://github.com/{ORG}/{repo}.git"
+    repo_url = f"https://github.com/{org}/{repo}.git"
     clone_path = clone_dir / repo
     git_dir = clone_path / ".git"
 
@@ -505,13 +606,14 @@ def remove_worktree(repo_clone: Path, work: Path, dry_run: bool = False) -> None
     )
 
 
-def merge_pr(pr: PRInfo, dry_run: bool = False) -> bool:
+def merge_pr(pr: PRInfo, org: str, dry_run: bool = False) -> bool:
     """Merge a ready PR via merge commit (GitHub signs the merge commit)."""
     logger.info("  Merging PR #%d via merge commit...", pr.number)
     try:
         _gh(
             ["pr", "merge", str(pr.number), "--merge", "--auto"],
             repo=pr.repo,
+            org=org,
             dry_run=dry_run,
         )
         return True
@@ -603,6 +705,7 @@ def _run_conflict_agent(agent: str, prompt: str, work: Path, pr_number: int) -> 
 
 def resolve_conflict_with_agent(
     pr: PRInfo,
+    org: str,
     repo_clone: Path,
     dry_run: bool = False,
     agent: str = "claude",
@@ -623,7 +726,7 @@ def resolve_conflict_with_agent(
         # agent spawn is what's gated, not the rebase that surfaces conflicts).
         # ensure_repo_clone is idempotent, so this reuses the shared clone if
         # already present and only forces a real clone when dry-run skipped it.
-        repo_clone = ensure_repo_clone(pr.repo, repo_clone.parent, dry_run=False)
+        repo_clone = ensure_repo_clone(pr.repo, org, repo_clone.parent, dry_run=False)
         add_pr_worktree(repo_clone, work, branch, base, dry_run=False)
 
         # Start rebase — will stop at conflicts
@@ -676,7 +779,7 @@ def resolve_conflict_with_agent(
 
             prompt = f"""You are resolving merge conflicts in a git rebase.
 
-Repository: {ORG}/{pr.repo}
+Repository: {org}/{pr.repo}
 PR: #{pr.number} — "{pr.title}"
 Branch `{branch}` is being rebased onto `origin/{base}`.
 Working directory: {work}
@@ -738,6 +841,7 @@ Rules:
 
 def process_repo(
     repo: str,
+    org: str,
     args: argparse.Namespace,
     clone_dir: Path,
     *,
@@ -754,7 +858,7 @@ def process_repo(
 
     logger.info("\n%s %s %s", symbols.banner, repo, symbols.banner)
     try:
-        prs = list_prs(repo)
+        prs = list_prs(repo, org)
     except RuntimeError as e:
         # A list failure must NOT be silently treated as "no PRs" — that would
         # skip the whole repo while reporting success. Count it as a failure so
@@ -778,7 +882,7 @@ def process_repo(
     def _repo_clone() -> Path:
         nonlocal repo_clone
         if repo_clone is None:
-            repo_clone = ensure_repo_clone(repo, clone_dir, dry_run=args.dry_run)
+            repo_clone = ensure_repo_clone(repo, org, clone_dir, dry_run=args.dry_run)
         return repo_clone
 
     status_labels = {
@@ -802,7 +906,7 @@ def process_repo(
         )
 
         if pr.status == PRStatus.READY:
-            ok = merge_pr(pr, dry_run=args.dry_run)
+            ok = merge_pr(pr, org, dry_run=args.dry_run)
             counts["merged" if ok else "failed"] += 1
 
         elif pr.status == PRStatus.OUTDATED:
@@ -816,6 +920,7 @@ def process_repo(
             else:
                 ok = resolve_conflict_with_agent(
                     pr,
+                    org,
                     _repo_clone(),
                     dry_run=args.dry_run,
                     agent=args.agent,
@@ -841,16 +946,29 @@ def _build_parser() -> argparse.ArgumentParser:
 
     """
     parser = argparse.ArgumentParser(
-        description="Sync all PRs across the HomericIntelligence fleet",
+        description="Sync all PRs across a configurable GitHub organization's fleet",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument("--dry-run", action="store_true", help="Print actions without executing")
     parser.add_argument(
+        "--org",
+        metavar="ORG",
+        default=None,
+        help="GitHub organization (overrides FLEET_ORG and .fleet.yml)",
+    )
+    parser.add_argument(
         "--repos",
         nargs="+",
         metavar="REPO",
-        help=f"Restrict to specific repos (default: all {len(ALL_REPOS)})",
-        default=ALL_REPOS,
+        default=None,
+        help="Restrict to specific repos (overrides FLEET_REPOS and .fleet.yml)",
+    )
+    parser.add_argument(
+        "--config",
+        metavar="PATH",
+        type=str,
+        default=None,
+        help="Path to fleet config YAML (default: ./.fleet.yml then repo-root .fleet.yml)",
     )
     parser.add_argument(
         "--skip-conflict-resolution",
@@ -877,8 +995,7 @@ def main() -> int:
     """Entry point for hephaestus-fleet-sync."""
     parser = _build_parser()
     args = parser.parse_args()
-    agent = resolve_agent(args.agent)
-    args.agent = agent
+    args.agent = resolve_agent(args.agent)
 
     logging.basicConfig(
         level=logging.DEBUG if args.verbose else logging.INFO,
@@ -886,10 +1003,19 @@ def main() -> int:
         datefmt="%H:%M:%S",
     )
 
-    repos = args.repos
+    try:
+        org, repos = resolve_fleet_config(args.org, args.repos, args.config)
+    except RuntimeError as e:
+        logger.error("%s", e)
+        if args.json:
+            emit_json_status(2, str(e))
+        return 2
+
+    args.org = org
+    args.repos = repos
     dry_tag = " [DRY RUN]" if args.dry_run else ""
     symbols = ASCII_SYMBOLS if args.ascii else UNICODE_SYMBOLS
-    logger.info("Fleet sync %s %d repo(s)%s", symbols.dash, len(repos), dry_tag)
+    logger.info("Fleet sync %s org=%s, %d repo(s)%s", symbols.dash, org, len(repos), dry_tag)
 
     totals: dict[str, int] = {
         "merged": 0,
@@ -902,7 +1028,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="hephaestus-fleet-") as tmp:
         clone_dir = Path(tmp)
         for repo in repos:
-            counts = process_repo(repo, args, clone_dir, symbols=symbols)
+            counts = process_repo(repo, org, args, clone_dir, symbols=symbols)
             for k, v in counts.items():
                 totals[k] = totals.get(k, 0) + v
 

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -209,26 +209,19 @@ def get_resign_exec() -> str:
 
 
 def _parse_env_repos(env_repos_raw: str | None) -> list[str] | None:
-    """Parse comma-separated FLEET_REPOS and validate non-empty.
+    """Parse comma-separated FLEET_REPOS, returning None if empty after splitting.
 
     Args:
         env_repos_raw: Raw FLEET_REPOS value from environment
 
     Returns:
-        List of repo names with whitespace trimmed, or None if input is None
-
-    Raises:
-        RuntimeError: If repos are set but all empty after trimming
+        List of repo names with whitespace trimmed, or None if input is None or empty after split
 
     """
     if env_repos_raw is None:
         return None
     env_repos = [r.strip() for r in env_repos_raw.split(",") if r.strip()]
-    if not env_repos:
-        raise RuntimeError(
-            "FLEET_REPOS is set but contains no valid repos after splitting on commas"
-        )
-    return env_repos
+    return env_repos if env_repos else None
 
 
 def _find_default_config() -> Path | None:
@@ -271,7 +264,9 @@ def _load_fleet_config(config_path: str | None) -> tuple[str | None, list[str] |
                 file_repos_raw = cfg.get("repos")
                 if isinstance(file_repos_raw, list):
                     file_repos = file_repos_raw
-            except (FileNotFoundError, ValueError) as e:
+            except FileNotFoundError as e:
+                raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
+            except ValueError as e:
                 raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
 
     return file_org, file_repos
@@ -285,7 +280,7 @@ def resolve_fleet_config(
     """Resolve fleet organization and repo list with layered config sources.
 
     Resolution order (highest to lowest priority):
-    1. CLI flags (cli_org, cli_repos)
+    1. CLI flags (cli_org, cli_repos) — applied per-key, partial CLI args merge
     2. Environment variables (FLEET_ORG, FLEET_REPOS)
     3. Config file (.fleet.yml at config_path, or auto-discovered)
 
@@ -301,29 +296,20 @@ def resolve_fleet_config(
         RuntimeError: If org or repos cannot be resolved from any source
 
     """
-    # Step 1: Try CLI flags
-    if cli_org is not None and cli_repos is not None:
-        return cli_org, cli_repos
-
-    # Step 2: Try environment variables (as strings, bypassing merge_with_env type coercion)
+    # Step 1: Load environment variables (as strings, bypassing merge_with_env type coercion)
     env_org = os.environ.get("FLEET_ORG", "").strip()
     env_repos_raw = os.environ.get("FLEET_REPOS")
+    env_repos = _parse_env_repos(env_repos_raw) if env_repos_raw is not None else None
 
-    if env_org and env_repos_raw is not None:
-        env_repos = _parse_env_repos(env_repos_raw)
-        return env_org, env_repos
-
-    # Step 3: Try config file
+    # Step 2: Load config file
     file_org, file_repos = _load_fleet_config(config_path)
 
-    # Merge results with fallback to environment or file values
+    # Step 3: Merge per-key with CLI taking precedence, then env, then file
     final_org = cli_org or env_org or file_org
     if not final_org:
-        raise RuntimeError(
-            "no fleet org configured. Set --org, FLEET_ORG, or org: in .fleet.yml"
-        )
+        raise RuntimeError("no fleet org configured. Set --org, FLEET_ORG, or org: in .fleet.yml")
 
-    final_repos = cli_repos or _parse_env_repos(env_repos_raw) or file_repos
+    final_repos = cli_repos or env_repos or file_repos
 
     if not final_repos:
         raise RuntimeError(

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -344,7 +344,17 @@ class TestMain:
         monkeypatch.setattr(fleet_sync, "process_repo", fake_process)
         monkeypatch.setattr(
             "sys.argv",
-            ["fleet-sync", "--org", "owner", "--repos", "a", "--json", "--dry-run", "--agent", "claude"],
+            [
+                "fleet-sync",
+                "--org",
+                "owner",
+                "--repos",
+                "a",
+                "--json",
+                "--dry-run",
+                "--agent",
+                "claude",
+            ],
         )
         assert fleet_sync.main() == 0
         payload = json.loads(capsys.readouterr().out)
@@ -368,7 +378,17 @@ class TestMain:
         monkeypatch.setattr(fleet_sync, "process_repo", fake_process)
         monkeypatch.setattr(
             "sys.argv",
-            ["fleet-sync", "--org", "owner", "--repos", "a", "--json", "--dry-run", "--agent", "claude"],
+            [
+                "fleet-sync",
+                "--org",
+                "owner",
+                "--repos",
+                "a",
+                "--json",
+                "--dry-run",
+                "--agent",
+                "claude",
+            ],
         )
         assert fleet_sync.main() == 1
         payload = json.loads(capsys.readouterr().out)
@@ -443,7 +463,7 @@ class TestTimeoutHandling:
         """_gh function uses NETWORK_TIMEOUT."""
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="[]")
-            fleet_sync_module._gh(["pr", "list"], repo="TestRepo")
+            fleet_sync_module._gh(["pr", "list"], repo="TestRepo", org="TestOrg")
             assert mock_run.called
             call_kwargs = mock_run.call_args[1]
             assert "timeout" in call_kwargs

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -332,7 +332,7 @@ class TestMain:
         """main() with --json emits ok envelope when no failures occur."""
         from hephaestus.github import fleet_sync
 
-        def fake_process(repo, args, clone_dir, *, symbols=None):
+        def fake_process(repo, org, args, clone_dir, *, symbols=None):
             return {
                 "merged": 1,
                 "rebased": 0,
@@ -344,7 +344,7 @@ class TestMain:
         monkeypatch.setattr(fleet_sync, "process_repo", fake_process)
         monkeypatch.setattr(
             "sys.argv",
-            ["fleet-sync", "--repos", "owner/a", "--json", "--dry-run", "--agent", "claude"],
+            ["fleet-sync", "--org", "owner", "--repos", "a", "--json", "--dry-run", "--agent", "claude"],
         )
         assert fleet_sync.main() == 0
         payload = json.loads(capsys.readouterr().out)
@@ -356,7 +356,7 @@ class TestMain:
         """main() with failures returns 1 and JSON envelope shows error."""
         from hephaestus.github import fleet_sync
 
-        def fake_process(repo, args, clone_dir, *, symbols=None):
+        def fake_process(repo, org, args, clone_dir, *, symbols=None):
             return {
                 "merged": 0,
                 "rebased": 0,
@@ -368,7 +368,7 @@ class TestMain:
         monkeypatch.setattr(fleet_sync, "process_repo", fake_process)
         monkeypatch.setattr(
             "sys.argv",
-            ["fleet-sync", "--repos", "owner/a", "--json", "--dry-run", "--agent", "claude"],
+            ["fleet-sync", "--org", "owner", "--repos", "a", "--json", "--dry-run", "--agent", "claude"],
         )
         assert fleet_sync.main() == 1
         payload = json.loads(capsys.readouterr().out)
@@ -381,7 +381,7 @@ class TestMain:
 
         calls = []
 
-        def fake_process(repo, args, clone_dir, *, symbols=None):
+        def fake_process(repo, org, args, clone_dir, *, symbols=None):
             calls.append(repo)
             return {
                 "merged": 0,
@@ -394,10 +394,10 @@ class TestMain:
         monkeypatch.setattr(fleet_sync, "process_repo", fake_process)
         monkeypatch.setattr(
             "sys.argv",
-            ["fleet-sync", "--repos", "owner/a", "owner/b", "--dry-run", "--agent", "claude"],
+            ["fleet-sync", "--org", "owner", "--repos", "a", "b", "--dry-run", "--agent", "claude"],
         )
         assert fleet_sync.main() == 0
-        assert calls == ["owner/a", "owner/b"]
+        assert calls == ["a", "b"]
 
 
 class TestTimeoutHandling:
@@ -529,7 +529,7 @@ class TestCloneReuseAndWorktrees:
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch.object(fleet_sync_module, "_git", side_effect=fake_git):
-            path = fleet_sync_module.ensure_repo_clone("RepoA", tmp_path)
+            path = fleet_sync_module.ensure_repo_clone("RepoA", "HomericIntelligence", tmp_path)
 
         assert path == tmp_path / "RepoA"
         assert calls[0][0] == "clone"
@@ -545,7 +545,7 @@ class TestCloneReuseAndWorktrees:
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch.object(fleet_sync_module, "_git", side_effect=fake_git):
-            path = fleet_sync_module.ensure_repo_clone("RepoA", tmp_path)
+            path = fleet_sync_module.ensure_repo_clone("RepoA", "HomericIntelligence", tmp_path)
 
         assert path == tmp_path / "RepoA"
         # Reuse path fetches, never clones.
@@ -925,7 +925,7 @@ class TestAsciiFlag:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capture_fleet_sync_logs
     ) -> None:
         """process_repo logs ASCII banner under ASCII_SYMBOLS — no module state."""
-        monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo: [])
+        monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo, _org: [])
 
         import argparse
 
@@ -940,7 +940,11 @@ class TestAsciiFlag:
             )
 
             fleet_sync_module.process_repo(
-                "test-repo", args, tmp_path, symbols=fleet_sync_module.ASCII_SYMBOLS
+                "test-repo",
+                "HomericIntelligence",
+                args,
+                tmp_path,
+                symbols=fleet_sync_module.ASCII_SYMBOLS,
             )
 
             # Check logged messages
@@ -952,7 +956,7 @@ class TestAsciiFlag:
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capture_fleet_sync_logs
     ) -> None:
         """Default kwarg gives Unicode — backward-compat for existing callers."""
-        monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo: [])
+        monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo, _org: [])
 
         import argparse
 
@@ -966,7 +970,7 @@ class TestAsciiFlag:
                 ascii=False,
             )
 
-            fleet_sync_module.process_repo("test-repo", args, tmp_path)
+            fleet_sync_module.process_repo("test-repo", "HomericIntelligence", args, tmp_path)
 
             # Check logged messages
             output = "\n".join(logged_messages)

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -620,7 +620,7 @@ class TestCloneReuseAndWorktrees:
         prs = [_pr(n, PRStatus.OUTDATED, head=f"feat{n}") for n in (1, 2, 3)]
         clone_count = [0]
 
-        def fake_ensure(repo, clone_dir, dry_run=False):
+        def fake_ensure(repo, org, clone_dir, dry_run=False):
             clone_count[0] += 1
             return clone_dir / repo
 
@@ -631,7 +631,7 @@ class TestCloneReuseAndWorktrees:
             patch.object(fleet_sync_module, "ensure_repo_clone", side_effect=fake_ensure),
             patch.object(fleet_sync_module, "rebase_and_resign", return_value=True),
         ):
-            counts = fleet_sync_module.process_repo("RepoA", args, tmp_path)
+            counts = fleet_sync_module.process_repo("RepoA", "HomericIntelligence", args, tmp_path)
 
         assert clone_count[0] == 1
         assert counts["rebased"] == 3
@@ -641,7 +641,7 @@ class TestCloneReuseAndWorktrees:
         prs = [_pr(1, PRStatus.READY, head="feat1")]
         clone_count = [0]
 
-        def fake_ensure(repo, clone_dir, dry_run=False):
+        def fake_ensure(repo, org, clone_dir, dry_run=False):
             clone_count[0] += 1
             return clone_dir / repo
 
@@ -652,7 +652,7 @@ class TestCloneReuseAndWorktrees:
             patch.object(fleet_sync_module, "ensure_repo_clone", side_effect=fake_ensure),
             patch.object(fleet_sync_module, "merge_pr", return_value=True),
         ):
-            counts = fleet_sync_module.process_repo("RepoA", args, tmp_path)
+            counts = fleet_sync_module.process_repo("RepoA", "HomericIntelligence", args, tmp_path)
 
         assert clone_count[0] == 0
         assert counts["merged"] == 1
@@ -870,13 +870,13 @@ class TestListPrsAuthorScope:
         """The ``gh pr list`` argv must include ``--author @me``."""
         captured_argv: list[list[str]] = []
 
-        def fake_gh(args, repo):
+        def fake_gh(args, repo=None, org=None, **kwargs):
             captured_argv.append(args)
             return MagicMock(stdout="[]")
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
 
-        fleet_sync_module.list_prs("RepoA")
+        fleet_sync_module.list_prs("RepoA", "HomericIntelligence")
 
         assert captured_argv, "_gh was never called"
         pr_list_argv = captured_argv[0]
@@ -895,10 +895,10 @@ class TestListPrsAuthorScope:
         monkeypatch.setattr(
             fleet_sync_module,
             "_fetch_pr_ci_state",
-            lambda repo, number: "SUCCESS",
+            lambda repo, number, org=None: "SUCCESS",
         )
 
-        def fake_gh(args, repo):
+        def fake_gh(args, repo=None, org=None, **kwargs):
             assert "--author" in args and args[args.index("--author") + 1] == "@me"
             payload = [
                 {
@@ -915,7 +915,7 @@ class TestListPrsAuthorScope:
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
 
-        prs = fleet_sync_module.list_prs("RepoA")
+        prs = fleet_sync_module.list_prs("RepoA", "HomericIntelligence")
 
         assert [p.number for p in prs] == [1]
 

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -692,7 +692,7 @@ class TestListPrs:
             return MagicMock(stdout=json.dumps({"statusCheckRollup": []}))
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
-        prs = fleet_sync_module.list_prs("ProjectHephaestus")
+        prs = fleet_sync_module.list_prs("ProjectHephaestus", "HomericIntelligence")
         json_idx = captured["list_args"].index("--json")
         json_fields = captured["list_args"][json_idx + 1]
         assert "statusCheckRollup" not in json_fields
@@ -728,7 +728,7 @@ class TestListPrs:
             )
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
-        prs = fleet_sync_module.list_prs("ProjectHephaestus")
+        prs = fleet_sync_module.list_prs("ProjectHephaestus", "HomericIntelligence")
         assert view_calls and view_calls[0][:3] == ["pr", "view", "7"]
         assert prs[0].ci_state == "SUCCESS"
         assert prs[0].status == PRStatus.READY
@@ -756,7 +756,7 @@ class TestListPrs:
             raise RuntimeError("504 on pr view")
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
-        prs = fleet_sync_module.list_prs("ProjectHephaestus")
+        prs = fleet_sync_module.list_prs("ProjectHephaestus", "HomericIntelligence")
         assert prs[0].ci_state == "UNKNOWN"
 
     def test_list_failure_raises_not_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -767,7 +767,7 @@ class TestListPrs:
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
         with pytest.raises(RuntimeError, match="could not list PRs"):
-            fleet_sync_module.list_prs("ProjectHephaestus")
+            fleet_sync_module.list_prs("ProjectHephaestus", "HomericIntelligence")
 
     def test_empty_list_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An actually-empty repo returns [] (distinct from a list failure)."""
@@ -776,7 +776,7 @@ class TestListPrs:
             return MagicMock(stdout="[]")
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
-        assert fleet_sync_module.list_prs("ProjectHephaestus") == []
+        assert fleet_sync_module.list_prs("ProjectHephaestus", "HomericIntelligence") == []
 
 
 class TestPrClassification:
@@ -818,7 +818,7 @@ class TestPrClassification:
             return MagicMock(stdout=json.dumps({"statusCheckRollup": rollup}))
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
-        return fleet_sync_module.list_prs("ProjectHephaestus")[0].status
+        return fleet_sync_module.list_prs("ProjectHephaestus", "HomericIntelligence")[0].status
 
     def test_blocked_mergeable_failing_is_outdated(self, monkeypatch) -> None:
         """BLOCKED+MERGEABLE with red CI = stale failure → rebase (OUTDATED)."""

--- a/tests/unit/github/test_fleet_sync_config.py
+++ b/tests/unit/github/test_fleet_sync_config.py
@@ -86,15 +86,54 @@ class TestResolveFleetConfig:
         assert all(isinstance(r, str) for r in repos)
 
     def test_env_repos_empty_after_split_raises(self, monkeypatch, tmp_path) -> None:
-        """FLEET_REPOS set but with no valid entries fails with clear error."""
+        """FLEET_REPOS set but with no valid entries fails with the differentiated error.
+
+        The matcher pins the FLEET_REPOS-specific diagnostic (``FLEET_REPOS is set``)
+        rather than the substring ``FLEET_REPOS``, which the generic fallback message
+        ("no fleet repos configured. Set --repos, FLEET_REPOS, ...") would also satisfy.
+        """
         monkeypatch.setenv("FLEET_ORG", "Org")
         monkeypatch.setenv("FLEET_REPOS", " , , ")
-        with pytest.raises(RuntimeError, match="FLEET_REPOS"):
+        with pytest.raises(RuntimeError, match=r"FLEET_REPOS is set but contains no valid entries"):
             resolve_fleet_config(
                 cli_org=None,
                 cli_repos=None,
                 config_path=str(tmp_path / "nope.yml"),
             )
+
+    def test_env_repos_empty_string_raises_differentiated_error(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """FLEET_REPOS='' (set but empty) hits the differentiated error, not the generic one.
+
+        ``FLEET_REPOS=''`` follows the set-but-empty path (raw is ``''`` not ``None``),
+        so operators must see the FLEET_REPOS-specific diagnostic to tell it apart from
+        leaving the variable unset.
+        """
+        monkeypatch.setenv("FLEET_ORG", "Org")
+        monkeypatch.setenv("FLEET_REPOS", "")
+        with pytest.raises(RuntimeError, match=r"FLEET_REPOS is set but contains no valid entries"):
+            resolve_fleet_config(
+                cli_org=None,
+                cli_repos=None,
+                config_path=str(tmp_path / "nope.yml"),
+            )
+
+    def test_cli_repos_override_bad_env_repos(self, monkeypatch, tmp_path) -> None:
+        """An explicit --repos overrides a malformed FLEET_REPOS without erroring.
+
+        The differentiated FLEET_REPOS error must NOT fire when a higher-priority CLI
+        value is present, since the bad env var is irrelevant in that case.
+        """
+        monkeypatch.setenv("FLEET_ORG", "Org")
+        monkeypatch.setenv("FLEET_REPOS", " , , ")
+        org, repos = resolve_fleet_config(
+            cli_org=None,
+            cli_repos=["repoX"],
+            config_path=str(tmp_path / "nope.yml"),
+        )
+        assert org == "Org"
+        assert repos == ["repoX"]
 
     def test_missing_config_file_falls_through_to_env(self, monkeypatch, tmp_path) -> None:
         """Missing config file does not raise — falls through to env vars."""

--- a/tests/unit/github/test_fleet_sync_config.py
+++ b/tests/unit/github/test_fleet_sync_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from hephaestus.github.fleet_sync import resolve_fleet_config
@@ -28,9 +30,7 @@ class TestResolveFleetConfig:
         cfg.write_text("org: FromFile\nrepos: [a, b]\n")
         monkeypatch.setenv("FLEET_ORG", "FromEnv")
         monkeypatch.setenv("FLEET_REPOS", "x,y")
-        org, repos = resolve_fleet_config(
-            cli_org=None, cli_repos=None, config_path=str(cfg)
-        )
+        org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=str(cfg))
         assert org == "FromEnv"
         assert repos == ["x", "y"]
 
@@ -40,9 +40,7 @@ class TestResolveFleetConfig:
         monkeypatch.delenv("FLEET_REPOS", raising=False)
         cfg = tmp_path / ".fleet.yml"
         cfg.write_text("org: FromFile\nrepos: [a, b]\n")
-        org, repos = resolve_fleet_config(
-            cli_org=None, cli_repos=None, config_path=str(cfg)
-        )
+        org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=str(cfg))
         assert org == "FromFile"
         assert repos == ["a", "b"]
 
@@ -69,7 +67,8 @@ class TestResolveFleetConfig:
         monkeypatch.setenv("FLEET_ORG", "Org")
         monkeypatch.setenv("FLEET_REPOS", "r1, r2 ,r3")
         _, repos = resolve_fleet_config(
-            cli_org=None, cli_repos=None,
+            cli_org=None,
+            cli_repos=None,
             config_path=str(tmp_path / "nonexistent.yml"),
         )
         assert repos == ["r1", "r2", "r3"]
@@ -79,7 +78,8 @@ class TestResolveFleetConfig:
         monkeypatch.setenv("FLEET_ORG", "Org")
         monkeypatch.setenv("FLEET_REPOS", "123,456")
         _, repos = resolve_fleet_config(
-            cli_org=None, cli_repos=None,
+            cli_org=None,
+            cli_repos=None,
             config_path=str(tmp_path / "nonexistent.yml"),
         )
         assert repos == ["123", "456"]
@@ -91,7 +91,8 @@ class TestResolveFleetConfig:
         monkeypatch.setenv("FLEET_REPOS", " , , ")
         with pytest.raises(RuntimeError, match="FLEET_REPOS"):
             resolve_fleet_config(
-                cli_org=None, cli_repos=None,
+                cli_org=None,
+                cli_repos=None,
                 config_path=str(tmp_path / "nope.yml"),
             )
 
@@ -100,7 +101,8 @@ class TestResolveFleetConfig:
         monkeypatch.setenv("FLEET_ORG", "Org")
         monkeypatch.setenv("FLEET_REPOS", "r1")
         org, repos = resolve_fleet_config(
-            cli_org=None, cli_repos=None,
+            cli_org=None,
+            cli_repos=None,
             config_path=str(tmp_path / "nope.yml"),
         )
         assert org == "Org"
@@ -110,16 +112,21 @@ class TestResolveFleetConfig:
         """When config_path is None, searches ./.fleet.yml then repo-root."""
         monkeypatch.delenv("FLEET_ORG", raising=False)
         monkeypatch.delenv("FLEET_REPOS", raising=False)
-        # In an arbitrary tmp_path with no local .fleet.yml, _find_default_config()
-        # will still find the bundled repo-root .fleet.yml (because __file__ is in the module).
-        # This test verifies that behavior.
+        # Create a temporary .fleet.yml in tmp_path
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("org: DiscoveredOrg\nrepos: [repo1, repo2]\n")
         monkeypatch.chdir(tmp_path)
-        org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=None)
-        # Should find the bundled .fleet.yml at repo root — verify structural properties
-        assert org is not None  # Config was successfully discovered and loaded
-        assert isinstance(org, str)
-        assert len(repos) > 0  # At least one repo configured
-        assert all(isinstance(r, str) for r in repos)
+
+        # Mock _find_default_config to return the tmp_path config file
+        # This isolates the test from the development environment and makes it portable
+        # to installed packages where the bundled .fleet.yml won't exist
+        with patch("hephaestus.github.fleet_sync._find_default_config") as mock_find:
+            mock_find.return_value = cfg
+            org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=None)
+
+        # Verify the mocked config was loaded
+        assert org == "DiscoveredOrg"
+        assert repos == ["repo1", "repo2"]
 
     def test_config_path_none_finds_cwd_file(self, monkeypatch, tmp_path) -> None:
         """config_path=None finds .fleet.yml in CWD if it exists."""

--- a/tests/unit/github/test_fleet_sync_config.py
+++ b/tests/unit/github/test_fleet_sync_config.py
@@ -115,9 +115,11 @@ class TestResolveFleetConfig:
         # This test verifies that behavior.
         monkeypatch.chdir(tmp_path)
         org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=None)
-        # Should find the bundled .fleet.yml at repo root
-        assert org == "HomericIntelligence"
-        assert len(repos) == 15
+        # Should find the bundled .fleet.yml at repo root — verify structural properties
+        assert org is not None  # Config was successfully discovered and loaded
+        assert isinstance(org, str)
+        assert len(repos) > 0  # At least one repo configured
+        assert all(isinstance(r, str) for r in repos)
 
     def test_config_path_none_finds_cwd_file(self, monkeypatch, tmp_path) -> None:
         """config_path=None finds .fleet.yml in CWD if it exists."""

--- a/tests/unit/github/test_fleet_sync_config.py
+++ b/tests/unit/github/test_fleet_sync_config.py
@@ -1,0 +1,130 @@
+"""Unit tests for fleet_sync config resolution (issue #716)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hephaestus.github.fleet_sync import resolve_fleet_config
+
+
+class TestResolveFleetConfig:
+    """Tests for resolve_fleet_config() layered resolution chain."""
+
+    def test_cli_args_override_everything(self, monkeypatch, tmp_path) -> None:
+        """CLI args have highest priority."""
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("org: FromFile\nrepos: [a, b]\n")
+        monkeypatch.setenv("FLEET_ORG", "FromEnv")
+        monkeypatch.setenv("FLEET_REPOS", "x,y")
+        org, repos = resolve_fleet_config(
+            cli_org="FromCli", cli_repos=["p", "q"], config_path=str(cfg)
+        )
+        assert org == "FromCli"
+        assert repos == ["p", "q"]
+
+    def test_env_overrides_file(self, monkeypatch, tmp_path) -> None:
+        """Environment variables override config file."""
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("org: FromFile\nrepos: [a, b]\n")
+        monkeypatch.setenv("FLEET_ORG", "FromEnv")
+        monkeypatch.setenv("FLEET_REPOS", "x,y")
+        org, repos = resolve_fleet_config(
+            cli_org=None, cli_repos=None, config_path=str(cfg)
+        )
+        assert org == "FromEnv"
+        assert repos == ["x", "y"]
+
+    def test_file_used_when_no_env_or_cli(self, monkeypatch, tmp_path) -> None:
+        """Config file is used when CLI and env are absent."""
+        monkeypatch.delenv("FLEET_ORG", raising=False)
+        monkeypatch.delenv("FLEET_REPOS", raising=False)
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("org: FromFile\nrepos: [a, b]\n")
+        org, repos = resolve_fleet_config(
+            cli_org=None, cli_repos=None, config_path=str(cfg)
+        )
+        assert org == "FromFile"
+        assert repos == ["a", "b"]
+
+    def test_missing_org_raises(self, monkeypatch, tmp_path) -> None:
+        """Missing org raises RuntimeError with actionable message."""
+        monkeypatch.delenv("FLEET_ORG", raising=False)
+        monkeypatch.delenv("FLEET_REPOS", raising=False)
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("repos: [a]\n")
+        with pytest.raises(RuntimeError, match="no fleet org configured"):
+            resolve_fleet_config(cli_org=None, cli_repos=None, config_path=str(cfg))
+
+    def test_missing_repos_raises(self, monkeypatch, tmp_path) -> None:
+        """Missing repos raises RuntimeError with actionable message."""
+        monkeypatch.delenv("FLEET_ORG", raising=False)
+        monkeypatch.delenv("FLEET_REPOS", raising=False)
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("org: SomeOrg\n")
+        with pytest.raises(RuntimeError, match="no fleet repos configured"):
+            resolve_fleet_config(cli_org=None, cli_repos=None, config_path=str(cfg))
+
+    def test_env_repos_comma_split(self, monkeypatch, tmp_path) -> None:
+        """FLEET_REPOS is comma-separated with whitespace trimmed."""
+        monkeypatch.setenv("FLEET_ORG", "Org")
+        monkeypatch.setenv("FLEET_REPOS", "r1, r2 ,r3")
+        _, repos = resolve_fleet_config(
+            cli_org=None, cli_repos=None,
+            config_path=str(tmp_path / "nonexistent.yml"),
+        )
+        assert repos == ["r1", "r2", "r3"]
+
+    def test_env_repos_numeric_not_coerced(self, monkeypatch, tmp_path) -> None:
+        """FLEET_REPOS=123,456 stays as strings, not converted to int (R0-Major regression)."""
+        monkeypatch.setenv("FLEET_ORG", "Org")
+        monkeypatch.setenv("FLEET_REPOS", "123,456")
+        _, repos = resolve_fleet_config(
+            cli_org=None, cli_repos=None,
+            config_path=str(tmp_path / "nonexistent.yml"),
+        )
+        assert repos == ["123", "456"]
+        assert all(isinstance(r, str) for r in repos)
+
+    def test_env_repos_empty_after_split_raises(self, monkeypatch, tmp_path) -> None:
+        """FLEET_REPOS set but with no valid entries fails with clear error."""
+        monkeypatch.setenv("FLEET_ORG", "Org")
+        monkeypatch.setenv("FLEET_REPOS", " , , ")
+        with pytest.raises(RuntimeError, match="FLEET_REPOS"):
+            resolve_fleet_config(
+                cli_org=None, cli_repos=None,
+                config_path=str(tmp_path / "nope.yml"),
+            )
+
+    def test_missing_config_file_falls_through_to_env(self, monkeypatch, tmp_path) -> None:
+        """Missing config file does not raise — falls through to env vars."""
+        monkeypatch.setenv("FLEET_ORG", "Org")
+        monkeypatch.setenv("FLEET_REPOS", "r1")
+        org, repos = resolve_fleet_config(
+            cli_org=None, cli_repos=None,
+            config_path=str(tmp_path / "nope.yml"),
+        )
+        assert org == "Org"
+        assert repos == ["r1"]
+
+    def test_config_path_none_searches_cwd_then_repo_root(self, monkeypatch, tmp_path) -> None:
+        """When config_path is None, searches ./.fleet.yml then repo-root."""
+        monkeypatch.delenv("FLEET_ORG", raising=False)
+        monkeypatch.delenv("FLEET_REPOS", raising=False)
+        # In an arbitrary tmp_path with no local .fleet.yml, _find_default_config()
+        # will still find the bundled repo-root .fleet.yml (because __file__ is in the module).
+        # This test verifies that behavior.
+        monkeypatch.chdir(tmp_path)
+        org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=None)
+        # Should find the bundled .fleet.yml at repo root
+        assert org == "HomericIntelligence"
+        assert len(repos) == 15
+
+    def test_config_path_none_finds_cwd_file(self, monkeypatch, tmp_path) -> None:
+        """config_path=None finds .fleet.yml in CWD if it exists."""
+        monkeypatch.delenv("FLEET_ORG", raising=False)
+        monkeypatch.delenv("FLEET_REPOS", raising=False)
+        (tmp_path / ".fleet.yml").write_text("org: CwdOrg\nrepos: [cwdrepo]\n")
+        monkeypatch.chdir(tmp_path)
+        org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=None)
+        assert org == "CwdOrg"
+        assert repos == ["cwdrepo"]


### PR DESCRIPTION
## Summary
- Moved hardcoded `ORG` and `ALL_REPOS` constants to `.fleet.yml` config file
- Added `--org` and `--repos` CLI flags for runtime overrides
- Added environment variable support (`FLEET_ORG`, `FLEET_REPOS`)
- Implemented three-layer resolution chain: CLI > env > config file > error

## Test plan
- [ ] All 38 unit tests pass (11 new config tests + 3 updated TestMain tests + 24 existing)
- [ ] Ruff linter passes (no style issues)
- [ ] mypy type checker passes
- [ ] Integration test for CLI entry point passes
- [ ] Verify that `hephaestus-fleet-sync --help` shows new flags
- [ ] Verify R0-Major regression: `FLEET_REPOS=123,456` stays as strings

## Acceptance Criteria
- [x] Move ORG and ALL_REPOS to config file (.fleet.yml)
- [x] Provide --org and --repos CLI flags with documented defaults
- [x] Allow env var override (FLEET_ORG, FLEET_REPOS)

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)