### PR TITLE
feat(automation): add ReviewerProtocol and ABC enforcement on BaseReviewer

### DIFF
--- a/hephaestus/automation/_interfaces.py
+++ b/hephaestus/automation/_interfaces.py
@@ -1,0 +1,22 @@
+"""Declared abstraction contracts for the automation pipeline.
+
+Import directly from this module — not via ``hephaestus.automation`` —
+to avoid defeating the lazy-export design of the package __init__.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ReviewerProtocol(Protocol):
+    """Structural contract satisfied by all four reviewer classes.
+
+    Verified: PRReviewer.run (pr_reviewer.py:396),
+              AddressReviewer.run (address_review.py:350),
+              AuditReviewer.run (audit_reviewer.py:197),
+              PlanReviewer.run (plan_reviewer.py:99).
+    """
+
+    def run(self) -> Any: ...

--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -29,7 +30,7 @@ from .worktree_manager import WorktreeManager
 logger = logging.getLogger(__name__)
 
 
-class BaseReviewer:
+class BaseReviewer(ABC):
     """Shared scaffolding for the reviewer CLIs.
 
     Collaborators are injected via constructor parameters (DIP-compliant).
@@ -163,3 +164,7 @@ class BaseReviewer:
             subclass_logger = logging.getLogger(type(self).__module__)
             subclass_logger.warning("Malformed review state for issue #%d (%s)", issue_number, exc)
             return None
+
+    @abstractmethod
+    def run(self) -> Any:
+        """Execute the review loop and return per-issue results."""

--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -317,3 +319,71 @@ class TestIsBotPrModeForSyntheticKey:
     def test_is_bot_pr_mode_false_for_real_issue(self, ci_driver: CIDriver) -> None:
         """Real issue-PR mappings return False."""
         assert not ci_driver._is_bot_pr_mode(100, 200)
+
+
+class TestFailingCheckPredicateSingleDefinition:
+    """Regression guard: FAILING_CHECK_CONCLUSIONS and _pr_is_failing must not be duplicated.
+
+    The DRY goal is satisfied when there is exactly one assignment to
+    FAILING_CHECK_CONCLUSIONS and exactly one function named _pr_is_failing
+    across the entire automation package.  This test catches future drift that
+    would re-introduce the three-copy situation described in issue #1345.
+    """
+
+    _AUTOMATION_DIR = Path(__file__).parents[3] / "hephaestus" / "automation"
+
+    def _count_assignments(self, target: str) -> list[Path]:
+        """Return paths of automation modules that assign to *target* at module level."""
+        hits: list[Path] = []
+        for py_file in self._AUTOMATION_DIR.rglob("*.py"):
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Assign):
+                    for t in node.targets:
+                        if isinstance(t, ast.Name) and t.id == target:
+                            hits.append(py_file)
+                elif (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and node.target.id == target
+                ):
+                    hits.append(py_file)
+        return hits
+
+    def _count_function_defs(self, name: str) -> list[Path]:
+        """Return paths of automation modules that define a function named *name*."""
+        hits: list[Path] = []
+        for py_file in self._AUTOMATION_DIR.rglob("*.py"):
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name == name:
+                    hits.append(py_file)
+        return hits
+
+    def test_failing_check_conclusions_defined_exactly_once(self) -> None:
+        """FAILING_CHECK_CONCLUSIONS must have a single canonical definition."""
+        hits = self._count_assignments("FAILING_CHECK_CONCLUSIONS")
+        assert len(hits) == 1, (
+            f"Expected exactly 1 definition of FAILING_CHECK_CONCLUSIONS, "
+            f"found {len(hits)}: {[str(p) for p in hits]}"
+        )
+        assert hits[0].name == "ci_driver.py", (
+            f"Canonical definition must be in ci_driver.py, not {hits[0].name}"
+        )
+
+    def test_pr_is_failing_defined_exactly_once(self) -> None:
+        """_pr_is_failing must have a single canonical definition."""
+        hits = self._count_function_defs("_pr_is_failing")
+        assert len(hits) == 1, (
+            f"Expected exactly 1 definition of _pr_is_failing, "
+            f"found {len(hits)}: {[str(p) for p in hits]}"
+        )
+        assert hits[0].name == "ci_driver.py", (
+            f"Canonical definition must be in ci_driver.py, not {hits[0].name}"
+        )

--- a/tests/unit/automation/test_interfaces.py
+++ b/tests/unit/automation/test_interfaces.py
@@ -1,0 +1,45 @@
+"""Verify that all four reviewer classes satisfy ReviewerProtocol."""
+
+from hephaestus.automation._interfaces import ReviewerProtocol
+
+
+class _ConcreteReviewer:
+    def run(self) -> dict:
+        return {}
+
+
+class _MissingReviewer:
+    pass
+
+
+def test_protocol_satisfied_by_stub() -> None:
+    assert isinstance(_ConcreteReviewer(), ReviewerProtocol)
+
+
+def test_protocol_violated_by_stub() -> None:
+    assert not isinstance(_MissingReviewer(), ReviewerProtocol)
+
+
+def test_pr_reviewer_satisfies_protocol() -> None:
+    """PRReviewer inherits BaseReviewer and defines run() — must satisfy."""
+    from hephaestus.automation.pr_reviewer import PRReviewer
+
+    assert issubclass(PRReviewer, ReviewerProtocol)
+
+
+def test_address_reviewer_satisfies_protocol() -> None:
+    from hephaestus.automation.address_review import AddressReviewer
+
+    assert issubclass(AddressReviewer, ReviewerProtocol)
+
+
+def test_audit_reviewer_satisfies_protocol() -> None:
+    from hephaestus.automation.audit_reviewer import AuditReviewer
+
+    assert issubclass(AuditReviewer, ReviewerProtocol)
+
+
+def test_plan_reviewer_satisfies_protocol() -> None:
+    from hephaestus.automation.plan_reviewer import PlanReviewer
+
+    assert issubclass(PlanReviewer, ReviewerProtocol)

--- a/tests/unit/automation/test_interfaces.py
+++ b/tests/unit/automation/test_interfaces.py
@@ -13,10 +13,12 @@ class _MissingReviewer:
 
 
 def test_protocol_satisfied_by_stub() -> None:
+    """A class with run() must satisfy ReviewerProtocol via runtime_checkable."""
     assert isinstance(_ConcreteReviewer(), ReviewerProtocol)
 
 
 def test_protocol_violated_by_stub() -> None:
+    """A class without run() must not satisfy ReviewerProtocol."""
     assert not isinstance(_MissingReviewer(), ReviewerProtocol)
 
 
@@ -28,18 +30,21 @@ def test_pr_reviewer_satisfies_protocol() -> None:
 
 
 def test_address_reviewer_satisfies_protocol() -> None:
+    """AddressReviewer implements run() and must satisfy ReviewerProtocol."""
     from hephaestus.automation.address_review import AddressReviewer
 
     assert issubclass(AddressReviewer, ReviewerProtocol)
 
 
 def test_audit_reviewer_satisfies_protocol() -> None:
+    """AuditReviewer implements run() and must satisfy ReviewerProtocol."""
     from hephaestus.automation.audit_reviewer import AuditReviewer
 
     assert issubclass(AuditReviewer, ReviewerProtocol)
 
 
 def test_plan_reviewer_satisfies_protocol() -> None:
+    """PlanReviewer implements run() and must satisfy ReviewerProtocol."""
     from hephaestus.automation.plan_reviewer import PlanReviewer
 
     assert issubclass(PlanReviewer, ReviewerProtocol)

--- a/tests/unit/automation/test_reviewer_base_contract.py
+++ b/tests/unit/automation/test_reviewer_base_contract.py
@@ -27,6 +27,9 @@ def _make_deps(tmp_path: Path) -> dict:
 class ConcreteReviewer(_reviewer_base.BaseReviewer):
     """Minimal concrete subclass for testing BaseReviewer's injection contract."""
 
+    def run(self) -> None:
+        """Stub implementation to satisfy the ABC abstractmethod contract."""
+
 
 def test_injection_wires_repo_root(tmp_path: Path) -> None:
     """Constructor injection must wire repo_root from the get_repo_root callable."""

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -471,8 +471,9 @@ def test_review_loop_resolves_conflict_before_first_review(tmp_path: Path) -> No
 
     def _iter(**_kwargs: Any) -> tuple[Any, ...]:
         call_order.append("review")
-        # verdict, grade, review_text, posted_thread_ids, go_blocked, reopened, should_break
-        return "GO", "A", "ok", [], False, [], True
+        # verdict, grade, review_text, posted_thread_ids, go_blocked, reopened,
+        # should_break, reopened_keys, validator_clean
+        return "GO", "A", "ok", [], False, [], True, set(), True
 
     with (
         mock.patch.object(phase, "_resolve_conflict_before_review", side_effect=_gate) as gate,


### PR DESCRIPTION
## Summary

- Adds `ReviewerProtocol` (a `runtime_checkable` `Protocol`) in `hephaestus/automation/_interfaces.py`, declaring the shared `run()` contract for all four reviewer classes (`PRReviewer`, `AddressReviewer`, `AuditReviewer`, `PlanReviewer`)
- Makes `BaseReviewer` abstract (`ABC`) with `@abstractmethod run()`, statically constraining `PRReviewer` and `AddressReviewer` to implement the entry-point
- Protocol lives in a private `_interfaces` module (not the lazy `__init__` exports) to avoid defeating the automation package's lazy-load design
- Six conformance tests verify all four concrete reviewer classes satisfy `ReviewerProtocol`

## Test plan

- [x] `pixi run pytest tests/unit/automation/test_interfaces.py -v` — 6/6 conformance tests pass
- [x] `pixi run pytest tests/unit/automation/ --no-cov` — full automation unit suite passes (exit 0)
- [x] `pixi run pytest tests/unit/validation/test_import_surface.py` — import surface unchanged (`abc` is stdlib)
- [x] `pixi run mypy` — no new errors (386 source files, Success)

Closes #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)