### PR TITLE
[Refactor] Skip duplicate pip-audit/sast on PRs in security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,6 +18,10 @@ permissions:
 jobs:
   pip-audit:
     name: Dependency vulnerability scan
+    # PR-time pip-audit runs in _required.yml (security/dependency-scan). Skip
+    # here on PRs to avoid the ~2x duplicate run; still runs on the weekly
+    # schedule + manual dispatch. See issue #1182.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -57,6 +61,10 @@ jobs:
 
   sast:
     name: Static Application Security Testing
+    # PR-time SAST runs in _required.yml (security/sast-scan). Skip here on PRs
+    # to avoid the ~2x duplicate run; still runs on the weekly schedule +
+    # manual dispatch. See issue #1182.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 


### PR DESCRIPTION
## Summary

`security.yml`'s `pip-audit` and `sast` jobs ran the identical `pixi run --environment lint pip-audit` / `sast` commands as `_required.yml`'s `security/dependency-scan` and `security/sast-scan` on every Python-touching PR — doubling runner cost (~2x) while satisfying **no** unique branch-protection context.

## Change

Add `if: github.event_name != 'pull_request'` to **only** the `pip-audit` and `sast` jobs:
- They **skip on PRs** (where `_required.yml` already runs the canonical `security/dependency-scan` + `security/sast-scan`).
- They **still run** on the weekly `schedule` (Monday cron) and `workflow_dispatch`.

`license-scan` is left **untouched**: it is unique to `security.yml`, absent from `_required.yml`, and blocks **only** on `pull_request` (`scripts/check_license_compatibility.py:307-308`). Its PR run is the only enforcing license gate (landed in #1252) and is preserved by construction.

## Why `if:` (not removing the trigger / not `workflow_call`)

- GitHub triggers are workflow-wide, not per-job — removing `on: pull_request` would drop `license-scan`'s PR enforcement. The per-job lever is a job-level `if:` on `github.event_name`.
- The two scan bodies are not byte-identical to `_required.yml` (inline `prefix-dev/setup-pixi` vs the composite `setup-pixi-env` action), so a `workflow_call` callee would add a new file + caller wiring to solve what a two-line `if:` already solves (KISS/YAGNI).

## Verification

- `pip-audit` + `sast` PR-gated (2 `if:` matches); `license-scan` has no `if:`; `on: pull_request` intact.
- `_required.yml` still owns `security/dependency-scan` + `security/sast-scan`.
- Required branch-protection contexts (`gh api .../rulesets`) are `security/dependency-scan` + `security/secrets-scan` — neither `security.yml` job name is required, so PR-time skips block nothing.
- `check-jsonschema --builtin-schema vendor.github-workflows` → `ok`; `yamllint` clean; pre-commit clean.

Closes #1182