### PR TITLE
fix(automation): distinguish drive-green learn failures

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -1493,6 +1493,38 @@ class CIDriver:
                 exc,
             )
 
+    @staticmethod
+    def _learn_record_terminal(record: dict[str, Any]) -> bool:
+        """Return whether a drive-green /learn record should not be retried."""
+        if record.get("learn_captured_at") or record.get("learn_succeeded_at"):
+            return True
+        return str(record.get("learn_status") or "").lower() in {"succeeded", "failed"}
+
+    def _mark_drive_green_learn_result(
+        self,
+        issue_number: int,
+        record: dict[str, Any],
+        *,
+        succeeded: bool,
+    ) -> None:
+        """Persist an explicit attempted/succeeded/failed learn result.
+
+        ``learn_captured_at`` is retained as the success timestamp for older
+        readers, but failure now records ``learn_status=failed`` without
+        claiming Mnemosyne was updated.
+        """
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        record["learn_attempted_at"] = timestamp
+        if succeeded:
+            record["learn_status"] = "succeeded"
+            record["learn_succeeded_at"] = timestamp
+            record["learn_captured_at"] = timestamp
+        else:
+            record["learn_status"] = "failed"
+            record["learn_succeeded_at"] = None
+            record["learn_captured_at"] = None
+        self._save_arming_state(issue_number, record)
+
     def _arm_drive_green(self, pr_number: int, pr_head_branch: str, pr_head_sha: str) -> None:
         """Record arming for every issue that resolved to ``pr_number``.
 
@@ -1511,15 +1543,18 @@ class CIDriver:
         armed_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         for issue_num in siblings:
             existing = self._load_arming_state(issue_num) or {}
-            if existing.get("learn_captured_at"):
-                # Already captured — don't overwrite the captured timestamp.
+            if self._learn_record_terminal(existing):
+                # Already attempted terminally — don't overwrite learn evidence.
                 continue
             record = {
                 "pr_number": pr_number,
                 "pr_head_branch": pr_head_branch,
                 "head_sha_at_arming": pr_head_sha,
                 "armed_at": armed_at,
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             }
             self._save_arming_state(issue_num, record)
             logger.info(
@@ -1701,8 +1736,8 @@ class CIDriver:
 
         Sweep every ``drive-green-armed-*.json`` at startup: drop records
         whose PR is CLOSED-not-merged, fire ``/learn`` once for records
-        whose PR is MERGED (then mark ``learn_captured_at``), leave OPEN
-        records alone for the normal per-issue path to handle.
+        whose PR is MERGED (then mark explicit succeeded/failed learn status),
+        leave OPEN records alone for the normal per-issue path to handle.
         """
         try:
             records = sorted(self.state_dir.glob("drive-green-armed-*.json"))
@@ -1722,7 +1757,7 @@ class CIDriver:
             record = self._load_arming_state(issue_number)
             if record is None:
                 continue
-            if record.get("learn_captured_at"):
+            if self._learn_record_terminal(record):
                 continue
             pr_number = record.get("pr_number")
             if not isinstance(pr_number, int):
@@ -1744,10 +1779,13 @@ class CIDriver:
                     issue_number,
                     pr_number,
                 )
-                self._run_drive_green_learnings(issue_number, pr_number)
+                learn_succeeded = self._run_drive_green_learnings(issue_number, pr_number)
                 self._run_drive_green_compact(issue_number, pr_number)
-                record["learn_captured_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-                self._save_arming_state(issue_number, record)
+                self._mark_drive_green_learn_result(
+                    issue_number,
+                    record,
+                    succeeded=learn_succeeded,
+                )
             elif state == "CLOSED":
                 logger.info(
                     "Arming sweep: issue #%s / PR #%s CLOSED-not-merged; dropping record",
@@ -1765,20 +1803,23 @@ class CIDriver:
         Called at the top of ``_drive_issue``. Returns:
 
         - ``WorkerResult(success=True, ...)`` if the arming record handled
-          the issue (merge detected + ``/learn`` fired, OR still in flight,
-          OR already-captured). Caller returns this directly without doing
-          any further drive work.
+          the issue (merge detected + ``/learn`` attempted, OR still in flight,
+          OR a terminal learn result already exists). Caller returns this
+          directly without doing any further drive work.
         - ``None`` if the issue should fall through to the normal drive
           path (no arming record, arming stale, or PR abandoned).
         """
         record = self._load_arming_state(issue_number)
         if record is None:
             return None
-        if record.get("learn_captured_at"):
+        if self._learn_record_terminal(record):
             logger.info(
-                "Issue #%s: /learn already captured at %s; skipping further drive",
+                "Issue #%s: /learn already terminal (%s at %s); skipping further drive",
                 issue_number,
-                record["learn_captured_at"],
+                record.get("learn_status") or "succeeded",
+                record.get("learn_captured_at")
+                or record.get("learn_succeeded_at")
+                or record.get("learn_attempted_at"),
             )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
@@ -1800,12 +1841,13 @@ class CIDriver:
             self.status_tracker.update_slot(
                 0, f"{issue_ref(issue_number)}: capturing post-merge /learn"
             )
-            self._run_drive_green_learnings(issue_number, pr_number)
+            learn_succeeded = self._run_drive_green_learnings(issue_number, pr_number)
             self._run_drive_green_compact(issue_number, pr_number)
-            # Mark captured even if /learn failed — it's best-effort and
-            # retrying it on every subsequent run would churn API calls.
-            record["learn_captured_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-            self._save_arming_state(issue_number, record)
+            self._mark_drive_green_learn_result(
+                issue_number,
+                record,
+                succeeded=learn_succeeded,
+            )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
         if state == "CLOSED":
@@ -1850,10 +1892,13 @@ class CIDriver:
             self.status_tracker.update_slot(
                 0, f"{issue_ref(issue_number)}: capturing post-merge /learn"
             )
-            self._run_drive_green_learnings(issue_number, pr_number)
+            learn_succeeded = self._run_drive_green_learnings(issue_number, pr_number)
             self._run_drive_green_compact(issue_number, pr_number)
-            record["learn_captured_at"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-            self._save_arming_state(issue_number, record)
+            self._mark_drive_green_learn_result(
+                issue_number,
+                record,
+                succeeded=learn_succeeded,
+            )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
         if outcome == "CLOSED":
             self._clear_arming_state(issue_number)

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -977,7 +977,10 @@ class TestDriveGreenLearnings:
         assert record["pr_number"] == 456
         assert record["pr_head_branch"] == "123-impl"
         assert record["head_sha_at_arming"] == "abc1234"
+        assert record["learn_attempted_at"] is None
         assert record["learn_captured_at"] is None
+        assert record["learn_status"] is None
+        assert record["learn_succeeded_at"] is None
 
     def test_arming_fans_out_across_shared_pr_group(self, driver: CIDriver) -> None:
         """A PR closing 9 issues → 9 arming records (so 9 /learns fire on merge)."""
@@ -1008,7 +1011,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "old-branch",
                 "head_sha_at_arming": "deadbee",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": "2026-01-02T00:00:00Z",
                 "learn_captured_at": "2026-01-02T00:00:00Z",
+                "learn_status": "succeeded",
+                "learn_succeeded_at": "2026-01-02T00:00:00Z",
             },
         )
 
@@ -1029,7 +1035,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             },
         )
         with (
@@ -1053,6 +1062,9 @@ class TestDriveGreenLearnings:
         record = driver._load_arming_state(42)
         assert record is not None
         assert record["learn_captured_at"] is not None
+        assert record["learn_attempted_at"] is not None
+        assert record["learn_status"] == "succeeded"
+        assert record["learn_succeeded_at"] == record["learn_captured_at"]
 
     def test_check_armed_pr_merged_skips_when_already_captured(self, driver: CIDriver) -> None:
         """learn_captured_at != None → return success without re-firing /learn."""
@@ -1063,7 +1075,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": "2026-01-02T00:00:00Z",
                 "learn_captured_at": "2026-01-02T00:00:00Z",
+                "learn_status": "succeeded",
+                "learn_succeeded_at": "2026-01-02T00:00:00Z",
             },
         )
         with (
@@ -1078,6 +1093,37 @@ class TestDriveGreenLearnings:
         mock_learn.assert_not_called()
         mock_state.assert_not_called()
 
+    def test_check_armed_pr_merged_skips_when_learn_failed_terminal(self, driver: CIDriver) -> None:
+        """learn_status=failed prevents retry without pretending capture succeeded."""
+        driver._save_arming_state(
+            42,
+            {
+                "pr_number": 500,
+                "pr_head_branch": "42-impl",
+                "head_sha_at_arming": "abc1234",
+                "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": "2026-01-02T00:00:00Z",
+                "learn_captured_at": None,
+                "learn_status": "failed",
+                "learn_succeeded_at": None,
+            },
+        )
+        with (
+            patch.object(driver, "_gh_pr_state") as mock_state,
+            patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+        ):
+            result = driver._check_arming_on_drive_start(42, 500)
+
+        assert result is not None
+        assert result.success is True
+        mock_learn.assert_not_called()
+        mock_state.assert_not_called()
+        record = driver._load_arming_state(42)
+        assert record is not None
+        assert record["learn_attempted_at"] == "2026-01-02T00:00:00Z"
+        assert record["learn_captured_at"] is None
+        assert record["learn_status"] == "failed"
+
     def test_check_armed_pr_open_at_same_sha_waits_then_pending(self, driver: CIDriver) -> None:
         """OPEN at the armed SHA → wait; still pending (TIMEOUT) keeps the record."""
         driver._save_arming_state(
@@ -1087,7 +1133,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             },
         )
         with (
@@ -1117,7 +1166,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             },
         )
         with (
@@ -1138,6 +1190,9 @@ class TestDriveGreenLearnings:
         record = driver._load_arming_state(42)
         assert record is not None
         assert record["learn_captured_at"] is not None
+        assert record["learn_attempted_at"] is not None
+        assert record["learn_status"] == "succeeded"
+        assert record["learn_succeeded_at"] == record["learn_captured_at"]
 
     def test_check_armed_pr_head_advanced_clears_record_and_falls_through(
         self, driver: CIDriver
@@ -1150,7 +1205,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             },
         )
         with patch.object(
@@ -1176,7 +1234,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             },
         )
         with (
@@ -1198,11 +1259,11 @@ class TestDriveGreenLearnings:
         result = driver._check_arming_on_drive_start(42, 500)
         assert result is None
 
-    def test_learn_failure_marks_captured_to_avoid_loop(self, driver: CIDriver) -> None:
-        """A failing /learn still flips learn_captured_at so we don't loop forever."""
+    def test_learn_failure_marks_failed_without_claiming_capture(self, driver: CIDriver) -> None:
+        """A failing /learn is terminal but does not claim Mnemosyne was updated."""
         # If /learn fails (model quota, network, etc.) and we retried it on
         # every subsequent run, we'd churn API calls for the same issue
-        # indefinitely. Best-effort: mark captured, log the failure, move on.
+        # indefinitely. Best-effort: mark failed, log the failure, move on.
         driver._save_arming_state(
             42,
             {
@@ -1210,7 +1271,10 @@ class TestDriveGreenLearnings:
                 "pr_head_branch": "42-impl",
                 "head_sha_at_arming": "abc1234",
                 "armed_at": "2026-01-01T00:00:00Z",
+                "learn_attempted_at": None,
                 "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
             },
         )
         with (
@@ -1227,7 +1291,10 @@ class TestDriveGreenLearnings:
         assert result.success is True
         record = driver._load_arming_state(42)
         assert record is not None
-        assert record["learn_captured_at"] is not None
+        assert record["learn_attempted_at"] is not None
+        assert record["learn_captured_at"] is None
+        assert record["learn_succeeded_at"] is None
+        assert record["learn_status"] == "failed"
 
     def test_learnings_run_with_codex(self, driver: CIDriver, tmp_path: Path) -> None:
         """Codex captures drive-green learnings without invoking Claude."""
@@ -2002,6 +2069,9 @@ class TestArmingSweep:
         issue: int,
         pr_number: int,
         learn_captured_at: str | None = None,
+        learn_status: str | None = None,
+        learn_attempted_at: str | None = None,
+        learn_succeeded_at: str | None = None,
     ) -> Path:
         path = driver.state_dir / f"drive-green-armed-{issue}.json"
         path.write_text(
@@ -2011,7 +2081,10 @@ class TestArmingSweep:
                     "pr_head_branch": f"{issue}-impl",
                     "head_sha_at_arming": "deadbeef",
                     "armed_at": "2026-05-31T00:00:00Z",
+                    "learn_attempted_at": learn_attempted_at,
                     "learn_captured_at": learn_captured_at,
+                    "learn_status": learn_status,
+                    "learn_succeeded_at": learn_succeeded_at,
                 }
             )
         )
@@ -2033,6 +2106,9 @@ class TestArmingSweep:
         mock_learn.assert_called_once_with(841, 843)
         record = json.loads((driver.state_dir / "drive-green-armed-841.json").read_text())
         assert record["learn_captured_at"] is not None
+        assert record["learn_attempted_at"] is not None
+        assert record["learn_status"] == "succeeded"
+        assert record["learn_succeeded_at"] == record["learn_captured_at"]
 
     def test_closed_not_merged_orphan_dropped(self, driver: CIDriver, tmp_path: Path) -> None:
         path = self._write_record(driver, issue=841, pr_number=843)
@@ -2056,7 +2132,13 @@ class TestArmingSweep:
 
     def test_already_captured_skipped(self, driver: CIDriver, tmp_path: Path) -> None:
         self._write_record(
-            driver, issue=841, pr_number=843, learn_captured_at="2026-05-31T00:00:00Z"
+            driver,
+            issue=841,
+            pr_number=843,
+            learn_captured_at="2026-05-31T00:00:00Z",
+            learn_status="succeeded",
+            learn_attempted_at="2026-05-31T00:00:00Z",
+            learn_succeeded_at="2026-05-31T00:00:00Z",
         )
         with (
             patch.object(driver, "_gh_pr_state") as mock_state,
@@ -2065,6 +2147,27 @@ class TestArmingSweep:
             driver._sweep_orphaned_arming_records()
         mock_state.assert_not_called()
         mock_learn.assert_not_called()
+
+    def test_already_failed_terminal_skipped(self, driver: CIDriver, tmp_path: Path) -> None:
+        self._write_record(
+            driver,
+            issue=841,
+            pr_number=843,
+            learn_captured_at=None,
+            learn_status="failed",
+            learn_attempted_at="2026-05-31T00:00:00Z",
+            learn_succeeded_at=None,
+        )
+        with (
+            patch.object(driver, "_gh_pr_state") as mock_state,
+            patch.object(driver, "_run_drive_green_learnings") as mock_learn,
+        ):
+            driver._sweep_orphaned_arming_records()
+        mock_state.assert_not_called()
+        mock_learn.assert_not_called()
+        record = json.loads((driver.state_dir / "drive-green-armed-841.json").read_text())
+        assert record["learn_captured_at"] is None
+        assert record["learn_status"] == "failed"
 
     def test_unknown_gh_state_left_alone(self, driver: CIDriver, tmp_path: Path) -> None:
         path = self._write_record(driver, issue=841, pr_number=843)
@@ -2076,8 +2179,10 @@ class TestArmingSweep:
         mock_learn.assert_not_called()
         assert path.exists()
 
-    def test_learn_failure_still_marks_captured(self, driver: CIDriver, tmp_path: Path) -> None:
-        """Best-effort: a /learn that throws still marks captured (no infinite retry)."""
+    def test_learn_exception_leaves_record_retryable(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        """Unexpected exceptions leave the record unclaimed and retryable."""
         self._write_record(driver, issue=841, pr_number=843)
         with (
             patch.object(driver, "_gh_pr_state", return_value={"state": "MERGED"}),
@@ -2096,6 +2201,23 @@ class TestArmingSweep:
                 driver._sweep_orphaned_arming_records()
         record = json.loads((driver.state_dir / "drive-green-armed-841.json").read_text())
         assert record["learn_captured_at"] is None
+
+    def test_merged_orphan_learn_false_marks_failed_not_captured(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        """A best-effort /learn failure is terminal but not recorded as captured."""
+        self._write_record(driver, issue=841, pr_number=843)
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"state": "MERGED"}),
+            patch.object(driver, "_run_drive_green_learnings", return_value=False) as mock_learn,
+        ):
+            driver._sweep_orphaned_arming_records()
+        mock_learn.assert_called_once_with(841, 843)
+        record = json.loads((driver.state_dir / "drive-green-armed-841.json").read_text())
+        assert record["learn_attempted_at"] is not None
+        assert record["learn_captured_at"] is None
+        assert record["learn_succeeded_at"] is None
+        assert record["learn_status"] == "failed"
 
 
 class TestRunSweeperWiring:


### PR DESCRIPTION
## Summary
- record drive-green /learn attempts with explicit attempted/succeeded/failed fields
- keep learn_captured_at as a success-only compatibility timestamp
- treat failed learn attempts as terminal to avoid retry loops without claiming Mnemosyne capture
- apply the same semantics to merged orphan sweeps and per-issue merge detection

## Tests
- uv run ruff check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- uv run ruff format --check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- uv run pytest --no-cov tests/unit/automation/test_ci_driver.py -q
- attempted full local pre-push pytest: 3819 passed, 101 skipped, coverage 85.63%, failed on known local environment issues unrelated to this diff: NATS localhost timeout, compare_benchmarks.py subprocess import path, and missing installed console scripts

Closes #1130