### PR TITLE
refactor(automation): replace BaseReviewer importlib test-seam with constructor injection

### DIFF
--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -11,14 +11,15 @@ Subclasses own only the work-specific methods (``_review_pr`` for
 
 from __future__ import annotations
 
-import importlib
 import logging
 import threading
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 from ._review_utils import instance_log
 from .curses_ui import CursesUI, ThreadLogManager
+from .git_utils import get_repo_root as _default_get_repo_root
 from .git_utils import issue_ref
 from .github_api import write_secure
 from .models import ReviewPhase, ReviewState, WorkerResult
@@ -28,50 +29,13 @@ from .worktree_manager import WorktreeManager
 logger = logging.getLogger(__name__)
 
 
-_MISSING = object()
-
-
-def _resolve_from_subclass_module(cls: type, name: str) -> Any:
-    """Look up ``name`` from the module that defines ``cls``.
-
-    Implements the test-seam contract documented on
-    :class:`BaseReviewer` (see :attr:`BaseReviewer._PATCHABLE_DEPENDENCIES`).
-    Tracked for removal under issue #710 (constructor-injection refactor).
-
-    Raises:
-        TypeError: If the subclass module does not re-export ``name``. The
-            error names the offending subclass, module, and the test-seam
-            contract so a future author of a third ``BaseReviewer`` subclass
-            gets an actionable message instead of a bare ``AttributeError``.
-
-    """
-    module = importlib.import_module(cls.__module__)
-    obj = getattr(module, name, _MISSING)
-    if obj is _MISSING:
-        raise TypeError(
-            f"{cls.__qualname__} must re-export {name!r} in its own module "
-            f"({cls.__module__}) for BaseReviewer's test-seam contract "
-            f"(see BaseReviewer._PATCHABLE_DEPENDENCIES, issue #710). "
-            f"Add `from .<source_module> import {name}  # noqa: F401` "
-            f"to {cls.__module__}."
-        )
-    return obj
-
-
 class BaseReviewer:
     """Shared scaffolding for the reviewer CLIs.
 
-    Test-seam contract (see issues #806, #710):
-        Concrete subclasses MUST re-export every symbol in
-        :attr:`_PATCHABLE_DEPENDENCIES` from their own module so unit tests
-        can patch them via ``patch("hephaestus.automation.<subclass>.<Name>")``.
-        ``__init__`` resolves these symbols dynamically from the subclass
-        module to honor that patch surface.
-
-        This inverts the natural ``base → subclass`` import direction; it is
-        accepted as a deliberate test-seam until the dependency-injection
-        refactor in #710 lands. Adding a fourth subclass? Re-export the four
-        names below and you are done.
+    Collaborators are injected via constructor parameters (DIP-compliant).
+    Each defaults to the real production implementation so production call
+    sites need no change.  Tests pass lightweight fakes directly without
+    monkeypatching module globals.
 
     Owns:
         - ``options``: subclass-specific options model (duck-typed; must expose
@@ -87,34 +51,39 @@ class BaseReviewer:
     Concrete subclasses override the work-specific methods only.
     """
 
-    # TODO(#710): replace this dynamic test-seam with constructor injection.
-    _PATCHABLE_DEPENDENCIES: tuple[str, ...] = (
-        "get_repo_root",
-        "WorktreeManager",
-        "StatusTracker",
-        "ThreadLogManager",
-    )
-
-    def __init__(self, options: Any) -> None:
+    def __init__(
+        self,
+        options: Any,
+        *,
+        get_repo_root: Callable[[], Any] = _default_get_repo_root,
+        worktree_manager_factory: Callable[[], WorktreeManager] = WorktreeManager,
+        status_tracker_factory: Callable[[int], StatusTracker] = StatusTracker,
+        log_manager_factory: Callable[[], ThreadLogManager] = ThreadLogManager,
+    ) -> None:
         """Initialize the shared reviewer scaffolding.
 
         Args:
             options: A subclass-specific options model. Must expose
                 ``max_workers`` (other attributes are read by subclasses).
+            get_repo_root: Callable returning the repo root path. Defaults to
+                :func:`.git_utils.get_repo_root`.
+            worktree_manager_factory: Zero-arg callable returning a
+                :class:`WorktreeManager`. Defaults to :class:`WorktreeManager`.
+            status_tracker_factory: One-arg callable accepting ``num_slots``
+                and returning a :class:`StatusTracker`. Defaults to
+                :class:`StatusTracker`.
+            log_manager_factory: Zero-arg callable returning a
+                :class:`ThreadLogManager`. Defaults to :class:`ThreadLogManager`.
 
         """
         self.options = options
-        resolved = {
-            name: _resolve_from_subclass_module(type(self), name)
-            for name in self._PATCHABLE_DEPENDENCIES
-        }
-        self.repo_root: Path = Path(resolved["get_repo_root"]())
+        self.repo_root: Path = Path(get_repo_root())
         self.state_dir: Path = self.repo_root / "build" / ".issue_implementer"
         self.state_dir.mkdir(parents=True, exist_ok=True)
 
-        self.worktree_manager: WorktreeManager = resolved["WorktreeManager"]()
-        self.status_tracker: StatusTracker = resolved["StatusTracker"](options.max_workers)
-        self.log_manager: ThreadLogManager = resolved["ThreadLogManager"]()
+        self.worktree_manager: WorktreeManager = worktree_manager_factory()
+        self.status_tracker: StatusTracker = status_tracker_factory(options.max_workers)
+        self.log_manager: ThreadLogManager = log_manager_factory()
 
         self.states: dict[int, ReviewState] = {}
         self.state_lock = threading.Lock()

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -47,16 +47,8 @@ from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
 from .claude_timeouts import address_review_claude_timeout
 from .comment_difficulty import classify_comments, format_todo_line
-
-# Re-exports honor BaseReviewer's test-seam contract (#710); see
-# BaseReviewer._PATCHABLE_DEPENDENCIES.  Tests patch these via
-# ``patch("hephaestus.automation.address_review.<Name>")``;
-# __all__ declares the intent so static-analysis tools do not flag them unused.
-__all__ = ["StatusTracker", "ThreadLogManager", "WorktreeManager", "get_repo_root"]
-
-from .curses_ui import CursesUI, ThreadLogManager
+from .curses_ui import CursesUI
 from .git_utils import (
-    get_repo_root,
     get_repo_slug,
     issue_ref,
     pr_ref,
@@ -69,8 +61,6 @@ from .github_api import (
 from .models import AddressReviewOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_address_review_prompt
 from .session_naming import AGENT_IMPLEMENTER
-from .status_tracker import StatusTracker
-from .worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
 
@@ -330,14 +320,17 @@ class AddressReviewer(BaseReviewer):
 
     options: AddressReviewOptions
 
-    def __init__(self, options: AddressReviewOptions) -> None:
+    def __init__(self, options: AddressReviewOptions, **kwargs: Any) -> None:
         """Initialize address reviewer.
 
         Args:
             options: Reviewer configuration options
+            **kwargs: Forwarded to :class:`BaseReviewer` for dependency
+                injection (``get_repo_root``, ``worktree_manager_factory``,
+                ``status_tracker_factory``, ``log_manager_factory``).
 
         """
-        super().__init__(options)
+        super().__init__(options, **kwargs)
 
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -41,21 +41,12 @@ from ._reviewer_base import BaseReviewer
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
-
-# Re-exports honor BaseReviewer's test-seam contract (#710); see
-# BaseReviewer._PATCHABLE_DEPENDENCIES.  Tests patch these via
-# ``patch("hephaestus.automation.pr_reviewer.<Name>")``;
-# __all__ declares the intent so static-analysis tools do not flag them unused.
-__all__ = ["StatusTracker", "ThreadLogManager", "WorktreeManager", "get_repo_root"]
-
-from .curses_ui import CursesUI, ThreadLogManager
+from .curses_ui import CursesUI
 from .git_utils import get_repo_root, get_repo_slug, issue_ref, pr_ref
 from .github_api import _gh_call, fetch_issue_info, gh_pr_review_post
 from .models import ReviewerOptions, ReviewPhase, ReviewState, WorkerResult
 from .prompts import get_pr_review_analysis_prompt
 from .session_naming import AGENT_PR_REVIEWER, reviewer_agent
-from .status_tracker import StatusTracker
-from .worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
 
@@ -376,14 +367,17 @@ class PRReviewer(BaseReviewer):
 
     options: ReviewerOptions
 
-    def __init__(self, options: ReviewerOptions):
+    def __init__(self, options: ReviewerOptions, **kwargs: Any) -> None:
         """Initialize PR reviewer.
 
         Args:
             options: Reviewer configuration options
+            **kwargs: Forwarded to :class:`BaseReviewer` for dependency
+                injection (``get_repo_root``, ``worktree_manager_factory``,
+                ``status_tracker_factory``, ``log_manager_factory``).
 
         """
-        super().__init__(options)
+        super().__init__(options, **kwargs)
 
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -34,16 +34,24 @@ def mock_options() -> AddressReviewOptions:
 
 
 @pytest.fixture
-def reviewer(mock_options: AddressReviewOptions, tmp_path: Path) -> AddressReviewer:
-    """Create an AddressReviewer with mocked repo root pointing to tmp_path."""
-    with (
-        patch("hephaestus.automation.address_review.get_repo_root", return_value=tmp_path),
-        patch("hephaestus.automation.address_review.WorktreeManager"),
-        patch("hephaestus.automation.address_review.StatusTracker"),
-    ):
-        ar = AddressReviewer(mock_options)
-        ar.state_dir = tmp_path  # point state writes to tmp
-        return ar
+def base_deps(tmp_path: Path) -> dict:
+    """Return constructor injection kwargs for AddressReviewer / PRReviewer."""
+    return dict(
+        get_repo_root=lambda: tmp_path,
+        worktree_manager_factory=MagicMock(return_value=MagicMock()),
+        status_tracker_factory=MagicMock(return_value=MagicMock()),
+        log_manager_factory=MagicMock(return_value=MagicMock()),
+    )
+
+
+@pytest.fixture
+def reviewer(
+    mock_options: AddressReviewOptions, base_deps: dict, tmp_path: Path
+) -> AddressReviewer:
+    """Create an AddressReviewer with mocked collaborators pointing to tmp_path."""
+    ar = AddressReviewer(mock_options, **base_deps)
+    ar.state_dir = tmp_path  # point state writes to tmp
+    return ar
 
 
 # ---------------------------------------------------------------------------
@@ -266,13 +274,14 @@ class TestResolveAddressedThreads:
         """dry_run=True → gh_pr_resolve_thread is called with dry_run=True."""
         mock_options.dry_run = True
 
-        with (
-            patch("hephaestus.automation.address_review.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.address_review.WorktreeManager"),
-            patch("hephaestus.automation.address_review.StatusTracker"),
-        ):
-            dry_reviewer = AddressReviewer(mock_options)
-            dry_reviewer.state_dir = tmp_path
+        dry_reviewer = AddressReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=MagicMock()),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
+        dry_reviewer.state_dir = tmp_path
 
         addressed = ["thread-1"]
         replies: dict[str, str] = {"thread-1": "Fixed"}
@@ -335,17 +344,16 @@ class TestAddressIssue:
         """dry_run=True → no worktree creation, no resolve, no push calls."""
         mock_options.dry_run = True
 
-        with (
-            patch("hephaestus.automation.address_review.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.address_review.WorktreeManager") as mock_wm_cls,
-            patch("hephaestus.automation.address_review.StatusTracker"),
-        ):
-            mock_wm = MagicMock()
-            mock_wm.create_worktree.return_value = tmp_path
-            mock_wm_cls.return_value = mock_wm
-
-            dry_reviewer = AddressReviewer(mock_options)
-            dry_reviewer.state_dir = tmp_path
+        mock_wm = MagicMock()
+        mock_wm.create_worktree.return_value = tmp_path
+        dry_reviewer = AddressReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=mock_wm),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
+        dry_reviewer.state_dir = tmp_path
 
         # Dry-run guard now fires BEFORE worktree creation, so we only need
         # gh_pr_list_unresolved_threads to return some threads (the guard
@@ -398,17 +406,16 @@ class TestAddressReviewerPreservedReporting:
         preserved: list,
     ) -> tuple["AddressReviewer", MagicMock]:
         """Create an AddressReviewer with a MagicMock WorktreeManager."""
-        with (
-            patch("hephaestus.automation.address_review.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.address_review.StatusTracker"),
-        ):
-            mock_wm = MagicMock()
-            mock_wm.preserved = preserved
-            with patch(
-                "hephaestus.automation.address_review.WorktreeManager", return_value=mock_wm
-            ):
-                ar = AddressReviewer(mock_options)
-                ar.state_dir = tmp_path
+        mock_wm = MagicMock()
+        mock_wm.preserved = preserved
+        ar = AddressReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=mock_wm),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
+        ar.state_dir = tmp_path
         return ar, mock_wm
 
     def test_preserved_worktrees_logged_after_cleanup(

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -625,13 +625,14 @@ class TestCheckThreadsForAddress:
         """dry_run=True → returns None (caller returns success)."""
         mock_options.dry_run = True
 
-        with (
-            patch("hephaestus.automation.address_review.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.address_review.WorktreeManager"),
-            patch("hephaestus.automation.address_review.StatusTracker"),
-        ):
-            dry_reviewer = AddressReviewer(mock_options)
-            dry_reviewer.state_dir = tmp_path
+        dry_reviewer = AddressReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=MagicMock()),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
+        dry_reviewer.state_dir = tmp_path
 
         threads_list = [{"id": "thread-1", "path": "file.py", "line": 10, "body": "fix this"}]
 

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -36,12 +36,12 @@ def mock_options() -> AddressReviewOptions:
 @pytest.fixture
 def base_deps(tmp_path: Path) -> dict:
     """Return constructor injection kwargs for AddressReviewer / PRReviewer."""
-    return dict(
-        get_repo_root=lambda: tmp_path,
-        worktree_manager_factory=MagicMock(return_value=MagicMock()),
-        status_tracker_factory=MagicMock(return_value=MagicMock()),
-        log_manager_factory=MagicMock(return_value=MagicMock()),
-    )
+    return {
+        "get_repo_root": lambda: tmp_path,
+        "worktree_manager_factory": MagicMock(return_value=MagicMock()),
+        "status_tracker_factory": MagicMock(return_value=MagicMock()),
+        "log_manager_factory": MagicMock(return_value=MagicMock()),
+    }
 
 
 @pytest.fixture

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -80,14 +80,20 @@ def mock_options() -> ReviewerOptions:
 
 
 @pytest.fixture
-def reviewer(mock_options: ReviewerOptions, tmp_path: Path) -> PRReviewer:
-    """Create PRReviewer with mocked repo root and state dir."""
-    with (
-        patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
-        patch("hephaestus.automation.pr_reviewer.WorktreeManager"),
-        patch("hephaestus.automation.pr_reviewer.StatusTracker"),
-    ):
-        return PRReviewer(mock_options)
+def base_deps(tmp_path: Path) -> dict:
+    """Return constructor injection kwargs for PRReviewer / AddressReviewer."""
+    return dict(
+        get_repo_root=lambda: tmp_path,
+        worktree_manager_factory=MagicMock(return_value=MagicMock()),
+        status_tracker_factory=MagicMock(return_value=MagicMock()),
+        log_manager_factory=MagicMock(return_value=MagicMock()),
+    )
+
+
+@pytest.fixture
+def reviewer(mock_options: ReviewerOptions, base_deps: dict) -> PRReviewer:
+    """Create PRReviewer with mocked collaborators."""
+    return PRReviewer(mock_options, **base_deps)
 
 
 # ---------------------------------------------------------------------------
@@ -163,16 +169,15 @@ class TestDryRunSkipsPost:
         """dry_run=True → gh_pr_review_post not called."""
         mock_options.dry_run = True
 
-        with (
-            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.pr_reviewer.WorktreeManager") as mock_wm_cls,
-            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
-        ):
-            mock_wm = MagicMock()
-            mock_wm.create_worktree.return_value = tmp_path
-            mock_wm_cls.return_value = mock_wm
-
-            dry_reviewer = PRReviewer(mock_options)
+        mock_wm = MagicMock()
+        mock_wm.create_worktree.return_value = tmp_path
+        dry_reviewer = PRReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=mock_wm),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
 
         analysis = {"comments": [{"path": "a.py", "line": 1, "body": "fix this"}], "summary": "ok"}
         with (
@@ -191,12 +196,13 @@ class TestDryRunSkipsPost:
         """_run_analysis_session returns placeholder dict when dry_run=True."""
         mock_options.dry_run = True
 
-        with (
-            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.pr_reviewer.WorktreeManager"),
-            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
-        ):
-            dry_reviewer = PRReviewer(mock_options)
+        dry_reviewer = PRReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=MagicMock()),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
 
         result = dry_reviewer._run_analysis_session(
             pr_number=42,
@@ -224,14 +230,14 @@ class TestIdempotencyGuard:
         completed_state = ReviewState(issue_number=123, pr_number=42, phase=ReviewPhase.COMPLETED)
         (state_dir / "review-123.json").write_text(completed_state.model_dump_json())
 
-        with (
-            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.pr_reviewer.WorktreeManager") as mock_wm_cls,
-            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
-        ):
-            mock_wm = MagicMock()
-            mock_wm_cls.return_value = mock_wm
-            live_reviewer = PRReviewer(mock_options)
+        mock_wm = MagicMock()
+        live_reviewer = PRReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=mock_wm),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
 
         with patch("hephaestus.automation.pr_reviewer.gh_pr_review_post") as mock_post:
             result = live_reviewer._review_pr(issue_number=123, pr_number=42)
@@ -249,15 +255,15 @@ class TestIdempotencyGuard:
         state_dir.mkdir(parents=True)
         (state_dir / "review-123.json").write_text("{not valid json!!!}")
 
-        with (
-            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.pr_reviewer.WorktreeManager") as mock_wm_cls,
-            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
-        ):
-            mock_wm = MagicMock()
-            mock_wm.create_worktree.return_value = tmp_path
-            mock_wm_cls.return_value = mock_wm
-            live_reviewer = PRReviewer(mock_options)
+        mock_wm = MagicMock()
+        mock_wm.create_worktree.return_value = tmp_path
+        live_reviewer = PRReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=mock_wm),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
 
         analysis = {"comments": [], "summary": "clean"}
         with (
@@ -278,16 +284,15 @@ class TestReviewPostsInlineComments:
         self, mock_options: ReviewerOptions, tmp_path: Path
     ) -> None:
         """Analysis returns valid JSON → gh_pr_review_post called with correct args."""
-        with (
-            patch("hephaestus.automation.pr_reviewer.get_repo_root", return_value=tmp_path),
-            patch("hephaestus.automation.pr_reviewer.WorktreeManager") as mock_wm_cls,
-            patch("hephaestus.automation.pr_reviewer.StatusTracker"),
-        ):
-            mock_wm = MagicMock()
-            mock_wm.create_worktree.return_value = tmp_path
-            mock_wm_cls.return_value = mock_wm
-
-            live_reviewer = PRReviewer(mock_options)
+        mock_wm = MagicMock()
+        mock_wm.create_worktree.return_value = tmp_path
+        live_reviewer = PRReviewer(
+            mock_options,
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=mock_wm),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
 
         comments = [{"path": "foo.py", "line": 5, "body": "Consider renaming this variable"}]
         analysis = {"comments": comments, "summary": "Looks mostly good"}

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -82,12 +82,12 @@ def mock_options() -> ReviewerOptions:
 @pytest.fixture
 def base_deps(tmp_path: Path) -> dict:
     """Return constructor injection kwargs for PRReviewer / AddressReviewer."""
-    return dict(
-        get_repo_root=lambda: tmp_path,
-        worktree_manager_factory=MagicMock(return_value=MagicMock()),
-        status_tracker_factory=MagicMock(return_value=MagicMock()),
-        log_manager_factory=MagicMock(return_value=MagicMock()),
-    )
+    return {
+        "get_repo_root": lambda: tmp_path,
+        "worktree_manager_factory": MagicMock(return_value=MagicMock()),
+        "status_tracker_factory": MagicMock(return_value=MagicMock()),
+        "log_manager_factory": MagicMock(return_value=MagicMock()),
+    }
 
 
 @pytest.fixture

--- a/tests/unit/automation/test_reviewer_base_contract.py
+++ b/tests/unit/automation/test_reviewer_base_contract.py
@@ -16,33 +16,36 @@ def _make_options(max_workers: int = 2) -> object:
 
 
 def _make_deps(tmp_path: Path) -> dict:
-    return dict(
-        get_repo_root=lambda: tmp_path,
-        worktree_manager_factory=MagicMock(return_value=MagicMock()),
-        status_tracker_factory=MagicMock(return_value=MagicMock()),
-        log_manager_factory=MagicMock(return_value=MagicMock()),
-    )
+    return {
+        "get_repo_root": lambda: tmp_path,
+        "worktree_manager_factory": MagicMock(return_value=MagicMock()),
+        "status_tracker_factory": MagicMock(return_value=MagicMock()),
+        "log_manager_factory": MagicMock(return_value=MagicMock()),
+    }
 
 
 class ConcreteReviewer(_reviewer_base.BaseReviewer):
-    pass
+    """Minimal concrete subclass for testing BaseReviewer's injection contract."""
 
 
 def test_injection_wires_repo_root(tmp_path: Path) -> None:
+    """Constructor injection must wire repo_root from the get_repo_root callable."""
     deps = _make_deps(tmp_path)
     r = ConcreteReviewer(_make_options(), **deps)
     assert r.repo_root == tmp_path
 
 
 def test_injection_calls_factories(tmp_path: Path) -> None:
+    """Constructor must call each factory exactly once, passing max_workers to status."""
     deps = _make_deps(tmp_path)
-    r = ConcreteReviewer(_make_options(max_workers=3), **deps)
+    ConcreteReviewer(_make_options(max_workers=3), **deps)
     deps["worktree_manager_factory"].assert_called_once_with()
     deps["status_tracker_factory"].assert_called_once_with(3)
     deps["log_manager_factory"].assert_called_once_with()
 
 
 def test_injected_instances_attached(tmp_path: Path) -> None:
+    """Factory return values must be attached to the reviewer instance."""
     deps = _make_deps(tmp_path)
     r = ConcreteReviewer(_make_options(), **deps)
     assert r.worktree_manager is deps["worktree_manager_factory"].return_value
@@ -56,5 +59,6 @@ def test_subclass_modules_no_longer_need_reexports() -> None:
 
 
 def test_no_importlib_in_base() -> None:
+    """BaseReviewer source must not contain any importlib usage."""
     src = inspect.getsource(_reviewer_base.BaseReviewer)
     assert "importlib" not in src

--- a/tests/unit/automation/test_reviewer_base_contract.py
+++ b/tests/unit/automation/test_reviewer_base_contract.py
@@ -1,39 +1,60 @@
-"""Lock the BaseReviewer test-seam contract (see issues #806, #710)."""
+"""Verify BaseReviewer constructor-injection contract (issues #710, #1194)."""
 
 from __future__ import annotations
 
-import pytest
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock
 
-from hephaestus.automation import _reviewer_base, address_review, pr_reviewer
+from hephaestus.automation import _reviewer_base
 
 
-@pytest.mark.parametrize("subclass_module", [pr_reviewer, address_review])
-@pytest.mark.parametrize(
-    "name", ["get_repo_root", "WorktreeManager", "StatusTracker", "ThreadLogManager"]
-)
-def test_subclass_module_reexports_patchable_dependency(subclass_module, name):
-    """Each concrete reviewer subclass must re-export every patchable dep."""
-    assert hasattr(subclass_module, name), (
-        f"{subclass_module.__name__} must re-export {name!r} for the "
-        f"BaseReviewer test-seam contract (issue #710)."
+def _make_options(max_workers: int = 2) -> object:
+    opts = MagicMock()
+    opts.max_workers = max_workers
+    return opts
+
+
+def _make_deps(tmp_path: Path) -> dict:
+    return dict(
+        get_repo_root=lambda: tmp_path,
+        worktree_manager_factory=MagicMock(return_value=MagicMock()),
+        status_tracker_factory=MagicMock(return_value=MagicMock()),
+        log_manager_factory=MagicMock(return_value=MagicMock()),
     )
 
 
-def test_patchable_dependencies_tuple_is_single_source_of_truth():
-    """The class-level tuple is the documented contract — do not drift."""
-    assert _reviewer_base.BaseReviewer._PATCHABLE_DEPENDENCIES == (
-        "get_repo_root",
-        "WorktreeManager",
-        "StatusTracker",
-        "ThreadLogManager",
-    )
+class ConcreteReviewer(_reviewer_base.BaseReviewer):
+    pass
 
 
-def test_missing_reexport_raises_actionable_typeerror():
-    """A third subclass that forgets the contract gets a pointed error."""
+def test_injection_wires_repo_root(tmp_path: Path) -> None:
+    deps = _make_deps(tmp_path)
+    r = ConcreteReviewer(_make_options(), **deps)
+    assert r.repo_root == tmp_path
 
-    class BogusSubclass(_reviewer_base.BaseReviewer):
-        pass
 
-    with pytest.raises(TypeError, match="test-seam contract"):
-        BogusSubclass(options=object())
+def test_injection_calls_factories(tmp_path: Path) -> None:
+    deps = _make_deps(tmp_path)
+    r = ConcreteReviewer(_make_options(max_workers=3), **deps)
+    deps["worktree_manager_factory"].assert_called_once_with()
+    deps["status_tracker_factory"].assert_called_once_with(3)
+    deps["log_manager_factory"].assert_called_once_with()
+
+
+def test_injected_instances_attached(tmp_path: Path) -> None:
+    deps = _make_deps(tmp_path)
+    r = ConcreteReviewer(_make_options(), **deps)
+    assert r.worktree_manager is deps["worktree_manager_factory"].return_value
+    assert r.status_tracker is deps["status_tracker_factory"].return_value
+    assert r.log_manager is deps["log_manager_factory"].return_value
+
+
+def test_subclass_modules_no_longer_need_reexports() -> None:
+    """The importlib monkeypatch contract is gone — no _PATCHABLE_DEPENDENCIES."""
+    assert not hasattr(_reviewer_base.BaseReviewer, "_PATCHABLE_DEPENDENCIES")
+
+
+def test_no_importlib_in_base() -> None:
+    src = inspect.getsource(_reviewer_base.BaseReviewer)
+    assert "importlib" not in src


### PR DESCRIPTION
Replace `_resolve_from_subclass_module` / `_PATCHABLE_DEPENDENCIES` with keyword-only factory parameters on `BaseReviewer.__init__`, resolving the DIP violation self-flagged as `TODO(#710)`.

## Changes

**`hephaestus/automation/_reviewer_base.py`**
- Remove `import importlib`, `_MISSING`, `_resolve_from_subclass_module`, and `_PATCHABLE_DEPENDENCIES`
- `BaseReviewer.__init__` gains four keyword-only params with production defaults: `get_repo_root`, `worktree_manager_factory`, `status_tracker_factory`, `log_manager_factory`

**`hephaestus/automation/pr_reviewer.py`**
- Remove `__all__` re-export block and `ThreadLogManager`, `StatusTracker`, `WorktreeManager` re-exports (no longer needed)
- `PRReviewer.__init__` forwards `**kwargs` to `super().__init__`

**`hephaestus/automation/address_review.py`**
- Same removal of re-export block; remove `get_repo_root` from git_utils import (not used in body)
- `AddressReviewer.__init__` forwards `**kwargs` to `super().__init__`

**`tests/unit/automation/test_reviewer_base_contract.py`** — rewritten to assert the injection API
**`tests/unit/automation/test_address_review.py`** — add `base_deps` fixture; replace `patch()` triples with direct injection
**`tests/unit/automation/test_pr_reviewer_posting.py`** — same

## Verification
- 1572 unit tests pass (`tests/unit/automation/`)
- Import surface boundary: `test_import_surface.py` + `test_automation_boundary.py` pass
- No new pre-commit failures (existing Ruff/Mypy failures in `test_choose_merge_flag_sh.py` are pre-existing on main)

Closes #1194