### PR TITLE
feat(ci): guard build/ scratch dir from becoming tracked (#1214)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -213,6 +213,18 @@ repos:
         language: system
         pass_filenames: false
         files: ^SECURITY\.md$
+      - id: check-build-dir-untracked
+        name: build/ must stay untracked (gitignored automation scratch)
+        description: >
+          build/ is the sanctioned, gitignored scratch dir for the automation
+          loop. Its name collides with the packaging-output convention, so a
+          stray `git add build/...` or a widened sdist allowlist could sweep
+          automation logs into a distribution. Fail if anything is tracked
+          under build/. See issue #1214.
+        entry: python3 scripts/check_build_dir_untracked.py
+        language: system
+        pass_filenames: false
+        always_run: true
 
 
   # Skill merge method check: skills must not hardcode merge flags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,17 @@ wheel into a plain virtualenv (`pip install -e '.[dev]'`) — pixi tooling is
 not available there, and any subpackage with POSIX-only assumptions is out
 of scope for this project's supported development environment (track those separately).
 
+### The `build/` directory
+
+`build/` is gitignored **automation scratch**, not packaging output. The
+automation loop writes work reports, loop logs, and audit artifacts there
+(see `hephaestus/automation/loop_runner.py`). Despite the name, no build or
+distribution artifacts come from it — the sdist `only-include` allowlist in
+`pyproject.toml` excludes it. Never `git add` anything under `build/`; the
+`check-build-dir-untracked` pre-commit hook enforces this (issue #1214). To
+clear local scratch, stop any running automation loop first, then
+`git clean -fdX build/` (removes only ignored files).
+
 ## Code Style
 
 We follow these style guidelines:

--- a/scripts/check_build_dir_untracked.py
+++ b/scripts/check_build_dir_untracked.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Reject tracked files under ``build/``.
+
+``build/`` is the sanctioned, gitignored scratch location for the automation
+loop (see ``hephaestus/automation/loop_runner.py`` and CLAUDE.md). Its name
+collides with the packaging-output convention, so a stray ``git add build/...``
+or a widened sdist allowlist could sweep automation logs into a distribution
+(issue #1214). This guard hard-fails if anything becomes tracked under
+``build/`` so the collision can never be realized.
+
+Usage:
+    python scripts/check_build_dir_untracked.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    """Return the repository root by walking up to the nearest ``pyproject.toml``."""
+    path = Path(__file__).resolve().parent
+    while path != path.parent:
+        if (path / "pyproject.toml").exists():
+            return path
+        path = path.parent
+    return Path(__file__).resolve().parent.parent
+
+
+def tracked_build_files(repo_root: Path) -> list[str]:
+    """Return git-tracked paths under ``build/`` (empty when clean)."""
+    result = subprocess.run(
+        ["git", "ls-files", "build/"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> int:
+    """Fail (exit 1) if any file is tracked under ``build/``."""
+    if len(sys.argv) > 1 and sys.argv[1] in ("--help", "-h"):
+        print(__doc__)
+        return 0
+    repo_root = get_repo_root()
+    tracked = tracked_build_files(repo_root)
+    if tracked:
+        print("ERROR: files are tracked under build/, which is gitignored")
+        print("automation scratch, not packaging output (issue #1214).")
+        for path in tracked:
+            print(f"  {path}")
+        print("\nUntrack them with: git rm --cached " + " ".join(tracked))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_check_build_dir_untracked.py
+++ b/tests/unit/scripts/test_check_build_dir_untracked.py
@@ -1,0 +1,54 @@
+"""Tests for scripts/check_build_dir_untracked.py (issue #1214)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "check_build_dir_untracked.py"
+_spec = importlib.util.spec_from_file_location("check_build_dir_untracked", _SCRIPT)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_passes_when_no_tracked_build_files(tmp_path: Path) -> None:
+    """A clean repo has zero tracked files under build/."""
+    repo = _init_repo(tmp_path)
+    assert _mod.tracked_build_files(repo) == []
+
+
+def test_detects_tracked_build_file(tmp_path: Path) -> None:
+    """A force-added file under build/ is reported as tracked."""
+    repo = _init_repo(tmp_path)
+    build = repo / "build"
+    build.mkdir()
+    (build / "leaked.log").write_text("junk", encoding="utf-8")
+    subprocess.run(["git", "add", "-f", "build/leaked.log"], cwd=repo, check=True)
+    assert _mod.tracked_build_files(repo) == ["build/leaked.log"]
+
+
+def test_main_exits_zero_on_clean_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """main() returns 0 when nothing is tracked under build/."""
+    repo = _init_repo(tmp_path)
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: repo)
+    assert _mod.main() == 0
+
+
+def test_help_flag_prints_doc_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--help must exit 0 AND print non-empty output (smoke-test contract)."""
+    monkeypatch.setattr("sys.argv", ["check_build_dir_untracked.py", "--help"])
+    assert _mod.main() == 0
+    out = capsys.readouterr().out
+    assert out.strip(), "--help produced no output"


### PR DESCRIPTION
## Summary

`build/` is the sanctioned, gitignored scratch location for the automation loop (`loop_runner.py` work reports, loop logs, audit artifacts), but its name collides with the packaging-output convention. The audit (issue #1214) flagged it as "one stray glob away from being swept into a distribution."

This PR adds a **regression guard** that hard-fails if any file ever becomes *tracked* under `build/`, closing the packaging-namespace collision structurally:

- **`scripts/check_build_dir_untracked.py`** — stdlib-only guard; `git ls-files build/` must stay empty. Honors `--help`/`-h` (smoke-test contract). No `# noqa` (S603 is not in the ruff `select`).
- **`tests/unit/scripts/test_check_build_dir_untracked.py`** — TDD RED-first; covers core logic + the `--help` contract directly.
- **`.pre-commit-config.yaml`** — `check-build-dir-untracked` `repo: local` hook (rides the required lint gate).
- **`CONTRIBUTING.md`** — documents the `build/` scratch convention and the safe local-cleanup path (`git clean -fdX build/` after stopping the loop).

## Why no deletion / no gitignore edit

- `git ls-files build/` → **0** tracked files (junk is untracked-but-on-disk).
- `.gitignore:5: build/` already ignores everything (`git check-ignore -v build/` confirms).
- The sdist `only-include` allowlist (`pyproject.toml`) excludes `build/` — harmless to the wheel.
- Deleting on-disk logs is futile: a live automation loop regenerates them within seconds.

## Verification

- `pytest tests/unit/scripts/` → 76 passed (incl. 4 new + auto-discovered smoke test for the new script).
- `ruff check` / `ruff format --check` → clean.
- `pre-commit run --files <changed>` → all hooks pass (markdownlint, mypy, ruff, bandit, new guard).

Closes #1214