### PR TITLE
feat(forensics): executable handler-ran contract guard (--verify)

### DIFF
--- a/hephaestus/forensics/__init__.py
+++ b/hephaestus/forensics/__init__.py
@@ -13,9 +13,14 @@ are otherwise hard to observe:
 """
 
 from .coredump_handler import (
+    BUNDLE_NOT_RUN,
+    BUNDLE_OK,
+    BUNDLE_RAN_WITH_ERRORS,
     DEFAULT_MAX_BYTES,
     DEFAULT_TARGET_DIRS,
+    VERIFY_SIGNAL_LOST_EXIT,
     resolve_target_dir,
+    verify_crash_bundle,
     write_core,
 )
 from .gdb_runner import (
@@ -25,11 +30,16 @@ from .gdb_runner import (
 )
 
 __all__ = [
+    "BUNDLE_NOT_RUN",
+    "BUNDLE_OK",
+    "BUNDLE_RAN_WITH_ERRORS",
     "DEFAULT_MAX_BYTES",
     "DEFAULT_TARGET_DIRS",
+    "VERIFY_SIGNAL_LOST_EXIT",
     "build_gdb_script",
     "resolve_command",
     "resolve_target_dir",
     "run_under_gdb",
+    "verify_crash_bundle",
     "write_core",
 ]

--- a/hephaestus/forensics/coredump_handler.py
+++ b/hephaestus/forensics/coredump_handler.py
@@ -208,7 +208,14 @@ def verify_crash_bundle(log_dir: Path) -> tuple[str, str]:
 
     # A `wrote ` line is the authoritative success signal; a successful capture
     # may also carry a chmod/max-bytes WARNING, so `wrote ` wins over WARNING.
-    if any(" wrote " in ln or ln.startswith("wrote ") for ln in lines):
+    # Each kept line is "<iso-timestamp> <message>"; split off the timestamp and
+    # check that the message portion starts with "wrote " so that an ERROR: line
+    # whose path happens to contain the substring " wrote " is not misclassified.
+    def _message_is_wrote(ln: str) -> bool:
+        parts = ln.split(maxsplit=1)
+        return len(parts) == 2 and parts[1].startswith("wrote ")
+
+    if any(_message_is_wrote(ln) for ln in lines):
         return BUNDLE_OK, f"{log_path} records a successful capture"
     return BUNDLE_RAN_WITH_ERRORS, (
         f"{log_path} records handler activity but no successful capture "

--- a/hephaestus/forensics/coredump_handler.py
+++ b/hephaestus/forensics/coredump_handler.py
@@ -37,7 +37,10 @@ maps to), pass it as a literal ``--target-dir`` argument in the
 Exit-code note: the kernel ignores this handler's exit code entirely. Every
 failure path therefore logs to ``handler.log`` next to the core directory
 instead of relying on exit status — a missing ``handler.log`` is the only
-signal that the handler did not run at all.
+signal that the handler did not run at all. This contract is enforced by
+:func:`verify_crash_bundle` (also exposed as ``hephaestus-coredump-handler
+--verify``, which exits 3 on a lost signal); a CI artifact step SHOULD run it
+and fail the job when it reports ``NOT_RUN``.
 """
 
 from __future__ import annotations
@@ -149,6 +152,70 @@ def _log(log_dir: Path, message: str) -> None:
             handle.write(f"{stamp} {message}\n")
 
 
+#: Verdicts returned by :func:`verify_crash_bundle`. ``NOT_RUN`` is the
+#: silent-loss case the handler contract guards against: a missing
+#: ``handler.log`` means the kernel never invoked the handler at all.
+BUNDLE_OK = "OK"
+BUNDLE_RAN_WITH_ERRORS = "RAN_WITH_ERRORS"
+BUNDLE_NOT_RUN = "NOT_RUN"
+
+#: Exit code returned by ``--verify`` when the failure signal was lost
+#: (verdict ``NOT_RUN``). Deliberately NOT 1 or 2: argparse exits 2 on usage
+#: errors and gdb_runner already returns 2, so a distinct code lets a CI gate
+#: tell "signal lost" apart from "bad command line".
+VERIFY_SIGNAL_LOST_EXIT = 3
+
+
+def verify_crash_bundle(log_dir: Path) -> tuple[str, str]:
+    """Enforce the handler's failure-signal contract on a crash bundle.
+
+    The kernel ignores a pipe handler's exit code, so every failure path logs
+    to ``handler.log`` instead (see module docstring). This makes that
+    convention executable: it inspects the bundle directory and classifies
+    whether the handler ran.
+
+    Classification keys off the lines :func:`_log` writes. A ``wrote `` line
+    means the core was captured (verdict :data:`BUNDLE_OK`) even if a WARNING
+    is also present, because a successful capture can still log a chmod or
+    ``COREDUMP_MAX_BYTES`` warning (see :func:`write_core` / :func:`main`). Any
+    other non-empty log means the handler ran but recorded no successful
+    capture (:data:`BUNDLE_RAN_WITH_ERRORS`). A missing/empty/unreadable log
+    means the handler never ran (:data:`BUNDLE_NOT_RUN`) — the silent-loss case.
+
+    Args:
+        log_dir: The directory ``handler.log`` is expected in (the parent of
+            the core ``target_dir``; see :func:`write_core`).
+
+    Returns:
+        A ``(verdict, detail)`` pair. ``verdict`` is one of the ``BUNDLE_*``
+        constants; ``detail`` is a human-readable explanation.
+
+    """
+    log_path = log_dir / "handler.log"
+    if not log_path.is_file():
+        return BUNDLE_NOT_RUN, (
+            f"{log_path} is missing — the handler never ran "
+            "(the kernel cannot report a pipe handler's exit code)"
+        )
+    try:
+        contents = log_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return BUNDLE_NOT_RUN, f"{log_path} is unreadable ({exc})"
+
+    lines = [ln for ln in contents.splitlines() if ln.strip()]
+    if not lines:
+        return BUNDLE_NOT_RUN, f"{log_path} is empty — no handler activity recorded"
+
+    # A `wrote ` line is the authoritative success signal; a successful capture
+    # may also carry a chmod/max-bytes WARNING, so `wrote ` wins over WARNING.
+    if any(" wrote " in ln or ln.startswith("wrote ") for ln in lines):
+        return BUNDLE_OK, f"{log_path} records a successful capture"
+    return BUNDLE_RAN_WITH_ERRORS, (
+        f"{log_path} records handler activity but no successful capture "
+        "(handler ran; inspect the log for the failure)"
+    )
+
+
 def write_core(
     stream: object,
     pid: str,
@@ -221,10 +288,20 @@ def _build_parser() -> argparse.ArgumentParser:
             "when a specific directory (e.g. a CI workspace path) is required."
         ),
     )
-    parser.add_argument("pid", help="PID of the crashing process (%%p)")
-    parser.add_argument("exe", help="executable basename (%%e)")
-    parser.add_argument("crash_time", help="crash time, seconds since epoch (%%t)")
-    parser.add_argument("signal", help="signal number (%%s)")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "verification mode: do not read stdin. Inspect the resolved bundle "
+            "directory and assert the handler-ran contract (a missing "
+            "handler.log means the handler never ran). Exit 0 if the handler "
+            "ran, 3 if its failure signal was lost. For CI artifact steps."
+        ),
+    )
+    parser.add_argument("pid", nargs="?", help="PID of the crashing process (%%p)")
+    parser.add_argument("exe", nargs="?", help="executable basename (%%e)")
+    parser.add_argument("crash_time", nargs="?", help="crash time, seconds since epoch (%%t)")
+    parser.add_argument("signal", nargs="?", help="signal number (%%s)")
     parser.add_argument(
         "global_pid",
         nargs="?",
@@ -234,6 +311,56 @@ def _build_parser() -> argparse.ArgumentParser:
     add_json_arg(parser)
     add_version_arg(parser)
     return parser
+
+
+def _resolve_candidates(target_dir: str | None) -> list[str]:
+    """Resolve ordered output-directory candidates from CLI/env/default.
+
+    Mirrors the precedence documented on :func:`main`: an explicit
+    ``--target-dir`` wins over ``COREDUMP_TARGET_DIRS`` (colon-separated),
+    which wins over :data:`DEFAULT_TARGET_DIRS`.
+
+    Args:
+        target_dir: The ``--target-dir`` CLI value, or ``None`` if unset.
+
+    Returns:
+        The ordered list of candidate directory paths (may contain empties).
+
+    """
+    if target_dir:
+        return [target_dir]
+    target_dirs = os.environ.get("COREDUMP_TARGET_DIRS")
+    return target_dirs.split(":") if target_dirs else list(DEFAULT_TARGET_DIRS)
+
+
+def _run_verify(target_dir: str | None, as_json: bool) -> int:
+    """Run ``--verify`` mode: assert the handler-ran contract, never read stdin.
+
+    Resolves the bundle directory *read-only* — it deliberately does NOT call
+    :func:`resolve_target_dir`, which would ``mkdir()`` the directory and so
+    fabricate the very directory whose absence is the lost-signal indicator.
+
+    Args:
+        target_dir: The ``--target-dir`` CLI value, or ``None`` if unset.
+        as_json: Whether to emit a JSON status envelope instead of plain text.
+
+    Returns:
+        ``0`` if the handler provably ran (``OK``/``RAN_WITH_ERRORS``), else
+        :data:`VERIFY_SIGNAL_LOST_EXIT` (verdict ``NOT_RUN``).
+
+    """
+    cleaned = [c for c in _resolve_candidates(target_dir) if c]
+    if not cleaned:
+        raise ValueError("no candidate target directories provided")
+    # log_dir is the parent of target_dir (see write_core).
+    target = next((Path(c) for c in cleaned if Path(c).is_dir()), Path(cleaned[-1]))
+    verdict, detail = verify_crash_bundle(target.parent)
+    exit_code = 0 if verdict in (BUNDLE_OK, BUNDLE_RAN_WITH_ERRORS) else VERIFY_SIGNAL_LOST_EXIT
+    if as_json:
+        emit_json_status(exit_code, message=detail, verdict=verdict)
+    else:
+        print(f"{verdict}: {detail}", file=sys.stdout if exit_code == 0 else sys.stderr)
+    return exit_code
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -259,6 +386,23 @@ def main(argv: list[str] | None = None) -> int:
     """
     args = _build_parser().parse_args(argv)
 
+    if args.verify:
+        return _run_verify(args.target_dir, args.json)
+
+    # Capture path: positionals are kernel-supplied. They are declared optional
+    # only so --verify can omit them; a real capture invocation missing them is
+    # a malformed core_pattern line and must fail loudly, not silently no-op.
+    missing = [
+        name for name in ("pid", "exe", "crash_time", "signal") if getattr(args, name) is None
+    ]
+    if missing:
+        msg = f"missing required argument(s) for capture: {', '.join(missing)}"
+        if args.json:
+            emit_json_status(1, message=msg)
+        else:
+            print(f"hephaestus-coredump-handler: {msg}", file=sys.stderr)
+        return 1
+
     # TTY guard: when invoked by the kernel, stdin is a pipe carrying the core
     # ELF. When invoked manually on a terminal with no piped input, reading
     # stdin would hang forever — refuse early.
@@ -275,13 +419,7 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     # --target-dir wins over the env var, which wins over the built-in default.
-    if args.target_dir:
-        candidates = [args.target_dir]
-    else:
-        target_dirs = os.environ.get("COREDUMP_TARGET_DIRS")
-        candidates = target_dirs.split(":") if target_dirs else list(DEFAULT_TARGET_DIRS)
-
-    target_dir = resolve_target_dir(candidates)
+    target_dir = resolve_target_dir(_resolve_candidates(args.target_dir))
 
     max_bytes_env = os.environ.get("COREDUMP_MAX_BYTES")
     if max_bytes_env and max_bytes_env.strip():

--- a/scripts/shell/coredump-host-handler.sh
+++ b/scripts/shell/coredump-host-handler.sh
@@ -127,6 +127,7 @@ SIZE=$(stat -c %s "$OUT" 2>/dev/null || echo "?")
 
 # Kernel-invoked: if the log append failed (e.g. LOG_DIR is unwritable), there
 # is no safe way to surface the error — the kernel has no channel for our exit
-# code. Failure here is silent by design; a downstream artifact-upload step
-# should surface a missing handler.log as "handler was not invoked".
+# code. Failure here is silent by design. A downstream artifact-upload step
+# MUST enforce the contract by running `hephaestus-coredump-handler --verify
+# --target-dir "$TARGET"` and failing the job when it exits 3 (NOT_RUN).
 true

--- a/tests/unit/forensics/test_coredump_handler.py
+++ b/tests/unit/forensics/test_coredump_handler.py
@@ -367,6 +367,27 @@ class TestVerifyCrashBundle:
         verdict, _ = verify_crash_bundle(tmp_path)
         assert verdict == BUNDLE_RAN_WITH_ERRORS
 
+    def test_error_line_with_embedded_wrote_substring_is_not_ok(self, tmp_path: Path) -> None:
+        """An ERROR line whose path embeds the literal ' wrote ' must not be OK.
+
+        The exe basename (%e) can contain spaces, so a failure path like
+        ``/cores/x wrote y`` must not be misclassified as a successful capture.
+        The classifier anchors on the message starting with ``wrote ``, so an
+        ``ERROR:`` message is correctly RAN_WITH_ERRORS.
+        """
+        from hephaestus.forensics.coredump_handler import (
+            BUNDLE_RAN_WITH_ERRORS,
+            verify_crash_bundle,
+        )
+
+        (tmp_path / "handler.log").write_text(
+            "2026-06-12T00:00:00+00:00 ERROR: failed to write core to "
+            "/x/core.1.evil wrote me.0.sig11 (disk full)\n",
+            encoding="utf-8",
+        )
+        verdict, _ = verify_crash_bundle(tmp_path)
+        assert verdict == BUNDLE_RAN_WITH_ERRORS
+
 
 class TestMainVerify:
     """CLI --verify mode (issue #1207)."""

--- a/tests/unit/forensics/test_coredump_handler.py
+++ b/tests/unit/forensics/test_coredump_handler.py
@@ -301,3 +301,143 @@ class TestMaxBytesEnvFallback:
         log_path = tmp_path / "handler.log"
         if log_path.exists():
             assert "COREDUMP_MAX_BYTES" not in log_path.read_text(encoding="utf-8")
+
+
+class TestVerifyCrashBundle:
+    """Tests for the executable handler-ran contract (issue #1207)."""
+
+    def test_missing_log_is_not_run(self, tmp_path: Path) -> None:
+        from hephaestus.forensics.coredump_handler import (
+            BUNDLE_NOT_RUN,
+            verify_crash_bundle,
+        )
+
+        verdict, _ = verify_crash_bundle(tmp_path)  # no handler.log present
+        assert verdict == BUNDLE_NOT_RUN
+
+    def test_empty_log_is_not_run(self, tmp_path: Path) -> None:
+        from hephaestus.forensics.coredump_handler import (
+            BUNDLE_NOT_RUN,
+            verify_crash_bundle,
+        )
+
+        (tmp_path / "handler.log").write_text("\n  \n", encoding="utf-8")
+        verdict, _ = verify_crash_bundle(tmp_path)
+        assert verdict == BUNDLE_NOT_RUN
+
+    def test_capture_line_is_ok(self, tmp_path: Path) -> None:
+        from hephaestus.forensics.coredump_handler import (
+            BUNDLE_OK,
+            verify_crash_bundle,
+        )
+
+        (tmp_path / "handler.log").write_text(
+            "2026-06-12T00:00:00+00:00 wrote /x/core.1.p.2.sig11 (10 bytes) signal=11 exe=p\n",
+            encoding="utf-8",
+        )
+        verdict, _ = verify_crash_bundle(tmp_path)
+        assert verdict == BUNDLE_OK
+
+    def test_successful_capture_with_chmod_warning_is_ok(self, tmp_path: Path) -> None:
+        """A `wrote` line + a WARNING (chmod/max_bytes) is still OK, not RAN_WITH_ERRORS."""
+        from hephaestus.forensics.coredump_handler import (
+            BUNDLE_OK,
+            verify_crash_bundle,
+        )
+
+        (tmp_path / "handler.log").write_text(
+            "2026-06-12T00:00:00+00:00 WARNING: chmod 644 /x/core.1 failed "
+            "(EPERM); file may be unreadable\n"
+            "2026-06-12T00:00:00+00:00 wrote /x/core.1 (10 bytes) signal=11 exe=p\n",
+            encoding="utf-8",
+        )
+        verdict, _ = verify_crash_bundle(tmp_path)
+        assert verdict == BUNDLE_OK
+
+    def test_error_without_wrote_is_ran_with_errors(self, tmp_path: Path) -> None:
+        from hephaestus.forensics.coredump_handler import (
+            BUNDLE_RAN_WITH_ERRORS,
+            verify_crash_bundle,
+        )
+
+        (tmp_path / "handler.log").write_text(
+            "2026-06-12T00:00:00+00:00 ERROR: failed to write core to /x/core.1 (disk full)\n",
+            encoding="utf-8",
+        )
+        verdict, _ = verify_crash_bundle(tmp_path)
+        assert verdict == BUNDLE_RAN_WITH_ERRORS
+
+
+class TestMainVerify:
+    """CLI --verify mode (issue #1207)."""
+
+    def test_verify_missing_bundle_exits_3(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b""))  # never read in verify mode
+        cores = tmp_path / "cores"  # parent (tmp_path) has no handler.log
+        rc = main(["--verify", "--target-dir", str(cores)])
+        assert rc == 3
+
+    def test_verify_present_log_exits_0(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b""))
+        cores = tmp_path / "cores"
+        (tmp_path / "handler.log").write_text(
+            "2026-06-12T00:00:00+00:00 wrote /x (5 bytes) signal=11 exe=p\n",
+            encoding="utf-8",
+        )
+        rc = main(["--verify", "--target-dir", str(cores)])
+        assert rc == 0
+
+    def test_verify_does_not_create_target_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Verify must not fabricate the directory whose absence is the signal."""
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b""))
+        cores = tmp_path / "cores"
+        main(["--verify", "--target-dir", str(cores)])
+        assert not cores.exists()
+
+    def test_verify_json_envelope_on_not_run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import json
+
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b""))
+        cores = tmp_path / "cores"
+        rc = main(["--verify", "--json", "--target-dir", str(cores)])
+        payload = json.loads(capsys.readouterr().out)
+        assert rc == 3
+        # emit_json_status: status is the string "error" for non-zero, code is in
+        # exit_code, and verdict arrives via **extra (per cli/utils.py).
+        assert payload["status"] == "error"
+        assert payload["exit_code"] == 3
+        assert payload["verdict"] == "NOT_RUN"
+
+
+class TestMainCaptureGuards:
+    """Capture path stays loud after positionals became optional (issue #1207)."""
+
+    def test_missing_positionals_without_verify_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A capture invocation missing kernel tokens must fail loudly, not no-op."""
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b"core-bytes"))
+        rc = main(["--target-dir", str(tmp_path / "cores")])  # no pid/exe/time/sig
+        assert rc == 1
+
+    def test_full_capture_still_writes_core(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: a complete capture invocation still writes the core."""
+        monkeypatch.setattr("sys.stdin", _FakeStdin(b"ELFDATA"))
+        cores = tmp_path / "cores"
+        cores.mkdir()
+        rc = main(["--target-dir", str(cores), "1234", "proc", "1700000000", "11", "5678"])
+        assert rc == 0
+        assert list(cores.glob("core.1234.proc.*.sig11"))


### PR DESCRIPTION
## Summary

Issue #1207 observed that the coredump handler's failure-signal contract — *"a missing `handler.log` means the handler never ran"* — was documented but **un-guarded**: nothing asserted it, so a downstream CI artifact step that forgets to check `handler.log` would silently lose the only failure signal.

This adds a small, tested, reusable `verify_crash_bundle()` plus a `--verify` mode on the existing `hephaestus-coredump-handler` console script, turning the prose convention into an executable, blocking check that CI or any consumer can call.

## What changed

- **`verify_crash_bundle(log_dir) -> (verdict, detail)`** classifies a crash bundle into `OK` / `RAN_WITH_ERRORS` / `NOT_RUN`. A `wrote ` line is the authoritative success signal (so a successful capture that also logged a chmod/`COREDUMP_MAX_BYTES` WARNING is still `OK`); a missing/empty/unreadable `handler.log` is `NOT_RUN` — the silent-loss case.
- **`--verify` CLI mode** exits `0` when the handler provably ran and `3` (`VERIFY_SIGNAL_LOST_EXIT`) on `NOT_RUN`. Exit `3` is deliberately distinct from argparse's usage-error `2` and `gdb_runner`'s `2`, so a CI gate can tell "signal lost" apart from "bad command line".
- **Read-only resolution**: `--verify` never `mkdir()`s the target dir, so it cannot fabricate the directory whose absence is the signal.
- **Capture path stays loud**: positionals became optional only so `--verify` can omit the kernel tokens; a real capture invocation missing them now fails with exit `1` instead of silently no-opping.
- **Doc/shell sync**: module docstring and `scripts/shell/coredump-host-handler.sh` comment now reference the executable guard.

## Tests

`TestVerifyCrashBundle`, `TestMainVerify`, and `TestMainCaptureGuards` cover all classification branches, the exit-`3` contract, the no-fabrication invariant, the JSON envelope (`status=="error"`, `exit_code==3`, `verdict=="NOT_RUN"`), and a full-capture regression. Full forensics + validation suites: 764 passed. `ruff`, `ruff format`, and `mypy` all clean.

Closes #1207