### PR TITLE
docs: clarify PR review process reflects actual pr-policy gate

### DIFF
--- a/.claude/workflows/development.md
+++ b/.claude/workflows/development.md
@@ -13,10 +13,10 @@ This file describes the typical development workflow for ProjectHephaestus.
 
 ## Code Review Process
 
-1. **Automated Checks**: All PRs must pass pre-commit hooks
-2. **Peer Review**: At least one other developer review required
-3. **Security Review**: Security-sensitive changes require special attention
-4. **Merge**: Use squash merge strategy with auto-merge enabled (`gh pr merge --auto --squash`)
+1. **Automated Checks**: All PRs must pass pre-commit hooks and the required CI status checks (`test (ubuntu-latest, 3.12, unit)` and `test (ubuntu-latest, 3.12, integration)`).
+2. **PR Policy Gate**: The `pr-policy` CI gate enforces three invariants — the PR body contains `Closes #<issue-number>`, auto-merge is enabled, and every commit is cryptographically signed (`git commit -S`). See `CLAUDE.md` §"Working with GitHub" for the canonical policy.
+3. **Optional Human Review**: This repo has no `required_pull_request_reviews` branch protection rule, so human review is optional. Security-sensitive changes should still be reviewed by a maintainer before auto-merge fires.
+4. **Merge**: Use squash merge strategy with auto-merge enabled (`gh pr merge --auto --squash`). Rebase merges are disabled at the repo level.
 
 ## Testing Workflow
 


### PR DESCRIPTION
## Summary

Updated `.claude/workflows/development.md` to accurately reflect the actual merge gate enforced by this repo — the required CI status checks (`pr-policy` gate) plus the three invariants from CLAUDE.md (signed commits, `Closes #<issue-number>` in PR body, and auto-merge squash) — and removed the misleading "At least one other developer review required" claim, which contradicts both the actual branch protection rules and the single-maintainer git history.

The PR policy gate is automated; human review is optional, not required.

Closes #760