### PR TITLE
fix(scripts_lib): support YAML sequence format in extract_ci_matrix_python_versions

### DIFF
--- a/hephaestus/scripts_lib/check_python_version_consistency.py
+++ b/hephaestus/scripts_lib/check_python_version_consistency.py
@@ -14,6 +14,12 @@ from pathlib import Path
 
 from hephaestus.utils.helpers import get_repo_root as _get_repo_root
 
+_CI_MATRIX_BRACKET_RE = re.compile(r"python-version:\s*\[([^\]]+)\]")
+_CI_MATRIX_SEQUENCE_RE = re.compile(
+    r"python-version:\s*\n((?:[ \t]+-\s*[\"']?\d+\.\d+[\"']?(?=\n|$)\n?)+)"
+)
+_CI_VERSION_RE = re.compile(r'["\']?(\d+\.\d+)["\']?')
+
 
 def get_repo_root() -> Path:
     """Find repository root, anchored to this module's location.
@@ -146,9 +152,15 @@ def extract_classifiers_python_versions(content: str) -> list[str]:
 def extract_ci_matrix_python_versions(content: str) -> list[str]:
     """Extract Python version strings from a GitHub Actions workflow file.
 
-    Looks for a ``python-version`` matrix key with an inline list, e.g.::
+    Supports two formats::
 
         python-version: ["3.10", "3.11", "3.12"]
+
+    and multi-line YAML sequence format::
+
+        python-version:
+          - "3.10"
+          - "3.11"
 
     Args:
         content: The raw YAML text of a GitHub Actions workflow file.
@@ -158,12 +170,17 @@ def extract_ci_matrix_python_versions(content: str) -> list[str]:
         if no ``python-version`` matrix key is found.
 
     """
-    match = re.search(r"python-version:\s*\[([^\]]+)\]", content)
-    if not match:
-        return []
-    raw = match.group(1)
-    versions = re.findall(r'["\']?(\d+\.\d+)["\']?', raw)
-    return sorted(set(versions))
+    bracket_match = _CI_MATRIX_BRACKET_RE.search(content)
+    if bracket_match:
+        versions = _CI_VERSION_RE.findall(bracket_match.group(1))
+        return sorted(set(versions))
+
+    sequence_match = _CI_MATRIX_SEQUENCE_RE.search(content)
+    if sequence_match:
+        versions = _CI_VERSION_RE.findall(sequence_match.group(1))
+        return sorted(set(versions))
+
+    return []
 
 
 def check_ci_matrix_coverage(repo_root: Path) -> bool:

--- a/tests/unit/scripts_lib/test_check_python_version_consistency.py
+++ b/tests/unit/scripts_lib/test_check_python_version_consistency.py
@@ -214,6 +214,34 @@ class TestExtractCiMatrixPythonVersions:
         content = 'python-version: ["3.12", "3.10", "3.12"]\n'
         assert extract_ci_matrix_python_versions(content) == ["3.10", "3.12"]
 
+    def test_extracts_sequence_format_double_quoted(self) -> None:
+        content = 'python-version:\n  - "3.10"\n  - "3.11"\n  - "3.12"\n'
+        assert extract_ci_matrix_python_versions(content) == ["3.10", "3.11", "3.12"]
+
+    def test_extracts_sequence_format_unquoted(self) -> None:
+        content = "python-version:\n  - 3.10\n  - 3.11\n"
+        assert extract_ci_matrix_python_versions(content) == ["3.10", "3.11"]
+
+    def test_extracts_sequence_format_single_quoted(self) -> None:
+        content = "python-version:\n  - '3.10'\n  - '3.12'\n"
+        assert extract_ci_matrix_python_versions(content) == ["3.10", "3.12"]
+
+    def test_extracts_sequence_format_deduplicates_and_sorts(self) -> None:
+        content = 'python-version:\n  - "3.12"\n  - "3.10"\n  - "3.12"\n'
+        assert extract_ci_matrix_python_versions(content) == ["3.10", "3.12"]
+
+    def test_bracket_format_takes_precedence_when_both_present(self) -> None:
+        content = 'python-version: ["3.11"]\npython-version:\n  - "3.10"\n'
+        assert extract_ci_matrix_python_versions(content) == ["3.11"]
+
+    def test_sequence_format_with_4_space_indent(self) -> None:
+        content = 'python-version:\n    - "3.10"\n    - "3.11"\n'
+        assert extract_ci_matrix_python_versions(content) == ["3.10", "3.11"]
+
+    def test_sequence_format_no_trailing_newline(self) -> None:
+        content = 'python-version:\n  - "3.10"\n  - "3.11"'
+        assert extract_ci_matrix_python_versions(content) == ["3.10", "3.11"]
+
 
 # ---------------------------------------------------------------------------
 # check_ci_matrix_coverage
@@ -285,6 +313,18 @@ class TestCheckCiMatrixCoverage:
         workflow_dir = tmp_path / ".github" / "workflows"
         workflow_dir.mkdir(parents=True)
         (workflow_dir / "test.yml").write_text('python-version: ["3.10", "3.11", "3.12"]\n')
+        assert check_ci_matrix_coverage(tmp_path) is True
+
+    def test_sequence_format_workflow_is_parsed(self, tmp_path: Path) -> None:
+        """check_ci_matrix_coverage reads sequence-format python-version correctly."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(
+            '"Programming Language :: Python :: 3.10",\n'
+            '"Programming Language :: Python :: 3.11",\n'
+        )
+        workflow_dir = tmp_path / ".github" / "workflows"
+        workflow_dir.mkdir(parents=True)
+        (workflow_dir / "test.yml").write_text("python-version:\n  - '3.10'\n  - '3.11'\n")
         assert check_ci_matrix_coverage(tmp_path) is True
 
 


### PR DESCRIPTION
Fixes `extract_ci_matrix_python_versions` in `hephaestus/scripts_lib/check_python_version_consistency.py` to handle the multi-line YAML sequence format used by many GitHub Actions workflows:

```yaml
python-version:
  - "3.10"
  - "3.11"
```

Previously, only the inline bracket format was matched. When a workflow used the sequence format, `extract_ci_matrix_python_versions` silently returned `[]`, causing `check_ci_matrix_coverage` to short-circuit at its early-return guard (`:200-202`) and report OK despite having no data to compare against.

## Changes

- **`hephaestus/scripts_lib/check_python_version_consistency.py`**: Adds three compiled module-level constants (`_CI_MATRIX_BRACKET_RE`, `_CI_MATRIX_SEQUENCE_RE`, `_CI_VERSION_RE`) and rewrites `extract_ci_matrix_python_versions` with bracket-first / sequence-fallback logic. Both paths share `_CI_VERSION_RE` (DRY). `(?=\n|$)` lookahead in the sequence regex correctly handles the final list item whether or not a trailing newline follows.
- **`tests/unit/scripts_lib/test_check_python_version_consistency.py`**: Adds 7 new unit tests to `TestExtractCiMatrixPythonVersions` (double-quoted, unquoted, single-quoted, dedup+sort, bracket-precedence, 4-space-indent, no-trailing-newline) and 1 integration test to `TestCheckCiMatrixCoverage` verifying the sequence format propagates through the full coverage check.

Closes #1284