### PR TITLE
docs(adr): update automation LoC figures to current measurements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Claude Code plugin format. All Python packages use lowercase_snake_case.
 
 ## Library vs product layer
 
-`hephaestus/automation/` is a **product layer** (19.7k LoC, 48% of the
+`hephaestus/automation/` is a **product layer** (26.1k LoC, 53.9% of the
 codebase) co-located with the utility library. It is gated behind the
 `HomericIntelligence-Hephaestus[automation]` optional extra. The base
 `import hephaestus` surface MUST NOT pull `curses`, `fcntl`, `pydantic`,

--- a/docs/adr/0001-automation-library-boundary.md
+++ b/docs/adr/0001-automation-library-boundary.md
@@ -6,7 +6,7 @@
 
 ## Context
 
-`hephaestus/automation/` is 19,726 LoC of the 41,034-LoC source tree (48%). It
+`hephaestus/automation/` is 26,125 LoC of the 48,498-LoC source tree (53.9%, as of 2026-06-13). It
 implements the full Claude/Codex automation pipeline: Planner, Implementer,
 CIDriver, PRReviewer, PlanReviewer, AddressReviewer, AuditReviewer,
 loop_runner, curses TUI, GitHub adapter, prompt assembly. The rest of


### PR DESCRIPTION
Update stale line-of-code figures in `docs/adr/0001-automation-library-boundary.md` and `CLAUDE.md`.

`hephaestus/automation/` has grown to **26,125 LoC of the 48,498-LoC source tree (53.9%)**, up from the stale 19,726 / 41,034 (48%) figures recorded at ADR-0001 authoring time (2026-06-05). The install-boundary remedy prescribed by ADR-0001 — `[automation]` optional extra, boundary tests, lazy-import enforcement — is already fully implemented and unchanged.

## Changes

- `docs/adr/0001-automation-library-boundary.md:9` — replace `19,726 LoC of the 41,034-LoC source tree (48%)` with `26,125 LoC of the 48,498-LoC source tree (53.9%, as of 2026-06-13)`
- `CLAUDE.md:62` — replace `(19.7k LoC, 48% of the` with `(26.1k LoC, 53.9% of the`

## Verification

- `grep -c '19,726' docs/adr/0001-automation-library-boundary.md` → 0 ✓
- `grep -c '19.7k' CLAUDE.md` → 0 ✓
- `pixi run pytest tests/unit/validation/ -v` → 676 passed, 16 skipped ✓
- markdownlint on both files → Passed ✓

Closes #1177