### PR TITLE
fix(automation): use two hour agent timeouts

### DIFF
--- a/hephaestus/automation/claude_timeouts.py
+++ b/hephaestus/automation/claude_timeouts.py
@@ -32,13 +32,13 @@ def _read_int_env(name: str, default: int) -> int:
 
 
 def planner_claude_timeout() -> int:
-    """Timeout for agent calls inside the planner (default 600s)."""
-    return _read_int_env("HEPH_PLANNER_AGENT_TIMEOUT", 600)
+    """Timeout for agent calls inside the planner (default 7200s)."""
+    return _read_int_env("HEPH_PLANNER_AGENT_TIMEOUT", 7200)
 
 
 def plan_reviewer_claude_timeout() -> int:
-    """Timeout for agent calls inside the plan reviewer (default 300s)."""
-    return _read_int_env("HEPH_PLAN_REVIEWER_AGENT_TIMEOUT", 300)
+    """Timeout for agent calls inside the plan reviewer (default 7200s)."""
+    return _read_int_env("HEPH_PLAN_REVIEWER_AGENT_TIMEOUT", 7200)
 
 
 def implementer_claude_timeout() -> int:
@@ -47,13 +47,13 @@ def implementer_claude_timeout() -> int:
 
 
 def advise_claude_timeout() -> int:
-    """Timeout for lightweight advise agent calls (default 360s)."""
-    return _read_int_env("HEPH_ADVISE_AGENT_TIMEOUT", 360)
+    """Timeout for advise agent calls (default 7200s)."""
+    return _read_int_env("HEPH_ADVISE_AGENT_TIMEOUT", 7200)
 
 
 def pr_reviewer_claude_timeout() -> int:
-    """Timeout for the PR reviewer's agent analysis (default 1200s)."""
-    return _read_int_env("HEPH_PR_REVIEWER_AGENT_TIMEOUT", 1200)
+    """Timeout for the PR reviewer's agent analysis (default 7200s)."""
+    return _read_int_env("HEPH_PR_REVIEWER_AGENT_TIMEOUT", 7200)
 
 
 def address_review_claude_timeout() -> int:
@@ -67,13 +67,13 @@ def ci_driver_claude_timeout() -> int:
 
 
 def learn_claude_timeout() -> int:
-    """Timeout for the post-impl ``/learn`` agent call (default 600s)."""
-    return _read_int_env("HEPH_LEARN_AGENT_TIMEOUT", 600)
+    """Timeout for ``/learn`` agent calls (default 7200s)."""
+    return _read_int_env("HEPH_LEARN_AGENT_TIMEOUT", 7200)
 
 
 def follow_up_claude_timeout() -> int:
-    """Timeout for the follow-up-issue agent session (default 600s)."""
-    return _read_int_env("HEPH_FOLLOW_UP_AGENT_TIMEOUT", 600)
+    """Timeout for the follow-up-issue agent session (default 7200s)."""
+    return _read_int_env("HEPH_FOLLOW_UP_AGENT_TIMEOUT", 7200)
 
 
 def gh_cli_timeout() -> int:

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -23,7 +23,7 @@ from typing import Any, Protocol
 
 from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
-from .claude_timeouts import planner_claude_timeout
+from .claude_timeouts import learn_claude_timeout, planner_claude_timeout
 from .git_utils import get_repo_root, issue_ref
 from .github_api import (
     gh_issue_add_labels,
@@ -602,7 +602,7 @@ class PlanReviewLoop:
                 model=planner_model(),
                 agent=AGENT_PLANNER,
                 issue_number=issue_number,
-                timeout=120,
+                timeout=learn_claude_timeout(),
             )
             self._write_planner_learn_record(issue_number, succeeded=True, output=output)
             return output

--- a/tests/unit/automation/test_claude_timeouts.py
+++ b/tests/unit/automation/test_claude_timeouts.py
@@ -9,6 +9,8 @@ import pytest
 
 from hephaestus.automation import claude_timeouts
 
+TWO_HOURS_S = 7200
+
 
 def _clear_planner_timeout_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HEPH_PLANNER_AGENT_TIMEOUT", raising=False)
@@ -19,7 +21,7 @@ def test_planner_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     """Planner timeout uses the documented default when unset."""
     _clear_planner_timeout_env(monkeypatch)
 
-    assert claude_timeouts.planner_claude_timeout() == 600
+    assert claude_timeouts.planner_claude_timeout() == TWO_HOURS_S
 
 
 @pytest.mark.parametrize(
@@ -29,55 +31,55 @@ def test_planner_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
             "HEPH_PLANNER_AGENT_TIMEOUT",
             "HEPH_PLANNER_CLAUDE_TIMEOUT",
             claude_timeouts.planner_claude_timeout,
-            600,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_PLAN_REVIEWER_AGENT_TIMEOUT",
             "HEPH_PLAN_REVIEWER_CLAUDE_TIMEOUT",
             claude_timeouts.plan_reviewer_claude_timeout,
-            300,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_IMPLEMENTER_AGENT_TIMEOUT",
             "HEPH_IMPLEMENTER_CLAUDE_TIMEOUT",
             claude_timeouts.implementer_claude_timeout,
-            7200,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_ADVISE_AGENT_TIMEOUT",
             "HEPH_ADVISE_CLAUDE_TIMEOUT",
             claude_timeouts.advise_claude_timeout,
-            360,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_PR_REVIEWER_AGENT_TIMEOUT",
             "HEPH_PR_REVIEWER_CLAUDE_TIMEOUT",
             claude_timeouts.pr_reviewer_claude_timeout,
-            1200,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_ADDRESS_REVIEW_AGENT_TIMEOUT",
             "HEPH_ADDRESS_REVIEW_CLAUDE_TIMEOUT",
             claude_timeouts.address_review_claude_timeout,
-            7200,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_CI_DRIVER_AGENT_TIMEOUT",
             "HEPH_CI_DRIVER_CLAUDE_TIMEOUT",
             claude_timeouts.ci_driver_claude_timeout,
-            7200,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_LEARN_AGENT_TIMEOUT",
             "HEPH_LEARN_CLAUDE_TIMEOUT",
             claude_timeouts.learn_claude_timeout,
-            600,
+            TWO_HOURS_S,
         ),
         (
             "HEPH_FOLLOW_UP_AGENT_TIMEOUT",
             "HEPH_FOLLOW_UP_CLAUDE_TIMEOUT",
             claude_timeouts.follow_up_claude_timeout,
-            600,
+            TWO_HOURS_S,
         ),
     ],
 )
@@ -113,16 +115,16 @@ def test_planner_timeout_invalid_agent_env_logs_and_defaults(
     monkeypatch.setenv("HEPH_PLANNER_AGENT_TIMEOUT", "slow")
 
     with caplog.at_level(logging.WARNING, logger="hephaestus.automation.claude_timeouts"):
-        assert claude_timeouts.planner_claude_timeout() == 600
+        assert claude_timeouts.planner_claude_timeout() == TWO_HOURS_S
 
     assert any("HEPH_PLANNER_AGENT_TIMEOUT" in record.message for record in caplog.records)
 
 
 def test_advise_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Advise timeout keeps its short default unless explicitly tuned."""
+    """Advise timeout uses the same 2h default as other agent calls."""
     monkeypatch.delenv("HEPH_ADVISE_AGENT_TIMEOUT", raising=False)
 
-    assert claude_timeouts.advise_claude_timeout() == 360
+    assert claude_timeouts.advise_claude_timeout() == TWO_HOURS_S
 
 
 def test_advise_timeout_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -585,6 +585,16 @@ class TestCapturePlannerLearnings:
             out = planner._capture_planner_learnings(123, "plan text")
         assert "learning A" in out
 
+    def test_uses_central_learn_timeout(
+        self, planner: Planner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Planner /learn must honor HEPH_LEARN_AGENT_TIMEOUT, not a short hard-code."""
+        monkeypatch.setenv("HEPH_LEARN_AGENT_TIMEOUT", "7200")
+        with patch.object(planner, "_call_claude", return_value="- learning A") as mock_call:
+            planner._capture_planner_learnings(123, "plan text")
+
+        assert mock_call.call_args.kwargs["timeout"] == 7200
+
     def test_resumes_planner_session(self, planner: Planner) -> None:
         """Stage 1: capturing learnings RESUMES the planner session (AGENT_PLANNER).
 


### PR DESCRIPTION
## Summary

- default all automation agent subprocess timeouts to 7,200 seconds
- keep `HEPH_*_AGENT_TIMEOUT` overrides intact
- leave specialized non-agent waits (`gh` calls and CI polling) unchanged

## Tests

- `uv run pytest --no-cov tests/unit/automation/test_claude_timeouts.py`
- `uv run ruff check hephaestus/automation/claude_timeouts.py tests/unit/automation/test_claude_timeouts.py`
- `uv run ruff format --check hephaestus/automation/claude_timeouts.py tests/unit/automation/test_claude_timeouts.py`
- `uv run mypy hephaestus/automation/claude_timeouts.py tests/unit/automation/test_claude_timeouts.py`

Closes #1145
