### PR TITLE
fix(automation): handle TimeoutExpired and OSError in _discover_bot_prs

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -411,7 +411,12 @@ class CIDriver:
                 check=False,
             )
             raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+            json.JSONDecodeError,
+        ) as exc:
             logger.info("Bot-PR discovery skipped: gh api failed (%s)", exc)
             return {}
 

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1799,6 +1799,34 @@ class TestBotPrDiscovery:
         ):
             assert driver._discover_bot_prs() == {}
 
+    def test_gh_timeout_returns_empty(self, driver: CIDriver, tmp_path: Path) -> None:
+        """Discovery returns empty dict when gh api times out (docstring contract)."""
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.get_repo_info",
+                return_value=("o", "r"),
+            ),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30),
+            ),
+        ):
+            assert driver._discover_bot_prs() == {}
+
+    def test_missing_gh_binary_returns_empty(self, driver: CIDriver, tmp_path: Path) -> None:
+        """Discovery returns empty dict when the gh binary is missing/unexecutable."""
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.get_repo_info",
+                return_value=("o", "r"),
+            ),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                side_effect=FileNotFoundError(2, "No such file or directory", "gh"),
+            ),
+        ):
+            assert driver._discover_bot_prs() == {}
+
     def test_discover_prs_unions_bot_prs_when_enabled(
         self, driver: CIDriver, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Adds `subprocess.TimeoutExpired`, `OSError`, and `FileNotFoundError` to the exception handler in `_discover_bot_prs` so the method degrades gracefully when `gh api` times out or the binary is unavailable.

Closes #1098