### PR TITLE
fix(automation): surface git fetch failures in automation loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,36 @@ with `--help` to see full usage.
 | `hephaestus-ensure-state-labels` | Idempotently provision `state:needs-plan` / `state:plan-no-go` / `state:plan-go` labels on one or more repos |
 | `hephaestus-audit-prs` | Audit ALL open PRs in one coordinator agent invocation |
 
+#### Running the automation loop from a source checkout (macOS / Codex)
+
+When `hephaestus-automation-loop` is not installed on `PATH` (fresh source
+checkout) and Claude is not installed, invoke the loop through `uv` and pin
+Codex as the agent:
+
+```bash
+# Prerequisites
+command -v uv             # uv installed
+command -v codex && codex login status   # Codex authenticated
+command -v gh && gh auth status          # gh authenticated
+
+# Title-scoped loop over open "nitpick" / "minor" issues
+issues=$(
+  gh issue list --state open --limit 500 --json number,title \
+    --jq '.[] | select((.title | ascii_downcase) | test("(^|[^a-z0-9_])(nitpick|minor)([^a-z0-9_]|$)")) | .number' \
+  | sort -n -u | paste -sd, -
+)
+
+test -n "$issues" \
+  && uv run hephaestus-automation-loop --issues "$issues" --agent codex \
+  || echo "No open nitpick/minor title issues found"
+```
+
+If the pre-loop `git fetch` is denied (e.g. macOS sandboxing returns
+`error: cannot open .git/FETCH_HEAD: Operation not permitted`) the loop now
+logs a WARNING and renders the trunk line as `[Repo] trunk=<sha> (stale)`
+so the refresh failure is visible rather than silently treated as a clean
+sync (#993).
+
 ### GitHub
 
 | Command | Description |

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -784,22 +784,50 @@ def _local_ahead_count(repo: str, repo_dir: Path, base_ref: str) -> int:
         return 0
 
 
-def _rebase_main(repo: str, repo_dir: Path) -> str:
-    """Fetch + rebase the remote default branch; return short trunk SHA."""
-    # The fetch touches the network, so route it through resilient_call:
-    # transient failures retry with backoff and a genuine stall is capped by
-    # NETWORK_TIMEOUT (#684). A timeout after retries is non-fatal here — the
-    # subsequent rebase against a stale remote base is still safe.
+def _rebase_main(repo: str, repo_dir: Path) -> tuple[str, bool]:
+    """Fetch + rebase the remote default branch.
+
+    Returns ``(short_sha, fetch_ok)`` — a 7-char SHA and a flag indicating
+    whether the network refresh succeeded. When ``fetch_ok`` is False the
+    rebase ran against whatever the local clone already had; callers should
+    surface the staleness in operator-facing logs but the SHA value itself
+    remains a clean git hash (no suffix) because it is exported to phase
+    subprocesses as ``HEPH_TRUNK_GITHASH`` and used for session naming
+    (``hephaestus/automation/session_naming.py:181``). Adding a suffix
+    would propagate the "stale" marker into every child session label and
+    would also break any future caller that consumed the env var as a git
+    ref. The staleness is conveyed via the second return value instead.
+    """
+    fetch_ok = True
     try:
-        resilient_call(
+        fetch_result = resilient_call(
             subprocess.run,
             ["git", "-C", str(repo_dir), "fetch", "origin", "--quiet"],
             check=False,
+            capture_output=True,
+            text=True,
             timeout=NETWORK_TIMEOUT,
             circuit_breaker_name="git-fetch",
         )
     except subprocess.TimeoutExpired:
         LOG.warning("[%s] git fetch timed out; rebasing against stale remote base", repo)
+        fetch_ok = False
+    else:
+        # subprocess.run(check=False) does NOT raise on non-zero rc. macOS
+        # sandbox denials surface here as rc=1 with stderr "cannot open
+        # .git/FETCH_HEAD: Operation not permitted" (#993). Without this
+        # inspection the loop logs the resulting trunk SHA as if the refresh
+        # succeeded, masking the permission problem.
+        rc = getattr(fetch_result, "returncode", 0)
+        if rc != 0:
+            stderr = (getattr(fetch_result, "stderr", "") or "").strip()
+            LOG.warning(
+                "[%s] git fetch failed (rc=%s); rebasing against stale remote base: %s",
+                repo,
+                rc,
+                stderr or "<no stderr>",
+            )
+            fetch_ok = False
     base_ref = _detect_remote_base_ref(repo, repo_dir)
     local_ahead = _local_ahead_count(repo, repo_dir, base_ref)
     rb = subprocess.run(
@@ -840,7 +868,7 @@ def _rebase_main(repo: str, repo_dir: Path) -> str:
         check=False,
         timeout=METADATA_TIMEOUT,
     )
-    return sha.stdout.strip() or "unknown"
+    return (sha.stdout.strip() or "unknown", fetch_ok)
 
 
 # ---------------------------------------------------------------------------
@@ -1110,8 +1138,11 @@ def _process_repo_inner(
         return result
 
     LOG.info("── %s (loop %d) ──", repo, loop_idx)
-    trunk_sha = _rebase_main(repo, repo_dir)
-    LOG.info("[%s] trunk=%s", repo, trunk_sha)
+    trunk_sha, fetch_ok = _rebase_main(repo, repo_dir)
+    if fetch_ok:
+        LOG.info("[%s] trunk=%s", repo, trunk_sha)
+    else:
+        LOG.info("[%s] trunk=%s (stale)", repo, trunk_sha)
 
     # Open-issue discovery happens once per repo per loop. When the operator
     # scopes the loop explicitly, reuse that bounded list for child phases.

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1139,10 +1139,8 @@ def _process_repo_inner(
 
     LOG.info("── %s (loop %d) ──", repo, loop_idx)
     trunk_sha, fetch_ok = _rebase_main(repo, repo_dir)
-    if fetch_ok:
-        LOG.info("[%s] trunk=%s", repo, trunk_sha)
-    else:
-        LOG.info("[%s] trunk=%s (stale)", repo, trunk_sha)
+    stale_suffix = "" if fetch_ok else " (stale)"
+    LOG.info("[%s] trunk=%s%s", repo, trunk_sha, stale_suffix)
 
     # Open-issue discovery happens once per repo per loop. When the operator
     # scopes the loop explicitly, reuse that bounded list for child phases.

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -94,7 +94,8 @@ class TestDiscoverPrsDirectMode:
             return_value=661,
         ):
             with patch.object(driver, "_validate_pr_open", return_value=True) as mock_validate:
-                result = driver._discover_prs([918])
+                with patch.object(driver, "_discover_failing_prs", return_value={}):
+                    result = driver._discover_prs([918])
 
         # PR 661 should appear exactly once, keyed by issue 918 (from issue path)
         assert result[918] == 661
@@ -116,7 +117,8 @@ class TestDiscoverPrsDirectMode:
             return_value=999,
         ):
             with patch.object(driver, "_validate_pr_open", return_value=True):
-                result = driver._discover_prs([918])
+                with patch.object(driver, "_discover_failing_prs", return_value={}):
+                    result = driver._discover_prs([918])
 
         # Issue 918 should map to PR 999
         assert result[918] == 999

--- a/tests/unit/automation/test_drive_green_pr_discovery.py
+++ b/tests/unit/automation/test_drive_green_pr_discovery.py
@@ -183,7 +183,7 @@ class TestProcessRepoSkipLogic:
         _, cfg = repo_inputs
         cfg = LoopConfig(phases=("drive-green",), loops=1, projects_dir=cfg.projects_dir)
         with (
-            patch.object(loop_runner, "_rebase_main", return_value="deadbeef"),
+            patch.object(loop_runner, "_rebase_main", return_value=("deadbee", True)),
             patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
             patch.object(loop_runner, "_count_failing_prs", return_value=0),
             patch.object(loop_runner, "run_phase") as mock_run,
@@ -201,7 +201,7 @@ class TestProcessRepoSkipLogic:
         _, cfg = repo_inputs
         cfg = LoopConfig(phases=("drive-green",), loops=1, projects_dir=cfg.projects_dir)
         with (
-            patch.object(loop_runner, "_rebase_main", return_value="deadbeef"),
+            patch.object(loop_runner, "_rebase_main", return_value=("deadbee", True)),
             patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
             patch.object(loop_runner, "_count_failing_prs", return_value=3),
             patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
@@ -222,7 +222,7 @@ class TestProcessRepoSkipLogic:
             projects_dir=cfg.projects_dir,
         )
         with (
-            patch.object(loop_runner, "_rebase_main", return_value="deadbeef"),
+            patch.object(loop_runner, "_rebase_main", return_value=("deadbee", True)),
             patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
             patch.object(loop_runner, "_count_failing_prs", return_value=0),
             patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -314,7 +314,7 @@ def test_process_repo_runs_all_phases_when_all_succeed(
     """Process repo runs all phases when all succeed."""
     _, cfg = repo_inputs
     with (
-        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1, 2]),
         patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
     ):
@@ -335,7 +335,7 @@ def test_process_repo_continues_after_phase_failure(repo_inputs: tuple[Path, Loo
         return PhaseResult(name=name, rc=rc, elapsed_s=0.1)
 
     with (
-        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
         patch.object(loop_runner, "_count_failing_prs", return_value=1),
         patch.object(loop_runner, "run_phase", side_effect=fake_run_phase),
@@ -364,7 +364,7 @@ def test_process_repo_skips_disabled_phases(repo_inputs: tuple[Path, LoopConfig]
     _, cfg = repo_inputs
     cfg = LoopConfig(loops=1, projects_dir=cfg.projects_dir, phases=("plan",))
     with (
-        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
         patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
     ):
@@ -382,7 +382,7 @@ def test_process_repo_skips_issue_phases_when_no_issues(
     """Process repo skips issue phases when no issues."""
     _, cfg = repo_inputs
     with (
-        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
         patch.object(loop_runner, "_count_failing_prs", return_value=0),
         patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
@@ -405,7 +405,7 @@ def test_process_repo_skips_drive_green_on_non_final_loop(
     _, cfg = repo_inputs
     cfg = LoopConfig(loops=3, projects_dir=cfg.projects_dir)
     with (
-        patch.object(loop_runner, "_rebase_main", return_value="abc1234"),
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
         patch.object(loop_runner, "_count_failing_prs", return_value=1),
         patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
@@ -416,6 +416,26 @@ def test_process_repo_skips_drive_green_on_non_final_loop(
     drive_green_loop3 = next(p for p in result_loop3.phases if p.name == "drive-green")
     assert drive_green_loop1.skipped and drive_green_loop1.skip_reason == "not final loop"
     assert not drive_green_loop3.skipped
+
+
+def test_process_repo_logs_trunk_stale_when_fetch_fails(
+    repo_inputs: tuple[Path, LoopConfig], caplog: pytest.LogCaptureFixture
+) -> None:
+    """When _rebase_main returns fetch_ok=False, the [repo] trunk= log line carries '(stale)'.
+
+    Operators see refresh failures (#993).
+    """
+    _, cfg = repo_inputs
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", False)),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[]),
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+        caplog.at_level("INFO", logger="hephaestus.automation.loop_runner"),
+    ):
+        process_repo("r", loop_idx=1, cfg=cfg)
+    assert any("trunk=abc1234 (stale)" in rec.message for rec in caplog.records), [
+        r.message for r in caplog.records
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -1048,9 +1068,11 @@ class TestSummarizeLoop:
 # ---------------------------------------------------------------------------
 
 
-def _completed(returncode: int = 0, stdout: str = "") -> subprocess.CompletedProcess[str]:
+def _completed(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
     """Build a CompletedProcess stand-in for mocked subprocess.run calls."""
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 class TestSubprocessTimeouts:
@@ -1146,17 +1168,19 @@ class TestResilientCallAdoption:
         ):
             mock_resilient.return_value = _completed()
 
-            def _run(argv: list[str], **_: object):
-                if "status" in argv:
-                    return _completed(stdout="")
+            def _run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
                 if "symbolic-ref" in argv:
                     return _completed(stdout="origin/main")
+                if "rev-list" in argv:
+                    return _completed(stdout="0")
                 if "rev-parse" in argv:
                     return _completed(stdout="abc1234")
                 return _completed()
 
             mock_run.side_effect = _run
-            _rebase_main("Repo", tmp_path)
+            sha, fetch_ok = _rebase_main("Repo", tmp_path)
+        assert sha == "abc1234"
+        assert fetch_ok is True
         assert mock_resilient.call_count == 1
         # The wrapped callable is the module's subprocess.run (here the patched mock).
         assert mock_resilient.call_args.args[0] is mock_run
@@ -1180,7 +1204,11 @@ class TestResilientCallAdoption:
                 _ensure_clone("Org", "Repo", dest)
 
     def test_rebase_main_fetch_timeout_is_non_fatal(self, tmp_path: Path) -> None:
-        """A timed-out fetch is logged and the rebase proceeds against stale main."""
+        """A timed-out fetch is logged; the rebase proceeds against stale main.
+
+        The returned ``fetch_ok`` flag is False so the caller can mark the
+        log line as stale (#993).
+        """
 
         def _hang(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
             raise subprocess.TimeoutExpired(cmd="git fetch", timeout=120)
@@ -1193,8 +1221,9 @@ class TestResilientCallAdoption:
             ),
         ):
             mock_run.return_value = _completed(stdout="def5678")
-            sha = _rebase_main("Repo", tmp_path)
+            sha, fetch_ok = _rebase_main("Repo", tmp_path)
         assert sha == "def5678"
+        assert fetch_ok is False
 
     def test_rebase_main_uses_origin_head_default_branch(self, tmp_path: Path) -> None:
         """Repos whose default branch is master must not be rebased against origin/main."""
@@ -1212,9 +1241,10 @@ class TestResilientCallAdoption:
             patch("hephaestus.automation.loop_runner.resilient_call", return_value=_completed()),
             patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run),
         ):
-            sha = _rebase_main("Repo", tmp_path)
+            sha, fetch_ok = _rebase_main("Repo", tmp_path)
 
         assert sha == "def5678"
+        assert fetch_ok is True
         assert ["git", "-C", str(tmp_path), "rebase", "origin/master", "--quiet"] in calls
         unexpected_reset = [
             "git",
@@ -1247,13 +1277,63 @@ class TestResilientCallAdoption:
             patch("hephaestus.automation.loop_runner.resilient_call", return_value=_completed()),
             patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run),
         ):
-            sha = _rebase_main("Repo", tmp_path)
+            sha, fetch_ok = _rebase_main("Repo", tmp_path)
 
         assert sha == "local12"
+        assert fetch_ok is True
         assert ["git", "-C", str(tmp_path), "rebase", "--abort"] in calls
         assert not any(
             call[:5] == ["git", "-C", str(tmp_path), "reset", "--hard"] for call in calls
         )
+
+    def test_rebase_main_fetch_nonzero_rc_marks_stale(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Non-zero git fetch rc (e.g. macOS sandboxing) must surface and mark stale.
+
+        The returned ``fetch_ok`` flag is False. The SHA value itself stays a
+        clean 7-char hash so ``HEPH_TRUNK_GITHASH`` and session naming downstream
+        remain unaffected.
+
+        Regression for #993: previously rc=1 silently passed through
+        ``resilient_call`` (subprocess.run with ``check=False`` does not raise)
+        and the loop logged a trunk SHA as if the refresh had succeeded.
+        """
+        fetch_failure = _completed(
+            returncode=1,
+            stderr="error: cannot open .git/FETCH_HEAD: Operation not permitted\n",
+        )
+
+        with (
+            patch(
+                "hephaestus.automation.loop_runner.resilient_call",
+                return_value=fetch_failure,
+            ),
+            patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run,
+            caplog.at_level("WARNING", logger="hephaestus.automation.loop_runner"),
+        ):
+            mock_run.return_value = _completed(stdout="abc1234")
+            sha, fetch_ok = _rebase_main("Repo", tmp_path)
+
+        assert sha == "abc1234"  # clean SHA — no suffix
+        assert fetch_ok is False
+        assert any(
+            "git fetch failed" in rec.message and "rc=1" in rec.message for rec in caplog.records
+        ), caplog.records
+
+    def test_rebase_main_fetch_success_returns_clean(self, tmp_path: Path) -> None:
+        """A zero-rc fetch returns ``fetch_ok=True`` and the unmodified SHA."""
+        with (
+            patch(
+                "hephaestus.automation.loop_runner.resilient_call",
+                return_value=_completed(returncode=0),
+            ),
+            patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = _completed(stdout="abc1234")
+            sha, fetch_ok = _rebase_main("Repo", tmp_path)
+        assert sha == "abc1234"
+        assert fetch_ok is True
 
 
 class TestDefaultPhaseTimeout:

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -10,6 +10,12 @@ import pytest
 from hephaestus.automation.worktree_manager import WorktreeDirtyError, WorktreeManager
 
 
+@pytest.fixture(autouse=True)
+def _clear_loop_trunk_githash(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep unit tests independent from automation-loop parent env."""
+    monkeypatch.delenv("HEPH_TRUNK_GITHASH", raising=False)
+
+
 class TestWorktreeManager:
     """Tests for WorktreeManager class."""
 


### PR DESCRIPTION
## Summary

- Make `_rebase_main` return `(sha, fetch_ok)` tuple to surface git fetch failures
- Log non-zero git fetch rc as WARNING (e.g., macOS sandbox denials)
- Render `[repo] trunk=<sha> (stale)` when fetch fails so operators see refresh failures
- Add regression tests for non-zero rc, timeout, and log rendering
- Document macOS / Codex source-checkout path in README (#993)

## Test plan

- All 95 tests pass in `tests/unit/automation/test_loop_runner.py`
- New tests verify: non-zero fetch rc → fetch_ok=False, timeout → fetch_ok=False, stale log rendering
- Pre-commit hooks pass on all modified files

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)