### PR TITLE
ci(pr-policy): mechanize Conventional Commits gate (DoD row 5)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -356,6 +356,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      # Check 3 invokes scripts/check_conventional_commit.py from the working
+      # tree, so the repo must be on disk. This job is otherwise pure API/gh.
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: "Fetch PR metadata"
         id: fetch
         env:

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -379,6 +379,7 @@ jobs:
                     nodes {
                       commit {
                         oid
+                        message
                         signature { isValid state }
                       }
                     }
@@ -438,6 +439,24 @@ jobs:
             exit 1
           fi
           echo "OK: all commits have verified signatures"
+
+      - name: "Check 3: commit subjects follow Conventional Commits"
+        if: always() && steps.fetch.outcome == 'success'
+        env:
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+          # Dependabot subjects are auto-generated; exempt like Check 1 (#1070).
+          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
+            echo "OK: Dependabot PR — Conventional Commit check is not applicable"
+            exit 0
+          fi
+          # Subject = first line of each commit message (GraphQL .commit.message
+          # verified to resolve). Pipe on stdin, one per line, into the shared
+          # validator (DoD row 5 / issue #1209). Empty set passes by design.
+          jq -r '.data.repository.pullRequest.commits.nodes[]
+                 | .commit.message | split("\n")[0]' commits.json \
+            | python3 scripts/check_conventional_commit.py -
 
   auto-merge-policy:
     name: auto-merge-policy

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -356,10 +356,16 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      # Check 3 invokes scripts/check_conventional_commit.py from the working
-      # tree, so the repo must be on disk. This job is otherwise pure API/gh.
+      # Check 3 invokes scripts/check_conventional_commit.py from the repo tree,
+      # so the source must be on disk. Pin the checkout to the PR head SHA: the
+      # default bare checkout resolves refs/pull/N/merge, which GitHub computes
+      # asynchronously and can lag a fresh push — checking out a merge commit
+      # that predates the validator and so misses the script. The head SHA is an
+      # immutable object id (not an attacker-controllable ref name), and the
+      # validator ships with the PR until it lands on main.
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: "Fetch PR metadata"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,11 @@
 #   floor pixi.toml owns. markdownlint-cli2 (CI action) and shellcheck (apt) have
 #   no pixi package and so are not version-checked here.
 
+# Ensure `pre-commit install` (documented in CONTRIBUTING.md / README.md) wires
+# BOTH the pre-commit and commit-msg stages, so the conventional-commit-msg hook
+# below actually fires without `--hook-type commit-msg`. See issue #1209.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
 
   # Python formatting and linting
@@ -243,6 +248,18 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+  # Conventional Commits enforcement (DoD row 5; issue #1209).
+  # commit-msg stage: pre-commit passes the message file path as the only arg.
+  - repo: local
+    hooks:
+      - id: conventional-commit-msg
+        name: Enforce Conventional Commits
+        description: Reject commit subjects that are not type(scope) description
+        entry: python3 scripts/check_conventional_commit.py
+        language: system
+        stages: [commit-msg]
+        pass_filenames: true
 
 
   # Skill merge method check: skills must not hardcode merge flags

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -15,7 +15,7 @@ A piece of work is **done** when every item below is true.
 | 2 | PR body contains the literal line `Closes #<issue-number>` (capital C, no colon, on its own line) | CI gate `pr-policy` (`.github/workflows/_required.yml`) |
 | 3 | Every commit on the branch is cryptographically signed (`git commit -S`) | CI gate `pr-policy` |
 | 4 | Auto-merge is disabled until `state:implementation-go`, then enabled with `--squash` (NOT `--rebase`; the repo disallows rebase merges) | CI gate `pr-policy` |
-| 5 | Commit messages follow Conventional Commits (`type(scope): description`) | PR reviewer (no automated gate) |
+| 5 | Commit messages follow Conventional Commits (`type(scope): description`) | CI gate `pr-policy` (Check 3) + local `commit-msg` hook `conventional-commit-msg` |
 | 6 | `pixi run ruff check hephaestus/ tests/` passes | CI job `lint` |
 | 7 | `pixi run ruff format --check hephaestus/ tests/` passes (no files would be reformatted) | CI job `lint` |
 | 8 | `pixi run mypy` returns `Success: no issues found in N source files` | CI job `lint` |

--- a/scripts/check_conventional_commit.py
+++ b/scripts/check_conventional_commit.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+r"""Validate that a commit subject follows Conventional Commits.
+
+Enforces DoD row 5 (docs/DEFINITION_OF_DONE.md): commit subjects must match
+``type(scope): description`` with an allowed type. Used by both the local
+``commit-msg`` pre-commit hook (the message file path is passed as argv[0])
+and the ``pr-policy`` CI job (each PR commit subject is piped on stdin via
+``-``, one per line).
+
+Usage:
+    # commit-msg hook: validate the message file
+    python scripts/check_conventional_commit.py .git/COMMIT_EDITMSG
+    # CI: validate subjects piped on stdin
+    printf '%s\\n' "fix(io): handle EOF" | python scripts/check_conventional_commit.py -
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ALLOWED_TYPES = frozenset(
+    {"feat", "fix", "docs", "refactor", "test", "chore", "ci", "build", "perf", "style", "revert"}
+)
+
+# git-generated subjects that are never Conventional Commits and must pass.
+_MACHINERY_PREFIXES = ("Merge ", "Revert ", "fixup!", "squash!")
+
+
+def validate_subject(subject: str) -> str | None:
+    """Return an error string if *subject* is not a valid Conventional Commit, else None.
+
+    Splits on the first colon only; extracts an optional ``(scope)`` via
+    index/rindex so nested parens survive; allows a trailing ``!`` breaking marker.
+
+    Args:
+        subject: A single commit subject line.
+
+    Returns:
+        ``None`` when the subject conforms, otherwise a human-readable error string.
+
+    """
+    subject = subject.rstrip("\n")
+    if not subject.strip():
+        return "empty commit subject"
+    if subject.startswith(_MACHINERY_PREFIXES):
+        return None
+    if ":" not in subject:
+        return f"missing 'type(scope): ' prefix in: {subject!r}"
+    prefix, message = subject.split(":", 1)
+    if not message.strip():
+        return f"empty description after ':' in: {subject!r}"
+    if "(" in prefix and prefix.rstrip().endswith((")", ")!")):
+        # Strip a trailing breaking-change '!' before scope extraction.
+        core = prefix[:-1] if prefix.rstrip().endswith("!") else prefix
+        scope = core[core.index("(") + 1 : core.rindex(")")]
+        if not scope.strip():
+            return f"empty scope '()' in: {subject!r}"
+        type_token = core[: core.index("(")]
+    else:
+        type_token = prefix[:-1] if prefix.endswith("!") else prefix
+    if type_token not in ALLOWED_TYPES:
+        return (
+            f"invalid type {type_token!r} in: {subject!r}; "
+            f"allowed: {', '.join(sorted(ALLOWED_TYPES))}"
+        )
+    return None
+
+
+def _subjects_from_args(argv: list[str]) -> list[str]:
+    """Return subject lines from a message file path (argv[0]) or stdin ('-').
+
+    File path (commit-msg stage): the subject is the first non-comment,
+    non-blank line of the message file. Stdin ('-', CI): every non-blank line
+    is treated as one subject.
+
+    Args:
+        argv: Positional arguments — a single message-file path, or ``["-"]``
+            (or empty) to read newline-delimited subjects from stdin.
+
+    Returns:
+        A list of subject lines to validate.
+
+    """
+    if not argv or argv[0] == "-":
+        return [line for line in sys.stdin.read().splitlines() if line.strip()]
+    text = Path(argv[0]).read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if line.strip() and not line.startswith("#"):
+            return [line]
+    return [""]
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate each subject; exit non-zero if any violation is found.
+
+    Args:
+        argv: Optional argument list (defaults to ``sys.argv[1:]``).
+
+    Returns:
+        ``0`` when every subject conforms (or there are none), ``1`` otherwise.
+
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args[:1] in (["--help"], ["-h"]):
+        print(__doc__)
+        return 0
+    subjects = _subjects_from_args(args)
+    # An empty subject set (no commits / empty stdin) is not a violation;
+    # the pr-policy signing + Closes checks cover the empty-commits anomaly.
+    failed = False
+    for subject in subjects:
+        err = validate_subject(subject)
+        if err:
+            print(f"FAILED: Conventional Commit check: {err}")
+            failed = True
+    if failed:
+        print(
+            "Commit subjects must follow Conventional Commits: "
+            "type(scope): description. See docs/DEFINITION_OF_DONE.md row 5."
+        )
+        return 1
+    print("PASSED: Conventional Commit check")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_conventional_commit.py
+++ b/tests/unit/scripts/test_check_conventional_commit.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/check_conventional_commit.py."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+
+from check_conventional_commit import (
+    _subjects_from_args,
+    validate_subject,
+)
+
+
+class TestValidateSubject:
+    """Tests for the ``validate_subject`` Conventional Commit parser."""
+
+    def test_accepts_simple_type(self) -> None:
+        assert validate_subject("fix: handle EOF") is None
+
+    def test_accepts_type_with_scope(self) -> None:
+        assert validate_subject("feat(io): add atomic write") is None
+
+    def test_accepts_nested_paren_scope(self) -> None:
+        assert validate_subject("feat(core(sub)): wire it") is None
+
+    def test_accepts_breaking_marker_with_scope(self) -> None:
+        assert validate_subject("feat(api)!: drop v1") is None
+
+    def test_accepts_breaking_marker_no_scope(self) -> None:
+        assert validate_subject("feat!: drop v1") is None
+
+    def test_accepts_genuine_multi_colon_description(self) -> None:
+        # Advise-named case: a colon INSIDE the description must not break parse.
+        assert validate_subject("fix: url: handle https://example.com") is None
+
+    def test_rejects_bracketed_prefix(self) -> None:  # the cited 67079cc3 form
+        assert validate_subject("[FIX] Replace bash -c") is not None
+
+    def test_rejects_unknown_type(self) -> None:
+        assert validate_subject("wip: stuff") is not None
+
+    def test_rejects_missing_colon(self) -> None:
+        assert validate_subject("add a thing") is not None
+
+    def test_rejects_empty_description(self) -> None:
+        assert validate_subject("fix: ") is not None
+
+    def test_rejects_empty_scope(self) -> None:
+        assert validate_subject("fix(): x") is not None
+
+    def test_rejects_empty_subject(self) -> None:
+        assert validate_subject("") is not None
+
+    def test_ignores_merge_and_revert_and_fixup(self) -> None:
+        assert validate_subject("Merge branch 'main'") is None
+        assert validate_subject('Revert "feat: x"') is None
+        assert validate_subject("fixup! fix: x") is None
+
+
+class TestSubjectsFromArgs:
+    """Tests for the ``_subjects_from_args`` file/stdin entry-point split."""
+
+    def test_reads_first_noncomment_line_from_msg_file(self, tmp_path: Path) -> None:
+        f = tmp_path / "COMMIT_EDITMSG"
+        f.write_text("feat(io): add thing\n\n# comment line\nbody text\n")
+        assert _subjects_from_args([str(f)]) == ["feat(io): add thing"]
+
+    def test_skips_leading_comment_lines(self, tmp_path: Path) -> None:
+        f = tmp_path / "COMMIT_EDITMSG"
+        f.write_text("# pre-filled comment\nfix: real subject\n")
+        assert _subjects_from_args([str(f)]) == ["fix: real subject"]


### PR DESCRIPTION
Mechanizes Definition-of-Done row 5 (`docs/DEFINITION_OF_DONE.md`), the only un-gated DoD item: Conventional Commits was convention-only (PR-reviewer, no automated gate). Commit `67079cc3` (`[FIX] Replace bash -c ...`) proves the gap let a non-conforming subject land.

## What changed

One pure-stdlib validator, two independently-verified enforcement points (DRY):

- **`scripts/check_conventional_commit.py`** — `validate_subject()` core + `_subjects_from_args()` file/stdin entry split. Handles nested-paren scopes, breaking `!` markers, multi-colon descriptions; exempts `Merge`/`Revert`/`fixup!`/`squash!` machinery.
- **`.pre-commit-config.yaml`** — a `commit-msg`-stage local hook **plus** `default_install_hook_types: [pre-commit, commit-msg]` so a plain `pre-commit install` actually wires it (the hook is otherwise inert under the documented install command).
- **`.github/workflows/_required.yml`** — **Check 3** in the existing required `pr-policy` job; extends the GraphQL commit query to fetch `message`, pipes each subject into the shared validator, exempts `dependabot[bot]` like Check 1, and passes an empty commit set by design.
- **`docs/DEFINITION_OF_DONE.md`** — flips row 5's enforcement cell.
- **`tests/unit/scripts/test_check_conventional_commit.py`** — 15 tests (parser cases + entry-point split).

## Verification

- 15 unit tests pass.
- commit-msg hook **provably fires**: blocks a bad subject (exit 1) and passes a good one (exit 0) via `pre-commit run --hook-stage commit-msg --commit-msg-filename`.
- Only the historical `[FIX]` (#937) subject deviates among the last 60 `origin/main` commits — the gate does not break legitimate work on day one.
- ruff / mypy / yamllint / markdownlint clean; workflow YAML parses.

Closes #1209