### PR TITLE
fix(automation): guard drive-green pushes

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2041,6 +2041,25 @@ class CIDriver:
             if c.get("status") == "completed" and c.get("conclusion") == "failure"
         ]
 
+    def _tracked_worktree_changes(self, worktree_path: Path, issue_number: int) -> list[str]:
+        """Return tracked dirty status lines for a post-agent worktree.
+
+        Untracked tool output such as a local ``uv.lock`` is intentionally
+        ignored. A no-commit turn that left tracked files modified is still
+        actionable even when the remote has no red required checks, as happens
+        for merge-conflict/behind-branch repairs where the agent fixed files but
+        forgot the signed commit.
+        """
+        status = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "status", "--porcelain"],
+            "failed to inspect worktree status for no-commit retry",
+        )
+        if status is None:
+            return []
+        return [line for line in status.splitlines() if line.strip() and not line.startswith("?? ")]
+
     def _pending_required_check_names(self, pr_number: int) -> list[str]:
         """Return names of required checks that are still in flight (not completed).
 
@@ -2073,31 +2092,48 @@ class CIDriver:
         pr_head_branch: str,
         failing_check_names: list[str],
         review_threads_block: str,
+        dirty_tracked_changes: list[str] | None = None,
     ) -> str:
         """Build the retry prompt when the agent returned without committing (#846).
 
         The retry must engage the agent enough to either (a) produce a real
-        fix or (b) explicitly say why CI cannot pass. The prompt names the
-        failing checks verbatim, re-emphasises the existing PR/branch
-        invariant, and re-emphasises signed commits — a no-commit retry is a
-        contract violation that the agent has to address head-on.
+        fix or (b) explicitly say why CI cannot pass / merge. The prompt names
+        the failing checks and/or dirty tracked files verbatim, re-emphasises
+        the existing PR/branch invariant, and re-emphasises signed commits — a
+        no-commit retry is a contract violation that the agent has to address
+        head-on.
         """
         failing_block = "\n".join(f"- {n}" for n in failing_check_names) or "- (unknown)"
+        dirty_lines = dirty_tracked_changes or []
+        dirty_block = "\n".join(f"- {line}" for line in dirty_lines)
+        if dirty_block:
+            dirty_block = (
+                "\n\nThe local worktree also contains uncommitted tracked changes "
+                "from the previous turn. Review this existing diff first and either "
+                f"commit it after verification or amend it before committing:\n\n{dirty_block}\n"
+            )
+        remote_block = (
+            "The required CI checks below are STILL failing on the remote"
+            if failing_check_names
+            else "The remote checks may be green, but the PR still needs a committed "
+            "repair before the driver can push"
+        )
         return (
             f"{review_threads_block}"
             f"## Force-Engagement Retry — Previous Turn Produced No Commit\n\n"
             f"You just returned from a CI-fix session for PR {pr_ref(pr_number)} "
             f"(issue {issue_ref(issue_number)}) WITHOUT producing a new commit on "
-            f"branch `{pr_head_branch}`. The required CI checks below are STILL "
-            f"failing on the remote:\n\n"
+            f"branch `{pr_head_branch}`. {remote_block}:\n\n"
             f"{failing_block}\n\n"
+            f"{dirty_block}"
             f"Returning no commit when required checks are still red is itself a "
-            f"bug — fix the code so the failing checks pass. If no code fix is "
-            f"possible, DO NOT commit a 'blocker' file: a new Markdown/docs file "
-            f"will itself fail the repo's lint gates (e.g. markdownlint) and turn "
-            f"one red check into two. Instead leave the tree unchanged and report "
-            f"the blocker via the `BLOCKED:` line below — do NOT commit any file to "
-            f"document it.\n\n"
+            f"bug; returning no commit after editing tracked files is also a bug. "
+            f"Fix the code so the failing checks pass and the PR can merge. If no "
+            f"code fix is possible, DO NOT commit a 'blocker' file: a new "
+            f"Markdown/docs file will itself fail the repo's lint gates (e.g. "
+            f"markdownlint) and turn one blocker into two. Instead leave the tree "
+            f"unchanged and report the blocker via the `BLOCKED:` line below — do "
+            f"NOT commit any file to document it.\n\n"
             f"Working directory: {worktree_path}\n"
             f"Current branch (DO NOT change, DO NOT create a new branch): "
             f"{pr_head_branch}\n\n"
@@ -2206,10 +2242,11 @@ class CIDriver:
         failing: list[str] = []
         for retry in range(1, max_retries + 1):
             failing = self._failing_required_check_names(pr_number)
-            if not failing:
+            dirty_tracked_changes = self._tracked_worktree_changes(worktree_path, issue_number)
+            if not failing and not dirty_tracked_changes:
                 logger.info(
-                    "Issue #%s: no-commit turn but PR #%s has no failing required "
-                    "checks; skipping force-engagement retry",
+                    "Issue #%s: no-commit turn but PR #%s has no failing required checks "
+                    "and no tracked worktree changes; skipping force-engagement retry",
                     issue_number,
                     pr_number,
                 )
@@ -2222,16 +2259,18 @@ class CIDriver:
                 worktree_path=worktree_path,
                 pr_head_branch=pr_head_branch,
                 failing_check_names=failing,
+                dirty_tracked_changes=dirty_tracked_changes,
                 review_threads_block=review_threads_block,
             )
 
+            retry_reason = ", ".join(failing) if failing else "tracked worktree changes"
             logger.warning(
                 "Issue #%s: no-commit on CI fix turn; re-invoking with "
-                "force-engagement prompt (retry %s/%s, failing: %s)",
+                "force-engagement prompt (retry %s/%s, reason: %s)",
                 issue_number,
                 retry,
                 max_retries,
-                ", ".join(failing) or "<unknown>",
+                retry_reason,
             )
 
             try:

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2815,17 +2815,6 @@ class CIDriver:
             True if the learnings session completed, False otherwise.
 
         """
-        # The Claude path resumes the deterministic AGENT_CI_DRIVER session via
-        # invoke_claude_with_session. Codex drive-green sessions are not
-        # persisted by this module, so there is no Session 3 to resume there.
-        if is_codex(self.options.agent):
-            logger.info(
-                "Issue #%s: skipping drive-green learnings (codex has no persisted "
-                "drive-green session to resume)",
-                issue_number,
-            )
-            return False
-
         prompt = (
             "/skills-registry-commands:learn "
             f"You just drove PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}) "
@@ -2853,6 +2842,15 @@ class CIDriver:
                     wt_err,
                 )
                 cwd = self.repo_root
+            if is_codex(self.options.agent):
+                run_codex_session(
+                    prompt,
+                    cwd=cwd,
+                    timeout=learn_claude_timeout(),
+                    sandbox="workspace-write",
+                )
+                logger.info("Issue #%s: drive-green learnings captured with Codex", issue_number)
+                return True
             invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -60,7 +60,7 @@ from .github_api import (
     gh_pr_list_unresolved_threads,
     gh_pr_resolve_thread,
 )
-from .learn import compact_session
+from .learn import build_learn_prompt, compact_session
 from .models import CIDriverOptions, WorkerResult
 from .pr_manager import pr_has_implementation_go_label
 from .prompts import get_advise_prompt_builder
@@ -2815,13 +2815,10 @@ class CIDriver:
             True if the learnings session completed, False otherwise.
 
         """
-        prompt = (
-            "/skills-registry-commands:learn "
+        prompt = build_learn_prompt(
             f"You just drove PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}) "
             "to green CI. Capture concise learnings about what made CI fail and how "
-            "you fixed it, scoped to this issue/PR. Commit the results and create a PR. "
-            "IMPORTANT: Only push skills to ProjectMnemosyne. "
-            "Do NOT create files under .claude-plugin/ in this repo."
+            "you fixed it, scoped to this issue/PR."
         )
         try:
             repo_slug = get_repo_slug(self.repo_root)

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2366,6 +2366,110 @@ class CIDriver:
             return False
         return True
 
+    def _git_stdout_for_push_guard(
+        self,
+        worktree_path: Path,
+        issue_number: int,
+        argv: list[str],
+        failure_message: str,
+    ) -> str | None:
+        """Run a git inspection command for the CI pre-push guard."""
+        try:
+            result = run(argv, cwd=worktree_path, capture_output=True, check=False)
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: %s: %s",
+                issue_number,
+                failure_message,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return None
+        if result.returncode != 0:
+            logger.error(
+                "Issue #%s: %s: %s",
+                issue_number,
+                failure_message,
+                (result.stderr or result.stdout or "")[:300],
+            )
+            return None
+        return result.stdout or ""
+
+    def _ci_fix_head_is_pushable(
+        self,
+        worktree_path: Path,
+        issue_number: int,
+        *,
+        base_ref: str = "origin/main",
+    ) -> bool:
+        """Return True when the post-agent worktree is safe to push.
+
+        ``_head_advanced`` only proves HEAD changed. A conflict-resolution agent
+        can still leave the index unmerged, leave tracked files uncommitted, or
+        accidentally detach at the base branch itself. None of those states may
+        be pushed to the PR head.
+        """
+        unmerged = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "diff", "--name-only", "--diff-filter=U"],
+            "failed to inspect merge state before push",
+        )
+        if unmerged is None:
+            return False
+        unmerged_paths = [line for line in unmerged.splitlines() if line.strip()]
+        if unmerged_paths:
+            logger.error(
+                "Issue #%s: refusing to push CI fix with unresolved merge paths: %s",
+                issue_number,
+                ", ".join(unmerged_paths[:10]),
+            )
+            return False
+
+        status = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "status", "--porcelain"],
+            "failed to inspect worktree status before push",
+        )
+        if status is None:
+            return False
+        tracked_dirty = [
+            line for line in status.splitlines() if line.strip() and not line.startswith("?? ")
+        ]
+        if tracked_dirty:
+            logger.error(
+                "Issue #%s: refusing to push CI fix with uncommitted tracked changes: %s",
+                issue_number,
+                ", ".join(tracked_dirty[:10]),
+            )
+            return False
+
+        ahead = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+            f"failed to inspect HEAD ahead of {base_ref} before push",
+        )
+        if ahead is None:
+            return False
+        try:
+            ahead_count = int(ahead.strip() or "0")
+        except ValueError:
+            logger.error(
+                "Issue #%s: refusing to push CI fix with invalid ahead count: %r",
+                issue_number,
+                ahead,
+            )
+            return False
+        if ahead_count <= 0:
+            logger.error(
+                "Issue #%s: refusing to push CI fix because HEAD has no commits ahead of %s",
+                issue_number,
+                base_ref,
+            )
+            return False
+        return True
+
     def _run_ci_fix_session(  # noqa: C901  # provider resume/fallback paths are intentionally coupled
         self,
         issue_number: int,
@@ -2517,6 +2621,8 @@ class CIDriver:
                         session_id=session_id,
                     ):
                         return False
+                if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
+                    return False
                 try:
                     push_current_branch_with_lease_on_divergence(
                         worktree_path,
@@ -2580,6 +2686,8 @@ class CIDriver:
                         session_id=session_id,
                     ):
                         return False
+                if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
+                    return False
                 try:
                     push_current_branch_with_lease_on_divergence(
                         worktree_path,

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1560,6 +1560,7 @@ _REVIEW_COMMENT_DEDUPE_STOPWORDS = {
     "coverage",
     "current",
     "future",
+    "only",
     "please",
     "production",
     "proves",
@@ -1573,6 +1574,18 @@ _REVIEW_COMMENT_DEDUPE_STOPWORDS = {
     "with",
     "without",
     "would",
+}
+
+_REVIEW_COMMENT_SIGNATURE_TOKENS = {
+    "claude",
+    "codex",
+    "is_codex",
+    "review_text",
+    "run_codex_text",
+    "stderr",
+    "stdout",
+    "summary",
+    "verdict",
 }
 
 
@@ -1589,11 +1602,15 @@ def _review_comment_keyword_tokens(body: str) -> set[str]:
     normalized = _normalize_review_comment_body(body)
     tokens: set[str] = set()
     for token in re.findall(r"[a-z0-9_#./-]+", normalized):
-        if len(token) < 4 and not token.startswith("#"):
-            continue
-        if token in _REVIEW_COMMENT_DEDUPE_STOPWORDS:
-            continue
-        tokens.add(token)
+        candidates = [token]
+        if any(sep in token for sep in "./-"):
+            candidates.extend(part for part in re.split(r"[./-]+", token) if part)
+        for candidate in candidates:
+            if len(candidate) < 4 and not candidate.startswith("#"):
+                continue
+            if candidate in _REVIEW_COMMENT_DEDUPE_STOPWORDS:
+                continue
+            tokens.add(candidate)
     return tokens
 
 
@@ -1620,6 +1637,9 @@ def _review_comment_already_covers(existing_body: str, new_body: str) -> bool:
             # a shorter restatement of the same finding is still suppressed.
             overlap_ratio = len(overlap) / min(len(existing_tokens), len(new_tokens))
             if len(overlap) >= 6 and overlap_ratio >= 0.6:
+                return True
+            signature_overlap = overlap & _REVIEW_COMMENT_SIGNATURE_TOKENS
+            if len(overlap) >= 6 and len(signature_overlap) >= 3:
                 return True
     return False
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1434,7 +1434,10 @@ def gh_current_login() -> str | None:
     return login or None
 
 
-def gh_pr_inline_comment_index(pr_number: int) -> dict[tuple[str, Any], tuple[str, str]]:
+ReviewCommentIndexKey = tuple[str, Any] | tuple[str, Any, str]
+
+
+def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tuple[str, str]]:
     """Map ``(path, line)`` → ``(comment_node_id, body)`` for unresolved bot threads.
 
     Returns the GraphQL node id AND current body of the FIRST comment of each
@@ -1456,7 +1459,8 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[tuple[str, Any], tuple[st
         "  repository(owner:$owner,name:$name){"
         "    pullRequest(number:$number){"
         "      reviewThreads(first:100){"
-        "        nodes{ isResolved path line comments(first:1){ nodes{ id body } } }"
+        "        nodes{ isResolved path line side:diffSide "
+        "comments(first:1){ nodes{ id body } } }"
         "      }"
         "    }"
         "  }"
@@ -1490,7 +1494,7 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[tuple[str, Any], tuple[st
         .get("reviewThreads", {})
         .get("nodes", [])
     )
-    index: dict[tuple[str, Any], tuple[str, str]] = {}
+    index: dict[ReviewCommentIndexKey, tuple[str, str]] = {}
     for node in nodes:
         if node.get("isResolved"):
             continue
@@ -1501,7 +1505,13 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[tuple[str, Any], tuple[st
         if not comment_id:
             continue
         body = comment_nodes[0].get("body") or ""
-        index[(node.get("path") or "", node.get("line"))] = (comment_id, body)
+        path = node.get("path") or ""
+        line = node.get("line")
+        side = node.get("side") or "RIGHT"
+        index[(path, line, side)] = (comment_id, body)
+        # Preserve the older key shape for callers/tests that predate diff-side
+        # support, and as a fallback if GitHub ever omits ``diffSide``.
+        index.setdefault((path, line), (comment_id, body))
     return index
 
 
@@ -1631,8 +1641,10 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
         return comments
     fresh: list[dict[str, Any]] = []
     for c in comments:
-        key = (c.get("path") or "", c.get("line"))
-        existing = index.get(key)
+        path = c.get("path") or ""
+        line = c.get("line")
+        side = c.get("side") or "RIGHT"
+        existing = index.get((path, line, side)) or index.get((path, line))
         if existing is None:
             fresh.append(c)
             continue
@@ -1643,28 +1655,31 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
         body = c.get("body") or ""
         if _review_comment_already_covers(existing_body, body):
             logger.info(
-                "PR #%s: skipped duplicate same-line review comment on %s:%s",
+                "PR #%s: skipped duplicate same-line review comment on %s:%s (%s)",
                 pr_number,
-                key[0],
-                key[1],
+                path,
+                line,
+                side,
             )
             continue
         combined = f"{existing_body}{_ADDITIONAL_REVIEW_NOTE_DELIMITER}{body}"
         try:
             gh_pr_update_review_comment(existing_id, combined)
             logger.info(
-                "PR #%s: edited existing comment on %s:%s instead of duplicating",
+                "PR #%s: edited existing comment on %s:%s (%s) instead of duplicating",
                 pr_number,
-                key[0],
-                key[1],
+                path,
+                line,
+                side,
             )
         except (OSError, subprocess.SubprocessError) as exc:
             # If the edit fails, fall back to posting the comment fresh.
             logger.warning(
-                "PR #%s: edit-in-place failed for %s:%s (%s); posting fresh",
+                "PR #%s: edit-in-place failed for %s:%s (%s): %s; posting fresh",
                 pr_number,
-                key[0],
-                key[1],
+                path,
+                line,
+                side,
                 exc,
             )
             fresh.append(c)
@@ -1881,8 +1896,8 @@ def gh_pr_list_unresolved_threads(
 
     Returns:
         List of thread dicts with keys: id (str), path (str), line (int | None),
-        body (str), author (str — the first comment's author login, ``""`` if
-        unknown).
+        side (str), body (str), author (str — the first comment's author login,
+        ``""`` if unknown), authors (list[str]), comments (list[dict]).
 
     """
     if dry_run:
@@ -1901,8 +1916,8 @@ def gh_pr_list_unresolved_threads(
         "  repository(owner:$owner,name:$name){"
         "    pullRequest(number:$number){"
         "      reviewThreads(first:100){"
-        "        nodes{ id isResolved path line "
-        "comments(first:1){ nodes{ body author{ login } } } }"
+        "        nodes{ id isResolved path line side:diffSide "
+        "comments(first:20){ nodes{ body author{ login } } } }"
         "      }"
         "    }"
         "  }"
@@ -1938,20 +1953,30 @@ def gh_pr_list_unresolved_threads(
     for node in nodes:
         if node.get("isResolved"):
             continue
-        first_comment_nodes = node.get("comments", {}).get("nodes", [])
-        first_comment = first_comment_nodes[0] if first_comment_nodes else {}
+        comment_nodes = node.get("comments", {}).get("nodes", [])
+        first_comment = comment_nodes[0] if comment_nodes else {}
         body = first_comment.get("body", "")
-        author = ""
-        author_node = first_comment.get("author")
-        if isinstance(author_node, dict):
-            author = author_node.get("login") or ""
+        comments: list[dict[str, str]] = []
+        authors: list[str] = []
+        for comment in comment_nodes:
+            comment_author = ""
+            author_node = comment.get("author")
+            if isinstance(author_node, dict):
+                comment_author = author_node.get("login") or ""
+            if comment_author:
+                authors.append(comment_author)
+            comments.append({"body": comment.get("body") or "", "author": comment_author})
+        author = authors[0] if authors else ""
         threads.append(
             {
                 "id": node["id"],
                 "path": node.get("path", ""),
                 "line": node.get("line"),
+                "side": node.get("side") or "RIGHT",
                 "body": body,
                 "author": author,
+                "authors": authors,
+                "comments": comments,
             }
         )
 

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -633,7 +633,7 @@ class IssueImplementer:
         issue_title: str,
         issue_body: str,
         worktree_path: Path,
-    ) -> None:
+    ) -> str:
         """Advise turn 1 of the implementer session (delegates to runner)."""
         return self.phase_runner._run_advise_as_implementer_turn(
             issue_number, issue_title, issue_body, worktree_path
@@ -652,6 +652,7 @@ class IssueImplementer:
         thread_id: int | None,
         state: ImplementationState | None = None,
         pr_number: int | None = None,
+        advise_findings: str = "",
     ) -> tuple[int, str | None, str | None]:
         """Run the bounded review loop for an implementation."""
         return self.phase_runner._run_impl_review_loop(
@@ -665,6 +666,7 @@ class IssueImplementer:
             thread_id=thread_id,
             state=state,
             pr_number=pr_number,
+            advise_findings=advise_findings,
         )
 
     def _run_impl_review_step(
@@ -678,6 +680,7 @@ class IssueImplementer:
         pr_number: int | None,
         iteration: int,
         prior_review: str | None,
+        advise_findings: str = "",
     ) -> tuple[str, list[str]]:
         """Run one in-loop review (posts inline PR threads) and return its verdict."""
         return self.phase_runner._run_impl_review_step(
@@ -689,6 +692,7 @@ class IssueImplementer:
             pr_number=pr_number,
             iteration=iteration,
             prior_review=prior_review,
+            advise_findings=advise_findings,
         )
 
     def _run_address_review_step(

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -136,10 +136,22 @@ def _prepend_advise(advise_findings: str, prompt: str) -> str:
 
 def _is_automation_owned_thread(thread: dict[str, Any], current_login: str | None) -> bool:
     """Return True for unresolved review threads the automation may resolve on GO."""
+    authors = {str(author).strip() for author in thread.get("authors", []) if str(author).strip()}
     author = (thread.get("author") or "").strip()
-    if current_login and author == current_login:
+    if author:
+        authors.add(author)
+    for comment in thread.get("comments", []):
+        comment_author = (comment.get("author") or "").strip()
+        if comment_author:
+            authors.add(comment_author)
+
+    if current_login and current_login in authors:
         return True
-    return author.endswith("[bot]")
+    automation_bot_logins = {
+        "github-actions[bot]",
+        "hephaestus[bot]",
+    }
+    return bool(authors & automation_bot_logins)
 
 
 def _claude_quota_reset_epoch(*texts: str) -> int | None:

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -393,9 +393,10 @@ class ImplementationPhaseRunner:
             # and are automatically visible to the implementation turn that
             # follows via --resume.  For Codex agents the old separate-session
             # path is retained because Codex has no multi-turn session model.
+            implementation_advise_findings = ""
             if self.options.enable_advise and not is_codex(self.options.agent):
                 self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
-                impl._run_advise_as_implementer_turn(
+                implementation_advise_findings = impl._run_advise_as_implementer_turn(
                     issue_number, issue.title, issue.body, worktree_path
                 )
 
@@ -408,6 +409,7 @@ class ImplementationPhaseRunner:
             if self.options.enable_advise and is_codex(self.options.agent):
                 self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
                 codex_advise_findings = impl._run_advise(issue_number, issue.title, issue.body)
+                implementation_advise_findings = codex_advise_findings
 
             session_id = impl._run_claude_code(
                 issue_number,
@@ -458,6 +460,7 @@ class ImplementationPhaseRunner:
                 thread_id=thread_id,
                 state=state,
                 pr_number=pr_number,
+                advise_findings=implementation_advise_findings,
             )
             with self.state_lock:
                 state.review_iterations = iterations
@@ -964,7 +967,7 @@ class ImplementationPhaseRunner:
         issue_title: str,
         issue_body: str,
         worktree_path: Path,
-    ) -> None:
+    ) -> str:
         """Send the advise prompt as the first turn of the implementer's Claude session.
 
         Unlike :meth:`_run_advise`, which creates a separate ``AGENT_ADVISE``
@@ -984,8 +987,8 @@ class ImplementationPhaseRunner:
         deterministic session UUID auto-resumes so the advise findings accumulate
         across iterations.
 
-        Any failure degrades gracefully — the exception is logged and swallowed
-        so the caller can still proceed to the implementation turn.
+        Any failure degrades gracefully inside ``run_advise`` and returns an
+        empty string, so the caller can still proceed to the implementation turn.
         """
         _impl_mod = self._impl_module
         repo_slug = _impl_mod.get_repo_slug(self.repo_root)
@@ -1026,7 +1029,7 @@ class ImplementationPhaseRunner:
             )
             return (stdout or "").strip()
 
-        run_advise(
+        return run_advise(
             issue_number=issue_number,
             issue_title=issue_title,
             issue_body=issue_body,
@@ -1196,12 +1199,17 @@ class ImplementationPhaseRunner:
 
         # Advise-first (#30): same two-turn pattern as the fresh-implementation path.
         # For Claude: advise as turn 1 of AGENT_IMPLEMENTER (cwd=worktree_path).
-        # For Codex: skip — no injection point in the review-loop path.
+        # For Codex: run advise separately and inject the findings into the
+        # review-loop context.
+        implementation_advise_findings = ""
         if self.options.enable_advise and not is_codex(self.options.agent):
             self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
-            impl._run_advise_as_implementer_turn(
+            implementation_advise_findings = impl._run_advise_as_implementer_turn(
                 issue_number, issue.title, issue.body, worktree_path
             )
+        elif self.options.enable_advise:
+            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
+            implementation_advise_findings = impl._run_advise(issue_number, issue.title, issue.body)
 
         iterations, last_verdict, last_grade = impl._run_impl_review_loop(
             issue_number=issue_number,
@@ -1214,6 +1222,7 @@ class ImplementationPhaseRunner:
             thread_id=thread_id,
             state=state,
             pr_number=existing_pr,
+            advise_findings=implementation_advise_findings,
         )
         with self.state_lock:
             state.review_iterations = iterations
@@ -1490,6 +1499,7 @@ class ImplementationPhaseRunner:
         thread_id: int | None,
         state: ImplementationState | None = None,
         pr_number: int | None = None,
+        advise_findings: str = "",
     ) -> tuple[int, str | None, str | None]:
         """Run the bounded in-loop review + address cycle for an implementation.
 
@@ -1547,6 +1557,7 @@ class ImplementationPhaseRunner:
                 pr_number=pr_number,
                 iteration=iteration,
                 prior_review=prior_review,
+                advise_findings=advise_findings,
             )
             impl._save_review_log(issue_number, iteration, review_text)
             iterations_run = iteration + 1
@@ -1764,6 +1775,7 @@ class ImplementationPhaseRunner:
         pr_number: int | None,
         iteration: int,
         prior_review: str | None,
+        advise_findings: str = "",
     ) -> tuple[str, list[str]]:
         """Run one in-loop review and return ``(review_text, posted_thread_ids)``.
 
@@ -1806,6 +1818,7 @@ class ImplementationPhaseRunner:
             plan_text=plan_text,
             plan_review_text=plan_review_text,
             diff_text=diff_text,
+            advise_findings=advise_findings,
             include_nitpicks=self.options.include_nitpicks,
         )
         try:

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -21,6 +21,19 @@ from .session_naming import session_uuid
 logger = logging.getLogger(__name__)
 
 
+def build_learn_prompt(context: str) -> str:
+    """Return the standard automation prompt for the user-facing /learn skill."""
+    detail = context.strip()
+    if detail:
+        detail = f" {detail}"
+    return (
+        f"/learn{detail}"
+        " Commit the results and create a PR."
+        " IMPORTANT: Only push skills to ProjectMnemosyne."
+        " Do NOT create files under .claude-plugin/ in this repo."
+    )
+
+
 def run_learn(
     session_id: str,
     worktree_path: Path,
@@ -66,12 +79,7 @@ def run_learn(
         try:
             codex_result = resume_codex_session(
                 session_id,
-                (
-                    "/skills-registry-commands:learn"
-                    " commit the results and create a PR."
-                    " IMPORTANT: Only push skills to ProjectMnemosyne."
-                    " Do NOT create files under .claude-plugin/ in this repo."
-                ),
+                build_learn_prompt(""),
                 cwd=worktree_path,
                 timeout=learn_claude_timeout(),
             )
@@ -97,12 +105,7 @@ def run_learn(
                 "claude",
                 "--resume",
                 session_id,
-                (
-                    "/skills-registry-commands:learn"
-                    " commit the results and create a PR."
-                    " IMPORTANT: Only push skills to ProjectMnemosyne."
-                    " Do NOT create files under .claude-plugin/ in this repo."
-                ),
+                build_learn_prompt(""),
                 "--print",
                 "--model",
                 effective_model,

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -413,6 +413,7 @@ class Planner:
         learnings: str,
         iteration: int,
         prior_review: str | None,
+        advise_findings: str = "",
     ) -> str:
         """Run reviewer pass (delegates to review_loop)."""
         return self.review_loop.run_plan_review(
@@ -423,6 +424,7 @@ class Planner:
             learnings=learnings,
             iteration=iteration,
             prior_review=prior_review,
+            advise_findings=advise_findings,
         )
 
     def _print_summary(self) -> None:

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -130,6 +130,7 @@ class PlannerHost(Protocol):
         learnings: str,
         iteration: int,
         prior_review: str | None,
+        advise_findings: str = "",
     ) -> str:
         """Run a reviewer pass on the current plan."""
         pass
@@ -268,6 +269,7 @@ class PlanReviewLoop:
                 learnings=learnings,
                 iteration=iteration,
                 prior_review=review_text,
+                advise_findings=cached_advise,
             )
 
             verdict = parse_review_verdict(review_text)
@@ -603,6 +605,7 @@ class PlanReviewLoop:
         learnings: str,
         iteration: int,
         prior_review: str | None,
+        advise_findings: str = "",
     ) -> str:
         """Run a reviewer pass on the current plan.
 
@@ -621,6 +624,8 @@ class PlanReviewLoop:
             learnings: Planner-captured learnings for this iteration.
             iteration: Iteration index (0, 1, or 2).
             prior_review: Previous iteration's review text, or ``None`` on iter 0.
+            advise_findings: Prior team learnings from ProjectMnemosyne, shared
+                with the plan reviewer so review also runs with advise context.
 
         Returns:
             Review text. On reviewer-call failure, returns a synthetic NoGo
@@ -635,6 +640,7 @@ class PlanReviewLoop:
             learnings=learnings,
             iteration=iteration,
             prior_review=prior_review,
+            advise_findings=advise_findings,
         )
         try:
             return self.planner._call_claude(

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -28,6 +28,7 @@ from .github_api import (
     gh_issue_remove_labels,
     gh_issue_upsert_comment,
 )
+from .learn import build_learn_prompt
 from .models import PLAN_COMMENT_MARKER
 from .prompts import get_plan_loop_review_prompt, get_plan_prompt
 from .review_state import PLAN_REVIEW_PREFIX
@@ -541,16 +542,16 @@ class PlanReviewLoop:
         return plan
 
     def capture_planner_learnings(self, issue_number: int, plan: str) -> str:
-        """Ask Claude to summarize what the planner just learned.
+        """Ask the planner session to run ``/learn`` for the plan it just wrote.
 
         Resumes the planner's own session (``AGENT_PLANNER``) rather than
         opening a separate learnings session, so the model still "remembers"
         the plan it just wrote and can introspect its own reasoning rather
-        than re-reading the plan cold. These learnings are passed to the
-        reviewer alongside the plan, giving the reviewer extra signal about
-        which aspects the planner is most/least confident in. Failure here is
-        non-fatal — return empty string and let the review proceed without
-        learnings.
+        than re-reading the plan cold. The prompt uses the user-facing
+        ``/learn`` skill command so the useful bits are written to
+        ProjectMnemosyne, then asks for short bullets to pass to the reviewer.
+        Failure here is non-fatal — return empty string and let the review
+        proceed without learnings.
 
         The pre-review learnings step inherits the planner's model
         (``planner_model()``) — /learn always runs on the same tier as the
@@ -564,18 +565,20 @@ class PlanReviewLoop:
             Bullet-point learnings text, or "" on any failure.
 
         """
-        prompt = (
+        context = (
             f"You just produced an implementation plan for GitHub issue "
             f"#{issue_number}. Below is the plan you wrote.\n\n"
-            "List 3-5 brief bullets describing:\n"
+            "Capture durable planning learnings for ProjectMnemosyne. Focus on:\n"
             "- The most uncertain assumptions in your plan\n"
             "- Any external sources, files, or APIs you relied on without "
             "directly verifying them\n"
             "- Risks the reviewer should focus on\n\n"
-            "Output only the bullets — no preamble, no headers.\n\n"
+            "After the /learn update, reply with only 3-5 brief bullets for the "
+            "plan reviewer — no preamble, no headers.\n\n"
             "---\n\n"
             f"{plan}"
         )
+        prompt = build_learn_prompt(context)
         try:
             return self.planner._call_claude(
                 prompt,

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -128,6 +128,7 @@ def run_pr_review_analysis(
         issue_body=context.get("issue_body", ""),
         ci_status=context.get("ci_status", ""),
         pr_description=context.get("pr_description", ""),
+        advise_findings=context.get("advise_findings", ""),
         # #1083: nitpicks are suppressed unless --nitpick threaded the flag into
         # the review context.
         include_nitpicks=bool(context.get("include_nitpicks", False)),
@@ -224,6 +225,7 @@ def gather_impl_review_context(
     plan_text: str,
     plan_review_text: str,
     diff_text: str,
+    advise_findings: str = "",
     include_nitpicks: bool = False,
 ) -> dict[str, Any]:
     """Assemble the PR-review context for an in-loop implementer review.
@@ -242,6 +244,7 @@ def gather_impl_review_context(
         plan_text: The implementation PLAN comment body (or "" if absent).
         plan_review_text: The PLAN_REVIEW comment body (or "" if absent).
         diff_text: ``gh pr diff`` / cumulative branch diff for the impl.
+        advise_findings: Prior ProjectMnemosyne findings from the advise step.
         include_nitpicks: Forwarded into the context so the reviewer prompt
             emits nitpick-severity comments only when ``--nitpick`` is set
             (#1083).
@@ -264,6 +267,7 @@ def gather_impl_review_context(
         "ci_status": "",
         "review_comments": "",
         "pr_description": "",
+        "advise_findings": advise_findings,
         "include_nitpicks": include_nitpicks,
     }
 

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -192,6 +192,11 @@ actually addressed in the current plan.
 
 ---
 
+**Prior Team Learnings for this review (untrusted):**
+{advise_findings_block}
+
+---
+
 **Current Plan (untrusted):**
 {plan_text_block}
 
@@ -254,6 +259,7 @@ def get_plan_loop_review_prompt(
     learnings: str,
     iteration: int,
     prior_review: str | None,
+    advise_findings: str = "",
 ) -> str:
     """Build the iteration-aware plan-loop review prompt.
 
@@ -265,6 +271,8 @@ def get_plan_loop_review_prompt(
         learnings: Learnings captured by the planner this iteration.
         iteration: Iteration index (0, 1, or 2).
         prior_review: Previous iteration's review text, or ``None`` on iter 0.
+        advise_findings: Prior team learnings from the advise step to give the
+            reviewer the same ProjectMnemosyne context the planner received.
 
     Returns:
         Formatted prompt for a fresh reviewer session.
@@ -280,6 +288,11 @@ def get_plan_loop_review_prompt(
         issue_number=issue_number,
         issue_title=issue_title,
         issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
+        advise_findings_block=_fence_untrusted(
+            "ADVISE_FINDINGS",
+            advise_findings or "_(no prior advise findings supplied)_",
+            nonce,
+        ),
         plan_text_block=_fence_untrusted("PLAN_TEXT", plan_text, nonce),
         learnings=learnings or "_(no learnings captured this iteration)_",
         prior_review_block=_prior_review_block(prior_review),

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -17,6 +17,9 @@ Analyze PR #{pr_number} linked to issue #{issue_number}.
 **Issue Description (untrusted):**
 {issue_body_block}
 
+**Prior Team Learnings for this review (untrusted):**
+{advise_findings_block}
+
 **PR Description (untrusted):**
 {pr_description_block}
 
@@ -105,6 +108,7 @@ def get_pr_review_analysis_prompt(
     issue_body: str = "",
     ci_status: str = "",
     pr_description: str = "",
+    advise_findings: str = "",
     include_nitpicks: bool = False,
 ) -> str:
     """Get the PR review analysis prompt for generating inline review comments.
@@ -123,6 +127,8 @@ def get_pr_review_analysis_prompt(
         issue_body: Issue body/description
         ci_status: CI check status summary
         pr_description: PR description body
+        advise_findings: Prior team learnings from ProjectMnemosyne to give the
+            reviewer continuity with the advise-first implementation turn.
         include_nitpicks: When False (default), the reviewer is told to OMIT
             ``nitpick``-severity comments entirely. When True (``--nitpick``),
             nitpick comments are re-enabled. Either way every emitted comment
@@ -139,6 +145,11 @@ def get_pr_review_analysis_prompt(
         issue_number=issue_number,
         pr_diff_block=_fence_untrusted("PR_DIFF", pr_diff, nonce),
         issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
+        advise_findings_block=_fence_untrusted(
+            "ADVISE_FINDINGS",
+            advise_findings or "_(no prior advise findings supplied)_",
+            nonce,
+        ),
         ci_status_block=_fence_untrusted("CI_STATUS", ci_status, nonce),
         pr_description_block=_fence_untrusted("PR_DESCRIPTION", pr_description, nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1242,7 +1242,8 @@ class TestDriveGreenLearnings:
         assert result is True
         mock_codex.assert_called_once()
         prompt = mock_codex.call_args.args[0]
-        assert "/skills-registry-commands:learn" in prompt
+        assert prompt.startswith("/learn ")
+        assert "/skills-registry-commands:learn" not in prompt
         assert "Only push skills to ProjectMnemosyne" in prompt
         assert mock_codex.call_args.kwargs["cwd"] == tmp_path
         mock_invoke.assert_not_called()

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1229,15 +1229,22 @@ class TestDriveGreenLearnings:
         assert record is not None
         assert record["learn_captured_at"] is not None
 
-    def test_learnings_skipped_for_codex(self, driver: CIDriver) -> None:
-        """Codex has no persisted drive-green session, so learnings is skipped."""
-        # Direct test of _run_drive_green_learnings — the codex path is
-        # untouched by the #840 arming rework.
+    def test_learnings_run_with_codex(self, driver: CIDriver, tmp_path: Path) -> None:
+        """Codex captures drive-green learnings without invoking Claude."""
         driver.options.agent = "codex"
-        with patch("hephaestus.automation.ci_driver.invoke_claude_with_session") as mock_invoke:
+        with (
+            patch.object(driver, "_get_worktree_path", return_value=tmp_path),
+            patch("hephaestus.automation.ci_driver.run_codex_session") as mock_codex,
+            patch("hephaestus.automation.ci_driver.invoke_claude_with_session") as mock_invoke,
+        ):
             result = driver._run_drive_green_learnings(123, 456)
 
-        assert result is False
+        assert result is True
+        mock_codex.assert_called_once()
+        prompt = mock_codex.call_args.args[0]
+        assert "/skills-registry-commands:learn" in prompt
+        assert "Only push skills to ProjectMnemosyne" in prompt
+        assert mock_codex.call_args.kwargs["cwd"] == tmp_path
         mock_invoke.assert_not_called()
 
 

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1635,7 +1635,7 @@ class TestNoCommitRetry:
     def test_retry_skipped_when_no_failing_required_checks(
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
-        """No-commit + green CI → no retry, returns False (don't perturb a passing PR)."""
+        """No-commit + green CI + clean tracked tree → no retry."""
         with (
             patch(
                 "hephaestus.automation.ci_driver.gh_pr_checks",
@@ -1645,6 +1645,10 @@ class TestNoCommitRetry:
             patch(
                 "hephaestus.automation.ci_driver.gh_pr_list_unresolved_threads",
                 return_value=[],
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.run",
+                return_value=MagicMock(stdout="?? uv.lock\n", stderr="", returncode=0),
             ),
         ):
             result = driver._retry_no_commit_once(
@@ -1658,11 +1662,56 @@ class TestNoCommitRetry:
         assert result is False
         mock_invoke.assert_not_called()
 
+    def test_retry_fires_when_green_but_tracked_changes_need_commit(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        """No-commit + green CI + tracked edits → retry asks agent to commit them."""
+        status = MagicMock(
+            stdout=(
+                " M hephaestus/automation/loop_runner.py\n M scripts/shell/install.sh\n?? uv.lock\n"
+            ),
+            stderr="",
+            returncode=0,
+        )
+        post_sha = MagicMock(stdout="deadbeef\n", stderr="", returncode=0)
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.gh_pr_checks",
+                return_value=[_make_check("lint", conclusion="success")],
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.gh_pr_list_unresolved_threads",
+                return_value=[],
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                return_value=("done", "sess"),
+            ) as mock_invoke,
+            patch("hephaestus.automation.ci_driver.run", side_effect=[status, post_sha]),
+        ):
+            result = driver._retry_no_commit_once(
+                issue_number=993,
+                pr_number=1065,
+                worktree_path=tmp_path,
+                pr_head_branch="993-auto-impl",
+                pre_agent_sha="cafef00d",
+                session_id=None,
+            )
+
+        assert result is True
+        mock_invoke.assert_called_once()
+        prompt = mock_invoke.call_args.kwargs["prompt"]
+        assert "uncommitted tracked changes" in prompt
+        assert "M hephaestus/automation/loop_runner.py" in prompt
+        assert "scripts/shell/install.sh" in prompt
+        assert "uv.lock" not in prompt
+
     def test_retry_fires_when_failing_and_returns_true_on_commit(
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
         """No-commit + failing CI → one resumed claude call; HEAD advanced ⇒ True."""
         post_sha = MagicMock(stdout="deadbeef\n")
+        clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
                 "hephaestus.automation.ci_driver.gh_pr_checks",
@@ -1676,7 +1725,7 @@ class TestNoCommitRetry:
                 "hephaestus.automation.ci_driver.invoke_claude_with_session",
                 return_value=("done", "sess"),
             ) as mock_invoke,
-            patch("hephaestus.automation.ci_driver.run", return_value=post_sha),
+            patch("hephaestus.automation.ci_driver.run", side_effect=[clean_status, post_sha]),
         ):
             result = driver._retry_no_commit_once(
                 issue_number=1,
@@ -1699,6 +1748,7 @@ class TestNoCommitRetry:
     ) -> None:
         """Retry returned without commit too → False + state_dir marker (#846)."""
         unchanged = MagicMock(stdout="cafef00d\n")  # post == pre
+        clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
                 "hephaestus.automation.ci_driver.gh_pr_checks",
@@ -1712,7 +1762,10 @@ class TestNoCommitRetry:
                 "hephaestus.automation.ci_driver.invoke_claude_with_session",
                 return_value=("nope", "sess"),
             ) as mock_invoke,
-            patch("hephaestus.automation.ci_driver.run", return_value=unchanged),
+            patch(
+                "hephaestus.automation.ci_driver.run",
+                side_effect=[clean_status, unchanged, clean_status, unchanged],
+            ),
         ):
             result = driver._retry_no_commit_once(
                 issue_number=1,
@@ -1769,6 +1822,7 @@ class TestNoCommitRetry:
         """Codex agent + session_id → resume_codex_session called once with the session."""
         driver.options.agent = "codex"
         post_sha = MagicMock(stdout="deadbeef\n")
+        clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
                 "hephaestus.automation.ci_driver.gh_pr_checks",
@@ -1783,7 +1837,7 @@ class TestNoCommitRetry:
                 return_value=AgentRunResult(stdout="ok", stderr="", session_id="s"),
             ) as mock_resume,
             patch("hephaestus.automation.ci_driver.run_codex_session") as mock_fresh,
-            patch("hephaestus.automation.ci_driver.run", return_value=post_sha),
+            patch("hephaestus.automation.ci_driver.run", side_effect=[clean_status, post_sha]),
         ):
             result = driver._retry_no_commit_once(
                 issue_number=1,

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -282,6 +282,7 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
             "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
         ) as mock_push,
         patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch") as mock_sync,
+        patch.object(driver, "_ci_fix_head_is_pushable", return_value=True),
         patch("hephaestus.automation.ci_driver.run", side_effect=pre_post_sequence),
     ):
         result = driver._run_ci_fix_session(
@@ -355,6 +356,50 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
     # And we must NOT have attempted a push — the prior bug was that a silent
     # no-op push exited 0 and the driver logged "pushed CI fixes" anyway.
     mock_push.assert_not_called()
+
+
+def test_ci_fix_head_not_pushable_with_unmerged_index(
+    driver: CIDriver,
+    tmp_path: Path,
+) -> None:
+    """A semantic conflict resolution is not pushable until the index is merged."""
+    with patch(
+        "hephaestus.automation.ci_driver.run",
+        return_value=MagicMock(
+            stdout="hephaestus/automation/loop_runner.py\n",
+            stderr="",
+            returncode=0,
+        ),
+    ):
+        assert driver._ci_fix_head_is_pushable(tmp_path, 993) is False
+
+
+def test_ci_fix_head_not_pushable_when_head_is_base_only(
+    driver: CIDriver,
+    tmp_path: Path,
+) -> None:
+    """Do not push detached origin/main over the PR branch after a failed rebase."""
+    responses = [
+        MagicMock(stdout="", stderr="", returncode=0),  # no unmerged paths
+        MagicMock(stdout="?? uv.lock\n", stderr="", returncode=0),  # generated untracked file
+        MagicMock(stdout="0\n", stderr="", returncode=0),  # no commits ahead of origin/main
+    ]
+    with patch("hephaestus.automation.ci_driver.run", side_effect=responses):
+        assert driver._ci_fix_head_is_pushable(tmp_path, 993) is False
+
+
+def test_ci_fix_head_pushable_with_clean_committed_pr_head(
+    driver: CIDriver,
+    tmp_path: Path,
+) -> None:
+    """A clean committed PR head remains pushable even with untracked tool output."""
+    responses = [
+        MagicMock(stdout="", stderr="", returncode=0),
+        MagicMock(stdout="?? uv.lock\n", stderr="", returncode=0),
+        MagicMock(stdout="1\n", stderr="", returncode=0),
+    ]
+    with patch("hephaestus.automation.ci_driver.run", side_effect=responses):
+        assert driver._ci_fix_head_is_pushable(tmp_path, 993) is True
 
 
 def test_codex_ci_advise_uses_codex_prompt_builder(driver: CIDriver) -> None:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2274,6 +2274,80 @@ class TestGhPrReviewPost:
     @patch("hephaestus.automation.github_api.io_write_secure")
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
     @patch("hephaestus.automation.github_api._gh_call")
+    def test_actual_1116_codex_review_restatements_are_skipped(
+        self,
+        mock_gh_call: Any,
+        _mock_repo: Any,
+        mock_write: Any,
+        mock_index: Any,
+        mock_update: Any,
+    ) -> None:
+        """Issue #1116: observed Codex/Claude coverage restatements are duplicates."""
+        mock_gh_call.side_effect = self._gh_call_side_effect(
+            "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
+        )
+        mock_index.return_value = {
+            (
+                "tests/unit/automation/test_pr_reviewer_posting.py",
+                540,
+            ): (
+                "COMMENT_NODE_540",
+                "This regression coverage only exercises the Claude result-envelope path. "
+                "The production diff also changed the Codex stdout path, so add a Codex "
+                "test where `summary` lacks a verdict and `review_text`/stdout contains "
+                "`Verdict: GO` or `Verdict: NOGO`; otherwise the second producer path can "
+                "regress without this suite catching it.",
+            ),
+        }
+
+        duplicate_bodies = [
+            (
+                "This regression only exercises the Claude JSON-envelope path. Production "
+                "also changed the Codex path to populate `review_text` from "
+                "`run_codex_text().stdout`; add a sibling test that patches "
+                "`is_codex`/`run_codex_text` and asserts a verdict-free `summary` still "
+                "returns verdict-bearing `review_text` for `--agent=codex`."
+            ),
+            (
+                "This regression test only exercises the Claude JSON-envelope path. The "
+                "production fix also changed the Codex stdout path, so please add a "
+                "Codex-path test that returns prose with `Verdict: GO`/`NOGO` and a "
+                "verdict-free JSON summary, then asserts `review_text` preserves the raw "
+                "stdout."
+            ),
+            (
+                "This regression test only exercises the Claude JSON-envelope path. The "
+                "production change also added `review_text` on the separate Codex stdout "
+                "branch selected by `is_codex(agent)`. Add a Codex case that patches "
+                "`is_codex=True` and `run_codex_text(stdout=...)`, then asserts `summary` "
+                "remains the JSON field while `review_text` contains the verdict-bearing "
+                "prose."
+            ),
+        ]
+
+        for body in duplicate_bodies:
+            gh_pr_review_post(
+                pr_number=1116,
+                comments=[
+                    {
+                        "path": "tests/unit/automation/test_pr_reviewer_posting.py",
+                        "line": 540,
+                        "side": "RIGHT",
+                        "body": body,
+                    }
+                ],
+                summary="Findings",
+                dedupe_existing=True,
+            )
+
+        mock_update.assert_not_called()
+        assert self._posted_comments(mock_write) == []
+
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    @patch("hephaestus.automation.github_api.io_write_secure")
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
     def test_same_line_contract_restatement_is_skipped_not_appended(
         self,
         mock_gh_call: Any,

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2403,6 +2403,7 @@ class TestGhPrInlineCommentIndex:
                                         "isResolved": False,
                                         "path": "a.py",
                                         "line": 2,
+                                        "side": "RIGHT",
                                         "comments": {"nodes": [{"id": "N1", "body": "keep me"}]},
                                     },
                                     {
@@ -2423,7 +2424,10 @@ class TestGhPrInlineCommentIndex:
         index = gh_pr_inline_comment_index(7)
 
         # Unresolved thread is indexed with id + body; resolved one is excluded.
-        assert index == {("a.py", 2): ("N1", "keep me")}
+        assert index == {
+            ("a.py", 2): ("N1", "keep me"),
+            ("a.py", 2, "RIGHT"): ("N1", "keep me"),
+        }
 
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
     @patch("hephaestus.automation.github_api._gh_call")

--- a/tests/unit/automation/test_github_api_review_threads.py
+++ b/tests/unit/automation/test_github_api_review_threads.py
@@ -58,8 +58,11 @@ class TestListUnresolvedThreadsParameterisation:
         assert "pullRequest(number: 42)" not in query  # regression guard
         assert 'owner: "owner"' not in query
         assert "owner=owner" in argv and "name=repo" in argv and "number=42" in argv
-        # The query must request the first comment's author login (#PR3).
+        # The query must request thread side and all comment authors so cleanup
+        # can reason over the full thread, not just the first flattened author.
         assert "author{ login }" in query
+        assert "side:diffSide" in query
+        assert "comments(first:20)" in query
 
     @patch("hephaestus.automation.github_api._gh_call")
     @patch("hephaestus.automation.github_api.get_repo_info")
@@ -72,7 +75,13 @@ class TestListUnresolvedThreadsParameterisation:
                 "isResolved": False,
                 "path": "a.py",
                 "line": 3,
-                "comments": {"nodes": [{"body": "nit", "author": {"login": "coderabbitai[bot]"}}]},
+                "side": "RIGHT",
+                "comments": {
+                    "nodes": [
+                        {"body": "nit", "author": {"login": "coderabbitai[bot]"}},
+                        {"body": "reply", "author": {"login": "mvillmow"}},
+                    ]
+                },
             },
             {
                 "id": "T_human",
@@ -99,5 +108,11 @@ class TestListUnresolvedThreadsParameterisation:
 
         by_id = {t["id"]: t for t in threads}
         assert by_id["T_bot"]["author"] == "coderabbitai[bot]"
+        assert by_id["T_bot"]["authors"] == ["coderabbitai[bot]", "mvillmow"]
+        assert by_id["T_bot"]["comments"] == [
+            {"body": "nit", "author": "coderabbitai[bot]"},
+            {"body": "reply", "author": "mvillmow"},
+        ]
+        assert by_id["T_bot"]["side"] == "RIGHT"
         assert by_id["T_human"]["author"] == "alice"
         assert by_id["T_noauthor"]["author"] == ""

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -140,6 +140,25 @@ class TestRunImplReviewLoop:
                 "line": 2,
                 "body": "old",
             },
+            {
+                "id": "T_nested_self",
+                "author": "coderabbitai[bot]",
+                "authors": ["coderabbitai[bot]", "mvillmow"],
+                "comments": [
+                    {"body": "old", "author": "coderabbitai[bot]"},
+                    {"body": "automation reply", "author": "mvillmow"},
+                ],
+                "path": "d.py",
+                "line": 4,
+                "body": "old",
+            },
+            {
+                "id": "T_other_bot",
+                "author": "coderabbitai[bot]",
+                "path": "e.py",
+                "line": 5,
+                "body": "bot",
+            },
             {"id": "T_human", "author": "alice", "path": "c.py", "line": 3, "body": "human"},
         ]
         with (
@@ -172,7 +191,7 @@ class TestRunImplReviewLoop:
         assert (iters, verdict, grade) == (1, "GO", "A")
         mock_addr.assert_not_called()
         resolved_ids = [call.args[0] for call in mock_resolve.call_args_list]
-        assert resolved_ids == ["T_self", "T_bot"]
+        assert resolved_ids == ["T_self", "T_bot", "T_nested_self"]
 
     def test_runs_3_iterations_on_sustained_nogo(
         self, implementer: IssueImplementer, tmp_path: Path

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -127,6 +127,27 @@ class TestRunImplReviewLoop:
         # Address step must NOT be called because iteration 0 already passed.
         mock_addr.assert_not_called()
 
+    def test_forwards_advise_findings_to_review_step(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        with patch.object(
+            implementer, "_run_impl_review_step", return_value=(_go(), [])
+        ) as mock_rev:
+            implementer._run_impl_review_loop(
+                issue_number=1,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=None,
+                thread_id=None,
+                pr_number=42,
+                advise_findings="prior team finding",
+            )
+
+        assert mock_rev.call_args.kwargs["advise_findings"] == "prior team finding"
+
     def test_go_resolves_only_automation_owned_stale_threads(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
@@ -997,6 +1018,31 @@ class TestRunImplReviewStep:
         assert "PLAN body" in ctx["issue_body"]
         assert "Verdict: GO" in ctx["issue_body"]
 
+    def test_passes_advise_findings_to_inline_review_context(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        with (
+            patch.object(implementer.phase_runner, "_fetch_plan_and_review", return_value=("", "")),
+            patch.object(implementer, "_collect_diff", return_value="the-diff"),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.review_pr_inline",
+                return_value=(_go(), []),
+            ) as mock_inline,
+        ):
+            implementer._run_impl_review_step(
+                issue_number=1,
+                issue_title="t",
+                issue_body="ib",
+                branch_name="b",
+                worktree_path=tmp_path,
+                pr_number=42,
+                iteration=0,
+                prior_review=None,
+                advise_findings="prior team finding",
+            )
+
+        assert mock_inline.call_args.kwargs["context"]["advise_findings"] == "prior team finding"
+
     def test_reviewer_uses_per_iteration_session_token(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
@@ -1453,6 +1499,54 @@ class TestReviewExistingPrShortCircuit:
         assert result.success is True
         mock_loop.assert_called_once()
         mock_verdict.assert_called_once()
+
+    def test_codex_existing_pr_forwards_advise_to_review_loop(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """Codex existing-PR review has no transcript injection, so pass context."""
+        implementer.options.agent = "codex"
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir(exist_ok=True)
+        state = ImplementationState(issue_number=1)
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.pr_has_implementation_state_label",
+                return_value=(False, False),
+            ),
+            patch.object(implementer.status_tracker, "update_slot"),
+            patch("hephaestus.automation.implementer.get_pr_head_branch", return_value="b"),
+            patch.object(
+                implementer.worktree_manager, "create_worktree", return_value=worktree_path
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
+                return_value=True,
+            ),
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
+            patch.object(implementer, "_save_state"),
+            patch("hephaestus.automation.implementer.fetch_issue_info") as mock_issue,
+            patch.object(
+                implementer, "_run_advise", return_value="prior team finding"
+            ) as mock_advise,
+            patch.object(
+                implementer, "_run_impl_review_loop", return_value=(1, "GO", "A")
+            ) as mock_loop,
+            patch.object(implementer.phase_runner, "_apply_impl_review_verdict"),
+            patch.object(implementer.phase_runner, "_run_post_pr_followup"),
+        ):
+            mock_issue.return_value.title = "title"
+            mock_issue.return_value.body = "body"
+            implementer.phase_runner._review_existing_pr(
+                issue_number=1,
+                existing_pr=555,
+                branch_name="1-branch",
+                state=state,
+                slot_id=None,
+                thread_id=None,
+            )
+
+        mock_advise.assert_called_once()
+        assert mock_loop.call_args.kwargs["advise_findings"] == "prior team finding"
 
     @pytest.mark.parametrize("learn_completed", [False, True])
     def test_existing_pr_runs_post_review_learn_when_needed(

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from hephaestus.automation.learn import learn_needs_rerun, run_learn
+from hephaestus.automation.learn import build_learn_prompt, learn_needs_rerun, run_learn
 
 
 class TestLearnNeedsRerun:
@@ -45,6 +45,13 @@ class TestLearnNeedsRerun:
 class TestRunLearn:
     """Tests for run_learn."""
 
+    def test_build_learn_prompt_uses_user_facing_command(self) -> None:
+        prompt = build_learn_prompt("Capture what happened.")
+
+        assert prompt.startswith("/learn Capture what happened.")
+        assert "/skills-registry-commands:learn" not in prompt
+        assert "Only push skills to ProjectMnemosyne" in prompt
+
     def test_success_writes_log_and_returns_true(self, tmp_path: Path) -> None:
         """Returns True and writes log on successful claude run."""
         worktree_path = tmp_path / "worktree"
@@ -53,10 +60,14 @@ class TestRunLearn:
         mock_result = MagicMock()
         mock_result.stdout = "Learn complete. PR created."
 
-        with patch("hephaestus.automation.learn.run", return_value=mock_result):
+        with patch("hephaestus.automation.learn.run", return_value=mock_result) as mock_run:
             result = run_learn("session-abc", worktree_path, 42, tmp_path)
 
         assert result is True
+        cmd_args = mock_run.call_args.args[0]
+        prompt = cmd_args[cmd_args.index("session-abc") + 1]
+        assert prompt.startswith("/learn")
+        assert "/skills-registry-commands:learn" not in prompt
         log_file = tmp_path / "learn-42.log"
         assert log_file.exists()
         assert log_file.read_text() == "Learn complete. PR created."
@@ -100,7 +111,9 @@ class TestRunLearn:
         mock_result = MagicMock()
         mock_result.stdout = "learned"
 
-        with patch("hephaestus.automation.learn.resume_codex_session", return_value=mock_result):
+        with patch(
+            "hephaestus.automation.learn.resume_codex_session", return_value=mock_result
+        ) as mock_resume:
             result = run_learn(
                 "session-abc",
                 worktree_path,
@@ -111,6 +124,9 @@ class TestRunLearn:
             )
 
         assert result is True
+        prompt = mock_resume.call_args.args[1]
+        assert prompt.startswith("/learn")
+        assert "/skills-registry-commands:learn" not in prompt
         assert (tmp_path / "learn-42.log").read_text() == "learned"
 
     def test_creates_state_dir_if_missing(self, tmp_path: Path) -> None:

--- a/tests/unit/automation/test_phase_agent_wiring.py
+++ b/tests/unit/automation/test_phase_agent_wiring.py
@@ -172,10 +172,12 @@ def test_planner_module_uses_its_expected_agents() -> None:
 
     Stage 1 (#455/#468/#484) changed two of these:
 
-    AGENT_PLANNER       — main planning call AND post-plan learnings capture.
-                          Learnings now RESUME the planner's own session (it
-                          previously opened a separate AGENT_LEARNINGS session)
-                          so the model still "remembers" the plan it wrote.
+    AGENT_PLANNER       — main planning call AND post-plan /learn capture.
+                          Learnings RESUME the planner's own session with the
+                          user-facing /learn command (it previously opened a
+                          separate AGENT_LEARNINGS session), so the model still
+                          "remembers" the plan it wrote and ProjectMnemosyne is
+                          updated.
     AGENT_ADVISE        — pre-plan advice call.
     AGENT_PLAN_REVIEWER — in-process plan-review call, now wrapped in
                           ``reviewer_agent(AGENT_PLAN_REVIEWER, iteration)`` so

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -544,6 +544,17 @@ class TestCapturePlannerLearnings:
         assert agent == AGENT_PLANNER
         assert agent != AGENT_LEARNINGS
 
+    def test_uses_user_facing_learn_command(self, planner: Planner) -> None:
+        """Planner learn capture must update ProjectMnemosyne through /learn."""
+        with patch.object(planner, "_call_claude", return_value="- learning A") as mock_call:
+            planner._capture_planner_learnings(123, "plan text")
+
+        prompt = mock_call.call_args.args[0]
+        assert prompt.startswith("/learn ")
+        assert "ProjectMnemosyne" in prompt
+        assert "/skills-registry-commands:learn" not in prompt
+        assert "plan text" in prompt
+
 
 class TestRunPlanReview:
     """The reviewer must fail safely to NoGo when the call errors."""

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -83,6 +83,23 @@ class TestRunPlanReviewLoop:
         assert mock_review.call_count == 1
         assert verdict_is_go is True
 
+    def test_forwards_advise_findings_to_plan_reviewer(self, planner: Planner) -> None:
+        """Plan review gets the same ProjectMnemosyne context as planning."""
+        planner.options.enable_advise = True
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
+                return_value={"title": "T", "body": "B"},
+            ),
+            patch.object(planner, "_run_advise", return_value="prior team learning"),
+            patch.object(planner, "_generate_plan", return_value="plan v0"),
+            patch.object(planner, "_capture_planner_learnings", return_value="learn0"),
+            patch.object(planner, "_run_plan_review", return_value=_go_review()) as mock_review,
+        ):
+            planner._run_plan_review_loop(123, slot_id=0)
+
+        assert mock_review.call_args.kwargs["advise_findings"] == "prior team learning"
+
     def test_runs_all_3_iterations_on_sustained_nogo(self, planner: Planner) -> None:
         """When every review says NOGO, the loop runs exactly 3 iterations."""
         with (

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -393,6 +393,19 @@ class TestGatherImplReviewContext:
         assert "no plan comment found" in ctx["issue_body"]
         assert "no plan-review comment found" in ctx["issue_body"]
 
+    def test_preserves_advise_findings_for_prompt(self) -> None:
+        ctx = gather_impl_review_context(
+            pr_number=42,
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            plan_text="",
+            plan_review_text="",
+            diff_text="",
+            advise_findings="prior team finding",
+        )
+        assert ctx["advise_findings"] == "prior team finding"
+
 
 class TestRunPrReviewAnalysis:
     """run_pr_review_analysis is the shared analysis core (standalone + in-loop)."""
@@ -441,6 +454,35 @@ class TestRunPrReviewAnalysis:
                 dry_run=False,
             )
         assert captured["agent"] == "pr-reviewer-r1"
+
+    def test_passes_advise_findings_to_prompt_builder(self, tmp_path: Path) -> None:
+        captured: dict[str, object] = {}
+
+        def _fake_prompt(**kwargs: object) -> str:
+            captured.update(kwargs)
+            return "prompt"
+
+        with (
+            patch(
+                "hephaestus.automation.pr_reviewer.get_pr_review_analysis_prompt",
+                side_effect=_fake_prompt,
+            ),
+            patch("hephaestus.automation.pr_reviewer.run_codex_text") as mock_codex,
+        ):
+            mock_codex.return_value = MagicMock(
+                stdout='Verdict: GO\n```json\n{"comments": [], "summary": "ok"}\n```'
+            )
+            run_pr_review_analysis(
+                pr_number=1,
+                issue_number=1,
+                worktree_path=tmp_path,
+                context={"advise_findings": "prior team finding"},
+                agent="codex",
+                state_dir=tmp_path,
+                dry_run=False,
+            )
+
+        assert captured["advise_findings"] == "prior team finding"
 
     def test_claude_path_preserves_review_text_for_verdict(self, tmp_path: Path) -> None:
         """Claude JSON summary may omit Verdict, but full prose must be returned."""

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -403,7 +403,7 @@ class TestUntrustedFencing:
         assert prompts._UNTRUSTED_NOTICE in out
 
     def test_plan_loop_review_prompt_fences_untrusted_fields(self) -> None:
-        """get_plan_loop_review_prompt fences issue_body and plan_text."""
+        """get_plan_loop_review_prompt fences issue_body, advise, and plan_text."""
         out = prompts.get_plan_loop_review_prompt(
             issue_number=1,
             issue_title="t",
@@ -412,8 +412,10 @@ class TestUntrustedFencing:
             learnings="",
             iteration=0,
             prior_review=None,
+            advise_findings=self.INJECTION,
         )
         assert self._fence_present(out, "ISSUE_BODY")
+        assert self._fence_present(out, "ADVISE_FINDINGS")
         assert self._fence_present(out, "PLAN_TEXT")
         assert prompts._UNTRUSTED_NOTICE in out
 

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -434,6 +434,18 @@ class TestUntrustedFencing:
         assert self._fence_present(out, "DIFF_TEXT")
         assert prompts._UNTRUSTED_NOTICE in out
 
+    def test_pr_review_analysis_prompt_fences_advise_findings(self) -> None:
+        """get_pr_review_analysis_prompt fences advise findings before review."""
+        out = prompts.get_pr_review_analysis_prompt(
+            pr_number=1,
+            issue_number=1,
+            issue_body=self.INJECTION,
+            advise_findings=self.INJECTION,
+        )
+        assert self._fence_present(out, "ISSUE_BODY")
+        assert self._fence_present(out, "ADVISE_FINDINGS")
+        assert prompts._UNTRUSTED_NOTICE in out
+
     def test_dirty_reused_worktree_decision_prompt_fences_status_and_diff(self) -> None:
         """Dirty worktree branch/status/diff inputs are untrusted and fenced."""
         out = prompts.get_dirty_reused_worktree_decision_prompt(


### PR DESCRIPTION
## Summary
- add a pre-push guard for drive-green CI fixes so an interrupted/conflicted agent run cannot push from an unmerged or base-only HEAD
- reject unresolved merge index state, uncommitted tracked changes, and HEADs with no commits ahead of origin/main before pushing to the PR branch
- add regression tests for the unmerged-index and detached-base cases observed while running the #993 automation loop

## Verification
- uv run pytest --no-cov tests/unit/automation/test_ci_driver.py -k "codex_ci_fix_session or ci_fix_head" -v
- uv run ruff check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- uv run ruff format --check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- uv run mypy hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- local pre-push full pytest reached 3782 passed / 101 skipped, with 8 pre-existing local-environment failures: NATS subprocess timeout, compare_benchmarks import path under plain subprocess, and missing installed console scripts

Closes #993