### PR TITLE
fix(automation): create-on-first-use, not always-resume (No conversation found)

### DIFF
--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -26,7 +26,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-from hephaestus.automation.session_naming import session_name
+from hephaestus.automation.session_naming import session_jsonl_path, session_name
 from hephaestus.github.rate_limit import detect_claude_usage_cap, detect_rate_limit
 
 logger = logging.getLogger(__name__)
@@ -71,14 +71,16 @@ def invoke_claude_with_session(
 ) -> tuple[str, str]:
     """Invoke Claude with a deterministic per-(repo, issue, agent, model) session.
 
-    The session id is ``uuid5`` of ``(repo, issue, agent, model)`` and the call
-    ALWAYS uses ``--resume <uuid>`` (#1166). The Claude harness creates the
-    session transparently on the first ``--resume`` for an id that does not yet
-    exist, so there is no separate create path, no create-vs-resume probe, and no
-    expired/contention fallback to a fresh id — every call for the same key
-    continues the SAME transcript, so cached context is reused instead of
-    re-sent. Because ``--resume`` is locked to the creating model, the model is
-    part of the key: switching a per-agent model simply starts that model's own
+    The session id is ``uuid5`` of ``(repo, issue, agent, model)``. The FIRST
+    call for a key uses ``--session-id`` to create the transcript; every later
+    call ``--resume``s it so cached context is reused instead of re-sent (#1166,
+    #1168). ``claude --resume`` does NOT auto-create — it errors "No conversation
+    found" for an unknown id — so create-on-first-use is required; the probe is
+    the model-keyed transcript file's existence. There is no expired/contention
+    recreate cascade (the old one mis-fired on 429s, re-sending full prompts 3×
+    and crossing models); a ``--session-id``/``--resume`` failure simply
+    propagates. Because ``--resume`` is locked to the creating model, the model
+    is part of the key: switching a per-agent model starts that model's own
     create-once-then-resume lineage rather than colliding with another model's
     transcript.
 
@@ -114,15 +116,32 @@ def invoke_claude_with_session(
         ``(repo, issue, agent, model)``.
 
     Raises:
-        subprocess.CalledProcessError: If the ``--resume`` call exits non-zero.
+        subprocess.CalledProcessError: If the create/resume call exits non-zero.
         subprocess.TimeoutExpired: If the call exceeds ``timeout``.
 
     """
-    del recreate_on_resume_failure  # back-compat shim only; always-resume model
+    del recreate_on_resume_failure  # back-compat shim only; no recreate cascade
     display_name = session_name(repo, issue, agent, model)
     sid = str(uuid.uuid5(uuid.NAMESPACE_DNS, display_name))
 
-    cmd: list[str] = ["claude", "--resume", sid, "--model", model, "--output-format", output_format]
+    # Create on FIRST use, resume after (#1168). ``claude --resume`` does NOT
+    # auto-create — it errors "No conversation found" for an unknown id — so the
+    # first call for a (repo, issue, agent, model) key must use ``--session-id``
+    # to create the transcript; every later call ``--resume``s it to reuse cached
+    # context. The probe is the transcript file's existence, which is model-keyed
+    # because ``sid`` is. This is NOT the old recreate-on-failure cascade (that
+    # mis-fired on 429s, re-sending full prompts 3x and crossing models); a
+    # ``--resume``/``--session-id`` failure now simply propagates.
+    create = not session_jsonl_path(sid, cwd).exists()
+    mode_args = ["--session-id", sid, "--name", display_name] if create else ["--resume", sid]
+    cmd: list[str] = [
+        "claude",
+        *mode_args,
+        "--model",
+        model,
+        "--output-format",
+        output_format,
+    ]
     if system_prompt_file is not None and system_prompt_file.exists():
         cmd += ["--system-prompt", str(system_prompt_file)]
     if allowed_tools:
@@ -146,12 +165,13 @@ def invoke_claude_with_session(
     if cid:
         env["GH_TRACE_ID"] = cid
 
-    logger.debug("claude invoke: agent=%s issue=%s sid=%s mode=resume", agent, issue, sid)
-    # ALWAYS --resume (#1166): the harness creates the session transparently when
-    # the id does not yet exist, so there is no create path, probe, or fallback.
-    # Resuming the same (repo, issue, agent, model) key reuses cached context
-    # instead of re-sending the full prompt — and never crosses models, since the
-    # model is part of the key.
+    logger.debug(
+        "claude invoke: agent=%s issue=%s sid=%s mode=%s",
+        agent,
+        issue,
+        sid,
+        "create" if create else "resume",
+    )
     result = subprocess.run(
         cmd,
         input=prompt if input_via_stdin else None,

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -11,9 +11,9 @@ What lives here:
   ``--resume`` targets a session that no longer exists locally.
 - :func:`invoke_claude_with_session` — the single entry point every
   automation phase must use. Picks ``--session-id`` (first call) vs
-  ``--resume`` (subsequent calls) based on whether the session's JSONL
-  transcript already exists, and falls back to ``--session-id`` on any
-  resume failure.
+  ``--resume`` (subsequent calls) based on whether the model-keyed JSONL
+  transcript already exists. No recreate-on-failure cascade — a create/resume
+  error propagates (#1168).
 """
 
 from __future__ import annotations

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -42,10 +42,23 @@ def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-class TestAlwaysResume:
-    """#1166: every call uses --resume; the harness creates on first use."""
+def _make_existing_jsonl(home: Path, cwd: Path, sid: str) -> None:
+    """Pre-create the transcript file so the helper takes the --resume path."""
+    encoded = str(cwd.resolve()).replace("/", "-")
+    target_dir = home / ".claude" / "projects" / encoded
+    target_dir.mkdir(parents=True, exist_ok=True)
+    (target_dir / f"{sid}.jsonl").write_text("{}\n")
 
-    def test_call_always_uses_resume_never_create(
+
+class TestCreateThenResume:
+    """#1168: first call --session-id (create), later calls --resume.
+
+    ``claude --resume`` does NOT auto-create — it errors "No conversation found"
+    for an unknown id — so the first call for a (repo, issue, agent, model) key
+    must create the session, and later calls resume it.
+    """
+
+    def test_first_call_creates_with_model_keyed_id(
         self, stub_run: MagicMock, fake_home: Path
     ) -> None:
         cwd = fake_home / "work"
@@ -59,21 +72,23 @@ class TestAlwaysResume:
             cwd=cwd,
         )
         argv = _argv(stub_run.call_args)
-        assert "--resume" in argv
+        # No transcript yet → create path.
+        assert "--session-id" in argv
+        assert "--name" in argv
+        assert "--resume" not in argv
         assert sid in argv
-        # No create path anymore: no --session-id / --name probing.
-        assert "--session-id" not in argv
-        assert "--name" not in argv
         assert out == "ok"
         # The session id includes the model (#1166).
         assert sid == session_uuid("R", 1, AGENT_PLANNER, "sonnet")
 
-    def test_resume_is_used_even_without_existing_transcript(
+    def test_subsequent_call_resumes_existing_transcript(
         self, stub_run: MagicMock, fake_home: Path
     ) -> None:
-        """No transcript on disk → still --resume (harness creates it lazily)."""
         cwd = fake_home / "work"
         cwd.mkdir()
+        sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet")
+        _make_existing_jsonl(fake_home, cwd, sid)
+
         invoke_claude_with_session(
             repo="R",
             issue=1,
@@ -83,8 +98,11 @@ class TestAlwaysResume:
             cwd=cwd,
         )
         argv = _argv(stub_run.call_args)
+        # Transcript exists → resume path; no re-create.
         assert "--resume" in argv
+        assert sid in argv
         assert "--session-id" not in argv
+        assert "--name" not in argv
 
     def test_different_models_get_different_uuids(
         self, stub_run: MagicMock, fake_home: Path
@@ -119,8 +137,8 @@ class TestAlwaysResume:
         )
         assert sid_planner != sid_reviewer
 
-    def test_resume_failure_propagates(self, fake_home: Path) -> None:
-        """A --resume non-zero exit is raised; there is no recreate fallback."""
+    def test_failure_propagates_without_recreate_cascade(self, fake_home: Path) -> None:
+        """A create/resume non-zero exit is raised; no recreate/fresh fallback."""
         cwd = fake_home / "work"
         cwd.mkdir()
         err = subprocess.CalledProcessError(
@@ -136,7 +154,7 @@ class TestAlwaysResume:
                     model="sonnet",
                     cwd=cwd,
                 )
-        # Exactly one attempt — no create/recreate/fresh cascade.
+        # Exactly one attempt — no recreate/fresh cascade.
         assert m.call_count == 1
 
 
@@ -244,28 +262,27 @@ class TestRecreateOnResumeFailureToggle:
 
 
 class TestEndToEndSessionResume:
-    """Two sequential invocations for the same tuple: create then resume.
+    """Two sequential invocations for the same key: create then resume (#1168).
 
-    The first call has no JSONL — must use ``--session-id``. The mocked
-    subprocess writes a JSONL on first call so the helper's existence
-    probe will report True on the second call, which must then use
-    ``--resume`` of the same UUID. This is the empirical proof that
-    cross-iteration cache reuse will trigger.
+    The first call has no JSONL → ``--session-id`` (create). The mocked
+    subprocess writes the JSONL on the first call so the existence probe reports
+    True on the second, which must then ``--resume`` the same UUID. Empirical
+    proof that cross-iteration cache reuse triggers.
     """
 
-    def test_both_calls_resume_same_uuid_distinct_prompts(self, fake_home: Path) -> None:
-        """Two calls for the same key both --resume the same uuid (#1166).
-
-        The id includes the model. Both invocations --resume (the harness
-        created it on the first), and the prompts are distinct — proving the
-        second call continues the transcript rather than replaying the first.
-        """
+    def test_create_then_resume_same_uuid_distinct_prompts(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
         expected_sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "sonnet")
 
-        with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
-            m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
+        # First call writes the transcript so the second call's probe finds it.
+        def _side_effect(*args: Any, **kwargs: Any) -> MagicMock:
+            _make_existing_jsonl(fake_home, cwd, expected_sid)
+            return MagicMock(stdout="ok", stderr="", returncode=0)
+
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run", side_effect=_side_effect
+        ) as m:
             _, sid1 = invoke_claude_with_session(
                 repo="ProjectScylla",
                 issue=1944,
@@ -287,12 +304,14 @@ class TestEndToEndSessionResume:
         assert m.call_count == 2
         first_argv = _argv(m.call_args_list[0])
         second_argv = _argv(m.call_args_list[1])
-        # Both calls --resume the same id; no create path.
-        for argv in (first_argv, second_argv):
-            assert "--resume" in argv
-            assert expected_sid in argv
-            assert "--session-id" not in argv
-        # The prompts are distinct — the second call did NOT replay the first.
+        # First creates, second resumes — same id.
+        assert "--session-id" in first_argv
+        assert expected_sid in first_argv
+        assert "--resume" not in first_argv
+        assert "--resume" in second_argv
+        assert expected_sid in second_argv
+        assert "--session-id" not in second_argv
+        # Distinct prompts — the second call did NOT replay the first.
         assert first_argv[-1] == "iter 0"
         assert second_argv[-1] == "iter 1"
 
@@ -307,6 +326,8 @@ class TestEndToEndSessionResume:
         cwd = fake_home / "work"
         cwd.mkdir()
         expected_sid = session_uuid("R", 1, AGENT_PLANNER, "sonnet")
+        # Existing transcript → resume path.
+        _make_existing_jsonl(fake_home, cwd, expected_sid)
 
         with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
             m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
@@ -323,4 +344,5 @@ class TestEndToEndSessionResume:
         argv = _argv(m.call_args)
         assert "--resume" in argv
         assert expected_sid in argv
+        assert "--session-id" not in argv
         assert "--session-id" not in argv

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -78,11 +78,11 @@ class TestCallClaude:
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
             assert args[0] == "claude"
-            # #1166: every call --resumes the deterministic session; the harness
-            # creates it on first use, so there is no --session-id/--name path.
-            assert "--resume" in args
-            assert "--session-id" not in args
-            assert "--name" not in args
+            # #1168: no transcript yet (HOME=tmp_path) → first call creates with
+            # --session-id; later calls would --resume. Session id is model-keyed.
+            assert "--session-id" in args
+            assert "--name" in args
+            assert "--resume" not in args
             assert "--model" in args
             assert "claude-opus-4-7" in args
             assert "--print" in args


### PR DESCRIPTION
## Summary

#1167 made `invoke_claude_with_session` ALWAYS `--resume`, on the (false)
premise that `claude --resume` auto-creates an unknown session. It does NOT:

```
$ claude --resume <fresh-uuid> --print 'hi'
No conversation found with session ID: <fresh-uuid>
```

#1167 also put the model in the session key, so EVERY existing session got a new
uuid → the first call for each `(repo, issue, agent, model)` key failed.
Observed live (issue #712 / opus-4-8): pr-reviewer-r0/r1/r2 all failed →
`reviewer-infrastructure ERROR`, PR left unlabeled. The session change made the
loop unable to run.

## Fix

Restore **create-on-first-use, resume-after** while keeping the two correct
parts of #1167:

- Probe the **model-keyed** transcript file's existence → `--session-id`
  (create) if absent, `--resume` if present.
- Model stays in the key (sessions never cross models).
- NO recreate-on-failure cascade — a create/resume error propagates. (The old
  cascade mis-fired on 429s, re-sending full prompts 3× and crossing models;
  that removal was the good part of #1167.)

## Test plan

- `pixi run pytest tests/unit/automation/` — 1452 passed
- Verified CLI contract: `--session-id <new>` creates; `--resume <existing>`
  resumes; `--resume <unknown>` → "No conversation found"
- Smoke: helper emits create on the first call for a key, resume after
- `TestCreateThenResume` / `TestEndToEndSessionResume` updated to the contract
- `pixi run mypy` clean; ruff clean

Closes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)