### PR TITLE
fix(automation): catch TimeoutExpired and OSError in failing-PR discovery

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -472,7 +472,12 @@ class CIDriver:
                 ],
             )
             pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+            json.JSONDecodeError,
+        ) as exc:
             logger.info("Failing-PR discovery skipped: gh pr list failed (%s)", exc)
             return {}
         if len(pulls) >= 1000:

--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -199,6 +199,28 @@ class TestDiscoverFailingPrs:
                 result = ci_driver._discover_failing_prs()
         assert result == {}
 
+    def test_discover_failing_prs_returns_empty_on_gh_timeout(self, ci_driver: CIDriver) -> None:
+        """Discovery returns empty dict when gh pr list times out (docstring contract)."""
+        import subprocess
+
+        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+            mock_repo_info.return_value = ("MyOrg", "MyRepo")
+            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+                mock_gh_call.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=30)
+                result = ci_driver._discover_failing_prs()
+        assert result == {}
+
+    def test_discover_failing_prs_returns_empty_on_missing_gh_binary(
+        self, ci_driver: CIDriver
+    ) -> None:
+        """Discovery returns empty dict when the gh binary is missing/unexecutable."""
+        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+            mock_repo_info.return_value = ("MyOrg", "MyRepo")
+            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+                mock_gh_call.side_effect = FileNotFoundError(2, "No such file or directory", "gh")
+                result = ci_driver._discover_failing_prs()
+        assert result == {}
+
     def test_discover_failing_prs_logs_warning_on_cap_hit(self, ci_driver: CIDriver) -> None:
         """A warning is logged when the 1000-PR cap is hit."""
         mock_output = [


### PR DESCRIPTION
## Summary

Widen the except clause in CIDriver._discover_failing_prs to catch subprocess.TimeoutExpired (gh CLI timeout) and OSError (missing/unexecutable gh binary). These transient failures should return the documented empty-dict fallback instead of escaping to the worker-thread exception handler.

Closes #1096