### PR TITLE
fix(automation): add shared max-workers validation helper (#723)

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -49,6 +49,35 @@ def setup_review_logging(verbose: bool = False) -> None:
     )
 
 
+def add_max_workers_arg(
+    parser: argparse.ArgumentParser,
+    *,
+    default: int = 3,
+    help_text: str = "Maximum number of parallel workers, 1-32 (default: 3)",
+) -> None:
+    """Add a validated ``--max-workers`` argument to ``parser``.
+
+    Centralises the validation used by every automation CLI so that
+    ``hephaestus-automation-loop`` cannot accept a value (e.g. ``0`` or ``-1``)
+    that a child phase will later reject — see #723.
+
+    Args:
+        parser: Parser to mutate.
+        default: Default worker count when the flag is omitted.
+        help_text: Help string. Callers that pass workers through to child
+            binaries (e.g. ``loop_runner``) override the default phrasing.
+
+    """
+    parser.add_argument(
+        "--max-workers",
+        type=int,
+        default=default,
+        choices=range(1, 33),
+        metavar="N",
+        help=help_text,
+    )
+
+
 def build_review_parser(
     description: str,
     epilog: str | None = None,
@@ -87,14 +116,7 @@ def build_review_parser(
         help=issues_help,
     )
     add_agent_argument(parser)
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
+    add_max_workers_arg(parser)
     parser.add_argument(
         "--dry-run",
         action="store_true",

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -32,7 +32,7 @@ from hephaestus.agents.runtime import (
 )
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 
-from ._review_utils import find_pr_for_issue
+from ._review_utils import add_max_workers_arg, find_pr_for_issue
 from .advise_runner import run_advise
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import advise_model, implementer_model
@@ -3117,14 +3117,7 @@ Examples:
         ),
     )
     add_agent_argument(parser)
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
+    add_max_workers_arg(parser)
     parser.add_argument(
         "--dry-run",
         action="store_true",

--- a/hephaestus/automation/implementer_cli.py
+++ b/hephaestus/automation/implementer_cli.py
@@ -22,6 +22,7 @@ import logging
 from pathlib import Path
 
 from hephaestus.agents.runtime import add_agent_argument, resolve_agent
+from hephaestus.automation._review_utils import add_max_workers_arg
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 
 from .models import ImplementerOptions
@@ -105,14 +106,7 @@ Examples:
         action="store_true",
         help="Resume previous implementation from saved state",
     )
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
+    add_max_workers_arg(parser)
     parser.add_argument(
         "--no-skip-closed",
         action="store_true",

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from hephaestus.agents.runtime import add_agent_argument, resolve_agent
+from hephaestus.automation._review_utils import add_max_workers_arg
 from hephaestus.automation.ci_driver import _pr_is_failing
 from hephaestus.automation.claude_timeouts import gh_cli_timeout
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
@@ -339,11 +340,9 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p.add_argument("--dry-run", action="store_true", help="Pass --dry-run to every phase")
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
-    p.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        help="Parallel workers per repo per phase (default: 3). Passed to each phase binary.",
+    add_max_workers_arg(
+        p,
+        help_text="Parallel workers per repo per phase (1-32, default: 3). Passes to child phases.",
     )
     p.add_argument(
         "--parallel-repos",

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
+from hephaestus.automation._review_utils import add_max_workers_arg
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 from hephaestus.github.rate_limit import wait_until
 
@@ -647,14 +648,7 @@ Examples:
         help="Issue numbers whose plans should be reviewed",
     )
     add_agent_argument(parser)
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Maximum number of parallel workers, 1-32 (default: 3)",
-    )
+    add_max_workers_arg(parser)
     parser.add_argument(
         "--dry-run",
         action="store_true",

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -182,3 +182,24 @@ class TestCLIEntryPointDiscovery:
     def test_no_duplicate_commands(self) -> None:
         commands = [ep[0] for ep in ENTRY_POINTS]
         assert len(commands) == len(set(commands)), "Duplicate command names in [project.scripts]"
+
+
+class TestMaxWorkersValidation:
+    """Regression for #723: --max-workers validation must be consistent."""
+
+    def test_automation_loop_rejects_zero_max_workers(self) -> None:
+        """hephaestus-automation-loop --max-workers=0 exits non-zero with clear error."""
+        binary = shutil.which("hephaestus-automation-loop")
+        if binary is None:
+            pytest.skip("hephaestus-automation-loop not on PATH")
+
+        result = subprocess.run(
+            [binary, "--max-workers", "0"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        assert result.returncode != 0, "Expected non-zero exit for --max-workers=0"
+        assert "--max-workers" in result.stderr, "Error must mention --max-workers argument"
+        assert "invalid choice" in result.stderr.lower(), "Error must mention invalid choice"

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -189,16 +189,21 @@ class TestMaxWorkersValidation:
 
     def test_automation_loop_rejects_zero_max_workers(self) -> None:
         """hephaestus-automation-loop --max-workers=0 exits non-zero with clear error."""
+        import os
+
         binary = shutil.which("hephaestus-automation-loop")
         if binary is None:
             pytest.skip("hephaestus-automation-loop not on PATH")
 
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
         result = subprocess.run(
             [binary, "--max-workers", "0"],
             capture_output=True,
             text=True,
             timeout=10,
             check=False,
+            env=env,
         )
         assert result.returncode != 0, "Expected non-zero exit for --max-workers=0"
         assert "--max-workers" in result.stderr, "Error must mention --max-workers argument"

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -194,6 +194,7 @@ class TestMaxWorkersValidation:
         binary = shutil.which("hephaestus-automation-loop")
         if binary is None:
             pytest.skip("hephaestus-automation-loop not on PATH")
+        assert binary is not None  # narrow Optional[str] for mypy
 
         env = os.environ.copy()
         env.pop("PYTHONPATH", None)

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -168,6 +168,26 @@ def test_parse_args_accepts_issue_scope() -> None:
     assert args.issues == [8, 13]
 
 
+@pytest.mark.parametrize("bad", ["0", "-1", "33", "100"])
+def test_parse_args_rejects_out_of_range_max_workers(bad: str) -> None:
+    """Regression for #723: loop_runner must reject --max-workers outside 1-32."""
+    with pytest.raises(SystemExit) as excinfo:
+        loop_runner._parse_args(["--max-workers", bad])
+    assert excinfo.value.code == 2
+
+
+def test_parse_args_accepts_valid_max_workers() -> None:
+    """Valid --max-workers in range 1-32 accepted."""
+    args = loop_runner._parse_args(["--max-workers", "8"])
+    assert args.max_workers == 8
+
+
+def test_parse_args_default_max_workers_is_three() -> None:
+    """Omitted --max-workers defaults to 3."""
+    args = loop_runner._parse_args([])
+    assert args.max_workers == 3
+
+
 # ---------------------------------------------------------------------------
 # run_phase — never raises, always returns PhaseResult
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -1,10 +1,14 @@
 """Tests for shared review utilities (_review_utils.py)."""
 
+import argparse
 import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hephaestus.automation._review_utils import (
+    add_max_workers_arg,
     find_pr_for_issue,
     get_pr_head_branch,
     parse_json_block,
@@ -266,3 +270,48 @@ class TestGetPrHeadBranch:
             side_effect=RuntimeError("gh boom"),
         ):
             assert get_pr_head_branch(996) is None
+
+
+# ---------------------------------------------------------------------------
+# add_max_workers_arg
+# ---------------------------------------------------------------------------
+
+
+class TestAddMaxWorkersArg:
+    """Tests for the shared add_max_workers_arg helper."""
+
+    def test_default_help_and_value(self) -> None:
+        """Default case: uses standard help text and default=3."""
+        parser = argparse.ArgumentParser()
+        add_max_workers_arg(parser)
+        args = parser.parse_args([])
+        assert args.max_workers == 3
+
+    def test_custom_help_text(self) -> None:
+        """Custom help_text is used in the parser."""
+        parser = argparse.ArgumentParser()
+        add_max_workers_arg(parser, help_text="custom help")
+        assert "custom help" in parser.format_help()
+
+    def test_accepts_valid_values(self) -> None:
+        """Valid range 1-32 accepted."""
+        parser = argparse.ArgumentParser()
+        add_max_workers_arg(parser)
+        args = parser.parse_args(["--max-workers", "16"])
+        assert args.max_workers == 16
+
+    @pytest.mark.parametrize("bad", ["0", "-1", "33", "100"])
+    def test_rejects_out_of_range(self, bad: str) -> None:
+        """Out-of-range values 0, -1, 33+ are rejected with exit code 2."""
+        parser = argparse.ArgumentParser()
+        add_max_workers_arg(parser)
+        with pytest.raises(SystemExit) as excinfo:
+            parser.parse_args(["--max-workers", bad])
+        assert excinfo.value.code == 2
+
+    def test_custom_default(self) -> None:
+        """Custom default value is honored."""
+        parser = argparse.ArgumentParser()
+        add_max_workers_arg(parser, default=8)
+        args = parser.parse_args([])
+        assert args.max_workers == 8


### PR DESCRIPTION
## Summary

Fixes inconsistent `--max-workers` validation between loop_runner and child automation CLIs.

The loop_runner CLI accepted invalid values (0, -1, 33+) and forwarded them to child phases that rejected them, producing confusing downstream argparse errors. This fix:

1. Extracts a shared `add_max_workers_arg()` helper to `_review_utils.py`
2. Uses it across all six automation CLIs for DRY compliance
3. Ensures upfront validation with clear error messages (exit code 2)

## Acceptance Criteria

- ✅ Add `choices=range(1, 33)` validation to loop_runner.py
- ✅ Extract shared `add_max_workers_arg(parser)` helper
- ✅ Regression test: `hephaestus-automation-loop --max-workers=0` exits with error

## Test Coverage

- Unit tests for `add_max_workers_arg()` contract
- Parametrized tests for loop_runner validation boundaries (0, -1, 33, 100)
- Integration test proving CLI error handling

Closes #723