### PR TITLE
docs(security): align Python version range with pyproject + CI matrix

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,9 @@
 
 ## Supported Versions
 
-As of the 0.9.x release line. Python >= 3.10 required.
+ProjectHephaestus supports **Python 3.10–3.13** (`requires-python = ">=3.10"` in
+`pyproject.toml`; CI exercises 3.10, 3.11, 3.12, and 3.13). See
+[COMPATIBILITY.md](COMPATIBILITY.md) for the full compatibility policy.
 
 | Version | Supported       |
 |---------|-----------------|


### PR DESCRIPTION
SECURITY.md:5 stated only "Python >= 3.10 required", omitting the tested ceiling
and any canonical source reference.

Replace with a precise statement that surfaces:
- The floor: `>=3.10` from `pyproject.toml` (canonical source)
- The tested range: 3.10, 3.11, 3.12, and 3.13 (per CI matrix in `test.yml`)
- A cross-reference to `COMPATIBILITY.md` for the full compatibility policy

Closes #1204