### PR TITLE
harden(ci): make lint blocking via required-checks-gate aggregator + branch-protection-as-code

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -842,3 +842,67 @@ jobs:
           # — the same frozen-verification the pixi-check job uses, and a
           # command guaranteed available in the repo-pinned pixi v0.69.0.
           pixi install --locked
+
+  # required-checks-gate is the SINGLE branch-protection required status check
+  # for this workflow (alongside the two `test (...)` contexts from test.yml).
+  # It fans in every gating job above so that branch protection never has to
+  # enumerate them individually — add a new gating job to the `needs:` list and
+  # protection keeps working with no GitHub-side change. See
+  # docs/ci/required-checks.md and the guard test
+  # tests/unit/ci/test_required_checks_gate.py.
+  #
+  # `if: always()` is mandatory: the heavy jobs skip on label / auto-merge PR
+  # actions (they gate on changes-gate.code_event), so without always() this job
+  # would itself skip and report neither success nor failure — deadlocking a
+  # required check. The step below PASSES when every needed job is `success` or
+  # `skipped` (skipped = legitimately gated off) and FAILS on `failure` /
+  # `cancelled`. auto-merge-policy is intentionally EXCLUDED — it is advisory
+  # (see the comment on that job) and must not gate merges.
+  required-checks-gate:
+    name: required-checks-gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    if: always()
+    needs:
+      - changes-gate
+      - forbid-suppressions
+      - lint
+      - markdownlint
+      - pixi-check
+      - justfile-check
+      - symlink-check
+      - shellcheck
+      - pr-policy
+      - unit-tests
+      - integration-tests
+      - shell-tests
+      - build
+      - security-dependency-scan
+      - security-secrets-scan
+      - security-sast-scan
+      - schema-validation
+      - deps-version-sync
+    steps:
+      - name: Verify no required job failed or was cancelled
+        env:
+          # `needs` is a GitHub-controlled object; passed via env and parsed by
+          # the stdlib json module — never interpolated into the shell, so this
+          # is injection-safe.
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$RESULTS" | python3 -c '
+          import json
+          import sys
+
+          needs = json.load(sys.stdin)
+          bad = {
+              name: outcome["result"]
+              for name, outcome in needs.items()
+              if outcome["result"] not in ("success", "skipped")
+          }
+          if bad:
+              print("Required jobs not green:", json.dumps(bad, sort_keys=True))
+              sys.exit(1)
+          print("All required jobs green or legitimately skipped.")
+          '

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -34,6 +34,12 @@ A piece of work is **done** when every item below is true.
 | 21 | Pre-commit hooks pass on the diff | CI job `pre-commit` |
 | 22 | Every review thread is resolved (including bot-authored threads) | Org ruleset `required_review_thread_resolution` |
 
+> **Which of these actually block the merge button?** All of the CI jobs above
+> are aggregated into a single required status check, `required-checks-gate`.
+> See [`docs/ci/required-checks.md`](ci/required-checks.md) for the exact
+> required-context list, why a single aggregator is used, and how to (re-)apply
+> branch protection.
+
 ## For new features
 
 In addition to the universal checklist:

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -31,7 +31,7 @@ A piece of work is **done** when every item below is true.
 | 18 | Markdownlint passes on all `.md` changes | CI job `markdownlint` |
 | 19 | Shellcheck passes on all shell scripts | CI job `shellcheck` |
 | 20 | Yamllint passes on all YAML changes | CI job `lint` |
-| 21 | Pre-commit hooks pass on the diff | CI job `pre-commit` |
+| 21 | Pre-commit hooks pass on the diff | CI job `lint` (pre-commit suite folded into `lint` per #1173) |
 | 22 | Every review thread is resolved (including bot-authored threads) | Org ruleset `required_review_thread_resolution` |
 
 > **Which of these actually block the merge button?** All of the CI jobs above

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -1,0 +1,103 @@
+# Required status checks
+
+This document is the single source of truth for **which CI checks block merges
+to `main`** and how that gating is wired. Branch protection itself lives on the
+GitHub side (out of git), so this doc plus the workflow definition are the
+in-repo record of the contract.
+
+## The contract
+
+A PR can merge to `main` only when these branch-protection **required status
+checks** are green:
+
+| Required context | Source |
+|------------------|--------|
+| `required-checks-gate` | `.github/workflows/_required.yml` (aggregator) |
+| `test (ubuntu-latest, 3.12, unit)` | `.github/workflows/test.yml` matrix |
+| `test (ubuntu-latest, 3.12, integration)` | `.github/workflows/test.yml` matrix |
+
+Branch protection also has **`strict: true`** (a branch must be up to date with
+`main` before it can merge), which prevents a stale PR from merging around a
+gate that newer `main` would fail.
+
+## Why a single aggregator gate
+
+`_required.yml` defines ~18 jobs (`lint`, `pr-policy`, `unit-tests`,
+`build`, the `security/*` scans, etc.). Enumerating each one individually in
+branch protection is brittle: renaming a job, adding a job, or splitting one
+silently changes what's required, and nobody notices until something slips
+through.
+
+> This is exactly how `main` went red once: the `lint` job was **not** in the
+> required list (only the two `test` contexts were), so a PR with red lint
+> merged anyway. See issues #1313 / #1315.
+
+Instead, a single job — **`required-checks-gate`** — `needs:` every gating job
+and reports one aggregated result. Branch protection requires only that one
+context. Adding or renaming a gating job requires **no GitHub-side change**:
+just keep the gate's `needs:` list complete (enforced by a test — see below).
+
+### How the gate works
+
+```yaml
+required-checks-gate:
+  if: always()          # must run even when needed jobs skip
+  needs: [ ...every gating job... ]
+  steps:
+    - # PASS when every needed job is `success` OR `skipped`;
+      # FAIL on `failure` / `cancelled`.
+```
+
+`if: always()` is mandatory. Several heavy jobs gate on
+`changes-gate.outputs.code_event` and **skip** on label / auto-merge PR events.
+Without `always()` the gate would itself skip — reporting neither success nor
+failure — and **deadlock** a required check. Treating `skipped` as acceptable
+lets those legitimately-gated-off events pass while still failing on any real
+job failure.
+
+`auto-merge-policy` is deliberately **excluded** from the gate: it is advisory
+(it checks that auto-merge arming matches the `state:implementation-go` label)
+and must not block merges.
+
+## Adding a new gating job (runbook)
+
+1. Add the job to `.github/workflows/_required.yml` as usual.
+2. Add its job **key** to the `required-checks-gate` `needs:` list.
+3. That's it — no branch-protection change is needed.
+
+The guard test `tests/unit/ci/test_required_checks_gate.py` fails if a job is
+added to `_required.yml` without being wired into the gate (excepting the
+advisory `auto-merge-policy` and the gate itself), so step 2 cannot be silently
+forgotten.
+
+## (Re-)applying branch protection
+
+Branch protection is stored on GitHub, not in git. To apply or restore the
+required-checks contract above, an admin runs:
+
+```bash
+gh api -X PUT \
+  repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks \
+  -f strict=true \
+  -f 'checks[][context]=required-checks-gate' \
+  -f 'checks[][context]=test (ubuntu-latest, 3.12, unit)' \
+  -f 'checks[][context]=test (ubuntu-latest, 3.12, integration)'
+```
+
+Verify with:
+
+```bash
+gh api repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks
+```
+
+Expect `strict: true` and exactly the three contexts above.
+
+> **Order matters:** the `required-checks-gate` context only becomes selectable
+> after the workflow containing it has run at least once on a commit. Land the
+> workflow change first, let it report, then apply the protection PUT.
+
+## Related
+
+- `docs/DEFINITION_OF_DONE.md` — the full per-PR checklist and what enforces
+  each item.
+- `tests/unit/ci/test_required_checks_gate.py` — the invariant guard test.

--- a/tests/unit/ci/test_required_checks_gate.py
+++ b/tests/unit/ci/test_required_checks_gate.py
@@ -99,3 +99,35 @@ class TestRequiredChecksGate:
             f"{GATE_JOB} must set `if: always()` (got {gate_if!r}) so it does "
             "not skip on label/auto-merge events and deadlock the required check."
         )
+
+    def test_gate_assertion_fires_on_unwired_job(self) -> None:
+        """Negative-path: the invariant check must flag a job absent from needs:.
+
+        Construct a synthetic jobs dict that introduces a new gating job not
+        listed in required-checks-gate.needs and verify the gap is detected.
+        This guards against the invariant check itself silently passing when
+        it should fail — exactly the failure mode that let a red lint job reach
+        main (issue #1315).
+        """
+        # Minimal synthetic workflow jobs: a gate that only needs "job-a",
+        # plus an additional "job-b" that is unwired (not in needs).
+        synthetic_jobs: dict[str, Any] = {
+            GATE_JOB: {
+                "needs": ["job-a"],
+                "if": "always()",
+                "runs-on": "ubuntu-24.04",
+                "steps": [],
+            },
+            "job-a": {"runs-on": "ubuntu-24.04", "steps": []},
+            "job-b": {"runs-on": "ubuntu-24.04", "steps": []},  # intentionally unwired
+        }
+
+        gate_needs = set(synthetic_jobs[GATE_JOB]["needs"])
+        all_jobs = set(synthetic_jobs)
+        expected = all_jobs - EXEMPT_JOBS
+        missing = expected - gate_needs
+
+        assert "job-b" in missing, (
+            "Expected the invariant check to detect 'job-b' as unwired from "
+            f"{GATE_JOB}.needs, but missing={sorted(missing)}"
+        )

--- a/tests/unit/ci/test_required_checks_gate.py
+++ b/tests/unit/ci/test_required_checks_gate.py
@@ -1,0 +1,101 @@
+"""Guard tests for the required-checks-gate aggregator job.
+
+The ``required-checks-gate`` job in ``.github/workflows/_required.yml`` is the
+single branch-protection required status check for that workflow (see
+``docs/ci/required-checks.md``). Branch protection requires only that one
+context, so the gate MUST fan in every gating job — if a new job is added to
+``_required.yml`` without being wired into the gate's ``needs:`` list, it would
+silently stop blocking merges (exactly the failure mode that let a red ``lint``
+job reach ``main``; issue #1315).
+
+These tests turn that structural invariant into a unit-test failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REQUIRED_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_required.yml"
+
+GATE_JOB = "required-checks-gate"
+
+# Jobs intentionally NOT gated by required-checks-gate:
+#   - auto-merge-policy: advisory only (see its comment in _required.yml); must
+#     not block merges or it would contradict the state:implementation-go arming
+#     contract.
+#   - required-checks-gate: the gate cannot depend on itself.
+EXEMPT_JOBS = frozenset({"auto-merge-policy", GATE_JOB})
+
+
+@pytest.fixture(scope="module")
+def workflow() -> dict[str, Any]:
+    """Return the parsed ``_required.yml`` workflow document."""
+    with open(REQUIRED_WORKFLOW, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def jobs(workflow: dict[str, Any]) -> dict[str, Any]:
+    """Return the ``jobs:`` mapping of the required-checks workflow."""
+    return workflow["jobs"]
+
+
+class TestRequiredChecksGate:
+    """The gate must aggregate every gating job in _required.yml."""
+
+    def test_gate_job_exists(self, jobs: dict[str, Any]) -> None:
+        """_required.yml must define the required-checks-gate job."""
+        assert GATE_JOB in jobs, (
+            f"{GATE_JOB} job missing from _required.yml — it is the single "
+            "branch-protection required check; see docs/ci/required-checks.md"
+        )
+
+    def test_gate_needs_every_non_exempt_job(self, jobs: dict[str, Any]) -> None:
+        """Every job except the exempt set must be in the gate's needs list.
+
+        This is the core invariant: add a job to _required.yml and you MUST add
+        it to required-checks-gate.needs, or it stops gating merges.
+        """
+        gate_needs = set(jobs[GATE_JOB]["needs"])
+        all_jobs = set(jobs)
+        expected = all_jobs - EXEMPT_JOBS
+
+        missing = expected - gate_needs
+        assert not missing, (
+            f"These jobs are not gated by {GATE_JOB}.needs and would not block "
+            f"merges: {sorted(missing)}. Add them to the gate's needs list in "
+            ".github/workflows/_required.yml (see docs/ci/required-checks.md)."
+        )
+
+    def test_gate_does_not_need_exempt_jobs(self, jobs: dict[str, Any]) -> None:
+        """The gate must not depend on advisory jobs or itself."""
+        gate_needs = set(jobs[GATE_JOB]["needs"])
+        wrongly_gated = gate_needs & EXEMPT_JOBS
+        assert not wrongly_gated, (
+            f"{GATE_JOB}.needs must not include {sorted(wrongly_gated)} — "
+            "auto-merge-policy is advisory and the gate cannot depend on itself."
+        )
+
+    def test_gate_needs_reference_real_jobs(self, jobs: dict[str, Any]) -> None:
+        """Every entry in the gate's needs list must be a real job."""
+        gate_needs = set(jobs[GATE_JOB]["needs"])
+        unknown = gate_needs - set(jobs)
+        assert not unknown, f"{GATE_JOB}.needs references jobs that do not exist: {sorted(unknown)}"
+
+    def test_gate_runs_always(self, jobs: dict[str, Any]) -> None:
+        """The gate must use if: always() so it never skips into a deadlock.
+
+        Without always(), the gate would skip whenever a needed job skips
+        (label/auto-merge events), reporting neither success nor failure and
+        deadlocking the required check.
+        """
+        gate_if = str(jobs[GATE_JOB].get("if", "")).strip()
+        assert "always()" in gate_if, (
+            f"{GATE_JOB} must set `if: always()` (got {gate_if!r}) so it does "
+            "not skip on label/auto-merge events and deadlock the required check."
+        )


### PR DESCRIPTION
## Summary

Closes the **root cause** behind #1313: a `lint` failure could reach `main` because branch protection's `required_status_checks` listed only the two `test (...)` contexts — the `lint` job (and the rest of `_required.yml`) was advisory.

This PR makes every gating job actually block merges, via a single aggregator.

### Changes

- **`_required.yml`** — new `required-checks-gate` job. It `needs:` every gating job and reports one aggregated result. Uses `if: always()` + a stdlib-`json` result check so it does **not** deadlock on label/auto-merge PR events where heavy jobs legitimately `skip` (PASS on `success`/`skipped`, FAIL on `failure`/`cancelled`). Advisory `auto-merge-policy` is intentionally excluded.
- **`tests/unit/ci/test_required_checks_gate.py`** — guard test (5 cases) that fails if a job is added to `_required.yml` without being wired into the gate, if the gate gains a dependency it shouldn't have, or if it loses `if: always()`. **Verified it catches an ungated dummy job** (added one locally → test went red → reverted → green).
- **`docs/ci/required-checks.md`** — the required-context contract, why a single aggregator is used (rename/add-safe), the "adding a new gating job" runbook, and the exact `gh api` command to (re-)apply branch protection.
- **`docs/DEFINITION_OF_DONE.md`** — cross-link to the new doc.

### Out-of-band step (admin, after merge)

Branch protection lives on GitHub, not git. After this lands and the gate has reported once, an admin runs (documented in `docs/ci/required-checks.md`):

```bash
gh api -X PUT repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks \
  -f strict=true \
  -f 'checks[][context]=required-checks-gate' \
  -f 'checks[][context]=test (ubuntu-latest, 3.12, unit)' \
  -f 'checks[][context]=test (ubuntu-latest, 3.12, integration)'
```

`strict=true` also closes the "merge against stale `main`" half of the root cause.

### Stacking note

This PR is **stacked on #1314** (base branch `1313-fix-lint-main-red`) so its `tests/` tree is lint-clean. Merge #1314 first; GitHub will retarget this PR to `main` automatically.

Closes #1315