### PR TITLE
fix(license-scan): classify marker-excluded deps via static fallback

### DIFF
--- a/scripts/check_license_compatibility.py
+++ b/scripts/check_license_compatibility.py
@@ -62,7 +62,7 @@ ALLOWED_EXTRA_COPYLEFT: dict[str, frozenset[str]] = {
 # test suite cross-checks both keys and values against NOTICE and against real
 # installed metadata when the dep is actually installable.
 STATIC_FALLBACK_LICENSES: dict[str, list[str]] = {
-    "tomli": ["MIT"],          # python_version < '3.11'; NOTICE:58
+    "tomli": ["MIT"],  # python_version < '3.11'; NOTICE:58
     "tzdata": ["Apache-2.0"],  # platform_system == 'Windows'; NOTICE:28
 }
 

--- a/scripts/check_license_compatibility.py
+++ b/scripts/check_license_compatibility.py
@@ -15,6 +15,9 @@ FAILS LOUDLY (never silently passes):
     -> coverage hole -> exit 2. CI installs `.[all]` on a setup-python runner first.
   * a license string not in the mapping tables -> exit (PR:1 / main:0) with a
     hint to extend TROVE_TO_SPDX / LICENSE_ALIASES.
+  * a markered-out dep (installable_now=False) with no entry in
+    STATIC_FALLBACK_LICENSES -> exit 2. Add the package + SPDX id from NOTICE,
+    then update the cross-check tests in tests/unit/scripts/.
 
 Stdlib only (importlib.metadata + packaging, both already runtime deps); runs
 under plain `python3` once the package + extras are pip-installed.
@@ -50,6 +53,17 @@ PERMISSIVE: frozenset[str] = frozenset({"MIT", "BSD-2-Clause", "BSD-3-Clause", "
 ALLOWED_EXTRA_COPYLEFT: dict[str, frozenset[str]] = {
     "pygithub": frozenset({"LGPL-3.0", "LGPL-3.0-only", "LGPL-3.0-or-later", "LGPL"}),
     "defusedxml": frozenset({"PSF-2.0", "Python-2.0"}),
+}
+
+# Static license fallback for deps whose markers exclude the current interpreter
+# or platform. These are never installed in this CI leg (Python 3.13 / Linux)
+# so importlib.metadata cannot reach them. Values are SPDX IDs taken from NOTICE
+# (the authoritative human-readable analysis). Keep in sync with NOTICE — the
+# test suite cross-checks both keys and values against NOTICE and against real
+# installed metadata when the dep is actually installable.
+STATIC_FALLBACK_LICENSES: dict[str, list[str]] = {
+    "tomli": ["MIT"],          # python_version < '3.11'; NOTICE:58
+    "tzdata": ["Apache-2.0"],  # platform_system == 'Windows'; NOTICE:28
 }
 
 TROVE_TO_SPDX: dict[str, str] = {
@@ -263,13 +277,22 @@ def scan(records: dict[str, dict] | None = None) -> list[tuple[str, list[str]]]:
                     file=sys.stderr,
                 )
                 sys.exit(2)
+            fallback = STATIC_FALLBACK_LICENSES.get(pkg)
+            if fallback is None:
+                print(
+                    f"FATAL: {pkg!r} is distributed (marker holds on another "
+                    "Python/platform) but not installed here and has no entry "
+                    "in STATIC_FALLBACK_LICENSES. Add it with its SPDX license "
+                    "from NOTICE, then update the cross-check tests.",
+                    file=sys.stderr,
+                )
+                sys.exit(2)
             print(
-                f"note: skipping {pkg!r} — distributed only under another "
-                "Python/platform (marker excludes this interpreter); it is "
-                "classified on the matching CI matrix row.",
+                f"note: {pkg!r} excluded by marker in this env; "
+                f"classifying via static fallback from NOTICE: {fallback}",
                 file=sys.stderr,
             )
-            continue
+            ids = fallback
         if not is_compatible(pkg, ids):
             violations.append((pkg, ids))
     return violations

--- a/tests/unit/scripts/test_check_license_compatibility.py
+++ b/tests/unit/scripts/test_check_license_compatibility.py
@@ -350,8 +350,10 @@ class TestStaticFallback:
                 f"{pkg!r} is in STATIC_FALLBACK_LICENSES but not mentioned in NOTICE — "
                 "NOTICE is the authoritative source; add the dep there first."
             )
+            pkg_lines = [line for line in notice_text.splitlines() if pkg.lower() in line.lower()]
             for spdx_id in spdx_ids:
-                assert spdx_id in notice_text, (
+                assert any(spdx_id in line for line in pkg_lines), (
                     f"STATIC_FALLBACK_LICENSES[{pkg!r}] = {spdx_ids!r} but SPDX id "
-                    f"{spdx_id!r} not found in NOTICE — update one to match the other."
+                    f"{spdx_id!r} not found on any NOTICE line mentioning {pkg!r} — "
+                    "update one to match the other."
                 )

--- a/tests/unit/scripts/test_check_license_compatibility.py
+++ b/tests/unit/scripts/test_check_license_compatibility.py
@@ -17,6 +17,7 @@ from check_license_compatibility import (
     ALLOWED_EXTRA_COPYLEFT,
     DIST_NAME,
     RUNTIME_EXTRAS,
+    STATIC_FALLBACK_LICENSES,
     _FixtureMeta,
     distributed_requirements,
     is_compatible,
@@ -139,9 +140,9 @@ class TestLoudFailure:
                     scan(None)
         assert exc.value.code == 2
 
-    def test_uninstalled_other_python_dep_skipped_not_failed(self):
-        # installable_now=False (marker excludes this interpreter, e.g. tomli on
-        # Python >= 3.11) => correctly absent => skipped, not a coverage hole.
+    def test_uninstalled_other_python_dep_with_fallback_classifies_not_fails(self):
+        # installable_now=False + known static fallback => classified compatible,
+        # not a coverage hole. tomli's fallback is MIT.
         with patch(
             "check_license_compatibility.distributed_requirements",
             return_value=[("tomli", False)],
@@ -257,3 +258,100 @@ class TestMain:
     def test_allowlist_covers_notice_extras(self):
         assert "pygithub" in ALLOWED_EXTRA_COPYLEFT
         assert "defusedxml" in ALLOWED_EXTRA_COPYLEFT
+
+
+class TestStaticFallback:
+    """STATIC_FALLBACK_LICENSES classifies marker-excluded deps instead of skipping.
+
+    Staleness mitigations:
+    - test_static_values_match_installed_metadata: cross-checks against real
+      importlib.metadata when the dep IS installable (catches license drift).
+    - test_static_values_match_notice: cross-checks against NOTICE (the
+      authoritative human-readable analysis per the script's own docstring).
+    """
+
+    def test_tomli_fallback_classifies_as_compatible(self):
+        # tomli: python_version < '3.11' marker; installable_now=False on Python 3.13.
+        with patch(
+            "check_license_compatibility.distributed_requirements",
+            return_value=[("tomli", False)],
+        ):
+            with patch(
+                "check_license_compatibility.md.metadata",
+                side_effect=md.PackageNotFoundError("tomli"),
+            ):
+                assert scan(None) == []
+
+    def test_tzdata_fallback_classifies_as_compatible(self):
+        # tzdata: platform_system == 'Windows' marker; installable_now=False on Linux.
+        with patch(
+            "check_license_compatibility.distributed_requirements",
+            return_value=[("tzdata", False)],
+        ):
+            with patch(
+                "check_license_compatibility.md.metadata",
+                side_effect=md.PackageNotFoundError("tzdata"),
+            ):
+                assert scan(None) == []
+
+    def test_unknown_markered_dep_exits_nonzero(self):
+        # A future marker-excluded dep with no static fallback must exit(2).
+        with patch(
+            "check_license_compatibility.distributed_requirements",
+            return_value=[("future-windows-only-dep", False)],
+        ):
+            with patch(
+                "check_license_compatibility.md.metadata",
+                side_effect=md.PackageNotFoundError("future-windows-only-dep"),
+            ):
+                with pytest.raises(SystemExit) as exc:
+                    scan(None)
+        assert exc.value.code == 2
+
+    def test_static_fallback_covers_all_markered_out_distributed_deps(self):
+        # Every dep that distributed_requirements() marks installable_now=False
+        # must be in STATIC_FALLBACK_LICENSES (presence check).
+        try:
+            reqs = distributed_requirements(None)
+        except (md.PackageNotFoundError, SystemExit):
+            pytest.skip("HomericIntelligence-Hephaestus not installed in this env")
+            return
+        markered_out = [name for name, installable_now in reqs if not installable_now]
+        for pkg in markered_out:
+            assert pkg in STATIC_FALLBACK_LICENSES, (
+                f"{pkg!r} is distributed but installable_now=False AND missing from "
+                "STATIC_FALLBACK_LICENSES — add it with its SPDX license from NOTICE."
+            )
+
+    @pytest.mark.parametrize("pkg", list(STATIC_FALLBACK_LICENSES))
+    def test_static_values_match_installed_metadata(self, pkg: str) -> None:
+        # Staleness mitigation: when the dep IS installed (e.g. tomli on Python 3.10,
+        # tzdata on Windows), the static value must match real importlib.metadata.
+        # On Python 3.13/Linux these deps are absent — skip, not fail.
+        try:
+            real_ids = set(resolve_license(md.metadata(pkg)))
+        except md.PackageNotFoundError:
+            pytest.skip(f"{pkg!r} not installed in this env (marker excludes it)")
+            return
+        static_ids = set(STATIC_FALLBACK_LICENSES[pkg])
+        assert static_ids & real_ids, (
+            f"STATIC_FALLBACK_LICENSES[{pkg!r}]={STATIC_FALLBACK_LICENSES[pkg]} "
+            f"shares no SPDX ids with real metadata {sorted(real_ids)} — "
+            "update the static map from NOTICE."
+        )
+
+    def test_static_values_match_notice(self) -> None:
+        # Staleness mitigation: every key/value in STATIC_FALLBACK_LICENSES must
+        # appear in NOTICE (the authoritative human-readable analysis). This runs
+        # on every Python/platform and catches drift without needing the dep installed.
+        notice_text = (_REPO_ROOT / "NOTICE").read_text()
+        for pkg, spdx_ids in STATIC_FALLBACK_LICENSES.items():
+            assert pkg in notice_text.lower(), (
+                f"{pkg!r} is in STATIC_FALLBACK_LICENSES but not mentioned in NOTICE — "
+                "NOTICE is the authoritative source; add the dep there first."
+            )
+            for spdx_id in spdx_ids:
+                assert spdx_id in notice_text, (
+                    f"STATIC_FALLBACK_LICENSES[{pkg!r}] = {spdx_ids!r} but SPDX id "
+                    f"{spdx_id!r} not found in NOTICE — update one to match the other."
+                )


### PR DESCRIPTION
## Summary

- `tomli` (python_version<3.11) and `tzdata` (platform_system==Windows) are distributed deps that are never installed on the single CI leg (Python 3.13/Linux), creating a permanent silent coverage hole in the license gate built by #1219.
- Add `STATIC_FALLBACK_LICENSES` dict with SPDX IDs sourced from NOTICE (`tomli`→MIT, `tzdata`→Apache-2.0).
- The silent-skip branch now looks up the fallback map; deps absent from the map `exit(2)` — a future marker-excluded dep cannot slip through without an explicit NOTICE-backed entry.
- Update the module docstring `FAILS LOUDLY` block and rename the corresponding test.
- Add `TestStaticFallback` (6 tests) including two staleness mitigations: value cross-check against real `importlib.metadata` (runs when dep is installed) and key+SPDX cross-check against NOTICE (runs unconditionally on every platform).

## Test plan

- [x] `pixi run pytest tests/unit/scripts/test_check_license_compatibility.py -v --no-cov` — 29 passed, 5 skipped
- [x] `pixi run pytest tests/unit/scripts/ -v --no-cov` — 125 passed, 5 skipped
- [x] Signed commit verified via `git log --show-signature -1`

Closes #1258