### PR TITLE
docs(release-notes): fix stale prompts.py:474-475 citation

### DIFF
--- a/docs/release-notes/plan-reviewer-final-verdict.md
+++ b/docs/release-notes/plan-reviewer-final-verdict.md
@@ -21,7 +21,10 @@ Two correctness fixes ride along:
 1. **Last-line-wins verdict parsing.** The gate now extracts every line
    matching `^**Verdict: (APPROVED|REVISE|BLOCK)**$` from the review body
    (regex, multiline) and uses the LAST match — matching the contract the
-   prompt gives Claude (`prompts.py:474-475`). The previous substring `in`
+   prompt gives Claude (the "last matching line" rule documented in
+   `hephaestus/automation/prompts/__init__.py`; the former single-file
+   `prompts.py` was split into the `hephaestus/automation/prompts/`
+   package). The previous substring `in`
    check could mis-fire True on a body that quoted the marker in prose or
    discussed APPROVED before settling on BLOCK.
 


### PR DESCRIPTION
The release note plan-reviewer-final-verdict.md cited the last-line-wins verdict contract at `prompts.py:474-475`. That single file was split into the `hephaestus/automation/prompts/` package, so the line-numbered citation was dangling and broke traceability of the documented behavior.

Fix: point the citation at the contract text now living in `hephaestus/automation/prompts/__init__.py` (the "last matching line" rule), and note the package split — without re-introducing a drift-prone line number.

Verified no remaining `prompts.py:NN` citations in `docs/`.

Closes #1192