### PR TITLE
fix(automation): drive existing open PRs through the review→label loop

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -102,6 +102,9 @@ def run_address_fix_session(
     parse_fn: Callable[[str], dict[str, Any]],
     log_file: Path,
     dry_run: bool = False,
+    task_block: str = "",
+    task_review_block: str = "",
+    diff_text: str = "",
 ) -> dict[str, Any]:
     """Run the address-review fix session and return the agent's parsed result.
 
@@ -127,6 +130,11 @@ def run_address_fix_session(
             path passes :func:`_parse_addressed_block`.
         log_file: Path to write the raw session log to.
         dry_run: When True, skip the agent call and return empty result.
+        task_block: Optional task (issue) text for the prompt's context section.
+            Supplied on the existing-PR review path so a fresh (non-resumed)
+            session can read the task and continue the work.
+        task_review_block: Optional plan-review verdict text for the context.
+        diff_text: Optional current implementation diff for the context.
 
     Returns:
         Parsed dict with ``"addressed"`` and ``"replies"`` keys.
@@ -153,6 +161,9 @@ def run_address_fix_session(
         issue_number=issue_number,
         worktree_path=str(worktree_path),
         threads_json=threads_json,
+        task_block=task_block,
+        task_review_block=task_review_block,
+        diff_text=diff_text,
     )
 
     prompt_file = worktree_path / f".claude-address-review-{issue_number}.md"

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -608,6 +608,9 @@ class IssueImplementer:
         branch_name: str,
         worktree_path: Path,
         iteration: int,
+        include_bootstrap_context: bool = False,
+        issue_title: str = "",
+        issue_body: str = "",
     ) -> bool:
         """Address the posted PR threads in-loop, resuming Session 2."""
         return self.phase_runner._run_address_review_step(
@@ -616,6 +619,9 @@ class IssueImplementer:
             branch_name=branch_name,
             worktree_path=worktree_path,
             iteration=iteration,
+            include_bootstrap_context=include_bootstrap_context,
+            issue_title=issue_title,
+            issue_body=issue_body,
         )
 
     def _resume_impl_with_feedback(

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -51,7 +51,7 @@ from .claude_invoke import (
 from .claude_models import advise_model, implementer_model, reviewer_model
 from .claude_timeouts import advise_claude_timeout, implementer_claude_timeout
 from .follow_up import parse_follow_up_items, run_follow_up_issues
-from .git_utils import issue_ref, pr_ref, run
+from .git_utils import issue_ref, pr_ref, run, sync_worktree_to_remote_branch
 from .github_api import gh_pr_list_unresolved_threads
 from .learn import learn_needs_rerun, run_learn
 from .models import (
@@ -66,6 +66,7 @@ from .pr_manager import (
     ensure_pr_created,
     mark_pr_implementation_go,
     mark_pr_implementation_no_go,
+    pr_has_implementation_state_label,
 )
 from .pr_reviewer import gather_impl_review_context, review_pr_inline
 from .prompts import (
@@ -250,32 +251,27 @@ class ImplementationPhaseRunner:
                     worktree_path=None,
                 )
 
-            # Skip implementation entirely when an open PR already exists for
-            # this issue. Re-running the agent would clobber in-flight work;
-            # an open PR from a prior loop is carried to green by the later
-            # drive-green stage. Checked BEFORE create_worktree() so the skip
-            # path costs nothing. Looked up via _impl_module so tests can patch
+            # When an open PR already exists for this issue, skip the
+            # plan/implement steps (the PR is already opened) but STILL drive it
+            # through the in-loop review → address cycle so a green PR earns the
+            # ``state:implementation-go`` label that drive-green requires to arm
+            # auto-merge. A pre-existing PR that never gets reviewed here would
+            # otherwise deadlock: implementer skips it, drive-green only reads
+            # the label and refuses to merge without it. Looked up via
+            # _impl_module so tests can patch
             # ``hephaestus.automation.implementer.find_pr_for_issue``.
             self.status_tracker.update_slot(
                 slot_id, f"{issue_ref(issue_number)}: Checking for existing PR"
             )
             existing_pr = self._impl_module.find_pr_for_issue(issue_number)
             if existing_pr is not None:
-                impl._log(
-                    "info",
-                    f"Issue #{issue_number}: open PR {pr_ref(existing_pr)} already exists — "
-                    f"skipping implementation (handled by later phases)",
-                    thread_id,
-                )
-                with self.state_lock:
-                    state.phase = ImplementationPhase.CREATING_PR
-                impl._save_state(state)
-                return WorkerResult(
+                return self._review_existing_pr(
                     issue_number=issue_number,
-                    success=True,
-                    pr_number=existing_pr,
+                    existing_pr=existing_pr,
                     branch_name=branch_name,
-                    already_has_pr=True,
+                    state=state,
+                    slot_id=slot_id,
+                    thread_id=thread_id,
                 )
 
             # Create worktree (only in non-dry-run mode)
@@ -410,22 +406,13 @@ class ImplementationPhaseRunner:
                 state.last_review_grade = last_grade
             impl._save_state(state)
 
-            if last_verdict == "GO":
-                mark_pr_implementation_go(pr_number)
-                if self.options.auto_merge:
-                    if slot_id is not None:
-                        self.status_tracker.update_slot(
-                            slot_id, f"{issue_ref(issue_number)}: enabling auto-merge"
-                        )
-                    enable_auto_merge_after_implementation_go(pr_number)
-            else:
-                mark_pr_implementation_no_go(pr_number)
-                impl._log(
-                    "warning",
-                    f"{issue_ref(issue_number)}: implementation review did not reach GO; "
-                    f"auto-merge remains disabled for {pr_ref(pr_number)}",
-                    thread_id,
-                )
+            self._apply_impl_review_verdict(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                last_verdict=last_verdict,
+                slot_id=slot_id,
+                thread_id=thread_id,
+            )
 
             # impl-learnings + follow-up filing stay in Session 2 (#28 §B),
             # resuming AGENT_IMPLEMENTER AFTER the loop converges.
@@ -872,11 +859,153 @@ class ImplementationPhaseRunner:
             build_prompt=get_advise_prompt_builder(self.options.agent),
         )
 
+    def _apply_impl_review_verdict(
+        self,
+        *,
+        issue_number: int,
+        pr_number: int,
+        last_verdict: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+    ) -> None:
+        """Label a PR from the review loop's final verdict and arm auto-merge.
+
+        Shared by both the fresh-implementation path and the existing-PR review
+        path so the GO → ``mark_pr_implementation_go`` (+ auto-merge) /
+        non-GO → ``mark_pr_implementation_no_go`` mapping cannot drift between
+        them.
+        """
+        impl = self.impl
+        if last_verdict == "GO":
+            mark_pr_implementation_go(pr_number)
+            if self.options.auto_merge:
+                if slot_id is not None:
+                    self.status_tracker.update_slot(
+                        slot_id, f"{issue_ref(issue_number)}: enabling auto-merge"
+                    )
+                enable_auto_merge_after_implementation_go(pr_number)
+        else:
+            mark_pr_implementation_no_go(pr_number)
+            impl._log(
+                "warning",
+                f"{issue_ref(issue_number)}: implementation review did not reach GO; "
+                f"auto-merge remains disabled for {pr_ref(pr_number)}",
+                thread_id,
+            )
+
+    def _review_existing_pr(
+        self,
+        *,
+        issue_number: int,
+        existing_pr: int,
+        branch_name: str,
+        state: ImplementationState,
+        slot_id: int | None,
+        thread_id: int | None,
+    ) -> WorkerResult:
+        """Drive an already-open PR through the in-loop review → address cycle.
+
+        Replaces the old "skip existing PRs entirely" shortcut. A pre-existing
+        PR is reviewed (and, on NOGO, fixed by the resumed implementer session)
+        so it earns the ``state:implementation-go`` label drive-green needs to
+        arm auto-merge — without this it would deadlock green-but-unmergeable.
+
+        Idempotency: a PR already carrying a terminal implementation-review
+        label (GO or NO-GO) was settled on a prior loop, so it short-circuits
+        without re-reviewing. Anti-clobber: the worktree is hard-reset to
+        ``origin/<branch>`` before the review loop so re-running never discards
+        commits that were pushed to the PR head, and the loop runs with
+        ``session_id=None`` (no agent edit session is started here — the address
+        step inside the loop resumes the implementer's own session by
+        deterministic id only when there are threads to fix).
+        """
+        impl = self.impl
+
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Checking implementation-review label"
+        )
+        has_go, has_no_go = pr_has_implementation_state_label(existing_pr)
+        if has_go or has_no_go:
+            impl._log(
+                "info",
+                f"Issue #{issue_number}: open PR {pr_ref(existing_pr)} already "
+                f"implementation-review {'GO' if has_go else 'NO-GO'} — skipping re-review "
+                "(handled by later phases)",
+                thread_id,
+            )
+            with self.state_lock:
+                state.phase = ImplementationPhase.CREATING_PR
+            impl._save_state(state)
+            return WorkerResult(
+                issue_number=issue_number,
+                success=True,
+                pr_number=existing_pr,
+                branch_name=branch_name,
+                already_has_pr=True,
+            )
+
+        # Reuse-or-create the worktree, then hard-reset it to the PR head so the
+        # reviewer sees the real PR state and any in-loop fix lands on top of it.
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR"
+        )
+        worktree_path = self.worktree_manager.create_worktree(issue_number, branch_name)
+        sync_worktree_to_remote_branch(worktree_path, branch_name)
+
+        with self.state_lock:
+            state.worktree_path = str(worktree_path)
+            state.branch_name = branch_name
+            state.pr_number = existing_pr
+            state.phase = ImplementationPhase.REVIEWING
+        impl._save_state(state)
+
+        issue = self._impl_module.fetch_issue_info(issue_number)
+        iterations, last_verdict, last_grade = impl._run_impl_review_loop(
+            issue_number=issue_number,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            issue_title=issue.title,
+            issue_body=issue.body,
+            session_id=None,
+            slot_id=slot_id,
+            thread_id=thread_id,
+            state=state,
+            pr_number=existing_pr,
+        )
+        with self.state_lock:
+            state.review_iterations = iterations
+            state.last_review_verdict = last_verdict
+            state.last_review_grade = last_grade
+        impl._save_state(state)
+
+        self._apply_impl_review_verdict(
+            issue_number=issue_number,
+            pr_number=existing_pr,
+            last_verdict=last_verdict,
+            slot_id=slot_id,
+            thread_id=thread_id,
+        )
+
+        impl._log(
+            "info",
+            f"Issue #{issue_number}: existing PR {pr_ref(existing_pr)} review complete "
+            f"(verdict={last_verdict or '?'})",
+            thread_id,
+        )
+        return WorkerResult(
+            issue_number=issue_number,
+            success=True,
+            pr_number=existing_pr,
+            branch_name=branch_name,
+            worktree_path=str(worktree_path),
+            already_has_pr=True,
+        )
+
     # ------------------------------------------------------------------
     # Strict review loop for implementer sessions
     # ------------------------------------------------------------------
 
-    def _run_impl_review_loop(  # noqa: C901  # in-loop review + address has several outcome paths
+    def _run_impl_review_loop(
         self,
         *,
         issue_number: int,
@@ -978,20 +1107,15 @@ class ImplementationPhaseRunner:
                 break
 
             # Address step: resume Session 2 to fix the posted threads, commit,
-            # push, and resolve the threads it actually addressed. Skipped when
-            # there is no PR (no inline threads to address) or no session to
-            # resume.
+            # push, and resolve the threads it actually addressed. Skipped only
+            # when there is no PR (no inline threads to address). ``session_id``
+            # is informational — the address step resumes ``AGENT_IMPLEMENTER``
+            # by its deterministic per-(repo,issue,agent) id (or starts a fresh
+            # implementer session when no transcript exists), so the existing-PR
+            # path (which has no initial session_id) can still fix review
+            # threads rather than dead-ending here.
             if pr_number is None:
                 continue
-            if session_id is None:
-                ref = issue_ref(issue_number)
-                impl._log(
-                    "warning",
-                    f"{ref}: cannot address review (no session_id from initial run); "
-                    "stopping review loop",
-                    thread_id,
-                )
-                break
             if slot_id is not None:
                 self.status_tracker.update_slot(
                     slot_id, f"{issue_ref(issue_number)}: addressing review [R{iteration}]"
@@ -1002,6 +1126,14 @@ class ImplementationPhaseRunner:
                 branch_name=branch_name,
                 worktree_path=worktree_path,
                 iteration=iteration,
+                # When the loop started without an initial implementer session
+                # (existing-PR review path), the address session may run fresh
+                # with no transcript to resume — give it the task + task-review
+                # + diff so it can read the work and continue. The fresh-impl
+                # path already carries this in its long-lived transcript.
+                include_bootstrap_context=session_id is None,
+                issue_title=issue_title,
+                issue_body=issue_body,
             )
             if not addressed:
                 ref = issue_ref(issue_number)
@@ -1114,6 +1246,9 @@ class ImplementationPhaseRunner:
         branch_name: str,
         worktree_path: Path,
         iteration: int,
+        include_bootstrap_context: bool = False,
+        issue_title: str = "",
+        issue_body: str = "",
     ) -> bool:
         """Address the posted PR threads in-loop, resuming Session 2.
 
@@ -1139,6 +1274,19 @@ class ImplementationPhaseRunner:
             )
             return False
 
+        # On the existing-PR path the address session may run fresh (no
+        # implementer transcript to resume), so it has no memory of the task or
+        # the implementation. Bootstrap it with the task, the plan-review, and
+        # the current diff. The fresh-impl path already carries this in its
+        # long-lived transcript, so the blocks stay empty there (no extra cost).
+        task_block = ""
+        task_review_block = ""
+        diff_text = ""
+        if include_bootstrap_context:
+            task_block = f"#{issue_number} {issue_title}\n\n{issue_body}".strip()
+            _, task_review_block = self._fetch_plan_and_review(issue_number)
+            diff_text = self.impl._collect_diff(worktree_path, branch_name)
+
         log_file = self.state_dir / f"address-review-{issue_number}-r{iteration}.log"
         fix_result = run_address_fix_session(
             issue_number=issue_number,
@@ -1150,6 +1298,9 @@ class ImplementationPhaseRunner:
             parse_fn=lambda text: self._parse_address_result(text, issue_number, iteration),
             log_file=log_file,
             dry_run=False,
+            task_block=task_block,
+            task_review_block=task_review_block,
+            diff_text=diff_text,
         )
         addressed: list[str] = fix_result.get("addressed", [])
         replies: dict[str, str] = fix_result.get("replies", {})

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -119,10 +119,11 @@ class WorkerResult(BaseModel):
     # failed — it should be retried on the next automation loop after the
     # planner amends and the reviewer re-evaluates. See #551.
     plan_review_not_go: bool = False
-    # Set True when the implementer skipped because an open PR already exists
-    # for this issue. Re-implementing would clobber in-flight work; the open
-    # PR is handled by the implementer's in-loop PR-review + address-review
-    # steps and the later drive-green stage. Not a failure.
+    # Set True when an open PR already existed for this issue, so the
+    # plan/implement steps were skipped. The PR is still driven through the
+    # in-loop PR-review + address-review cycle here (to earn the
+    # implementation-GO label) unless it was already settled by a prior loop.
+    # Not a failure.
     already_has_pr: bool = False
     # Set True when the reviewer short-circuited (plan already cleared GO, or no
     # plan comment yet); the issue was not reviewed this pass and does not

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -29,6 +29,7 @@ from .prompts import get_pr_description
 from .state_labels import (
     STATE_IMPLEMENTATION_GO,
     STATE_IMPLEMENTATION_NO_GO,
+    has_label,
     is_implementation_go,
 )
 from .status_tracker import StatusTracker
@@ -131,6 +132,46 @@ def pr_has_implementation_go_label(pr: dict[str, object]) -> bool:
             if isinstance(name, str):
                 names.append(name)
     return is_implementation_go(names)
+
+
+def _pr_label_names(pr_number: int) -> list[str]:
+    """Return the label names on a PR by number, best-effort.
+
+    Fetches ``gh pr view <n> --json labels`` and normalizes the ``labels``
+    array (each entry is a ``{"name": ...}`` dict) to a flat list of names.
+    Any subprocess or JSON failure yields an empty list so callers can treat a
+    fetch error as "no labels" without raising.
+    """
+    try:
+        result = _gh_call(["pr", "view", str(pr_number), "--json", "labels"], check=False)
+        pr = cast(dict[str, object], json.loads(result.stdout or "{}"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Could not fetch PR #%s labels: %s", pr_number, exc)
+        return []
+    labels = pr.get("labels")
+    if not isinstance(labels, list):
+        return []
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
+def pr_has_implementation_state_label(pr_number: int) -> tuple[bool, bool]:
+    """Return ``(has_go, has_no_go)`` for a PR's implementation-review labels.
+
+    Used to decide whether an existing PR has already been settled by a prior
+    implementation-review pass (either terminal label) so the in-loop review is
+    not re-run every loop. Best-effort: a fetch failure yields ``(False, False)``
+    so the caller treats it as "not yet reviewed" and proceeds.
+    """
+    names = _pr_label_names(pr_number)
+    return is_implementation_go(names), has_label(names, STATE_IMPLEMENTATION_NO_GO)
 
 
 def enable_auto_merge_after_implementation_go(pr_number: int) -> None:

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -16,7 +16,7 @@ These threads live on the PR, not on the issue.
 **Working Directory:** {worktree_path}
 
 {untrusted_notice}
-
+{context_block}
 **Review Threads to Address (untrusted):**
 {threads_json_block}
 
@@ -84,11 +84,52 @@ Rules for the JSON block (UNCHANGED — the pipeline parses exactly this):
 """
 
 
+def _build_context_block(
+    task_block: str,
+    task_review_block: str,
+    diff_text: str,
+    nonce: str,
+) -> str:
+    """Render the optional TASK / TASK_REVIEW / DIFF context for the address prompt.
+
+    These are supplied when the address session may run WITHOUT a prior
+    implementer transcript to resume (the existing-PR review path): a fresh
+    session has no memory of the task or the implementation, so it must read the
+    task, the task-review, and the current diff to continue the work correctly.
+    Each is fenced as untrusted (issue/PR text + diff are GitHub-sourced).
+    Returns an empty string when none are supplied (the resume path already
+    carries this context in its transcript).
+    """
+    sections: list[str] = []
+    if task_block.strip():
+        sections.append(
+            "**Task — the linked issue (untrusted):**\n"
+            + _fence_untrusted("TASK", task_block, nonce)
+        )
+    if task_review_block.strip():
+        sections.append(
+            "**Task review — the plan-review verdict (untrusted):**\n"
+            + _fence_untrusted("TASK_REVIEW", task_review_block, nonce)
+        )
+    if diff_text.strip():
+        sections.append(
+            "**Current implementation diff (untrusted):**\n"
+            + _fence_untrusted("DIFF", diff_text, nonce)
+        )
+    if not sections:
+        return ""
+    return "\n" + "\n\n".join(sections) + "\n"
+
+
 def get_address_review_prompt(
     pr_number: int,
     issue_number: int,
     worktree_path: str,
     threads_json: str,
+    *,
+    task_block: str = "",
+    task_review_block: str = "",
+    diff_text: str = "",
 ) -> str:
     """Get the address review prompt for fixing inline review thread feedback.
 
@@ -100,6 +141,13 @@ def get_address_review_prompt(
         issue_number: Linked GitHub issue number
         worktree_path: Path to the git worktree containing the PR branch
         threads_json: JSON string of unresolved review threads (array of thread dicts)
+        task_block: Optional task (issue title + body) text, rendered as an
+            untrusted context section. Supply when the address session may run
+            without a prior implementer transcript (existing-PR review path).
+        task_review_block: Optional plan-review verdict text, rendered as an
+            untrusted context section.
+        diff_text: Optional current implementation diff, rendered as an untrusted
+            context section.
 
     Returns:
         Formatted address review prompt
@@ -112,4 +160,5 @@ def get_address_review_prompt(
         worktree_path=worktree_path,
         threads_json_block=_fence_untrusted("THREADS_JSON", threads_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        context_block=_build_context_block(task_block, task_review_block, diff_text, nonce),
     )

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -406,13 +406,15 @@ class TestPlanReviewVerdictGate:
 # ---------------------------------------------------------------------------
 
 
-class TestExistingPrSkipsImplementation:
-    """``_implement_issue`` must short-circuit when an open PR already exists.
+class TestExistingPrEntersReviewLoop:
+    """``_implement_issue`` drives an already-open PR through the review loop.
 
-    The guard runs BEFORE worktree creation and the plan-review gate, so a
-    re-run of the loop never re-implements (and never clobbers) an issue that
-    already has an in-flight PR. The open PR is handled by the implementer's
-    in-loop PR-review + address-review steps and the later drive-green stage.
+    Replaces the old "skip existing PRs entirely" behavior: a pre-existing PR
+    is reviewed (and fixed on NOGO) so it can earn the ``state:implementation-go``
+    label that drive-green requires — otherwise it deadlocks green-but-unmergeable.
+    The plan/implement steps are still skipped (the PR is already open), and the
+    worktree is hard-reset to ``origin/<branch>`` first to avoid clobbering
+    pushed work. A PR already carrying a terminal label short-circuits.
     """
 
     @pytest.fixture
@@ -427,7 +429,68 @@ class TestExistingPrSkipsImplementation:
         with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
             return IssueImplementer(options)
 
-    def test_existing_pr_skips_before_worktree_and_agent(
+    def test_existing_pr_without_label_runs_review_and_labels_go(
+        self, impl: IssueImplementer, tmp_path: Path
+    ) -> None:
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
+
+        with (
+            patch(
+                "hephaestus.automation.implementer.find_pr_for_issue",
+                return_value=777,
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, False),
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
+            ) as sync,
+            patch.object(
+                impl.worktree_manager, "create_worktree", return_value=worktree_path
+            ) as create_wt,
+            patch.object(impl, "_save_state"),
+            patch.object(impl, "_has_plan") as has_plan,
+            patch.object(impl, "_run_claude_code") as run_agent,
+            patch.object(impl, "_finalize_pr") as finalize_pr,
+            patch.object(impl, "_run_impl_review_loop", return_value=(1, "GO", "A")) as review_loop,
+            patch(
+                "hephaestus.automation.implementer.fetch_issue_info",
+                return_value=MagicMock(title="t", body="b"),
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"
+            ) as mark_go,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_no_go"
+            ) as mark_no_go,
+            patch(
+                "hephaestus.automation.implementer_phase_runner."
+                "enable_auto_merge_after_implementation_go"
+            ),
+        ):
+            result = impl._implement_issue(1)
+
+        assert result.success is True
+        assert result.already_has_pr is True
+        assert result.pr_number == 777
+        # Worktree IS created and synced; the implement agent and PR creation
+        # are NOT (the PR already exists).
+        create_wt.assert_called_once()
+        sync.assert_called_once()
+        run_agent.assert_not_called()
+        has_plan.assert_not_called()
+        finalize_pr.assert_not_called()
+        # Review loop ran with no initial session_id against the existing PR.
+        review_loop.assert_called_once()
+        assert review_loop.call_args.kwargs["session_id"] is None
+        assert review_loop.call_args.kwargs["pr_number"] == 777
+        # GO verdict labels the PR implementation-GO.
+        mark_go.assert_called_once_with(777)
+        mark_no_go.assert_not_called()
+
+    def test_existing_pr_with_go_label_short_circuits(
         self, impl: IssueImplementer, tmp_path: Path
     ) -> None:
         with (
@@ -435,20 +498,84 @@ class TestExistingPrSkipsImplementation:
                 "hephaestus.automation.implementer.find_pr_for_issue",
                 return_value=777,
             ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(True, False),
+            ),
             patch.object(impl.worktree_manager, "create_worktree") as create_wt,
             patch.object(impl, "_save_state"),
-            patch.object(impl, "_has_plan") as has_plan,
-            patch.object(impl, "_run_claude_code") as run_agent,
+            patch.object(impl, "_run_impl_review_loop") as review_loop,
         ):
             result = impl._implement_issue(1)
 
         assert result.success is True
         assert result.already_has_pr is True
         assert result.pr_number == 777
-        # No worktree, no plan check, no agent session on the skip path.
+        # Already settled — no worktree, no review.
         create_wt.assert_not_called()
-        has_plan.assert_not_called()
+        review_loop.assert_not_called()
+
+    def test_existing_pr_with_no_go_label_short_circuits(
+        self, impl: IssueImplementer, tmp_path: Path
+    ) -> None:
+        with (
+            patch(
+                "hephaestus.automation.implementer.find_pr_for_issue",
+                return_value=777,
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, True),
+            ),
+            patch.object(impl.worktree_manager, "create_worktree") as create_wt,
+            patch.object(impl, "_save_state"),
+            patch.object(impl, "_run_impl_review_loop") as review_loop,
+        ):
+            result = impl._implement_issue(1)
+
+        assert result.success is True
+        assert result.already_has_pr is True
+        create_wt.assert_not_called()
+        review_loop.assert_not_called()
+
+    def test_existing_pr_review_no_go_marks_no_go(
+        self, impl: IssueImplementer, tmp_path: Path
+    ) -> None:
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
+
+        with (
+            patch(
+                "hephaestus.automation.implementer.find_pr_for_issue",
+                return_value=777,
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, False),
+            ),
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
+            patch.object(impl.worktree_manager, "create_worktree", return_value=worktree_path),
+            patch.object(impl, "_save_state"),
+            patch.object(impl, "_run_claude_code") as run_agent,
+            patch.object(impl, "_run_impl_review_loop", return_value=(3, "NOGO", "D")),
+            patch(
+                "hephaestus.automation.implementer.fetch_issue_info",
+                return_value=MagicMock(title="t", body="b"),
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"
+            ) as mark_go,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_no_go"
+            ) as mark_no_go,
+        ):
+            result = impl._implement_issue(1)
+
+        assert result.success is True
+        assert result.already_has_pr is True
         run_agent.assert_not_called()
+        mark_no_go.assert_called_once_with(777)
+        mark_go.assert_not_called()
 
     def test_no_existing_pr_proceeds(self, impl: IssueImplementer, tmp_path: Path) -> None:
         """When no PR exists, the guard is transparent and work proceeds."""

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -183,15 +183,23 @@ class TestRunImplReviewLoop:
         mock_addr.assert_not_called()
         assert mock_rev.call_count == 1
 
-    def test_no_session_id_stops_before_addressing(
+    def test_no_session_id_still_addresses(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """Without a session_id we cannot resume Session 2, so we never address."""
+        """session_id=None (existing-PR path) still addresses review threads.
+
+        The address step resumes AGENT_IMPLEMENTER by its deterministic id, or
+        starts a fresh implementer session bootstrapped with the task/diff — so
+        a pre-existing PR with no initial session is fixed rather than
+        dead-ending. The loop runs to GO on the second iteration here.
+        """
         with (
             patch.object(
-                implementer, "_run_impl_review_step", return_value=(_nogo(), ["t0"])
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo(), ["t0"]), (_go(), [])],
             ) as mock_rev,
-            patch.object(implementer, "_run_address_review_step") as mock_addr,
+            patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
         ):
             iters, verdict, _ = implementer._run_impl_review_loop(
                 issue_number=1,
@@ -205,10 +213,13 @@ class TestRunImplReviewLoop:
                 pr_number=42,
             )
 
-        assert iters == 1
-        assert verdict == "NOGO"
-        mock_addr.assert_not_called()
-        assert mock_rev.call_count == 1
+        assert iters == 2
+        assert verdict == "GO"
+        # Addressing ran despite no initial session_id, and was told to include
+        # bootstrap context (no transcript guaranteed on this path).
+        mock_addr.assert_called_once()
+        assert mock_addr.call_args.kwargs["include_bootstrap_context"] is True
+        assert mock_rev.call_count == 2
 
     def test_prior_review_passed_to_next_reviewer(
         self, implementer: IssueImplementer, tmp_path: Path

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -259,3 +259,32 @@ class TestCoAuthorLine:
         commit_msg = commit_call[-1]
         assert "Co-Authored-By: Codex <noreply@openai.com>" in commit_msg
         mock_model.assert_not_called()
+
+
+class TestImplementationStateLabel:
+    """Tests for pr_has_implementation_state_label (existing-PR idempotency gate)."""
+
+    def test_go_label(self) -> None:
+        gh_mock = _status('{"labels": [{"name": "state:implementation-go"}]}')
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_has_implementation_state_label(7) == (True, False)
+
+    def test_no_go_label(self) -> None:
+        gh_mock = _status('{"labels": [{"name": "state:implementation-no-go"}]}')
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_has_implementation_state_label(7) == (False, True)
+
+    def test_no_label(self) -> None:
+        gh_mock = _status('{"labels": [{"name": "bug"}]}')
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_has_implementation_state_label(7) == (False, False)
+
+    def test_empty_labels(self) -> None:
+        gh_mock = _status('{"labels": []}')
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_has_implementation_state_label(7) == (False, False)
+
+    def test_malformed_json_returns_false_false(self) -> None:
+        gh_mock = _status("not json")
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_has_implementation_state_label(7) == (False, False)

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -739,3 +739,29 @@ class TestAddressReviewPrompt:
             threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "use {x: 1}"}]',
         )
         assert "use {x: 1}" in out
+
+    def test_no_bootstrap_context_by_default(self) -> None:
+        """Without the optional context args, no TASK/DIFF fenced sections appear."""
+        out = self._build()
+        assert "_TASK\n" not in out
+        assert "_DIFF\n" not in out
+        assert "Current implementation diff" not in out
+
+    def test_bootstrap_context_included_when_supplied(self) -> None:
+        """Existing-PR path: task + task-review + diff render as fenced sections."""
+        out = prompts.get_address_review_prompt(
+            pr_number=42,
+            issue_number=7,
+            worktree_path="/tmp/wt",
+            threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "fix"}]',
+            task_block="#7 Title\n\nDo the thing",
+            task_review_block="Plan review: GO",
+            diff_text="diff --git a/a.py b/a.py",
+        )
+        assert "Do the thing" in out
+        assert "Plan review: GO" in out
+        assert "diff --git a/a.py b/a.py" in out
+        # Each bootstrap section is fenced as untrusted (BEGIN_<nonce>_<LABEL>).
+        assert "_TASK\n" in out
+        assert "_TASK_REVIEW\n" in out
+        assert "_DIFF\n" in out


### PR DESCRIPTION
## Summary

A pre-existing open PR was hard-skipped by `_implement_issue` before the in-loop review → address cycle, so it never earned the `state:implementation-go` label that `drive-green` requires to arm auto-merge — leaving green PRs permanently unmergeable. This was the root cause of "the automation didn't fix any PRs": 9 green PRs sat blocked solely on the missing label.

## What changed

- `implementer_phase_runner._implement_issue`: the existing-PR branch now routes into a new `_review_existing_pr` instead of returning early.
  - **Idempotency:** short-circuit only when the PR already carries a terminal implementation-review label (GO/NO-GO) — `pr_manager.pr_has_implementation_state_label`.
  - **Anti-clobber:** reuse/create the worktree, then `sync_worktree_to_remote_branch` (hard-reset to `origin/<branch>`). This replaces the old "skip to avoid clobber" rationale.
  - Run the in-loop review → address cycle against the existing PR and label per the final verdict (shared `_apply_impl_review_verdict` helper, used by both the fresh and existing-PR paths).
- `_run_impl_review_loop` no longer dead-ends when it started without an initial `session_id`. The address step resumes the implementer session by its deterministic id, or runs a fresh session **bootstrapped** with the task + plan-review + diff via new optional `get_address_review_prompt` context blocks (threaded through `run_address_fix_session`).

Library change only; this is the correct default behavior (no new flag). `drive-green` throughput (final-loop-only gating + 3600s per-phase timeout) is a separate concern tracked by #818–#821.

## Tests

- `test_implementer.py`: existing-PR-no-label → review runs + GO labels; already-GO/NO-GO → short-circuit; review NO-GO → no-go label. Fresh path unchanged.
- `test_implementer_loop.py`: `session_id=None` now addresses (was: dead-ended).
- `test_pr_manager.py`: `pr_has_implementation_state_label` GO/NO-GO/none/malformed.
- `test_prompts.py`: address prompt renders bootstrap context only when supplied.

All 1120 automation unit tests pass; ruff + mypy clean.

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)