### PR TITLE
feat(ci): add SECURITY.md supported-versions drift check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -206,6 +206,13 @@ repos:
         language: system
         pass_filenames: false
         files: ^SECURITY\.md$
+      - id: check-security-version-consistency
+        name: Check SECURITY.md supported versions match git tags
+        description: Ensure SECURITY.md supported/EOL rows track the latest vX.Y.Z tag
+        entry: python3 scripts/check_security_version_consistency.py
+        language: system
+        pass_filenames: false
+        files: ^SECURITY\.md$
 
 
   # Skill merge method check: skills must not hardcode merge flags

--- a/scripts/check_security_version_consistency.py
+++ b/scripts/check_security_version_consistency.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Check SECURITY.md supported-versions table matches the latest git tag.
+
+ProjectHephaestus uses hatch-vcs dynamic versioning (CLAUDE.md "Version
+Management"). The canonical version is the most recent `vX.Y.Z` git tag,
+not any pyproject.toml field. This hook fails if SECURITY.md's supported
+row drifts away from that latest tag's X.Y minor series.
+
+Policy enforced: exactly ONE supported (✅) X.Y.x row and exactly ONE EOL
+(❌) "< X.Y" row, both anchored to the latest released minor. If the
+project moves to a multi-series support policy, update SECURITY.md AND
+relax this script's row-count check together.
+
+NOTE: get_repo_root() is duplicated across scripts/check_python_version_consistency.py
+and scripts/check_version_single_source.py. The reusable version at
+hephaestus/utils/helpers.py:99 is intentionally not imported here because
+pre-commit hooks run via raw `python3` (no `pixi run` wrapper) to avoid
+forcing a pixi env build on every commit; importing from `hephaestus`
+would require switching this hook to `pixi run --environment default`.
+A future consolidation PR can extract these into a stdlib helper.
+
+Usage:
+    python3 scripts/check_security_version_consistency.py
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+GIT_TAG_CMD = ["tag", "--list", "v[0-9]*.*", "--sort=-v:refname"]
+
+
+def get_repo_root() -> Path:
+    """Return the repo root directory (where pyproject.toml exists)."""
+    path = Path(__file__).resolve().parent
+    while path != path.parent:
+        if (path / "pyproject.toml").exists():
+            return path
+        path = path.parent
+    return Path(__file__).resolve().parent.parent
+
+
+def latest_release_minor(repo_root: Path) -> str | None:
+    """Return the X.Y of the most recent vX.Y.Z tag, or None if no tags."""
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *GIT_TAG_CMD],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        m = re.match(r"^v(\d+)\.(\d+)\.\d+$", line.strip())
+        if m:
+            return f"{m.group(1)}.{m.group(2)}"
+    return None
+
+
+def extract_table_rows(content: str) -> tuple[list[str], list[str]]:
+    """Return (supported_xy_list, eol_threshold_xy_list) from SECURITY.md table.
+
+    Returns ALL matching rows so the caller can enforce the
+    exactly-one-supported, exactly-one-EOL policy.
+    """
+    supported = re.findall(r"^\|\s*(\d+\.\d+)\.x\s*\|\s*✅[^|]*\|\s*$", content, re.MULTILINE)
+    eol = re.findall(r"^\|\s*<\s*(\d+\.\d+)\s*\|\s*❌[^|]*\|\s*$", content, re.MULTILINE)
+    return supported, eol
+
+
+def main() -> int:
+    """Check SECURITY.md version table matches latest git tag."""
+    repo_root = get_repo_root()
+    security_path = repo_root / "SECURITY.md"
+    if not security_path.exists():
+        print(f"ERROR: SECURITY.md not found at {security_path}")
+        return 1
+
+    latest = latest_release_minor(repo_root)
+    if latest is None:
+        print("WARNING: no vX.Y.Z tags found — skipping SECURITY.md drift check")
+        return 0
+
+    supported, eol = extract_table_rows(security_path.read_text())
+
+    if len(supported) != 1:
+        print(
+            f"ERROR: SECURITY.md must contain exactly ONE supported (✅) row; "
+            f"found {len(supported)}: {supported}"
+        )
+        print(
+            "  If the policy is changing to multi-series support, update both "
+            "SECURITY.md and the row-count check in this script together."
+        )
+        return 1
+    if len(eol) != 1:
+        print(
+            f"ERROR: SECURITY.md must contain exactly ONE EOL (❌ '< X.Y') row; "
+            f"found {len(eol)}: {eol}"
+        )
+        return 1
+
+    supported_xy, eol_xy = supported[0], eol[0]
+    if supported_xy == latest and eol_xy == latest:
+        print(f"OK: SECURITY.md supported = {supported_xy}.x matches latest tag v{latest}.*")
+        return 0
+
+    print("ERROR: SECURITY.md supported-versions table is out of sync with git tags")
+    print(f"  latest released minor: {latest} (from `git tag --list 'v[0-9]*.*'`)")
+    print(f"  SECURITY.md supported row: {supported_xy}.x")
+    print(f"  SECURITY.md EOL threshold: < {eol_xy}")
+    print(f"  fix: update SECURITY.md to show '{latest}.x' supported, '< {latest}' EOL")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_security_version_consistency.py
+++ b/tests/unit/scripts/test_check_security_version_consistency.py
@@ -1,0 +1,174 @@
+"""Tests for scripts/check_security_version_consistency.py."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from check_security_version_consistency import (
+    GIT_TAG_CMD,
+    extract_table_rows,
+    latest_release_minor,
+    main,
+)
+
+
+class TestExtractTableRows:
+    """Tests for extract_table_rows function."""
+
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            pytest.param(
+                "| 0.9.x | ✅ Supported    |\n| < 0.9 | ❌ End of life |\n",
+                (["0.9"], ["0.9"]),
+                id="canonical_rows",
+            ),
+            pytest.param(
+                "|0.9.x|✅ Supported|\n|< 0.9|❌ EOL|\n",
+                (["0.9"], ["0.9"]),
+                id="no_padding",
+            ),
+            pytest.param(
+                "| 1.0.x | ✅ |\n| < 1.0 | ❌ |\n",
+                (["1.0"], ["1.0"]),
+                id="post_1_0",
+            ),
+            pytest.param(
+                "| 1.10.x | ✅ |\n| < 1.10 | ❌ |\n",
+                (["1.10"], ["1.10"]),
+                id="multi_digit_minor",
+            ),
+        ],
+    )
+    def test_parses(self, content, expected):
+        assert extract_table_rows(content) == expected
+
+    def test_no_table_returns_empty_lists(self):
+        assert extract_table_rows("no table here") == ([], [])
+
+    def test_only_supported_row(self):
+        content = "| 0.9.x | ✅ Supported |\n"
+        supported, eol = extract_table_rows(content)
+        assert supported == ["0.9"]
+        assert eol == []
+
+    def test_only_eol_row(self):
+        content = "| < 0.9 | ❌ EOL |\n"
+        supported, eol = extract_table_rows(content)
+        assert supported == []
+        assert eol == ["0.9"]
+
+    def test_multiple_supported_rows(self):
+        content = "| 1.0.x | ✅ Supported |\n| 0.9.x | ✅ Supported |\n| < 0.9 | ❌ EOL |\n"
+        supported, eol = extract_table_rows(content)
+        assert supported == ["1.0", "0.9"]
+        assert eol == ["0.9"]
+
+
+class TestLatestReleaseMinor:
+    """Tests for latest_release_minor function."""
+
+    def test_picks_highest_semver_tag(self, tmp_path):
+        with patch("check_security_version_consistency.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = "v0.9.4\nv0.9.0\nv0.8.0\n"
+            assert latest_release_minor(tmp_path) == "0.9"
+
+    def test_ignores_non_semver(self, tmp_path):
+        with patch("check_security_version_consistency.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = "release-1\nv0.9.0-rc1\nv0.9.0\n"
+            assert latest_release_minor(tmp_path) == "0.9"
+
+    def test_multi_digit_minor_ordering(self, tmp_path):
+        # git --sort=-v:refname yields v1.10.0 before v1.9.0; ensure script honors it
+        with patch("check_security_version_consistency.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = "v1.10.0\nv1.9.0\nv1.0.0\n"
+            assert latest_release_minor(tmp_path) == "1.10"
+
+    def test_no_tags(self, tmp_path):
+        with patch("check_security_version_consistency.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = ""
+            assert latest_release_minor(tmp_path) is None
+
+    def test_git_command_invoked_with_expected_args(self, tmp_path):
+        with patch("check_security_version_consistency.subprocess.run") as run:
+            run.return_value.returncode = 0
+            run.return_value.stdout = "v0.9.0\n"
+            latest_release_minor(tmp_path)
+            args = run.call_args[0][0]
+            assert args == ["git", "-C", str(tmp_path), *GIT_TAG_CMD]
+            assert "--sort=-v:refname" in args
+            assert "v[0-9]*.*" in args
+
+
+class TestMain:
+    """Tests for main function."""
+
+    def _write_canonical(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("")
+        (tmp_path / "SECURITY.md").write_text(
+            "| 0.9.x | ✅ Supported    |\n| < 0.9 | ❌ End of life |\n"
+        )
+
+    def test_ok_when_aligned(self, tmp_path, monkeypatch, capsys):
+        self._write_canonical(tmp_path)
+        monkeypatch.setattr("check_security_version_consistency.get_repo_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "check_security_version_consistency.latest_release_minor",
+            lambda _r: "0.9",
+        )
+        assert main() == 0
+        assert "OK" in capsys.readouterr().out
+
+    def test_fails_when_drifted(self, tmp_path, monkeypatch, capsys):
+        self._write_canonical(tmp_path)
+        monkeypatch.setattr("check_security_version_consistency.get_repo_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "check_security_version_consistency.latest_release_minor",
+            lambda _r: "1.0",
+        )
+        assert main() == 1
+        assert "out of sync" in capsys.readouterr().out
+
+    def test_skips_when_no_tags(self, tmp_path, monkeypatch, capsys):
+        self._write_canonical(tmp_path)
+        monkeypatch.setattr("check_security_version_consistency.get_repo_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "check_security_version_consistency.latest_release_minor",
+            lambda _r: None,
+        )
+        assert main() == 0
+        assert "WARNING" in capsys.readouterr().out
+
+    def test_fails_when_multiple_supported_rows(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "pyproject.toml").write_text("")
+        (tmp_path / "SECURITY.md").write_text(
+            "| 1.0.x | ✅ Supported |\n| 0.9.x | ✅ Supported |\n| < 0.9 | ❌ EOL |\n"
+        )
+        monkeypatch.setattr("check_security_version_consistency.get_repo_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "check_security_version_consistency.latest_release_minor",
+            lambda _r: "1.0",
+        )
+        assert main() == 1
+        out = capsys.readouterr().out
+        assert "exactly ONE supported" in out
+        assert "multi-series" in out
+
+    def test_fails_when_no_eol_row(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "pyproject.toml").write_text("")
+        (tmp_path / "SECURITY.md").write_text("| 0.9.x | ✅ Supported |\n")
+        monkeypatch.setattr("check_security_version_consistency.get_repo_root", lambda: tmp_path)
+        monkeypatch.setattr(
+            "check_security_version_consistency.latest_release_minor",
+            lambda _r: "0.9",
+        )
+        assert main() == 1
+        assert "exactly ONE EOL" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Add pre-commit hook and script to verify SECURITY.md supported-versions table stays aligned with actual git tags. ProjectHephaestus uses hatch-vcs dynamic versioning from git tags; this hook prevents table drift when new vX.Y.Z tags are released without updating SECURITY.md.

## Changes

- Add `scripts/check_security_version_consistency.py` (stdlib-only drift check)
- Add `tests/unit/scripts/test_check_security_version_consistency.py` (18 comprehensive tests)
- Wire hook into `.pre-commit-config.yaml` (scoped to SECURITY.md, no collateral blocking)
- Validates exactly-one supported row and exactly-one EOL row policy
- Returns 0 when aligned, 1 when drift detected

## Verification

- All 18 unit tests pass
- Script passes against real repo: `OK: SECURITY.md supported = 0.9.x matches latest tag v0.9.*`
- Pre-commit hook passes: `Check SECURITY.md supported versions match git tags...Passed`
- House style checks pass: ruff format + ruff check

Closes #776