### PR TITLE
fix(deps): raise ruff floor to >=0.15 and add cross-manifest regression guard

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -64,7 +64,7 @@ editables = ">=0.5,<1"
 # environment keeps its own solve-group so resolves stay isolated.
 pre-commit = ">=3.0,<5"
 types-pyyaml = ">=6.0.12,<7"
-ruff = ">=0.1.0,<1"
+ruff = ">=0.15,<1"
 mypy = ">=1.8.0,<3"
 # yamllint floor tracks the .pre-commit-config.yaml mirror rev (v1.38.0) so the
 # local hook and the pixi-driven CI `lint` job resolve the same major/minor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dev = [
     "pytest>=9.0,<10",
     "pytest-cov>=7.0,<8",
     "pre-commit>=3.0,<5",
-    "ruff>=0.1.0,<1",
+    "ruff>=0.15,<1",
     # Upper-cap kept in lockstep with pixi.toml [feature.dev]/[feature.lint] —
     # mypy 1.x and 2.x have different error semantics; CI tests only 1.x.
     # Enforced by tests/unit/scripts/test_dependency_floor_consistency.py.

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -329,3 +329,71 @@ class TestPytestConsistency:
             f"pixi.toml [feature.dev]={pixi_dev_cap}. "
             "Update both together — see issue #785."
         )
+
+
+class TestRuffConsistency:
+    """Tests for ruff floor/cap consistency across pyproject.toml and pixi.toml.
+
+    ruff 0.1.x and 0.15.x enforce different lint rulesets; the pixi-driven CI
+    resolves the cap declared in pixi.toml [feature.shared], so a pip-install
+    user on ``.[dev]`` must see the same floor or they land on an untested
+    ruleset. Tracks issue #1201.
+
+    Comparisons use packaging.version.Version (PEP 440) so that "0.15"
+    and "0.15.0" compare equal semantically.
+
+    Note: reads pixi.toml [feature.shared.dependencies] only — if ruff is ever
+    added under [feature.lint.dependencies], extend this test to check that key.
+    """
+
+    def test_ruff_floor_matches_across_manifests(self, repo_root: Path) -> None:
+        """Ruff floor in pyproject.toml dev extra must equal pixi shared feature."""
+        pyproject_path = repo_root / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+
+        dev_deps = pyproject["project"]["optional-dependencies"]["dev"]
+        pyproject_spec = TestPytestConsistency._find_dep(dev_deps, "ruff")
+        assert pyproject_spec is not None, "ruff not found in [project.optional-dependencies.dev]"
+
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        pixi_shared_spec = pixi["feature"]["shared"]["dependencies"]["ruff"]
+
+        pyproject_floor = Version(_floor(pyproject_spec))
+        pixi_shared_floor = Version(_floor(pixi_shared_spec))
+
+        assert pyproject_floor == pixi_shared_floor, (
+            "ruff floor skew (semantic): "
+            f"pyproject.toml dev={pyproject_floor} vs "
+            f"pixi.toml [feature.shared]={pixi_shared_floor}. "
+            "Update both together — see issue #1201."
+        )
+
+    def test_ruff_upper_cap_matches_across_manifests(self, repo_root: Path) -> None:
+        """Ruff upper-cap in pyproject.toml dev extra must equal pixi shared feature."""
+        pyproject_path = repo_root / "pyproject.toml"
+        with open(pyproject_path, "rb") as f:
+            pyproject = tomllib.load(f)
+
+        dev_deps = pyproject["project"]["optional-dependencies"]["dev"]
+        pyproject_spec = TestPytestConsistency._find_dep(dev_deps, "ruff")
+        assert pyproject_spec is not None, "ruff not found in [project.optional-dependencies.dev]"
+
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        pixi_shared_spec = pixi["feature"]["shared"]["dependencies"]["ruff"]
+
+        pyproject_cap = Version(_upper_cap(pyproject_spec))
+        pixi_shared_cap = Version(_upper_cap(pixi_shared_spec))
+
+        assert pyproject_cap == pixi_shared_cap, (
+            "ruff upper-cap skew (semantic): "
+            f"pyproject.toml dev={pyproject_cap} vs "
+            f"pixi.toml [feature.shared]={pixi_shared_cap}. "
+            "Update both together — see issue #1201."
+        )


### PR DESCRIPTION
Raise the ruff floor from `>=0.1.0` to `>=0.15` in both `pyproject.toml` and `pixi.toml`, aligned with the version CI actually resolves (`0.15.12` per `pixi.lock`). Adds `TestRuffConsistency` to `tests/unit/scripts/test_dependency_floor_consistency.py` with floor and upper-cap parity tests using PEP 440 semantic comparison — closing the regression gate that exists for mypy/pytest but was missing for ruff.

## Changes

- `pyproject.toml:52`: `ruff>=0.1.0,<1` → `ruff>=0.15,<1`
- `pixi.toml:67`: `ruff = ">=0.1.0,<1"` → `ruff = ">=0.15,<1"`
- `tests/unit/scripts/test_dependency_floor_consistency.py`: add `TestRuffConsistency` with `test_ruff_floor_matches_across_manifests` and `test_ruff_upper_cap_matches_across_manifests`

## Test plan

- [ ] `pixi run pytest tests/unit/scripts/test_dependency_floor_consistency.py::TestRuffConsistency -v` — 2 new tests pass
- [ ] All 8 tests in the consistency file pass (no regressions in mypy/pytest/PyGithub guards)
- [ ] `pixi run ruff check hephaestus scripts tests` — clean (pre-existing errors unrelated to this PR)

Closes #1201