### PR TITLE
feat(ci-driver): add direct --prs mode to bypass issue discovery

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -127,10 +127,16 @@ class CIDriver:
             self._sweep_orphaned_arming_records()
 
         # Empty --issues is allowed: bot-PR discovery (#848) may still
-        # surface open Dependabot PRs to drive. Only abort if BOTH input
-        # issues and bot discovery are off.
-        if not self.options.issues and not self.options.include_bot_prs:
-            logger.warning("No issues to process and bot-PR discovery disabled")
+        # surface open Dependabot PRs to drive. Only abort if ALL input
+        # sources are off: no issues, no direct PRs, and no bot discovery.
+        if (
+            not self.options.issues
+            and not self.options.prs
+            and not self.options.include_bot_prs
+        ):
+            logger.warning(
+                "No issues, no direct PRs, and bot-PR discovery disabled"
+            )
             return {}
 
         # Pre-discover PRs — only submit workers for issues that have an open PR.
@@ -415,7 +421,7 @@ class CIDriver:
         """
         return issue_number == pr_number
 
-    def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:
+    def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:  # noqa: C901
         """Pre-discover open PRs for all issues, deduped by PR.
 
         When a single PR closes multiple issues (a legitimate ``pr-policy``
@@ -483,6 +489,27 @@ class CIDriver:
                     canonical,
                     deferred,
                 )
+
+        # Direct PR mode (#918). Operator-supplied PR numbers bypass
+        # find_pr_for_issue entirely. Validate each PR exists and is OPEN
+        # via ``gh pr view`` before adding to the work set; invalid PRs are
+        # logged and skipped, not raised, so one typo doesn't kill the batch.
+        # Keyed by PR number as the synthetic issue, matching the bot-PR
+        # convention so ``_is_bot_pr_mode`` short-circuits downstream.
+        for pr_num in self.options.prs:
+            if pr_num in deduped.values():
+                logger.info(
+                    "Direct PR #%s already discovered via --issues; skipping duplicate",
+                    pr_num,
+                )
+                continue
+            if not self._validate_pr_open(pr_num):
+                logger.warning(
+                    "Direct PR #%s is not OPEN or does not exist; skipping", pr_num
+                )
+                continue
+            deduped[pr_num] = pr_num
+            self.shared_pr_issues.setdefault(pr_num, [pr_num])
 
         # Union with open bot-authored PRs (#848). Bot PRs are keyed by their
         # own number as the synthetic issue; ``_is_bot_pr_mode`` detects the
@@ -1147,6 +1174,31 @@ class CIDriver:
 
         """
         return find_pr_for_issue(issue_number)
+
+    def _validate_pr_open(self, pr_number: int) -> bool:
+        """Return True iff ``pr_number`` exists and is in OPEN state.
+
+        Used by direct --prs mode (#918) to filter out typo'd or closed PR
+        numbers before worker submission. Mirrors the strategy-2 check in
+        ``find_pr_for_issue``.
+
+        Args:
+            pr_number: GitHub PR number.
+
+        Returns:
+            True if the PR exists and is OPEN, False otherwise.
+
+        """
+        try:
+            result = _gh_call(
+                ["pr", "view", str(pr_number), "--json", "number,state"],
+                check=False,
+            )
+            data = json.loads(result.stdout or "{}")
+            return str(data.get("state", "")).upper() == "OPEN"
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.debug("PR #%s validation failed: %s", pr_number, exc)
+            return False
 
     def _get_pr_branch(self, pr_number: int) -> str:
         """Get the head branch name of a PR.
@@ -2543,6 +2595,9 @@ Examples:
   # Drive CI for specific issues
   %(prog)s --issues 123 456 789
 
+  # Drive specific PRs directly
+  %(prog)s --prs 661 662 664 666
+
   # Dry run (no GitHub writes or git pushes)
   %(prog)s --issues 123 --dry-run
 
@@ -2563,6 +2618,19 @@ Examples:
             "Issue numbers whose PRs should be driven to green CI. Optional: "
             "when omitted, the driver still picks up open bot-authored PRs via "
             "--include-bot-prs (default on) (#848)."
+        ),
+    )
+    parser.add_argument(
+        "--prs",
+        type=int,
+        nargs="*",
+        default=[],
+        metavar="PR",
+        help=(
+            "PR numbers to drive directly, bypassing issue-to-PR discovery (#918). "
+            "Use when the PR body uses 'Refs #N' or the PR is otherwise not "
+            "reachable via the strict Closes-link lookup. May be combined with "
+            "--issues; duplicate PRs are deduped."
         ),
     )
     add_agent_argument(parser)
@@ -2756,11 +2824,12 @@ def main() -> int:
         return 2
     log.debug("ci_driver gate passed: %s", reason)
 
-    log.info("Starting CI driver for issues: %s", args.issues)
+    log.info("Starting CI driver for issues: %s, direct PRs: %s", args.issues, args.prs)
 
     try:
         options = CIDriverOptions(
             issues=args.issues,
+            prs=args.prs,
             agent=agent,
             max_workers=args.max_workers,
             dry_run=args.dry_run,

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -129,14 +129,8 @@ class CIDriver:
         # Empty --issues is allowed: bot-PR discovery (#848) may still
         # surface open Dependabot PRs to drive. Only abort if ALL input
         # sources are off: no issues, no direct PRs, and no bot discovery.
-        if (
-            not self.options.issues
-            and not self.options.prs
-            and not self.options.include_bot_prs
-        ):
-            logger.warning(
-                "No issues, no direct PRs, and bot-PR discovery disabled"
-            )
+        if not self.options.issues and not self.options.prs and not self.options.include_bot_prs:
+            logger.warning("No issues, no direct PRs, and bot-PR discovery disabled")
             return {}
 
         # Pre-discover PRs — only submit workers for issues that have an open PR.
@@ -504,9 +498,7 @@ class CIDriver:
                 )
                 continue
             if not self._validate_pr_open(pr_num):
-                logger.warning(
-                    "Direct PR #%s is not OPEN or does not exist; skipping", pr_num
-                )
+                logger.warning("Direct PR #%s is not OPEN or does not exist; skipping", pr_num)
                 continue
             deduped[pr_num] = pr_num
             self.shared_pr_issues.setdefault(pr_num, [pr_num])

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -243,6 +243,10 @@ class CIDriverOptions(BaseModel):
     """Options for the CIDriver workflow."""
 
     issues: list[int] = Field(default_factory=list)
+    # Direct PR numbers to drive. Bypasses issue-to-PR discovery entirely
+    # (#918). Used when the operator already knows the PR numbers and the
+    # PRs do not use a strict ``Closes #N`` link (e.g. ``Refs #N``).
+    prs: list[int] = Field(default_factory=list)
     agent: str = "claude"
     max_workers: int = 3
     dry_run: bool = False

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -28,9 +28,7 @@ class TestParseArgsPrs:
 
     def test_prs_combined_with_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """--prs and --issues can be used together."""
-        monkeypatch.setattr(
-            sys, "argv", ["ci", "--issues", "918", "--prs", "661", "662"]
-        )
+        monkeypatch.setattr(sys, "argv", ["ci", "--issues", "918", "--prs", "661", "662"])
         args = ci_driver._parse_args()
         assert args.issues == [918]
         assert args.prs == [661, 662]
@@ -57,12 +55,8 @@ class TestDiscoverPrsDirectMode:
         driver.options.prs = [661, 662]
 
         # Mock _validate_pr_open to return True for these PRs
-        with patch.object(
-            driver, "_validate_pr_open", return_value=True
-        ) as mock_validate:
-            with patch.object(
-                driver, "_find_pr_for_issue", return_value=None
-            ):
+        with patch.object(driver, "_validate_pr_open", return_value=True) as mock_validate:
+            with patch.object(driver, "_find_pr_for_issue", return_value=None):
                 result = driver._discover_prs([])
 
         assert 661 in result.values()
@@ -79,12 +73,8 @@ class TestDiscoverPrsDirectMode:
         """Direct PRs populate shared_pr_issues[pr] = [pr]."""
         driver.options.prs = [661]
 
-        with patch.object(
-            driver, "_validate_pr_open", return_value=True
-        ):
-            with patch.object(
-                driver, "_find_pr_for_issue", return_value=None
-            ):
+        with patch.object(driver, "_validate_pr_open", return_value=True):
+            with patch.object(driver, "_find_pr_for_issue", return_value=None):
                 driver._discover_prs([])
 
         assert driver.shared_pr_issues.get(661) == [661]
@@ -100,9 +90,7 @@ class TestDiscoverPrsDirectMode:
             "_find_pr_for_issue",
             return_value=661,
         ):
-            with patch.object(
-                driver, "_validate_pr_open", return_value=True
-            ) as mock_validate:
+            with patch.object(driver, "_validate_pr_open", return_value=True) as mock_validate:
                 result = driver._discover_prs([918])
 
         # PR 661 should appear exactly once, keyed by issue 918 (from issue path)
@@ -124,9 +112,7 @@ class TestDiscoverPrsDirectMode:
             "_find_pr_for_issue",
             return_value=999,
         ):
-            with patch.object(
-                driver, "_validate_pr_open", return_value=True
-            ):
+            with patch.object(driver, "_validate_pr_open", return_value=True):
                 result = driver._discover_prs([918])
 
         # Issue 918 should map to PR 999
@@ -144,12 +130,8 @@ class TestDiscoverPrsDirectMode:
         def validate_side_effect(pr_num):
             return pr_num != 662  # 662 is closed/non-existent
 
-        with patch.object(
-            driver, "_validate_pr_open", side_effect=validate_side_effect
-        ):
-            with patch.object(
-                driver, "_find_pr_for_issue", return_value=None
-            ):
+        with patch.object(driver, "_validate_pr_open", side_effect=validate_side_effect):
+            with patch.object(driver, "_find_pr_for_issue", return_value=None):
                 result = driver._discover_prs([])
 
         # Valid PRs included
@@ -163,12 +145,8 @@ class TestDiscoverPrsDirectMode:
         driver.options.prs = [661]
         driver.options.include_bot_prs = False
 
-        with patch.object(
-            driver, "_validate_pr_open", return_value=True
-        ):
-            with patch.object(
-                driver, "_find_pr_for_issue", return_value=None
-            ):
+        with patch.object(driver, "_validate_pr_open", return_value=True):
+            with patch.object(driver, "_find_pr_for_issue", return_value=None):
                 result = driver._discover_prs([])
 
         assert result.get(661) == 661
@@ -178,12 +156,8 @@ class TestDiscoverPrsDirectMode:
         driver.options.prs = [661]
         driver.options.include_bot_prs = False
 
-        with patch.object(
-            driver, "_validate_pr_open", return_value=True
-        ):
-            with patch.object(
-                driver, "_find_pr_for_issue", return_value=None
-            ):
+        with patch.object(driver, "_validate_pr_open", return_value=True):
+            with patch.object(driver, "_find_pr_for_issue", return_value=None):
                 result = driver._discover_prs([])
 
         assert result.get(661) == 661
@@ -194,27 +168,21 @@ class TestRunGateWithPrs:
 
     def test_run_gate_does_not_abort_with_prs(self) -> None:
         """run() gate does not abort when --prs is supplied (only issues+bot are checked)."""
-        # The gate logic is: abort only if issues AND prs AND include_bot_prs are all empty
-        # With prs=[661], the gate should pass
-        options = CIDriverOptions(
-            issues=[], prs=[661], include_bot_prs=False
-        )
-        # We can't easily mock the full run() without mocking ThreadPoolExecutor,
-        # so we just verify the gate condition is correct
-        # The gate check is: if not issues and not prs and not include_bot_prs: return {}
-        # With prs=[661], this should NOT trigger the early return
-        should_abort = (
-            not options.issues
-            and not options.prs
-            and not options.include_bot_prs
-        )
-        assert should_abort is False
+        options = CIDriverOptions(issues=[], prs=[661], include_bot_prs=False)
+        driver = CIDriver(options)
+
+        # Mock _discover_prs to return {661: 661} and _sweep_orphaned_arming_records
+        # to avoid network I/O
+        with patch.object(driver, "_discover_prs", return_value={661: 661}):
+            with patch.object(driver, "_sweep_orphaned_arming_records"):
+                result = driver.run()
+
+        # Verify the gate did not abort by checking result is not an empty dict
+        assert result != {}
 
     def test_run_gate_aborts_with_no_issues_no_prs_no_bot_prs(self) -> None:
         """run() aborts when all sources are empty."""
-        options = CIDriverOptions(
-            issues=[], prs=[], include_bot_prs=False
-        )
+        options = CIDriverOptions(issues=[], prs=[], include_bot_prs=False)
         driver = CIDriver(options)
         result = driver.run()
         assert result == {}
@@ -227,12 +195,8 @@ class TestMainPrsFlow:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """main() threads --prs into CIDriverOptions.prs."""
-        monkeypatch.setattr(
-            sys, "argv", ["ci", "--prs", "661", "662", "--dry-run", "--force-run"]
-        )
-        with patch(
-            "hephaestus.automation.ci_driver.CIDriver"
-        ) as mock_driver_class:
+        monkeypatch.setattr(sys, "argv", ["ci", "--prs", "661", "662", "--dry-run", "--force-run"])
+        with patch("hephaestus.automation.ci_driver.CIDriver") as mock_driver_class:
             with patch(
                 "hephaestus.automation.ci_driver._evaluate_run_result",
                 return_value=0,
@@ -251,16 +215,10 @@ class TestMainPrsFlow:
         options = call_args[0][0]
         assert options.prs == [661, 662]
 
-    def test_main_prs_json_output_includes_open_prs(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_main_prs_json_output_includes_open_prs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """--prs --json output includes open PRs from result."""
-        monkeypatch.setattr(
-            sys, "argv", ["ci", "--prs", "661", "662", "--json", "--force-run"]
-        )
-        with patch(
-            "hephaestus.automation.ci_driver.CIDriver"
-        ) as mock_driver_class:
+        monkeypatch.setattr(sys, "argv", ["ci", "--prs", "661", "662", "--json", "--force-run"])
+        with patch("hephaestus.automation.ci_driver.CIDriver") as mock_driver_class:
             with patch(
                 "hephaestus.automation.ci_driver._evaluate_run_result",
                 return_value=0,
@@ -272,9 +230,13 @@ class TestMainPrsFlow:
 
                 ci_driver.main()
 
-        # _evaluate_run_result should be called with the results and options
+        # Verify that _evaluate_run_result was called with a result dict
+        # containing the PR keys 661 and 662
         call_args = mock_eval.call_args
         assert call_args is not None
+        result_dict = call_args[0][0]
+        assert 661 in result_dict
+        assert 662 in result_dict
 
 
 class TestValidatePrOpen:
@@ -285,12 +247,8 @@ class TestValidatePrOpen:
         options = CIDriverOptions()
         driver = CIDriver(options)
 
-        with patch(
-            "hephaestus.automation.ci_driver._gh_call"
-        ) as mock_gh_call:
-            mock_gh_call.return_value.stdout = json.dumps(
-                {"state": "OPEN", "number": 661}
-            )
+        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            mock_gh_call.return_value.stdout = json.dumps({"state": "OPEN", "number": 661})
             result = driver._validate_pr_open(661)
 
         assert result is True
@@ -300,12 +258,8 @@ class TestValidatePrOpen:
         options = CIDriverOptions()
         driver = CIDriver(options)
 
-        with patch(
-            "hephaestus.automation.ci_driver._gh_call"
-        ) as mock_gh_call:
-            mock_gh_call.return_value.stdout = json.dumps(
-                {"state": "CLOSED", "number": 661}
-            )
+        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            mock_gh_call.return_value.stdout = json.dumps({"state": "CLOSED", "number": 661})
             result = driver._validate_pr_open(661)
 
         assert result is False
@@ -315,12 +269,22 @@ class TestValidatePrOpen:
         options = CIDriverOptions()
         driver = CIDriver(options)
 
-        with patch(
-            "hephaestus.automation.ci_driver._gh_call"
-        ) as mock_gh_call:
+        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
             import subprocess
+
             mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
             result = driver._validate_pr_open(999)
+
+        assert result is False
+
+    def test_validate_pr_open_returns_false_for_empty_stdout(self):
+        """_validate_pr_open returns False when stdout is None (empty response)."""
+        options = CIDriverOptions()
+        driver = CIDriver(options)
+
+        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            mock_gh_call.return_value.stdout = None
+            result = driver._validate_pr_open(661)
 
         assert result is False
 
@@ -329,12 +293,8 @@ class TestValidatePrOpen:
         options = CIDriverOptions()
         driver = CIDriver(options)
 
-        with patch(
-            "hephaestus.automation.ci_driver._gh_call"
-        ) as mock_gh_call:
-            mock_gh_call.return_value.stdout = json.dumps(
-                {"state": "OPEN", "number": 661}
-            )
+        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            mock_gh_call.return_value.stdout = json.dumps({"state": "OPEN", "number": 661})
             driver._validate_pr_open(661)
 
         mock_gh_call.assert_called_once()

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -1,0 +1,345 @@
+"""Tests for direct --prs mode in CI driver (issue #918)."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation import ci_driver
+from hephaestus.automation.ci_driver import CIDriver
+from hephaestus.automation.models import CIDriverOptions
+
+
+class TestParseArgsPrs:
+    """Verify --prs argparse integration."""
+
+    def test_prs_parses_integers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--prs accepts PR numbers as integers."""
+        monkeypatch.setattr(sys, "argv", ["ci", "--prs", "661", "662", "664", "666"])
+        args = ci_driver._parse_args()
+        assert args.prs == [661, 662, 664, 666]
+
+    def test_prs_defaults_to_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--prs defaults to empty list when omitted."""
+        monkeypatch.setattr(sys, "argv", ["ci"])
+        args = ci_driver._parse_args()
+        assert args.prs == []
+
+    def test_prs_combined_with_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--prs and --issues can be used together."""
+        monkeypatch.setattr(
+            sys, "argv", ["ci", "--issues", "918", "--prs", "661", "662"]
+        )
+        args = ci_driver._parse_args()
+        assert args.issues == [918]
+        assert args.prs == [661, 662]
+
+    def test_prs_alone_without_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--prs can be used without --issues."""
+        monkeypatch.setattr(sys, "argv", ["ci", "--prs", "661", "662"])
+        args = ci_driver._parse_args()
+        assert args.prs == [661, 662]
+        assert args.issues == []
+
+
+class TestDiscoverPrsDirectMode:
+    """Unit tests for _discover_prs with options.prs populated."""
+
+    @pytest.fixture
+    def driver(self, tmp_path) -> CIDriver:
+        """Create a CIDriver with default options."""
+        options = CIDriverOptions()
+        return CIDriver(options)
+
+    def test_direct_prs_alone_keyed_by_pr_number(self, driver: CIDriver) -> None:
+        """Direct PRs alone bypass issue discovery, keyed by PR number."""
+        driver.options.prs = [661, 662]
+
+        # Mock _validate_pr_open to return True for these PRs
+        with patch.object(
+            driver, "_validate_pr_open", return_value=True
+        ) as mock_validate:
+            with patch.object(
+                driver, "_find_pr_for_issue", return_value=None
+            ):
+                result = driver._discover_prs([])
+
+        assert 661 in result.values()
+        assert 662 in result.values()
+        # Each PR is keyed by itself (synthetic issue)
+        assert result[661] == 661
+        assert result[662] == 662
+        # Validate was called for each PR
+        assert mock_validate.call_count == 2
+        mock_validate.assert_any_call(661)
+        mock_validate.assert_any_call(662)
+
+    def test_direct_prs_populate_shared_pr_issues(self, driver: CIDriver) -> None:
+        """Direct PRs populate shared_pr_issues[pr] = [pr]."""
+        driver.options.prs = [661]
+
+        with patch.object(
+            driver, "_validate_pr_open", return_value=True
+        ):
+            with patch.object(
+                driver, "_find_pr_for_issue", return_value=None
+            ):
+                driver._discover_prs([])
+
+        assert driver.shared_pr_issues.get(661) == [661]
+
+    def test_issues_and_prs_overlap_deduped(self, driver: CIDriver) -> None:
+        """When both --issues and --prs name the same PR, dedup (issue wins)."""
+        driver.options.prs = [661]
+        driver.options.include_bot_prs = False
+
+        # Mock find_pr_for_issue to return 661 for issue 918
+        with patch.object(
+            driver,
+            "_find_pr_for_issue",
+            return_value=661,
+        ):
+            with patch.object(
+                driver, "_validate_pr_open", return_value=True
+            ) as mock_validate:
+                result = driver._discover_prs([918])
+
+        # PR 661 should appear exactly once, keyed by issue 918 (from issue path)
+        assert result[918] == 661
+        # Direct-PR path should see 661 already in deduped.values() and skip it
+        # Validate should NOT be called for the direct-PR duplicate
+        mock_validate.assert_not_called()
+        # Only one entry in the result
+        assert len(result) == 1
+
+    def test_issues_and_prs_disjoint_both_included(self, driver: CIDriver) -> None:
+        """When --issues and --prs are disjoint, both PRs appear in result."""
+        driver.options.prs = [661, 662]
+        driver.options.include_bot_prs = False
+
+        # Issue 918 maps to PR 999
+        with patch.object(
+            driver,
+            "_find_pr_for_issue",
+            return_value=999,
+        ):
+            with patch.object(
+                driver, "_validate_pr_open", return_value=True
+            ):
+                result = driver._discover_prs([918])
+
+        # Issue 918 should map to PR 999
+        assert result[918] == 999
+        # Direct PRs 661 and 662 should also appear, keyed by themselves
+        assert result[661] == 661
+        assert result[662] == 662
+        assert len(result) == 3
+
+    def test_closed_pr_dropped_with_warning(self, driver: CIDriver) -> None:
+        """Closed PRs are dropped with a warning, not raised."""
+        driver.options.prs = [661, 662, 663]
+        driver.options.include_bot_prs = False
+
+        def validate_side_effect(pr_num):
+            return pr_num != 662  # 662 is closed/non-existent
+
+        with patch.object(
+            driver, "_validate_pr_open", side_effect=validate_side_effect
+        ):
+            with patch.object(
+                driver, "_find_pr_for_issue", return_value=None
+            ):
+                result = driver._discover_prs([])
+
+        # Valid PRs included
+        assert result.get(661) == 661
+        assert result.get(663) == 663
+        # Closed PR excluded
+        assert 662 not in result.values()
+
+    def test_prs_honored_without_issues(self, driver: CIDriver) -> None:
+        """--prs is honored even when issue_numbers is empty."""
+        driver.options.prs = [661]
+        driver.options.include_bot_prs = False
+
+        with patch.object(
+            driver, "_validate_pr_open", return_value=True
+        ):
+            with patch.object(
+                driver, "_find_pr_for_issue", return_value=None
+            ):
+                result = driver._discover_prs([])
+
+        assert result.get(661) == 661
+
+    def test_prs_honored_with_bot_prs_disabled(self, driver: CIDriver) -> None:
+        """--prs works with include_bot_prs=False."""
+        driver.options.prs = [661]
+        driver.options.include_bot_prs = False
+
+        with patch.object(
+            driver, "_validate_pr_open", return_value=True
+        ):
+            with patch.object(
+                driver, "_find_pr_for_issue", return_value=None
+            ):
+                result = driver._discover_prs([])
+
+        assert result.get(661) == 661
+
+
+class TestRunGateWithPrs:
+    """Verify run() does not abort early when --prs supplied."""
+
+    def test_run_gate_does_not_abort_with_prs(self) -> None:
+        """run() gate does not abort when --prs is supplied (only issues+bot are checked)."""
+        # The gate logic is: abort only if issues AND prs AND include_bot_prs are all empty
+        # With prs=[661], the gate should pass
+        options = CIDriverOptions(
+            issues=[], prs=[661], include_bot_prs=False
+        )
+        # We can't easily mock the full run() without mocking ThreadPoolExecutor,
+        # so we just verify the gate condition is correct
+        # The gate check is: if not issues and not prs and not include_bot_prs: return {}
+        # With prs=[661], this should NOT trigger the early return
+        should_abort = (
+            not options.issues
+            and not options.prs
+            and not options.include_bot_prs
+        )
+        assert should_abort is False
+
+    def test_run_gate_aborts_with_no_issues_no_prs_no_bot_prs(self) -> None:
+        """run() aborts when all sources are empty."""
+        options = CIDriverOptions(
+            issues=[], prs=[], include_bot_prs=False
+        )
+        driver = CIDriver(options)
+        result = driver.run()
+        assert result == {}
+
+
+class TestMainPrsFlow:
+    """End-to-end via main() with --prs."""
+
+    def test_main_prs_flows_through_to_driver_options(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """main() threads --prs into CIDriverOptions.prs."""
+        monkeypatch.setattr(
+            sys, "argv", ["ci", "--prs", "661", "662", "--dry-run", "--force-run"]
+        )
+        with patch(
+            "hephaestus.automation.ci_driver.CIDriver"
+        ) as mock_driver_class:
+            with patch(
+                "hephaestus.automation.ci_driver._evaluate_run_result",
+                return_value=0,
+            ):
+                mock_instance = MagicMock()
+                mock_instance.run.return_value = {}
+                mock_instance.open_prs_remaining = []
+                mock_driver_class.return_value = mock_instance
+
+                # Import and call main
+                ci_driver.main()
+
+        # Verify CIDriver was instantiated with options.prs=[661, 662]
+        call_args = mock_driver_class.call_args
+        assert call_args is not None
+        options = call_args[0][0]
+        assert options.prs == [661, 662]
+
+    def test_main_prs_json_output_includes_open_prs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--prs --json output includes open PRs from result."""
+        monkeypatch.setattr(
+            sys, "argv", ["ci", "--prs", "661", "662", "--json", "--force-run"]
+        )
+        with patch(
+            "hephaestus.automation.ci_driver.CIDriver"
+        ) as mock_driver_class:
+            with patch(
+                "hephaestus.automation.ci_driver._evaluate_run_result",
+                return_value=0,
+            ) as mock_eval:
+                mock_instance = MagicMock()
+                mock_instance.run.return_value = {661: None, 662: None}
+                mock_instance.open_prs_remaining = [661, 662]
+                mock_driver_class.return_value = mock_instance
+
+                ci_driver.main()
+
+        # _evaluate_run_result should be called with the results and options
+        call_args = mock_eval.call_args
+        assert call_args is not None
+
+
+class TestValidatePrOpen:
+    """Unit tests for the _validate_pr_open helper."""
+
+    def test_validate_pr_open_returns_true_for_open_pr(self):
+        """_validate_pr_open returns True for an OPEN PR."""
+        options = CIDriverOptions()
+        driver = CIDriver(options)
+
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call"
+        ) as mock_gh_call:
+            mock_gh_call.return_value.stdout = json.dumps(
+                {"state": "OPEN", "number": 661}
+            )
+            result = driver._validate_pr_open(661)
+
+        assert result is True
+
+    def test_validate_pr_open_returns_false_for_closed_pr(self):
+        """_validate_pr_open returns False for a CLOSED PR."""
+        options = CIDriverOptions()
+        driver = CIDriver(options)
+
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call"
+        ) as mock_gh_call:
+            mock_gh_call.return_value.stdout = json.dumps(
+                {"state": "CLOSED", "number": 661}
+            )
+            result = driver._validate_pr_open(661)
+
+        assert result is False
+
+    def test_validate_pr_open_returns_false_for_nonexistent_pr(self):
+        """_validate_pr_open returns False for non-existent PR."""
+        options = CIDriverOptions()
+        driver = CIDriver(options)
+
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call"
+        ) as mock_gh_call:
+            import subprocess
+            mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
+            result = driver._validate_pr_open(999)
+
+        assert result is False
+
+    def test_validate_pr_open_calls_gh_pr_view_correctly(self):
+        """_validate_pr_open calls gh pr view with correct args."""
+        options = CIDriverOptions()
+        driver = CIDriver(options)
+
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call"
+        ) as mock_gh_call:
+            mock_gh_call.return_value.stdout = json.dumps(
+                {"state": "OPEN", "number": 661}
+            )
+            driver._validate_pr_open(661)
+
+        mock_gh_call.assert_called_once()
+        call_args = mock_gh_call.call_args[0][0]
+        assert "pr" in call_args
+        assert "view" in call_args
+        assert "661" in call_args
+        assert "--json" in call_args

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -173,12 +173,12 @@ class TestRunGateWithPrs:
 
         # Mock _discover_prs to return {661: 661} and _sweep_orphaned_arming_records
         # to avoid network I/O
-        with patch.object(driver, "_discover_prs", return_value={661: 661}):
+        with patch.object(driver, "_discover_prs", return_value={661: 661}) as mock_discover:
             with patch.object(driver, "_sweep_orphaned_arming_records"):
-                result = driver.run()
+                driver.run()
 
-        # Verify the gate did not abort by checking result is not an empty dict
-        assert result != {}
+        # Verify the gate did not abort by checking that _discover_prs was called
+        mock_discover.assert_called_once()
 
     def test_run_gate_aborts_with_no_issues_no_prs_no_bot_prs(self) -> None:
         """run() aborts when all sources are empty."""
@@ -233,10 +233,8 @@ class TestMainPrsFlow:
         # Verify that _evaluate_run_result was called with a result dict
         # containing the PR keys 661 and 662
         call_args = mock_eval.call_args
-        assert call_args is not None
         result_dict = call_args[0][0]
-        assert 661 in result_dict
-        assert 662 in result_dict
+        assert 661 in result_dict and 662 in result_dict
 
 
 class TestValidatePrOpen:

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -196,18 +196,19 @@ class TestMainPrsFlow:
     ) -> None:
         """main() threads --prs into CIDriverOptions.prs."""
         monkeypatch.setattr(sys, "argv", ["ci", "--prs", "661", "662", "--dry-run", "--force-run"])
-        with patch("hephaestus.automation.ci_driver.CIDriver") as mock_driver_class:
-            with patch(
-                "hephaestus.automation.ci_driver._evaluate_run_result",
-                return_value=0,
-            ):
-                mock_instance = MagicMock()
-                mock_instance.run.return_value = {}
-                mock_instance.open_prs_remaining = []
-                mock_driver_class.return_value = mock_instance
+        with patch("hephaestus.automation.ci_driver.resolve_agent", return_value="claude"):
+            with patch("hephaestus.automation.ci_driver.CIDriver") as mock_driver_class:
+                with patch(
+                    "hephaestus.automation.ci_driver._evaluate_run_result",
+                    return_value=0,
+                ):
+                    mock_instance = MagicMock()
+                    mock_instance.run.return_value = {}
+                    mock_instance.open_prs_remaining = []
+                    mock_driver_class.return_value = mock_instance
 
-                # Import and call main
-                ci_driver.main()
+                    # Import and call main
+                    ci_driver.main()
 
         # Verify CIDriver was instantiated with options.prs=[661, 662]
         call_args = mock_driver_class.call_args
@@ -218,17 +219,18 @@ class TestMainPrsFlow:
     def test_main_prs_json_output_includes_open_prs(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """--prs --json output includes open PRs from result."""
         monkeypatch.setattr(sys, "argv", ["ci", "--prs", "661", "662", "--json", "--force-run"])
-        with patch("hephaestus.automation.ci_driver.CIDriver") as mock_driver_class:
-            with patch(
-                "hephaestus.automation.ci_driver._evaluate_run_result",
-                return_value=0,
-            ) as mock_eval:
-                mock_instance = MagicMock()
-                mock_instance.run.return_value = {661: None, 662: None}
-                mock_instance.open_prs_remaining = [661, 662]
-                mock_driver_class.return_value = mock_instance
+        with patch("hephaestus.automation.ci_driver.resolve_agent", return_value="claude"):
+            with patch("hephaestus.automation.ci_driver.CIDriver") as mock_driver_class:
+                with patch(
+                    "hephaestus.automation.ci_driver._evaluate_run_result",
+                    return_value=0,
+                ) as mock_eval:
+                    mock_instance = MagicMock()
+                    mock_instance.run.return_value = {661: None, 662: None}
+                    mock_instance.open_prs_remaining = [661, 662]
+                    mock_driver_class.return_value = mock_instance
 
-                ci_driver.main()
+                    ci_driver.main()
 
         # Verify that _evaluate_run_result was called with a result dict
         # containing the PR keys 661 and 662


### PR DESCRIPTION
## Summary

Add direct `--prs` CLI mode to `drive_prs_green` allowing operators to specify PR numbers directly, bypassing issue-to-PR discovery. Enables driving PRs that use `Refs #N` instead of `Closes #N` (e.g., Radiance #661, #662, #664, #666).

## Changes

- **models.py**: Add `prs: list[int]` field to `CIDriverOptions`
- **ci_driver.py**: 
  - Add `--prs [PR ...]` argparse argument with help and example
  - Implement `_validate_pr_open()` to validate PR state before work submission
  - Extend `_discover_prs()` to union direct PRs after issue discovery, keyed as synthetic issues
  - Update empty-input gate to check `options.prs` in addition to `options.issues`
  - Thread `args.prs` through `main()` to `CIDriverOptions`
- **test_ci_driver_prs_mode.py**: Comprehensive test suite covering parse, discovery, dedup, validation, and gate logic

## Testing

✅ All 20 new tests pass (parse args, discover PRs, dedup, closed PR handling, gate logic, main flow, validation)
✅ All 121 existing ci_driver tests pass
✅ Full automation suite passes
✅ Type checking passes (mypy)
✅ Linting passes (ruff)

Closes #918