### PR TITLE
fix(automation): dedup review findings only against unresolved threads

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1567,34 +1567,6 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tu
     return index
 
 
-def gh_pr_inline_comment_history_index(pr_number: int) -> dict[ReviewCommentIndexKey, list[str]]:
-    """Map ``(path, line)`` → historical inline review bodies, resolved or not.
-
-    Unlike :func:`gh_pr_inline_comment_index`, this index includes resolved
-    threads and carries only bodies, never comment IDs. It is used solely to
-    suppress materially identical reviewer findings after an earlier thread was
-    resolved; resolved comments must not be edited or re-opened just because a
-    later reviewer restates the same finding (#1116).
-    """
-    history: dict[ReviewCommentIndexKey, list[str]] = {}
-    for node in _fetch_pr_inline_review_thread_nodes(pr_number):
-        path = node.get("path") or ""
-        line = node.get("line")
-        side = node.get("side") or "RIGHT"
-        comment_nodes = node.get("comments", {}).get("nodes", [])
-        bodies = [
-            str(comment.get("body") or "")
-            for comment in comment_nodes
-            if isinstance(comment, dict) and str(comment.get("body") or "").strip()
-        ]
-        if not bodies:
-            continue
-        history.setdefault((path, line, side), []).extend(bodies)
-        # Preserve the older key shape for side-less lookup fallback.
-        history.setdefault((path, line), []).extend(bodies)
-    return history
-
-
 def gh_pr_update_review_comment(comment_node_id: str, body: str) -> None:
     """Replace a PR review comment's body via ``updatePullRequestReviewComment``.
 
@@ -1725,21 +1697,27 @@ def _review_comment_already_covers(existing_body: str, new_body: str) -> bool:
 
 
 def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Edit comments whose line already has a bot comment; return the rest.
+    """Edit comments whose line already has an UNRESOLVED bot comment; keep the rest.
 
-    For each comment whose ``(path, line)`` is in the existing-comment index,
-    first skip it if the existing body already covers the same finding. If the
-    finding is genuinely new, rewrite the existing comment to
-    ``existing_body + new_body`` (a single edit that preserves the original
-    text, #1085) and drop it from the returned list. Resolved historical
-    comments are used only as duplicate evidence; they are never edited.
-    Comments on fresh lines are returned unchanged for posting. Fails open: an
-    empty index returns *comments* unchanged, and an edit that raises falls back
-    to posting that comment fresh.
+    For each comment whose ``(path, line)`` matches an UNRESOLVED existing bot
+    thread, skip it if the existing body already covers the same finding, else
+    rewrite that thread's comment to ``existing_body + new_body`` (a single edit
+    preserving the original text, #1085) and drop it from the returned list.
+
+    Findings on fresh lines — including lines whose only prior comment is a
+    RESOLVED thread — are returned unchanged for posting. Dedup is deliberately
+    NOT done against resolved history (#1152 reversed #1116): a resolved thread
+    is supposed to mean the finding was *fixed and verified*, so if the reviewer
+    re-raises it the resolution was wrong and the finding MUST re-surface as a
+    fresh thread — otherwise a force-resolved-but-unaddressed finding is
+    silently suppressed, leaving the GO gate with zero unresolved threads and
+    letting the PR converge with the issue still unfixed.
+
+    Fails open: an empty index returns *comments* unchanged, and an edit that
+    raises falls back to posting that comment fresh.
     """
     editable_index = gh_pr_inline_comment_index(pr_number)
-    history_index = gh_pr_inline_comment_history_index(pr_number)
-    if not editable_index and not history_index:
+    if not editable_index:
         return comments
     fresh: list[dict[str, Any]] = []
     for c in comments:
@@ -1747,22 +1725,6 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
         line = c.get("line")
         side = c.get("side") or "RIGHT"
         body = c.get("body") or ""
-
-        historical_bodies = history_index.get((path, line, side)) or history_index.get(
-            (path, line), []
-        )
-        if any(
-            _review_comment_already_covers(existing_body, body)
-            for existing_body in historical_bodies
-        ):
-            logger.info(
-                "PR #%s: skipped duplicate same-line review comment on %s:%s (%s)",
-                pr_number,
-                path,
-                line,
-                side,
-            )
-            continue
 
         editable = editable_index.get((path, line, side)) or editable_index.get((path, line))
         if editable is None:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -25,7 +25,6 @@ from hephaestus.automation.github_api import (
     gh_list_open_issues,
     gh_pr_checks,
     gh_pr_create,
-    gh_pr_inline_comment_history_index,
     gh_pr_inline_comment_index,
     gh_pr_resolve_thread,
     gh_pr_review_post,
@@ -2338,34 +2337,34 @@ class TestGhPrReviewPost:
         assert self._posted_comments(mock_write) == []
 
     @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
-    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_history_index")
     @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
     @patch("hephaestus.automation.github_api.io_write_secure")
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_resolved_same_line_duplicate_comment_is_skipped_not_edited(
+    def test_finding_matching_only_a_resolved_thread_is_reposted(
         self,
         mock_gh_call: Any,
         _mock_repo: Any,
         mock_write: Any,
         mock_index: Any,
-        mock_history: Any,
         mock_update: Any,
     ) -> None:
-        """Issue #1116: resolved historical findings suppress duplicate re-reviews."""
+        """#1152 reverses #1116: a finding matching only a RESOLVED thread re-posts.
+
+        A resolved thread is supposed to mean the finding was fixed and verified.
+        If the reviewer re-raises it, the resolution was wrong (e.g. the old gate
+        force-resolved it without addressing), so it must re-surface as a fresh
+        thread rather than be suppressed — otherwise the GO gate sees zero
+        unresolved threads and the PR converges with the issue unfixed.
+
+        ``gh_pr_inline_comment_index`` (UNRESOLVED threads only) returns ``{}``
+        here, so the line has no open thread and the finding posts fresh.
+        """
         mock_gh_call.side_effect = self._gh_call_side_effect(
             "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
         )
+        # No UNRESOLVED thread on the line — the only prior comment was resolved.
         mock_index.return_value = {}
-        mock_history.return_value = {
-            ("a.py", 2, "RIGHT"): [
-                "This regression coverage only exercises the Claude result-envelope path. "
-                "The production diff also changed the Codex stdout path, so add a Codex "
-                "test where `summary` lacks a verdict and `review_text`/stdout contains "
-                "`Verdict: GO` or `Verdict: NOGO`; otherwise the second producer path can "
-                "regress without this suite catching it."
-            ],
-        }
 
         gh_pr_review_post(
             pr_number=1116,
@@ -2374,22 +2373,17 @@ class TestGhPrReviewPost:
                     "path": "a.py",
                     "line": 2,
                     "side": "RIGHT",
-                    "body": (
-                        "This regression test only exercises the Claude JSON-envelope path. "
-                        "The production fix also changed the Codex stdout path, so please add "
-                        "a Codex-path test that returns prose with `Verdict: GO`/`NOGO` and a "
-                        "verdict-free JSON summary, then asserts `review_text` preserves the "
-                        "raw stdout."
-                    ),
+                    "body": "Real finding the old gate force-resolved without fixing.",
                 }
             ],
             summary="Findings",
             dedupe_existing=True,
         )
 
+        # The finding was NOT edited into a (nonexistent) open thread...
         mock_update.assert_not_called()
-        mock_write.assert_not_called()
-        assert not any(
+        # ...it was posted fresh as a new review.
+        assert any(
             "repos/owner/repo/pulls/1116/reviews" in str(arg)
             for call in mock_gh_call.call_args_list
             for arg in (call.args[0] if call.args else call.kwargs.get("args", []))
@@ -2636,51 +2630,6 @@ class TestGhPrInlineCommentIndex:
         result.stdout = "not json{"
         mock_gh_call.return_value = result
         assert gh_pr_inline_comment_index(7) == {}
-
-
-class TestGhPrInlineCommentHistoryIndex:
-    """gh_pr_inline_comment_history_index includes resolved comments for dedupe."""
-
-    @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))
-    @patch("hephaestus.automation.github_api._gh_call")
-    def test_indexes_resolved_and_unresolved_thread_bodies(
-        self, mock_gh_call: Any, _mock_repo: Any
-    ) -> None:
-        result = Mock()
-        result.stdout = json.dumps(
-            {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "reviewThreads": {
-                                "nodes": [
-                                    {
-                                        "isResolved": True,
-                                        "path": "a.py",
-                                        "line": 2,
-                                        "side": "RIGHT",
-                                        "comments": {"nodes": [{"id": "N1", "body": "old"}]},
-                                    },
-                                    {
-                                        "isResolved": False,
-                                        "path": "a.py",
-                                        "line": 2,
-                                        "side": "RIGHT",
-                                        "comments": {"nodes": [{"id": "N2", "body": "open"}]},
-                                    },
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        )
-        mock_gh_call.return_value = result
-
-        history = gh_pr_inline_comment_history_index(7)
-
-        assert history[("a.py", 2, "RIGHT")] == ["old", "open"]
-        assert history[("a.py", 2)] == ["old", "open"]
 
 
 class TestValidReviewPositions:


### PR DESCRIPTION
## Summary

Follow-up to #1155. With the GO gate fixed to require zero *unresolved* threads,
a second hole surfaced in `_edit_or_keep_comments`: the same-line dedup
consulted the history index (resolved + unresolved) and **skipped** any reviewer
finding matching a *resolved* historical comment (#1116).

The old buggy gate (#1152) force-resolved findings without addressing them. So
the R0 reviewer re-finds a real bug, the dedup matches it against the stale
resolved comment and drops it (`posted 0 thread(s)`), the GO gate sees zero
unresolved threads, and the PR converges GO with the bug unfixed. Reproduced
live re-running #1062 (issue #821): `found 2 inline comment(s)` on
ci_driver.py:368/:426 → `skipped duplicate same-line review comment` ×2 →
`R0: Verdict=GO threads=0` → GO.

## Fix

A resolved thread is supposed to mean the finding was fixed and verified, so a
re-raised finding matching only a resolved thread MUST re-surface. Dedup now
runs ONLY against `gh_pr_inline_comment_index` (unresolved threads): match an
open thread → edit in place; match only a resolved thread → post fresh. Removed
the now-unused `gh_pr_inline_comment_history_index` + its test; inverted the
#1116 test to assert the resolved-match finding re-posts. Forward-safe: the
#1155 gate no longer force-resolves.

## Test plan

- `pixi run pytest tests/unit/automation/` — 1447 passed
- New `test_finding_matching_only_a_resolved_thread_is_reposted`; inverted the
  old #1116 suppression test
- `pixi run mypy` clean; ruff clean

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)