### PR TITLE
[Fix] fleet_sync: rebase stale-failing PRs instead of skipping them

### DIFF
--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -370,7 +370,15 @@ def list_prs(repo: str) -> list[PRInfo]:
 
         if mergeable == "CONFLICTING":
             status = PRStatus.CONFLICTED
-        elif ci == "FAILURE":
+        elif ci == "FAILURE" and merge_state == "CLEAN":
+            # FAILING means a genuine, PR-specific failure: the branch is already
+            # up to date with its base (CLEAN) yet CI is red. Skip — a rebase
+            # wouldn't change the outcome. We require CLEAN here so that a PR
+            # which is merely BEHIND/BLOCKED with a STALE red result (its checks
+            # ran against an old base, commonly a failure already fixed on main)
+            # is NOT skipped — it falls through to OUTDATED and gets rebased,
+            # which re-runs CI fresh. Without the CLEAN guard, a fix landing on
+            # main strands the entire queue as "FAILING".
             status = PRStatus.FAILING
         elif merge_state == "BEHIND":
             status = PRStatus.OUTDATED

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -580,3 +580,80 @@ class TestListPrs:
 
         monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
         assert fleet_sync_module.list_prs("ProjectHephaestus") == []
+
+
+class TestPrClassification:
+    """Regression tests for #1029: stale-failing PRs must be rebased, not skipped.
+
+    A FAILING classification (skip) must require the branch to be up to date with
+    its base (mergeStateStatus CLEAN). A PR that is BEHIND or BLOCKED with a red
+    CI result has stale checks (ran against an old base, often a failure already
+    fixed on main) and must classify as OUTDATED so it gets rebased and re-run —
+    otherwise a fix landing on main strands the entire queue as FAILING.
+    """
+
+    def _classify(self, monkeypatch, *, mergeable: str, state: str, ci: str):
+        """Run list_prs with a single stubbed PR and return its PRStatus."""
+
+        def fake_gh(args, repo=None, **kwargs):
+            if args[:2] == ["pr", "list"]:
+                return MagicMock(
+                    stdout=json.dumps(
+                        [
+                            {
+                                "number": 1,
+                                "title": "t",
+                                "headRefName": "h",
+                                "baseRefName": "main",
+                                "headRefOid": "sha",
+                                "mergeable": mergeable,
+                                "mergeStateStatus": state,
+                            }
+                        ]
+                    )
+                )
+            # per-PR CI fetch: map desired ci_state to a rollup
+            rollup = []
+            if ci == "FAILURE":
+                rollup = [{"conclusion": "FAILURE", "state": "FAILURE"}]
+            elif ci == "SUCCESS":
+                rollup = [{"conclusion": "SUCCESS", "state": "SUCCESS"}]
+            return MagicMock(stdout=json.dumps({"statusCheckRollup": rollup}))
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+        return fleet_sync_module.list_prs("ProjectHephaestus")[0].status
+
+    def test_blocked_mergeable_failing_is_outdated(self, monkeypatch) -> None:
+        """BLOCKED+MERGEABLE with red CI = stale failure → rebase (OUTDATED)."""
+        assert (
+            self._classify(monkeypatch, mergeable="MERGEABLE", state="BLOCKED", ci="FAILURE")
+            == PRStatus.OUTDATED
+        )
+
+    def test_behind_failing_is_outdated(self, monkeypatch) -> None:
+        """BEHIND with red CI = stale failure → rebase (OUTDATED)."""
+        assert (
+            self._classify(monkeypatch, mergeable="MERGEABLE", state="BEHIND", ci="FAILURE")
+            == PRStatus.OUTDATED
+        )
+
+    def test_clean_failing_is_failing(self, monkeypatch) -> None:
+        """CLEAN (up to date) with red CI = genuine PR failure → skip (FAILING)."""
+        assert (
+            self._classify(monkeypatch, mergeable="MERGEABLE", state="CLEAN", ci="FAILURE")
+            == PRStatus.FAILING
+        )
+
+    def test_conflicting_is_conflicted(self, monkeypatch) -> None:
+        """CONFLICTING always classifies as CONFLICTED regardless of CI."""
+        assert (
+            self._classify(monkeypatch, mergeable="CONFLICTING", state="DIRTY", ci="FAILURE")
+            == PRStatus.CONFLICTED
+        )
+
+    def test_clean_success_is_ready(self, monkeypatch) -> None:
+        """CLEAN + green CI = READY."""
+        assert (
+            self._classify(monkeypatch, mergeable="MERGEABLE", state="CLEAN", ci="SUCCESS")
+            == PRStatus.READY
+        )


### PR DESCRIPTION
list_prs classified any PR with CI=FAILURE as FAILING (skip), even when the red result was STALE — the branch was BEHIND/BLOCKED and its checks ran against an old base (commonly a failure already fixed on main). After fixes landed on main (#1021/#1026/#1028), all ~55 open PRs showed their old failing runs, so a fleet-sync dry-run skipped every one as FAILING and rebased nothing — stranding the entire queue.

Fix: require mergeStateStatus == CLEAN for the FAILING classification. Only a PR up to date with its base yet still red is a genuine PR-specific failure worth skipping. A BEHIND/BLOCKED+MERGEABLE PR with stale red CI now classifies as OUTDATED → gets rebased → CI re-runs fresh. CONFLICTING still classifies as CONFLICTED.

Tests: new TestPrClassification (5) covering blocked-failing→outdated, behind-failing→outdated, clean-failing→failing, conflicting→conflicted, clean-success→ready. mypy + ruff clean; 42 fleet_sync tests pass.

Closes #1029