### PR TITLE
[Fix] automation: parse in-loop review verdict from prose, not the JSON summary

### DIFF
--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -92,9 +92,10 @@ def run_pr_review_analysis(
     Shared core of the standalone ``PRReviewer._run_analysis_session`` and the
     in-loop implementer review step (Stage 2, #28). Builds the PR-review
     analysis prompt, invokes the selected reviewer agent (Claude or Codex), and
-    returns the parsed ``{"comments", "summary"}`` dict. The reviewer prompt's
-    strict rubric emits a ``Grade:`` / ``Verdict:`` line inside ``summary`` so
-    callers can derive a verdict via
+    returns a dict with ``comments`` (inline findings), ``summary`` (the JSON
+    summary, posted as the review body), and ``review_text`` (the full reviewer
+    PROSE). The ``Verdict:`` line lives in the PROSE, NOT the summary — so
+    callers derive the verdict from ``review_text`` via
     :func:`~hephaestus.automation.claude_invoke.parse_review_verdict`.
 
     Args:
@@ -111,12 +112,17 @@ def run_pr_review_analysis(
         dry_run: When True, skip the agent call and return a placeholder dict.
 
     Returns:
-        Parsed analysis dict with ``"comments"`` and ``"summary"`` keys.
+        Parsed analysis dict with ``"comments"``, ``"summary"``, and
+        ``"review_text"`` (verdict-bearing prose) keys.
 
     """
     if dry_run:
         logger.info("[DRY RUN] Would run analysis session for PR #%s", pr_number)
-        return {"comments": [], "summary": "[DRY RUN] analysis skipped"}
+        return {
+            "comments": [],
+            "summary": "[DRY RUN] analysis skipped",
+            "review_text": "Verdict: GO\n",
+        }
 
     prompt = get_pr_review_analysis_prompt(
         pr_number=pr_number,
@@ -145,6 +151,10 @@ def run_pr_review_analysis(
             )
             log_file.write_text(result.stdout or "")
             parsed = _parse_json_block(result.stdout or "")
+            # The Verdict:/Grade: line lives in the reviewer PROSE, not the JSON
+            # summary block. Surface the raw output so callers parse the real
+            # verdict (parse_review_verdict) instead of the verdict-free summary.
+            parsed["review_text"] = result.stdout or ""
             logger.info(
                 "Analysis complete for PR #%s; found %s inline comment(s)",
                 pr_number,
@@ -181,6 +191,11 @@ def run_pr_review_analysis(
             response_text = stdout or ""
 
         parsed = _parse_json_block(response_text)
+        # The Verdict:/Grade: line lives in the reviewer PROSE (response_text),
+        # NOT the JSON summary block. Surface it so callers parse the real
+        # verdict via parse_review_verdict rather than the verdict-free summary
+        # (else a well-formed `Verdict: NOGO` is misread as AMBIGUOUS).
+        parsed["review_text"] = response_text
         logger.info(
             "Analysis complete for PR #%s; found %s inline comment(s)",
             pr_number,
@@ -275,8 +290,15 @@ def review_pr_inline(
     iteration (``reviewer_agent(AGENT_PR_REVIEWER, iteration)``) so the reviewer
     never inherits its own prior verdict, posts the analysis findings as inline
     PR review threads via :func:`gh_pr_review_post`, and returns the reviewer's
-    summary text (carrying the ``Grade:`` / ``Verdict:`` line) plus the IDs of
-    the threads it created.
+    VERDICT-BEARING PROSE (carrying the ``Verdict:`` line) plus the IDs of the
+    threads it created.
+
+    The verdict (``Verdict: GO|NOGO``) lives in the reviewer prose, NOT in the
+    JSON ``summary`` field — so this returns ``review_text`` (the prose), which
+    the caller feeds to :func:`parse_review_verdict`. The (verdict-free) JSON
+    ``summary`` is still what gets POSTED to GitHub as the review body. Returning
+    ``summary`` here instead would make every well-formed ``Verdict: NOGO`` parse
+    as AMBIGUOUS.
 
     Args:
         pr_number: GitHub PR number to review.
@@ -289,8 +311,9 @@ def review_pr_inline(
         dry_run: When True, skip the agent call and posting.
 
     Returns:
-        ``(summary_text, posted_thread_ids)``. On dry-run, returns the
-        placeholder summary and an empty list.
+        ``(review_text, posted_thread_ids)`` where ``review_text`` is the
+        verdict-bearing reviewer prose. On dry-run, returns a verdict-bearing
+        placeholder and an empty list.
 
     """
     review_token = reviewer_agent(AGENT_PR_REVIEWER, iteration)
@@ -306,6 +329,9 @@ def review_pr_inline(
     )
     comments: list[dict[str, Any]] = analysis.get("comments", [])
     summary: str = analysis.get("summary", "")
+    # The verdict lives in the prose; fall back to summary only if review_text is
+    # somehow absent (keeps the loop functioning rather than KeyError-ing).
+    review_text: str = analysis.get("review_text") or summary
 
     if dry_run:
         logger.info(
@@ -313,7 +339,7 @@ def review_pr_inline(
             len(comments),
             pr_ref(pr_number),
         )
-        return summary, []
+        return review_text, []
 
     thread_ids = gh_pr_review_post(
         pr_number=pr_number,
@@ -330,7 +356,7 @@ def review_pr_inline(
         len(thread_ids),
         pr_ref(pr_number),
     )
-    return summary, thread_ids
+    return review_text, thread_ids
 
 
 class PRReviewer(BaseReviewer):

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -527,3 +527,77 @@ class TestReviewPrInline:
             )
         assert thread_ids == []
         mock_post.assert_not_called()
+
+
+class TestVerdictFromProseNotSummary:
+    """The verdict (Verdict: GO/NOGO) lives in the review PROSE, not the JSON summary.
+
+    Regression for the AMBIGUOUS misread: review_pr_inline must return the
+    verdict-bearing prose so parse_review_verdict sees `Verdict: NOGO`, even
+    though the JSON `summary` field (posted to GitHub) carries no verdict line.
+    """
+
+    def test_run_analysis_surfaces_review_text_with_verdict(self, tmp_path: Path) -> None:
+        """run_pr_review_analysis returns the prose body (carrying Verdict:) as review_text."""
+        prose = (
+            "## Review\nFindings here.\n\n"
+            "Verdict: NOGO — two real defects.\n\n"
+            '```json\n{"comments": [], "summary": "two defects (no verdict here)"}\n```'
+        )
+        # Claude wraps the prose in a JSON result envelope.
+        envelope = json.dumps({"result": prose})
+
+        def _fake_invoke(**_: object) -> tuple[str, str]:
+            return (envelope, "")
+
+        with (
+            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
+            patch("hephaestus.automation.pr_reviewer.get_repo_slug", return_value="Repo"),
+            patch(
+                "hephaestus.automation.pr_reviewer.invoke_claude_with_session",
+                side_effect=_fake_invoke,
+            ),
+        ):
+            out = run_pr_review_analysis(
+                pr_number=1,
+                issue_number=1,
+                worktree_path=tmp_path,
+                context={"pr_diff": "d"},
+                agent="claude",
+                state_dir=tmp_path,
+                dry_run=False,
+            )
+        # summary is the JSON field (no verdict); review_text is the prose (has verdict).
+        assert out["summary"] == "two defects (no verdict here)"
+        assert "Verdict: NOGO" in out["review_text"]
+
+    def test_review_pr_inline_returns_verdict_text_not_summary(self, tmp_path: Path) -> None:
+        """review_pr_inline returns the verdict-bearing prose, so the loop parses NOGO."""
+        from hephaestus.automation.claude_invoke import parse_review_verdict
+
+        analysis = {
+            "comments": [
+                {"path": "a.py", "line": 1, "side": "RIGHT", "severity": "major", "body": "x"}
+            ],
+            "summary": "a defect (no verdict token here)",
+            "review_text": "## Review\nProse.\n\nVerdict: NOGO — a real defect.\n",
+        }
+        with (
+            patch(
+                "hephaestus.automation.pr_reviewer.run_pr_review_analysis", return_value=analysis
+            ),
+            patch("hephaestus.automation.pr_reviewer.gh_pr_review_post", return_value=["thread-1"]),
+        ):
+            review_text, thread_ids = review_pr_inline(
+                pr_number=1,
+                issue_number=1,
+                worktree_path=tmp_path,
+                context={},
+                agent="claude",
+                iteration=0,
+                state_dir=tmp_path,
+                dry_run=False,
+            )
+        # The returned text must carry the verdict so the loop reads NOGO, not AMBIGUOUS.
+        assert parse_review_verdict(review_text).verdict == "NOGO"
+        assert thread_ids == ["thread-1"]


### PR DESCRIPTION
## Summary

After #1112 removed the policy-check block, the in-loop reviewer emits a well-formed `Verdict: NOGO`/`GO` line in its **prose** — but the loop logged `Verdict=AMBIGUOUS` and could never converge on GO.

**Observed live** (issue #725 → PR #996): the reviewer wrote a genuinely good review with `Verdict: NOGO` and 2 correct inline findings (TECH_DEBT.md falsely bans all TODOs vs. the existing `# TODO(#710)`; broken `docs/COMPATIBILITY.md` path), posted 2 threads — yet `parse_review_verdict` returned **AMBIGUOUS**.

**Root cause:** `review_pr_inline()` returned `analysis["summary"]` (the one-line JSON `summary` field), which `_run_impl_review_step` fed to `parse_review_verdict`. But the `Verdict:` line lives in the reviewer **prose** (`result`), not the `summary`. `run_pr_review_analysis` parsed the prose only for the JSON comment block and discarded the rest — so the verdict text never reached the parser. (Masked before #1112, which crammed everything into the summary.)

## Fix
- `run_pr_review_analysis` returns a `review_text` key = the full reviewer prose (Claude `result` / Codex stdout / dry-run placeholder), alongside `comments` + `summary`.
- `review_pr_inline` returns `review_text` (verdict-bearing prose) instead of `summary`, so the loop's `parse_review_verdict` reads the real `Verdict:` line. The (verdict-free) JSON `summary` is still POSTED to GitHub as the review body.

Completes the review-loop chain (#1112 removed the false policy verdict; #1114 stopped the zero-thread R0 converge): the loop can now reach a real GO/NOGO and drive the address/implement step.

## Tests
- `TestVerdictFromProseNotSummary` — `run_pr_review_analysis` surfaces `review_text` carrying `Verdict:`; `review_pr_inline` returns prose so `parse_review_verdict` reads NOGO (not AMBIGUOUS) when the summary has no verdict.

73 pr_reviewer/implementer-loop tests pass; `ruff` + `mypy` (342 files) clean.

Closes #1115