### PR TITLE
test(automation): isolate TestFilterIssues label fetch from live repo

### DIFF
--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -892,6 +892,13 @@ class TestFilterIssues:
                 "hephaestus.automation.planner_state.prefetch_issue_states",
                 return_value={},
             ),
+            # Isolate from the live repo: the batched label fetch would otherwise
+            # hit the network for the real issue #123 (which carries plan-go) and
+            # drop it. Empty labels → issue falls through to the worker (#1156).
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={},
+            ),
         ):
             result = planner._filter_issues()
 
@@ -902,9 +909,15 @@ class TestFilterIssues:
         """Closed-issue filtering (cheap, batched GraphQL) stays in the pre-pass."""
         from hephaestus.automation.models import IssueState
 
-        with patch(
-            "hephaestus.automation.planner_state.prefetch_issue_states",
-            return_value={123: IssueState.CLOSED},
+        with (
+            patch(
+                "hephaestus.automation.planner_state.prefetch_issue_states",
+                return_value={123: IssueState.CLOSED},
+            ),
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={},
+            ),
         ):
             result = planner._filter_issues()
 
@@ -914,9 +927,16 @@ class TestFilterIssues:
         """Open issues survive the pre-pass and are returned for the worker pool."""
         from hephaestus.automation.models import IssueState
 
-        with patch(
-            "hephaestus.automation.planner_state.prefetch_issue_states",
-            return_value={123: IssueState.OPEN},
+        with (
+            patch(
+                "hephaestus.automation.planner_state.prefetch_issue_states",
+                return_value={123: IssueState.OPEN},
+            ),
+            # Isolate from the live repo's label state for issue #123 (#1156).
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={},
+            ),
         ):
             result = planner._filter_issues()
 

--- a/tests/unit/automation/test_planner_main.py
+++ b/tests/unit/automation/test_planner_main.py
@@ -93,6 +93,14 @@ def test_run_skips_issue_with_existing_plan() -> None:
         patch.object(planner, "_has_existing_plan", return_value=True) as mock_has,
         patch.object(planner, "_call_claude") as mock_claude,
         patch.object(planner, "_post_plan") as mock_post,
+        # Isolate the pre-pass label filter from the live repo: without this the
+        # batched fetch sees real issue #123's plan-go label and drops it before
+        # the worker, so _has_existing_plan never runs (#1156). Empty labels →
+        # the issue reaches the worker, where the mocked guard returns True.
+        patch(
+            "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+            return_value={},
+        ),
     ):
         results = planner.run()
 


### PR DESCRIPTION
## Summary

`TestFilterIssues` and `test_run_skips_issue_with_existing_plan` patched
`prefetch_issue_states` but not `fetch_all_issue_labels_graphql`, which
`PlannerStateManager.filter()` also calls. So they made a REAL `gh` call for
issue #123 — which actually carries `state:plan-go` in this repo — and the
filter (correctly) dropped it, so tests expecting `[123]` got `[]`.

They only passed before because the batched label fetch was broken
(single-quoted GraphQL, fixed in #1148, merged). Fixing the fetch exposed the
latent network dependency.

## Fix

Patch `fetch_all_issue_labels_graphql -> {}` in the affected tests so they no
longer touch the network or depend on #123's live label state.

## Test plan

- `pixi run pytest tests/unit/automation/test_planner_loop.py tests/unit/automation/test_planner_main.py tests/unit/automation/test_planner_state.py` — 63 passed
- ruff clean

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)