### PR TITLE
fix(automation): stop reviewer infra failures from forcing NOGO + state:skip

### DIFF
--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -312,8 +312,15 @@ class ReviewVerdict:
 
     Attributes:
         grade: Letter grade extracted from ``Grade: <X>`` line. ``None`` if absent.
-        verdict: One of ``"GO"``, ``"NOGO"``, or ``"AMBIGUOUS"``.
+        verdict: One of ``"GO"``, ``"NOGO"``, ``"AMBIGUOUS"``, or ``"ERROR"``.
         raw: Full review text (kept for downstream prompts and logs).
+
+    ``"ERROR"`` is reserved for **reviewer-infrastructure failures** (the
+    reviewer subprocess raised — API 400, timeout, crash, empty output). It is
+    deliberately distinct from ``"NOGO"`` so the loop does not mistake "the
+    reviewer never ran" for "the reviewer judged the code not ready": an ERROR
+    must not burn toward ``state:skip`` exhaustion and must not stamp a
+    go/no-go label (#911 / PR #1069).
 
     """
 
@@ -326,14 +333,25 @@ class ReviewVerdict:
         """True only on an unambiguous GO."""
         return self.verdict == "GO"
 
+    @property
+    def is_error(self) -> bool:
+        """True when the verdict is a reviewer-infrastructure failure sentinel."""
+        return self.verdict == "ERROR"
+
 
 _GRADE_RE = re.compile(
     r"^\s*\**\s*Grade\s*:\s*\**\s*([A-F][+-]?)(?![A-Za-z])",
     re.MULTILINE | re.IGNORECASE,
 )
 _VERDICT_RE = re.compile(
-    r"^\s*\**\s*Verdict\s*:\s*\**\s*(GO|NO[\s-]?GO)\b", re.MULTILINE | re.IGNORECASE
+    r"^\s*\**\s*Verdict\s*:\s*\**\s*(GO|NO[\s-]?GO|ERROR)\b", re.MULTILINE | re.IGNORECASE
 )
+
+# Sentinel review text emitted when the reviewer subprocess itself fails
+# (e.g. an API 400 from an advisor-tier mismatch, a timeout, or a crash). It
+# parses to ``verdict="ERROR"`` via :func:`parse_review_verdict`, which the
+# review loop treats as inconclusive — re-review next loop, never skip/label.
+INFRA_ERROR_REVIEW_TEXT = "Grade: F\nVerdict: ERROR\n"
 
 
 def parse_review_verdict(text: str) -> ReviewVerdict:
@@ -341,10 +359,13 @@ def parse_review_verdict(text: str) -> ReviewVerdict:
 
     Looks for lines like:
         Grade: B+
-        Verdict: GO     (or NOGO, NO-GO, NO GO)
+        Verdict: GO     (or NOGO, NO-GO, NO GO, ERROR)
 
     A response missing or contradicting these markers is treated as
-    AMBIGUOUS — which the loop treats as NoGo (continue iterating).
+    AMBIGUOUS — which the loop treats as NoGo (continue iterating). An explicit
+    ``Verdict: ERROR`` marks a reviewer-infrastructure failure (see
+    :data:`INFRA_ERROR_REVIEW_TEXT`) and is surfaced as ``verdict="ERROR"`` so
+    callers can distinguish it from a genuine NOGO.
 
     Args:
         text: The full review text from Claude.
@@ -359,7 +380,12 @@ def parse_review_verdict(text: str) -> ReviewVerdict:
     verdict_match = _VERDICT_RE.search(text)
     if verdict_match:
         raw_verdict = re.sub(r"[\s-]", "", verdict_match.group(1).upper())
-        verdict = "GO" if raw_verdict == "GO" else "NOGO"
+        if raw_verdict == "GO":
+            verdict = "GO"
+        elif raw_verdict == "ERROR":
+            verdict = "ERROR"
+        else:
+            verdict = "NOGO"
     else:
         verdict = "AMBIGUOUS"
 

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -44,6 +44,7 @@ from .address_review import (
 )
 from .advise_runner import run_advise
 from .claude_invoke import (
+    INFRA_ERROR_REVIEW_TEXT,
     SESSION_EXPIRED_PHRASES,
     parse_review_verdict,
 )
@@ -1037,8 +1038,23 @@ class ImplementationPhaseRunner:
         path so the GO → ``mark_pr_implementation_go`` (+ auto-merge) /
         non-GO → ``mark_pr_implementation_no_go`` mapping cannot drift between
         them.
+
+        An ``ERROR`` verdict (reviewer-infrastructure failure) applies **neither**
+        label: the PR was never actually reviewed, so it must be left unlabeled
+        for the "no go/no-go label → re-review" path to pick it up next loop
+        (#911 / PR #1069). Labeling it no-go would falsely record a review that
+        never happened; labeling it go would arm auto-merge on unreviewed code.
         """
         impl = self.impl
+        if last_verdict == "ERROR":
+            impl._log(
+                "warning",
+                f"{issue_ref(issue_number)}: implementation review hit a reviewer-"
+                f"infrastructure error; leaving {pr_ref(pr_number)} unlabeled for "
+                "re-review (no implementation go/no-go label, auto-merge unchanged)",
+                thread_id,
+            )
+            return
         if last_verdict == "GO":
             mark_pr_implementation_go(pr_number)
             if self.options.auto_merge:
@@ -1663,7 +1679,18 @@ class ImplementationPhaseRunner:
         # (e.g. a malformed verdict) gets MAX_REVIEW_ITERATIONS chances instead
         # of stranding a fixable PR after R0. ``last_verdict`` is None only when
         # there was no PR to review (dry-run / no-PR path).
-        exhausted = iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict != "GO"
+        #
+        # ERROR (reviewer-infrastructure failure — API 400, timeout, crash) is
+        # NOT a real verdict: the reviewer never actually judged the code, so an
+        # exhausted run that ended in ERROR must NOT be skipped. Skipping there
+        # strands a never-reviewed PR (#911 / PR #1069). Leave the issue/PR
+        # unlabeled so the "no go/no-go label → re-review" path re-runs the loop
+        # next time the reviewer infra is healthy.
+        exhausted = (
+            iterations_run >= MAX_REVIEW_ITERATIONS
+            and last_verdict != "GO"
+            and last_verdict != "ERROR"
+        )
         if (
             pr_number is not None
             and last_verdict is not None
@@ -1679,6 +1706,14 @@ class ImplementationPhaseRunner:
             )
             with contextlib.suppress(Exception):
                 gh_issue_add_labels(issue_number, [STATE_SKIP])
+        elif last_verdict == "ERROR":
+            logger.warning(
+                "#%d: review loop ended in reviewer-infrastructure ERROR after %d "
+                "iteration(s) — leaving PR unlabeled for re-review (no %s)",
+                issue_number,
+                iterations_run,
+                STATE_SKIP,
+            )
 
         return iterations_run, last_verdict, last_grade
 
@@ -1809,14 +1844,15 @@ class ImplementationPhaseRunner:
             )
         except Exception as e:
             logger.error(
-                "#%s R%s: in-loop PR review failed: %s; treating as NOGO so the loop continues",
+                "#%s R%s: in-loop PR review failed: %s; recording ERROR (re-review next "
+                "loop, no skip/label) so an infra failure isn't mistaken for a NOGO",
                 issue_number,
                 iteration,
                 e,
             )
             return (
                 f"In-loop reviewer invocation failed at iteration {iteration}: {e}\n\n"
-                "Grade: F\nVerdict: NOGO\n"
+                f"{INFRA_ERROR_REVIEW_TEXT}"
             ), []
 
     def _run_address_review_step(
@@ -2165,14 +2201,15 @@ class ImplementationPhaseRunner:
             return output
         except Exception as e:
             logger.error(
-                "#%s R%s: impl reviewer call failed: %s; treating as NOGO so the loop continues",
+                "#%s R%s: impl reviewer call failed: %s; recording ERROR (re-review next "
+                "loop, no skip/label) so an infra failure isn't mistaken for a NOGO",
                 issue_number,
                 iteration,
                 e,
             )
             return (
                 f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
-                "Grade: F\nVerdict: NOGO\n"
+                f"{INFRA_ERROR_REVIEW_TEXT}"
             )
 
     def _collect_diff(self, worktree_path: Path, branch_name: str) -> str:

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Protocol
 
-from .claude_invoke import parse_review_verdict
+from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
 from .claude_timeouts import planner_claude_timeout
 from .git_utils import issue_ref
@@ -289,7 +289,19 @@ class PlanReviewLoop:
             # NOGO (each iteration) → state:plan-no-go.
             # Either way, remove state:needs-plan (and the opposite terminal
             # label if it was set on a prior pass).
-            self._apply_state_label(issue_number, is_go=verdict.is_go)
+            # An ERROR verdict (reviewer-infra failure) is NOT a real verdict —
+            # leave the plan labels untouched so the issue stays in its prior
+            # state and gets re-reviewed next loop, rather than mislabeling a
+            # never-reviewed plan as state:plan-no-go.
+            if verdict.is_error:
+                logger.warning(
+                    "%s R%s: reviewer infrastructure failure — leaving plan labels "
+                    "unchanged for re-review next loop",
+                    issue_ref(issue_number),
+                    iteration,
+                )
+            else:
+                self._apply_state_label(issue_number, is_go=verdict.is_go)
 
             if verdict.is_go:
                 logger.info(
@@ -643,12 +655,13 @@ class PlanReviewLoop:
             )
         except Exception as e:
             logger.error(
-                "%s R%s: reviewer call failed: %s; treating as NOGO so the loop continues",
+                "%s R%s: reviewer call failed: %s; recording ERROR (re-review next loop, "
+                "no plan-no-go label) so an infra failure isn't mistaken for a NOGO",
                 issue_ref(issue_number),
                 iteration,
                 e,
             )
             return (
                 f"Reviewer invocation failed at iteration {iteration}: {e}\n\n"
-                "Grade: F\nVerdict: NOGO\n"
+                f"{INFRA_ERROR_REVIEW_TEXT}"
             )

--- a/tests/unit/automation/test_claude_invoke.py
+++ b/tests/unit/automation/test_claude_invoke.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
+from hephaestus.automation.claude_invoke import (
+    INFRA_ERROR_REVIEW_TEXT,
+    ReviewVerdict,
+    parse_review_verdict,
+)
 
 
 class TestParseReviewVerdict:
@@ -55,3 +59,42 @@ class TestParseReviewVerdict:
         v = parse_review_verdict("grade: c-\nverdict: nogo")
         assert v.grade == "C-"
         assert v.verdict == "NOGO"
+
+
+class TestInfraErrorVerdict:
+    """Reviewer-infrastructure failures parse to a distinct ERROR verdict.
+
+    A 400/timeout/crash from the reviewer subprocess must NOT be laundered into
+    a real ``NOGO`` — that would burn review iterations and trigger a spurious
+    ``state:skip`` on a PR that was never actually reviewed (#911 / PR #1069).
+    """
+
+    def test_sentinel_text_parses_to_error_verdict(self) -> None:
+        """The infra-error sentinel text resolves to verdict=ERROR."""
+        v = parse_review_verdict(INFRA_ERROR_REVIEW_TEXT)
+        assert v.verdict == "ERROR"
+        assert v.is_error is True
+        assert v.is_go is False
+
+    def test_error_verdict_round_trips_through_text(self) -> None:
+        """An ERROR verdict survives the text → log → re-parse round-trip.
+
+        The loop persists ``review_text`` and re-parses it, so the sentinel
+        must be recognizable as ERROR on a second parse, not collapse to NOGO.
+        """
+        first = parse_review_verdict(
+            f"Reviewer crashed at iteration 2\n\n{INFRA_ERROR_REVIEW_TEXT}"
+        )
+        assert first.verdict == "ERROR"
+        assert parse_review_verdict(first.raw).verdict == "ERROR"
+
+    def test_real_nogo_is_not_error(self) -> None:
+        """A genuine reviewer NOGO is distinct from an infra ERROR."""
+        v = parse_review_verdict("Grade: F\nVerdict: NOGO")
+        assert v.verdict == "NOGO"
+        assert v.is_error is False
+
+    def test_go_is_not_error(self) -> None:
+        """A GO verdict is not an error."""
+        v = parse_review_verdict("Grade: A\nVerdict: GO")
+        assert v.is_error is False

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -49,6 +49,13 @@ def _ambiguous() -> str:
     return "Some prose with no verdict line.\n"
 
 
+def _error() -> str:
+    # Reviewer-infrastructure failure sentinel → parse_review_verdict returns ERROR.
+    from hephaestus.automation.claude_invoke import INFRA_ERROR_REVIEW_TEXT
+
+    return f"Reviewer invocation failed at iteration 0: boom\n\n{INFRA_ERROR_REVIEW_TEXT}"
+
+
 def test_codex_implementer_advise_uses_codex_prompt_builder(
     implementer: IssueImplementer,
 ) -> None:
@@ -275,6 +282,75 @@ class TestRunImplReviewLoop:
 
         assert verdict == "NOGO"
         mock_label.assert_called_once_with(7, [STATE_SKIP])
+
+    def test_infra_error_exhaustion_does_not_apply_state_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A run that exhausts on reviewer-infra ERROR must NOT apply ``state:skip``.
+
+        Regression for #911 / PR #1069: a reviewer API 400 (advisor-tier
+        mismatch) produced an ERROR every iteration; the PR was never reviewed,
+        so skipping it strands a healthy PR. The issue must stay unlabeled for
+        re-review.
+        """
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[
+                    (_error(), []),
+                    (_error(), []),
+                    (_error(), []),
+                ],
+            ),
+            patch.object(implementer, "_run_address_review_step", return_value=True),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
+            ) as mock_label,
+        ):
+            _, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=911,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=1069,
+            )
+
+        assert verdict == "ERROR"
+        mock_label.assert_not_called()
+
+    def test_infra_error_verdict_applies_neither_implementation_label(
+        self, implementer: IssueImplementer
+    ) -> None:
+        """An ERROR verdict applies neither implementation-go nor -no-go.
+
+        The PR was never reviewed, so it must be left unlabeled for the
+        "no go/no-go label → re-review" path — not falsely marked no-go (which
+        records a review that never happened) or go (which arms auto-merge on
+        unreviewed code).
+        """
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_go"
+            ) as mock_go,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.mark_pr_implementation_no_go"
+            ) as mock_no_go,
+        ):
+            implementer.phase_runner._apply_impl_review_verdict(
+                issue_number=911,
+                pr_number=1069,
+                last_verdict="ERROR",
+                slot_id=None,
+                thread_id=None,
+            )
+
+        mock_go.assert_not_called()
+        mock_no_go.assert_not_called()
 
     def test_ambiguous_zero_threads_re_reviews_then_skips_on_exhaustion(
         self, implementer: IssueImplementer, tmp_path: Path
@@ -597,10 +673,21 @@ class TestRunImplReviewLoop:
 
 
 class TestRunImplReviewFailsSafe:
-    """When the reviewer call itself fails, treat as NoGo."""
+    """When the reviewer call itself fails, surface a distinct ERROR verdict.
 
-    def test_synthetic_nogo_on_subprocess_failure(self, implementer: IssueImplementer) -> None:
-        """Reviewer subprocess failure synthesizes a NOGO verdict."""
+    A reviewer-infrastructure failure (subprocess crash, API 400, timeout) must
+    NOT be laundered into a real NOGO — that burns review iterations and
+    triggers a spurious ``state:skip`` on a PR that was never reviewed
+    (#911 / PR #1069). It emits an ERROR sentinel so the loop re-reviews
+    instead.
+    """
+
+    def test_infra_failure_emits_error_verdict_not_nogo(
+        self, implementer: IssueImplementer
+    ) -> None:
+        """Reviewer subprocess failure synthesizes an ERROR verdict, not NOGO."""
+        from hephaestus.automation.claude_invoke import parse_review_verdict
+
         with patch(
             "hephaestus.automation.implementer.subprocess.run",
             side_effect=RuntimeError("claude down"),
@@ -614,8 +701,10 @@ class TestRunImplReviewFailsSafe:
                 iteration=0,
                 prior_review=None,
             )
-        assert "Verdict: NOGO" in out
-        assert "Grade: F" in out
+        verdict = parse_review_verdict(out)
+        assert verdict.verdict == "ERROR"
+        assert verdict.is_error is True
+        assert "Verdict: NOGO" not in out
 
 
 class TestResumeImplWithFeedback:
@@ -1042,10 +1131,17 @@ class TestRunImplReviewStep:
         mock_diff_rev.assert_called_once()
         mock_inline.assert_not_called()
 
-    def test_inline_failure_synthesizes_nogo(
+    def test_inline_failure_emits_error_verdict(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """If the in-loop reviewer raises, the step returns a synthetic NOGO."""
+        """If the in-loop reviewer raises, the step returns an ERROR sentinel.
+
+        Not a NOGO — a reviewer-infrastructure failure must be distinguishable
+        from a genuine reviewer NOGO so the loop re-reviews instead of skipping
+        (#911 / PR #1069).
+        """
+        from hephaestus.automation.claude_invoke import parse_review_verdict
+
         with (
             patch.object(implementer.phase_runner, "_fetch_plan_and_review", return_value=("", "")),
             patch.object(implementer, "_collect_diff", return_value="d"),
@@ -1066,8 +1162,8 @@ class TestRunImplReviewStep:
             )
 
         assert thread_ids == []
-        assert "Verdict: NOGO" in text
-        assert "Grade: F" in text
+        assert parse_review_verdict(text).verdict == "ERROR"
+        assert "Verdict: NOGO" not in text
 
 
 class TestRunAddressReviewStep:

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -60,6 +60,13 @@ def _nogo_review(grade: str = "D") -> str:
     return f"Significant gaps.\n\nGrade: {grade}\nVerdict: NOGO\n"
 
 
+def _error_review() -> str:
+    # Reviewer-infrastructure failure sentinel → parse_review_verdict → ERROR.
+    from hephaestus.automation.claude_invoke import INFRA_ERROR_REVIEW_TEXT
+
+    return f"Reviewer invocation failed at iteration 0: boom\n\n{INFRA_ERROR_REVIEW_TEXT}"
+
+
 class TestRunPlanReviewLoop:
     """Integration tests for _run_plan_review_loop end-to-end."""
 
@@ -134,6 +141,38 @@ class TestRunPlanReviewLoop:
         assert mock_plan.call_count == 2
         assert mock_review.call_count == 2
         assert verdict_is_go is True
+
+    def test_infra_error_review_leaves_plan_labels_unchanged(self, planner: Planner) -> None:
+        """A reviewer-infra ERROR must NOT apply state:plan-no-go.
+
+        Mirrors the implementation-loop fix (#911): an infra failure is not a
+        real verdict, so the plan stays unlabeled for re-review rather than
+        being mislabeled no-go.
+        """
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.gh_issue_json",
+                return_value={"title": "T", "body": "B"},
+            ),
+            patch.object(
+                planner,
+                "_generate_plan",
+                side_effect=["plan v0", "plan v1", "plan v2"],
+            ),
+            patch.object(planner, "_capture_planner_learnings", return_value=""),
+            patch.object(
+                planner,
+                "_run_plan_review",
+                side_effect=[_error_review(), _error_review(), _error_review()],
+            ),
+            patch.object(planner.review_loop, "_apply_state_label") as mock_label,
+        ):
+            _plan, _review, iters, verdict_is_go = planner._run_plan_review_loop(123, slot_id=0)
+
+        # All three iterations were infra errors — never a real verdict.
+        assert verdict_is_go is False
+        assert iters == MAX_REVIEW_ITERATIONS == 3
+        mock_label.assert_not_called()
 
     def test_prior_review_passed_to_next_plan(self, planner: Planner) -> None:
         """Iteration N+1 must receive iteration N's review as `prior_review`."""
@@ -546,10 +585,16 @@ class TestCapturePlannerLearnings:
 
 
 class TestRunPlanReview:
-    """The reviewer must fail safely to NoGo when the call errors."""
+    """The reviewer must surface a distinct ERROR when the call itself errors."""
 
-    def test_review_call_failure_returns_synthetic_nogo(self, planner: Planner) -> None:
-        """Reviewer call failure synthesizes a NOGO verdict so the loop continues."""
+    def test_review_call_failure_returns_error_verdict_not_nogo(self, planner: Planner) -> None:
+        """Reviewer-infra failure yields an ERROR verdict, not a fabricated NOGO.
+
+        A genuine NOGO would stamp ``state:plan-no-go`` on a plan that was never
+        reviewed; the ERROR sentinel keeps the plan unlabeled for re-review.
+        """
+        from hephaestus.automation.claude_invoke import parse_review_verdict
+
         with patch.object(planner, "_call_claude", side_effect=RuntimeError("review down")):
             out = planner._run_plan_review(
                 issue_number=1,
@@ -560,8 +605,8 @@ class TestRunPlanReview:
                 iteration=0,
                 prior_review=None,
             )
-        assert "Verdict: NOGO" in out
-        assert "Grade: F" in out
+        assert parse_review_verdict(out).verdict == "ERROR"
+        assert "Verdict: NOGO" not in out
 
     def test_uses_fresh_per_iteration_reviewer_session(self, planner: Planner) -> None:
         """Stage 1: the reviewer gets a FRESH session per iteration (``-r{iteration}``).


### PR DESCRIPTION
## Summary

When the in-loop reviewer subprocess itself fails — an API 400 (the Fable advisor-tier mismatch that hit #911), a timeout, a crash, or empty output — the review loop fabricated a real `Grade: F / Verdict: NOGO`. That is indistinguishable from a genuine reviewer NOGO, so after `MAX_REVIEW_ITERATIONS` of forced-NOGO it stamped `state:skip` on the issue and `state:implementation-no-go` on PR #1069 — a PR that was **never actually reviewed**.

## Fix

Reviewer-infrastructure failure now gets a distinct `Verdict: ERROR` sentinel (`INFRA_ERROR_REVIEW_TEXT`), surfaced by `parse_review_verdict` as `verdict="ERROR"` with a new `ReviewVerdict.is_error`. The loop treats ERROR as **inconclusive**, not a verdict:

- exhaustion on ERROR does **not** apply `state:skip`
- `_apply_impl_review_verdict` applies **neither** `state:implementation-go` nor `-no-go` on ERROR
- the plan reviewer leaves plan labels unchanged on ERROR

The PR/issue is left unlabeled, so the existing **"no go/no-go label → re-review"** path re-runs the review next loop once the reviewer infra is healthy. State labels stay the source of truth; an infra failure is no longer mistaken for a verdict.

All three laundering sites are fixed: `_run_impl_review_step` (PR-inline), `_run_impl_review` (diff-only), and `_run_plan_review` (plan reviewer).

## Out of scope

The Fable advisor-tier 400 itself is a Claude Code settings matter — the repo wires no advisor tool, so it can't be fixed in code here. (`/advisor` disable, or pointing the advisor at the same/higher tier, resolves it.)

## Verification

- `pixi run ruff check` — clean
- `pixi run mypy` — `Success: no issues found in 342 source files`
- `pixi run pytest` (implementer_loop / claude_invoke / planner_loop / pr_manager / state_labels / ci_driver) — 289 passed
- New + flipped tests assert: infra failure → ERROR (not NOGO); ERROR exhaustion → no `state:skip`; ERROR → neither implementation label; ERROR → plan labels unchanged; genuine sustained NOGO → still skips on real exhaustion.

## Manual cleanup (follow-up, separate from this PR)

The spurious labels on the live objects should be removed so the loop re-reviews #1069:

\`\`\`bash
gh issue edit 911 --remove-label state:skip
gh issue edit 1069 --remove-label state:implementation-no-go
\`\`\`

Closes #1123

🤖 Generated with [Claude Code](https://claude.com/claude-code)