### PR TITLE
fix(automation): persist implementer learn attempts

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -292,7 +292,9 @@ def resolve_addressed_threads(
 
     Args:
         addressed: Thread-id strings Claude reported as fixed.
-        replies: Mapping of thread-id to a one-line reply describing the fix.
+        replies: Mapping of thread-id to a one-line reply describing the fix. The
+            mapping is retained for the agent-output contract but intentionally
+            not posted; resolving quietly avoids adding duplicate review noise.
         presented_thread_ids: Thread IDs we presented to Claude (the unresolved
             set on this PR at fix time).
         dry_run: Forwarded to :func:`gh_pr_resolve_thread`.
@@ -306,9 +308,8 @@ def resolve_addressed_threads(
                 thread_id,
             )
             continue
-        reply = replies.get(thread_id, "Addressed in code.")
         try:
-            gh_pr_resolve_thread(thread_id, reply, dry_run=dry_run)
+            gh_pr_resolve_thread(thread_id, dry_run=dry_run)
         except Exception as e:
             logger.warning("Could not resolve thread %s: %s", thread_id, e)
 
@@ -972,7 +973,9 @@ class AddressReviewer(BaseReviewer):
 
         Args:
             addressed: List of thread_id strings Claude reported as fixed
-            replies: Mapping of thread_id to one-line reply describing the fix
+            replies: Mapping of thread_id to one-line reply describing the fix.
+                Retained for the agent-output contract; resolution is quiet and
+                does not post these replies to GitHub.
             presented_thread_ids: Set of thread IDs we presented to Claude
                 (i.e. the unresolved set on this PR at fix time)
 

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -7,8 +7,10 @@ Provides:
 
 from __future__ import annotations
 
+import json
 import logging
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
 from hephaestus.agents.runtime import resume_codex_session, session_agent_matches
@@ -19,6 +21,32 @@ from .git_utils import run
 from .session_naming import session_uuid
 
 logger = logging.getLogger(__name__)
+
+
+def _write_learn_record(
+    state_dir: Path,
+    issue_number: int,
+    *,
+    succeeded: bool,
+    log_file: Path,
+    error: str = "",
+) -> None:
+    """Persist explicit implementer ``/learn`` attempt evidence."""
+    timestamp = datetime.now(timezone.utc).isoformat()
+    record: dict[str, object] = {
+        "issue_number": issue_number,
+        "learn_attempted_at": timestamp,
+        "learn_status": "succeeded" if succeeded else "failed",
+        "learn_succeeded_at": timestamp if succeeded else None,
+        "log_path": str(log_file),
+    }
+    if error:
+        record["error"] = error
+    record_file = state_dir / f"learn-{issue_number}.json"
+    try:
+        record_file.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+    except OSError as exc:
+        logger.warning("Learn record write failed for issue #%s: %s", issue_number, exc)
 
 
 def build_learn_prompt(context: str) -> str:
@@ -75,6 +103,13 @@ def run_learn(
         )
         logger.warning("Learn skipped for issue #%s: %s", issue_number, message)
         log_file.write_text(f"FAILED: {message}\n")
+        _write_learn_record(
+            state_dir,
+            issue_number,
+            succeeded=False,
+            log_file=log_file,
+            error=message,
+        )
         return False
 
     if agent == "codex":
@@ -86,12 +121,20 @@ def run_learn(
                 timeout=learn_claude_timeout(),
             )
             log_file.write_text(codex_result.stdout)
+            _write_learn_record(state_dir, issue_number, succeeded=True, log_file=log_file)
             logger.info("Learn completed for issue #%s", issue_number)
             logger.info("Learn log: %s", log_file)
             return True
         except Exception as e:  # broad catch: external agent process; non-blocking
             logger.warning("Learn failed for issue #%s: %s", issue_number, e)
             log_file.write_text(f"FAILED: {e}\n")
+            _write_learn_record(
+                state_dir,
+                issue_number,
+                succeeded=False,
+                log_file=log_file,
+                error=str(e),
+            )
             return False
 
     # /learn is a SIMPLE-complexity task (summarization + file writes), so we
@@ -121,6 +164,7 @@ def run_learn(
         )
         # Write output to log file
         log_file.write_text(result.stdout or "")
+        _write_learn_record(state_dir, issue_number, succeeded=True, log_file=log_file)
         logger.info("Learn completed for issue #%s", issue_number)
         logger.info("Learn log: %s", log_file)
         return True
@@ -134,6 +178,13 @@ def run_learn(
         if hasattr(e, "stderr"):
             error_output += f"\nSTDERR:\n{e.stderr or ''}"
         log_file.write_text(error_output)
+        _write_learn_record(
+            state_dir,
+            issue_number,
+            succeeded=False,
+            log_file=log_file,
+            error=str(e),
+        )
 
         # Non-blocking: never re-raise
         return False

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -270,11 +270,7 @@ def _resolve_addressed_prior_threads(
         if str(thread_id) in unaddressed_ids:
             continue  # still open — re-opened above
         try:
-            gh_pr_resolve_thread(
-                thread_id,
-                "Verified addressed by the current diff; resolving.",
-                dry_run=False,
-            )
+            gh_pr_resolve_thread(thread_id, dry_run=False)
             resolved.append(thread_id)
         except (subprocess.CalledProcessError, OSError) as exc:
             logger.warning("Failed to resolve addressed thread %s: %s", thread_id, exc)

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -213,7 +213,7 @@ class TestResolveAddressedThreads:
         with patch("hephaestus.automation.address_review.gh_pr_resolve_thread") as mock_resolve:
             reviewer._resolve_addressed_threads(addressed, replies, presented)
 
-        mock_resolve.assert_called_once_with("thread-id-1", "Fixed the issue", dry_run=False)
+        mock_resolve.assert_called_once_with("thread-id-1", dry_run=False)
 
     def test_resolve_multiple_addressed_threads(self, reviewer: AddressReviewer) -> None:
         """All addressed threads present in the unresolved set are resolved."""
@@ -260,7 +260,7 @@ class TestResolveAddressedThreads:
         with patch("hephaestus.automation.address_review.gh_pr_resolve_thread") as mock_resolve:
             reviewer._resolve_addressed_threads(addressed, replies, presented)
 
-        mock_resolve.assert_called_once_with("thread-real", "Fixed", dry_run=False)
+        mock_resolve.assert_called_once_with("thread-real", dry_run=False)
 
     def test_dry_run_no_resolve(self, mock_options: AddressReviewOptions, tmp_path: Path) -> None:
         """dry_run=True → gh_pr_resolve_thread is called with dry_run=True."""
@@ -284,7 +284,7 @@ class TestResolveAddressedThreads:
 
         # With dry_run=True, gh_pr_resolve_thread is called but internally is a no-op;
         # we verify the dry_run flag is forwarded correctly.
-        mock_resolve.assert_called_once_with("thread-1", "Fixed", dry_run=True)
+        mock_resolve.assert_called_once_with("thread-1", dry_run=True)
 
 
 class TestCommitIfChanges:
@@ -488,12 +488,12 @@ class TestResolveAddressedThreadsModuleLevel:
                 dry_run=False,
             )
         # The hallucinated id (not in the presented set) must NOT be resolved.
-        mock_resolve.assert_called_once_with("t-real", "fixed", dry_run=False)
+        mock_resolve.assert_called_once_with("t-real", dry_run=False)
 
     def test_forwards_dry_run(self) -> None:
         with patch("hephaestus.automation.address_review.gh_pr_resolve_thread") as mock_resolve:
             resolve_addressed_threads(["t1"], {"t1": "r"}, {"t1"}, dry_run=True)
-        mock_resolve.assert_called_once_with("t1", "r", dry_run=True)
+        mock_resolve.assert_called_once_with("t1", dry_run=True)
 
 
 class TestRunAddressFixSessionModuleLevel:

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -1,5 +1,6 @@
 """Tests for the learn module."""
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -71,6 +72,12 @@ class TestRunLearn:
         log_file = tmp_path / "learn-42.log"
         assert log_file.exists()
         assert log_file.read_text() == "Learn complete. PR created."
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["issue_number"] == 42
+        assert record["learn_status"] == "succeeded"
+        assert record["learn_attempted_at"]
+        assert record["learn_succeeded_at"] == record["learn_attempted_at"]
+        assert record["log_path"] == str(log_file)
 
     def test_failure_writes_failed_log_and_returns_false(self, tmp_path: Path) -> None:
         """Returns False and writes FAILED: log on exception."""
@@ -84,6 +91,12 @@ class TestRunLearn:
         log_file = tmp_path / "learn-42.log"
         assert log_file.exists()
         assert log_file.read_text().startswith("FAILED:")
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["issue_number"] == 42
+        assert record["learn_status"] == "failed"
+        assert record["learn_attempted_at"]
+        assert record["learn_succeeded_at"] is None
+        assert record["error"] == "claude crashed"
 
     def test_codex_skips_legacy_claude_session(self, tmp_path: Path) -> None:
         """Legacy sessions must not be resumed through Codex."""
@@ -102,6 +115,9 @@ class TestRunLearn:
         assert result is False
         mock_resume.assert_not_called()
         assert (tmp_path / "learn-42.log").read_text().startswith("FAILED:")
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "failed"
+        assert "selected agent is codex" in record["error"]
 
     def test_codex_resumes_matching_codex_session(self, tmp_path: Path) -> None:
         """Codex sessions with provider metadata should resume through Codex."""
@@ -128,6 +144,7 @@ class TestRunLearn:
         assert prompt.startswith("/learn")
         assert "/skills-registry-commands:learn" not in prompt
         assert (tmp_path / "learn-42.log").read_text() == "learned"
+        assert json.loads((tmp_path / "learn-42.json").read_text())["learn_status"] == "succeeded"
 
     def test_creates_state_dir_if_missing(self, tmp_path: Path) -> None:
         """Creates state_dir if it does not exist."""

--- a/tests/unit/automation/test_review_validator.py
+++ b/tests/unit/automation/test_review_validator.py
@@ -83,10 +83,11 @@ class TestValidatePriorCommentsAddressed:
         assert reopened == []
         assert is_clean is True
         post.assert_not_called()
-        # Both prior threads (T1, T2) were confirmed addressed → resolved.
-        # gh_pr_resolve_thread(thread_id, reply) is called positionally.
+        # Both prior threads (T1, T2) were confirmed addressed → resolved
+        # quietly, without adding another review-thread reply.
         resolved_ids = {c.args[0] for c in resolve.call_args_list}
         assert resolved_ids == {"T1", "T2"}
+        assert all(c.kwargs == {"dry_run": False} for c in resolve.call_args_list)
 
     def test_partial_resolves_only_addressed_threads(self, tmp_path: Path) -> None:
         """Only the addressed thread is resolved; the unaddressed one stays open.
@@ -120,10 +121,10 @@ class TestValidatePriorCommentsAddressed:
             )
         assert reopened == ["NEW"]
         assert is_clean is False
-        # The resolve call is positional: gh_pr_resolve_thread(thread_id, reply).
         resolved_ids = {c.args[0] for c in resolve.call_args_list}
         # Only the addressed thread (T2) is resolved; T1 (unaddressed) stays open.
         assert resolved_ids == {"T2"}
+        assert resolve.call_args.kwargs == {"dry_run": False}
 
     def test_resolves_by_id_not_path_line(self, tmp_path: Path) -> None:
         """#1085 C2: two threads on the SAME (path, line) resolve independently.


### PR DESCRIPTION
Closes #1136

## Summary
- persist implementer /learn attempts to build/.issue_implementer/learn-<issue>.json
- record explicit succeeded/failed learn status alongside the existing retryable log
- resolve addressed review threads quietly without adding duplicate reply comments

## Tests
- uv run pytest --no-cov tests/unit/automation/test_learn.py
- uv run pytest --no-cov tests/unit/automation/test_implementer.py -k 'learn or advise'
- uv run pytest --no-cov tests/unit/automation/test_implementer_loop.py -k 'learn'
- uv run pytest --no-cov tests/unit/automation/test_review_validator.py tests/unit/automation/test_address_review.py tests/unit/automation/test_ci_driver.py -k 'resolve or ReplyAndResolveBotThreads'
- uv run pytest --no-cov tests/unit/automation/test_github_api.py -k '1116 or same_line or duplicate'
- uv run ruff check hephaestus/automation/learn.py tests/unit/automation/test_learn.py
- uv run ruff check hephaestus/automation/address_review.py hephaestus/automation/review_validator.py tests/unit/automation/test_address_review.py tests/unit/automation/test_review_validator.py
- uv run ruff format --check hephaestus/automation/learn.py tests/unit/automation/test_learn.py
- uv run ruff format --check hephaestus/automation/address_review.py hephaestus/automation/review_validator.py tests/unit/automation/test_address_review.py tests/unit/automation/test_review_validator.py
- uv run mypy hephaestus/automation/learn.py tests/unit/automation/test_learn.py
