### PR TITLE
docs(claude): remove dangling .claude/shared/ pointer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,7 +414,6 @@ pre-commit run --all-files
 1. Check existing GitHub issues and discussions
 2. Review documentation in docs/ directory
 3. Post implementation questions as issue comments
-4. Refer to shared documentation in .claude/shared/
 
 ## Key Files and Directories
 


### PR DESCRIPTION
Removes the dangling list item at CLAUDE.md:417 — "Refer to shared documentation in .claude/shared/" — which pointed at a directory that does not exist (root .claude/ has only security/, workflows/, settings.json).

The immediately-preceding item ("Review documentation in docs/ directory") already directs agents to the real shared-docs location, so removal loses no guidance (DRY/KISS) and resolves the POLA violation flagged by the audit.

Verification:
- `grep -n "\.claude/shared" CLAUDE.md` → no output (reference removed)
- `.claude/shared/` confirmed absent on disk
- docs/ pointer retained at the prior list item
- markdownlint passes (no MD0xx regression)

Closes #1211