### PR TITLE
feat(automation): scope PR discovery to viewer-authored PRs by default

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -54,6 +54,7 @@ from .git_utils import (
     sync_worktree_to_remote_branch,
 )
 from .github_api import (
+    GitHubUnavailableError,
     _gh_call,
     gh_issue_json,
     gh_pr_checks,
@@ -405,7 +406,11 @@ class CIDriver:
             return self._viewer_login
         try:
             result = _gh_call(["api", "user", "-q", ".login"], check=True)
-        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            GitHubUnavailableError,
+        ) as exc:
             raise RuntimeError(
                 "Could not resolve viewer login via `gh api user`: "
                 f"{exc}. Re-authenticate with `gh auth login`, or pass "
@@ -438,8 +443,17 @@ class CIDriver:
 
         Returns:
             Mapping of ``pr_number -> pr_number`` for every open bot PR.
-            Empty dict if the lookup fails or returns nothing — bot
-            discovery must never abort the drive.
+            Empty dict if the ``gh api`` pulls lookup fails or returns
+            nothing — bot discovery must never abort the drive on a list
+            failure.
+
+        Raises:
+            RuntimeError: When the default @me author filter is active
+                (``--all`` not set) and viewer-login resolution fails. This
+                fail-CLOSED abort is intentional per #821 (POLA): a broken
+                ``gh auth`` must never silently widen scope to every author's
+                PRs. Pass ``--all`` to opt out of the filter and bypass the
+                resolver entirely.
 
         """
         try:

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -131,6 +131,11 @@ class CIDriver:
         # arming record (and therefore its own /learn capture once the PR
         # actually merges in a subsequent run). #840 +on top of #834.
         self.shared_pr_issues: dict[int, list[int]] = {}
+        # Viewer login cache (#821). Resolved lazily on first use of the
+        # author filter; empty string means "not yet resolved". When
+        # options.include_all_authors=True the filter is bypassed and this
+        # stays empty so a broken `gh auth` does not block --all runs.
+        self._viewer_login: str = ""
 
     def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # thread pool + finally + preserve report
         """Run the CI driver on all configured issues.
@@ -331,8 +336,12 @@ class CIDriver:
 
         # The REST shape exposes ``head.ref`` and ``auto_merge`` (snake_case);
         # normalise to the gh-CLI shape consumers downstream already use.
+        viewer = "" if self.options.include_all_authors else self._resolve_viewer_login()
         normalised: list[dict[str, Any]] = []
         for pr in raw_pulls:
+            user = pr.get("user") or {}
+            if viewer and user.get("login") != viewer:
+                continue  # #821: hide other-author PRs from the done-gate sweep
             labels = pr.get("labels") or []
             normalised.append(
                 {
@@ -343,7 +352,7 @@ class CIDriver:
                     "labels": [
                         label.get("name", "") for label in labels if isinstance(label, dict)
                     ],
-                    "isBot": (pr.get("user") or {}).get("type") == "Bot",
+                    "isBot": user.get("type") == "Bot",
                 }
             )
         return normalised
@@ -384,6 +393,33 @@ class CIDriver:
         # Re-list so the final gate sees the freshly-armed PRs as armed_pending
         # rather than needs_action.
         return self._list_open_prs_remaining()
+
+    def _resolve_viewer_login(self) -> str:
+        """Return the authenticated `gh api user` login. Fail CLOSED on error.
+
+        Lazy + cached: only called when the author filter is active. Raises
+        ``RuntimeError`` with operator guidance on any failure so a broken
+        `gh` auth never silently widens scope to all PRs (#821 POLA).
+        """
+        if self._viewer_login:
+            return self._viewer_login
+        try:
+            result = _gh_call(["api", "user", "-q", ".login"], check=True)
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            raise RuntimeError(
+                "Could not resolve viewer login via `gh api user`: "
+                f"{exc}. Re-authenticate with `gh auth login`, or pass "
+                "--all to opt out of the @me filter (#821)."
+            ) from exc
+        login = (result.stdout or "").strip()
+        if not login:
+            raise RuntimeError(
+                "Could not resolve viewer login via `gh api user`: "
+                "empty response. Re-authenticate with `gh auth login`, "
+                "or pass --all to opt out of the @me filter (#821)."
+            )
+        self._viewer_login = login
+        return login
 
     def _discover_bot_prs(self) -> dict[int, int]:
         """Enumerate every open ``is_bot=true`` PR on the repo (#848).
@@ -431,11 +467,14 @@ class CIDriver:
             logger.info("Bot-PR discovery skipped: gh api failed (%s)", exc)
             return {}
 
+        viewer = "" if self.options.include_all_authors else self._resolve_viewer_login()
         bot_prs: dict[int, int] = {}
         for pr in raw_pulls:
             user = pr.get("user") or {}
             if user.get("type") != "Bot":
                 continue
+            if viewer and user.get("login") != viewer:
+                continue  # #821: not viewer-owned and --all not set
             number = pr.get("number")
             if isinstance(number, int):
                 bot_prs[number] = number
@@ -3092,6 +3131,9 @@ Examples:
 
   # Verbose
   %(prog)s -v
+
+  # Drive every open PR, including teammates' and bots' (default is @me only)
+  %(prog)s --all
         """,
     )
 
@@ -3153,6 +3195,19 @@ Examples:
             "unions every open is_bot=true PR with the issue-driven list so "
             "Dependabot PRs are not architecturally invisible (#848). Pass "
             "this flag only when you explicitly want issue-driven scope."
+        ),
+    )
+    parser.add_argument(
+        "--all",
+        dest="include_all_authors",
+        action="store_true",
+        default=False,
+        help=(
+            "Include PRs opened by other actors (teammates, bots). Without "
+            "this flag, only PRs authored by the authenticated viewer "
+            "(`gh api user`) are driven (#821). NOTE: when scoped to issues "
+            "(--issues N), the resolved PR is processed regardless of "
+            "author — issue-scoped takes precedence."
         ),
     )
     parser.add_argument(
@@ -3267,6 +3322,7 @@ def main() -> int:
             enable_ui=not args.no_ui and not args.json,
             verbose=args.verbose,
             include_bot_prs=args.include_bot_prs,
+            include_all_authors=args.include_all_authors,
             enable_mechanical_rebase=args.enable_mechanical_rebase,
         )
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -266,6 +266,7 @@ class LoopConfig:
     dry_run: bool = False
     no_advise: bool = False
     nitpick: bool = False
+    drive_green_all: bool = False
     allow_unsafe_phase_order: bool = False
     # ``model`` is the catch-all applied to every phase when set; per-phase
     # fields below take precedence over it. The /learn step is not a separate
@@ -374,6 +375,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--nitpick",
         action="store_true",
         help="Pass --nitpick to review phases (reviewer emits nitpick comments)",
+    )
+    p.add_argument(
+        "--drive-green-all",
+        action="store_true",
+        help=(
+            "Pass --all to the drive-green phase: drive every open PR, "
+            "including those opened by teammates and bots. By default "
+            "drive-green operates only on PRs authored by the authenticated "
+            "viewer (#821)."
+        ),
     )
     p.add_argument(
         "--allow-unsafe-phase-order",
@@ -997,6 +1008,9 @@ def _build_phase_argv(
     if isinstance(threshold, int) and loop_idx >= threshold:
         argv.append("--no-follow-up")
 
+    if phase == "drive-green" and cfg.drive_green_all:
+        argv.append("--all")
+
     return argv
 
 
@@ -1500,6 +1514,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         dry_run=args.dry_run,
         no_advise=args.no_advise,
         nitpick=args.nitpick,
+        drive_green_all=args.drive_green_all,
         allow_unsafe_phase_order=args.allow_unsafe_phase_order,
         model=args.model,
         planner_model=args.planner_model,

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -267,6 +267,12 @@ class CIDriverOptions(BaseModel):
     # etc.) carry no ``Closes #N`` link so they are architecturally invisible
     # to issue-driven discovery; without this they leak forever.
     include_bot_prs: bool = True
+    # When False (default, #821), discovery is restricted to PRs whose
+    # author.login matches the authenticated `gh api user` viewer login.
+    # Set True via the CLI's --all flag to drive every open PR (teammates'
+    # and bots' included). Issue-scoped lookups (`--issues N`) bypass this
+    # filter — they always resolve to the matching PR regardless of author.
+    include_all_authors: bool = False
     # When True (default), _drive_issue first attempts a mechanical ``git
     # rebase`` onto the base branch for PRs that are behind/conflicting, pushing
     # the result with --force-with-lease — no agent spend. Only PRs whose rebase

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -490,6 +490,7 @@ class TestOpenPrsRemaining:
         """Empty paginated response → ``open_prs_remaining`` is empty."""
         # gh api --paginate emits a concatenated JSON array; an empty repo
         # surfaces as ``[]``. The driver must read this as "done".
+        driver.options.include_all_authors = True  # #821: this test verifies empty-list handling, not author scope
         result_mock = MagicMock(stdout="[]")
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
@@ -502,6 +503,7 @@ class TestOpenPrsRemaining:
         """REST snake_case fields are normalised to the gh-CLI camelCase shape."""
         # gh api returns the GitHub REST shape (``head.ref``, ``auto_merge``);
         # downstream consumers in this module expect gh-CLI shape.
+        driver.options.include_all_authors = True  # #821: this test verifies normalization, not author scope
         rest_pulls = [
             {
                 "number": 1,
@@ -549,6 +551,7 @@ class TestOpenPrsRemaining:
         # The conservative default: if we can't list open PRs we don't claim
         # the repo is clean. ``main()`` reads non-empty open_prs_remaining as
         # a failure.
+        driver.options.include_all_authors = True  # #821: this test verifies gh-failure handling, not author scope
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
             patch(
@@ -565,6 +568,7 @@ class TestOpenPrsRemaining:
         """The call must include ``--paginate`` so all open PRs are returned, not 100."""
         # Without --paginate a repo with 200 open dependabot PRs would falsely
         # pass the done-check after looking at only 100.
+        driver.options.include_all_authors = True  # #821: this test verifies pagination, not author scope
         result_mock = MagicMock(stdout="[]")
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
@@ -1938,6 +1942,7 @@ class TestBotPrDiscovery:
     """``_discover_bot_prs`` and ``_discover_prs`` bot-mode union."""
 
     def test_no_bot_prs_returns_empty(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.options.include_all_authors = True  # #821: this test verifies empty-list handling, not author scope
         with (
             patch(
                 "hephaestus.automation.ci_driver.get_repo_info",
@@ -1951,6 +1956,7 @@ class TestBotPrDiscovery:
             assert driver._discover_bot_prs() == {}
 
     def test_bot_prs_returned_as_self_keyed_map(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.options.include_all_authors = True  # #821: this test verifies bot-type filter, not author scope
         raw = [
             {"number": 100, "user": {"type": "Bot", "login": "app/dependabot"}},
             {"number": 101, "user": {"type": "User", "login": "alice"}},
@@ -1971,6 +1977,7 @@ class TestBotPrDiscovery:
         assert result == {100: 100, 102: 102}
 
     def test_gh_failure_returns_empty(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.options.include_all_authors = True  # #821: this test verifies gh-failure handling, not author scope
         with (
             patch(
                 "hephaestus.automation.ci_driver.get_repo_info",

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -490,7 +490,8 @@ class TestOpenPrsRemaining:
         """Empty paginated response → ``open_prs_remaining`` is empty."""
         # gh api --paginate emits a concatenated JSON array; an empty repo
         # surfaces as ``[]``. The driver must read this as "done".
-        driver.options.include_all_authors = True  # #821: this test verifies empty-list handling, not author scope
+        # #821: this test verifies empty-list handling, not author scope.
+        driver.options.include_all_authors = True
         result_mock = MagicMock(stdout="[]")
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
@@ -503,7 +504,8 @@ class TestOpenPrsRemaining:
         """REST snake_case fields are normalised to the gh-CLI camelCase shape."""
         # gh api returns the GitHub REST shape (``head.ref``, ``auto_merge``);
         # downstream consumers in this module expect gh-CLI shape.
-        driver.options.include_all_authors = True  # #821: this test verifies normalization, not author scope
+        # #821: this test verifies normalization, not author scope.
+        driver.options.include_all_authors = True
         rest_pulls = [
             {
                 "number": 1,
@@ -551,7 +553,8 @@ class TestOpenPrsRemaining:
         # The conservative default: if we can't list open PRs we don't claim
         # the repo is clean. ``main()`` reads non-empty open_prs_remaining as
         # a failure.
-        driver.options.include_all_authors = True  # #821: this test verifies gh-failure handling, not author scope
+        # #821: this test verifies gh-failure handling, not author scope.
+        driver.options.include_all_authors = True
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
             patch(
@@ -568,7 +571,8 @@ class TestOpenPrsRemaining:
         """The call must include ``--paginate`` so all open PRs are returned, not 100."""
         # Without --paginate a repo with 200 open dependabot PRs would falsely
         # pass the done-check after looking at only 100.
-        driver.options.include_all_authors = True  # #821: this test verifies pagination, not author scope
+        # #821: this test verifies pagination, not author scope.
+        driver.options.include_all_authors = True
         result_mock = MagicMock(stdout="[]")
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
@@ -1942,7 +1946,8 @@ class TestBotPrDiscovery:
     """``_discover_bot_prs`` and ``_discover_prs`` bot-mode union."""
 
     def test_no_bot_prs_returns_empty(self, driver: CIDriver, tmp_path: Path) -> None:
-        driver.options.include_all_authors = True  # #821: this test verifies empty-list handling, not author scope
+        # #821: this test verifies empty-list handling, not author scope.
+        driver.options.include_all_authors = True
         with (
             patch(
                 "hephaestus.automation.ci_driver.get_repo_info",
@@ -1956,7 +1961,8 @@ class TestBotPrDiscovery:
             assert driver._discover_bot_prs() == {}
 
     def test_bot_prs_returned_as_self_keyed_map(self, driver: CIDriver, tmp_path: Path) -> None:
-        driver.options.include_all_authors = True  # #821: this test verifies bot-type filter, not author scope
+        # #821: this test verifies bot-type filter, not author scope.
+        driver.options.include_all_authors = True
         raw = [
             {"number": 100, "user": {"type": "Bot", "login": "app/dependabot"}},
             {"number": 101, "user": {"type": "User", "login": "alice"}},
@@ -1977,7 +1983,8 @@ class TestBotPrDiscovery:
         assert result == {100: 100, 102: 102}
 
     def test_gh_failure_returns_empty(self, driver: CIDriver, tmp_path: Path) -> None:
-        driver.options.include_all_authors = True  # #821: this test verifies gh-failure handling, not author scope
+        # #821: this test verifies gh-failure handling, not author scope.
+        driver.options.include_all_authors = True
         with (
             patch(
                 "hephaestus.automation.ci_driver.get_repo_info",

--- a/tests/unit/automation/test_ci_driver_author_scope.py
+++ b/tests/unit/automation/test_ci_driver_author_scope.py
@@ -1,0 +1,217 @@
+"""Author-scope tests for CIDriver discovery (#821)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation.ci_driver import CIDriver
+from hephaestus.automation.models import CIDriverOptions
+
+
+@pytest.fixture
+def mock_options() -> CIDriverOptions:
+    """Minimal options for author-scope tests. Mirrors test_ci_driver.py:54."""
+    return CIDriverOptions(
+        issues=[123],
+        max_workers=1,
+        dry_run=False,
+        enable_ui=False,
+        enable_advise=False,
+        max_fix_iterations=1,
+    )
+
+
+@pytest.fixture
+def driver(mock_options: CIDriverOptions, tmp_path: Path) -> CIDriver:
+    """CIDriver with mocked repo root. Mirrors test_ci_driver.py:74."""
+    with (
+        patch("hephaestus.automation.ci_driver.get_repo_root", return_value=tmp_path),
+        patch("hephaestus.automation.ci_driver.WorktreeManager"),
+        patch("hephaestus.automation.ci_driver.StatusTracker"),
+    ):
+        d = CIDriver(mock_options)
+        d.state_dir = tmp_path
+        return d
+
+
+@pytest.fixture
+def viewer_driver(driver: CIDriver) -> CIDriver:
+    """Driver with viewer login pre-cached to 'mvillmow' so filter is deterministic."""
+    driver._viewer_login = "mvillmow"
+    return driver
+
+
+# Mixed-author /pulls payload — note `login` keys on every fixture PR.
+_MIXED_PULLS = [
+    {
+        "number": 100,
+        "user": {"type": "User", "login": "mvillmow"},
+        "auto_merge": None,
+        "title": "mine",
+        "head": {"ref": "b1"},
+        "labels": [],
+    },
+    {
+        "number": 101,
+        "user": {"type": "User", "login": "alice"},
+        "auto_merge": None,
+        "title": "alice",
+        "head": {"ref": "b2"},
+        "labels": [],
+    },
+    {
+        "number": 102,
+        "user": {"type": "Bot", "login": "dependabot[bot]"},
+        "auto_merge": None,
+        "title": "bot",
+        "head": {"ref": "b3"},
+        "labels": [],
+    },
+]
+
+
+class TestDefaultScopedDiscovery:
+    """include_all_authors=False (default) hides non-viewer PRs."""
+
+    def test_bot_pr_discovery_filters_to_viewer(self, viewer_driver: CIDriver) -> None:
+        viewer_driver.options.include_all_authors = False
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
+            ),
+        ):
+            assert viewer_driver._discover_bot_prs() == {}
+
+    def test_open_prs_remaining_filters_to_viewer(self, viewer_driver: CIDriver) -> None:
+        viewer_driver.options.include_all_authors = False
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
+            ),
+        ):
+            remaining = viewer_driver._list_open_prs_remaining()
+        assert [pr["number"] for pr in remaining] == [100]
+
+
+class TestAllFlagScopedDiscovery:
+    """include_all_authors=True (--all) restores broad discovery."""
+
+    def test_bot_pr_discovery_returns_all_bots(self, driver: CIDriver) -> None:
+        driver.options.include_all_authors = True
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
+            ),
+        ):
+            assert driver._discover_bot_prs() == {102: 102}
+
+    def test_open_prs_remaining_returns_all_prs(self, driver: CIDriver) -> None:
+        driver.options.include_all_authors = True
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
+            ),
+        ):
+            remaining = driver._list_open_prs_remaining()
+        assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]
+
+
+class TestIssueScopedOverridesAuthor:
+    """`--issues N` bypasses the author filter (AC9)."""
+
+    def test_explicit_issue_with_other_author_pr(self, viewer_driver: CIDriver) -> None:
+        viewer_driver.options.include_all_authors = False
+        with (
+            patch.object(viewer_driver, "_find_pr_for_issue", return_value=101),
+            patch.object(viewer_driver, "_discover_bot_prs", return_value={}),
+        ):
+            assert viewer_driver._discover_prs([814]) == {814: 101}
+
+
+class TestResolveViewerLogin:
+    """Viewer login resolution is lazy, cached, and fails CLOSED."""
+
+    def test_resolve_caches_value(self, driver: CIDriver) -> None:
+        driver._viewer_login = ""  # reset
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call", return_value=MagicMock(stdout="mvillmow\n")
+        ) as mock_gh:
+            assert driver._resolve_viewer_login() == "mvillmow"
+            assert driver._resolve_viewer_login() == "mvillmow"
+        assert mock_gh.call_count == 1
+
+    def test_resolve_failure_raises_runtimeerror(self, driver: CIDriver) -> None:
+        driver._viewer_login = ""
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call",
+            side_effect=subprocess.CalledProcessError(1, ["gh"]),
+        ):
+            with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
+                driver._resolve_viewer_login()
+
+    def test_resolve_empty_stdout_raises(self, driver: CIDriver) -> None:
+        driver._viewer_login = ""
+        with patch("hephaestus.automation.ci_driver._gh_call", return_value=MagicMock(stdout="")):
+            with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
+                driver._resolve_viewer_login()
+
+    def test_resolve_gh_not_installed_raises(self, driver: CIDriver) -> None:
+        driver._viewer_login = ""
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call",
+            side_effect=FileNotFoundError("gh not on PATH"),
+        ):
+            with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
+                driver._resolve_viewer_login()
+
+
+class TestAllFlagSkipsViewerResolution:
+    """When --all is set, viewer resolution is not required."""
+
+    def test_discover_bot_prs_under_all_does_not_call_resolver(self, driver: CIDriver) -> None:
+        driver.options.include_all_authors = True
+        with (
+            patch.object(
+                driver,
+                "_resolve_viewer_login",
+                side_effect=RuntimeError("should not be called"),
+            ),
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
+            ),
+        ):
+            assert driver._discover_bot_prs() == {102: 102}
+
+    def test_list_open_prs_remaining_under_all_does_not_call_resolver(
+        self, driver: CIDriver
+    ) -> None:
+        driver.options.include_all_authors = True
+        with (
+            patch.object(
+                driver,
+                "_resolve_viewer_login",
+                side_effect=RuntimeError("should not be called"),
+            ),
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
+            ),
+        ):
+            remaining = driver._list_open_prs_remaining()
+        assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]

--- a/tests/unit/automation/test_ci_driver_author_scope.py
+++ b/tests/unit/automation/test_ci_driver_author_scope.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation.ci_driver import CIDriver
+from hephaestus.automation.github_api import GitHubUnavailableError
 from hephaestus.automation.models import CIDriverOptions
 
 
@@ -173,6 +174,21 @@ class TestResolveViewerLogin:
         with patch(
             "hephaestus.automation.ci_driver._gh_call",
             side_effect=FileNotFoundError("gh not on PATH"),
+        ):
+            with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
+                driver._resolve_viewer_login()
+
+    def test_resolve_breaker_open_raises_with_guidance(self, driver: CIDriver) -> None:
+        """Open circuit breaker still fails CLOSED with operator guidance.
+
+        ``GitHubUnavailableError`` (raised when the breaker opens) is mapped
+        to a ``RuntimeError`` carrying the `gh auth login` / --all guidance
+        rather than propagating raw (#821).
+        """
+        driver._viewer_login = ""
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call",
+            side_effect=GitHubUnavailableError("circuit breaker open"),
         ):
             with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
                 driver._resolve_viewer_login()

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -179,14 +179,19 @@ class TestRunGateWithPrs:
         options = CIDriverOptions(issues=[], prs=[661], include_bot_prs=False)
         driver = CIDriver(options)
 
-        # Mock _discover_prs, _sweep_orphaned_arming_records, and _drive_issue
-        # to avoid network I/O (circuit breaker would trip on real _gh_call).
+        # Mock _discover_prs, _sweep_orphaned_arming_records, _drive_issue, and
+        # _list_open_prs_remaining to avoid network I/O (circuit breaker would
+        # trip on real _gh_call). The post-drive done-check
+        # (_list_open_prs_remaining) resolves the viewer login via `gh api user`
+        # under the default @me author filter (#821); without gh auth (CI) that
+        # raises, so it must be mocked here alongside the other I/O paths.
         # Return a proper WorkerResult so run() can call result.success without error.
         fake_result = WorkerResult(issue_number=661, success=True)
         with patch.object(driver, "_discover_prs", return_value={661: 661}) as mock_discover:
             with patch.object(driver, "_sweep_orphaned_arming_records"):
                 with patch.object(driver, "_drive_issue", return_value=fake_result):
-                    driver.run()
+                    with patch.object(driver, "_list_open_prs_remaining", return_value=[]):
+                        driver.run()
 
         # Verify the gate did not abort by checking that _discover_prs was called
         mock_discover.assert_called_once()

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -677,6 +677,30 @@ def test_build_phase_argv_plan_uses_parallel_worker_flag() -> None:
     assert argv[argv.index("--parallel") + 1] == "4"
 
 
+def test_build_phase_argv_drive_green_default_omits_all_flag() -> None:
+    """Default drive-green (no --drive-green-all) omits --all flag (#821)."""
+    cfg = LoopConfig(phases=("drive-green",))
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
+        argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[1], loop_idx=1)
+    assert argv is not None and "--all" not in argv
+
+
+def test_build_phase_argv_drive_green_all_flag_appends_all() -> None:
+    """--drive-green-all flag appends --all to drive-green phase argv (#821)."""
+    cfg = LoopConfig(phases=("drive-green",), drive_green_all=True)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
+        argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[1], loop_idx=1)
+    assert argv is not None and "--all" in argv
+
+
+def test_build_phase_argv_drive_green_all_flag_not_passed_to_other_phases() -> None:
+    """--drive-green-all flag only affects drive-green phase, not others (#821)."""
+    cfg = LoopConfig(phases=("implement",), drive_green_all=True)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
+        argv = loop_runner._build_phase_argv("implement", cfg, open_issues=[1], loop_idx=1)
+    assert argv is not None and "--all" not in argv
+
+
 def test_phase_env_does_not_inject_loop_index_envs(monkeypatch: pytest.MonkeyPatch) -> None:
     """Loop env vars are no longer injected for any phase (#820)."""
     # _phase_env copies os.environ; clean any ambient vars so the assertion


### PR DESCRIPTION
## Summary

Implement @me-only scoping for `drive_prs_green.py` with `--all` flag for opt-in broad discovery. Default discovery filters to PRs where `author.login` matches the authenticated `gh api user`; `--all` bypasses the filter. Issue-scoped PRs (`--issues N`) bypass the author filter so issue-specific invocations always drive the matching PR regardless of author. Add `--drive-green-all` flag to loop-runner for passing `--all` through to drive-green phase. Filter applied at discovery time via lazy, cached viewer-login resolution with fail-CLOSED semantics.

## Test plan

- [x] All 1124 existing automation unit tests pass
- [x] New test class `TestDefaultScopedDiscovery` verifies author filter blocks non-viewer PRs
- [x] New test class `TestAllFlagScopedDiscovery` verifies `--all` broadens discovery to all PRs
- [x] New test class `TestIssueScopedOverridesAuthor` verifies `--issues N` bypasses author filter
- [x] New test class `TestResolveViewerLogin` verifies lazy, cached, fail-CLOSED resolution
- [x] New test class `TestAllFlagSkipsViewerResolution` verifies `--all` skips resolver entirely
- [x] Three new loop-runner tests verify `--drive-green-all` flag behavior
- [x] Seven existing ci_driver tests patched to preserve test intent under new author filter
- [x] `pixi run mypy`: Success with no issues
- [x] `pixi run ruff check`: All checks pass
- [x] `pixi run ruff format`: Formatting verified

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)