### PR TITLE
fix(test): use import_tomllib for Python 3.10 compat (unbreak main)

### DIFF
--- a/tests/unit/scripts/test_check_license_compatibility.py
+++ b/tests/unit/scripts/test_check_license_compatibility.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-import tomllib
 from packaging.requirements import Requirement
+
+from hephaestus.io.toml import import_tomllib
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
 
@@ -193,6 +194,12 @@ class TestAllExtraCompleteness:
     """Coverage depends on `[all]` aggregating every runtime extra (Finding 3)."""
 
     def test_all_extra_covers_runtime_extras(self):
+        # tomllib is stdlib only on 3.11+; the helper falls back to the tomli
+        # backport on 3.10 (the floor of the CI matrix) so this test runs there.
+        tomllib = import_tomllib()
+        if tomllib is None:
+            pytest.skip("tomllib/tomli not available to parse pyproject.toml")
+            return  # unreachable (pytest.skip raises); narrows tomllib for mypy
         data = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
         optional = data["project"]["optional-dependencies"]
         # all_specs is list[str], e.g.


### PR DESCRIPTION
PR #1252 merged a bare import tomllib; tomllib is stdlib only on 3.11+, so the 3.10 CI matrix job fails collection with ModuleNotFoundError. Use hephaestus.io.toml.import_tomllib() (tomli fallback on 3.10). #1262 fixed lint on this file but not the import.

Closes #1263