### PR TITLE
docs(readme): add scripts_lib/ to directory tree (20 subpackages)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ ProjectHephaestus is the shared utilities and tooling repository of the HomericI
 
 ```text
 ProjectHephaestus/
-├── hephaestus/                 # Python source code (19 documented subpackages)
+├── hephaestus/                 # Python source code (20 documented subpackages)
 │   ├── agents/                 # Agent frontmatter + loader + runtime
 │   ├── automation/             # Issue planning / implementation / PR review pipeline
 │   ├── benchmarks/             # Benchmark comparison utilities

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ ProjectHephaestus/
 │   ├── markdown/      # Markdown linting and link fixing
 │   ├── nats/          # NATS JetStream subscriber (event-driven workflows)
 │   ├── resilience/    # Circuit breaker + retry + subprocess resilience primitives
+│   ├── scripts_lib/   # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/        # System information collection
 │   ├── utils/         # General utility functions (slugify, retry, subprocess)
 │   ├── validation/    # README, schema, and structural validation

--- a/tests/unit/validation/test_readme_subpackage_tree.py
+++ b/tests/unit/validation/test_readme_subpackage_tree.py
@@ -1,0 +1,31 @@
+"""Guard: README directory tree must list every hephaestus/ subpackage.
+
+Prevents doc-vs-reality drift (issue #1188): scripts_lib/ was on disk but
+absent from the README tree while the doc still claimed 19 subpackages.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGE_DIR = REPO_ROOT / "hephaestus"
+README = REPO_ROOT / "README.md"
+
+
+def _real_subpackages() -> set[str]:
+    """Return the names of every importable hephaestus/ subpackage on disk."""
+    return {
+        p.name
+        for p in PACKAGE_DIR.iterdir()
+        if p.is_dir() and (p / "__init__.py").exists() and not p.name.startswith("__")
+    }
+
+
+def test_readme_tree_lists_every_subpackage() -> None:
+    """Every real subpackage must appear in the README directory tree block."""
+    readme = README.read_text(encoding="utf-8")
+    missing = sorted(
+        name
+        for name in _real_subpackages()
+        if f"├── {name}/" not in readme and f"└── {name}/" not in readme
+    )
+    assert not missing, f"README directory tree omits subpackage(s): {missing}"


### PR DESCRIPTION
The README directory tree (README.md:88-112) listed 19 subpackages but the package has 20 — `hephaestus/scripts_lib/` was on disk and tracked yet absent from the structure block. This is the lone drift the audit flagged.

## Changes
- README.md: insert `scripts_lib/` alphabetically between `resilience/` and `system/`, column-aligned to the surrounding comments.
- CLAUDE.md:28: bump the stale `19 documented subpackages` count to `20` (CLAUDE.md:62 `19.7k LoC` is an unrelated metric, left untouched).
- tests/unit/validation/test_readme_subpackage_tree.py: regression guard — enumerates every importable `hephaestus/` subpackage on disk and asserts each appears in the README tree, so the tree cannot silently drift again.

## Verification
- `grep -n scripts_lib/ README.md` → present
- `grep -n "20 documented subpackages" CLAUDE.md` → present
- corpus sweep for stale `19 ... subpackage` → clean
- `pixi run python -m pytest tests/unit/validation/test_readme_subpackage_tree.py` → 1 passed
- `pre-commit run --files README.md CLAUDE.md tests/unit/validation/test_readme_subpackage_tree.py` → all hooks pass (markdownlint, ruff, mypy, README CLI table sync, unit test structure)

Closes #1188