### PR TITLE
chore(lint): fix ruff-format drift in 6 automation files

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -399,7 +399,15 @@ class ReviewPhase(StageMixin):
         prior_addressed_threads: list[dict[str, Any]] = []
 
         for iteration in range(MAX_REVIEW_ITERATIONS):
-            last_verdict, last_grade, review_text, posted_thread_ids, go_blocked_by_automation, reopened, should_break = self._process_review_iteration(  # noqa: E501
+            (
+                last_verdict,
+                last_grade,
+                review_text,
+                posted_thread_ids,
+                go_blocked_by_automation,
+                reopened,
+                should_break,
+            ) = self._process_review_iteration(
                 issue_number=issue_number,
                 issue_title=issue_title,
                 issue_body=issue_body,
@@ -446,7 +454,12 @@ class ReviewPhase(StageMixin):
             if not addressed:
                 break
 
-        self._finalize_review_outcome(issue_number=issue_number, pr_number=pr_number, last_verdict=last_verdict, iterations_run=iterations_run)  # noqa: E501
+        self._finalize_review_outcome(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            last_verdict=last_verdict,
+            iterations_run=iterations_run,
+        )
         return iterations_run, last_verdict, last_grade
 
     def _process_review_iteration(
@@ -517,7 +530,15 @@ class ReviewPhase(StageMixin):
                 thread_id=thread_id,
             )
 
-        return last_verdict, last_grade, review_text, posted_thread_ids, go_blocked_by_automation, reopened, should_break  # noqa: E501
+        return (
+            last_verdict,
+            last_grade,
+            review_text,
+            posted_thread_ids,
+            go_blocked_by_automation,
+            reopened,
+            should_break,
+        )
 
     def _run_address_step_if_needed(
         self,

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -547,9 +547,7 @@ class AddressReviewer(BaseReviewer):
             review_state.pr_number = pr_number
         branch_name = review_state.branch_name or f"{issue_number}-auto-impl"
 
-        self.status_tracker.update_slot(
-            slot_id, f"{issue_ref(issue_number)}: Setting up worktree"
-        )
+        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Setting up worktree")
         worktree_path = self._get_or_create_worktree(issue_number, branch_name, review_state)
 
         with self.state_lock:
@@ -629,20 +627,24 @@ class AddressReviewer(BaseReviewer):
 
         thread_id = threading.get_ident()
         self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Starting")
-        self._log("info", f"Addressing PR {pr_ref(pr_number)} for issue {issue_ref(issue_number)}", thread_id)  # noqa: E501
+        self._log(
+            "info",
+            f"Addressing PR {pr_ref(pr_number)} for issue {issue_ref(issue_number)}",
+            thread_id,
+        )
 
         try:
             threads = self._check_threads_for_address(issue_number, pr_number, thread_id)
             if threads is None:
-                return WorkerResult(
-                    issue_number=issue_number, success=True, pr_number=pr_number
-                )
+                return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
             session_id, review_state, branch_name, worktree_path = self._setup_address_state(
                 issue_number, pr_number, slot_id
             )
 
-            self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Running Claude fix")  # noqa: E501
+            self.status_tracker.update_slot(
+                slot_id, f"{issue_ref(issue_number)}: Running Claude fix"
+            )
             fix_result = self._run_fix_session(
                 issue_number=issue_number,
                 pr_number=pr_number,
@@ -652,7 +654,11 @@ class AddressReviewer(BaseReviewer):
             )
             addressed: list[str] = fix_result.get("addressed", [])
             replies: dict[str, str] = fix_result.get("replies", {})
-            self._log("info", f"Claude addressed {len(addressed)} thread(s) on PR {pr_ref(pr_number)}", thread_id)  # noqa: E501
+            self._log(
+                "info",
+                f"Claude addressed {len(addressed)} thread(s) on PR {pr_ref(pr_number)}",
+                thread_id,
+            )
             self._commit_push_and_resolve(
                 issue_number=issue_number,
                 pr_number=pr_number,

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -757,7 +757,9 @@ class CIDriver:
                 logger.warning(
                     "Issue #%s: CI checks still pending after %ss (limit %ss), "
                     "treating as not yet failing",
-                    issue_number, poll_elapsed, max_wait,
+                    issue_number,
+                    poll_elapsed,
+                    max_wait,
                 )
                 return None
 
@@ -767,7 +769,10 @@ class CIDriver:
             )
             logger.debug(
                 "Issue #%s: CI checks pending, sleeping %ss (attempt %s, %ss elapsed)",
-                issue_number, sleep_secs, poll_attempt + 1, poll_elapsed,
+                issue_number,
+                sleep_secs,
+                poll_attempt + 1,
+                poll_elapsed,
             )
             time.sleep(sleep_secs)
             poll_elapsed += sleep_secs
@@ -783,12 +788,18 @@ class CIDriver:
         """
         self.status_tracker.update_slot(acquired_slot, f"{pr_ref(pr_number)}: enabling auto-merge")
         if self.options.dry_run:
-            logger.info("[dry_run] Would enable auto-merge for PR #%s (issue #%s)", pr_number, issue_number)  # noqa: E501
+            logger.info(
+                "[dry_run] Would enable auto-merge for PR #%s (issue #%s)", pr_number, issue_number
+            )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
-        merge_ok = self._enable_auto_merge(pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number))  # noqa: E501
+        merge_ok = self._enable_auto_merge(
+            pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number)
+        )
         if merge_ok:
-            self.status_tracker.update_slot(acquired_slot, f"{pr_ref(pr_number)}: arming for post-merge /learn")  # noqa: E501
+            self.status_tracker.update_slot(
+                acquired_slot, f"{pr_ref(pr_number)}: arming for post-merge /learn"
+            )
             gh_state = self._gh_pr_state(pr_number)
             pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
             self._arm_drive_green(pr_number, self._get_pr_branch(pr_number), pr_head_sha)
@@ -797,12 +808,16 @@ class CIDriver:
             if outcome == "FAILING":
                 fix_result = self._attempt_ci_fixes(issue_number, pr_number, acquired_slot)
                 if fix_result is not None and fix_result.success:
-                    rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)  # noqa: E501
+                    rearmed = self._recheck_and_arm_after_fix(
+                        issue_number, pr_number, acquired_slot
+                    )
                     return rearmed if rearmed is not None else fix_result
                 if fix_result is not None:
                     return fix_result
                 return WorkerResult(
-                    issue_number=issue_number, success=False, pr_number=pr_number,
+                    issue_number=issue_number,
+                    success=False,
+                    pr_number=pr_number,
                     error=f"CI fix failed after {self.options.max_fix_iterations} attempt(s)",
                 )
             if outcome == "DIRTY":
@@ -810,7 +825,9 @@ class CIDriver:
             if outcome == "BLOCKED":
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
         return WorkerResult(
-            issue_number=issue_number, success=merge_ok, pr_number=pr_number,
+            issue_number=issue_number,
+            success=merge_ok,
+            pr_number=pr_number,
             error=None if merge_ok else f"auto-merge failed for PR {pr_ref(pr_number)}",
         )
 
@@ -827,13 +844,17 @@ class CIDriver:
             logger.info(
                 "Issue #%s: PR #%s is green but lacks state:implementation-go; "
                 "leaving auto-merge disabled until implementation review approves it",
-                issue_number, pr_number,
+                issue_number,
+                pr_number,
             )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
         return self._arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
 
     def _handle_failing_pr(
-        self, issue_number: int, pr_number: int, acquired_slot: int,
+        self,
+        issue_number: int,
+        pr_number: int,
+        acquired_slot: int,
         required_checks: list[dict[str, Any]],
     ) -> WorkerResult:
         """Handle a PR where at least one required check has failed.
@@ -844,7 +865,8 @@ class CIDriver:
         if not failing:
             logger.info(
                 "Issue #%s: PR #%s checks concluded with non-green, non-failure conclusions (e.g. cancelled)",  # noqa: E501
-                issue_number, pr_number,
+                issue_number,
+                pr_number,
             )
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
@@ -857,13 +879,13 @@ class CIDriver:
         if fix_result is not None:
             return fix_result
         return WorkerResult(
-            issue_number=issue_number, success=False, pr_number=pr_number,
+            issue_number=issue_number,
+            success=False,
+            pr_number=pr_number,
             error=f"CI fix failed after {self.options.max_fix_iterations} attempt(s)",
         )
 
-    def _drive_issue(
-        self, issue_number: int, pr_number: int, slot_id: int
-    ) -> WorkerResult:
+    def _drive_issue(self, issue_number: int, pr_number: int, slot_id: int) -> WorkerResult:
         """Drive a single issue's PR toward green CI.
 
         Args:
@@ -877,7 +899,9 @@ class CIDriver:
         """
         acquired_slot: int | None = self.status_tracker.acquire_slot()
         if acquired_slot is None:
-            return WorkerResult(issue_number=issue_number, success=False, error="Failed to acquire worker slot")  # noqa: E501
+            return WorkerResult(
+                issue_number=issue_number, success=False, error="Failed to acquire worker slot"
+            )
 
         try:
             armed_result = self._check_arming_on_drive_start(issue_number, pr_number)
@@ -896,7 +920,9 @@ class CIDriver:
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
             _checks, required_checks = poll_result
 
-            all_green = all(c.get("conclusion") in ("success", "skipped", "neutral") for c in required_checks)  # noqa: E501
+            all_green = all(
+                c.get("conclusion") in ("success", "skipped", "neutral") for c in required_checks
+            )
             if all_green:
                 return self._handle_green_pr(issue_number, pr_number, acquired_slot)
             return self._handle_failing_pr(issue_number, pr_number, acquired_slot, required_checks)
@@ -2555,7 +2581,9 @@ class CIDriver:
         except subprocess.CalledProcessError as exc:
             logger.error(
                 "Issue #%s: failed to sync worktree to origin/%s before CI fix: %s",
-                issue_number, pr_head_branch, (exc.stderr or exc.stdout or "")[:300],
+                issue_number,
+                pr_head_branch,
+                (exc.stderr or exc.stdout or "")[:300],
             )
             return None
         try:
@@ -2563,13 +2591,19 @@ class CIDriver:
         except subprocess.CalledProcessError as exc:
             logger.error(
                 "Issue #%s: failed to snapshot HEAD before CI fix session: %s",
-                issue_number, (exc.stderr or exc.stdout or "")[:300],
+                issue_number,
+                (exc.stderr or exc.stdout or "")[:300],
             )
             return None
 
     def _build_ci_fix_prompt(
-        self, issue_number: int, pr_number: int, worktree_path: Path,
-        ci_logs: str, pr_head_branch: str, advise_findings: str,
+        self,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        ci_logs: str,
+        pr_head_branch: str,
+        advise_findings: str,
     ) -> str:
         """Build the CI-fix agent prompt string."""
         advise_block = ""
@@ -2623,7 +2657,9 @@ class CIDriver:
             return False
         try:
             push_current_branch_with_lease_on_divergence(
-                worktree_path, branch=pr_head_branch, push_ref=f"HEAD:{pr_head_branch}",
+                worktree_path,
+                branch=pr_head_branch,
+                push_ref=f"HEAD:{pr_head_branch}",
             )
             logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
             return True
@@ -2646,29 +2682,50 @@ class CIDriver:
             if session_id:
                 try:
                     codex_result = resume_codex_session(
-                        session_id, prompt, cwd=worktree_path, timeout=ci_driver_claude_timeout(),
+                        session_id,
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
                     )
                 except subprocess.CalledProcessError as e:
                     logger.warning(
                         "Issue #%s: Codex resume session %r failed for PR #%s; falling back to fresh: %s",  # noqa: E501
-                        issue_number, session_id, pr_number, (e.stderr or e.stdout or "")[:300],
+                        issue_number,
+                        session_id,
+                        pr_number,
+                        (e.stderr or e.stdout or "")[:300],
                     )
                     codex_result = run_codex_session(
-                        prompt, cwd=worktree_path, timeout=ci_driver_claude_timeout(), sandbox="workspace-write",  # noqa: E501
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                        sandbox="workspace-write",
                     )
             else:
                 codex_result = run_codex_session(
-                    prompt, cwd=worktree_path, timeout=ci_driver_claude_timeout(), sandbox="workspace-write",  # noqa: E501
+                    prompt,
+                    cwd=worktree_path,
+                    timeout=ci_driver_claude_timeout(),
+                    sandbox="workspace-write",
                 )
-            logger.debug("Issue #%s: Codex CI fix output: %s", issue_number, codex_result.stdout[:500])  # noqa: E501
+            logger.debug(
+                "Issue #%s: Codex CI fix output: %s", issue_number, codex_result.stdout[:500]
+            )
         except subprocess.CalledProcessError as e:
             logger.error(
                 "Issue #%s: Codex CI fix session returned exit code %s: %s",
-                issue_number, e.returncode, (e.stderr or e.stdout or "")[:300],
+                issue_number,
+                e.returncode,
+                (e.stderr or e.stdout or "")[:300],
             )
             return False
         return self._finalize_ci_fix_push(
-            issue_number, pr_number, worktree_path, pr_head_branch, pre_agent_sha, session_id,
+            issue_number,
+            pr_number,
+            worktree_path,
+            pr_head_branch,
+            pre_agent_sha,
+            session_id,
         )
 
     def _invoke_claude_ci_fix(
@@ -2697,19 +2754,30 @@ class CIDriver:
                 extra_args=["--dangerously-skip-permissions"],
                 input_via_stdin=True,
             )
-            claude_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")  # noqa: E501
+            claude_result = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=stdout, stderr=""
+            )
         except subprocess.CalledProcessError as exc:
             claude_result = subprocess.CompletedProcess(
-                args=exc.cmd, returncode=exc.returncode,
-                stdout=exc.stdout or "", stderr=exc.stderr or "",
+                args=exc.cmd,
+                returncode=exc.returncode,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
             )
         if claude_result.returncode == 0:
             return self._finalize_ci_fix_push(
-                issue_number, pr_number, worktree_path, pr_head_branch, pre_agent_sha, session_id,
+                issue_number,
+                pr_number,
+                worktree_path,
+                pr_head_branch,
+                pre_agent_sha,
+                session_id,
             )
         logger.error(
             "Issue #%s: Claude CI fix session returned exit code %s: %s",
-            issue_number, claude_result.returncode, claude_result.stderr[:300],
+            issue_number,
+            claude_result.returncode,
+            claude_result.stderr[:300],
         )
         return False
 
@@ -2743,27 +2811,50 @@ class CIDriver:
             True if the fix session succeeded and the branch was pushed.
 
         """
-        pre_agent_sha = self._sync_worktree_and_snapshot_sha(issue_number, worktree_path, pr_head_branch)  # noqa: E501
+        pre_agent_sha = self._sync_worktree_and_snapshot_sha(
+            issue_number, worktree_path, pr_head_branch
+        )
         if pre_agent_sha is None:
             return False
 
         prompt = self._build_ci_fix_prompt(
-            issue_number, pr_number, worktree_path, ci_logs, pr_head_branch, advise_findings,
+            issue_number,
+            pr_number,
+            worktree_path,
+            ci_logs,
+            pr_head_branch,
+            advise_findings,
         )
 
         try:
             if is_codex(self.options.agent):
                 return self._invoke_codex_ci_fix(
-                    issue_number, pr_number, worktree_path, prompt, pr_head_branch, pre_agent_sha, session_id,  # noqa: E501
+                    issue_number,
+                    pr_number,
+                    worktree_path,
+                    prompt,
+                    pr_head_branch,
+                    pre_agent_sha,
+                    session_id,
                 )
             return self._invoke_claude_ci_fix(
-                issue_number, pr_number, worktree_path, prompt, pr_head_branch, pre_agent_sha, session_id,  # noqa: E501
+                issue_number,
+                pr_number,
+                worktree_path,
+                prompt,
+                pr_head_branch,
+                pre_agent_sha,
+                session_id,
             )
         except subprocess.TimeoutExpired:
-            logger.error("Issue #%s: Claude CI fix session timed out for PR #%s", issue_number, pr_number)  # noqa: E501
+            logger.error(
+                "Issue #%s: Claude CI fix session timed out for PR #%s", issue_number, pr_number
+            )
             return False
         except Exception as e:
-            logger.error("Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e)  # noqa: E501
+            logger.error(
+                "Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e
+            )
             return False
 
     def _enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -223,7 +223,9 @@ class ImplementationPhaseRunner:
                 f"create PR for #{issue_number}",
                 thread_id,
             )
-            return WorkerResult(issue_number=issue_number, success=True, branch_name=branch_name, worktree_path=None)  # noqa: E501
+            return WorkerResult(
+                issue_number=issue_number, success=True, branch_name=branch_name, worktree_path=None
+            )
 
         # When an open PR already exists for this issue, skip the
         # plan/implement steps (the PR is already opened) but STILL drive it
@@ -231,7 +233,9 @@ class ImplementationPhaseRunner:
         # ``state:implementation-go`` label that drive-green requires to arm
         # auto-merge. Imported top-level so tests patch
         # ``hephaestus.automation.implementer_phase_runner.find_pr_for_issue``.
-        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Checking for existing PR")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Checking for existing PR"
+        )
         existing_pr = find_pr_for_issue(issue_number)
         if existing_pr is not None:
             return self._review_existing_pr(
@@ -283,7 +287,9 @@ class ImplementationPhaseRunner:
         impl = self.impl
         slot_id = self.status_tracker.acquire_slot()
         if slot_id is None:
-            return WorkerResult(issue_number=issue_number, success=False, error="Failed to acquire worker slot")  # noqa: E501
+            return WorkerResult(
+                issue_number=issue_number, success=False, error="Failed to acquire worker slot"
+            )
 
         thread_id = threading.get_ident()
 
@@ -297,21 +303,27 @@ class ImplementationPhaseRunner:
         except subprocess.TimeoutExpired as e:
             error_msg = f"Timeout: {' '.join(e.cmd[:3])} exceeded {e.timeout}s"
             impl._log("error", error_msg, thread_id)
-            return self._record_issue_failure(issue_number, slot_id, thread_id, error_msg, persist_error=error_msg)  # noqa: E501
+            return self._record_issue_failure(
+                issue_number, slot_id, thread_id, error_msg, persist_error=error_msg
+            )
 
         except subprocess.CalledProcessError as e:
             error_msg = f"Command failed (exit {e.returncode}): {' '.join(e.cmd[:3])}"
             impl._log("error", error_msg, thread_id)
             if e.stderr:
                 impl._log("error", f"stderr: {e.stderr[:300]}", thread_id)
-            return self._record_issue_failure(issue_number, slot_id, thread_id, error_msg, persist_error=str(e))  # noqa: E501
+            return self._record_issue_failure(
+                issue_number, slot_id, thread_id, error_msg, persist_error=str(e)
+            )
 
         except RuntimeError as e:
             return self._handle_runtime_error(issue_number, slot_id, thread_id, e)
 
         except Exception as e:  # broad catch: top-level worker boundary, must not crash thread pool
             impl._log("error", f"Unexpected {type(e).__name__}: {e}", thread_id)
-            return self._record_issue_failure(issue_number, slot_id, thread_id, str(e)[:80], persist_error=str(e))  # noqa: E501
+            return self._record_issue_failure(
+                issue_number, slot_id, thread_id, str(e)[:80], persist_error=str(e)
+            )
 
         finally:
             self.status_tracker.release_slot(slot_id)
@@ -484,7 +496,9 @@ class ImplementationPhaseRunner:
                 issue_number, issue.title, issue.body, worktree_path
             )
 
-        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Running {self.options.agent}"
+        )
         codex_advise_findings = ""
         if self.options.enable_advise and is_codex(self.options.agent):
             self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Advising")
@@ -654,7 +668,9 @@ class ImplementationPhaseRunner:
                 thread_id,
             )
 
-        self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{issue_ref(issue_number)}: Preparing worktree for existing PR"
+        )
         worktree_path = self.worktree_manager.create_worktree(issue_number, pr_branch)
         # ``create_worktree`` may REUSE a worktree with uncommitted changes from
         # another session; ``reset --hard`` would silently discard them. Only when
@@ -749,7 +765,9 @@ class ImplementationPhaseRunner:
         """
         impl = self.impl
 
-        self.status_tracker.update_slot(slot_id, f"{pr_ref(existing_pr)}: Checking implementation-review label")  # noqa: E501
+        self.status_tracker.update_slot(
+            slot_id, f"{pr_ref(existing_pr)}: Checking implementation-review label"
+        )
         has_go, has_no_go = pr_has_implementation_state_label(existing_pr)
         if has_go:
             impl._log(
@@ -763,8 +781,11 @@ class ImplementationPhaseRunner:
                 state.phase = ImplementationPhase.CREATING_PR
             impl._save_state(state)
             return WorkerResult(
-                issue_number=issue_number, success=True, pr_number=existing_pr,
-                branch_name=branch_name, already_has_pr=True,
+                issue_number=issue_number,
+                success=True,
+                pr_number=existing_pr,
+                branch_name=branch_name,
+                already_has_pr=True,
             )
         if has_no_go:
             impl._log(
@@ -800,8 +821,12 @@ class ImplementationPhaseRunner:
             thread_id,
         )
         return WorkerResult(
-            issue_number=issue_number, success=True, pr_number=existing_pr,
-            branch_name=pr_branch, worktree_path=str(worktree_path), already_has_pr=True,
+            issue_number=issue_number,
+            success=True,
+            pr_number=existing_pr,
+            branch_name=pr_branch,
+            worktree_path=str(worktree_path),
+            already_has_pr=True,
         )
 
     # ------------------------------------------------------------------

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -679,12 +679,10 @@ class TestSetupAddressState:
             patch.object(reviewer, "_save_review_state"),
             patch.object(reviewer.status_tracker, "update_slot"),
         ):
-            session_id, review_state, branch_name, worktree_path = (
-                reviewer._setup_address_state(
-                    issue_number=123,
-                    pr_number=456,
-                    slot_id=0,
-                )
+            session_id, review_state, branch_name, worktree_path = reviewer._setup_address_state(
+                issue_number=123,
+                pr_number=456,
+                slot_id=0,
             )
 
         assert session_id is None
@@ -715,12 +713,10 @@ class TestSetupAddressState:
             patch.object(reviewer, "_save_review_state") as mock_save,
             patch.object(reviewer.status_tracker, "update_slot"),
         ):
-            session_id, review_state, _branch_name, _worktree_path = (
-                reviewer._setup_address_state(
-                    issue_number=123,
-                    pr_number=456,
-                    slot_id=0,
-                )
+            session_id, review_state, _branch_name, _worktree_path = reviewer._setup_address_state(
+                issue_number=123,
+                pr_number=456,
+                slot_id=0,
             )
 
         # pr_number should be updated to the new value
@@ -736,7 +732,9 @@ class TestCommitPushAndResolve:
     the real replies dict (not {}) to _resolve_addressed_threads.
     """
 
-    def test_passes_real_replies_dict_to_resolve(self, reviewer: AddressReviewer, tmp_path: Path) -> None:  # noqa: E501
+    def test_passes_real_replies_dict_to_resolve(
+        self, reviewer: AddressReviewer, tmp_path: Path
+    ) -> None:
         """The helper must forward the REAL replies dict to _resolve_addressed_threads.
 
         This is the critical safeguard against the historically-buggy {}

--- a/tests/unit/automation/test_implementer_phase_runner.py
+++ b/tests/unit/automation/test_implementer_phase_runner.py
@@ -10,7 +10,6 @@ import pytest
 from hephaestus.automation.implementer import IssueImplementer
 from hephaestus.automation.models import ImplementerOptions, WorkerResult
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -131,9 +130,7 @@ class TestPrepareWorktreeForExistingPr:
                 "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
                 return_value=True,
             ),
-            patch(
-                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
-            ),
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
         ):
             worktree_path, pr_branch = runner._prepare_worktree_for_existing_pr(
                 issue_number=1,
@@ -169,9 +166,7 @@ class TestPrepareWorktreeForExistingPr:
                 "hephaestus.automation.implementer_phase_runner.is_clean_working_tree",
                 return_value=True,
             ),
-            patch(
-                "hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"
-            ),
+            patch("hephaestus.automation.implementer_phase_runner.sync_worktree_to_remote_branch"),
         ):
             _worktree_path, pr_branch = runner._prepare_worktree_for_existing_pr(
                 issue_number=1,


### PR DESCRIPTION
origin/main carried ruff-format drift in 6 automation files. The pre-commit hooks run `ruff format hephaestus/ scripts/ tests/` over whole directories, so every local commit reformats them and aborts with "files were modified by this hook" — blocking all new PRs.

This PR applies the format-only / line-reflow changes (no logic change). Verified behavior-preserving: 199 automation tests (ci_driver, address_review, implementer_phase_runner) pass unchanged.

Unblocks the output.log root-cause fix PRs (RC1-RC6).

Closes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)