### PR TITLE
fix(automation): dedupe resolved review findings

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1437,30 +1437,23 @@ def gh_current_login() -> str | None:
 ReviewCommentIndexKey = tuple[str, Any] | tuple[str, Any, str]
 
 
-def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tuple[str, str]]:
-    """Map ``(path, line)`` → ``(comment_node_id, body)`` for unresolved bot threads.
+def _fetch_pr_inline_review_thread_nodes(pr_number: int) -> list[dict[str, Any]]:
+    """Return PR review-thread nodes used by inline-comment dedupe helpers.
 
-    Returns the GraphQL node id AND current body of the FIRST comment of each
-    unresolved review thread, keyed by its ``(path, line)``. Used by
-    :func:`gh_pr_review_post` to detect a line that already has a comment so the
-    new content can be **appended** to the existing body in place rather than
-    posted as a duplicate (#1083). The body is required because the
-    ``updatePullRequestReviewComment`` mutation REPLACES the body — the caller
-    must concatenate ``existing + new`` or the original comment is lost (#1085).
-    Fails open: returns ``{}`` on any API/parse error so the caller posts
-    everything as before.
+    Fails open: returns ``[]`` on any API/parse error so callers preserve their
+    existing post-as-usual behaviour.
     """
     owner, repo = get_repo_info()
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner) or not re.match(r"^[a-zA-Z0-9_-]+$", repo):
         logger.error("Invalid owner/repo format: %s/%s", owner, repo)
-        return {}
+        return []
     query = (
         "query($owner:String!,$name:String!,$number:Int!){"
         "  repository(owner:$owner,name:$name){"
         "    pullRequest(number:$number){"
         "      reviewThreads(first:100){"
         "        nodes{ isResolved path line side:diffSide "
-        "comments(first:1){ nodes{ id body } } }"
+        "comments(first:20){ nodes{ id body } } }"
         "      }"
         "    }"
         "  }"
@@ -1484,8 +1477,8 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tu
         )
         data = json.loads(result.stdout or "{}")
     except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
-        logger.warning("PR #%s: could not fetch inline-comment index (%s)", pr_number, exc)
-        return {}
+        logger.warning("PR #%s: could not fetch inline review-thread nodes (%s)", pr_number, exc)
+        return []
 
     nodes = (
         data.get("data", {})
@@ -1494,8 +1487,26 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tu
         .get("reviewThreads", {})
         .get("nodes", [])
     )
+    if not isinstance(nodes, list):
+        return []
+    return [node for node in nodes if isinstance(node, dict)]
+
+
+def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tuple[str, str]]:
+    """Map ``(path, line)`` → ``(comment_node_id, body)`` for unresolved bot threads.
+
+    Returns the GraphQL node id AND current body of the FIRST comment of each
+    unresolved review thread, keyed by its ``(path, line)``. Used by
+    :func:`gh_pr_review_post` to detect a line that already has a comment so the
+    new content can be **appended** to the existing body in place rather than
+    posted as a duplicate (#1083). The body is required because the
+    ``updatePullRequestReviewComment`` mutation REPLACES the body — the caller
+    must concatenate ``existing + new`` or the original comment is lost (#1085).
+    Fails open: returns ``{}`` on any API/parse error so the caller posts
+    everything as before.
+    """
     index: dict[ReviewCommentIndexKey, tuple[str, str]] = {}
-    for node in nodes:
+    for node in _fetch_pr_inline_review_thread_nodes(pr_number):
         if node.get("isResolved"):
             continue
         comment_nodes = node.get("comments", {}).get("nodes", [])
@@ -1513,6 +1524,34 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tu
         # support, and as a fallback if GitHub ever omits ``diffSide``.
         index.setdefault((path, line), (comment_id, body))
     return index
+
+
+def gh_pr_inline_comment_history_index(pr_number: int) -> dict[ReviewCommentIndexKey, list[str]]:
+    """Map ``(path, line)`` → historical inline review bodies, resolved or not.
+
+    Unlike :func:`gh_pr_inline_comment_index`, this index includes resolved
+    threads and carries only bodies, never comment IDs. It is used solely to
+    suppress materially identical reviewer findings after an earlier thread was
+    resolved; resolved comments must not be edited or re-opened just because a
+    later reviewer restates the same finding (#1116).
+    """
+    history: dict[ReviewCommentIndexKey, list[str]] = {}
+    for node in _fetch_pr_inline_review_thread_nodes(pr_number):
+        path = node.get("path") or ""
+        line = node.get("line")
+        side = node.get("side") or "RIGHT"
+        comment_nodes = node.get("comments", {}).get("nodes", [])
+        bodies = [
+            str(comment.get("body") or "")
+            for comment in comment_nodes
+            if isinstance(comment, dict) and str(comment.get("body") or "").strip()
+        ]
+        if not bodies:
+            continue
+        history.setdefault((path, line, side), []).extend(bodies)
+        # Preserve the older key shape for side-less lookup fallback.
+        history.setdefault((path, line), []).extend(bodies)
+    return history
 
 
 def gh_pr_update_review_comment(comment_node_id: str, body: str) -> None:
@@ -1651,28 +1690,47 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
     first skip it if the existing body already covers the same finding. If the
     finding is genuinely new, rewrite the existing comment to
     ``existing_body + new_body`` (a single edit that preserves the original
-    text, #1085) and drop it from the returned list. Comments on fresh lines
-    are returned unchanged for posting. Fails open: an empty index returns
-    *comments* unchanged, and an edit that raises falls back to posting that
-    comment fresh.
+    text, #1085) and drop it from the returned list. Resolved historical
+    comments are used only as duplicate evidence; they are never edited.
+    Comments on fresh lines are returned unchanged for posting. Fails open: an
+    empty index returns *comments* unchanged, and an edit that raises falls back
+    to posting that comment fresh.
     """
-    index = gh_pr_inline_comment_index(pr_number)
-    if not index:
+    editable_index = gh_pr_inline_comment_index(pr_number)
+    history_index = gh_pr_inline_comment_history_index(pr_number)
+    if not editable_index and not history_index:
         return comments
     fresh: list[dict[str, Any]] = []
     for c in comments:
         path = c.get("path") or ""
         line = c.get("line")
         side = c.get("side") or "RIGHT"
-        existing = index.get((path, line, side)) or index.get((path, line))
-        if existing is None:
+        body = c.get("body") or ""
+
+        historical_bodies = history_index.get((path, line, side)) or history_index.get(
+            (path, line), []
+        )
+        if any(
+            _review_comment_already_covers(existing_body, body)
+            for existing_body in historical_bodies
+        ):
+            logger.info(
+                "PR #%s: skipped duplicate same-line review comment on %s:%s (%s)",
+                pr_number,
+                path,
+                line,
+                side,
+            )
+            continue
+
+        editable = editable_index.get((path, line, side)) or editable_index.get((path, line))
+        if editable is None:
             fresh.append(c)
             continue
         # #1085: updatePullRequestReviewComment REPLACES the body, so concatenate
         # the existing body + the new note. Passing only the suffix would destroy
         # the original comment.
-        existing_id, existing_body = existing
-        body = c.get("body") or ""
+        existing_id, existing_body = editable
         if _review_comment_already_covers(existing_body, body):
             logger.info(
                 "PR #%s: skipped duplicate same-line review comment on %s:%s (%s)",

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -25,6 +25,7 @@ from hephaestus.automation.github_api import (
     gh_list_open_issues,
     gh_pr_checks,
     gh_pr_create,
+    gh_pr_inline_comment_history_index,
     gh_pr_inline_comment_index,
     gh_pr_resolve_thread,
     gh_pr_review_post,
@@ -2270,6 +2271,64 @@ class TestGhPrReviewPost:
         assert self._posted_comments(mock_write) == []
 
     @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_history_index")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    @patch("hephaestus.automation.github_api.io_write_secure")
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_resolved_same_line_duplicate_comment_is_skipped_not_edited(
+        self,
+        mock_gh_call: Any,
+        _mock_repo: Any,
+        mock_write: Any,
+        mock_index: Any,
+        mock_history: Any,
+        mock_update: Any,
+    ) -> None:
+        """Issue #1116: resolved historical findings suppress duplicate re-reviews."""
+        mock_gh_call.side_effect = self._gh_call_side_effect(
+            "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
+        )
+        mock_index.return_value = {}
+        mock_history.return_value = {
+            ("a.py", 2, "RIGHT"): [
+                "This regression coverage only exercises the Claude result-envelope path. "
+                "The production diff also changed the Codex stdout path, so add a Codex "
+                "test where `summary` lacks a verdict and `review_text`/stdout contains "
+                "`Verdict: GO` or `Verdict: NOGO`; otherwise the second producer path can "
+                "regress without this suite catching it."
+            ],
+        }
+
+        gh_pr_review_post(
+            pr_number=1116,
+            comments=[
+                {
+                    "path": "a.py",
+                    "line": 2,
+                    "side": "RIGHT",
+                    "body": (
+                        "This regression test only exercises the Claude JSON-envelope path. "
+                        "The production fix also changed the Codex stdout path, so please add "
+                        "a Codex-path test that returns prose with `Verdict: GO`/`NOGO` and a "
+                        "verdict-free JSON summary, then asserts `review_text` preserves the "
+                        "raw stdout."
+                    ),
+                }
+            ],
+            summary="Findings",
+            dedupe_existing=True,
+        )
+
+        mock_update.assert_not_called()
+        mock_write.assert_not_called()
+        assert not any(
+            "repos/owner/repo/pulls/1116/reviews" in str(arg)
+            for call in mock_gh_call.call_args_list
+            for arg in (call.args[0] if call.args else call.kwargs.get("args", []))
+        )
+
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
     @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
     @patch("hephaestus.automation.github_api.io_write_secure")
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
@@ -2510,6 +2569,51 @@ class TestGhPrInlineCommentIndex:
         result.stdout = "not json{"
         mock_gh_call.return_value = result
         assert gh_pr_inline_comment_index(7) == {}
+
+
+class TestGhPrInlineCommentHistoryIndex:
+    """gh_pr_inline_comment_history_index includes resolved comments for dedupe."""
+
+    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_indexes_resolved_and_unresolved_thread_bodies(
+        self, mock_gh_call: Any, _mock_repo: Any
+    ) -> None:
+        result = Mock()
+        result.stdout = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [
+                                    {
+                                        "isResolved": True,
+                                        "path": "a.py",
+                                        "line": 2,
+                                        "side": "RIGHT",
+                                        "comments": {"nodes": [{"id": "N1", "body": "old"}]},
+                                    },
+                                    {
+                                        "isResolved": False,
+                                        "path": "a.py",
+                                        "line": 2,
+                                        "side": "RIGHT",
+                                        "comments": {"nodes": [{"id": "N2", "body": "open"}]},
+                                    },
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        )
+        mock_gh_call.return_value = result
+
+        history = gh_pr_inline_comment_history_index(7)
+
+        assert history[("a.py", 2, "RIGHT")] == ["old", "open"]
+        assert history[("a.py", 2)] == ["old", "open"]
 
 
 class TestValidReviewPositions:


### PR DESCRIPTION
## Summary

- include resolved inline review threads in duplicate-finding detection
- keep resolved historical comments read-only so they are never edited or reopened
- add #1116 regression coverage for same-line review restatements

## Tests

- `uv run pytest --no-cov tests/unit/automation/test_github_api.py`
- `uv run mypy hephaestus/automation/github_api.py tests/unit/automation/test_github_api.py`
- `uv run ruff check hephaestus/automation/github_api.py tests/unit/automation/test_github_api.py`
- `uv run ruff format --check hephaestus/automation/github_api.py tests/unit/automation/test_github_api.py`

Closes #1141
