### PR TITLE
fix(validation): detect duplicate H2 tier sections in COMPATIBILITY.md

### DIFF
--- a/hephaestus/validation/cli_tier_docs.py
+++ b/hephaestus/validation/cli_tier_docs.py
@@ -42,6 +42,7 @@ class TierDocFinding:
     # kind values: "missing-from-docs" | "missing-from-pyproject"
     #              | "invalid-tier" | "parser-found-no-rows"
     #              | "duplicate-tier" | "conflicting-tier"
+    #              | "duplicate-section"
     kind: str
     detail: str
 
@@ -65,29 +66,39 @@ def load_pyproject_scripts(pyproject_path: Path) -> dict[str, str]:
 
 def load_documented_tiers(
     compatibility_path: Path,
-) -> tuple[dict[str, str], dict[str, list[str]]]:
+) -> tuple[dict[str, str], dict[str, list[str]], int]:
     """Parse the Console-Script Stability Tiers table.
 
     Skips separator rows (``|---|---|``) and the header row. Stops at the
     next section heading or first non-table line after the table starts.
+    Accumulates rows from ALL ``## Console-Script Stability Tiers`` sections
+    into the same ``occurrences`` dict so cross-section contradictions are
+    detected.
 
     Returns:
-        A ``(tiers, occurrences)`` pair. ``tiers`` is the flattened
-        ``{cli: tier}`` mapping (last occurrence wins, used for the
+        A ``(tiers, occurrences, section_count)`` triple. ``tiers`` is the
+        flattened ``{cli: tier}`` mapping (last occurrence wins, used for the
         membership/valid-value checks). ``occurrences`` is
         ``{cli: [tier, tier, ...]}`` preserving EVERY parsed row so the
-        caller can detect a CLI documented more than once.
+        caller can detect a CLI documented more than once. ``section_count``
+        is the number of ``## Console-Script Stability Tiers`` headers found;
+        >1 indicates a duplicate section.
 
     """
     occurrences: dict[str, list[str]] = {}
     in_section = False
     in_table = False
+    section_count = 0
     for line in compatibility_path.read_text(encoding="utf-8").splitlines():
         if _SECTION_HEADER_RE.match(line):
             in_section = True
+            in_table = False
+            section_count += 1
             continue
         if in_section and line.startswith("## ") and not _SECTION_HEADER_RE.match(line):
-            break  # next H2 ends the section
+            in_section = False  # exit section; keep scanning for another tier section
+            in_table = False
+            continue
         if not in_section:
             continue
         if _TABLE_HEADER_RE.search(line):
@@ -103,7 +114,7 @@ def load_documented_tiers(
             if m:
                 occurrences.setdefault(m.group(1), []).append(m.group(2))
     tiers = {cli: vals[-1] for cli, vals in occurrences.items()}
-    return tiers, occurrences
+    return tiers, occurrences, section_count
 
 
 def find_duplicate_tiers(occurrences: dict[str, list[str]]) -> list[TierDocFinding]:
@@ -226,8 +237,20 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     repo_root = args.repo_root or get_repo_root()
     scripts = load_pyproject_scripts(repo_root / "pyproject.toml")
-    tiers, occurrences = load_documented_tiers(repo_root / "COMPATIBILITY.md")
+    tiers, occurrences, section_count = load_documented_tiers(repo_root / "COMPATIBILITY.md")
     duplicates = find_duplicate_tiers(occurrences)
+    if section_count > 1:
+        duplicates.append(
+            TierDocFinding(
+                cli="<section>",
+                kind="duplicate-section",
+                detail=(
+                    f"COMPATIBILITY.md contains {section_count} "
+                    "'## Console-Script Stability Tiers' sections; "
+                    "merge them into one to prevent cross-section contradictions"
+                ),
+            )
+        )
     findings = find_violations(scripts, tiers, duplicates)
     print(format_json(findings) if args.json else format_report(findings))
     return 0 if not findings else 1

--- a/tests/integration/test_choose_merge_flag_sh.py
+++ b/tests/integration/test_choose_merge_flag_sh.py
@@ -27,7 +27,7 @@ def test_shell_helper_errors_on_missing_arg() -> None:
     assert "missing required argument" in out.stderr
 
 
-def _run_with_mock_gh(json_body: str, repo: str = "owner/repo") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+def _run_with_mock_gh(json_body: str, repo: str = "owner/repo") -> subprocess.CompletedProcess[str]:
     """Run choose_merge_flag with a mock gh function returning json_body."""
     script = f"""
 gh() {{
@@ -52,12 +52,15 @@ def test_shell_helper_handles_gh_stderr_noise() -> None:
 
     Regression guard for the safety fix: fails against the unfixed 2>&1 version.
     """
+    merge_settings = (
+        '{"allow_rebase_merge":true,"allow_squash_merge":true,"allow_merge_commit":true}'
+    )
     script = f"""
 gh() {{
     case "$1" in
         api)
             printf '%s\\n' 'warning: new gh release available' >&2
-            printf '%s\\n' '{{"allow_rebase_merge":true,"allow_squash_merge":true,"allow_merge_commit":true}}'
+            printf '%s\\n' '{merge_settings}'
             ;;
         *) command gh "$@" ;;
     esac
@@ -93,3 +96,11 @@ def test_shell_helper_exits_1_when_no_methods_allowed() -> None:
     result = _run_with_mock_gh(body)
     assert result.returncode == 1
     assert "allows no merge methods" in result.stderr
+
+
+def test_shell_helper_selects_merge_when_rebase_and_squash_disallowed() -> None:
+    """Falls back to merge commit when both rebase and squash are not permitted."""
+    body = '{"allow_rebase_merge":false,"allow_squash_merge":false,"allow_merge_commit":true}'
+    result = _run_with_mock_gh(body)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "--merge"

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -678,7 +678,10 @@ class TestCapturePlannerLearnings:
         assert (state_dir / "planner-learn-123.log").read_text().startswith("FAILED:")
 
     def test_oswrite_failure_is_nonfatal(self, planner: Planner, tmp_path: Any) -> None:
-        """OSError in record write must not propagate — capture_planner_learnings still returns output."""
+        """OSError in record write must not propagate.
+
+        capture_planner_learnings still returns output.
+        """
         with (
             patch(
                 "hephaestus.automation.planner_review_loop.get_repo_root",

--- a/tests/unit/validation/test_cli_tier_docs.py
+++ b/tests/unit/validation/test_cli_tier_docs.py
@@ -159,7 +159,7 @@ class TestCrossSectionDetection:
             "|-----|------|\n"
             "| `hephaestus-foo` | Internal |\n"
         )
-        tiers, occ, section_count = load_documented_tiers(md)
+        _tiers, occ, section_count = load_documented_tiers(md)
         assert occ == {"hephaestus-foo": ["Stable", "Internal"]}
         assert section_count == 2
         findings = find_duplicate_tiers(occ)
@@ -180,8 +180,7 @@ class TestCrossSectionDetection:
         """main() emits duplicate-section when COMPATIBILITY.md has two tier sections."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
-            '[project]\nname = "test"\n\n'
-            '[project.scripts]\nhephaestus-foo = "pkg:main"\n'
+            '[project]\nname = "test"\n\n[project.scripts]\nhephaestus-foo = "pkg:main"\n'
         )
         md = tmp_path / "COMPATIBILITY.md"
         md.write_text(

--- a/tests/unit/validation/test_cli_tier_docs.py
+++ b/tests/unit/validation/test_cli_tier_docs.py
@@ -81,7 +81,7 @@ class TestParsing:
             "| `hephaestus-bar` | Provisional | Another |\n"
             "\n## Next Section\n"
         )
-        tiers, _ = load_documented_tiers(md)
+        tiers, _, _ = load_documented_tiers(md)
         assert tiers == {"hephaestus-foo": "Stable", "hephaestus-bar": "Provisional"}
 
     def test_load_tiers_stops_at_next_section(self, tmp_path: Path) -> None:
@@ -94,13 +94,13 @@ class TestParsing:
             "## Other Section\n"
             "| `hephaestus-bar` | Internal | y |\n"  # NOT in scope
         )
-        tiers, _ = load_documented_tiers(md)
+        tiers, _, _ = load_documented_tiers(md)
         assert tiers == {"hephaestus-foo": "Stable"}
 
     def test_load_tiers_missing_section_returns_empty(self, tmp_path: Path) -> None:
         md = tmp_path / "COMPATIBILITY.md"
         md.write_text("# Just a doc\nNo section here.\n")
-        tiers, _ = load_documented_tiers(md)
+        tiers, _, _ = load_documented_tiers(md)
         assert tiers == {}
 
 
@@ -129,7 +129,7 @@ class TestDuplicateDetection:
             "| `hephaestus-foo` | Internal | contradictory second |\n"
             "## Next\n"
         )
-        tiers, occ = load_documented_tiers(md)
+        tiers, occ, _ = load_documented_tiers(md)
         assert occ == {"hephaestus-foo": ["Stable", "Internal"]}
         assert tiers == {"hephaestus-foo": "Internal"}  # flattened: last-write-wins
         assert find_duplicate_tiers(occ)[0].kind == "conflicting-tier"
@@ -139,6 +139,80 @@ class TestDuplicateDetection:
         dups = find_duplicate_tiers({"hephaestus-foo": ["Stable", "Internal"]})
         v = find_violations({"hephaestus-foo": "x:y"}, {"hephaestus-foo": "Internal"}, dups)
         assert any(f.kind == "conflicting-tier" for f in v)
+
+
+class TestCrossSectionDetection:
+    """Tests for cross-section duplicate detection (issue #1257)."""
+
+    def test_two_tier_sections_same_cli_conflict_flagged(self, tmp_path: Path) -> None:
+        """Concrete repro from issue #1257: two sections, contradictory tiers."""
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+            "\n## Public API\n\n"
+            "Some text.\n\n"
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Internal |\n"
+        )
+        tiers, occ, section_count = load_documented_tiers(md)
+        assert occ == {"hephaestus-foo": ["Stable", "Internal"]}
+        assert section_count == 2
+        findings = find_duplicate_tiers(occ)
+        assert any(f.kind == "conflicting-tier" for f in findings)
+
+    def test_section_count_one_for_normal_doc(self, tmp_path: Path) -> None:
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+        )
+        _, _, section_count = load_documented_tiers(md)
+        assert section_count == 1
+
+    def test_duplicate_section_finding_emitted_by_main(self, tmp_path: Path) -> None:
+        """main() emits duplicate-section when COMPATIBILITY.md has two tier sections."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '[project]\nname = "test"\n\n'
+            '[project.scripts]\nhephaestus-foo = "pkg:main"\n'
+        )
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+            "\n## Other\n\n"
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+        )
+        result = main(["--repo-root", str(tmp_path)])
+        assert result == 1  # non-zero exit due to duplicate-section
+
+    def test_non_tier_h2_still_ends_section(self, tmp_path: Path) -> None:
+        """Existing contract: rows under ## Other Section are NOT parsed."""
+        md = tmp_path / "COMPATIBILITY.md"
+        md.write_text(
+            "## Console-Script Stability Tiers\n"
+            "| CLI | Tier |\n"
+            "|-----|------|\n"
+            "| `hephaestus-foo` | Stable |\n"
+            "## Other Section\n"
+            "| `hephaestus-bar` | Internal |\n"
+        )
+        tiers, occ, section_count = load_documented_tiers(md)
+        assert tiers == {"hephaestus-foo": "Stable"}
+        assert "hephaestus-bar" not in occ
+        assert section_count == 1
 
 
 class TestRealRepo:


### PR DESCRIPTION
## Summary

- `load_documented_tiers` previously `break`ed on the first non-matching H2, silently ignoring any second `## Console-Script Stability Tiers` section. A document with two such sections and contradictory tiers (`hephaestus-foo|Stable` / `hephaestus-foo|Internal`) returned `find_duplicate_tiers()==[]` and the validator reported OK.
- Replace `break` with `in_section=False; in_table=False; continue` so the scanner keeps scanning and re-enters the next matching tier section.
- Return a 3-tuple `(tiers, occurrences, section_count)` from `load_documented_tiers`; `main()` emits a `duplicate-section` `TierDocFinding` when `section_count > 1`.
- Add `TestCrossSectionDetection` (4 new tests): issue repro, normal-doc baseline, `main()` integration, regression canary.
- Update 4 existing test unpackings from 2-tuple to 3-tuple.

## Test plan

- [x] `pixi run python -m pytest tests/unit/validation/test_cli_tier_docs.py -v --no-cov` → 20 passed
- [x] `TestCrossSectionDetection::test_two_tier_sections_same_cli_conflict_flagged` — exact issue repro
- [x] `TestRealRepo::test_repo_has_no_tier_doc_violations` — live COMPATIBILITY.md still passes (single section)
- [x] Commit signed (GPG, `Good signature`)

Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)