### PR TITLE
feat(skills): make auto-merge detect repo merge settings dynamically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -184,6 +184,17 @@ repos:
         files: ^SECURITY\.md$
 
 
+  # Skill merge method check: skills must not hardcode merge flags
+  - repo: local
+    hooks:
+      - id: skill-merge-method
+        name: Skill files use choose_merge_flag (no hardcoded merge method)
+        description: Forbid hardcoded `gh pr merge --auto --(rebase|squash|merge)` in skills/**/SKILL.md
+        entry: pixi run python -m hephaestus.validation.skill_merge_method
+        language: system
+        files: ^skills/.*/SKILL\.md$
+        pass_filenames: false
+
   # Dependency-sync check: requirements*.txt entries must exist in pixi.toml
   # and fall within the declared range. See hephaestus.config.dep_sync.
   - repo: local

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -261,7 +261,20 @@ git -C {worktree_path} push --force-with-lease --force-if-includes origin {branc
 ```bash
 PR=$(gh pr list --repo {repo_slug} --head {branch} --json number --jq '.[0].number // empty')
 if [ -n "$PR" ]; then
-  gh pr merge --auto --merge "$PR"
+  HELPER=""
+  for cand in \
+      "${{HEPHAESTUS_REPO_ROOT:-}}/scripts/choose_merge_flag.sh" \
+      "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/choose_merge_flag.sh" \
+      "$HOME/Projects/ProjectHephaestus/scripts/choose_merge_flag.sh"; do
+    if [ -r "$cand" ]; then HELPER="$cand"; break; fi
+  done
+  if [ -n "$HELPER" ]; then
+    . "$HELPER"
+    MERGE_FLAG=$(choose_merge_flag {repo_slug}) || MERGE_FLAG="--squash"
+  else
+    MERGE_FLAG="--squash"
+  fi
+  gh pr merge --auto "$MERGE_FLAG" "$PR"
 fi
 ```
 

--- a/hephaestus/validation/skill_merge_method.py
+++ b/hephaestus/validation/skill_merge_method.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Lint: skill files must not hardcode the gh pr merge method.
+
+Scans skills/*/SKILL.md for the pattern
+    gh pr merge ... --auto --(rebase|squash|merge)
+and fails on any match unless it is inside a fenced code block whose
+preceding non-blank line is exactly the marker
+    <!-- merge-method-allowed: example -->
+
+Usage: python -m hephaestus.validation.skill_merge_method
+"""
+import re
+import sys
+from pathlib import Path
+
+HARDCODED = re.compile(
+    r"gh\s+pr\s+merge\b[^\n]*--auto\b[^\n]*--(rebase|squash|merge)\b"
+)
+MARKER = "<!-- merge-method-allowed: example -->"
+FENCE = re.compile(r"^\s*```")
+
+
+def _block_is_marked(lines: list[str], idx: int) -> bool:
+    """Return True if the fenced block containing 1-indexed line ``idx`` is marked."""
+    fence_open = None
+    for i in range(idx - 1, -1, -1):
+        if FENCE.match(lines[i]):
+            fence_open = i
+            break
+    if fence_open is None:
+        return False
+    for j in range(fence_open - 1, -1, -1):
+        if lines[j].strip() == "":
+            continue
+        return lines[j].strip() == MARKER
+    return False
+
+
+def scan(root: Path) -> list[tuple[Path, int, str]]:
+    findings: list[tuple[Path, int, str]] = []
+    for path in sorted((root / "skills").glob("*/SKILL.md")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for idx, line in enumerate(lines, start=1):
+            if not HARDCODED.search(line):
+                continue
+            if _block_is_marked(lines, idx):
+                continue
+            findings.append((path, idx, line.rstrip()))
+    return findings
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    findings = scan(repo_root)
+    if not findings:
+        return 0
+    for path, lineno, text in findings:
+        rel = path.relative_to(repo_root)
+        print(f"{rel}:{lineno}: hardcoded gh pr merge method — use choose_merge_flag")
+        print(f"    {text}")
+    print(
+        "\nReplace with the choose_merge_flag snippet (see "
+        "skills/finish-branch/SKILL.md) or mark an instructional example "
+        f"with '{MARKER}' on the line above its fence."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hephaestus/validation/skill_merge_method.py
+++ b/hephaestus/validation/skill_merge_method.py
@@ -9,13 +9,12 @@ preceding non-blank line is exactly the marker
 
 Usage: python -m hephaestus.validation.skill_merge_method
 """
+
 import re
 import sys
 from pathlib import Path
 
-HARDCODED = re.compile(
-    r"gh\s+pr\s+merge\b[^\n]*--auto\b[^\n]*--(rebase|squash|merge)\b"
-)
+HARDCODED = re.compile(r"gh\s+pr\s+merge\b[^\n]*--auto\b[^\n]*--(rebase|squash|merge)\b")
 MARKER = "<!-- merge-method-allowed: example -->"
 FENCE = re.compile(r"^\s*```")
 
@@ -37,6 +36,15 @@ def _block_is_marked(lines: list[str], idx: int) -> bool:
 
 
 def scan(root: Path) -> list[tuple[Path, int, str]]:
+    """Scan skill files for hardcoded gh pr merge methods.
+
+    Args:
+        root: Repository root directory
+
+    Returns:
+        List of (path, line_number, line_text) tuples for violations
+
+    """
     findings: list[tuple[Path, int, str]] = []
     for path in sorted((root / "skills").glob("*/SKILL.md")):
         lines = path.read_text(encoding="utf-8").splitlines()
@@ -50,6 +58,12 @@ def scan(root: Path) -> list[tuple[Path, int, str]]:
 
 
 def main() -> int:
+    """Entry point for skill merge method linter.
+
+    Returns:
+        0 if no violations found, 1 otherwise
+
+    """
     repo_root = Path(__file__).resolve().parents[2]
     findings = scan(repo_root)
     if not findings:

--- a/scripts/choose_merge_flag.sh
+++ b/scripts/choose_merge_flag.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Source this file to get choose_merge_flag().
+#
+# Usage:
+#   . "<path>/scripts/choose_merge_flag.sh"
+#   MERGE_FLAG=$(choose_merge_flag HomericIntelligence/ProjectMnemosyne) || exit 1
+#   gh pr merge "$PR" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
+#
+# Preference order: rebase (linear history) -> squash -> merge commit.
+# Exit codes:
+#   0  printed flag to stdout
+#   1  gh api failed OR repo allows no methods (message on stderr)
+#   2  missing argument (message on stderr)
+choose_merge_flag() {
+    local repo="$1"
+    if [ -z "$repo" ]; then
+        echo "choose_merge_flag: missing required argument <owner/repo>" >&2
+        return 2
+    fi
+    local raw flag
+    if ! raw=$(gh api "repos/${repo}" 2>&1); then
+        echo "choose_merge_flag: gh api repos/${repo} failed: ${raw}" >&2
+        echo "  (check: gh auth status; token needs 'repo' scope; repo exists)" >&2
+        return 1
+    fi
+    flag=$(printf '%s' "$raw" | jq -r '[
+        (if .allow_rebase_merge then "--rebase" else empty end),
+        (if .allow_squash_merge then "--squash" else empty end),
+        (if .allow_merge_commit then "--merge"  else empty end)
+    ] | .[0] // ""' 2>/dev/null)
+    if [ -z "$flag" ]; then
+        echo "choose_merge_flag: target repo ${repo} allows no merge methods" >&2
+        return 1
+    fi
+    printf '%s\n' "$flag"
+}

--- a/skills/finish-branch/SKILL.md
+++ b/skills/finish-branch/SKILL.md
@@ -99,8 +99,23 @@ Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
 EOF
 )"
 
-# Enable auto-merge (mandatory under repo PR policy)
-gh pr merge --auto --rebase
+# Enable auto-merge (mandatory under repo PR policy).
+# Pick the method this repo actually allows (rebase -> squash -> merge).
+HELPER=""
+for cand in \
+    "${HEPHAESTUS_REPO_ROOT:-}/scripts/choose_merge_flag.sh" \
+    "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/choose_merge_flag.sh" \
+    "$HOME/Projects/ProjectHephaestus/scripts/choose_merge_flag.sh"; do
+    if [ -r "$cand" ]; then HELPER="$cand"; break; fi
+done
+if [ -n "$HELPER" ]; then
+    . "$HELPER"
+    MERGE_FLAG=$(choose_merge_flag "$(gh repo view --json nameWithOwner --jq .nameWithOwner)") \
+        || MERGE_FLAG="--squash"   # safe org-wide default per HomericIntelligence policy
+else
+    MERGE_FLAG="--squash"
+fi
+gh pr merge --auto "$MERGE_FLAG"
 ```
 
 Then: Cleanup worktree (Step 5)

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -419,7 +419,20 @@ Agent(description="Create skill C", prompt="...skill C content...")
     # Enable auto-merge so the PR merges automatically once CI passes
     # Note: gh pr merge requires a PR number when using --repo
     PR_NUMBER=$(gh pr list --repo HomericIntelligence/ProjectMnemosyne --head "skill/<name>" --json number --jq '.[0].number')
-    gh pr merge "$PR_NUMBER" --auto --squash --repo HomericIntelligence/ProjectMnemosyne
+    HELPER=""
+    for cand in \
+        "${HEPHAESTUS_REPO_ROOT:-}/scripts/choose_merge_flag.sh" \
+        "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/choose_merge_flag.sh" \
+        "$HOME/Projects/ProjectHephaestus/scripts/choose_merge_flag.sh"; do
+        if [ -r "$cand" ]; then HELPER="$cand"; break; fi
+    done
+    if [ -n "$HELPER" ]; then
+        . "$HELPER"
+        MERGE_FLAG=$(choose_merge_flag HomericIntelligence/ProjectMnemosyne) || MERGE_FLAG="--squash"
+    else
+        MERGE_FLAG="--squash"
+    fi
+    gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
     ```
 
 10. **Cleanup worktree** (always clean up after PR creation):

--- a/skills/myrmidon-swarm/SKILL.md
+++ b/skills/myrmidon-swarm/SKILL.md
@@ -315,7 +315,16 @@ Sub-agents that create PRs must follow:
 3. `git commit -m "type(scope): description"`
 4. `git push -u origin <branch>`
 5. `gh pr create --title "..." --body "..."`
-6. `gh pr merge --auto --squash`
+6. Arm auto-merge with `choose_merge_flag`:
+
+   ```bash
+   . "$(git rev-parse --show-toplevel 2>/dev/null)/scripts/choose_merge_flag.sh" \
+       || . "$HOME/Projects/ProjectHephaestus/scripts/choose_merge_flag.sh"
+   MERGE_FLAG=$(choose_merge_flag "$(gh repo view --json nameWithOwner --jq .nameWithOwner)") || MERGE_FLAG="--squash"
+   gh pr merge --auto "$MERGE_FLAG"
+   ```
+
+   (Picks rebase → squash → merge per the target repo's allowed methods.)
 </constraints>
 
 <agent_prompt_template>

--- a/skills/tidy/SKILL.md
+++ b/skills/tidy/SKILL.md
@@ -24,8 +24,8 @@ Tidy local branches and fix failed rebases with a Myrmidon swarm.
 3. Parses gh-tidy's output for `"WARNING: Unable to auto-rebase the following branches"`.
 4. Spawns one Sonnet Myrmidon agent per failing branch (max 5 concurrent) to complete
    the rebase using semantic conflict resolution.
-5. After each agent succeeds, re-arms `gh pr merge --auto --merge` on the branch's PR
-   if one exists.
+5. After each agent succeeds, re-arms auto-merge on the branch's PR using
+   `choose_merge_flag` (preference rebase → squash → merge, per target repo settings).
 6. Prints a final summary: rebased / subsumed / still failing.
 
 ## What the Swarm Does NOT Do

--- a/tests/integration/test_choose_merge_flag_sh.py
+++ b/tests/integration/test_choose_merge_flag_sh.py
@@ -6,17 +6,22 @@ SNIPPET = REPO / "scripts" / "choose_merge_flag.sh"
 
 
 def test_shell_helper_defines_function() -> None:
+    """Verify that choose_merge_flag is defined as a function."""
     out = subprocess.run(
         ["bash", "-c", f". {SNIPPET} && type choose_merge_flag"],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     )
     assert "choose_merge_flag is a function" in out.stdout
 
 
 def test_shell_helper_errors_on_missing_arg() -> None:
+    """Verify that choose_merge_flag returns error when called without arguments."""
     out = subprocess.run(
         ["bash", "-c", f". {SNIPPET} && choose_merge_flag"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert out.returncode == 2
     assert "missing required argument" in out.stderr

--- a/tests/integration/test_choose_merge_flag_sh.py
+++ b/tests/integration/test_choose_merge_flag_sh.py
@@ -1,0 +1,22 @@
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+SNIPPET = REPO / "scripts" / "choose_merge_flag.sh"
+
+
+def test_shell_helper_defines_function() -> None:
+    out = subprocess.run(
+        ["bash", "-c", f". {SNIPPET} && type choose_merge_flag"],
+        capture_output=True, text=True, check=True,
+    )
+    assert "choose_merge_flag is a function" in out.stdout
+
+
+def test_shell_helper_errors_on_missing_arg() -> None:
+    out = subprocess.run(
+        ["bash", "-c", f". {SNIPPET} && choose_merge_flag"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 2
+    assert "missing required argument" in out.stderr

--- a/tests/unit/github/test_tidy_agent_prompt_merge_method.py
+++ b/tests/unit/github/test_tidy_agent_prompt_merge_method.py
@@ -1,20 +1,19 @@
 """Regression: tidy agent-prompt template must not hardcode gh pr merge method."""
+
 import re
 
 from hephaestus.github import tidy
 
 
 def test_agent_prompt_does_not_hardcode_merge_method() -> None:
-    # Since the template is created in _make_agent_prompt, we need to call it with dummy params
-    # and verify the output doesn't contain hardcoded merge flags
+    """Verify tidy agent prompt does not hardcode gh pr merge method."""
     import inspect
-    
+
     # Get the source of _make_agent_prompt
     source = inspect.getsource(tidy._make_agent_prompt)
-    
+
     # Check for hardcoded merge flags in the source
     assert not re.search(r"--auto\s+--(rebase|squash|merge)\b", source), (
-        "tidy._make_agent_prompt still hardcodes a merge method; "
-        "use choose_merge_flag instead."
+        "tidy._make_agent_prompt still hardcodes a merge method; use choose_merge_flag instead."
     )
     assert "choose_merge_flag" in source

--- a/tests/unit/github/test_tidy_agent_prompt_merge_method.py
+++ b/tests/unit/github/test_tidy_agent_prompt_merge_method.py
@@ -1,0 +1,20 @@
+"""Regression: tidy agent-prompt template must not hardcode gh pr merge method."""
+import re
+
+from hephaestus.github import tidy
+
+
+def test_agent_prompt_does_not_hardcode_merge_method() -> None:
+    # Since the template is created in _make_agent_prompt, we need to call it with dummy params
+    # and verify the output doesn't contain hardcoded merge flags
+    import inspect
+    
+    # Get the source of _make_agent_prompt
+    source = inspect.getsource(tidy._make_agent_prompt)
+    
+    # Check for hardcoded merge flags in the source
+    assert not re.search(r"--auto\s+--(rebase|squash|merge)\b", source), (
+        "tidy._make_agent_prompt still hardcodes a merge method; "
+        "use choose_merge_flag instead."
+    )
+    assert "choose_merge_flag" in source

--- a/tests/unit/validation/test_skill_merge_method.py
+++ b/tests/unit/validation/test_skill_merge_method.py
@@ -13,6 +13,7 @@ def _make_skill(tmp_path: Path, name: str, body: str) -> Path:
 
 
 def test_flags_hardcoded_rebase(tmp_path: Path) -> None:
+    """Verify detection of hardcoded --rebase flag."""
     _make_skill(tmp_path, "bad", "```bash\ngh pr merge --auto --rebase\n```\n")
     findings = scan(tmp_path)
     assert len(findings) == 1
@@ -20,12 +21,14 @@ def test_flags_hardcoded_rebase(tmp_path: Path) -> None:
 
 
 def test_flags_hardcoded_squash_and_merge(tmp_path: Path) -> None:
-    _make_skill(tmp_path, "bad1", '```bash\ngh pr merge $P --auto --squash --repo X/Y\n```\n')
+    """Verify detection of hardcoded --squash and --merge flags."""
+    _make_skill(tmp_path, "bad1", "```bash\ngh pr merge $P --auto --squash --repo X/Y\n```\n")
     _make_skill(tmp_path, "bad2", "```bash\ngh pr merge --auto --merge\n```\n")
     assert len(scan(tmp_path)) == 2
 
 
 def test_allows_marked_example_block(tmp_path: Path) -> None:
+    """Verify that marked example blocks are excluded from linting."""
     _make_skill(
         tmp_path,
         "good",
@@ -40,6 +43,7 @@ def test_allows_marked_example_block(tmp_path: Path) -> None:
 
 
 def test_marker_only_applies_to_immediate_block(tmp_path: Path) -> None:
+    """Verify that marker only exempts the immediately following code block."""
     _make_skill(
         tmp_path,
         "tricky",
@@ -62,6 +66,7 @@ def test_marker_only_applies_to_immediate_block(tmp_path: Path) -> None:
 
 
 def test_clean_repo_passes(tmp_path: Path) -> None:
+    """Verify that repos with no violations pass the check."""
     _make_skill(tmp_path, "fine", "# nothing to see here\n")
     assert scan(tmp_path) == []
 

--- a/tests/unit/validation/test_skill_merge_method.py
+++ b/tests/unit/validation/test_skill_merge_method.py
@@ -1,0 +1,72 @@
+import textwrap
+from pathlib import Path
+
+from hephaestus.validation.skill_merge_method import scan
+
+
+def _make_skill(tmp_path: Path, name: str, body: str) -> Path:
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    p = skill_dir / "SKILL.md"
+    p.write_text(textwrap.dedent(body).lstrip("\n"), encoding="utf-8")
+    return p
+
+
+def test_flags_hardcoded_rebase(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "bad", "```bash\ngh pr merge --auto --rebase\n```\n")
+    findings = scan(tmp_path)
+    assert len(findings) == 1
+    assert findings[0][1] == 2
+
+
+def test_flags_hardcoded_squash_and_merge(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "bad1", '```bash\ngh pr merge $P --auto --squash --repo X/Y\n```\n')
+    _make_skill(tmp_path, "bad2", "```bash\ngh pr merge --auto --merge\n```\n")
+    assert len(scan(tmp_path)) == 2
+
+
+def test_allows_marked_example_block(tmp_path: Path) -> None:
+    _make_skill(
+        tmp_path,
+        "good",
+        """
+        <!-- merge-method-allowed: example -->
+        ```bash
+        gh pr merge --auto --rebase   # OLD: do not copy
+        ```
+        """,
+    )
+    assert scan(tmp_path) == []
+
+
+def test_marker_only_applies_to_immediate_block(tmp_path: Path) -> None:
+    _make_skill(
+        tmp_path,
+        "tricky",
+        """
+        <!-- merge-method-allowed: example -->
+        ```bash
+        gh pr merge --auto --rebase
+        ```
+
+        some prose
+
+        ```bash
+        gh pr merge --auto --squash
+        ```
+        """,
+    )
+    findings = scan(tmp_path)
+    assert len(findings) == 1
+    assert "--squash" in findings[0][2]
+
+
+def test_clean_repo_passes(tmp_path: Path) -> None:
+    _make_skill(tmp_path, "fine", "# nothing to see here\n")
+    assert scan(tmp_path) == []
+
+
+def test_real_repo_skills_pass() -> None:
+    """The real skills/ tree must be clean after this PR lands."""
+    repo_root = Path(__file__).resolve().parents[3]
+    assert scan(repo_root) == []


### PR DESCRIPTION
## Summary

Replace hardcoded `gh pr merge --auto` flags across skill files with dynamic detection based on each repository's allowed merge methods. Fixes the issue where skills fail when the target repo doesn't support the hardcoded method.

- Skills previously failed if they hardcoded `--rebase` on squash-only repos or `--squash` on rebase-only repos
- New `choose_merge_flag` helper queries `gh api` and returns the first allowed method in preference order: rebase → squash → merge
- Includes lint validation and tests to prevent regression

## Test Plan

- [x] Unit tests for `skill_merge_method` lint (detects hardcoded flags, exempts marked examples)
- [x] Integration tests for `choose_merge_flag.sh` helper (function definition, error handling)
- [x] Regression test for `tidy.py` agent-prompt template (no hardcoded flags)
- [x] Pre-commit hook integrated and passes full linting suite
- [x] All 9 new tests pass; full test suite: 3519 passed, 19 skipped

## Files Changed

- **New**: `scripts/choose_merge_flag.sh` — Shell helper with tiered fallback
- **New**: `hephaestus/validation/skill_merge_method.py` — Lint module
- **New**: 3 test files covering helper, lint, and tidy regression
- **Modified**: 5 skill files + 1 Python module to use dynamic detection
- **Modified**: `.pre-commit-config.yaml` — Added skill-merge-method hook

Closes #911
Closes #721

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>