### PR TITLE
fix(automation): resolve stale review threads quietly

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -2006,55 +2006,60 @@ def gh_pr_list_unresolved_threads(
 
 def gh_pr_resolve_thread(
     thread_id: str,
-    reply_body: str,
+    reply_body: str | None = None,
     dry_run: bool = False,
 ) -> None:
-    """Resolve a PR review thread with a reply comment.
+    """Resolve a PR review thread, optionally adding a reply first.
 
     Args:
         thread_id: GraphQL node ID of the review thread
-        reply_body: Reply comment text
+        reply_body: Optional reply comment text. When omitted, the thread is
+            resolved without adding another review comment.
         dry_run: If True, log intent without posting
 
     """
     if dry_run:
-        logger.info("[dry_run] Would resolve thread %r with reply: %r", thread_id, reply_body)
+        if reply_body:
+            logger.info("[dry_run] Would resolve thread %r with reply: %r", thread_id, reply_body)
+        else:
+            logger.info("[dry_run] Would resolve thread %r without reply", thread_id)
         return
 
-    # Step 1: post a reply to the thread via GraphQL addPullRequestReviewThreadReply.
-    # NOTE (#999): the deprecated ``addPullRequestReviewComment`` input type has no
-    # ``pullRequestReviewThreadId`` field, so it failed on every call. The reply-to-
-    # thread surface is ``addPullRequestReviewThreadReply``, whose input accepts
-    # ``pullRequestReviewThreadId`` + ``body``.
-    reply_mutation = """
+    if reply_body:
+        # Step 1: post a reply to the thread via GraphQL addPullRequestReviewThreadReply.
+        # NOTE (#999): the deprecated ``addPullRequestReviewComment`` input type has no
+        # ``pullRequestReviewThreadId`` field, so it failed on every call. The reply-to-
+        # thread surface is ``addPullRequestReviewThreadReply``, whose input accepts
+        # ``pullRequestReviewThreadId`` + ``body``.
+        reply_mutation = """
 mutation AddReply($threadId: ID!, $body: String!) {
   addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $threadId, body: $body}) {
     comment { id }
   }
 }
 """
-    reply_result = _gh_call(
-        [
-            "api",
-            "graphql",
-            "-f",
-            f"query={reply_mutation}",
-            "-f",
-            f"threadId={thread_id}",
-            "-f",
-            f"body={reply_body}",
-        ]
-    )
-    # JSONDecodeError is benign here — only an explicit ``errors`` array must
-    # surface. ``contextlib.suppress`` lets the helper raise on errors while
-    # silently absorbing the no-body case.
-    with contextlib.suppress(json.JSONDecodeError):
-        _check_graphql_errors(
-            json.loads(reply_result.stdout or "{}"),
-            f"gh_pr_resolve_thread.reply(thread={thread_id})",
+        reply_result = _gh_call(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={reply_mutation}",
+                "-f",
+                f"threadId={thread_id}",
+                "-f",
+                f"body={reply_body}",
+            ]
         )
+        # JSONDecodeError is benign here — only an explicit ``errors`` array must
+        # surface. ``contextlib.suppress`` lets the helper raise on errors while
+        # silently absorbing the no-body case.
+        with contextlib.suppress(json.JSONDecodeError):
+            _check_graphql_errors(
+                json.loads(reply_result.stdout or "{}"),
+                f"gh_pr_resolve_thread.reply(thread={thread_id})",
+            )
 
-    # Step 2: resolve the thread
+    # Resolve the thread.
     resolve_mutation = """
 mutation ResolveThread($threadId: ID!) {
   resolveReviewThread(input: {threadId: $threadId}) {

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1743,11 +1743,7 @@ class ImplementationPhaseRunner:
             if not tid:
                 continue
             try:
-                gh_pr_resolve_thread(
-                    tid,
-                    "Resolved by the automation reviewer after a GO implementation review.",
-                    dry_run=False,
-                )
+                gh_pr_resolve_thread(tid, dry_run=False)
                 resolved += 1
             except Exception as exc:
                 impl._log(

--- a/tests/unit/automation/test_ci_driver_prs_mode.py
+++ b/tests/unit/automation/test_ci_driver_prs_mode.py
@@ -94,7 +94,8 @@ class TestDiscoverPrsDirectMode:
             return_value=661,
         ):
             with patch.object(driver, "_validate_pr_open", return_value=True) as mock_validate:
-                result = driver._discover_prs([918])
+                with patch.object(driver, "_discover_failing_prs", return_value={}):
+                    result = driver._discover_prs([918])
 
         # PR 661 should appear exactly once, keyed by issue 918 (from issue path)
         assert result[918] == 661
@@ -116,7 +117,8 @@ class TestDiscoverPrsDirectMode:
             return_value=999,
         ):
             with patch.object(driver, "_validate_pr_open", return_value=True):
-                result = driver._discover_prs([918])
+                with patch.object(driver, "_discover_failing_prs", return_value={}):
+                    result = driver._discover_prs([918])
 
         # Issue 918 should map to PR 999
         assert result[918] == 999

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2632,6 +2632,19 @@ class TestGhPrResolveThread:
         assert len(thread_id_fields) == 2
 
     @patch("hephaestus.automation.github_api._gh_call")
+    def test_resolve_without_reply_does_not_add_thread_comment(self, mock_gh_call: Any) -> None:
+        """Stale-thread cleanup can resolve without adding duplicate review noise."""
+        mock_gh_call.return_value = Mock(stdout="{}")
+
+        gh_pr_resolve_thread("PRRT_quiet")
+
+        queries = self._graphql_queries(mock_gh_call)
+        joined = "\n".join(queries)
+        assert "resolveReviewThread" in joined
+        assert "addPullRequestReviewThreadReply" not in joined
+        assert mock_gh_call.call_count == 1
+
+    @patch("hephaestus.automation.github_api._gh_call")
     def test_dry_run_sends_nothing(self, mock_gh_call: Any) -> None:
         gh_pr_resolve_thread("PRRT_abc", "reply", dry_run=True)
         mock_gh_call.assert_not_called()

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -213,6 +213,11 @@ class TestRunImplReviewLoop:
         mock_addr.assert_not_called()
         resolved_ids = [call.args[0] for call in mock_resolve.call_args_list]
         assert resolved_ids == ["T_self", "T_bot", "T_nested_self"]
+        assert all(
+            call.args == (thread_id,)
+            for call, thread_id in zip(mock_resolve.call_args_list, resolved_ids, strict=True)
+        )
+        assert all(call.kwargs == {"dry_run": False} for call in mock_resolve.call_args_list)
 
     def test_runs_3_iterations_on_sustained_nogo(
         self, implementer: IssueImplementer, tmp_path: Path


### PR DESCRIPTION
## Summary
- allow review threads to be resolved without adding a reply comment
- use quiet resolution for post-GO stale automation-thread cleanup
- suppress the actual #1116 same-line restatement shapes instead of appending duplicate review notes
- isolate direct PR discovery tests from failing-PR discovery side effects

## Tests
- uv run pytest --no-cov tests/unit/automation/test_ci_driver_prs_mode.py tests/unit/automation/test_github_api.py::TestGhPrResolveThread tests/unit/automation/test_implementer_loop.py::TestRunImplReviewLoop::test_go_resolves_only_automation_owned_stale_threads -q
- uv run pytest --no-cov tests/unit/automation/test_github_api.py tests/unit/automation/test_github_api_review_threads.py tests/unit/automation/test_implementer_loop.py -q

Local pre-push full pytest was also attempted and reached coverage, but failed on known local environment issues: NATS localhost timeout, subprocess import path for compare_benchmarks.py, and missing installed console scripts. GitHub CI should provide the authoritative full gate.

Closes #1129