### PR TITLE
[Fix] fleet_sync resign-email key guard + nats deliver_policy type

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,14 +30,11 @@ jobs:
           pixi-version: v0.69.0
           environments: lint
           locked: true
-
-      - name: Cache pixi environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: |
-            .pixi
-            ~/.cache/rattler/cache
-          key: pixi-lint-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          # setup-pixi already caches `.pixi` keyed exactly on the pixi.lock
+          # hash. A second actions/cache step over `.pixi` restored a STALE env
+          # (saved by an earlier poisoned run under the same exact key) on top
+          # of this --locked install, downgrading urllib3 2.7.0 -> 2.6.3 so
+          # pip-audit failed against an already-patched lock. Do not add one.
 
       - name: Run pip-audit
         id: pip-audit
@@ -72,14 +69,11 @@ jobs:
           pixi-version: v0.69.0
           environments: lint
           locked: true
-
-      - name: Cache pixi environments
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
-        with:
-          path: |
-            .pixi
-            ~/.cache/rattler/cache
-          key: pixi-lint-${{ runner.os }}-${{ hashFiles('pixi.lock') }}
+          # setup-pixi already caches `.pixi` keyed exactly on the pixi.lock
+          # hash. A second actions/cache step over `.pixi` restored a STALE env
+          # (saved by an earlier poisoned run under the same exact key) on top
+          # of this --locked install, downgrading urllib3 2.7.0 -> 2.6.3 so
+          # pip-audit failed against an already-patched lock. Do not add one.
 
       - name: Run bandit (SAST)
         id: bandit

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -46,6 +46,98 @@ logger = get_logger(__name__)
 ORG = "HomericIntelligence"
 
 
+def _signing_key_uid_emails() -> list[str] | None:
+    """Return the email addresses on the configured GPG signing key, lowercased.
+
+    Reads ``git config user.signingkey`` and lists the UID emails on that key
+    via ``gpg --list-keys --with-colons``. Returns ``None`` (meaning "cannot
+    determine — skip the check") when:
+
+    - no ``user.signingkey`` is configured,
+    - ``gpg`` is not installed / not on PATH,
+    - the key cannot be read, or
+    - the lookup times out.
+
+    Returns an empty list only when the key exists but exposes no UID emails.
+    """
+    try:
+        key_result = subprocess.run(
+            ["git", "config", "--get", "user.signingkey"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=METADATA_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    signing_key = key_result.stdout.strip()
+    if key_result.returncode != 0 or not signing_key:
+        return None
+
+    try:
+        gpg_result = subprocess.run(
+            ["gpg", "--list-keys", "--with-colons", signing_key],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=METADATA_TIMEOUT,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if gpg_result.returncode != 0:
+        return None
+
+    emails: list[str] = []
+    # ``uid`` records put the user-id string in field 10 (1-indexed); the email
+    # is the part inside angle brackets, e.g. "Name <addr@example.com>".
+    for line in gpg_result.stdout.splitlines():
+        fields = line.split(":")
+        if not fields or fields[0] != "uid" or len(fields) < 10:
+            continue
+        uid = fields[9]
+        start = uid.find("<")
+        end = uid.find(">", start + 1)
+        if start != -1 and end != -1:
+            emails.append(uid[start + 1 : end].strip().lower())
+    return emails
+
+
+def _validate_resign_email(email: str) -> str:
+    """Validate ``email`` matches the GPG signing key, then return it.
+
+    fleet_sync re-signs every rebased commit with ``git commit -S`` using the
+    local GPG key. GitHub only marks a signature ``verified`` when the commit's
+    committer email is one of the *verified emails on the account that owns the
+    signing key* — in practice, one of the key's UID emails. If we re-sign with
+    an email that is not on the key (e.g. an operator's bot/no-reply alias that
+    was never added to the key), the commit signs fine locally yet GitHub reports
+    ``{verified: false, reason: "no_user"}`` and the ``pr-policy`` "every commit
+    is signed" check rejects the PR at merge. Catch that here so fleet_sync fails
+    fast with an actionable message instead of producing commits that pr-policy
+    will silently reject across the whole fleet.
+
+    Set ``FLEET_SKIP_EMAIL_KEY_CHECK=1`` to bypass (e.g. signing format other than
+    OpenPGP, or a deliberately unusual setup).
+    """
+    if os.environ.get("FLEET_SKIP_EMAIL_KEY_CHECK", "").strip():
+        return email
+    key_emails = _signing_key_uid_emails()
+    if key_emails is None:
+        # Cannot determine the key's identities (no signingkey, gpg absent,
+        # unreadable key); don't block — the operator may sign by other means.
+        return email
+    if email.lower() not in key_emails:
+        raise RuntimeError(
+            f"fleet_sync: resign email {email!r} is not a UID on the configured "
+            f"GPG signing key (key UIDs: {key_emails or 'none'}). Re-signing with "
+            "this email would produce commits GitHub marks unverified, failing the "
+            "pr-policy 'every commit is signed' check at merge. Set FLEET_GIT_EMAIL "
+            "(or git config user.email) to an address on the signing key, or set "
+            "FLEET_SKIP_EMAIL_KEY_CHECK=1 to bypass."
+        )
+    return email
+
+
 def get_resign_email() -> str:
     """Return the email address used to re-sign rebased commits.
 
@@ -55,13 +147,18 @@ def get_resign_email() -> str:
     2. ``git config --global --get user.email``.
     3. ``git config --get user.email`` (any scope).
 
+    The resolved email is validated against the configured GPG signing key's
+    UID emails (see :func:`_validate_resign_email`); a mismatch raises
+    :class:`RuntimeError` because re-signing with it would produce commits
+    GitHub marks unverified, failing ``pr-policy`` at merge.
+
     Raises :class:`RuntimeError` if none is configured — fleet_sync must never
     silently re-sign with a fallback identity that doesn't belong to the
     operator.
     """
     env = os.environ.get("FLEET_GIT_EMAIL", "").strip()
     if env:
-        return env
+        return _validate_resign_email(env)
     for args in (["--global"], []):
         try:
             result = subprocess.run(
@@ -73,7 +170,7 @@ def get_resign_email() -> str:
             )
             email = result.stdout.strip()
             if result.returncode == 0 and email:
-                return email
+                return _validate_resign_email(email)
         except subprocess.TimeoutExpired:
             continue
     raise RuntimeError(

--- a/hephaestus/nats/config.py
+++ b/hephaestus/nats/config.py
@@ -15,9 +15,16 @@ Usage::
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
+
+# Valid JetStream first-subscription deliver policies. These string values match
+# nats.js.api.DeliverPolicy's enum values, so the subscriber can build the enum
+# directly from the configured string (see hephaestus/nats/subscriber.py).
+DeliverPolicyStr = Literal[
+    "all", "last", "new", "by_start_sequence", "by_start_time", "last_per_subject"
+]
 
 
 class NATSConfig(BaseModel):
@@ -44,7 +51,7 @@ class NATSConfig(BaseModel):
         default="hephaestus-subscriber",
         description="Durable consumer name for at-least-once delivery",
     )
-    deliver_policy: str = Field(
+    deliver_policy: DeliverPolicyStr = Field(
         default="new",
         description="JetStream deliver policy (new, all, last, etc.)",
     )

--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -280,6 +280,7 @@ class NATSSubscriberThread(threading.Thread):
                     module="nats",
                 )
                 import nats as nats_client
+                from nats.js.api import DeliverPolicy
         except ImportError:
             logger.error(
                 "nats-py is not installed. "
@@ -293,6 +294,11 @@ class NATSSubscriberThread(threading.Thread):
         try:
             js = nc.jetstream()
             subjects = self._config.subjects or ["hi.tasks.>"]
+            # The config carries deliver_policy as a plain string (e.g. "new")
+            # for YAML/env ergonomics; js.subscribe expects the DeliverPolicy
+            # enum. DeliverPolicy is a str-valued enum whose values match the
+            # config strings, so construct it directly.
+            deliver_policy = DeliverPolicy(self._config.deliver_policy)
             subscriptions = []
             for i, subject in enumerate(subjects):
                 durable = (
@@ -304,7 +310,7 @@ class NATSSubscriberThread(threading.Thread):
                     subject=subject,
                     durable=durable,
                     stream=self._config.stream,
-                    deliver_policy=self._config.deliver_policy,
+                    deliver_policy=deliver_policy,
                 )
                 subscriptions.append(sub)
 

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -409,6 +409,8 @@ class TestTimeoutHandling:
     def test_get_resign_email_with_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """get_resign_email handles TimeoutExpired by trying next config source."""
         monkeypatch.delenv("FLEET_GIT_EMAIL", raising=False)
+        # Isolate resolution from the #1025 GPG-key-match guard.
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
 
         call_count = [0]
 
@@ -429,6 +431,8 @@ class TestTimeoutHandling:
     def test_get_resign_email_uses_metadata_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """get_resign_email uses METADATA_TIMEOUT."""
         monkeypatch.delenv("FLEET_GIT_EMAIL", raising=False)
+        # Isolate resolution from the #1025 GPG-key-match guard.
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
 
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stdout="test@example.com\n")

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -173,12 +173,18 @@ class TestPRInfo:
 
 
 class TestGetResignEmail:
-    """Regression tests for #497: resign email is configurable, not hardcoded."""
+    """Regression tests for #497: resign email is configurable, not hardcoded.
+
+    These exercise email *resolution*; the GPG-key-match guard (#1025) is
+    bypassed with FLEET_SKIP_EMAIL_KEY_CHECK so resolution is tested in
+    isolation. The guard itself is covered by TestResignEmailKeyGuard.
+    """
 
     def test_env_var_takes_precedence(self, monkeypatch) -> None:
         """FLEET_GIT_EMAIL is used when set."""
         from hephaestus.github.fleet_sync import get_resign_email
 
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
         monkeypatch.setenv("FLEET_GIT_EMAIL", "alice@example.com")
         assert get_resign_email() == "alice@example.com"
 
@@ -186,6 +192,7 @@ class TestGetResignEmail:
         """An empty FLEET_GIT_EMAIL falls back to git config."""
         from hephaestus.github import fleet_sync
 
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
         monkeypatch.setenv("FLEET_GIT_EMAIL", "")
 
         # Stub subprocess.run so the test does not depend on the operator's
@@ -226,10 +233,95 @@ class TestGetResignEmail:
         """get_resign_exec() inlines the resolved email into the git command."""
         from hephaestus.github.fleet_sync import get_resign_exec
 
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
         monkeypatch.setenv("FLEET_GIT_EMAIL", "carol@example.com")
         cmd = get_resign_exec()
         assert "user.email=carol@example.com" in cmd
         assert "commit --amend --no-edit -S --reset-author" in cmd
+
+
+class TestResignEmailKeyGuard:
+    """Regression tests for #1025: re-sign email must match the GPG signing key.
+
+    A commit re-signed with an email that is not on the configured signing key
+    signs locally but GitHub reports verified=false/reason=no_user, so pr-policy
+    rejects the PR at merge. get_resign_email() must catch this and fail fast.
+    """
+
+    def _stub_signing_key(self, monkeypatch, *, signingkey: str, uids: list[str]) -> None:
+        """Stub git+gpg so the signing key reports ``uids`` as its UID emails."""
+
+        def fake_run(cmd, *args, **kwargs):
+            result = MagicMock()
+            if cmd[:3] == ["git", "config", "--get"] and cmd[3] == "user.signingkey":
+                result.returncode = 0 if signingkey else 1
+                result.stdout = f"{signingkey}\n" if signingkey else ""
+            elif cmd[:2] == ["gpg", "--list-keys"]:
+                result.returncode = 0
+                result.stdout = "".join(
+                    f"uid:-::::1700000000::HASH::Name <{e}>::::::::::0:\n" for e in uids
+                )
+            else:
+                result.returncode = 1
+                result.stdout = ""
+            return result
+
+        monkeypatch.setattr("hephaestus.github.fleet_sync.subprocess.run", fake_run)
+
+    def test_email_on_key_is_accepted(self, monkeypatch) -> None:
+        """Resolution succeeds when the email is a UID on the signing key."""
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.delenv("FLEET_SKIP_EMAIL_KEY_CHECK", raising=False)
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "Dev@Example.com")  # case-insensitive
+        self._stub_signing_key(monkeypatch, signingkey="ABC123", uids=["dev@example.com"])
+        assert fleet_sync.get_resign_email() == "Dev@Example.com"
+
+    def test_email_not_on_key_raises(self, monkeypatch) -> None:
+        """A mismatch fails fast with an actionable pr-policy message."""
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.delenv("FLEET_SKIP_EMAIL_KEY_CHECK", raising=False)
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "bot@users.noreply.github.com")
+        self._stub_signing_key(monkeypatch, signingkey="ABC123", uids=["dev@example.com"])
+        with pytest.raises(RuntimeError, match="not a UID on the configured"):
+            fleet_sync.get_resign_email()
+
+    def test_skip_env_bypasses_check(self, monkeypatch) -> None:
+        """FLEET_SKIP_EMAIL_KEY_CHECK lets a mismatched email through."""
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "bot@users.noreply.github.com")
+        self._stub_signing_key(monkeypatch, signingkey="ABC123", uids=["dev@example.com"])
+        assert fleet_sync.get_resign_email() == "bot@users.noreply.github.com"
+
+    def test_no_signing_key_skips_check(self, monkeypatch) -> None:
+        """When no signingkey is configured, the check is skipped (cannot verify)."""
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.delenv("FLEET_SKIP_EMAIL_KEY_CHECK", raising=False)
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "anything@example.com")
+        self._stub_signing_key(monkeypatch, signingkey="", uids=[])
+        assert fleet_sync.get_resign_email() == "anything@example.com"
+
+    def test_gpg_missing_skips_check(self, monkeypatch) -> None:
+        """When gpg is not installed, the check is skipped rather than blocking."""
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.delenv("FLEET_SKIP_EMAIL_KEY_CHECK", raising=False)
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "anything@example.com")
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:2] == ["gpg", "--list-keys"]:
+                raise FileNotFoundError("gpg")
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "ABC123\n"
+            return result
+
+        monkeypatch.setattr("hephaestus.github.fleet_sync.subprocess.run", fake_run)
+        assert fleet_sync.get_resign_email() == "anything@example.com"
 
 
 class TestMain:


### PR DESCRIPTION
Two related fixes uncovered while unblocking the PR queue.

## 1. fleet_sync resign-email guard (Closes #1025)
fleet_sync re-signs every rebased commit with `git commit -S`. GitHub only marks a signature verified when the committer email is on the account that owns the signing key. If the resolved resign email (FLEET_GIT_EMAIL or git config user.email) is not a UID on the configured GPG key, commits sign locally but GitHub reports `verified=false / reason=no_user`, and pr-policy rejects the PR at merge — silently, across the whole fleet. (This exact trap bit a hand-authored commit this session.)

`get_resign_email()` now validates the resolved email against the signing key UID emails (`_signing_key_uid_emails()` + `_validate_resign_email()`), raising an actionable error on mismatch. Skipped when undeterminable (no user.signingkey, gpg absent, timeout); bypass with `FLEET_SKIP_EMAIL_KEY_CHECK=1`.

## 2. nats deliver_policy type fix
`pixi run mypy` (default env — the pre-commit hook entry) failed on `subscriber.py:307`: `js.subscribe` expects `DeliverPolicy | None` but `NATSConfig.deliver_policy` was a plain `str`. Pre-existing on main; blocked every local commit via the mypy hook. Constrain the config field to a `Literal` of valid policy values and convert to the `DeliverPolicy` enum at the call site (lazy import preserved).

Verified: `pixi run mypy` clean (315 files); ruff check/format clean; new TestResignEmailKeyGuard tests pass (5) plus the existing resign tests.

Closes #1025