### PR TITLE
fix(automation): exclude post-loop records from loops_run in main()

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1692,7 +1692,7 @@ def main(argv: list[str] | None = None) -> int:  # noqa: C901
     results = run_loop(cfg, repos)
 
     # Compute actual loops run (may be less than cfg.loops due to early exit)
-    loops_run = max((r.loop_idx for r in results), default=0)
+    loops_run = max((r.loop_idx for r in results if not r.is_post_loop), default=0)
 
     failures = [r for r in results if r.any_failure]
     if failures:

--- a/tests/unit/automation/test_loop_runner_early_exit.py
+++ b/tests/unit/automation/test_loop_runner_early_exit.py
@@ -711,6 +711,34 @@ class TestMainLoopsRunReporting:
         assert captured["failed_repos"] == []
         assert captured["rc"] == 0
 
+    def test_main_loops_run_excludes_post_loop_records(self) -> None:
+        """Post-loop records (is_post_loop=True) must not inflate loops_run.
+
+        When early exit fires on loop 1 of 5 and _run_post_loop_stages appends a
+        RepoResult with loop_idx=5 and is_post_loop=True, loops_run must still be
+        1, not 5.  The post-loop record is tagged via is_post_loop=True — the
+        dedicated flag documented at loop_runner.py:234 — not merely by having a
+        non-empty post_loop_phases list.
+        """
+        results = [
+            RepoResult(
+                repo="r1",
+                loop_idx=1,
+                phases=[PhaseResult(name="plan", rc=0, work_units=0)],
+            ),
+            RepoResult(
+                repo="r1",
+                loop_idx=5,
+                is_post_loop=True,
+                post_loop_phases=[PhaseResult(name="drive-green", rc=0, work_units=0)],
+            ),
+        ]
+
+        captured = self._run_main_with_results(results, configured_loops=5)
+
+        assert captured["loops_run"] == 1
+        assert captured["rc"] == 0
+
     def test_main_loops_run_all_loops(self) -> None:
         """When all configured loops complete, loops_run==cfg.loops."""
         results = [


### PR DESCRIPTION
## Summary

- `main()` in `loop_runner.py` computed `loops_run` over the full `run_loop` result list, which includes post-loop `RepoResult` records carrying `loop_idx=cfg.loops`
- When early-exit fires on loop 1 of 5 and `_run_post_loop_stages` runs, `loops_run` was inflated to 5 instead of 1
- Fix: filter with `not r.is_post_loop` (the dedicated boolean flag at line 1395), mirroring the canonical filter already applied at line 1525 inside `run_loop`
- Adds `TestMainLoopsRunReporting.test_main_loops_run_excludes_post_loop_records` as a regression guard

Closes #1153