### PR TITLE
docs: clarify subpackage/skill count scope in repo-structure comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ ProjectHephaestus is the shared utilities and tooling repository of the HomericI
 
 ```text
 ProjectHephaestus/
-├── hephaestus/                 # Python source code (19 subpackages)
+├── hephaestus/                 # Python source code (19 documented subpackages)
 │   ├── agents/                 # Agent frontmatter + loader + runtime
 │   ├── automation/             # Issue planning / implementation / PR review pipeline
 │   ├── benchmarks/             # Benchmark comparison utilities
@@ -46,7 +46,7 @@ ProjectHephaestus/
 │   ├── validation/             # README, schema, and structural validation
 │   └── version/                # Version management
 ├── scripts/                    # Automation and maintenance scripts
-├── skills/                     # Claude Code skill definitions (23 entries; kebab-case naming for plugin format)
+├── skills/                     # Claude Code skill definitions (23 SKILL.md skills; kebab-case naming for plugin format)
 ├── tests/                      # Unit and integration tests
 │   ├── unit/                   # Unit tests (mirrors hephaestus/ structure)
 │   └── integration/            # Integration tests

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -39,7 +39,7 @@ says nothing about the Python package version and vice versa. See
 
 ## Stability Tiers
 
-ProjectHephaestus ships 19 subpackages with different maturity levels. Only the
+ProjectHephaestus ships 19 documented subpackages with different maturity levels. Only the
 **stable** subpackages below are covered by the [deprecation policy](#deprecation-policy);
 **provisional** subpackages may change without notice, even across minor versions.
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` (the first file agents read) and `COMPATIBILITY.md` carried two structural counts the audit flagged as stale/ambiguous. Each "subpackages" number annotates an adjacent curated enumeration of **19**, so the fix makes the number and its list *agree* by clarifying scope — not by bumping to the raw filesystem count (which would contradict the 19-entry list below it).

## Changes

- `CLAUDE.md:28` — `(19 subpackages)` → `(19 documented subpackages)`: the number now matches the 19-entry tree directly below it. The 20th real dir, `hephaestus/scripts_lib/`, is internal repo-meta pre-commit tooling (absent from `hephaestus.__init__` re-exports and every curated list), so "documented subpackages = 19" is correct.
- `CLAUDE.md:49` — `23 entries` → `23 SKILL.md skills`: states the unit. The number was already correct (`find skills -name SKILL.md | wc -l` → 23); the 24th dir (`_repo_analyze_common`) is shared partials with no `SKILL.md`.
- `COMPATIBILITY.md:42` — `19 subpackages` → `19 documented subpackages`: matches its 7-stable + 12-provisional = 19 tier tables.

## Verification

- CLAUDE.md tree enumerates exactly 19 leaf entries (number == list)
- COMPATIBILITY.md tier tables enumerate 7 + 12 = 19 (number == list)
- `SKILL.md` count == 23
- No orphan "20 subpackages" claim introduced
- markdownlint-cli2 passes on both files

Docs-only change; no code or tests affected.

Closes #1212