### PR TITLE
test(utils): pin get_repo_root first-match-up contract for nested markers

### DIFF
--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -156,6 +156,50 @@ class TestGetRepoRoot:
         result = get_repo_root(None)
         assert isinstance(result, Path)
 
+    def test_nested_git_stops_at_inner_git(self, tmp_path):
+        """Inner .git wins over outer .git — first-match-up (innermost) semantics."""
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        (outer / ".git").mkdir(parents=True)
+        (inner / ".git").mkdir(parents=True)
+        seed = inner / "src" / "module"
+        seed.mkdir(parents=True)
+        assert get_repo_root(seed) == inner.resolve()
+
+    def test_nested_pyproject_stops_at_inner_pyproject(self, tmp_path):
+        """Inner pyproject.toml wins over outer pyproject.toml."""
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        outer.mkdir(parents=True)
+        inner.mkdir(parents=True)
+        (outer / "pyproject.toml").write_text("[project]\n")
+        (inner / "pyproject.toml").write_text("[project]\n")
+        seed = inner / "src"
+        seed.mkdir(parents=True)
+        assert get_repo_root(seed) == inner.resolve()
+
+    def test_nested_pyproject_stops_at_inner_when_outer_has_git(self, tmp_path):
+        """Inner pyproject.toml wins over outer .git."""
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        (outer / ".git").mkdir(parents=True)
+        inner.mkdir(parents=True)
+        (inner / "pyproject.toml").write_text("[project]\n")
+        seed = inner / "src"
+        seed.mkdir(parents=True)
+        assert get_repo_root(seed) == inner.resolve()
+
+    def test_nested_git_stops_at_inner_when_outer_has_pyproject(self, tmp_path):
+        """Inner .git wins over outer pyproject.toml."""
+        outer = tmp_path / "outer"
+        inner = outer / "inner"
+        outer.mkdir(parents=True)
+        (outer / "pyproject.toml").write_text("[project]\n")
+        (inner / ".git").mkdir(parents=True)
+        seed = inner / "src"
+        seed.mkdir(parents=True)
+        assert get_repo_root(seed) == inner.resolve()
+
 
 class TestRunSubprocess:
     """Tests for run_subprocess."""


### PR DESCRIPTION
Add four regression tests to `TestGetRepoRoot` covering the full nested-marker matrix that was identified in PR #1266 (issue #1181): `git/git`, `pyproject/pyproject`, `git-outer/pyproject-inner`, and `pyproject-outer/git-inner`. Each test asserts the resolver stops at the innermost marker, pinning the first-match-up semantics of `get_repo_root()` at `hephaestus/utils/helpers.py:99-127`.

All assertions use `inner.resolve()` to match the resolver's own `Path(start_path).resolve()` call at `helpers.py:117`, ensuring stability on symlinked `$TMPDIR` environments (macOS CI, some Linux setups).

No production code changes — purely additive test coverage.

Closes #1267