### PR TITLE
fix(automation): tighten planner-learn record-writing robustness

### DIFF
--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -88,15 +88,15 @@ def _write_learn_record(
 def build_learn_prompt(context: str) -> str:
     """Return the standard automation prompt for the user-facing /learn skill."""
     detail = context.strip()
-    if detail:
-        detail = f" {detail}"
+    suffix = f" {detail}" if detail else ""
     return (
-        f"/learn{detail}"
+        "/learn"
         " EXECUTE the /learn skill-creation workflow for ProjectMnemosyne."
         " Do NOT return a plan. Do NOT ask for approval."
         " Commit the results and create a PR."
         " IMPORTANT: Only push skills to ProjectMnemosyne."
         " Do NOT create files under .claude-plugin/ in this repo."
+        f"{suffix}"
     )
 
 

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
@@ -596,6 +597,7 @@ class PlanReviewLoop:
             f"{plan}"
         )
         prompt = build_learn_prompt(context)
+        _learn_start = time.monotonic()
         try:
             output = self.planner._call_claude(
                 prompt,
@@ -604,13 +606,17 @@ class PlanReviewLoop:
                 issue_number=issue_number,
                 timeout=learn_claude_timeout(),
             )
-            self._write_planner_learn_record(issue_number, succeeded=True, output=output)
+            self._write_planner_learn_record(
+                issue_number, succeeded=True, output=output, start=_learn_start
+            )
             return output
         except Exception as e:
             logger.warning(
                 "%s: planner-learnings capture failed (non-fatal): %s", issue_ref(issue_number), e
             )
-            self._write_planner_learn_record(issue_number, succeeded=False, error=str(e))
+            self._write_planner_learn_record(
+                issue_number, succeeded=False, error=str(e), start=_learn_start
+            )
             return ""
 
     def _planner_learn_state_dir(self) -> Path:
@@ -625,6 +631,7 @@ class PlanReviewLoop:
         succeeded: bool,
         output: str = "",
         error: str = "",
+        start: float = 0.0,
     ) -> None:
         """Persist explicit planner ``/learn`` attempt evidence.
 
@@ -635,14 +642,14 @@ class PlanReviewLoop:
         try:
             state_dir = self._planner_learn_state_dir()
             timestamp = datetime.now(timezone.utc).isoformat()
-            log_file = state_dir / f"planner-learn-{issue_number}.log"
+            duration = round(time.monotonic() - start, 3) if start else None
             record_file = state_dir / f"planner-learn-{issue_number}.json"
-            log_file.write_text(output if succeeded else f"FAILED: {error}\n")
+            log_file = state_dir / f"planner-learn-{issue_number}.log"
             record = {
                 "issue_number": issue_number,
                 "learn_attempted_at": timestamp,
+                "learn_duration_s": duration,
                 "learn_status": "succeeded" if succeeded else "failed",
-                "learn_succeeded_at": timestamp if succeeded else None,
                 "log_path": str(log_file),
             }
             if succeeded:
@@ -658,6 +665,7 @@ class PlanReviewLoop:
             if error:
                 record["error"] = error
             record_file.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+            log_file.write_text(output if succeeded else f"FAILED: {error}\n")
         except OSError as exc:
             logger.warning(
                 "%s: failed to write planner-learnings state (non-fatal): %s",

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -75,9 +75,12 @@ class TestRunLearn:
     def test_build_learn_prompt_uses_user_facing_command(self) -> None:
         prompt = build_learn_prompt("Capture what happened.")
 
-        assert prompt.startswith("/learn Capture what happened.")
+        assert prompt.startswith("/learn EXECUTE")
+        assert "Capture what happened." in prompt
         assert "/skills-registry-commands:learn" not in prompt
         assert "Only push skills to ProjectMnemosyne" in prompt
+        # Directives must appear before the context detail
+        assert prompt.index("Do NOT return a plan") < prompt.index("Capture what happened.")
 
     def test_success_writes_log_and_returns_true(self, tmp_path: Path) -> None:
         """Returns True and writes log on successful claude run."""

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -622,6 +622,9 @@ class TestCapturePlannerLearnings:
         assert "ProjectMnemosyne" in prompt
         assert "/skills-registry-commands:learn" not in prompt
         assert "plan text" in prompt
+        # Directives must appear before the context/plan body (item 4)
+        assert "Do NOT return a plan" in prompt
+        assert prompt.index("Do NOT return a plan") < prompt.index("plan text")
 
     def test_writes_success_record(self, planner: Planner, tmp_path: Any) -> None:
         """A successful planner /learn attempt leaves durable evidence."""
@@ -640,7 +643,9 @@ class TestCapturePlannerLearnings:
         assert record["issue_number"] == 123
         assert record["learn_status"] == "succeeded"
         assert record["learn_attempted_at"]
-        assert record["learn_succeeded_at"] == record["learn_attempted_at"]
+        assert "learn_succeeded_at" not in record
+        assert record["learn_duration_s"] is not None
+        assert record["learn_duration_s"] >= 0.0
         assert record["mnemosyne_update_status"] == "unverified"
         assert record["mnemosyne_update_urls"] == []
         assert record["mnemosyne_update_pr_numbers"] == []
@@ -663,12 +668,30 @@ class TestCapturePlannerLearnings:
         assert record["issue_number"] == 123
         assert record["learn_status"] == "failed"
         assert record["learn_attempted_at"]
-        assert record["learn_succeeded_at"] is None
+        assert "learn_succeeded_at" not in record
+        assert record["learn_duration_s"] is not None
+        assert record["learn_duration_s"] >= 0.0
         assert record["error"] == "claude down"
         assert record["mnemosyne_update_status"] == "failed"
         assert record["mnemosyne_update_urls"] == []
         assert record["mnemosyne_update_pr_numbers"] == []
         assert (state_dir / "planner-learn-123.log").read_text().startswith("FAILED:")
+
+    def test_oswrite_failure_is_nonfatal(self, planner: Planner, tmp_path: Any) -> None:
+        """OSError in record write must not propagate — capture_planner_learnings still returns output."""
+        with (
+            patch(
+                "hephaestus.automation.planner_review_loop.get_repo_root",
+                return_value=tmp_path,
+            ),
+            patch.object(planner, "_call_claude", return_value="- learning A\n"),
+            patch(
+                "hephaestus.automation.planner_review_loop.Path.write_text",
+                side_effect=OSError("permission denied"),
+            ),
+        ):
+            out = planner._capture_planner_learnings(123, "plan text")
+        assert out == "- learning A\n"
 
 
 class TestRunPlanReview:


### PR DESCRIPTION
Four minor robustness/quality improvements from the strict review of #1135:

1. **Write order**: `.json` is now written before `.log` in `_write_planner_learn_record`, so the authoritative metadata record lands first. A partial-write failure can no longer leave a `.log` ghost with no corresponding `.json`.

2. **OSError-swallow test**: Added `test_oswrite_failure_is_nonfatal` — patches `Path.write_text` to raise `OSError` and asserts `capture_planner_learnings` still returns its output without propagating.

3. **`learn_succeeded_at` → `learn_duration_s`**: Replaced the redundant `learn_succeeded_at` field (always equalled `learn_attempted_at`) with a real `learn_duration_s` captured via `time.monotonic()` before the `_call_claude` call.

4. **Prompt directive placement**: Moved "Do NOT return a plan. Do NOT ask for approval." directives to the front of `build_learn_prompt`, before the context detail suffix, so they appear before the long plan text rather than buried after it.

Closes #1138