### PR TITLE
refactor(ci): remove dead skip-if-absent guards in pixi-check and justfile-check

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -237,23 +237,12 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - name: Skip if no pixi.toml
-        id: detect
-        run: |
-          if [ ! -f pixi.toml ]; then
-            echo "::notice::No pixi.toml in repo, skipping pixi-check"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: Setup pixi
-        if: steps.detect.outputs.skip == 'false'
         uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
         with:
           pixi-version: v0.69.0
           cache: true
       - name: pixi install (locked)
-        if: steps.detect.outputs.skip == 'false'
         run: |
           if [ -f pixi.lock ]; then
             pixi install --locked
@@ -272,22 +261,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - name: Skip if no justfile
-        id: detect
-        run: |
-          if [ ! -f justfile ] && [ ! -f Justfile ]; then
-            echo "::notice::No justfile in repo, skipping justfile-check"
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
       - name: Install just
-        if: steps.detect.outputs.skip == 'false'
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
           just-version: "1.36.0"
       - name: Validate justfile
-        if: steps.detect.outputs.skip == 'false'
         run: |
           just --evaluate >/dev/null
           just --list >/dev/null


### PR DESCRIPTION
Remove speculative detect-and-skip scaffolding from the `pixi-check` and `justfile-check` jobs in `.github/workflows/_required.yml`.

Both `pixi.toml` and `justfile` are committed to this repo. The detect steps always emitted `skip=false` and the four `if: steps.detect.outputs.skip == 'false'` guards were never taken. This is dead complexity that violates KISS and YAGNI.

## Changes

- Deleted `Skip if no pixi.toml` step (with `id: detect`) from `pixi-check`
- Removed two `if: steps.detect.outputs.skip == 'false'` guards from `pixi-check`
- Deleted `Skip if no justfile` step (with `id: detect`) from `justfile-check`
- Removed two `if: steps.detect.outputs.skip == 'false'` guards from `justfile-check`

Net: 22 lines removed, 0 added. Both jobs now run unconditionally (gated only by the existing `changes-gate` job-level `if:`).

## Verification

- YAML syntax valid: `python3 -c "import yaml; yaml.safe_load(open(...))"` → `YAML OK`
- No detect remnants: `grep -c "steps.detect.outputs.skip|Skip if no"` → `0`
- Required actions still present: `setup-pixi`, `setup-just`, `pixi install`, `just --evaluate` all confirmed in the file

Closes #1200