### PR TITLE
[CI] _required.yml: only run policy jobs on label/auto-merge events

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -9,6 +9,15 @@ on:
     # Re-running on auto_merge_enabled / auto_merge_disabled, labeled /
     # unlabeled, and ready_for_review makes that gate converge on the true
     # state with no timing reliance. See pr-policy below.
+    #
+    # IMPORTANT: a pull_request trigger applies to the WHOLE workflow, so the
+    # label / auto-merge event types would otherwise re-run EVERY job on each
+    # label change. Those four actions exist solely for pr-policy /
+    # auto-merge-policy to re-converge, so the `changes-gate` job below gates the
+    # 16 heavy jobs to skip on labeled/unlabeled/auto_merge_enabled/
+    # auto_merge_disabled — only the two policy jobs run on those events. The
+    # heavy jobs' results from the last code push still stand for the SHA, so
+    # branch-protection required checks remain satisfied.
     types:
       - opened
       - synchronize
@@ -29,10 +38,45 @@ permissions:
   contents: read
 
 jobs:
+  # Decides whether this event should run the 16 heavy jobs. A pull_request
+  # trigger fires the whole workflow, but the labeled / unlabeled /
+  # auto_merge_enabled / auto_merge_disabled actions exist only so pr-policy and
+  # auto-merge-policy re-converge — the heavy jobs must NOT re-run on them. This
+  # job always runs (no gate on itself) and the heavy jobs `needs:` it.
+  # ``github.event.action`` is a GitHub-controlled enum (empty on `push`), passed
+  # via env: and never interpolated into the script — injection-safe.
+  changes-gate:
+    name: changes-gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      code_event: ${{ steps.decide.outputs.code_event }}
+    steps:
+      - name: Decide whether this event runs the heavy jobs
+        id: decide
+        env:
+          ACTION: ${{ github.event.action }}
+        run: |
+          set -euo pipefail
+          # Heavy jobs skip ONLY on label / auto-merge PR actions. `push` has no
+          # action (empty) → falls to the default → code_event=true.
+          case "$ACTION" in
+            labeled | unlabeled | auto_merge_enabled | auto_merge_disabled)
+              echo "code_event=false" >> "$GITHUB_OUTPUT"
+              echo "Label/auto-merge event ($ACTION) — heavy jobs skipped; only policy jobs run."
+              ;;
+            *)
+              echo "code_event=true" >> "$GITHUB_OUTPUT"
+              echo "Code event (${ACTION:-push}) — heavy jobs run."
+              ;;
+          esac
+
   forbid-suppressions:
     name: forbid-suppressions
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
 
@@ -118,6 +162,8 @@ jobs:
     name: lint
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -144,7 +190,8 @@ jobs:
     name: markdownlint
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    needs: lint
+    needs: [lint, changes-gate]
+    if: needs.changes-gate.outputs.code_event == 'true'
     permissions:
       contents: read
     steps:
@@ -161,7 +208,8 @@ jobs:
     name: pixi-check
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    needs: lint
+    needs: [lint, changes-gate]
+    if: needs.changes-gate.outputs.code_event == 'true'
     permissions:
       contents: read
     steps:
@@ -195,7 +243,8 @@ jobs:
     name: justfile-check
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    needs: lint
+    needs: [lint, changes-gate]
+    if: needs.changes-gate.outputs.code_event == 'true'
     permissions:
       contents: read
     steps:
@@ -224,7 +273,8 @@ jobs:
     name: symlink-check
     runs-on: ubuntu-24.04
     timeout-minutes: 3
-    needs: lint
+    needs: [lint, changes-gate]
+    if: needs.changes-gate.outputs.code_event == 'true'
     permissions:
       contents: read
     steps:
@@ -236,7 +286,8 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-24.04
     timeout-minutes: 3
-    needs: lint
+    needs: [lint, changes-gate]
+    if: needs.changes-gate.outputs.code_event == 'true'
     permissions:
       contents: read
     steps:
@@ -446,6 +497,8 @@ jobs:
     name: unit-tests
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -483,6 +536,8 @@ jobs:
     name: integration-tests
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -510,6 +565,8 @@ jobs:
     name: shell-tests
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -526,6 +583,8 @@ jobs:
     name: build
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -561,6 +620,8 @@ jobs:
     name: security/dependency-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -594,6 +655,8 @@ jobs:
     name: security/secrets-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -617,6 +680,8 @@ jobs:
     name: security/sast-scan
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -650,6 +715,8 @@ jobs:
     name: schema-validation
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
@@ -681,6 +748,8 @@ jobs:
     name: deps/version-sync
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
## Summary

Adding/removing a label (or toggling auto-merge) on a PR re-ran **all 18** `_required.yml` jobs — the full unit+integration test matrix (py3.10–3.13), security scans, build, lint — because the `pull_request` trigger's `labeled/unlabeled/auto_merge_enabled/auto_merge_disabled` types apply to the whole workflow. Those event types exist only so `pr-policy` / `auto-merge-policy` re-converge (#1080). The automation loop toggles `state:implementation-*` / `state:skip` labels constantly, so this wasted a lot of CI.

## Fix
- Add a `changes-gate` job: outputs `code_event=false` on `labeled/unlabeled/auto_merge_enabled/auto_merge_disabled` actions, `true` otherwise (incl. `push` — empty action). `github.event.action` is passed via `env:`, never interpolated into the script (injection-safe).
- Gate the **16 heavy jobs** on `needs: changes-gate` + `if: needs.changes-gate.outputs.code_event == 'true'`. The 5 `needs: lint` jobs become `needs: [lint, changes-gate]`.
- `pr-policy` and `auto-merge-policy` stay **ungated** — they keep their `event_name == 'pull_request'` guard and still run on label/auto-merge events.

Skipped required checks still report a status and GitHub keeps the SHA's prior real result, so the `homeric-main-baseline` ruleset (lint, unit-tests, integration-tests, security/*, build, schema-validation, deps/version-sync, pr-policy) stays satisfied.

## Verification
This PR is its own self-test: **after CI runs once, adding then removing a label on it should re-run only `changes-gate` + `pr-policy` + `auto-merge-policy`** — the 16 heavy jobs should show *skipped*, not re-run. yamllint + pre-commit workflow-policy hooks pass locally.

Closes #1107