### PR TITLE
[Docs] Ship tracked .mcp.json with empty mcpServers + runbook

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,11 @@ protection and the `pr-policy` required-check gate
 - `.claude/settings.json` carries project-level plugin enablement.
 - `.claude-plugin/` ships the marketplace manifests (the project itself is a
   Claude Code plugin); see also [`docs/plugin-installation.md`](docs/plugin-installation.md).
+- **MCP** (Model Context Protocol): `.mcp.json` at the repo root is the
+  project-scoped, version-controlled MCP config. Its `mcpServers` map is empty
+  — ecosystem integration runs through plugin marketplaces (Mnemosyne), NATS
+  (`hephaestus/nats/`), and HTTP REST (Agamemnon/Hermes), none of which is MCP.
+  To add a server, edit `.mcp.json`; see [`docs/mcp.md`](docs/mcp.md).
 - The deferred follow-ups for cross-agent abstraction (a formal `AgentProtocol`)
   and for wiring `hephaestus.resilience` into the GitHub call path are tracked
   in issues #468 and #469.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ See the [README](../README.md) for installation and development setup instructio
 
 - [Plugin Installation Guide](plugin-installation.md) — Install the Claude Code or Codex plugin and enable skills in your project
 - [Audit Reviewer](audit-reviewer.md) — `hephaestus-audit-prs`: coordinator-pattern auditor for ALL open PRs (issue #994)
+- [MCP Configuration](mcp.md) — Project-scoped `.mcp.json` and how to add a Model Context Protocol server
 
 ## Contributing
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,48 @@
+# Model Context Protocol (MCP) Configuration
+
+ProjectHephaestus ships a project-scoped `.mcp.json` at the repository root
+with an empty `mcpServers` map. No MCP servers are configured yet — the file
+exists so the configuration surface is explicit and version-controlled for the
+whole team, per the Claude Code project-scope convention.
+
+## Why the ecosystem references but does not use MCP
+
+The HomericIntelligence ecosystem integrates through mechanisms that are *not*
+MCP servers:
+
+- **Claude Code plugin marketplaces** — e.g. the Mnemosyne marketplace the
+  `learn` skill writes to (see `AGENTS.md`). A marketplace is a plugin source,
+  not an MCP server.
+- **NATS JetStream** — event-driven workflows in `hephaestus/nats/`.
+- **HTTP REST** — Agamemnon agent-management and Hermes message routing.
+
+None of these is wired through MCP, which is why `mcpServers` is empty today.
+
+## Startup behaviour
+
+Adding a server here is safe even if its endpoint is unreachable. MCP startup
+is non-blocking by default: unreachable servers connect in the background, and
+Claude Code prompts for approval before first use of any project-scoped server.
+Only a server marked `alwaysLoad: true` blocks startup, and only up to a
+5-second connect timeout.
+
+## Adding a server
+
+Add an entry under `mcpServers` in `.mcp.json`. A stdio server uses `command`
+plus `args`; an HTTP server uses `type: "http"` and `url`. Example entry:
+
+```json
+{
+  "mcpServers": {
+    "example": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-example"],
+      "env": {}
+    }
+  }
+}
+```
+
+Commit the change so every team member gets the same server. Run
+`claude mcp list` to confirm the server is picked up (project-scoped servers
+awaiting approval show as `⏸ Pending approval`).

--- a/tests/unit/docs/test_mcp_config.py
+++ b/tests/unit/docs/test_mcp_config.py
@@ -1,0 +1,34 @@
+"""Enforce a valid, version-controlled MCP configuration (issue #1186)."""
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_mcp_json_exists_and_is_valid() -> None:
+    """The project-scoped .mcp.json must exist and parse as JSON."""
+    config = REPO_ROOT / ".mcp.json"
+    assert config.exists(), ".mcp.json must exist and be version-controlled"
+    data = json.loads(config.read_text())
+    assert isinstance(data.get("mcpServers"), dict), (
+        ".mcp.json must contain a 'mcpServers' object (may be empty)"
+    )
+
+
+def test_declared_mcp_servers_are_well_formed() -> None:
+    """Every declared server must have a command (stdio) or url (http/ws)."""
+    data = json.loads((REPO_ROOT / ".mcp.json").read_text())
+    for name, cfg in data["mcpServers"].items():
+        assert isinstance(cfg, dict), f"server {name!r} must be an object"
+        has_command = isinstance(cfg.get("command"), str)
+        has_url = isinstance(cfg.get("url"), str)
+        assert has_command or has_url, f"MCP server {name!r} must declare a 'command' or 'url'"
+
+
+def test_mcp_posture_is_documented() -> None:
+    """The MCP posture must be documented in docs/mcp.md and AGENTS.md."""
+    doc = REPO_ROOT / "docs" / "mcp.md"
+    assert doc.exists(), "docs/mcp.md must document the MCP posture"
+    assert "Model Context Protocol" in doc.read_text()
+    assert "MCP" in (REPO_ROOT / "AGENTS.md").read_text()


### PR DESCRIPTION
## Summary

Closes the audit gap from #1186: the repo had no `.mcp.json` and no `mcpServers` key anywhere, so an auditor could not tell whether MCP was deliberately unused or simply forgotten.

This ships a **tracked, project-scoped `.mcp.json`** at the repo root with an empty `mcpServers: {}` map — the canonical Claude Code shape that is designed to be checked into version control — plus a `docs/mcp.md` runbook and an `AGENTS.md` entry explaining the repo's actual integration substrate (Claude Code plugin marketplaces, NATS, HTTP REST — none of which is MCP) and how to add a server.

## Changes

- `.mcp.json` — tracked, `{"mcpServers": {}}` (inert: starts zero servers).
- `docs/mcp.md` — runbook: why the ecosystem references but does not use MCP, non-blocking + approval-gated startup behaviour, and how to add a server (all fences top-level, MD031-safe).
- `AGENTS.md` — MCP bullet under `## Configuration / boundaries`.
- `docs/index.md` — link to the new runbook.
- `tests/unit/docs/test_mcp_config.py` — structural regression test: `.mcp.json` exists, is valid JSON, has a dict `mcpServers`, any declared server is well-formed (`command` or `url`), and the posture is documented. Does **not** forbid future servers.

## Verification

- `pixi run python -m pytest tests/unit/docs/test_mcp_config.py` — 3 passed.
- `pre-commit run markdownlint-cli2 --files docs/mcp.md AGENTS.md docs/index.md` — Passed (MD031 is live in `.markdownlint.yaml`).
- ruff check/format, mypy, unit-test-structure hooks — all Passed.
- `.mcp.json` parses and `mcpServers` is a dict.

Closes #1186