### PR TITLE
refactor(automation): extract three rendering passes in _refresh_display

### DIFF
--- a/hephaestus/automation/curses_ui.py
+++ b/hephaestus/automation/curses_ui.py
@@ -223,7 +223,7 @@ class CursesUI:
             except KeyboardInterrupt:
                 break
 
-    def _refresh_display(self) -> None:  # noqa: C901  # TUI rendering with many display states
+    def _refresh_display(self) -> None:
         """Refresh the curses display."""
         if not self.stdscr:
             return
@@ -236,9 +236,26 @@ class CursesUI:
         if len(title) < width:
             self.stdscr.addstr(0, 0, title, curses.A_BOLD)
 
-        # Display worker status slots
+        row = self._draw_workers(start_row=2, height=height, width=width)
+        row = self._draw_separator(start_row=row, height=height, width=width)
+        self._draw_logs(start_row=row, height=height, width=width)
+
+        self.stdscr.refresh()
+
+    def _draw_workers(self, start_row: int, height: int, width: int) -> int:
+        """Render worker status slots; return the next free row.
+
+        Args:
+            start_row: Row to start drawing at
+            height: Terminal height in rows
+            width: Terminal width in columns
+
+        Returns:
+            The next free row after the worker slots
+
+        """
         statuses = self.status_tracker.get_status()
-        row = 2
+        row = start_row
         for i, status in enumerate(statuses):
             if row >= height - 1:
                 break
@@ -258,37 +275,64 @@ class CursesUI:
                 self.stdscr.addstr(row, 0, status_text, attr)
 
             row += 1
+        return row
 
-        # Display separator
-        if row < height - 1:
+    def _draw_separator(self, start_row: int, height: int, width: int) -> int:
+        """Render the horizontal separator; return the next free row.
+
+        Args:
+            start_row: Row to start drawing at
+            height: Terminal height in rows
+            width: Terminal width in columns
+
+        Returns:
+            The next free row after the separator
+
+        """
+        if start_row >= height - 1:
+            return start_row
+        with contextlib.suppress(curses.error):
+            self.stdscr.addstr(start_row, 0, "-" * min(width - 1, 80))
+        return start_row + 1
+
+    def _draw_logs(self, start_row: int, height: int, width: int) -> int:
+        """Render the recent-activity log tail; return the next free row.
+
+        Args:
+            start_row: Row to start drawing at
+            height: Terminal height in rows
+            width: Terminal width in columns
+
+        Returns:
+            The next free row after the logs
+
+        """
+        row = start_row
+        if row >= height - 1:
+            return row
+
+        with contextlib.suppress(curses.error):
+            self.stdscr.addstr(row, 0, "Recent Activity:", curses.A_BOLD)
+        row += 1
+
+        # Gather recent logs from all threads
+        all_logs: list[str] = []
+        # Take snapshot to avoid RuntimeError if dict changes during iteration
+        for buffer in list(self.log_manager.buffers.values()):
+            all_logs.extend(buffer.get_recent(10))
+
+        # Display most recent logs
+        for log_msg in all_logs[-(height - row - 1) :]:
+            if row >= height - 1:
+                break
+
+            # Truncate to fit width
+            if len(log_msg) > width - 1:
+                log_msg = log_msg[: width - 4] + "..."
+
             with contextlib.suppress(curses.error):
-                self.stdscr.addstr(row, 0, "-" * min(width - 1, 80))
+                self.stdscr.addstr(row, 0, log_msg)
+
             row += 1
 
-        # Display recent logs
-        if row < height - 1:
-            with contextlib.suppress(curses.error):
-                self.stdscr.addstr(row, 0, "Recent Activity:", curses.A_BOLD)
-            row += 1
-
-            # Gather recent logs from all threads
-            all_logs: list[str] = []
-            # Take snapshot to avoid RuntimeError if dict changes during iteration
-            for buffer in list(self.log_manager.buffers.values()):
-                all_logs.extend(buffer.get_recent(10))
-
-            # Display most recent logs
-            for log_msg in all_logs[-(height - row - 1) :]:
-                if row >= height - 1:
-                    break
-
-                # Truncate to fit width
-                if len(log_msg) > width - 1:
-                    log_msg = log_msg[: width - 4] + "..."
-
-                with contextlib.suppress(curses.error):
-                    self.stdscr.addstr(row, 0, log_msg)
-
-                row += 1
-
-        self.stdscr.refresh()
+        return row

--- a/tests/unit/automation/test_curses_ui.py
+++ b/tests/unit/automation/test_curses_ui.py
@@ -1,7 +1,7 @@
 """Tests for the curses_ui module."""
 
 import threading
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from hephaestus.automation.curses_ui import CursesUI, LogBuffer, ThreadLogManager
 from hephaestus.automation.status_tracker import StatusTracker
@@ -165,3 +165,116 @@ class TestCursesUI:
             ui._run_ui()
 
         assert ui.running is False
+
+    def test_draw_workers_returns_next_row(self) -> None:
+        """Test _draw_workers returns the next free row."""
+        ui = self._make_ui(num_workers=2)
+        ui.stdscr = MagicMock()
+        ui.status_tracker.update_slot(0, "working")
+        ui.status_tracker.update_slot(1, "idle")
+
+        with (
+            patch("hephaestus.automation.curses_ui.curses.has_colors", return_value=False),
+            patch("hephaestus.automation.curses_ui.curses.color_pair"),
+        ):
+            next_row = ui._draw_workers(start_row=2, height=10, width=80)
+
+        # Should have rendered 2 workers starting at row 2, so next row is 4
+        assert next_row == 4
+
+    def test_draw_workers_stops_at_height_boundary(self) -> None:
+        """Test _draw_workers stops rendering when it hits the height boundary."""
+        ui = self._make_ui(num_workers=5)
+        ui.stdscr = MagicMock()
+        for i in range(5):
+            ui.status_tracker.update_slot(i, f"task {i}")
+
+        with (
+            patch("hephaestus.automation.curses_ui.curses.has_colors", return_value=False),
+            patch("hephaestus.automation.curses_ui.curses.color_pair"),
+        ):
+            next_row = ui._draw_workers(start_row=8, height=10, width=80)
+
+        # Only 1 worker can fit before height - 1 (9), so next row is 9
+        assert next_row == 9
+
+    def test_draw_workers_truncates_long_status(self) -> None:
+        """Test _draw_workers truncates long status text."""
+        ui = self._make_ui(num_workers=1)
+        ui.stdscr = MagicMock()
+        long_status = "x" * 100
+        ui.status_tracker.update_slot(0, long_status)
+
+        with (
+            patch("hephaestus.automation.curses_ui.curses.has_colors", return_value=False),
+            patch("hephaestus.automation.curses_ui.curses.color_pair"),
+        ):
+            ui._draw_workers(start_row=2, height=10, width=80)
+
+        # Check that addstr was called with truncated text
+        calls = ui.stdscr.addstr.call_args_list
+        assert len(calls) > 0
+        # Text should be truncated to width - 4 + "..."
+        text_arg = calls[0][0][2]
+        assert len(text_arg) <= 80 - 1
+
+    def test_draw_separator_returns_next_row(self) -> None:
+        """Test _draw_separator returns the next free row."""
+        ui = self._make_ui()
+        ui.stdscr = MagicMock()
+
+        with patch("hephaestus.automation.curses_ui.contextlib.suppress"):
+            next_row = ui._draw_separator(start_row=4, height=10, width=80)
+
+        assert next_row == 5
+
+    def test_draw_separator_stops_at_boundary(self) -> None:
+        """Test _draw_separator doesn't draw if at boundary."""
+        ui = self._make_ui()
+        ui.stdscr = MagicMock()
+
+        next_row = ui._draw_separator(start_row=9, height=10, width=80)
+
+        # Should return start_row unchanged since it's at height - 1
+        assert next_row == 9
+        ui.stdscr.addstr.assert_not_called()
+
+    def test_draw_logs_returns_next_row(self) -> None:
+        """Test _draw_logs returns the next free row."""
+        ui = self._make_ui()
+        ui.stdscr = MagicMock()
+        ui.log_manager.log(1, "test log")
+
+        with patch("hephaestus.automation.curses_ui.curses.A_BOLD", 1):
+            next_row = ui._draw_logs(start_row=5, height=10, width=80)
+
+        # Should have at least rendered the header
+        assert next_row >= 6
+
+    def test_draw_logs_stops_at_boundary(self) -> None:
+        """Test _draw_logs returns immediately if at boundary."""
+        ui = self._make_ui()
+        ui.stdscr = MagicMock()
+
+        next_row = ui._draw_logs(start_row=9, height=10, width=80)
+
+        # Should return start_row unchanged since it's at height - 1
+        assert next_row == 9
+        ui.stdscr.addstr.assert_not_called()
+
+    def test_draw_logs_truncates_long_messages(self) -> None:
+        """Test _draw_logs truncates long log messages."""
+        ui = self._make_ui()
+        ui.stdscr = MagicMock()
+        long_msg = "x" * 100
+        ui.log_manager.log(1, long_msg)
+
+        with patch("hephaestus.automation.curses_ui.curses.A_BOLD", 1):
+            ui._draw_logs(start_row=5, height=10, width=80)
+
+        # Check that messages are truncated
+        calls = ui.stdscr.addstr.call_args_list
+        # Second call (after header) should have truncated message
+        if len(calls) > 1:
+            text_arg = calls[1][0][2]
+            assert len(text_arg) <= 80 - 1

--- a/tests/unit/automation/test_curses_ui.py
+++ b/tests/unit/automation/test_curses_ui.py
@@ -223,8 +223,7 @@ class TestCursesUI:
         ui = self._make_ui()
         ui.stdscr = MagicMock()
 
-        with patch("hephaestus.automation.curses_ui.contextlib.suppress"):
-            next_row = ui._draw_separator(start_row=4, height=10, width=80)
+        next_row = ui._draw_separator(start_row=4, height=10, width=80)
 
         assert next_row == 5
 


### PR DESCRIPTION
## Summary

Decompose the 69-line `_refresh_display` method into three instance methods—`_draw_workers`, `_draw_separator`, `_draw_logs`—each carrying its own cyclomatic-complexity budget. Each helper takes `start_row`, `height`, `width` and returns the next free row, preserving the linear row-threading pattern without mutable state.

Removes the `# noqa: C901` suppression per the project rule prohibiting suppressions without fixing the underlying issue. Visible TUI output and public API are unchanged.

## Test plan

- ✅ All existing tests pass
- ✅ New unit tests for each helper method covering:
  - Return value (next row calculation)
  - Height boundary handling
  - Text truncation for wide terminals
- ✅ Pre-commit hooks pass (ruff, mypy, bandit, complexity check)

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)