### PR TITLE
feat(automation): drive-green replies to and resolves bot review threads

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -58,6 +58,7 @@ from .github_api import (
     gh_issue_json,
     gh_pr_checks,
     gh_pr_list_unresolved_threads,
+    gh_pr_resolve_thread,
 )
 from .models import CIDriverOptions, WorkerResult
 from .pr_manager import pr_has_implementation_go_label
@@ -1125,6 +1126,9 @@ class CIDriver:
                     issue_number,
                     iteration + 1,
                 )
+                # Acknowledge automated review comments the fix addressed by
+                # replying + resolving the bot threads (human threads untouched).
+                self._reply_and_resolve_bot_threads(pr_number)
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
             logger.warning("Issue #%s: CI fix attempt %s failed", issue_number, iteration + 1)
@@ -1691,24 +1695,33 @@ class CIDriver:
             logger.warning("Could not load session_id for issue #%s: %s", issue_number, e)
             return None
 
+    def _list_unresolved_threads_safe(self, pr_number: int) -> list[dict[str, Any]]:
+        """Fetch unresolved review threads, swallowing lookup failures.
+
+        Shared by the prompt-context formatter and the post-fix bot-thread
+        reply/resolve step so both run off a single fetch contract. Network/JSON
+        errors are downgraded to an info log and yield an empty list — neither
+        caller is ever gated on review-thread availability (#846).
+        """
+        try:
+            return gh_pr_list_unresolved_threads(pr_number, dry_run=self.options.dry_run)
+        except Exception as exc:
+            logger.info(
+                "Issue PR #%s: failed to fetch unresolved review threads (%s); "
+                "skipping review-thread handling",
+                pr_number,
+                exc,
+            )
+            return []
+
     def _format_review_threads_block(self, pr_number: int) -> str:
         """Render unresolved PR review threads as a Markdown block for the prompt.
 
         Returns the empty string when there are no unresolved threads or when
         the lookup fails — the CI fix loop is never gated on review-thread
-        availability (#846). Network/JSON errors are downgraded to an info log
-        so a transient GitHub blip cannot block forward progress.
+        availability (#846).
         """
-        try:
-            threads = gh_pr_list_unresolved_threads(pr_number, dry_run=self.options.dry_run)
-        except Exception as exc:
-            logger.info(
-                "Issue PR #%s: failed to fetch unresolved review threads (%s); "
-                "skipping review-thread injection",
-                pr_number,
-                exc,
-            )
-            return ""
+        threads = self._list_unresolved_threads_safe(pr_number)
         if not threads:
             return ""
         lines = [
@@ -1734,6 +1747,61 @@ class CIDriver:
         lines.append("---")
         lines.append("")
         return "\n".join(lines)
+
+    @staticmethod
+    def _is_bot_author(login: str) -> bool:
+        """Return True for automated review authors (GitHub App / bot accounts).
+
+        GitHub App authors carry a ``[bot]`` suffix on their login
+        (``github-actions[bot]``, ``coderabbitai[bot]``, ``dependabot[bot]``).
+        Human review threads are never auto-resolved — only the bot's own reply
+        thread is closed after the CI fix addresses it.
+        """
+        return login.endswith("[bot]")
+
+    def _reply_and_resolve_bot_threads(self, pr_number: int) -> int:
+        """Reply to and resolve automated review threads after a successful CI fix.
+
+        ci_driver surfaces unresolved threads to the fix prompt but cannot rely
+        on GitHub auto-resolving a bot thread when its line moves. After a fix
+        lands, post a templated reply on each BOT-authored unresolved thread and
+        resolve it, so the PR's automated review comments are acknowledged
+        rather than left dangling. Human threads are left untouched. Best-effort:
+        a failure on one thread is logged and skipped (never blocks the fix).
+
+        Returns the number of threads resolved.
+        """
+        if self.options.dry_run:
+            return 0
+        threads = self._list_unresolved_threads_safe(pr_number)
+        resolved = 0
+        for t in threads:
+            if not self._is_bot_author(t.get("author") or ""):
+                continue
+            thread_id = t.get("id")
+            if not thread_id:
+                continue
+            try:
+                gh_pr_resolve_thread(
+                    thread_id,
+                    "Addressed by the automated CI fix on this PR.",
+                    dry_run=False,
+                )
+                resolved += 1
+            except Exception as exc:
+                logger.info(
+                    "PR #%s: could not reply/resolve bot thread %s (%s); skipping",
+                    pr_number,
+                    thread_id,
+                    exc,
+                )
+        if resolved:
+            logger.info(
+                "PR #%s: replied to and resolved %s automated review thread(s)",
+                pr_number,
+                resolved,
+            )
+        return resolved
 
     def _failing_required_check_names(self, pr_number: int) -> list[str]:
         """Return names of required checks that are currently failing.

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1549,7 +1549,9 @@ def gh_pr_list_unresolved_threads(
         dry_run: If True, return empty list
 
     Returns:
-        List of thread dicts with keys: id (str), path (str), line (int | None), body (str)
+        List of thread dicts with keys: id (str), path (str), line (int | None),
+        body (str), author (str — the first comment's author login, ``""`` if
+        unknown).
 
     """
     if dry_run:
@@ -1568,7 +1570,8 @@ def gh_pr_list_unresolved_threads(
         "  repository(owner:$owner,name:$name){"
         "    pullRequest(number:$number){"
         "      reviewThreads(first:100){"
-        "        nodes{ id isResolved path line comments(first:1){ nodes{ body } } }"
+        "        nodes{ id isResolved path line "
+        "comments(first:1){ nodes{ body author{ login } } } }"
         "      }"
         "    }"
         "  }"
@@ -1605,13 +1608,19 @@ def gh_pr_list_unresolved_threads(
         if node.get("isResolved"):
             continue
         first_comment_nodes = node.get("comments", {}).get("nodes", [])
-        body = first_comment_nodes[0]["body"] if first_comment_nodes else ""
+        first_comment = first_comment_nodes[0] if first_comment_nodes else {}
+        body = first_comment.get("body", "")
+        author = ""
+        author_node = first_comment.get("author")
+        if isinstance(author_node, dict):
+            author = author_node.get("login") or ""
         threads.append(
             {
                 "id": node["id"],
                 "path": node.get("path", ""),
                 "line": node.get("line"),
                 "body": body,
+                "author": author,
             }
         )
 

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -143,6 +143,72 @@ class TestLoadImplSessionId:
 
 
 # ---------------------------------------------------------------------------
+# _reply_and_resolve_bot_threads
+# ---------------------------------------------------------------------------
+
+
+class TestReplyAndResolveBotThreads:
+    """After a CI fix, bot review threads are replied to + resolved; humans aren't."""
+
+    def test_resolves_only_bot_threads(self, driver: CIDriver) -> None:
+        threads = [
+            {"id": "T_bot", "path": "a.py", "line": 1, "body": "nit", "author": "x[bot]"},
+            {"id": "T_human", "path": "b.py", "line": 2, "body": "?", "author": "alice"},
+        ]
+        with (
+            patch.object(driver, "_list_unresolved_threads_safe", return_value=threads),
+            patch("hephaestus.automation.ci_driver.gh_pr_resolve_thread") as resolve,
+        ):
+            count = driver._reply_and_resolve_bot_threads(999)
+
+        assert count == 1
+        resolve.assert_called_once()
+        assert resolve.call_args.args[0] == "T_bot"
+
+    def test_no_threads_is_noop(self, driver: CIDriver) -> None:
+        with (
+            patch.object(driver, "_list_unresolved_threads_safe", return_value=[]),
+            patch("hephaestus.automation.ci_driver.gh_pr_resolve_thread") as resolve,
+        ):
+            assert driver._reply_and_resolve_bot_threads(999) == 0
+        resolve.assert_not_called()
+
+    def test_dry_run_is_noop(self, driver: CIDriver) -> None:
+        driver.options.dry_run = True
+        with (
+            patch.object(driver, "_list_unresolved_threads_safe") as lister,
+            patch("hephaestus.automation.ci_driver.gh_pr_resolve_thread") as resolve,
+        ):
+            assert driver._reply_and_resolve_bot_threads(999) == 0
+        lister.assert_not_called()
+        resolve.assert_not_called()
+
+    def test_per_thread_failure_is_skipped(self, driver: CIDriver) -> None:
+        threads = [
+            {"id": "T_bot1", "path": "a", "line": 1, "body": "x", "author": "b[bot]"},
+            {"id": "T_bot2", "path": "b", "line": 2, "body": "y", "author": "b[bot]"},
+        ]
+        with (
+            patch.object(driver, "_list_unresolved_threads_safe", return_value=threads),
+            patch(
+                "hephaestus.automation.ci_driver.gh_pr_resolve_thread",
+                side_effect=[RuntimeError("boom"), None],
+            ) as resolve,
+        ):
+            count = driver._reply_and_resolve_bot_threads(999)
+
+        # First raised, second succeeded — one resolved, no exception propagated.
+        assert count == 1
+        assert resolve.call_count == 2
+
+    def test_is_bot_author(self) -> None:
+        assert CIDriver._is_bot_author("github-actions[bot]") is True
+        assert CIDriver._is_bot_author("dependabot[bot]") is True
+        assert CIDriver._is_bot_author("alice") is False
+        assert CIDriver._is_bot_author("") is False
+
+
+# ---------------------------------------------------------------------------
 # _parse_json_block
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/automation/test_github_api_review_threads.py
+++ b/tests/unit/automation/test_github_api_review_threads.py
@@ -58,3 +58,46 @@ class TestListUnresolvedThreadsParameterisation:
         assert "pullRequest(number: 42)" not in query  # regression guard
         assert 'owner: "owner"' not in query
         assert "owner=owner" in argv and "name=repo" in argv and "number=42" in argv
+        # The query must request the first comment's author login (#PR3).
+        assert "author{ login }" in query
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_surfaces_comment_author_login(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        """Each unresolved thread dict carries the first comment's author login."""
+        mock_repo_info.return_value = ("owner", "repo")
+        nodes = [
+            {
+                "id": "T_bot",
+                "isResolved": False,
+                "path": "a.py",
+                "line": 3,
+                "comments": {"nodes": [{"body": "nit", "author": {"login": "coderabbitai[bot]"}}]},
+            },
+            {
+                "id": "T_human",
+                "isResolved": False,
+                "path": "b.py",
+                "line": None,
+                "comments": {"nodes": [{"body": "hmm", "author": {"login": "alice"}}]},
+            },
+            {
+                "id": "T_noauthor",
+                "isResolved": False,
+                "path": "c.py",
+                "line": 1,
+                "comments": {"nodes": [{"body": "x", "author": None}]},
+            },
+        ]
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {"data": {"repository": {"pullRequest": {"reviewThreads": {"nodes": nodes}}}}}
+        )
+        mock_gh_call.return_value = mock_result
+
+        threads = gh_pr_list_unresolved_threads(42)
+
+        by_id = {t["id"]: t for t in threads}
+        assert by_id["T_bot"]["author"] == "coderabbitai[bot]"
+        assert by_id["T_human"]["author"] == "alice"
+        assert by_id["T_noauthor"]["author"] == ""


### PR DESCRIPTION
## Summary

`drive-green` surfaced unresolved PR review threads into its CI-fix prompt but never replied to or resolved them — relying on GitHub auto-resolving when the cited line changes. Automated/bot review comments were frequently left dangling even after the fix landed.

## What changed

- `gh_pr_list_unresolved_threads` GraphQL now selects the first comment's `author{ login }` and surfaces it as `author` on each thread dict.
- `CIDriver._reply_and_resolve_bot_threads`: after a successful CI fix, posts a templated reply + resolves each **bot-authored** unresolved thread (via the existing `gh_pr_resolve_thread`). Human threads are left untouched. Best-effort (per-thread failures logged and skipped); dry-run is a no-op.
- `_format_review_threads_block` and the new step share one `_list_unresolved_threads_safe` fetch (DRY).

`max_fix_iterations` (default 1) remains the operator knob for "the correct number of iterations" — documented on `CIDriver`, not changed here (YAGNI).

## Tests

- `test_github_api_review_threads.py`: query requests `author{ login }`; bot/human/no-author logins surface correctly.
- `test_ci_driver.py`: only bot threads resolved; human threads untouched; empty/dry-run no-ops; per-thread failure skipped; `_is_bot_author`.

ruff + mypy clean.

Closes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)