### PR TITLE
fix(automation): persist planner learn attempts

### DIFF
--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -28,6 +28,8 @@ def build_learn_prompt(context: str) -> str:
         detail = f" {detail}"
     return (
         f"/learn{detail}"
+        " EXECUTE the /learn skill-creation workflow for ProjectMnemosyne."
+        " Do NOT return a plan. Do NOT ask for approval."
         " Commit the results and create a PR."
         " IMPORTANT: Only push skills to ProjectMnemosyne."
         " Do NOT create files under .claude-plugin/ in this repo."

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -15,13 +15,16 @@ on the worker-pool driver. No behavior change.
 
 from __future__ import annotations
 
+import json
 import logging
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Protocol
 
 from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
 from .claude_timeouts import planner_claude_timeout
-from .git_utils import issue_ref
+from .git_utils import get_repo_root, issue_ref
 from .github_api import (
     gh_issue_add_labels,
     gh_issue_json,
@@ -594,18 +597,63 @@ class PlanReviewLoop:
         )
         prompt = build_learn_prompt(context)
         try:
-            return self.planner._call_claude(
+            output = self.planner._call_claude(
                 prompt,
                 model=planner_model(),
                 agent=AGENT_PLANNER,
                 issue_number=issue_number,
                 timeout=120,
             )
+            self._write_planner_learn_record(issue_number, succeeded=True, output=output)
+            return output
         except Exception as e:
             logger.warning(
                 "%s: planner-learnings capture failed (non-fatal): %s", issue_ref(issue_number), e
             )
+            self._write_planner_learn_record(issue_number, succeeded=False, error=str(e))
             return ""
+
+    def _planner_learn_state_dir(self) -> Path:
+        state_dir = get_repo_root() / "build" / ".issue_implementer"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        return state_dir
+
+    def _write_planner_learn_record(
+        self,
+        issue_number: int,
+        *,
+        succeeded: bool,
+        output: str = "",
+        error: str = "",
+    ) -> None:
+        """Persist explicit planner ``/learn`` attempt evidence.
+
+        Planner learn is best-effort and must never block planning, but the
+        automation loop needs durable evidence that the learn step was tried
+        and whether it actually succeeded.
+        """
+        try:
+            state_dir = self._planner_learn_state_dir()
+            timestamp = datetime.now(timezone.utc).isoformat()
+            log_file = state_dir / f"planner-learn-{issue_number}.log"
+            record_file = state_dir / f"planner-learn-{issue_number}.json"
+            log_file.write_text(output if succeeded else f"FAILED: {error}\n")
+            record = {
+                "issue_number": issue_number,
+                "learn_attempted_at": timestamp,
+                "learn_status": "succeeded" if succeeded else "failed",
+                "learn_succeeded_at": timestamp if succeeded else None,
+                "log_path": str(log_file),
+            }
+            if error:
+                record["error"] = error
+            record_file.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+        except OSError as exc:
+            logger.warning(
+                "%s: failed to write planner-learnings state (non-fatal): %s",
+                issue_ref(issue_number),
+                exc,
+            )
 
     def run_plan_review(
         self,

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import patch
 
@@ -607,9 +608,51 @@ class TestCapturePlannerLearnings:
 
         prompt = mock_call.call_args.args[0]
         assert prompt.startswith("/learn ")
+        assert "EXECUTE the /learn skill-creation workflow" in prompt
         assert "ProjectMnemosyne" in prompt
         assert "/skills-registry-commands:learn" not in prompt
         assert "plan text" in prompt
+
+    def test_writes_success_record(self, planner: Planner, tmp_path: Any) -> None:
+        """A successful planner /learn attempt leaves durable evidence."""
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.get_repo_root",
+                return_value=tmp_path,
+            ),
+            patch.object(planner, "_call_claude", return_value="- learning A\n"),
+        ):
+            out = planner._capture_planner_learnings(123, "plan text")
+
+        state_dir = tmp_path / "build" / ".issue_implementer"
+        record = json.loads((state_dir / "planner-learn-123.json").read_text())
+        assert out == "- learning A\n"
+        assert record["issue_number"] == 123
+        assert record["learn_status"] == "succeeded"
+        assert record["learn_attempted_at"]
+        assert record["learn_succeeded_at"] == record["learn_attempted_at"]
+        assert (state_dir / "planner-learn-123.log").read_text() == "- learning A\n"
+
+    def test_writes_failure_record(self, planner: Planner, tmp_path: Any) -> None:
+        """A failed planner /learn attempt is explicit but still non-fatal."""
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.get_repo_root",
+                return_value=tmp_path,
+            ),
+            patch.object(planner, "_call_claude", side_effect=RuntimeError("claude down")),
+        ):
+            out = planner._capture_planner_learnings(123, "plan text")
+
+        state_dir = tmp_path / "build" / ".issue_implementer"
+        record = json.loads((state_dir / "planner-learn-123.json").read_text())
+        assert out == ""
+        assert record["issue_number"] == 123
+        assert record["learn_status"] == "failed"
+        assert record["learn_attempted_at"]
+        assert record["learn_succeeded_at"] is None
+        assert record["error"] == "claude down"
+        assert (state_dir / "planner-learn-123.log").read_text().startswith("FAILED:")
 
 
 class TestRunPlanReview:


### PR DESCRIPTION
Closes #1134

## Summary
- persist planner /learn attempts to build/.issue_implementer/planner-learn-<issue>.json and .log
- record explicit succeeded/failed planner learn status without blocking the planner loop
- harden the shared /learn prompt so agents execute the ProjectMnemosyne learn workflow instead of returning a plan

## Tests
- uv run pytest --no-cov tests/unit/automation/test_planner_loop.py
- uv run pytest --no-cov tests/unit/automation/test_planner_loop.py::TestCapturePlannerLearnings
- uv run ruff check hephaestus/automation/learn.py hephaestus/automation/planner_review_loop.py tests/unit/automation/test_planner_loop.py
- uv run ruff format --check hephaestus/automation/learn.py hephaestus/automation/planner_review_loop.py tests/unit/automation/test_planner_loop.py
- uv run mypy hephaestus/automation/learn.py hephaestus/automation/planner_review_loop.py tests/unit/automation/test_planner_loop.py

## Local pre-push note
The full local pre-push pytest hook still fails on unrelated host setup issues: NATS localhost timeout, subprocess import path for scripts/compare_benchmarks.py, and missing installed console-script entry points. The full run reached 3821 passed / 101 skipped / 85.64% coverage before failing those existing environment buckets.
