### PR TITLE
fix(automation): provision implementation state labels

### DIFF
--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -1,10 +1,10 @@
-"""Idempotently provision the ``state:*`` plan-state labels on one or more repos.
+"""Idempotently provision automation ``state:*`` labels on one or more repos.
 
 Pairs with :mod:`hephaestus.automation.state_labels` (the single source of truth
 for the labels) and is the one-shot operator tool used after #704 ships: run
-once with ``--org`` to create the three labels across the whole
-HomericIntelligence org so the reviewer's first label-application call doesn't
-race against a missing label.
+once with ``--org`` to create/update the plan-state, implementation-review, and
+skip labels across the whole HomericIntelligence org so the first
+label-application call doesn't race against a missing label.
 
 The script is idempotent: GitHub's ``gh label create --force`` upserts the
 label (creating it if absent, updating colour/description if present), so
@@ -86,7 +86,7 @@ def _gh_list_org_repos(org: str, *, timeout: int = 60) -> list[str]:
 
 
 def ensure_labels_on_repo(repo: str, *, dry_run: bool = False) -> int:
-    """Create the three ``state:*`` labels on ``repo``.
+    """Create/update the automation ``state:*`` labels on ``repo``.
 
     Args:
         repo: ``OWNER/NAME`` slug.
@@ -156,8 +156,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="hephaestus-ensure-state-labels",
         description=(
-            "Idempotently provision the state:* plan-state labels "
-            "(state:needs-plan, state:plan-no-go, state:plan-go) on one or more repos."
+            "Idempotently provision automation state:* labels "
+            "(plan-state, implementation-review, and skip) on one or more repos."
         ),
     )
     target = parser.add_mutually_exclusive_group()

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -1,10 +1,10 @@
-"""GitHub-issue state-label vocabulary for the automation pipeline.
+"""GitHub issue/PR state-label vocabulary for the automation pipeline.
 
 The automation pipeline uses three mutually-exclusive ``state:*`` labels as the
 single source of truth for an issue's plan-review status. This module is the
-authoritative definition of those labels and the small helpers that interpret
-them; the reviewer, planner, implementer, and the org-wide provisioning script
-all import from here.
+authoritative definition of those labels, the PR-scoped implementation-review
+labels, and the small helpers that interpret them; the reviewer, planner,
+implementer, and the org-wide provisioning script all import from here.
 
 State machine
 -------------
@@ -34,7 +34,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 # Single source of truth for the three plan-state labels. All label-aware code
-# in the pipeline imports these constants — do not hard-code the names.
+# in the pipeline imports these constants; do not hard-code the names.
 STATE_NEEDS_PLAN = "state:needs-plan"
 STATE_PLAN_NO_GO = "state:plan-no-go"
 STATE_PLAN_GO = "state:plan-go"
@@ -74,6 +74,16 @@ STATE_LABEL_SPECS: dict[str, dict[str, str]] = {
     STATE_PLAN_GO: {
         "color": "0e8a16",  # green — approved
         "description": "Plan approved by reviewer; implementer may proceed.",
+    },
+    STATE_IMPLEMENTATION_NO_GO: {
+        "color": "d93f0b",  # red — blocked
+        "description": (
+            "Implementation-reviewer's latest verdict was NOGO; implementer should revise."
+        ),
+    },
+    STATE_IMPLEMENTATION_GO: {
+        "color": "0e8a16",  # green — approved
+        "description": "Implementation approved by reviewer; drive-green may proceed.",
     },
     STATE_SKIP: {
         "color": "ededed",  # grey — intentionally inert

--- a/tests/unit/automation/test_ensure_state_labels.py
+++ b/tests/unit/automation/test_ensure_state_labels.py
@@ -21,6 +21,8 @@ from hephaestus.automation.ensure_state_labels import (
     main,
 )
 from hephaestus.automation.state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
     STATE_LABEL_SPECS,
     STATE_NEEDS_PLAN,
     STATE_PLAN_GO,
@@ -73,9 +75,11 @@ class TestEnsureLabelsOnRepo:
             assert "--description" in args
             assert "--force" in args
             seen_labels.add(args[3])
-        # Every spec'd label was exercised (includes state:skip, #1083).
+        # Every spec'd label was exercised (includes implementation labels and
+        # state:skip, #1083).
         assert seen_labels == set(STATE_LABEL_SPECS.keys())
         assert {STATE_NEEDS_PLAN, STATE_PLAN_NO_GO, STATE_PLAN_GO} <= seen_labels
+        assert {STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTATION_GO} <= seen_labels
 
     def test_dry_run_issues_zero_calls(self, mock_run: MagicMock) -> None:
         issued = ensure_labels_on_repo("owner/name", dry_run=True)

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 import pytest
 
 from hephaestus.automation.state_labels import (
+    ALL_IMPLEMENTATION_STATE_LABELS,
     ALL_STATE_LABELS,
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
     STATE_LABEL_SPECS,
     STATE_NEEDS_PLAN,
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
     STATE_SKIP,
     has_label,
+    is_implementation_go,
     is_plan_go,
     is_plan_no_go,
     is_skipped,
@@ -45,11 +49,12 @@ class TestLabelVocabulary:
     def test_label_specs_cover_every_label(self) -> None:
         """The provisioning script needs a colour+description for each label.
 
-        Specs must cover every plan-state label (``ALL_STATE_LABELS``) plus the
-        independent ``state:skip`` override (#1083) — i.e. specs is a superset
-        of the plan-state tuple.
+        Specs must cover every plan-state label, every PR-scoped
+        implementation-review label, and the independent ``state:skip``
+        override (#1083).
         """
         assert set(ALL_STATE_LABELS) <= set(STATE_LABEL_SPECS.keys())
+        assert set(ALL_IMPLEMENTATION_STATE_LABELS) <= set(STATE_LABEL_SPECS.keys())
         assert STATE_SKIP in STATE_LABEL_SPECS
         for spec in STATE_LABEL_SPECS.values():
             assert "color" in spec
@@ -63,10 +68,23 @@ class TestLabelVocabulary:
         assert STATE_SKIP not in ALL_STATE_LABELS
         assert STATE_SKIP.startswith("state:")
 
+    def test_implementation_labels_are_independent_of_plan_state(self) -> None:
+        """Implementation-review state is PR-scoped, not part of issue plan state."""
+        assert set(ALL_IMPLEMENTATION_STATE_LABELS) == {
+            STATE_IMPLEMENTATION_NO_GO,
+            STATE_IMPLEMENTATION_GO,
+        }
+        assert set(ALL_IMPLEMENTATION_STATE_LABELS).isdisjoint(ALL_STATE_LABELS)
+
     def test_is_skipped(self) -> None:
         assert is_skipped(["bug", STATE_SKIP]) is True
         assert is_skipped([STATE_PLAN_GO]) is False
         assert is_skipped([]) is False
+
+    def test_is_implementation_go(self) -> None:
+        assert is_implementation_go([STATE_IMPLEMENTATION_GO]) is True
+        assert is_implementation_go([STATE_IMPLEMENTATION_NO_GO]) is False
+        assert is_implementation_go([]) is False
 
 
 class TestHasLabel:


### PR DESCRIPTION
## Summary

- add implementation-review GO/NOGO labels to `STATE_LABEL_SPECS`
- update `hephaestus-ensure-state-labels` wording to cover all automation state labels
- add regression tests proving provisioning covers implementation-review labels

## Tests

- `uv run pytest --no-cov tests/unit/automation/test_state_labels.py tests/unit/automation/test_ensure_state_labels.py`
- `uv run ruff check hephaestus/automation/state_labels.py hephaestus/automation/ensure_state_labels.py tests/unit/automation/test_state_labels.py tests/unit/automation/test_ensure_state_labels.py`
- `uv run mypy hephaestus/automation/state_labels.py hephaestus/automation/ensure_state_labels.py tests/unit/automation/test_state_labels.py tests/unit/automation/test_ensure_state_labels.py`

Closes #1143
