### PR TITLE
fix(ci): raise coverage floor to 83% and consolidate to single source of truth

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -559,8 +559,7 @@ jobs:
       - name: Run unit tests
         run: |
           pytest tests/unit --override-ini="addopts=" -v --strict-markers \
-            --cov=hephaestus --cov-report=term-missing --cov-report=xml \
-            --cov-fail-under=80
+            --cov=hephaestus --cov-report=term-missing --cov-report=xml
 
       - name: Check unit test structure
         # Use the strict CLI (also flags loose test_*.py files at tests/unit/ root).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ name: Test
 #
 # The authoritative required gate is `.github/workflows/_required.yml`: it runs
 # lint (ruff/yamllint/mypy), the canonical unit-tests + integration-tests jobs
-# (Python 3.12, with --cov-fail-under=80 + per-module coverage floors), the
+# (Python 3.12, coverage gated by [tool.coverage.report].fail_under in pyproject.toml + per-module coverage floors), the
 # build smoke test, and the security/schema/pr-policy gates.
 #
 # To fix the DRY violation (and ~2x runner cost) flagged in #687, this workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,7 @@ def function_name(param: str, optional_param: Optional[int] = None) -> bool:
 - Type hints required for all functions
 - Clear docstrings for public functions and classes
 - Comprehensive error handling
-- Comprehensive test coverage (unit tests)
+- Comprehensive test coverage (unit tests) — 83%+ test coverage enforced; target 90%
 - Follow PEP 8 style guidelines
 
 ## Key Development Principles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,6 @@ addopts = [
     "--strict-markers",
     "--cov=hephaestus",
     "--cov-report=term-missing",
-    "--cov-fail-under=80",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
@@ -265,7 +264,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 83
 precision = 2
 show_missing = true
 skip_covered = false


### PR DESCRIPTION
## Summary

- Raises `[tool.coverage.report].fail_under` from 80 to 83 (measured CI baseline: 85.76%, `floor(85.76)-2`), closing the 10-point gap between the stated 90% target and the enforced gate incrementally
- Removes the duplicate `--cov-fail-under=80` from `pyproject.toml` addopts and from the `.github/workflows/_required.yml` unit-test step — `[tool.coverage.report].fail_under` is now the single source of truth, read automatically by pytest-cov
- Updates `CLAUDE.md:140` to add `83%+ test coverage enforced; target 90%`, satisfying `check_claude_md_threshold()` which previously errored on the missing `<N>%+ test coverage` pattern
- Updates `test.yml:21` comment to remove the stale `--cov-fail-under=80` reference

## Test plan

- [x] `pixi run pytest tests/unit -q` — 4054 passed, 21 skipped; TOTAL 85.57% ≥ 83% gate
- [x] `pixi run hephaestus-check-doc-config --repo-root . --skip-test-count` — exit 0
- [x] `grep "fail_under" pyproject.toml` → `fail_under = 83` (raised, not a no-op)
- [x] `grep -n "cov-fail-under" pyproject.toml .github/workflows/_required.yml` → zero matches (single source of truth)

Closes #1198