### PR TITLE
fix(utils): make max_delay a hard ceiling in retry backoff

### DIFF
--- a/hephaestus/utils/retry.py
+++ b/hephaestus/utils/retry.py
@@ -62,12 +62,14 @@ def _compute_backoff_delay(
         attempt: Zero-based attempt index (0 for the first retry).
         initial_delay: Initial delay in seconds before first retry.
         backoff_factor: Multiplier for delay between retries.
-        max_delay: Optional cap (applied *before* jitter so the actual sleep
-            value can reach max_delay * 1.25 at most when jitter=True).
+        max_delay: Optional hard cap on the sleep value. Applied *after* jitter
+            so the returned delay never exceeds max_delay (subject to the 0.1s
+            minimum floor below).
         jitter: If True, perturb the delay by ±25 %.
 
     Returns:
-        Sleep duration in seconds (always >= 0.1).
+        Sleep duration in seconds (always >= 0.1, and <= max_delay when a cap
+        is set and max_delay >= 0.1).
 
     """
     delay: float = initial_delay * (backoff_factor**attempt)
@@ -75,6 +77,11 @@ def _compute_backoff_delay(
         delay = min(delay, max_delay)
     if jitter:
         delay = float(delay + random.uniform(-0.25 * delay, 0.25 * delay))
+    # Re-apply the cap *after* jitter so max_delay is a hard ceiling, not an
+    # advisory target. Without this, +25% jitter could push the sleep to
+    # max_delay * 1.25 (see issue #1206).
+    if max_delay is not None:
+        delay = min(delay, max_delay)
     return max(0.1, delay)
 
 
@@ -97,7 +104,8 @@ def retry_with_backoff(
         jitter: Add random jitter to delay times (default: True)
         retry_on: Tuple of exception types to retry on (default: all exceptions)
         logger: Optional logging function for retry attempts
-        max_delay: Maximum delay cap in seconds (default: None, no cap)
+        max_delay: Maximum delay cap in seconds — a hard ceiling honored even
+            with jitter enabled (default: None, no cap)
         retry_predicate: Optional callable applied *after* the ``retry_on``
             isinstance check. If provided and the predicate returns ``False``
             for the raised exception, the exception is re-raised immediately

--- a/tests/unit/utils/test_retry.py
+++ b/tests/unit/utils/test_retry.py
@@ -167,6 +167,34 @@ class TestRetryWithBackoff:
         for call in mock_sleep.call_args_list:
             assert call[0][0] <= 2.0
 
+    @patch("hephaestus.utils.retry.random.uniform")
+    @patch("time.sleep")
+    def test_max_delay_hard_ceiling_with_jitter(self, mock_sleep, mock_uniform):
+        """max_delay is a hard ceiling even when jitter pushes the delay up (#1206)."""
+        # Force jitter to its maximum positive value (+25% of the delay).
+        mock_uniform.side_effect = lambda lo, hi: hi
+
+        call_count = 0
+
+        def flaky():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 4:
+                raise ValueError("fail")
+            return "ok"
+
+        decorated = retry_with_backoff(
+            max_retries=4,
+            initial_delay=1.0,
+            backoff_factor=10,
+            jitter=True,
+            max_delay=2.0,
+        )(flaky)
+        assert decorated() == "ok"
+        # Pre-fix, max jitter would yield 2.0 * 1.25 = 2.5; the cap must hold.
+        for call in mock_sleep.call_args_list:
+            assert call[0][0] <= 2.0
+
 
 class TestRetryOnNetworkError:
     """Tests for retry_on_network_error convenience decorator."""
@@ -258,9 +286,9 @@ class TestRetryWithJitter:
 
         with pytest.warns(DeprecationWarning, match="retry_with_jitter"):
             retry_with_jitter(flaky, max_retries=4, base_delay=1.0, max_delay=2.0)
-        # All sleep calls should be <= max_delay * 1.25 (jitter upper bound)
+        # max_delay is a hard ceiling — jitter must not push the sleep above it.
         for c in mock_sleep.call_args_list:
-            assert c[0][0] <= 2.0 * 1.25 + 0.1
+            assert c[0][0] <= 2.0
 
     def test_emits_deprecation_warning(self):
         """retry_with_jitter() always emits DeprecationWarning."""


### PR DESCRIPTION
## Summary

`_compute_backoff_delay` in `hephaestus/utils/retry.py` applied the `max_delay`
cap *before* jitter, so with `jitter=True` the actual sleep could reach
`max_delay * 1.25` — the docstring even acknowledged this. The cap was therefore
advisory rather than a hard ceiling: a caller setting `max_delay` to bound
worst-case latency did not actually get that bound.

## Fix

Re-apply `min(delay, max_delay)` *after* jitter so `max_delay` becomes a true
hard ceiling. The pre-jitter clamp is intentionally retained — it keeps jitter
proportional to the capped delay rather than to an unbounded exponential, so
high-attempt delays still spread around the cap instead of collapsing to exactly
`max_delay` (which would defeat the thundering-herd purpose of jitter). The
`max(0.1, delay)` floor remains the final operation.

## Tests

- Added `test_max_delay_hard_ceiling_with_jitter`: forces `random.uniform` to its
  `+25%` maximum and asserts the sleep never exceeds `max_delay` with
  `jitter=True` (fails RED against the old code: `2.5 <= 2.0`).
- Tightened `test_max_delay_respected`, which encoded the buggy `* 1.25`
  tolerance, to assert `<= max_delay`.
- `test_max_delay_caps_backoff` (`jitter=False`) is unchanged and remains the
  regression anchor.

All 23 tests in `test_retry.py` pass; `ruff format`, `ruff check`, and `mypy`
are clean.

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)