### PR TITLE
docs(automation): document test-patch contract for implementer modules

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -1,10 +1,54 @@
-"""Bulk issue implementation using the selected coding agent in parallel worktrees.
+r"""Bulk issue implementation using the selected coding agent in parallel worktrees.
 
 Provides:
 - Dependency-aware parallel implementation
 - Git worktree isolation
 - State persistence and resume
 - CI fix automation
+
+Test-Patch Contract
+-------------------
+This module owns a **minimal** patch surface.  After the #714 extraction, most
+patchable collaborators moved to :mod:`.implementer_phase_runner` (see its
+top-level comment block for the full list).  Only two patch paths still target
+``hephaestus.automation.implementer.<name>`` in the test suite:
+
+  Symbol            Mechanism                Notes
+  ----------------- ------------------------ ----------------------------------------
+  get_repo_root     direct import + ``as``   Used by ``IssueImplementer.__init__``
+                    alias (mypy re-export)   and ``main``; patched in every test that
+                                             constructs an ``IssueImplementer``.
+  subprocess.run    stdlib ``import          Patched at the dotted path
+                    subprocess`` (line 13)   ``…implementer.subprocess.run`` via
+                                             Python's standard attribute-traversal
+                                             during ``patch()``.
+
+Keep-in-sync command (run when adding a new patch surface here):
+
+    grep -rn 'patch.*hephaestus\\.automation\\.implementer\\.' tests/ \\
+      | grep -v 'implementer_phase_runner\\|implementer_cli\\|implementer_state'
+
+When adding a new patchable dependency to *this* module:
+
+  1. Import it here using ``from .module import name as name`` (mypy
+     ``implicit_reexport=false``) so the re-export is explicit.
+  2. Add a row to the table above.
+  3. If the dependency is also called from :mod:`.implementer_phase_runner`,
+     add it there with a top-level import instead — do NOT bridge it back
+     through this module (that recreates the #714 cycle).
+
+For the full list of patchable symbols in the phase-runner (``fetch_issue_info``,
+``find_pr_for_issue``, ``is_plan_review_go``, ``invoke_claude_with_session``,
+``get_repo_slug``, ``AGENT_IMPLEMENTER``, ``AGENT_ADVISE``,
+``current_trunk_githash``, ``review_state``, …) see the comment block in
+:mod:`.implementer_phase_runner` above its ``from .session_naming import`` line.
+
+Why not constructor-injected collaborators: this module is patched by 16+
+existing test call sites across ``test_implementer.py`` and
+``test_implementer_loop.py``.  Converting to DI would require editing every
+one.  See issue #710's tradeoff analysis and the team's
+``python-module-decomposition-and-refactor-patterns`` skill, Phase 11
+(Reverse-Delegation), validated by PR #674.
 """
 
 from __future__ import annotations
@@ -22,62 +66,27 @@ from hephaestus.agents.runtime import (
     is_codex,
 )
 
-# ---------------------------------------------------------------------------
-# Test-patch contract (load-bearing). The symbols below are real call sites in
-# THIS module's own body (``IssueImplementer`` + ``main``) and double as patch
-# surfaces: tests ``patch("hephaestus.automation.implementer.<X>", ...)`` to
-# intercept them.
-#
-# Symbols that the per-issue phase runner calls (``find_pr_for_issue``,
-# ``is_plan_review_go``, ``fetch_issue_info``, ``invoke_claude_with_session``,
-# ``get_repo_slug``, ``AGENT_IMPLEMENTER``, ``AGENT_ADVISE``,
-# ``current_trunk_githash``, ``review_state``) are NO LONGER re-exported here.
-# Since #714 the runner imports them directly from their source modules and
-# tests patch them at ``hephaestus.automation.implementer_phase_runner.<X>``.
-# Re-exporting them here would be a dead shim whose silent no-op patches would
-# let tests hit real network/disk.
-# ---------------------------------------------------------------------------
+# Imports for the Test-Patch Contract — see module docstring for the full table.
+# Each symbol here is either a real call site in IssueImplementer/main or an
+# explicit re-export required by tests or the public API.
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
 
-# ``get_repo_root`` is re-exported with an explicit ``as`` alias so that
-# ``main`` (defined below) and tests patching ``implementer.get_repo_root``
-# share one lookup site.
-#
-# Patched by: tests/unit/automation/test_implementer.py;
-#             tests/unit/automation/test_implementer_loop.py
-# Runtime call site: ``IssueImplementer.__init__`` + ``main``
+# Patched at ``hephaestus.automation.implementer.get_repo_root`` by every test
+# that constructs an IssueImplementer.  Explicit ``as`` alias satisfies mypy
+# ``implicit_reexport=false`` and makes the re-export intentional.
 from .git_utils import (
     get_repo_root as get_repo_root,
 )
-
-# ``run`` is a real call site for ``IssueImplementer._health_check``; it does
-# double duty as a patch surface.
 from .git_utils import run
-
-# ``fetch_issue_info`` is a real call site (``IssueImplementer._load_issues``),
-# not a shim.
 from .github_api import fetch_issue_info
-
-# ``gh_list_open_issues`` is re-exported with an explicit ``as`` alias so
-# ``main`` (defined below) and tests patching ``implementer.gh_list_open_issues``
-# share one lookup site.
 from .github_api import (
     gh_list_open_issues as gh_list_open_issues,
 )
 
-# ``MAX_REVIEW_ITERATIONS`` is re-exported so tests that import it via
-# ``hephaestus.automation.implementer`` see the same value the runtime loop
-# in :class:`ImplementationPhaseRunner` uses. Single source of truth lives
-# in ``implementer_phase_runner``.
-#
-# Argument parsing and logging setup live in ``implementer_cli`` (extracted
-# for SRP — see #468). Re-exported here with explicit ``as`` aliases (required
-# by mypy) so existing tests calling ``implementer._parse_args()`` and patching
-# ``implementer.<dep>`` continue to work unchanged. ``main`` itself is defined
-# in THIS module (not re-imported from ``implementer_cli``) so the console
-# script ``hephaestus.automation.implementer:main`` resolves directly and no
-# deferred import is needed to break the cycle (#714).
+# _parse_args / _setup_logging live in implementer_cli (SRP extraction #468).
+# Re-exported with explicit ``as`` aliases so tests calling
+# ``implementer._parse_args()`` continue to work unchanged.
 from .implementer_cli import (
     _parse_args as _parse_args,
 )

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -18,8 +18,8 @@ top-level comment block for the full list).  Only two patch paths still target
   get_repo_root     direct import + ``as``   Used by ``IssueImplementer.__init__``
                     alias (mypy re-export)   and ``main``; patched in every test that
                                              constructs an ``IssueImplementer``.
-  subprocess.run    stdlib ``import          Patched at the dotted path
-                    subprocess`` (line 13)   ``…implementer.subprocess.run`` via
+  subprocess.run    stdlib top-level         Patched at the dotted path
+                    ``import subprocess``    ``…implementer.subprocess.run`` via
                                              Python's standard attribute-traversal
                                              during ``patch()``.
 

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -67,15 +67,30 @@ from .pr_manager import (
 from .prompts import get_dirty_reused_worktree_decision_prompt, get_implementation_prompt
 from .review_state import is_plan_review_go
 
-# Patchable symbols (``find_pr_for_issue``, ``get_pr_head_branch``,
-# ``is_plan_review_go``, ``fetch_issue_info``, ``invoke_claude_with_session``,
-# ``get_repo_slug``, ``AGENT_IMPLEMENTER``, ``AGENT_ADVISE``,
-# ``current_trunk_githash``) are imported top-level from their true source
-# modules and reached by their bare names below. Tests patch them at
-# ``hephaestus.automation.implementer_phase_runner.<X>`` — the module that owns
-# these call sites — instead of through a deferred per-runner module-pointer
-# indirection. This breaks the import cycle the old indirection created with ``implementer``
-# (#714). ``current_trunk_githash`` is patch-only (used by tests).
+# Test-Patch Contract — patchable symbols owned by this module.
+# All symbols below are imported top-level from their true source modules so
+# that tests patch them at ``hephaestus.automation.implementer_phase_runner.<X>``.
+# This is the pattern established by #714 (which removed the old deferred
+# per-runner ``from . import implementer`` back-pointer that caused an import
+# cycle with :mod:`.implementer`).
+#
+#   Symbol                    Patched by
+#   ------------------------- ----------------------------------------------------
+#   find_pr_for_issue         test_implementer.py (TestReviewExistingPR)
+#   get_pr_head_branch        test_implementer.py (TestReviewExistingPR)
+#   is_plan_review_go         test_implementer.py / test_implementer_loop.py
+#   fetch_issue_info          test_implementer.py / test_implementer_loop.py
+#   invoke_claude_with_session test_implementer.py / test_implementer_loop.py
+#   get_repo_slug             test_implementer.py
+#   AGENT_IMPLEMENTER         test_implementer.py / test_implementer_loop.py
+#   AGENT_ADVISE              test_implementer.py / test_implementer_loop.py
+#   current_trunk_githash     test_implementer.py (patch-only; not used at runtime)
+#   review_state (submodule)  test_implementer.py (via ``from . import review_state``)
+#   run                       test_implementer_loop.py (health-check)
+#   sync_worktree_to_remote_branch  test_implementer_loop.py
+#   ensure_pr_auto_merge_deferred   test_implementer.py
+#
+# Keep in sync: grep -rn 'patch.*hephaestus\.automation\.implementer_phase_runner\.' tests/
 from .session_naming import (  # noqa: F401
     AGENT_ADVISE,
     AGENT_IMPLEMENTER,


### PR DESCRIPTION
## Summary

- Replace scattered inline comments in `implementer.py` with a module-level **Test-Patch Contract** docstring documenting the two patch surfaces still owned by `hephaestus.automation.implementer` (`get_repo_root` and `subprocess.run`) and cross-referencing the phase-runner table for the rest
- Expand the comment block in `implementer_phase_runner.py` into a named table listing every patchable symbol the module owns, the test files that patch each, and a keep-in-sync grep command
- No functional code changes; purely documentation/comment improvement addressing AC1 and AC3 of issue #710

## Context

After PR #674 (Reverse-Delegation) and issue #714 (cycle-break extraction), the actual patch surface on `hephaestus.automation.implementer` shrank to just `get_repo_root` and `subprocess.run`. All other patchable collaborators (`fetch_issue_info`, `find_pr_for_issue`, `is_plan_review_go`, `invoke_claude_with_session`, `get_repo_slug`, `AGENT_IMPLEMENTER`, `AGENT_ADVISE`, `current_trunk_githash`, `review_state`) now live in `implementer_phase_runner` and are documented there.

The old comment blocks were stale (listed pre-#714 symbols) and scattered across 4 different comment blocks. This PR consolidates them into discoverable, accurate documentation.

## Test plan

- [x] `pixi run ruff check hephaestus/automation/implementer.py hephaestus/automation/implementer_phase_runner.py` — All checks passed
- [x] `pixi run mypy` — Success: no issues found in 384 source files
- [x] `pixi run pytest tests/unit/automation/test_implementer.py tests/unit/automation/test_implementer_loop.py` — 103 passed
- [x] `pixi run pytest tests/unit/automation/` — 1571 passed
- [x] `pixi run pytest tests/integration/test_cli_entry_points.py -k implement` — 5 passed

Closes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)