### PR TITLE
docs(readme): prefix pre-commit install with 'pixi run' for pixi-only model

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ For local development, use [Pixi](https://pixi.sh) to manage the environment:
 
 ```bash
 pixi install
-pre-commit install
+pixi run pre-commit install
 ```
 
 ## Library vs product layer


### PR DESCRIPTION
The README "Development setup" block instructed a bare `pre-commit install` after `pixi install`. Because `pre-commit` is a pixi-env dependency (not globally installed), its binary is not on PATH after only `pixi install`, so the bare command fails with "command not found" on a clean machine.

This one-line fix prefixes the command with `pixi run`, bringing the README into agreement with the two canonical sources that already use the working form:

- `CONTRIBUTING.md:61`
- `scripts/shell/install_hooks.sh:9`

Docs-only change; markdownlint is the only relevant gate and passes.

Closes #1215