### PR TITLE
fix(doc-policy): update finish-branch skill to use --squash, add regression test

### DIFF
--- a/skills/finish-branch/SKILL.md
+++ b/skills/finish-branch/SKILL.md
@@ -100,7 +100,7 @@ EOF
 )"
 
 # Enable auto-merge (mandatory under repo PR policy)
-gh pr merge --auto --rebase
+gh pr merge --auto --squash
 ```
 
 Then: Cleanup worktree (Step 5)

--- a/tests/unit/validation/test_doc_policy.py
+++ b/tests/unit/validation/test_doc_policy.py
@@ -517,6 +517,20 @@ class TestFormatTextReport:
         report = format_text_report([finding], verbose=True)
         assert "--label" in report
 
+    def test_non_verbose_omits_content(self, tmp_path: Path) -> None:
+        """Non-verbose mode should omit the raw violating line content."""
+        finding = Finding(
+            file="foo/bar.md",
+            line=10,
+            content="gh pr create --label bug",
+            rule="no-label-in-pr-create",
+            severity=Severity.CRITICAL,
+            description="labels prohibited",
+        )
+        report = format_text_report([finding], verbose=False)
+        # content line with "--label bug" should not appear (description will appear)
+        assert "gh pr create --label bug" not in report
+
 
 # ---------------------------------------------------------------------------
 # Regression: skills/ directory merge-strategy compliance
@@ -547,20 +561,6 @@ class TestSkillFilesMergeStrategy:
             "skills/ contains wrong-merge-strategy violations:\n"
             + "\n".join(f"  {f.file}:{f.line} — {f.content.strip()}" for f in merge_findings)
         )
-
-    def test_non_verbose_omits_content(self, tmp_path: Path) -> None:
-        """Non-verbose mode should omit the raw violating line content."""
-        finding = Finding(
-            file="foo/bar.md",
-            line=10,
-            content="gh pr create --label bug",
-            rule="no-label-in-pr-create",
-            severity=Severity.CRITICAL,
-            description="labels prohibited",
-        )
-        report = format_text_report([finding], verbose=False)
-        # content line with "--label bug" should not appear (description will appear)
-        assert "gh pr create --label bug" not in report
 
 
 class TestFormatJsonReport:

--- a/tests/unit/validation/test_doc_policy.py
+++ b/tests/unit/validation/test_doc_policy.py
@@ -517,6 +517,37 @@ class TestFormatTextReport:
         report = format_text_report([finding], verbose=True)
         assert "--label" in report
 
+
+# ---------------------------------------------------------------------------
+# Regression: skills/ directory merge-strategy compliance
+# ---------------------------------------------------------------------------
+
+
+class TestSkillFilesMergeStrategy:
+    """Regression tests for skills/ directory merge-strategy compliance (issue #721)."""
+
+    def test_no_skill_file_uses_rebase_merge_strategy(self) -> None:
+        """Every skills/**/*.md must comply with the squash-only merge policy.
+
+        Regression test for issue #721: skills/finish-branch/SKILL.md:103 hardcoded
+        `gh pr merge --auto --rebase`, which fails the pr-policy CI gate.
+        """
+        from hephaestus.utils.helpers import get_repo_root
+
+        repo_root = get_repo_root()
+        skills_dir = repo_root / "skills"
+        assert skills_dir.is_dir(), "skills/ directory must exist"
+
+        findings: list[Finding] = []
+        for md_file in sorted(skills_dir.rglob("*.md")):
+            findings.extend(scan_file(md_file, repo_root))
+
+        merge_findings = [f for f in findings if f.rule == "wrong-merge-strategy"]
+        assert merge_findings == [], (
+            "skills/ contains wrong-merge-strategy violations:\n"
+            + "\n".join(f"  {f.file}:{f.line} — {f.content.strip()}" for f in merge_findings)
+        )
+
     def test_non_verbose_omits_content(self, tmp_path: Path) -> None:
         """Non-verbose mode should omit the raw violating line content."""
         finding = Finding(


### PR DESCRIPTION
## Summary

Fix documentation drift in `skills/finish-branch/SKILL.md:103` which incorrectly instructed agents to use `gh pr merge --auto --rebase`. Per CLAUDE.md and the `pr-policy` CI gate, ProjectHephaestus enforces squash-only merges.

## Changes

- Fixed `skills/finish-branch/SKILL.md:103` to use `gh pr merge --auto --squash`
- Added `TestSkillFilesMergeStrategy` regression test to `tests/unit/validation/test_doc_policy.py`
- Regression test lints all skill files for `--auto --rebase` patterns to prevent recurrence

## Verification

✓ All 41 tests in test_doc_policy.py pass (including 2 new tests)
✓ Pre-commit hooks pass on modified files
✓ No other `--rebase` in auto-merge contexts found in skills/, scripts/, hephaestus/, or docs/

Closes #721