### PR TITLE
fix(automation): model in session key, always --resume (no recreate cascade)

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2997,6 +2997,7 @@ class CIDriver:
             issue=issue_number,
             agent=AGENT_CI_DRIVER,
             cwd=cwd,
+            model=implementer_model(),
         )
 
     def _parse_json_block(self, text: str) -> dict[str, Any]:

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -22,13 +22,11 @@ import logging
 import os
 import re
 import subprocess
-import time
 import uuid
-from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from hephaestus.automation.session_naming import session_jsonl_path, session_name
+from hephaestus.automation.session_naming import session_name
 from hephaestus.github.rate_limit import detect_claude_usage_cap, detect_rate_limit
 
 logger = logging.getLogger(__name__)
@@ -54,41 +52,7 @@ def _session_expired(stderr: str, stdout: str) -> bool:
     return any(phrase in blob for phrase in SESSION_EXPIRED_PHRASES)
 
 
-def _run_fresh_session(
-    run_session: Callable[..., subprocess.CompletedProcess[str]],
-    display_name: str,
-    contended_sid: str,
-) -> tuple[str, str]:
-    """Create and run a brand-new uuid4 session, decoupled from a contended id.
-
-    Both the create path and the resume path fall back here when the
-    deterministic uuid5 session id is unrecoverable (another worker holds it).
-    uuid4 guarantees no collision with the deterministic id or another worker's
-    fresh one, so the call proceeds instead of aborting.
-
-    Args:
-        run_session: The ``_run`` closure from :func:`invoke_claude_with_session`.
-        display_name: Base session name; the fresh id's prefix is appended.
-        contended_sid: The deterministic id that could not be used (for logs).
-
-    Returns:
-        ``(stdout, fresh_sid)`` from the fresh session.
-
-    """
-    fresh_sid = str(uuid.uuid4())
-    fresh_name = f"{display_name}-{fresh_sid[:8]}"
-    logger.warning(
-        "claude session %s unrecoverable; creating fresh session %s",
-        contended_sid,
-        fresh_sid,
-    )
-    return (
-        run_session(create=True, sid_override=fresh_sid, name_override=fresh_name).stdout,
-        fresh_sid,
-    )
-
-
-def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + create vs resume + expired fallback toggle
+def invoke_claude_with_session(
     *,
     repo: str,
     issue: int | str,
@@ -103,21 +67,23 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
     extra_args: list[str] | None = None,
     output_format: str = "text",
     input_via_stdin: bool = False,
-    recreate_on_resume_failure: bool = True,
+    recreate_on_resume_failure: bool = True,  # accepted for back-compat; no longer used
 ) -> tuple[str, str]:
-    """Invoke Claude with a deterministic session.
+    """Invoke Claude with a deterministic per-(repo, issue, agent, model) session.
 
-    First call for the ``(repo, issue, agent)`` tuple uses
-    ``--session-id <uuid>`` to create the session. Every later call uses
-    ``--resume <uuid>``. The session is scoped to the artifact (issue/PR),
-    not to a commit SHA, so the transcript persists across main-bumps for
-    the entire lifetime of the issue (#841). By default any ``--resume``
-    failure retries once with ``--session-id`` to recreate; quota-cap
-    detection happens one layer up. Pass ``recreate_on_resume_failure=False``
-    to propagate the ``CalledProcessError`` instead — needed by callers
-    that must apply their own session-expired classification (e.g. the
-    impl review-loop feedback path stops iterating on expiry rather than
-    restarting).
+    The session id is ``uuid5`` of ``(repo, issue, agent, model)`` and the call
+    ALWAYS uses ``--resume <uuid>`` (#1166). The Claude harness creates the
+    session transparently on the first ``--resume`` for an id that does not yet
+    exist, so there is no separate create path, no create-vs-resume probe, and no
+    expired/contention fallback to a fresh id — every call for the same key
+    continues the SAME transcript, so cached context is reused instead of
+    re-sent. Because ``--resume`` is locked to the creating model, the model is
+    part of the key: switching a per-agent model simply starts that model's own
+    create-once-then-resume lineage rather than colliding with another model's
+    transcript.
+
+    The session is scoped to the artifact (issue/PR), not a commit SHA, so the
+    transcript persists across main-bumps for the issue's lifetime (#841).
 
     Args:
         repo: Repository slug (e.g. ``"ProjectScylla"``).
@@ -127,11 +93,9 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
             :mod:`hephaestus.automation.session_naming`.
         prompt: Prompt text. Passed as a positional argv unless
             ``input_via_stdin`` is True.
-        model: ``--model`` value (use ``planner_model()`` /
-            ``reviewer_model()`` / ``implementer_model()`` from
-            :mod:`claude_models`).
-        cwd: Working directory for the subprocess. Also determines where
-            the session JSONL is probed.
+        model: ``--model`` value; also part of the session key so a session
+            never crosses models.
+        cwd: Working directory for the subprocess.
         timeout: Subprocess timeout in seconds.
         system_prompt_file: Optional ``--system-prompt`` file.
         allowed_tools: Optional ``--allowedTools`` value (e.g.
@@ -140,154 +104,66 @@ def invoke_claude_with_session(  # noqa: C901  # state machine: argv assembly + 
         extra_args: Any additional flags.
         output_format: ``--output-format`` (``"text"``, ``"json"``, or
             ``"stream-json"``).
-        input_via_stdin: When True, ``prompt`` is fed via stdin instead of
-            argv (matches the existing :mod:`plan_reviewer` invocation).
-        recreate_on_resume_failure: When ``True`` (default), any
-            ``--resume`` failure triggers a fresh ``--session-id`` retry.
-            When ``False``, the underlying ``CalledProcessError`` is
-            re-raised so the caller can distinguish expired-session from
-            transient errors itself.
+        input_via_stdin: When True, ``prompt`` is fed via stdin instead of argv.
+        recreate_on_resume_failure: Deprecated/ignored. Retained so existing
+            keyword callers keep working; the always-resume model needs no
+            recreate toggle.
 
     Returns:
-        ``(stdout, session_uuid)``. The session UUID is the deterministic
-        value derived from the tuple — it equals what the CLI's
-        ``--output-format=json`` would report as ``session_id``.
+        ``(stdout, session_uuid)`` — the deterministic id derived from
+        ``(repo, issue, agent, model)``.
 
     Raises:
-        subprocess.CalledProcessError: If a ``--session-id`` create call
-            exits non-zero, or if both the ``--resume`` and the subsequent
-            recreate attempt fail, or if ``--resume`` fails when
-            ``recreate_on_resume_failure=False``.
+        subprocess.CalledProcessError: If the ``--resume`` call exits non-zero.
         subprocess.TimeoutExpired: If the call exceeds ``timeout``.
 
     """
-    display_name = session_name(repo, issue, agent)
+    del recreate_on_resume_failure  # back-compat shim only; always-resume model
+    display_name = session_name(repo, issue, agent, model)
     sid = str(uuid.uuid5(uuid.NAMESPACE_DNS, display_name))
-    transcript = session_jsonl_path(sid, cwd)
-    should_resume = transcript.exists()
 
-    base_tail: list[str] = ["--model", model, "--output-format", output_format]
+    cmd: list[str] = ["claude", "--resume", sid, "--model", model, "--output-format", output_format]
     if system_prompt_file is not None and system_prompt_file.exists():
-        base_tail += ["--system-prompt", str(system_prompt_file)]
+        cmd += ["--system-prompt", str(system_prompt_file)]
     if allowed_tools:
-        base_tail += ["--allowedTools", allowed_tools]
+        cmd += ["--allowedTools", allowed_tools]
     if permission_mode:
-        base_tail += ["--permission-mode", permission_mode]
+        cmd += ["--permission-mode", permission_mode]
     if extra_args:
-        base_tail += extra_args
-    base_tail.append("--print")
+        cmd += extra_args
+    cmd.append("--print")
     if not input_via_stdin:
-        base_tail.append(prompt)
+        cmd.append(prompt)
 
-    def _build(
-        create: bool, sid_override: str | None = None, name_override: str | None = None
-    ) -> list[str]:
-        use_sid = sid_override or sid
-        use_name = name_override or display_name
-        mode = ["--session-id", use_sid, "--name", use_name] if create else ["--resume", use_sid]
-        return ["claude", *mode, *base_tail]
+    env = os.environ.copy()
+    # CLAUDECODE is set by an outer Claude Code process to refuse nested
+    # invocations; clear it so the automation subprocess can launch.
+    env["CLAUDECODE"] = ""
+    # Propagate correlation ID to subprocess if set (for gh tracing).
+    from hephaestus.logging.utils import get_current_correlation_id
 
-    def _run(
-        create: bool, sid_override: str | None = None, name_override: str | None = None
-    ) -> subprocess.CompletedProcess[str]:
-        env = os.environ.copy()
-        # CLAUDECODE is set by an outer Claude Code process to refuse nested
-        # invocations; clear it so the automation subprocess can launch.
-        env["CLAUDECODE"] = ""
-        # Propagate correlation ID to subprocess if set (for gh tracing).
-        from hephaestus.logging.utils import get_current_correlation_id
+    cid = get_current_correlation_id()
+    if cid:
+        env["GH_TRACE_ID"] = cid
 
-        cid = get_current_correlation_id()
-        if cid:
-            env["GH_TRACE_ID"] = cid
-        cmd = _build(create, sid_override=sid_override, name_override=name_override)
-        logger.debug(
-            "claude invoke: agent=%s issue=%s sid=%s mode=%s",
-            agent,
-            issue,
-            sid_override or sid,
-            "create" if create else "resume",
-        )
-        return subprocess.run(
-            cmd,
-            input=prompt if input_via_stdin else None,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=timeout,
-            env=env,
-            stdin=subprocess.DEVNULL if not input_via_stdin else None,
-            cwd=str(cwd),
-        )
-
-    if not should_resume:
-        try:
-            return _run(create=True).stdout, sid
-        except subprocess.CalledProcessError as exc:
-            # Defense in depth (#822): the probe says no transcript exists
-            # but the CLI says the session is already registered. Encoding
-            # drift between hephaestus and the CLI can desync the probe;
-            # treat the rejection as proof the session exists and resume it.
-            stderr = (exc.stderr or "") + (exc.stdout or "")
-            if "already in use" not in stderr.lower():
-                raise
-            # Under concurrency (3 parallel CI-fix workers) two workers can race
-            # on the same deterministic UUIDv5 session before the transcript is
-            # on disk; the loser hits "already in use" (observed: ProjectHermes
-            # #647). The session may still be initializing in the sibling worker,
-            # so resume can ALSO fail. Retry resume with backoff; if it never
-            # frees, fall back to a FRESH unique session so the drive proceeds
-            # instead of aborting the PR.
-            logger.warning(
-                "claude --session-id %s rejected as already in use; resuming instead",
-                sid,
-            )
-            for resume_attempt in range(3):
-                try:
-                    return _run(create=False).stdout, sid
-                except subprocess.CalledProcessError as resume_exc:
-                    logger.warning(
-                        "claude --resume %s failed (attempt %s/3): %s",
-                        sid,
-                        resume_attempt + 1,
-                        ((resume_exc.stderr or "") + (resume_exc.stdout or ""))[:200],
-                    )
-                    time.sleep(2 * (resume_attempt + 1))
-            # Resume never succeeded — derive a fresh, unique session so this
-            # worker is not coupled to the contended id.
-            return _run_fresh_session(_run, display_name, sid)
-
-    try:
-        return _run(create=False).stdout, sid
-    except subprocess.CalledProcessError as exc:
-        if not recreate_on_resume_failure:
-            raise
-        # Any --resume failure falls back to a fresh session. The known
-        # SESSION_EXPIRED phrases are the common case; transient failures
-        # (the CLI itself crashed, a corrupted transcript, etc.) also
-        # benefit from recreating rather than re-raising and losing the
-        # call entirely. Quota-cap detection happens one layer up.
-        expired = _session_expired(exc.stderr or "", exc.stdout or "")
-        log = logger.warning if expired else logger.info
-        log(
-            "claude --resume %s failed (exit=%s, expired=%s); recreating session",
-            sid,
-            exc.returncode,
-            expired,
-        )
-        try:
-            return _run(create=True).stdout, sid
-        except subprocess.CalledProcessError as recreate_exc:
-            # The recreate reuses the deterministic sid, so under concurrency a
-            # sibling worker that just created this session makes the recreate
-            # collide with "already in use" too (observed: planner ProjectHermes).
-            # Without this guard the error propagated as "Session ID … is already
-            # in use" and aborted the call. Fall back to a fresh unique session,
-            # mirroring the should_resume=False path above.
-            recreate_err = (recreate_exc.stderr or "") + (recreate_exc.stdout or "")
-            if "already in use" not in recreate_err.lower():
-                raise
-            return _run_fresh_session(_run, display_name, sid)
+    logger.debug("claude invoke: agent=%s issue=%s sid=%s mode=resume", agent, issue, sid)
+    # ALWAYS --resume (#1166): the harness creates the session transparently when
+    # the id does not yet exist, so there is no create path, probe, or fallback.
+    # Resuming the same (repo, issue, agent, model) key reuses cached context
+    # instead of re-sending the full prompt — and never crosses models, since the
+    # model is part of the key.
+    result = subprocess.run(
+        cmd,
+        input=prompt if input_via_stdin else None,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=timeout,
+        env=env,
+        stdin=subprocess.DEVNULL if not input_via_stdin else None,
+        cwd=str(cwd),
+    )
+    return result.stdout, sid
 
 
 def scan_quota_reset(*texts: str) -> int | None:

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -917,6 +917,7 @@ class ImplementationPhaseRunner:
             issue=issue_number,
             agent=self._impl_module.AGENT_IMPLEMENTER,
             cwd=worktree_path,
+            model=implementer_model(),
         )
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -265,8 +265,9 @@ def compact_session(
     agent: str,
     cwd: Path,
     timeout: int = 60,
+    model: str | None = None,
 ) -> bool:
-    """Send ``/compact`` to the (repo, issue, agent) Claude session.
+    """Send ``/compact`` to the (repo, issue, agent, model) Claude session.
 
     Best-effort transcript summarisation. Fires immediately after ``/learn``
     on a durably-done stage so the next ``--resume`` reads a summary instead
@@ -287,7 +288,7 @@ def compact_session(
         a non-zero exit code (e.g. /compact skill not registered).
 
     """
-    sid = session_uuid(repo, issue, agent)
+    sid = session_uuid(repo, issue, agent, model)
     try:
         result = subprocess.run(
             [

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -27,6 +27,7 @@ letting each agent resume itself across loop iterations.
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import uuid
 from pathlib import Path
@@ -121,19 +122,41 @@ def _is_valid_agent(agent: str) -> bool:
     return bool(sep) and base in _PER_ITERATION_REVIEWERS and suffix.isdigit()
 
 
-def session_name(repo: str, issue: int | str, agent: str) -> str:
+def _model_token(model: str | None) -> str:
+    """Normalize a model id into a filesystem/name-safe session-key token.
+
+    ``claude --resume`` is locked to the model that created the session, so the
+    model MUST be part of the deterministic key — otherwise switching
+    ``--implementer-model`` (or any per-agent model) between runs resumes a
+    transcript created under a different model, which the CLI rejects (#1166).
+    Returns ``""`` when no model is given (legacy callers keep the old key).
+    """
+    if not model:
+        return ""
+    return re.sub(r"[^A-Za-z0-9._-]", "-", model.strip())
+
+
+def session_name(repo: str, issue: int | str, agent: str, model: str | None = None) -> str:
     """Return the human-readable session name.
 
-    The tuple is intentionally **(repo, issue, agent) only** — no githash.
-    The Claude transcript persists across main-bumps so a long-running
-    drive (CI fix loop, planner, implementer) resumes its context whenever
-    the same artifact (issue/PR) is touched again, instead of being
-    discarded every time main advances (#841).
+    The key is **(repo, issue, agent, model)**. The model is part of the key
+    because ``claude --resume`` is locked to the creating model: a session
+    created under one model cannot be resumed under another, so each
+    ``(repo, issue, agent, model)`` gets its OWN create-once-then-resume lineage
+    (#1166). Omitting ``model`` reproduces the historical ``(repo, issue, agent)``
+    key for backward compatibility.
+
+    No githash is included — the transcript persists across main-bumps so a
+    long-running drive (CI fix loop, planner, implementer) resumes its context
+    whenever the same artifact is touched again, instead of being discarded
+    every time main advances (#841).
 
     Args:
         repo: Repository slug without owner (e.g. ``"ProjectScylla"``).
         issue: Issue number; leading ``#`` is stripped.
         agent: One of the ``AGENT_*`` constants in this module.
+        model: Optional model id; appended to the key when given so sessions
+            never cross models.
 
     Returns:
         Underscore-joined name suitable for ``claude --name``.
@@ -153,12 +176,14 @@ def session_name(repo: str, issue: int | str, agent: str) -> str:
     issue_s = str(issue).lstrip("#").strip()
     if not issue_s:
         raise ValueError("issue must be non-empty")
-    return f"{repo_s}_{issue_s}_{agent}"
+    model_token = _model_token(model)
+    base = f"{repo_s}_{issue_s}_{agent}"
+    return f"{base}_{model_token}" if model_token else base
 
 
-def session_uuid(repo: str, issue: int | str, agent: str) -> str:
-    """Return the deterministic UUIDv5 session ID for the tuple."""
-    name = session_name(repo, issue, agent)
+def session_uuid(repo: str, issue: int | str, agent: str, model: str | None = None) -> str:
+    """Return the deterministic UUIDv5 session ID for the (repo, issue, agent, model) key."""
+    name = session_name(repo, issue, agent, model)
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, name))
 
 

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -10,10 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation.claude_invoke import (
-    SESSION_EXPIRED_PHRASES,
-    invoke_claude_with_session,
-)
+from hephaestus.automation.claude_invoke import invoke_claude_with_session
 from hephaestus.automation.session_naming import (
     AGENT_PLAN_REVIEWER,
     AGENT_PLANNER,
@@ -52,10 +49,12 @@ def _make_existing_jsonl(home: Path, cwd: Path, sid: str) -> None:
     (target_dir / f"{sid}.jsonl").write_text("{}\n")
 
 
-class TestCreateVsResume:
-    """First call vs subsequent call: --session-id vs --resume."""
+class TestAlwaysResume:
+    """#1166: every call uses --resume; the harness creates on first use."""
 
-    def test_first_call_uses_session_id(self, stub_run: MagicMock, fake_home: Path) -> None:
+    def test_call_always_uses_resume_never_create(
+        self, stub_run: MagicMock, fake_home: Path
+    ) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
         out, sid = invoke_claude_with_session(
@@ -67,18 +66,21 @@ class TestCreateVsResume:
             cwd=cwd,
         )
         argv = _argv(stub_run.call_args)
-        assert "--session-id" in argv
-        assert "--name" in argv
-        assert "--resume" not in argv
+        assert "--resume" in argv
+        assert sid in argv
+        # No create path anymore: no --session-id / --name probing.
+        assert "--session-id" not in argv
+        assert "--name" not in argv
         assert out == "ok"
-        assert sid == session_uuid("R", 1, AGENT_PLANNER)
+        # The session id includes the model (#1166).
+        assert sid == session_uuid("R", 1, AGENT_PLANNER, "sonnet")
 
-    def test_subsequent_call_uses_resume(self, stub_run: MagicMock, fake_home: Path) -> None:
+    def test_resume_is_used_even_without_existing_transcript(
+        self, stub_run: MagicMock, fake_home: Path
+    ) -> None:
+        """No transcript on disk → still --resume (harness creates it lazily)."""
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER)
-        _make_existing_jsonl(fake_home, cwd, sid)
-
         invoke_claude_with_session(
             repo="R",
             issue=1,
@@ -89,9 +91,27 @@ class TestCreateVsResume:
         )
         argv = _argv(stub_run.call_args)
         assert "--resume" in argv
-        assert sid in argv
         assert "--session-id" not in argv
-        assert "--name" not in argv
+
+    def test_different_models_get_different_uuids(
+        self, stub_run: MagicMock, fake_home: Path
+    ) -> None:
+        """Switching the model gives a DIFFERENT session id (#1166).
+
+        --resume is locked to the creating model, so each model must have its own
+        create-once-then-resume lineage; the id therefore varies by model.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        _, sid_sonnet = invoke_claude_with_session(
+            repo="R", issue=1, agent=AGENT_PLANNER, prompt="hi", model="sonnet", cwd=cwd
+        )
+        _, sid_opus = invoke_claude_with_session(
+            repo="R", issue=1, agent=AGENT_PLANNER, prompt="hi", model="opus", cwd=cwd
+        )
+        assert sid_sonnet != sid_opus
+        assert sid_sonnet == session_uuid("R", 1, AGENT_PLANNER, "sonnet")
+        assert sid_opus == session_uuid("R", 1, AGENT_PLANNER, "opus")
 
     def test_different_agents_get_different_uuids(
         self, stub_run: MagicMock, fake_home: Path
@@ -99,151 +119,22 @@ class TestCreateVsResume:
         cwd = fake_home / "work"
         cwd.mkdir()
         _, sid_planner = invoke_claude_with_session(
-            repo="R",
-            issue=1,
-            agent=AGENT_PLANNER,
-            prompt="hi",
-            model="sonnet",
-            cwd=cwd,
+            repo="R", issue=1, agent=AGENT_PLANNER, prompt="hi", model="sonnet", cwd=cwd
         )
         _, sid_reviewer = invoke_claude_with_session(
-            repo="R",
-            issue=1,
-            agent=AGENT_PLAN_REVIEWER,
-            prompt="hi",
-            model="sonnet",
-            cwd=cwd,
+            repo="R", issue=1, agent=AGENT_PLAN_REVIEWER, prompt="hi", model="sonnet", cwd=cwd
         )
         assert sid_planner != sid_reviewer
 
-
-class TestSessionExpiredFallback:
-    """When --resume hits a missing session, fall back to --session-id."""
-
-    def test_expired_resume_falls_back_to_create(self, fake_home: Path) -> None:
+    def test_resume_failure_propagates(self, fake_home: Path) -> None:
+        """A --resume non-zero exit is raised; there is no recreate fallback."""
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER)
-        _make_existing_jsonl(fake_home, cwd, sid)
-
-        expired_exc = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=["claude"],
-            output="",
-            stderr=SESSION_EXPIRED_PHRASES[0],
-        )
-        ok = MagicMock(stdout="recovered", stderr="", returncode=0)
-        with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
-            side_effect=[expired_exc, ok],
-        ) as m:
-            out, returned_sid = invoke_claude_with_session(
-                repo="R",
-                issue=1,
-                agent=AGENT_PLANNER,
-                prompt="hi",
-                model="sonnet",
-                cwd=cwd,
-            )
-        assert out == "recovered"
-        assert returned_sid == sid
-        assert m.call_count == 2
-        first_argv = _argv(m.call_args_list[0])
-        second_argv = _argv(m.call_args_list[1])
-        assert "--resume" in first_argv
-        assert "--session-id" in second_argv
-        assert "--resume" not in second_argv
-
-    def test_resume_failure_always_falls_back(self, fake_home: Path) -> None:
-        """Any --resume non-zero exit triggers recreate, not just SESSION_EXPIRED.
-
-        The deleted ``address_review`` code had ``or True`` on its fallback
-        guard for exactly this reason: a transient CLI error on resume
-        should still recreate rather than lose the call entirely. Quota
-        detection lives one layer up in each phase's wrapper.
-        """
-        cwd = fake_home / "work"
-        cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER)
-        _make_existing_jsonl(fake_home, cwd, sid)
-
-        transient = subprocess.CalledProcessError(
-            returncode=2, cmd=["claude"], output="", stderr="some unclassified error"
-        )
-        ok = MagicMock(stdout="ok", stderr="", returncode=0)
-        with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
-            side_effect=[transient, ok],
-        ) as m:
-            out, _ = invoke_claude_with_session(
-                repo="R",
-                issue=1,
-                agent=AGENT_PLANNER,
-                prompt="hi",
-                model="sonnet",
-                cwd=cwd,
-            )
-        assert out == "ok"
-        assert m.call_count == 2
-        assert "--session-id" in _argv(m.call_args_list[1])
-
-    def test_resume_then_recreate_collision_falls_back_to_fresh_session(
-        self, fake_home: Path
-    ) -> None:
-        """Resume fails, recreate collides 'already in use' → fresh uuid4 session.
-
-        Regression: the resume path recreated with the SAME deterministic sid,
-        so under concurrency a sibling worker holding that session made the
-        recreate collide too, and the error propagated as "Session ID … is
-        already in use" (observed: planner ProjectHermes). It must instead fall
-        back to a brand-new unique session, like the no-transcript path.
-        """
-        cwd = fake_home / "work"
-        cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER)
-        _make_existing_jsonl(fake_home, cwd, sid)
-
-        resume_fail = subprocess.CalledProcessError(
-            returncode=1, cmd=["claude"], output="", stderr="transient resume error"
-        )
-        recreate_collision = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=["claude"],
-            output="",
-            stderr="Error: Session ID is already in use.",
-        )
-        ok = MagicMock(stdout="fresh-ok", stderr="", returncode=0)
-        with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
-            side_effect=[resume_fail, recreate_collision, ok],
-        ) as m:
-            out, returned_sid = invoke_claude_with_session(
-                repo="R",
-                issue=1,
-                agent=AGENT_PLANNER,
-                prompt="hi",
-                model="sonnet",
-                cwd=cwd,
-            )
-        assert out == "fresh-ok"
-        # A brand-new uuid4 session, not the contended deterministic one.
-        assert returned_sid != sid
-        assert m.call_count == 3
-        # The final call creates the fresh session with that new id.
-        final_argv = _argv(m.call_args_list[2])
-        assert "--session-id" in final_argv
-        assert returned_sid in final_argv
-
-    def test_create_failure_propagates(self, fake_home: Path) -> None:
-        """A first-call (--session-id) failure for an unrelated reason is not retried."""
-        cwd = fake_home / "work"
-        cwd.mkdir()
-        other = subprocess.CalledProcessError(
-            returncode=2, cmd=["claude"], output="", stderr="quota exhausted"
+        err = subprocess.CalledProcessError(
+            returncode=2, cmd=["claude"], output="", stderr="some error"
         )
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
-            side_effect=other,
+            "hephaestus.automation.claude_invoke.subprocess.run", side_effect=err
         ) as m:
             with pytest.raises(subprocess.CalledProcessError):
                 invoke_claude_with_session(
@@ -254,93 +145,8 @@ class TestSessionExpiredFallback:
                     model="sonnet",
                     cwd=cwd,
                 )
+        # Exactly one attempt — no create/recreate/fresh cascade.
         assert m.call_count == 1
-
-    def test_create_already_in_use_falls_back_to_resume(self, fake_home: Path) -> None:
-        """Fall back to --resume when --session-id is rejected as already-in-use.
-
-        Defends against encoding drift between hephaestus's transcript probe
-        and the Claude CLI's actual session storage. (#822)
-        """
-        cwd = fake_home / "work"
-        cwd.mkdir()
-        already = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=["claude"],
-            output="",
-            stderr="Error: Session ID abc is already in use.",
-        )
-        ok = subprocess.CompletedProcess(
-            args=["claude"], returncode=0, stdout="resumed-ok", stderr=""
-        )
-        with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
-            side_effect=[already, ok],
-        ) as m:
-            stdout, _ = invoke_claude_with_session(
-                repo="R",
-                issue=1,
-                agent=AGENT_PLANNER,
-                prompt="hi",
-                model="sonnet",
-                cwd=cwd,
-            )
-        assert stdout == "resumed-ok"
-        assert m.call_count == 2
-        first_argv = m.call_args_list[0][0][0]
-        second_argv = m.call_args_list[1][0][0]
-        assert "--session-id" in first_argv
-        assert "--resume" in second_argv
-
-    def test_in_use_then_resume_fails_creates_fresh_session(self, fake_home: Path) -> None:
-        """Create in-use → resume keeps failing → fall back to a FRESH session.
-
-        Under 3 parallel CI-fix workers, two can race on the same deterministic
-        session UUID; the loser hits "already in use" and resume can also fail
-        while the sibling is still initializing. Rather than aborting the PR
-        (observed: ProjectHermes #647), derive a fresh unique session.
-        """
-        cwd = fake_home / "work"
-        cwd.mkdir()
-        already = subprocess.CalledProcessError(
-            returncode=1,
-            cmd=["claude"],
-            output="",
-            stderr="Error: Session ID abc is already in use.",
-        )
-        resume_fail = subprocess.CalledProcessError(
-            returncode=1, cmd=["claude"], output="", stderr="cannot resume: locked"
-        )
-        fresh_ok = subprocess.CompletedProcess(
-            args=["claude"], returncode=0, stdout="fresh-ok", stderr=""
-        )
-        # create(in-use) → resume×3 fail → fresh create ok
-        with (
-            patch(
-                "hephaestus.automation.claude_invoke.subprocess.run",
-                side_effect=[already, resume_fail, resume_fail, resume_fail, fresh_ok],
-            ) as m,
-            patch("hephaestus.automation.claude_invoke.time.sleep"),
-        ):
-            stdout, returned_sid = invoke_claude_with_session(
-                repo="R",
-                issue=1,
-                agent=AGENT_PLANNER,
-                prompt="hi",
-                model="sonnet",
-                cwd=cwd,
-            )
-        assert stdout == "fresh-ok"
-        # 1 create + 3 resume + 1 fresh create
-        assert m.call_count == 5
-        # The final call is a fresh --session-id create with a DIFFERENT id.
-        final_argv = m.call_args_list[-1][0][0]
-        assert "--session-id" in final_argv
-        fresh_sid = final_argv[final_argv.index("--session-id") + 1]
-        assert returned_sid == fresh_sid
-        # The deterministic id and the fresh id must differ.
-        orig_sid = m.call_args_list[0][0][0][m.call_args_list[0][0][0].index("--session-id") + 1]
-        assert fresh_sid != orig_sid
 
 
 class TestArgvAssembly:
@@ -418,29 +224,34 @@ class TestArgvAssembly:
 
 
 class TestRecreateOnResumeFailureToggle:
-    """recreate_on_resume_failure=False propagates instead of falling back."""
+    """recreate_on_resume_failure is a back-compat no-op now (#1166).
 
-    def test_propagates_called_process_error(self, fake_home: Path) -> None:
+    The always-resume model never recreates, so the toggle's value no longer
+    changes behavior — a --resume failure always propagates as a single call.
+    The kwarg is retained only so existing callers keep working.
+    """
+
+    def test_toggle_is_accepted_and_call_propagates(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid = session_uuid("R", 1, AGENT_PLANNER)
-        _make_existing_jsonl(fake_home, cwd, sid)
-
         boom = subprocess.CalledProcessError(
             returncode=1, cmd=["claude"], output="", stderr="session not found"
         )
-        with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom) as m:
-            with pytest.raises(subprocess.CalledProcessError):
-                invoke_claude_with_session(
-                    repo="R",
-                    issue=1,
-                    agent=AGENT_PLANNER,
-                    prompt="hi",
-                    model="sonnet",
-                    cwd=cwd,
-                    recreate_on_resume_failure=False,
-                )
-        assert m.call_count == 1
+        for toggle in (True, False):
+            with patch(
+                "hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom
+            ) as m:
+                with pytest.raises(subprocess.CalledProcessError):
+                    invoke_claude_with_session(
+                        repo="R",
+                        issue=1,
+                        agent=AGENT_PLANNER,
+                        prompt="hi",
+                        model="sonnet",
+                        cwd=cwd,
+                        recreate_on_resume_failure=toggle,
+                    )
+            assert m.call_count == 1  # single attempt regardless of toggle
 
 
 class TestEndToEndSessionResume:
@@ -453,24 +264,19 @@ class TestEndToEndSessionResume:
     cross-iteration cache reuse will trigger.
     """
 
-    def test_create_then_resume_lands_on_same_uuid(self, fake_home: Path) -> None:
+    def test_both_calls_resume_same_uuid_distinct_prompts(self, fake_home: Path) -> None:
+        """Two calls for the same key both --resume the same uuid (#1166).
+
+        The id includes the model. Both invocations --resume (the harness
+        created it on the first), and the prompts are distinct — proving the
+        second call continues the transcript rather than replaying the first.
+        """
         cwd = fake_home / "work"
         cwd.mkdir()
-        expected_sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
+        expected_sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "sonnet")
 
-        # The first call's mock must write the JSONL on disk to simulate
-        # what the real ``claude --session-id`` invocation does.
-        encoded = str(cwd.resolve()).replace("/", "-")
-        transcript_dir = fake_home / ".claude" / "projects" / encoded
-
-        def _side_effect(*args: Any, **kwargs: Any) -> MagicMock:
-            transcript_dir.mkdir(parents=True, exist_ok=True)
-            (transcript_dir / f"{expected_sid}.jsonl").write_text("{}\n")
-            return MagicMock(stdout="ok", stderr="", returncode=0)
-
-        with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run", side_effect=_side_effect
-        ) as m:
+        with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
+            m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
             _, sid1 = invoke_claude_with_session(
                 repo="ProjectScylla",
                 issue=1944,
@@ -490,36 +296,28 @@ class TestEndToEndSessionResume:
 
         assert sid1 == sid2 == expected_sid
         assert m.call_count == 2
-
         first_argv = _argv(m.call_args_list[0])
         second_argv = _argv(m.call_args_list[1])
-
-        assert "--session-id" in first_argv
-        assert expected_sid in first_argv
-        assert "--resume" not in first_argv
-
-        assert "--resume" in second_argv
-        assert expected_sid in second_argv
-        assert "--session-id" not in second_argv
-
+        # Both calls --resume the same id; no create path.
+        for argv in (first_argv, second_argv):
+            assert "--resume" in argv
+            assert expected_sid in argv
+            assert "--session-id" not in argv
         # The prompts are distinct — the second call did NOT replay the first.
         assert first_argv[-1] == "iter 0"
         assert second_argv[-1] == "iter 1"
 
     def test_session_id_is_githash_invariant(self, fake_home: Path) -> None:
-        """The session UUID depends only on (repo, issue, agent) — #841.
+        """The session UUID depends only on (repo, issue, agent, model) — #841/#1166.
 
         Regression for #841: the prior behavior fed ``current_trunk_githash``
-        into the session-naming tuple, so every main-bump forked a new
-        session family. The whole loop is now PR/issue-scoped: the same
-        (repo, issue, agent) tuple must always resume the same transcript.
+        into the session-naming tuple, so every main-bump forked a new session
+        family. The loop is PR/issue-scoped: the same (repo, issue, agent, model)
+        key must always resume the same transcript regardless of the trunk SHA.
         """
         cwd = fake_home / "work"
         cwd.mkdir()
-        sid_first_call = session_uuid("R", 1, AGENT_PLANNER)
-
-        # Pre-populate the transcript so the call resumes rather than creates.
-        _make_existing_jsonl(fake_home, cwd, sid_first_call)
+        expected_sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet")
 
         with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
             m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
@@ -532,9 +330,8 @@ class TestEndToEndSessionResume:
                 cwd=cwd,
             )
 
-        assert returned_sid == sid_first_call
+        assert returned_sid == expected_sid
         argv = _argv(m.call_args)
-        # Existing transcript → resume the same session, never create a new one.
         assert "--resume" in argv
-        assert sid_first_call in argv
+        assert expected_sid in argv
         assert "--session-id" not in argv

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -42,13 +42,6 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-def _make_existing_jsonl(home: Path, cwd: Path, sid: str) -> None:
-    encoded = str(cwd.resolve()).replace("/", "-")
-    target_dir = home / ".claude" / "projects" / encoded
-    target_dir.mkdir(parents=True)
-    (target_dir / f"{sid}.jsonl").write_text("{}\n")
-
-
 class TestAlwaysResume:
     """#1166: every call uses --resume; the harness creates on first use."""
 
@@ -133,9 +126,7 @@ class TestAlwaysResume:
         err = subprocess.CalledProcessError(
             returncode=2, cmd=["claude"], output="", stderr="some error"
         )
-        with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run", side_effect=err
-        ) as m:
+        with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=err) as m:
             with pytest.raises(subprocess.CalledProcessError):
                 invoke_claude_with_session(
                     repo="R",
@@ -238,9 +229,7 @@ class TestRecreateOnResumeFailureToggle:
             returncode=1, cmd=["claude"], output="", stderr="session not found"
         )
         for toggle in (True, False):
-            with patch(
-                "hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom
-            ) as m:
+            with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom) as m:
                 with pytest.raises(subprocess.CalledProcessError):
                     invoke_claude_with_session(
                         repo="R",

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -78,9 +78,11 @@ class TestCallClaude:
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
             assert args[0] == "claude"
-            # First call has no existing JSONL → --session-id path.
-            assert "--session-id" in args
-            assert "--name" in args
+            # #1166: every call --resumes the deterministic session; the harness
+            # creates it on first use, so there is no --session-id/--name path.
+            assert "--resume" in args
+            assert "--session-id" not in args
+            assert "--name" not in args
             assert "--model" in args
             assert "claude-opus-4-7" in args
             assert "--print" in args

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -137,6 +137,26 @@ class TestSessionUUID:
     def test_different_issue_different_uuid(self) -> None:
         assert session_uuid("R", 1, AGENT_PLANNER) != session_uuid("R", 2, AGENT_PLANNER)
 
+    def test_different_model_different_uuid(self) -> None:
+        """#1166: the model is part of the key so sessions never cross models."""
+        a = session_uuid("R", 1, AGENT_PLANNER, "claude-sonnet-4-6")
+        b = session_uuid("R", 1, AGENT_PLANNER, "claude-opus-4-8")
+        assert a != b
+
+    def test_omitting_model_preserves_legacy_key(self) -> None:
+        """Backward compat: no model reproduces the historical (repo, issue, agent) id."""
+        from hephaestus.automation.session_naming import session_name
+
+        assert session_name("R", 1, AGENT_PLANNER) == "R_1_planner"
+        assert session_name("R", 1, AGENT_PLANNER, None) == "R_1_planner"
+
+    def test_model_token_sanitized_into_key(self) -> None:
+        from hephaestus.automation.session_naming import session_name
+
+        # Slashes/colons in a model id are normalized to a name-safe token.
+        name = session_name("R", 1, AGENT_PLANNER, "us.anthropic/opus:4-8")
+        assert name == "R_1_planner_us.anthropic-opus-4-8"
+
     def test_each_agent_constant_yields_distinct_uuid(self) -> None:
         agents = [
             AGENT_PLANNER,


### PR DESCRIPTION
## Summary

The Claude session key was `(repo, issue, agent)` — **model-agnostic** — and
`invoke_claude_with_session` probed create-vs-resume then fell through
recreate → fresh-uuid4 on any `--resume` failure. Two token-waste defects:

1. **Cross-model resume corruption.** `claude --resume` is locked to the creating
   model, so switching a per-agent model between runs resumed a transcript from a
   different model → CLI rejects → recreate re-sends the full prompt.
2. **429 mis-recreate amplification.** A quota cap is not "session expired", but
   the recreate fired on ANY resume failure, re-sending the entire multi-KB
   prompt up to 3× per capped call and destroying context reuse. This is what
   made opus batches blow through the hourly session limit.

## Fix

- `session_name`/`session_uuid` take an optional `model`; the key becomes
  `(repo, issue, agent, model)`. Each model gets its own create-once-then-resume
  lineage, so per-agent model switches never collide.
- `invoke_claude_with_session` **always** issues `--resume <uuid>` — the harness
  creates the session transparently on first use, so there is no probe, no create
  path, no recreate/fresh cascade. One subprocess call per invocation. `--resume`
  failures propagate cleanly (the quota-cap waiter is one layer up).
- `compact_session` gains `model` so `/compact` targets the same keyed session.

Removed the dead `_run_fresh_session` + the create-vs-resume / expired-fallback
tests; `recreate_on_resume_failure` is retained as an accepted-but-ignored
back-compat kwarg. Net −277 lines. Per-agent model knobs build on this next.

## Test plan

- `pixi run pytest tests/unit/automation/` — 1452 passed
- New: model-in-key uuids differ; legacy no-model key preserved; always-resume
  argv; resume-failure-propagates (single call, no cascade)
- Smoke-verified: `invoke_claude_with_session(..., model="claude-opus-4-8")` →
  `['claude','--resume',<model-keyed-uuid>,'--model','claude-opus-4-8',…]`
- `pixi run mypy` clean; ruff clean

Closes #1166

🤖 Generated with [Claude Code](https://claude.com/claude-code)