### PR TITLE
test(integration): add --merge fallback path to choose_merge_flag tests

### DIFF
--- a/tests/integration/test_choose_merge_flag_sh.py
+++ b/tests/integration/test_choose_merge_flag_sh.py
@@ -93,3 +93,11 @@ def test_shell_helper_exits_1_when_no_methods_allowed() -> None:
     result = _run_with_mock_gh(body)
     assert result.returncode == 1
     assert "allows no merge methods" in result.stderr
+
+
+def test_shell_helper_selects_merge_when_rebase_and_squash_disallowed() -> None:
+    """Falls back to merge commit when both rebase and squash are not permitted."""
+    body = '{"allow_rebase_merge":false,"allow_squash_merge":false,"allow_merge_commit":true}'
+    result = _run_with_mock_gh(body)
+    assert result.returncode == 0
+    assert result.stdout.strip() == "--merge"


### PR DESCRIPTION
Add the missing integration test for the `--merge` fallback path in `scripts/choose_merge_flag.sh`.

`tests/integration/test_choose_merge_flag_sh.py` covered the rebase (all allowed) and squash (rebase=false) tiers but not the third tier: merge-commit fallback (rebase=false, squash=false, merge-commit=true). The new test `test_shell_helper_selects_merge_when_rebase_and_squash_disallowed` exercises line 32 of `choose_merge_flag.sh` using the existing `_run_with_mock_gh` helper.

Closes #1277