### PR TITLE
[Fix] Honor --json in hephaestus-check-repo-analyze-skills

### DIFF
--- a/hephaestus/validation/repo_analyze_skills.py
+++ b/hephaestus/validation/repo_analyze_skills.py
@@ -16,7 +16,7 @@ from string import Template
 
 import yaml
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg
+from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMMON_DIR = REPO_ROOT / "skills" / "_repo_analyze_common"
@@ -165,14 +165,24 @@ def main(argv: list[str] | None = None) -> int:
             current = target.read_text(encoding="utf-8") if target.exists() else ""
             if current != rendered:
                 drift.append(variant["name"])
-    if drift and not args.write:
-        print(f"Drift detected in: {', '.join(drift)}", file=sys.stderr)
-        print(
-            "Run: pixi run --environment default hephaestus-check-repo-analyze-skills --write",
-            file=sys.stderr,
+    has_drift = bool(drift) and not args.write
+    exit_code = 1 if has_drift else 0
+    remediation = "Run: pixi run --environment default hephaestus-check-repo-analyze-skills --write"
+
+    if args.json:
+        message = f"Drift detected in: {', '.join(drift)}" if has_drift else "No drift detected"
+        emit_json_status(
+            exit_code,
+            message=message,
+            drift=drift,
+            remediation=remediation if has_drift else None,
         )
-        return 1
-    return 0
+        return exit_code
+
+    if has_drift:
+        print(f"Drift detected in: {', '.join(drift)}", file=sys.stderr)
+        print(remediation, file=sys.stderr)
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tests/unit/validation/test_repo_analyze_skills.py
+++ b/tests/unit/validation/test_repo_analyze_skills.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from hephaestus.validation.repo_analyze_skills import main
@@ -95,3 +96,47 @@ def test_rendered_skill_md_files_use_lf_line_endings() -> None:
     for name in EXPECTED_VARIANTS:
         raw = (SKILLS_DIR / name / "SKILL.md").read_bytes()
         assert b"\r\n" not in raw, f"{name}: CRLF detected"
+
+
+def test_json_flag_emits_valid_json_on_clean_tree(capsys) -> None:
+    """--json on a clean tree emits a parseable ok envelope to stdout, exit 0."""
+    assert main(["--check", "--json"]) == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["status"] == "ok"
+    assert payload["exit_code"] == 0
+    assert payload["drift"] == []
+
+
+def test_json_flag_emits_drift_envelope_on_tampering(capsys) -> None:
+    """--json surfaces drift as a JSON list with exit_code 1, not silent text."""
+    partial = SKILLS_DIR / "_repo_analyze_common" / "principles.md"
+    backup = partial.read_text()
+    try:
+        partial.write_text(backup + "<!-- tamper -->\n")
+        assert main(["--check", "--json"]) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "error"
+        assert payload["exit_code"] == 1
+        assert payload["drift"]  # non-empty list of drifted variant names
+        assert set(payload["drift"]).issubset(EXPECTED_VARIANTS)
+    finally:
+        partial.write_text(backup)
+
+
+def test_json_flag_with_write_emits_ok_envelope(capsys) -> None:
+    """--json --write reports success as JSON instead of being ignored."""
+    snapshots: dict[str, bytes] = {}
+    for name in EXPECTED_VARIANTS:
+        skill_md = SKILLS_DIR / name / "SKILL.md"
+        if skill_md.exists():
+            snapshots[name] = skill_md.read_bytes()
+    try:
+        assert main(["--write", "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["status"] == "ok"
+        assert payload["exit_code"] == 0
+        assert payload["drift"] == []
+    finally:
+        for name, content in snapshots.items():
+            (SKILLS_DIR / name / "SKILL.md").write_bytes(content)


### PR DESCRIPTION
## Summary

`hephaestus-check-repo-analyze-skills` registered `--json` via `add_json_arg(parser)` but `main()` never read `args.json`, so passing `--json` silently emitted the plain-text/stderr drift output with no JSON and no error — a POLA violation flagged by the strict repo audit (#1217). Every other data/status CLI in the repo correctly branches on `args.json`.

## Changes

- **`hephaestus/validation/repo_analyze_skills.py`**: import `emit_json_status` and wire `args.json` into `main()`'s terminal logic. When `--json` is passed, emit a machine-readable status envelope on stdout carrying the real exit code (`1` on drift, `0` clean), the `drift` list, and a remediation hint. The non-JSON text path (two stderr lines, `return 1`/`0`) is preserved exactly. `--json` is honored in `--write` mode too for POLA consistency.
- **`tests/unit/validation/test_repo_analyze_skills.py`**: replace the help-text-only coverage gap with three behavioral tests that parse `main(["--json"])` output with `json.loads` and assert envelope contents + exit code for the clean, drift, and write paths.

This is a status-shaped CLI (pass/fail + exit code, no structured data model), so `emit_json_status()` is used per the `add_json_arg` docstring contract, not `format_output()`.

## Verification

- `pixi run python -m pytest tests/unit/validation/test_repo_analyze_skills.py -v` — 11 passed (target module 100% coverage)
- `pixi run mypy` — Success, no issues in 371 source files
- `pixi run ruff check` / `ruff format` — clean
- Integration help-guard (`test_cli_entry_points.py -k json`) — still passes (flag stays registered)
- End-to-end module invocation confirms valid JSON on both clean (`status:ok`, exit 0) and drift (`status:error`, exit 1) paths

Closes #1217