### PR TITLE
[Fix] automation-loop: use the PR's real head branch in _review_existing_pr

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -288,3 +288,31 @@ def find_pr_for_issue(
         logger.debug("Body search failed for issue #%d: %s", issue_number, e)
 
     return None
+
+
+def get_pr_head_branch(pr_number: int) -> str | None:
+    """Return the real head branch of ``pr_number`` via ``gh pr view``.
+
+    The automation loop must operate on the PR's ACTUAL head branch, never an
+    assumed ``{issue}-auto-impl`` name: ``find_pr_for_issue`` can resolve a PR
+    via PR-body ``Closes #N`` search, in which case the head branch may be named
+    after a different issue (or a bundle). Using the assumed name makes
+    ``git fetch origin <assumed-branch>`` fail with ``exit 128`` (no such ref).
+
+    Args:
+        pr_number: GitHub PR number.
+
+    Returns:
+        The PR's ``headRefName``, or ``None`` if it cannot be determined
+        (gh failure, parse error, or an empty field) so the caller can fall
+        back safely rather than crash.
+
+    """
+    try:
+        result = _gh_call(["pr", "view", str(pr_number), "--json", "headRefName"])
+        data = json.loads(result.stdout or "{}")
+        branch = data.get("headRefName") or None
+        return str(branch) if branch else None
+    except Exception as e:
+        logger.warning("Could not fetch head branch for PR #%d: %s", pr_number, e)
+        return None

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -57,10 +57,18 @@ from . import (  # noqa: F401  # test-patch shim — see contract above
     review_state,
 )
 
-# Patched by: tests/unit/automation/test_implementer.py:{274,354,390,435,460};
-#             tests/unit/automation/test_implementer_loop.py:559
-# Runtime call site: ``implementer_phase_runner.py:262`` (via ``_impl_module``)
-from ._review_utils import find_pr_for_issue  # noqa: F401  # test-patch shim
+# Both re-exported as test-patch shims, reached at runtime via ``_impl_module``:
+#   - ``find_pr_for_issue``: locate the open PR for an issue.
+#       Patched by: tests/unit/automation/test_implementer.py:{274,354,390,435,460};
+#                   tests/unit/automation/test_implementer_loop.py:559
+#   - ``get_pr_head_branch``: resolve a PR's REAL head branch so
+#       ``_review_existing_pr`` never assumes ``{issue}-auto-impl`` (the assumption
+#       makes ``git fetch`` fail with exit 128 when the PR lives on another branch).
+# Runtime call site: ``implementer_phase_runner.py`` (via ``_impl_module``).
+from ._review_utils import (
+    find_pr_for_issue,  # noqa: F401  # test-patch shim
+    get_pr_head_branch,  # noqa: F401  # test-patch shim
+)
 
 # Patched by: tests/unit/automation/test_implementer_loop.py:{324,346,366,388}
 # Runtime call site: ``implementer_phase_runner.py:{855,1305,1580}`` (via ``_impl_module``)

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1043,9 +1043,13 @@ class ImplementationPhaseRunner:
         (auto-merge arming is drive-green's job). ``state:implementation-no-go``
         is NOT terminal — a NO-GO PR failed review and re-enters the
         review→address→re-review cycle until it earns GO, so it does NOT
-        short-circuit. Anti-clobber: the worktree is hard-reset to
-        ``origin/<branch>`` before the review loop so re-running never discards
-        commits that were pushed to the PR head, and the loop runs with
+        short-circuit. The worktree is prepared on the PR's REAL head branch
+        (resolved via ``get_pr_head_branch``), never the assumed
+        ``{issue}-auto-impl`` — the PR may have been matched by body ``Closes #N``
+        search and live on a differently-named branch. Anti-clobber: the worktree
+        is hard-reset to ``origin/<pr-head>`` before the review loop so re-running
+        never discards commits that were pushed to the PR head, and the loop runs
+        with
         ``session_id=None`` (no agent edit session is started here — the address
         step inside the loop resumes the implementer's own session by
         deterministic id only when there are threads to fix).
@@ -1088,17 +1092,31 @@ class ImplementationPhaseRunner:
                 thread_id,
             )
 
+        # Resolve the PR's REAL head branch — never assume ``{issue}-auto-impl``.
+        # ``find_pr_for_issue`` may have matched this PR via PR-body ``Closes #N``
+        # search, so its head branch can be named after a different issue (or a
+        # bundle). Fetching the assumed name fails with ``git fetch ... exit 128``.
+        # Fall back to the passed-in name only if the lookup fails.
+        pr_branch = self._impl_module.get_pr_head_branch(existing_pr) or branch_name
+        if pr_branch != branch_name:
+            impl._log(
+                "info",
+                f"Issue #{issue_number}: {pr_ref(existing_pr)} head branch is "
+                f"{pr_branch!r} (not the assumed {branch_name!r}); using the real branch",
+                thread_id,
+            )
+
         # Reuse-or-create the worktree, then hard-reset it to the PR head so the
         # reviewer sees the real PR state and any in-loop fix lands on top of it.
         self.status_tracker.update_slot(
             slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR"
         )
-        worktree_path = self.worktree_manager.create_worktree(issue_number, branch_name)
-        sync_worktree_to_remote_branch(worktree_path, branch_name)
+        worktree_path = self.worktree_manager.create_worktree(issue_number, pr_branch)
+        sync_worktree_to_remote_branch(worktree_path, pr_branch)
 
         with self.state_lock:
             state.worktree_path = str(worktree_path)
-            state.branch_name = branch_name
+            state.branch_name = pr_branch
             state.pr_number = existing_pr
             state.phase = ImplementationPhase.REVIEWING
         impl._save_state(state)
@@ -1117,7 +1135,7 @@ class ImplementationPhaseRunner:
         iterations, last_verdict, last_grade = impl._run_impl_review_loop(
             issue_number=issue_number,
             worktree_path=worktree_path,
-            branch_name=branch_name,
+            branch_name=pr_branch,
             issue_title=issue.title,
             issue_body=issue.body,
             session_id=None,
@@ -1150,7 +1168,7 @@ class ImplementationPhaseRunner:
             issue_number=issue_number,
             success=True,
             pr_number=existing_pr,
-            branch_name=branch_name,
+            branch_name=pr_branch,
             worktree_path=str(worktree_path),
             already_has_pr=True,
         )

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -445,6 +445,10 @@ class TestExistingPrEntersReviewLoop:
                 return_value=(False, False),
             ),
             patch(
+                "hephaestus.automation.implementer.get_pr_head_branch",
+                return_value="1-auto-impl",
+            ),
+            patch(
                 "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
             ) as sync,
             patch.object(
@@ -535,7 +539,13 @@ class TestExistingPrEntersReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
                 return_value=(False, True),
             ),
-            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
+            patch(
+                "hephaestus.automation.implementer.get_pr_head_branch",
+                return_value="708-auto-impl",
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
+            ) as sync,
             patch.object(
                 impl.worktree_manager, "create_worktree", return_value=worktree_path
             ) as create_wt,
@@ -564,6 +574,11 @@ class TestExistingPrEntersReviewLoop:
         create_wt.assert_called_once()
         review_loop.assert_called_once()
         mark_go.assert_called_once_with(777)
+        # Regression guard: the worktree is prepared/synced on the PR's REAL head
+        # branch (708-auto-impl from get_pr_head_branch), NOT the assumed
+        # "1-auto-impl" — otherwise git fetch fails with exit 128.
+        assert create_wt.call_args.args[1] == "708-auto-impl"
+        assert sync.call_args.args[1] == "708-auto-impl"
 
     def test_existing_pr_review_no_go_marks_no_go(
         self, impl: IssueImplementer, tmp_path: Path
@@ -579,6 +594,10 @@ class TestExistingPrEntersReviewLoop:
             patch(
                 "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
                 return_value=(False, False),
+            ),
+            patch(
+                "hephaestus.automation.implementer.get_pr_head_branch",
+                return_value="1-auto-impl",
             ),
             patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
             patch.object(impl.worktree_manager, "create_worktree", return_value=worktree_path),

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -1290,9 +1290,13 @@ class TestReviewExistingPrShortCircuit:
                 return_value=(has_go, has_no_go),
             ),
             patch.object(implementer.status_tracker, "update_slot"),
+            patch(
+                "hephaestus.automation.implementer.get_pr_head_branch",
+                return_value="real-pr-branch",
+            ),
             patch.object(
                 implementer.worktree_manager, "create_worktree", return_value=worktree_path
-            ),
+            ) as mock_create_wt,
             patch(
                 "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
             ) as mock_sync,
@@ -1314,13 +1318,13 @@ class TestReviewExistingPrShortCircuit:
                 slot_id=None,
                 thread_id=None,
             )
-        return result, mock_loop, mock_verdict, mock_sync
+        return result, mock_loop, mock_verdict, mock_sync, mock_create_wt
 
     def test_go_pr_short_circuits_without_review(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
         """A GO-labeled PR returns success and does NOT re-run the review loop."""
-        result, mock_loop, mock_verdict, mock_sync = self._call(
+        result, mock_loop, mock_verdict, mock_sync, _ = self._call(
             implementer, tmp_path, has_go=True, has_no_go=False
         )
         assert result.success is True
@@ -1334,22 +1338,64 @@ class TestReviewExistingPrShortCircuit:
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
         """A NO-GO-labeled PR re-runs implementation + review (the fix)."""
-        result, mock_loop, mock_verdict, mock_sync = self._call(
+        result, mock_loop, mock_verdict, mock_sync, mock_create_wt = self._call(
             implementer, tmp_path, has_go=False, has_no_go=True
         )
         assert result.success is True
         mock_loop.assert_called_once()
         mock_verdict.assert_called_once()
-        # Worktree is hard-reset to the PR head before the loop runs.
+        # Worktree is prepared + hard-reset on the PR's REAL head branch
+        # (from get_pr_head_branch), NOT the assumed "1-branch" passed in.
         mock_sync.assert_called_once()
+        assert mock_sync.call_args.args[1] == "real-pr-branch"
+        assert mock_create_wt.call_args.args[1] == "real-pr-branch"
+        assert result.branch_name == "real-pr-branch"
 
     def test_unlabeled_pr_runs_review_loop(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
         """An unlabeled existing PR runs the review loop (behavior preserved)."""
-        result, mock_loop, mock_verdict, _ = self._call(
+        result, mock_loop, mock_verdict, _, _ = self._call(
             implementer, tmp_path, has_go=False, has_no_go=False
         )
         assert result.success is True
         mock_loop.assert_called_once()
         mock_verdict.assert_called_once()
+
+    def test_no_go_falls_back_to_assumed_branch_when_lookup_fails(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """If get_pr_head_branch returns None, fall back to the passed-in name."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
+        state = ImplementationState(issue_number=1)
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, True),
+            ),
+            patch.object(implementer.status_tracker, "update_slot"),
+            patch("hephaestus.automation.implementer.get_pr_head_branch", return_value=None),
+            patch.object(
+                implementer.worktree_manager, "create_worktree", return_value=worktree_path
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
+            ) as mock_sync,
+            patch.object(implementer, "_save_state"),
+            patch("hephaestus.automation.implementer.fetch_issue_info") as mock_issue,
+            patch.object(implementer, "_run_advise_as_implementer_turn"),
+            patch.object(implementer, "_run_impl_review_loop", return_value=(1, "GO", "A")),
+            patch.object(implementer.phase_runner, "_apply_impl_review_verdict"),
+        ):
+            mock_issue.return_value.title = "title"
+            mock_issue.return_value.body = "body"
+            implementer.phase_runner._review_existing_pr(
+                issue_number=1,
+                existing_pr=555,
+                branch_name="1-auto-impl",
+                state=state,
+                slot_id=None,
+                thread_id=None,
+            )
+        assert mock_sync.call_args.args[1] == "1-auto-impl"

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -4,7 +4,11 @@ import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from hephaestus.automation._review_utils import find_pr_for_issue, parse_json_block
+from hephaestus.automation._review_utils import (
+    find_pr_for_issue,
+    get_pr_head_branch,
+    parse_json_block,
+)
 
 # ---------------------------------------------------------------------------
 # parse_json_block
@@ -228,3 +232,37 @@ class TestFindPrForIssue:
             result = find_pr_for_issue(123)
 
         assert result == 10
+
+
+class TestGetPrHeadBranch:
+    """get_pr_head_branch returns the PR's REAL head branch, not an assumption.
+
+    Regression for the wrong-branch bug: the loop assumed ``{issue}-auto-impl``
+    and ran ``git fetch origin {issue}-auto-impl`` which fails (exit 128) when
+    the existing PR was opened from a differently-named branch (e.g. found via
+    body ``Closes #N`` search, not the branch-name strategy).
+    """
+
+    def test_returns_real_head_ref_name(self) -> None:
+        """Reads headRefName from `gh pr view` and returns it verbatim."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result({"headRefName": "708-auto-impl"}),
+        ):
+            assert get_pr_head_branch(996) == "708-auto-impl"
+
+    def test_returns_none_on_missing_field(self) -> None:
+        """Empty/absent headRefName → None so the caller can fall back safely."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result({}),
+        ):
+            assert get_pr_head_branch(996) is None
+
+    def test_returns_none_on_gh_failure(self) -> None:
+        """A gh/parse failure degrades to None, never raises."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=RuntimeError("gh boom"),
+        ):
+            assert get_pr_head_branch(996) is None


### PR DESCRIPTION
## Summary

Fixes the wrong-branch crash exposed by #1104's NO-GO re-review path. `_review_existing_pr` prepared the worktree with the assumed branch `{issue}-auto-impl` instead of the PR's actual head branch, so `git fetch origin {issue}-auto-impl` failed with `exit 128` whenever the PR lived on a differently-named branch.

**Observed live** (scoped run `--issues 725,711`): issue #725 → PR #996, real head branch `708-auto-impl`. `git fetch origin 725-auto-impl` → `fatal: couldn't find remote ref` every loop. (GO PR #711/#997 was correctly skipped; only the NO-GO re-review path hit this.)

**Root cause:** `find_pr_for_issue` can match a PR via PR-body `Closes #N` search, in which case its head branch is named after a different issue or a bundle. Latent until #1104 let NO-GO PRs reach `sync_worktree_to_remote_branch`.

## Changes
- `_review_utils.get_pr_head_branch(pr_number)` — `gh pr view --json headRefName`; returns `None` on failure for safe fallback.
- `_review_existing_pr` resolves the real head branch and uses it for worktree create + sync + review loop + `WorkerResult`; falls back to the assumed name only if lookup fails. Fresh-implementation path keeps the `{issue}-auto-impl` convention (it creates the branch).

## Tests
- `test_review_utils.py::TestGetPrHeadBranch` — real branch / missing field / gh failure.
- `test_implementer_loop.py::TestReviewExistingPrShortCircuit` — NO-GO uses the real branch (`real-pr-branch`) for create+sync+result; fallback-to-assumed when lookup returns None.
- `test_implementer.py::TestExistingPrEntersReviewLoop` — regression guard asserting `708-auto-impl` is used, not the assumed `1-auto-impl`.

94 affected tests pass (hermetic, 0.7s); `ruff` + `mypy` clean.

Closes #1105