### PR TITLE
fix(skills): stop advise/learn from emitting CI-failing Mnemosyne PRs

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -399,7 +399,15 @@ class ReviewPhase(StageMixin):
         prior_addressed_threads: list[dict[str, Any]] = []
 
         for iteration in range(MAX_REVIEW_ITERATIONS):
-            last_verdict, last_grade, review_text, posted_thread_ids, go_blocked_by_automation, reopened, should_break = self._process_review_iteration(  # noqa: E501
+            (
+                last_verdict,
+                last_grade,
+                review_text,
+                posted_thread_ids,
+                go_blocked_by_automation,
+                reopened,
+                should_break,
+            ) = self._process_review_iteration(
                 issue_number=issue_number,
                 issue_title=issue_title,
                 issue_body=issue_body,
@@ -446,7 +454,12 @@ class ReviewPhase(StageMixin):
             if not addressed:
                 break
 
-        self._finalize_review_outcome(issue_number=issue_number, pr_number=pr_number, last_verdict=last_verdict, iterations_run=iterations_run)  # noqa: E501
+        self._finalize_review_outcome(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            last_verdict=last_verdict,
+            iterations_run=iterations_run,
+        )
         return iterations_run, last_verdict, last_grade
 
     def _process_review_iteration(
@@ -517,7 +530,15 @@ class ReviewPhase(StageMixin):
                 thread_id=thread_id,
             )
 
-        return last_verdict, last_grade, review_text, posted_thread_ids, go_blocked_by_automation, reopened, should_break  # noqa: E501
+        return (
+            last_verdict,
+            last_grade,
+            review_text,
+            posted_thread_ids,
+            go_blocked_by_automation,
+            reopened,
+            should_break,
+        )
 
     def _run_address_step_if_needed(
         self,

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -547,9 +547,7 @@ class AddressReviewer(BaseReviewer):
             review_state.pr_number = pr_number
         branch_name = review_state.branch_name or f"{issue_number}-auto-impl"
 
-        self.status_tracker.update_slot(
-            slot_id, f"{issue_ref(issue_number)}: Setting up worktree"
-        )
+        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Setting up worktree")
         worktree_path = self._get_or_create_worktree(issue_number, branch_name, review_state)
 
         with self.state_lock:
@@ -629,20 +627,24 @@ class AddressReviewer(BaseReviewer):
 
         thread_id = threading.get_ident()
         self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Starting")
-        self._log("info", f"Addressing PR {pr_ref(pr_number)} for issue {issue_ref(issue_number)}", thread_id)  # noqa: E501
+        self._log(
+            "info",
+            f"Addressing PR {pr_ref(pr_number)} for issue {issue_ref(issue_number)}",
+            thread_id,
+        )
 
         try:
             threads = self._check_threads_for_address(issue_number, pr_number, thread_id)
             if threads is None:
-                return WorkerResult(
-                    issue_number=issue_number, success=True, pr_number=pr_number
-                )
+                return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
             session_id, review_state, branch_name, worktree_path = self._setup_address_state(
                 issue_number, pr_number, slot_id
             )
 
-            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Running Claude fix")  # noqa: E501
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: Running Claude fix"
+            )
             fix_result = self._run_fix_session(
                 issue_number=issue_number,
                 pr_number=pr_number,
@@ -652,7 +654,11 @@ class AddressReviewer(BaseReviewer):
             )
             addressed: list[str] = fix_result.get("addressed", [])
             replies: dict[str, str] = fix_result.get("replies", {})
-            self._log("info", f"Claude addressed {len(addressed)} thread(s) on PR {pr_ref(pr_number)}", thread_id)  # noqa: E501
+            self._log(
+                "info",
+                f"Claude addressed {len(addressed)} thread(s) on PR {pr_ref(pr_number)}",
+                thread_id,
+            )
             self._commit_push_and_resolve(
                 issue_number=issue_number,
                 pr_number=pr_number,

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -757,7 +757,9 @@ class CIDriver:
                 logger.warning(
                     "Issue #%s: CI checks still pending after %ss (limit %ss), "
                     "treating as not yet failing",
-                    issue_number, poll_elapsed, max_wait,
+                    issue_number,
+                    poll_elapsed,
+                    max_wait,
                 )
                 return None
 
@@ -767,7 +769,10 @@ class CIDriver:
             )
             logger.debug(
                 "Issue #%s: CI checks pending, sleeping %ss (attempt %s, %ss elapsed)",
-                issue_number, sleep_secs, poll_attempt + 1, poll_elapsed,
+                issue_number,
+                sleep_secs,
+                poll_attempt + 1,
+                poll_elapsed,
             )
             time.sleep(sleep_secs)
             poll_elapsed += sleep_secs
@@ -783,12 +788,18 @@ class CIDriver:
         """
         self.status_tracker.update_slot(acquired_slot, f"{pr_ref(pr_number)}: enabling auto-merge")
         if self.options.dry_run:
-            logger.info("[dry_run] Would enable auto-merge for PR #%s (issue #%s)", pr_number, issue_number)  # noqa: E501
+            logger.info(
+                "[dry_run] Would enable auto-merge for PR #%s (issue #%s)", pr_number, issue_number
+            )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
-        merge_ok = self._enable_auto_merge(pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number))  # noqa: E501
+        merge_ok = self._enable_auto_merge(
+            pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number)
+        )
         if merge_ok:
-            self.status_tracker.update_slot(acquired_slot, f"{pr_ref(pr_number)}: arming for post-merge /learn")  # noqa: E501
+            self.status_tracker.update_slot(
+                acquired_slot, f"{pr_ref(pr_number)}: arming for post-merge /learn"
+            )
             gh_state = self._gh_pr_state(pr_number)
             pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
             self._arm_drive_green(pr_number, self._get_pr_branch(pr_number), pr_head_sha)
@@ -797,12 +808,16 @@ class CIDriver:
             if outcome == "FAILING":
                 fix_result = self._attempt_ci_fixes(issue_number, pr_number, acquired_slot)
                 if fix_result is not None and fix_result.success:
-                    rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)  # noqa: E501
+                    rearmed = self._recheck_and_arm_after_fix(
+                        issue_number, pr_number, acquired_slot
+                    )
                     return rearmed if rearmed is not None else fix_result
                 if fix_result is not None:
                     return fix_result
                 return WorkerResult(
-                    issue_number=issue_number, success=False, pr_number=pr_number,
+                    issue_number=issue_number,
+                    success=False,
+                    pr_number=pr_number,
                     error=f"CI fix failed after {self.options.max_fix_iterations} attempt(s)",
                 )
             if outcome == "DIRTY":
@@ -810,7 +825,9 @@ class CIDriver:
             if outcome == "BLOCKED":
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
         return WorkerResult(
-            issue_number=issue_number, success=merge_ok, pr_number=pr_number,
+            issue_number=issue_number,
+            success=merge_ok,
+            pr_number=pr_number,
             error=None if merge_ok else f"auto-merge failed for PR {pr_ref(pr_number)}",
         )
 
@@ -827,13 +844,17 @@ class CIDriver:
             logger.info(
                 "Issue #%s: PR #%s is green but lacks state:implementation-go; "
                 "leaving auto-merge disabled until implementation review approves it",
-                issue_number, pr_number,
+                issue_number,
+                pr_number,
             )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
         return self._arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
 
     def _handle_failing_pr(
-        self, issue_number: int, pr_number: int, acquired_slot: int,
+        self,
+        issue_number: int,
+        pr_number: int,
+        acquired_slot: int,
         required_checks: list[dict[str, Any]],
     ) -> WorkerResult:
         """Handle a PR where at least one required check has failed.
@@ -844,7 +865,8 @@ class CIDriver:
         if not failing:
             logger.info(
                 "Issue #%s: PR #%s checks concluded with non-green, non-failure conclusions (e.g. cancelled)",  # noqa: E501
-                issue_number, pr_number,
+                issue_number,
+                pr_number,
             )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
@@ -857,13 +879,13 @@ class CIDriver:
         if fix_result is not None:
             return fix_result
         return WorkerResult(
-            issue_number=issue_number, success=False, pr_number=pr_number,
+            issue_number=issue_number,
+            success=False,
+            pr_number=pr_number,
             error=f"CI fix failed after {self.options.max_fix_iterations} attempt(s)",
         )
 
-    def _drive_issue(
-        self, issue_number: int, pr_number: int, slot_id: int
-    ) -> WorkerResult:
+    def _drive_issue(self, issue_number: int, pr_number: int, slot_id: int) -> WorkerResult:
         """Drive a single issue's PR toward green CI.
 
         Args:
@@ -877,7 +899,9 @@ class CIDriver:
         """
         acquired_slot: int | None = self.status_tracker.acquire_slot()
         if acquired_slot is None:
-            return WorkerResult(issue_number=issue_number, success=False, error="Failed to acquire worker slot")  # noqa: E501
+            return WorkerResult(
+                issue_number=issue_number, success=False, error="Failed to acquire worker slot"
+            )
 
         try:
             armed_result = self._check_arming_on_drive_start(issue_number, pr_number)
@@ -896,7 +920,9 @@ class CIDriver:
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
             _checks, required_checks = poll_result
 
-            all_green = all(c.get("conclusion") in ("success", "skipped", "neutral") for c in required_checks)  # noqa: E501
+            all_green = all(
+                c.get("conclusion") in ("success", "skipped", "neutral") for c in required_checks
+            )
             if all_green:
                 return self._handle_green_pr(issue_number, pr_number, acquired_slot)
             return self._handle_failing_pr(issue_number, pr_number, acquired_slot, required_checks)
@@ -2555,7 +2581,9 @@ class CIDriver:
         except subprocess.CalledProcessError as exc:
             logger.error(
                 "Issue #%s: failed to sync worktree to origin/%s before CI fix: %s",
-                issue_number, pr_head_branch, (exc.stderr or exc.stdout or "")[:300],
+                issue_number,
+                pr_head_branch,
+                (exc.stderr or exc.stdout or "")[:300],
             )
             return None
         try:
@@ -2563,13 +2591,19 @@ class CIDriver:
         except subprocess.CalledProcessError as exc:
             logger.error(
                 "Issue #%s: failed to snapshot HEAD before CI fix session: %s",
-                issue_number, (exc.stderr or exc.stdout or "")[:300],
+                issue_number,
+                (exc.stderr or exc.stdout or "")[:300],
             )
             return None
 
     def _build_ci_fix_prompt(
-        self, issue_number: int, pr_number: int, worktree_path: Path,
-        ci_logs: str, pr_head_branch: str, advise_findings: str,
+        self,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        ci_logs: str,
+        pr_head_branch: str,
+        advise_findings: str,
     ) -> str:
         """Build the CI-fix agent prompt string."""
         advise_block = ""
@@ -2623,7 +2657,9 @@ class CIDriver:
             return False
         try:
             push_current_branch_with_lease_on_divergence(
-                worktree_path, branch=pr_head_branch, push_ref=f"HEAD:{pr_head_branch}",
+                worktree_path,
+                branch=pr_head_branch,
+                push_ref=f"HEAD:{pr_head_branch}",
             )
             logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
             return True
@@ -2646,29 +2682,50 @@ class CIDriver:
             if session_id:
                 try:
                     codex_result = resume_codex_session(
-                        session_id, prompt, cwd=worktree_path, timeout=ci_driver_claude_timeout(),
+                        session_id,
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
                     )
                 except subprocess.CalledProcessError as e:
                     logger.warning(
                         "Issue #%s: Codex resume session %r failed for PR #%s; falling back to fresh: %s",  # noqa: E501
-                        issue_number, session_id, pr_number, (e.stderr or e.stdout or "")[:300],
+                        issue_number,
+                        session_id,
+                        pr_number,
+                        (e.stderr or e.stdout or "")[:300],
                     )
                     codex_result = run_codex_session(
-                        prompt, cwd=worktree_path, timeout=ci_driver_claude_timeout(), sandbox="workspace-write",  # noqa: E501
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                        sandbox="workspace-write",
                     )
             else:
                 codex_result = run_codex_session(
-                    prompt, cwd=worktree_path, timeout=ci_driver_claude_timeout(), sandbox="workspace-write",  # noqa: E501
+                    prompt,
+                    cwd=worktree_path,
+                    timeout=ci_driver_claude_timeout(),
+                    sandbox="workspace-write",
                 )
-            logger.debug("Issue #%s: Codex CI fix output: %s", issue_number, codex_result.stdout[:500])  # noqa: E501
+            logger.debug(
+                "Issue #%s: Codex CI fix output: %s", issue_number, codex_result.stdout[:500]
+            )
         except subprocess.CalledProcessError as e:
             logger.error(
                 "Issue #%s: Codex CI fix session returned exit code %s: %s",
-                issue_number, e.returncode, (e.stderr or e.stdout or "")[:300],
+                issue_number,
+                e.returncode,
+                (e.stderr or e.stdout or "")[:300],
             )
             return False
         return self._finalize_ci_fix_push(
-            issue_number, pr_number, worktree_path, pr_head_branch, pre_agent_sha, session_id,
+            issue_number,
+            pr_number,
+            worktree_path,
+            pr_head_branch,
+            pre_agent_sha,
+            session_id,
         )
 
     def _invoke_claude_ci_fix(
@@ -2697,19 +2754,30 @@ class CIDriver:
                 extra_args=["--dangerously-skip-permissions"],
                 input_via_stdin=True,
             )
-            claude_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")  # noqa: E501
+            claude_result = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=stdout, stderr=""
+            )
         except subprocess.CalledProcessError as exc:
             claude_result = subprocess.CompletedProcess(
-                args=exc.cmd, returncode=exc.returncode,
-                stdout=exc.stdout or "", stderr=exc.stderr or "",
+                args=exc.cmd,
+                returncode=exc.returncode,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
             )
         if claude_result.returncode == 0:
             return self._finalize_ci_fix_push(
-                issue_number, pr_number, worktree_path, pr_head_branch, pre_agent_sha, session_id,
+                issue_number,
+                pr_number,
+                worktree_path,
+                pr_head_branch,
+                pre_agent_sha,
+                session_id,
             )
         logger.error(
             "Issue #%s: Claude CI fix session returned exit code %s: %s",
-            issue_number, claude_result.returncode, claude_result.stderr[:300],
+            issue_number,
+            claude_result.returncode,
+            claude_result.stderr[:300],
         )
         return False
 
@@ -2743,27 +2811,50 @@ class CIDriver:
             True if the fix session succeeded and the branch was pushed.
 
         """
-        pre_agent_sha = self._sync_worktree_and_snapshot_sha(issue_number, worktree_path, pr_head_branch)  # noqa: E501
+        pre_agent_sha = self._sync_worktree_and_snapshot_sha(
+            issue_number, worktree_path, pr_head_branch
+        )
         if pre_agent_sha is None:
             return False
 
         prompt = self._build_ci_fix_prompt(
-            issue_number, pr_number, worktree_path, ci_logs, pr_head_branch, advise_findings,
+            issue_number,
+            pr_number,
+            worktree_path,
+            ci_logs,
+            pr_head_branch,
+            advise_findings,
         )
 
         try:
             if is_codex(self.options.agent):
                 return self._invoke_codex_ci_fix(
-                    issue_number, pr_number, worktree_path, prompt, pr_head_branch, pre_agent_sha, session_id,  # noqa: E501
+                    issue_number,
+                    pr_number,
+                    worktree_path,
+                    prompt,
+                    pr_head_branch,
+                    pre_agent_sha,
+                    session_id,
                 )
             return self._invoke_claude_ci_fix(
-                issue_number, pr_number, worktree_path, prompt, pr_head_branch, pre_agent_sha, session_id,  # noqa: E501
+                issue_number,
+                pr_number,
+                worktree_path,
+                prompt,
+                pr_head_branch,
+                pre_agent_sha,
+                session_id,
             )
         except subprocess.TimeoutExpired:
-            logger.error("Issue #%s: Claude CI fix session timed out for PR #%s", issue_number, pr_number)  # noqa: E501
+            logger.error(
+                "Issue #%s: Claude CI fix session timed out for PR #%s", issue_number, pr_number
+            )
             return False
         except Exception as e:
-            logger.error("Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e)  # noqa: E501
+            logger.error(
+                "Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e
+            )
             return False
 
     def _enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -223,7 +223,9 @@ class ImplementationPhaseRunner:
                 f"create PR for #{issue_number}",
                 thread_id,
             )
-            return WorkerResult(issue_number=issue_number, success=True, branch_name=branch_name, worktree_path=None)  # noqa: E501
+            return WorkerResult(
+                issue_number=issue_number, success=True, branch_name=branch_name, worktree_path=None
+            )
 
         # When an open PR already exists for this issue, skip the
         # plan/implement steps (the PR is already opened) but STILL drive it
@@ -231,7 +233,9 @@ class ImplementationPhaseRunner:
         # ``state:implementation-go`` label that drive-green requires to arm
         # auto-merge. Imported top-level so tests patch
         # ``hephaestus.automation.implementer_phase_runner.find_pr_for_issue``.
-        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Checking for existing PR")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Checking for existing PR"
+        )
         existing_pr = find_pr_for_issue(issue_number)
         if existing_pr is not None:
             return self._review_existing_pr(
@@ -283,7 +287,9 @@ class ImplementationPhaseRunner:
         impl = self.impl
         slot_id = self.status_tracker.acquire_slot()
         if slot_id is None:
-            return WorkerResult(issue_number=issue_number, success=False, error="Failed to acquire worker slot")  # noqa: E501
+            return WorkerResult(
+                issue_number=issue_number, success=False, error="Failed to acquire worker slot"
+            )
 
         thread_id = threading.get_ident()
 
@@ -297,21 +303,27 @@ class ImplementationPhaseRunner:
         except subprocess.TimeoutExpired as e:
             error_msg = f"Timeout: {' '.join(e.cmd[:3])} exceeded {e.timeout}s"
             impl._log("error", error_msg, thread_id)
-            return self._record_issue_failure(issue_number, slot_id, thread_id, error_msg, persist_error=error_msg)  # noqa: E501
+            return self._record_issue_failure(
+                issue_number, slot_id, thread_id, error_msg, persist_error=error_msg
+            )
 
         except subprocess.CalledProcessError as e:
             error_msg = f"Command failed (exit {e.returncode}): {' '.join(e.cmd[:3])}"
             impl._log("error", error_msg, thread_id)
             if e.stderr:
                 impl._log("error", f"stderr: {e.stderr[:300]}", thread_id)
-            return self._record_issue_failure(issue_number, slot_id, thread_id, error_msg, persist_error=str(e))  # noqa: E501
+            return self._record_issue_failure(
+                issue_number, slot_id, thread_id, error_msg, persist_error=str(e)
+            )
 
         except RuntimeError as e:
             return self._handle_runtime_error(issue_number, slot_id, thread_id, e)
 
         except Exception as e:  # broad catch: top-level worker boundary, must not crash thread pool
             impl._log("error", f"Unexpected {type(e).__name__}: {e}", thread_id)
-            return self._record_issue_failure(issue_number, slot_id, thread_id, str(e)[:80], persist_error=str(e))  # noqa: E501
+            return self._record_issue_failure(
+                issue_number, slot_id, thread_id, str(e)[:80], persist_error=str(e)
+            )
 
         finally:
             self.status_tracker.release_slot(slot_id)
@@ -484,7 +496,9 @@ class ImplementationPhaseRunner:
                 issue_number, issue.title, issue.body, worktree_path
             )
 
-        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}"
+        )
         codex_advise_findings = ""
         if self.options.enable_advise and is_codex(self.options.agent):
             self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
@@ -654,7 +668,9 @@ class ImplementationPhaseRunner:
                 thread_id,
             )
 
-        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR"
+        )
         worktree_path = self.worktree_manager.create_worktree(issue_number, pr_branch)
         # ``create_worktree`` may REUSE a worktree with uncommitted changes from
         # another session; ``reset --hard`` would silently discard them. Only when
@@ -749,7 +765,9 @@ class ImplementationPhaseRunner:
         """
         impl = self.impl
 
-        self.status_tracker.update_slot(slot_id, f"{pr_ref(existing_pr)}: Checking implementation-review label")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{pr_ref(existing_pr)}: Checking implementation-review label"
+        )
         has_go, has_no_go = pr_has_implementation_state_label(existing_pr)
         if has_go:
             impl._log(
@@ -763,8 +781,11 @@ class ImplementationPhaseRunner:
                 state.phase = ImplementationPhase.CREATING_PR
             impl._save_state(state)
             return WorkerResult(
-                issue_number=issue_number, success=True, pr_number=existing_pr,
-                branch_name=branch_name, already_has_pr=True,
+                issue_number=issue_number,
+                success=True,
+                pr_number=existing_pr,
+                branch_name=branch_name,
+                already_has_pr=True,
             )
         if has_no_go:
             impl._log(
@@ -800,8 +821,12 @@ class ImplementationPhaseRunner:
             thread_id,
         )
         return WorkerResult(
-            issue_number=issue_number, success=True, pr_number=existing_pr,
-            branch_name=pr_branch, worktree_path=str(worktree_path), already_has_pr=True,
+            issue_number=issue_number,
+            success=True,
+            pr_number=existing_pr,
+            branch_name=pr_branch,
+            worktree_path=str(worktree_path),
+            already_has_pr=True,
         )
 
     # ------------------------------------------------------------------

--- a/skills/advise/SKILL.md
+++ b/skills/advise/SKILL.md
@@ -39,9 +39,7 @@ When the user invokes this command:
        # Clone fresh
        mkdir -p "$HOME/.agent-brain"
        gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
-       # Fresh clone → install pre-commit hooks (one-time per clone) so any later /learn
-       # in this clone has working hooks.
-       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
+       ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )  # so any later /learn has hooks
      fi
 
      # Always update to latest main before searching
@@ -49,13 +47,18 @@ When the user invokes this command:
      git -C "$MNEMOSYNE_DIR" checkout main
      git -C "$MNEMOSYNE_DIR" pull --ff-only origin main
 
-     # Already checked out → verify pre-commit is installed and working; (re)install if not.
-     if [ ! -f "$MNEMOSYNE_DIR/.git/hooks/pre-commit" ]; then
-       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
-     fi
-     ( cd "$MNEMOSYNE_DIR" && pre-commit validate-config >/dev/null 2>&1 ) \
-       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' in $MNEMOSYNE_DIR"
+     # Verify pre-commit is genuinely installed; (re)install if not.
+     ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )
    fi
+
+   # ensure_precommit_installed: do NOT test [ -f .git/hooks/pre-commit ] — in a worktree .git
+   # is a file, and a stray core.hooksPath can fake the path. Ask the resolved hook instead:
+   ensure_precommit_installed() {
+     local hooks_dir; hooks_dir="$(git rev-parse --git-path hooks)"
+     grep -qs 'pre-commit' "$hooks_dir/pre-commit" || pre-commit install --install-hooks
+     pre-commit validate-config >/dev/null 2>&1 \
+       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' here"
+   }
    ```
 
 2. **Parse the user's goal** from $ARGUMENTS

--- a/skills/advise/SKILL.md
+++ b/skills/advise/SKILL.md
@@ -39,12 +39,22 @@ When the user invokes this command:
        # Clone fresh
        mkdir -p "$HOME/.agent-brain"
        gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       # Fresh clone → install pre-commit hooks (one-time per clone) so any later /learn
+       # in this clone has working hooks.
+       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
      fi
 
      # Always update to latest main before searching
      git -C "$MNEMOSYNE_DIR" fetch origin
      git -C "$MNEMOSYNE_DIR" checkout main
      git -C "$MNEMOSYNE_DIR" pull --ff-only origin main
+
+     # Already checked out → verify pre-commit is installed and working; (re)install if not.
+     if [ ! -f "$MNEMOSYNE_DIR/.git/hooks/pre-commit" ]; then
+       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
+     fi
+     ( cd "$MNEMOSYNE_DIR" && pre-commit validate-config >/dev/null 2>&1 ) \
+       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' in $MNEMOSYNE_DIR"
    fi
    ```
 
@@ -109,7 +119,23 @@ If the user wants more detail, read the full skill `.md` file and its `.history`
 for the most relevant matches.
 
 > **Note**: If the user's goal involves **creating or fixing skills**, remind them to run
-> `/learn` which captures session learnings and creates or amends a skill file.
+> `/learn` which captures session learnings and creates or amends a skill file. Before they
+> do, run the **open-PR check** for any skill you matched above and warn if one is already
+> being amended — this catches duplication at the advise stage, before any work starts:
+>
+> ```bash
+> # For each matched skill <name>, surface open PRs already amending it:
+> gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+>   --search "<name> in:title" --json number,headRefName,title
+> gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+>   --json number,headRefName,files \
+>   --jq '.[] | select(.files[].path == "skills/<name>.md") | {number, headRefName}'
+> ```
+>
+> If an open PR already amends the skill, tell the user to **stack on that PR's branch**
+> rather than open a new one (see `/learn` Step 2 amend-lock rule). Forking a fresh
+> `origin/main` branch for an already-in-flight skill is what produced the duplicate,
+> mutually-conflicting PR pileup.
 
 ## Output Format
 

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -207,8 +207,16 @@ Agent(description="Create skill C", prompt="...skill C content...")
 
    Before writing the "Verified Workflow" section, answer these questions honestly:
    - Was the workflow actually executed end-to-end? (Not just pre-commit hooks — the actual tests/code)
-   - Did CI pass with these changes? If not, the section MUST be titled "Proposed Workflow" not "Verified Workflow"
+   - Did CI pass with these changes? If not, convey that **inside** the section (see below) — do
+     NOT rename the header.
    - Were the results observed in CI, or only locally? If only locally, state: "Verified locally only — CI validation pending"
+
+   **CRITICAL — the section header MUST stay `## Verified Workflow` regardless of verification
+   level.** `validate_plugins.py` requires the literal string `## Verified Workflow` (it does a
+   plain substring check for it); renaming it to `## Proposed Workflow` causes a hard
+   `validate` failure: `Missing required section: ## Verified Workflow`. For an unverified or
+   `verified-precommit` skill, keep the header and add a status note as the first line of the
+   section instead (see Step 6).
 
    **Verification levels** (must be stated in the skill):
    - `verified-ci`: Tests pass in CI (highest confidence)
@@ -255,8 +263,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
        # Clone fresh
        mkdir -p "$HOME/.agent-brain"
        gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
-       # Fresh clone → install pre-commit hooks (one-time per clone)
-       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
+       ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )  # see helper below
      fi
 
      # Always update to latest main before starting
@@ -264,14 +271,30 @@ Agent(description="Create skill C", prompt="...skill C content...")
      git -C "$MNEMOSYNE_DIR" checkout main
      git -C "$MNEMOSYNE_DIR" pull --ff-only origin main
 
-     # Already checked out → verify pre-commit is installed and working; (re)install if not.
-     if [ ! -f "$MNEMOSYNE_DIR/.git/hooks/pre-commit" ]; then
-       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
-     fi
-     # Sanity-check the hooks resolve (catches a stale/broken pre-commit cache early).
-     ( cd "$MNEMOSYNE_DIR" && pre-commit validate-config >/dev/null 2>&1 ) \
-       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' in $MNEMOSYNE_DIR"
+     # Verify pre-commit is genuinely installed; (re)install if not.
+     ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )
    fi
+   ```
+
+   **Robust pre-commit check (`ensure_precommit_installed`).** Do NOT test
+   `[ -f "$DIR/.git/hooks/pre-commit" ]`: it is wrong two ways — (1) in a **worktree**, `.git`
+   is a *file* (a `gitdir:` pointer), not a directory, so the path never exists even when hooks
+   are installed; (2) a stray `core.hooksPath` (e.g. pointing back at the default `.git/hooks`)
+   can make the file exist while `pre-commit install` was never run. Ask the resolved hook for
+   the pre-commit signature instead (define this helper before the setup block above):
+
+   ```bash
+   ensure_precommit_installed() {
+     # Resolve the hooks dir git actually uses (honors core.hooksPath and worktrees)
+     local hooks_dir; hooks_dir="$(git rev-parse --git-path hooks)"
+     # The pre-commit-managed hook contains a recognizable marker line.
+     if ! grep -qs 'pre-commit' "$hooks_dir/pre-commit"; then
+       pre-commit install --install-hooks
+     fi
+     # Final sanity check: config parses and a hook actually fires.
+     pre-commit validate-config >/dev/null 2>&1 \
+       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' here"
+   }
 
    # Create a worktree for branch isolation (never checkout branches in the base repo)
    WORKTREE_DIR="/tmp/mnemosyne-skill-<name>"
@@ -357,7 +380,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
    - `category`: one of 9 valid categories (no "refactoring" — use "architecture")
    - All required fields in frontmatter: name, description, category, date, version, verification
    - All required markdown sections: Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters
-   - **If verification is `unverified` or `verified-precommit`**: rename the section to "Proposed Workflow" instead of "Verified Workflow" and add a warning: "> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms."
+   - **If verification is `unverified` or `verified-precommit`**: **keep the `## Verified Workflow` header** (the validator requires that literal string — renaming to "Proposed Workflow" causes `Missing required section: ## Verified Workflow`). Instead, make the **first line of the section** a warning blockquote: "> **Warning:** This workflow has not been validated end-to-end. Treat as a hypothesis until CI confirms." Optionally add a `> _(Proposed — not yet verified)_` subtitle under the header.
 
    **File 2: `skills/<name>.notes.md`** (optional):
    - Raw session details, code snippets, debugging logs
@@ -403,8 +426,10 @@ Agent(description="Create skill C", prompt="...skill C content...")
               "## Failed Attempts" "## Results & Parameters"; do
      grep -qF "$sec" "skills/<name>.md" || echo "MISSING SECTION: $sec"
    done
-   #    (For an unverified/verified-precommit skill, "## Verified Workflow" is renamed
-   #    "## Proposed Workflow" — accept either: grep -qE '## (Verified|Proposed) Workflow'.)
+   #    The header is ALWAYS literally "## Verified Workflow" — even for unverified skills the
+   #    validator requires that exact string, so never rename it to "## Proposed Workflow"
+   #    (that itself triggers "Missing required section: ## Verified Workflow"). Convey
+   #    unverified status with a warning blockquote inside the section (Step 6), not the header.
    #    Any "MISSING SECTION" line = the validate gate WILL fail. Add the section before
    #    committing. This is the exact defect behind PRs that ADD a skill missing 4 sections.
 
@@ -596,6 +621,7 @@ Existing skill found?
 | markdownlint `MD056/table-column-count` "Too many cells" | An unescaped literal `\|` inside a table cell (regex, shell pipe, `a\|b`) is parsed as a column separator | Escape inline pipes as `\|`, or balance the row so its cell count matches the header. **Not caught by `validate_plugins.py`** — only the CI `markdownlint` gate; run markdownlint locally first |
 | markdownlint `MD012/no-multiple-blanks` | Two or more consecutive blank lines (often left between generated sections) | Collapse to a single blank line. Run markdownlint locally — it flags **all** rules (MD012, MD040, …), not just MD056 |
 | `validate` "Missing required section: ## X" on **your own new file** | `/learn` generated the skill without all 5 required sections | Generate from the full Step 6 template; run the Step 7 required-section self-check (grep for all 5 `##` headers) before committing |
+| `validate` "Missing required section: ## Verified Workflow" despite the section looking present | The header was renamed to `## Proposed Workflow` for an unverified skill — but `validate_plugins.py` substring-matches the literal `## Verified Workflow` | Always keep the `## Verified Workflow` header; put the "not yet verified" warning as a blockquote inside the section, never in the header |
 | `validate`/`markdownlint` red on a file you didn't touch | A pre-existing broken file on `main` (the validator/linter scans the whole `skills/` dir) | Not your bug — surface it to the user as a separate fix PR; do not claim `verified-ci` while the gate is red |
 
 ### Issue: PR already exists

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -112,6 +112,32 @@ Agent(description="Create skill C", prompt="...skill C content...")
    grep -l "<keyword>" "$MNEMOSYNE_DIR/skills/"*.md 2>/dev/null | head -20
    ```
 
+   **CRITICAL — Check for an OPEN PR already amending this skill (amend-lock):**
+
+   Searching only the local `main` clone is NOT enough. Multiple agents run `/learn` in
+   parallel; if each forks a fresh `origin/main` branch to amend the **same** skill, every
+   branch edits the same `.md`/`.history` and they all become mutually conflicting (DIRTY).
+   This is the #1 cause of the duplicate-PR pileup. Before creating any branch:
+
+   ```bash
+   # (a) Open PRs whose title names the skill
+   gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+     --search "<name> in:title" --json number,headRefName,title
+   # (b) Open PRs that touch the file even if the title differs
+   gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+     --json number,headRefName,files \
+     --jq '.[] | select(.files[].path == "skills/<name>.md") | {number, headRefName}'
+   ```
+
+   **Decision rule:**
+
+   - **An open PR already amends this skill** → do **NOT** fork a new `origin/main` branch.
+     Either (a) add your learning to that PR's existing `headRefName` (check it out, amend,
+     push), or (b) if that branch is unavailable, create your worktree branch **from** it
+     (`git worktree add <dir> -b skill/<name>-followup origin/<headRefName>`) so your change
+     **stacks** on theirs instead of conflicting. Reference the existing PR number.
+   - **No open PR** → proceed with the normal worktree-from-`origin/main` flow (Step 5).
+
    **If an existing skill covers the same topic → AMEND it** (don't create a new file):
 
    a. Read the existing skill to understand its current state
@@ -190,6 +216,23 @@ Agent(description="Create skill C", prompt="...skill C content...")
    - `verified-precommit`: Only pre-commit hooks pass (formatting, linting)
    - `unverified`: Approach is theoretically sound but never executed
 
+   **CRITICAL — `verified-ci` is a claim about THIS PR's gate, not about local checks.**
+   You may write `verified-ci` **only after** the skill PR's required gate
+   (`validate` **and** `markdownlint`) is observed **green** on the open PR:
+
+   ```bash
+   gh pr view <PR> --repo HomericIntelligence/ProjectMnemosyne \
+     --json mergeStateStatus,statusCheckRollup \
+     --jq '{state: .mergeStateStatus, failing: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name]}'
+   ```
+
+   Passing `validate_plugins.py` + markdownlint **locally is `verified-local`, not
+   `verified-ci`** — local runs do not exercise the full CI gate (ruff, mypy, pytest). Set
+   the skill to `verified-local` at creation time, and only bump it to `verified-ci` once you
+   have seen the gate go green. Do **not** label a skill `verified-ci` while its own PR is
+   `BLOCKED`/`DIRTY` with a red `validate`/`markdownlint` — that is the overclaim that made the
+   backlog's verification levels untrustworthy.
+
    Add this as a frontmatter field:
 
    ```yaml
@@ -212,12 +255,22 @@ Agent(description="Create skill C", prompt="...skill C content...")
        # Clone fresh
        mkdir -p "$HOME/.agent-brain"
        gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       # Fresh clone → install pre-commit hooks (one-time per clone)
+       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
      fi
 
      # Always update to latest main before starting
      git -C "$MNEMOSYNE_DIR" fetch origin
      git -C "$MNEMOSYNE_DIR" checkout main
      git -C "$MNEMOSYNE_DIR" pull --ff-only origin main
+
+     # Already checked out → verify pre-commit is installed and working; (re)install if not.
+     if [ ! -f "$MNEMOSYNE_DIR/.git/hooks/pre-commit" ]; then
+       ( cd "$MNEMOSYNE_DIR" && pre-commit install --install-hooks )
+     fi
+     # Sanity-check the hooks resolve (catches a stale/broken pre-commit cache early).
+     ( cd "$MNEMOSYNE_DIR" && pre-commit validate-config >/dev/null 2>&1 ) \
+       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' in $MNEMOSYNE_DIR"
    fi
 
    # Create a worktree for branch isolation (never checkout branches in the base repo)
@@ -331,12 +384,41 @@ Agent(description="Create skill C", prompt="...skill C content...")
    | 5 | Markdown has all 5 sections: Overview, When to Use, Verified Workflow, Failed Attempts, Results & Parameters | "Missing required section" |
    | 6 | `## Failed Attempts` has pipe-delimited table | "Failed Attempts table missing required columns" |
    | 7 | `## Quick Reference` is subsection `### Quick Reference` (under Verified Workflow) | "Quick Reference should use ###" |
+   | 8 | **Every markdown table's header pipe-count equals each body row's pipe-count**; a literal `\|` inside cell text is escaped | markdownlint `MD056/table-column-count` (CI-only gate, NOT caught by `validate_plugins.py`) |
+
+   > **#8 is the single most common CI failure for skill PRs.** The Overview, Failed Attempts,
+   > and Results tables are the usual offenders: an unescaped `|` inside a cell (e.g. a regex,
+   > a shell pipe, or `a\|b`) is read as a column separator, so the row has more cells than the
+   > header. Write inline pipes as `\|`. `validate_plugins.py` does **not** check this — only
+   > the markdownlint gate does, so you MUST run markdownlint locally (below).
+
+   Run **all three** checks from the worktree root before committing, in this order
+   (markdownlint first — it is the gate most skill PRs fail on):
 
    ```bash
+   # 1) markdownlint — EXACTLY as CI runs it (catches MD056 table-column-count, etc.)
+   #    Run from the worktree root so it picks up the repo's .markdownlint.yaml.
+   npx --yes markdownlint-cli2 --config .markdownlint.yaml "skills/<name>.md" "skills/<name>.history"
+   #    Must exit 0. Fix every MDxxx error. Do NOT add a markdownlint-disable comment to
+   #    silence MD056 — the forbid-suppressions gate rejects blanket disables, and a broken
+   #    table is a real defect. Balance the pipes or escape the inline `|` instead.
+
+   # 2) plugin validator — note this lints the ENTIRE skills/ dir, not just your file (see below)
    python3 scripts/validate_plugins.py
+
+   # 3) pre-commit — runs the hooks CI also relies on (ruff, ruff-format, signed-commit check)
+   pre-commit run --files "skills/<name>.md" "skills/<name>.history"
    ```
 
-   If validation fails, fix errors and re-run. Do NOT commit until it passes.
+   If any of the three fails, fix errors and re-run. Do NOT commit until all pass.
+
+   **Whole-repo validation (`validate_plugins.py` lints all of `skills/`):** if step 2 reports
+   errors in files you did **not** touch, the `validate` gate is **already red on `main`** and
+   your PR will inherit the red gate through no fault of your change. Likewise, run markdownlint
+   over the whole dir (`npx --yes markdownlint-cli2 --config .markdownlint.yaml "skills/*.md"`)
+   if your PR's `markdownlint` gate fails on a file you didn't edit. In either case: do **not**
+   claim `verified-ci`, and surface the pre-existing breakage to the user — it needs its own
+   fix PR; your amendment did not cause it.
 
 8. **Commit and push**:
 
@@ -443,16 +525,34 @@ Agent(description="Create skill C", prompt="...skill C content...")
     git -C "$MNEMOSYNE_DIR" worktree prune
     ```
 
+11. **Report honest status — enabling auto-merge is NOT "done":**
+
+    The PR merges only when the required gate (`validate` + `markdownlint`) goes green. Until
+    then it is `BLOCKED`. When reporting status, report the **actual** state and any failing
+    checks — never assume success because auto-merge was armed:
+
+    ```bash
+    gh pr view "$PR_NUMBER" --repo HomericIntelligence/ProjectMnemosyne \
+      --json mergeStateStatus,statusCheckRollup \
+      --jq '{state: .mergeStateStatus, failing: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name]}'
+    ```
+
+    If `failing` is non-empty, the skill is at best `verified-local` — fix the checks (re-run
+    markdownlint/validate locally per Step 7) before claiming completion. (Mirrors the
+    auto-merge-after-go discipline: arming `--auto` does not by itself merge anything.)
+
 ## Amendment Workflow Summary
 
 ```text
 Existing skill found?
-├─ YES → Amend workflow:
-│   1. Read existing skill
-│   2. Create/append to <name>.history with previous version snapshot
-│   3. Update <name>.md in-place (new data, bump version, update date)
-│   4. Add history frontmatter field if first amendment
-│   5. Commit both files
+├─ YES → Open PR already amends it? (gh pr list search, Step 2)
+│   ├─ YES → Stack on that PR's branch (push to it, or branch FROM it). Do NOT fork main.
+│   └─ NO  → Amend workflow:
+│       1. Read existing skill
+│       2. Create/append to <name>.history with previous version snapshot
+│       3. Update <name>.md in-place (new data, bump version, update date)
+│       4. Add history frontmatter field if first amendment
+│       5. Commit both files
 │
 └─ NO → New skill workflow:
     1. Create <name>.md with full template
@@ -460,6 +560,11 @@ Existing skill found?
     3. No history file needed yet
     4. Commit
 ```
+
+> **Lesson (from the 2026-06-13 Mnemosyne backlog):** forking a fresh `origin/main` branch
+> while ~8 other open PRs already amended the same skill (`python-module-decomposition`,
+> `stale-documentation-audit`) produced ~35 mutually-DIRTY PRs — modify/modify conflicts on
+> the same `.md`/`.history`. Always run the open-PR check in Step 2 and stack instead of fork.
 
 ## Common Issues & Solutions
 
@@ -474,6 +579,8 @@ Existing skill found?
 | "Failed Attempts table missing required columns" | Table format incorrect | Use: \| Attempt \| What Was Tried \| Why It Failed \| Lesson Learned \| |
 | "Quick Reference should use ###" | Using `## Quick Reference` instead of `###` | Demote to `### Quick Reference` (subsection of Verified Workflow) |
 | Skill not in marketplace | File not committed or in wrong location | Verify in `skills/<name>.md` (root of skills dir, not nested) |
+| markdownlint `MD056/table-column-count` "Too many cells" | An unescaped literal `\|` inside a table cell (regex, shell pipe, `a\|b`) is parsed as a column separator | Escape inline pipes as `\|`, or balance the row so its cell count matches the header. **Not caught by `validate_plugins.py`** — only the CI `markdownlint` gate; run markdownlint locally first |
+| `validate`/`markdownlint` red on a file you didn't touch | A pre-existing broken file on `main` (the validator/linter scans the whole `skills/` dir) | Not your bug — surface it to the user as a separate fix PR; do not claim `verified-ci` while the gate is red |
 
 ### Issue: PR already exists
 

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -396,12 +396,26 @@ Agent(description="Create skill C", prompt="...skill C content...")
    (markdownlint first — it is the gate most skill PRs fail on):
 
    ```bash
-   # 1) markdownlint — EXACTLY as CI runs it (catches MD056 table-column-count, etc.)
+   # 0) Required-section self-check — guarantees validate_plugins.py won't fail with
+   #    "Missing required section". Generate the file FROM the full template (Step 6) so all
+   #    five headers exist by construction, then prove it before anything else:
+   for sec in "## Overview" "## When to Use" "## Verified Workflow" \
+              "## Failed Attempts" "## Results & Parameters"; do
+     grep -qF "$sec" "skills/<name>.md" || echo "MISSING SECTION: $sec"
+   done
+   #    (For an unverified/verified-precommit skill, "## Verified Workflow" is renamed
+   #    "## Proposed Workflow" — accept either: grep -qE '## (Verified|Proposed) Workflow'.)
+   #    Any "MISSING SECTION" line = the validate gate WILL fail. Add the section before
+   #    committing. This is the exact defect behind PRs that ADD a skill missing 4 sections.
+
+   # 1) markdownlint — EXACTLY as CI runs it. It checks ALL rules, not just tables:
+   #    MD056 (table-column-count) AND e.g. MD012 (no-multiple-blanks), MD013, MD040, etc.
    #    Run from the worktree root so it picks up the repo's .markdownlint.yaml.
    npx --yes markdownlint-cli2 --config .markdownlint.yaml "skills/<name>.md" "skills/<name>.history"
-   #    Must exit 0. Fix every MDxxx error. Do NOT add a markdownlint-disable comment to
-   #    silence MD056 — the forbid-suppressions gate rejects blanket disables, and a broken
-   #    table is a real defect. Balance the pipes or escape the inline `|` instead.
+   #    Must exit 0. Fix every MDxxx error it reports — do not assume MD056 is the only one.
+   #    Common offenders: MD056 (unbalanced table pipes), MD012 (≥2 consecutive blank lines).
+   #    Do NOT add a markdownlint-disable comment to silence an error — the forbid-suppressions
+   #    gate rejects blanket disables, and the defect is real. Fix the markdown instead.
 
    # 2) plugin validator — note this lints the ENTIRE skills/ dir, not just your file (see below)
    python3 scripts/validate_plugins.py
@@ -580,6 +594,8 @@ Existing skill found?
 | "Quick Reference should use ###" | Using `## Quick Reference` instead of `###` | Demote to `### Quick Reference` (subsection of Verified Workflow) |
 | Skill not in marketplace | File not committed or in wrong location | Verify in `skills/<name>.md` (root of skills dir, not nested) |
 | markdownlint `MD056/table-column-count` "Too many cells" | An unescaped literal `\|` inside a table cell (regex, shell pipe, `a\|b`) is parsed as a column separator | Escape inline pipes as `\|`, or balance the row so its cell count matches the header. **Not caught by `validate_plugins.py`** — only the CI `markdownlint` gate; run markdownlint locally first |
+| markdownlint `MD012/no-multiple-blanks` | Two or more consecutive blank lines (often left between generated sections) | Collapse to a single blank line. Run markdownlint locally — it flags **all** rules (MD012, MD040, …), not just MD056 |
+| `validate` "Missing required section: ## X" on **your own new file** | `/learn` generated the skill without all 5 required sections | Generate from the full Step 6 template; run the Step 7 required-section self-check (grep for all 5 `##` headers) before committing |
 | `validate`/`markdownlint` red on a file you didn't touch | A pre-existing broken file on `main` (the validator/linter scans the whole `skills/` dir) | Not your bug — surface it to the user as a separate fix PR; do not claim `verified-ci` while the gate is red |
 
 ### Issue: PR already exists

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -679,12 +679,10 @@ class TestSetupAddressState:
             patch.object(reviewer, "_save_review_state"),
             patch.object(reviewer.status_tracker, "update_slot"),
         ):
-            session_id, review_state, branch_name, worktree_path = (
-                reviewer._setup_address_state(
-                    issue_number=123,
-                    pr_number=456,
-                    slot_id=0,
-                )
+            session_id, review_state, branch_name, worktree_path = reviewer._setup_address_state(
+                issue_number=123,
+                pr_number=456,
+                slot_id=0,
             )
 
         assert session_id is None
@@ -715,12 +713,10 @@ class TestSetupAddressState:
             patch.object(reviewer, "_save_review_state") as mock_save,
             patch.object(reviewer.status_tracker, "update_slot"),
         ):
-            session_id, review_state, _branch_name, _worktree_path = (
-                reviewer._setup_address_state(
-                    issue_number=123,
-                    pr_number=456,
-                    slot_id=0,
-                )
+            session_id, review_state, _branch_name, _worktree_path = reviewer._setup_address_state(
+                issue_number=123,
+                pr_number=456,
+                slot_id=0,
             )
 
         # pr_number should be updated to the new value
@@ -736,7 +732,9 @@ class TestCommitPushAndResolve:
     the real replies dict (not {}) to _resolve_addressed_threads.
     """
 
-    def test_passes_real_replies_dict_to_resolve(self, reviewer: AddressReviewer, tmp_path: Path) -> None:  # noqa: E501
+    def test_passes_real_replies_dict_to_resolve(
+        self, reviewer: AddressReviewer, tmp_path: Path
+    ) -> None:
         """The helper must forward the REAL replies dict to _resolve_addressed_threads.
 
         This is the critical safeguard against the historically-buggy {}

--- a/tests/unit/automation/test_implementer_phase_runner.py
+++ b/tests/unit/automation/test_implementer_phase_runner.py
@@ -10,7 +10,6 @@ import pytest
 from hephaestus.automation.implementer import IssueImplementer
 from hephaestus.automation.models import ImplementerOptions, WorkerResult
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -131,9 +130,7 @@ class TestPrepareWorktreeForExistingPr:
                 "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
                 return_value=True,
             ),
-            patch(
-                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
-            ),
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
         ):
             worktree_path, pr_branch = runner._prepare_worktree_for_existing_pr(
                 issue_number=1,
@@ -169,9 +166,7 @@ class TestPrepareWorktreeForExistingPr:
                 "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
                 return_value=True,
             ),
-            patch(
-                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
-            ),
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
         ):
             _worktree_path, pr_branch = runner._prepare_worktree_for_existing_pr(
                 issue_number=1,


### PR DESCRIPTION
## Summary

The `/learn` and `/advise` skills produce ProjectMnemosyne skill PRs that recurringly fail CI. A scan of the **117 open Mnemosyne PRs** (required gate = `validate` + `markdownlint`) traced four repeating failure classes to gaps in the skills, and this PR closes each at the source.

| Recurring failure | Root cause | Fix in this PR |
|---|---|---|
| markdownlint `MD056/table-column-count` (7 PRs) | `/learn` ran only `validate_plugins.py`, never markdownlint; unescaped inline `\|` in a table passed locally, died in CI | `/learn` Step 7 now runs `markdownlint-cli2 --config .markdownlint.yaml` + an MD056 checklist row + Common Issues rows |
| Duplicate, mutually-conflicting amendment PRs (~9 on `python-module-decomposition`, ~14 on `stale-documentation-audit`; ~35 DIRTY) | `/learn` only searched the local `main` clone, not open PRs, so parallel agents each forked a separate branch | `/learn` Step 2 amend-lock: check open PRs, stack-don't-fork; `/advise` warns pre-work |
| Whole-repo `validate` reddened by one broken file already on `main` | `/learn` never ran/interpreted the whole-repo validate | Step 7 documents the whole-repo scan and to surface, not misattribute, pre-existing breakage |
| Overclaimed `verified-ci` while the PR gate was red | honesty gate keyed loosely on "did CI pass" | `verified-ci` now requires an observed-green gate; default `verified-local`; report real `mergeStateStatus` |

Also: install pre-commit on fresh clone and verify it on existing clones in both skills' repo-setup, and add `pre-commit run` to `/learn` validation.

## Verification

- `markdownlint-cli2 --config .markdownlint.yaml` flags `MD056` on a malformed table (Expected 2 / Actual 4) — reproduces the exact CI failure the new step would have caught locally.
- The dedup query surfaces the duplicate `python-module-decomposition` PR cluster (9+ PRs) — proves the amend-lock rule would have prevented the fork-instead-of-stack pileup.
- `pre-commit run --files skills/learn/SKILL.md skills/advise/SKILL.md` passes (Markdown Lint, skill-catalog, merge-flag checks all green).

Out of scope (handled in another session): driving the 117 PRs to merge, rebasing the DIRTY ones, and fixing the broken file on Mnemosyne `main`.

Closes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)