### PR TITLE
[Fix] automation: remove redundant in-loop PR-reviewer policy checks

### DIFF
--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -49,7 +49,7 @@ from .claude_timeouts import pr_reviewer_claude_timeout
 __all__ = ["StatusTracker", "ThreadLogManager", "WorktreeManager", "get_repo_root"]
 
 from .curses_ui import CursesUI, ThreadLogManager
-from .git_utils import get_repo_info, get_repo_root, get_repo_slug, issue_ref, pr_ref
+from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref
 from .github_api import _gh_call, fetch_issue_info, gh_pr_review_post
 from .models import ReviewerOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_pr_review_analysis_prompt
@@ -58,79 +58,6 @@ from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
-
-
-_SIGNING_GRAPHQL_QUERY = """
-query($owner: String!, $name: String!, $pr: Int!) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $pr) {
-      commits(first: 100) {
-        nodes {
-          commit {
-            oid
-            signature { isValid signer { login } }
-          }
-        }
-      }
-    }
-  }
-}
-"""
-
-
-def _fetch_signing_state(pr_number: int) -> list[dict[str, Any]]:
-    """Fetch per-commit signing state for *pr_number* via the GitHub GraphQL API.
-
-    The REST projection of ``gh pr view --json commits`` does NOT expose the
-    ``signature`` subfield, so we go to GraphQL. Each returned element is a
-    dict ``{"oid", "signature_valid", "signer"}`` matching the schema the
-    reviewer prompt expects. A null GraphQL ``signature`` (unsigned commit)
-    is coerced to ``signature_valid=False`` rather than dropped.
-
-    Failures are returned as an empty list; the reviewer treats an empty
-    signing-state as a policy NOGO, so the caller still surfaces the
-    violation rather than silently passing.
-    """
-    try:
-        owner, name = get_repo_info()
-        result = _gh_call(
-            [
-                "api",
-                "graphql",
-                "-f",
-                f"query={_SIGNING_GRAPHQL_QUERY}",
-                "-F",
-                f"owner={owner}",
-                "-F",
-                f"name={name}",
-                "-F",
-                f"pr={pr_number}",
-            ],
-        )
-        data = json.loads(result.stdout or "{}")
-        nodes = (
-            data.get("data", {})
-            .get("repository", {})
-            .get("pullRequest", {})
-            .get("commits", {})
-            .get("nodes", [])
-        )
-    except Exception as exc:
-        logger.warning("PR #%d: failed to fetch signing state via GraphQL: %s", pr_number, exc)
-        return []
-
-    out: list[dict[str, Any]] = []
-    for node in nodes:
-        commit = node.get("commit") or {}
-        signature = commit.get("signature") or {}
-        out.append(
-            {
-                "oid": commit.get("oid", ""),
-                "signature_valid": bool(signature.get("isValid", False)),
-                "signer": (signature.get("signer") or {}).get("login"),
-            }
-        )
-    return out
 
 
 def _parse_json_block(text: str) -> dict[str, Any]:
@@ -198,8 +125,6 @@ def run_pr_review_analysis(
         issue_body=context.get("issue_body", ""),
         ci_status=context.get("ci_status", ""),
         pr_description=context.get("pr_description", ""),
-        auto_merge_enabled=bool(context.get("auto_merge_enabled", False)),
-        commits_signing_state=context.get("commits_signing_state") or [],
         # #1083: nitpicks are suppressed unless --nitpick threaded the flag into
         # the review context.
         include_nitpicks=bool(context.get("include_nitpicks", False)),
@@ -328,8 +253,6 @@ def gather_impl_review_context(
         "ci_status": "",
         "review_comments": "",
         "pr_description": "",
-        "auto_merge_enabled": True,
-        "commits_signing_state": [],
         "include_nitpicks": include_nitpicks,
     }
 
@@ -533,8 +456,7 @@ class PRReviewer(BaseReviewer):
 
         Returns:
             Dictionary with keys: pr_diff, issue_body, ci_status,
-            review_comments, pr_description, auto_merge_enabled,
-            commits_signing_state.
+            review_comments, pr_description.
 
         """
         context: dict[str, Any] = {
@@ -543,8 +465,6 @@ class PRReviewer(BaseReviewer):
             "ci_status": "",
             "review_comments": "",
             "pr_description": "",
-            "auto_merge_enabled": False,
-            "commits_signing_state": [],
         }
 
         # Fetch PR diff. This is the only field we treat as load-bearing —
@@ -563,15 +483,10 @@ class PRReviewer(BaseReviewer):
                 f"PR {pr_ref(pr_number)} returned an empty diff — refusing to review"
             )
 
-        # Fetch PR description, reviews/comments, and policy state. Best-effort
-        # for everything except policy state — but the reviewer prompt treats
-        # an empty signing-state list as a NOGO, so a failure here surfaces
-        # as a policy violation rather than silently passing.
-        #
-        # Note: `gh pr view --json commits` returns commit OIDs but NOT the
-        # `signature` subfield. Per-commit signing state must come from the
-        # GraphQL API (see ``_fetch_signing_state``); auto-merge and body
-        # still come from the REST projection here.
+        # Fetch PR description and reviews/comments (best-effort). PR policy
+        # (Closes #N, signed commits, deferred auto-merge) is NOT fetched or
+        # checked here — the GitHub CI gates ``pr-policy`` / ``auto-merge-policy``
+        # enforce it authoritatively. The in-loop reviewer is code-quality only.
         try:
             result = _gh_call(
                 [
@@ -579,16 +494,11 @@ class PRReviewer(BaseReviewer):
                     "view",
                     str(pr_number),
                     "--json",
-                    "body,reviews,comments,autoMergeRequest",
+                    "body,reviews,comments",
                 ],
             )
             pr_data = json.loads(result.stdout or "{}")
             context["pr_description"] = pr_data.get("body", "")
-
-            # Policy state: auto-merge.
-            context["auto_merge_enabled"] = pr_data.get("autoMergeRequest") is not None
-            # Policy state: per-commit signing via GraphQL.
-            context["commits_signing_state"] = _fetch_signing_state(pr_number)
 
             # Aggregate review comments
             review_parts: list[str] = []

--- a/hephaestus/automation/prompts/_strict_rubric.py
+++ b/hephaestus/automation/prompts/_strict_rubric.py
@@ -130,13 +130,14 @@ _PR_STRICT_RUBRIC_DIMENSIONS = """
 **PR-review-specific graded dimensions (each starts at F; promote only on
 concrete evidence from the artifacts above):**
 
-D1 — Policy compliance (HIGHEST PRIORITY / NOGO gate).
-    The three mandatory gates below (Closes #N / auto-merge deferred until
-    implementation GO / signed commits) are graded as a single dimension. ANY
-    violation forces an overall NOGO verdict, regardless of every other
-    dimension's grade.
-    Policy compliance is NEVER weighed against code quality — it is a
-    hard precondition.
+D1 — Correctness & completeness (HIGHEST PRIORITY / NOGO gate).
+    Does the diff correctly and completely do what the issue asks, without
+    introducing bugs, regressions, or security holes? A genuine correctness
+    defect forces an overall NOGO verdict regardless of every other dimension.
+    NOTE: repo PR policy (Closes #N / deferred auto-merge / signed commits) is
+    NOT graded here — the GitHub CI gates ``pr-policy`` (required) and
+    ``auto-merge-policy`` (advisory) enforce it authoritatively. Do not re-check
+    policy; focus on whether the code is correct and complete.
 
 D2 — Diff review of CHANGED lines only.
     Restrict findings to lines actually modified in the PR diff above.
@@ -396,11 +397,11 @@ downgrade accordingly.
 # Per-stage strict rubric: PR REVIEW
 #
 # Composite rubric injected into PR_REVIEW_ANALYSIS_PROMPT (site 4 / #581).
-# Order: strict grading scale → PR-specific dimensions (D1 policy is the
-# NOGO gate) → seven software-engineering principles. The existing
-# policy-checks block in PR_REVIEW_ANALYSIS_PROMPT remains the
-# authoritative description of the three gates referenced by D1, and the
-# trailing JSON output format remains byte-exact for `_parse_json_block`.
+# Order: strict grading scale → PR-specific dimensions (D1 correctness is the
+# NOGO gate) → seven software-engineering principles. Repo PR policy (Closes #N
+# / deferred auto-merge / signed commits) is NOT graded here — the CI gates
+# pr-policy + auto-merge-policy own it. The trailing JSON output format remains
+# byte-exact for `_parse_json_block`.
 # ---------------------------------------------------------------------------
 _PR_STRICT_RUBRIC = (
     _STRICT_GRADING_AND_ANTI_INFLATION

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -4,9 +4,7 @@ Contains the PR review analysis prompt (inline-comment generator) and the
 plain PR description template.
 """
 
-import json
 import secrets
-from typing import Any
 
 from ._shared import _UNTRUSTED_NOTICE, _fence_untrusted
 from ._strict_rubric import _PR_STRICT_RUBRIC
@@ -28,45 +26,18 @@ Analyze PR #{pr_number} linked to issue #{issue_number}.
 **PR Diff (untrusted):**
 {pr_diff_block}
 
-**Auto-merge State (untrusted):**
-{auto_merge_state_block}
-
-**Commit Signing State (untrusted):**
-{commits_signing_block}
-
 ---
 
 {strict_rubric}
 
 ---
 
-**Policy checks (MANDATORY — run these BEFORE any code-quality review):**
+**Code-quality review:**
 
-This repository enforces three non-negotiable PR properties. If ANY check fails,
-your summary MUST begin with `POLICY VIOLATION:` and your final verdict line
-MUST be `Verdict: NOGO`. Inline code-quality findings can be reported in
-addition, but the NOGO verdict cannot be overridden by them.
-
-1. **Closes #N:** the PR Description above must contain a line matching the
-   regex `^Closes #\\d+\\s*$` (case-sensitive `Closes`, hash + number, on its
-   own line). `Fixes`, `Resolves`, `closes`, `Closes:` do NOT satisfy the
-   policy. If absent, NOGO and quote the relevant lines of the description.
-2. **Auto-merge deferred until implementation GO:** the Auto-merge State block
-   above contains a single line. During implementation review it MUST read
-   `auto_merge_enabled=false`. If it reads `auto_merge_enabled=true`, NOGO with
-   a note explaining auto-merge must stay disabled until this review returns GO
-   and the automation applies `state:implementation-go`.
-3. **Signed commits:** the Commit Signing State block above is a JSON array
-   where each element is `{{"oid": "<sha>", "signature_valid": <bool>,
-   "signer": "<login or null>"}}`. EVERY element must have
-   `signature_valid: true`. If any commit has `signature_valid: false` or the
-   array is empty, NOGO and list the offending OIDs.
-
-If all three checks pass, proceed to code-quality review below.
-
----
-
-**Code-quality review (only if policy checks pass):**
+> Note: repo PR policies (`Closes #N`, signed commits, deferred auto-merge) are
+> enforced authoritatively by the GitHub CI gates `pr-policy` (required) and
+> `auto-merge-policy` (advisory). Do NOT re-check them here — focus solely on
+> code correctness, completeness, and quality.
 
 Review the PR for correctness, completeness, and code quality. Identify any issues that should
 be addressed as inline review comments.
@@ -74,7 +45,7 @@ be addressed as inline review comments.
 **Comment severity (MANDATORY — tag every inline comment):**
 
 Classify each inline comment with a `severity`:
-- `critical` — correctness/security bug, data loss, or a policy violation.
+- `critical` — correctness/security bug or data loss.
 - `major` — a real design/maintainability problem that should be fixed before merge.
 - `minor` — a small but genuine improvement (naming, missing edge case, light duplication).
 - `nitpick` — purely cosmetic / stylistic / subjective preference with no functional impact.
@@ -86,8 +57,8 @@ The review prose + inline comments explain *why*; the verdict line is a binary
 gate. Write your analysis in prose, then end your response with exactly one of
 the two verdict lines below (the parser takes the LAST matching line):
 
-Verdict: GO — Policy passes, auto-merge is deferred, and code is acceptable.
-Verdict: NOGO — Policy violation OR fundamental code problem (explain in the review).
+Verdict: GO — Code is correct, complete, and acceptable to merge.
+Verdict: NOGO — A fundamental code problem must be fixed first (explain in the review).
 
 After the verdict line, emit a single fenced JSON block:
 
@@ -104,10 +75,8 @@ Rules for the JSON block:
   - `side`: always `"RIGHT"` for new code
   - `severity`: one of `"critical"`, `"major"`, `"minor"`, `"nitpick"` (see above)
   - `body`: the review comment text (string)
-- `summary`: overall review verdict, max 200 characters. If any policy check
-  failed, this MUST start with `POLICY VIOLATION:` followed by the failing
-  check name(s) (e.g. `POLICY VIOLATION: Closes, signed-commits`).
-- If there are no inline comments AND all policy checks pass, emit:
+- `summary`: overall review verdict, max 200 characters.
+- If there are no inline comments AND the code is acceptable, emit:
   `{{"comments": [], "summary": "LGTM"}}`
 - Emit only one JSON block, at the very end of your response (the parser takes the LAST one).
 """
@@ -136,13 +105,16 @@ def get_pr_review_analysis_prompt(
     issue_body: str = "",
     ci_status: str = "",
     pr_description: str = "",
-    auto_merge_enabled: bool = False,
-    commits_signing_state: list[dict[str, Any]] | None = None,
     include_nitpicks: bool = False,
 ) -> str:
     """Get the PR review analysis prompt for generating inline review comments.
 
     All free-text fields are fenced as untrusted (see module docstring).
+
+    Repo PR policies (`Closes #N`, signed commits, deferred auto-merge) are NOT
+    checked here — the GitHub CI gates ``pr-policy`` (required) and
+    ``auto-merge-policy`` (advisory) enforce them authoritatively. The in-loop
+    reviewer does code-quality review only.
 
     Args:
         pr_number: GitHub PR number
@@ -151,14 +123,6 @@ def get_pr_review_analysis_prompt(
         issue_body: Issue body/description
         ci_status: CI check status summary
         pr_description: PR description body
-        auto_merge_enabled: Whether GitHub auto-merge is currently enabled on
-            the PR. Callers MUST pass the real value; the default ``False``
-            exists only to keep the signature backward-compatible and will
-            cause the reviewer to emit a NOGO verdict.
-        commits_signing_state: List of per-commit signing summaries. Each
-            element must be a dict with keys ``oid`` (str), ``signature_valid``
-            (bool), and ``signer`` (str or None). Defaults to an empty list,
-            which the reviewer treats as a policy failure.
         include_nitpicks: When False (default), the reviewer is told to OMIT
             ``nitpick``-severity comments entirely. When True (``--nitpick``),
             nitpick comments are re-enabled. Either way every emitted comment
@@ -169,8 +133,6 @@ def get_pr_review_analysis_prompt(
 
     """
     nonce = secrets.token_hex(8).upper()
-    auto_merge_state = f"auto_merge_enabled={'true' if auto_merge_enabled else 'false'}"
-    signing_state_json = json.dumps(commits_signing_state or [])
     nitpick_directive = _NITPICK_INCLUDE if include_nitpicks else _NITPICK_SUPPRESS
     return PR_REVIEW_ANALYSIS_PROMPT.format(
         pr_number=pr_number,
@@ -179,8 +141,6 @@ def get_pr_review_analysis_prompt(
         issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
         ci_status_block=_fence_untrusted("CI_STATUS", ci_status, nonce),
         pr_description_block=_fence_untrusted("PR_DESCRIPTION", pr_description, nonce),
-        auto_merge_state_block=_fence_untrusted("AUTO_MERGE_STATE", auto_merge_state, nonce),
-        commits_signing_block=_fence_untrusted("COMMITS_SIGNING_STATE", signing_state_json, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
         strict_rubric=_PR_STRICT_RUBRIC.strip(),
         nitpick_directive=nitpick_directive,

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -311,153 +311,45 @@ class TestReviewPostsInlineComments:
         assert result.pr_number == 42
 
 
-class TestGatherPrContextPolicyState:
-    """Tests that _gather_pr_context collects auto-merge + commit signing state.
+class TestGatherPrContextNoPolicyState:
+    """_gather_pr_context no longer collects policy state (Closes/auto-merge/signing).
 
-    The policy gate in PR_REVIEW_ANALYSIS_PROMPT depends on two new fields
-    being populated; if they are absent or misparsed the reviewer treats the
-    PR as a policy failure, so this is load-bearing.
+    Policy is enforced by the CI gates pr-policy + auto-merge-policy; the in-loop
+    reviewer is code-quality only, so the context must NOT carry the removed
+    ``auto_merge_enabled`` / ``commits_signing_state`` keys and must NOT make the
+    GraphQL signing-state call. It still collects ``pr_description`` for review.
     """
 
-    def _gh_call_side_effect(
-        self,
-        diff_text: str,
-        pr_view_json: dict[str, Any],
-        graphql_nodes: list[dict[str, Any]] | None = None,
-        checks_json: list[dict[str, Any]] | None = None,
-    ) -> Any:
-        """Build a side_effect for the four _gh_call invocations.
-
-        Order: pr diff, pr view --json (body+autoMergeRequest), api graphql
-        (signing state), pr checks --json. The reviewer calls them in that
-        sequence in ``_gather_pr_context``.
-        """
-        diff_result = MagicMock(returncode=0, stdout=diff_text, stderr="")
-        view_result = MagicMock(returncode=0, stdout=json.dumps(pr_view_json), stderr="")
-        graphql_payload = {
-            "data": {"repository": {"pullRequest": {"commits": {"nodes": graphql_nodes or []}}}}
-        }
-        graphql_result = MagicMock(returncode=0, stdout=json.dumps(graphql_payload), stderr="")
-        checks_result = MagicMock(returncode=0, stdout=json.dumps(checks_json or []), stderr="")
-        return [diff_result, view_result, graphql_result, checks_result]
-
-    def test_extracts_auto_merge_enabled(self, reviewer: PRReviewer, tmp_path: Path) -> None:
-        with (
-            patch("hephaestus.automation.pr_reviewer._gh_call") as mock_gh,
-            patch(
-                "hephaestus.automation.pr_reviewer.get_repo_info",
-                return_value=("owner", "repo"),
-            ),
-            patch(
-                "hephaestus.automation.pr_reviewer.fetch_issue_info",
-                return_value=MagicMock(body=""),
-            ),
-        ):
-            mock_gh.side_effect = self._gh_call_side_effect(
-                diff_text="diff --git a/x b/x\n+y\n",
-                pr_view_json={
-                    "body": "Closes #1",
-                    "reviews": [],
-                    "comments": [],
-                    "autoMergeRequest": {"enabledBy": {"login": "alice"}},
-                },
-                graphql_nodes=[
-                    {
-                        "commit": {
-                            "oid": "abc",
-                            "signature": {"isValid": True, "signer": {"login": "alice"}},
-                        }
-                    }
-                ],
-            )
-            ctx = reviewer._gather_pr_context(pr_number=1, issue_number=1, worktree_path=tmp_path)
-        assert ctx["auto_merge_enabled"] is True
-        assert ctx["commits_signing_state"] == [
-            {"oid": "abc", "signature_valid": True, "signer": "alice"}
-        ]
-
-    def test_extracts_auto_merge_disabled(self, reviewer: PRReviewer, tmp_path: Path) -> None:
-        with (
-            patch("hephaestus.automation.pr_reviewer._gh_call") as mock_gh,
-            patch(
-                "hephaestus.automation.pr_reviewer.get_repo_info",
-                return_value=("owner", "repo"),
-            ),
-            patch(
-                "hephaestus.automation.pr_reviewer.fetch_issue_info",
-                return_value=MagicMock(body=""),
-            ),
-        ):
-            mock_gh.side_effect = self._gh_call_side_effect(
-                diff_text="diff --git a/x b/x\n+y\n",
-                pr_view_json={
-                    "body": "Closes #1",
-                    "reviews": [],
-                    "comments": [],
-                    "autoMergeRequest": None,
-                },
-                graphql_nodes=[],
-            )
-            ctx = reviewer._gather_pr_context(pr_number=1, issue_number=1, worktree_path=tmp_path)
-        assert ctx["auto_merge_enabled"] is False
-
-    def test_unsigned_commit_yields_signature_valid_false(
+    def test_context_omits_policy_keys_and_skips_signing_graphql(
         self, reviewer: PRReviewer, tmp_path: Path
     ) -> None:
-        """GitHub returns commit.signature == null for unsigned commits."""
+        diff_result = MagicMock(returncode=0, stdout="diff --git a/x b/x\n+y\n", stderr="")
+        view_result = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"body": "Closes #1", "reviews": [], "comments": []}),
+            stderr="",
+        )
+        checks_result = MagicMock(returncode=0, stdout="[]", stderr="")
         with (
             patch("hephaestus.automation.pr_reviewer._gh_call") as mock_gh,
-            patch(
-                "hephaestus.automation.pr_reviewer.get_repo_info",
-                return_value=("owner", "repo"),
-            ),
             patch(
                 "hephaestus.automation.pr_reviewer.fetch_issue_info",
                 return_value=MagicMock(body=""),
             ),
         ):
-            mock_gh.side_effect = self._gh_call_side_effect(
-                diff_text="diff --git a/x b/x\n+y\n",
-                pr_view_json={
-                    "body": "Closes #1",
-                    "reviews": [],
-                    "comments": [],
-                    "autoMergeRequest": None,
-                },
-                graphql_nodes=[{"commit": {"oid": "deadbeef", "signature": None}}],
-            )
+            mock_gh.side_effect = [diff_result, view_result, checks_result]
             ctx = reviewer._gather_pr_context(pr_number=1, issue_number=1, worktree_path=tmp_path)
-        assert ctx["commits_signing_state"] == [
-            {"oid": "deadbeef", "signature_valid": False, "signer": None}
-        ]
 
-    def test_pr_view_failure_leaves_policy_state_at_nogo_default(
-        self, reviewer: PRReviewer, tmp_path: Path
-    ) -> None:
-        """`gh pr view` failure must default policy state to a NOGO.
-
-        If we silently treated a fetch failure as "no policy state needed",
-        the reviewer prompt would pass a PR that ought to be blocked.
-        """
-        with (
-            patch("hephaestus.automation.pr_reviewer._gh_call") as mock_gh,
-            patch(
-                "hephaestus.automation.pr_reviewer.get_repo_info",
-                return_value=("owner", "repo"),
-            ),
-            patch(
-                "hephaestus.automation.pr_reviewer.fetch_issue_info",
-                return_value=MagicMock(body=""),
-            ),
-        ):
-            diff_result = MagicMock(returncode=0, stdout="diff\n+x\n", stderr="")
-            # pr view fails → outer except handler skips both auto-merge AND
-            # the graphql signing fetch, so we only need a checks mock after.
-            checks_result = MagicMock(returncode=0, stdout="[]", stderr="")
-            mock_gh.side_effect = [diff_result, RuntimeError("API down"), checks_result]
-            ctx = reviewer._gather_pr_context(pr_number=1, issue_number=1, worktree_path=tmp_path)
-        assert ctx["auto_merge_enabled"] is False
-        assert ctx["commits_signing_state"] == []
+        # Policy keys are gone; code-quality fields remain.
+        assert "auto_merge_enabled" not in ctx
+        assert "commits_signing_state" not in ctx
+        assert ctx["pr_description"] == "Closes #1"
+        # No `api graphql` signing-state call is made anymore.
+        argvs = [c.args[0] for c in mock_gh.call_args_list if c.args]
+        assert not any("graphql" in argv for argv in argvs), "signing-state GraphQL call removed"
+        # The `gh pr view` projection no longer requests autoMergeRequest.
+        view_argv: list[str] = next((a for a in argvs if a[:2] == ["pr", "view"]), [])
+        assert "autoMergeRequest" not in "".join(view_argv)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -75,17 +75,25 @@ class TestPRReviewAnalysisPrompt:
         assert "PR #10" in out
         assert "issue #5" in out
 
-    def test_lists_three_policy_checks(self) -> None:
+    def test_omits_policy_checks_defers_to_ci_gates(self) -> None:
+        """The reviewer no longer enforces repo policy — CI gates own it.
+
+        Closes #N / signed-commits / deferred-auto-merge are enforced by the
+        pr-policy + auto-merge-policy CI gates, not the in-loop LLM reviewer
+        (which fabricated false POLICY VIOLATIONs from empty/stale data).
+        """
         out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
-        # Each of the three policy checks must be explicitly enumerated.
-        assert "Closes #N" in out or "Closes #\\d" in out
-        assert "auto_merge_enabled" in out
-        assert "MUST read" in out
-        assert "auto_merge_enabled=false" in out
-        assert "signature_valid" in out
-        # The NOGO / POLICY VIOLATION sentinels must be present.
-        assert "POLICY VIOLATION" in out
+        # The removed policy machinery must be gone.
+        assert "POLICY VIOLATION" not in out
+        assert "auto_merge_enabled" not in out
+        assert "signature_valid" not in out
+        assert "COMMITS_SIGNING_STATE" not in out
+        assert "Policy checks (MANDATORY" not in out
+        # But the prompt should tell the reviewer the CI gates own policy.
+        assert "pr-policy" in out
+        # The code-quality verdict contract stays intact.
         assert "Verdict: NOGO" in out
+        assert "Verdict: GO" in out
 
     def test_nitpicks_suppressed_by_default(self) -> None:
         """#1083: by default the reviewer must be told to OMIT nitpick comments."""
@@ -114,16 +122,6 @@ class TestPRReviewAnalysisPrompt:
         assert "nitpick" in out
         assert "major" in out
 
-    def test_passes_auto_merge_state(self) -> None:
-        on = prompts.get_pr_review_analysis_prompt(
-            pr_number=1, issue_number=1, auto_merge_enabled=True
-        )
-        off = prompts.get_pr_review_analysis_prompt(
-            pr_number=1, issue_number=1, auto_merge_enabled=False
-        )
-        assert "auto_merge_enabled=true" in on
-        assert "auto_merge_enabled=false" in off
-
     def test_pr_review_prompt_contains_strict_rubric(self) -> None:
         """Prompt must embed the strict rubric.
 
@@ -135,7 +133,7 @@ class TestPRReviewAnalysisPrompt:
         assert "DEFAULT IS F" in out
         assert "ANTI-INFLATION RULES" in out
         # PR-specific stage dimensions.
-        assert "D1 — Policy compliance" in out
+        assert "D1 — Correctness & completeness" in out
         assert "D2 — Diff review of CHANGED lines only" in out
         assert "D3 — Inline-comment quality" in out
         assert "D4 — CI failure analysis" in out
@@ -177,34 +175,6 @@ class TestPRReviewAnalysisPrompt:
         preceding_open = out.rfind("```", 0, last_fence_close)
         assert preceding_open != -1
         assert out[preceding_open : preceding_open + 7] == "```json"
-
-    def test_pr_review_prompt_preserves_policy_gates(self) -> None:
-        """All three policy gates must still appear in the prompt.
-
-        Closes #N, auto-merge, and signed commits remain alongside the new
-        rubric — the rubric references them as the highest-priority NOGO
-        gate.
-        """
-        out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
-        assert "Closes #N" in out
-        assert "auto-merge" in out.lower()
-        assert "Signed commits" in out or "signed commits" in out.lower()
-        # The mandatory policy-checks header must remain.
-        assert "Policy checks (MANDATORY" in out
-
-    def test_passes_commit_signing_state(self) -> None:
-        out = prompts.get_pr_review_analysis_prompt(
-            pr_number=1,
-            issue_number=1,
-            commits_signing_state=[
-                {"oid": "abc123", "signature_valid": True, "signer": "alice"},
-                {"oid": "def456", "signature_valid": False, "signer": None},
-            ],
-        )
-        # The JSON-serialized state must round-trip into the fenced block.
-        assert "abc123" in out
-        assert "def456" in out
-        assert "signature_valid" in out
 
 
 class TestPlanPrompt:


### PR DESCRIPTION
## Summary

The in-loop LLM reviewer enforced three repo policies — `Closes #N`, deferred auto-merge, signed commits — via both the prompt's "Policy checks" block AND the strict rubric's D1 dimension, emitting a generic `POLICY VIOLATION: <names>` verdict. On **PR #996** it posted a **false** violation: the body has `Closes #725`/`#726`, auto-merge is OFF, and the commit IS signed.

**Root cause:** the policy data fetches **fail open to "violation"** — `_fetch_signing_state` returns `[]` on any error and the prompt treats an empty array as NOGO, so a transient GraphQL failure (or an empty/wrong context, e.g. a PR-as-issue run) fabricates a violation. The message is also generic, so the user has to guess.

## Fix

These checks are **redundant**: the GitHub CI gates `pr-policy` (Closes #N + signed commits, REQUIRED) and `auto-merge-policy` (advisory) already enforce them authoritatively. Remove the in-loop policy enforcement and let the CI gates own it.

- `prompts/pr_review.py`: drop the "Policy checks (MANDATORY)" section, the auto-merge/signing data blocks, the `POLICY VIOLATION` summary contract, and the `auto_merge_enabled`/`commits_signing_state` params. `Verdict: GO/NOGO` is now code-quality only.
- `prompts/_strict_rubric.py`: replace D1 "Policy compliance" with D1 "Correctness & completeness"; note that the CI gates own policy.
- `pr_reviewer.py`: delete `_fetch_signing_state` + the signing GraphQL query; stop fetching/passing auto-merge + signing state; drop `autoMergeRequest` from the `gh pr view` projection.

The in-loop reviewer now does code-quality review only. Net `+78/-345`.

## Tests
- `test_prompts.py` — assert the policy machinery is gone (`POLICY VIOLATION`/`auto_merge_enabled`/`COMMITS_SIGNING_STATE`/"Policy checks (MANDATORY)" absent), the CI-gate note present, verdict contract intact, D1 renamed.
- `test_pr_reviewer_posting.py` — `_gather_pr_context` no longer carries policy keys and makes no signing GraphQL call.

All prompt + pr_reviewer suites green; `ruff` + `mypy` (342 files) clean.

## Out of scope
- PR #996's existing false POLICY VIOLATION comments — left as-is (per request).
- The CI gates `pr-policy` / `auto-merge-policy` — unchanged; they remain the single source of policy enforcement.

Closes #1111