### PR TITLE
docs(scripts): fix MD032 violations in INSTALLER_ARCHITECTURE.md

### DIFF
--- a/docs/INSTALLER_ARCHITECTURE.md
+++ b/docs/INSTALLER_ARCHITECTURE.md
@@ -21,6 +21,7 @@ Three verified pillars justify keeping the sections in a single file:
 ### 1. Shared Result Counters
 
 Every section increments `_PASS`/`_FAIL`/`_WARN`/`_SKIP` counters (defined in `lib/install_helpers.sh:21`) to track installation outcomes. Splitting into per-tool installers would require either:
+
 - Replicating the counter logic in each child script, or
 - Building a dispatcher that threads the counters through every call
 
@@ -29,6 +30,7 @@ Both violate KISS/YAGNI for a script with no current caller pain.
 ### 2. The `--role` Filter
 
 A single `--role` argument (values: `all`, `worker`, `control`) is parsed once at the entry point and used by the `should_check_worker` and `should_check_control` helper functions (lines 53–54 of `install.sh`) to gate entire sections. All 12 sections obey the same filter. A per-tool split would require either:
+
 - Replicating role-gating logic in each child, or
 - Threading role state through a dispatcher
 


### PR DESCRIPTION
PR #984 merged docs/INSTALLER_ARCHITECTURE.md with two MD032/blanks-around-lists violations (lists not surrounded by blank lines) in the SRP sections. The repo markdownlint CI gate runs on the all-files glob with markdownlint v0.40.0, so the violation fails markdownlint on every PR until fixed. The local pre-commit hook excludes docs/, so it was not caught before #984 merged.

This adds the two missing blank lines before the lists. Verified clean with markdownlint-cli2 v0.20.0 (markdownlint v0.40.0), matching the CI action.

Closes #1223