### PR TITLE
fix(automation): exit poll early on BLOCKED PR; treat no-changes as state:skip

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -694,6 +694,14 @@ class CIDriver:
                         )
                     if outcome == "DIRTY":
                         return self._resolve_dirty_pr(issue_number, pr_number, acquired_slot)
+                    if outcome == "BLOCKED":
+                        # Branch-protection gate (e.g. unresolved conversations).
+                        # Nothing for the bot to fix — leave armed and yield success.
+                        return WorkerResult(
+                            issue_number=issue_number,
+                            success=True,
+                            pr_number=pr_number,
+                        )
                 return WorkerResult(
                     issue_number=issue_number,
                     success=merge_ok,
@@ -1413,7 +1421,10 @@ class CIDriver:
         Returns:
             One of ``"MERGED"``, ``"CLOSED"``, ``"FAILING"``, ``"DIRTY"`` (the
             PR has a merge conflict and will never merge while armed — caller
-            should rebase/resolve), or ``"TIMEOUT"``.
+            should rebase/resolve), ``"BLOCKED"`` (branch-protection gate such
+            as unresolved conversations or a required human review blocks the
+            merge — nothing the bot can fix; caller should leave armed and
+            yield), or ``"TIMEOUT"``.
 
         """
         if self.options.dry_run:
@@ -1464,6 +1475,24 @@ class CIDriver:
                     merge_status,
                 )
                 return "DIRTY"
+
+            # A BLOCKED PR is gated by branch protection (e.g. required
+            # conversation resolution, required human review) rather than by
+            # CI checks. Exit early only when we can confirm the block is a
+            # branch-protection gate and not just in-flight checks: GitHub
+            # also reports BLOCKED while required checks are still running.
+            # Guard: no failing AND no pending required checks.
+            if merge_status == "BLOCKED" and not failing:
+                pending = self._pending_required_check_names(pr_number)
+                if not pending:
+                    logger.warning(
+                        "Issue #%s: PR #%s is BLOCKED by branch protection "
+                        "(unresolved conversations or required review) — "
+                        "cannot auto-merge; leaving armed and exiting poll early",
+                        issue_number,
+                        pr_number,
+                    )
+                    return "BLOCKED"
 
             sleep_secs = min(2**attempt, 60)
             if elapsed + sleep_secs > max_wait:
@@ -1657,7 +1686,7 @@ class CIDriver:
             # re-arms and routes to the fix / _resolve_dirty_pr handling.
             self._clear_arming_state(issue_number)
             return None
-        # TIMEOUT — still pending; leave armed for a later pass to resolve.
+        # TIMEOUT / BLOCKED — still pending; leave armed for a later pass to resolve.
         return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
     def _load_impl_session_id(self, issue_number: int) -> str | None:
@@ -1833,6 +1862,29 @@ class CIDriver:
             for c in required
             if c.get("status") == "completed" and c.get("conclusion") == "failure"
         ]
+
+    def _pending_required_check_names(self, pr_number: int) -> list[str]:
+        """Return names of required checks that are still in flight (not completed).
+
+        Used by the BLOCKED early-exit guard in ``_wait_for_pr_terminal`` to
+        distinguish branch-protection blocks (all checks green but conversations
+        unresolved) from pending-CI blocks (checks still running).  Returns an
+        empty list on lookup failure — the caller then conservatively assumes no
+        checks are pending and exits the poll.
+        """
+        try:
+            checks = gh_pr_checks(pr_number, dry_run=self.options.dry_run)
+        except Exception as exc:
+            logger.info(
+                "PR #%s: failed to fetch CI checks for BLOCKED pending guard (%s)",
+                pr_number,
+                exc,
+            )
+            return []
+        if not checks:
+            return []
+        required = [c for c in checks if c.get("required")] or checks
+        return [c.get("name", "") for c in required if c.get("status") != "completed"]
 
     def _force_engagement_prompt(
         self,

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -478,6 +478,28 @@ class ImplementationPhaseRunner:
             )
 
         except RuntimeError as e:
+            # "No changes produced" means the branch has 0 commits vs main —
+            # the implementation already landed via a prior merged PR. Treat
+            # this as success and apply state:skip so future loops don't
+            # re-attempt the issue.
+            msg = str(e)
+            if "no commits vs" in msg.lower() or "no changes produced" in msg.lower():
+                impl._log(
+                    "info",
+                    f"Issue #{issue_number}: no new commits vs main — "
+                    "work already merged; applying state:skip",
+                    thread_id,
+                )
+                self.status_tracker.update_slot(
+                    slot_id, f"{issue_ref(issue_number)}: already implemented — state:skip"
+                )
+                with contextlib.suppress(Exception):
+                    gh_issue_add_labels(issue_number, [STATE_SKIP])
+                return WorkerResult(
+                    issue_number=issue_number,
+                    success=True,
+                )
+
             impl._log("error", f"Runtime error: {e}", thread_id)
 
             # Show failure in UI before releasing slot

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -2220,6 +2220,58 @@ class TestWaitForPrTerminal:
         # With a 0s budget the very first sleep would overrun → no sleep at all.
         mock_sleep.assert_not_called()
 
+    def test_open_blocked_no_failing_no_pending_returns_blocked(self, driver: CIDriver) -> None:
+        # OPEN, mergeStateStatus BLOCKED (e.g. unresolved conversations), no
+        # failing and no pending CI checks → branch-protection gate, exit immediately.
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "mergeStateStatus": "BLOCKED"},
+            ),
+            patch.object(driver, "_failing_required_check_names", return_value=[]),
+            patch.object(driver, "_pending_required_check_names", return_value=[]),
+            patch("hephaestus.automation.ci_driver.time.sleep") as mock_sleep,
+        ):
+            assert driver._wait_for_pr_terminal(1, 2) == "BLOCKED"
+        mock_sleep.assert_not_called()
+
+    def test_open_blocked_with_failing_checks_does_not_short_circuit(
+        self, driver: CIDriver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # OPEN, mergeStateStatus BLOCKED, but a required check is ALSO failing.
+        # GitHub reports BLOCKED while checks are in flight; the failing check
+        # takes priority — return FAILING, not BLOCKED.
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "mergeStateStatus": "BLOCKED"},
+            ),
+            patch.object(driver, "_failing_required_check_names", return_value=["lint"]),
+        ):
+            assert driver._wait_for_pr_terminal(1, 2) == "FAILING"
+
+    def test_open_blocked_with_pending_checks_does_not_short_circuit(
+        self, driver: CIDriver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # OPEN, mergeStateStatus BLOCKED, no failing checks but a required check
+        # is still in progress — GitHub reports BLOCKED while checks are still
+        # running. Must NOT exit early; should continue polling (TIMEOUT here
+        # because HEPH_PR_MERGE_MAX_WAIT=0).
+        monkeypatch.setenv("HEPH_PR_MERGE_MAX_WAIT", "0")
+        with (
+            patch.object(
+                driver,
+                "_gh_pr_state",
+                return_value={"state": "OPEN", "mergeStateStatus": "BLOCKED"},
+            ),
+            patch.object(driver, "_failing_required_check_names", return_value=[]),
+            patch.object(driver, "_pending_required_check_names", return_value=["ci/build"]),
+            patch("hephaestus.automation.ci_driver.time.sleep"),
+        ):
+            assert driver._wait_for_pr_terminal(1, 2) == "TIMEOUT"
+
     def test_dry_run_short_circuits_to_timeout(
         self, mock_options: CIDriverOptions, tmp_path: Path
     ) -> None:

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -771,3 +771,57 @@ class TestStateSkipLabel:
 
         mock_add.assert_called_once_with(normal)
         assert 43 not in impl.resolver.completed
+
+
+class TestNoChangesProducedAppliesStateSkip:
+    """When the agent produces no commits vs main, the work already landed.
+
+    ``_implement_issue`` must: (1) apply ``state:skip`` to the issue so future
+    loops don't re-attempt it, (2) return ``WorkerResult(success=True)`` so the
+    issue does NOT count as a failure and inflate the exit code.
+    """
+
+    @pytest.fixture
+    def impl(self, tmp_path: Path) -> IssueImplementer:
+        options = ImplementerOptions(
+            issues=[1],
+            dry_run=False,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            return IssueImplementer(options)
+
+    def test_no_changes_returns_success_and_applies_state_skip(
+        self, impl: IssueImplementer, tmp_path: Path
+    ) -> None:
+        worktree_path = tmp_path / "wt"
+        worktree_path.mkdir()
+        no_changes_error = RuntimeError(
+            "No changes produced for issue HomericIntelligence/ProjectHephaestus#736: "
+            "branch '736-auto-impl' has no commits vs 'main'. "
+            "Skipping PR creation (the implementation session made no net change)."
+        )
+        with (
+            patch(
+                "hephaestus.automation.implementer.find_pr_for_issue",
+                return_value=None,
+            ),
+            patch.object(impl.worktree_manager, "create_worktree", return_value=worktree_path),
+            patch.object(impl, "_save_state"),
+            patch.object(impl, "_has_plan", return_value=True),
+            patch("hephaestus.automation.implementer.is_plan_review_go", return_value=True),
+            patch("hephaestus.automation.implementer.fetch_issue_info"),
+            patch.object(impl, "_run_advise", return_value=""),
+            patch.object(impl, "_run_claude_code", return_value="session-id"),
+            patch.object(impl, "_finalize_pr", side_effect=no_changes_error),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+            ) as mock_label,
+        ):
+            result = impl.phase_runner._implement_issue(736)
+
+        assert result.success is True
+        assert result.issue_number == 736
+        mock_label.assert_called_once_with(736, ["state:skip"])


### PR DESCRIPTION
## Summary

Two root causes from `output.log` (2026-06-07 run):

- **Bug #1088 — BLOCKED poll loop**: `_wait_for_pr_terminal` polled for the full 1800s when a PR's `mergeStateStatus=BLOCKED` due to branch protection (required conversation resolution with unresolved human threads). Adds a BLOCKED early-exit guarded by a new `_pending_required_check_names` check so the bot doesn't bail while CI checks are still in-flight. Both callers updated to handle `"BLOCKED"` return value.

- **Bug #1089 — no-changes = failure**: When a branch has 0 commits vs `main` (work already merged), `pr_manager` raised `RuntimeError("No changes produced...")` which counted as a failure and inflated `rc=1`. Detects this specific message in the `RuntimeError` handler, applies `state:skip`, and returns `success=True`.

## Test plan

- [ ] `test_open_blocked_no_failing_no_pending_returns_blocked` — BLOCKED + all clear → returns `"BLOCKED"` immediately, no sleep
- [ ] `test_open_blocked_with_failing_checks_does_not_short_circuit` — BLOCKED + failing check → returns `"FAILING"`
- [ ] `test_open_blocked_with_pending_checks_does_not_short_circuit` — BLOCKED + pending check → continues polling (TIMEOUT)
- [ ] `test_no_changes_returns_success_and_applies_state_skip` — RuntimeError("No changes produced") → `state:skip` applied, `success=True`
- [ ] Full unit suite: `pixi run pytest tests/unit` → 3402 passed, 1 pre-existing unrelated failure

Closes #1088
Closes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)