### PR TITLE
fix(automation): review-loop correctness + tiered per-comment dispatch, --nitpick, state:skip

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -46,6 +46,7 @@ from ._reviewer_base import BaseReviewer
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
 from .claude_timeouts import address_review_claude_timeout
+from .comment_difficulty import classify_comments, format_todo_line
 from .curses_ui import CursesUI, ThreadLogManager  # noqa: F401  (ThreadLogManager re-exported)
 from .git_utils import (  # noqa: F401  (get_repo_root re-exported)
     get_repo_root,
@@ -109,9 +110,11 @@ def run_address_fix_session(
     """Run the address-review fix session and return the agent's parsed result.
 
     Shared core of :meth:`AddressReviewer._run_fix_session` and the in-loop
-    implementer address step (Stage 2, #28). Builds the address-review prompt
-    (which fans out one sub-agent per file, #661), runs the implementer agent,
-    and returns the parsed ``{"addressed", "replies"}`` dict.
+    implementer address step (Stage 2, #28). Classifies each comment's fix
+    difficulty (#1083), builds the address-review prompt (which fans out one
+    sub-agent per COMMENT at the model tier matching its difficulty, with
+    same-file comments serialized), runs the implementer agent, and returns the
+    parsed ``{"addressed", "replies"}`` dict.
 
     The Claude path resumes the implementer's deterministic
     :data:`AGENT_IMPLEMENTER` session so fixes land in the same long-lived
@@ -156,11 +159,28 @@ def run_address_fix_session(
         ]
     )
 
+    # #1083: classify each comment's fix difficulty (separate cheap sub-agent),
+    # then render the difficulty-annotated todo list that drives one-sub-agent-
+    # per-comment dispatch at the matching model tier. Classification degrades to
+    # "medium" on any failure, so this never blocks the fix session.
+    difficulties = classify_comments(
+        threads=threads,
+        agent=agent,
+        issue_number=issue_number,
+        worktree_path=worktree_path,
+        repo_root=repo_root,
+        state_dir=log_file.parent,
+    )
+    todo_block = "\n".join(
+        format_todo_line(t, difficulties.get(t["id"], "medium")) for t in threads
+    )
+
     prompt = get_address_review_prompt(
         pr_number=pr_number,
         issue_number=issue_number,
         worktree_path=str(worktree_path),
         threads_json=threads_json,
+        todo_block=todo_block,
         task_block=task_block,
         task_review_block=task_review_block,
         diff_text=diff_text,
@@ -201,8 +221,10 @@ def run_address_fix_session(
             output_format="json",
             permission_mode="dontAsk",
             # Task: the session acts as a coordinator that dispatches one
-            # sub-agent per file of review threads. Skill: each sub-agent
-            # runs /hephaestus:advise before fixing. See prompts/address_review.py.
+            # sub-agent per review COMMENT, at the model tier matching the
+            # comment's classified difficulty (#1083), serializing same-file
+            # comments. Skill: each sub-agent runs /hephaestus:advise before
+            # fixing. See prompts/address_review.py.
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,Task,Skill",
             input_via_stdin=True,
         )

--- a/hephaestus/automation/comment_difficulty.py
+++ b/hephaestus/automation/comment_difficulty.py
@@ -1,0 +1,183 @@
+"""Classify PR review comments by difficulty and map to a model tier (#1083).
+
+The in-loop address step fixes one review comment per sub-agent. To spend the
+right amount of model capability on each, a cheap read-only classifier labels
+every unresolved comment ``simple`` / ``medium`` / ``hard``; the label then
+selects the fix sub-agent's model tier:
+
+- ``simple`` → Haiku (typo, rename, doc tweak, one-line guard)
+- ``medium`` → Sonnet (localized logic change, small refactor, edge case)
+- ``hard``   → Opus (cross-cutting design change, tricky correctness/security)
+
+The classifier is a separate sub-agent (not the reviewer and not the fixer) so
+the difficulty judgment is independent of both. Classification failures degrade
+gracefully to ``medium`` (the safe middle tier) — a misclassification must never
+block the address step.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.runtime import is_codex, run_codex_text
+
+from ._review_utils import parse_json_block
+from .claude_invoke import invoke_claude_with_session
+from .claude_models import HAIKU, OPUS, SONNET, advise_model
+from .claude_timeouts import advise_claude_timeout
+from .git_utils import get_repo_slug
+from .prompts import get_comment_difficulty_prompt
+from .session_naming import AGENT_COMMENT_CLASSIFIER
+
+logger = logging.getLogger(__name__)
+
+#: Allowed difficulty labels, in ascending order of effort.
+DIFFICULTIES = ("simple", "medium", "hard")
+
+#: Difficulty → model tier. Unknown labels fall back to the middle tier.
+_DIFFICULTY_MODEL = {
+    "simple": HAIKU,
+    "medium": SONNET,
+    "hard": OPUS,
+}
+
+#: Default applied when the classifier omits or mis-labels a thread.
+_DEFAULT_DIFFICULTY = "medium"
+
+
+def model_for_difficulty(difficulty: str) -> str:
+    """Return the model ID for a difficulty label.
+
+    Unknown labels map to the middle (Sonnet) tier so a bad classification
+    never silently downgrades a hard fix to Haiku.
+    """
+    return _DIFFICULTY_MODEL.get(difficulty, SONNET)
+
+
+def format_todo_line(thread: dict[str, Any], difficulty: str) -> str:
+    """Render one thread as ``@ <file> Line <#> - <difficulty> - <description>``.
+
+    The description is the comment body's first line (review bodies are often
+    multi-line; the todo wants a one-glance summary). A null/absent line renders
+    as ``Line ?``.
+    """
+    path = thread.get("path") or "__general__"
+    line = thread.get("line")
+    line_str = str(line) if isinstance(line, int) else "?"
+    body = (thread.get("body") or "").strip()
+    description = body.splitlines()[0].strip() if body else "(no description)"
+    return f"@ {path} Line {line_str} - {difficulty} - {description}"
+
+
+def _run_classifier_session(
+    *,
+    threads: list[dict[str, Any]],
+    agent: str,
+    issue_number: int,
+    worktree_path: Path,
+    repo_root: Path,
+    state_dir: Path,
+) -> dict[str, str]:
+    """Run the read-only classifier sub-agent; return ``{thread_id: difficulty}``.
+
+    On any agent/parse failure returns an empty dict — the caller then defaults
+    every thread to ``medium``.
+    """
+    comments_json = json.dumps(
+        [
+            {
+                "thread_id": t["id"],
+                "path": t.get("path", ""),
+                "line": t.get("line"),
+                "body": t.get("body", ""),
+            }
+            for t in threads
+        ]
+    )
+    prompt = get_comment_difficulty_prompt(
+        issue_number=issue_number,
+        comments_json=comments_json,
+    )
+    log_file = state_dir / f"comment-difficulty-{issue_number}.log"
+    try:
+        if is_codex(agent):
+            result = run_codex_text(
+                prompt,
+                cwd=worktree_path,
+                timeout=advise_claude_timeout(),
+                sandbox="read-only",
+            )
+            log_file.write_text(result.stdout or "")
+            parsed = parse_json_block(result.stdout or "")
+        else:
+            stdout, _ = invoke_claude_with_session(
+                repo=get_repo_slug(repo_root),
+                issue=issue_number,
+                agent=AGENT_COMMENT_CLASSIFIER,
+                prompt=prompt,
+                model=advise_model(),
+                cwd=worktree_path,
+                timeout=advise_claude_timeout(),
+                output_format="json",
+                permission_mode="dontAsk",
+                allowed_tools="Read,Glob,Grep",
+                input_via_stdin=True,
+            )
+            log_file.write_text(stdout or "")
+            try:
+                data = json.loads(stdout or "{}")
+                response_text: str = data.get("result", stdout or "")
+            except (json.JSONDecodeError, AttributeError):
+                response_text = stdout or ""
+            parsed = parse_json_block(response_text)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.warning(
+            "Issue #%s: comment-difficulty classifier failed (%s); defaulting to medium",
+            issue_number,
+            exc,
+        )
+        return {}
+
+    classifications = parsed.get("classifications", {})
+    if not isinstance(classifications, dict):
+        return {}
+    # Keep only valid string→difficulty entries.
+    return {
+        str(tid): str(diff) for tid, diff in classifications.items() if str(diff) in DIFFICULTIES
+    }
+
+
+def classify_comments(
+    *,
+    threads: list[dict[str, Any]],
+    agent: str,
+    issue_number: int,
+    worktree_path: Path,
+    repo_root: Path,
+    state_dir: Path,
+    dry_run: bool = False,
+) -> dict[str, str]:
+    """Classify each thread's difficulty; return ``{thread_id: difficulty}``.
+
+    Every thread in *threads* is present in the result. Threads the classifier
+    omitted or mis-labeled default to ``medium`` so the caller always has a tier
+    for each. Returns ``{}`` for an empty thread list and never raises.
+    """
+    if not threads:
+        return {}
+    if dry_run:
+        return {t["id"]: _DEFAULT_DIFFICULTY for t in threads}
+
+    classified = _run_classifier_session(
+        threads=threads,
+        agent=agent,
+        issue_number=issue_number,
+        worktree_path=worktree_path,
+        repo_root=repo_root,
+        state_dir=state_dir,
+    )
+    return {t["id"]: classified.get(t["id"], _DEFAULT_DIFFICULTY) for t in threads}

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1363,12 +1363,146 @@ def _filter_comments_to_diff(
     return kept
 
 
+def gh_pr_inline_comment_index(pr_number: int) -> dict[tuple[str, Any], str]:
+    """Map ``(path, line)`` → review-comment node id for unresolved bot threads.
+
+    Returns the GraphQL node id of the FIRST comment of each unresolved review
+    thread, keyed by its ``(path, line)``. Used by :func:`gh_pr_review_post` to
+    detect a line that already has a comment so the new content can be appended
+    in place rather than posted as a duplicate (#1083). Fails open: returns
+    ``{}`` on any API/parse error so the caller posts everything as before.
+    """
+    owner, repo = get_repo_info()
+    if not re.match(r"^[a-zA-Z0-9_-]+$", owner) or not re.match(r"^[a-zA-Z0-9_-]+$", repo):
+        logger.error("Invalid owner/repo format: %s/%s", owner, repo)
+        return {}
+    query = (
+        "query($owner:String!,$name:String!,$number:Int!){"
+        "  repository(owner:$owner,name:$name){"
+        "    pullRequest(number:$number){"
+        "      reviewThreads(first:100){"
+        "        nodes{ isResolved path line comments(first:1){ nodes{ id } } }"
+        "      }"
+        "    }"
+        "  }"
+        "}"
+    )
+    try:
+        result = _gh_call(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={repo}",
+                "-F",
+                f"number={int(pr_number)}",
+            ],
+            check=False,
+        )
+        data = json.loads(result.stdout or "{}")
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        logger.warning("PR #%s: could not fetch inline-comment index (%s)", pr_number, exc)
+        return {}
+
+    nodes = (
+        data.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+    index: dict[tuple[str, Any], str] = {}
+    for node in nodes:
+        if node.get("isResolved"):
+            continue
+        comment_nodes = node.get("comments", {}).get("nodes", [])
+        if not comment_nodes:
+            continue
+        comment_id = comment_nodes[0].get("id")
+        if not comment_id:
+            continue
+        index[(node.get("path") or "", node.get("line"))] = comment_id
+    return index
+
+
+def gh_pr_update_review_comment(comment_node_id: str, body: str) -> None:
+    """Replace a PR review comment's body via ``updatePullRequestReviewComment``.
+
+    Used to edit an existing inline comment in place (#1083) instead of posting
+    a duplicate on the same line.
+    """
+    mutation = (
+        "mutation($id:ID!,$body:String!){"
+        "  updatePullRequestReviewComment(input:{pullRequestReviewCommentId:$id,body:$body}){"
+        "    pullRequestReviewComment{ id }"
+        "  }"
+        "}"
+    )
+    _gh_call(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={mutation}",
+            "-f",
+            f"id={comment_node_id}",
+            "-f",
+            f"body={body}",
+        ]
+    )
+
+
+def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Edit comments whose line already has a bot comment; return the rest.
+
+    For each comment whose ``(path, line)`` is in the existing-comment index,
+    append its body to the existing comment (a single edit) and drop it from the
+    returned list. Comments on fresh lines are returned unchanged for posting.
+    Fails open: an empty index returns *comments* unchanged.
+    """
+    index = gh_pr_inline_comment_index(pr_number)
+    if not index:
+        return comments
+    fresh: list[dict[str, Any]] = []
+    for c in comments:
+        key = (c.get("path") or "", c.get("line"))
+        existing_id = index.get(key)
+        if existing_id is None:
+            fresh.append(c)
+            continue
+        appended = "\n\n---\n_Additional review note (same line):_\n\n" + (c.get("body") or "")
+        try:
+            gh_pr_update_review_comment(existing_id, appended)
+            logger.info(
+                "PR #%s: edited existing comment on %s:%s instead of duplicating",
+                pr_number,
+                key[0],
+                key[1],
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            # If the edit fails, fall back to posting the comment fresh.
+            logger.warning(
+                "PR #%s: edit-in-place failed for %s:%s (%s); posting fresh",
+                pr_number,
+                key[0],
+                key[1],
+                exc,
+            )
+            fresh.append(c)
+    return fresh
+
+
 def gh_pr_review_post(
     pr_number: int,
     comments: list[dict[str, Any]],
     summary: str,
     event: str = "COMMENT",
     dry_run: bool = False,
+    dedupe_existing: bool = False,
 ) -> list[str]:
     """Post a PR review with inline comments via GitHub GraphQL API.
 
@@ -1378,6 +1512,12 @@ def gh_pr_review_post(
         summary: Overall review summary body
         event: Review event type: COMMENT, APPROVE, or REQUEST_CHANGES
         dry_run: If True, log intent and return empty list without posting
+        dedupe_existing: When True (#1083), a comment whose ``(path, line)``
+            already has an unresolved bot review comment is EDITED in place
+            (the new body is appended) rather than posted as a duplicate thread.
+            Only the genuinely new comments are posted as fresh threads. Fails
+            open: if the existing-comment index cannot be fetched, every comment
+            is posted as before.
 
     Returns:
         List of created review thread IDs (empty on dry_run or if no comments)
@@ -1415,6 +1555,13 @@ def gh_pr_review_post(
     if comments:
         diff_result = _gh_call(["pr", "diff", str(pr_number)], check=False)
         comments = _filter_comments_to_diff(comments, diff_result.stdout or "")
+
+    # #1083: edit-in-place instead of duplicating. If a comment targets a line
+    # that already has an unresolved bot comment, append the new body to that
+    # comment and drop it from the to-post set. Fails open (posts everything) if
+    # the existing-comment index can't be fetched.
+    if comments and dedupe_existing:
+        comments = _edit_or_keep_comments(pr_number, comments)
 
     review_comments = [
         {

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -89,6 +89,7 @@ from .models import (
 from .pr_manager import commit_changes, create_pr
 from .review_state import is_plan_review_go  # noqa: F401
 from .session_naming import AGENT_ADVISE, AGENT_IMPLEMENTER, current_trunk_githash  # noqa: F401
+from .state_labels import is_skipped
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
@@ -268,6 +269,15 @@ class IssueImplementer:
 
             try:
                 issue = fetch_issue_info(issue_num)
+
+                # Manual override (#1083): a ``state:skip`` label removes the
+                # issue from all phases. Treat it as completed so dependents are
+                # not blocked, and never add it to the work graph.
+                if is_skipped(issue.labels):
+                    logger.info("Skipping #%s (state:skip)", issue_num)
+                    self.resolver.completed.add(issue_num)
+                    continue
+
                 self.resolver.add_issue(issue)
 
                 # Load dependencies recursively

--- a/hephaestus/automation/implementer_cli.py
+++ b/hephaestus/automation/implementer_cli.py
@@ -144,6 +144,11 @@ Examples:
         help="Skip the advise step before implementation",
     )
     parser.add_argument(
+        "--nitpick",
+        action="store_true",
+        help="Let the reviewer emit nitpick-severity comments (suppressed by default)",
+    )
+    parser.add_argument(
         "--no-ui",
         action="store_true",
         help="Disable curses UI (use plain logging instead)",
@@ -208,6 +213,7 @@ def main() -> int:
         enable_learn=not args.no_learn,
         enable_follow_up=not args.no_follow_up,
         enable_ui=not args.no_ui and not args.json,
+        include_nitpicks=args.nitpick,
     )
 
     if args.health_check:

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -40,7 +40,6 @@ from hephaestus.agents.runtime import (
 from hephaestus.github.rate_limit import wait_until
 
 from .address_review import (
-    resolve_addressed_threads,
     run_address_fix_session,
 )
 from .advise_runner import run_advise
@@ -52,7 +51,7 @@ from .claude_models import advise_model, implementer_model, reviewer_model
 from .claude_timeouts import advise_claude_timeout, implementer_claude_timeout
 from .follow_up import parse_follow_up_items, run_follow_up_issues
 from .git_utils import issue_ref, pr_ref, run, sync_worktree_to_remote_branch
-from .github_api import gh_pr_list_unresolved_threads
+from .github_api import gh_issue_add_labels, gh_pr_list_unresolved_threads
 from .learn import learn_needs_rerun, run_learn
 from .models import (
     ImplementationPhase,
@@ -76,6 +75,7 @@ from .prompts import (
     get_implementation_prompt,
 )
 from .review_validator import validate_prior_comments_addressed
+from .state_labels import STATE_SKIP
 
 # NOTE: ``is_plan_review_go``, ``fetch_issue_info``,
 # ``invoke_claude_with_session``, ``get_repo_slug``, ``current_trunk_githash``,
@@ -1231,6 +1231,30 @@ class ImplementationPhaseRunner:
                 iterations_run,
             )
 
+        # #1083 Bug 2: the loop must reach an explicit GO to be considered
+        # converged. Any other terminal outcome — exhausting
+        # MAX_REVIEW_ITERATIONS without GO, or a reviewer that posts zero
+        # threads yet never says GO (the "stuck AMBIGUOUS" case in output.log) —
+        # means the automation could not drive this issue to a clean state on
+        # its own. Apply ``state:skip`` so the next loop does not re-attempt it
+        # (and an operator can remove the label to re-queue it). ``last_verdict``
+        # is None only when there was no PR to review (dry-run / no-PR path),
+        # which must not be skipped.
+        if (
+            pr_number is not None
+            and last_verdict is not None
+            and last_verdict != "GO"
+            and not self.options.dry_run
+        ):
+            logger.info(
+                "#%d: review loop ended non-GO (verdict=%r) — applying %s",
+                issue_number,
+                last_verdict,
+                STATE_SKIP,
+            )
+            with contextlib.suppress(Exception):
+                gh_issue_add_labels(issue_number, [STATE_SKIP])
+
         return iterations_run, last_verdict, last_grade
 
     def _run_impl_review_step(
@@ -1375,17 +1399,32 @@ class ImplementationPhaseRunner:
             diff_text=diff_text,
         )
         addressed: list[str] = fix_result.get("addressed", [])
-        replies: dict[str, str] = fix_result.get("replies", {})
 
-        # Commit + push the fixes the address session produced.
-        self._commit_if_changes(issue_number, worktree_path)
+        # #1083 Bug 1: gate "addressed" on a REAL commit. The fix session's
+        # self-reported ``addressed`` list is not trusted on its own — a session
+        # can claim it resolved a thread while leaving the worktree clean (e.g.
+        # replying "documented as a limitation" with no code change). Only when
+        # _commit_if_changes actually produced a commit do we push and report
+        # progress, so a no-op fix can never advance the loop.
+        committed = self._commit_if_changes(issue_number, worktree_path)
+        if not (addressed and committed):
+            logger.info(
+                "#%s R%s: address step produced no committed change "
+                "(addressed=%s, committed=%s) — not counted as progress",
+                issue_number,
+                iteration,
+                bool(addressed),
+                committed,
+            )
+            return False
         self._push_branch(branch_name, worktree_path)
 
-        # Resolve only the threads actually addressed, guarded against
-        # hallucinated/cross-PR thread IDs (#661).
-        presented_thread_ids = {t["id"] for t in threads}
-        resolve_addressed_threads(addressed, replies, presented_thread_ids, dry_run=False)
-        return bool(addressed)
+        # #1083 Bug 1/Move-to-reviewer: resolution is NO LONGER done here. The
+        # validator (review_validator.validate_prior_comments_addressed) resolves
+        # each prior thread only after a fresh read-only sub-agent confirms the
+        # current diff actually addresses it. This closes the "resolved without
+        # implementing" hole — a self-reported fix with no diff change stays open.
+        return True
 
     def _parse_address_result(self, text: str, issue_number: int, iteration: int) -> dict[str, Any]:
         """Parse the address-session JSON block, tracing parse failures.
@@ -1431,11 +1470,18 @@ class ImplementationPhaseRunner:
             logger.warning("#%s: failed to fetch PLAN/PLAN_REVIEW context: %s", issue_number, e)
         return plan_text, plan_review_text
 
-    def _commit_if_changes(self, issue_number: int, worktree_path: Path) -> None:
+    def _commit_if_changes(self, issue_number: int, worktree_path: Path) -> bool:
         """Commit any pending changes from the in-loop address step.
 
         Silently skips when the worktree is clean. Mirrors
         ``AddressReviewer._commit_if_changes``.
+
+        Returns:
+            ``True`` iff a commit was actually created. ``False`` when the
+            worktree was clean (nothing to commit) or the commit failed. The
+            caller (#1083) uses this to gate progress/resolution on a real
+            change rather than the model's self-report.
+
         """
         result = run(
             ["git", "status", "--porcelain"],
@@ -1444,12 +1490,14 @@ class ImplementationPhaseRunner:
         )
         if not result.stdout.strip():
             logger.info("No changes to commit for issue #%s", issue_number)
-            return
+            return False
         try:
             commit_changes(issue_number, worktree_path, self.options.agent)
             logger.info("Committed in-loop address changes for issue #%s", issue_number)
+            return True
         except RuntimeError as e:
             logger.warning("Commit skipped for issue #%s: %s", issue_number, e)
+            return False
 
     def _push_branch(self, branch_name: str, worktree_path: Path) -> None:
         """Push *branch_name* to origin after an in-loop address step.

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1310,6 +1310,7 @@ class ImplementationPhaseRunner:
             plan_text=plan_text,
             plan_review_text=plan_review_text,
             diff_text=diff_text,
+            include_nitpicks=self.options.include_nitpicks,
         )
         try:
             return review_pr_inline(

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -261,6 +261,7 @@ class LoopConfig:
     issues: list[int] = field(default_factory=list)
     dry_run: bool = False
     no_advise: bool = False
+    nitpick: bool = False
     allow_unsafe_phase_order: bool = False
     planner_model: str = ""
     reviewer_model: str = ""
@@ -362,6 +363,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--no-advise",
         action="store_true",
         help="Pass --no-advise to phases that support the advise preflight",
+    )
+    p.add_argument(
+        "--nitpick",
+        action="store_true",
+        help="Pass --nitpick to review phases (reviewer emits nitpick comments)",
     )
     p.add_argument(
         "--allow-unsafe-phase-order",
@@ -797,6 +803,7 @@ _PHASE_FLAGS: dict[str, dict[str, object]] = {
         "no_ui": True,
         "issues": "explicit",
         "advise": True,
+        "nitpick": True,
         "follow_up_loop_threshold": 3,
     },
     "drive-green": {
@@ -804,6 +811,7 @@ _PHASE_FLAGS: dict[str, dict[str, object]] = {
         "no_ui": True,
         "issues": "open",
         "advise": True,
+        "nitpick": True,
     },
 }
 
@@ -830,6 +838,8 @@ def _build_phase_argv(
         argv.append("--dry-run")
     if cfg.no_advise and flags.get("advise"):
         argv.append("--no-advise")
+    if cfg.nitpick and flags.get("nitpick"):
+        argv.append("--nitpick")
 
     issue_mode = flags.get("issues")
     issue_numbers = cfg.issues if issue_mode == "explicit" else open_issues
@@ -1339,6 +1349,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         issues=args.issues or [],
         dry_run=args.dry_run,
         no_advise=args.no_advise,
+        nitpick=args.nitpick,
         allow_unsafe_phase_order=args.allow_unsafe_phase_order,
         planner_model=args.planner_model,
         reviewer_model=args.reviewer_model,

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -172,6 +172,9 @@ class ImplementerOptions(BaseModel):
     enable_ui: bool = True
     # A2-004: opt-in pre-PR test gate; defaults to False for rollout safety.
     run_pre_pr_tests: bool = False
+    # #1083: when False (default) the reviewer omits nitpick-severity comments;
+    # --nitpick re-enables them.
+    include_nitpicks: bool = False
 
 
 class ReviewPhase(str, Enum):

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -193,6 +193,9 @@ def run_pr_review_analysis(
         pr_description=context.get("pr_description", ""),
         auto_merge_enabled=bool(context.get("auto_merge_enabled", False)),
         commits_signing_state=context.get("commits_signing_state") or [],
+        # #1083: nitpicks are suppressed unless --nitpick threaded the flag into
+        # the review context.
+        include_nitpicks=bool(context.get("include_nitpicks", False)),
     )
 
     prompt_file = worktree_path / f".claude-pr-review-{issue_number}.md"
@@ -278,6 +281,7 @@ def gather_impl_review_context(
     plan_text: str,
     plan_review_text: str,
     diff_text: str,
+    include_nitpicks: bool = False,
 ) -> dict[str, Any]:
     """Assemble the PR-review context for an in-loop implementer review.
 
@@ -295,6 +299,9 @@ def gather_impl_review_context(
         plan_text: The implementation PLAN comment body (or "" if absent).
         plan_review_text: The PLAN_REVIEW comment body (or "" if absent).
         diff_text: ``gh pr diff`` / cumulative branch diff for the impl.
+        include_nitpicks: Forwarded into the context so the reviewer prompt
+            emits nitpick-severity comments only when ``--nitpick`` is set
+            (#1083).
 
     Returns:
         Context dict consumable by :func:`run_pr_review_analysis`.
@@ -316,6 +323,7 @@ def gather_impl_review_context(
         "pr_description": "",
         "auto_merge_enabled": True,
         "commits_signing_state": [],
+        "include_nitpicks": include_nitpicks,
     }
 
 
@@ -382,6 +390,9 @@ def review_pr_inline(
         comments=comments,
         summary=summary,
         dry_run=False,
+        # #1083: a later review iteration commenting on a line an earlier
+        # iteration already flagged edits that comment instead of duplicating.
+        dedupe_existing=True,
     )
     logger.info(
         "In-loop review R%s posted %s thread(s) on PR %s",
@@ -798,6 +809,9 @@ class PRReviewer(BaseReviewer):
                     comments=comments,
                     summary=summary,
                     dry_run=False,
+                    # #1083: edit an existing comment on a line instead of
+                    # duplicating it on re-review.
+                    dedupe_existing=True,
                 )
                 self._log(
                     "info",

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -69,6 +69,7 @@ from .planning import (
 )
 from .pr_review import (
     PR_REVIEW_ANALYSIS_PROMPT,
+    get_comment_difficulty_prompt,
     get_pr_description,
     get_pr_review_analysis_prompt,
     get_review_validation_prompt,
@@ -90,6 +91,7 @@ __all__ = [
     "get_advise_prompt",
     "get_advise_prompt_builder",
     "get_codex_advise_prompt",
+    "get_comment_difficulty_prompt",
     "get_follow_up_prompt",
     "get_impl_loop_review_prompt",
     "get_impl_resume_feedback_prompt",

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -26,45 +26,58 @@ The block above is a JSON array where each element has:
 - `line`: line number (integer or null)
 - `body`: the reviewer's comment text
 
+**Your TODO list — one line per review comment (already classified by difficulty):**
+
+{todo_block}
+
+Each todo line has the form `@ <file> Line <#> - <difficulty> - <description>`.
+Every one of these comments MUST be resolved before you finish.
+
 ---
 
 **Your task (coordinator):**
 
-1. Parse the review-threads JSON above and **group the threads by `path`** (one group
-   per distinct file). Threads with a null/empty `path` (PR-level / general comments)
-   form one extra group keyed as `__general__`.
+1. Treat the TODO list as the unit of work: there is ONE sub-agent per review
+   comment (NOT one per file). For each todo line, dispatch a sub-agent with the
+   Task tool (`subagent_type: "general-purpose"`) to fix exactly that one comment.
 
-2. For EACH file group, dispatch ONE sub-agent using the Task tool
-   (`subagent_type: "general-purpose"`). Dispatch all groups, one sub-agent per file.
-   Each sub-agent OWNS exactly one file and must not touch any other file — this
-   prevents two agents editing the same file and causing merge/commit contention.
+2. **Model tier by difficulty** — set each sub-agent's model from the todo line's
+   difficulty:
+   - `simple` → `haiku` (claude-haiku-4-5): mechanical/local fix.
+   - `medium` → `sonnet` (claude-sonnet-4-6): localized logic / small refactor.
+   - `hard`   → `opus` (claude-opus-4-7): cross-cutting or subtle correctness fix.
+
+3. **Serialize same-file comments.** Two sub-agents must NEVER edit the same file
+   at the same time. Group the todo lines by `<file>`: dispatch DIFFERENT files in
+   parallel, but run the comments that share a file SEQUENTIALLY (one finishes and
+   returns before the next on that file starts). This prevents concurrent writes
+   to one file from clobbering each other.
 
    Give each sub-agent a self-contained prompt that instructs it to:
    a. FIRST run the team-knowledge skill to pull prior learnings relevant to this fix:
       `Skill(skill: "hephaestus:advise", args: "<short description of the review feedback>")`.
       Use whatever it surfaces to inform the fix; do not skip this step.
-   b. Read the owned file at `path` in the working directory `{worktree_path}` and apply
-      the code fix for ALL of that file's review threads (you will pass it the thread
-      bodies + line numbers + thread_ids for its file only).
-   c. Report back, for each `thread_id` it handled, a one-line reply describing the fix —
-      or, if a thread is not addressable in code, say so and leave it out of the fixed set.
+   b. Read the cited file/line in the working directory `{worktree_path}` and apply the
+      code fix for its ONE assigned review comment (you pass it the thread body, line, and
+      thread_id).
+   c. Report back the `thread_id` and a one-line reply describing the fix — or, if the
+      comment is not addressable in code, say so and leave it out of the fixed set.
 
    **Each sub-agent prompt MUST include these guardrails (critical):**
    - "Do NOT background your work, do NOT exit early, and do NOT defer. Complete the fix
-     synchronously and return only when the file is fully edited."
-   - "You own ONLY the file `<path>`. Do not read-modify any other file. Do not commit,
-     push, or run git — the coordinator handles that."
-   - "Return your result as a compact list mapping each thread_id to a one-line reply."
+     synchronously and return only when the edit is done."
+   - "Do not commit, push, or run git — the coordinator handles that."
+   - "Return your result as `thread_id -> one-line reply`."
 
-3. After ALL sub-agents have returned, you (the coordinator) integrate their results and
+4. After ALL sub-agents have returned, you (the coordinator) integrate their results and
    run the gates from the working directory:
    - Run tests: `pixi run python -m pytest tests/ -v`
    - Run pre-commit: `pre-commit run --all-files`
    - Fix any issues found (you may edit files directly at this stage).
    - Commit all changes (do NOT push).
 
-4. Trust but verify: only mark a thread `addressed` if the owning sub-agent actually
-   edited the file for it. If a sub-agent claimed a fix but the file is unchanged for that
+5. Trust but verify: only mark a thread `addressed` if the assigned sub-agent actually
+   edited the code for it. If a sub-agent claimed a fix but the file is unchanged for that
    thread, drop it from `addressed`.
 
 **Output format:**
@@ -127,6 +140,7 @@ def get_address_review_prompt(
     worktree_path: str,
     threads_json: str,
     *,
+    todo_block: str = "",
     task_block: str = "",
     task_review_block: str = "",
     diff_text: str = "",
@@ -141,6 +155,11 @@ def get_address_review_prompt(
         issue_number: Linked GitHub issue number
         worktree_path: Path to the git worktree containing the PR branch
         threads_json: JSON string of unresolved review threads (array of thread dicts)
+        todo_block: Pre-rendered, difficulty-classified todo list — one line per
+            comment in the form ``@ <file> Line <#> - <difficulty> - <desc>``
+            (built by :mod:`hephaestus.automation.comment_difficulty`, #1083).
+            Drives the one-sub-agent-per-comment dispatch and per-comment model
+            tier. Trusted (we generate it ourselves from the threads).
         task_block: Optional task (issue title + body) text, rendered as an
             untrusted context section. Supply when the address session may run
             without a prior implementer transcript (existing-PR review path).
@@ -159,6 +178,7 @@ def get_address_review_prompt(
         issue_number=issue_number,
         worktree_path=worktree_path,
         threads_json_block=_fence_untrusted("THREADS_JSON", threads_json, nonce),
+        todo_block=todo_block or "_(no todo lines)_",
         untrusted_notice=_UNTRUSTED_NOTICE,
         context_block=_build_context_block(task_block, task_review_block, diff_text, nonce),
     )

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -71,6 +71,16 @@ If all three checks pass, proceed to code-quality review below.
 Review the PR for correctness, completeness, and code quality. Identify any issues that should
 be addressed as inline review comments.
 
+**Comment severity (MANDATORY — tag every inline comment):**
+
+Classify each inline comment with a `severity`:
+- `critical` — correctness/security bug, data loss, or a policy violation.
+- `major` — a real design/maintainability problem that should be fixed before merge.
+- `minor` — a small but genuine improvement (naming, missing edge case, light duplication).
+- `nitpick` — purely cosmetic / stylistic / subjective preference with no functional impact.
+
+{nitpick_directive}
+
 **Output format (verdict contract — MANDATORY):**
 The review prose + inline comments explain *why*; the verdict line is a binary
 gate. Write your analysis in prose, then end your response with exactly one of
@@ -82,7 +92,9 @@ Verdict: NOGO — Policy violation OR fundamental code problem (explain in the r
 After the verdict line, emit a single fenced JSON block:
 
 ```json
-{{"comments": [{{"path": "...", "line": 1, "side": "RIGHT", "body": "..."}}], "summary": "..."}}
+{{"comments": [
+  {{"path": "...", "line": 1, "side": "RIGHT", "severity": "minor", "body": "..."}}
+], "summary": "..."}}
 ```
 
 Rules for the JSON block:
@@ -90,6 +102,7 @@ Rules for the JSON block:
   - `path`: file path relative to repo root (string)
   - `line`: line number in the file (integer, must be a changed line in the diff)
   - `side`: always `"RIGHT"` for new code
+  - `severity`: one of `"critical"`, `"major"`, `"minor"`, `"nitpick"` (see above)
   - `body`: the review comment text (string)
 - `summary`: overall review verdict, max 200 characters. If any policy check
   failed, this MUST start with `POLICY VIOLATION:` followed by the failing
@@ -98,6 +111,22 @@ Rules for the JSON block:
   `{{"comments": [], "summary": "LGTM"}}`
 - Emit only one JSON block, at the very end of your response (the parser takes the LAST one).
 """
+
+
+#: Default (nitpick-suppressed) directive. Keeps the review focused on
+#: actionable findings — matches the strict rubric's D3 "omit filler" stance.
+_NITPICK_SUPPRESS = (
+    "By DEFAULT, DO NOT emit `nitpick`-severity comments at all — omit them "
+    "entirely. Only emit `critical`, `major`, and `minor` comments. A cosmetic "
+    "preference is not worth a review thread unless explicitly requested."
+)
+
+#: Opt-in directive when ``--nitpick`` is set: nitpicks are welcome.
+_NITPICK_INCLUDE = (
+    "Nitpick mode is ENABLED: you MAY emit `nitpick`-severity comments in "
+    "addition to the others. Still tag them `nitpick` so they can be filtered "
+    "downstream."
+)
 
 
 def get_pr_review_analysis_prompt(
@@ -109,6 +138,7 @@ def get_pr_review_analysis_prompt(
     pr_description: str = "",
     auto_merge_enabled: bool = False,
     commits_signing_state: list[dict[str, Any]] | None = None,
+    include_nitpicks: bool = False,
 ) -> str:
     """Get the PR review analysis prompt for generating inline review comments.
 
@@ -129,6 +159,10 @@ def get_pr_review_analysis_prompt(
             element must be a dict with keys ``oid`` (str), ``signature_valid``
             (bool), and ``signer`` (str or None). Defaults to an empty list,
             which the reviewer treats as a policy failure.
+        include_nitpicks: When False (default), the reviewer is told to OMIT
+            ``nitpick``-severity comments entirely. When True (``--nitpick``),
+            nitpick comments are re-enabled. Either way every emitted comment
+            carries a ``severity`` tag (#1083).
 
     Returns:
         Formatted PR review analysis prompt
@@ -137,6 +171,7 @@ def get_pr_review_analysis_prompt(
     nonce = secrets.token_hex(8).upper()
     auto_merge_state = f"auto_merge_enabled={'true' if auto_merge_enabled else 'false'}"
     signing_state_json = json.dumps(commits_signing_state or [])
+    nitpick_directive = _NITPICK_INCLUDE if include_nitpicks else _NITPICK_SUPPRESS
     return PR_REVIEW_ANALYSIS_PROMPT.format(
         pr_number=pr_number,
         issue_number=issue_number,
@@ -148,6 +183,7 @@ def get_pr_review_analysis_prompt(
         commits_signing_block=_fence_untrusted("COMMITS_SIGNING_STATE", signing_state_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
         strict_rubric=_PR_STRICT_RUBRIC.strip(),
+        nitpick_directive=nitpick_directive,
     )
 
 
@@ -233,6 +269,72 @@ def get_review_validation_prompt(
         issue_number=issue_number,
         prior_comments_block=_fence_untrusted("PRIOR_COMMENTS", prior_comments_json, nonce),
         diff_block=_fence_untrusted("DIFF", diff_text, nonce),
+        untrusted_notice=_UNTRUSTED_NOTICE,
+    )
+
+
+COMMENT_DIFFICULTY_PROMPT = """
+You are CLASSIFYING the difficulty of unresolved PR review comments on issue
+#{issue_number}, so the right model tier can be assigned to fix each one.
+
+You are NOT reviewing the code and NOT fixing anything. For each comment, judge
+how hard the FIX is, using these tiers:
+
+- `simple` — mechanical / local: a typo, rename, doc tweak, import, one-line
+  guard, or formatting. A junior model can do it from the comment alone.
+- `medium` — a localized logic change, a small refactor, handling an edge case,
+  or a test addition that needs reading one or two functions.
+- `hard` — cross-cutting or subtle: a design change spanning files, a tricky
+  correctness/concurrency/security fix, or anything needing real reasoning about
+  invariants. When genuinely unsure between two tiers, pick the HIGHER one.
+
+{untrusted_notice}
+
+**Review comments to classify (untrusted):**
+{comments_block}
+
+The block above is a JSON array; each element has `thread_id`, `path`, `line`,
+and `body`.
+
+**Output format:**
+Write brief reasoning in prose, then end with exactly one fenced JSON block
+mapping each `thread_id` to its difficulty:
+
+```json
+{{"classifications": {{"<thread_id>": "simple|medium|hard"}}}}
+```
+
+Rules:
+- Include EVERY `thread_id` from the input exactly once.
+- Use only the three labels `simple`, `medium`, `hard`.
+- Emit only one JSON block, at the very end (the parser takes the LAST one).
+"""
+
+
+def get_comment_difficulty_prompt(
+    issue_number: int,
+    comments_json: str,
+) -> str:
+    """Get the prompt that classifies review-comment fix difficulty (#1083).
+
+    Used by :mod:`hephaestus.automation.comment_difficulty` to label each
+    unresolved comment ``simple`` / ``medium`` / ``hard`` so the per-comment fix
+    sub-agent runs at the matching model tier. The comment bodies are fenced as
+    untrusted (GitHub-sourced).
+
+    Args:
+        issue_number: Linked GitHub issue number (for log/context only).
+        comments_json: JSON array string of comment dicts
+            (``thread_id``/``path``/``line``/``body``).
+
+    Returns:
+        Formatted comment-difficulty classification prompt.
+
+    """
+    nonce = secrets.token_hex(8).upper()
+    return COMMENT_DIFFICULTY_PROMPT.format(
+        issue_number=issue_number,
+        comments_block=_fence_untrusted("REVIEW_COMMENTS", comments_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
     )
 

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -230,6 +230,9 @@ def validate_prior_comments_addressed(
             f"Re-opening {len(comments)} prior review comment(s) the current diff does not address."
         ),
         dry_run=False,
+        # #1083: if the line already carries a bot comment, edit it in place
+        # rather than stacking a duplicate re-open thread.
+        dedupe_existing=True,
     )
     logger.info(
         "PR %s R%s: re-opened %s unaddressed review comment(s)",

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -2,19 +2,28 @@
 
 The in-loop review → address cycle (see
 :meth:`hephaestus.automation.implementer_phase_runner.ImplementationPhaseRunner._run_impl_review_loop`)
-resolves review threads on the implementer's *self-report*. This module adds an
-independent check: after the implementer claims it addressed the previous
-iteration's comments, a FRESH read-only sub-agent compares each prior comment
-against the current diff and re-opens any the diff does not actually resolve.
+used to resolve review threads on the implementer's *self-report* — the
+implementer claimed it addressed a thread and the orchestrator resolved it,
+even when no commit was produced (#1083). This module is now the single owner
+of thread resolution, and it is evidence-based: a FRESH read-only sub-agent
+compares each prior comment against the current diff and partitions them:
 
-Re-opening is done by posting a NEW inline review thread (GitHub has no
-"unresolve" mutation, and the unresolved-thread lister filters resolved threads
-out — so an already-resolved thread cannot be reopened in place). The new thread
-cites the original comment and explains what is still missing, then the loop
-treats the validation as NOGO so the address step runs again.
+- **Addressed** — the diff genuinely resolves the comment. The validator
+  resolves the thread in place (:func:`gh_pr_resolve_thread`).
+- **Not addressed** — re-opened by posting a NEW inline review thread (GitHub
+  has no "unresolve" mutation, and the unresolved-thread lister filters
+  resolved threads out — so an already-resolved thread cannot be reopened in
+  place). The new thread cites the original comment and explains what is still
+  missing, then the loop treats the validation as NOGO so the address step runs
+  again.
 
-This respects the #375 own-threads-only guarantee (the validator posts its own
-threads via :func:`gh_pr_review_post`) and never mutates human threads.
+The implementer's address step no longer resolves anything; it only applies the
+fix, commits, and pushes. A clean worktree (no real fix) therefore leaves the
+diff unchanged, the validator judges the thread NOT addressed, and it stays
+open — closing the "resolved without implementing" hole.
+
+This respects the #375 own-threads-only guarantee (the validator posts and
+resolves only its own / the bot's threads) and never mutates human threads.
 """
 
 from __future__ import annotations
@@ -32,7 +41,7 @@ from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
 from .git_utils import get_repo_root, get_repo_slug, pr_ref
-from .github_api import gh_pr_review_post
+from .github_api import gh_pr_resolve_thread, gh_pr_review_post
 from .prompts import get_review_validation_prompt
 from .session_naming import AGENT_PR_REVIEWER, reviewer_agent
 
@@ -146,7 +155,9 @@ def validate_prior_comments_addressed(
     Returns:
         ``(reopened_thread_ids, is_clean)``. ``is_clean`` is True when nothing
         was re-opened (every prior comment is addressed, or there was nothing to
-        validate); False when at least one comment was re-opened.
+        validate); False when at least one comment was re-opened. As a side
+        effect, every prior thread the validator confirms addressed is resolved
+        in place (#1083).
 
     """
     if not prior_threads:
@@ -176,6 +187,17 @@ def validate_prior_comments_addressed(
         review_agent=reviewer_agent(AGENT_PR_REVIEWER, iteration),
         state_dir=state_dir,
     )
+
+    # Resolve the threads the validator confirms addressed (#1083). A prior
+    # thread is "addressed" when its (path, line) is NOT among the unaddressed
+    # items the sub-agent flagged. This is the evidence-based resolution that
+    # replaces the implementer's self-report: a clean worktree leaves the diff
+    # unchanged, so nothing is judged addressed and nothing is resolved.
+    unaddressed_keys = {
+        (item.get("path") or "", item.get("line")) for item in unaddressed if isinstance(item, dict)
+    }
+    _resolve_addressed_prior_threads(prior_threads, unaddressed_keys)
+
     if not unaddressed:
         return [], True
 
@@ -216,3 +238,36 @@ def validate_prior_comments_addressed(
         len(thread_ids),
     )
     return thread_ids, False
+
+
+def _resolve_addressed_prior_threads(
+    prior_threads: list[dict[str, Any]],
+    unaddressed_keys: set[tuple[str, Any]],
+) -> list[str]:
+    """Resolve every prior thread the validator did not flag as unaddressed.
+
+    A thread is considered addressed when its ``(path, line)`` is absent from
+    *unaddressed_keys* (the set the validation sub-agent flagged). Only threads
+    carrying a real ``id`` are resolved — this is the #375 own-threads guard,
+    since ``prior_threads`` is always the set the loop itself posted/snapshotted.
+
+    Returns the list of resolved thread IDs (useful for logging/tests).
+    """
+    resolved: list[str] = []
+    for thread in prior_threads:
+        thread_id = thread.get("id")
+        if not thread_id:
+            continue
+        key = (thread.get("path") or "", thread.get("line"))
+        if key in unaddressed_keys:
+            continue  # still open — re-opened above
+        try:
+            gh_pr_resolve_thread(
+                thread_id,
+                "Verified addressed by the current diff; resolving.",
+                dry_run=False,
+            )
+            resolved.append(thread_id)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            logger.warning("Failed to resolve addressed thread %s: %s", thread_id, exc)
+    return resolved

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -40,6 +40,9 @@ AGENT_IMPLEMENTER = "implementer"
 AGENT_PR_REVIEWER = "pr-reviewer"
 AGENT_ADDRESS_REVIEW = "address-review"
 AGENT_CI_DRIVER = "ci-driver"
+# #1083: cheap read-only sub-agent that labels each review comment's fix
+# difficulty (simple/medium/hard) to pick the per-comment fixer's model tier.
+AGENT_COMMENT_CLASSIFIER = "comment-classifier"
 
 _ALL_AGENTS = frozenset(
     {
@@ -51,6 +54,7 @@ _ALL_AGENTS = frozenset(
         AGENT_PR_REVIEWER,
         AGENT_ADDRESS_REVIEW,
         AGENT_CI_DRIVER,
+        AGENT_COMMENT_CLASSIFIER,
     }
 )
 

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -50,6 +50,13 @@ STATE_IMPLEMENTATION_NO_GO = "state:implementation-no-go"
 STATE_IMPLEMENTATION_GO = "state:implementation-go"
 ALL_IMPLEMENTATION_STATE_LABELS = (STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTATION_GO)
 
+#: Manual override: when present on an issue OR its PR, every automation phase
+#: skips that work item entirely (#1083). Unlike the plan/implementation state
+#: labels this is operator-applied (or auto-applied by the review loop when it
+#: exhausts MAX_REVIEW_ITERATIONS without a GO), and it is independent of all
+#: other state labels — so it deliberately lives outside the tuples above.
+STATE_SKIP = "state:skip"
+
 #: Per-label colour (hex without leading ``#``) and short description. The
 #: provisioning script (``hephaestus-ensure-state-labels``) uses these when
 #: creating the labels on a repo so they have a consistent look across the org.
@@ -67,6 +74,10 @@ STATE_LABEL_SPECS: dict[str, dict[str, str]] = {
     STATE_PLAN_GO: {
         "color": "0e8a16",  # green — approved
         "description": "Plan approved by reviewer; implementer may proceed.",
+    },
+    STATE_SKIP: {
+        "color": "ededed",  # grey — intentionally inert
+        "description": "Automation skips this issue/PR in every phase.",
     },
 }
 
@@ -102,6 +113,15 @@ def is_plan_no_go(labels: Iterable[str]) -> bool:
 def is_implementation_go(labels: Iterable[str]) -> bool:
     """Return ``True`` iff a PR carries the implementation-review GO label."""
     return has_label(labels, STATE_IMPLEMENTATION_GO)
+
+
+def is_skipped(labels: Iterable[str]) -> bool:
+    """Return ``True`` iff the issue/PR carries the ``state:skip`` override.
+
+    When set, every automation phase skips the work item (#1083). Honored on
+    both issues and their PRs.
+    """
+    return has_label(labels, STATE_SKIP)
 
 
 def needs_plan(labels: Iterable[str]) -> bool:

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -548,3 +548,44 @@ class TestRunAddressFixSessionModuleLevel:
         assert out["addressed"] == ["t1"]
         # Fixes land in the long-lived implementer session, not a fresh one.
         assert captured["agent"] == AGENT_IMPLEMENTER
+
+    def test_classifies_and_embeds_todo_list(self, tmp_path: Path) -> None:
+        """The fix session classifies each comment and embeds a todo line.
+
+        #1083: the difficulty-annotated todo line lands in the coordinator
+        prompt.
+        """
+        prompts: dict[str, str] = {}
+
+        def _fake_invoke(*, agent: str, prompt: str, **_: object) -> tuple[str, str]:
+            prompts[agent] = prompt
+            return ('{"result": "```json\\n{\\"addressed\\": [], \\"replies\\": {}}\\n```"}', "")
+
+        with (
+            patch("hephaestus.automation.address_review.get_repo_slug", return_value="Repo"),
+            patch(
+                "hephaestus.automation.address_review.invoke_claude_with_session",
+                side_effect=_fake_invoke,
+            ),
+            # Force the classifier result so the todo line's difficulty is known.
+            patch(
+                "hephaestus.automation.comment_difficulty._run_classifier_session",
+                return_value={"t1": "hard"},
+            ),
+        ):
+            run_address_fix_session(
+                issue_number=1,
+                pr_number=42,
+                worktree_path=tmp_path,
+                threads=[{"id": "t1", "path": "a.py", "line": 7, "body": "rework locking"}],
+                agent="claude",
+                repo_root=tmp_path,
+                parse_fn=_parse_addressed_block,
+                log_file=tmp_path / "log.txt",
+                dry_run=False,
+            )
+
+        from hephaestus.automation.session_naming import AGENT_IMPLEMENTER
+
+        coordinator_prompt = prompts[AGENT_IMPLEMENTER]
+        assert "@ a.py Line 7 - hard - rework locking" in coordinator_prompt

--- a/tests/unit/automation/test_comment_difficulty.py
+++ b/tests/unit/automation/test_comment_difficulty.py
@@ -1,0 +1,116 @@
+"""Tests for hephaestus.automation.comment_difficulty (#1083).
+
+A classifier sub-agent labels each unresolved review comment simple/medium/hard;
+the label selects the model tier for the per-comment fix sub-agent and is
+rendered into the coordinator's todo list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from hephaestus.automation import comment_difficulty as cd
+from hephaestus.automation.claude_models import HAIKU, OPUS, SONNET
+
+
+class TestDifficultyToModel:
+    """simple→haiku, medium→sonnet, hard→opus."""
+
+    def test_simple_is_haiku(self) -> None:
+        assert cd.model_for_difficulty("simple") == HAIKU
+
+    def test_medium_is_sonnet(self) -> None:
+        assert cd.model_for_difficulty("medium") == SONNET
+
+    def test_hard_is_opus(self) -> None:
+        assert cd.model_for_difficulty("hard") == OPUS
+
+    def test_unknown_defaults_to_medium_tier(self) -> None:
+        # An unrecognized label is treated as medium (safe middle tier).
+        assert cd.model_for_difficulty("bogus") == SONNET
+
+
+class TestTodoLine:
+    """Each comment renders as '@ <file> Line <#> - <difficulty> - <description>'."""
+
+    def test_format_with_line(self) -> None:
+        thread = {"id": "T1", "path": "a.py", "line": 42, "body": "guard the null case"}
+        line = cd.format_todo_line(thread, "hard")
+        assert line == "@ a.py Line 42 - hard - guard the null case"
+
+    def test_format_without_line(self) -> None:
+        thread = {"id": "T1", "path": "a.py", "line": None, "body": "general note"}
+        line = cd.format_todo_line(thread, "simple")
+        assert line == "@ a.py Line ? - simple - general note"
+
+    def test_description_is_first_line_only(self) -> None:
+        thread = {"id": "T1", "path": "a.py", "line": 1, "body": "summary line\nmore detail"}
+        line = cd.format_todo_line(thread, "medium")
+        assert line == "@ a.py Line 1 - medium - summary line"
+
+
+class TestClassifyComments:
+    """classify_comments runs a cheap sub-agent and maps thread_id→difficulty."""
+
+    def test_returns_difficulty_per_thread(self, tmp_path: Path) -> None:
+        threads = [
+            {"id": "T1", "path": "a.py", "line": 1, "body": "typo"},
+            {"id": "T2", "path": "b.py", "line": 2, "body": "rework the locking"},
+        ]
+        with patch.object(
+            cd,
+            "_run_classifier_session",
+            return_value={"T1": "simple", "T2": "hard"},
+        ):
+            out = cd.classify_comments(
+                threads=threads,
+                agent="claude",
+                issue_number=1,
+                worktree_path=tmp_path,
+                repo_root=tmp_path,
+                state_dir=tmp_path,
+            )
+        assert out == {"T1": "simple", "T2": "hard"}
+
+    def test_unclassified_thread_defaults_to_medium(self, tmp_path: Path) -> None:
+        threads = [{"id": "T1", "path": "a.py", "line": 1, "body": "x"}]
+        # Classifier omits T1 entirely → defaults applied.
+        with patch.object(cd, "_run_classifier_session", return_value={}):
+            out = cd.classify_comments(
+                threads=threads,
+                agent="claude",
+                issue_number=1,
+                worktree_path=tmp_path,
+                repo_root=tmp_path,
+                state_dir=tmp_path,
+            )
+        assert out == {"T1": "medium"}
+
+    def test_dry_run_defaults_all_to_medium_without_agent(self, tmp_path: Path) -> None:
+        threads = [{"id": "T1", "path": "a.py", "line": 1, "body": "x"}]
+        with patch.object(cd, "_run_classifier_session") as sess:
+            out = cd.classify_comments(
+                threads=threads,
+                agent="claude",
+                issue_number=1,
+                worktree_path=tmp_path,
+                repo_root=tmp_path,
+                state_dir=tmp_path,
+                dry_run=True,
+            )
+        sess.assert_not_called()
+        assert out == {"T1": "medium"}
+
+    def test_no_threads_returns_empty(self, tmp_path: Path) -> None:
+        with patch.object(cd, "_run_classifier_session") as sess:
+            out = cd.classify_comments(
+                threads=[],
+                agent="claude",
+                issue_number=1,
+                worktree_path=tmp_path,
+                repo_root=tmp_path,
+                state_dir=tmp_path,
+            )
+        sess.assert_not_called()
+        assert out == {}

--- a/tests/unit/automation/test_ensure_state_labels.py
+++ b/tests/unit/automation/test_ensure_state_labels.py
@@ -57,8 +57,8 @@ class TestEnsureLabelsOnRepo:
     def test_issues_one_create_per_label(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _ok_proc()
         issued = ensure_labels_on_repo("owner/name")
-        assert issued == len(STATE_LABEL_SPECS) == 3
-        assert mock_run.call_count == 3
+        assert issued == len(STATE_LABEL_SPECS)
+        assert mock_run.call_count == len(STATE_LABEL_SPECS)
 
     def test_passes_label_name_color_description_and_force(self, mock_run: MagicMock) -> None:
         mock_run.return_value = _ok_proc()
@@ -73,8 +73,9 @@ class TestEnsureLabelsOnRepo:
             assert "--description" in args
             assert "--force" in args
             seen_labels.add(args[3])
-        # All three state labels were exercised.
-        assert seen_labels == {STATE_NEEDS_PLAN, STATE_PLAN_NO_GO, STATE_PLAN_GO}
+        # Every spec'd label was exercised (includes state:skip, #1083).
+        assert seen_labels == set(STATE_LABEL_SPECS.keys())
+        assert {STATE_NEEDS_PLAN, STATE_PLAN_NO_GO, STATE_PLAN_GO} <= seen_labels
 
     def test_dry_run_issues_zero_calls(self, mock_run: MagicMock) -> None:
         issued = ensure_labels_on_repo("owner/name", dry_run=True)
@@ -84,14 +85,14 @@ class TestEnsureLabelsOnRepo:
     def test_label_create_failure_does_not_abort(self, mock_run: MagicMock) -> None:
         """A single failed label-create is logged but the others are still attempted."""
         # First call fails, remaining succeed.
+        n = len(STATE_LABEL_SPECS)
         mock_run.side_effect = [
             _fail_proc(rc=2, stderr="not authorized"),
-            _ok_proc(),
-            _ok_proc(),
+            *(_ok_proc() for _ in range(n - 1)),
         ]
         issued = ensure_labels_on_repo("owner/name")
-        assert issued == 2
-        assert mock_run.call_count == 3
+        assert issued == n - 1
+        assert mock_run.call_count == n
 
 
 class TestGhListOrgRepos:
@@ -128,17 +129,16 @@ class TestMain:
     """End-to-end CLI smoke tests."""
 
     def test_main_default_uses_detected_repo(self, mock_run: MagicMock) -> None:
-        # ``gh repo view`` discovers the repo; then 3 label creates run.
+        # ``gh repo view`` discovers the repo; then one create per label runs.
+        n = len(STATE_LABEL_SPECS)
         mock_run.side_effect = [
             _ok_proc(stdout="HomericIntelligence/ProjectScylla"),  # gh repo view
-            _ok_proc(),  # label 1
-            _ok_proc(),  # label 2
-            _ok_proc(),  # label 3
+            *(_ok_proc() for _ in range(n)),  # one create per label
         ]
         rc = main([])
         assert rc == 0
-        # 1 detect + 3 label creates = 4 total subprocess calls.
-        assert mock_run.call_count == 4
+        # 1 detect + n label creates total subprocess calls.
+        assert mock_run.call_count == 1 + n
 
     def test_main_org_enumerates_and_applies_to_each(self, mock_run: MagicMock) -> None:
         mock_run.side_effect = [
@@ -151,12 +151,12 @@ class TestMain:
                     ]
                 )
             ),
-            # 3 labels x 2 repos = 6 label creates
-            *(_ok_proc() for _ in range(6)),
+            # n labels x 2 repos label creates
+            *(_ok_proc() for _ in range(len(STATE_LABEL_SPECS) * 2)),
         ]
         rc = main(["--org", "AnOrg"])
         assert rc == 0
-        assert mock_run.call_count == 1 + 6
+        assert mock_run.call_count == 1 + len(STATE_LABEL_SPECS) * 2
 
     def test_main_dry_run_calls_no_label_create(self, mock_run: MagicMock) -> None:
         mock_run.side_effect = [
@@ -171,11 +171,11 @@ class TestMain:
         assert mock_run.call_count == 1
 
     def test_main_specific_repo_skips_org_enumeration(self, mock_run: MagicMock) -> None:
-        mock_run.side_effect = [_ok_proc() for _ in range(3)]
+        mock_run.side_effect = [_ok_proc() for _ in range(len(STATE_LABEL_SPECS))]
         rc = main(["--repo", "owner/name"])
         assert rc == 0
-        # No 'gh repo list' call — exactly 3 label creates.
-        assert mock_run.call_count == 3
+        # No 'gh repo list' call — exactly one create per label.
+        assert mock_run.call_count == len(STATE_LABEL_SPECS)
         for call in mock_run.call_args_list:
             args = call[0][0]
             assert args[:3] == ["gh", "label", "create"]

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2023,6 +2023,78 @@ class TestGhPrReviewPost:
         posted = self._posted_comments(mock_write)
         assert {c["body"] for c in posted} == {"keep me"}
 
+    # ------------------------------------------------------------------
+    # #1083: a line that already has a (bot) review comment is EDITED, not
+    # duplicated.
+    # ------------------------------------------------------------------
+
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    @patch("hephaestus.automation.github_api.io_write_secure")
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_existing_line_comment_is_edited_not_duplicated(
+        self,
+        mock_gh_call: Any,
+        _mock_repo: Any,
+        mock_write: Any,
+        mock_index: Any,
+        mock_update: Any,
+    ) -> None:
+        """A comment on a line that already has a bot comment edits it in place."""
+        mock_gh_call.side_effect = self._gh_call_side_effect(
+            "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
+        )
+        # a.py:2 already has a bot comment; a.py:3 does not.
+        mock_index.return_value = {("a.py", 2): "COMMENT_NODE_A2"}
+
+        gh_pr_review_post(
+            pr_number=7,
+            comments=[
+                {"path": "a.py", "line": 2, "side": "RIGHT", "body": "more on line 2"},
+                {"path": "a.py", "line": 3, "side": "RIGHT", "body": "fresh on line 3"},
+            ],
+            summary="Findings",
+            dedupe_existing=True,
+        )
+
+        # Line 2 was edited in place (append), not re-posted.
+        mock_update.assert_called_once()
+        assert mock_update.call_args.args[0] == "COMMENT_NODE_A2"
+        assert "more on line 2" in mock_update.call_args.args[1]
+        # Only the genuinely new line-3 comment is posted as a fresh thread.
+        posted = self._posted_comments(mock_write)
+        assert {c["body"] for c in posted} == {"fresh on line 3"}
+
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    @patch("hephaestus.automation.github_api.io_write_secure")
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_dedupe_disabled_posts_everything(
+        self,
+        mock_gh_call: Any,
+        _mock_repo: Any,
+        mock_write: Any,
+        mock_index: Any,
+        mock_update: Any,
+    ) -> None:
+        """dedupe_existing=False keeps the legacy post-everything behavior."""
+        mock_gh_call.side_effect = self._gh_call_side_effect(
+            "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
+        )
+
+        gh_pr_review_post(
+            pr_number=7,
+            comments=[{"path": "a.py", "line": 2, "side": "RIGHT", "body": "x"}],
+            summary="Findings",
+            dedupe_existing=False,
+        )
+
+        mock_index.assert_not_called()
+        mock_update.assert_not_called()
+        assert {c["body"] for c in self._posted_comments(mock_write)} == {"x"}
+
 
 class TestValidReviewPositions:
     """_valid_review_positions / _filter_comments_to_diff: diff-hunk parsing (#1039)."""

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -698,3 +698,76 @@ class TestRunWithNothingToImplement:
             impl.run()
 
         mock_load_epic.assert_called_once_with(123)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1083 — `state:skip` label gates an issue out of all phases
+# ---------------------------------------------------------------------------
+
+
+class TestStateSkipLabel:
+    """``state:skip`` on an issue makes _load_issues skip it entirely.
+
+    Mirrors the existing ``skip_closed`` gate: a skipped issue is marked
+    completed in the resolver (so dependents are not blocked) and is never
+    added to the work graph.
+    """
+
+    @pytest.fixture
+    def impl(self, tmp_path: Path) -> IssueImplementer:
+        options = ImplementerOptions(
+            epic_number=0,
+            issues=[1],
+            max_workers=1,
+            skip_closed=True,
+            auto_merge=False,
+            dry_run=True,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            return IssueImplementer(options)
+
+    def test_issue_with_state_skip_label_is_skipped(self, impl: IssueImplementer) -> None:
+        from hephaestus.automation.models import IssueInfo
+
+        skipped = IssueInfo(number=42, title="t", labels=["state:skip"])
+        with (
+            patch(
+                "hephaestus.automation.github_api.prefetch_issue_states",
+                return_value={},
+            ),
+            patch(
+                "hephaestus.automation.implementer.fetch_issue_info",
+                return_value=skipped,
+            ) as mock_fetch,
+            patch.object(impl.resolver, "add_issue") as mock_add,
+        ):
+            impl._load_issues([42])
+
+        # Skipped issue must not enter the work graph but must count as done.
+        mock_fetch.assert_called_once_with(42)
+        mock_add.assert_not_called()
+        assert 42 in impl.resolver.completed
+
+    def test_issue_without_state_skip_label_is_loaded(self, impl: IssueImplementer) -> None:
+        from hephaestus.automation.models import IssueInfo
+
+        normal = IssueInfo(number=43, title="t", labels=["state:plan-go"])
+        with (
+            patch(
+                "hephaestus.automation.github_api.prefetch_issue_states",
+                return_value={},
+            ),
+            patch(
+                "hephaestus.automation.implementer.fetch_issue_info",
+                return_value=normal,
+            ),
+            patch.object(impl.resolver, "_load_dependencies"),
+            patch.object(impl.resolver, "add_issue") as mock_add,
+        ):
+            impl._load_issues([43])
+
+        mock_add.assert_called_once_with(normal)
+        assert 43 not in impl.resolver.completed

--- a/tests/unit/automation/test_implementer_cli.py
+++ b/tests/unit/automation/test_implementer_cli.py
@@ -78,6 +78,16 @@ class TestParseArgs:
         args = implementer_cli._parse_args()
         assert args.no_advise is True
 
+    def test_nitpick_defaults_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["impl"])
+        args = implementer_cli._parse_args()
+        assert args.nitpick is False
+
+    def test_nitpick_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["impl", "--nitpick"])
+        args = implementer_cli._parse_args()
+        assert args.nitpick is True
+
     def test_epic_and_issues_mutually_exclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sys, "argv", ["impl", "--epic", "1", "--issues", "2"])
         with pytest.raises(SystemExit):

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -87,6 +87,9 @@ class TestRunImplReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.validate_prior_comments_addressed",
                 return_value=([], True),
             ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels",
+            ),
         ):
             yield
 
@@ -177,6 +180,132 @@ class TestRunImplReviewLoop:
         assert iters == 1  # only the iter-0 review executed before the loop stopped
         assert verdict == "NOGO"
         assert mock_rev.call_count == 1
+
+    def test_exhaustion_without_go_applies_state_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """Exhausting MAX_REVIEW_ITERATIONS without GO applies ``state:skip``.
+
+        #1083 Bug 2: a sustained NOGO run that never reaches GO must label the
+        issue ``state:skip`` so the next loop skips it.
+        """
+        from hephaestus.automation.state_labels import STATE_SKIP
+
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[
+                    (_nogo("D"), ["t0"]),
+                    (_nogo("C"), ["t1"]),
+                    (_nogo("B"), ["t2"]),
+                ],
+            ),
+            patch.object(implementer, "_run_address_review_step", return_value=True),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+            ) as mock_label,
+        ):
+            _, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=7,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "NOGO"
+        mock_label.assert_called_once_with(7, [STATE_SKIP])
+
+    def test_zero_threads_without_go_applies_state_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """Zero threads but no GO applies ``state:skip``.
+
+        #1083 Bug 2: a reviewer that posts zero threads but never says GO is the
+        'stuck AMBIGUOUS' case — apply ``state:skip`` rather than reporting a
+        clean termination.
+        """
+        from hephaestus.automation.state_labels import STATE_SKIP
+
+        with (
+            patch.object(implementer, "_run_impl_review_step", return_value=(_nogo("C"), [])),
+            patch.object(implementer, "_run_address_review_step"),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+            ) as mock_label,
+        ):
+            _, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=8,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "NOGO"
+        mock_label.assert_called_once_with(8, [STATE_SKIP])
+
+    def test_go_does_not_apply_state_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A GO verdict must never apply ``state:skip``."""
+        with (
+            patch.object(implementer, "_run_impl_review_step", return_value=(_go(), [])),
+            patch.object(implementer, "_run_address_review_step"),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+            ) as mock_label,
+        ):
+            implementer._run_impl_review_loop(
+                issue_number=9,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        mock_label.assert_not_called()
+
+    def test_dry_run_does_not_apply_state_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """Dry-run must not mutate labels even on a non-GO outcome."""
+        implementer.options.dry_run = True
+        try:
+            with (
+                patch.object(implementer, "_run_impl_review_step", return_value=(_nogo("C"), [])),
+                patch.object(implementer, "_run_address_review_step"),
+                patch(
+                    "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+                ) as mock_label,
+            ):
+                implementer._run_impl_review_loop(
+                    issue_number=10,
+                    worktree_path=tmp_path,
+                    branch_name="b",
+                    issue_title="t",
+                    issue_body="ib",
+                    session_id="sess",
+                    slot_id=0,
+                    thread_id=None,
+                    pr_number=42,
+                )
+            mock_label.assert_not_called()
+        finally:
+            implementer.options.dry_run = False
 
     def test_no_blocking_threads_terminates_loop(
         self, implementer: IssueImplementer, tmp_path: Path
@@ -839,10 +968,13 @@ class TestRunImplReviewStep:
 class TestRunAddressReviewStep:
     """Stage 2 (#28): _run_address_review_step folds in address-review in-loop."""
 
-    def test_addresses_commits_pushes_and_resolves(
+    def test_addresses_commits_and_pushes_but_does_not_resolve(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """The step lists threads, runs the fix session, commits, pushes, resolves."""
+        """The step fixes + commits + pushes but no longer resolves threads.
+
+        #1083: resolution is now the validator's job (evidence-based).
+        """
         threads = [
             {"id": "t1", "path": "a.py", "line": 1, "body": "fix a"},
             {"id": "t2", "path": "b.py", "line": 2, "body": "fix b"},
@@ -856,11 +988,9 @@ class TestRunAddressReviewStep:
                 "hephaestus.automation.implementer_phase_runner.run_address_fix_session",
                 return_value={"addressed": ["t1"], "replies": {"t1": "fixed a"}},
             ) as mock_fix,
-            patch.object(implementer.phase_runner, "_commit_if_changes") as mock_commit,
+            # A real commit was produced.
+            patch.object(implementer.phase_runner, "_commit_if_changes", return_value=True),
             patch.object(implementer.phase_runner, "_push_branch") as mock_push,
-            patch(
-                "hephaestus.automation.implementer_phase_runner.resolve_addressed_threads"
-            ) as mock_resolve,
         ):
             addressed = implementer._run_address_review_step(
                 issue_number=1,
@@ -871,14 +1001,50 @@ class TestRunAddressReviewStep:
             )
 
         assert addressed is True
-        # The fix session resumes Session 2 (AGENT_IMPLEMENTER) via the shared core.
         assert mock_fix.call_args.kwargs["agent"] == implementer.options.agent
-        mock_commit.assert_called_once()
         mock_push.assert_called_once()
-        # Hallucination guard: presented set is exactly the threads we listed.
-        resolve_args = mock_resolve.call_args
-        assert resolve_args.args[0] == ["t1"]
-        assert resolve_args.args[2] == {"t1", "t2"}
+        # Resolution must NOT be imported/used here anymore.
+        assert not hasattr(
+            __import__(
+                "hephaestus.automation.implementer_phase_runner",
+                fromlist=["resolve_addressed_threads"],
+            ),
+            "resolve_addressed_threads",
+        )
+
+    def test_no_commit_means_not_addressed(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A self-reported fix with no commit must not count as addressed.
+
+        #1083 Bug 1: a clean worktree means nothing changed, so the loop must
+        not treat the session's self-report as progress.
+        """
+        threads = [{"id": "t1", "path": "a.py", "line": 1, "body": "fix a"}]
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_pr_list_unresolved_threads",
+                return_value=threads,
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.run_address_fix_session",
+                return_value={"addressed": ["t1"], "replies": {"t1": "claimed"}},
+            ),
+            # Worktree was clean — no commit produced.
+            patch.object(implementer.phase_runner, "_commit_if_changes", return_value=False),
+            patch.object(implementer.phase_runner, "_push_branch") as mock_push,
+        ):
+            addressed = implementer._run_address_review_step(
+                issue_number=1,
+                pr_number=42,
+                branch_name="b",
+                worktree_path=tmp_path,
+                iteration=0,
+            )
+
+        # No real change → the loop must not treat this as progress.
+        assert addressed is False
+        mock_push.assert_not_called()
 
     def test_no_unresolved_threads_returns_false(
         self, implementer: IssueImplementer, tmp_path: Path
@@ -918,9 +1084,8 @@ class TestRunAddressReviewStep:
                 "hephaestus.automation.implementer_phase_runner.run_address_fix_session",
                 return_value={"addressed": [], "replies": {}},
             ),
-            patch.object(implementer.phase_runner, "_commit_if_changes"),
+            patch.object(implementer.phase_runner, "_commit_if_changes", return_value=False),
             patch.object(implementer.phase_runner, "_push_branch"),
-            patch("hephaestus.automation.implementer_phase_runner.resolve_addressed_threads"),
         ):
             addressed = implementer._run_address_review_step(
                 issue_number=1,

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -146,6 +146,22 @@ def test_parse_args_accepts_no_advise() -> None:
     assert args.no_advise is True
 
 
+def test_parse_args_accepts_nitpick() -> None:
+    """The loop runner can enable nitpick comments across review phases."""
+    assert loop_runner._parse_args(["--nitpick"]).nitpick is True
+    assert loop_runner._parse_args([]).nitpick is False
+
+
+def test_build_phase_argv_implement_forwards_nitpick() -> None:
+    """#1083: --nitpick threads into the implement phase argv when set."""
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/impl", [])):
+        on = loop_runner._build_phase_argv("implement", LoopConfig(nitpick=True), open_issues=[1])
+        off = loop_runner._build_phase_argv("implement", LoopConfig(nitpick=False), open_issues=[1])
+    assert on is not None and off is not None
+    assert "--nitpick" in on
+    assert "--nitpick" not in off
+
+
 def test_parse_args_accepts_issue_scope() -> None:
     """The loop runner can scope child phases to a comma-separated issue list."""
     args = loop_runner._parse_args(["--issues", "8, 13"])

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -87,6 +87,33 @@ class TestPRReviewAnalysisPrompt:
         assert "POLICY VIOLATION" in out
         assert "Verdict: NOGO" in out
 
+    def test_nitpicks_suppressed_by_default(self) -> None:
+        """#1083: by default the reviewer must be told to OMIT nitpick comments."""
+        out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
+        assert "nitpick" in out.lower()
+        # Default mode instructs suppression.
+        assert "do not emit" in out.lower() or "omit" in out.lower()
+
+    def test_nitpicks_included_when_flag_set(self) -> None:
+        """#1083: include_nitpicks=True re-enables nitpick comments."""
+        on = prompts.get_pr_review_analysis_prompt(
+            pr_number=1, issue_number=1, include_nitpicks=True
+        )
+        off = prompts.get_pr_review_analysis_prompt(
+            pr_number=1, issue_number=1, include_nitpicks=False
+        )
+        # The two prompts must differ in how they instruct on nitpicks.
+        assert on != off
+        assert "nitpick" in on.lower()
+
+    def test_comment_schema_carries_severity(self) -> None:
+        """#1083: each inline comment object must include a severity field."""
+        out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
+        assert "severity" in out
+        # The allowed severities are documented for the reviewer.
+        assert "nitpick" in out
+        assert "major" in out
+
     def test_passes_auto_merge_state(self) -> None:
         on = prompts.get_pr_review_analysis_prompt(
             pr_number=1, issue_number=1, auto_merge_enabled=True
@@ -131,11 +158,13 @@ class TestPRReviewAnalysisPrompt:
         block — any change to the schema or fence ordering breaks parsing.
         """
         out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
-        # The schema example must appear verbatim.
+        # The schema example object must appear verbatim (now on its own line so
+        # the fenced block stays within the line-length limit).
         assert (
-            '{"comments": [{"path": "...", "line": 1, "side": "RIGHT", "body": "..."}], '
-            '"summary": "..."}'
+            '{"path": "...", "line": 1, "side": "RIGHT", "severity": "minor", "body": "..."}'
         ) in out
+        assert '"comments": [' in out
+        assert '"summary": "..."}' in out
         # The LGTM example must appear verbatim.
         assert '{"comments": [], "summary": "LGTM"}' in out
         # The last fenced code block in the prompt must be the JSON block — the
@@ -675,7 +704,13 @@ class TestImplLoopStrictRubric:
 
 
 class TestAddressReviewPrompt:
-    """The address-review prompt is a coordinator that fans out per-file sub-agents."""
+    """The address-review prompt is a coordinator that fans out per-COMMENT sub-agents.
+
+    #1083: dispatch is now one sub-agent per review comment (not per file), each
+    at the model tier matching the comment's classified difficulty, with
+    same-file comments serialized to avoid worktree write conflicts. Each comment
+    is presented as a todo line ``@ <file> Line <#> - <difficulty> - <desc>``.
+    """
 
     def _build(self) -> str:
         return prompts.get_address_review_prompt(
@@ -683,6 +718,7 @@ class TestAddressReviewPrompt:
             issue_number=7,
             worktree_path="/tmp/wt",
             threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "fix"}]',
+            todo_block="@ a.py Line 1 - simple - fix",
         )
 
     def test_substitutes_args(self) -> None:
@@ -691,12 +727,34 @@ class TestAddressReviewPrompt:
         assert "7" in out
         assert "/tmp/wt" in out
 
-    def test_instructs_per_file_subagent_fanout(self) -> None:
+    def test_renders_todo_list(self) -> None:
         out = self._build()
-        # Coordinator groups by file and dispatches one sub-agent per file via Task.
-        assert "group the threads by `path`" in out or "group the threads by `path`" in out.lower()
+        # The pre-classified todo line is embedded verbatim.
+        assert "@ a.py Line 1 - simple - fix" in out
+
+    def test_instructs_per_comment_subagent_dispatch(self) -> None:
+        out = self._build()
         assert "Task tool" in out
-        assert "ONE sub-agent" in out
+        # One sub-agent per comment (not per file).
+        assert "one sub-agent per" in out.lower()
+        assert "comment" in out.lower()
+
+    def test_instructs_model_tier_by_difficulty(self) -> None:
+        """simple→haiku, medium→sonnet, hard→opus mapping is stated."""
+        out = self._build()
+        assert "simple" in out and "haiku" in out.lower()
+        assert "medium" in out and "sonnet" in out.lower()
+        assert "hard" in out and "opus" in out.lower()
+
+    def test_instructs_serialize_same_file(self) -> None:
+        """Same-file comments must run serially to avoid write conflicts."""
+        out = self._build()
+        assert "same file" in out.lower() or "same `path`" in out.lower()
+        assert "serial" in out.lower() or "sequential" in out.lower()
+
+    def test_requires_all_comments_resolved(self) -> None:
+        out = self._build()
+        assert "ALL" in out and ("must be" in out.lower() or "resolve" in out.lower())
 
     def test_instructs_advise_skill(self) -> None:
         """Each sub-agent must consult /hephaestus:advise before fixing."""
@@ -711,12 +769,10 @@ class TestAddressReviewPrompt:
         # PR threads live on the PR, not the issue.
         assert "live on the PR" in out
 
-    def test_has_no_early_exit_and_file_ownership_guardrails(self) -> None:
+    def test_has_no_early_exit_guardrails(self) -> None:
         out = self._build()
         assert "do NOT exit early" in out
         assert "Do NOT background" in out
-        # File ownership: a sub-agent owns exactly one file.
-        assert "OWNS exactly one file" in out
 
     def test_preserves_json_block_contract(self) -> None:
         """The final JSON-block contract the pipeline parses must be intact."""
@@ -737,6 +793,7 @@ class TestAddressReviewPrompt:
             issue_number=1,
             worktree_path="/tmp/wt",
             threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "use {x: 1}"}]',
+            todo_block="@ a.py Line 1 - simple - use {x: 1}",
         )
         assert "use {x: 1}" in out
 
@@ -754,6 +811,7 @@ class TestAddressReviewPrompt:
             issue_number=7,
             worktree_path="/tmp/wt",
             threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "fix"}]',
+            todo_block="@ a.py Line 1 - simple - fix",
             task_block="#7 Title\n\nDo the thing",
             task_review_block="Plan review: GO",
             diff_text="diff --git a/a.py b/a.py",

--- a/tests/unit/automation/test_review_validator.py
+++ b/tests/unit/automation/test_review_validator.py
@@ -159,6 +159,9 @@ class TestValidatePriorCommentsAddressed:
             patch.object(
                 review_validator, "gh_pr_review_post", return_value=["NEW_THREAD"]
             ) as post,
+            # b.py thread is "addressed" → the validator resolves it; mock so no
+            # real gh call (which would trip the github-api circuit breaker).
+            patch.object(review_validator, "gh_pr_resolve_thread"),
         ):
             reopened, is_clean = review_validator.validate_prior_comments_addressed(
                 pr_number=42,
@@ -189,6 +192,9 @@ class TestValidatePriorCommentsAddressed:
         with (
             patch.object(review_validator, "_run_validation_session", return_value=unaddressed),
             patch.object(review_validator, "gh_pr_review_post") as post,
+            # Both real threads are "addressed" (the unaddressed item has no
+            # path) → the validator resolves them; mock to avoid real gh calls.
+            patch.object(review_validator, "gh_pr_resolve_thread"),
         ):
             reopened, is_clean = review_validator.validate_prior_comments_addressed(
                 pr_number=42,

--- a/tests/unit/automation/test_review_validator.py
+++ b/tests/unit/automation/test_review_validator.py
@@ -59,10 +59,16 @@ class TestValidatePriorCommentsAddressed:
         run.assert_not_called()
         post.assert_not_called()
 
-    def test_all_addressed_posts_nothing(self, tmp_path: Path) -> None:
+    def test_all_addressed_posts_nothing_and_resolves_all(self, tmp_path: Path) -> None:
+        """Confirming all prior threads addressed resolves them all in place.
+
+        #1083: evidence-based resolution moves from the implementer's
+        self-report to the validator/reviewer.
+        """
         with (
             patch.object(review_validator, "_run_validation_session", return_value=[]),
             patch.object(review_validator, "gh_pr_review_post") as post,
+            patch.object(review_validator, "gh_pr_resolve_thread") as resolve,
         ):
             reopened, is_clean = review_validator.validate_prior_comments_addressed(
                 pr_number=1,
@@ -77,6 +83,67 @@ class TestValidatePriorCommentsAddressed:
         assert reopened == []
         assert is_clean is True
         post.assert_not_called()
+        # Both prior threads (T1, T2) were confirmed addressed → resolved.
+        resolved_ids = {
+            c.kwargs.get("thread_id", c.args[0] if c.args else None) for c in resolve.call_args_list
+        }
+        assert resolved_ids == {"T1", "T2"}
+
+    def test_partial_resolves_only_addressed_threads(self, tmp_path: Path) -> None:
+        """Only the addressed thread is resolved; the unaddressed one stays open.
+
+        #1083: a.py is unaddressed (re-opened); b.py is addressed → only T2 is
+        resolved, T1 is not.
+        """
+        unaddressed = [
+            {
+                "path": "a.py",
+                "line": 3,
+                "original_body": "guard the null case",
+                "detail": "still dereferences x",
+            }
+        ]
+        with (
+            patch.object(review_validator, "_run_validation_session", return_value=unaddressed),
+            patch.object(review_validator, "gh_pr_review_post", return_value=["NEW"]),
+            patch.object(review_validator, "gh_pr_resolve_thread") as resolve,
+        ):
+            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+                pr_number=42,
+                issue_number=1,
+                worktree_path=tmp_path,
+                prior_threads=_threads(),
+                diff_text="diff",
+                agent="claude",
+                iteration=1,
+                state_dir=tmp_path,
+            )
+        assert reopened == ["NEW"]
+        assert is_clean is False
+        resolved_ids = {
+            c.kwargs.get("thread_id", c.args[0] if c.args else None) for c in resolve.call_args_list
+        }
+        # Only the addressed thread (T2 / b.py) is resolved; T1 stays open.
+        assert resolved_ids == {"T2"}
+
+    def test_dry_run_resolves_nothing(self, tmp_path: Path) -> None:
+        with (
+            patch.object(review_validator, "_run_validation_session") as run,
+            patch.object(review_validator, "gh_pr_resolve_thread") as resolve,
+        ):
+            review_validator.validate_prior_comments_addressed(
+                pr_number=1,
+                issue_number=1,
+                worktree_path=tmp_path,
+                prior_threads=_threads(),
+                diff_text="diff",
+                agent="claude",
+                iteration=1,
+                state_dir=tmp_path,
+                dry_run=True,
+            )
+        run.assert_not_called()
+        resolve.assert_not_called()
 
     def test_unaddressed_reopens_new_inline_thread(self, tmp_path: Path) -> None:
         unaddressed = [

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -15,9 +15,11 @@ from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
+    STATE_SKIP,
     has_label,
     is_plan_go,
     is_plan_no_go,
+    is_skipped,
     needs_plan,
 )
 
@@ -41,14 +43,30 @@ class TestLabelVocabulary:
             assert label.startswith("state:")
 
     def test_label_specs_cover_every_label(self) -> None:
-        """The provisioning script needs a colour+description for each label."""
-        assert set(STATE_LABEL_SPECS.keys()) == set(ALL_STATE_LABELS)
+        """The provisioning script needs a colour+description for each label.
+
+        Specs must cover every plan-state label (``ALL_STATE_LABELS``) plus the
+        independent ``state:skip`` override (#1083) — i.e. specs is a superset
+        of the plan-state tuple.
+        """
+        assert set(ALL_STATE_LABELS) <= set(STATE_LABEL_SPECS.keys())
+        assert STATE_SKIP in STATE_LABEL_SPECS
         for spec in STATE_LABEL_SPECS.values():
             assert "color" in spec
             assert "description" in spec
             # Hex colour without leading '#'.
             assert len(spec["color"]) == 6
             int(spec["color"], 16)
+
+    def test_skip_label_is_independent_of_plan_state(self) -> None:
+        """``state:skip`` is an override, not a plan-state label."""
+        assert STATE_SKIP not in ALL_STATE_LABELS
+        assert STATE_SKIP.startswith("state:")
+
+    def test_is_skipped(self) -> None:
+        assert is_skipped(["bug", STATE_SKIP]) is True
+        assert is_skipped([STATE_PLAN_GO]) is False
+        assert is_skipped([]) is False
 
 
 class TestHasLabel:


### PR DESCRIPTION
## Summary

Fixes the implement→review loop, which (per a real run's `output.log`) was resolving review comments without implementing or testing them, and terminating "too fast". Also adds the requested dispatch/UX features.

### Correctness fixes
- **Resolution gated on a real commit.** `_commit_if_changes` now returns whether a commit was actually created; the address step counts as progress only when one was, and no longer resolves threads on the model's self-report. (Bug 1: PR #743 in the log logged `No changes to commit` then resolved all 6 threads anyway.)
- **Resolution moved to the reviewer (evidence-based).** `review_validator` now partitions prior threads against the new diff: addressed → resolved in place; not-addressed → re-opened. A self-reported fix with no diff change stays open.
- **Require explicit GO to terminate.** The loop no longer treats "zero threads posted" as success. Any non-GO terminal outcome (exhausting `MAX_REVIEW_ITERATIONS`, or a reviewer that posts zero threads yet never says GO) auto-applies `state:skip`. (Bug 2.)

### Features
- **`state:skip` label** — honored on issues (skips all phases via `_load_issues`), auto-provisioned by `hephaestus-ensure-state-labels`, auto-applied by the loop on a non-GO terminal outcome.
- **`--nitpick` flag** — reviewer tags every comment with a severity and OMITS `nitpick`-severity comments by default; `--nitpick` re-enables them. Threaded through `loop_runner` → `implementer_cli` → `ImplementerOptions` → review context → prompt.
- **Per-comment tiered dispatch** — a cheap classifier sub-agent labels each comment simple/medium/hard; the address coordinator now dispatches one sub-agent per comment (same-file serialized) at the matching model tier (simple→haiku, medium→sonnet, hard→opus), each rendered as a todo line `@ <file> Line <#> - <difficulty> - <description>`.
- **Edit-in-place** — a comment on a line that already has an unresolved bot comment edits it instead of posting a duplicate (fails open).

## Testing
- New/updated unit tests across `test_state_labels`, `test_ensure_state_labels`, `test_implementer`, `test_implementer_loop`, `test_review_validator`, `test_prompts`, `test_comment_difficulty`, `test_implementer_cli`, `test_loop_runner`, `test_github_api`, `test_address_review`.
- Full `tests/unit/automation/` suite: **1174 passed**. `ruff` clean, `mypy` clean (320 files).

Implemented via TDD (RED→GREEN per behavior).

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)