### PR TITLE
fix(automation): run implementer advise as session turn 1; use implementer_model() for learn

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -9,10 +9,15 @@ live here once (DRY) rather than being copied into ``planner.py``,
 
 The only thing that differs per stage is *how* the selected agent is invoked.
 Callers therefore pass an ``invoke`` callable that takes the advise prompt and
-returns the agent's text output; this module owns everything around it. The
-advise call always runs under
-:data:`~hephaestus.automation.session_naming.AGENT_ADVISE` — a distinct, cheap,
-read-only session — so it never pollutes the stage's main transcript.
+returns the agent's text output; this module owns everything around it.
+
+For the planner and CI-driver, the ``invoke`` callable targets ``AGENT_ADVISE``
+(a distinct, cheap, read-only session) so the findings are returned as text and
+injected into the stage's own prompt context.  The implementer's Claude path
+instead targets ``AGENT_IMPLEMENTER`` with ``cwd=worktree_path`` so that the
+advise step is the *first turn* of the implementer's session — the findings
+live in the transcript and the implementation turn auto-resumes them via
+``--resume`` without any text injection.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -619,6 +619,18 @@ class IssueImplementer:
         """Run the advise-first step before implementing (delegates to runner)."""
         return self.phase_runner._run_advise(issue_number, issue_title, issue_body)
 
+    def _run_advise_as_implementer_turn(
+        self,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        worktree_path: Path,
+    ) -> None:
+        """Advise turn 1 of the implementer session (delegates to runner)."""
+        return self.phase_runner._run_advise_as_implementer_turn(
+            issue_number, issue_title, issue_body, worktree_path
+        )
+
     def _run_impl_review_loop(
         self,
         *,

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -345,23 +345,33 @@ class ImplementationPhaseRunner:
             issue = self._impl_module.fetch_issue_info(issue_number)
 
             # Advise-first (#30): pull prior learnings from ProjectMnemosyne
-            # before the implementation session. Runs under AGENT_ADVISE (its
-            # own cheap read-only session), gated by enable_advise; the findings
-            # are prepended to the implementation prompt context below.
-            advise_findings = ""
-            if self.options.enable_advise:
+            # before the implementation session.  For Claude agents the advise
+            # prompt is sent as the *first turn* of the implementer's own
+            # session (cwd=worktree_path) so the findings live in the transcript
+            # and are automatically visible to the implementation turn that
+            # follows via --resume.  For Codex agents the old separate-session
+            # path is retained because Codex has no multi-turn session model.
+            if self.options.enable_advise and not is_codex(self.options.agent):
                 self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
-                advise_findings = impl._run_advise(issue_number, issue.title, issue.body)
+                impl._run_advise_as_implementer_turn(
+                    issue_number, issue.title, issue.body, worktree_path
+                )
 
             # Run the selected implementation agent
             self.status_tracker.update_slot(
                 slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}"
             )
+            # Codex: run advise separately (returns findings text) then inject.
+            codex_advise_findings = ""
+            if self.options.enable_advise and is_codex(self.options.agent):
+                self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
+                codex_advise_findings = impl._run_advise(issue_number, issue.title, issue.body)
+
             session_id = impl._run_claude_code(
                 issue_number,
                 worktree_path,
                 _prepend_advise(
-                    advise_findings,
+                    codex_advise_findings,
                     get_implementation_prompt(
                         issue_number=issue_number,
                         issue_title=issue.title,
@@ -846,6 +856,7 @@ class ImplementationPhaseRunner:
             slot_id,
             agent=self.options.agent,
             session_agent=session_agent,
+            model=implementer_model(),
         )
 
     def _compact_implementer_session(self, issue_number: int, worktree_path: Path) -> None:
@@ -859,14 +870,14 @@ class ImplementationPhaseRunner:
         )
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
-        """Search ProjectMnemosyne for prior learnings before implementing.
+        """Search ProjectMnemosyne for prior learnings — planner's separate-session path.
 
-        Stage 2's advise-first step. Runs under ``AGENT_ADVISE`` (a distinct,
-        cheap, read-only session) — NOT the implementer's Session 2 — so it
-        mirrors the planner's advise behavior and never pollutes the impl
-        transcript. The findings are prepended to the implementation prompt
-        context by the caller. Delegates the Mnemosyne setup + prompt build to
-        the shared :mod:`advise_runner`; any failure degrades to a skip marker.
+        Used by the planner (and Codex) where advise runs under ``AGENT_ADVISE``
+        (a distinct, cheap, read-only session) and returns text findings for the
+        caller to inject into its own prompt context.  Claude implementer sessions
+        use :meth:`_run_advise_as_implementer_turn` instead, which makes advise
+        the *first turn* of the implementer's own session so the findings live in
+        the transcript and inform the implementation turn directly.
         """
         _impl_mod = self._impl_module
 
@@ -898,6 +909,82 @@ class ImplementationPhaseRunner:
             issue_body=issue_body,
             invoke=_invoke,
             build_prompt=get_advise_prompt_builder(self.options.agent),
+        )
+
+    def _run_advise_as_implementer_turn(
+        self,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        worktree_path: Path,
+    ) -> None:
+        """Send the advise prompt as the first turn of the implementer's Claude session.
+
+        Unlike :meth:`_run_advise`, which creates a separate ``AGENT_ADVISE``
+        session and returns text, this method sends the advise prompt directly to
+        ``AGENT_IMPLEMENTER`` (using ``cwd=worktree_path`` so the session transcript
+        is co-located with the subsequent implementation turn).  The advise findings
+        live in the implementer's own transcript, so turn 2 (the implementation
+        prompt) automatically inherits them via ``--resume`` — no text injection
+        needed.
+
+        Codex does not support this two-turn flow; callers must guard with
+        ``is_codex`` and fall back to :meth:`_run_advise` + text injection for
+        Codex agents.
+
+        On first run ``invoke_claude_with_session`` auto-creates the session
+        (``transcript.exists()`` is False).  On subsequent loops the same
+        deterministic session UUID auto-resumes so the advise findings accumulate
+        across iterations.
+
+        Any failure degrades gracefully — the exception is logged and swallowed
+        so the caller can still proceed to the implementation turn.
+        """
+        _impl_mod = self._impl_module
+        repo_slug = _impl_mod.get_repo_slug(self.repo_root)
+
+        # Fetch plan and plan-review from GitHub comments to give advise the full
+        # context of what's been planned (same anchored selection as
+        # _fetch_plan_and_review so PLAN_REVIEW comments are distinguished from
+        # the PLAN comment).
+        plan_text, plan_review_text = self._fetch_plan_and_review(issue_number)
+
+        def _build_prompt_with_plan(**kw: object) -> str:
+            # Claude runs with cwd=worktree_path, so pass worktree_path as the
+            # relativization root.  marketplace.json lives under build/ in the main
+            # repo, not under the worktree, so _relativize_path will fall back to
+            # the absolute path — which is always readable regardless of cwd.
+            kw["repo_root"] = str(worktree_path)
+            base_prompt = get_advise_prompt_builder(self.options.agent)(**kw)
+            if not plan_text and not plan_review_text:
+                return base_prompt
+            parts = []
+            if plan_text:
+                parts.append(f"## Implementation Plan\n\n{plan_text}")
+            if plan_review_text:
+                parts.append(f"## Plan Review\n\n{plan_review_text}")
+            plan_block = "\n\n".join(parts)
+            return f"{plan_block}\n\n---\n\n{base_prompt}"
+
+        def _invoke(prompt: str) -> str:
+            stdout, _ = _impl_mod.invoke_claude_with_session(
+                repo=repo_slug,
+                issue=issue_number,
+                agent=_impl_mod.AGENT_IMPLEMENTER,
+                prompt=prompt,
+                model=implementer_model(),
+                cwd=worktree_path,
+                timeout=advise_claude_timeout(),
+                output_format="text",
+            )
+            return (stdout or "").strip()
+
+        run_advise(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            invoke=_invoke,
+            build_prompt=_build_prompt_with_plan,
         )
 
     def _apply_impl_review_verdict(

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -29,6 +29,7 @@ def run_learn(
     slot_id: int | None = None,
     agent: str = "claude",
     session_agent: str | None = None,
+    model: str | None = None,
 ) -> bool:
     """Resume agent session to run /learn.
 
@@ -38,6 +39,10 @@ def run_learn(
         issue_number: Issue number
         state_dir: Directory for state/log files
         slot_id: Worker slot ID (unused; kept for interface symmetry)
+        model: Override the model used for /learn. When ``None`` (default)
+            the configured ``HEPH_LEARN_MODEL`` / ``learn_model()`` is used.
+            Pass ``implementer_model()`` so the implementer's /learn turn runs
+            on the same model tier the session was created with.
 
     Returns:
         True if learn completed successfully, False otherwise
@@ -81,10 +86,11 @@ def run_learn(
 
     # /learn is a SIMPLE-complexity task (summarization + file writes), so we
     # use the configured learn model (default: Haiku) but accept operator
-    # overrides via HEPH_LEARN_MODEL. We can't route through `call_claude`
-    # here because we need `--resume` semantics with full Bash/Edit tools;
-    # instead we add the model flag directly.
-    # (The shared `call_claude` helper handles the loop-review paths.)
+    # overrides via HEPH_LEARN_MODEL. Callers may pass `model` explicitly to
+    # run /learn on the same model tier as the session (e.g. implementer_model()).
+    # We can't route through `call_claude` here because we need `--resume`
+    # semantics with full Bash/Edit tools; instead we add the model flag directly.
+    effective_model = model if model is not None else learn_model()
     try:
         result = run(
             [
@@ -99,7 +105,7 @@ def run_learn(
                 ),
                 "--print",
                 "--model",
-                learn_model(),
+                effective_model,
                 "--permission-mode",
                 "dontAsk",
                 "--allowedTools",

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -279,7 +279,7 @@ class TestPlanReviewVerdictGate:
                 return_value=gate_return,
             ),
             # Everything past the gate — only reached when gate returns True.
-            patch.object(impl, "_run_advise", return_value="<!-- advise step skipped: test -->"),
+            patch.object(impl, "_run_advise_as_implementer_turn"),
             patch.object(impl, "_run_claude_code", return_value="sess-1"),
             patch.object(
                 impl,
@@ -594,7 +594,7 @@ class TestExistingPrEntersReviewLoop:
                 "hephaestus.automation.implementer.is_plan_review_go",
                 return_value=True,
             ),
-            patch.object(impl, "_run_advise", return_value="<!-- advise step skipped: test -->"),
+            patch.object(impl, "_run_advise_as_implementer_turn"),
             patch.object(impl, "_run_claude_code", return_value="sess-1"),
             patch.object(impl, "_run_impl_review_loop", return_value=(1, "GO", "A")),
             patch.object(impl, "_finalize_pr", return_value=999),
@@ -813,7 +813,7 @@ class TestNoChangesProducedAppliesStateSkip:
             patch.object(impl, "_has_plan", return_value=True),
             patch("hephaestus.automation.implementer.is_plan_review_go", return_value=True),
             patch("hephaestus.automation.implementer.fetch_issue_info"),
-            patch.object(impl, "_run_advise", return_value=""),
+            patch.object(impl, "_run_advise_as_implementer_turn"),
             patch.object(impl, "_run_claude_code", return_value="session-id"),
             patch.object(impl, "_finalize_pr", side_effect=no_changes_error),
             patch(
@@ -825,3 +825,100 @@ class TestNoChangesProducedAppliesStateSkip:
         assert result.success is True
         assert result.issue_number == 736
         mock_label.assert_called_once_with(736, ["state:skip"])
+
+
+# ---------------------------------------------------------------------------
+# Two-turn advise mechanism: verify cwd + agent invariants
+# ---------------------------------------------------------------------------
+
+
+class TestAdviseAsImplementerTurn:
+    """_run_advise_as_implementer_turn routes the advise prompt to AGENT_IMPLEMENTER.
+
+    This is the critical invariant: Claude advise runs as the *first turn* of
+    the implementer's own session (not a separate AGENT_ADVISE session), and
+    cwd=worktree_path ensures the transcript is co-located with the
+    implementation turn that follows.
+    """
+
+    @pytest.fixture
+    def impl(self, tmp_path: Path) -> IssueImplementer:
+        options = ImplementerOptions(
+            issues=[1],
+            dry_run=False,
+            enable_learn=False,
+            enable_follow_up=False,
+            enable_ui=False,
+            enable_advise=True,
+        )
+        with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
+            return IssueImplementer(options)
+
+    def test_invokes_under_agent_implementer_with_worktree_cwd(
+        self, impl: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """run_advise calls _invoke with agent=AGENT_IMPLEMENTER and cwd=worktree_path."""
+        from hephaestus.automation.session_naming import AGENT_IMPLEMENTER
+
+        worktree_path = tmp_path / "build" / ".worktrees" / "issue-1"
+        worktree_path.mkdir(parents=True)
+
+        captured_kwargs: list[dict] = []
+
+        def _fake_invoke_with_session(**kw: object) -> tuple[str, None]:
+            captured_kwargs.append(kw)
+            return ("findings text", None)
+
+        with (
+            patch(
+                "hephaestus.automation.implementer.invoke_claude_with_session",
+                side_effect=_fake_invoke_with_session,
+            ),
+            patch(
+                "hephaestus.automation.advise_runner.resolve_marketplace",
+                return_value=(tmp_path / "marketplace.json", ""),
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner."
+                "ImplementationPhaseRunner._fetch_plan_and_review",
+                return_value=("plan text", "review text"),
+            ),
+        ):
+            impl._run_advise_as_implementer_turn(
+                issue_number=1,
+                issue_title="Fix the widget",
+                issue_body="It is broken",
+                worktree_path=worktree_path,
+            )
+
+        assert len(captured_kwargs) == 1, "Expected exactly one invoke_claude_with_session call"
+        call = captured_kwargs[0]
+        assert call["agent"] == AGENT_IMPLEMENTER, (
+            f"Expected agent=AGENT_IMPLEMENTER but got agent={call['agent']!r}"
+        )
+        assert call["cwd"] == worktree_path, (
+            f"Expected cwd=worktree_path but got cwd={call['cwd']!r}"
+        )
+
+    def test_learn_passes_implementer_model(self, impl: IssueImplementer, tmp_path: Path) -> None:
+        """_run_learn forwards implementer_model() to run_learn, not the Haiku default."""
+        from hephaestus.automation.claude_models import implementer_model
+
+        captured: list[dict] = []
+
+        def _fake_run_learn(*args: object, **kw: object) -> bool:
+            captured.append({"args": args, "kwargs": kw})
+            return True
+
+        with patch(
+            "hephaestus.automation.implementer_phase_runner.run_learn",
+            side_effect=_fake_run_learn,
+        ):
+            impl._run_learn("sess-1", tmp_path, issue_number=1)
+
+        assert captured, "Expected run_learn to be called"
+        call_kw = captured[0]["kwargs"]
+        assert "model" in call_kw, "_run_learn must pass model= to run_learn"
+        assert call_kw["model"] == implementer_model(), (
+            f"Expected implementer_model() but got {call_kw['model']!r}"
+        )

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -807,7 +807,7 @@ class TestImplementationAutoMergeGate:
             patch.object(implementer, "_save_state"),
             patch("hephaestus.automation.implementer.find_pr_for_issue", return_value=None),
             patch("hephaestus.automation.implementer.is_plan_review_go", return_value=True),
-            patch.object(implementer, "_run_advise", return_value=""),
+            patch.object(implementer, "_run_advise_as_implementer_turn"),
             patch.object(implementer, "_run_claude_code", return_value="session-1"),
             patch.object(implementer, "_finalize_pr", return_value=456),
             patch.object(

--- a/tests/unit/automation/test_phase_agent_wiring.py
+++ b/tests/unit/automation/test_phase_agent_wiring.py
@@ -261,30 +261,56 @@ def test_per_iteration_reviewer_does_not_pin_foreign_agent(
     )
 
 
-# Advise-first (#30): each of the three stages opens its run with an /advise
-# step under AGENT_ADVISE, gated by ``enable_advise``. Each entry maps the
-# stage's source file(s) that must contain that wiring.
-ADVISE_FIRST_STAGES: list[tuple[str, tuple[str, ...]]] = [
+# Advise-first (#30): each stage opens its run with an /advise step gated by
+# ``enable_advise``.  The planner and CI driver always run advise under
+# AGENT_ADVISE (a cheap, separate read-only session).  The implementer has two
+# paths: Codex still uses AGENT_ADVISE, but Claude uses AGENT_IMPLEMENTER as
+# turn 1 so the findings live in the implementer's own transcript.
+ADVISE_FIRST_STAGES_ADVISE_AGENT: list[tuple[str, tuple[str, ...]]] = [
     # Stage 1: the planner runs advise once before the plan loop.
     ("planner.py", ("planner_review_loop.py",)),
-    # Stage 2: the implementer runs advise before the impl session.
-    ("implementer_phase_runner.py", ()),
     # Stage 3: the CI driver runs advise before the fix loop.
     ("ci_driver.py", ()),
 ]
 
 
-@pytest.mark.parametrize("module_file, companions", ADVISE_FIRST_STAGES)
+@pytest.mark.parametrize("module_file, companions", ADVISE_FIRST_STAGES_ADVISE_AGENT)
 def test_stage_runs_advise_under_advise_agent(
     module_file: str, companions: tuple[str, ...]
 ) -> None:
-    """Every stage runs /advise under AGENT_ADVISE, gated by enable_advise.
+    """Planner and CI driver run /advise under AGENT_ADVISE, gated by enable_advise.
 
     Advise-first (#30) is the mechanism that pulls prior learnings into each
-    stage before it acts. The cheap, read-only advise session always runs under
+    stage before it acts. For these stages the advise session always runs under
     ``AGENT_ADVISE`` (never the stage's own session), and every stage must let
     operators turn it off via ``enable_advise``.
     """
     src = _read_phase_sources(module_file, companions)
     assert "AGENT_ADVISE" in src, f"{module_file} must run its advise step under AGENT_ADVISE"
     assert "enable_advise" in src, f"{module_file} must gate advise behind enable_advise"
+
+
+def test_implementer_runs_advise_as_first_turn_of_implementer_session() -> None:
+    """The implementer runs /advise as turn 1 of the implementer's own session.
+
+    Unlike the planner/CI-driver, the Claude implementer does NOT use a separate
+    AGENT_ADVISE session.  Instead, _run_advise_as_implementer_turn sends the
+    advise prompt to AGENT_IMPLEMENTER with cwd=worktree_path so the findings
+    live in the same transcript that the implementation turn resumes from.
+
+    Codex falls back to AGENT_ADVISE via _run_advise (no multi-turn session
+    support), so AGENT_ADVISE must also remain present for that path.
+    """
+    src = _read_phase_sources("implementer_phase_runner.py", ())
+    assert "AGENT_IMPLEMENTER" in src, (
+        "implementer_phase_runner.py must route Claude advise under AGENT_IMPLEMENTER"
+    )
+    assert "_run_advise_as_implementer_turn" in src, (
+        "implementer_phase_runner.py must implement _run_advise_as_implementer_turn"
+    )
+    assert "AGENT_ADVISE" in src, (
+        "implementer_phase_runner.py must keep AGENT_ADVISE for the Codex fallback path"
+    )
+    assert "enable_advise" in src, (
+        "implementer_phase_runner.py must gate advise behind enable_advise"
+    )


### PR DESCRIPTION
## Summary

- **Bug 1 — advise in wrong session**: The implementer was spawning a separate `AGENT_ADVISE` session and injecting the findings as text into a *new* `AGENT_IMPLEMENTER` session. Fixed: advise is now the first turn of the implementer's own `AGENT_IMPLEMENTER` session (`cwd=worktree_path`), with the plan + plan-review context prepended. The implementation turn inherits findings via `--resume`. Codex falls back to the old `AGENT_ADVISE` path (no multi-turn support).
- **Bug 2 — learn uses wrong model**: `run_learn()` hardcoded `learn_model()` (Haiku) when resuming the implementer session. Fixed: `run_learn()` now accepts a `model=` parameter; `_run_learn()` passes `implementer_model()`.
- **Path fix**: The advise prompt builder relativizes `marketplace_path` against `repo_root`. Since Claude runs with `cwd=worktree_path`, the relativized path would not resolve. Fixed by passing `worktree_path` as the relativization root so `_relativize_path` falls back to the absolute path.

## Test plan

- [ ] `pixi run pytest tests/unit/automation/test_implementer.py::TestAdviseAsImplementerTurn` — new tests verify `agent=AGENT_IMPLEMENTER`, `cwd=worktree_path`, and `model=implementer_model()`
- [ ] `pixi run pytest tests/unit/automation/test_phase_agent_wiring.py` — updated wiring test reflects the two-path design (Claude = `AGENT_IMPLEMENTER` turn 1; Codex = `AGENT_ADVISE`)
- [ ] `pixi run pytest tests/unit/automation/` — 1303 passed, 0 failed

> **Note**: The existing-PR review path (`_review_existing_pr`) does not yet receive the two-turn advise flow. That is a separate follow-up and was intentionally deferred from this fix.

Closes #1099

🤖 Generated with [Claude Code](https://claude.com/claude-code)