### PR TITLE
refactor(automation): Remove hardcoded Odysseus skip list

### DIFF
--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -73,10 +73,7 @@ def _gh_list_org_repos(org: str, *, timeout: int = 60) -> list[str]:
     except json.JSONDecodeError as exc:
         raise SystemExit(f"gh repo list returned invalid JSON: {exc}") from exc
     return sorted(
-        e["name"]
-        for e in entries
-        if not e.get("isArchived", False)
-        and not e.get("isFork", False)
+        e["name"] for e in entries if not e.get("isArchived", False) and not e.get("isFork", False)
     )
 
 

--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -39,10 +39,6 @@ from .state_labels import STATE_LABEL_SPECS
 
 logger = logging.getLogger(__name__)
 
-# Repo names to skip when iterating an org (matches loop_runner's policy: skip
-# archives, forks, and the special "Odysseus" sandbox repo).
-_SKIP_REPO_NAMES: frozenset[str] = frozenset({"Odysseus"})
-
 
 def _gh_list_org_repos(org: str, *, timeout: int = 60) -> list[str]:
     """Return non-archived, non-fork repo names for ``org``.
@@ -81,7 +77,6 @@ def _gh_list_org_repos(org: str, *, timeout: int = 60) -> list[str]:
         for e in entries
         if not e.get("isArchived", False)
         and not e.get("isFork", False)
-        and e["name"] not in _SKIP_REPO_NAMES
     )
 
 
@@ -169,10 +164,7 @@ def _build_parser() -> argparse.ArgumentParser:
     target.add_argument(
         "--org",
         metavar="ORG",
-        help=(
-            "Apply to every non-archived, non-fork repo in the org "
-            "(Odysseus is skipped, matching loop_runner)."
-        ),
+        help="Apply to every non-archived, non-fork repo in the org.",
     )
     parser.add_argument(
         "--dry-run",

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -595,10 +595,7 @@ def _gh_list_repos(org: str) -> list[str]:
     except json.JSONDecodeError as exc:
         raise SystemExit(f"gh repo list returned invalid JSON: {exc}") from exc
     return [
-        e["name"]
-        for e in entries
-        if not e.get("isArchived", False)
-        and not e.get("isFork", False)
+        e["name"] for e in entries if not e.get("isArchived", False) and not e.get("isFork", False)
     ]
 
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -567,7 +567,7 @@ def _detect_cwd_repo() -> tuple[str | None, str | None]:
 
 
 def _gh_list_repos(org: str) -> list[str]:
-    """Return non-archived, non-fork, non-Odysseus repos for ``org``."""
+    """Return non-archived, non-fork repos for ``org``."""
     try:
         out = subprocess.run(
             [
@@ -599,7 +599,6 @@ def _gh_list_repos(org: str) -> list[str]:
         for e in entries
         if not e.get("isArchived", False)
         and not e.get("isFork", False)
-        and e.get("name") != "Odysseus"
     ]
 
 

--- a/tests/unit/automation/test_ensure_state_labels.py
+++ b/tests/unit/automation/test_ensure_state_labels.py
@@ -3,8 +3,8 @@
 The script is a thin CLI wrapper around ``gh label create --force``. Tests
 mock the ``subprocess.run`` boundary and assert: (1) the right gh commands
 are built per repo and per label, (2) dry-run mutates nothing, (3) org
-enumeration filters archived/fork repos and the Odysseus sandbox, (4) the
-script is idempotent under multiple runs.
+enumeration filters archived/fork repos only — no name-based exclusion,
+(4) the script is idempotent under multiple runs.
 """
 
 from __future__ import annotations
@@ -100,7 +100,7 @@ class TestEnsureLabelsOnRepo:
 
 
 class TestGhListOrgRepos:
-    """Org enumeration filters archives, forks, and Odysseus."""
+    """Org enumeration filters archives and forks only (no name-based skip)."""
 
     def test_returns_sorted_non_archived_non_fork_names(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _ok_proc(
@@ -115,8 +115,22 @@ class TestGhListOrgRepos:
             )
         )
         names = _gh_list_org_repos("AnOrg")
-        # Sorted, archives/forks/Odysseus excluded.
-        assert names == ["ProjectAlpha", "ProjectZeta"]
+        # Sorted, archives/forks excluded. Odysseus is INCLUDED (issue #814).
+        assert names == ["Odysseus", "ProjectAlpha", "ProjectZeta"]
+
+    def test_does_not_filter_by_name(self, mock_run: MagicMock) -> None:
+        """Regression for #814: only isArchived/isFork gate inclusion, never name."""
+        mock_run.return_value = _ok_proc(
+            stdout=json.dumps(
+                [
+                    {"name": "Odysseus", "isArchived": False, "isFork": False},
+                    {"name": "Hephaestus", "isArchived": False, "isFork": False},
+                    {"name": "AnyName", "isArchived": False, "isFork": False},
+                ]
+            )
+        )
+        names = _gh_list_org_repos("AnOrg")
+        assert names == ["AnyName", "Hephaestus", "Odysseus"]
 
     def test_propagates_gh_list_failure(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _fail_proc(rc=4, stderr="rate limit")

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -760,7 +760,10 @@ def test_repos_argparse_rejects_space_separated() -> None:
 
 
 def test_gh_list_repos_filters_forks_and_archived() -> None:
-    """``isFork: true`` and ``isArchived: true`` entries are excluded."""
+    """``isFork: true`` and ``isArchived: true`` entries are excluded.
+
+    Repo names are NOT filtered — only isArchived/isFork status gates inclusion.
+    """
     payload = (
         '[{"name":"keep","isFork":false,"isArchived":false},'
         '{"name":"drop-fork","isFork":true,"isArchived":false},'
@@ -772,10 +775,26 @@ def test_gh_list_repos_filters_forks_and_archived() -> None:
             args=[], returncode=0, stdout=payload, stderr=""
         )
         names = loop_runner._gh_list_repos("MyOrg")
-    assert names == ["keep"]
+    # Odysseus is included — no name-based filtering (issue #814).
+    assert sorted(names) == ["Odysseus", "keep"]
     invoked_argv = mock_run.call_args[0][0]
     assert "--no-archived" in invoked_argv
     assert "name,isArchived,isFork" in invoked_argv
+
+
+def test_gh_list_repos_does_not_filter_by_name() -> None:
+    """Regression for #814: only isArchived/isFork gate inclusion, never name."""
+    payload = (
+        '[{"name":"Odysseus","isFork":false,"isArchived":false},'
+        '{"name":"Hephaestus","isFork":false,"isArchived":false},'
+        '{"name":"AnyName","isFork":false,"isArchived":false}]'
+    )
+    with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
+        mock_run.return_value = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=payload, stderr=""
+        )
+        names = loop_runner._gh_list_repos("MyOrg")
+    assert sorted(names) == ["AnyName", "Hephaestus", "Odysseus"]
 
 
 def test_list_open_issue_numbers_returns_all_open_sorted() -> None:


### PR DESCRIPTION
## Summary

This refactoring eliminates a single-element exclusion frozenset (`_SKIP_REPO_NAMES`) that violated DRY, YAGNI, and POLA principles by silently excluding the Odysseus repo from org-wide automation.

**Changes:**
- Remove `_SKIP_REPO_NAMES` constant from `ensure_state_labels.py`
- Remove name-based filtering from `_gh_list_repos()` and `_gh_list_org_repos()`
- Update docstrings to remove "non-Odysseus" references
- Update help text in `--org` argument
- Update tests to assert no repos are filtered by name

**After this change:** Both `_gh_list_repos()` and `_gh_list_org_repos()` return every non-archived, non-fork repo uniformly. Org-wide automation gates now apply consistently without special cases.

## Test Plan

- [x] All 1112 automation unit tests pass
- [x] Two new regression tests pin the "no name-based filtering" contract
- [x] Two existing tests updated to expect Odysseus in returned lists
- [x] Full verification: `grep -rn 'odysseus' hephaestus/` returns zero hits (excluding ecosystem list)
- [x] Full verification: `grep -rn '_SKIP_REPO_NAMES' hephaestus/` returns zero hits

Closes #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)