### PR TITLE
fix(automation): improve observability for follow_up failure logging

### DIFF
--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -25,6 +25,8 @@ import contextlib
 import json
 import logging
 import re
+import subprocess
+import traceback
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -54,6 +56,12 @@ _SECTION_HEADINGS: dict[str, str] = {
     "safety": "## Safety",
     "critical_bug": "## Critical bug",
 }
+
+_EXPECTED_FOLLOW_UP_FAILURES: tuple[type[BaseException], ...] = (
+    subprocess.CalledProcessError,
+    json.JSONDecodeError,
+    OSError,
+)
 
 
 @dataclass(frozen=True)
@@ -458,15 +466,30 @@ def run_follow_up_issues(  # noqa: C901  # quota-check + parse + file paths are 
         )
         return response
 
-    except (
-        Exception
-    ) as e:  # broad: top-level boundary; follow-up failure must NEVER block the PR pipeline
-        logger.warning("Follow-up issues failed for issue #%d: %s", issue_number, e)
-        error_output = f"FAILED: {e}\n"
+    except Exception as e:  # broad boundary; follow-up failure must NEVER block the PR pipeline
+        exc_type = type(e).__name__
+        if isinstance(e, _EXPECTED_FOLLOW_UP_FAILURES):
+            logger.warning(
+                "Follow-up issues failed for issue #%d [%s]: %s",
+                issue_number,
+                exc_type,
+                e,
+                exc_info=True,
+            )
+        else:
+            logger.error(
+                "Unexpected follow-up failure for issue #%d [%s]: %s",
+                issue_number,
+                exc_type,
+                e,
+                exc_info=True,
+            )
+        error_output = f"FAILED: [{exc_type}] {e}\n"
         if hasattr(e, "stdout"):
             error_output += f"\nSTDOUT:\n{e.stdout or ''}"
         if hasattr(e, "stderr"):
             error_output += f"\nSTDERR:\n{e.stderr or ''}"
+        error_output += f"\nTRACEBACK:\n{traceback.format_exc()}"
         with contextlib.suppress(Exception):
             follow_up_log.write_text(error_output)
         return None

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -366,6 +366,64 @@ class TestRunFollowUpIssues:
         prompt_file = worktree_path / ".claude-followup-42.md"
         assert not prompt_file.exists()
 
+    def test_failure_log_includes_exception_type(self, tmp_path: Path) -> None:
+        """Acceptance: error log records exception class name for observability."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+        with patch(
+            "hephaestus.automation.follow_up.run",
+            side_effect=RuntimeError("claude failed"),
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+        log_text = (tmp_path / "follow-up-42.log").read_text()
+        assert log_text.startswith("FAILED: [RuntimeError]")
+        assert "TRACEBACK:" in log_text
+
+    def test_unexpected_exception_logged_at_error(self, tmp_path: Path, caplog: Any) -> None:
+        """Acceptance: programmer bugs (AttributeError etc.) surface at ERROR with exc_info."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+        with (
+            caplog.at_level("WARNING", logger="hephaestus.automation.follow_up"),
+            patch(
+                "hephaestus.automation.follow_up.run",
+                side_effect=AttributeError("bug"),
+            ),
+        ):
+            response = run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+        assert response is None  # safety contract still holds
+        error_records = [
+            r
+            for r in caplog.records
+            if r.levelname == "ERROR" and r.name == "hephaestus.automation.follow_up"
+        ]
+        assert error_records, "expected an ERROR-level record for unexpected exception"
+        assert any("AttributeError" in r.getMessage() for r in error_records)
+        assert any(r.exc_info is not None for r in error_records)
+
+    def test_expected_exception_logged_at_warning(self, tmp_path: Path, caplog: Any) -> None:
+        """Acceptance: known pipeline failures (CalledProcessError) stay at WARNING."""
+        import subprocess
+
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+        with (
+            caplog.at_level("WARNING", logger="hephaestus.automation.follow_up"),
+            patch(
+                "hephaestus.automation.follow_up.run",
+                side_effect=subprocess.CalledProcessError(1, "claude"),
+            ),
+        ):
+            run_follow_up_issues("sess", worktree_path, 42, tmp_path)
+        follow_up_records = [
+            r for r in caplog.records if r.name == "hephaestus.automation.follow_up"
+        ]
+        warning_records = [r for r in follow_up_records if r.levelname == "WARNING"]
+        error_records = [r for r in follow_up_records if r.levelname == "ERROR"]
+        assert warning_records, "expected at least one WARNING record"
+        assert not error_records, "expected pipeline failure must not escalate to ERROR"
+        assert any(r.exc_info is not None for r in warning_records)
+
     def test_status_tracker_updated_once_for_consolidated_issue(self, tmp_path: Path) -> None:
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()


### PR DESCRIPTION
## Summary

Add exception type classification and traceback logging to the broad exception boundary in run_follow_up_issues. Expected pipeline failures (CalledProcessError, JSONDecodeError, OSError) are logged at WARNING with exc_info=True; unexpected failures (programmer bugs) escalate to ERROR. Exception type and traceback are now captured in the on-disk log file for post-mortem debugging.

The safety contract is preserved: the boundary still returns None and never blocks the PR pipeline.

Closes #807