### PR TITLE
fix(automation): secondary rate limit triggers 15s exponential backoff

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -25,6 +25,7 @@ from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_claude_usage_limit,
     detect_rate_limit,
+    detect_secondary_rate_limit,
     gh_global_throttle_acquire,
     gh_rate_limit_reset_epoch,
     wait_until,
@@ -427,6 +428,24 @@ def _gh_call_impl(
                     _log_token_scope_remediation(args, stderr)
                 raise
 
+            # Secondary rate limit carries no reset epoch — check both stderr
+            # and stdout (GraphQL errors can land on stdout).
+            stdout = e.stdout if e.stdout else ""
+            if detect_secondary_rate_limit(stderr) or detect_secondary_rate_limit(stdout):
+                logger.warning(
+                    "GitHub secondary rate limit hit (attempt %s), waiting before retry",
+                    attempt + 1,
+                )
+                _handle_rate_limit_attempt(
+                    reset_epoch=0,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    retry_on_rate_limit=retry_on_rate_limit,
+                    cause=e,
+                    base_wait_seconds=15,
+                )
+                continue
+
             if attempt == max_retries - 1:
                 raise
 
@@ -518,6 +537,7 @@ def _handle_rate_limit_attempt(
     max_retries: int,
     retry_on_rate_limit: bool,
     cause: BaseException,
+    base_wait_seconds: int = 60,
 ) -> None:
     """Wait for a rate-limit reset, or raise :class:`GitHubRateLimitError`.
 
@@ -525,6 +545,19 @@ def _handle_rate_limit_attempt(
     two except-blocks in :func:`_gh_call` share identical behavior. Raises
     immediately if retries are disabled or exhausted; otherwise sleeps and
     returns so the caller can ``continue`` the retry loop.
+
+    Args:
+        reset_epoch: Unix timestamp when the rate limit resets, or ``0`` when
+            unknown (no epoch embedded in the error message).
+        attempt: Current attempt index (0-based).
+        max_retries: Total retry budget.
+        retry_on_rate_limit: If False, raise immediately instead of waiting.
+        cause: The exception that triggered this call.
+        base_wait_seconds: Initial wait duration (seconds) when ``reset_epoch``
+            is ``0`` (no epoch available).  Doubles each attempt, capped at
+            300s.  Defaults to 60; pass 15 for secondary rate limits which
+            carry no reset epoch but typically clear faster.
+
     """
     if not retry_on_rate_limit or attempt == max_retries - 1:
         raise GitHubRateLimitError(
@@ -534,7 +567,7 @@ def _handle_rate_limit_attempt(
     if reset_epoch > 0:
         wait_until(reset_epoch)
         return
-    wait_seconds = min(60 * (2**attempt), 300)  # cap at 5 minutes
+    wait_seconds = min(base_wait_seconds * (2**attempt), 300)  # cap at 5 minutes
     logger.warning("Rate limited but no reset time, waiting %ss", wait_seconds)
     time.sleep(wait_seconds)
 

--- a/hephaestus/github/rate_limit.py
+++ b/hephaestus/github/rate_limit.py
@@ -49,6 +49,30 @@ GRAPHQL_RATE_LIMIT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Regex matching GitHub secondary rate-limit messages, e.g.:
+#   "You have exceeded a secondary rate limit. Please wait a few minutes before you try again."
+SECONDARY_RATE_LIMIT_RE = re.compile(
+    r"exceeded a secondary rate limit",
+    re.IGNORECASE,
+)
+
+
+def detect_secondary_rate_limit(text: str) -> bool:
+    """Return True if *text* contains a GitHub secondary rate-limit message.
+
+    Secondary rate limits differ from primary ones: they carry no reset epoch
+    and are triggered by request frequency or concurrency, not hourly quotas.
+
+    Args:
+        text: Text to search (typically ``gh`` CLI stderr or stdout).
+
+    Returns:
+        True if a secondary rate-limit message is detected.
+
+    """
+    return bool(SECONDARY_RATE_LIMIT_RE.search(text))
+
+
 # Regex matching Claude CLI usage-cap messages, e.g.:
 #   "You're out of extra usage · resets May 8, 5pm (America/Los_Angeles)"
 #   "Claude usage limit reached · resets 9pm (America/Los_Angeles)"

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -692,6 +692,90 @@ class TestGhCall:
         # (range(2) = [0, 1], each iteration tries resilient_call with max_retries=2)
         assert mock_run.call_count >= 2  # At least the outer iterations
 
+    @patch("hephaestus.automation.github_api.time")
+    @patch("hephaestus.automation.github_api.run")
+    def test_secondary_rate_limit_retries_with_15s_base_backoff(
+        self, mock_run: Any, mock_time: Any
+    ) -> None:
+        """Secondary rate limit triggers 15s base backoff, not 1s generic retry.
+
+        When stderr contains 'exceeded a secondary rate limit', _gh_call_impl
+        must route through _handle_rate_limit_attempt(base_wait_seconds=15)
+        instead of the generic 2**attempt path, so the first wait is 15s.
+        """
+        secondary_msg = (
+            "gh: You have exceeded a secondary rate limit. "
+            "Please wait a few minutes before you try again."
+        )
+        success = Mock(spec=subprocess.CompletedProcess)
+        success.stdout = "ok"
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "gh", stderr=secondary_msg),
+            success,
+        ]
+        mock_time.sleep = Mock()
+        mock_time.monotonic = __import__("time").monotonic
+        mock_time.time = __import__("time").time
+
+        result = _gh_call(["issue", "view", "123"], max_retries=6)
+
+        assert result.stdout == "ok"
+        # Filter out sub-second throttle sleeps; only the secondary-rate-limit
+        # wait (>=1s) matters here.  First such sleep must be 15s (base), not 1s.
+        sleep_calls = [c[0][0] for c in mock_time.sleep.call_args_list if c[0][0] >= 1]
+        assert sleep_calls, "Expected at least one rate-limit sleep call"
+        first_wait = sleep_calls[0]
+        assert first_wait == 15, f"Expected 15s base wait, got {first_wait}s"
+
+    @patch("hephaestus.automation.github_api.time")
+    @patch("hephaestus.automation.github_api.run")
+    def test_secondary_rate_limit_raises_rate_limit_error_when_retry_disabled(
+        self, mock_run: Any, mock_time: Any
+    ) -> None:
+        """Secondary rate limit with retry_on_rate_limit=False raises GitHubRateLimitError."""
+        secondary_msg = (
+            "gh: You have exceeded a secondary rate limit. "
+            "Please wait a few minutes before you try again."
+        )
+        mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr=secondary_msg)
+        mock_time.sleep = Mock()
+        mock_time.monotonic = __import__("time").monotonic
+        mock_time.time = __import__("time").time
+
+        with pytest.raises(GitHubRateLimitError):
+            _gh_call(["issue", "view", "123"], max_retries=6, retry_on_rate_limit=False)
+
+    @patch("hephaestus.automation.github_api.time")
+    @patch("hephaestus.automation.github_api.run")
+    def test_secondary_rate_limit_backoff_doubles_each_attempt(
+        self, mock_run: Any, mock_time: Any
+    ) -> None:
+        """Secondary rate limit backoff doubles: 15s, 30s, capped at 300s."""
+        secondary_msg = (
+            "gh: You have exceeded a secondary rate limit. "
+            "Please wait a few minutes before you try again."
+        )
+        success = Mock(spec=subprocess.CompletedProcess)
+        success.stdout = "ok"
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, "gh", stderr=secondary_msg),
+            subprocess.CalledProcessError(1, "gh", stderr=secondary_msg),
+            success,
+        ]
+        mock_time.sleep = Mock()
+        mock_time.monotonic = __import__("time").monotonic
+        mock_time.time = __import__("time").time
+
+        result = _gh_call(["issue", "view", "123"], max_retries=6)
+
+        assert result.stdout == "ok"
+        # Filter out sub-second throttle sleeps; only the secondary-rate-limit
+        # waits (>=15s) matter for this assertion.
+        sleep_calls = [c[0][0] for c in mock_time.sleep.call_args_list if c[0][0] >= 1]
+        assert len(sleep_calls) >= 2, f"Expected >=2 rate-limit sleeps, got {sleep_calls}"
+        assert sleep_calls[0] == 15, f"Expected 15s (attempt 0), got {sleep_calls[0]}"
+        assert sleep_calls[1] == 30, f"Expected 30s (attempt 1), got {sleep_calls[1]}"
+
 
 # NOTE on patch targets: tests in TestGhCall patch "hephaestus.automation.github_api.run"
 # because _gh_call (defined in github_api) calls run() imported from .git_utils.

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -10,10 +10,12 @@ from hephaestus.github.rate_limit import (
     ALLOWED_TIMEZONES,
     GRAPHQL_RATE_LIMIT_RE,
     RATE_LIMIT_RE,
+    SECONDARY_RATE_LIMIT_RE,
     _rate_limit_probe_cache,
     detect_claude_usage_cap,
     detect_claude_usage_limit,
     detect_rate_limit,
+    detect_secondary_rate_limit,
     gh_global_throttle_acquire,
     gh_rate_limit_reset_epoch,
     parse_reset_epoch,
@@ -42,6 +44,48 @@ class TestRateLimitRegex:
     def test_no_match_on_unrelated_text(self) -> None:
         """Returns None for text without rate limit message."""
         assert RATE_LIMIT_RE.search("Everything is fine") is None
+
+
+class TestSecondaryRateLimitRegex:
+    """Tests for SECONDARY_RATE_LIMIT_RE and detect_secondary_rate_limit."""
+
+    def test_matches_github_secondary_message(self) -> None:
+        """Matches the exact GitHub secondary rate-limit message."""
+        text = (
+            "gh: You have exceeded a secondary rate limit. "
+            "Please wait a few minutes before you try again."
+        )
+        assert SECONDARY_RATE_LIMIT_RE.search(text) is not None
+
+    def test_matches_case_insensitive(self) -> None:
+        """Match is case-insensitive."""
+        assert SECONDARY_RATE_LIMIT_RE.search("Exceeded A Secondary Rate Limit") is not None
+
+    def test_no_match_on_primary_rate_limit(self) -> None:
+        """Does not match primary rate-limit messages."""
+        assert SECONDARY_RATE_LIMIT_RE.search("API rate limit exceeded") is None
+
+    def test_no_match_on_unrelated_text(self) -> None:
+        """Returns None for unrelated text."""
+        assert SECONDARY_RATE_LIMIT_RE.search("Everything is fine") is None
+
+    def test_detect_secondary_rate_limit_true(self) -> None:
+        """detect_secondary_rate_limit returns True for the exact GH message."""
+        text = (
+            "gh: You have exceeded a secondary rate limit. "
+            "Please wait a few minutes before you try again. "
+            "For more on scraping GitHub and how it may affect your rights, "
+            "please review our Terms of Service"
+        )
+        assert detect_secondary_rate_limit(text) is True
+
+    def test_detect_secondary_rate_limit_false_for_primary(self) -> None:
+        """detect_secondary_rate_limit returns False for primary rate-limit text."""
+        assert detect_secondary_rate_limit("API rate limit exceeded for user ID 42") is False
+
+    def test_detect_secondary_rate_limit_false_for_empty(self) -> None:
+        """detect_secondary_rate_limit returns False for empty string."""
+        assert detect_secondary_rate_limit("") is False
 
 
 class TestParseResetEpoch:


### PR DESCRIPTION
## Summary

- Add `SECONDARY_RATE_LIMIT_RE` and `detect_secondary_rate_limit()` to `rate_limit.py` to match GitHub's secondary rate limit message ("exceeded a secondary rate limit")
- In `_gh_call_impl`, detect secondary rate limits before the generic transient path and route through `_handle_rate_limit_attempt(base_wait_seconds=15)`, giving waits of 15s → 30s → 60s → 120s → 240s → 300s (capped)
- Add `base_wait_seconds` kwarg to `_handle_rate_limit_attempt` (default 60 — no change to primary rate limit behavior)
- Secondary limits now log a clear warning ("GitHub secondary rate limit hit (attempt N), waiting before retry"), respect `retry_on_rate_limit=False`, and raise `GitHubRateLimitError` on retry exhaustion

## Test plan

- [ ] `TestSecondaryRateLimitRegex` (7 tests) — regex and `detect_secondary_rate_limit` function
- [ ] `TestGhCall::test_secondary_rate_limit_retries_with_15s_base_backoff` — first wait is 15s
- [ ] `TestGhCall::test_secondary_rate_limit_raises_rate_limit_error_when_retry_disabled` — `retry_on_rate_limit=False` raises `GitHubRateLimitError`
- [ ] `TestGhCall::test_secondary_rate_limit_backoff_doubles_each_attempt` — waits are 15s, 30s

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)