### PR TITLE
[Fix] automation: re-review on zero-thread non-GO instead of converging at R0

### DIFF
--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1440,18 +1440,18 @@ class ImplementationPhaseRunner:
                 )
                 break
 
-            # Convergence on "no blocking unresolved threads": the reviewer
-            # found nothing actionable to post AND the validator re-opened
-            # nothing, so there is nothing to address.
+            # Converge ONLY on an explicit Verdict: GO (handled above). A non-GO
+            # pass with NO posted threads (and nothing re-opened) must NOT end the
+            # loop here — a single garbage/AMBIGUOUS review would otherwise strand
+            # a fixable PR after R0. There is nothing to address (no threads), so
+            # skip the address step and RE-REVIEW on the next iteration; the loop
+            # is bounded by MAX_REVIEW_ITERATIONS and applies ``state:skip`` only
+            # on TRUE exhaustion (post-loop block). This is the "zero threads !=
+            # GO" rule from the pr-review-loop skill (verified-ci): don't converge
+            # on a zero-thread AMBIGUOUS/NO-GO pass.
             if pr_number is not None and not posted_thread_ids and not reopened:
-                ref = issue_ref(issue_number)
-                impl._log(
-                    "info",
-                    f"{ref}: no blocking review threads on iteration {iteration} — "
-                    "review loop terminated",
-                    thread_id,
-                )
-                break
+                prior_review = review_text
+                continue
 
             # Save this review for next iteration's context.
             prior_review = review_text
@@ -1519,20 +1519,19 @@ class ImplementationPhaseRunner:
             )
 
         # #1083 Bug 2 / #1085 C3: the loop must reach an explicit GO to be
-        # considered converged. Apply ``state:skip`` only when the automation has
-        # genuinely run out of road, NOT on every non-GO outcome:
-        #   * true exhaustion — ran all MAX_REVIEW_ITERATIONS without a GO, or
-        #   * AMBIGUOUS — the reviewer could not even render a verdict ("stuck").
-        # A plain NOGO that broke early (e.g. iteration-0 with zero actionable
-        # threads) stays retryable on the next loop, so a fixable issue is not
-        # permanently stranded after a single bad review. ``last_verdict`` is
-        # None only when there was no PR to review (dry-run / no-PR path).
+        # considered converged. Apply ``state:skip`` only on TRUE iteration
+        # exhaustion — ran all MAX_REVIEW_ITERATIONS without a GO — NOT on a
+        # single non-GO (including AMBIGUOUS) outcome. Per the pr-review-loop
+        # skill (verified-ci), a zero-thread AMBIGUOUS/NO-GO pass no longer ends
+        # the loop early (it re-reviews above), so a transient garbage review
+        # (e.g. a malformed verdict) gets MAX_REVIEW_ITERATIONS chances instead
+        # of stranding a fixable PR after R0. ``last_verdict`` is None only when
+        # there was no PR to review (dry-run / no-PR path).
         exhausted = iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict != "GO"
-        is_ambiguous = last_verdict == "AMBIGUOUS"
         if (
             pr_number is not None
             and last_verdict is not None
-            and (exhausted or is_ambiguous)
+            and exhausted
             and not self.options.dry_run
         ):
             logger.info(

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -226,50 +226,23 @@ class TestRunImplReviewLoop:
         assert verdict == "NOGO"
         mock_label.assert_called_once_with(7, [STATE_SKIP])
 
-    def test_ambiguous_zero_threads_applies_state_skip(
+    def test_ambiguous_zero_threads_re_reviews_then_skips_on_exhaustion(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """An AMBIGUOUS (no verdict line), zero-thread review applies ``state:skip``.
+        """A zero-thread AMBIGUOUS pass re-reviews to exhaustion, THEN skips.
 
-        #1085 C3: AMBIGUOUS is the genuine 'stuck' case — the reviewer could not
-        even render a verdict — so skip immediately rather than spinning.
+        Per the pr-review-loop skill (verified-ci): "zero threads != GO" — a
+        single garbage/AMBIGUOUS review (e.g. a malformed verdict line) must NOT
+        end the loop at R0. It re-reviews up to MAX_REVIEW_ITERATIONS and applies
+        ``state:skip`` only on TRUE exhaustion.
         """
         from hephaestus.automation.state_labels import STATE_SKIP
 
         with (
-            patch.object(implementer, "_run_impl_review_step", return_value=(_ambiguous(), [])),
-            patch.object(implementer, "_run_address_review_step"),
-            patch(
-                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
-            ) as mock_label,
-        ):
-            _, verdict, _ = implementer._run_impl_review_loop(
-                issue_number=8,
-                worktree_path=tmp_path,
-                branch_name="b",
-                issue_title="t",
-                issue_body="ib",
-                session_id="sess",
-                slot_id=0,
-                thread_id=None,
-                pr_number=42,
-            )
-
-        assert verdict == "AMBIGUOUS"
-        mock_label.assert_called_once_with(8, [STATE_SKIP])
-
-    def test_iter0_zero_thread_nogo_does_not_apply_skip(
-        self, implementer: IssueImplementer, tmp_path: Path
-    ) -> None:
-        """#1085 C3: a single iteration-0 NOGO with zero threads must NOT skip.
-
-        A plain NOGO that posts no actionable threads is retryable on the next
-        loop — only true exhaustion (or AMBIGUOUS) applies ``state:skip``, so a
-        fixable issue isn't permanently stranded after one bad review.
-        """
-        with (
-            patch.object(implementer, "_run_impl_review_step", return_value=(_nogo("C"), [])),
-            patch.object(implementer, "_run_address_review_step"),
+            patch.object(
+                implementer, "_run_impl_review_step", return_value=(_ambiguous(), [])
+            ) as mock_rev,
+            patch.object(implementer, "_run_address_review_step") as mock_addr,
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
             ) as mock_label,
@@ -286,9 +259,50 @@ class TestRunImplReviewLoop:
                 pr_number=42,
             )
 
-        assert verdict == "NOGO"
-        assert iters == 1  # broke at iteration 0, not exhausted
-        mock_label.assert_not_called()
+        assert verdict == "AMBIGUOUS"
+        assert iters == MAX_REVIEW_ITERATIONS == 3  # re-reviewed to exhaustion
+        assert mock_rev.call_count == 3
+        # No threads ever posted → the address step never runs.
+        mock_addr.assert_not_called()
+        # Skip applied only on true exhaustion.
+        mock_label.assert_called_once_with(8, [STATE_SKIP])
+
+    def test_iter0_zero_thread_nogo_re_reviews_not_skip_at_r0(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A zero-thread NO-GO must NOT end the loop or skip at R0.
+
+        It re-reviews (the next pass may surface threads or reach GO). Here the
+        reviewer flips to GO on R1, so the loop converges WITHOUT skipping.
+        """
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo("C"), []), (_go(), [])],
+            ) as mock_rev,
+            patch.object(implementer, "_run_address_review_step") as mock_addr,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+            ) as mock_label,
+        ):
+            iters, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=8,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "GO"
+        assert iters == 2  # R0 NO-GO re-reviewed → R1 GO
+        assert mock_rev.call_count == 2
+        mock_addr.assert_not_called()  # no threads → nothing to address
+        mock_label.assert_not_called()  # reached GO, no skip
 
     def test_go_does_not_apply_state_skip(
         self, implementer: IssueImplementer, tmp_path: Path
@@ -343,10 +357,15 @@ class TestRunImplReviewLoop:
         finally:
             implementer.options.dry_run = False
 
-    def test_no_blocking_threads_terminates_loop(
+    def test_zero_thread_nogo_re_reviews_to_exhaustion(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """A NOGO verdict but zero posted threads converges (nothing to address)."""
+        """A persistent zero-thread NO-GO re-reviews to exhaustion (does not stop at R0).
+
+        "Zero threads != GO": a non-GO review with nothing actionable to address
+        must NOT converge the loop — it re-reviews up to MAX_REVIEW_ITERATIONS so
+        a transient bad review cannot strand a fixable PR.
+        """
         with (
             patch.object(
                 implementer, "_run_impl_review_step", return_value=(_nogo("C"), [])
@@ -365,11 +384,11 @@ class TestRunImplReviewLoop:
                 pr_number=42,
             )
 
-        assert iters == 1
+        assert iters == MAX_REVIEW_ITERATIONS == 3
         assert verdict == "NOGO"
-        # No threads posted → nothing to address → loop stops without addressing.
+        # No threads posted → nothing to address; loop re-reviews, never addresses.
         mock_addr.assert_not_called()
-        assert mock_rev.call_count == 1
+        assert mock_rev.call_count == 3
 
     def test_no_session_id_still_addresses(
         self, implementer: IssueImplementer, tmp_path: Path


### PR DESCRIPTION
## Summary

The in-loop review cycle terminated whenever the reviewer posted **zero threads**, regardless of verdict — so an AMBIGUOUS or NO-GO zero-thread pass ended the loop at R0.

**Observed live** (`--issues 725,711`): issue #725 → PR #996 got a malformed review (only a `POLICY VIOLATION:` summary line, no `Verdict:` line → `parse_review_verdict` = AMBIGUOUS) with 0 threads. The loop treated "0 threads" as convergence, **terminated at R0** (`Verdict=AMBIGUOUS Grade=? threads=0`), and applied `state:skip` — so #725 was never re-reviewed or implemented.

This violated the verified-ci `pr-review-loop-orchestration-agent-patterns` skill: *"Converge ONLY on an explicit `Verdict: GO`; a zero-thread pass with verdict AMBIGUOUS or NO-GO ends the loop too fast."*

## Fix

- A non-GO pass with no posted threads (and nothing re-opened) **re-reviews** on the next iteration instead of converging — bounded by `MAX_REVIEW_ITERATIONS`. GO still converges immediately; a posted-thread NO-GO still runs the address step (and stops if the address step resolves nothing).
- `state:skip` is applied only on **TRUE iteration exhaustion** (ran all `MAX_REVIEW_ITERATIONS` without GO), not on a single iteration-0 AMBIGUOUS/NO-GO. Removed the premature `is_ambiguous` immediate-skip.

Gives a transient/garbage review `MAX_REVIEW_ITERATIONS` chances instead of stranding a fixable PR after R0. Complements #1112 (which removed the false-POLICY-VIOLATION source).

## Tests
- `test_zero_thread_nogo_re_reviews_to_exhaustion` — persistent zero-thread NO-GO re-reviews to exhaustion (iters==3), never addresses.
- `test_iter0_zero_thread_nogo_re_reviews_not_skip_at_r0` — R0 NO-GO re-reviews → R1 GO converges, no skip.
- `test_ambiguous_zero_threads_re_reviews_then_skips_on_exhaustion` — AMBIGUOUS re-reviews to exhaustion, then skips.
- Unchanged: GO converges at R0; posted-thread NO-GO whose address step resolves nothing still breaks.

81 implementer-suite tests pass; `ruff` + `mypy` (342 files) clean.

Closes #1113