### PR TITLE
fix(datasets): validate URL scheme to make nosec B310 claim true (#1185)

### DIFF
--- a/hephaestus/datasets/downloader.py
+++ b/hephaestus/datasets/downloader.py
@@ -36,12 +36,45 @@ import time
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 from hephaestus.logging.utils import get_logger
 
 logger = get_logger(__name__)
+
+# Network schemes permitted for dataset downloads. Restricting to http(s)
+# blocks ``file://``, ``ftp://``, and other ``urlopen``-supported schemes that
+# would otherwise turn an attacker-controlled ``base_url`` into a local-file or
+# SSRF read (CWE-918 / CWE-22). This guard is what makes the ``nosec B310``
+# annotation on the ``urlopen`` call below accurate.
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
+
+
+def _validate_url_scheme(url: str) -> str:
+    """Return *url* unchanged if its scheme is an allowed http(s) scheme.
+
+    Args:
+        url: The fully-qualified URL whose scheme should be validated.
+
+    Returns:
+        The original *url* when its scheme is permitted.
+
+    Raises:
+        ValueError: If *url* uses any scheme other than ``http``/``https``
+            (e.g. ``file://``, ``ftp://``), which could be abused for local
+            file disclosure or SSRF.
+
+    """
+    scheme = urlparse(url).scheme.lower()
+    if scheme not in _ALLOWED_URL_SCHEMES:
+        raise ValueError(
+            f"Refusing non-HTTP(S) dataset URL: {url!r} "
+            f"(scheme {scheme!r}; allowed: {sorted(_ALLOWED_URL_SCHEMES)})"
+        )
+    return url
+
 
 # Per-file MD5 checksums for integrity verification. Values are the
 # upstream-published MD5s used by torchvision; they detect MITM tampering and
@@ -113,7 +146,7 @@ class DatasetDownloader:
             retry_delays: Delay times between retries (exponential backoff)
 
         """
-        self.base_url = base_url.rstrip("/")
+        self.base_url = _validate_url_scheme(base_url.rstrip("/"))
         self.user_agent = user_agent
         self.max_retries = max_retries
         self.retry_delays = retry_delays or [1.0, 2.0, 4.0]
@@ -132,7 +165,10 @@ class DatasetDownloader:
             True if successful, False otherwise
 
         """
-        url = f"{self.base_url}/{filename}"
+        # Re-validate the fully-constructed URL: ``self.base_url`` may have been
+        # reassigned after construction (e.g. EMNIST mirror fallback), so the
+        # constructor-time check is not sufficient on its own.
+        url = _validate_url_scheme(f"{self.base_url}/{filename}")
         max_retries = max_retries if max_retries is not None else self.max_retries
         last_error = None
 
@@ -144,7 +180,7 @@ class DatasetDownloader:
 
             try:
                 request = Request(url, headers={"User-Agent": self.user_agent})
-                with urlopen(request) as response:  # nosec B310 - base_url is always a hardcoded HTTPS dataset URL; file:// and custom schemes are not accepted
+                with urlopen(request) as response:  # nosec B310 - url scheme validated to http(s) via _validate_url_scheme above; file://, ftp:// and other schemes raise ValueError before this call
                     total_size = int(response.headers.get("Content-Length", 0))
                     downloaded = 0
                     block_size = 8192
@@ -564,7 +600,7 @@ class EMNISTDownloader(DatasetDownloader):
             logger.info("Downloading EMNIST %s split...", split)
             downloaded = False
             for base_url in [self.base_url, *self._fallback_urls]:
-                self.base_url = base_url
+                self.base_url = _validate_url_scheme(base_url)
                 if self.download_with_retry(zip_name, zip_path):
                     downloaded = True
                     break

--- a/tests/unit/datasets/test_downloader.py
+++ b/tests/unit/datasets/test_downloader.py
@@ -44,6 +44,32 @@ class TestDatasetDownloader:
         d = DatasetDownloader("http://example.com", user_agent="TestAgent/1.0")
         assert d.user_agent == "TestAgent/1.0"
 
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "file:///etc/passwd",
+            "ftp://example.com/data",
+            "gopher://example.com",
+            "data:text/plain;base64,AA==",
+            "/etc/passwd",  # no scheme at all
+        ],
+    )
+    def test_init_rejects_non_http_scheme(self, bad_url: str) -> None:
+        """Constructing with a non-http(s) base URL raises ValueError."""
+        with pytest.raises(ValueError, match="non-HTTP"):
+            DatasetDownloader(bad_url)
+
+    def test_download_rejects_non_http_scheme_after_reassignment(self, tmp_path: Path) -> None:
+        """A base_url reassigned to file:// is rejected before urlopen.
+
+        Guards the EMNIST mirror-fallback path, which mutates ``base_url``
+        after construction and would otherwise bypass the constructor check.
+        """
+        downloader = DatasetDownloader("https://example.com")
+        downloader.base_url = "file:///etc"
+        with pytest.raises(ValueError, match="non-HTTP"):
+            downloader.download_with_retry("passwd", tmp_path / "out")
+
     def test_decompress_gz(self, tmp_path: Path) -> None:
         """decompress_gz unpacks a valid gzip file."""
         content = b"hello compressed world"


### PR DESCRIPTION
## Summary

`hephaestus/datasets/downloader.py` carried a `# nosec B310` annotation claiming `base_url` "is always a hardcoded HTTPS dataset URL; file:// and custom schemes are not accepted" — but the claim was **false**. `base_url` is a public constructor parameter, stored verbatim, and `urlopen` was called on `f"{base_url}/{filename}"` with **no scheme validation**. A caller could pass `file:///etc/passwd`, `ftp://…`, etc. (CWE-918 SSRF / CWE-22 local-file read).

## Fix

- Added `_validate_url_scheme()` that rejects any scheme outside `{http, https}` with a `ValueError`.
- Enforced in the `DatasetDownloader` constructor **and** re-checked at the `urlopen` call site — the EMNIST mirror-fallback path reassigns `self.base_url` after construction, so the constructor check alone is insufficient.
- `http` is permitted alongside `https` because existing tests and usages legitimately use `http://` URLs.
- Updated the `nosec B310` comment to accurately describe the now-real validation.

## Tests

- `test_init_rejects_non_http_scheme` — parametrized over `file://`, `ftp://`, `gopher://`, `data:`, and a schemeless path; all raise `ValueError`.
- `test_download_rejects_non_http_scheme_after_reassignment` — guards the EMNIST reassignment path.

## Verification

- `pytest tests/unit/datasets` — 52 passed
- `ruff check` + `ruff format` — clean
- `mypy` — no issues (372 files)
- `pre-commit run bandit` — Passed

Closes #1185