### PR TITLE
fix(validation): detect duplicate H2 tier sections in COMPATIBILITY.md

### DIFF
--- a/hephaestus/validation/cli_tier_docs.py
+++ b/hephaestus/validation/cli_tier_docs.py
@@ -42,6 +42,7 @@ class TierDocFinding:
     # kind values: "missing-from-docs" | "missing-from-pyproject"
     #              | "invalid-tier" | "parser-found-no-rows"
     #              | "duplicate-tier" | "conflicting-tier"
+    #              | "duplicate-section"
     kind: str
     detail: str
 
@@ -65,29 +66,37 @@ def load_pyproject_scripts(pyproject_path: Path) -> dict[str, str]:
 
 def load_documented_tiers(
     compatibility_path: Path,
-) -> tuple[dict[str, str], dict[str, list[str]]]:
+) -> tuple[dict[str, str], dict[str, list[str]], int]:
     """Parse the Console-Script Stability Tiers table.
 
-    Skips separator rows (``|---|---|``) and the header row. Stops at the
-    next section heading or first non-table line after the table starts.
+    Skips separator rows (``|---|---|``) and the header row. Continues past
+    non-target H2 headings so that a SECOND ``## Console-Script Stability
+    Tiers`` section later in the file is also parsed (and detected as a
+    duplicate-section violation by :func:`find_duplicate_sections`).
 
     Returns:
-        A ``(tiers, occurrences)`` pair. ``tiers`` is the flattened
-        ``{cli: tier}`` mapping (last occurrence wins, used for the
-        membership/valid-value checks). ``occurrences`` is
-        ``{cli: [tier, tier, ...]}`` preserving EVERY parsed row so the
-        caller can detect a CLI documented more than once.
+        A ``(tiers, occurrences, section_count)`` triple. ``tiers`` is the
+        flattened ``{cli: tier}`` mapping (last occurrence wins). ``occurrences``
+        is ``{cli: [tier, tier, ...]}`` preserving EVERY row across ALL matching
+        sections. ``section_count`` is the number of ``## Console-Script
+        Stability Tiers`` headers found; >1 means a duplicate-section violation.
 
     """
     occurrences: dict[str, list[str]] = {}
     in_section = False
     in_table = False
+    section_count = 0
     for line in compatibility_path.read_text(encoding="utf-8").splitlines():
         if _SECTION_HEADER_RE.match(line):
             in_section = True
+            in_table = False
+            section_count += 1
             continue
-        if in_section and line.startswith("## ") and not _SECTION_HEADER_RE.match(line):
-            break  # next H2 ends the section
+        if line.startswith("## ") and not _SECTION_HEADER_RE.match(line):
+            # A different H2: exit the current section but keep scanning.
+            in_section = False
+            in_table = False
+            continue
         if not in_section:
             continue
         if _TABLE_HEADER_RE.search(line):
@@ -103,7 +112,7 @@ def load_documented_tiers(
             if m:
                 occurrences.setdefault(m.group(1), []).append(m.group(2))
     tiers = {cli: vals[-1] for cli, vals in occurrences.items()}
-    return tiers, occurrences
+    return tiers, occurrences, section_count
 
 
 def find_duplicate_tiers(occurrences: dict[str, list[str]]) -> list[TierDocFinding]:
@@ -139,6 +148,27 @@ def find_duplicate_tiers(occurrences: dict[str, list[str]]) -> list[TierDocFindi
                 )
             )
     return findings
+
+
+def find_duplicate_sections(section_count: int) -> list[TierDocFinding]:
+    """Emit a finding when the target section header appears more than once.
+
+    A document with two ``## Console-Script Stability Tiers`` sections is
+    self-contradictory regardless of whether individual rows conflict.
+    """
+    if section_count <= 1:
+        return []
+    return [
+        TierDocFinding(
+            cli="<section>",
+            kind="duplicate-section",
+            detail=(
+                f"COMPATIBILITY.md contains {section_count} "
+                f"'## Console-Script Stability Tiers' sections; "
+                "remove all but one to eliminate cross-section contradictions"
+            ),
+        )
+    ]
 
 
 def find_violations(
@@ -226,8 +256,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     repo_root = args.repo_root or get_repo_root()
     scripts = load_pyproject_scripts(repo_root / "pyproject.toml")
-    tiers, occurrences = load_documented_tiers(repo_root / "COMPATIBILITY.md")
-    duplicates = find_duplicate_tiers(occurrences)
+    tiers, occurrences, section_count = load_documented_tiers(repo_root / "COMPATIBILITY.md")
+    duplicates = find_duplicate_sections(section_count) + find_duplicate_tiers(occurrences)
     findings = find_violations(scripts, tiers, duplicates)
     print(format_json(findings) if args.json else format_report(findings))
     return 0 if not findings else 1

--- a/tests/unit/validation/test_cli_tier_docs.py
+++ b/tests/unit/validation/test_cli_tier_docs.py
@@ -8,6 +8,7 @@ import pytest
 
 from hephaestus.utils.helpers import get_repo_root
 from hephaestus.validation.cli_tier_docs import (
+    find_duplicate_sections,
     find_duplicate_tiers,
     find_violations,
     load_documented_tiers,
@@ -81,7 +82,7 @@ class TestParsing:
             "| `hephaestus-bar` | Provisional | Another |\n"
             "\n## Next Section\n"
         )
-        tiers, _ = load_documented_tiers(md)
+        tiers, _, _ = load_documented_tiers(md)
         assert tiers == {"hephaestus-foo": "Stable", "hephaestus-bar": "Provisional"}
 
     def test_load_tiers_stops_at_next_section(self, tmp_path: Path) -> None:
@@ -94,13 +95,13 @@ class TestParsing:
             "## Other Section\n"
             "| `hephaestus-bar` | Internal | y |\n"  # NOT in scope
         )
-        tiers, _ = load_documented_tiers(md)
+        tiers, _, _ = load_documented_tiers(md)
         assert tiers == {"hephaestus-foo": "Stable"}
 
     def test_load_tiers_missing_section_returns_empty(self, tmp_path: Path) -> None:
         md = tmp_path / "COMPATIBILITY.md"
         md.write_text("# Just a doc\nNo section here.\n")
-        tiers, _ = load_documented_tiers(md)
+        tiers, _, _ = load_documented_tiers(md)
         assert tiers == {}
 
 
@@ -129,7 +130,7 @@ class TestDuplicateDetection:
             "| `hephaestus-foo` | Internal | contradictory second |\n"
             "## Next\n"
         )
-        tiers, occ = load_documented_tiers(md)
+        tiers, occ, _ = load_documented_tiers(md)
         assert occ == {"hephaestus-foo": ["Stable", "Internal"]}
         assert tiers == {"hephaestus-foo": "Internal"}  # flattened: last-write-wins
         assert find_duplicate_tiers(occ)[0].kind == "conflicting-tier"
@@ -139,6 +140,86 @@ class TestDuplicateDetection:
         dups = find_duplicate_tiers({"hephaestus-foo": ["Stable", "Internal"]})
         v = find_violations({"hephaestus-foo": "x:y"}, {"hephaestus-foo": "Internal"}, dups)
         assert any(f.kind == "conflicting-tier" for f in v)
+
+
+class TestDuplicateSectionDetection:
+    """Tests for find_duplicate_sections() and the cross-section parser path."""
+
+    def test_no_finding_when_single_section(self) -> None:
+        assert find_duplicate_sections(1) == []
+
+    def test_no_finding_when_zero_sections(self) -> None:
+        assert find_duplicate_sections(0) == []
+
+    def test_duplicate_section_flagged(self) -> None:
+        v = find_duplicate_sections(2)
+        assert len(v) == 1 and v[0].kind == "duplicate-section"
+        assert v[0].cli == "<section>"
+        assert "2" in v[0].detail
+
+    def test_parser_counts_two_sections(self, tmp_path: Path) -> None:
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier | Notes |\n"
+            "|-----|------|-------|\n"
+            "| `hephaestus-foo` | Stable | first section |\n"
+            "## Public API\n"
+            "Some content.\n"
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier | Notes |\n"
+            "|-----|------|-------|\n"
+            "| `hephaestus-foo` | Internal | second section contradicts first |\n"
+        )
+        tiers, occ, section_count = load_documented_tiers(md)
+        assert section_count == 2
+        assert occ == {"hephaestus-foo": ["Stable", "Internal"]}
+        assert tiers == {"hephaestus-foo": "Internal"}  # last-write-wins
+
+    def test_cross_section_conflict_surfaces_both_findings(self, tmp_path: Path) -> None:
+        """A two-section doc with a conflicting row emits duplicate-section AND conflicting-tier."""
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+            "## Other\n"
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Internal |\n"
+        )
+        tiers, occ, section_count = load_documented_tiers(md)
+        sec_findings = find_duplicate_sections(section_count)
+        dup_findings = find_duplicate_tiers(occ)
+        all_findings = find_violations(
+            {"hephaestus-foo": "x:y"}, tiers, sec_findings + dup_findings
+        )
+        kinds = {f.kind for f in all_findings}
+        assert "duplicate-section" in kinds
+        assert "conflicting-tier" in kinds
+
+    def test_two_sections_same_tier_no_conflict_but_duplicate_section_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+            "## Other\n"
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+        )
+        _, occ, section_count = load_documented_tiers(md)
+        sec_findings = find_duplicate_sections(section_count)
+        dup_findings = find_duplicate_tiers(occ)
+        assert any(f.kind == "duplicate-section" for f in sec_findings)
+        assert any(f.kind == "duplicate-tier" for f in dup_findings)
 
 
 class TestRealRepo:


### PR DESCRIPTION
## Summary

- `load_documented_tiers` previously `break`d at the first non-matching H2, silently swallowing any second `## Console-Script Stability Tiers` section — the exact failure that required a manual 76-line deletion in PR #1248.
- Replace `break` with continue-scan: on a non-target H2, reset state but keep scanning the rest of the file.
- Accumulate rows from **all** matching sections into the same `occurrences` dict so `find_duplicate_tiers` detects cross-section conflicts for free.
- Return a 3-tuple `(tiers, occurrences, section_count)`; add `find_duplicate_sections(section_count)` that emits a `duplicate-section` `TierDocFinding` when `section_count > 1`.
- Wire `find_duplicate_sections` into `main()` alongside `find_duplicate_tiers`.
- Add `TestDuplicateSectionDetection` (5 tests) covering the new helper and the cross-section parser path; update all existing 2-tuple unpacks to 3-tuple.

## Test plan

- [ ] `pixi run pytest tests/unit/validation/test_cli_tier_docs.py -v --no-cov` → 22 passed
- [ ] `TestRealRepo::test_repo_has_no_tier_doc_violations` passes (live COMPATIBILITY.md is single-section)
- [ ] `TestDuplicateSectionDetection::test_parser_counts_two_sections` confirms section_count=2 for a two-section contradictory doc
- [ ] `TestDuplicateSectionDetection::test_cross_section_conflict_surfaces_both_findings` confirms both `duplicate-section` and `conflicting-tier` are emitted

Closes #1255