### PR TITLE
refactor(automation): move drive-green to post-loop terminal stage

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -222,6 +222,11 @@ class RepoResult:
     # metrics (#818). Populated only by the post-loop RepoResult returned
     # by ``_run_post_loop_stages``; per-loop RepoResults leave this empty.
     post_loop_phases: list[PhaseResult] = field(default_factory=list)
+    # True only for records produced by ``_run_post_loop_stages`` (#818).
+    # Tagging explicitly lets per-loop counting exclude post-loop records
+    # even when a crashed/uncloned repo leaves BOTH phase lists empty —
+    # emptiness alone cannot distinguish a post-loop record from a per-loop one.
+    is_post_loop: bool = False
     # Populated when the WORKER itself crashed (not a phase failure).
     runner_error: str | None = None
 
@@ -299,6 +304,13 @@ class LoopConfig:
     loops: int = 5
     max_workers: int = 3
     parallel_repos: int = 1
+    # Dataclass default is loop-body-only by design: it covers ONLY the
+    # iteration phases (``ALL_PHASES``), deliberately excluding post-loop
+    # terminal stages like drive-green. This differs from the CLI ``--phases``
+    # default (``ALL_SELECTABLE`` = loop phases + post-loop stages, set in
+    # ``_parse_args``): an operator on the CLI opts into drive-green by default,
+    # but a bare ``LoopConfig()`` (tests/programmatic callers) gets a quiet
+    # loop-only run that never touches existing PRs via ``_run_post_loop_stages``.
     phases: tuple[str, ...] = ALL_PHASES
     agent: str = "claude"
     issues: list[int] = field(default_factory=list)
@@ -1352,7 +1364,7 @@ def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]
         if _shutdown_requested():
             LOG.warning("[%s] post-loop SKIP (shutdown requested)", repo)
             break
-        result = RepoResult(repo=repo, loop_idx=cfg.loops)
+        result = RepoResult(repo=repo, loop_idx=cfg.loops, is_post_loop=True)
         repo_dir = _resolve_repo_dir(cfg.projects_dir, repo)
         if not (repo_dir / ".git").exists():
             result.runner_error = f"repo {repo} not cloned at {repo_dir}"
@@ -1477,11 +1489,12 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
     all_results.extend(post_loop_results)
 
     # Report actual loops run (may be less than cfg.loops due to early
-    # exit). Post-loop RepoResults always have non-empty post_loop_phases
-    # AND empty phases, so filtering by ``not r.post_loop_phases`` reliably
-    # excludes them — this prevents the post-loop record's loop_idx=cfg.loops
-    # from spuriously inflating the count when early-exit cut the loop short.
-    per_loop_results = [r for r in all_results if not r.post_loop_phases]
+    # exit). Post-loop RepoResults are tagged ``is_post_loop=True`` by
+    # ``_run_post_loop_stages``, so filtering on that flag reliably excludes
+    # them even when a crashed/uncloned repo leaves both phase lists empty.
+    # This prevents the post-loop record's loop_idx=cfg.loops from spuriously
+    # inflating the count when early-exit cut the loop body short.
+    per_loop_results = [r for r in all_results if not r.is_post_loop]
     actual_loops = max((r.loop_idx for r in per_loop_results), default=0)
     LOG.info(
         "✓ Completed %d of %d loop(s) across %d repo(s).",

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1,11 +1,16 @@
 """Multi-repo, multi-stage automation loop driver.
 
 Replaces ``scripts/run_automation_loop.sh``. Iterates over all
-non-archived HomericIntelligence repos, running the 3-stage pipeline
-(plan → implement → drive-green) ``--loops`` times per repo. Plan-review,
-PR-review, and address-review are no longer standalone phases — the planner
-owns its review loop and the implementer absorbs PR-review + thread-addressing
-in-loop (#455/#468/#484).
+non-archived HomericIntelligence repos. Per loop iteration, runs the
+2-phase iteration body (``plan`` → ``implement``) ``--loops`` times per
+repo. After the loop body finishes (whether by exhaustion or early-exit),
+runs the post-loop terminal stages (``drive-green``) **once per repo**.
+
+Plan-review, PR-review, and address-review are no longer standalone phases —
+the planner owns its review loop and the implementer absorbs PR-review +
+thread-addressing in-loop (#455/#468/#484). ``drive-green`` was promoted
+from "third loop phase, final-loop only" to "post-loop terminal stage" in
+#818 — it is a per-repo terminal action, not an iteration step.
 
 The key correctness invariant — and the reason this replaces the bash
 version — is that each phase is a plain ``subprocess.run`` call inside a
@@ -75,18 +80,27 @@ def _default_phase_timeout_s() -> float:
         return float(default)
 
 
-# Canonical phase ordering. The pipeline collapsed from 6 phases to 3
-# session-stable stages (#455/#468/#484): the former standalone review-plans,
-# review-prs, and address-review phases are now in-loop steps of plan/implement
-# (the planner owns its review loop; the implementer absorbs PR-review +
-# thread-addressing). Index 0 = stage 1 (plan), index 2 = stage 3 (drive-green).
+# Canonical loop-body ordering. The pipeline collapsed from 6 phases to 2
+# session-stable iteration phases (#455/#468/#484/#818): plan-review,
+# PR-review, and address-review fold into plan/implement, and drive-green
+# was promoted from "final-loop-only phase" to a post-loop terminal stage
+# (see ALL_POST_LOOP_STAGES below).
 ALL_PHASES: tuple[str, ...] = (
     "plan",
     "implement",
-    "drive-green",
 )
 
-FINAL_LOOP_ONLY_PHASES: frozenset[str] = frozenset({"drive-green"})
+# Post-loop terminal stages. Run once per repo AFTER all loop iterations
+# finish (exhaustion or early-exit). Per #818, drive-green belongs here
+# because it polls existing PRs — it is a terminal action, not an iteration
+# step. Operators select it with ``--phases drive-green`` (same flag, no
+# new arg); the runner partitions selected names into loop phases vs.
+# post-loop stages internally.
+ALL_POST_LOOP_STAGES: tuple[str, ...] = ("drive-green",)
+
+# Union used by --phases validation. Operators may select any combination
+# of loop phases and post-loop stages on the same flag.
+ALL_SELECTABLE: tuple[str, ...] = ALL_PHASES + ALL_POST_LOOP_STAGES
 
 # DEFAULT_PROJECTS_DIR is re-exported from hephaestus.config.paths so existing
 # tests that patch this module-level name continue to work. See #704: the
@@ -132,9 +146,10 @@ def _parse_issue_list(value: str) -> list[int]:
 
 
 # drive-green discovers PRs directly via gh and no longer requires an
-# input issue list (#820, #819). plan + implement auto-discover their own.
-# The set is kept (currently empty) so any future phase that genuinely
-# needs an issue list has one place to opt in.
+# input issue list (#820, #819) — see ``_count_failing_prs`` and the
+# post-loop check in ``_run_post_loop_stages``. plan + implement
+# auto-discover their own. The set is kept (currently empty) so any
+# future phase that genuinely needs an issue list has one place to opt in.
 PHASES_REQUIRING_ISSUES: frozenset[str] = frozenset()
 
 # Sentinel for cooperative shutdown on SIGINT/SIGTERM. Worker threads
@@ -202,17 +217,33 @@ class RepoResult:
     repo: str
     loop_idx: int
     phases: list[PhaseResult] = field(default_factory=list)
+    # Post-loop terminal stages (drive-green) recorded separately from
+    # per-loop ``phases`` so they don't pollute per-loop convergence
+    # metrics (#818). Populated only by the post-loop RepoResult returned
+    # by ``_run_post_loop_stages``; per-loop RepoResults leave this empty.
+    post_loop_phases: list[PhaseResult] = field(default_factory=list)
     # Populated when the WORKER itself crashed (not a phase failure).
     runner_error: str | None = None
 
     @property
     def any_failure(self) -> bool:
-        """True when any phase failed or the worker itself crashed."""
-        return self.runner_error is not None or any(p.failed for p in self.phases)
+        """True when any phase (loop or post-loop) failed or the worker crashed."""
+        return (
+            self.runner_error is not None
+            or any(p.failed for p in self.phases)
+            or any(p.failed for p in self.post_loop_phases)
+        )
 
     @property
     def produced_work(self) -> bool:
-        """Whether any convergence-relevant phase produced work."""
+        """Whether any convergence-relevant LOOP phase produced work.
+
+        Post-loop stages never count toward convergence — they are
+        terminal, not iterative — so ``post_loop_phases`` is intentionally
+        excluded here. The early-exit predicate at the end of ``run_loop``
+        operates on per-loop ``loop_results`` only, so this property is
+        never consulted on a post-loop RepoResult.
+        """
         return any(p.produced_work for p in self.phases if p.name in _CONVERGENCE_PHASES)
 
 
@@ -251,6 +282,14 @@ def _summarize_loop(loop_results: list[RepoResult], loop_idx: int, elapsed_s: fl
         f"loop {loop_idx}: planned={total_planned} implemented={total_implemented} "
         f"skipped={total_skipped} elapsed={elapsed}"
     )
+
+
+def _summarize_post_loop(results: list[RepoResult]) -> str:
+    """One-line summary of post-loop terminal stage outcomes per repo."""
+    ran = sum(1 for r in results for p in r.post_loop_phases if not p.skipped and not p.failed)
+    skipped = sum(1 for r in results for p in r.post_loop_phases if p.skipped)
+    failed = sum(1 for r in results for p in r.post_loop_phases if p.failed)
+    return f"post-loop: stages_ran={ran} skipped={skipped} failed={failed} repos={len(results)}"
 
 
 @dataclass
@@ -336,7 +375,10 @@ def _read_work_report(path: str) -> int | None:
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         prog="hephaestus-automation-loop",
-        description="Run the 3-stage automation pipeline across HomericIntelligence repos.",
+        description=(
+            "Run the 2-stage loop body and post-loop terminal stages across "
+            "HomericIntelligence repos."
+        ),
     )
     p.add_argument("--dry-run", action="store_true", help="Pass --dry-run to every phase")
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
@@ -352,8 +394,13 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p.add_argument(
         "--phases",
-        default=",".join(ALL_PHASES),
-        help=f"Comma-separated subset of phases to run. Valid: {','.join(ALL_PHASES)}",
+        default=",".join(ALL_SELECTABLE),
+        help=(
+            "Comma-separated subset of phases/stages to run. "
+            f"Valid: {','.join(ALL_SELECTABLE)} "
+            "(plan/implement are loop-body phases; drive-green is a "
+            "post-loop terminal stage that runs once per repo)."
+        ),
     )
     add_agent_argument(p)
     p.add_argument(
@@ -449,20 +496,20 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def _validate_phases(phases_csv: str) -> tuple[str, ...]:
     selected = tuple(p.strip() for p in phases_csv.split(",") if p.strip())
-    invalid = [p for p in selected if p not in ALL_PHASES]
+    invalid = [p for p in selected if p not in ALL_SELECTABLE]
     if invalid:
-        raise SystemExit(f"Unknown phase(s): {invalid}. Valid: {','.join(ALL_PHASES)}")
+        raise SystemExit(f"Unknown phase(s): {invalid}. Valid: {','.join(ALL_SELECTABLE)}")
     return selected
 
 
 def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
-    """Dependency-ordering safety warnings for the 3-stage pipeline.
+    """Dependency-ordering safety warnings for the 2-phase loop body.
 
-    Plan-review and PR-review/address-review are no longer separate phases —
-    the planner owns its review loop and the implementer absorbs PR-review +
-    thread-addressing in-loop, so the only cross-stage ordering hazard left is
-    running drive-green without implement (it would poll PRs not produced this
-    invocation).
+    Plan-review and PR-review/address-review fold into plan/implement; the
+    only remaining ordering hazard is selecting plan without implement
+    (planning-only, produces no PRs). Per #818, drive-green is a post-loop
+    terminal stage and intentionally supports being run without implement
+    ("drive existing PRs without opening new work").
     """
     warnings: list[str] = []
     selected = set(cfg.phases)
@@ -471,40 +518,7 @@ def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
             "--phases includes 'plan' but not 'implement'; this is planning-only "
             "and will not create implementation PRs"
         )
-    if "drive-green" in selected and "implement" not in selected:
-        warnings.append(
-            "--phases includes 'drive-green' but not 'implement'; "
-            "drive-green will run against PRs not touched this invocation"
-        )
     return warnings
-
-
-def _has_pending_drive_green_work(cfg: LoopConfig, repos: list[str]) -> bool:
-    """Return True when drive-green still has PRs to drive across any repo.
-
-    drive-green runs as the terminal phase AFTER the implement loop converges
-    (it is in :data:`FINAL_LOOP_ONLY_PHASES`). Early-exit must therefore not
-    fire while there is still drive-green work to do — but the mere fact that
-    drive-green is *selected* is not, by itself, pending work. We gate on
-    whether any open PR actually needs CI/merge attention, using the same
-    ``_count_failing_prs`` predicate the driver uses so the gate cannot drift.
-
-    When drive-green is not selected, there is no terminal work to wait for.
-    Returns ``True`` (conservatively keep looping) when at least one repo has a
-    failing/un-green PR.
-    """
-    if "drive-green" not in cfg.phases:
-        return False
-    # An explicit --issues scope pins the work set to specific PRs/issues, but
-    # ``_count_failing_prs`` scans ALL open repo PRs (it has no issue filter), so
-    # it's the wrong signal here — a clean repo-wide scan would wrongly say "no
-    # pending work" and let the loop converge before the terminal drive-green
-    # pass runs against the pinned issues. Keep looping (defer to --loops as the
-    # bound) rather than early-exiting and abandoning the operator's explicit
-    # drive-green work.
-    if cfg.issues:
-        return True
-    return any(_count_failing_prs(cfg.org, repo) > 0 for repo in repos)
 
 
 # ---------------------------------------------------------------------------
@@ -1170,31 +1184,6 @@ def _process_repo_inner(
             )
             continue
 
-        # Some phases only run on the configured final loop. Mirrors bash behavior.
-        if phase in FINAL_LOOP_ONLY_PHASES and loop_idx != cfg.loops:
-            LOG.info("[%s] phase %s SKIP (not final loop)", repo, phase)
-            result.phases.append(
-                PhaseResult(name=phase, skipped=True, skip_reason="not final loop")
-            )
-            continue
-
-        if phase in PHASES_REQUIRING_ISSUES and not open_issues:
-            LOG.info("[%s] phase %s SKIP (no open issues)", repo, phase)
-            result.phases.append(
-                PhaseResult(name=phase, skipped=True, skip_reason="no open issues")
-            )
-            continue
-
-        if phase == "drive-green" and not cfg.issues:
-            failing = _count_failing_prs(cfg.org, repo)
-            if failing == 0:
-                LOG.info("[%s] phase %s SKIP (no failing PRs)", repo, phase)
-                result.phases.append(
-                    PhaseResult(name=phase, skipped=True, skip_reason="no failing PRs")
-                )
-                continue
-            LOG.info("[%s] phase %s has %d failing PR(s) — running", repo, phase, failing)
-
         phase_result = run_phase(
             repo=repo,
             repo_dir=repo_dir,
@@ -1312,6 +1301,102 @@ def _maybe_sleep_for_rate_budget(loop_idx: int, total_loops: int) -> None:
         time.sleep(min(1.0, deadline - time.monotonic()))
 
 
+def _post_loop_stage_skip_reason(
+    cfg: LoopConfig, repo: str, stage: str, open_issues: list[int]
+) -> str | None:
+    """Return a skip reason for ``stage`` in repo ``repo``, or ``None`` to run.
+
+    Encapsulates the per-stage work-discovery gates so ``_run_post_loop_stages``
+    stays under the project complexity budget. Matches the in-loop gating used
+    pre-#818 plus the issue-list gate retained for any future stage opting in
+    via :data:`PHASES_REQUIRING_ISSUES`.
+    """
+    if stage in PHASES_REQUIRING_ISSUES and not open_issues:
+        return "no open issues"
+    # drive-green discovers failing PRs directly (#819 / PR #1060).
+    # When --issues pins specific PRs, defer to drive-green itself.
+    if stage == "drive-green" and not cfg.issues:
+        failing = _count_failing_prs(cfg.org, repo)
+        if failing == 0:
+            return "no failing PRs"
+        LOG.info("[%s] stage %s has %d failing PR(s) — running", repo, stage, failing)
+    return None
+
+
+def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
+    """Run post-loop terminal stages (drive-green) once per repo.
+
+    Iterates ``repos`` sequentially (no thread pool) — post-loop stages are
+    terminal and per-repo, so concurrent execution offers no benefit and
+    risks two workers hitting the same PRs. Returns a list of RepoResult
+    with ``loop_idx=cfg.loops`` and ``post_loop_phases`` populated. Any
+    repo-level exception is captured in ``runner_error`` so the helper
+    never raises to the caller (parity with ``process_repo``).
+
+    The ``loop_idx=cfg.loops`` argument to ``run_phase`` deliberately makes
+    ``_phase_env`` set ``HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS`` for the
+    child process — this IS the terminal pass, so the existing env contract
+    naturally produces the correct values without any drive-green-specific
+    branch.
+    """
+    selected_post = [s for s in ALL_POST_LOOP_STAGES if s in cfg.phases]
+    if not selected_post:
+        return []
+
+    LOG.info("━" * 60)
+    LOG.info("▶ POST-LOOP STAGES: %s", ",".join(selected_post))
+    LOG.info("━" * 60)
+
+    results: list[RepoResult] = []
+    for repo in repos:
+        if _shutdown_requested():
+            LOG.warning("[%s] post-loop SKIP (shutdown requested)", repo)
+            break
+        result = RepoResult(repo=repo, loop_idx=cfg.loops)
+        repo_dir = _resolve_repo_dir(cfg.projects_dir, repo)
+        if not (repo_dir / ".git").exists():
+            result.runner_error = f"repo {repo} not cloned at {repo_dir}"
+            results.append(result)
+            continue
+        try:
+            trunk_sha, _fetch_ok = _rebase_main(repo, repo_dir)
+            open_issues = cfg.issues or _list_open_issue_numbers(cfg.org, repo)
+            for stage in selected_post:
+                skip_reason = _post_loop_stage_skip_reason(cfg, repo, stage, open_issues)
+                if skip_reason is not None:
+                    LOG.info("[%s] stage %s SKIP (%s)", repo, stage, skip_reason)
+                    result.post_loop_phases.append(
+                        PhaseResult(name=stage, skipped=True, skip_reason=skip_reason)
+                    )
+                    continue
+                stage_result = run_phase(
+                    repo=repo,
+                    repo_dir=repo_dir,
+                    phase=stage,
+                    cfg=cfg,
+                    loop_idx=cfg.loops,
+                    open_issues=open_issues,
+                    trunk_sha=trunk_sha,
+                )
+                result.post_loop_phases.append(stage_result)
+                if stage_result.failed:
+                    LOG.warning(
+                        "[%s] post-loop stage %s FAILED rc=%d — retry with: "
+                        "hephaestus-automation-loop --phases %s --repos %s --loops 1",
+                        repo,
+                        stage,
+                        stage_result.rc,
+                        stage,
+                        repo,
+                    )
+        except Exception as exc:
+            tb = traceback.format_exc()
+            result.runner_error = f"{type(exc).__name__}: {exc}\n{tb}"
+            LOG.error("[%s] post-loop runner crashed: %s", repo, exc)
+        results.append(result)
+    return results
+
+
 def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
     """Drive ``cfg.loops`` iterations across ``repos``. Returns flat result list.
 
@@ -1365,24 +1450,19 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
         LOG.info("%s", _summarize_loop(loop_results, loop_idx, elapsed_s))
         LOG.info("Loop %d complete.", loop_idx)
 
-        # Early-exit: the pipeline has converged when the full pass across ALL
-        # repos produced zero new plan work, no failures, AND there is no
-        # remaining drive-green work (every open PR is green / already
-        # state:implementation-go). drive-green is the terminal phase that runs
-        # after the implement loop converges, so we stop as soon as there are no
-        # plans to make and no PRs left to drive — rather than spinning out the
-        # full --loops just because drive-green is selected. --loops stays an
-        # upper bound. (#614; convergence-on-no-pending-PR refinement.)
+        # Early-exit: when the full pass across ALL repos produced zero
+        # convergence-relevant work (0 new plans) and no failures, the
+        # iteration body has converged. Post-loop stages still run after
+        # the break (see below). --loops remains an upper bound. (#614/#818)
         if (
             loop_idx < cfg.loops
-            and not _has_pending_drive_green_work(cfg, repos)
             and not any(r.any_failure for r in loop_results)
             and not any(r.produced_work for r in loop_results)
         ):
             LOG.info(
                 "Early exit after loop %d/%d: full pass produced 0 new plans"
-                " across all %d repo(s) and no open PR needs drive-green."
-                " Remaining loops skipped.",
+                " across all %d repo(s). Remaining loops skipped;"
+                " post-loop stages will still run.",
                 loop_idx,
                 cfg.loops,
                 len(repos),
@@ -1391,14 +1471,26 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
 
         _maybe_sleep_for_rate_budget(loop_idx, cfg.loops)
 
-    # Report actual loops run (may be less than cfg.loops due to early exit)
-    actual_loops = max((r.loop_idx for r in all_results), default=0)
+    # Post-loop terminal stages run once per repo regardless of how the
+    # iteration body exited (exhaustion or early-exit). Per #818.
+    post_loop_results = _run_post_loop_stages(cfg, repos)
+    all_results.extend(post_loop_results)
+
+    # Report actual loops run (may be less than cfg.loops due to early
+    # exit). Post-loop RepoResults always have non-empty post_loop_phases
+    # AND empty phases, so filtering by ``not r.post_loop_phases`` reliably
+    # excludes them — this prevents the post-loop record's loop_idx=cfg.loops
+    # from spuriously inflating the count when early-exit cut the loop short.
+    per_loop_results = [r for r in all_results if not r.post_loop_phases]
+    actual_loops = max((r.loop_idx for r in per_loop_results), default=0)
     LOG.info(
         "✓ Completed %d of %d loop(s) across %d repo(s).",
         actual_loops,
         cfg.loops,
         len(repos),
     )
+    if post_loop_results:
+        LOG.info("%s", _summarize_post_loop(post_loop_results))
     return all_results
 
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1345,11 +1345,11 @@ def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]
     repo-level exception is captured in ``runner_error`` so the helper
     never raises to the caller (parity with ``process_repo``).
 
-    The ``loop_idx=cfg.loops`` argument to ``run_phase`` deliberately makes
-    ``_phase_env`` set ``HEPH_LOOP_INDEX == HEPH_TOTAL_LOOPS`` for the
-    child process — this IS the terminal pass, so the existing env contract
-    naturally produces the correct values without any drive-green-specific
-    branch.
+    Post-loop stages run ``run_phase`` with ``loop_idx=cfg.loops`` to mark
+    this as the terminal pass. The old ``HEPH_LOOP_INDEX``/``HEPH_TOTAL_LOOPS``
+    env-gating contract was removed in #820/#1061, so ``_phase_env`` no longer
+    injects loop-index env vars for any phase; the post-loop semantics are now
+    expressed purely by this dedicated terminal stage rather than via env vars.
     """
     selected_post = [s for s in ALL_POST_LOOP_STAGES if s in cfg.phases]
     if not selected_post:

--- a/tests/unit/automation/test_drive_green_pr_discovery.py
+++ b/tests/unit/automation/test_drive_green_pr_discovery.py
@@ -15,7 +15,6 @@ from hephaestus.automation.loop_runner import (
     PhaseResult,
     _build_phase_argv,
     _count_failing_prs,
-    process_repo,
 )
 
 
@@ -173,23 +172,34 @@ class TestBuildPhaseArgv:
         assert argv[issues_idx + 1 : issues_idx + 3] == ["123", "456"]
 
 
-class TestProcessRepoSkipLogic:
-    """Tests for drive-green SKIP logic in process_repo."""
+class TestPostLoopDriveGreenSkipLogic:
+    """Tests for drive-green SKIP logic in ``_run_post_loop_stages`` (post-#818).
+
+    drive-green moved out of the loop body and into the post-loop terminal
+    stage. The same work-discovery gate (``_count_failing_prs``, --issues
+    override) now lives in ``_run_post_loop_stages`` rather than
+    ``process_repo``; these tests pin that invariant at the new home.
+    """
 
     def test_drive_green_skips_with_reason_no_failing_prs(
         self, repo_inputs: tuple[Path, LoopConfig]
     ) -> None:
         """drive-green SKIPs with reason 'no failing PRs' when no failing PRs exist."""
-        _, cfg = repo_inputs
-        cfg = LoopConfig(phases=("drive-green",), loops=1, projects_dir=cfg.projects_dir)
+        projects, cfg = repo_inputs
+        cfg = LoopConfig(phases=("drive-green",), loops=1, projects_dir=projects)
         with (
             patch.object(loop_runner, "_rebase_main", return_value=("deadbee", True)),
             patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
             patch.object(loop_runner, "_count_failing_prs", return_value=0),
+            patch.object(
+                loop_runner,
+                "_resolve_repo_dir",
+                side_effect=lambda pd, r: pd / r,
+            ),
             patch.object(loop_runner, "run_phase") as mock_run,
         ):
-            result = process_repo("r", loop_idx=1, cfg=cfg)
-        drive_green = next(p for p in result.phases if p.name == "drive-green")
+            results = loop_runner._run_post_loop_stages(cfg, ["r"])
+        drive_green = next(p for p in results[0].post_loop_phases if p.name == "drive-green")
         assert drive_green.skipped
         assert drive_green.skip_reason == "no failing PRs"
         mock_run.assert_not_called()
@@ -198,35 +208,45 @@ class TestProcessRepoSkipLogic:
         self, repo_inputs: tuple[Path, LoopConfig]
     ) -> None:
         """drive-green RUNS when failing PRs exist but no issues are scoped."""
-        _, cfg = repo_inputs
-        cfg = LoopConfig(phases=("drive-green",), loops=1, projects_dir=cfg.projects_dir)
+        projects, cfg = repo_inputs
+        cfg = LoopConfig(phases=("drive-green",), loops=1, projects_dir=projects)
         with (
             patch.object(loop_runner, "_rebase_main", return_value=("deadbee", True)),
             patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
             patch.object(loop_runner, "_count_failing_prs", return_value=3),
+            patch.object(
+                loop_runner,
+                "_resolve_repo_dir",
+                side_effect=lambda pd, r: pd / r,
+            ),
             patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
         ):
-            result = process_repo("r", loop_idx=1, cfg=cfg)
-        drive_green = next(p for p in result.phases if p.name == "drive-green")
+            results = loop_runner._run_post_loop_stages(cfg, ["r"])
+        drive_green = next(p for p in results[0].post_loop_phases if p.name == "drive-green")
         assert not drive_green.skipped
 
     def test_drive_green_runs_when_operator_scoped_issues_present(
         self, repo_inputs: tuple[Path, LoopConfig]
     ) -> None:
         """drive-green RUNS when operator passes --issues, regardless of failing PR count."""
-        _, cfg = repo_inputs
+        projects, cfg = repo_inputs
         cfg = LoopConfig(
             issues=[10],
             phases=("drive-green",),
             loops=1,
-            projects_dir=cfg.projects_dir,
+            projects_dir=projects,
         )
         with (
             patch.object(loop_runner, "_rebase_main", return_value=("deadbee", True)),
             patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
             patch.object(loop_runner, "_count_failing_prs", return_value=0),
+            patch.object(
+                loop_runner,
+                "_resolve_repo_dir",
+                side_effect=lambda pd, r: pd / r,
+            ),
             patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
         ):
-            result = process_repo("r", loop_idx=1, cfg=cfg)
-        drive_green = next(p for p in result.phases if p.name == "drive-green")
+            results = loop_runner._run_post_loop_stages(cfg, ["r"])
+        drive_green = next(p for p in results[0].post_loop_phases if p.name == "drive-green")
         assert not drive_green.skipped

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -47,13 +47,15 @@ from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 
 def test_all_phases_is_three_stage_pipeline() -> None:
-    """The pipeline collapsed to exactly (plan, implement, drive-green).
+    """The loop body collapsed to exactly (plan, implement); drive-green moved post-loop.
 
-    Plan-review, PR-review, and address-review are no longer standalone phases;
-    they fold into plan/implement. This pins the canonical topology so a stray
-    re-introduction of a retired phase fails loudly.
+    Plan-review, PR-review, and address-review fold into plan/implement
+    (#455/#468/#484); drive-green moved to ALL_POST_LOOP_STAGES (#818).
     """
-    assert ALL_PHASES == ("plan", "implement", "drive-green")
+    from hephaestus.automation.loop_runner import ALL_POST_LOOP_STAGES
+
+    assert ALL_PHASES == ("plan", "implement")
+    assert ALL_POST_LOOP_STAGES == ("drive-green",)
 
 
 @pytest.mark.parametrize("dropped", ["review-plans", "review-prs", "address-review"])
@@ -102,11 +104,12 @@ def test_validate_phases_rejects_typo() -> None:
         _validate_phases("plan,implmnt")
 
 
-def test_phase_order_warnings_drive_green_without_implement_warns() -> None:
-    """drive-green selected without implement triggers the cross-stage warning."""
-    cfg = LoopConfig(phases=("drive-green",))
-    warnings = _phase_order_warnings(cfg)
-    assert any("drive-green" in w and "implement" in w for w in warnings)
+def test_phase_order_warnings_drive_green_no_longer_warns() -> None:
+    """Per #818, drive-green without implement is a legitimate operator intent."""
+    cfg_alone = LoopConfig(phases=("drive-green",))
+    cfg_with = LoopConfig(phases=("implement", "drive-green"))
+    assert all("drive-green" not in w for w in _phase_order_warnings(cfg_alone))
+    assert all("drive-green" not in w for w in _phase_order_warnings(cfg_with))
 
 
 def test_phase_order_warnings_plan_without_implement_warns() -> None:
@@ -114,12 +117,6 @@ def test_phase_order_warnings_plan_without_implement_warns() -> None:
     cfg = LoopConfig(phases=("plan",))
     warnings = _phase_order_warnings(cfg)
     assert any("planning-only" in w and "implementation PRs" in w for w in warnings)
-
-
-def test_phase_order_warnings_drive_green_with_implement_silent() -> None:
-    """drive-green selected alongside implement produces no warning."""
-    cfg = LoopConfig(phases=("implement", "drive-green"))
-    assert _phase_order_warnings(cfg) == []
 
 
 def test_phase_order_warnings_silent_on_full_pipeline() -> None:
@@ -395,51 +392,6 @@ def test_process_repo_skips_disabled_phases(repo_inputs: tuple[Path, LoopConfig]
     for name in ALL_PHASES[1:]:
         assert by_name[name].skipped
         assert by_name[name].skip_reason == "disabled by --phases"
-
-
-def test_process_repo_skips_issue_phases_when_no_issues(
-    repo_inputs: tuple[Path, LoopConfig],
-) -> None:
-    """Process repo no longer gates plan/implement on an issue list (#820).
-
-    PHASES_REQUIRING_ISSUES is empty, so only drive-green has a work gate
-    (the failing-PR gate). plan and implement auto-discover and still run.
-    """
-    _, cfg = repo_inputs
-    with (
-        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
-        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
-        patch.object(loop_runner, "_count_failing_prs", return_value=0),
-        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
-    ):
-        result = process_repo("r", loop_idx=1, cfg=cfg)
-    by_name = {p.name: p for p in result.phases}
-    # drive-green has no failing PRs to drive, so it skips.
-    assert by_name["drive-green"].skipped
-    assert by_name["drive-green"].skip_reason == "no failing PRs"
-    # plan and implement auto-discover, so they still run
-    assert not by_name["plan"].skipped
-    assert not by_name["implement"].skipped
-
-
-def test_process_repo_skips_drive_green_on_non_final_loop(
-    repo_inputs: tuple[Path, LoopConfig],
-) -> None:
-    """Process repo skips drive green on non final loop."""
-    _, cfg = repo_inputs
-    cfg = LoopConfig(loops=3, projects_dir=cfg.projects_dir)
-    with (
-        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
-        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
-        patch.object(loop_runner, "_count_failing_prs", return_value=1),
-        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
-    ):
-        result_loop1 = process_repo("r", loop_idx=1, cfg=cfg)
-        result_loop3 = process_repo("r", loop_idx=3, cfg=cfg)
-    drive_green_loop1 = next(p for p in result_loop1.phases if p.name == "drive-green")
-    drive_green_loop3 = next(p for p in result_loop3.phases if p.name == "drive-green")
-    assert drive_green_loop1.skipped and drive_green_loop1.skip_reason == "not final loop"
-    assert not drive_green_loop3.skipped
 
 
 def test_process_repo_logs_trunk_stale_when_fetch_fails(

--- a/tests/unit/automation/test_loop_runner_early_exit.py
+++ b/tests/unit/automation/test_loop_runner_early_exit.py
@@ -439,31 +439,9 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=5, projects_dir=projects, phases=("plan", "implement"))
-
-        call_count = 0
-
-        def fake_process(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
-            nonlocal call_count
-            call_count += 1
-            return _zero_work_result(repo, loop_idx)
-
-        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
-            results = run_loop(cfg, repos=["r1"])
-
-        # Only loop 1 should have run — early-exit fires immediately.
-        assert max(r.loop_idx for r in results) == 1
-        assert call_count == 1
-
-    def test_no_early_exit_while_drive_green_has_failing_prs(self, tmp_path: Path) -> None:
-        """drive-green selected + a failing PR blocks early-exit before the final loop.
-
-        Even with 0 new plan work, the loop must keep going while there is still
-        drive-green work (an open PR that isn't green / implementation-go) to do.
-        """
-        projects = tmp_path
-        (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=3, projects_dir=projects)  # default phases incl. drive-green
+        cfg = LoopConfig(
+            loops=5, projects_dir=projects, phases=("plan", "implement"), org="testorg"
+        )
 
         call_count = 0
 
@@ -474,13 +452,48 @@ class TestRunLoopEarlyExit:
 
         with (
             patch.object(loop_runner, "process_repo", side_effect=fake_process),
-            patch.object(loop_runner, "_count_failing_prs", return_value=1),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
         ):
             results = run_loop(cfg, repos=["r1"])
 
-        # A failing PR keeps the loop running to the cap.
-        assert max(r.loop_idx for r in results) == 3
-        assert call_count == 3
+        # Only loop 1 should have run — early-exit fires immediately.
+        assert max(r.loop_idx for r in results) == 1
+        assert call_count == 1
+
+    def test_early_exit_still_fires_with_post_loop_drive_green_selected(
+        self, tmp_path: Path
+    ) -> None:
+        """Per #818: drive-green is post-loop, so its selection does NOT block early-exit.
+
+        Pre-#818 this test asserted that selecting drive-green prevented early-exit
+        before loop 3 (so the final-loop-only phase could fire). With drive-green
+        promoted to a post-loop terminal stage, early-exit fires after loop 1
+        on a zero-work pass — drive-green is invoked AFTER the iteration body
+        by ``_run_post_loop_stages`` regardless. The loop_runner_post_loop.py
+        suite asserts the post-loop invocation; this test pins the early-exit
+        behaviour for the loop body itself.
+        """
+        projects = tmp_path
+        (projects / "r1" / ".git").mkdir(parents=True)
+        cfg = LoopConfig(loops=3, projects_dir=projects, org="testorg")
+
+        call_count = 0
+
+        def fake_process(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
+            nonlocal call_count
+            call_count += 1
+            return _zero_work_result(repo, loop_idx)
+
+        with (
+            patch.object(loop_runner, "process_repo", side_effect=fake_process),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
+        ):
+            results = run_loop(cfg, repos=["r1"])
+
+        # Early-exit fires on loop 1 even with drive-green selected.
+        per_loop = [r for r in results if not r.post_loop_phases]
+        assert max(r.loop_idx for r in per_loop) == 1
+        assert call_count == 1
 
     def test_early_exit_when_drive_green_selected_but_no_failing_prs(self, tmp_path: Path) -> None:
         """drive-green selected but NO failing PR + 0 plan work → converge early.
@@ -517,12 +530,15 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=3, projects_dir=projects)
+        cfg = LoopConfig(loops=3, projects_dir=projects, org="testorg")
 
         def fake_process(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
             return _work_result(repo, loop_idx)
 
-        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
+        with (
+            patch.object(loop_runner, "process_repo", side_effect=fake_process),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
+        ):
             results = run_loop(cfg, repos=["r1"])
 
         assert max(r.loop_idx for r in results) == 3
@@ -536,7 +552,7 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=3, projects_dir=projects)
+        cfg = LoopConfig(loops=3, projects_dir=projects, org="testorg")
 
         call_count = 0
 
@@ -545,7 +561,10 @@ class TestRunLoopEarlyExit:
             call_count += 1
             return _failed_result(repo, loop_idx)
 
-        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
+        with (
+            patch.object(loop_runner, "process_repo", side_effect=fake_process),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
+        ):
             results = run_loop(cfg, repos=["r1"])
 
         # All 3 loops must run — failure blocks early-exit.
@@ -560,12 +579,15 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=1, projects_dir=projects)
+        cfg = LoopConfig(loops=1, projects_dir=projects, org="testorg")
 
         def fake_process(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
             return _zero_work_result(repo, loop_idx)
 
-        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
+        with (
+            patch.object(loop_runner, "process_repo", side_effect=fake_process),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
+        ):
             results = run_loop(cfg, repos=["r1"])
 
         # Exactly one result — the single configured loop ran to completion.
@@ -580,12 +602,15 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=3, projects_dir=projects)
+        cfg = LoopConfig(loops=3, projects_dir=projects, org="testorg")
 
         def fake_process(repo: str, loop_idx: int, cfg: LoopConfig) -> RepoResult:
             return _unknown_work_result(repo, loop_idx)
 
-        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
+        with (
+            patch.object(loop_runner, "process_repo", side_effect=fake_process),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
+        ):
             results = run_loop(cfg, repos=["r1"])
 
         # All 3 loops run because unknown phases are treated as productive.
@@ -599,7 +624,7 @@ class TestRunLoopEarlyExit:
         projects = tmp_path
         for repo in ("r1", "r2"):
             (projects / repo / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=5, projects_dir=projects)
+        cfg = LoopConfig(loops=5, projects_dir=projects, org="testorg")
 
         call_counts: dict[str, int] = {"r1": 0, "r2": 0}
 
@@ -611,7 +636,10 @@ class TestRunLoopEarlyExit:
             # r2 produces no work
             return _zero_work_result(repo, loop_idx)
 
-        with patch.object(loop_runner, "process_repo", side_effect=fake_process):
+        with (
+            patch.object(loop_runner, "process_repo", side_effect=fake_process),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
+        ):
             results = run_loop(cfg, repos=["r1", "r2"])
 
         # All 5 loops should run because r1 is always productive.
@@ -853,34 +881,10 @@ class TestPlannerMainWorkReport:
         assert captured["work"] == 0
 
 
-class TestHasPendingDriveGreenWork:
-    """Convergence gate: drive-green pending-work detection (#1128 review)."""
-
-    def test_not_selected_returns_false(self) -> None:
-        """No drive-green phase → no terminal work to wait for."""
-        cfg = LoopConfig(phases=("plan", "implement"))
-        assert loop_runner._has_pending_drive_green_work(cfg, ["r1"]) is False
-
-    def test_explicit_issues_keeps_looping(self) -> None:
-        """--issues scope → keep looping (repo-wide PR scan is the wrong signal).
-
-        ``_count_failing_prs`` has no issue filter, so a clean repo-wide scan
-        would wrongly converge before the terminal drive-green pass runs against
-        the pinned issues. Must return True and must NOT call _count_failing_prs.
-        """
-        cfg = LoopConfig(issues=[7, 8])  # default phases include drive-green
-        with patch.object(loop_runner, "_count_failing_prs") as mock_count:
-            assert loop_runner._has_pending_drive_green_work(cfg, ["r1"]) is True
-        mock_count.assert_not_called()
-
-    def test_failing_pr_means_pending(self) -> None:
-        """A failing PR in any repo → pending drive-green work."""
-        cfg = LoopConfig()  # default phases, no --issues
-        with patch.object(loop_runner, "_count_failing_prs", side_effect=[0, 2]):
-            assert loop_runner._has_pending_drive_green_work(cfg, ["r1", "r2"]) is True
-
-    def test_no_failing_pr_means_converged(self) -> None:
-        """All repos green → no pending drive-green work (loop may converge)."""
-        cfg = LoopConfig()
-        with patch.object(loop_runner, "_count_failing_prs", return_value=0):
-            assert loop_runner._has_pending_drive_green_work(cfg, ["r1", "r2"]) is False
+# NOTE: ``TestHasPendingDriveGreenWork`` was removed when #818 promoted
+# drive-green out of the loop body and into the post-loop terminal stage
+# (``_run_post_loop_stages``). The "still has failing PRs" gate now lives
+# inside that helper as a per-stage skip-reason (covered by
+# ``tests/unit/automation/test_loop_runner_post_loop.py::``
+# ``test_run_post_loop_stages_skips_when_no_failing_prs``), so the function
+# under test (``_has_pending_drive_green_work``) no longer exists.

--- a/tests/unit/automation/test_loop_runner_early_exit.py
+++ b/tests/unit/automation/test_loop_runner_early_exit.py
@@ -475,7 +475,12 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=3, projects_dir=projects, org="testorg")
+        cfg = LoopConfig(
+            loops=3,
+            projects_dir=projects,
+            org="testorg",
+            phases=("plan", "implement", "drive-green"),
+        )
 
         call_count = 0
 
@@ -504,7 +509,10 @@ class TestRunLoopEarlyExit:
         """
         projects = tmp_path
         (projects / "r1" / ".git").mkdir(parents=True)
-        cfg = LoopConfig(loops=5, projects_dir=projects)  # default phases incl. drive-green
+        # Default phases are loop-body-only (``ALL_PHASES`` = plan, implement);
+        # drive-green is NOT in the bare-``LoopConfig()`` default post-#818, so
+        # the post-loop block is exercised separately and stubbed out here.
+        cfg = LoopConfig(loops=5, projects_dir=projects)
 
         call_count = 0
 
@@ -515,7 +523,7 @@ class TestRunLoopEarlyExit:
 
         with (
             patch.object(loop_runner, "process_repo", side_effect=fake_process),
-            patch.object(loop_runner, "_count_failing_prs", return_value=0),
+            patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
         ):
             results = run_loop(cfg, repos=["r1"])
 

--- a/tests/unit/automation/test_loop_runner_post_loop.py
+++ b/tests/unit/automation/test_loop_runner_post_loop.py
@@ -214,12 +214,21 @@ def test_plan_without_implement_still_warns() -> None:
     assert any("plan" in w and "implement" in w for w in warnings)
 
 
-def test_post_loop_phase_env_marks_terminal(tmp_path: Path) -> None:
-    """_phase_env called with loop_idx=cfg.loops produces terminal env vars."""
+def test_post_loop_phase_env_omits_loop_index(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Post-loop drive-green env no longer carries loop-index vars (#820/#1061).
+
+    The HEPH_LOOP_INDEX/HEPH_TOTAL_LOOPS env-gating contract was removed; the
+    terminal-pass semantics are expressed by the dedicated post-loop stage, not
+    by env vars, so even ``loop_idx=cfg.loops`` must not inject them.
+    """
+    monkeypatch.delenv("HEPH_LOOP_INDEX", raising=False)
+    monkeypatch.delenv("HEPH_TOTAL_LOOPS", raising=False)
     cfg = _cfg(tmp_path, loops=5)
     env = loop_runner._phase_env(cfg, loop_idx=cfg.loops, trunk_sha="abc", phase="drive-green")
-    assert env["HEPH_LOOP_INDEX"] == "5"
-    assert env["HEPH_TOTAL_LOOPS"] == "5"
+    assert "HEPH_LOOP_INDEX" not in env
+    assert "HEPH_TOTAL_LOOPS" not in env
 
 
 def test_validate_phases_accepts_all_selectable() -> None:

--- a/tests/unit/automation/test_loop_runner_post_loop.py
+++ b/tests/unit/automation/test_loop_runner_post_loop.py
@@ -1,0 +1,274 @@
+"""Tests for post-loop terminal stages (drive-green) (#818)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.automation import loop_runner
+from hephaestus.automation.loop_runner import (
+    ALL_PHASES,
+    ALL_POST_LOOP_STAGES,
+    ALL_SELECTABLE,
+    LoopConfig,
+    PhaseResult,
+)
+
+
+def _ok(name: str, work_units: int = 0) -> PhaseResult:
+    return PhaseResult(name=name, rc=0, work_units=work_units)
+
+
+def _cfg(tmp_path: Path, **overrides: object) -> LoopConfig:
+    projects = tmp_path / "Projects"
+    projects.mkdir()
+    base: dict[str, object] = {"projects_dir": projects, "org": "testorg"}
+    base.update(overrides)
+    return LoopConfig(**base)  # type: ignore[arg-type]
+
+
+def _patch_run_loop_externals(calls: list):
+    """Patch external collaborators of run_loop so tests are hermetic."""
+
+    def _record(**kw):
+        calls.append((kw["loop_idx"], kw["repo"], kw["phase"]))
+        return _ok(kw["phase"], work_units=0)
+
+    return [
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        # Post-merge: drive-green's work-discovery gate is _count_failing_prs
+        # (#819). Return >0 so the post-loop stage actually invokes run_phase.
+        patch.object(loop_runner, "_count_failing_prs", return_value=1),
+        patch.object(
+            loop_runner,
+            "_resolve_repo_dir",
+            side_effect=lambda projects_dir, repo: projects_dir / repo,
+        ),
+        patch.object(loop_runner, "_clone_missing_repos"),
+        patch.object(loop_runner, "_preflight_token_scopes"),
+        patch.object(loop_runner, "run_phase", side_effect=_record),
+    ]
+
+
+def _ensure_repo_dirs(cfg: LoopConfig, repos: list[str]) -> None:
+    for r in repos:
+        (cfg.projects_dir / r / ".git").mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Symbol-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_all_phases_excludes_drive_green() -> None:
+    """ALL_PHASES is (plan, implement); drive-green is a post-loop stage."""
+    assert ALL_PHASES == ("plan", "implement")
+    assert ALL_POST_LOOP_STAGES == ("drive-green",)
+    assert ALL_SELECTABLE == ("plan", "implement", "drive-green")
+
+
+def test_final_loop_only_symbols_removed() -> None:
+    """Regression: FINAL_LOOP_ONLY_PHASES and _has_pending_final_loop_phase deleted."""
+    assert not hasattr(loop_runner, "FINAL_LOOP_ONLY_PHASES")
+    assert not hasattr(loop_runner, "_has_pending_final_loop_phase")
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 1: drive-green alone, loops>1
+# ---------------------------------------------------------------------------
+
+
+def test_drive_green_alone_runs_once_per_repo_loops_5(tmp_path: Path) -> None:
+    """`--phases drive-green --loops 5` → drive-green once per repo, no loop phases."""
+    cfg = _cfg(tmp_path, loops=5, phases=("drive-green",))
+    repos = ["r1", "r2"]
+    _ensure_repo_dirs(cfg, repos)
+    calls: list = []
+    cms = _patch_run_loop_externals(calls)
+    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+        results = loop_runner.run_loop(cfg, repos)
+    dg_calls = [c for c in calls if c[2] == "drive-green"]
+    loop_phase_calls = [c for c in calls if c[2] in ALL_PHASES]
+    assert sorted(c[1] for c in dg_calls) == ["r1", "r2"], dg_calls
+    assert loop_phase_calls == [], loop_phase_calls
+    # Recorded under post_loop_phases, not phases
+    post = [(r.repo, p.name) for r in results for p in r.post_loop_phases]
+    assert sorted(post) == [("r1", "drive-green"), ("r2", "drive-green")]
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 2: drive-green alongside loop phases, runs once
+# ---------------------------------------------------------------------------
+
+
+def test_drive_green_with_loop_phases_runs_once_per_repo(tmp_path: Path) -> None:
+    """Default `--loops 5` (plan+implement+drive-green) → drive-green once per repo."""
+    cfg = _cfg(tmp_path, loops=3, phases=ALL_SELECTABLE)
+    repos = ["r1"]
+    _ensure_repo_dirs(cfg, repos)
+    calls: list = []
+
+    def _record(**kw):
+        calls.append((kw["loop_idx"], kw["repo"], kw["phase"]))
+        # plan reports work to keep early-exit from firing
+        wu = 1 if kw["phase"] == "plan" else 0
+        return PhaseResult(name=kw["phase"], rc=0, work_units=wu)
+
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        patch.object(loop_runner, "_count_failing_prs", return_value=1),
+        patch.object(loop_runner, "_resolve_repo_dir", side_effect=lambda pd, r: pd / r),
+        patch.object(loop_runner, "_clone_missing_repos"),
+        patch.object(loop_runner, "_preflight_token_scopes"),
+        patch.object(loop_runner, "run_phase", side_effect=_record),
+    ):
+        loop_runner.run_loop(cfg, repos)
+    dg = [c for c in calls if c[2] == "drive-green"]
+    plan = [c for c in calls if c[2] == "plan"]
+    impl = [c for c in calls if c[2] == "implement"]
+    assert len(dg) == 1, dg
+    assert len(plan) == 3, plan
+    assert len(impl) == 3, impl
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 3: --phases plan,implement does NOT invoke drive-green
+# ---------------------------------------------------------------------------
+
+
+def test_phases_plan_implement_does_not_invoke_drive_green(tmp_path: Path) -> None:
+    """`--phases plan,implement --loops 5` → no drive-green anywhere."""
+    cfg = _cfg(tmp_path, loops=5, phases=("plan", "implement"))
+    repos = ["r1", "r2"]
+    _ensure_repo_dirs(cfg, repos)
+    calls: list = []
+    cms = _patch_run_loop_externals(calls)
+    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+        results = loop_runner.run_loop(cfg, repos)
+    assert all(c[2] != "drive-green" for c in calls), calls
+    assert all(not r.post_loop_phases for r in results), results
+
+
+def test_phases_plan_only_does_not_invoke_drive_green(tmp_path: Path) -> None:
+    """`--phases plan` → no drive-green anywhere."""
+    cfg = _cfg(tmp_path, loops=3, phases=("plan",))
+    repos = ["r1"]
+    _ensure_repo_dirs(cfg, repos)
+    calls: list = []
+    cms = _patch_run_loop_externals(calls)
+    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+        results = loop_runner.run_loop(cfg, repos)
+    assert all(c[2] != "drive-green" for c in calls), calls
+    assert all(not r.post_loop_phases for r in results), results
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion 4: early-exit on loop 1 still runs post-loop drive-green
+# ---------------------------------------------------------------------------
+
+
+def test_early_exit_loop_1_still_runs_post_loop_drive_green(tmp_path: Path) -> None:
+    """Early-exit (zero-work) on loop 1 still triggers post-loop drive-green per repo."""
+    cfg = _cfg(tmp_path, loops=5, phases=ALL_SELECTABLE)
+    repos = ["r1", "r2"]
+    _ensure_repo_dirs(cfg, repos)
+    calls: list = []
+    cms = _patch_run_loop_externals(calls)  # all phases report work_units=0
+    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+        loop_runner.run_loop(cfg, repos)
+    plan_calls = [c for c in calls if c[2] == "plan"]
+    dg_calls = [c for c in calls if c[2] == "drive-green"]
+    # Early-exit fires after loop 1 → plan invoked exactly once per repo
+    assert sorted(c[1] for c in plan_calls) == ["r1", "r2"], plan_calls
+    # Post-loop drive-green still runs once per repo
+    assert sorted(c[1] for c in dg_calls) == ["r1", "r2"], dg_calls
+
+
+# ---------------------------------------------------------------------------
+# Other regressions
+# ---------------------------------------------------------------------------
+
+
+def test_drive_green_without_implement_no_warning() -> None:
+    """Drive-green without implement is now legitimate, not a warning."""
+    cfg = LoopConfig(phases=("drive-green",))
+    warnings = loop_runner._phase_order_warnings(cfg)
+    assert all("drive-green" not in w for w in warnings), warnings
+
+
+def test_drive_green_with_implement_still_no_warning() -> None:
+    """Drive-green + implement also produces no warning."""
+    cfg = LoopConfig(phases=("implement", "drive-green"))
+    warnings = loop_runner._phase_order_warnings(cfg)
+    assert all("drive-green" not in w for w in warnings), warnings
+
+
+def test_plan_without_implement_still_warns() -> None:
+    """Plan-only configuration still emits the predecessor warning."""
+    cfg = LoopConfig(phases=("plan",))
+    warnings = loop_runner._phase_order_warnings(cfg)
+    assert any("plan" in w and "implement" in w for w in warnings)
+
+
+def test_post_loop_phase_env_marks_terminal(tmp_path: Path) -> None:
+    """_phase_env called with loop_idx=cfg.loops produces terminal env vars."""
+    cfg = _cfg(tmp_path, loops=5)
+    env = loop_runner._phase_env(cfg, loop_idx=cfg.loops, trunk_sha="abc", phase="drive-green")
+    assert env["HEPH_LOOP_INDEX"] == "5"
+    assert env["HEPH_TOTAL_LOOPS"] == "5"
+
+
+def test_validate_phases_accepts_all_selectable() -> None:
+    """_validate_phases accepts loop phases and post-loop stages."""
+    assert loop_runner._validate_phases("plan,implement,drive-green") == (
+        "plan",
+        "implement",
+        "drive-green",
+    )
+    assert loop_runner._validate_phases("drive-green") == ("drive-green",)
+    with pytest.raises(SystemExit):
+        loop_runner._validate_phases("nonexistent")
+
+
+def test_run_post_loop_stages_skips_when_no_failing_prs(tmp_path: Path) -> None:
+    """drive-green is skipped with reason 'no failing PRs' when nothing needs CI driving.
+
+    Post-merge with #819 / PR #1060, drive-green's work-discovery gate is
+    ``_count_failing_prs`` rather than the open-issues list — drive-green
+    polls existing PRs and there is no work when every PR is already green.
+    """
+    cfg = _cfg(tmp_path, loops=1, phases=("drive-green",))
+    repos = ["r1"]
+    _ensure_repo_dirs(cfg, repos)
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        patch.object(loop_runner, "_count_failing_prs", return_value=0),
+        patch.object(loop_runner, "_resolve_repo_dir", side_effect=lambda pd, r: pd / r),
+        patch.object(loop_runner, "run_phase") as run_phase_mock,
+    ):
+        results = loop_runner._run_post_loop_stages(cfg, repos)
+    run_phase_mock.assert_not_called()
+    assert len(results) == 1
+    assert len(results[0].post_loop_phases) == 1
+    assert results[0].post_loop_phases[0].skipped is True
+    assert results[0].post_loop_phases[0].skip_reason == "no failing PRs"
+
+
+def test_run_post_loop_stages_records_crash_in_runner_error(tmp_path: Path) -> None:
+    """An exception in the helper is captured in runner_error, not propagated."""
+    cfg = _cfg(tmp_path, loops=1, phases=("drive-green",))
+    repos = ["r1"]
+    _ensure_repo_dirs(cfg, repos)
+    with (
+        patch.object(loop_runner, "_rebase_main", side_effect=RuntimeError("boom")),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
+        patch.object(loop_runner, "_resolve_repo_dir", side_effect=lambda pd, r: pd / r),
+    ):
+        results = loop_runner._run_post_loop_stages(cfg, repos)
+    assert len(results) == 1
+    assert "RuntimeError: boom" in (results[0].runner_error or "")


### PR DESCRIPTION
## Summary

Refactor `loop_runner.py` so `drive-green` transitions from "third loop phase, final-loop only" to a dedicated post-loop terminal stage that runs once per repo *after* all loop iterations (including early-exit). This fixes the unreachable code issue: `--phases drive-green --loops N` now correctly runs `drive-green` once per repo regardless of N, with no spurious "not final loop" skips on loops 1..N-1.

## Test Plan

- [x] All 142 tests pass (89 existing + 39 early-exit + 14 new post-loop)
- [x] mypy: no errors
- [x] ruff: all checks passed
- [x] Acceptance criterion 1: `--phases drive-green --loops 5` runs drive-green once per repo
- [x] Acceptance criterion 2: `--loops 5` default runs plan+implement loop, then drive-green once per repo (including on early-exit)
- [x] Acceptance criterion 3: `--phases plan,implement --loops 5` does NOT invoke drive-green
- [x] Acceptance criterion 4: Early-exit on loop 1 still triggers post-loop drive-green per repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #818