### PR TITLE
[Fix] fleet_sync: per-PR check status (no 504 at scale) + no silent list no-op

### DIFF
--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -309,8 +309,37 @@ def _ci_state(checks: list[dict[str, Any]]) -> str:
     return "SUCCESS"
 
 
+def _fetch_pr_ci_state(repo: str, number: int) -> str:
+    """Fetch a single PR's statusCheckRollup and reduce it to a CI state.
+
+    Fetched per-PR rather than in the bulk list: requesting statusCheckRollup for
+    every open PR in one ``gh pr list`` call makes GitHub GraphQL return HTTP 504
+    at scale (~50+ PRs), because that field aggregates every check on every PR.
+    One PR per call stays well within limits. On any failure we return
+    "UNKNOWN" so a single flaky check fetch downgrades that PR's readiness
+    (it falls through to a rebase) rather than aborting the whole run.
+    """
+    try:
+        result = _gh(
+            ["pr", "view", str(number), "--json", "statusCheckRollup"],
+            repo=repo,
+        )
+        data = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as e:
+        logger.warning("Could not fetch CI state for %s#%s: %s", repo, number, e)
+        return "UNKNOWN"
+    return _ci_state(data.get("statusCheckRollup") or [])
+
+
 def list_prs(repo: str) -> list[PRInfo]:
-    """List all open PRs in a repo with their readiness status."""
+    """List all open PRs in a repo with their readiness status.
+
+    The bulk ``gh pr list`` deliberately omits ``statusCheckRollup`` — requesting
+    it for every PR 504s at scale (see #1027). CI state is fetched per-PR via
+    :func:`_fetch_pr_ci_state`. A genuine list failure is raised, never swallowed
+    into an empty list (which would masquerade as "no open PRs" and silently skip
+    the entire queue).
+    """
     try:
         result = _gh(
             [
@@ -319,24 +348,23 @@ def list_prs(repo: str) -> list[PRInfo]:
                 "--state",
                 "open",
                 "--json",
-                (
-                    "number,title,headRefName,baseRefName,headRefOid,"
-                    "mergeable,mergeStateStatus,statusCheckRollup"
-                ),
+                ("number,title,headRefName,baseRefName,headRefOid,mergeable,mergeStateStatus"),
                 "--limit",
                 "100",
             ],
             repo=repo,
         )
-    except subprocess.CalledProcessError as e:
-        logger.warning("Could not list PRs for %s: %s", repo, e)
-        return []
+        prs_raw: list[dict[str, Any]] = json.loads(result.stdout)
+    except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as e:
+        # Do NOT return [] here: an empty list is indistinguishable from "this
+        # repo has no open PRs", which would make fleet_sync report success
+        # while silently skipping every PR. Fail loudly instead.
+        raise RuntimeError(f"fleet_sync: could not list PRs for {repo}: {e}") from e
 
-    prs_raw: list[dict[str, Any]] = json.loads(result.stdout)
     out: list[PRInfo] = []
 
     for p in prs_raw:
-        ci = _ci_state(p.get("statusCheckRollup") or [])
+        ci = _fetch_pr_ci_state(repo, p["number"])
         mergeable = p.get("mergeable", "UNKNOWN")
         merge_state = p.get("mergeStateStatus", "UNKNOWN")
 
@@ -604,7 +632,16 @@ def process_repo(
     }
 
     logger.info("\n══ %s ══", repo)
-    prs = list_prs(repo)
+    try:
+        prs = list_prs(repo)
+    except RuntimeError as e:
+        # A list failure must NOT be silently treated as "no PRs" — that would
+        # skip the whole repo while reporting success. Count it as a failure so
+        # the run's exit status reflects the unprocessed queue, and continue to
+        # the next repo.
+        logger.error("  %s", e)
+        counts["failed"] += 1
+        return counts
 
     if not prs:
         logger.info("  No open PRs")

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -329,8 +330,6 @@ class TestMain:
 
     def test_main_success_json(self, monkeypatch, capsys) -> None:
         """main() with --json emits ok envelope when no failures occur."""
-        import json
-
         from hephaestus.github import fleet_sync
 
         def fake_process(repo, args, clone_dir):
@@ -355,8 +354,6 @@ class TestMain:
 
     def test_main_failure_json(self, monkeypatch, capsys) -> None:
         """main() with failures returns 1 and JSON envelope shows error."""
-        import json
-
         from hephaestus.github import fleet_sync
 
         def fake_process(repo, args, clone_dir):
@@ -462,3 +459,124 @@ class TestTimeoutHandling:
             call_kwargs = mock_run.call_args[1]
             assert "timeout" in call_kwargs
             assert call_kwargs["timeout"] == fleet_sync_module.NETWORK_TIMEOUT
+
+
+class TestListPrs:
+    """Regression tests for #1027: statusCheckRollup must not be bulk-fetched.
+
+    Requesting statusCheckRollup for every open PR in one `gh pr list` call 504s
+    at scale. The bulk list omits it; CI state is fetched per-PR. A genuine list
+    failure must raise, never be swallowed into an empty list.
+    """
+
+    def test_bulk_list_omits_statuscheckrollup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The bulk `gh pr list --json` must NOT request statusCheckRollup."""
+        captured: dict[str, list[str]] = {}
+
+        def fake_gh(args, repo=None, **kwargs):
+            if args[:2] == ["pr", "list"]:
+                captured["list_args"] = args
+                return MagicMock(
+                    stdout=json.dumps(
+                        [
+                            {
+                                "number": 1,
+                                "title": "t",
+                                "headRefName": "h",
+                                "baseRefName": "main",
+                                "headRefOid": "sha",
+                                "mergeable": "MERGEABLE",
+                                "mergeStateStatus": "BEHIND",
+                            }
+                        ]
+                    )
+                )
+            # pr view (per-PR CI fetch)
+            return MagicMock(stdout=json.dumps({"statusCheckRollup": []}))
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+        prs = fleet_sync_module.list_prs("ProjectHephaestus")
+        json_idx = captured["list_args"].index("--json")
+        json_fields = captured["list_args"][json_idx + 1]
+        assert "statusCheckRollup" not in json_fields
+        assert len(prs) == 1
+        assert prs[0].number == 1
+
+    def test_ci_state_fetched_per_pr(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CI state (statusCheckRollup) is fetched via a per-PR `gh pr view`."""
+        view_calls: list[list[str]] = []
+
+        def fake_gh(args, repo=None, **kwargs):
+            if args[:2] == ["pr", "list"]:
+                return MagicMock(
+                    stdout=json.dumps(
+                        [
+                            {
+                                "number": 7,
+                                "title": "t",
+                                "headRefName": "h",
+                                "baseRefName": "main",
+                                "headRefOid": "sha",
+                                "mergeable": "MERGEABLE",
+                                "mergeStateStatus": "CLEAN",
+                            }
+                        ]
+                    )
+                )
+            view_calls.append(args)
+            return MagicMock(
+                stdout=json.dumps(
+                    {"statusCheckRollup": [{"conclusion": "SUCCESS", "state": "SUCCESS"}]}
+                )
+            )
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+        prs = fleet_sync_module.list_prs("ProjectHephaestus")
+        assert view_calls and view_calls[0][:3] == ["pr", "view", "7"]
+        assert prs[0].ci_state == "SUCCESS"
+        assert prs[0].status == PRStatus.READY
+
+    def test_per_pr_ci_failure_returns_unknown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A flaky per-PR CI fetch downgrades to UNKNOWN, not a whole-run abort."""
+
+        def fake_gh(args, repo=None, **kwargs):
+            if args[:2] == ["pr", "list"]:
+                return MagicMock(
+                    stdout=json.dumps(
+                        [
+                            {
+                                "number": 9,
+                                "title": "t",
+                                "headRefName": "h",
+                                "baseRefName": "main",
+                                "headRefOid": "sha",
+                                "mergeable": "MERGEABLE",
+                                "mergeStateStatus": "BEHIND",
+                            }
+                        ]
+                    )
+                )
+            raise RuntimeError("504 on pr view")
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+        prs = fleet_sync_module.list_prs("ProjectHephaestus")
+        assert prs[0].ci_state == "UNKNOWN"
+
+    def test_list_failure_raises_not_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A genuine bulk-list failure raises rather than returning []."""
+
+        def fake_gh(args, repo=None, **kwargs):
+            raise subprocess.CalledProcessError(1, ["gh"], stderr="HTTP 504")
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+        with pytest.raises(RuntimeError, match="could not list PRs"):
+            fleet_sync_module.list_prs("ProjectHephaestus")
+
+    def test_empty_list_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An actually-empty repo returns [] (distinct from a list failure)."""
+
+        def fake_gh(args, repo=None, **kwargs):
+            return MagicMock(stdout="[]")
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+        assert fleet_sync_module.list_prs("ProjectHephaestus") == []


### PR DESCRIPTION
fleet_sync.list_prs() requested statusCheckRollup for up to 100 PRs in one gh pr list call. With ~58 open PRs, GitHub GraphQL returns HTTP 504 (statusCheckRollup aggregates every check on every PR). The error was swallowed into an empty list, so fleet_sync logged "No open PRs" and exited success while skipping the ENTIRE queue — a silent no-op that masks every PR.

Discovered while trying to run fleet-sync to rebase the open PRs after main was unblocked (#1021, #1026).

Fix:
- Drop statusCheckRollup from the bulk list (cheap fields only); fetch CI state per-PR via _fetch_pr_ci_state (gh pr view <n>), which does not 504. A flaky per-PR fetch downgrades that PR to CI=UNKNOWN rather than aborting the whole run.
- list_prs now raises on a genuine list failure instead of returning []; process_repo counts it as a failure (run exit status reflects the unprocessed queue) and continues to the next repo.

Tests: new TestListPrs (5) covering bulk-omits-statusCheckRollup, per-PR fetch, per-PR failure -> UNKNOWN, list-failure-raises, empty-list-returns-empty. mypy + ruff clean.

Closes #1027