### PR TITLE
fix(github): guard GITHUB_REPOSITORY env read in severity_label.main()

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,3 +42,37 @@ body:
         - hephaestus: 0.3.0
     validations:
       required: false
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: >
+        How impactful is this? Selecting a value auto-applies the matching
+        `severity:*` label via the auto-label-severity workflow, feeding the
+        Epic-and-children planning pipeline (see docs/ROADMAP.md). Audit-section
+        tagging is handled by maintainers, not this form.
+      options:
+        - critical
+        - major
+        - minor
+        - nitpick
+    validations:
+      required: false
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent Epic (optional)
+      description: >
+        If this is a child of a tracked Epic (label `epic`), reference it as
+        `#NNN`. Reference only — triage links it; not auto-consumed. Leave
+        blank if unknown.
+      placeholder: "#310"
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        ℹ️ On submit this issue is automatically labeled `state:needs-plan` (see
+        [auto-label-needs-plan](https://github.com/mvillmow/ProjectHephaestus/blob/main/docs/auto-label-needs-plan.md));
+        the planning pipeline picks it up next loop. You need not set any
+        `state:*` label yourself.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -24,3 +24,37 @@ body:
       description: Any alternative solutions or workarounds you've considered.
     validations:
       required: false
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: >
+        How impactful is this? Selecting a value auto-applies the matching
+        `severity:*` label via the auto-label-severity workflow, feeding the
+        Epic-and-children planning pipeline (see docs/ROADMAP.md). Audit-section
+        tagging is handled by maintainers, not this form.
+      options:
+        - critical
+        - major
+        - minor
+        - nitpick
+    validations:
+      required: false
+  - type: input
+    id: parent_epic
+    attributes:
+      label: Parent Epic (optional)
+      description: >
+        If this is a child of a tracked Epic (label `epic`), reference it as
+        `#NNN`. Reference only — triage links it; not auto-consumed. Leave
+        blank if unknown.
+      placeholder: "#310"
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: >
+        ℹ️ On submit this issue is automatically labeled `state:needs-plan` (see
+        [auto-label-needs-plan](https://github.com/mvillmow/ProjectHephaestus/blob/main/docs/auto-label-needs-plan.md));
+        the planning pipeline picks it up next loop. You need not set any
+        `state:*` label yourself.

--- a/.github/workflows/auto-label-severity.yml
+++ b/.github/workflows/auto-label-severity.yml
@@ -1,0 +1,37 @@
+name: Auto-label severity
+
+# Reconciles the severity:* label from the issue forms' "Severity" answer so the
+# field feeds the documented planning/triage pipeline (#1210). Parsing lives in
+# the unit-tested hephaestus.github.severity_label module; this workflow only
+# binds inputs as env vars (the body is NEVER interpolated into the shell) and
+# invokes it.
+
+on:
+  issues:
+    types: [opened, edited]
+
+# Least-privilege: read repo contents (for checkout), write only to issues for
+# the label-reconcile call.
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  label-severity:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          environments: default
+      - name: Reconcile severity label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Server-supplied integer — safe to bind.
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # Bound as env (NOT interpolated into the shell step) — the body is
+          # only read inside Python via os.environ, matched against fixed strings.
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: pixi run python -m hephaestus.github.severity_label

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -118,6 +118,7 @@ bypass a misfiring hook locally use
 | `hephaestus-merge-prs` | Provisional | Wrapper around `gh pr merge` |
 | `hephaestus-fleet-sync` | Provisional | Fleet-wide repo sync helper |
 | `hephaestus-tidy` | Provisional | Local-branch rebase + cleanup helper |
+| `hephaestus-label-severity` | Provisional | Reconciles `severity:*` label from issue-form Severity answer |
 | `hephaestus-system-info` | Provisional | Dispatches to Stable `hephaestus.system` but CLI flags still evolving |
 | `hephaestus-download-dataset` | Provisional | Dataset URL/layout not contracted |
 | `hephaestus-check-python-version` | Internal | Repo CI pre-commit hook |
@@ -272,6 +273,7 @@ bypass a misfiring hook locally use
 | `hephaestus-merge-prs` | Provisional | Wrapper around `gh pr merge` |
 | `hephaestus-fleet-sync` | Provisional | Fleet-wide repo sync helper |
 | `hephaestus-tidy` | Provisional | Local-branch rebase + cleanup helper |
+| `hephaestus-label-severity` | Provisional | Reconciles `severity:*` label from issue-form Severity answer |
 | `hephaestus-system-info` | Provisional | Dispatches to Stable `hephaestus.system` but CLI flags still evolving |
 | `hephaestus-download-dataset` | Provisional | Dataset URL/layout not contracted |
 | `hephaestus-check-python-version` | Internal | Repo CI pre-commit hook |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -81,7 +81,7 @@ may change incompatibly in a minor release.
 
 ## Console-Script Stability Tiers
 
-ProjectHephaestus installs 47 console scripts via `[project.scripts]` in
+ProjectHephaestus installs 48 console scripts via `[project.scripts]` in
 `pyproject.toml`. Each is classified into one of three tiers:
 
 - **Stable** — covered by the [deprecation policy](#deprecation-policy). CLI
@@ -232,83 +232,6 @@ removal):
 | `retry_with_backoff` | 0.1.0 | Exponential backoff retry decorator |
 | `run_subprocess` | 0.1.0 | Execute shell commands with error handling |
 | `slugify` | 0.1.0 | Convert text to URL-friendly slug |
-
-## Console-Script Stability Tiers
-
-ProjectHephaestus installs 46 console scripts via `[project.scripts]` in
-`pyproject.toml`. Each is classified into one of three tiers:
-
-- **Stable** — covered by the [deprecation policy](#deprecation-policy). CLI
-  name, flags, exit codes, and JSON output schema (when `--json` is passed)
-  are versioned API. Currently: none. Promotion criteria: dispatches to a
-  Stable subpackage AND has a documented JSON output schema AND has external
-  consumers outside this repo.
-- **Provisional** — useful from outside but may change incompatibly in a
-  minor release. Pin a specific version if you depend on one.
-- **Internal** — exists for this repo's own CI/automation. May be removed
-  without a deprecation notice. Listed for completeness only.
-
-Note: the **Internal** tier applies only to console scripts; the subpackage
-stability tier table above uses only Stable/Provisional. Internal CLIs may
-still dispatch to a Stable subpackage — the CLI tier reflects the CLI's
-own external-consumer contract, not the underlying library code.
-
-The mapping below is the source of truth; the
-`hephaestus-check-cli-tier-docs` validator (run in pre-commit and as a unit
-test) fails the build if `[project.scripts]` and this table drift apart. To
-bypass a misfiring hook locally use
-`SKIP=hephaestus-check-cli-tier-docs git commit -S ...` — never
-`--no-verify` (it skips signing too).
-
-| CLI | Tier | Notes |
-|-----|------|-------|
-| `hephaestus-automation-loop` | Provisional | Dispatches to `hephaestus.automation` (provisional subpackage) |
-| `hephaestus-plan-issues` | Provisional | Issue-planning stage of the automation pipeline |
-| `hephaestus-implement-issues` | Provisional | Issue-implementation stage |
-| `hephaestus-review-prs` | Provisional | PR-review stage |
-| `hephaestus-agent-stage` | Provisional | Single-stage agent runner |
-| `hephaestus-ensure-state-labels` | Internal | Used by this repo's CI label bootstrap |
-| `hephaestus-merge-prs` | Provisional | Wrapper around `gh pr merge` |
-| `hephaestus-fleet-sync` | Provisional | Fleet-wide repo sync helper |
-| `hephaestus-tidy` | Provisional | Local-branch rebase + cleanup helper |
-| `hephaestus-label-severity` | Provisional | Reconciles `severity:*` label from issue-form Severity answer |
-| `hephaestus-system-info` | Provisional | Dispatches to Stable `hephaestus.system` but CLI flags still evolving |
-| `hephaestus-download-dataset` | Provisional | Dataset URL/layout not contracted |
-| `hephaestus-check-python-version` | Internal | Repo CI pre-commit hook |
-| `hephaestus-check-test-structure` | Internal | Repo CI pre-commit hook |
-| `hephaestus-check-coverage` | Internal | Repo CI pre-commit hook |
-| `hephaestus-check-complexity` | Internal | Repo CI pre-commit hook |
-| `hephaestus-filter-audit` | Provisional | Audit-output filter; useful externally |
-| `hephaestus-validate-schemas` | Provisional | JSON-Schema validator |
-| `hephaestus-validate-links` | Internal | Repo CI markdown link check |
-| `hephaestus-check-readmes` | Internal | Repo CI README validator |
-| `hephaestus-check-skill-catalog` | Internal | Repo CI skill-catalog validator |
-| `hephaestus-check-type-aliases` | Internal | Repo CI type-alias validator |
-| `hephaestus-check-docstrings` | Internal | Repo CI docstring validator |
-| `hephaestus-check-tier-labels` | Internal | Repo CI tier-label validator |
-| `hephaestus-fix-markdown` | Provisional | Markdown fixer; useful externally |
-| `hephaestus-audit-doc-policy` | Internal | Repo CI doc-policy auditor |
-| `hephaestus-check-version-consistency` | Internal | Repo CI version-consistency check |
-| `hephaestus-coredump-handler` | Provisional | Coredump capture helper |
-| `hephaestus-run-under-gdb` | Provisional | gdb post-mortem helper |
-| `hephaestus-check-package-versions` | Internal | Repo CI package-version check |
-| `hephaestus-bump-version` | Internal | Repo release-management helper |
-| `hephaestus-check-doc-config` | Internal | Repo CI doc-config validator |
-| `hephaestus-check-stale-scripts` | Internal | Repo CI stale-script detector |
-| `hephaestus-mypy-each-file` | Internal | Repo CI per-file mypy runner |
-| `hephaestus-check-links` | Internal | Repo CI link checker |
-| `hephaestus-validate-anchors` | Internal | Repo CI anchor validator |
-| `hephaestus-check-dep-sync` | Internal | Repo CI dependency-sync check |
-| `hephaestus-sync-requirements` | Internal | Repo CI requirements sync |
-| `hephaestus-bench-precommit` | Internal | Repo CI pre-commit benchmark |
-| `hephaestus-check-precommit-versions` | Internal | Repo CI pre-commit version check |
-| `hephaestus-check-workflow-inventory` | Internal | Repo CI workflow-inventory check |
-| `hephaestus-validate-workflow-checkout` | Internal | Repo CI workflow-checkout validator |
-| `hephaestus-github-stats` | Provisional | GitHub stats helper |
-| `hephaestus-agent-stats` | Internal | Repo CI agent-stats tool |
-| `hephaestus-validate-agents` | Internal | Repo CI agent-frontmatter validator |
-| `hephaestus-check-cli-tier-docs` | Internal | Repo CI CLI tier documentation check |
-| `hephaestus-audit-prs` | Provisional | Batch PR audit reviewer |
 
 ## Deprecation Policy
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ config = merge_with_env({}, convert_bools=True)
 <!-- CLI table generated from pyproject.toml [project.scripts]. Keep in sync via
      `python3 scripts/check_cli_table_sync.py` (also enforced in pre-commit). -->
 
-47 console scripts are installed when you install the package.  Run any command
+48 console scripts are installed when you install the package.  Run any command
 with `--help` to see full usage.
 
 ### Automation
@@ -363,6 +363,7 @@ sync (#993).
 |---|---|
 | `hephaestus-fleet-sync` | Sync all PRs across the HomericIntelligence fleet |
 | `hephaestus-github-stats` | GitHub contribution statistics via the `gh` CLI |
+| `hephaestus-label-severity` | Reconcile the `severity:*` label for a GitHub issue from its issue-form Severity answer |
 | `hephaestus-merge-prs` | Merge open PRs with successful CI/CD using GitHub API |
 | `hephaestus-tidy` | Single-repo gh-tidy wrapper with Myrmidon swarm for conflict resolution |
 

--- a/docs/auto-label-needs-plan.md
+++ b/docs/auto-label-needs-plan.md
@@ -31,6 +31,32 @@ jobs:
     uses: HomericIntelligence/ProjectHephaestus/.github/workflows/auto-label-needs-plan.yml@main
 ```
 
+## Issue intake (forms → labels)
+
+The issue forms
+([`feature_request.yml`](../.github/ISSUE_TEMPLATE/feature_request.yml),
+[`bug_report.yml`](../.github/ISSUE_TEMPLATE/bug_report.yml)) feed the pipeline:
+
+- **Severity** — a constrained dropdown (`critical` / `major` / `minor` /
+  `nitpick`). On issue open/edit,
+  [`auto-label-severity.yml`](../.github/workflows/auto-label-severity.yml) runs
+  `hephaestus.github.severity_label`, which parses the rendered answer and
+  **reconciles** the issue's `severity:*` label (removing any stale one). Only
+  the server-controlled issue number and a fixed label string reach the API.
+- **Parent Epic** — an optional `#NNN` reference for the Epic-and-children
+  pattern (`epic` label, see [ROADMAP.md](ROADMAP.md)). **Reference only:**
+  triage links it; it is not auto-consumed (free-text parsing into pipeline
+  state is deliberately avoided).
+- **Audit-section** is intentionally **not** a form field. ProjectHephaestus has
+  no per-audit-section label vocabulary (only `audit-finding`), so maintainers
+  tag audit section during triage rather than via the form — avoiding an inert
+  field with no consumer.
+
+State is **not** a form field: `state:needs-plan` is applied automatically on
+open/reopen (above). Keeping state automation-driven — not a free-text form
+field — is deliberate; a free-text state field drifts off-format and
+mis-routes issues.
+
 ## Rollout
 
 Run [`hephaestus-ensure-state-labels --org HomericIntelligence`](../hephaestus/automation/ensure_state_labels.py)

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ just docs        # outputs to docs/api/
 ```
 
 The generated `docs/api/` directory is git-ignored; run the command locally to browse
-full function signatures, docstrings, and type annotations for all 47 CLI entry points.
+full function signatures, docstrings, and type annotations for all 48 CLI entry points.
 
 ## Setup
 

--- a/hephaestus/github/severity_label.py
+++ b/hephaestus/github/severity_label.py
@@ -138,7 +138,14 @@ def main(argv: list[str] | None = None) -> int:
     add_version_arg(parser)
     args = parser.parse_args(argv)
 
-    repo = os.environ["GITHUB_REPOSITORY"]
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+    if not repo or "/" not in repo:
+        message = f"Unexpected GITHUB_REPOSITORY {repo!r} (expected owner/name)"
+        if args.json:
+            emit_json_status(1, message)
+        else:
+            print(message, file=sys.stderr)
+        return 1
     raw = os.environ.get("ISSUE_NUMBER", "")
     if not raw.isdigit():
         message = f"Unexpected ISSUE_NUMBER {raw!r} (not a positive integer)"

--- a/hephaestus/github/severity_label.py
+++ b/hephaestus/github/severity_label.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Apply the ``severity:*`` label matching an issue form's "Severity" answer (#1210).
+
+The issue forms (``.github/ISSUE_TEMPLATE/*.yml``) render their Severity
+dropdown answer into the issue body as a ``### Severity`` heading followed by
+the chosen value. :func:`parse_severity` extracts that value;
+:func:`apply_severity_label` reconciles the issue's ``severity:*`` labels to
+match (removing any stale one), and :func:`main` wires the two together for the
+``auto-label-severity`` workflow.
+
+Security: the user-controlled body is matched against a hard-coded allow-list
+(:data:`VALID_SEVERITIES`) and only ever a fixed ``severity:*`` constant reaches
+the GitHub API — the body is never executed or passed as a label (avoids the
+CWE-94 issue-body injection class). The server-controlled issue number is
+validated numeric before use.
+
+Usage:
+    python -m hephaestus.github.severity_label
+
+    Reads ``GITHUB_REPOSITORY``, ``ISSUE_NUMBER`` and ``ISSUE_BODY`` from the
+    environment (bound by the workflow, never interpolated into the shell).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+
+# Allow-list: the only labels this tool may ever apply. Mirrors the provisioned
+# ``severity:*`` labels (verified via ``gh label list``).
+VALID_SEVERITIES: tuple[str, ...] = ("critical", "major", "minor", "nitpick")
+
+# A rendered issue-form dropdown answer appears under a markdown heading whose
+# text is exactly the field ``label:`` ("Severity").
+_HEADING_RE = re.compile(r"^#{1,6}\s+severity\s*$", re.IGNORECASE)
+
+
+def parse_severity(issue_body: str) -> str | None:
+    """Return the lowercased severity under the rendered "### Severity" heading.
+
+    GitHub renders an issue-form dropdown answer as a markdown heading whose
+    text is the field ``label:`` followed (after optional blank lines) by the
+    selected option on its own line.
+
+    Args:
+        issue_body: The full rendered issue body.
+
+    Returns:
+        One of :data:`VALID_SEVERITIES`, or ``None`` when no recognised
+        severity is found (including the ``_No response_`` placeholder), so
+        callers treat "unset" as a safe no-op.
+
+    """
+    lines = issue_body.splitlines()
+    for idx, line in enumerate(lines):
+        if not _HEADING_RE.match(line.strip()):
+            continue
+        # Scan the next few non-blank lines for an allow-listed value.
+        for follow in lines[idx + 1 : idx + 5]:
+            candidate = follow.strip().lower()
+            if not candidate:
+                continue
+            if candidate in VALID_SEVERITIES:
+                return candidate
+            break  # first non-blank line wasn't a severity → stop
+    return None
+
+
+def _gh(*args: str) -> str:
+    """Run ``gh`` with the given args (list form — never ``shell=True``)."""
+    return subprocess.run(["gh", *args], check=True, capture_output=True, text=True).stdout
+
+
+def apply_severity_label(repo: str, issue_number: int, selected: str | None) -> None:
+    """Reconcile the issue's ``severity:*`` labels to exactly ``selected``.
+
+    Lists the issue's current labels, removes any ``severity:*`` label that is
+    not the selected one, then adds the selected one (idempotent). With
+    ``selected=None`` all ``severity:*`` labels are removed and none is added.
+
+    Args:
+        repo: ``owner/name`` slug.
+        issue_number: The server-controlled issue number.
+        selected: A value from :data:`VALID_SEVERITIES`, or ``None`` to clear.
+
+    """
+    current = _gh(
+        "api",
+        f"repos/{repo}/issues/{issue_number}/labels",
+        "--jq",
+        ".[].name",
+    ).split()
+    target = f"severity:{selected}" if selected else None
+    # Remove any stale severity:* label (reconciliation, not just add).
+    for name in current:
+        if name.startswith("severity:") and name != target:
+            _gh(
+                "api",
+                "--method",
+                "DELETE",
+                f"repos/{repo}/issues/{issue_number}/labels/{name}",
+            )
+    if target and target not in current:
+        _gh(
+            "api",
+            "--method",
+            "POST",
+            f"repos/{repo}/issues/{issue_number}/labels",
+            "-f",
+            f"labels[]={target}",
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Reconcile the severity label for the issue named by the environment.
+
+    Args:
+        argv: Optional argument vector (defaults to ``sys.argv[1:]``); used so
+            ``--help`` works without requiring the workflow env vars.
+
+    Returns:
+        Process exit code (0 on success, 1 on a non-numeric issue number).
+
+    """
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reconcile the severity:* label for a GitHub issue from its issue-form "
+            "Severity answer. Reads GITHUB_REPOSITORY, ISSUE_NUMBER and ISSUE_BODY "
+            "from the environment."
+        )
+    )
+    add_json_arg(parser)
+    add_version_arg(parser)
+    args = parser.parse_args(argv)
+
+    repo = os.environ["GITHUB_REPOSITORY"]
+    raw = os.environ.get("ISSUE_NUMBER", "")
+    if not raw.isdigit():
+        message = f"Unexpected ISSUE_NUMBER {raw!r} (not a positive integer)"
+        if args.json:
+            emit_json_status(1, message)
+        else:
+            print(message, file=sys.stderr)
+        return 1
+    selected = parse_severity(os.environ.get("ISSUE_BODY", ""))
+    apply_severity_label(repo, int(raw), selected)
+    message = f"Reconciled severity label to: {selected or '(none)'}"
+    if args.json:
+        emit_json_status(0, message, severity=selected)
+    else:
+        print(message)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ hephaestus-ensure-state-labels = "hephaestus.automation.ensure_state_labels:main
 hephaestus-merge-prs = "hephaestus.github.pr_merge:main"
 hephaestus-fleet-sync = "hephaestus.github.fleet_sync:main"
 hephaestus-tidy = "hephaestus.github.tidy:main"
+hephaestus-label-severity = "hephaestus.github.severity_label:main"
 hephaestus-system-info = "hephaestus.system.info:main"
 hephaestus-download-dataset = "hephaestus.datasets.downloader:main"
 hephaestus-check-python-version = "hephaestus.validation.python_version:main"

--- a/tests/unit/github/test_issue_templates.py
+++ b/tests/unit/github/test_issue_templates.py
@@ -1,0 +1,85 @@
+"""Validate issue forms + severity tagger wiring feed the pipeline (#1210)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATE_DIR = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+SEVERITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "auto-label-severity.yml"
+FORMS = ["feature_request.yml", "bug_report.yml"]
+
+SEVERITY_OPTIONS = ["critical", "major", "minor", "nitpick"]
+PROVISIONED_DEFAULT_LABELS = {"enhancement", "bug"}
+
+
+def _load(form: str) -> dict:
+    return yaml.safe_load((TEMPLATE_DIR / form).read_text(encoding="utf-8"))
+
+
+def _field(data: dict, field_id: str) -> dict:
+    for item in data["body"]:
+        if item.get("id") == field_id:
+            return item
+    raise AssertionError(f"missing field id={field_id!r}")
+
+
+def test_forms_are_valid_yaml_with_body() -> None:
+    """Both issue forms parse as YAML with a list-valued ``body``."""
+    for form in FORMS:
+        assert isinstance(_load(form).get("body"), list)
+
+
+def test_severity_dropdown_schema_valid_no_default() -> None:
+    """Severity is an optional dropdown with all four options and no brittle default."""
+    for form in FORMS:
+        sev = _field(_load(form), "severity")
+        assert sev["type"] == "dropdown"
+        opts = sev["attributes"]["options"]
+        assert opts and all(o in opts for o in SEVERITY_OPTIONS)
+        assert "default" not in sev["attributes"]
+        assert sev.get("validations", {}).get("required", False) is False
+
+
+def test_parent_epic_is_optional_input() -> None:
+    """Parent Epic is an optional free-text ``input`` (reference only)."""
+    for form in FORMS:
+        p = _field(_load(form), "parent_epic")
+        assert p["type"] == "input"
+        assert p.get("validations", {}).get("required", False) is False
+
+
+def test_forms_seed_only_existing_labels() -> None:
+    """Forms seed only provisioned default labels (no phantom labels)."""
+    for form in FORMS:
+        for lbl in _load(form).get("labels", []):
+            assert lbl in PROVISIONED_DEFAULT_LABELS, f"{form} seeds unknown {lbl!r}"
+
+
+def test_forms_document_auto_state_label() -> None:
+    """A markdown block documents the automatic ``state:needs-plan`` labelling."""
+    for form in FORMS:
+        md = " ".join(
+            i["attributes"]["value"] for i in _load(form)["body"] if i.get("type") == "markdown"
+        )
+        assert "state:needs-plan" in md
+
+
+def test_severity_workflow_injection_safe() -> None:
+    """The body is bound as env and never interpolated into any shell step."""
+    text = SEVERITY_WORKFLOW.read_text(encoding="utf-8")
+    wf = yaml.safe_load(text)
+    assert wf["permissions"]["issues"] == "write"
+    # Body bound as env, never interpolated into any shell step. Inspect the
+    # parsed run: commands directly (not a naive string split) so a comment
+    # mentioning the body cannot mask a real interpolation.
+    assert "ISSUE_BODY: ${{ github.event.issue.body }}" in text
+    run_commands = [
+        step["run"] for job in wf["jobs"].values() for step in job["steps"] if "run" in step
+    ]
+    assert run_commands, "workflow has no run: steps to check"
+    for command in run_commands:
+        assert "${{ github.event.issue.body }}" not in command
+        assert "${{ github.event.issue.number }}" not in command

--- a/tests/unit/github/test_severity_label.py
+++ b/tests/unit/github/test_severity_label.py
@@ -129,6 +129,22 @@ def test_main_rejects_non_numeric_issue_number(monkeypatch: pytest.MonkeyPatch) 
     assert sl.main([]) == 1
 
 
+def test_main_rejects_missing_github_repository(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing GITHUB_REPOSITORY exits 1 with a descriptive error."""
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_BODY", "### Severity\n\nmajor\n")
+    assert sl.main([]) == 1
+
+
+def test_main_rejects_malformed_github_repository(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A GITHUB_REPOSITORY value without '/' exits 1 with a descriptive error."""
+    monkeypatch.setenv("GITHUB_REPOSITORY", "no-slash-here")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_BODY", "### Severity\n\nmajor\n")
+    assert sl.main([]) == 1
+
+
 def test_main_reconciles_on_valid_input(monkeypatch: pytest.MonkeyPatch) -> None:
     """Valid input parses the severity and reconciles the label."""
     monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")

--- a/tests/unit/github/test_severity_label.py
+++ b/tests/unit/github/test_severity_label.py
@@ -1,0 +1,146 @@
+"""Tests for :mod:`hephaestus.github.severity_label` (#1210).
+
+These run the SAME parser the auto-label-severity workflow runs, against
+sample GitHub-rendered issue bodies, so a body-rendering-format mismatch fails
+here instead of silently no-op'ing in CI.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from hephaestus.github import severity_label as sl
+
+# A faithful sample of how GitHub renders an issue-form dropdown answer.
+RENDERED_BODY = """\
+### Motivation
+
+Something is slow.
+
+### Severity
+
+major
+
+### Parent Epic (optional)
+
+#310
+"""
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("critical", "critical"),
+        ("major", "major"),
+        ("minor", "minor"),
+        ("nitpick", "nitpick"),
+    ],
+)
+def test_parse_severity_extracts_each_option(value: str, expected: str) -> None:
+    """Each rendered severity option is extracted from a faithful body."""
+    body = RENDERED_BODY.replace("major", value)
+    assert sl.parse_severity(body) == expected
+
+
+def test_parse_severity_handles_no_response() -> None:
+    """The ``_No response_`` placeholder yields ``None`` (safe no-op)."""
+    body = RENDERED_BODY.replace("major", "_No response_")
+    assert sl.parse_severity(body) is None
+
+
+def test_parse_severity_blank_lines_between_heading_and_value() -> None:
+    """Blank lines between the heading and the value are skipped."""
+    body = "### Severity\n\n\nminor\n"
+    assert sl.parse_severity(body) == "minor"
+
+
+def test_parse_severity_missing_section() -> None:
+    """A body without a Severity heading yields ``None``."""
+    assert sl.parse_severity("### Motivation\n\ntext\n") is None
+
+
+def test_parse_severity_ignores_non_severity_first_line() -> None:
+    """A stray sentence under the heading is not a severity → ``None``."""
+    assert sl.parse_severity("### Severity\n\nnot sure really\n") is None
+
+
+def test_parse_severity_case_insensitive_value() -> None:
+    """The selected value is matched case-insensitively and lowercased."""
+    assert sl.parse_severity("### Severity\n\nMAJOR\n") == "major"
+
+
+def test_apply_reconciles_stale_label() -> None:
+    """A changed severity deletes the stale label and adds the new one."""
+    calls: list[list[str]] = []
+
+    def fake_gh(*args: str) -> str:
+        calls.append(list(args))
+        if "--jq" in args:
+            return "severity:major\nbug\n"
+        return ""
+
+    with mock.patch.object(sl, "_gh", side_effect=fake_gh):
+        sl.apply_severity_label("o/r", 5, "minor")
+
+    # Stale severity:major deleted; severity:minor added; bug untouched.
+    assert any("DELETE" in c and c[-1].endswith("severity:major") for c in calls)
+    assert any("labels[]=severity:minor" in c for c in calls)
+    assert not any(c[-1].endswith("/labels/bug") for c in calls)
+
+
+def test_apply_idempotent_when_already_correct() -> None:
+    """An already-correct label triggers neither a DELETE nor a POST."""
+
+    def fake_gh(*args: str) -> str:
+        if "--jq" in args:
+            return "severity:minor\nenhancement\n"
+        return ""
+
+    with mock.patch.object(sl, "_gh", side_effect=fake_gh) as m:
+        sl.apply_severity_label("o/r", 9, "minor")
+
+    assert not any("DELETE" in c.args for c in m.call_args_list)
+    assert not any("POST" in c.args for c in m.call_args_list)
+
+
+def test_apply_no_selection_removes_all_severity() -> None:
+    """Clearing the selection removes all ``severity:*`` and adds none."""
+
+    def fake_gh(*args: str) -> str:
+        if "--jq" in args:
+            return "severity:minor\nenhancement\n"
+        return ""
+
+    with mock.patch.object(sl, "_gh", side_effect=fake_gh) as m:
+        sl.apply_severity_label("o/r", 7, None)
+
+    deleted = [c for c in m.call_args_list if "DELETE" in c.args]
+    assert any(c.args[-1].endswith("severity:minor") for c in deleted)
+    assert not any("POST" in c.args for c in m.call_args_list)
+
+
+def test_main_rejects_non_numeric_issue_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-numeric (injection-shaped) issue number exits 1 without API calls."""
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("ISSUE_NUMBER", "7; rm -rf /")
+    monkeypatch.setenv("ISSUE_BODY", "### Severity\n\nmajor\n")
+    assert sl.main([]) == 1
+
+
+def test_main_reconciles_on_valid_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Valid input parses the severity and reconciles the label."""
+    monkeypatch.setenv("GITHUB_REPOSITORY", "o/r")
+    monkeypatch.setenv("ISSUE_NUMBER", "42")
+    monkeypatch.setenv("ISSUE_BODY", "### Severity\n\nmajor\n")
+    with mock.patch.object(sl, "apply_severity_label") as applied:
+        assert sl.main([]) == 0
+    applied.assert_called_once_with("o/r", 42, "major")
+
+
+def test_main_help_does_not_touch_env() -> None:
+    """``--help`` exits 0 without requiring the workflow env vars (entry-point test)."""
+    with pytest.raises(SystemExit) as exc:
+        sl.main(["--help"])
+    assert exc.value.code == 0


### PR DESCRIPTION
Replace the bare `os.environ["GITHUB_REPOSITORY"]` at `severity_label.py:141`
with `os.environ.get("GITHUB_REPOSITORY", "")` plus an explicit validation
guard, so that invoking `hephaestus-label-severity` outside the workflow exits
cleanly with an error message instead of raising `KeyError`.  The guard mirrors
the existing `ISSUE_NUMBER` pattern immediately below it.

Two new unit tests cover the missing-var and malformed-var paths:
- `test_main_rejects_missing_github_repository`
- `test_main_rejects_malformed_github_repository`

Also fixes merge artefacts introduced when rebasing onto `1210-auto-impl`:
duplicate `## Console-Script Stability Tiers` section in `COMPATIBILITY.md`,
duplicate table rows, stale script count (47→48), and README/docs count drift.

Closes #1300