### PR TITLE
fix(automation): require zero unresolved threads before GO

### DIFF
--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -63,7 +63,6 @@ from .github_api import (
     gh_current_login,
     gh_issue_add_labels,
     gh_pr_list_unresolved_threads,
-    gh_pr_resolve_thread,
 )
 from .learn import compact_session, learn_needs_rerun, run_learn
 from .models import (
@@ -1551,16 +1550,38 @@ class ImplementationPhaseRunner:
         prior_addressed_threads: list[dict[str, Any]] = []
 
         for iteration in range(MAX_REVIEW_ITERATIONS):
-            # Validation step (#28 follow-up): before the fresh review, verify a
-            # sub-agent that the prior iteration's comments were truly addressed
-            # by the current diff. Anything still unaddressed is re-opened as a
-            # new inline thread so it flows back into the address step below.
+            # Step 1 (#1152): before the fresh review, verify (via the read-only
+            # sub-agent) that every PRIOR review comment was truly addressed by
+            # the current diff — resolving the ones confirmed fixed and re-opening
+            # the ones that aren't. On iteration 0 of the existing-PR path there
+            # is no prior-address snapshot, so seed it with the PR's currently
+            # unresolved threads; otherwise pre-existing threads would never be
+            # verified and the GO gate below would (wrongly) ignore them. From
+            # iteration 1 on, ``prior_addressed_threads`` is the snapshot the
+            # previous address step was asked to fix.
+            #
+            # The seed only applies to the existing-PR review path
+            # (``session_id is None`` — see ``_review_existing_pr``): that PR
+            # arrives with threads from earlier loops that must be re-verified
+            # before a GO. The fresh-implementation path (``session_id`` set) has
+            # no prior threads at iteration 0 — its threads are posted by R0's own
+            # review — so seeding there would wrongly validate not-yet-addressed
+            # comments against an empty diff.
+            threads_to_validate = prior_addressed_threads
+            if (
+                not threads_to_validate
+                and session_id is None
+                and pr_number is not None
+                and not self.options.dry_run
+            ):
+                with contextlib.suppress(Exception):
+                    threads_to_validate = gh_pr_list_unresolved_threads(pr_number, dry_run=False)
             reopened = self._validate_prior_threads(
                 issue_number=issue_number,
                 pr_number=pr_number,
                 branch_name=branch_name,
                 worktree_path=worktree_path,
-                prior_threads=prior_addressed_threads,
+                prior_threads=threads_to_validate,
                 iteration=iteration,
                 thread_id=thread_id,
             )
@@ -1607,50 +1628,72 @@ class ImplementationPhaseRunner:
             # validator just re-opened prior comments — those unresolved
             # re-opened threads must still be addressed. Treat the iteration as
             # NOGO so the address step below runs against them.
+            go_blocked_by_automation = False
             if reopened:
                 last_verdict = "NOGO"
             elif verdict.is_go:
-                # A GO cannot stand while unresolved HUMAN review threads remain
-                # on the PR. ``_resolve_automation_threads_after_go`` clears
-                # automation's own stale threads and returns the count of
-                # remaining non-automation (human) threads. If any remain, the
-                # PR is not actually done — downgrade to NOGO and keep iterating
-                # (address step runs below) rather than labelling it GO.
-                blocking_threads = 0
+                # GO converges ONLY when the PR has ZERO unresolved review threads
+                # (#1152). The reviewer's verdict alone is not enough: a reviewer
+                # can emit GO while the SAME pass posts new findings, or while
+                # prior automation threads remain open. The GO label must be
+                # earned by a clean pass where every comment has been addressed
+                # (by the implementer) and verified resolved (by the prior-thread
+                # validator that ran at the top of this iteration). This gate
+                # RESOLVES NOTHING — it only counts what is still open.
+                automation_unresolved = 0
+                human_unresolved = 0
                 if pr_number is not None and not self.options.dry_run:
-                    blocking_threads = self._resolve_automation_threads_after_go(
+                    (
+                        automation_unresolved,
+                        human_unresolved,
+                    ) = self._count_unresolved_threads_blocking_go(
                         issue_number=issue_number,
                         pr_number=pr_number,
                         thread_id=thread_id,
                     )
-                if blocking_threads and pr_number is not None:
-                    # GO cannot stand while HUMAN review threads remain open.
-                    # Automation must NOT resolve them and cannot fix them — a
-                    # human has to. So break immediately with a distinct terminal
-                    # state rather than re-reviewing to exhaustion (the GO review
-                    # posts no new threads, so the address step below would be
-                    # skipped by the zero-thread guard and the loop would just
-                    # spin GO→downgrade→re-review). HUMAN_BLOCKED is excluded from
-                    # the post-loop state:skip so the PR stays unlabeled, awaiting
-                    # the human; the loop re-runs next pass via the "no go/no-go
-                    # label → re-review" path once threads are resolved.
+                if human_unresolved and pr_number is not None:
+                    # A GO cannot stand while a HUMAN review thread is open.
+                    # Automation must NOT resolve it and cannot fix it — a human
+                    # has to. Break with a distinct terminal state (no spin to
+                    # exhaustion, no state:skip) so the PR stays unlabeled,
+                    # awaiting the human; the loop re-runs next pass via the
+                    # "no go/no-go label → re-review" path once threads resolve.
                     last_verdict = "HUMAN_BLOCKED"
                     impl._log(
                         "info",
                         f"{pr_ref(pr_number)}: reviewer said GO but "
-                        f"{blocking_threads} unresolved human review thread(s) remain "
+                        f"{human_unresolved} unresolved human review thread(s) remain "
                         f"— not accepting GO; awaiting human resolution, "
                         f"leaving PR unlabeled",
                         thread_id,
                     )
                     break
-                impl._log(
-                    "info",
-                    f"{pr_ref(pr_number) if pr_number is not None else issue_ref(issue_number)}"
-                    f": GO on iteration {iteration} — review loop terminated",
-                    thread_id,
-                )
-                break
+                if automation_unresolved and pr_number is not None:
+                    # GO + open automation thread(s): the work is NOT actually
+                    # done. Downgrade to NOGO so the address step (below) fixes
+                    # and resolves them, and the next iteration re-reviews to
+                    # confirm. ``go_blocked_by_automation`` forces the address
+                    # step to run even though this GO pass may have posted no new
+                    # threads (otherwise the zero-thread guard would skip it and
+                    # the loop would spin GO→downgrade to exhaustion).
+                    last_verdict = "NOGO"
+                    go_blocked_by_automation = True
+                    impl._log(
+                        "info",
+                        f"{pr_ref(pr_number)}: reviewer said GO but "
+                        f"{automation_unresolved} unresolved automation review thread(s) "
+                        "remain — addressing and re-reviewing before GO can stand",
+                        thread_id,
+                    )
+                else:
+                    impl._log(
+                        "info",
+                        f"{pr_ref(pr_number) if pr_number is not None else issue_ref(issue_number)}"
+                        f": GO on iteration {iteration} — all review threads resolved, "
+                        "review loop terminated",
+                        thread_id,
+                    )
+                    break
 
             # Converge ONLY on an explicit Verdict: GO (handled above). A non-GO
             # pass with NO posted threads (and nothing re-opened) must NOT end the
@@ -1661,7 +1704,12 @@ class ImplementationPhaseRunner:
             # on TRUE exhaustion (post-loop block). This is the "zero threads !=
             # GO" rule from the pr-review-loop skill (verified-ci): don't converge
             # on a zero-thread AMBIGUOUS/NO-GO pass.
-            if pr_number is not None and not posted_thread_ids and not reopened:
+            if (
+                pr_number is not None
+                and not posted_thread_ids
+                and not reopened
+                and not go_blocked_by_automation
+            ):
                 prior_review = review_text
                 continue
 
@@ -1787,26 +1835,38 @@ class ImplementationPhaseRunner:
 
         return iterations_run, last_verdict, last_grade
 
-    def _resolve_automation_threads_after_go(
+    def _count_unresolved_threads_blocking_go(
         self,
         *,
         issue_number: int,
         pr_number: int,
         thread_id: int | None,
-    ) -> int:
-        """Resolve stale automation-owned review threads after a GO verdict.
+    ) -> tuple[int, int]:
+        """Count unresolved review threads that block a GO, by ownership.
 
-        A fresh reviewer session can legitimately conclude the PR is now GO
-        while older automation comments remain unresolved on GitHub. Resolve
-        only threads authored by the current automation identity or bot
-        accounts; never close human reviewer threads from this automatic GO
-        cleanup pass.
+        A GO verdict may NOT stand while ANY review thread is unresolved — not
+        even an automation-owned one. The earlier implementation bulk-resolved
+        automation threads here so a GO could converge immediately; that was
+        wrong (#1152). A reviewer can emit ``Verdict: GO`` in the SAME pass that
+        posts new inline findings, and force-resolving those "automation-owned"
+        threads accepted the GO without the implementer ever addressing them or
+        a subsequent review verifying the fix. The GO label must only be earned
+        once every comment has been genuinely addressed AND a clean re-review
+        confirms zero unresolved threads.
 
-        Returns the number of unresolved threads that are NOT automation-owned
-        and therefore still block the PR (human review threads). The caller uses
-        this to refuse a GO while any human thread remains open — a GO cannot
-        stand on a PR with unresolved human review threads. Returns 0 when the
-        thread list can't be fetched (fail-open: don't block GO on an API blip).
+        This method therefore RESOLVES NOTHING. It returns
+        ``(automation_unresolved, human_unresolved)``:
+
+        * ``human_unresolved > 0`` — automation cannot fix human threads, so the
+          caller breaks with a distinct ``HUMAN_BLOCKED`` terminal state.
+        * ``automation_unresolved > 0`` — the caller downgrades GO to NOGO so the
+          address step fixes (and resolves only what it actually addressed) and a
+          re-review re-evaluates. Convergence requires a GO pass that leaves zero
+          unresolved threads.
+
+        Returns ``(0, 0)`` when the thread list can't be fetched (fail-open:
+        don't strand a GO on a transient API blip — a genuinely unresolved
+        thread re-surfaces on the next loop's existing-PR re-review).
         """
         impl = self.impl
         try:
@@ -1818,40 +1878,27 @@ class ImplementationPhaseRunner:
                 f"after GO for {pr_ref(pr_number)}: {exc}",
                 thread_id,
             )
-            return 0
+            return (0, 0)
         if not threads:
-            return 0
+            return (0, 0)
 
         current_login = gh_current_login()
-        resolved = 0
-        blocking = 0
+        automation_unresolved = 0
+        human_unresolved = 0
         for thread in threads:
-            if not _is_automation_owned_thread(thread, current_login):
-                # Human-owned thread — automation must not resolve it, and it
-                # blocks GO until a human resolves it.
-                blocking += 1
-                continue
-            tid = thread.get("id")
-            if not tid:
-                continue
-            try:
-                gh_pr_resolve_thread(tid, dry_run=False)
-                resolved += 1
-            except Exception as exc:
-                impl._log(
-                    "warning",
-                    f"{issue_number}: could not resolve stale automation "
-                    f"review thread {tid!r} on {pr_ref(pr_number)}: {exc}",
-                    thread_id,
-                )
-        if resolved:
+            if _is_automation_owned_thread(thread, current_login):
+                automation_unresolved += 1
+            else:
+                human_unresolved += 1
+        if automation_unresolved or human_unresolved:
             impl._log(
                 "info",
-                f"{issue_number}: resolved {resolved} stale automation-owned "
-                f"review thread(s) after GO on {pr_ref(pr_number)}",
+                f"{issue_number}: GO pass left {automation_unresolved} automation + "
+                f"{human_unresolved} human unresolved thread(s) on {pr_ref(pr_number)} "
+                "— GO cannot stand until all are addressed and a clean re-review confirms",
                 thread_id,
             )
-        return blocking
+        return (automation_unresolved, human_unresolved)
 
     def _run_impl_review_step(
         self,

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -268,21 +268,27 @@ class TestRunImplReviewLoop:
         assert iters == 1
         mock_addr2.assert_not_called()
         mock_label.assert_not_called()  # no state:skip applied
-        # Automation-owned threads were still resolved on the GO attempt;
-        # the human thread (T_human) was never resolved by automation.
+        # The GO gate force-resolves NOTHING (#1152): a human thread is present,
+        # so automation must never close it, and the gate no longer bulk-resolves
+        # automation threads either (they'd be verified/addressed, but the human
+        # block ends the loop first). The human thread is never resolved here.
         resolved_ids = {call.args[0] for call in mock_resolve.call_args_list}
         assert "T_human" not in resolved_ids
-        assert {"T_self", "T_bot", "T_nested_self"} <= resolved_ids
 
-    def test_go_accepted_when_only_automation_threads_remain(
+    def test_go_does_not_stand_while_automation_threads_unresolved(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """GO terminates the loop when every unresolved thread is automation-owned.
+        """A GO pass must NOT converge while automation threads remain unresolved (#1152).
 
-        Automation cleans up its own stale threads on GO; with no human thread
-        left, the GO stands and the loop terminates at iteration 0.
+        The OLD behavior force-resolved automation-owned threads on GO and
+        accepted the verdict. That let a reviewer say GO while leaving real,
+        unaddressed findings open — they were never fixed by the implementer nor
+        verified by a re-review. The corrected rule: an unresolved automation
+        thread downgrades GO to NOGO so the address step runs; the GO label is
+        only earned by a clean pass with ZERO unresolved threads. Nothing is
+        force-resolved here.
         """
-        threads = [
+        automation_threads = [
             {"id": "T_self", "author": "mvillmow", "path": "a.py", "line": 1, "body": "old"},
             {
                 "id": "T_bot",
@@ -293,11 +299,17 @@ class TestRunImplReviewLoop:
             },
         ]
         with (
-            patch.object(implementer, "_run_impl_review_step", return_value=(_go(), [])),
-            patch.object(implementer, "_run_address_review_step") as mock_addr,
+            # R0 emits GO but 2 automation threads are still unresolved; R1 sees a
+            # clean board (address step fixed + resolved them) and GO stands.
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_go(), []), (_go(), [])],
+            ),
+            patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_pr_list_unresolved_threads",
-                return_value=threads,
+                side_effect=[automation_threads, automation_threads, []],
             ),
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_current_login",
@@ -307,7 +319,7 @@ class TestRunImplReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.gh_pr_resolve_thread"
             ) as mock_resolve,
         ):
-            iters, verdict, grade = implementer._run_impl_review_loop(
+            iters, verdict, _grade = implementer._run_impl_review_loop(
                 issue_number=1,
                 worktree_path=tmp_path,
                 branch_name="b",
@@ -319,17 +331,59 @@ class TestRunImplReviewLoop:
                 pr_number=42,
             )
 
-        assert (iters, verdict, grade) == (1, "GO", "A")
-        mock_addr.assert_not_called()
-        resolved_ids = [call.args[0] for call in mock_resolve.call_args_list]
-        assert resolved_ids == ["T_self", "T_bot"]
-        # Each resolve call passes the thread id positionally and dry_run=False
-        # (signature guard carried over from main).
-        assert all(
-            call.args == (thread_id,)
-            for call, thread_id in zip(mock_resolve.call_args_list, resolved_ids, strict=True)
-        )
-        assert all(call.kwargs == {"dry_run": False} for call in mock_resolve.call_args_list)
+        # GO did not converge at R0 (threads open) — address ran, R1 confirmed GO.
+        assert verdict == "GO"
+        assert iters == 2
+        mock_addr.assert_called()  # the address step ran to fix the open threads
+        # The GO gate itself force-resolved NOTHING; only the address step (which
+        # we stubbed) resolves what it actually fixed.
+        mock_resolve.assert_not_called()
+
+    def test_go_does_not_converge_when_same_pass_posts_new_threads(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A reviewer that emits GO while posting NEW findings must not converge (#1152).
+
+        This is the exact bug: ``Verdict: GO`` alongside freshly-posted inline
+        threads. Those threads must be addressed and re-verified, never accepted
+        as-is.
+        """
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                # R0: GO but posts a brand-new thread t0; R1: clean GO.
+                side_effect=[(_go(), ["t0"]), (_go(), [])],
+            ),
+            patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_pr_list_unresolved_threads",
+                side_effect=[
+                    [{"id": "t0", "author": "mvillmow", "path": "a.py", "line": 1, "body": "x"}],
+                    [{"id": "t0", "author": "mvillmow", "path": "a.py", "line": 1, "body": "x"}],
+                    [],
+                ],
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.gh_current_login",
+                return_value="mvillmow",
+            ),
+        ):
+            iters, verdict, _grade = implementer._run_impl_review_loop(
+                issue_number=1,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "GO"
+        assert iters == 2  # did NOT accept GO on R0; addressed then re-reviewed
+        mock_addr.assert_called()
 
     def test_runs_3_iterations_on_sustained_nogo(
         self, implementer: IssueImplementer, tmp_path: Path
@@ -773,6 +827,13 @@ class TestRunImplReviewLoop:
         R0 NOGO → address. R1 the validator re-opens a prior comment AND the
         reviewer now says GO — but the re-open must override GO, forcing the loop
         to address again rather than terminating with an unaddressed comment.
+        By R2 the board is clean (no unresolved threads) so the GO stands (#1152:
+        GO requires zero unresolved threads).
+
+        ``_validate_prior_threads`` is patched directly to control the re-open
+        signal per iteration, decoupling this assertion from the snapshot
+        plumbing; the GO gate always sees a clean board so the ONLY thing keeping
+        the loop alive past R1 is the validator re-open.
         """
         with (
             patch.object(implementer, "_collect_diff", return_value="diff"),
@@ -784,30 +845,21 @@ class TestRunImplReviewLoop:
                 side_effect=[(_nogo("D"), ["t0"]), (_go(), []), (_go(), [])],
             ) as mock_rev,
             patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
+            # GO gate always sees a clean board (zero unresolved threads).
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_pr_list_unresolved_threads",
-                # Automation-owned thread (posted by the reviewer bot) — the
-                # GO-gate resolves/ignores it, so it doesn't block the eventual
-                # GO. Only HUMAN threads block GO.
-                return_value=[
-                    {
-                        "id": "T",
-                        "author": "github-actions[bot]",
-                        "path": "a.py",
-                        "line": 1,
-                        "body": "fix",
-                    }
-                ],
+                return_value=[],
             ),
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_current_login",
                 return_value="mvillmow",
             ),
             patch("hephaestus.automation.implementer_phase_runner.gh_pr_resolve_thread"),
-            patch(
-                "hephaestus.automation.implementer_phase_runner.validate_prior_comments_addressed",
-                # R1 validation re-opens; R2 validation is clean.
-                side_effect=[(["RE1"], False), ([], True)],
+            # R0 clean, R1 re-opens (overrides GO), R2 clean.
+            patch.object(
+                implementer.phase_runner,
+                "_validate_prior_threads",
+                side_effect=[[], ["RE1"], []],
             ) as mock_validate,
         ):
             iters, verdict, _ = implementer._run_impl_review_loop(
@@ -828,8 +880,8 @@ class TestRunImplReviewLoop:
         assert mock_rev.call_count == 3
         # Address ran after R0 and after the overridden R1 (not after R2's clean GO).
         assert mock_addr.call_count == 2
-        # Validation ran on iterations 1 and 2 (skipped on iteration 0 — no prior).
-        assert mock_validate.call_count == 2
+        # Validation ran every iteration (R0, R1, R2).
+        assert mock_validate.call_count == 3
 
     def test_no_pr_falls_back_to_diff_only_reviewer(
         self, implementer: IssueImplementer, tmp_path: Path

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -286,19 +286,14 @@ class TestRunImplReviewLoop:
         only earned by a clean pass with ZERO unresolved threads. Nothing is
         force-resolved here.
         """
-        automation_threads = [
-            {"id": "T_self", "author": "mvillmow", "path": "a.py", "line": 1, "body": "old"},
-            {
-                "id": "T_bot",
-                "author": "github-actions[bot]",
-                "path": "b.py",
-                "line": 2,
-                "body": "old",
-            },
-        ]
+
+        def _automation_thread(tid: str, author: str, path: str, line: int) -> dict[str, object]:
+            return {"id": tid, "author": author, "path": path, "line": line, "body": "old"}
+
         with (
             # R0 emits GO but 2 automation threads are still unresolved; R1 sees a
-            # clean board (address step fixed + resolved them) and GO stands.
+            # clean board (address step fixed + resolved them) and GO stands. The
+            # two open snapshots feed R0's GO gate and R1's pre-address snapshot.
             patch.object(
                 implementer,
                 "_run_impl_review_step",
@@ -307,7 +302,17 @@ class TestRunImplReviewLoop:
             patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_pr_list_unresolved_threads",
-                side_effect=[automation_threads, automation_threads, []],
+                side_effect=[
+                    [
+                        _automation_thread("T_self", "mvillmow", "a.py", 1),
+                        _automation_thread("T_bot", "github-actions[bot]", "b.py", 2),
+                    ],
+                    [
+                        _automation_thread("T_self", "mvillmow", "a.py", 1),
+                        _automation_thread("T_bot", "github-actions[bot]", "b.py", 2),
+                    ],
+                    [],
+                ],
             ),
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_current_login",

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -242,9 +242,7 @@ class TestRunImplReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.gh_current_login",
                 return_value="mvillmow",
             ),
-            patch(
-                "hephaestus.automation.github_api.gh_pr_resolve_thread"
-            ) as mock_resolve,
+            patch("hephaestus.automation.github_api.gh_pr_resolve_thread") as mock_resolve,
             patch.object(implementer, "_run_address_review_step") as mock_addr2,
             patch(
                 "hephaestus.automation.implementer_phase_runner.gh_issue_add_labels"
@@ -315,9 +313,7 @@ class TestRunImplReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.gh_current_login",
                 return_value="mvillmow",
             ),
-            patch(
-                "hephaestus.automation.github_api.gh_pr_resolve_thread"
-            ) as mock_resolve,
+            patch("hephaestus.automation.github_api.gh_pr_resolve_thread") as mock_resolve,
         ):
             iters, verdict, _grade = implementer._run_impl_review_loop(
                 issue_number=1,

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -243,7 +243,7 @@ class TestRunImplReviewLoop:
                 return_value="mvillmow",
             ),
             patch(
-                "hephaestus.automation.implementer_phase_runner.gh_pr_resolve_thread"
+                "hephaestus.automation.github_api.gh_pr_resolve_thread"
             ) as mock_resolve,
             patch.object(implementer, "_run_address_review_step") as mock_addr2,
             patch(
@@ -316,7 +316,7 @@ class TestRunImplReviewLoop:
                 return_value="mvillmow",
             ),
             patch(
-                "hephaestus.automation.implementer_phase_runner.gh_pr_resolve_thread"
+                "hephaestus.automation.github_api.gh_pr_resolve_thread"
             ) as mock_resolve,
         ):
             iters, verdict, _grade = implementer._run_impl_review_loop(
@@ -854,7 +854,7 @@ class TestRunImplReviewLoop:
                 "hephaestus.automation.implementer_phase_runner.gh_current_login",
                 return_value="mvillmow",
             ),
-            patch("hephaestus.automation.implementer_phase_runner.gh_pr_resolve_thread"),
+            patch("hephaestus.automation.github_api.gh_pr_resolve_thread"),
             # R0 clean, R1 re-opens (overrides GO), R2 clean.
             patch.object(
                 implementer.phase_runner,


### PR DESCRIPTION
## Summary

The implementer's in-loop review gate could apply `state:implementation-go` to a
PR whose review comments were **never addressed**. On a GO verdict it called
`_resolve_automation_threads_after_go`, which bulk-resolved every automation-owned
unresolved thread and accepted the GO — only *human* threads blocked it. A
reviewer can emit `Verdict: GO` in the **same pass that posts new findings**
(seen live on PR #1062 / issue #821), so those just-posted findings were
force-resolved and the PR went GO without the implementer addressing them or any
re-review verifying.

## New convergence rule (verify-then-decide)

Per maintainer, in order, every review iteration:

1. **Reconcile prior threads** — the read-only validator verifies each prior
   comment against the current diff: resolve confirmed-fixed, re-open
   unaddressed. Seeded from the PR's currently-unresolved threads on iteration 0
   of the existing-PR path (`session_id is None`) so pre-existing threads are
   verified before GO.
2. **Re-review** the code (confirm fixes, no new issues).
3. **Decide GO/NOGO** — GO converges **only when zero unresolved threads remain**.

`_resolve_automation_threads_after_go` (resolved threads) is replaced by
`_count_unresolved_threads_blocking_go` (**resolves nothing**; returns
`(automation_unresolved, human_unresolved)`). Unresolved human → `HUMAN_BLOCKED`;
unresolved automation → downgrade GO→NOGO so the address step fixes it and a
re-review re-evaluates. Cap at `MAX_REVIEW_ITERATIONS` then `state:skip` on true
exhaustion — never force a GO.

## Test plan

- `pixi run pytest tests/unit/automation/test_implementer_loop.py` — 68 passed
- New regression tests: GO+unresolved-automation does not converge;
  GO+same-pass-posted-threads does not converge; validator re-open overrides GO;
  human thread → HUMAN_BLOCKED with no force-resolve
- `pixi run mypy` clean; full automation suite green except 6 pre-existing
  `test_planner_*` failures unrelated to this change (present on clean main)

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)