### PR TITLE
ci(pr-policy): split auto-merge check into advisory non-required job

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -42,12 +42,15 @@ Builds and publishes the package to PyPI on version tag push (`v*`).
 
 The consolidated required-status-check gate that runs on every pull request to
 `main` (and on push to `main`). It aggregates lint, markdownlint, `pixi-check`,
-shellcheck, the `pr-policy` gate (enforces `Closes #N`, signed commits, and
-the auto-merge state machine), unit/integration/shell tests, wheel build,
-security scans (pip-audit, Gitleaks, bandit), workflow-schema validation, and
-version-sync. It also re-runs on `auto_merge_enabled` / `auto_merge_disabled`
-and `labeled` / `unlabeled` events so the `pr-policy` auto-merge check
-converges without timing races.
+shellcheck, the `pr-policy` gate (enforces `Closes #N` and signed commits),
+unit/integration/shell tests, wheel build, security scans (pip-audit, Gitleaks,
+bandit), workflow-schema validation, and version-sync. It also runs the
+advisory `auto-merge-policy` job (the auto-merge ↔ `state:implementation-go`
+state machine), which is intentionally **not** a required check so its
+timing-sensitive verdict never blocks merge — it fails its own job only on a
+mismatch as a visible signal. The workflow re-runs on `auto_merge_enabled` /
+`auto_merge_disabled` and `labeled` / `unlabeled` events so the
+`auto-merge-policy` job converges without timing races.
 
 ### Enable Auto-Merge on Implementation GO Workflow (`workflows/enable-auto-merge-on-implementation-go.yml`)
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -259,21 +259,19 @@ jobs:
 
   pr-policy:
     name: pr-policy
-    # Enforces repo PR policy on every PR. Three independent checks (each
-    # gated by `if: always()` so one failure still surfaces the others):
+    # Enforces the two HARD repo PR policies on every PR. Both checks are gated
+    # by `if: always()` so one failure still surfaces the other:
     #   1. PR body contains `Closes #N` on its own line.
-    #   2. Auto-merge matches implementation-review state:
-    #      disabled before `state:implementation-go`, enabled after it.
-    #   3. Every commit on the PR has a verified signature.
+    #   2. Every commit on the PR has a verified signature.
+    # The auto-merge ↔ implementation-review state machine moved to the separate
+    # `auto-merge-policy` job (#1080) so its timing-sensitive verdict no longer
+    # blocks merge — it is intentionally NOT in the required-checks ruleset.
     # Push events are skipped because there is no PR to inspect.
     #
-    # This gate intentionally has NO `needs:` — it runs immediately and
-    # re-runs whenever auto-merge is toggled or labels change (see the
-    # auto_merge_enabled / auto_merge_disabled and labeled / unlabeled trigger
-    # types in `on.pull_request` above), so the auto-merge check (#2) converges
-    # on the PR's true state without depending on another job's timing.
-    # The earlier `needs: lint` workaround (#680) only
-    # delayed the read and left a required-check-skipped-on-lint-failure wrinkle.
+    # This gate intentionally has NO `needs:` — it runs immediately so the body
+    # and signature checks report without depending on another job's timing.
+    # The earlier `needs: lint` workaround (#680) only delayed the read and left
+    # a required-check-skipped-on-lint-failure wrinkle.
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
@@ -291,13 +289,13 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
-          # `gh pr view --json body,autoMergeRequest,labels` exposes body,
-          # auto-merge state, and implementation-review labels but DOES NOT
-          # expose per-commit signatures; we use the GraphQL API for that. Two
-          # separate queries are fine here — the workflow runs at most once per
-          # PR event and the policy gate must be cheap to read and debug.
+          # `gh pr view --json body` exposes the PR body (for the Closes #N
+          # check) but DOES NOT expose per-commit signatures; we use the GraphQL
+          # API for that. Two separate queries are fine here — the workflow runs
+          # at most once per PR event and the policy gate must be cheap to read
+          # and debug. (The auto-merge/labels read moved to auto-merge-policy.)
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json body,autoMergeRequest,labels,state \
+            --json body \
             > pr.json
           gh api graphql \
             -f query='query($owner:String!,$name:String!,$pr:Int!) {
@@ -328,7 +326,7 @@ jobs:
           set -euo pipefail
           # Dependabot PR bodies are auto-generated and structurally never carry
           # a `Closes #N` line. Exempt ONLY this body check for dependabot[bot]
-          # (#1070) — Check 2 (auto-merge) and Check 3 (signing) still apply.
+          # (#1070) — Check 2 (signing) and the auto-merge-policy job still apply.
           if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
             echo "OK: Dependabot PR — 'Closes #N' body check is not applicable"
             exit 0
@@ -346,10 +344,53 @@ jobs:
             exit 1
           fi
 
-      - name: "Check 2: auto-merge matches implementation-review state"
+      - name: "Check 2: every commit is signed"
         if: always() && steps.fetch.outcome == 'success'
         run: |
           set -euo pipefail
+          # Build "<oid> <isValid>" rows from the GraphQL response. A null
+          # signature object means an unsigned commit, which the // false
+          # default coerces to false (rather than dropping the row).
+          bad=$(jq -r '.data.repository.pullRequest.commits.nodes[]
+                       | "\(.commit.oid) \(.commit.signature.isValid // false)"' commits.json \
+                | awk '$2 != "true" { print $1 }')
+          if [ -n "$bad" ]; then
+            echo "::error::The following commits are unsigned or have invalid signatures:"
+            # shellcheck disable=SC2086  # word-splitting of $bad is intentional
+            printf '  %s\n' $bad
+            msg="::error::Every commit MUST be cryptographically signed."
+            msg+=" Re-sign with: git rebase --exec 'git commit --amend --no-edit -S' origin/main"
+            echo "$msg"
+            exit 1
+          fi
+          echo "OK: all commits have verified signatures"
+
+  auto-merge-policy:
+    name: auto-merge-policy
+    # Advisory (NOT a required check): verifies auto-merge matches the
+    # implementation-review state — disabled before `state:implementation-go`,
+    # enabled after it. Split out of `pr-policy` (#1080) so this timing-sensitive
+    # verdict no longer BLOCKS merge; it fails its OWN job only on a mismatch, as
+    # a visible signal. Keep this job OUT of the branch-protection required-checks
+    # ruleset. Like pr-policy it has no `needs:` and re-runs on auto_merge_enabled
+    # / auto_merge_disabled and labeled / unlabeled events so it converges on the
+    # PR's true state.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: "Auto-merge matches implementation-review state"
+        run: |
+          set -euo pipefail
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json autoMergeRequest,labels,state \
+            > pr.json
           pr_state=$(jq -r '.state // ""' pr.json)
           if [ "$pr_state" != "OPEN" ]; then
             echo "OK: PR state is $pr_state; auto-merge policy is terminal"
@@ -400,27 +441,6 @@ jobs:
             fi
             echo "OK: auto-merge is deferred until implementation review GO"
           fi
-
-      - name: "Check 3: every commit is signed"
-        if: always() && steps.fetch.outcome == 'success'
-        run: |
-          set -euo pipefail
-          # Build "<oid> <isValid>" rows from the GraphQL response. A null
-          # signature object means an unsigned commit, which the // false
-          # default coerces to false (rather than dropping the row).
-          bad=$(jq -r '.data.repository.pullRequest.commits.nodes[]
-                       | "\(.commit.oid) \(.commit.signature.isValid // false)"' commits.json \
-                | awk '$2 != "true" { print $1 }')
-          if [ -n "$bad" ]; then
-            echo "::error::The following commits are unsigned or have invalid signatures:"
-            # shellcheck disable=SC2086  # word-splitting of $bad is intentional
-            printf '  %s\n' $bad
-            msg="::error::Every commit MUST be cryptographically signed."
-            msg+=" Re-sign with: git rebase --exec 'git commit --amend --no-edit -S' origin/main"
-            echo "$msg"
-            exit 1
-          fi
-          echo "OK: all commits have verified signatures"
 
   unit-tests:
     name: unit-tests

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -224,20 +224,38 @@ class TestEnableAutoMergeOnImplementationGoWorkflow:
         assert 'if [ "$auto_merge" != "null" ] && [ -n "$auto_merge" ]; then' in text
         assert "already has auto-merge enabled" in text
 
-    def test_pr_policy_waits_for_label_workflow_to_converge(self) -> None:
-        """pr-policy must not race the label-triggered auto-merge workflow."""
+    def test_auto_merge_policy_waits_for_label_workflow_to_converge(self) -> None:
+        """The auto-merge-policy job must not race the label-triggered workflow.
+
+        The auto-merge ↔ implementation-go state machine was split out of the
+        required ``pr-policy`` gate into the advisory ``auto-merge-policy`` job
+        (#1080); the convergence behavior moved with it.
+        """
         text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+        assert "auto-merge-policy" in text
         assert "Waiting for label-triggered auto-merge workflow" in text
         assert 'gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"' in text
         assert "--json autoMergeRequest,labels,state" in text
         assert "sleep 10" in text
 
-    def test_pr_policy_treats_merged_prs_as_terminal(self) -> None:
+    def test_auto_merge_policy_treats_merged_prs_as_terminal(self) -> None:
         """GitHub clears autoMergeRequest after merge, so merged PRs must pass."""
         text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
-        assert "--json body,autoMergeRequest,labels,state" in text
+        assert "--json autoMergeRequest,labels,state" in text
         assert "pr_state=$(jq -r '.state // \"\"' pr.json)" in text
         assert "auto-merge policy is terminal" in text
+
+    def test_pr_policy_no_longer_blocks_on_auto_merge_state(self) -> None:
+        """pr-policy keeps only the hard gates; auto-merge moved to its own job.
+
+        The split (#1080) makes the auto-merge verdict non-blocking: pr-policy
+        fetches only the body it needs and no longer reads auto-merge/labels.
+        """
+        text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+        # pr-policy's own metadata fetch is body-only now.
+        assert "--json body\n" in text or "--json body \\" in text
+        # The auto-merge error lives in the advisory job, which is present.
+        assert "Auto-merge is enabled before implementation review GO." in text
 
 
 class TestCollectWorkflowFiles:


### PR DESCRIPTION
## Summary

The required `pr-policy` gate bundled the timing-sensitive auto-merge ↔ `state:implementation-go` state machine, which **blocked merge** — e.g. a PR that armed auto-merge before the GO label failed the gate even with correct code (hit live on #1073/#1075/#1077 this week).

This splits that check out of `pr-policy` into a separate **advisory** job.

## What changed (`.github/workflows/_required.yml`)

- **`pr-policy`** (required) now enforces only the two hard gates: `Closes #N` body line + every commit signed. Its metadata fetch is trimmed to `--json body` (it no longer reads auto-merge/labels/state).
- **`auto-merge-policy`** (new, **NOT** a required check) runs the exact same auto-merge ↔ implementation-go verdict — including the label-workflow convergence wait — and **fails its own job only** on a mismatch, so it stays a visible signal but never blocks merge. Same no-`needs:` + re-run-on-`auto_merge_*`/`labeled` behavior.

> **Operator action required:** keep `auto-merge-policy` out of the branch-protection required-checks ruleset (it is advisory by design).

`.github/README.md` updated; `tests/unit/ci/test_workflows.py` updated to assert the split (auto-merge convergence + merged-terminal behavior now under the new job; pr-policy proven body-only).

## Verification

- `check-jsonschema --builtin-schema vendor.github-workflows` → `ok -- validation done`.
- All 107 `tests/unit/ci/` tests pass.

Closes #1080

🤖 Generated with [Claude Code](https://claude.com/claude-code)