### PR TITLE
fix(automation): record mnemosyne learn evidence

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -60,7 +60,7 @@ from .github_api import (
     gh_pr_list_unresolved_threads,
     gh_pr_resolve_thread,
 )
-from .learn import build_learn_prompt, compact_session
+from .learn import build_learn_prompt, compact_session, mnemosyne_update_evidence
 from .models import CIDriverOptions, WorkerResult
 from .pr_manager import pr_has_implementation_go_label
 from .prompts import get_advise_prompt_builder
@@ -1519,10 +1519,20 @@ class CIDriver:
             record["learn_status"] = "succeeded"
             record["learn_succeeded_at"] = timestamp
             record["learn_captured_at"] = timestamp
+            record.update(
+                getattr(self, "_last_drive_green_learn_evidence", mnemosyne_update_evidence(""))
+            )
         else:
             record["learn_status"] = "failed"
             record["learn_succeeded_at"] = None
             record["learn_captured_at"] = None
+            record.update(
+                {
+                    "mnemosyne_update_status": "failed",
+                    "mnemosyne_update_urls": [],
+                    "mnemosyne_update_pr_numbers": [],
+                }
+            )
         self._save_arming_state(issue_number, record)
 
     def _arm_drive_green(self, pr_number: int, pr_head_branch: str, pr_head_sha: str) -> None:
@@ -2900,6 +2910,7 @@ class CIDriver:
             "to green CI. Capture concise learnings about what made CI fail and how "
             "you fixed it, scoped to this issue/PR."
         )
+        self._last_drive_green_learn_evidence = mnemosyne_update_evidence("")
         try:
             repo_slug = get_repo_slug(self.repo_root)
             # Best-effort: try to resume in the original worktree (so the
@@ -2920,15 +2931,18 @@ class CIDriver:
                 )
                 cwd = self.repo_root
             if is_codex(self.options.agent):
-                run_codex_session(
+                codex_result = run_codex_session(
                     prompt,
                     cwd=cwd,
                     timeout=learn_claude_timeout(),
                     sandbox="workspace-write",
                 )
+                self._last_drive_green_learn_evidence = mnemosyne_update_evidence(
+                    codex_result.stdout or ""
+                )
                 logger.info("Issue #%s: drive-green learnings captured with Codex", issue_number)
                 return True
-            invoke_claude_with_session(
+            stdout, _ = invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,
                 agent=AGENT_CI_DRIVER,
@@ -2944,6 +2958,7 @@ class CIDriver:
                 extra_args=["--dangerously-skip-permissions"],
                 input_via_stdin=True,
             )
+            self._last_drive_green_learn_evidence = mnemosyne_update_evidence(stdout or "")
             logger.info("Issue #%s: drive-green learnings captured", issue_number)
             return True
         except Exception as e:  # broad: external claude process; non-blocking

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from hephaestus.agents.runtime import resume_codex_session, session_agent_matches
 
@@ -22,6 +24,29 @@ from .session_naming import session_uuid
 
 logger = logging.getLogger(__name__)
 
+_MNEMOSYNE_URL_RE = re.compile(
+    r"https://github\.com/HomericIntelligence/ProjectMnemosyne/(?:pull|commit)/[A-Za-z0-9._/-]+"
+)
+_MNEMOSYNE_PR_REF_RE = re.compile(r"\bHomericIntelligence/ProjectMnemosyne#(?P<number>\d+)\b")
+
+
+def mnemosyne_update_evidence(output: str) -> dict[str, Any]:
+    """Extract ProjectMnemosyne update evidence from a ``/learn`` response.
+
+    A successful agent turn is not proof that ProjectMnemosyne changed. Treat
+    concrete ProjectMnemosyne PR/commit URLs or owner/repo issue-style PR refs
+    as confirmation; otherwise mark the update as unverified.
+    """
+    text = output if isinstance(output, str) else str(output or "")
+    urls = sorted(set(_MNEMOSYNE_URL_RE.findall(text)))
+    pr_numbers = sorted({int(m.group("number")) for m in _MNEMOSYNE_PR_REF_RE.finditer(text)})
+    status = "confirmed" if urls or pr_numbers else "unverified"
+    return {
+        "mnemosyne_update_status": status,
+        "mnemosyne_update_urls": urls,
+        "mnemosyne_update_pr_numbers": pr_numbers,
+    }
+
 
 def _write_learn_record(
     state_dir: Path,
@@ -29,6 +54,7 @@ def _write_learn_record(
     *,
     succeeded: bool,
     log_file: Path,
+    output: str = "",
     error: str = "",
 ) -> None:
     """Persist explicit implementer ``/learn`` attempt evidence."""
@@ -40,6 +66,16 @@ def _write_learn_record(
         "learn_succeeded_at": timestamp if succeeded else None,
         "log_path": str(log_file),
     }
+    if succeeded:
+        record.update(mnemosyne_update_evidence(output))
+    else:
+        record.update(
+            {
+                "mnemosyne_update_status": "failed",
+                "mnemosyne_update_urls": [],
+                "mnemosyne_update_pr_numbers": [],
+            }
+        )
     if error:
         record["error"] = error
     record_file = state_dir / f"learn-{issue_number}.json"
@@ -121,7 +157,13 @@ def run_learn(
                 timeout=learn_claude_timeout(),
             )
             log_file.write_text(codex_result.stdout)
-            _write_learn_record(state_dir, issue_number, succeeded=True, log_file=log_file)
+            _write_learn_record(
+                state_dir,
+                issue_number,
+                succeeded=True,
+                log_file=log_file,
+                output=codex_result.stdout or "",
+            )
             logger.info("Learn completed for issue #%s", issue_number)
             logger.info("Learn log: %s", log_file)
             return True
@@ -164,7 +206,13 @@ def run_learn(
         )
         # Write output to log file
         log_file.write_text(result.stdout or "")
-        _write_learn_record(state_dir, issue_number, succeeded=True, log_file=log_file)
+        _write_learn_record(
+            state_dir,
+            issue_number,
+            succeeded=True,
+            log_file=log_file,
+            output=result.stdout or "",
+        )
         logger.info("Learn completed for issue #%s", issue_number)
         logger.info("Learn log: %s", log_file)
         return True

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -31,7 +31,7 @@ from .github_api import (
     gh_issue_remove_labels,
     gh_issue_upsert_comment,
 )
-from .learn import build_learn_prompt
+from .learn import build_learn_prompt, mnemosyne_update_evidence
 from .models import PLAN_COMMENT_MARKER
 from .prompts import get_plan_loop_review_prompt, get_plan_prompt
 from .review_state import PLAN_REVIEW_PREFIX
@@ -645,6 +645,16 @@ class PlanReviewLoop:
                 "learn_succeeded_at": timestamp if succeeded else None,
                 "log_path": str(log_file),
             }
+            if succeeded:
+                record.update(mnemosyne_update_evidence(output))
+            else:
+                record.update(
+                    {
+                        "mnemosyne_update_status": "failed",
+                        "mnemosyne_update_urls": [],
+                        "mnemosyne_update_pr_numbers": [],
+                    }
+                )
             if error:
                 record["error"] = error
             record_file.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1064,6 +1064,7 @@ class TestDriveGreenLearnings:
         assert record["learn_attempted_at"] is not None
         assert record["learn_status"] == "succeeded"
         assert record["learn_succeeded_at"] == record["learn_captured_at"]
+        assert record["mnemosyne_update_status"] == "unverified"
 
     def test_check_armed_pr_merged_skips_when_already_captured(self, driver: CIDriver) -> None:
         """learn_captured_at != None → return success without re-firing /learn."""
@@ -1294,13 +1295,22 @@ class TestDriveGreenLearnings:
         assert record["learn_captured_at"] is None
         assert record["learn_succeeded_at"] is None
         assert record["learn_status"] == "failed"
+        assert record["mnemosyne_update_status"] == "failed"
 
     def test_learnings_run_with_codex(self, driver: CIDriver, tmp_path: Path) -> None:
         """Codex captures drive-green learnings without invoking Claude."""
         driver.options.agent = "codex"
+        mock_codex_result = type(
+            "CodexResult",
+            (),
+            {"stdout": "Opened https://github.com/HomericIntelligence/ProjectMnemosyne/pull/77"},
+        )()
         with (
             patch.object(driver, "_get_worktree_path", return_value=tmp_path),
-            patch("hephaestus.automation.ci_driver.run_codex_session") as mock_codex,
+            patch(
+                "hephaestus.automation.ci_driver.run_codex_session",
+                return_value=mock_codex_result,
+            ) as mock_codex,
             patch("hephaestus.automation.ci_driver.invoke_claude_with_session") as mock_invoke,
         ):
             result = driver._run_drive_green_learnings(123, 456)
@@ -1313,6 +1323,7 @@ class TestDriveGreenLearnings:
         assert "Only push skills to ProjectMnemosyne" in prompt
         assert mock_codex.call_args.kwargs["cwd"] == tmp_path
         mock_invoke.assert_not_called()
+        assert driver._last_drive_green_learn_evidence["mnemosyne_update_status"] == "confirmed"
 
 
 # ---------------------------------------------------------------------------
@@ -2108,6 +2119,7 @@ class TestArmingSweep:
         assert record["learn_attempted_at"] is not None
         assert record["learn_status"] == "succeeded"
         assert record["learn_succeeded_at"] == record["learn_captured_at"]
+        assert record["mnemosyne_update_status"] == "unverified"
 
     def test_closed_not_merged_orphan_dropped(self, driver: CIDriver, tmp_path: Path) -> None:
         path = self._write_record(driver, issue=841, pr_number=843)

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -4,7 +4,12 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from hephaestus.automation.learn import build_learn_prompt, learn_needs_rerun, run_learn
+from hephaestus.automation.learn import (
+    build_learn_prompt,
+    learn_needs_rerun,
+    mnemosyne_update_evidence,
+    run_learn,
+)
 
 
 class TestLearnNeedsRerun:
@@ -46,6 +51,27 @@ class TestLearnNeedsRerun:
 class TestRunLearn:
     """Tests for run_learn."""
 
+    def test_mnemosyne_update_evidence_requires_project_mnemosyne_signal(self) -> None:
+        evidence = mnemosyne_update_evidence("Learn complete. PR created.")
+
+        assert evidence == {
+            "mnemosyne_update_status": "unverified",
+            "mnemosyne_update_urls": [],
+            "mnemosyne_update_pr_numbers": [],
+        }
+
+    def test_mnemosyne_update_evidence_extracts_pr_url_and_ref(self) -> None:
+        evidence = mnemosyne_update_evidence(
+            "Opened https://github.com/HomericIntelligence/ProjectMnemosyne/pull/45 "
+            "and referenced HomericIntelligence/ProjectMnemosyne#46"
+        )
+
+        assert evidence["mnemosyne_update_status"] == "confirmed"
+        assert evidence["mnemosyne_update_urls"] == [
+            "https://github.com/HomericIntelligence/ProjectMnemosyne/pull/45"
+        ]
+        assert evidence["mnemosyne_update_pr_numbers"] == [46]
+
     def test_build_learn_prompt_uses_user_facing_command(self) -> None:
         prompt = build_learn_prompt("Capture what happened.")
 
@@ -78,6 +104,9 @@ class TestRunLearn:
         assert record["learn_attempted_at"]
         assert record["learn_succeeded_at"] == record["learn_attempted_at"]
         assert record["log_path"] == str(log_file)
+        assert record["mnemosyne_update_status"] == "unverified"
+        assert record["mnemosyne_update_urls"] == []
+        assert record["mnemosyne_update_pr_numbers"] == []
 
     def test_failure_writes_failed_log_and_returns_false(self, tmp_path: Path) -> None:
         """Returns False and writes FAILED: log on exception."""
@@ -97,6 +126,7 @@ class TestRunLearn:
         assert record["learn_attempted_at"]
         assert record["learn_succeeded_at"] is None
         assert record["error"] == "claude crashed"
+        assert record["mnemosyne_update_status"] == "failed"
 
     def test_codex_skips_legacy_claude_session(self, tmp_path: Path) -> None:
         """Legacy sessions must not be resumed through Codex."""
@@ -144,7 +174,9 @@ class TestRunLearn:
         assert prompt.startswith("/learn")
         assert "/skills-registry-commands:learn" not in prompt
         assert (tmp_path / "learn-42.log").read_text() == "learned"
-        assert json.loads((tmp_path / "learn-42.json").read_text())["learn_status"] == "succeeded"
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "succeeded"
+        assert record["mnemosyne_update_status"] == "unverified"
 
     def test_creates_state_dir_if_missing(self, tmp_path: Path) -> None:
         """Creates state_dir if it does not exist."""

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -631,6 +631,9 @@ class TestCapturePlannerLearnings:
         assert record["learn_status"] == "succeeded"
         assert record["learn_attempted_at"]
         assert record["learn_succeeded_at"] == record["learn_attempted_at"]
+        assert record["mnemosyne_update_status"] == "unverified"
+        assert record["mnemosyne_update_urls"] == []
+        assert record["mnemosyne_update_pr_numbers"] == []
         assert (state_dir / "planner-learn-123.log").read_text() == "- learning A\n"
 
     def test_writes_failure_record(self, planner: Planner, tmp_path: Any) -> None:
@@ -652,6 +655,9 @@ class TestCapturePlannerLearnings:
         assert record["learn_attempted_at"]
         assert record["learn_succeeded_at"] is None
         assert record["error"] == "claude down"
+        assert record["mnemosyne_update_status"] == "failed"
+        assert record["mnemosyne_update_urls"] == []
+        assert record["mnemosyne_update_pr_numbers"] == []
         assert (state_dir / "planner-learn-123.log").read_text().startswith("FAILED:")
 
 


### PR DESCRIPTION
Closes #1139

## Summary
- add shared ProjectMnemosyne update evidence extraction for `/learn` output
- record `mnemosyne_update_status`, URLs, and PR refs in implementer/planner learn JSON
- propagate the same evidence into drive-green learn arming records

## Tests
- uv run pytest --no-cov tests/unit/automation/test_learn.py tests/unit/automation/test_planner_loop.py -k 'learn'
- uv run pytest --no-cov tests/unit/automation/test_ci_driver.py -k 'learn or arming'
- uv run ruff check hephaestus/automation/learn.py hephaestus/automation/planner_review_loop.py hephaestus/automation/ci_driver.py tests/unit/automation/test_learn.py tests/unit/automation/test_planner_loop.py tests/unit/automation/test_ci_driver.py
- uv run ruff format --check hephaestus/automation/learn.py hephaestus/automation/planner_review_loop.py hephaestus/automation/ci_driver.py tests/unit/automation/test_learn.py tests/unit/automation/test_planner_loop.py tests/unit/automation/test_ci_driver.py
- uv run mypy hephaestus/automation/learn.py hephaestus/automation/planner_review_loop.py hephaestus/automation/ci_driver.py tests/unit/automation/test_learn.py tests/unit/automation/test_planner_loop.py tests/unit/automation/test_ci_driver.py
