### PR TITLE
ci(version-sync): make deps/version-sync a real gate

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -820,36 +820,48 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install package (for __version__)
-        run: pip install -e "." --no-deps
+      - name: Install package (for __version__ and checker imports)
+        # Install WITH deps: the single-source checker imports
+        # ``hephaestus.utils.helpers``, which imports ``packaging`` (a declared
+        # core dependency). ``--no-deps`` would skip ``packaging`` and the
+        # checker below would ModuleNotFoundError instead of asserting.
+        run: pip install -e "."
 
-      - name: Check version consistency
+      - name: Check version single-source-of-truth (pyproject + pixi.toml)
         run: |
           set -euo pipefail
 
-          # Extract version from pyproject.toml via hatch-vcs (dynamic)
-          DYNAMIC=$(python -c "
-          import tomllib
-          with open('pyproject.toml', 'rb') as f:
-              d = tomllib.load(f)
-          dynamic = d.get('project', {}).get('dynamic', [])
-          print('dynamic' if 'version' in dynamic else 'static')
-          ")
-          echo "Version strategy: $DYNAMIC"
-
-          # Resolve the actual installed version
+          # Diagnostics (informational only).
           PKG_VERSION=$(python -c "import hephaestus; print(hephaestus.__version__)")
           echo "Installed __version__: $PKG_VERSION"
 
-          # If a VERSION file exists, cross-check it
-          if [ -f VERSION ]; then
-            FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
-            echo "VERSION file: $FILE_VERSION"
-            if [ "$PKG_VERSION" != "$FILE_VERSION" ]; then
-              echo "ERROR: __version__ ($PKG_VERSION) does not match VERSION file ($FILE_VERSION)"
-              exit 1
-            fi
-            echo "Version files are in sync."
-          else
-            echo "No VERSION file present — skipping file cross-check."
-          fi
+          # ENFORCEMENT (legs 1+2): the tested checker asserts there is no
+          # static [project].version, that version is in [project].dynamic,
+          # that [tool.hatch.version].source == "vcs", and that pixi.toml has
+          # no [workspace].version. Under `set -e` a non-zero exit fails the
+          # job — this is the live exit-1 path the old dead VERSION-file
+          # branch never provided.
+          #
+          # Invoked as an installed module (-m) rather than the scripts/ shim:
+          # the module form is immune to sys.path[0]/CWD-dependent __file__
+          # resolution, so the checker's get_repo_root() anchors to the
+          # installed package and reads the checked-out pyproject.toml.
+          python -m hephaestus.scripts_lib.check_version_single_source
+
+      - name: Set up pixi (for lockfile sync check)
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
+        with:
+          pixi-version: v0.69.0
+          cache: true
+
+      - name: Check pixi.lock is in sync with pixi.toml
+        run: |
+          set -euo pipefail
+          # ENFORCEMENT (leg 3): the DoD names this job for the full
+          # "pyproject.toml then pixi.toml then pixi.lock" contract
+          # (docs/DEFINITION_OF_DONE.md:28). The checker above covers
+          # pyproject + pixi.toml but never reads pixi.lock. `pixi install
+          # --locked` exits non-zero if pixi.toml changed without re-locking
+          # — the same frozen-verification the pixi-check job uses, and a
+          # command guaranteed available in the repo-pinned pixi v0.69.0.
+          pixi install --locked


### PR DESCRIPTION
## Summary

The required check `deps/version-sync` (`.github/workflows/_required.yml`) asserted **nothing**: `DYNAMIC` was computed and echoed but never branched on, and its only `exit 1` lived inside a dead `if [ -f VERSION ]` block (no `VERSION` file exists in the repo). The job therefore passed for any version configuration (#1181).

This makes the job genuinely enforce the three-file contract its name and `docs/DEFINITION_OF_DONE.md:28` promise — "pyproject.toml then pixi.toml then pixi.lock".

## Changes

- **Drop `--no-deps`** on the editable install. The single-source checker imports `hephaestus.utils.helpers` → `packaging` (a declared core dep, `pyproject.toml:29`); `--no-deps` would `ModuleNotFoundError` instead of asserting.
- **Legs 1+2** — invoke the already-tested checker `hephaestus.scripts_lib.check_version_single_source` via `python -m` so `get_repo_root()` anchors to the installed package (immune to `sys.path[0]`/CWD `__file__` resolution). Under `set -e`, a violation (static `[project].version`, missing `dynamic`, wrong hatch source, pixi `[workspace].version`) fails the job — the live exit-1 path the dead VERSION branch never provided. Re-uses the checker covered by `tests/unit/scripts_lib/test_check_version_single_source.py` rather than re-deriving in bash (avoids the regex false-PASS class of #435).
- **Leg 3** — add `pixi install --locked` to assert `pixi.lock` is in sync with `pixi.toml`: the DoD-named pixi.lock leg the old job dropped. Uses the repo-pinned pixi `v0.69.0`, the same frozen verification the `pixi-check` job already runs (guaranteed to support `--locked`).
- **Delete** the computed-and-discarded `DYNAMIC` block and the dead `VERSION`-file branch (YAGNI).

## Why not delete the job?

`deps/version-sync` is a **pinned required status check** in the active org ruleset. Deleting the job without de-listing the context would leave every PR permanently `BLOCKED` on a check that never reports. The correct move is to make the pinned gate assert its named contract directly.

## Verification (clean venv mirroring CI: `pip install -e .` + bare `python`)

- Leg 1+2: checker exits **0** on clean `main`, **1** on a synthetic static-`[project].version` violation, **0** restored; `packaging` imports under the exact CI install.
- Leg 3: `pixi install --locked` exits **0** on a clean tree, **1** on a `pixi.toml` drift, **0** restored.
- `yamllint` clean; `check-jsonschema --builtin-schema vendor.github-workflows` → `ok`.
- 21 existing checker unit tests pass.

Closes #1181