### PR TITLE
[Fix] automation-loop: re-review NO-GO PRs + de-duplicate per-phase issue discovery

### DIFF
--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1038,9 +1038,12 @@ class ImplementationPhaseRunner:
         so it earns the ``state:implementation-go`` label drive-green needs to
         arm auto-merge — without this it would deadlock green-but-unmergeable.
 
-        Idempotency: a PR already carrying a terminal implementation-review
-        label (GO or NO-GO) was settled on a prior loop, so it short-circuits
-        without re-reviewing. Anti-clobber: the worktree is hard-reset to
+        Idempotency: a PR already carrying ``state:implementation-go`` was
+        settled on a prior loop, so it short-circuits without re-reviewing
+        (auto-merge arming is drive-green's job). ``state:implementation-no-go``
+        is NOT terminal — a NO-GO PR failed review and re-enters the
+        review→address→re-review cycle until it earns GO, so it does NOT
+        short-circuit. Anti-clobber: the worktree is hard-reset to
         ``origin/<branch>`` before the review loop so re-running never discards
         commits that were pushed to the PR head, and the loop runs with
         ``session_id=None`` (no agent edit session is started here — the address
@@ -1053,12 +1056,14 @@ class ImplementationPhaseRunner:
             slot_id, f"{issue_ref(issue_number)}: Checking implementation-review label"
         )
         has_go, has_no_go = pr_has_implementation_state_label(existing_pr)
-        if has_go or has_no_go:
+        if has_go:
+            # GO is terminal: the PR passed review on a prior loop. Auto-merge
+            # arming is drive-green's job, so re-reviewing here is wasted work.
             impl._log(
                 "info",
                 f"Issue #{issue_number}: open PR {pr_ref(existing_pr)} already "
-                f"implementation-review {'GO' if has_go else 'NO-GO'} — skipping re-review "
-                "(handled by later phases)",
+                "implementation-review GO — skipping re-review "
+                "(settled; auto-merge handled by drive-green)",
                 thread_id,
             )
             with self.state_lock:
@@ -1070,6 +1075,17 @@ class ImplementationPhaseRunner:
                 pr_number=existing_pr,
                 branch_name=branch_name,
                 already_has_pr=True,
+            )
+        if has_no_go:
+            # NO-GO is NOT terminal: the PR failed review and must be
+            # re-implemented + re-reviewed until it earns GO. Fall through into
+            # the review→address→re-review cycle below.
+            impl._log(
+                "info",
+                f"Issue #{issue_number}: open PR {pr_ref(existing_pr)} is "
+                "implementation-review NO-GO — re-running implement + review loop "
+                "to drive it toward GO",
+                thread_id,
             )
 
         # Reuse-or-create the worktree, then hard-reset it to the PR head so the

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -564,13 +564,19 @@ def _gh_list_repos(org: str) -> list[str]:
     ]
 
 
-def _gh_issue_numbers_for(org: str, repo: str, filter_flag: str) -> set[int]:
-    """Return open-issue numbers in ``org/repo`` matching one ``gh issue list`` filter.
+def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
+    """Return ALL open issue numbers in ``org/repo``, sorted ascending.
 
-    ``filter_flag`` is one of ``"--author"`` / ``"--assignee"``; the value is
-    always ``@me`` (current authenticated gh user). Returns an empty set on
-    any failure (rate limit, auth error, etc.) so callers can fall back
-    safely.
+    This is the loop's single canonical issue-discovery call: the result is
+    passed down to the plan/implement child phases via ``--issues`` so they do
+    NOT each re-run their own ``gh issue list``. The scope is ALL open issues
+    (no ``@me`` author/assignee filter) so it matches the child phases'
+    ``gh_list_open_issues`` semantics exactly — the loop's convergence and
+    failing-PR gates then agree with the work the phases actually do.
+
+    Sorted ascending so the implementer phase processes oldest-first. Returns
+    an empty list on any failure (rate limit, auth error, timeout) so callers
+    fall back safely.
     """
     try:
         out = subprocess.run(
@@ -582,10 +588,8 @@ def _gh_issue_numbers_for(org: str, repo: str, filter_flag: str) -> set[int]:
                 f"{org}/{repo}",
                 "--state",
                 "open",
-                filter_flag,
-                "@me",
                 "--limit",
-                "200",
+                "500",
                 "--json",
                 "number",
                 "--jq",
@@ -597,23 +601,10 @@ def _gh_issue_numbers_for(org: str, repo: str, filter_flag: str) -> set[int]:
             timeout=gh_cli_timeout(),
         )
     except subprocess.TimeoutExpired:
-        return set()
+        return []
     if out.returncode != 0:
-        return set()
-    return {int(x) for x in out.stdout.split() if x.strip().isdigit()}
-
-
-def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
-    """Return open issue numbers in ``org/repo`` authored by OR assigned to ``@me``.
-
-    GitHub treats ``--author`` and ``--assignee`` as AND, so we issue two
-    queries and union the results to get OR semantics. Sorted ascending
-    so the implementer phase processes oldest-first.
-    """
-    union = _gh_issue_numbers_for(org, repo, "--author") | _gh_issue_numbers_for(
-        org, repo, "--assignee"
-    )
-    return sorted(union)
+        return []
+    return sorted(int(x) for x in out.stdout.split() if x.strip().isdigit())
 
 
 def _count_open_issues(org: str, repo: str) -> int:
@@ -847,11 +838,15 @@ def _resolve_phase_bin(phase: str) -> tuple[str, list[str]] | None:
 #                  loop_idx >= threshold (bash equivalent: FOLLOW_UP_FLAG
 #                  set on loop ≥ 3, scripts/run_automation_loop.sh:415-418)
 _PHASE_FLAGS: dict[str, dict[str, object]] = {
-    "plan": {"worker_arg": "--parallel", "no_ui": False, "issues": "explicit", "advise": True},
+    # plan/implement use "open": forward the loop-discovered open-issue list so
+    # the child phase does NOT re-run its own ``gh issue list`` every phase /
+    # every loop. drive-green stays "explicit" — #819 made it discover failing
+    # PRs directly (not via the issue list), so it must NOT receive open_issues.
+    "plan": {"worker_arg": "--parallel", "no_ui": False, "issues": "open", "advise": True},
     "implement": {
         "worker_arg": "--max-workers",
         "no_ui": True,
-        "issues": "explicit",
+        "issues": "open",
         "advise": True,
         "nitpick": True,
         "follow_up_loop_threshold": 3,

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -516,9 +516,16 @@ class TestExistingPrEntersReviewLoop:
         create_wt.assert_not_called()
         review_loop.assert_not_called()
 
-    def test_existing_pr_with_no_go_label_short_circuits(
+    def test_existing_pr_with_no_go_label_re_enters_review_loop(
         self, impl: IssueImplementer, tmp_path: Path
     ) -> None:
+        """A NO-GO PR is NOT settled — it re-enters implement + review to earn GO.
+
+        Regression guard for the bug where ``has_go or has_no_go`` short-circuited
+        NO-GO PRs identically to GO, leaving them untouched every loop.
+        """
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
         with (
             patch(
                 "hephaestus.automation.implementer.find_pr_for_issue",
@@ -528,16 +535,35 @@ class TestExistingPrEntersReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
                 return_value=(False, True),
             ),
-            patch.object(impl.worktree_manager, "create_worktree") as create_wt,
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
+            patch.object(
+                impl.worktree_manager, "create_worktree", return_value=worktree_path
+            ) as create_wt,
             patch.object(impl, "_save_state"),
-            patch.object(impl, "_run_impl_review_loop") as review_loop,
+            patch(
+                "hephaestus.automation.implementer.fetch_issue_info",
+                return_value=MagicMock(title="t", body="b"),
+            ),
+            patch.object(impl, "_run_advise_as_implementer_turn"),
+            patch.object(impl, "_run_impl_review_loop", return_value=(2, "GO", "A")) as review_loop,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"
+            ) as mark_go,
+            patch("hephaestus.automation.implementer_phase_runner.mark_pr_implementation_no_go"),
+            patch(
+                "hephaestus.automation.implementer_phase_runner."
+                "enable_auto_merge_after_implementation_go"
+            ),
         ):
             result = impl._implement_issue(1)
 
         assert result.success is True
         assert result.already_has_pr is True
-        create_wt.assert_not_called()
-        review_loop.assert_not_called()
+        # NO-GO re-enters the loop: worktree prepped + review loop run, and on a
+        # GO verdict from the re-review the PR is re-labeled GO (no longer skipped).
+        create_wt.assert_called_once()
+        review_loop.assert_called_once()
+        mark_go.assert_called_once_with(777)
 
     def test_existing_pr_review_no_go_marks_no_go(
         self, impl: IssueImplementer, tmp_path: Path

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -1261,3 +1261,95 @@ class TestCompactImplementerSession:
 
                 # _run_learn returned True but agent is codex → compact skipped
                 mock_compact.assert_not_called()
+
+
+class TestReviewExistingPrShortCircuit:
+    """``_review_existing_pr`` short-circuits on GO only; NO-GO re-enters the loop.
+
+    A pre-existing PR labeled ``state:implementation-go`` is settled (auto-merge
+    is drive-green's job) so re-review is skipped. A PR labeled
+    ``state:implementation-no-go`` is NOT settled — it failed review and must be
+    re-implemented + re-reviewed until it earns GO. Treating NO-GO as terminal
+    (the prior ``has_go or has_no_go`` guard) left NO-GO PRs untouched every loop.
+    """
+
+    def _call(
+        self,
+        implementer: IssueImplementer,
+        tmp_path: Path,
+        *,
+        has_go: bool,
+        has_no_go: bool,
+    ):
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
+        state = ImplementationState(issue_number=1)
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(has_go, has_no_go),
+            ),
+            patch.object(implementer.status_tracker, "update_slot"),
+            patch.object(
+                implementer.worktree_manager, "create_worktree", return_value=worktree_path
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
+            ) as mock_sync,
+            patch.object(implementer, "_save_state"),
+            patch("hephaestus.automation.implementer.fetch_issue_info") as mock_issue,
+            patch.object(implementer, "_run_advise_as_implementer_turn"),
+            patch.object(
+                implementer, "_run_impl_review_loop", return_value=(1, "GO", "A")
+            ) as mock_loop,
+            patch.object(implementer.phase_runner, "_apply_impl_review_verdict") as mock_verdict,
+        ):
+            mock_issue.return_value.title = "title"
+            mock_issue.return_value.body = "body"
+            result = implementer.phase_runner._review_existing_pr(
+                issue_number=1,
+                existing_pr=555,
+                branch_name="1-branch",
+                state=state,
+                slot_id=None,
+                thread_id=None,
+            )
+        return result, mock_loop, mock_verdict, mock_sync
+
+    def test_go_pr_short_circuits_without_review(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A GO-labeled PR returns success and does NOT re-run the review loop."""
+        result, mock_loop, mock_verdict, mock_sync = self._call(
+            implementer, tmp_path, has_go=True, has_no_go=False
+        )
+        assert result.success is True
+        assert result.already_has_pr is True
+        assert result.pr_number == 555
+        mock_loop.assert_not_called()
+        mock_verdict.assert_not_called()
+        mock_sync.assert_not_called()
+
+    def test_no_go_pr_re_enters_review_loop(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A NO-GO-labeled PR re-runs implementation + review (the fix)."""
+        result, mock_loop, mock_verdict, mock_sync = self._call(
+            implementer, tmp_path, has_go=False, has_no_go=True
+        )
+        assert result.success is True
+        mock_loop.assert_called_once()
+        mock_verdict.assert_called_once()
+        # Worktree is hard-reset to the PR head before the loop runs.
+        mock_sync.assert_called_once()
+
+    def test_unlabeled_pr_runs_review_loop(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """An unlabeled existing PR runs the review loop (behavior preserved)."""
+        result, mock_loop, mock_verdict, _ = self._call(
+            implementer, tmp_path, has_go=False, has_no_go=False
+        )
+        assert result.success is True
+        mock_loop.assert_called_once()
+        mock_verdict.assert_called_once()

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -25,7 +25,6 @@ from hephaestus.automation.loop_runner import (
     RepoResult,
     _default_phase_timeout_s,
     _ensure_clone,
-    _gh_issue_numbers_for,
     _phase_order_warnings,
     _preflight_token_scopes,
     _rate_limit_remaining,
@@ -469,29 +468,58 @@ def test_run_loop_continues_when_one_repo_fails(repo_inputs: tuple[Path, LoopCon
 # ---------------------------------------------------------------------------
 
 
-def test_build_phase_argv_plan_omits_issues() -> None:
-    """Build phase argv plan omits issues."""
+def test_build_phase_argv_plan_forwards_open_issues_when_unscoped() -> None:
+    """Unscoped plan forwards the loop-discovered open-issue list via --issues.
+
+    This avoids the child phase re-running its own ``gh issue list`` — the
+    loop already discovered the issues once per loop and passes them down.
+    """
     cfg = LoopConfig()
     with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/plan", [])):
         argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[1, 2])
     assert argv is not None
+    assert "--issues" in argv
+    assert argv[argv.index("--issues") + 1 : argv.index("--issues") + 3] == ["1", "2"]
+
+
+def test_build_phase_argv_plan_omits_issues_when_none_discovered() -> None:
+    """Plan omits --issues when there are no open issues to forward."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/plan", [])):
+        argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[])
+    assert argv is not None
     assert "--issues" not in argv
 
 
+def test_build_phase_argv_implement_forwards_open_issues_when_unscoped() -> None:
+    """Unscoped implement forwards the loop-discovered open-issue list via --issues."""
+    cfg = LoopConfig()
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/impl", [])):
+        argv = loop_runner._build_phase_argv("implement", cfg, open_issues=[3, 5])
+    assert argv is not None
+    assert "--issues" in argv
+    assert argv[argv.index("--issues") + 1 : argv.index("--issues") + 3] == ["3", "5"]
+
+
 def test_build_phase_argv_plan_forwards_explicit_issues() -> None:
-    """Plan receives --issues only when the loop is explicitly scoped."""
+    """Plan receives the operator's explicit scope.
+
+    When the loop is scoped, ``process_repo`` sets ``open_issues = cfg.issues``
+    (loop_runner.py:1069), so the explicit scope flows through the open-issue
+    list — that is what the child phase receives.
+    """
     cfg = LoopConfig(issues=[8, 13])
     with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/plan", [])):
-        argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[1, 2])
+        argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[8, 13])
     assert argv is not None
     assert argv[argv.index("--issues") + 1 : argv.index("--issues") + 3] == ["8", "13"]
 
 
 def test_build_phase_argv_implement_forwards_explicit_issues() -> None:
-    """Implement receives the loop issue scope when set."""
+    """Implement receives the loop issue scope when set (via open_issues)."""
     cfg = LoopConfig(issues=[8])
     with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/impl", [])):
-        argv = loop_runner._build_phase_argv("implement", cfg, open_issues=[1, 2])
+        argv = loop_runner._build_phase_argv("implement", cfg, open_issues=[8])
     assert argv is not None
     assert argv[argv.index("--issues") + 1] == "8"
 
@@ -680,41 +708,37 @@ def test_gh_list_repos_filters_forks_and_archived() -> None:
     assert "name,isArchived,isFork" in invoked_argv
 
 
-def test_list_open_issue_numbers_unions_author_and_assignee() -> None:
-    """Author + assignee queries are unioned (OR semantics) and sorted."""
-    calls = {"author": "10\n12\n", "assignee": "12\n7\n"}
+def test_list_open_issue_numbers_returns_all_open_sorted() -> None:
+    """A single all-open query is parsed and sorted ascending."""
 
     def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        if "--author" in argv:
-            return subprocess.CompletedProcess(
-                args=argv, returncode=0, stdout=calls["author"], stderr=""
-            )
-        if "--assignee" in argv:
-            return subprocess.CompletedProcess(
-                args=argv, returncode=0, stdout=calls["assignee"], stderr=""
-            )
-        raise AssertionError(f"unexpected argv: {argv!r}")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="12\n7\n10\n", stderr="")
 
     with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run):
         nums = loop_runner._list_open_issue_numbers("MyOrg", "MyRepo")
     assert nums == [7, 10, 12]
 
 
-def test_list_open_issue_numbers_passes_at_me() -> None:
-    """``@me`` is passed for both ``--author`` and ``--assignee``."""
-    seen_filters: list[str] = []
+def test_list_open_issue_numbers_queries_all_open_no_me_filter() -> None:
+    """The canonical discovery is repo-wide open issues — NO @me filter.
+
+    Matching the child phases' ``gh_list_open_issues`` semantics keeps the
+    loop's convergence / failing-PR gates in agreement with the phases.
+    """
+    seen_argv: list[str] = []
 
     def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        for flag in ("--author", "--assignee"):
-            if flag in argv:
-                idx = argv.index(flag)
-                seen_filters.append(f"{flag}={argv[idx + 1]}")
+        seen_argv.extend(argv)
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
 
     with patch("hephaestus.automation.loop_runner.subprocess.run", side_effect=fake_run):
         loop_runner._list_open_issue_numbers("Org", "Repo")
-    assert "--author=@me" in seen_filters
-    assert "--assignee=@me" in seen_filters
+    assert "--author" not in seen_argv
+    assert "--assignee" not in seen_argv
+    assert "@me" not in seen_argv
+    assert "--repo" in seen_argv
+    assert "Org/Repo" in seen_argv
+    assert seen_argv[seen_argv.index("--state") + 1] == "open"
 
 
 def test_resolve_org_and_repos_cwd_default() -> None:
@@ -994,7 +1018,7 @@ class TestSubprocessTimeouts:
         """``gh issue list`` is bounded by gh_cli_timeout()."""
         with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
             mock_run.return_value = _completed(stdout="1\n2\n")
-            _gh_issue_numbers_for("Org", "Repo", "--author")
+            loop_runner._list_open_issue_numbers("Org", "Repo")
         assert mock_run.call_args.kwargs["timeout"] == gh_cli_timeout()
 
     def test_preflight_token_scopes_passes_timeout(self) -> None:
@@ -1033,11 +1057,11 @@ class TestSubprocessTimeouts:
             with pytest.raises(SystemExit, match="timed out"):
                 loop_runner._gh_list_repos("MyOrg")
 
-    def test_gh_issue_numbers_timeout_returns_empty_set(self) -> None:
-        """A timed-out issue query degrades to an empty set, not a crash."""
+    def test_gh_issue_numbers_timeout_returns_empty_list(self) -> None:
+        """A timed-out issue query degrades to an empty list, not a crash."""
         with patch("hephaestus.automation.loop_runner.subprocess.run") as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=120)
-            assert _gh_issue_numbers_for("Org", "Repo", "--author") == set()
+            assert loop_runner._list_open_issue_numbers("Org", "Repo") == []
 
 
 class TestResilientCallAdoption:


### PR DESCRIPTION
## Summary

The automation loop never drove already-created PRs through the implement+review loop. Confirmed by tracing a real 5-loop `output.log` run plus the code (two background Explore agents).

### Root cause 1 — NO-GO PRs skipped as settled
`_review_existing_pr` short-circuited on `has_go or has_no_go`, treating a `state:implementation-no-go` PR identically to a settled GO PR. With every existing PR already labeled (10 GO, 50 NO-GO in the observed run), all were skipped every loop (`Successful: 0 / Skipped: 60`) while the deferred-to `drive-green` phase was itself skipped — so NO-GO PRs were never re-implemented or re-reviewed.

**Fix:** short-circuit on **GO only**. A NO-GO PR falls through into the existing `_run_impl_review_loop`, which already runs NO-GO → address → re-review → converge-on-GO.

### Root cause 2 — per-phase issue re-discovery
The loop discovered open issues once per loop but didn't pass them down, so each phase re-ran its own `gh issue list`; the two discovery paths also disagreed in scope.

**Fix:** forward the loop-discovered open-issue list to `plan`/`implement` via `--issues`; make loop_runner discovery all-open to match the phases' `gh_list_open_issues` scope. `drive-green` keeps its direct failing-PR discovery (#819) and is unchanged.

## Tests
- `test_implementer_loop.py::TestReviewExistingPrShortCircuit` — GO short-circuits; NO-GO + unlabeled enter the loop.
- `test_implementer.py::TestExistingPrEntersReviewLoop::test_existing_pr_with_no_go_label_re_enters_review_loop` — regression guard (rewritten from the old assert-skip test).
- `test_loop_runner.py` — argv forwards open_issues for plan/implement (not drive-green); all-open discovery; timeout fallback.

All changed-module tests pass; `ruff` + `mypy` clean.

Closes #1103