### PR TITLE
fix(automation): defer to GitHub for SSH-signed commits git can't verify

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -925,6 +925,35 @@ def _assert_body_has_closes(body: str) -> None:
 _ACCEPTABLE_SIG_STATUSES = frozenset({"G", "U"})
 
 
+def _gh_commit_is_verified(oid: str) -> bool:
+    """Return True if GitHub reports *oid*'s signature as verified.
+
+    The local ``git log --format=%G?`` check returns ``N`` (no signature) for a
+    commit that is actually **SSH-signed** when the local checkout has no
+    ``gpg.ssh.allowedSignersFile`` configured — git cannot verify SSH signatures
+    without it. GitHub, however, validates the signature server-side and exposes
+    the result at ``repos/{owner}/{repo}/commits/{sha}`` under
+    ``.commit.verification.verified``. That flag is the source of truth at PR
+    time (the same rationale that makes ``U`` acceptable above), so we consult
+    it before declaring a policy violation. Any lookup failure returns False so
+    the caller falls back to the strict local verdict (fail safe).
+    """
+    try:
+        owner, name = get_repo_info()
+        result = _gh_call(
+            [
+                "api",
+                f"repos/{owner}/{name}/commits/{oid}",
+                "--jq",
+                ".commit.verification.verified",
+            ],
+        )
+        return (result.stdout or "").strip().lower() == "true"
+    except Exception as exc:  # pragma: no cover - logged, treated as unverified
+        logger.warning("Could not confirm GitHub signature for %s: %s", oid[:10], exc)
+        return False
+
+
 def _assert_branch_commits_signed(branch: str, base: str = "main") -> None:
     """Raise if any commit on *branch* (since *base*) is unsigned or invalid.
 
@@ -932,6 +961,13 @@ def _assert_branch_commits_signed(branch: str, base: str = "main") -> None:
     status. The base ref is fetched first to ensure the range is meaningful in
     detached/shallow clones; failure to fetch is non-fatal because the existing
     local ref is sufficient when present.
+
+    A commit whose local status is *not* acceptable (e.g. ``N`` for an
+    SSH-signed commit the local checkout can't verify without
+    ``gpg.ssh.allowedSignersFile``) is re-checked against GitHub's commit
+    verification API before it is flagged — GitHub's ``verified`` flag is
+    authoritative at PR time. Only commits that fail BOTH the local check and
+    the API check are treated as policy violations.
     """
     # Best-effort fetch of the base ref. Don't fail signing checks just because
     # the operator is offline — the local base is usually fresh enough.
@@ -960,6 +996,11 @@ def _assert_branch_commits_signed(branch: str, base: str = "main") -> None:
             continue
         oid, status = parts[0], parts[1].strip()
         if status not in _ACCEPTABLE_SIG_STATUSES:
+            # Local git couldn't bless it — but it may be SSH-signed and simply
+            # unverifiable here. Defer to GitHub's authoritative verdict before
+            # flagging it as a policy violation.
+            if _gh_commit_is_verified(oid):
+                continue
             bad.append((oid, status))
 
     if bad:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1350,10 +1350,13 @@ class TestGhPrCreate:
             )
         mock_gh_call.assert_not_called()
 
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified", return_value=False)
     @patch("hephaestus.automation.github_api.run")
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_rejects_unsigned_commit(self, mock_gh_call: Any, mock_run: Any) -> None:
-        """An 'N' (no signature) commit must abort PR creation."""
+    def test_rejects_unsigned_commit(
+        self, mock_gh_call: Any, mock_run: Any, _mock_verified: Any
+    ) -> None:
+        """An 'N' commit that GitHub also reports unverified must abort PR creation."""
         # First run() call: git fetch (best-effort, contextlib.suppress); ignored
         # Second run() call: git log --format='%H %G?' against origin/<base>
         fetch_result = Mock(returncode=0, stdout="", stderr="")
@@ -1367,12 +1370,16 @@ class TestGhPrCreate:
                 body=_POLICY_BODY,
                 auto_merge=True,
             )
+        # PR creation (_gh_call) must not run once signing fails.
         mock_gh_call.assert_not_called()
 
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified", return_value=False)
     @patch("hephaestus.automation.github_api.run")
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_rejects_bad_signature(self, mock_gh_call: Any, mock_run: Any) -> None:
-        """A 'B' (bad signature) commit must abort PR creation."""
+    def test_rejects_bad_signature(
+        self, mock_gh_call: Any, mock_run: Any, _mock_verified: Any
+    ) -> None:
+        """A 'B' commit that GitHub also reports unverified must abort PR creation."""
         fetch_result = Mock(returncode=0, stdout="", stderr="")
         log_result = Mock(returncode=0, stdout="aaa111bbb B\n", stderr="")
         mock_run.side_effect = [fetch_result, log_result]
@@ -1406,6 +1413,66 @@ class TestGhPrCreate:
         assert pr_number == 42
         # Pre-flight dedup list + create (auto_merge defaults False).
         assert mock_gh_call.call_count == 2
+
+
+class TestAssertBranchCommitsSignedApiFallback:
+    """SSH-signed commits the local checkout can't verify must not false-NOGO.
+
+    When a commit is SSH-signed but ``gpg.ssh.allowedSignersFile`` is not
+    configured locally, ``git log --format=%G?`` returns ``N`` (or ``E``) even
+    though GitHub has authoritatively verified the signature. The local check
+    must consult the GitHub commit-verification API before declaring a policy
+    violation, since GitHub's ``verified`` flag is the source of truth at PR
+    time (the same rationale that makes ``U`` acceptable). Regression for the
+    implementer false-NOGO on pre-existing SSH-signed branches.
+    """
+
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified")
+    @patch("hephaestus.automation.github_api.run")
+    def test_local_unverifiable_but_github_verified_is_accepted(
+        self, mock_run: Any, mock_verified: Any
+    ) -> None:
+        from hephaestus.automation.github_api import _assert_branch_commits_signed
+
+        fetch_result = Mock(returncode=0, stdout="", stderr="")
+        # Local can't verify the SSH signature -> 'N'.
+        log_result = Mock(returncode=0, stdout="aaa111bbb N\n", stderr="")
+        mock_run.side_effect = [fetch_result, log_result]
+        # GitHub says it's verified.
+        mock_verified.return_value = True
+
+        # Must NOT raise.
+        _assert_branch_commits_signed("feature-branch", base="main")
+        mock_verified.assert_called_once_with("aaa111bbb")
+
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified")
+    @patch("hephaestus.automation.github_api.run")
+    def test_local_unverifiable_and_github_unverified_still_raises(
+        self, mock_run: Any, mock_verified: Any
+    ) -> None:
+        from hephaestus.automation.github_api import _assert_branch_commits_signed
+
+        fetch_result = Mock(returncode=0, stdout="", stderr="")
+        log_result = Mock(returncode=0, stdout="aaa111bbb N\n", stderr="")
+        mock_run.side_effect = [fetch_result, log_result]
+        # GitHub also says unverified (genuinely unsigned) -> policy violation.
+        mock_verified.return_value = False
+
+        with pytest.raises(ValueError, match="Unsigned or invalid commits"):
+            _assert_branch_commits_signed("feature-branch", base="main")
+
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified")
+    @patch("hephaestus.automation.github_api.run")
+    def test_good_local_signature_skips_api_call(self, mock_run: Any, mock_verified: Any) -> None:
+        from hephaestus.automation.github_api import _assert_branch_commits_signed
+
+        fetch_result = Mock(returncode=0, stdout="", stderr="")
+        log_result = Mock(returncode=0, stdout="aaa111bbb G\n", stderr="")
+        mock_run.side_effect = [fetch_result, log_result]
+
+        _assert_branch_commits_signed("feature-branch", base="main")
+        # 'G' is locally good — no API round-trip needed.
+        mock_verified.assert_not_called()
 
 
 class TestWriteSecure:


### PR DESCRIPTION
## Summary

`_assert_branch_commits_signed` in `hephaestus/automation/github_api.py`
false-NOGO'd SSH-signed commits the local checkout cannot verify.
`git log --format=%G?` returns `N` for an SSH-signed commit when
`gpg.ssh.allowedSignersFile` is not configured — git literally errors with
`gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature
verification`. When the automation loop re-encountered a pre-existing branch
whose commit was SSH-signed by a prior run, the implementer aborted the entire
issue:

```
ERROR implementer: Issue #1096 failed: Unsigned or invalid commits on branch
'1096-auto-impl' (vs main): a2b9e52107='N'. ...
```

…even though GitHub reports that exact commit `verified: true, reason: valid`.

## Fix

GitHub's `verified` flag is authoritative at PR time (the same rationale the
code already uses to accept `U`). Added `_gh_commit_is_verified(oid)` querying
`repos/{owner}/{repo}/commits/{sha}` → `.commit.verification.verified`, and
consult it for any commit whose local status is not `G`/`U` before flagging.
Only commits failing BOTH checks are policy violations; API failure → unverified
(fail safe).

## Test plan

- `pixi run pytest tests/unit/automation/test_github_api.py` — 143 passed
- New `TestAssertBranchCommitsSignedApiFallback`: local-unverifiable+GitHub-verified accepted; local-unverifiable+GitHub-unverified raises; good-local-sig skips the API call
- Verified against the real commit: `_gh_commit_is_verified('a2b9e52…') == True`
- `pixi run mypy` clean

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)