### PR TITLE
refactor(cli): move json import to module level

### DIFF
--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -11,6 +11,7 @@ Follows development principles:
 """
 
 import argparse
+import json
 import sys
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -139,8 +140,6 @@ def emit_json_status(exit_code: int, message: str | None = None, **extra: Any) -
         **extra: Additional fields to merge into the envelope.
 
     """
-    import json
-
     envelope: dict[str, Any] = {
         "status": "ok" if exit_code == 0 else "error",
         "exit_code": exit_code,
@@ -243,8 +242,6 @@ def format_output(data: Any, format_type: str = "text") -> str:
 
     """
     if format_type == "json":
-        import json
-
         return json.dumps(data, indent=2)
     elif format_type == "table" and isinstance(data, (list, tuple)):
         if data and isinstance(data[0], dict):


### PR DESCRIPTION
## Summary

Move the `json` standard-library import from inside `emit_json_status()` (line 142) and `format_output()` (line 246) to module level in `hephaestus/cli/utils.py`. This eliminates duplicated per-call imports, restoring consistency with existing module-level imports (`argparse`, `sys`, `collections.abc`) and resolving the KISS/DRY nitpick from audit finding S14.

## Changes

- Add `import json` to the module-level import block (alphabetically ordered between `argparse` and `sys`)
- Remove `import json` from inside `emit_json_status()` 
- Remove `import json` from inside `format_output()`

No behavior change — Python's import cache makes per-call imports cheap, but this is a code-cleanliness fix.

## Testing

All CLI utility tests pass (49 tests), including the 7 JSON-specific tests:
- `TestFormatOutput::test_json_format` ✓
- `TestEmitJsonStatus::test_ok_status_on_zero_exit` ✓
- `TestEmitJsonStatus::test_error_status_on_nonzero_exit` ✓
- `TestEmitJsonStatus::test_message_included` ✓
- `TestEmitJsonStatus::test_extra_fields_merged` ✓

Closes #810