### PR TITLE
feat(automation): add --model flag so the loop runs on one model with no env vars

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -35,7 +35,7 @@ from hephaestus.cli.utils import add_json_arg, emit_json_status
 from ._review_utils import find_pr_for_issue
 from .advise_runner import run_advise
 from .claude_invoke import invoke_claude_with_session
-from .claude_models import advise_model, implementer_model, learn_model
+from .claude_models import advise_model, implementer_model
 from .claude_timeouts import (
     advise_claude_timeout,
     ci_driver_claude_timeout,
@@ -2750,7 +2750,10 @@ class CIDriver:
                 issue=issue_number,
                 agent=AGENT_CI_DRIVER,
                 prompt=prompt,
-                model=learn_model(),
+                # /learn inherits the parent phase's model. drive-green resumes
+                # the implementer's session, and ``claude --resume`` is locked to
+                # the model that created it, so we must use implementer_model().
+                model=implementer_model(),
                 cwd=cwd,
                 timeout=learn_claude_timeout(),
                 output_format="text",

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -265,6 +265,10 @@ class LoopConfig:
     no_advise: bool = False
     nitpick: bool = False
     allow_unsafe_phase_order: bool = False
+    # ``model`` is the catch-all applied to every phase when set; per-phase
+    # fields below take precedence over it. The /learn step is not a separate
+    # knob — it inherits its parent phase's model at the call site.
+    model: str = ""
     planner_model: str = ""
     reviewer_model: str = ""
     implementer_model: str = ""
@@ -375,6 +379,16 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--allow-unsafe-phase-order",
         action="store_true",
         help="Silence dependency-ordering warnings when --phases skips a recommended predecessor",
+    )
+    p.add_argument(
+        "--model",
+        default="",
+        help=(
+            "Model ID applied to every phase (planner, reviewer, implementer, advise) "
+            "for child processes, so no HEPH_*_MODEL env vars are required. The /learn "
+            "step inherits its parent phase's model automatically. A per-phase flag below "
+            "overrides this for that phase."
+        ),
     )
     p.add_argument("--planner-model", default="", help="HEPH_PLANNER_MODEL for child processes")
     p.add_argument(
@@ -954,12 +968,20 @@ def _phase_env(
     benign but a behavioral divergence from the bash version.
     """
     env = os.environ.copy()
-    if cfg.planner_model:
-        env["HEPH_PLANNER_MODEL"] = cfg.planner_model
-    if cfg.reviewer_model:
-        env["HEPH_REVIEWER_MODEL"] = cfg.reviewer_model
-    if cfg.implementer_model:
-        env["HEPH_IMPLEMENTER_MODEL"] = cfg.implementer_model
+    # Precedence per phase: explicit per-phase flag > catch-all --model > any
+    # ambient HEPH_*_MODEL the operator exported > the phase default resolved
+    # in the child. Only export when we have a value so we never clobber an
+    # ambient env var with an empty string. --model also covers advise, so an
+    # all-one-model run needs no env vars; /learn inherits its parent phase
+    # downstream (see claude_models / the learn call sites).
+    if planner := (cfg.planner_model or cfg.model):
+        env["HEPH_PLANNER_MODEL"] = planner
+    if reviewer := (cfg.reviewer_model or cfg.model):
+        env["HEPH_REVIEWER_MODEL"] = reviewer
+    if implementer := (cfg.implementer_model or cfg.model):
+        env["HEPH_IMPLEMENTER_MODEL"] = implementer
+    if cfg.model:
+        env["HEPH_ADVISE_MODEL"] = cfg.model
     env["HEPH_TRUNK_GITHASH"] = trunk_sha
     project_root = str(Path(__file__).resolve().parents[2])
     if env.get("PYTHONPATH"):
@@ -1438,6 +1460,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
         no_advise=args.no_advise,
         nitpick=args.nitpick,
         allow_unsafe_phase_order=args.allow_unsafe_phase_order,
+        model=args.model,
         planner_model=args.planner_model,
         reviewer_model=args.reviewer_model,
         implementer_model=args.implementer_model,
@@ -1484,10 +1507,11 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
     if cfg.issues:
         LOG.info("Issues: %s", ",".join(str(n) for n in cfg.issues))
     LOG.info(
-        "Models: planner=%s reviewer=%s implementer=%s",
-        cfg.planner_model or "<default>",
-        cfg.reviewer_model or "<default>",
-        cfg.implementer_model or "<default>",
+        "Models: planner=%s reviewer=%s implementer=%s advise=%s",
+        cfg.planner_model or cfg.model or "<default>",
+        cfg.reviewer_model or cfg.model or "<default>",
+        cfg.implementer_model or cfg.model or "<default>",
+        cfg.model or "<default>",
     )
 
     results = run_loop(cfg, repos)

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -19,7 +19,7 @@ import logging
 from typing import Any, Protocol
 
 from .claude_invoke import parse_review_verdict
-from .claude_models import learn_model, planner_model, reviewer_model
+from .claude_models import planner_model, reviewer_model
 from .claude_timeouts import planner_claude_timeout
 from .git_utils import issue_ref
 from .github_api import (
@@ -552,8 +552,9 @@ class PlanReviewLoop:
         non-fatal — return empty string and let the review proceed without
         learnings.
 
-        Uses ``learn_model()`` (Haiku by default) per the per-phase model
-        selection in :mod:`hephaestus.automation.claude_models`.
+        The pre-review learnings step inherits the planner's model
+        (``planner_model()``) — /learn always runs on the same tier as the
+        phase it is learning from, rather than carrying its own knob.
 
         Args:
             issue_number: GitHub issue number (used in prompt for grounding).
@@ -578,7 +579,7 @@ class PlanReviewLoop:
         try:
             return self.planner._call_claude(
                 prompt,
-                model=learn_model(),
+                model=planner_model(),
                 agent=AGENT_PLANNER,
                 issue_number=issue_number,
                 timeout=120,

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -648,19 +648,68 @@ def test_phase_env_loop_index_only_for_drive_green(monkeypatch: pytest.MonkeyPat
     assert env_dg["HEPH_TOTAL_LOOPS"] == "5"
 
 
-def test_phase_env_model_vars_only_when_non_empty() -> None:
+def test_phase_env_model_vars_only_when_non_empty(monkeypatch: pytest.MonkeyPatch) -> None:
     """Model env vars only present when their cfg field is non-empty."""
+    for var in ("HEPH_PLANNER_MODEL", "HEPH_REVIEWER_MODEL", "HEPH_IMPLEMENTER_MODEL"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.delenv("HEPH_ADVISE_MODEL", raising=False)
+
     cfg_empty = LoopConfig()
     env = loop_runner._phase_env(cfg_empty, loop_idx=1, trunk_sha="abc", phase="plan")
     assert "HEPH_PLANNER_MODEL" not in env
     assert "HEPH_REVIEWER_MODEL" not in env
     assert "HEPH_IMPLEMENTER_MODEL" not in env
+    assert "HEPH_ADVISE_MODEL" not in env
 
     cfg_set = LoopConfig(planner_model="opus", reviewer_model="sonnet", implementer_model="opus")
     env_set = loop_runner._phase_env(cfg_set, loop_idx=1, trunk_sha="abc", phase="plan")
     assert env_set["HEPH_PLANNER_MODEL"] == "opus"
     assert env_set["HEPH_REVIEWER_MODEL"] == "sonnet"
     assert env_set["HEPH_IMPLEMENTER_MODEL"] == "opus"
+
+
+def test_phase_env_model_fans_out_to_all_phases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--model (cfg.model) sets every phase env var so no HEPH_*_MODEL is needed."""
+    for var in (
+        "HEPH_PLANNER_MODEL",
+        "HEPH_REVIEWER_MODEL",
+        "HEPH_IMPLEMENTER_MODEL",
+        "HEPH_ADVISE_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = LoopConfig(model="claude-fable-5")
+    env = loop_runner._phase_env(cfg, loop_idx=1, trunk_sha="abc", phase="plan")
+    assert env["HEPH_PLANNER_MODEL"] == "claude-fable-5"
+    assert env["HEPH_REVIEWER_MODEL"] == "claude-fable-5"
+    assert env["HEPH_IMPLEMENTER_MODEL"] == "claude-fable-5"
+    assert env["HEPH_ADVISE_MODEL"] == "claude-fable-5"
+
+
+def test_phase_env_per_phase_flag_overrides_catch_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A per-phase flag wins over the catch-all --model for that phase only."""
+    for var in (
+        "HEPH_PLANNER_MODEL",
+        "HEPH_REVIEWER_MODEL",
+        "HEPH_IMPLEMENTER_MODEL",
+        "HEPH_ADVISE_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = LoopConfig(model="claude-fable-5", reviewer_model="claude-sonnet-4-6")
+    env = loop_runner._phase_env(cfg, loop_idx=1, trunk_sha="abc", phase="plan")
+    assert env["HEPH_PLANNER_MODEL"] == "claude-fable-5"
+    assert env["HEPH_REVIEWER_MODEL"] == "claude-sonnet-4-6"
+    assert env["HEPH_IMPLEMENTER_MODEL"] == "claude-fable-5"
+    assert env["HEPH_ADVISE_MODEL"] == "claude-fable-5"
+
+
+def test_parse_args_model_flag_wires_to_namespace() -> None:
+    """--model parses into args.model (the path main() reads into cfg.model)."""
+    args = loop_runner._parse_args(["--model", "claude-fable-5"])
+    assert args.model == "claude-fable-5"
+    # Default is empty so the catch-all is inert unless explicitly passed.
+    assert loop_runner._parse_args([]).model == ""
 
 
 def test_phase_env_trunk_sha_always_set() -> None:


### PR DESCRIPTION
## Summary

Adds a catch-all `--model` flag to `hephaestus-automation-loop` so an operator can run every phase on a single model with **no `HEPH_*_MODEL` env vars**:

```bash
hephaestus-automation-loop --model claude-fable-5 --loops 5
```

`--model` fans out to planner, reviewer, implementer, and advise child-process env vars. Per-phase flags still override it; an ambient `HEPH_*_MODEL` is never clobbered with an empty string.

## /learn inherits its parent phase's model

`/learn` is not a separate knob — it runs on the same tier as the phase it learns from. Two call sites that hardcoded `learn_model()` are fixed:

- **drive-green** (`ci_driver.py`) → `implementer_model()`. drive-green resumes the implementer's session and `claude --resume` is locked to that session's model, so this is a correctness fix.
- **pre-review learnings** (`planner_review_loop.py`) → `planner_model()`.

`learn_model()` / `HEPH_LEARN_MODEL` remain as the fallback default inside `learn.py`.

## Verification

- `pixi run ruff check` — clean
- `pixi run mypy` — `Success: no issues found in 342 source files`
- `pixi run pytest` (loop_runner / ci_driver / planner_loop / claude_models / learn) — 296 passed, including new fan-out, per-phase-override, and parse-level tests
- End-to-end `--model claude-fable-5 --dry-run` confirms the flag reaches the pipeline; status line prints `planner=claude-fable-5 reviewer=… implementer=claude-fable-5 advise=claude-fable-5`

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)