### PR TITLE
docs(roadmap): fix stale excluded-module count (6 → 12)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ The strict 2026-04-28 repository audit (Epic #310) is now **closed**. The active
 
 3. **CLI Tool Coverage Expansion** — Expanding the CLI entry point test suite from 13 of 37 declared tools to full coverage, ensuring all command-line interfaces are properly validated.
 
-4. **Test Coverage Hardening** — Bringing 6 excluded automation modules into coverage measurement with mocked unit tests for core orchestration logic.
+4. **Test Coverage Hardening** — Bringing 12 excluded automation modules into coverage measurement with mocked unit tests for core orchestration logic.
 
 5. **Security & Dependency Management** — Hard-blocking pip-audit failures in CI and resolving dependency consistency issues across pixi.toml and pyproject.toml.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ omit = [
     "*/__init__.py",
     # Full orchestration loops require a live claude/gh CLI — integration test territory.
     # Pure-function helpers in these modules are tested in tests/unit/automation/ instead.
-    # The allowlist of these 11 modules is frozen in tests/unit/validation/test_omit_allowlist.py
+    # The allowlist of these 12 modules is frozen in tests/unit/validation/test_omit_allowlist.py
     # to prevent silent growth of the omit list, and their importability is guarded by
     # tests/integration/test_orchestration_smoke.py.
     "hephaestus/automation/implementer.py",

--- a/tests/integration/test_orchestration_smoke.py
+++ b/tests/integration/test_orchestration_smoke.py
@@ -1,11 +1,11 @@
 """Smoke tests for omitted orchestration modules — integration backstop.
 
-These tests validate that the 11 automation modules omitted from coverage
+These tests validate that the 12 automation modules omitted from coverage
 (per pyproject.toml[tool.coverage.run].omit) remain importable and their
 console entry points work correctly.
 
 Module enumeration and entry-point discovery verified at plan time:
-- All 11 modules are importable (guards against import regressions)
+- All 12 modules are importable (guards against import regressions)
 - 4 modules have console scripts: implementer, planner, loop_runner, pr_reviewer
 - 2 modules are script-less but have main(): address_review, ci_driver
 - 5 modules lack main() entirely: implementer_cli (only argument parsing /
@@ -18,7 +18,7 @@ import sys
 
 import pytest
 
-# All 11 omitted orchestration modules
+# All 12 omitted orchestration modules
 OMITTED_MODULES = [
     "hephaestus.automation.implementer",
     "hephaestus.automation.implementer_cli",


### PR DESCRIPTION
Corrects doc/config drift in docs/ROADMAP.md:17, which claimed "6 excluded automation modules" while the coverage omit list in pyproject.toml enumerates 12 hephaestus/automation modules.

The authoritative count is the frozen allowlist in tests/unit/validation/test_omit_allowlist.py (12 modules), which the OMITTED_MODULES list in tests/integration/test_orchestration_smoke.py also matches. The issue framed this as "6 vs 11", but verification showed the real count is 12 — the "11" in the issue derives from stale comments that also disagree with the test. This PR fixes all of them in one pass:

- docs/ROADMAP.md:17 — 6 → 12
- pyproject.toml:244 — "these 11 modules" → "these 12 modules"
- tests/integration/test_orchestration_smoke.py — docstring (x2) + inline comment, 11 → 12

No new test added: test_omit_allowlist.py already deterministically enforces exactly 12 modules, which is the code-side source-of-truth guard.

Verification:
- pixi run python -m pytest tests/unit/validation/test_omit_allowlist.py tests/integration/test_orchestration_smoke.py — 20 passed
- pre-commit on changed files — all hooks pass
- corpus-wide re-grep for stale "6 excluded"/"11 modules" — clean

Closes #1191