### PR TITLE
fix(scripts): isolate gh stderr from jq input in choose_merge_flag

### DIFF
--- a/scripts/choose_merge_flag.sh
+++ b/scripts/choose_merge_flag.sh
@@ -17,9 +17,12 @@ choose_merge_flag() {
         echo "choose_merge_flag: missing required argument <owner/repo>" >&2
         return 2
     fi
-    local raw flag
-    if ! raw=$(gh api "repos/${repo}" 2>&1); then
-        echo "choose_merge_flag: gh api repos/${repo} failed: ${raw}" >&2
+    local raw flag _err_file
+    _err_file=$(mktemp)
+    # shellcheck disable=SC2064
+    trap "rm -f '$_err_file'" RETURN
+    if ! raw=$(gh api "repos/${repo}" 2>"$_err_file"); then
+        echo "choose_merge_flag: gh api repos/${repo} failed: $(cat "$_err_file")" >&2
         echo "  (check: gh auth status; token needs 'repo' scope; repo exists)" >&2
         return 1
     fi

--- a/tests/integration/test_choose_merge_flag_sh.py
+++ b/tests/integration/test_choose_merge_flag_sh.py
@@ -25,3 +25,71 @@ def test_shell_helper_errors_on_missing_arg() -> None:
     )
     assert out.returncode == 2
     assert "missing required argument" in out.stderr
+
+
+def _run_with_mock_gh(json_body: str, repo: str = "owner/repo") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    """Run choose_merge_flag with a mock gh function returning json_body."""
+    script = f"""
+gh() {{
+    case "$1" in
+        api) printf '%s\\n' '{json_body}' ;;
+        *) command gh "$@" ;;
+    esac
+}}
+export -f gh
+. {SNIPPET}
+choose_merge_flag {repo}
+"""
+    return subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_shell_helper_handles_gh_stderr_noise() -> None:
+    """Stderr from gh (warnings, banners) must not corrupt jq input.
+
+    Regression guard for the safety fix: fails against the unfixed 2>&1 version.
+    """
+    script = f"""
+gh() {{
+    case "$1" in
+        api)
+            printf '%s\\n' 'warning: new gh release available' >&2
+            printf '%s\\n' '{{"allow_rebase_merge":true,"allow_squash_merge":true,"allow_merge_commit":true}}'
+            ;;
+        *) command gh "$@" ;;
+    esac
+}}
+export -f gh
+. {SNIPPET}
+choose_merge_flag owner/repo
+"""
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, f"stderr noise broke jq parse: stderr={result.stderr!r}"
+    assert result.stdout.strip() == "--rebase"
+
+
+def test_shell_helper_selects_rebase_when_all_allowed() -> None:
+    """Preference order: rebase wins when all three methods are allowed."""
+    body = '{"allow_rebase_merge":true,"allow_squash_merge":true,"allow_merge_commit":true}'
+    result = _run_with_mock_gh(body)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "--rebase"
+
+
+def test_shell_helper_selects_squash_when_rebase_disallowed() -> None:
+    """Falls back to squash when rebase is not permitted."""
+    body = '{"allow_rebase_merge":false,"allow_squash_merge":true,"allow_merge_commit":false}'
+    result = _run_with_mock_gh(body)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "--squash"
+
+
+def test_shell_helper_exits_1_when_no_methods_allowed() -> None:
+    """Returns exit 1 and diagnostic message when repo permits no merge methods."""
+    body = '{"allow_rebase_merge":false,"allow_squash_merge":false,"allow_merge_commit":false}'
+    result = _run_with_mock_gh(body)
+    assert result.returncode == 1
+    assert "allows no merge methods" in result.stderr


### PR DESCRIPTION
Isolates `gh api` stderr from the JSON body that `jq` parses in `choose_merge_flag()`.

## Summary

- Replace `2>&1` with `mktemp` temp file + `trap "rm -f '$_err_file'" RETURN` so deprecation warnings, rate-limit notices, and `GH_DEBUG` traces never corrupt the JSON piped to `jq`
- Add regression guard test (`test_shell_helper_handles_gh_stderr_noise`) that fails against the unfixed script and passes after the fix
- Add three positive-path integration tests: rebase preference order, squash fallback, no-methods exit-1

## Test plan

- [x] TDD RED confirmed: `test_shell_helper_handles_gh_stderr_noise` fails against unfixed `2>&1` version
- [x] TDD GREEN confirmed: all 6 tests pass after fix (`pixi run pytest tests/integration/test_choose_merge_flag_sh.py -v --no-cov`)
- [x] Commit is GPG-signed

Closes #1125