### PR TITLE
fix(automation): fail fast on 422 and GraphQL schema errors in _gh_call

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -272,8 +272,13 @@ _NON_TRANSIENT_PATTERNS = [
         r"(?:^|\s)404(?:\s|$)|not found",
         r"(?:^|\s)400(?:\s|$)|bad request",
         r"(?:^|\s)401(?:\s|$)|unauthorized",
+        r"(?:^|\s)422(?:\s|$)|unprocessable entity",
         r"invalid argument",
         r"unknown json field",
+        # GraphQL schema errors are deterministic — a bad mutation/field or an
+        # unused variable can never succeed on retry (#1040).
+        r"doesn't accept argument",
+        r"is declared by .* but not used",
     )
 ]
 _NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -391,6 +391,50 @@ class TestGhCall:
         assert mock_run.call_count == 1
 
     @patch("hephaestus.automation.github_api.run")
+    def test_fail_fast_on_unprocessable_entity(self, mock_run: Any) -> None:
+        """422 Unprocessable Entity must fail fast without retry.
+
+        Regression (#1040): a malformed review POST (e.g. an inline comment on a
+        line outside the diff hunk) returns ``gh: Unprocessable Entity (HTTP 422)``,
+        a deterministic validation error. It was retried 5x with exponential
+        backoff (~31s wasted) before raising and being mis-reported as a NOGO.
+        """
+        _github_api_module._GH_BREAKER.reset()
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, "gh", stderr="gh: Unprocessable Entity (HTTP 422)"
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _gh_call(["api", "-X", "POST", "repos/o/r/pulls/1/reviews", "--input", "x.json"])
+
+        assert mock_run.call_count == 1
+
+    @patch("hephaestus.automation.github_api.run")
+    def test_fail_fast_on_graphql_schema_error(self, mock_run: Any) -> None:
+        """GraphQL schema errors (bad argument / unused variable) must fail fast.
+
+        Regression (#1040): a wrong mutation field produced
+        ``gh: InputObject '...' doesn't accept argument '...'`` /
+        ``Variable $x is declared by ... but not used`` — permanent schema errors
+        that were nonetheless retried 5x before raising.
+        """
+        _github_api_module._GH_BREAKER.reset()
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1,
+            "gh",
+            stderr=(
+                "gh: InputObject 'AddPullRequestReviewCommentInput' doesn't accept "
+                "argument 'pullRequestReviewThreadId'\n"
+                "Variable $threadId is declared by AddReply but not used"
+            ),
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _gh_call(["api", "graphql", "-f", "query=mutation {...}"])
+
+        assert mock_run.call_count == 1
+
+    @patch("hephaestus.automation.github_api.run")
     @patch("hephaestus.automation.github_api.time.sleep")
     def test_retry_on_transient_error(self, mock_sleep: Any, mock_run: Any) -> None:
         """Test retry on transient errors with jitter.


### PR DESCRIPTION
## Summary

`_NON_TRANSIENT_PATTERNS` in `hephaestus/automation/github_api.py` classifies which `gh` failures are non-retryable. It listed 403/404/400/401/invalid-argument/unknown-json-field/token-scope but **omitted HTTP 422 / Unprocessable Entity and GraphQL schema errors**. Those are deterministic — a malformed payload or a wrong mutation field can never succeed on retry — yet `_gh_call_impl` retried them 5× with `2**attempt` backoff (~31s wasted per failure) before raising, flooding logs and delaying the inevitable failure.

This adds the missing patterns:
- `(?:^|\s)422(?:\s|$)|unprocessable entity`
- `doesn't accept argument`
- `is declared by .* but not used`

## Testing

- New `test_fail_fast_on_unprocessable_entity` and `test_fail_fast_on_graphql_schema_error` assert a **single** attempt (no retries). Both fail on pristine code (6 attempts) and pass with the fix.
- The new tests reset the module circuit breaker directly (matching the existing `test_circuit_breaker_wraps_gh_call_impl` pattern) so the added failing calls don't leak breaker state into sibling tests.
- Full `test_github_api.py` → 114 passed; `ruff` + `mypy` clean.

Surfaced in the same automation-loop run (`output.log`) as #999 (thread-reply mutation, PR #1041) and #1039 (review POST 422 / diff-hunk validation). This PR makes those deterministic failures fail fast; #1039 prevents the 422 from being produced in the first place.

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)