### PR TITLE
perf(automation): reduce token usage via terse directives + tool scoping

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -1110,6 +1110,7 @@ class CIDriver:
                 cwd=self.repo_root,
                 timeout=advise_claude_timeout(),
                 output_format="text",
+                allowed_tools="Read,Glob,Grep,Bash",
             )
             return (stdout or "").strip()
 

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -834,6 +834,7 @@ class ImplementationPhaseRunner:
                     cwd=worktree_path,
                     timeout=advise_claude_timeout(),
                     output_format="text",
+                    allowed_tools="Read,Glob,Grep,Bash",
                 )
             decision = _parse_dirty_reused_worktree_decision(output)
         except Exception as e:

--- a/hephaestus/automation/planner_claude.py
+++ b/hephaestus/automation/planner_claude.py
@@ -94,6 +94,7 @@ class PlannerClaudeRunner:
                 cwd=repo_root,
                 timeout=timeout,
                 system_prompt_file=self.options.system_prompt_file,
+                allowed_tools="Read,Glob,Grep,Bash",
                 extra_args=extra_args,
             )
             response = stdout.strip()

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -25,6 +25,7 @@ importers continue to work unchanged.
 # previously did ``from hephaestus.automation.prompts import _fence_untrusted``
 # or ``prompts._STRICT_GRADING_AND_ANTI_INFLATION``. The ``as`` aliases tell
 # ruff these are intentional re-exports, not unused imports.
+from ._shared import _TERSE_OUTPUT_DIRECTIVE as _TERSE_OUTPUT_DIRECTIVE
 from ._shared import _UNTRUSTED_NOTICE as _UNTRUSTED_NOTICE
 from ._shared import _fence_untrusted as _fence_untrusted
 from ._shared import _iteration_guidance as _iteration_guidance

--- a/hephaestus/automation/prompts/_shared.py
+++ b/hephaestus/automation/prompts/_shared.py
@@ -97,3 +97,22 @@ def _prior_review_block(prior_review: str | None) -> str:
         "\n---\n\n**Prior review (from previous iteration) — verify these findings "
         f"have been addressed:**\n\n{prior_review}\n"
     )
+
+
+# Token-reduction directive (#1082). Composed into every agent prompt via
+# `.format(terse_output_directive=_TERSE_OUTPUT_DIRECTIVE)`. The GitHub-output
+# carve-out MUST stay the first line so brevity never truncates pr-policy
+# artifacts (see learn-agents-fabricate-closes-issue-numbers.md). The
+# no-early-exit clause is bounded to *transient* external state so agents do
+# NOT spin on permanent failures (auth, 4xx) — see
+# swarm-agents-quit-early-on-polling.md.
+_TERSE_OUTPUT_DIRECTIVE: str = """\
+GitHub-posted review bodies, PR descriptions, and issue comments retain full detail required by pr-policy and reviewers. The directives below apply to your reasoning, console output, and intermediate results — NOT to the final artifact posted to GitHub.
+
+## Output discipline (token budget)
+
+- Skip preamble, postamble, restating the task, narrating tool calls, or end-of-turn summaries.
+- Return verdicts as a single line: `Verdict: <result> | Reason: <one line>`.
+- Prefer bullet lists over prose; cite `file.py:line` instead of quoting blocks; reference issue/PR numbers, not their bodies.
+- Do NOT exit early while a *transient* external dependency is still in progress (CI runs queued/in_progress, auto-merge waiting on green). On permanent failures (4xx, auth errors, missing required reviews), return immediately with the failure reason.
+"""  # noqa: E501

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -2,7 +2,7 @@
 
 import secrets
 
-from ._shared import _UNTRUSTED_NOTICE, _fence_untrusted
+from ._shared import _TERSE_OUTPUT_DIRECTIVE, _UNTRUSTED_NOTICE, _fence_untrusted
 
 ADDRESS_REVIEW_PROMPT = """
 You are the COORDINATOR for addressing the review threads on PR #{pr_number}
@@ -14,6 +14,8 @@ the current diff so the same implement session can re-review and converge.
 These threads live on the PR, not on the issue.
 
 **Working Directory:** {worktree_path}
+
+{terse_output_directive}
 
 {untrusted_notice}
 {context_block}
@@ -184,4 +186,5 @@ def get_address_review_prompt(
         todo_block=_fence_untrusted("TODO_LIST", todo_block or "_(no todo lines)_", nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
         context_block=_build_context_block(task_block, task_review_block, diff_text, nonce),
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )

--- a/hephaestus/automation/prompts/advise.py
+++ b/hephaestus/automation/prompts/advise.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 from hephaestus.agents.runtime import is_codex
 
-from ._shared import _relativize_path
+from ._shared import _TERSE_OUTPUT_DIRECTIVE, _relativize_path
 
 ADVISE_PROMPT = """
 Search the team knowledge base for relevant prior learnings before planning this issue.
@@ -14,6 +14,8 @@ Search the team knowledge base for relevant prior learnings before planning this
 {issue_body}
 
 ---
+
+{terse_output_directive}
 
 **Your task:**
 1. Read the skills marketplace: {marketplace_path}
@@ -59,6 +61,8 @@ Issue #{issue_number}: {issue_title}
 Body:
 {issue_body}
 
+{terse_output_directive}
+
 Return the advise findings only, in markdown. Do not implement or modify files.
 """
 
@@ -91,6 +95,7 @@ def get_advise_prompt(
         issue_title=issue_title,
         issue_body=issue_body,
         marketplace_path=safe_marketplace_path,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 
@@ -113,6 +118,7 @@ def get_codex_advise_prompt(
         issue_number=issue_number,
         issue_title=issue_title,
         issue_body=issue_body,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 

--- a/hephaestus/automation/prompts/follow_up.py
+++ b/hephaestus/automation/prompts/follow_up.py
@@ -1,8 +1,12 @@
 """Follow-up prompt: identify in-scope follow-ups discovered during implementation."""
 
+from ._shared import _TERSE_OUTPUT_DIRECTIVE
+
 FOLLOW_UP_PROMPT = """
 Review your work on issue #{issue_number} and identify follow-up items
 **discovered during implementation** that fall within strict scope.
+
+{terse_output_directive}
 
 ## Scope (HARD GUARDRAIL)
 
@@ -108,4 +112,7 @@ def get_follow_up_prompt(issue_number: int) -> str:
         Formatted follow-up prompt
 
     """
-    return FOLLOW_UP_PROMPT.format(issue_number=issue_number)
+    return FOLLOW_UP_PROMPT.format(
+        issue_number=issue_number,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
+    )

--- a/hephaestus/automation/prompts/implementation.py
+++ b/hephaestus/automation/prompts/implementation.py
@@ -7,6 +7,7 @@ review prompt, and the resume-after-NOGO feedback prompt.
 import secrets
 
 from ._shared import (
+    _TERSE_OUTPUT_DIRECTIVE,
     _UNTRUSTED_NOTICE,
     _fence_untrusted,
     _iteration_guidance,
@@ -49,6 +50,8 @@ Implement GitHub issue #{issue_number}.
 - Run `gh issue view {issue_number} --comments` to read the full plan and its
   plan review, plus any comments
 - Follow the project's Python conventions and type hint all function signatures
+
+{terse_output_directive}
 
 **Critical Requirements:**
 1. Read the issue description and any existing plan carefully
@@ -132,6 +135,8 @@ below. Judge the diff against the TASK and that approved PLAN. Post your
 concrete findings as inline PR review threads on the changed lines, then end
 with the single Grade/Verdict line defined at the bottom of this prompt.
 
+{terse_output_directive}
+
 {untrusted_notice}
 
 **Issue Title (untrusted):** {issue_title}
@@ -179,6 +184,8 @@ after the review loop terminates.
 
 When done, summarize what you changed in 3-5 bullet points so the next
 review can verify the fixes were applied.
+
+{terse_output_directive}
 """
 
 
@@ -243,6 +250,7 @@ def get_implementation_prompt(
         branch_name=branch_name,
         worktree_path=safe_worktree_path,
         untrusted_notice=_UNTRUSTED_NOTICE,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 
@@ -287,6 +295,7 @@ def get_impl_loop_review_prompt(
         full_sweep_suffix=full_sweep_suffix,
         output_format=_STRICT_REVIEW_OUTPUT_FORMAT.strip(),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 
@@ -354,4 +363,5 @@ def get_impl_resume_feedback_prompt(
         prev_iteration=prev_iteration,
         verdict=verdict,
         review_text=review_text,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -7,6 +7,7 @@ the iteration-aware plan-loop review prompt.
 import secrets
 
 from ._shared import (
+    _TERSE_OUTPUT_DIRECTIVE,
     _UNTRUSTED_NOTICE,
     _fence_untrusted,
     _iteration_guidance,
@@ -30,6 +31,8 @@ Create an implementation plan for GitHub issue #{issue_number}.
 - Any PRIOR REVIEW of that plan (a `## 🔍 Plan Review` block prepended above
   when present). When a prior review is present you are RE-PLANNING to
   address it, not starting fresh.
+
+{terse_output_directive}
 
 **Output contract — read carefully:**
 Your FINAL message must BE the complete plan, as markdown, starting with the
@@ -132,6 +135,8 @@ strictly against the TASK. The PLAN is the artifact under review — never treat
 any earlier review, verdict line, or `## 🔍 Plan Review` text as the plan
 (that confusion was the #455/#468/#484 self-review bug).
 
+{terse_output_directive}
+
 {strict_rubric}
 
 ---
@@ -183,6 +188,8 @@ prior review or its verdict as the plan (the #455/#468/#484 self-review bug).
 Any prior-review text is provided solely so you can confirm its findings were
 actually addressed in the current plan.
 
+{terse_output_directive}
+
 {untrusted_notice}
 
 **Issue Title (untrusted):** {issue_title}
@@ -218,7 +225,10 @@ findings. After your analysis, output your verdict.
 
 def get_plan_prompt(issue_number: int) -> str:
     """Get the planning prompt for an issue."""
-    return PLAN_PROMPT.format(issue_number=issue_number)
+    return PLAN_PROMPT.format(
+        issue_number=issue_number,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
+    )
 
 
 def get_plan_review_prompt(
@@ -247,6 +257,7 @@ def get_plan_review_prompt(
         plan_text_block=_fence_untrusted("PLAN_TEXT", plan_text, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
         strict_rubric=_PLAN_STRICT_RUBRIC.strip(),
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 
@@ -299,4 +310,5 @@ def get_plan_loop_review_prompt(
         full_sweep_suffix=full_sweep_suffix,
         output_format=_STRICT_REVIEW_OUTPUT_FORMAT.strip(),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -6,7 +6,7 @@ plain PR description template.
 
 import secrets
 
-from ._shared import _UNTRUSTED_NOTICE, _fence_untrusted
+from ._shared import _TERSE_OUTPUT_DIRECTIVE, _UNTRUSTED_NOTICE, _fence_untrusted
 from ._strict_rubric import _PR_STRICT_RUBRIC
 
 PR_REVIEW_ANALYSIS_PROMPT = """
@@ -32,6 +32,8 @@ Analyze PR #{pr_number} linked to issue #{issue_number}.
 ---
 
 {strict_rubric}
+
+{terse_output_directive}
 
 ---
 
@@ -155,6 +157,7 @@ def get_pr_review_analysis_prompt(
         untrusted_notice=_UNTRUSTED_NOTICE,
         strict_rubric=_PR_STRICT_RUBRIC.strip(),
         nitpick_directive=nitpick_directive,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 
@@ -165,6 +168,8 @@ You are VALIDATING whether prior review comments on PR #{pr_number}
 You are NOT performing a fresh review. Do not raise new concerns. Your ONLY
 job is, for each PRIOR review comment below, to decide whether the CURRENT
 diff actually resolves it.
+
+{terse_output_directive}
 
 {untrusted_notice}
 
@@ -261,10 +266,13 @@ def get_review_validation_prompt(
         prior_comments_block=_fence_untrusted("PRIOR_COMMENTS", prior_comments_json, nonce),
         diff_block=_fence_untrusted("DIFF", diff_text, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 
 COMMENT_DIFFICULTY_PROMPT = """
+{terse_output_directive}
+
 You are CLASSIFYING the difficulty of unresolved PR review comments on issue
 #{issue_number}, so the right model tier can be assigned to fix each one.
 
@@ -327,6 +335,7 @@ def get_comment_difficulty_prompt(
         issue_number=issue_number,
         comments_block=_fence_untrusted("REVIEW_COMMENTS", comments_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
+        terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
 

--- a/tests/unit/automation/test_invoke_allowed_tools_scoping.py
+++ b/tests/unit/automation/test_invoke_allowed_tools_scoping.py
@@ -1,0 +1,64 @@
+"""Every invoke_claude_with_session call must pass an --allowedTools scope (#1082)."""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+AUTOMATION_DIR = pathlib.Path(__file__).parents[3] / "hephaestus" / "automation"
+
+# (filename, minimum tools, gh_required)
+# gh_required=True means the agent itself may shell to gh and so needs "Bash".
+# False = orchestrator posts on the agent's behalf; agent is read-only analysis.
+CALL_SITES = [
+    ("address_review.py", {"Read", "Write", "Edit", "Glob", "Grep", "Bash"}, True),
+    ("pr_reviewer.py", {"Read", "Glob", "Grep"}, False),
+    ("plan_reviewer.py", {"Read", "Glob", "Grep"}, False),
+    ("review_validator.py", {"Read", "Glob", "Grep"}, False),
+    ("planner_claude.py", {"Read", "Glob", "Grep", "Bash"}, True),
+    ("ci_driver.py", {"Read", "Glob", "Grep", "Bash"}, True),
+    ("implementer_phase_runner.py", {"Read", "Glob", "Grep", "Bash"}, True),
+    ("comment_difficulty.py", {"Read", "Glob", "Grep"}, False),
+]
+
+
+def _allowed_tools_kwargs(path: pathlib.Path) -> list[str]:
+    tree = ast.parse(path.read_text())
+    out: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        # Handle both forms: invoke_claude_with_session(...) and
+        # _impl_mod.invoke_claude_with_session(...)
+        name = getattr(fn, "attr", None) or getattr(fn, "id", None)
+        if name != "invoke_claude_with_session":
+            continue
+        kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+        if "allowed_tools" not in kwargs:
+            pytest.fail(
+                f"{path.name}: invoke_claude_with_session call missing allowed_tools= kwarg"
+            )
+        val = kwargs["allowed_tools"]
+        if not (isinstance(val, ast.Constant) and isinstance(val.value, str)):
+            pytest.fail(
+                f"{path.name}: allowed_tools must be a string literal "
+                "(this test asserts that contract)"
+            )
+        out.append(val.value)
+    return out
+
+
+@pytest.mark.parametrize("filename, min_tools, gh_required", CALL_SITES)
+def test_call_site_scope(filename: str, min_tools: set[str], gh_required: bool) -> None:
+    """Verify each automation call site passes correct allowed_tools scope."""
+    values = _allowed_tools_kwargs(AUTOMATION_DIR / filename)
+    assert values, f"{filename}: no invoke_claude_with_session call found"
+    for v in values:
+        tools = {t.strip() for t in v.split(",") if t.strip()}
+        missing = min_tools - tools
+        assert not missing, f"{filename} scope {v!r} missing {missing}"
+        if gh_required:
+            assert "Bash" in tools, f"{filename} scope {v!r} must include Bash for gh CLI access"

--- a/tests/unit/automation/test_prompt_terseness.py
+++ b/tests/unit/automation/test_prompt_terseness.py
@@ -1,0 +1,105 @@
+"""Verify the shared terse-output directive is composed into every agent prompt (#1082)."""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from hephaestus.automation.prompts import (
+    get_address_review_prompt,
+    get_advise_prompt,
+    get_codex_advise_prompt,
+    get_comment_difficulty_prompt,
+    get_follow_up_prompt,
+    get_impl_loop_review_prompt,
+    get_impl_resume_feedback_prompt,
+    get_implementation_prompt,
+    get_plan_loop_review_prompt,
+    get_plan_prompt,
+    get_plan_review_prompt,
+    get_pr_review_analysis_prompt,
+    get_review_validation_prompt,
+)
+from hephaestus.automation.prompts._shared import _TERSE_OUTPUT_DIRECTIVE
+
+# Distinctive phrase from the directive; verified at plan time to be absent
+# from every existing prompt file (grep -rnE "Output discipline|token budget"
+# hephaestus/automation/prompts/ returned no hits, exit 1).
+SENTINEL = "Output discipline (token budget)"
+
+
+def test_terse_directive_leads_with_github_carveout() -> None:
+    """Carve-out MUST be the first non-blank line so brevity never truncates pr-policy artifacts."""
+    first_line = _TERSE_OUTPUT_DIRECTIVE.lstrip().splitlines()[0]
+    assert "GitHub-posted" in first_line
+    assert "retain full detail" in first_line
+
+
+# Each lambda's kwargs match the exact signature read from the source at plan
+# time. Required kwargs are provided with minimal sentinel values; optionals
+# are omitted.
+PROMPT_BUILDERS = [
+    lambda: get_plan_prompt(issue_number=1),
+    lambda: get_plan_review_prompt(issue_number=1, issue_title="t", issue_body="b", plan_text="p"),
+    lambda: get_plan_loop_review_prompt(
+        issue_number=1,
+        issue_title="t",
+        issue_body="b",
+        plan_text="p",
+        learnings="",
+        iteration=0,
+        prior_review=None,
+    ),
+    lambda: get_implementation_prompt(issue_number=1),
+    lambda: get_impl_loop_review_prompt(
+        issue_number=1,
+        issue_title="t",
+        issue_body="b",
+        diff_text="",
+        files_changed="",
+        iteration=0,
+        prior_review=None,
+    ),
+    lambda: get_impl_resume_feedback_prompt(
+        issue_number=1, prev_iteration=0, verdict="NOGO", review_text=""
+    ),
+    lambda: get_pr_review_analysis_prompt(pr_number=1, issue_number=1),
+    lambda: get_review_validation_prompt(pr_number=1, issue_number=1, prior_comments_json="[]"),
+    lambda: get_address_review_prompt(
+        pr_number=1, issue_number=1, worktree_path="/x", threads_json="[]"
+    ),
+    lambda: get_follow_up_prompt(issue_number=1),
+    lambda: get_advise_prompt(
+        issue_number=1,
+        issue_title="t",
+        issue_body="b",
+        marketplace_path="m.json",
+    ),
+    lambda: get_codex_advise_prompt(
+        issue_number=1,
+        issue_title="t",
+        issue_body="b",
+        marketplace_path="m.json",
+    ),
+    lambda: get_comment_difficulty_prompt(issue_number=1, comments_json="[]"),
+]
+
+
+@pytest.mark.parametrize("build", PROMPT_BUILDERS)
+def test_each_prompt_includes_terse_directive(build) -> None:
+    """Verify terse directive is composed into each agent prompt."""
+    text = build()
+    assert SENTINEL in text, "shared terse directive missing from composed prompt"
+
+
+def test_terse_directive_defined_in_single_module() -> None:
+    """Verify directive is defined in _shared.py only, not redefined elsewhere."""
+    pkg = pathlib.Path(__file__).parents[3] / "hephaestus" / "automation" / "prompts"
+    for py in pkg.glob("*.py"):
+        if py.name == "_shared.py":
+            continue
+        body = py.read_text()
+        assert "_TERSE_OUTPUT_DIRECTIVE =" not in body, (
+            f"{py.name} re-defines the directive — import it from _shared instead"
+        )


### PR DESCRIPTION
## Summary

- Add shared `_TERSE_OUTPUT_DIRECTIVE` to prompts/_shared.py, composed into all agent prompts (planning, implementation, pr_review, address_review, follow_up, advise)
- Add explicit `allowed_tools` scoping to 3 previously unscoped call sites (planner_claude, ci_driver advise, implementer_phase_runner advise)
- Add unit tests verifying directive composition and allowed_tools presence
- Carve-out: GitHub-posted artifacts retain full detail; brevity applies to agent thinking/console output only

## Test plan

- Unit tests for terse directive composition: `test_prompt_terseness.py` verifies the shared directive is composed into each prompt
- Unit tests for allowed_tools scoping: `test_invoke_allowed_tools_scoping.py` verifies each call site passes the correct tool scope and includes `Bash`
- All existing automation tests pass: 1159 tests in `tests/unit/automation/`

Closes #1082