### PR TITLE
fix(lint): raise max-complexity to 12 and document all C901 suppressions

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -140,7 +140,7 @@ class CIDriver:
         # stays empty so a broken `gh auth` does not block --all runs.
         self._viewer_login: str = ""
 
-    def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # thread pool + finally + preserve report
+    def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # orchestration: thread pool + finally + preserve report across exception paths
         """Run the CI driver on all configured issues.
 
         Returns:
@@ -584,7 +584,7 @@ class CIDriver:
         """
         return issue_number == pr_number
 
-    def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:  # noqa: C901
+    def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:  # noqa: C901  # orchestration: multi-PR dedup with fallback discovery across issue/PR mappings
         """Pre-discover open PRs for all issues, deduped by PR.
 
         When a single PR closes multiple issues (a legitimate ``pr-policy``
@@ -708,7 +708,7 @@ class CIDriver:
                 self.shared_pr_issues.setdefault(pr_num, [pr_num])
         return deduped
 
-    def _drive_issue(  # noqa: C901  # poll loop + required-check classification + fix path
+    def _drive_issue(  # noqa: C901  # orchestration: poll loop + required-check classification + CI-fix path
         self, issue_number: int, pr_number: int, slot_id: int
     ) -> WorkerResult:
         """Drive a single issue's PR toward green CI.
@@ -1760,7 +1760,7 @@ class CIDriver:
             elapsed += sleep_secs
             attempt += 1
 
-    def _sweep_orphaned_arming_records(self) -> None:  # noqa: C901  # one record loop with three state branches; splitting it just hides the contract
+    def _sweep_orphaned_arming_records(self) -> None:
         """Drop CLOSED records and capture missed ``/learn`` for MERGED orphans (#848).
 
         The per-issue ``_check_arming_on_drive_start`` only fires when the
@@ -2587,7 +2587,7 @@ class CIDriver:
             return False
         return True
 
-    def _run_ci_fix_session(  # noqa: C901  # provider resume/fallback paths are intentionally coupled
+    def _run_ci_fix_session(  # noqa: C901  # orchestration: provider resume/fallback paths are intentionally coupled
         self,
         issue_number: int,
         pr_number: int,

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -335,7 +335,7 @@ def _persist_rejected(
         path.write_text(json.dumps(payload, indent=2) + "\n")
 
 
-def run_follow_up_issues(  # noqa: C901  # quota-check + parse + file paths are unavoidably coupled
+def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + file paths are unavoidably coupled
     session_id: str,
     worktree_path: Path,
     issue_number: int,

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -182,7 +182,7 @@ class IssueImplementer:
         ui_msg = f"{prefix}: {msg}" if prefix else msg
         self.log_manager.log(tid, ui_msg)
 
-    def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # branchy orchestration body is intentionally linear
+    def run(self) -> dict[int, WorkerResult]:
         """Run the implementer.
 
         Returns:
@@ -369,7 +369,7 @@ class IssueImplementer:
 
         return {}
 
-    def _implement_all(self) -> dict[int, WorkerResult]:  # noqa: C901  # orchestration with many retry/outcome paths
+    def _implement_all(self) -> dict[int, WorkerResult]:  # noqa: C901  # orchestration: many retry/outcome paths
         """Implement all issues with dependency awareness.
 
         Returns:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1605,7 +1605,7 @@ def _resolve_org_and_repos(
     return (detected_org, [detected_repo], None)
 
 
-def main(argv: list[str] | None = None) -> int:  # noqa: C901
+def main(argv: list[str] | None = None) -> int:
     """Console-script entry point. Returns the process exit code."""
     args = _parse_args(argv)
     _setup_logging(args.verbose)

--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -422,7 +422,7 @@ def fetch_all_issue_labels_graphql(
     return result_map
 
 
-def is_plan_review_go(  # noqa: C901  # labels-first gate with comment-scan backfill
+def is_plan_review_go(  # noqa: C901  # validation: labels-first gate with comment-scan backfill; many independent rule checks
     issue_number: int,
     comments: list[dict[str, Any]] | None = None,
     issue_labels: list[str] | None = None,

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -202,7 +202,7 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
         logger.error("  Failed to merge PR #%d. API message: %s", pr_number, message)
 
 
-def main() -> int:  # noqa: C901
+def main() -> int:  # noqa: C901  # CLI dispatch: many command branches + retry paths for PR merge automation
     """Serve as the main entry point for PR merge automation."""
     parser = argparse.ArgumentParser(
         description="Merge open PRs with successful CI/CD into main (squash via PR API)"

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -510,7 +510,7 @@ def _print_summary(results: dict[str, str]) -> int:
     return 0 if not failed else 1
 
 
-def main() -> int:  # noqa: C901
+def main() -> int:  # noqa: C901  # CLI dispatch: many command branches for tidy workflow stages
     """Entry point for hephaestus-tidy."""
     args = _build_arg_parser().parse_args()
     agent = resolve_agent(args.agent)

--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -262,7 +262,7 @@ class VersionManager:
         for init_file in self.init_files:
             self.update_init_file(init_file, version, verbose=verbose)
 
-    def verify(self, version: str, verbose: bool = True) -> bool:  # noqa: C901
+    def verify(self, version: str, verbose: bool = True) -> bool:  # noqa: C901  # validation: many independent version-file consistency checks
         """Verify that all version files are consistent.
 
         Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 10
+max-complexity = 12
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "D102", "D107"]


### PR DESCRIPTION
Raises ruff McCabe threshold from 10 to 12 — the team's established threshold for orchestration/CLI code — dropping 3 `# noqa: C901` directives that are now below the new limit (avoiding RUF100 unused-noqa failures) and adding explicit category-prefixed rationale to all 10 remaining suppressions.

## Changes

**`pyproject.toml`**: `max-complexity = 10` → `max-complexity = 12`

**3 suppressions dropped** (CC ≤ 12 at new threshold → would produce RUF100 failures):
- `ci_driver.py:_sweep_orphaned_arming_records` (CC=11)
- `implementer.py:run` (CC=11)
- `loop_runner.py:main` (CC=12)

**10 suppressions retained with documented rationale** (CC > 12):
- `ci_driver.py:run` (CC=18) — orchestration: thread pool + finally + preserve report across exception paths
- `ci_driver.py:_discover_prs` (CC=15) — orchestration: multi-PR dedup with fallback discovery
- `ci_driver.py:_drive_issue` (CC=23) — orchestration: poll loop + required-check classification + CI-fix path
- `ci_driver.py:_run_ci_fix_session` (CC=20) — orchestration: provider resume/fallback paths intentionally coupled
- `implementer.py:_implement_all` (CC=14) — orchestration: many retry/outcome paths
- `follow_up.py:run_follow_up_issues` (CC=14) — orchestration: quota-check + parse + file paths coupled
- `review_state.py:is_plan_review_go` (CC=13) — validation: labels-first gate with comment-scan backfill
- `manager.py:verify` (CC=20) — validation: many independent version-file consistency checks
- `pr_merge.py:main` (CC=18) — CLI dispatch: many command branches + retry paths
- `tidy.py:main` (CC=13) — CLI dispatch: many command branches for tidy workflow stages

## Verification

- `pixi run ruff check hephaestus/ --select C901` → All checks passed!
- `pixi run ruff check hephaestus/ tests/` → All checks passed!
- 10 surviving suppressions, all with `# noqa: C901  # <category>: <specifics>` format

Closes #1195