### PR TITLE
feat(github): add --ascii flag to fleet_sync for ASCII-only output

### DIFF
--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -868,7 +868,7 @@ def main() -> int:
         "--ascii",
         action="store_true",
         help="Use ASCII equivalents for Unicode glyphs in log output "
-             "(== for ══, * for ✓, -> for →, -- for —). "
+             "(== for ==, * for *, -> for ->, -- for --). "
              "Use this when piping stdout to ASCII-only consumers.",
     )
     add_json_arg(parser)

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -43,6 +43,20 @@ from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 logger = get_logger(__name__)
 
+
+@dataclass(frozen=True)
+class Symbols:
+    """Glyphs used in user-facing log output. Frozen for safe sharing across calls."""
+
+    banner: str
+    check: str
+    arrow: str
+    dash: str
+
+
+UNICODE_SYMBOLS = Symbols(banner="══", check="✓", arrow="→", dash="—")
+ASCII_SYMBOLS = Symbols(banner="==", check="*", arrow="->", dash="--")
+
 ORG = "HomericIntelligence"
 
 
@@ -519,7 +533,13 @@ def merge_pr(pr: PRInfo, dry_run: bool = False) -> bool:
         return False
 
 
-def rebase_and_resign(pr: PRInfo, repo_clone: Path, dry_run: bool = False) -> bool:
+def rebase_and_resign(
+    pr: PRInfo,
+    repo_clone: Path,
+    dry_run: bool = False,
+    *,
+    symbols: Symbols = UNICODE_SYMBOLS,
+) -> bool:
     """Fetch PR branch, rebase it on origin/base, re-sign all commits, push.
 
     Operates in a per-PR worktree off the shared ``repo_clone`` (#1044) rather
@@ -540,12 +560,14 @@ def rebase_and_resign(pr: PRInfo, repo_clone: Path, dry_run: bool = False) -> bo
         )
 
         if result.returncode != 0:
-            logger.warning("  Rebase failed for PR #%d — conflict detected", pr.number)
+            logger.warning(
+                "  Rebase failed for PR #%d %s conflict detected", pr.number, symbols.dash
+            )
             _git(["rebase", "--abort"], cwd=work, dry_run=dry_run, check=False)
             return False
 
         _git(["push", "--force-with-lease", "origin", branch], cwd=work, dry_run=dry_run)
-        logger.info("  ✓ Rebased and re-signed PR #%d", pr.number)
+        logger.info("  %s Rebased and re-signed PR #%d", symbols.check, pr.number)
         return True
 
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
@@ -597,6 +619,8 @@ def resolve_conflict_with_agent(
     repo_clone: Path,
     dry_run: bool = False,
     agent: str = "claude",
+    *,
+    symbols: Symbols = UNICODE_SYMBOLS,
 ) -> bool:
     """Spawn the selected agent to semantically resolve merge conflicts, then re-sign.
 
@@ -710,7 +734,7 @@ Rules:
             timeout=NETWORK_TIMEOUT,
         )
         if branch in verify.stdout:
-            logger.info("  ✓ Conflict resolved and pushed for PR #%d", pr.number)
+            logger.info("  %s Conflict resolved and pushed for PR #%d", symbols.check, pr.number)
             return True
 
         logger.warning("  Agent did not push branch for PR #%d", pr.number)
@@ -729,6 +753,8 @@ def process_repo(
     repo: str,
     args: argparse.Namespace,
     clone_dir: Path,
+    *,
+    symbols: Symbols = UNICODE_SYMBOLS,
 ) -> dict[str, int]:
     """Process all open PRs in one repo. Returns counts by outcome."""
     counts: dict[str, int] = {
@@ -739,7 +765,7 @@ def process_repo(
         "failed": 0,
     }
 
-    logger.info("\n══ %s ══", repo)
+    logger.info("\n%s %s %s", symbols.banner, repo, symbols.banner)
     try:
         prs = list_prs(repo)
     except RuntimeError as e:
@@ -793,12 +819,12 @@ def process_repo(
             counts["merged" if ok else "failed"] += 1
 
         elif pr.status == PRStatus.OUTDATED:
-            ok = rebase_and_resign(pr, _repo_clone(), dry_run=args.dry_run)
+            ok = rebase_and_resign(pr, _repo_clone(), dry_run=args.dry_run, symbols=symbols)
             counts["rebased" if ok else "failed"] += 1
 
         elif pr.status == PRStatus.CONFLICTED:
             if args.skip_conflict_resolution:
-                logger.info("  → Skipping (--skip-conflict-resolution)")
+                logger.info("  %s Skipping (--skip-conflict-resolution)", symbols.arrow)
                 counts["skipped"] += 1
             else:
                 ok = resolve_conflict_with_agent(
@@ -806,11 +832,12 @@ def process_repo(
                     _repo_clone(),
                     dry_run=args.dry_run,
                     agent=args.agent,
+                    symbols=symbols,
                 )
                 counts["conflict_resolved" if ok else "failed"] += 1
 
         else:
-            logger.info("  → Skipping (CI failing or unknown state)")
+            logger.info("  %s Skipping (CI failing or unknown state)", symbols.arrow)
             counts["skipped"] += 1
 
     return counts
@@ -837,6 +864,13 @@ def main() -> int:
     )
     add_agent_argument(parser)
     parser.add_argument("--verbose", "-v", action="store_true", help="Debug logging")
+    parser.add_argument(
+        "--ascii",
+        action="store_true",
+        help="Use ASCII equivalents for Unicode glyphs in log output "
+             "(== for ══, * for ✓, -> for →, -- for —). "
+             "Use this when piping stdout to ASCII-only consumers.",
+    )
     add_json_arg(parser)
     add_version_arg(parser)
     args = parser.parse_args()
@@ -851,7 +885,8 @@ def main() -> int:
 
     repos = args.repos
     dry_tag = " [DRY RUN]" if args.dry_run else ""
-    logger.info("Fleet sync — %d repo(s)%s", len(repos), dry_tag)
+    symbols = ASCII_SYMBOLS if args.ascii else UNICODE_SYMBOLS
+    logger.info("Fleet sync %s %d repo(s)%s", symbols.dash, len(repos), dry_tag)
 
     totals: dict[str, int] = {
         "merged": 0,
@@ -864,7 +899,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="hephaestus-fleet-") as tmp:
         clone_dir = Path(tmp)
         for repo in repos:
-            counts = process_repo(repo, args, clone_dir)
+            counts = process_repo(repo, args, clone_dir, symbols=symbols)
             for k, v in counts.items():
                 totals[k] = totals.get(k, 0) + v
 

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -843,8 +843,16 @@ def process_repo(
     return counts
 
 
-def main() -> int:
-    """Entry point for hephaestus-fleet-sync."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for hephaestus-fleet-sync.
+
+    Extracted from ``main`` so the production parser (including the
+    ``--ascii`` flag) can be inspected directly by unit tests.
+
+    Returns:
+        The fully configured :class:`argparse.ArgumentParser`.
+
+    """
     parser = argparse.ArgumentParser(
         description="Sync all PRs across the HomericIntelligence fleet",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -867,12 +875,20 @@ def main() -> int:
     parser.add_argument(
         "--ascii",
         action="store_true",
-        help="Use ASCII equivalents for Unicode glyphs in log output "
-             "(== for ==, * for *, -> for ->, -- for --). "
-             "Use this when piping stdout to ASCII-only consumers.",
+        help=(
+            "Use ASCII fallbacks (==, *, ->, --) instead of Unicode "
+            "box/check/arrow/dash glyphs in log output; use when piping "
+            "stdout to ASCII-only consumers."
+        ),
     )
     add_json_arg(parser)
     add_version_arg(parser)
+    return parser
+
+
+def main() -> int:
+    """Entry point for hephaestus-fleet-sync."""
+    parser = _build_parser()
     args = parser.parse_args()
     agent = resolve_agent(args.agent)
     args.agent = agent

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -477,6 +477,47 @@ def _pr(number: int, status: PRStatus, head: str = "feat") -> PRInfo:
     )
 
 
+@pytest.fixture
+def capture_fleet_sync_logs():
+    r"""Fixture to capture fleet_sync logger messages.
+
+    Context manager that captures log messages from the fleet_sync module logger
+    by attaching a custom handler. Automatically cleans up on exit.
+
+    Yields:
+        list: A list that will be populated with log message strings as they are emitted.
+
+    Usage:
+        with capture_fleet_sync_logs() as messages:
+            # ... code that logs ...
+            assert "expected message" in "\n".join(messages)
+
+    """
+    import logging
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _capture():
+        messages = []
+
+        class _TestHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                messages.append(record.getMessage())
+
+        # Get the underlying logger (ContextLogger wraps a LoggerAdapter)
+        logger_adapter = fleet_sync_module.logger
+        underlying_logger = logger_adapter.logger
+        handler = _TestHandler()
+        underlying_logger.addHandler(handler)
+
+        try:
+            yield messages
+        finally:
+            underlying_logger.removeHandler(handler)
+
+    return _capture()
+
+
 class TestCloneReuseAndWorktrees:
     """#1044: clone each repo once, use worktrees per PR instead of re-cloning."""
 
@@ -881,28 +922,14 @@ class TestAsciiFlag:
         assert fleet_sync_module.ASCII_SYMBOLS.dash == "--"
 
     def test_process_repo_emits_ascii_banner_when_ascii_symbols_passed(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capture_fleet_sync_logs
     ) -> None:
         """process_repo logs ASCII banner under ASCII_SYMBOLS — no module state."""
         monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo: [])
 
         import argparse
-        import logging
 
-        # Capture logger output directly
-        logged_messages = []
-
-        class TestHandler(logging.Handler):
-            def emit(self, record: logging.LogRecord) -> None:
-                logged_messages.append(record.getMessage())
-
-        # Get the underlying logger (ContextLogger wraps a LoggerAdapter)
-        logger_adapter = fleet_sync_module.logger
-        underlying_logger = logger_adapter.logger
-        handler = TestHandler()
-        underlying_logger.addHandler(handler)
-
-        try:
+        with capture_fleet_sync_logs as logged_messages:
             args = argparse.Namespace(
                 dry_run=True,
                 skip_conflict_resolution=True,
@@ -920,32 +947,16 @@ class TestAsciiFlag:
             output = "\n".join(logged_messages)
             assert "== test-repo ==" in output, f"Expected ASCII banner in: {output}"
             assert "══" not in output, f"Unexpected Unicode banner in: {output}"
-        finally:
-            underlying_logger.removeHandler(handler)
 
     def test_process_repo_emits_unicode_banner_by_default(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capture_fleet_sync_logs
     ) -> None:
         """Default kwarg gives Unicode — backward-compat for existing callers."""
         monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo: [])
 
         import argparse
-        import logging
 
-        # Capture logger output directly
-        logged_messages = []
-
-        class TestHandler(logging.Handler):
-            def emit(self, record: logging.LogRecord) -> None:
-                logged_messages.append(record.getMessage())
-
-        # Get the underlying logger (ContextLogger wraps a LoggerAdapter)
-        logger_adapter = fleet_sync_module.logger
-        underlying_logger = logger_adapter.logger
-        handler = TestHandler()
-        underlying_logger.addHandler(handler)
-
-        try:
+        with capture_fleet_sync_logs as logged_messages:
             args = argparse.Namespace(
                 dry_run=True,
                 skip_conflict_resolution=True,
@@ -960,5 +971,3 @@ class TestAsciiFlag:
             # Check logged messages
             output = "\n".join(logged_messages)
             assert "══ test-repo ══" in output, f"Expected Unicode banner in: {output}"
-        finally:
-            underlying_logger.removeHandler(handler)

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -332,7 +332,7 @@ class TestMain:
         """main() with --json emits ok envelope when no failures occur."""
         from hephaestus.github import fleet_sync
 
-        def fake_process(repo, args, clone_dir):
+        def fake_process(repo, args, clone_dir, *, symbols=None):
             return {
                 "merged": 1,
                 "rebased": 0,
@@ -356,7 +356,7 @@ class TestMain:
         """main() with failures returns 1 and JSON envelope shows error."""
         from hephaestus.github import fleet_sync
 
-        def fake_process(repo, args, clone_dir):
+        def fake_process(repo, args, clone_dir, *, symbols=None):
             return {
                 "merged": 0,
                 "rebased": 0,
@@ -381,7 +381,7 @@ class TestMain:
 
         calls = []
 
-        def fake_process(repo, args, clone_dir):
+        def fake_process(repo, args, clone_dir, *, symbols=None):
             calls.append(repo)
             return {
                 "merged": 0,
@@ -857,3 +857,108 @@ class TestListPrsAuthorScope:
         prs = fleet_sync_module.list_prs("RepoA")
 
         assert [p.number for p in prs] == [1]
+
+
+class TestAsciiFlag:
+    """--ascii swaps Unicode glyphs in log output for portable ASCII."""
+
+    def test_symbols_dataclass_is_frozen(self) -> None:
+        """Symbols instances are frozen to prevent accidental mutation."""
+        from dataclasses import FrozenInstanceError
+
+        with pytest.raises(FrozenInstanceError):
+            fleet_sync_module.ASCII_SYMBOLS.check = "X"
+
+    def test_presets_have_expected_glyphs(self) -> None:
+        """Unicode and ASCII symbol presets have the correct glyphs."""
+        assert fleet_sync_module.UNICODE_SYMBOLS.check == "✓"
+        assert fleet_sync_module.UNICODE_SYMBOLS.banner == "══"
+        assert fleet_sync_module.UNICODE_SYMBOLS.arrow == "→"
+        assert fleet_sync_module.UNICODE_SYMBOLS.dash == "—"
+        assert fleet_sync_module.ASCII_SYMBOLS.check == "*"
+        assert fleet_sync_module.ASCII_SYMBOLS.banner == "=="
+        assert fleet_sync_module.ASCII_SYMBOLS.arrow == "->"
+        assert fleet_sync_module.ASCII_SYMBOLS.dash == "--"
+
+    def test_process_repo_emits_ascii_banner_when_ascii_symbols_passed(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """process_repo logs ASCII banner under ASCII_SYMBOLS — no module state."""
+        monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo: [])
+
+        import argparse
+        import logging
+
+        # Capture logger output directly
+        logged_messages = []
+
+        class TestHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                logged_messages.append(record.getMessage())
+
+        # Get the underlying logger (ContextLogger wraps a LoggerAdapter)
+        logger_adapter = fleet_sync_module.logger
+        underlying_logger = logger_adapter.logger
+        handler = TestHandler()
+        underlying_logger.addHandler(handler)
+
+        try:
+            args = argparse.Namespace(
+                dry_run=True,
+                skip_conflict_resolution=True,
+                agent="claude",
+                json=False,
+                verbose=False,
+                ascii=True,
+            )
+
+            fleet_sync_module.process_repo(
+                "test-repo", args, tmp_path, symbols=fleet_sync_module.ASCII_SYMBOLS
+            )
+
+            # Check logged messages
+            output = "\n".join(logged_messages)
+            assert "== test-repo ==" in output, f"Expected ASCII banner in: {output}"
+            assert "══" not in output, f"Unexpected Unicode banner in: {output}"
+        finally:
+            underlying_logger.removeHandler(handler)
+
+    def test_process_repo_emits_unicode_banner_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Default kwarg gives Unicode — backward-compat for existing callers."""
+        monkeypatch.setattr(fleet_sync_module, "list_prs", lambda _repo: [])
+
+        import argparse
+        import logging
+
+        # Capture logger output directly
+        logged_messages = []
+
+        class TestHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                logged_messages.append(record.getMessage())
+
+        # Get the underlying logger (ContextLogger wraps a LoggerAdapter)
+        logger_adapter = fleet_sync_module.logger
+        underlying_logger = logger_adapter.logger
+        handler = TestHandler()
+        underlying_logger.addHandler(handler)
+
+        try:
+            args = argparse.Namespace(
+                dry_run=True,
+                skip_conflict_resolution=True,
+                agent="claude",
+                json=False,
+                verbose=False,
+                ascii=False,
+            )
+
+            fleet_sync_module.process_repo("test-repo", args, tmp_path)
+
+            # Check logged messages
+            output = "\n".join(logged_messages)
+            assert "══ test-repo ══" in output, f"Expected Unicode banner in: {output}"
+        finally:
+            underlying_logger.removeHandler(handler)

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -971,3 +971,36 @@ class TestAsciiFlag:
             # Check logged messages
             output = "\n".join(logged_messages)
             assert "══ test-repo ══" in output, f"Expected Unicode banner in: {output}"
+
+    def test_ascii_flag_registered_on_production_parser(self) -> None:
+        """The real parser registers --ascii as a default-False store_true flag.
+
+        Guards against the flag being dropped from ``main`` without a test
+        failing — the behavioral tests pass ``symbols=`` directly and bypass
+        argparse entirely.
+        """
+        parser = fleet_sync_module._build_parser()
+
+        ascii_action = next((a for a in parser._actions if "--ascii" in a.option_strings), None)
+        assert ascii_action is not None, "--ascii flag is not registered on the parser"
+        assert ascii_action.default is False
+        assert ascii_action.const is True  # store_true
+
+        # Parsing without the flag yields ascii=False; with it, ascii=True.
+        assert parser.parse_args([]).ascii is False
+        assert parser.parse_args(["--ascii"]).ascii is True
+
+    def test_ascii_help_describes_glyph_swap_not_identity_mapping(self) -> None:
+        """--ascii help text describes what it replaces, not ASCII->ASCII noise.
+
+        Regression guard for the self-contradictory ``== for ==`` mapping that
+        conveyed nothing about what the flag swaps.
+        """
+        parser = fleet_sync_module._build_parser()
+        ascii_action = next(a for a in parser._actions if "--ascii" in a.option_strings)
+        help_text = ascii_action.help or ""
+
+        assert "Unicode" in help_text, "help must name what is being replaced"
+        # The garbled self-mapping must not reappear.
+        assert "== for ==" not in help_text
+        assert "* for *" not in help_text


### PR DESCRIPTION
## Summary

Add `--ascii` flag to `hephaestus-fleet-sync` that swaps Unicode glyphs (══, ✓, →, —) for ASCII equivalents (==, *, ->, --) in log output. This enables safe pipeline consumption by ASCII-only consumers like CI log shippers and legacy syslog forwarders.

## Design

Uses a frozen `Symbols` dataclass with `UNICODE_SYMBOLS` and `ASCII_SYMBOLS` presets. The selected preset is passed as a keyword argument through `process_repo` → helper functions, maintaining backward compatibility and determinism without global state.

- Added `Symbols` dataclass with four glyph fields (banner, check, arrow, dash)
- Created `UNICODE_SYMBOLS` (default) and `ASCII_SYMBOLS` presets
- Updated function signatures: `process_repo`, `rebase_and_resign`, `resolve_conflict_with_agent`
- Updated all logger.info/warning calls in user-facing output to use symbols
- Added comprehensive unit tests with `TestAsciiFlag` class

## Test Plan

- All existing fleet_sync tests pass (52 total)
- New tests verify:
  - Symbols dataclass is frozen
  - Presets have expected glyphs
  - process_repo emits correct banners under both presets
- No regressions in existing functionality
- `--ascii` flag appears in help text
- No Unicode literals remain in logger calls

Closes #809

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>