### PR TITLE
refactor(automation): extract _invoke_agent_session and _push_ci_fix helpers

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2250,7 +2250,144 @@ class CIDriver:
                 exc,
             )
 
-    def _retry_no_commit_once(  # codex/claude branches stay coupled to keep one retry path
+    def _invoke_agent_session(
+        self,
+        *,
+        prompt: str,
+        session_id: str | None,
+        worktree_path: Path,
+        issue_number: int,
+        pr_number: int,
+    ) -> subprocess.CompletedProcess[str]:
+        """Dispatch a prompt to the configured agent (codex or claude).
+
+        Returns a CompletedProcess whose returncode signals success or failure:
+        - returncode == 0: agent ran successfully (stdout has output)
+        - returncode != 0: agent failed (stderr has details)
+
+        For codex, returncode is synthetic — AgentRunResult has no returncode
+        field; success is "no CalledProcessError" (hephaestus/agents/runtime.py).
+        For claude, returncode comes from the subprocess exit code.
+
+        CalledProcessError is absorbed from all codex paths into a non-zero
+        CompletedProcess. TimeoutExpired propagates to the caller so it can
+        log a distinct timeout message.
+        """
+        if is_codex(self.options.agent):
+            if session_id:
+                try:
+                    result = resume_codex_session(
+                        session_id,
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                    )
+                except subprocess.CalledProcessError as exc:
+                    logger.warning(
+                        "Issue #%s: Codex resume session %r failed for PR #%s; "
+                        "falling back to fresh session: %s",
+                        issue_number,
+                        session_id,
+                        pr_number,
+                        (exc.stderr or exc.stdout or "")[:300],
+                    )
+                    try:
+                        result = run_codex_session(
+                            prompt,
+                            cwd=worktree_path,
+                            timeout=ci_driver_claude_timeout(),
+                            sandbox="workspace-write",
+                        )
+                    except subprocess.CalledProcessError as fresh_exc:
+                        return subprocess.CompletedProcess(
+                            args=fresh_exc.cmd,
+                            returncode=fresh_exc.returncode,
+                            stdout=fresh_exc.stdout or "",
+                            stderr=fresh_exc.stderr or "",
+                        )
+            else:
+                try:
+                    result = run_codex_session(
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                        sandbox="workspace-write",
+                    )
+                except subprocess.CalledProcessError as exc:
+                    return subprocess.CompletedProcess(
+                        args=exc.cmd,
+                        returncode=exc.returncode,
+                        stdout=exc.stdout or "",
+                        stderr=exc.stderr or "",
+                    )
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=result.stdout, stderr=result.stderr or ""
+            )
+
+        repo_slug = get_repo_slug(self.repo_root)
+        try:
+            stdout, _ = invoke_claude_with_session(
+                repo=repo_slug,
+                issue=issue_number,
+                agent=AGENT_CI_DRIVER,
+                prompt=prompt,
+                model=implementer_model(),
+                cwd=worktree_path,
+                timeout=ci_driver_claude_timeout(),
+                output_format="json",
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                extra_args=["--dangerously-skip-permissions"],
+                input_via_stdin=True,
+            )
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+        except subprocess.CalledProcessError as exc:
+            return subprocess.CompletedProcess(
+                args=exc.cmd,
+                returncode=exc.returncode,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
+            )
+
+    def _push_ci_fix(
+        self,
+        *,
+        worktree_path: Path,
+        pre_agent_sha: str,
+        issue_number: int,
+        pr_number: int,
+        pr_head_branch: str,
+        session_id: str | None,
+    ) -> bool:
+        """Check head advancement, retry if needed, then push CI fixes.
+
+        Shared post-agent contract for both codex and claude providers (#846).
+        Returns True if fixes were pushed, False on any failure or no-commit.
+        """
+        if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):  # noqa: SIM102
+            if not self._retry_no_commit_once(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                worktree_path=worktree_path,
+                pr_head_branch=pr_head_branch,
+                pre_agent_sha=pre_agent_sha,
+                session_id=session_id,
+            ):
+                return False
+        if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
+            return False
+        try:
+            push_current_branch_with_lease_on_divergence(
+                worktree_path,
+                branch=pr_head_branch,
+                push_ref=f"HEAD:{pr_head_branch}",
+            )
+            logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
+            return True
+        except Exception as push_err:
+            logger.error("Issue #%s: git push failed after CI fix: %s", issue_number, push_err)
+            return False
+
+    def _retry_no_commit_once(
         self,
         *,
         issue_number: int,
@@ -2329,64 +2466,27 @@ class CIDriver:
             )
 
             try:
-                if is_codex(self.options.agent):
-                    if session_id:
-                        try:
-                            resume_codex_session(
-                                session_id,
-                                retry_prompt,
-                                cwd=worktree_path,
-                                timeout=ci_driver_claude_timeout(),
-                            )
-                        except subprocess.CalledProcessError as exc:
-                            logger.warning(
-                                "Issue #%s: Codex retry resume failed for PR #%s; "
-                                "falling back to fresh session: %s",
-                                issue_number,
-                                pr_number,
-                                (exc.stderr or exc.stdout or "")[:300],
-                            )
-                            run_codex_session(
-                                retry_prompt,
-                                cwd=worktree_path,
-                                timeout=ci_driver_claude_timeout(),
-                                sandbox="workspace-write",
-                            )
-                    else:
-                        run_codex_session(
-                            retry_prompt,
-                            cwd=worktree_path,
-                            timeout=ci_driver_claude_timeout(),
-                            sandbox="workspace-write",
-                        )
-                else:
-                    repo_slug = get_repo_slug(self.repo_root)
-                    invoke_claude_with_session(
-                        repo=repo_slug,
-                        issue=issue_number,
-                        agent=AGENT_CI_DRIVER,
-                        prompt=retry_prompt,
-                        model=implementer_model(),
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                        output_format="json",
-                        allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                        extra_args=["--dangerously-skip-permissions"],
-                        input_via_stdin=True,
-                    )
-            except subprocess.CalledProcessError as exc:
-                logger.error(
-                    "Issue #%s: no-commit retry session failed for PR #%s: %s",
-                    issue_number,
-                    pr_number,
-                    (exc.stderr or exc.stdout or "")[:300],
+                retry_result = self._invoke_agent_session(
+                    prompt=retry_prompt,
+                    session_id=session_id,
+                    worktree_path=worktree_path,
+                    issue_number=issue_number,
+                    pr_number=pr_number,
                 )
-                return False
             except subprocess.TimeoutExpired:
                 logger.error(
                     "Issue #%s: no-commit retry session timed out for PR #%s",
                     issue_number,
                     pr_number,
+                )
+                return False
+
+            if retry_result.returncode != 0:
+                logger.error(
+                    "Issue #%s: no-commit retry session failed for PR #%s: %s",
+                    issue_number,
+                    pr_number,
+                    (retry_result.stderr or "")[:300],
                 )
                 return False
 
@@ -2628,159 +2728,6 @@ class CIDriver:
             f"Commit message: fix: Address CI failures for PR {pr_ref(pr_number)}\n"
         )
 
-    def _finalize_ci_fix_push(
-        self,
-        issue_number: int,
-        pr_number: int,
-        worktree_path: Path,
-        pr_head_branch: str,
-        pre_agent_sha: str,
-        session_id: str | None,
-    ) -> bool:
-        """Check head advance, retry if needed, then push CI-fix commits.
-
-        Returns ``True`` on a successful push, ``False`` on any failure. Shared
-        by both the Codex and Claude invocation paths to eliminate the verbatim
-        32-line push-tail duplication.
-        """
-        if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):  # noqa: SIM102
-            if not self._retry_no_commit_once(
-                issue_number=issue_number,
-                pr_number=pr_number,
-                worktree_path=worktree_path,
-                pr_head_branch=pr_head_branch,
-                pre_agent_sha=pre_agent_sha,
-                session_id=session_id,
-            ):
-                return False
-        if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
-            return False
-        try:
-            push_current_branch_with_lease_on_divergence(
-                worktree_path,
-                branch=pr_head_branch,
-                push_ref=f"HEAD:{pr_head_branch}",
-            )
-            logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
-            return True
-        except Exception as push_err:
-            logger.error("Issue #%s: git push failed after CI fix: %s", issue_number, push_err)
-            return False
-
-    def _invoke_codex_ci_fix(
-        self,
-        issue_number: int,
-        pr_number: int,
-        worktree_path: Path,
-        prompt: str,
-        pr_head_branch: str,
-        pre_agent_sha: str,
-        session_id: str | None,
-    ) -> bool:
-        """Run the Codex agent for a CI fix session and push on success."""
-        try:
-            if session_id:
-                try:
-                    codex_result = resume_codex_session(
-                        session_id,
-                        prompt,
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                    )
-                except subprocess.CalledProcessError as e:
-                    logger.warning(
-                        "Issue #%s: Codex resume session %r failed for PR #%s; falling back to fresh: %s",  # noqa: E501
-                        issue_number,
-                        session_id,
-                        pr_number,
-                        (e.stderr or e.stdout or "")[:300],
-                    )
-                    codex_result = run_codex_session(
-                        prompt,
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                        sandbox="workspace-write",
-                    )
-            else:
-                codex_result = run_codex_session(
-                    prompt,
-                    cwd=worktree_path,
-                    timeout=ci_driver_claude_timeout(),
-                    sandbox="workspace-write",
-                )
-            logger.debug(
-                "Issue #%s: Codex CI fix output: %s", issue_number, codex_result.stdout[:500]
-            )
-        except subprocess.CalledProcessError as e:
-            logger.error(
-                "Issue #%s: Codex CI fix session returned exit code %s: %s",
-                issue_number,
-                e.returncode,
-                (e.stderr or e.stdout or "")[:300],
-            )
-            return False
-        return self._finalize_ci_fix_push(
-            issue_number,
-            pr_number,
-            worktree_path,
-            pr_head_branch,
-            pre_agent_sha,
-            session_id,
-        )
-
-    def _invoke_claude_ci_fix(
-        self,
-        issue_number: int,
-        pr_number: int,
-        worktree_path: Path,
-        prompt: str,
-        pr_head_branch: str,
-        pre_agent_sha: str,
-        session_id: str | None,
-    ) -> bool:
-        """Run the Claude agent for a CI fix session and push on success."""
-        repo_slug = get_repo_slug(self.repo_root)
-        try:
-            stdout, _ = invoke_claude_with_session(
-                repo=repo_slug,
-                issue=issue_number,
-                agent=AGENT_CI_DRIVER,
-                prompt=prompt,
-                model=implementer_model(),
-                cwd=worktree_path,
-                timeout=ci_driver_claude_timeout(),
-                output_format="json",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                extra_args=["--dangerously-skip-permissions"],
-                input_via_stdin=True,
-            )
-            claude_result = subprocess.CompletedProcess(
-                args=[], returncode=0, stdout=stdout, stderr=""
-            )
-        except subprocess.CalledProcessError as exc:
-            claude_result = subprocess.CompletedProcess(
-                args=exc.cmd,
-                returncode=exc.returncode,
-                stdout=exc.stdout or "",
-                stderr=exc.stderr or "",
-            )
-        if claude_result.returncode == 0:
-            return self._finalize_ci_fix_push(
-                issue_number,
-                pr_number,
-                worktree_path,
-                pr_head_branch,
-                pre_agent_sha,
-                session_id,
-            )
-        logger.error(
-            "Issue #%s: Claude CI fix session returned exit code %s: %s",
-            issue_number,
-            claude_result.returncode,
-            claude_result.stderr[:300],
-        )
-        return False
-
     def _run_ci_fix_session(
         self,
         issue_number: int,
@@ -2827,35 +2774,40 @@ class CIDriver:
         )
 
         try:
-            if is_codex(self.options.agent):
-                return self._invoke_codex_ci_fix(
-                    issue_number,
-                    pr_number,
-                    worktree_path,
-                    prompt,
-                    pr_head_branch,
-                    pre_agent_sha,
-                    session_id,
-                )
-            return self._invoke_claude_ci_fix(
-                issue_number,
-                pr_number,
-                worktree_path,
-                prompt,
-                pr_head_branch,
-                pre_agent_sha,
-                session_id,
+            agent_result = self._invoke_agent_session(
+                prompt=prompt,
+                session_id=session_id,
+                worktree_path=worktree_path,
+                issue_number=issue_number,
+                pr_number=pr_number,
             )
         except subprocess.TimeoutExpired:
-            logger.error(
-                "Issue #%s: Claude CI fix session timed out for PR #%s", issue_number, pr_number
-            )
+            logger.error("Issue #%s: CI fix session timed out for PR #%s", issue_number, pr_number)
             return False
         except Exception as e:
             logger.error(
                 "Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e
             )
             return False
+
+        if agent_result.returncode != 0:
+            logger.error(
+                "Issue #%s: CI fix session returned exit code %s: %s",
+                issue_number,
+                agent_result.returncode,
+                (agent_result.stderr or "")[:300],
+            )
+            return False
+
+        logger.debug("Issue #%s: CI fix output: %s", issue_number, agent_result.stdout[:500])
+        return self._push_ci_fix(
+            worktree_path=worktree_path,
+            pre_agent_sha=pre_agent_sha,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_head_branch=pr_head_branch,
+            session_id=session_id,
+        )
 
     def _enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:
         """Enable auto-merge for the given PR using squash strategy.

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -318,6 +318,8 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
     fresh_result = AgentRunResult(stdout="no changes needed", stderr="", session_id="x")
     # Pre and post snapshots return the SAME SHA → agent made no commit.
     unchanged_sha = MagicMock(stdout="cafef00d\n")
+    # _tracked_worktree_changes also calls run(git status --porcelain).
+    clean_status = MagicMock(stdout="", stderr="", returncode=0)
 
     with (
         patch(
@@ -330,7 +332,7 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
         patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch"),
         patch(
             "hephaestus.automation.ci_driver.run",
-            side_effect=[unchanged_sha, unchanged_sha],
+            side_effect=[unchanged_sha, unchanged_sha, clean_status],
         ),
         patch(
             "hephaestus.automation.ci_driver.gh_pr_list_unresolved_threads",
@@ -2951,6 +2953,257 @@ class TestScopedDoneGate:
 
         remaining_nums = {pr["number"] for pr in driver.open_prs_remaining}
         assert remaining_nums == {996, 1032}, "unscoped run keeps all open PRs"
+
+
+# ---------------------------------------------------------------------------
+# _invoke_agent_session
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeAgentSession:
+    """Unit tests for CIDriver._invoke_agent_session (provider dispatch helper)."""
+
+    def test_claude_success_returns_rc0(self, driver: CIDriver, tmp_path: Path) -> None:
+        with patch(
+            "hephaestus.automation.ci_driver.invoke_claude_with_session",
+            return_value=("output text", "sess-id"),
+        ) as mock_invoke:
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id=None,
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 0
+        assert result.stdout == "output text"
+        mock_invoke.assert_called_once()
+
+    def test_claude_error_returns_nonzero_rc(self, driver: CIDriver, tmp_path: Path) -> None:
+        with patch(
+            "hephaestus.automation.ci_driver.invoke_claude_with_session",
+            side_effect=subprocess.CalledProcessError(1, ["claude"], stderr="boom"),
+        ):
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id=None,
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 1
+        assert "boom" in result.stderr
+
+    def test_codex_resume_success(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.options.agent = "codex"
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.resume_codex_session",
+                return_value=AgentRunResult(stdout="ok", stderr="", session_id="s"),
+            ) as mock_resume,
+            patch("hephaestus.automation.ci_driver.run_codex_session") as mock_fresh,
+        ):
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id="existing-session",
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 0
+        mock_resume.assert_called_once()
+        mock_fresh.assert_not_called()
+
+    def test_codex_resume_failure_falls_back_to_fresh_success(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        driver.options.agent = "codex"
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.resume_codex_session",
+                side_effect=subprocess.CalledProcessError(1, ["codex"], stderr="resume-fail"),
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.run_codex_session",
+                return_value=AgentRunResult(stdout="fresh ok", stderr="", session_id="s2"),
+            ) as mock_fresh,
+        ):
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id="stale-session",
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 0
+        mock_fresh.assert_called_once()
+
+    def test_codex_resume_failure_fresh_also_fails_returns_nonzero_rc(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        """Both resume and fresh codex fail → CompletedProcess(returncode!=0), no exception."""
+        driver.options.agent = "codex"
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.resume_codex_session",
+                side_effect=subprocess.CalledProcessError(1, ["codex"], stderr="resume-fail"),
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.run_codex_session",
+                side_effect=subprocess.CalledProcessError(2, ["codex"], stderr="fresh-fail"),
+            ),
+        ):
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id="stale-session",
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 2
+        assert "fresh-fail" in result.stderr
+
+    def test_codex_no_session_fresh_failure_returns_nonzero_rc(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        """No session_id + fresh codex fails → CompletedProcess(returncode!=0), no exception."""
+        driver.options.agent = "codex"
+        with patch(
+            "hephaestus.automation.ci_driver.run_codex_session",
+            side_effect=subprocess.CalledProcessError(3, ["codex"], stderr="fail"),
+        ):
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id=None,
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 3
+
+    def test_codex_no_session_runs_fresh(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.options.agent = "codex"
+        with (
+            patch("hephaestus.automation.ci_driver.resume_codex_session") as mock_resume,
+            patch(
+                "hephaestus.automation.ci_driver.run_codex_session",
+                return_value=AgentRunResult(stdout="done", stderr="", session_id="s3"),
+            ) as mock_fresh,
+        ):
+            result = driver._invoke_agent_session(
+                prompt="fix it",
+                session_id=None,
+                worktree_path=tmp_path,
+                issue_number=1,
+                pr_number=2,
+            )
+        assert result.returncode == 0
+        mock_resume.assert_not_called()
+        mock_fresh.assert_called_once()
+
+    def test_timeout_propagates_to_caller(self, driver: CIDriver, tmp_path: Path) -> None:
+        """TimeoutExpired escapes the helper so callers can log a distinct timeout message."""
+        with patch(
+            "hephaestus.automation.ci_driver.invoke_claude_with_session",
+            side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=60),
+        ):
+            with pytest.raises(subprocess.TimeoutExpired):
+                driver._invoke_agent_session(
+                    prompt="fix it",
+                    session_id=None,
+                    worktree_path=tmp_path,
+                    issue_number=1,
+                    pr_number=2,
+                )
+
+
+# ---------------------------------------------------------------------------
+# _push_ci_fix
+# ---------------------------------------------------------------------------
+
+
+class TestPushCiFix:
+    """Unit tests for CIDriver._push_ci_fix (post-agent contract helper)."""
+
+    def test_returns_true_when_head_advanced_and_push_succeeds(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        post_sha = MagicMock(stdout="deadbeef\n")
+        clean_status = MagicMock(stdout="", stderr="", returncode=0)
+        # rev-list --count for _ci_fix_head_is_pushable; return "1" (1 commit ahead)
+        ahead_count = MagicMock(stdout="1\n", stderr="", returncode=0)
+        no_untracked = MagicMock(stdout="", returncode=0)
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.run",
+                side_effect=[post_sha, clean_status, no_untracked, ahead_count],
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+            ) as mock_push,
+        ):
+            result = driver._push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="cafef00d",
+                issue_number=1,
+                pr_number=2,
+                pr_head_branch="1-fix",
+                session_id=None,
+            )
+        assert result is True
+        mock_push.assert_called_once()
+
+    def test_returns_false_when_head_not_advanced_and_retry_fails(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        unchanged = MagicMock(stdout="cafef00d\n")
+        clean_status = MagicMock(stdout="", stderr="", returncode=0)
+        with (
+            patch(
+                "hephaestus.automation.ci_driver.gh_pr_checks",
+                return_value=[_make_check("lint", conclusion="failure")],
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.gh_pr_list_unresolved_threads",
+                return_value=[],
+            ),
+            # Agent fails → _retry_no_commit_once returns False immediately
+            patch(
+                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                side_effect=subprocess.CalledProcessError(1, ["claude"], stderr="err"),
+            ),
+            patch(
+                "hephaestus.automation.ci_driver.run",
+                side_effect=[unchanged, clean_status],
+            ),
+        ):
+            result = driver._push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="cafef00d",
+                issue_number=1,
+                pr_number=2,
+                pr_head_branch="1-fix",
+                session_id=None,
+            )
+        assert result is False
+
+    def test_returns_false_when_not_pushable(self, driver: CIDriver, tmp_path: Path) -> None:
+        post_sha = MagicMock(stdout="deadbeef\n")
+        # Unmerged index entries → not pushable
+        unmerged = MagicMock(stdout="UU conflict.py\n", stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.ci_driver.run",
+            side_effect=[post_sha, unmerged],
+        ):
+            result = driver._push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="cafef00d",
+                issue_number=1,
+                pr_number=2,
+                pr_head_branch="1-fix",
+                session_id=None,
+            )
+        assert result is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Extract provider dispatch into `_invoke_agent_session` and the duplicated post-agent push contract into `_push_ci_fix`, eliminating OCP-violating inline provider conditionals in `_retry_no_commit_once` and `_run_ci_fix_session`.

## Changes

- **`_invoke_agent_session`**: single dispatch helper that absorbs `CalledProcessError` from all codex paths (resume + fresh fallback + no-session fresh) into `CompletedProcess(returncode!=0)`; propagates `TimeoutExpired` so callers log a distinct timeout message. Returns synthetic `returncode=0` for codex (`AgentRunResult` has no `returncode` field).
- **`_push_ci_fix`**: DRYs the character-identical 17-line post-agent block previously duplicated at the codex and claude call sites in `_run_ci_fix_session`.
- **`_run_ci_fix_session`**: `# noqa: C901` removed (McCabe complexity ≤ 6 after refactor; verified with `ruff check --select C901`).
- **`_retry_no_commit_once`**: coupling comment and inline provider dispatch replaced by `_invoke_agent_session` call; returns False immediately on non-zero returncode (preserving existing `CalledProcessError` semantics).
- Updated `test_codex_ci_fix_session_skips_push_when_head_did_not_advance` to supply the extra `run()` side_effect for `_tracked_worktree_changes` that was previously masked by the outer `except Exception` handler.
- Added `TestInvokeAgentSession` (8 tests, full branch matrix including double-failure absorption and `TimeoutExpired` propagation) and `TestPushCiFix` (3 tests).

Closes #1196