### PR TITLE
chore(gitignore): ignore LEARNINGS_ISSUE_*.md scratch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ docs/api/
 # hatch-vcs generated version file
 hephaestus/_version.py
 
+# Automation scratch files (per-issue learnings, planning notes, etc.) — see #1023
+LEARNINGS_ISSUE_*.md
+
 # Python
 *__pycache__/
 *.py[cod]


### PR DESCRIPTION
Prevent per-issue automation scratch files from being accidentally committed to the repo root.

Adds a `.gitignore` entry for `LEARNINGS_ISSUE_*.md` patterns to suppress automation-generated learnings files that should never be tracked.

Closes #1023