### PR TITLE
ci(pre-commit): wire hephaestus-check-precommit-versions hook to enforce rev drift (#1183)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,10 @@
 #                                                      this rev current with it
 #     - markdownlint-cli2 (DavidAnson rev)          ⇄ CI markdownlint-cli2-action
 #     - pre-commit-hooks (pre-commit/pre-commit-hooks rev) ⇄ meta hooks, no pixi pkg
-#   `hephaestus-check-precommit-versions` flags drift for the pixi-backed tools.
+#   The `hephaestus-check-precommit-versions` hook (wired as a local hook below)
+#   flags drift for the pixi-backed mirrored tools — currently `yamllint`, whose
+#   floor pixi.toml owns. markdownlint-cli2 (CI action) and shellcheck (apt) have
+#   no pixi package and so are not version-checked here.
 
 repos:
 
@@ -183,6 +186,21 @@ repos:
         language: system
         pass_filenames: false
         files: ^(pyproject\.toml|pixi\.toml|\.github/workflows/.*\.yml)$
+
+  # Pre-commit rev drift check: mirrored external hook revs (e.g. yamllint)
+  # must stay within their pixi.toml version floors. See the single-source-of-
+  # truth note at the top of this file and issue #1183.
+  - repo: local
+    hooks:
+      - id: hephaestus-check-precommit-versions
+        name: hephaestus check pre-commit rev drift
+        description: Ensure mirrored .pre-commit-config.yaml hook revs match pixi.toml version floors
+        # --environment default is explicit because the pre-commit CI job runs
+        # in the lint env; the hephaestus-* console scripts live in default.
+        entry: pixi run --environment default hephaestus-check-precommit-versions
+        language: system
+        pass_filenames: false
+        files: ^(\.pre-commit-config\.yaml|pixi\.toml)$
 
   # Version single source of truth check
   - repo: local

--- a/hephaestus/ci/precommit.py
+++ b/hephaestus/ci/precommit.py
@@ -49,10 +49,19 @@ else:
 # ---------------------------------------------------------------------------
 
 #: Default mapping from external pre-commit repo URL to pixi.toml package name.
+#:
+#: Only tools that are *pixi-backed* (have a version floor in pixi.toml) belong
+#: here, so the hook can flag local-vs-CI drift. ``yamllint`` is the mirrored
+#: external hook whose floor pixi.toml owns (see the single-source-of-truth note
+#: at the top of ``.pre-commit-config.yaml``). ``mirrors-mypy`` maps to the
+#: ``mypy`` floor for repos that mirror mypy as an external hook. Meta hooks
+#: like ``pre-commit/pre-commit-hooks`` are intentionally absent: they have no
+#: pixi package (they run in pre-commit's own venv), so requiring a pixi entry
+#: would produce a false MISSING finding.
 DEFAULT_HOOK_TO_PIXI_MAP: dict[str, str] = {
     "https://github.com/pre-commit/mirrors-mypy": "mypy",
     "https://github.com/kynan/nbstripout": "nbstripout",
-    "https://github.com/pre-commit/pre-commit-hooks": "pre-commit-hooks",
+    "https://github.com/adrienverge/yamllint": "yamllint",
 }
 
 

--- a/tests/unit/automation/test_invoke_allowed_tools_scoping.py
+++ b/tests/unit/automation/test_invoke_allowed_tools_scoping.py
@@ -42,12 +42,12 @@ def _allowed_tools_kwargs(path: pathlib.Path) -> list[str]:
                 f"{path.name}: invoke_claude_with_session call missing allowed_tools= kwarg"
             )
         val = kwargs["allowed_tools"]
-        if not (isinstance(val, ast.Constant) and isinstance(val.value, str)):
-            pytest.fail(
-                f"{path.name}: allowed_tools must be a string literal "
-                "(this test asserts that contract)"
-            )
-        out.append(val.value)
+        if isinstance(val, ast.Constant) and isinstance(val.value, str):
+            out.append(val.value)
+            continue
+        pytest.fail(
+            f"{path.name}: allowed_tools must be a string literal (this test asserts that contract)"
+        )
     return out
 
 


### PR DESCRIPTION
## Summary

`.pre-commit-config.yaml`'s header note promised that
`hephaestus-check-precommit-versions` enforces that mirrored external hook revs
stay within their `pixi.toml` version floors, and the console script existed
(`pyproject.toml [project.scripts]`), but it was wired **nowhere** as a hook or
CI step. The invariant was unenforced (issue #1183).

## Changes

- **Wire the hook**: added `hephaestus-check-precommit-versions` as a local
  pre-commit hook scoped to `.pre-commit-config.yaml` and `pixi.toml`, following
  the existing `hephaestus-*` local-hook pattern
  (`pixi run --environment default ...`, `language: system`,
  `pass_filenames: false`).
- **Fix the check to match its documented intent**: `DEFAULT_HOOK_TO_PIXI_MAP`
  previously mapped `pre-commit/pre-commit-hooks` (a meta-hook with **no** pixi
  package), so the check exited 1 on `main` with a false `MISSING` finding. The
  map now tracks the actually pixi-backed mirrored tool
  (`adrienverge/yamllint -> yamllint`) and drops the meta-hook entry. Updated the
  header note to state accurately which tools are version-checked
  (`yamllint`; markdownlint-cli2 and shellcheck have no pixi package). The wired
  hook now **passes** — no rev drift exists once the map reflects reality.

## Unblock (unrelated pre-existing CI debt)

`main`'s CI pre-commit gate was already **red** on
`tests/unit/automation/test_invoke_allowed_tools_scoping.py:50`
(`"expr" has no attribute "value"`) — the sole failure, blocking *all* PRs. The
negated compound `isinstance` guard did not narrow `val` to `ast.Constant`.
Restructured to a positive `isinstance` guard so mypy narrows correctly. Pure
type-narrowing fix; the 8 assertions are unchanged and still pass.

## Verification

- `pixi run --environment lint pre-commit run hephaestus-check-precommit-versions --all-files` → Passed
- `pixi run --environment lint pre-commit run --all-files` → green (RC=0, no Failed)
- `pytest tests/unit/ci/test_precommit.py tests/unit/automation/test_invoke_allowed_tools_scoping.py` → 51 passed

Closes #1183

🤖 Generated with [Claude Code](https://claude.com/claude-code)