### PR TITLE
fix(lint): unbreak main ruff-format + mypy after concurrent merges

### DIFF
--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -292,10 +292,7 @@ class TestPlanReviewVerdictGate:
             patch.object(impl, "_run_post_pr_followup"),
             patch("hephaestus.automation.implementer_phase_runner.ensure_pr_auto_merge_deferred"),
             patch("hephaestus.automation._review_phase.mark_pr_implementation_go"),
-            patch(
-                "hephaestus.automation._review_phase."
-                "enable_auto_merge_after_implementation_go"
-            ),
+            patch("hephaestus.automation._review_phase.enable_auto_merge_after_implementation_go"),
             patch(
                 "hephaestus.automation.implementer.fetch_issue_info",
                 return_value=MagicMock(title="t", body="b"),
@@ -470,16 +467,9 @@ class TestExistingPrEntersReviewLoop:
                 return_value=MagicMock(title="t", body="b"),
             ),
             patch.object(impl, "_run_advise_as_implementer_turn"),
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_go"
-            ) as mark_go,
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_no_go"
-            ) as mark_no_go,
-            patch(
-                "hephaestus.automation._review_phase."
-                "enable_auto_merge_after_implementation_go"
-            ),
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_go") as mark_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_no_go") as mark_no_go,
+            patch("hephaestus.automation._review_phase.enable_auto_merge_after_implementation_go"),
         ):
             result = impl._implement_issue(1)
 
@@ -566,14 +556,9 @@ class TestExistingPrEntersReviewLoop:
             ),
             patch.object(impl, "_run_advise_as_implementer_turn"),
             patch.object(impl, "_run_impl_review_loop", return_value=(2, "GO", "A")) as review_loop,
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_go"
-            ) as mark_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_go") as mark_go,
             patch("hephaestus.automation._review_phase.mark_pr_implementation_no_go"),
-            patch(
-                "hephaestus.automation._review_phase."
-                "enable_auto_merge_after_implementation_go"
-            ),
+            patch("hephaestus.automation._review_phase.enable_auto_merge_after_implementation_go"),
         ):
             result = impl._implement_issue(1)
 
@@ -623,12 +608,8 @@ class TestExistingPrEntersReviewLoop:
                 return_value=MagicMock(title="t", body="b"),
             ),
             patch.object(impl, "_run_advise_as_implementer_turn"),
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_go"
-            ) as mark_go,
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_no_go"
-            ) as mark_no_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_go") as mark_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_no_go") as mark_no_go,
         ):
             result = impl._implement_issue(1)
 
@@ -661,10 +642,7 @@ class TestExistingPrEntersReviewLoop:
             patch.object(impl, "_finalize_pr", return_value=999),
             patch("hephaestus.automation.implementer_phase_runner.ensure_pr_auto_merge_deferred"),
             patch("hephaestus.automation._review_phase.mark_pr_implementation_go"),
-            patch(
-                "hephaestus.automation._review_phase."
-                "enable_auto_merge_after_implementation_go"
-            ),
+            patch("hephaestus.automation._review_phase.enable_auto_merge_after_implementation_go"),
             patch.object(impl, "_run_post_pr_followup"),
             patch(
                 "hephaestus.automation.implementer.fetch_issue_info",

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -62,9 +62,7 @@ def test_codex_implementer_advise_uses_codex_prompt_builder(
     """Codex implementer runs should trigger the Codex `$advise` skill prompt."""
     implementer.options.agent = "codex"
 
-    with patch(
-        "hephaestus.automation._implement_phase.run_advise", return_value="findings"
-    ) as run:
+    with patch("hephaestus.automation._implement_phase.run_advise", return_value="findings") as run:
         result = implementer._run_advise(123, "Test Issue", "Issue body")
 
     assert result == "findings"
@@ -244,9 +242,7 @@ class TestRunImplReviewLoop:
             ),
             patch("hephaestus.automation.github_api.gh_pr_resolve_thread") as mock_resolve,
             patch.object(implementer, "_run_address_review_step") as mock_addr2,
-            patch(
-                "hephaestus.automation._review_phase.gh_issue_add_labels"
-            ) as mock_label,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
             iters, verdict, _grade = implementer._run_impl_review_loop(
                 issue_number=1,
@@ -469,9 +465,7 @@ class TestRunImplReviewLoop:
                 ],
             ),
             patch.object(implementer, "_run_address_review_step", return_value=True),
-            patch(
-                "hephaestus.automation._review_phase.gh_issue_add_labels"
-            ) as mock_label,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
             _, verdict, _ = implementer._run_impl_review_loop(
                 issue_number=7,
@@ -509,9 +503,7 @@ class TestRunImplReviewLoop:
                 ],
             ),
             patch.object(implementer, "_run_address_review_step", return_value=True),
-            patch(
-                "hephaestus.automation._review_phase.gh_issue_add_labels"
-            ) as mock_label,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
             _, verdict, _ = implementer._run_impl_review_loop(
                 issue_number=911,
@@ -539,12 +531,8 @@ class TestRunImplReviewLoop:
         unreviewed code).
         """
         with (
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_go"
-            ) as mock_go,
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_no_go"
-            ) as mock_no_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_go") as mock_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_no_go") as mock_no_go,
         ):
             implementer.phase_runner._apply_impl_review_verdict(
                 issue_number=911,
@@ -567,12 +555,8 @@ class TestRunImplReviewLoop:
         an unresolved PR) or no-go (recording a converged failure).
         """
         with (
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_go"
-            ) as mock_go,
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_no_go"
-            ) as mock_no_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_go") as mock_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_no_go") as mock_no_go,
         ):
             implementer.phase_runner._apply_impl_review_verdict(
                 issue_number=911,
@@ -602,9 +586,7 @@ class TestRunImplReviewLoop:
                 implementer, "_run_impl_review_step", return_value=(_ambiguous(), [])
             ) as mock_rev,
             patch.object(implementer, "_run_address_review_step") as mock_addr,
-            patch(
-                "hephaestus.automation._review_phase.gh_issue_add_labels"
-            ) as mock_label,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
             iters, verdict, _ = implementer._run_impl_review_loop(
                 issue_number=8,
@@ -641,9 +623,7 @@ class TestRunImplReviewLoop:
                 side_effect=[(_nogo("C"), []), (_go(), [])],
             ) as mock_rev,
             patch.object(implementer, "_run_address_review_step") as mock_addr,
-            patch(
-                "hephaestus.automation._review_phase.gh_issue_add_labels"
-            ) as mock_label,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
             iters, verdict, _ = implementer._run_impl_review_loop(
                 issue_number=8,
@@ -670,9 +650,7 @@ class TestRunImplReviewLoop:
         with (
             patch.object(implementer, "_run_impl_review_step", return_value=(_go(), [])),
             patch.object(implementer, "_run_address_review_step"),
-            patch(
-                "hephaestus.automation._review_phase.gh_issue_add_labels"
-            ) as mock_label,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
             implementer._run_impl_review_loop(
                 issue_number=9,
@@ -697,9 +675,7 @@ class TestRunImplReviewLoop:
             with (
                 patch.object(implementer, "_run_impl_review_step", return_value=(_nogo("C"), [])),
                 patch.object(implementer, "_run_address_review_step"),
-                patch(
-                    "hephaestus.automation._review_phase.gh_issue_add_labels"
-                ) as mock_label,
+                patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
             ):
                 implementer._run_impl_review_loop(
                     issue_number=10,
@@ -1195,15 +1171,10 @@ class TestImplementationAutoMergeGate:
             patch(
                 "hephaestus.automation.implementer_phase_runner.ensure_pr_auto_merge_deferred"
             ) as mock_defer,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_go") as mock_go,
+            patch("hephaestus.automation._review_phase.mark_pr_implementation_no_go") as mock_nogo,
             patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_go"
-            ) as mock_go,
-            patch(
-                "hephaestus.automation._review_phase.mark_pr_implementation_no_go"
-            ) as mock_nogo,
-            patch(
-                "hephaestus.automation._review_phase."
-                "enable_auto_merge_after_implementation_go"
+                "hephaestus.automation._review_phase.enable_auto_merge_after_implementation_go"
             ) as mock_arm,
             patch.object(
                 implementer.worktree_manager, "create_worktree", return_value=worktree_path
@@ -1528,9 +1499,7 @@ class TestRunAddressReviewStep:
                 "hephaestus.automation._review_phase.gh_pr_list_unresolved_threads",
                 return_value=[],
             ),
-            patch(
-                "hephaestus.automation._review_phase.run_address_fix_session"
-            ) as mock_fix,
+            patch("hephaestus.automation._review_phase.run_address_fix_session") as mock_fix,
         ):
             addressed = implementer._run_address_review_step(
                 issue_number=1,
@@ -1629,9 +1598,7 @@ class TestCompactImplementerSession:
         self, impl: IssueImplementer, tmp_path: Path
     ) -> None:
         """Verify /compact is called after /learn succeeds."""
-        with patch(
-            "hephaestus.automation._implement_phase.compact_session"
-        ) as mock_compact:
+        with patch("hephaestus.automation._implement_phase.compact_session") as mock_compact:
             mock_compact.return_value = True
 
             impl.phase_runner._compact_implementer_session(842, tmp_path)

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -146,7 +146,7 @@ def test_implement_phase_run_claude_code_dry_run(tmp_path: Path) -> None:
 def test_implement_phase_run_claude_code_dispatches_claude(tmp_path: Path) -> None:
     """_run_claude_code routes to the Claude session for non-codex agents."""
     ctx = _make_ctx(tmp_path)
-    ctx.impl._run_claude_impl_session = mock.MagicMock(return_value="sess-1")  # type: ignore[attr-defined]
+    ctx.impl._run_claude_impl_session = mock.MagicMock(return_value="sess-1")  # type: ignore[method-assign]
     phase = ImplementPhase(ctx)
     with mock.patch("hephaestus.automation._implement_phase.is_codex", return_value=False):
         assert phase._run_claude_code(7, tmp_path, "prompt") == "sess-1"
@@ -161,8 +161,8 @@ def test_implement_phase_run_claude_code_dispatches_claude(tmp_path: Path) -> No
 def test_pr_create_finalize_persists_pr_number(tmp_path: Path) -> None:
     """_finalize_pr ensures the PR exists and persists its number on state."""
     ctx = _make_ctx(tmp_path)
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[attr-defined]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[attr-defined]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[method-assign]
     phase = PRCreatePhase(ctx)
     state = SimpleNamespace(phase=None, pr_number=None)
     pr = phase._finalize_pr(7, "7-auto-impl", tmp_path, cast(Any, state), slot_id=None)
@@ -175,8 +175,8 @@ def test_pr_create_finalize_persists_pr_number(tmp_path: Path) -> None:
 def test_pr_create_finalize_runs_pre_pr_tests_when_enabled(tmp_path: Path) -> None:
     """_finalize_pr runs the opt-in pre-PR test gate before creating the PR."""
     ctx = _make_ctx(tmp_path, run_pre_pr_tests=True)
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=9)  # type: ignore[attr-defined]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=False)  # type: ignore[attr-defined]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=9)  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=False)  # type: ignore[method-assign]
     phase = PRCreatePhase(ctx)
     state = SimpleNamespace(phase=None, pr_number=None)
     phase._finalize_pr(7, "b", tmp_path, cast(Any, state), slot_id=None)


### PR DESCRIPTION
main's required `lint` job is RED after this session's rapid concurrent PR merges:

1. **ruff-format** — `tests/unit/automation/test_implementer.py` + `test_implementer_loop.py` landed slightly unformatted (passed per-PR, the all-files check on merged main catches it). `ruff format` collapses some wrapped `patch(...)` calls — purely cosmetic.
2. **mypy** — `tests/unit/automation/test_stage_phases.py` (from #998's decompose) used `# type: ignore[attr-defined]` on 5 method→MagicMock assignments; post-decompose the methods exist, so the correct code is `[method-assign]`.

Diff is formatting-only + the 5 ignore-code corrections — no logic changes. Verified: full `mypy` (368 files) Success, complete pre-commit suite green.

This unblocks the v0.9.5 release (lint is a required check since #1174).

Closes #1229