### PR TITLE
fix(utils): resolve Path.cwd() fallback and symlink-fragile assertions in get_repo_root

### DIFF
--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -114,7 +114,7 @@ def get_repo_root(start_path: str | Path | None = None) -> Path:
         fallback.
 
     """
-    start_path = Path.cwd() if start_path is None else Path(start_path).resolve()
+    start_path = Path.cwd().resolve() if start_path is None else Path(start_path).resolve()
 
     path = start_path
     while path != path.parent:  # Stop at filesystem root

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -137,7 +137,7 @@ class TestGetRepoRoot:
         subdir = mock_git_repo / "src" / "module"
         subdir.mkdir(parents=True)
         result = get_repo_root(subdir)
-        assert result == mock_git_repo
+        assert result == mock_git_repo.resolve()
 
     def test_returns_start_path_when_no_git(self, tmp_path):
         """Returns start_path when no .git found."""
@@ -149,12 +149,13 @@ class TestGetRepoRoot:
     def test_accepts_string_path(self, mock_git_repo):
         """Accepts a string path argument."""
         result = get_repo_root(str(mock_git_repo))
-        assert result == mock_git_repo
+        assert result == mock_git_repo.resolve()
 
     def test_uses_cwd_when_none(self):
         """Uses current working directory when start_path is None."""
         result = get_repo_root(None)
         assert isinstance(result, Path)
+        assert result.is_absolute()
 
     def test_nested_git_stops_at_inner_git(self, tmp_path):
         """Inner .git wins over outer .git — first-match-up (innermost) semantics."""


### PR DESCRIPTION
Fix two defects in `get_repo_root` and its test suite, both follow-ups from #1267.

## Changes

- **`hephaestus/utils/helpers.py:117`** — add `.resolve()` to the `Path.cwd()` branch so both arms of the ternary produce a resolved path. The fallback return at line 127 previously returned an unresolved path when `start_path` was `None`, violating the docstring contract ("returns the resolved start path as a fallback").
- **`tests/unit/utils/test_general_utils.py:140`** — add `.resolve()` to expected value in `test_finds_git_repo` to fix symlink-fragile assertion (macOS `$TMPDIR` is a symlink).
- **`tests/unit/utils/test_general_utils.py:152`** — same fix in `test_accepts_string_path`. Both are now consistent with lines 167/179/188 in the same class.
- **`tests/unit/utils/test_general_utils.py:157`** — add `assert result.is_absolute()` to `test_uses_cwd_when_none` as the regression guard for the resolved-path contract (prescribed by the issue body).

## Out of scope

Items considered and rejected as out of scope are recorded in the issue body, not filed as separate issues.

Closes #1309