### PR TITLE
fix(lint): clear 4 pre-commit violations blocking main

### DIFF
--- a/tests/integration/test_choose_merge_flag_sh.py
+++ b/tests/integration/test_choose_merge_flag_sh.py
@@ -27,7 +27,7 @@ def test_shell_helper_errors_on_missing_arg() -> None:
     assert "missing required argument" in out.stderr
 
 
-def _run_with_mock_gh(json_body: str, repo: str = "owner/repo") -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+def _run_with_mock_gh(json_body: str, repo: str = "owner/repo") -> subprocess.CompletedProcess[str]:
     """Run choose_merge_flag with a mock gh function returning json_body."""
     script = f"""
 gh() {{
@@ -52,12 +52,15 @@ def test_shell_helper_handles_gh_stderr_noise() -> None:
 
     Regression guard for the safety fix: fails against the unfixed 2>&1 version.
     """
+    merge_settings = (
+        '{"allow_rebase_merge":true,"allow_squash_merge":true,"allow_merge_commit":true}'
+    )
     script = f"""
 gh() {{
     case "$1" in
         api)
             printf '%s\\n' 'warning: new gh release available' >&2
-            printf '%s\\n' '{{"allow_rebase_merge":true,"allow_squash_merge":true,"allow_merge_commit":true}}'
+            printf '%s\\n' '{merge_settings}'
             ;;
         *) command gh "$@" ;;
     esac

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -678,7 +678,10 @@ class TestCapturePlannerLearnings:
         assert (state_dir / "planner-learn-123.log").read_text().startswith("FAILED:")
 
     def test_oswrite_failure_is_nonfatal(self, planner: Planner, tmp_path: Any) -> None:
-        """OSError in record write must not propagate — capture_planner_learnings still returns output."""
+        """OSError in record write must not propagate.
+
+        capture_planner_learnings still returns output.
+        """
         with (
             patch(
                 "hephaestus.automation.planner_review_loop.get_repo_root",

--- a/tests/unit/scripts_lib/test_check_python_version_consistency.py
+++ b/tests/unit/scripts_lib/test_check_python_version_consistency.py
@@ -319,8 +319,7 @@ class TestCheckCiMatrixCoverage:
         """check_ci_matrix_coverage reads sequence-format python-version correctly."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(
-            '"Programming Language :: Python :: 3.10",\n'
-            '"Programming Language :: Python :: 3.11",\n'
+            '"Programming Language :: Python :: 3.10",\n"Programming Language :: Python :: 3.11",\n'
         )
         workflow_dir = tmp_path / ".github" / "workflows"
         workflow_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

`main` was RED — the `lint` job failed on every push due to four pre-commit violations present on `main`. This PR clears all four so `main` goes green again.

| # | Hook | Fix |
|---|------|-----|
| 1 | ruff-format | reformat `tests/unit/scripts_lib/test_check_python_version_consistency.py` |
| 2 | ruff-check E501 | extract `merge_settings` var in `tests/integration/test_choose_merge_flag_sh.py:60` |
| 3 | ruff-check E501 | split docstring in `tests/unit/automation/test_planner_loop.py:681` |
| 4 | mypy unused-ignore | parameterise `CompletedProcess[str]`, drop stale `# type: ignore[type-arg]` in `test_choose_merge_flag_sh.py:30` |

The emitted shell heredoc text is byte-identical (only the Python-side string assembly changed).

## Root cause

- **A** — PR #1294 raised the ruff floor `0.1.x → 0.15`; violations #2/#4 merged earlier (#1275, #1279) under the old ruleset and now fail retroactively.
- **B** — `lint` is **not** a required status check (only the two `test` contexts are), so violation #1 (#1308) merged with red lint.

This PR fixes the symptom. The structural prevention (aggregator gate making lint blocking + branch-protection-as-code) is a separate PR.

## Verification

```
ruff format --check tests/   → 213 files already formatted
ruff check hephaestus/ scripts/ tests/ → All checks passed!
mypy → Success: no issues found in 389 source files
pre-commit run --all-files → all hooks Passed
pytest (3 affected files) → 105 passed
```

Closes #1313