### PR TITLE
[Fix] automation-loop: reuse worktree on branch collision + scope drive-green to --issues

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -236,6 +236,17 @@ class CIDriver:
         # this is empty (#838). Stored on the driver so ``main()`` can check
         # it without changing ``run()``'s established return type.
         self.open_prs_remaining = [] if self.options.dry_run else self._list_open_prs_remaining()
+        # When the operator scoped the run with --issues, "repo done" and
+        # auto-merge arming must consider ONLY the PRs this run drove (the
+        # pr_map values), not every open PR on the repo. Otherwise a scoped
+        # run arms unrelated PRs and fails rc=1 on out-of-scope open PRs (POLA,
+        # mirrors the discovery gates above). The no-args sweep keeps the full
+        # repo-wide done-check.
+        if self.options.issues and self.open_prs_remaining:
+            scoped_prs = set(pr_map.values())
+            self.open_prs_remaining = [
+                pr for pr in self.open_prs_remaining if pr.get("number") in scoped_prs
+            ]
         # Arm auto-merge on every implementation-GO un-armed open PR before
         # the final report (#882). The implementation-GO label is the policy
         # gate: PRs must not be queued for merge until in-loop implementation
@@ -612,7 +623,11 @@ class CIDriver:
         # would otherwise 404 on the synthetic key. PRs already discovered via
         # the issue-driven path are NOT overwritten — a bot PR that happens to
         # carry a Closes link (rare but possible) stays under its real issue.
-        if self.options.include_bot_prs:
+        #
+        # Like failing-PR discovery below, this widening is suppressed when the
+        # operator passed --issues: a scoped run must touch ONLY the selected
+        # issues' PRs, not unrelated Dependabot PRs (POLA, #819).
+        if self.options.include_bot_prs and not self.options.issues:
             bot_prs = self._discover_bot_prs()
             for pr_num, _ in bot_prs.items():
                 if pr_num in deduped.values():

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -52,6 +52,7 @@ from .claude_timeouts import advise_claude_timeout, implementer_claude_timeout
 from .follow_up import parse_follow_up_items, run_follow_up_issues
 from .git_utils import (
     get_repo_slug,
+    is_clean_working_tree,
     issue_ref,
     pr_ref,
     run,
@@ -1112,6 +1113,20 @@ class ImplementationPhaseRunner:
             slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR"
         )
         worktree_path = self.worktree_manager.create_worktree(issue_number, pr_branch)
+        # ``create_worktree`` may have REUSED a worktree another issue already
+        # had checked out for ``pr_branch`` (git forbids one branch in two
+        # worktrees). A reused worktree can carry uncommitted changes from that
+        # other session; the ``reset --hard`` inside sync_worktree_to_remote_branch
+        # would silently discard them. Only when dirty, let an agent decide
+        # whether to commit (the work belongs to this branch) or stash it
+        # (unrelated/uncertain) before we sync to the PR head.
+        if not is_clean_working_tree(worktree_path):
+            self._resolve_dirty_reused_worktree(
+                issue_number=issue_number,
+                worktree_path=worktree_path,
+                branch_name=pr_branch,
+                thread_id=thread_id,
+            )
         sync_worktree_to_remote_branch(worktree_path, pr_branch)
 
         with self.state_lock:
@@ -1172,6 +1187,107 @@ class ImplementationPhaseRunner:
             worktree_path=str(worktree_path),
             already_has_pr=True,
         )
+
+    def _resolve_dirty_reused_worktree(
+        self,
+        *,
+        issue_number: int,
+        worktree_path: Path,
+        branch_name: str,
+        thread_id: int | None,
+    ) -> None:
+        """Decide commit-vs-stash for a REUSED worktree's uncommitted changes.
+
+        ``create_worktree`` can reuse a worktree another issue already had checked
+        out for ``branch_name``; that worktree may carry uncommitted work the
+        upcoming ``reset --hard`` would discard. Rather than guess, a bounded agent
+        turn inspects the diff and decides:
+
+        - **commit** — the changes belong to ``branch_name`` (same feature/PR), so
+          commit them onto the branch so the reset preserves them as history.
+        - **stash** — the changes are unrelated or their ownership is unclear; stash
+          them so they survive the reset without polluting the PR.
+
+        Best-effort: any failure falls back to ``git stash`` (the safe default —
+        preserves the work without committing it to the wrong branch) and is logged.
+        Codex has no two-turn injection point here, so it always stashes.
+        """
+        impl = self.impl
+        _impl_mod = self._impl_module
+        status = run(
+            ["git", "status", "--porcelain"],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+        )
+        diff = run(
+            ["git", "diff", "HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+        )
+
+        decision = "stash"  # safe default
+        if not is_codex(self.options.agent):
+            try:
+                prompt = (
+                    "A reused git worktree on branch "
+                    f"`{branch_name}` has uncommitted changes that are about to be "
+                    "discarded by `git reset --hard origin/<branch>`. Decide whether "
+                    "these changes BELONG to this branch (answer COMMIT) or are "
+                    "unrelated / ownership unclear (answer STASH). Reply with a single "
+                    "word on the last line: COMMIT or STASH.\n\n"
+                    f"## git status --porcelain\n{(status.stdout or '').strip()}\n\n"
+                    f"## git diff HEAD (truncated)\n{(diff.stdout or '')[:6000]}"
+                )
+                repo_slug = _impl_mod.get_repo_slug(self.repo_root)
+                stdout, _ = _impl_mod.invoke_claude_with_session(
+                    repo=repo_slug,
+                    issue=issue_number,
+                    agent=_impl_mod.AGENT_ADVISE,
+                    prompt=prompt,
+                    model=advise_model(),
+                    cwd=worktree_path,
+                    timeout=advise_claude_timeout(),
+                    output_format="text",
+                )
+                last = (stdout or "").strip().splitlines()
+                verdict = last[-1].strip().upper() if last else ""
+                if "COMMIT" in verdict:
+                    decision = "commit"
+            except Exception as e:
+                impl._log(
+                    "warning",
+                    f"Issue #{issue_number}: dirty-worktree decision agent failed "
+                    f"({e}); defaulting to stash",
+                    thread_id,
+                )
+
+        if decision == "commit":
+            impl._log(
+                "info",
+                f"Issue #{issue_number}: committing reused-worktree changes onto "
+                f"{branch_name} before sync (agent decided COMMIT)",
+                thread_id,
+            )
+            run(["git", "add", "-A"], cwd=worktree_path, check=False)
+            run(
+                ["git", "commit", "-S", "-m", f"chore: salvage in-progress work on {branch_name}"],
+                cwd=worktree_path,
+                check=False,
+            )
+        else:
+            impl._log(
+                "info",
+                f"Issue #{issue_number}: stashing reused-worktree changes before sync "
+                "(agent decided STASH or defaulted)",
+                thread_id,
+            )
+            run(
+                ["git", "stash", "push", "-u", "-m", f"reused-worktree-{issue_number}"],
+                cwd=worktree_path,
+                check=False,
+            )
 
     def _validate_prior_threads(
         self,

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -144,6 +144,24 @@ class WorktreeManager:
 
             worktree_path = self.base_dir / f"issue-{issue_number}"
 
+            # Reuse, don't collide: git forbids the same branch in two worktrees.
+            # When ``branch_name`` is already checked out elsewhere (e.g. a PR
+            # resolved to its real head branch ``708-auto-impl`` which the
+            # issue-708 worktree already holds), ``git worktree add`` would fail
+            # with "already used by worktree at ..." (exit 128). Return that
+            # existing worktree and register it under this issue; the caller then
+            # syncs it to the PR head (fetch + reset --hard origin/<branch>).
+            existing = self._worktree_holding_branch(branch_name)
+            if existing is not None and existing != worktree_path:
+                logger.info(
+                    "Branch %s already checked out at %s — reusing that worktree for issue #%s",
+                    branch_name,
+                    existing,
+                    issue_number,
+                )
+                self.worktrees[issue_number] = existing
+                return existing
+
             # Remove existing directory if present
             if worktree_path.exists():
                 logger.warning("Removing existing worktree directory: %s", worktree_path)
@@ -366,6 +384,24 @@ class WorktreeManager:
             logger.info("Pruned stale worktrees")
         except Exception as e:
             logger.error("Failed to prune worktrees: %s", e)
+
+    def _worktree_holding_branch(self, branch_name: str) -> Path | None:
+        """Return the path of the worktree that has ``branch_name`` checked out.
+
+        git refuses to check out the same branch in two worktrees, so before
+        adding a worktree we must detect an existing one holding the branch and
+        reuse it. ``list_worktrees`` reports the branch as the full ref
+        ``refs/heads/<name>``; match on that. Returns ``None`` if no worktree
+        holds the branch (or on any lookup failure — caller falls back to add).
+        """
+        target_ref = f"refs/heads/{branch_name}"
+        try:
+            for wt in self.list_worktrees():
+                if wt.get("branch") == target_ref:
+                    return Path(wt["path"])
+        except Exception as e:
+            logger.debug("worktree-holding-branch lookup failed for %s: %s", branch_name, e)
+        return None
 
     def list_worktrees(self) -> list[dict[str, str]]:
         """List all git worktrees in the repository.

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1830,10 +1830,19 @@ class TestBotPrDiscovery:
     def test_discover_prs_unions_bot_prs_when_enabled(
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
-        """include_bot_prs=True (default) unions bot PRs into the deduped map."""
+        """include_bot_prs=True unions bot PRs ONLY on an UNSCOPED run.
+
+        Bot-PR discovery is suppressed when --issues is set (a scoped run must
+        touch only the selected issues' PRs); the union behavior applies to the
+        no-args backlog sweep. Clear options.issues so the gate allows the union.
+        """
+        driver.options.issues = []  # unscoped — bot PRs are in scope
         with (
             patch.object(driver, "_find_pr_for_issue", return_value=500),
             patch.object(driver, "_discover_bot_prs", return_value={900: 900, 901: 901}),
+            # failing-PR discovery also runs on an unscoped run; keep it empty
+            # so this test isolates the bot-PR union.
+            patch.object(driver, "_discover_failing_prs", return_value={}),
         ):
             result = driver._discover_prs([42])
         # issue 42 → PR 500 PLUS the two bot PRs as self-keyed entries.
@@ -1855,9 +1864,11 @@ class TestBotPrDiscovery:
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
         """A bot-PR collision with an issue-driven PR must not displace the issue key."""
+        driver.options.issues = []  # unscoped so bot discovery actually runs
         with (
             patch.object(driver, "_find_pr_for_issue", return_value=900),
             patch.object(driver, "_discover_bot_prs", return_value={900: 900}),
+            patch.object(driver, "_discover_failing_prs", return_value={}),
         ):
             result = driver._discover_prs([42])
         # Issue 42 already drives PR 900; bot enumeration must not add a
@@ -2627,3 +2638,62 @@ class TestRunDriveGreenCompact:
                 # Verify compact_session was called with repo_root
                 call_kwargs = mock_compact.call_args[1]
                 assert call_kwargs["cwd"] == driver.repo_root
+
+
+class TestScopedDoneGate:
+    """A --issues-scoped run gates 'repo done' / arming on ONLY the scoped PRs."""
+
+    def test_scoped_run_filters_open_prs_to_scoped_only(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        """open_prs_remaining keeps only PRs this run drove; unrelated PRs dropped."""
+        driver.options.issues = [725, 711]
+        # Drove PRs 996 (issue 725) and 997 (issue 711).
+        scoped_map = {725: 996, 711: 997}
+        # The repo has many more open PRs; only the scoped ones should remain.
+        all_open = [
+            {"number": 996, "title": "scoped", "autoMergeRequest": None},
+            {"number": 997, "title": "scoped", "autoMergeRequest": None},
+            {"number": 1032, "title": "unrelated dependabot", "autoMergeRequest": None},
+            {"number": 988, "title": "unrelated", "autoMergeRequest": None},
+        ]
+        with (
+            patch.object(driver, "_sweep_orphaned_arming_records"),
+            patch.object(driver, "_discover_prs", return_value=scoped_map),
+            patch.object(driver, "_drive_issue", return_value=MagicMock()),
+            patch.object(driver.worktree_manager, "cleanup_all"),
+            patch.object(driver.worktree_manager, "preserved", []),
+            patch.object(driver, "_list_open_prs_remaining", return_value=all_open),
+            patch.object(
+                driver, "_arm_all_unarmed_open_prs", side_effect=lambda prs: prs
+            ) as mock_arm,
+        ):
+            driver.run()
+
+        remaining_nums = {pr["number"] for pr in driver.open_prs_remaining}
+        assert remaining_nums == {996, 997}, "out-of-scope PRs must be dropped"
+        # Arming is only offered the scoped PRs.
+        armed_nums = {pr["number"] for pr in mock_arm.call_args[0][0]}
+        assert armed_nums == {996, 997}
+
+    def test_unscoped_run_keeps_all_open_prs(self, driver: CIDriver, tmp_path: Path) -> None:
+        """With no --issues, the full repo-wide done-check is preserved."""
+        driver.options.issues = []
+        driver.options.include_bot_prs = True
+        all_open = [
+            {"number": 996, "title": "x", "autoMergeRequest": None},
+            {"number": 1032, "title": "y", "autoMergeRequest": None},
+        ]
+        with (
+            patch.object(driver, "_sweep_orphaned_arming_records"),
+            patch.object(driver, "_discover_prs", return_value={996: 996}),
+            patch.object(driver, "_drive_issue", return_value=MagicMock()),
+            patch.object(driver.worktree_manager, "cleanup_all"),
+            patch.object(driver.worktree_manager, "preserved", []),
+            patch.object(driver, "_list_open_prs_remaining", return_value=all_open),
+            patch.object(driver, "_arm_all_unarmed_open_prs", side_effect=lambda prs: prs),
+        ):
+            driver.run()
+
+        remaining_nums = {pr["number"] for pr in driver.open_prs_remaining}
+        assert remaining_nums == {996, 1032}, "unscoped run keeps all open PRs"

--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -270,17 +270,25 @@ class TestDiscoverPrsUnion:
                     result = ci_driver._discover_prs([])
         assert result == {10: 10, 20: 20}
 
-    def test_discover_prs_skips_failing_path_when_issues_scoped(self, ci_driver: CIDriver) -> None:
-        """Failing-PR discovery is NOT invoked when --issues is provided."""
+    def test_discover_prs_skips_failing_and_bot_paths_when_issues_scoped(
+        self, ci_driver: CIDriver
+    ) -> None:
+        """Neither failing-PR NOR bot-PR discovery is invoked when --issues is set.
+
+        A scoped run must touch ONLY the selected issues' PRs — not unrelated
+        Dependabot PRs or every failing PR on the repo (POLA, #819).
+        """
         ci_driver.options.issues = [100]
+        ci_driver.options.include_bot_prs = True  # default-on, must be suppressed when scoped
 
         with patch.object(ci_driver, "_discover_failing_prs") as mock_failing:
             with patch.object(ci_driver, "_find_pr_for_issue") as mock_find:
                 mock_find.return_value = 200
                 with patch.object(ci_driver, "_discover_bot_prs") as mock_bot:
-                    mock_bot.return_value = {}
+                    mock_bot.return_value = {999: 999}  # would leak in if not suppressed
                     result = ci_driver._discover_prs([100])
         mock_failing.assert_not_called()
+        mock_bot.assert_not_called()
         assert result == {100: 200}
 
     def test_discover_prs_dedupes_across_bot_and_failing(self, ci_driver: CIDriver) -> None:

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -6,7 +6,7 @@ import json
 import subprocess
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1399,3 +1399,122 @@ class TestReviewExistingPrShortCircuit:
                 thread_id=None,
             )
         assert mock_sync.call_args.args[1] == "1-auto-impl"
+
+
+class TestResolveDirtyReusedWorktree:
+    """A reused worktree that is dirty gets an agent commit-vs-stash decision."""
+
+    def test_clean_worktree_skips_decision_agent(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """When the reused worktree is clean, no decision agent runs."""
+        wt = tmp_path / "worktree"
+        wt.mkdir(exist_ok=True)
+        state = ImplementationState(issue_number=1)
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, True),
+            ),
+            patch.object(implementer.status_tracker, "update_slot"),
+            patch("hephaestus.automation.implementer.get_pr_head_branch", return_value="b"),
+            patch.object(implementer.worktree_manager, "create_worktree", return_value=wt),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
+                return_value=True,
+            ),
+            patch.object(
+                implementer.phase_runner, "_resolve_dirty_reused_worktree"
+            ) as mock_resolve,
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
+            patch.object(implementer, "_save_state"),
+            patch("hephaestus.automation.implementer.fetch_issue_info") as mock_issue,
+            patch.object(implementer, "_run_advise_as_implementer_turn"),
+            patch.object(implementer, "_run_impl_review_loop", return_value=(1, "GO", "A")),
+            patch.object(implementer.phase_runner, "_apply_impl_review_verdict"),
+        ):
+            mock_issue.return_value.title = "t"
+            mock_issue.return_value.body = "b"
+            implementer.phase_runner._review_existing_pr(
+                issue_number=1,
+                existing_pr=5,
+                branch_name="1-auto-impl",
+                state=state,
+                slot_id=None,
+                thread_id=None,
+            )
+        mock_resolve.assert_not_called()
+
+    def test_dirty_worktree_invokes_decision_agent(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """When the reused worktree is dirty, the decision agent runs before sync."""
+        wt = tmp_path / "worktree"
+        wt.mkdir(exist_ok=True)
+        state = ImplementationState(issue_number=1)
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, True),
+            ),
+            patch.object(implementer.status_tracker, "update_slot"),
+            patch("hephaestus.automation.implementer.get_pr_head_branch", return_value="b"),
+            patch.object(implementer.worktree_manager, "create_worktree", return_value=wt),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
+                return_value=False,
+            ),
+            patch.object(
+                implementer.phase_runner, "_resolve_dirty_reused_worktree"
+            ) as mock_resolve,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
+            ) as mock_sync,
+            patch.object(implementer, "_save_state"),
+            patch("hephaestus.automation.implementer.fetch_issue_info") as mock_issue,
+            patch.object(implementer, "_run_advise_as_implementer_turn"),
+            patch.object(implementer, "_run_impl_review_loop", return_value=(1, "GO", "A")),
+            patch.object(implementer.phase_runner, "_apply_impl_review_verdict"),
+        ):
+            mock_issue.return_value.title = "t"
+            mock_issue.return_value.body = "b"
+            implementer.phase_runner._review_existing_pr(
+                issue_number=1,
+                existing_pr=5,
+                branch_name="1-auto-impl",
+                state=state,
+                slot_id=None,
+                thread_id=None,
+            )
+        mock_resolve.assert_called_once()
+        # Decision must run BEFORE the hard-reset sync.
+        mock_sync.assert_called_once()
+
+    def test_decision_agent_commit_verdict_commits(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A COMMIT verdict commits; STASH/default stashes (best-effort, no raise)."""
+        wt = tmp_path / "worktree"
+        wt.mkdir(exist_ok=True)
+        implementer.options.agent = "claude"
+        with (
+            patch.object(
+                implementer.phase_runner._impl_module,
+                "invoke_claude_with_session",
+                return_value=("reasoning...\nCOMMIT", None),
+            ),
+            patch.object(
+                implementer.phase_runner._impl_module, "get_repo_slug", return_value="o/r"
+            ),
+            patch("hephaestus.automation.implementer_phase_runner.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(stdout="", returncode=0)
+            implementer.phase_runner._resolve_dirty_reused_worktree(
+                issue_number=1,
+                worktree_path=wt,
+                branch_name="708-auto-impl",
+                thread_id=None,
+            )
+        argvs = [c[0][0] for c in mock_run.call_args_list]
+        assert any(a[:2] == ["git", "commit"] for a in argvs), "COMMIT verdict must commit"
+        assert not any(a[:2] == ["git", "stash"] for a in argvs)

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -53,7 +53,9 @@ class TestWorktreeManager:
         mock_run.return_value.stdout = "origin/main"
         manager = WorktreeManager()
 
-        worktree_path = manager.create_worktree(123, "123-feature")
+        # No existing worktree holds this branch (collision check returns None).
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            worktree_path = manager.create_worktree(123, "123-feature")
 
         assert worktree_path == manager.base_dir / "issue-123"
         assert manager.worktrees[123] == worktree_path
@@ -92,11 +94,12 @@ class TestWorktreeManager:
         mock_run.return_value.stdout = "origin/main"
         manager = WorktreeManager()
 
-        # Create first worktree
-        path1 = manager.create_worktree(123, "123-feature")
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            # Create first worktree
+            path1 = manager.create_worktree(123, "123-feature")
 
-        # Try to create same worktree again
-        path2 = manager.create_worktree(123, "123-feature")
+            # Try to create same worktree again
+            path2 = manager.create_worktree(123, "123-feature")
 
         assert path1 == path2
         # First creation: base detection, local rev-parse, ls-remote (branch
@@ -148,7 +151,8 @@ class TestWorktreeManager:
         mock_run.side_effect = [rev_parse, ls_remote, fetch, add]
 
         manager = WorktreeManager()
-        manager.create_worktree(768, "768-auto-impl")
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            manager.create_worktree(768, "768-auto-impl")
 
         argvs = [c[0][0] for c in mock_run.call_args_list]
         # A fetch of the remote branch must occur.
@@ -175,7 +179,8 @@ class TestWorktreeManager:
         mock_run.side_effect = [rev_parse, ls_remote, detect, add]
 
         manager = WorktreeManager()
-        manager.create_worktree(999, "999-auto-impl")
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            manager.create_worktree(999, "999-auto-impl")
 
         add_argv = next(
             c[0][0] for c in mock_run.call_args_list if c[0][0][:3] == ["git", "worktree", "add"]
@@ -200,7 +205,8 @@ class TestWorktreeManager:
         mock_run.side_effect = [rev_parse, add]
 
         manager = WorktreeManager()
-        manager.create_worktree(123, "123-feature")
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            manager.create_worktree(123, "123-feature")
 
         argvs = [c[0][0] for c in mock_run.call_args_list]
         assert not any("ls-remote" in a for a in argvs)
@@ -562,3 +568,82 @@ class TestBaseBranchDetectionRaisesOnFailure:
             mgr = WorktreeManager()
 
         assert mgr.repo_root == tmp_path
+
+
+class TestCreateWorktreeBranchCollision:
+    """create_worktree reuses an existing worktree when the branch is checked out there.
+
+    Regression for the exit-128 collision: the implement loop resolves a PR's
+    real head branch (e.g. 708-auto-impl) for a DIFFERENT issue (#725), but that
+    branch is already checked out in the issue-708 worktree. git forbids the same
+    branch in two worktrees, so `git worktree add` failed. Reuse the existing
+    worktree instead of forcing or adding a second one.
+    """
+
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_reuses_worktree_already_holding_branch(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
+        mock_get_root.return_value = tmp_path
+        mock_run.return_value.stdout = "origin/main"
+        manager = WorktreeManager()
+
+        existing = manager.base_dir / "issue-708"
+
+        # The branch 708-auto-impl is already checked out in the issue-708 worktree.
+        with patch.object(
+            manager,
+            "list_worktrees",
+            return_value=[
+                {"path": str(existing), "branch": "refs/heads/708-auto-impl", "commit": "abc"},
+            ],
+        ):
+            # Now ask for a worktree for issue #725 on that same branch.
+            result = manager.create_worktree(725, "708-auto-impl")
+
+        # Reuses the existing path, registers it under #725, and does NOT add a
+        # second worktree for the same branch.
+        assert result == existing
+        assert manager.worktrees[725] == existing
+        add_calls = [
+            c for c in mock_run.call_args_list if c[0] and c[0][0][:3] == ["git", "worktree", "add"]
+        ]
+        assert add_calls == [], "must NOT run `git worktree add` when reusing"
+
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_no_reuse_when_branch_not_checked_out_elsewhere(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
+        """When the branch is NOT in any worktree, normal add path runs."""
+        mock_get_root.return_value = tmp_path
+        mock_run.return_value.stdout = "origin/main"
+        manager = WorktreeManager()
+
+        with patch.object(manager, "list_worktrees", return_value=[]):
+            result = manager.create_worktree(123, "123-auto-impl")
+
+        assert result == manager.base_dir / "issue-123"
+        add_calls = [
+            c for c in mock_run.call_args_list if c[0] and c[0][0][:3] == ["git", "worktree", "add"]
+        ]
+        assert len(add_calls) == 1, "fresh branch must add exactly one worktree"
+
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_worktree_holding_branch_matches_full_ref(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
+        """_worktree_holding_branch matches on refs/heads/<name>, returns the path."""
+        mock_get_root.return_value = tmp_path
+        mock_run.return_value.stdout = "origin/main"
+        manager = WorktreeManager()
+        p = manager.base_dir / "issue-708"
+        with patch.object(
+            manager,
+            "list_worktrees",
+            return_value=[{"path": str(p), "branch": "refs/heads/708-auto-impl", "commit": "x"}],
+        ):
+            assert manager._worktree_holding_branch("708-auto-impl") == p
+            assert manager._worktree_holding_branch("999-auto-impl") is None


### PR DESCRIPTION
## Summary

Two bugs surfaced by a scoped run (`--issues 725,711`) after the NO-GO re-review (#1104) and real-PR-branch (#1106) fixes landed.

### Bug A — worktree branch collision (exit 128)
`_review_existing_pr` resolves PR #996's real head branch `708-auto-impl` (for issue #725), then `create_worktree` ran `git worktree add .../issue-725 708-auto-impl` →
`fatal: '708-auto-impl' is already used by worktree at '.../issue-708'`. git forbids the same branch in two worktrees.

**Fix:** when the branch is already checked out elsewhere, REUSE that worktree (no `--force`) and register it under the new issue; the caller's `sync_worktree_to_remote_branch` then updates/rebases it to the PR head. When the reused worktree is dirty, a bounded agent decides commit-vs-stash before the `reset --hard` (safe default: stash; Codex always stashes).

### Bug B — drive-green ignored `--issues` scope
A scoped run still (1) ran bot-PR discovery (pulled in Dependabot PR #1032) and (2) scanned ALL 59 open PRs in the repo-done/arming gate, arming unrelated PRs and failing `rc=1`.

**Fix:** suppress bot-PR discovery when `options.issues` is set (mirrors the existing failing-PR gate at #819), and restrict the done-gate/arming to only the scoped PRs (`pr_map` values). The no-args backlog sweep keeps full repo-wide behavior.

## Tests
- `test_worktree_manager.py::TestCreateWorktreeBranchCollision` — reuse on collision; no-reuse otherwise; `_worktree_holding_branch` ref matching.
- `test_implementer_loop.py::TestResolveDirtyReusedWorktree` — clean skips agent; dirty invokes it; COMMIT verdict commits.
- `test_ci_driver_failing_pr_discovery.py` — bot+failing discovery both suppressed when scoped.
- `test_ci_driver.py::TestScopedDoneGate` — scoped run filters open-PRs/arming to scoped PRs; unscoped keeps all. Updated `TestBotPrDiscovery` to exercise the union on the unscoped path.

Full `ci_driver.py` suite (139) + worktree/implementer suites green; `ruff` + `mypy` clean.

Closes #1109