### PR TITLE
fix(ci_driver): warn on PRs with missing user.login under author filter

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -344,6 +344,16 @@ class CIDriver:
         for pr in raw_pulls:
             user = pr.get("user") or {}
             if viewer and user.get("login") != viewer:
+                if user.get("login") is None:
+                    logger.warning(
+                        "PR #%s has no user.login; skipping under author filter (#821)",
+                        pr.get("number"),
+                        extra={
+                            "missing_field": "user.login",
+                            "filter": "author",
+                            "pr_number": pr.get("number"),
+                        },
+                    )
                 continue  # #821: hide other-author PRs from the done-gate sweep
             labels = pr.get("labels") or []
             normalised.append(
@@ -490,6 +500,16 @@ class CIDriver:
             if user.get("type") != "Bot":
                 continue
             if viewer and user.get("login") != viewer:
+                if user.get("login") is None:
+                    logger.warning(
+                        "PR #%s has no user.login; skipping under author filter (#821)",
+                        pr.get("number"),
+                        extra={
+                            "missing_field": "user.login",
+                            "filter": "author",
+                            "pr_number": pr.get("number"),
+                        },
+                    )
                 continue  # #821: not viewer-owned and --all not set
             number = pr.get("number")
             if isinstance(number, int):

--- a/tests/unit/automation/test_ci_driver_author_scope.py
+++ b/tests/unit/automation/test_ci_driver_author_scope.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -48,6 +49,28 @@ def viewer_driver(driver: CIDriver) -> CIDriver:
 
 
 # Mixed-author /pulls payload — note `login` keys on every fixture PR.
+_MISSING_LOGIN_PULLS = [
+    {
+        "number": 200,
+        "user": {"type": "User", "login": None},
+        "auto_merge": None,
+        "title": "malformed-no-login",
+        "head": {"ref": "bx"},
+        "labels": [],
+    },
+]
+
+_MISSING_LOGIN_BOT_PULLS = [
+    {
+        "number": 201,
+        "user": {"type": "Bot", "login": None},
+        "auto_merge": None,
+        "title": "malformed-bot-no-login",
+        "head": {"ref": "by"},
+        "labels": [],
+    },
+]
+
 _MIXED_PULLS = [
     {
         "number": 100,
@@ -231,3 +254,84 @@ class TestAllFlagSkipsViewerResolution:
         ):
             remaining = driver._list_open_prs_remaining()
         assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]
+
+
+class TestMissingUserLogin:
+    """PRs with user.login=None emit a warning instead of silently disappearing (#1152)."""
+
+    def test_list_open_prs_remaining_warns_on_missing_login(
+        self, viewer_driver: CIDriver, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_PULLS)),
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+        ):
+            result = viewer_driver._list_open_prs_remaining()
+
+        assert result == []
+        assert any(
+            "PR #200 has no user.login" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+
+    def test_discover_bot_prs_warns_on_missing_login(
+        self, viewer_driver: CIDriver, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_BOT_PULLS)),
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+        ):
+            result = viewer_driver._discover_bot_prs()
+
+        assert result == {}
+        assert any(
+            "PR #201 has no user.login" in record.message and record.levelname == "WARNING"
+            for record in caplog.records
+        )
+
+    def test_list_open_prs_remaining_no_warning_under_all(
+        self, driver: CIDriver, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning must NOT fire when --all is set (viewer filter bypassed entirely)."""
+        driver.options.include_all_authors = True
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_PULLS)),
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+        ):
+            result = driver._list_open_prs_remaining()
+
+        assert any(r["number"] == 200 for r in result), "PR must appear in results under --all"
+        assert not any("has no user.login" in record.message for record in caplog.records), (
+            "Warning must not fire when viewer filter is bypassed"
+        )
+
+    def test_discover_bot_prs_no_warning_under_all(
+        self, driver: CIDriver, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Warning must NOT fire when --all is set (viewer filter bypassed entirely)."""
+        driver.options.include_all_authors = True
+        with (
+            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.ci_driver._gh_call",
+                return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_BOT_PULLS)),
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+        ):
+            driver._discover_bot_prs()
+
+        assert not any("has no user.login" in record.message for record in caplog.records), (
+            "Warning must not fire when viewer filter is bypassed"
+        )


### PR DESCRIPTION
Add `logger.warning()` at both author-filter sites in `ci_driver.py` so that a PR with `None`/missing `user.login` emits a visible log line instead of silently disappearing from discovery.

## Changes

- `hephaestus/automation/ci_driver.py`: nested `if user.get("login") is None: logger.warning(...)` guard at both filter sites (`_list_open_prs_remaining:346` and `_discover_bot_prs:492`), emitting structured `extra={"missing_field": "user.login", "filter": "author", "pr_number": ...}` for log aggregation
- `tests/unit/automation/test_ci_driver_author_scope.py`: added `import logging`, two new fixtures (`_MISSING_LOGIN_PULLS`, `_MISSING_LOGIN_BOT_PULLS`), and `TestMissingUserLogin` class with four tests (two positive warning assertions, two negative asserting warning does NOT fire under `--all`)

Closes #1152