### PR TITLE
docs(migration): sync version header to v0.9.5 + add drift guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-> **Status (as of 2026-05-28):** The latest released version is **0.9.2** (tag-driven
+> **Status (as of 2026-06-12):** The latest released version is **0.9.5** (tag-driven
 > via hatch-vcs). **1.0 has not been released yet** — the section below is the
 > *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
 > prepare. There are currently **no breaking changes between 0.9.x releases**: upgrading

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,4 +52,4 @@ We also capture session learnings in ProjectMnemosyne via the `/learn` skill, pr
 
 This roadmap is reviewed and updated at the end of each release cycle (typically monthly). As new Epics are created or project priorities shift, the roadmap is refreshed to reflect current focus areas. To propose changes, open an issue and reference this document.
 
-Last updated: 2026-05-28
+Last updated: 2026-06-12

--- a/tests/unit/docs/test_version_currency.py
+++ b/tests/unit/docs/test_version_currency.py
@@ -1,0 +1,56 @@
+"""Regression test: MIGRATION.md version claim must not trail the latest git tag.
+
+Pattern D (stop maintaining the number by hand): instead of relying on a human
+to notice the dated 'latest released version' line has gone stale, this test
+fails CI when the documented version is *older* than the canonical hatch-vcs
+version (latest vX.Y.Z git tag). See issue #1208.
+
+This test is designed to RUN in CI, not skip: the unit-test job checks out with
+``fetch-tags: true`` (see .github/workflows/test.yml). If tags are somehow
+absent, the test FAILS LOUD with remediation guidance rather than skipping --
+a guard that silently skips is not a guard.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from hephaestus.version.consistency import _version_from_git_tag
+from hephaestus.version.parsing import parse_version_tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+MIGRATION_MD = REPO_ROOT / "docs" / "MIGRATION.md"
+
+# Matches: "The latest released version is **0.9.5**"
+_LATEST_RE = re.compile(r"latest released version is \*\*(\d+\.\d+\.\d+)\*\*", re.IGNORECASE)
+
+
+def test_migration_md_version_does_not_trail_latest_git_tag() -> None:
+    """Fail if MIGRATION.md's 'latest released version' trails the newest git tag."""
+    canonical = _version_from_git_tag(REPO_ROOT)
+    if canonical is None:
+        pytest.fail(
+            "Could not resolve the latest vX.Y.Z git tag, so doc-version drift "
+            "cannot be checked. This usually means tags were not fetched. Run "
+            "`git fetch --tags`, or in CI ensure the checkout step sets "
+            "`fetch-depth: 0` and `fetch-tags: true` (see .github/workflows/test.yml). "
+            "This test fails loud rather than skipping so the guard is never a no-op."
+        )
+
+    text = MIGRATION_MD.read_text(encoding="utf-8")
+    match = _LATEST_RE.search(text)
+    assert match is not None, (
+        "MIGRATION.md no longer contains a 'latest released version is **X.Y.Z**' "
+        "line; update the regex in this test or restore the line."
+    )
+    documented = match.group(1)
+
+    documented_tuple = parse_version_tuple(documented, on_non_numeric="raise")
+    canonical_tuple = parse_version_tuple(canonical, on_non_numeric="raise")
+
+    assert documented_tuple >= canonical_tuple, (
+        f"MIGRATION.md claims the latest release is {documented} but a newer git "
+        f"tag v{canonical} has shipped. The doc version is stale -- bump the "
+        f"'latest released version is **X.Y.Z**' line in docs/MIGRATION.md to {canonical}."
+    )


### PR DESCRIPTION
## Summary

`docs/MIGRATION.md` and `docs/ROADMAP.md` dated currency claims trailed the release line by three patch versions — the docs said `0.9.2` / `2026-05-28`, but the latest git tag is `v0.9.5`. This is the "documentation currency" debt the project flags in its own ROADMAP audit-remediation list.

### Changes

1. **Sync both docs** to `v0.9.5` / `2026-06-12` (`docs/MIGRATION.md:3`, `docs/ROADMAP.md:55`). `ROADMAP.md:9` is left untouched — "the strict 2026-05-28 audit" is a historical event name, not a currency claim.
2. **Add a CI-effective drift-detection regression test** (`tests/unit/docs/test_version_currency.py`) that ties the MIGRATION.md "latest released version" line to the canonical hatch-vcs authority (latest `vX.Y.Z` git tag via `_version_from_git_tag`) so the line can never silently trail the tag again.
3. **Make the guard load-bearing in CI**: `.github/workflows/test.yml` checkout now sets `fetch-depth: 0` + `fetch-tags: true` (mirroring `auto-tag.yml` / `release.yml`) so the test resolves a tag in CI instead of `None`. If tags are ever absent, the test **fails loud** with remediation guidance rather than skipping.

### Semantics

Uses `>=` (not `==`) comparison so a freshly-pushed newer tag does not instantly red `main` — it only fails for the genuinely-stale case this issue targets (`0.9.2 < 0.9.5`).

### Verification

- RED→GREEN confirmed: test fails (assertion, not skip) on the stale `0.9.2` state, passes after the sync. `0 skipped`.
- `tests/unit/version` + `tests/unit/docs`: 86 passed.
- Corpus re-grep: no stale `0.9.2` / `2026-05-28` strings remain except the historical `ROADMAP.md:9` audit name.
- pre-commit (ruff, mypy, yamllint, test-structure) passes on all changed files.

Closes #1208