### PR TITLE
refactor(utils): consolidate get_repo_root duplicates (#1221)

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -11,8 +11,11 @@ import logging
 import subprocess
 from pathlib import Path
 
-from hephaestus.utils.helpers import get_repo_root as _get_repo_root
-from hephaestus.utils.helpers import run_subprocess
+# ``get_repo_root`` is re-exported (not redefined) so that the single canonical
+# implementation in ``hephaestus.utils.helpers`` is used everywhere, while
+# ``hephaestus.automation.git_utils.get_repo_root`` remains a stable, patchable
+# import path for the automation package and its tests.
+from hephaestus.utils.helpers import get_repo_root, run_subprocess
 from hephaestus.utils.retry import retry_with_backoff
 
 logger = logging.getLogger(__name__)
@@ -57,22 +60,6 @@ def run(
         log_on_error=log_errors,
         env=env,
     )
-
-
-def get_repo_root(path: Path | None = None) -> Path:
-    """Find the git repository root directory.
-
-    Args:
-        path: Starting path for search (defaults to cwd)
-
-    Returns:
-        Path to repository root
-
-    Raises:
-        RuntimeError: If not in a git repository
-
-    """
-    return _get_repo_root(path)
 
 
 _repo_info_cache: dict[Path | None, tuple[str, str]] = {}

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -14,8 +14,11 @@ from pathlib import Path
 # ``get_repo_root`` is re-exported (not redefined) so that the single canonical
 # implementation in ``hephaestus.utils.helpers`` is used everywhere, while
 # ``hephaestus.automation.git_utils.get_repo_root`` remains a stable, patchable
-# import path for the automation package and its tests.
-from hephaestus.utils.helpers import get_repo_root, run_subprocess
+# import path for the automation package and its tests. The ``X as X`` form
+# marks it an explicit re-export so mypy does not flag ``attr-defined`` at the
+# 13 import sites under --no-implicit-reexport.
+from hephaestus.utils.helpers import get_repo_root as get_repo_root
+from hephaestus.utils.helpers import run_subprocess
 from hephaestus.utils.retry import retry_with_backoff
 
 logger = logging.getLogger(__name__)

--- a/hephaestus/scripts_lib/check_python_version_consistency.py
+++ b/hephaestus/scripts_lib/check_python_version_consistency.py
@@ -12,15 +12,17 @@ import re
 import sys
 from pathlib import Path
 
+from hephaestus.utils.helpers import get_repo_root as _get_repo_root
+
 
 def get_repo_root() -> Path:
-    """Find repository root by looking for pyproject.toml."""
-    path = Path(__file__).resolve().parent.parent.parent
-    while path != path.parent:
-        if (path / "pyproject.toml").exists():
-            return path
-        path = path.parent
-    return Path(__file__).resolve().parent.parent.parent
+    """Find repository root, anchored to this module's location.
+
+    Delegates to the canonical :func:`hephaestus.utils.helpers.get_repo_root`,
+    seeding the search from this file so resolution is independent of the
+    current working directory (this script may run from anywhere).
+    """
+    return _get_repo_root(Path(__file__).resolve().parent)
 
 
 def extract_pyproject_versions(content: str) -> dict[str, str]:

--- a/hephaestus/scripts_lib/check_version_single_source.py
+++ b/hephaestus/scripts_lib/check_version_single_source.py
@@ -23,6 +23,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from hephaestus.utils.helpers import get_repo_root as _get_repo_root
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover - exercised only on Python 3.10
@@ -30,13 +32,13 @@ else:  # pragma: no cover - exercised only on Python 3.10
 
 
 def get_repo_root() -> Path:
-    """Find repository root by looking for pyproject.toml."""
-    path = Path(__file__).resolve().parent.parent.parent
-    while path != path.parent:
-        if (path / "pyproject.toml").exists():
-            return path
-        path = path.parent
-    return Path(__file__).resolve().parent.parent.parent
+    """Find repository root, anchored to this module's location.
+
+    Delegates to the canonical :func:`hephaestus.utils.helpers.get_repo_root`,
+    seeding the search from this file so resolution is independent of the
+    current working directory (this script may run from anywhere).
+    """
+    return _get_repo_root(Path(__file__).resolve().parent)
 
 
 def _load_toml(path: Path) -> dict[str, Any]:

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -97,25 +97,33 @@ def flatten_dict(d: dict[str, Any], parent_key: str = "", sep: str = ".") -> dic
 
 
 def get_repo_root(start_path: str | Path | None = None) -> Path:
-    """Find repository root by looking for .git directory.
+    """Find repository root by walking up to a ``.git`` or ``pyproject.toml`` marker.
+
+    This is the single canonical repository-root resolver for the codebase. It
+    accepts an optional starting path so callers anchored to a file (e.g.
+    ``Path(__file__)``) and callers relying on the current working directory can
+    share one implementation. A directory is treated as the repository root if it
+    contains either a ``.git`` entry (git checkout) or a ``pyproject.toml`` file
+    (project marker), covering both git-based and packaging-based callers.
 
     Args:
         start_path: Starting path to search from. Defaults to current directory.
 
     Returns:
-        Path to repository root if found, otherwise the original start_path as fallback.
+        Path to repository root if found, otherwise the resolved start path as a
+        fallback.
 
     """
     start_path = Path.cwd() if start_path is None else Path(start_path).resolve()
 
     path = start_path
     while path != path.parent:  # Stop at filesystem root
-        if (path / ".git").exists():
+        if (path / ".git").exists() or (path / "pyproject.toml").exists():
             return path
         path = path.parent
 
-    # If we get here, we didn't find a .git directory
-    # Return the original start path as fallback
+    # No marker found anywhere on the path to the filesystem root; fall back to
+    # the original start path.
     return start_path
 
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -70,15 +70,18 @@ class TestRun:
 class TestGetRepoRoot:
     """Tests for get_repo_root function."""
 
-    @patch("hephaestus.automation.git_utils._get_repo_root")
-    def test_successful_detection(self, mock_get_root: Any) -> None:
-        """Test successful repository root detection."""
-        mock_get_root.return_value = Path("/home/user/repo")
+    @patch("hephaestus.utils.helpers.Path.cwd")
+    def test_successful_detection(self, mock_cwd: Any, tmp_path: Any) -> None:
+        """Test successful repository root detection via the canonical resolver."""
+        repo = tmp_path / "repo"
+        (repo / ".git").mkdir(parents=True)
+        sub = repo / "src" / "pkg"
+        sub.mkdir(parents=True)
+        mock_cwd.return_value = sub
 
         root = get_repo_root()
 
-        assert root == Path("/home/user/repo")
-        mock_get_root.assert_called_once()
+        assert root == repo
 
     def test_returns_path(self, tmp_path: Any) -> None:
         """Test that get_repo_root returns a Path object."""


### PR DESCRIPTION
Consolidates four divergent get_repo_root implementations into a single canonical resolver in hephaestus/utils/helpers.py.

- helpers.get_repo_root is now the one implementation, generalized to accept an optional start path and to treat either a .git entry or a pyproject.toml file as the repo-root marker (a superset of all prior callers).
- hephaestus/automation/git_utils.py re-exports the canonical function (drops its wrapper def; still patchable as hephaestus.automation.git_utils.get_repo_root).
- The two scripts_lib modules (check_python_version_consistency.py, check_version_single_source.py) delegate to it, seeding the search from their own module location so resolution stays cwd-independent.
- Updated the git_utils test that patched the removed internal alias.

Verification: tests/unit/{utils,automation,scripts} 1769 passed; ruff check hephaestus clean; mypy success (374 files).

Closes #1221