### PR TITLE
fix(automation): pass owner/name as GraphQL variables in batch fetch

### DIFF
--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -294,14 +294,32 @@ def fetch_all_issue_comments_graphql(
         )
         for idx, num in enumerate(issue_numbers)
     ]
-    query = f"query{{repository(owner:{owner!r},name:{name!r}){{{' '.join(fragments)}}}}}"
+    # owner/name MUST be passed as GraphQL variables, not interpolated. The
+    # {owner!r} repr produces single-quoted literals (owner:'Owner'), which is
+    # invalid GraphQL (only double quotes are accepted) and gh rejects with
+    # "Expected VALUE, actual: UNKNOWN_CHAR". Mirror fetch_issue_review_comments.
+    query = (
+        f"query($owner:String!,$name:String!)"
+        f"{{repository(owner:$owner,name:$name){{{' '.join(fragments)}}}}}"
+    )
 
     # Map alias index back to issue number for result assembly.
     idx_to_num = dict(enumerate(issue_numbers))
     result_map: dict[int, list[dict[str, Any]]] = {num: [] for num in issue_numbers}
 
     try:
-        result = _gh_call(["api", "graphql", "-f", f"query={query}"])
+        result = _gh_call(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+            ],
+        )
         data = json.loads(result.stdout)
         repo_data = data.get("data", {}).get("repository", {})
         for alias, issue_data in repo_data.items():
@@ -358,13 +376,28 @@ def fetch_all_issue_labels_graphql(
         (f"issue{idx}: issue(number: {int(num)}){{labels(first: 50){{nodes{{name}}}}}}")
         for idx, num in enumerate(issue_numbers)
     ]
-    query = f"query{{repository(owner:{owner!r},name:{name!r}){{{' '.join(fragments)}}}}}"
+    # owner/name as GraphQL variables (see fetch_all_issue_comments_graphql).
+    query = (
+        f"query($owner:String!,$name:String!)"
+        f"{{repository(owner:$owner,name:$name){{{' '.join(fragments)}}}}}"
+    )
 
     idx_to_num = dict(enumerate(issue_numbers))
     result_map: dict[int, list[str]] = {num: [] for num in issue_numbers}
 
     try:
-        result = _gh_call(["api", "graphql", "-f", f"query={query}"])
+        result = _gh_call(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+            ],
+        )
         data = json.loads(result.stdout)
         repo_data = data.get("data", {}).get("repository", {})
         for alias, issue_data in repo_data.items():

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -448,3 +448,62 @@ class TestFetchAllIssueLabelsGraphql:
             result = fetch_all_issue_labels_graphql([10, 11])
 
         assert result == {10: [], 11: []}
+
+    def test_owner_name_passed_as_graphql_variables_not_interpolated(self) -> None:
+        """Regression: owner/name must be GraphQL variables, not interpolated.
+
+        The original implementation interpolated ``{owner!r}`` into the query
+        body, producing single-quoted GraphQL string literals
+        (``owner:'HomericIntelligence'``). GraphQL only accepts double-quoted
+        strings, so ``gh`` rejected every batch label fetch with
+        ``Expected VALUE, actual: UNKNOWN_CHAR``. Pass owner/name as ``-F``
+        variables instead, matching ``fetch_issue_review_comments``.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from hephaestus.automation.review_state import fetch_all_issue_labels_graphql
+
+        with (
+            patch("hephaestus.automation.review_state.get_repo_root", return_value="/tmp/repo"),
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("HomericIntelligence", "ProjectHephaestus"),
+            ),
+            patch("hephaestus.automation.review_state._gh_call") as mock_gh,
+        ):
+            mock_gh.return_value = MagicMock(stdout=json.dumps({"data": {"repository": {}}}))
+            fetch_all_issue_labels_graphql([10, 11])
+
+        argv = mock_gh.call_args.args[0]
+        query_arg = next(a for a in argv if a.startswith("query="))
+        # No single-quoted GraphQL string literals (invalid GraphQL).
+        assert "'HomericIntelligence'" not in query_arg
+        assert "'ProjectHephaestus'" not in query_arg
+        # owner/name supplied as declared variables, passed via -F.
+        assert "$owner" in query_arg and "$name" in query_arg
+        assert "owner=HomericIntelligence" in argv
+        assert "name=ProjectHephaestus" in argv
+
+    def test_comments_owner_name_passed_as_graphql_variables(self) -> None:
+        """Same regression guard for the batched comments fetch."""
+        from unittest.mock import MagicMock, patch
+
+        from hephaestus.automation.review_state import fetch_all_issue_comments_graphql
+
+        with (
+            patch("hephaestus.automation.review_state.get_repo_root", return_value="/tmp/repo"),
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("HomericIntelligence", "ProjectHephaestus"),
+            ),
+            patch("hephaestus.automation.review_state._gh_call") as mock_gh,
+        ):
+            mock_gh.return_value = MagicMock(stdout=json.dumps({"data": {"repository": {}}}))
+            fetch_all_issue_comments_graphql([10])
+
+        argv = mock_gh.call_args.args[0]
+        query_arg = next(a for a in argv if a.startswith("query="))
+        assert "'HomericIntelligence'" not in query_arg
+        assert "$owner" in query_arg and "$name" in query_arg
+        assert "owner=HomericIntelligence" in argv
+        assert "name=ProjectHephaestus" in argv


### PR DESCRIPTION
## Summary

The two batched GraphQL helpers in `hephaestus/automation/review_state.py`
(`fetch_all_issue_comments_graphql`, `fetch_all_issue_labels_graphql`) built
their query via `{owner!r}` interpolation, producing **single-quoted** GraphQL
string literals (`owner:'HomericIntelligence'`). GraphQL only accepts
double-quoted strings, so `gh` rejected every batch call:

```
gh: Expected VALUE, actual: UNKNOWN_CHAR ("H") at [1, 24]
```

Surfaced live in the automation loop's plan phase — the retry/circuit-breaker
masked it (loop still rc=0) but the planner lost its cheap "drop already-GO
issues" fast-path and flooded the logs every loop.

## Fix

Pass `owner`/`name` as declared GraphQL variables (`query($owner:String!,$name:String!)`
+ `-F owner=… -F name=…`) in both helpers, mirroring the already-correct
single-issue `fetch_issue_review_comments`. Added two regression tests asserting
the emitted query carries no single-quoted literals and that owner/name are
passed as `-F` variables.

## Test plan

- `pixi run pytest tests/unit/automation/test_review_state.py` — 42 passed
- New tests fail against the old interpolation (verified RED) and pass after the fix

Closes #1147

🤖 Generated with [Claude Code](https://claude.com/claude-code)