### PR TITLE
refactor(automation): replace _SHUTDOWN_REQUESTED bool with threading.Event

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -29,6 +29,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import time
 import traceback
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -135,17 +136,17 @@ PHASES_REQUIRING_ISSUES: frozenset[str] = frozenset({"drive-green"})
 
 # Sentinel for cooperative shutdown on SIGINT/SIGTERM. Worker threads
 # check this between phases so an in-flight subprocess can still finish
-# but the next phase is skipped.
-_SHUTDOWN_REQUESTED = False
+# but the next phase is skipped. threading.Event provides atomic, GIL-safe
+# set/check semantics without the global-mutation footgun.
+_SHUTDOWN_EVENT = threading.Event()
 
 
 def _shutdown_requested() -> bool:
-    return _SHUTDOWN_REQUESTED
+    return _SHUTDOWN_EVENT.is_set()
 
 
 def _request_shutdown(signum: int, _frame: object) -> None:
-    global _SHUTDOWN_REQUESTED
-    _SHUTDOWN_REQUESTED = True
+    _SHUTDOWN_EVENT.set()
     LOG.warning("Signal %s received — requesting cooperative shutdown", signum)
 
 

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -9,6 +9,7 @@ subsequent phases from being attempted.
 
 from __future__ import annotations
 
+import signal
 import subprocess
 import sys
 from pathlib import Path
@@ -1208,3 +1209,15 @@ class TestDefaultPhaseTimeout:
         ):
             main(["--repos", "Repo", "--phase-timeout", "0", "--loops", "1", "--agent", "claude"])
         assert captured["cfg"].phase_timeout_s is None
+
+
+def test_shutdown_event_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_request_shutdown sets the Event; _shutdown_requested observes it."""
+    import threading
+
+    # Isolate from any prior test that may have set the module-level Event.
+    monkeypatch.setattr(loop_runner, "_SHUTDOWN_EVENT", threading.Event())
+
+    assert loop_runner._shutdown_requested() is False
+    loop_runner._request_shutdown(signal.SIGINT, None)
+    assert loop_runner._shutdown_requested() is True


### PR DESCRIPTION
## Summary

Replace the mutable module-level bool `_SHUTDOWN_REQUESTED` with the idiomatic stdlib pattern: a module-level `threading.Event`. This removes the bare cross-thread bool read (which relies on CPython GIL semantics rather than an atomic primitive) and matches the canonical Python shutdown-signaling pattern.

Pure refactor — no behavior change. Helper functions preserved at module scope for call-site readability.

## Test plan

- All 93 existing tests in test_loop_runner.py pass
- New unit test `test_shutdown_event_roundtrip` validates the Event roundtrip via `_request_shutdown()` / `_shutdown_requested()`
- Verified old global name is fully gone via `grep -rn "_SHUTDOWN_REQUESTED"`
- Linting passes on both modified files

Closes #808