### PR TITLE
fix(automation): resolve ci review threads quietly

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2017,14 +2017,14 @@ class CIDriver:
         return login.endswith("[bot]")
 
     def _reply_and_resolve_bot_threads(self, pr_number: int) -> int:
-        """Reply to and resolve automated review threads after a successful CI fix.
+        """Resolve automated review threads after a successful CI fix.
 
         ci_driver surfaces unresolved threads to the fix prompt but cannot rely
         on GitHub auto-resolving a bot thread when its line moves. After a fix
-        lands, post a templated reply on each BOT-authored unresolved thread and
-        resolve it, so the PR's automated review comments are acknowledged
-        rather than left dangling. Human threads are left untouched. Best-effort:
-        a failure on one thread is logged and skipped (never blocks the fix).
+        lands, resolve each BOT-authored unresolved thread without adding
+        another reply comment, so automated review comments are closed rather
+        than left dangling. Human threads are left untouched. Best-effort: a
+        failure on one thread is logged and skipped (never blocks the fix).
 
         Returns the number of threads resolved.
         """
@@ -2039,22 +2039,18 @@ class CIDriver:
             if not thread_id:
                 continue
             try:
-                gh_pr_resolve_thread(
-                    thread_id,
-                    "Addressed by the automated CI fix on this PR.",
-                    dry_run=False,
-                )
+                gh_pr_resolve_thread(thread_id, dry_run=False)
                 resolved += 1
             except Exception as exc:
                 logger.info(
-                    "PR #%s: could not reply/resolve bot thread %s (%s); skipping",
+                    "PR #%s: could not resolve bot thread %s (%s); skipping",
                     pr_number,
                     thread_id,
                     exc,
                 )
         if resolved:
             logger.info(
-                "PR #%s: replied to and resolved %s automated review thread(s)",
+                "PR #%s: resolved %s automated review thread(s)",
                 pr_number,
                 resolved,
             )

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -166,7 +166,7 @@ class TestLoadImplSessionId:
 
 
 class TestReplyAndResolveBotThreads:
-    """After a CI fix, bot review threads are replied to + resolved; humans aren't."""
+    """After a CI fix, bot review threads are resolved quietly; humans aren't."""
 
     def test_resolves_only_bot_threads(self, driver: CIDriver) -> None:
         threads = [
@@ -180,8 +180,7 @@ class TestReplyAndResolveBotThreads:
             count = driver._reply_and_resolve_bot_threads(999)
 
         assert count == 1
-        resolve.assert_called_once()
-        assert resolve.call_args.args[0] == "T_bot"
+        resolve.assert_called_once_with("T_bot", dry_run=False)
 
     def test_no_threads_is_noop(self, driver: CIDriver) -> None:
         with (


### PR DESCRIPTION
## Summary
- resolve drive-green bot-authored review threads without adding a reply comment
- keep human-authored review threads untouched
- update tests to assert no reply body is passed when resolving CI bot threads

## Tests
- uv run ruff check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- uv run ruff format --check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py
- uv run pytest --no-cov tests/unit/automation/test_ci_driver.py::TestReplyAndResolveBotThreads tests/unit/automation/test_github_api.py::TestGhPrResolveThread -q
- uv run pytest --no-cov tests/unit/automation/test_ci_driver.py -q

Closes #1132