### PR TITLE
fix(automation): scope fleet_sync to @me-authored PRs; exempt Dependabot from Closes#N

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -320,8 +320,19 @@ jobs:
 
       - name: "Check 1: PR body contains 'Closes #N'"
         if: always() && steps.fetch.outcome == 'success'
+        env:
+          # PR author login (github.event.pull_request.user.login), passed via
+          # env so the untrusted value never interpolates into the run script.
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
+          # Dependabot PR bodies are auto-generated and structurally never carry
+          # a `Closes #N` line. Exempt ONLY this body check for dependabot[bot]
+          # (#1070) — Check 2 (auto-merge) and Check 3 (signing) still apply.
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "OK: Dependabot PR — 'Closes #N' body check is not applicable"
+            exit 0
+          fi
           # jq -r reads the untrusted body into a shell variable; downstream
           # use is `printf '%s\n' "$body" | grep`, which never word-splits or
           # interprets the body as a command, so injection is not possible.

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -339,6 +339,16 @@ def list_prs(repo: str) -> list[PRInfo]:
     :func:`_fetch_pr_ci_state`. A genuine list failure is raised, never swallowed
     into an empty list (which would masquerade as "no open PRs" and silently skip
     the entire queue).
+
+    Discovery is scoped to ``--author @me`` (#1070): fleet_sync rebases and
+    re-signs every PR it returns (:func:`rebase_and_resign` runs
+    ``commit --amend --reset-author -S`` then force-pushes). Run against a PR the
+    current user did NOT author — most notably a Dependabot bump — that rewrite
+    strips the native GitHub web-flow signature and stamps the local identity,
+    and when the amend runs in a shell where gpg-agent was not warmed it silently
+    produces an UNSIGNED commit that blocks merge. ``@me`` is resolved
+    server-side by gh, so only the current user's PRs are ever surfaced and
+    re-signed; bot and other contributors' PRs are left untouched.
     """
     try:
         result = _gh(
@@ -347,6 +357,8 @@ def list_prs(repo: str) -> list[PRInfo]:
                 "list",
                 "--state",
                 "open",
+                "--author",
+                "@me",
                 "--json",
                 ("number,title,headRefName,baseRefName,headRefOid,mergeable,mergeStateStatus"),
                 "--limit",

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -793,3 +793,67 @@ class TestPrClassification:
             self._classify(monkeypatch, mergeable="MERGEABLE", state="CLEAN", ci="SUCCESS")
             == PRStatus.READY
         )
+
+
+class TestListPrsAuthorScope:
+    """list_prs must only ever surface PRs authored by the current user.
+
+    Regression guard for #1070: fleet_sync rebases and re-signs every PR it
+    lists, which on a Dependabot (or any other author's) PR strips the native
+    signature and stamps the local identity — silently producing an UNSIGNED
+    commit that blocks merge. Scoping discovery to ``--author @me`` means the
+    automation never touches a PR the current user did not author.
+    """
+
+    def test_list_prs_filters_to_current_user(self, monkeypatch) -> None:
+        """The ``gh pr list`` argv must include ``--author @me``."""
+        captured_argv: list[list[str]] = []
+
+        def fake_gh(args, repo):
+            captured_argv.append(args)
+            return MagicMock(stdout="[]")
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+
+        fleet_sync_module.list_prs("RepoA")
+
+        assert captured_argv, "_gh was never called"
+        pr_list_argv = captured_argv[0]
+        assert "--author" in pr_list_argv, pr_list_argv
+        author_value = pr_list_argv[pr_list_argv.index("--author") + 1]
+        assert author_value == "@me", pr_list_argv
+
+    def test_non_self_authored_pr_is_never_returned(self, monkeypatch) -> None:
+        """A PR returned by gh is still surfaced (gh applies the @me filter).
+
+        gh resolves ``--author @me`` server-side, so by the time the JSON comes
+        back it already excludes other authors. This asserts the wiring: the
+        author filter rides on the same call that returns the list, so no
+        separate client-side filtering can drift out of sync.
+        """
+        monkeypatch.setattr(
+            fleet_sync_module,
+            "_fetch_pr_ci_state",
+            lambda repo, number: "SUCCESS",
+        )
+
+        def fake_gh(args, repo):
+            assert "--author" in args and args[args.index("--author") + 1] == "@me"
+            payload = [
+                {
+                    "number": 1,
+                    "title": "mine",
+                    "headRefName": "feat",
+                    "baseRefName": "main",
+                    "headRefOid": "deadbeef",
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                }
+            ]
+            return MagicMock(stdout=json.dumps(payload))
+
+        monkeypatch.setattr(fleet_sync_module, "_gh", fake_gh)
+
+        prs = fleet_sync_module.list_prs("RepoA")
+
+        assert [p.number for p in prs] == [1]


### PR DESCRIPTION
## Summary

Two related defects let CI block Dependabot PRs that should pass. Surfaced while fixing #1031, whose head commit came back `verification.reason=unsigned`.

### Root cause
`fleet_sync.list_prs` listed **every** open PR with no author filter; `rebase_and_resign` then ran `git commit --amend --no-edit -S --reset-author` and force-pushed each one. On a Dependabot PR that rewrite strips GitHub's native web-flow signature and stamps the local identity — and when the amend runs in a sub-shell where gpg-agent wasn't warmed, the commit silently lands **unsigned**, which `required_signatures` + pr-policy then block.

### Changes
- **`hephaestus/github/fleet_sync.py`** — `list_prs` now passes `--author @me` to `gh pr list`. `@me` resolves server-side (same pattern as `loop_runner._gh_issue_numbers_for`), so fleet automation only ever rebases/re-signs the current user's own PRs. Dependabot and other contributors' PRs are left untouched, preserving their native signatures.
- **`.github/workflows/_required.yml`** — pr-policy Check 1 (`Closes #N` body grep) is exempted for `dependabot[bot]`-authored PRs, whose auto-generated bodies structurally never carry it. Checks 2 (auto-merge) and 3 (signing) remain fully enforced. The PR author login is passed via `env:` and never interpolated into the run script.

### Tests
`TestListPrsAuthorScope` (TDD, RED→GREEN) asserts the `gh pr list` argv carries `--author @me` and that the filter rides on the same call that returns the list. Full `test_fleet_sync.py` suite: 50 passed.

Closes #1070