### PR TITLE
fix(deps): pin pip to >=23.0,<27 in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -40,7 +40,10 @@ dev-install = "pip install -e . --no-deps"
 # experimental 3.14 free-threaded build (cp314t), which is outside the support
 # matrix and not CI-tested. See issue #1184.
 python = ">=3.10,<3.14"
-pip = "*"
+# Load-bearing for `dev-install` (pip install -e . --no-deps) and pip-audit.
+# Floor 23.0: first stable PEP 660 editable-install release; cap blocks the
+# next untested major (installed 26.x in CI). Bump cap after testing 27.x.
+pip = ">=23.0,<27"
 pydantic = ">=2.12.5,<3"
 pygments = ">=2.20.0"  # CVE-2026-4539
 pygithub = ">=2.9.1,<3"

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -397,3 +397,56 @@ class TestRuffConsistency:
             f"pixi.toml [feature.shared]={pixi_shared_cap}. "
             "Update both together — see issue #1201."
         )
+
+
+class TestPipPinning:
+    """pip in pixi.toml [dependencies] must carry both a >= floor and a < cap.
+
+    pip is load-bearing for the dev-install editable path and pip-audit flows;
+    an unbounded '*' would permit an untested major to silently land. Tracks
+    issue #1202.
+    """
+
+    def test_pip_has_floor_and_cap(self, repo_root: Path) -> None:
+        """pip spec must be parseable by both _floor() and _upper_cap()."""
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        assert "dependencies" in pixi, "No [dependencies] section in pixi.toml"
+        assert "pip" in pixi["dependencies"], "pip not found in [dependencies]"
+
+        spec = pixi["dependencies"]["pip"]
+        # Delegate to the established helpers — raises AssertionError if floor/cap absent.
+        _floor(spec)
+        _upper_cap(spec)
+
+    def test_pip_floor_is_at_least_23(self, repo_root: Path) -> None:
+        """pip floor must be >= 23.0 for stable PEP 660 editable-install support."""
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        spec = pixi["dependencies"]["pip"]
+        floor = Version(_floor(spec))
+        assert floor >= Version("23.0"), (
+            f"pip floor too low ({floor}); must be >= 23.0 for PEP 660 editable support"
+        )
+
+    def test_pip_cap_blocks_next_major_only(self, repo_root: Path) -> None:
+        """pip cap must be exactly one major ahead of the installed 26.x series.
+
+        Asserts Version("26") < cap <= Version("27") so the test rejects both
+        a downgrade cap (<= 26) and a permissive cap (>= 28) that would admit
+        untested majors.
+        """
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        spec = pixi["dependencies"]["pip"]
+        cap = Version(_upper_cap(spec))
+        assert Version("26") < cap <= Version("27"), (
+            f"pip cap {cap} must be > 26 (no downgrade) and <= 27 (block untested major); "
+            "update when CI tests pip 27.x"
+        )

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -408,7 +408,7 @@ class TestPipPinning:
     """
 
     def test_pip_has_floor_and_cap(self, repo_root: Path) -> None:
-        """pip spec must be parseable by both _floor() and _upper_cap()."""
+        """Pip spec must be parseable by both _floor() and _upper_cap()."""
         pixi_path = repo_root / "pixi.toml"
         with open(pixi_path, "rb") as f:
             pixi = tomllib.load(f)
@@ -422,7 +422,7 @@ class TestPipPinning:
         _upper_cap(spec)
 
     def test_pip_floor_is_at_least_23(self, repo_root: Path) -> None:
-        """pip floor must be >= 23.0 for stable PEP 660 editable-install support."""
+        """Pip floor must be >= 23.0 for stable PEP 660 editable-install support."""
         pixi_path = repo_root / "pixi.toml"
         with open(pixi_path, "rb") as f:
             pixi = tomllib.load(f)
@@ -434,7 +434,7 @@ class TestPipPinning:
         )
 
     def test_pip_cap_blocks_next_major_only(self, repo_root: Path) -> None:
-        """pip cap must be exactly one major ahead of the installed 26.x series.
+        """Pip cap must be exactly one major ahead of the installed 26.x series.
 
         Asserts Version("26") < cap <= Version("27") so the test rejects both
         a downgrade cap (<= 26) and a permissive cap (>= 28) that would admit


### PR DESCRIPTION
Pin `pip` in `pixi.toml` from the unbounded `"*"` to `">=23.0,<27"`.

## Changes

- **`pixi.toml`**: replaces `pip = "*"` with `pip = ">=23.0,<27"` plus a rationale comment following the `urllib3`/`pyjwt` comment pattern.
  - Floor `>=23.0`: pip 23.0 is the first release with stable PEP 660 editable-install support, which `dev-install = "pip install -e . --no-deps"` relies on.
  - Cap `<27`: installed major is 26, so cap = `installed_major + 1` per team KB rule — blocks the next untested major while permitting all current 26.x patch releases.
- **`tests/unit/scripts/test_dependency_floor_consistency.py`**: adds `TestPipPinning` class with three regression tests using the existing `_floor`/`_upper_cap` helpers (DRY), enforcing floor ≥ 23.0 and a two-sided cap assertion `Version("26") < cap <= Version("27")`.

## Verification

- `pixi install` re-solved cleanly; `git diff pixi.lock` was empty (pip 26.1.2 already satisfies `>=23.0,<27`).
- All 9 tests in `test_dependency_floor_consistency.py` pass.

Closes #1202