### PR TITLE
fix(docs): correct stale install.sh line-number citations in architecture doc and bats header

### DIFF
--- a/docs/INSTALLER_ARCHITECTURE.md
+++ b/docs/INSTALLER_ARCHITECTURE.md
@@ -40,7 +40,7 @@ The final summary block (`install.sh:968–988`) aggregates results from **all s
 
 ## What the Script Is *Not*
 
-The entry-point guard at `install.sh:137–141` returns early when the script is
+The entry-point guard at `install.sh:178–180` returns early when the script is
 sourced rather than executed (its inline comment anticipates Odysseus phase
 scripts as the intended sourcing consumer).
 

--- a/tests/shell/scripts/test_install_install_branches.bats
+++ b/tests/shell/scripts/test_install_install_branches.bats
@@ -2,7 +2,7 @@
 # Regression tests for scripts/shell/install.sh — the four if-block rewrites
 # that replaced broken `A || B && C || D` short-circuit chains (issue #788).
 #
-# Each test sources the script (the entry-point guard at install.sh:127-129
+# Each test sources the script (the entry-point guard at install.sh:178-180
 # returns before argument parsing), resets the counters, stubs apt_install/pip3
 # to return a chosen rc, then re-runs the rewritten if-block and asserts that
 # exactly one of _PASS / _FAIL advanced by exactly 1.
@@ -17,7 +17,7 @@ setup() {
     INSTALL=true
 }
 
-# ── Harness sanity: sourcing guard at install.sh:127-129 worked; helpers loaded ──
+# ── Harness sanity: sourcing guard at install.sh:178-180 worked; helpers loaded ──
 @test "sourcing guard exposes helpers and counters" {
     declare -F check_pass >/dev/null
     declare -F check_fail >/dev/null


### PR DESCRIPTION
Fixes two stale line-number citations left over from code churn after
PR #792/#984. The entry-point guard (`if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then return 0; fi`) moved to `install.sh:178–180`, but:

- `docs/INSTALLER_ARCHITECTURE.md:43` still cited `install.sh:137–141`
- `tests/shell/scripts/test_install_install_branches.bats` cited `install.sh:127-129` in two header comments (lines 5 and 20)

Both updated to `178-180` / `178–180`. No functional change — comments and doc text only.

Closes #1222