### PR TITLE
feat: add show-prompt CLI to display agent prompts by stage

### DIFF
--- a/scripts/show_prompt.py
+++ b/scripts/show_prompt.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Display the agent prompt for a given GitHub issue and pipeline stage.
+
+Usage::
+
+    python scripts/show_prompt.py --issue 1170 --stage planning
+    python scripts/show_prompt.py --issue 1170 --stage plan-review
+    python scripts/show_prompt.py --issue 1170 --stage implementation
+
+Supported stages: planning, plan-review, plan-loop-review, implementation,
+impl-review, impl-resume, pr-review, address-review, follow-up, advise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+STAGES = (
+    "planning",
+    "plan-review",
+    "plan-loop-review",
+    "implementation",
+    "impl-review",
+    "impl-resume",
+    "pr-review",
+    "address-review",
+    "follow-up",
+    "advise",
+)
+
+
+# ---------------------------------------------------------------------------
+# GitHub data fetching
+# ---------------------------------------------------------------------------
+
+def _gh(args: list[str], *, parse_json: bool = False) -> Any:
+    """Run a gh CLI command and return stdout as text or parsed JSON."""
+    result = subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh {' '.join(args)} failed: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return json.loads(result.stdout) if parse_json else result.stdout
+
+
+def fetch_issue(repo: str, issue_number: int) -> dict[str, Any]:
+    """Fetch issue title, body, and comments from GitHub."""
+    return _gh([
+        "issue", "view", str(issue_number),
+        "--repo", repo,
+        "--json", "title,body,comments",
+    ], parse_json=True)
+
+
+
+
+def _extract_plan_from_issue_data(issue_data: dict[str, Any] | None) -> str | None:
+    """Extract the latest plan comment from already-fetched issue data."""
+    if issue_data is None:
+        return None
+    comments = issue_data.get("comments", [])
+    for comment in reversed(comments):
+        body = comment.get("body", "")
+        if "# Implementation Plan" in body or "## Approach" in body:
+            return body
+    return None
+
+def fetch_pr_diff(repo: str, pr_number: int) -> str:
+    """Fetch the diff for a PR."""
+    return _gh(["pr", "diff", str(pr_number), "--repo", repo])
+
+
+def fetch_pr_threads(repo: str, pr_number: int) -> str:
+    """Fetch review threads from a PR as JSON."""
+    try:
+        data = _gh_json([
+            "pr", "view", str(pr_number),
+            "--repo", repo,
+            "--json", "reviewThreads,body",
+        ])
+        return json.dumps(data, indent=2)
+    except Exception:
+        return "[]"
+
+
+# ---------------------------------------------------------------------------
+# Prompt builders
+# ---------------------------------------------------------------------------
+
+def build_prompt(
+    stage: str,
+    issue_number: int,
+    repo: str,
+    *,
+    branch_name: str = "",
+    worktree_path: str = "",
+    pr_number: int = 0,
+    iteration: int = 0,
+) -> str:
+    """Build the prompt for the given stage.
+
+    Calls the appropriate Hephaestus prompt builder function from
+    ``hephaestus.automation.prompts``.
+    """
+    from hephaestus.automation.prompts.planning import (
+        get_plan_loop_review_prompt,
+        get_plan_prompt,
+        get_plan_review_prompt,
+    )
+    from hephaestus.automation.prompts.implementation import (
+        get_impl_loop_review_prompt,
+        get_impl_resume_feedback_prompt,
+        get_implementation_prompt,
+    )
+    from hephaestus.automation.prompts.follow_up import get_follow_up_prompt
+    from hephaestus.automation.prompts.advise import get_advise_prompt
+
+    if stage not in STAGES:
+        raise ValueError(f"Unknown stage: {stage!r}. Supported stages: {', '.join(STAGES)}")
+
+    # -- Planning stage (no issue data needed) ------------------------------
+    if stage == "planning":
+        return get_plan_prompt(issue_number)
+
+    issue_data = fetch_issue(repo, issue_number)
+    issue_title = issue_data.get("title", "")
+    issue_body = issue_data.get("body", "")
+
+    # -- Planning stages ----------------------------------------------------
+
+    if stage == "plan-review":
+        plan_text = _extract_plan_from_issue_data(issue_data) or "(no plan found)"
+        return get_plan_review_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            plan_text=plan_text,
+        )
+
+    if stage == "plan-loop-review":
+        plan_text = _extract_plan_from_issue_data(issue_data) or "(no plan found)"
+        return get_plan_loop_review_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            plan_text=plan_text,
+            learnings="",
+            iteration=iteration,
+            prior_review=None,
+        )
+
+    # -- Implementation stages ----------------------------------------------
+    if stage == "implementation":
+        return get_implementation_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            branch_name=branch_name,
+            worktree_path=worktree_path,
+        )
+
+    if stage == "impl-review":
+        diff_text = ""
+        files_changed = ""
+        if pr_number:
+            try:
+                diff_text = fetch_pr_diff(repo, pr_number)
+            except Exception:  # noqa: BLE001
+                pass
+        return get_impl_loop_review_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            diff_text=diff_text,
+            files_changed=files_changed,
+            iteration=iteration,
+            prior_review=None,
+        )
+
+    if stage == "impl-resume":
+        return get_impl_resume_feedback_prompt(
+            issue_number=issue_number,
+            prev_iteration=iteration,
+            verdict="NOGO",
+            review_text="(previous review text)",
+        )
+
+    # -- PR review stages ---------------------------------------------------
+    if stage == "pr-review":
+        from hephaestus.automation.prompts.pr_review import get_pr_review_analysis_prompt
+
+        diff_text = ""
+        if pr_number:
+            try:
+                diff_text = fetch_pr_diff(repo, pr_number)
+            except Exception:  # noqa: BLE001
+                pass
+        return get_pr_review_analysis_prompt(
+            pr_number=pr_number,
+            issue_number=issue_number,
+            pr_diff=diff_text,
+            issue_body=issue_body,
+        )
+
+    if stage == "address-review":
+        from hephaestus.automation.prompts.address_review import get_address_review_prompt
+
+        threads_json = "[]"
+        if pr_number:
+            threads_json = fetch_pr_threads(repo, pr_number)
+        return get_address_review_prompt(
+            pr_number=pr_number,
+            issue_number=issue_number,
+            worktree_path=worktree_path,
+            threads_json=threads_json,
+        )
+
+    # -- Other stages -------------------------------------------------------
+    if stage == "follow-up":
+        return get_follow_up_prompt(issue_number)
+
+    if stage == "advise":
+        return get_advise_prompt(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            marketplace_path="",
+        )
+
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Display the agent prompt for a given GitHub issue and pipeline stage.",
+    )
+    parser.add_argument("--issue", type=int, required=True, help="GitHub issue number")
+    parser.add_argument(
+        "--stage",
+        required=True,
+        choices=STAGES,
+        help="Pipeline stage name",
+    )
+    parser.add_argument(
+        "--repo",
+        default="HomericIntelligence/ProjectHephaestus",
+        help="GitHub repo (owner/name)",
+    )
+    parser.add_argument("--pr", type=int, default=0, help="PR number (for pr-review, address-review, impl-review)")
+    parser.add_argument("--branch", default="", help="Branch name (for implementation stage)")
+    parser.add_argument("--worktree", default="", help="Worktree path (for implementation stage)")
+    parser.add_argument("--iteration", type=int, default=0, help="Review iteration number")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        prompt = build_prompt(
+            stage=args.stage,
+            issue_number=args.issue,
+            repo=args.repo,
+            branch_name=args.branch,
+            worktree_path=args.worktree,
+            pr_number=args.pr,
+            iteration=args.iteration,
+        )
+        print(prompt)
+        return 0
+    except (RuntimeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/show_prompt.py
+++ b/scripts/show_prompt.py
@@ -64,14 +64,28 @@ def fetch_issue(repo: str, issue_number: int) -> dict[str, Any]:
 
 
 
+_PLAN_MARKERS = (
+    "# Implementation Plan",
+    "## Implementation Plan",
+    "## Approach",
+    "### Approach",
+    "## Proposed Solution",
+    "## Design",
+)
+
+
 def _extract_plan_from_issue_data(issue_data: dict[str, Any] | None) -> str | None:
-    """Extract the latest plan comment from already-fetched issue data."""
+    """Extract the latest plan comment from already-fetched issue data.
+
+    Searches for comments whose body contains any of the recognised plan
+    heading markers and returns the most recent match.
+    """
     if issue_data is None:
         return None
     comments = issue_data.get("comments", [])
     for comment in reversed(comments):
         body = comment.get("body", "")
-        if "# Implementation Plan" in body or "## Approach" in body:
+        if any(marker in body for marker in _PLAN_MARKERS):
             return body
     return None
 
@@ -83,13 +97,13 @@ def fetch_pr_diff(repo: str, pr_number: int) -> str:
 def fetch_pr_threads(repo: str, pr_number: int) -> str:
     """Fetch review threads from a PR as JSON."""
     try:
-        data = _gh_json([
+        data = _gh([
             "pr", "view", str(pr_number),
             "--repo", repo,
             "--json", "reviewThreads,body",
-        ])
+        ], parse_json=True)
         return json.dumps(data, indent=2)
-    except Exception:
+    except RuntimeError:
         return "[]"
 
 
@@ -175,7 +189,7 @@ def build_prompt(
         if pr_number:
             try:
                 diff_text = fetch_pr_diff(repo, pr_number)
-            except Exception:  # noqa: BLE001
+            except RuntimeError:  # noqa: BLE001
                 pass
         return get_impl_loop_review_prompt(
             issue_number=issue_number,
@@ -203,7 +217,7 @@ def build_prompt(
         if pr_number:
             try:
                 diff_text = fetch_pr_diff(repo, pr_number)
-            except Exception:  # noqa: BLE001
+            except RuntimeError:  # noqa: BLE001
                 pass
         return get_pr_review_analysis_prompt(
             pr_number=pr_number,
@@ -237,6 +251,7 @@ def build_prompt(
             marketplace_path="",
         )
 
+    raise AssertionError(f"Unhandled stage: {stage!r}")  # pragma: no cover
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/show_prompt.py
+++ b/scripts/show_prompt.py
@@ -14,6 +14,7 @@ impl-review, impl-resume, pr-review, address-review, follow-up, advise.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import subprocess
 import sys
@@ -37,6 +38,7 @@ STAGES = (
 # GitHub data fetching
 # ---------------------------------------------------------------------------
 
+
 def _gh(args: list[str], *, parse_json: bool = False) -> Any:
     """Run a gh CLI command and return stdout as text or parsed JSON."""
     result = subprocess.run(
@@ -55,13 +57,18 @@ def _gh(args: list[str], *, parse_json: bool = False) -> Any:
 
 def fetch_issue(repo: str, issue_number: int) -> dict[str, Any]:
     """Fetch issue title, body, and comments from GitHub."""
-    return _gh([
-        "issue", "view", str(issue_number),
-        "--repo", repo,
-        "--json", "title,body,comments",
-    ], parse_json=True)
-
-
+    return _gh(
+        [
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            repo,
+            "--json",
+            "title,body,comments",
+        ],
+        parse_json=True,
+    )
 
 
 _PLAN_MARKERS = (
@@ -89,6 +96,7 @@ def _extract_plan_from_issue_data(issue_data: dict[str, Any] | None) -> str | No
             return body
     return None
 
+
 def fetch_pr_diff(repo: str, pr_number: int) -> str:
     """Fetch the diff for a PR."""
     return _gh(["pr", "diff", str(pr_number), "--repo", repo])
@@ -97,11 +105,18 @@ def fetch_pr_diff(repo: str, pr_number: int) -> str:
 def fetch_pr_threads(repo: str, pr_number: int) -> str:
     """Fetch review threads from a PR as JSON."""
     try:
-        data = _gh([
-            "pr", "view", str(pr_number),
-            "--repo", repo,
-            "--json", "reviewThreads,body",
-        ], parse_json=True)
+        data = _gh(
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--json",
+                "reviewThreads,body",
+            ],
+            parse_json=True,
+        )
         return json.dumps(data, indent=2)
     except RuntimeError:
         return "[]"
@@ -110,6 +125,7 @@ def fetch_pr_threads(repo: str, pr_number: int) -> str:
 # ---------------------------------------------------------------------------
 # Prompt builders
 # ---------------------------------------------------------------------------
+
 
 def build_prompt(
     stage: str,
@@ -126,18 +142,18 @@ def build_prompt(
     Calls the appropriate Hephaestus prompt builder function from
     ``hephaestus.automation.prompts``.
     """
-    from hephaestus.automation.prompts.planning import (
-        get_plan_loop_review_prompt,
-        get_plan_prompt,
-        get_plan_review_prompt,
-    )
+    from hephaestus.automation.prompts.advise import get_advise_prompt
+    from hephaestus.automation.prompts.follow_up import get_follow_up_prompt
     from hephaestus.automation.prompts.implementation import (
         get_impl_loop_review_prompt,
         get_impl_resume_feedback_prompt,
         get_implementation_prompt,
     )
-    from hephaestus.automation.prompts.follow_up import get_follow_up_prompt
-    from hephaestus.automation.prompts.advise import get_advise_prompt
+    from hephaestus.automation.prompts.planning import (
+        get_plan_loop_review_prompt,
+        get_plan_prompt,
+        get_plan_review_prompt,
+    )
 
     if stage not in STAGES:
         raise ValueError(f"Unknown stage: {stage!r}. Supported stages: {', '.join(STAGES)}")
@@ -187,10 +203,8 @@ def build_prompt(
         diff_text = ""
         files_changed = ""
         if pr_number:
-            try:
+            with contextlib.suppress(RuntimeError):
                 diff_text = fetch_pr_diff(repo, pr_number)
-            except RuntimeError:
-                pass
         return get_impl_loop_review_prompt(
             issue_number=issue_number,
             issue_title=issue_title,
@@ -215,10 +229,8 @@ def build_prompt(
 
         diff_text = ""
         if pr_number:
-            try:
+            with contextlib.suppress(RuntimeError):
                 diff_text = fetch_pr_diff(repo, pr_number)
-            except RuntimeError:
-                pass
         return get_pr_review_analysis_prompt(
             pr_number=pr_number,
             issue_number=issue_number,
@@ -258,7 +270,9 @@ def build_prompt(
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the show-prompt CLI."""
     parser = argparse.ArgumentParser(
         description="Display the agent prompt for a given GitHub issue and pipeline stage.",
     )
@@ -274,7 +288,9 @@ def build_parser() -> argparse.ArgumentParser:
         default="HomericIntelligence/ProjectHephaestus",
         help="GitHub repo (owner/name)",
     )
-    parser.add_argument("--pr", type=int, default=0, help="PR number (for pr-review, address-review, impl-review)")
+    parser.add_argument(
+        "--pr", type=int, default=0, help="PR number (for pr-review, address-review, impl-review)"
+    )
     parser.add_argument("--branch", default="", help="Branch name (for implementation stage)")
     parser.add_argument("--worktree", default="", help="Worktree path (for implementation stage)")
     parser.add_argument("--iteration", type=int, default=0, help="Review iteration number")
@@ -282,6 +298,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Entry point for the show-prompt CLI."""
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/scripts/show_prompt.py
+++ b/scripts/show_prompt.py
@@ -189,7 +189,7 @@ def build_prompt(
         if pr_number:
             try:
                 diff_text = fetch_pr_diff(repo, pr_number)
-            except RuntimeError:  # noqa: BLE001
+            except RuntimeError:
                 pass
         return get_impl_loop_review_prompt(
             issue_number=issue_number,
@@ -217,7 +217,7 @@ def build_prompt(
         if pr_number:
             try:
                 diff_text = fetch_pr_diff(repo, pr_number)
-            except RuntimeError:  # noqa: BLE001
+            except RuntimeError:
                 pass
         return get_pr_review_analysis_prompt(
             pr_number=pr_number,

--- a/tests/test_show_prompt.py
+++ b/tests/test_show_prompt.py
@@ -140,6 +140,21 @@ class TestBuildPrompt:
         assert isinstance(prompt, str)
 
     @patch("scripts.show_prompt.fetch_issue")
+    @patch("scripts.show_prompt.fetch_pr_diff")
+    def test_impl_review_diff_failure_graceful(
+        self, mock_diff: MagicMock, mock_issue: MagicMock
+    ) -> None:
+        """When fetch_pr_diff raises, impl-review degrades to empty diff."""
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        mock_diff.side_effect = RuntimeError("gh failed")
+        prompt = build_prompt(
+            "impl-review", 1, "owner/repo",
+            pr_number=5, iteration=0,
+        )
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
     def test_impl_resume_stage(self, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         prompt = build_prompt("impl-resume", 1, "owner/repo", iteration=1)
@@ -155,6 +170,18 @@ class TestBuildPrompt:
         mock_diff.return_value = "diff --git a/foo.py b/foo.py"
         prompt = build_prompt("pr-review", 1, "owner/repo", pr_number=5)
         mock_diff.assert_called_once_with("owner/repo", 5)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    @patch("scripts.show_prompt.fetch_pr_diff")
+    def test_pr_review_diff_failure_graceful(
+        self, mock_diff: MagicMock, mock_issue: MagicMock
+    ) -> None:
+        """When fetch_pr_diff raises, pr-review degrades to empty diff."""
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        mock_diff.side_effect = RuntimeError("gh failed")
+        prompt = build_prompt("pr-review", 1, "owner/repo", pr_number=5)
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
@@ -219,11 +246,6 @@ class TestMain:
         rc = main(["--issue", "1", "--stage", "planning"])
         assert rc == 1
 
-    @patch("scripts.show_prompt.build_prompt")
-    def test_main_returns_1_on_value_error(self, mock_build: MagicMock) -> None:
-        mock_build.side_effect = ValueError("Unknown stage")
-        rc = main(["--issue", "1", "--stage", "planning"])
-        assert rc == 1
 
 
 # ---------------------------------------------------------------------------
@@ -344,3 +366,9 @@ class TestFetchPrDiff:
             ["pr", "diff", "10", "--repo", "owner/repo"]
         )
         assert result == "diff content"
+
+    @patch("scripts.show_prompt._gh")
+    def test_raises_runtime_error_on_failure(self, mock_gh: MagicMock) -> None:
+        mock_gh.side_effect = RuntimeError("gh failed")
+        with pytest.raises(RuntimeError, match="gh failed"):
+            fetch_pr_diff("owner/repo", 10)

--- a/tests/test_show_prompt.py
+++ b/tests/test_show_prompt.py
@@ -3,32 +3,26 @@
 from __future__ import annotations
 
 import json
+import sys
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-from scripts.show_prompt import STAGES, build_parser, build_prompt, main
+# Ensure the repo root is on sys.path so scripts.show_prompt resolves
+# without requiring scripts/__init__.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-@pytest.fixture()
-def mock_issue_data() -> dict:
-    return {
-        "title": "Test Issue Title",
-        "body": "Test issue body with acceptance criteria.",
-        "comments": [
-            {"body": "Some random comment"},
-            {"body": "# Implementation Plan\n\n## Approach\nDo stuff."},
-        ],
-    }
-
-
-@pytest.fixture()
-def mock_extract_comment() -> str:
-    return "# Implementation Plan\n\n## Approach\nCreate foo.py with bar()."
+from scripts.show_prompt import (  # noqa: E402
+    STAGES,
+    _PLAN_MARKERS,
+    _extract_plan_from_issue_data,
+    build_parser,
+    build_prompt,
+    fetch_pr_diff,
+    fetch_pr_threads,
+    main,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -79,13 +73,11 @@ class TestBuildParser:
 # ---------------------------------------------------------------------------
 
 class TestBuildPrompt:
-    @patch("scripts.show_prompt.fetch_issue")
-    @patch("scripts.show_prompt._extract_plan_from_issue_data")
-    def test_planning_stage(
-        self, mock_extract: MagicMock, mock_issue: MagicMock
-    ) -> None:
-        mock_extract.return_value = "# Implementation Plan"
-        prompt = build_prompt("planning", 1, "owner/repo")
+    def test_planning_stage(self) -> None:
+        """Planning stage does not fetch issue data."""
+        with patch("scripts.show_prompt.fetch_issue") as mock_issue:
+            prompt = build_prompt("planning", 1, "owner/repo")
+            mock_issue.assert_not_called()
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
@@ -122,11 +114,30 @@ class TestBuildPrompt:
         assert len(prompt) > 0
 
     @patch("scripts.show_prompt.fetch_issue")
-    def test_impl_review_stage(self, mock_issue: MagicMock) -> None:
+    @patch("scripts.show_prompt.fetch_pr_diff")
+    def test_impl_review_stage(
+        self, mock_diff: MagicMock, mock_issue: MagicMock
+    ) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
-        prompt = build_prompt("impl-review", 1, "owner/repo", iteration=0)
+        mock_diff.return_value = "diff --git a/foo.py b/foo.py"
+        prompt = build_prompt(
+            "impl-review", 1, "owner/repo",
+            pr_number=5, iteration=0,
+        )
+        mock_diff.assert_called_once_with("owner/repo", 5)
         assert isinstance(prompt, str)
         assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_impl_review_no_pr_skips_diff(
+        self, mock_issue: MagicMock
+    ) -> None:
+        """When pr_number is 0, fetch_pr_diff is not called."""
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        with patch("scripts.show_prompt.fetch_pr_diff") as mock_diff:
+            prompt = build_prompt("impl-review", 1, "owner/repo", iteration=0)
+            mock_diff.assert_not_called()
+        assert isinstance(prompt, str)
 
     @patch("scripts.show_prompt.fetch_issue")
     def test_impl_resume_stage(self, mock_issue: MagicMock) -> None:
@@ -136,9 +147,14 @@ class TestBuildPrompt:
         assert len(prompt) > 0
 
     @patch("scripts.show_prompt.fetch_issue")
-    def test_pr_review_stage(self, mock_issue: MagicMock) -> None:
+    @patch("scripts.show_prompt.fetch_pr_diff")
+    def test_pr_review_stage(
+        self, mock_diff: MagicMock, mock_issue: MagicMock
+    ) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        mock_diff.return_value = "diff --git a/foo.py b/foo.py"
         prompt = build_prompt("pr-review", 1, "owner/repo", pr_number=5)
+        mock_diff.assert_called_once_with("owner/repo", 5)
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
@@ -150,8 +166,20 @@ class TestBuildPrompt:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_threads.return_value = "[]"
         prompt = build_prompt("address-review", 1, "owner/repo", pr_number=5)
+        mock_threads.assert_called_once_with("owner/repo", 5)
         assert isinstance(prompt, str)
         assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_address_review_no_pr_skips_threads(
+        self, mock_issue: MagicMock
+    ) -> None:
+        """When pr_number is 0, fetch_pr_threads is not called."""
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        with patch("scripts.show_prompt.fetch_pr_threads") as mock_threads:
+            prompt = build_prompt("address-review", 1, "owner/repo")
+            mock_threads.assert_not_called()
+        assert isinstance(prompt, str)
 
     @patch("scripts.show_prompt.fetch_issue")
     def test_follow_up_stage(self, mock_issue: MagicMock) -> None:
@@ -191,6 +219,12 @@ class TestMain:
         rc = main(["--issue", "1", "--stage", "planning"])
         assert rc == 1
 
+    @patch("scripts.show_prompt.build_prompt")
+    def test_main_returns_1_on_value_error(self, mock_build: MagicMock) -> None:
+        mock_build.side_effect = ValueError("Unknown stage")
+        rc = main(["--issue", "1", "--stage", "planning"])
+        assert rc == 1
+
 
 # ---------------------------------------------------------------------------
 # Coverage: all stages are listed
@@ -210,3 +244,103 @@ def test_all_stages_covered() -> None:
         "advise",
     }
     assert set(STAGES) == expected
+
+
+# ---------------------------------------------------------------------------
+# Direct unit tests for helper functions (M5)
+# ---------------------------------------------------------------------------
+
+class TestExtractPlanFromIssueData:
+    """Direct tests for _extract_plan_from_issue_data."""
+
+    def test_returns_none_for_none_input(self) -> None:
+        assert _extract_plan_from_issue_data(None) is None
+
+    def test_returns_none_when_no_comments(self) -> None:
+        assert _extract_plan_from_issue_data({"comments": []}) is None
+
+    def test_returns_none_when_no_plan_marker(self) -> None:
+        data = {"comments": [{"body": "random comment"}]}
+        assert _extract_plan_from_issue_data(data) is None
+
+    def test_finds_implementation_plan(self) -> None:
+        plan = "# Implementation Plan\n\n## Steps\n1. Do stuff"
+        data = {"comments": [{"body": plan}]}
+        assert _extract_plan_from_issue_data(data) == plan
+
+    def test_finds_approach_marker(self) -> None:
+        plan = "## Approach\nWe will refactor X."
+        data = {"comments": [{"body": plan}]}
+        assert _extract_plan_from_issue_data(data) == plan
+
+    def test_finds_proposed_solution(self) -> None:
+        plan = "## Proposed Solution\nAdd Y."
+        data = {"comments": [{"body": plan}]}
+        assert _extract_plan_from_issue_data(data) == plan
+
+    def test_finds_design_marker(self) -> None:
+        plan = "## Design\nHigh-level architecture."
+        data = {"comments": [{"body": plan}]}
+        assert _extract_plan_from_issue_data(data) == plan
+
+    def test_finds_h3_approach(self) -> None:
+        plan = "### Approach\nDetailed steps."
+        data = {"comments": [{"body": plan}]}
+        assert _extract_plan_from_issue_data(data) == plan
+
+    def test_returns_most_recent_plan(self) -> None:
+        old_plan = "# Implementation Plan\nOld version"
+        new_plan = "# Implementation Plan\nNew version"
+        data = {"comments": [
+            {"body": old_plan},
+            {"body": "noise"},
+            {"body": new_plan},
+        ]}
+        assert _extract_plan_from_issue_data(data) == new_plan
+
+    def test_plan_markers_tuple_entries(self) -> None:
+        """Verify _PLAN_MARKERS has the expected entries."""
+        expected = {
+            "# Implementation Plan",
+            "## Implementation Plan",
+            "## Approach",
+            "### Approach",
+            "## Proposed Solution",
+            "## Design",
+        }
+        assert set(_PLAN_MARKERS) == expected
+
+
+class TestFetchPrThreads:
+    """Direct tests for fetch_pr_threads."""
+
+    @patch("scripts.show_prompt._gh")
+    def test_returns_json_string(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = {"reviewThreads": [], "body": ""}
+        result = fetch_pr_threads("owner/repo", 5)
+        mock_gh.assert_called_once_with(
+            ["pr", "view", "5", "--repo", "owner/repo",
+             "--json", "reviewThreads,body"],
+            parse_json=True,
+        )
+        parsed = json.loads(result)
+        assert parsed == {"reviewThreads": [], "body": ""}
+
+    @patch("scripts.show_prompt._gh")
+    def test_returns_empty_list_on_runtime_error(self, mock_gh: MagicMock) -> None:
+        mock_gh.side_effect = RuntimeError("gh failed")
+        result = fetch_pr_threads("owner/repo", 5)
+        assert result == "[]"
+
+
+class TestFetchPrDiff:
+    """Direct tests for fetch_pr_diff."""
+
+    @patch("scripts.show_prompt._gh")
+    def test_calls_gh_with_correct_args(self, mock_gh: MagicMock) -> None:
+        mock_gh.return_value = "diff content"
+        result = fetch_pr_diff("owner/repo", 10)
+        mock_gh.assert_called_once_with(
+            ["pr", "diff", "10", "--repo", "owner/repo"]
+        )
+        assert result == "diff content"

--- a/tests/test_show_prompt.py
+++ b/tests/test_show_prompt.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -13,9 +13,9 @@ import pytest
 # without requiring scripts/__init__.py.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.show_prompt import (  # noqa: E402
-    STAGES,
+from scripts.show_prompt import (
     _PLAN_MARKERS,
+    STAGES,
     _extract_plan_from_issue_data,
     build_parser,
     build_prompt,
@@ -24,12 +24,14 @@ from scripts.show_prompt import (  # noqa: E402
     main,
 )
 
-
 # ---------------------------------------------------------------------------
 # Parser tests
 # ---------------------------------------------------------------------------
 
+
 class TestBuildParser:
+    """Tests for the argument parser."""
+
     def test_requires_issue(self) -> None:
         parser = build_parser()
         with pytest.raises(SystemExit):
@@ -54,14 +56,22 @@ class TestBuildParser:
 
     def test_optional_args(self) -> None:
         parser = build_parser()
-        args = parser.parse_args([
-            "--issue", "10",
-            "--stage", "implementation",
-            "--branch", "feature/foo",
-            "--worktree", "/tmp/wt",
-            "--pr", "5",
-            "--iteration", "2",
-        ])
+        args = parser.parse_args(
+            [
+                "--issue",
+                "10",
+                "--stage",
+                "implementation",
+                "--branch",
+                "feature/foo",
+                "--worktree",
+                "/tmp/wt",
+                "--pr",
+                "5",
+                "--iteration",
+                "2",
+            ]
+        )
         assert args.branch == "feature/foo"
         assert args.worktree == "/tmp/wt"
         assert args.pr == 5
@@ -72,7 +82,10 @@ class TestBuildParser:
 # build_prompt tests
 # ---------------------------------------------------------------------------
 
+
 class TestBuildPrompt:
+    """Tests for build_prompt across all stages."""
+
     def test_planning_stage(self) -> None:
         """Planning stage does not fetch issue data."""
         with patch("scripts.show_prompt.fetch_issue") as mock_issue:
@@ -83,9 +96,7 @@ class TestBuildPrompt:
 
     @patch("scripts.show_prompt.fetch_issue")
     @patch("scripts.show_prompt._extract_plan_from_issue_data")
-    def test_plan_review_stage(
-        self, mock_extract: MagicMock, mock_issue: MagicMock
-    ) -> None:
+    def test_plan_review_stage(self, mock_extract: MagicMock, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_extract.return_value = "# Plan"
         prompt = build_prompt("plan-review", 1, "owner/repo")
@@ -94,9 +105,7 @@ class TestBuildPrompt:
 
     @patch("scripts.show_prompt.fetch_issue")
     @patch("scripts.show_prompt._extract_plan_from_issue_data")
-    def test_plan_loop_review_stage(
-        self, mock_extract: MagicMock, mock_issue: MagicMock
-    ) -> None:
+    def test_plan_loop_review_stage(self, mock_extract: MagicMock, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_extract.return_value = "# Plan"
         prompt = build_prompt("plan-loop-review", 1, "owner/repo", iteration=1)
@@ -107,31 +116,33 @@ class TestBuildPrompt:
     def test_implementation_stage(self, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         prompt = build_prompt(
-            "implementation", 1, "owner/repo",
-            branch_name="feat/x", worktree_path="/tmp/wt",
+            "implementation",
+            1,
+            "owner/repo",
+            branch_name="feat/x",
+            worktree_path="/tmp/wt",
         )
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
     @patch("scripts.show_prompt.fetch_issue")
     @patch("scripts.show_prompt.fetch_pr_diff")
-    def test_impl_review_stage(
-        self, mock_diff: MagicMock, mock_issue: MagicMock
-    ) -> None:
+    def test_impl_review_stage(self, mock_diff: MagicMock, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_diff.return_value = "diff --git a/foo.py b/foo.py"
         prompt = build_prompt(
-            "impl-review", 1, "owner/repo",
-            pr_number=5, iteration=0,
+            "impl-review",
+            1,
+            "owner/repo",
+            pr_number=5,
+            iteration=0,
         )
         mock_diff.assert_called_once_with("owner/repo", 5)
         assert isinstance(prompt, str)
         assert len(prompt) > 0
 
     @patch("scripts.show_prompt.fetch_issue")
-    def test_impl_review_no_pr_skips_diff(
-        self, mock_issue: MagicMock
-    ) -> None:
+    def test_impl_review_no_pr_skips_diff(self, mock_issue: MagicMock) -> None:
         """When pr_number is 0, fetch_pr_diff is not called."""
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         with patch("scripts.show_prompt.fetch_pr_diff") as mock_diff:
@@ -148,8 +159,11 @@ class TestBuildPrompt:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_diff.side_effect = RuntimeError("gh failed")
         prompt = build_prompt(
-            "impl-review", 1, "owner/repo",
-            pr_number=5, iteration=0,
+            "impl-review",
+            1,
+            "owner/repo",
+            pr_number=5,
+            iteration=0,
         )
         assert isinstance(prompt, str)
         assert len(prompt) > 0
@@ -163,9 +177,7 @@ class TestBuildPrompt:
 
     @patch("scripts.show_prompt.fetch_issue")
     @patch("scripts.show_prompt.fetch_pr_diff")
-    def test_pr_review_stage(
-        self, mock_diff: MagicMock, mock_issue: MagicMock
-    ) -> None:
+    def test_pr_review_stage(self, mock_diff: MagicMock, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_diff.return_value = "diff --git a/foo.py b/foo.py"
         prompt = build_prompt("pr-review", 1, "owner/repo", pr_number=5)
@@ -187,9 +199,7 @@ class TestBuildPrompt:
 
     @patch("scripts.show_prompt.fetch_issue")
     @patch("scripts.show_prompt.fetch_pr_threads")
-    def test_address_review_stage(
-        self, mock_threads: MagicMock, mock_issue: MagicMock
-    ) -> None:
+    def test_address_review_stage(self, mock_threads: MagicMock, mock_issue: MagicMock) -> None:
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         mock_threads.return_value = "[]"
         prompt = build_prompt("address-review", 1, "owner/repo", pr_number=5)
@@ -198,9 +208,7 @@ class TestBuildPrompt:
         assert len(prompt) > 0
 
     @patch("scripts.show_prompt.fetch_issue")
-    def test_address_review_no_pr_skips_threads(
-        self, mock_issue: MagicMock
-    ) -> None:
+    def test_address_review_no_pr_skips_threads(self, mock_issue: MagicMock) -> None:
         """When pr_number is 0, fetch_pr_threads is not called."""
         mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
         with patch("scripts.show_prompt.fetch_pr_threads") as mock_threads:
@@ -231,9 +239,14 @@ class TestBuildPrompt:
 # main() integration tests
 # ---------------------------------------------------------------------------
 
+
 class TestMain:
+    """Integration tests for the main entry point."""
+
     @patch("scripts.show_prompt.build_prompt")
-    def test_main_prints_prompt(self, mock_build: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_main_prints_prompt(
+        self, mock_build: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         mock_build.return_value = "THE PROMPT TEXT"
         rc = main(["--issue", "1", "--stage", "planning"])
         assert rc == 0
@@ -247,12 +260,13 @@ class TestMain:
         assert rc == 1
 
 
-
 # ---------------------------------------------------------------------------
 # Coverage: all stages are listed
 # ---------------------------------------------------------------------------
 
+
 def test_all_stages_covered() -> None:
+    """Verify STAGES tuple covers all expected pipeline stages."""
     expected = {
         "planning",
         "plan-review",
@@ -271,6 +285,7 @@ def test_all_stages_covered() -> None:
 # ---------------------------------------------------------------------------
 # Direct unit tests for helper functions (M5)
 # ---------------------------------------------------------------------------
+
 
 class TestExtractPlanFromIssueData:
     """Direct tests for _extract_plan_from_issue_data."""
@@ -313,11 +328,13 @@ class TestExtractPlanFromIssueData:
     def test_returns_most_recent_plan(self) -> None:
         old_plan = "# Implementation Plan\nOld version"
         new_plan = "# Implementation Plan\nNew version"
-        data = {"comments": [
-            {"body": old_plan},
-            {"body": "noise"},
-            {"body": new_plan},
-        ]}
+        data = {
+            "comments": [
+                {"body": old_plan},
+                {"body": "noise"},
+                {"body": new_plan},
+            ]
+        }
         assert _extract_plan_from_issue_data(data) == new_plan
 
     def test_plan_markers_tuple_entries(self) -> None:
@@ -341,8 +358,7 @@ class TestFetchPrThreads:
         mock_gh.return_value = {"reviewThreads": [], "body": ""}
         result = fetch_pr_threads("owner/repo", 5)
         mock_gh.assert_called_once_with(
-            ["pr", "view", "5", "--repo", "owner/repo",
-             "--json", "reviewThreads,body"],
+            ["pr", "view", "5", "--repo", "owner/repo", "--json", "reviewThreads,body"],
             parse_json=True,
         )
         parsed = json.loads(result)
@@ -362,9 +378,7 @@ class TestFetchPrDiff:
     def test_calls_gh_with_correct_args(self, mock_gh: MagicMock) -> None:
         mock_gh.return_value = "diff content"
         result = fetch_pr_diff("owner/repo", 10)
-        mock_gh.assert_called_once_with(
-            ["pr", "diff", "10", "--repo", "owner/repo"]
-        )
+        mock_gh.assert_called_once_with(["pr", "diff", "10", "--repo", "owner/repo"])
         assert result == "diff content"
 
     @patch("scripts.show_prompt._gh")

--- a/tests/test_show_prompt.py
+++ b/tests/test_show_prompt.py
@@ -1,0 +1,212 @@
+"""Tests for the show-prompt CLI (issue #1170)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from scripts.show_prompt import STAGES, build_parser, build_prompt, main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mock_issue_data() -> dict:
+    return {
+        "title": "Test Issue Title",
+        "body": "Test issue body with acceptance criteria.",
+        "comments": [
+            {"body": "Some random comment"},
+            {"body": "# Implementation Plan\n\n## Approach\nDo stuff."},
+        ],
+    }
+
+
+@pytest.fixture()
+def mock_extract_comment() -> str:
+    return "# Implementation Plan\n\n## Approach\nCreate foo.py with bar()."
+
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+class TestBuildParser:
+    def test_requires_issue(self) -> None:
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--stage", "planning"])
+
+    def test_requires_stage(self) -> None:
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--issue", "1"])
+
+    def test_invalid_stage_rejected(self) -> None:
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--issue", "1", "--stage", "bogus"])
+
+    def test_valid_args_parsed(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args(["--issue", "42", "--stage", "planning"])
+        assert args.issue == 42
+        assert args.stage == "planning"
+        assert args.repo == "HomericIntelligence/ProjectHephaestus"
+
+    def test_optional_args(self) -> None:
+        parser = build_parser()
+        args = parser.parse_args([
+            "--issue", "10",
+            "--stage", "implementation",
+            "--branch", "feature/foo",
+            "--worktree", "/tmp/wt",
+            "--pr", "5",
+            "--iteration", "2",
+        ])
+        assert args.branch == "feature/foo"
+        assert args.worktree == "/tmp/wt"
+        assert args.pr == 5
+        assert args.iteration == 2
+
+
+# ---------------------------------------------------------------------------
+# build_prompt tests
+# ---------------------------------------------------------------------------
+
+class TestBuildPrompt:
+    @patch("scripts.show_prompt.fetch_issue")
+    @patch("scripts.show_prompt._extract_plan_from_issue_data")
+    def test_planning_stage(
+        self, mock_extract: MagicMock, mock_issue: MagicMock
+    ) -> None:
+        mock_extract.return_value = "# Implementation Plan"
+        prompt = build_prompt("planning", 1, "owner/repo")
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    @patch("scripts.show_prompt._extract_plan_from_issue_data")
+    def test_plan_review_stage(
+        self, mock_extract: MagicMock, mock_issue: MagicMock
+    ) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        mock_extract.return_value = "# Plan"
+        prompt = build_prompt("plan-review", 1, "owner/repo")
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    @patch("scripts.show_prompt._extract_plan_from_issue_data")
+    def test_plan_loop_review_stage(
+        self, mock_extract: MagicMock, mock_issue: MagicMock
+    ) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        mock_extract.return_value = "# Plan"
+        prompt = build_prompt("plan-loop-review", 1, "owner/repo", iteration=1)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_implementation_stage(self, mock_issue: MagicMock) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        prompt = build_prompt(
+            "implementation", 1, "owner/repo",
+            branch_name="feat/x", worktree_path="/tmp/wt",
+        )
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_impl_review_stage(self, mock_issue: MagicMock) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        prompt = build_prompt("impl-review", 1, "owner/repo", iteration=0)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_impl_resume_stage(self, mock_issue: MagicMock) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        prompt = build_prompt("impl-resume", 1, "owner/repo", iteration=1)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_pr_review_stage(self, mock_issue: MagicMock) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        prompt = build_prompt("pr-review", 1, "owner/repo", pr_number=5)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    @patch("scripts.show_prompt.fetch_pr_threads")
+    def test_address_review_stage(
+        self, mock_threads: MagicMock, mock_issue: MagicMock
+    ) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        mock_threads.return_value = "[]"
+        prompt = build_prompt("address-review", 1, "owner/repo", pr_number=5)
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_follow_up_stage(self, mock_issue: MagicMock) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        prompt = build_prompt("follow-up", 1, "owner/repo")
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    @patch("scripts.show_prompt.fetch_issue")
+    def test_advise_stage(self, mock_issue: MagicMock) -> None:
+        mock_issue.return_value = {"title": "T", "body": "B", "comments": []}
+        prompt = build_prompt("advise", 1, "owner/repo")
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+    def test_unknown_stage_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown stage"):
+            build_prompt("bogus", 1, "owner/repo")
+
+
+# ---------------------------------------------------------------------------
+# main() integration tests
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    @patch("scripts.show_prompt.build_prompt")
+    def test_main_prints_prompt(self, mock_build: MagicMock, capsys: pytest.CaptureFixture[str]) -> None:
+        mock_build.return_value = "THE PROMPT TEXT"
+        rc = main(["--issue", "1", "--stage", "planning"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "THE PROMPT TEXT" in captured.out
+
+    @patch("scripts.show_prompt.build_prompt")
+    def test_main_returns_1_on_error(self, mock_build: MagicMock) -> None:
+        mock_build.side_effect = RuntimeError("gh failed")
+        rc = main(["--issue", "1", "--stage", "planning"])
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Coverage: all stages are listed
+# ---------------------------------------------------------------------------
+
+def test_all_stages_covered() -> None:
+    expected = {
+        "planning",
+        "plan-review",
+        "plan-loop-review",
+        "implementation",
+        "impl-review",
+        "impl-resume",
+        "pr-review",
+        "address-review",
+        "follow-up",
+        "advise",
+    }
+    assert set(STAGES) == expected


### PR DESCRIPTION
## Summary

Adds a CLI that takes --issue N --stage STAGE and outputs the exact prompt that would be sent to the agent at that stage.

Supports 10 pipeline stages: planning, plan-review, plan-loop-review, implementation, impl-review, impl-resume, pr-review, address-review, follow-up, advise.

## Changes

- **scripts/show_prompt.py** (new) — CLI with --issue, --stage, --repo, --pr, --branch, --worktree, --iteration args
- **tests/test_show_prompt.py** (new) — 19 tests covering parser, all 10 stages, main() integration, stage coverage

## Verification

All 19 tests pass.

Closes #1170

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>