### PR TITLE
fix(rate-limit): session-limit detector + single common quota resolver

### DIFF
--- a/hephaestus/automation/_implement_phase.py
+++ b/hephaestus/automation/_implement_phase.py
@@ -58,21 +58,14 @@ def _prepend_advise(advise_findings: str, prompt: str) -> str:
 def _claude_quota_reset_epoch(*texts: str) -> int | None:
     """Find a quota-reset epoch across one or more output streams.
 
-    Kept local to the implementation path so the agent-call paths don't
-    import back through the coordinator module.
+    Thin wrapper over the single common resolver
+    :func:`hephaestus.github.rate_limit.resolve_quota_reset_epoch` (#1321) so
+    every agent-call path shares one detection surface — including the Claude
+    session-limit 429 phrasing that the older two-detector logic missed.
     """
-    from hephaestus.github.rate_limit import detect_claude_usage_cap, detect_rate_limit
+    from hephaestus.github.rate_limit import resolve_quota_reset_epoch
 
-    for text in texts:
-        if not text:
-            continue
-        epoch = detect_rate_limit(text)
-        if epoch is not None:
-            return epoch
-        epoch = detect_claude_usage_cap(text)
-        if epoch is not None:
-            return epoch
-    return None
+    return resolve_quota_reset_epoch(*texts)
 
 
 class ImplementPhase(StageMixin):

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from hephaestus.automation.session_naming import session_jsonl_path, session_name
-from hephaestus.github.rate_limit import detect_claude_usage_cap, detect_rate_limit
+from hephaestus.github.rate_limit import resolve_quota_reset_epoch
 
 logger = logging.getLogger(__name__)
 
@@ -189,17 +189,15 @@ def invoke_claude_with_session(
 def scan_quota_reset(*texts: str) -> int | None:
     """Find a quota-reset epoch across one or more output streams.
 
-    Inspects each text for either form of rate-limit message — the GitHub-CLI
-    "Limit reached ..." form or the Claude-CLI "out of extra usage · resets
-    ..." form. ``is not None`` chaining preserves an epoch of ``0`` (rate-
-    limited, reset time unknown) instead of confusing it with "no rate limit".
+    Thin wrapper over the single common resolver
+    :func:`hephaestus.github.rate_limit.resolve_quota_reset_epoch` (#1321), so
+    the planner and plan-reviewer agent paths share one detection surface with
+    the implementer — including the Claude session-limit 429 phrasing the older
+    two-detector logic missed. ``is not None`` chaining preserves an epoch of
+    ``0`` (rate-limited, reset time unknown) instead of confusing it with "no
+    rate limit".
     """
-    for text in texts:
-        for detect in (detect_rate_limit, detect_claude_usage_cap):
-            epoch = detect(text)
-            if epoch is not None:
-                return epoch
-    return None
+    return resolve_quota_reset_epoch(*texts)
 
 
 @dataclass(frozen=True)

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import codex_json_stdout, resume_codex_session, session_agent_matches
-from hephaestus.github.rate_limit import detect_claude_usage_cap, wait_until
+from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from .claude_timeouts import follow_up_claude_timeout
 from .git_utils import issue_ref, run
@@ -414,7 +414,7 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
         # IssueImplementer._run_claude_code.
         if isinstance(data, dict) and data.get("is_error"):
             err_text = str(data.get("result") or "")
-            reset_epoch = detect_claude_usage_cap(err_text)
+            reset_epoch = resolve_quota_reset_epoch(err_text)
             if reset_epoch is not None and reset_epoch > 0:
                 logger.error(
                     "Claude usage cap hit during follow-up for issue #%d; waiting for reset",

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -11,11 +11,14 @@ import json
 import logging
 import re
 import subprocess
+import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import resume_codex_session, session_agent_matches
+from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from .claude_models import learn_model
 from .claude_timeouts import learn_claude_timeout
@@ -23,6 +26,16 @@ from .git_utils import run
 from .session_naming import session_uuid
 
 logger = logging.getLogger(__name__)
+
+# Bound the wait-and-retry loop in :func:`run_learn`. A rate-limited ``/learn``
+# must wait for the quota reset and re-invoke rather than silently dropping the
+# learning (#1331), but a misdetected rate-limit message must not spin forever.
+_LEARN_RATE_LIMIT_MAX_RETRIES = 5
+
+# Fixed back-off (seconds) applied when ``resolve_quota_reset_epoch`` returns the
+# ``0`` "rate-limited, reset unknown" sentinel. Waiting a few minutes lets a
+# transient/secondary limit clear without busy-looping on an unknown deadline.
+_LEARN_UNKNOWN_RESET_BACKOFF_SECONDS = 300
 
 _MNEMOSYNE_URL_RE = re.compile(
     r"https://github\.com/HomericIntelligence/ProjectMnemosyne/(?:pull|commit)/[A-Za-z0-9._/-]+"
@@ -100,6 +113,65 @@ def build_learn_prompt(context: str) -> str:
     )
 
 
+def _record_learn_failure(
+    state_dir: Path, issue_number: int, log_file: Path, *, log_text: str, error: str
+) -> None:
+    """Write the FAILED: log + record for a non-recoverable ``/learn`` failure."""
+    logger.warning("Learn failed for issue #%s: %s", issue_number, error)
+    log_file.write_text(log_text)
+    _write_learn_record(
+        state_dir,
+        issue_number,
+        succeeded=False,
+        log_file=log_file,
+        error=error,
+    )
+
+
+def _record_learn_success(
+    state_dir: Path, issue_number: int, log_file: Path, *, stdout: str
+) -> None:
+    """Write the log + record for a successful ``/learn`` run."""
+    log_file.write_text(stdout)
+    _write_learn_record(
+        state_dir,
+        issue_number,
+        succeeded=True,
+        log_file=log_file,
+        output=stdout,
+    )
+    logger.info("Learn completed for issue #%s", issue_number)
+    logger.info("Learn log: %s", log_file)
+
+
+def _wait_for_quota_reset(reset_epoch: int, issue_number: int) -> None:
+    """Block until a detected quota reset, handling the ``0`` unknown sentinel.
+
+    ``resolve_quota_reset_epoch`` returns ``0`` when a rate-limit message is
+    present but carries no parseable reset time. For that sentinel we back off a
+    fixed interval rather than busy-looping on an unknown deadline; otherwise we
+    wait until the concrete reset epoch.
+
+    Args:
+        reset_epoch: Reset epoch from :func:`resolve_quota_reset_epoch` (may be
+            ``0`` for an unknown reset).
+        issue_number: Issue number, for logging.
+
+    """
+    if reset_epoch > 0:
+        logger.warning(
+            "Learn rate-limited for issue #%s; waiting for reset before retry", issue_number
+        )
+        wait_until(reset_epoch)
+    else:
+        logger.warning(
+            "Learn rate-limited for issue #%s with unknown reset; backing off %ds before retry",
+            issue_number,
+            _LEARN_UNKNOWN_RESET_BACKOFF_SECONDS,
+        )
+        wait_until(int(time.time()) + _LEARN_UNKNOWN_RESET_BACKOFF_SECONDS)
+
+
 def run_learn(
     session_id: str,
     worktree_path: Path,
@@ -149,35 +221,21 @@ def run_learn(
         return False
 
     if agent == "codex":
-        try:
-            codex_result = resume_codex_session(
-                session_id,
-                build_learn_prompt(""),
-                cwd=worktree_path,
-                timeout=learn_claude_timeout(),
+
+        def _invoke_codex() -> str:
+            return (
+                resume_codex_session(
+                    session_id,
+                    build_learn_prompt(""),
+                    cwd=worktree_path,
+                    timeout=learn_claude_timeout(),
+                ).stdout
+                or ""
             )
-            log_file.write_text(codex_result.stdout)
-            _write_learn_record(
-                state_dir,
-                issue_number,
-                succeeded=True,
-                log_file=log_file,
-                output=codex_result.stdout or "",
-            )
-            logger.info("Learn completed for issue #%s", issue_number)
-            logger.info("Learn log: %s", log_file)
-            return True
-        except Exception as e:  # broad catch: external agent process; non-blocking
-            logger.warning("Learn failed for issue #%s: %s", issue_number, e)
-            log_file.write_text(f"FAILED: {e}\n")
-            _write_learn_record(
-                state_dir,
-                issue_number,
-                succeeded=False,
-                log_file=log_file,
-                error=str(e),
-            )
-            return False
+
+        return _run_learn_with_retry(
+            _invoke_codex, state_dir=state_dir, issue_number=issue_number, log_file=log_file
+        )
 
     # /learn is a SIMPLE-complexity task (summarization + file writes), so we
     # use the configured learn model (default: Haiku) but accept operator
@@ -186,56 +244,102 @@ def run_learn(
     # We can't route through `call_claude` here because we need `--resume`
     # semantics with full Bash/Edit tools; instead we add the model flag directly.
     effective_model = model if model is not None else learn_model()
-    try:
-        result = run(
-            [
-                "claude",
-                "--resume",
-                session_id,
-                build_learn_prompt(""),
-                "--print",
-                "--model",
-                effective_model,
-                "--permission-mode",
-                "dontAsk",
-                "--allowedTools",
-                "Read,Write,Edit,Glob,Grep,Bash",
-            ],
-            cwd=worktree_path,
-            timeout=learn_claude_timeout(),
-        )
-        # Write output to log file
-        log_file.write_text(result.stdout or "")
-        _write_learn_record(
-            state_dir,
-            issue_number,
-            succeeded=True,
-            log_file=log_file,
-            output=result.stdout or "",
-        )
-        logger.info("Learn completed for issue #%s", issue_number)
-        logger.info("Learn log: %s", log_file)
+    learn_command = [
+        "claude",
+        "--resume",
+        session_id,
+        build_learn_prompt(""),
+        "--print",
+        "--model",
+        effective_model,
+        "--permission-mode",
+        "dontAsk",
+        "--allowedTools",
+        "Read,Write,Edit,Glob,Grep,Bash",
+    ]
+
+    def _invoke_claude() -> str:
+        return run(learn_command, cwd=worktree_path, timeout=learn_claude_timeout()).stdout or ""
+
+    return _run_learn_with_retry(
+        _invoke_claude, state_dir=state_dir, issue_number=issue_number, log_file=log_file
+    )
+
+
+def _run_learn_with_retry(
+    invoke: Callable[[], str],
+    *,
+    state_dir: Path,
+    issue_number: int,
+    log_file: Path,
+) -> bool:
+    """Invoke a ``/learn`` agent command, waiting + retrying on a rate limit.
+
+    /learn is ALWAYS attempted. When the invocation is rate-limited (e.g. right
+    after a 429 session-limit) — detected via the single common resolver
+    :func:`resolve_quota_reset_epoch` on the agent's stdout/stderr — we wait for
+    the reset window and re-invoke the SAME command instead of dropping the
+    learning (#1331). The agent CLI may signal a limit either by returning
+    success with the message in stdout OR by raising with it in stdout/stderr,
+    so both are inspected. A genuine non-rate-limit failure records ``FAILED:``
+    and returns ``False``. The loop is bounded by
+    :data:`_LEARN_RATE_LIMIT_MAX_RETRIES` so a misdetected message can't spin
+    forever.
+
+    Args:
+        invoke: Zero-arg callable that runs the agent command and returns its
+            stdout. Raises (with optional ``stdout``/``stderr`` attributes) on
+            subprocess failure.
+        state_dir: Directory for state/log files.
+        issue_number: Issue number.
+        log_file: Path to the ``learn-{issue}.log`` file.
+
+    Returns:
+        True if learn completed successfully, False otherwise.
+
+    """
+    for _attempt in range(_LEARN_RATE_LIMIT_MAX_RETRIES + 1):
+        try:
+            stdout = invoke()
+        except Exception as e:  # broad catch: external agent process; non-blocking
+            err_stdout = getattr(e, "stdout", "") or ""
+            err_stderr = getattr(e, "stderr", "") or ""
+            error_output = f"FAILED: {e}\n"
+            if hasattr(e, "stdout"):
+                error_output += f"\nSTDOUT:\n{err_stdout}"
+            if hasattr(e, "stderr"):
+                error_output += f"\nSTDERR:\n{err_stderr}"
+            # A rate-limit/session-limit failure is recoverable: wait for the
+            # reset and re-invoke. Only a genuine failure records FAILED:.
+            reset_epoch = resolve_quota_reset_epoch(err_stderr, err_stdout, str(e))
+            if reset_epoch is not None:
+                log_file.write_text(error_output)
+                _wait_for_quota_reset(reset_epoch, issue_number)
+                continue
+            _record_learn_failure(
+                state_dir, issue_number, log_file, log_text=error_output, error=str(e)
+            )
+            # Non-blocking: never re-raise
+            return False
+
+        # The agent CLI can exit 0 while emitting its 429/session-limit message
+        # in the stdout payload. Detect it and wait/retry rather than recording
+        # a bogus success.
+        reset_epoch = resolve_quota_reset_epoch(stdout)
+        if reset_epoch is not None:
+            log_file.write_text(stdout)
+            _wait_for_quota_reset(reset_epoch, issue_number)
+            continue
+        _record_learn_success(state_dir, issue_number, log_file, stdout=stdout)
         return True
-    except Exception as e:  # broad catch: external claude process; non-blocking, must not propagate
-        logger.warning("Learn failed for issue #%s: %s", issue_number, e)
 
-        # Save failure output to log file
-        error_output = f"FAILED: {e}\n"
-        if hasattr(e, "stdout"):
-            error_output += f"\nSTDOUT:\n{e.stdout or ''}"
-        if hasattr(e, "stderr"):
-            error_output += f"\nSTDERR:\n{e.stderr or ''}"
-        log_file.write_text(error_output)
-        _write_learn_record(
-            state_dir,
-            issue_number,
-            succeeded=False,
-            log_file=log_file,
-            error=str(e),
-        )
-
-        # Non-blocking: never re-raise
-        return False
+    # Retry budget exhausted while still rate-limited: record a failure so the
+    # learn is re-run later rather than silently marked complete.
+    message = f"rate-limited after {_LEARN_RATE_LIMIT_MAX_RETRIES} retries; learn not completed"
+    _record_learn_failure(
+        state_dir, issue_number, log_file, log_text=f"FAILED: {message}\n", error=message
+    )
+    return False
 
 
 def learn_needs_rerun(issue_number: int, state_dir: Path) -> bool:

--- a/hephaestus/github/__init__.py
+++ b/hephaestus/github/__init__.py
@@ -43,7 +43,9 @@ from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
     detect_claude_usage_limit,
     detect_rate_limit,
+    detect_session_limit,
     parse_reset_epoch,
+    resolve_quota_reset_epoch,
     wait_until,
 )
 from hephaestus.github.stats import (
@@ -65,6 +67,7 @@ __all__ = [
     "detect_claude_usage_limit",
     "detect_rate_limit",
     "detect_repo_from_remote",
+    "detect_session_limit",
     "format_stats_table",
     "get_commits_stats",
     "get_current_repo",
@@ -73,6 +76,7 @@ __all__ = [
     "gh_call",
     "local_branch_exists",
     "parse_reset_epoch",
+    "resolve_quota_reset_epoch",
     "validate_date",
     "wait_until",
 ]

--- a/hephaestus/github/rate_limit.py
+++ b/hephaestus/github/rate_limit.py
@@ -84,6 +84,21 @@ CLAUDE_USAGE_CAP_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Regex matching Claude CLI session-limit messages, e.g.:
+#   "You've hit your session limit · resets 4:20am"
+#   "You've hit your session limit · resets 9pm (America/Los_Angeles)"
+# Unlike CLAUDE_USAGE_CAP_RE, the parenthesized timezone is OPTIONAL here:
+# the session-limit phrasing emitted by ``claude -p`` on a 429 frequently
+# omits it (#1321). The optional ``resets <time>`` is captured when present;
+# when the whole "resets ..." clause is absent the message still matches so
+# callers can fall back to a probe / unknown-reset sentinel.
+CLAUDE_SESSION_LIMIT_RE = re.compile(
+    r"(?:hit your |reached your |you'?ve hit your |)session limit"
+    r"(?:.*?resets\s+(?P<time>\d{1,2}(?::\d{2})?(?:am|pm)?)"
+    r"\s*(?:\((?P<tz>[^)]+)\))?)?",
+    re.IGNORECASE,
+)
+
 # Months for parsing date-prefixed usage-cap messages
 _MONTHS = {
     "jan": 1,
@@ -424,6 +439,77 @@ def detect_claude_usage_cap(text: str) -> int | None:
     if date_str:
         return _parse_reset_with_date(date_str, time_str, tz)
     return parse_reset_epoch(time_str, tz)
+
+
+def detect_session_limit(text: str) -> int | None:
+    """Detect a Claude CLI session-limit message and return the reset epoch.
+
+    Recognizes the 429 phrasing ``claude -p`` emits when the per-session quota
+    is exhausted, e.g.::
+
+        You've hit your session limit · resets 4:20am
+
+    Crucially this form often omits the parenthesized timezone that
+    :func:`detect_claude_usage_cap` requires, so that detector misses it and
+    the orchestrator hard-fails instead of waiting (#1321). When a ``resets
+    <time>`` clause is present the epoch is parsed (defaulting the timezone via
+    :func:`parse_reset_epoch`'s ``America/Los_Angeles`` fallback and its
+    today/tomorrow logic). When the message matches but carries no reset time,
+    ``0`` is returned as the "rate-limited, reset unknown" sentinel so callers
+    back off rather than treating it as "no limit".
+
+    Args:
+        text: Text to search (CLI stderr, or the stdout JSON ``result`` field
+            of an ``is_error: true`` response).
+
+    Returns:
+        Unix timestamp when the session limit resets, ``0`` if a session-limit
+        message is present without a parseable reset time, or ``None`` if no
+        session-limit message is found.
+
+    """
+    m = CLAUDE_SESSION_LIMIT_RE.search(text)
+    if not m:
+        return None
+    time_str = m.group("time")
+    if not time_str:
+        return 0
+    # tz is optional; parse_reset_epoch falls back to America/Los_Angeles when
+    # tz is empty/unknown, and to tomorrow when the time is already past.
+    return parse_reset_epoch(time_str, m.group("tz") or "")
+
+
+def resolve_quota_reset_epoch(*texts: str) -> int | None:
+    """Find a quota-reset epoch across one or more output streams.
+
+    This is the **single common resolver** for every agent-invocation path
+    (implement, review, plan, follow-up/``/learn``). It runs all quota
+    detectors so a phrasing gap is fixed once here rather than in each call
+    site (#1321):
+
+    * :func:`detect_rate_limit` — ``gh`` REST / GraphQL limit messages.
+    * :func:`detect_claude_usage_cap` — Claude usage-cap messages (with tz).
+    * :func:`detect_session_limit` — Claude session-limit 429s (tz optional).
+
+    ``is not None`` chaining preserves an epoch of ``0`` (rate-limited, reset
+    unknown) instead of confusing it with "no rate limit".
+
+    Args:
+        *texts: One or more output streams to inspect (stderr and/or stdout).
+
+    Returns:
+        The first reset epoch found (possibly ``0`` for unknown-reset), or
+        ``None`` if no quota message is present in any stream.
+
+    """
+    for text in texts:
+        if not text:
+            continue
+        for detect in (detect_rate_limit, detect_claude_usage_cap, detect_session_limit):
+            epoch = detect(text)
+            if epoch is not None:
+                return epoch
+    return None
 
 
 def _countdown_loop(epoch: int, is_interrupted: Callable[[], bool]) -> None:

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -514,8 +514,9 @@ class TestRunFollowUpIsErrorHandling:
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
-        # Simulate a usage-cap message that detect_claude_usage_cap would parse.
-        # We patch detect_claude_usage_cap to return a future epoch.
+        # Simulate a quota message the common resolver would parse. We patch
+        # resolve_quota_reset_epoch (the single detection surface, #1321) to
+        # return a future epoch.
         import time
 
         future_epoch = int(time.time()) + 3600
@@ -528,7 +529,7 @@ class TestRunFollowUpIsErrorHandling:
         with (
             patch("hephaestus.automation.follow_up.run", return_value=mock_result),
             patch(
-                "hephaestus.automation.follow_up.detect_claude_usage_cap",
+                "hephaestus.automation.follow_up.resolve_quota_reset_epoch",
                 return_value=future_epoch,
             ),
             patch("hephaestus.automation.follow_up.wait_until") as mock_wait,

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -1,10 +1,12 @@
 """Tests for the learn module."""
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from hephaestus.automation.learn import (
+    _LEARN_RATE_LIMIT_MAX_RETRIES,
     build_learn_prompt,
     learn_needs_rerun,
     mnemosyne_update_evidence,
@@ -250,3 +252,165 @@ class TestRunLearn:
         cmd_args = mock_run.call_args[0][0]
         model_idx = cmd_args.index("--model")
         assert cmd_args[model_idx + 1] == "claude-opus-4-7"
+
+
+class TestRunLearnRateLimitRetry:
+    """Tests for the wait-and-retry behavior on a rate-limited /learn (#1331)."""
+
+    # A Claude session-limit 429 message carrying a parseable reset time; the
+    # common resolver (resolve_quota_reset_epoch) parses this to a future epoch.
+    _RATE_LIMIT_MSG = "You've hit your session limit · resets 11:59pm (America/Los_Angeles)"
+
+    def test_rate_limited_stdout_waits_then_retries_and_succeeds(self, tmp_path: Path) -> None:
+        """A rate-limit message in stdout triggers wait_until + a second invocation."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        first = MagicMock()
+        first.stdout = self._RATE_LIMIT_MSG
+        second = MagicMock()
+        second.stdout = "Learn complete. PR created."
+
+        with (
+            patch("hephaestus.automation.learn.run", side_effect=[first, second]) as mock_run,
+            patch("hephaestus.automation.learn.wait_until") as mock_wait,
+        ):
+            result = run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is True
+        # Two invocations: the rate-limited one and the successful retry.
+        assert mock_run.call_count == 2
+        mock_wait.assert_called_once()
+        # The retry re-issues the SAME command.
+        assert mock_run.call_args_list[0].args[0] == mock_run.call_args_list[1].args[0]
+        log_file = tmp_path / "learn-42.log"
+        assert not log_file.read_text().startswith("FAILED:")
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "succeeded"
+
+    def test_rate_limited_exception_waits_then_retries_and_succeeds(self, tmp_path: Path) -> None:
+        """A rate-limit message in a raised CalledProcessError triggers wait + retry."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        err = subprocess.CalledProcessError(
+            returncode=1, cmd=["claude"], output="", stderr=self._RATE_LIMIT_MSG
+        )
+        success = MagicMock()
+        success.stdout = "Learn complete."
+
+        with (
+            patch("hephaestus.automation.learn.run", side_effect=[err, success]) as mock_run,
+            patch("hephaestus.automation.learn.wait_until") as mock_wait,
+        ):
+            result = run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is True
+        assert mock_run.call_count == 2
+        mock_wait.assert_called_once()
+        log_file = tmp_path / "learn-42.log"
+        assert not log_file.read_text().startswith("FAILED:")
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "succeeded"
+
+    def test_unknown_reset_sentinel_backs_off_fixed_interval(self, tmp_path: Path) -> None:
+        """A rate-limit message with no reset time (epoch 0) backs off a fixed interval."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        # Session-limit phrasing WITHOUT a "resets ..." clause -> resolver yields 0.
+        first = MagicMock()
+        first.stdout = "You've hit your session limit"
+        second = MagicMock()
+        second.stdout = "Learn complete."
+
+        with (
+            patch("hephaestus.automation.learn.run", side_effect=[first, second]),
+            patch("hephaestus.automation.learn.wait_until") as mock_wait,
+            patch("hephaestus.automation.learn.time.time", return_value=1_000_000),
+        ):
+            result = run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is True
+        # Backed off a fixed interval (now + backoff), not epoch 0.
+        mock_wait.assert_called_once_with(1_000_000 + 300)
+
+    def test_persistent_rate_limit_respects_retry_bound(self, tmp_path: Path) -> None:
+        """A message that always parses as rate-limited stops after the retry bound."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        always = MagicMock()
+        always.stdout = self._RATE_LIMIT_MSG
+
+        with (
+            patch("hephaestus.automation.learn.run", return_value=always) as mock_run,
+            patch("hephaestus.automation.learn.wait_until") as mock_wait,
+        ):
+            result = run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is False
+        # Bounded: max_retries + 1 attempts, then give up (no infinite loop).
+        assert mock_run.call_count == _LEARN_RATE_LIMIT_MAX_RETRIES + 1
+        assert mock_wait.call_count == _LEARN_RATE_LIMIT_MAX_RETRIES + 1
+        log_file = tmp_path / "learn-42.log"
+        assert log_file.read_text().startswith("FAILED:")
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "failed"
+        assert "rate-limited after" in record["error"]
+
+    def test_genuine_failure_records_failed_without_retry(self, tmp_path: Path) -> None:
+        """A non-rate-limit failure records FAILED: and returns False without retrying."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        with (
+            patch(
+                "hephaestus.automation.learn.run",
+                side_effect=RuntimeError("disk full"),
+            ) as mock_run,
+            patch("hephaestus.automation.learn.wait_until") as mock_wait,
+        ):
+            result = run_learn("session-abc", worktree_path, 42, tmp_path)
+
+        assert result is False
+        # Genuine failure: a single attempt, no wait, no retry.
+        assert mock_run.call_count == 1
+        mock_wait.assert_not_called()
+        log_file = tmp_path / "learn-42.log"
+        assert log_file.read_text().startswith("FAILED:")
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "failed"
+        assert record["error"] == "disk full"
+
+    def test_codex_rate_limited_waits_then_retries(self, tmp_path: Path) -> None:
+        """Codex /learn also waits and retries on a rate-limit message (#1331)."""
+        worktree_path = tmp_path / "worktree"
+        worktree_path.mkdir()
+
+        first = MagicMock()
+        first.stdout = self._RATE_LIMIT_MSG
+        second = MagicMock()
+        second.stdout = "learned"
+
+        with (
+            patch(
+                "hephaestus.automation.learn.resume_codex_session",
+                side_effect=[first, second],
+            ) as mock_resume,
+            patch("hephaestus.automation.learn.wait_until") as mock_wait,
+        ):
+            result = run_learn(
+                "session-abc",
+                worktree_path,
+                42,
+                tmp_path,
+                agent="codex",
+                session_agent="codex",
+            )
+
+        assert result is True
+        assert mock_resume.call_count == 2
+        mock_wait.assert_called_once()
+        record = json.loads((tmp_path / "learn-42.json").read_text())
+        assert record["learn_status"] == "succeeded"

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -16,9 +16,11 @@ from hephaestus.github.rate_limit import (
     detect_claude_usage_limit,
     detect_rate_limit,
     detect_secondary_rate_limit,
+    detect_session_limit,
     gh_global_throttle_acquire,
     gh_rate_limit_reset_epoch,
     parse_reset_epoch,
+    resolve_quota_reset_epoch,
     wait_until,
 )
 
@@ -343,6 +345,88 @@ class TestDetectClaudeUsageCap:
         )
         epoch = detect_claude_usage_cap(json_blob)
         assert epoch is not None
+
+
+class TestDetectSessionLimit:
+    """Tests for detect_session_limit (#1321).
+
+    The Claude CLI emits ``"You've hit your session limit · resets 4:20am"`` on
+    a 429 — crucially WITHOUT the parenthesized timezone that
+    detect_claude_usage_cap requires. The old two-detector logic missed it, so
+    the orchestrator hard-failed instead of waiting for the reset.
+    """
+
+    def test_returns_none_for_unrelated_text(self) -> None:
+        assert detect_session_limit("Normal output, nothing wrong") is None
+
+    def test_parses_time_without_timezone(self) -> None:
+        epoch = detect_session_limit("You've hit your session limit \xb7 resets 4:20am")
+        assert epoch is not None
+        assert epoch > int(time.time())
+
+    def test_parses_time_with_timezone(self) -> None:
+        text = "You've hit your session limit \xb7 resets 9pm (America/Los_Angeles)"
+        epoch = detect_session_limit(text)
+        assert epoch is not None
+        assert epoch > int(time.time())
+
+    def test_bare_message_returns_zero_sentinel(self) -> None:
+        """A session-limit message with no parseable reset time yields 0.
+
+        ``0`` means "rate-limited, reset unknown" — callers must back off
+        rather than treat it as "no limit" (which ``None`` signals).
+        """
+        assert detect_session_limit("You've hit your session limit") == 0
+
+    def test_finds_message_inside_json_payload(self) -> None:
+        json_blob = (
+            '{"is_error": true, "api_error_status": 429, '
+            '"result": "You\'ve hit your session limit \xb7 resets 4:20am"}'
+        )
+        epoch = detect_session_limit(json_blob)
+        assert epoch is not None
+        assert epoch > int(time.time())
+
+
+class TestResolveQuotaResetEpoch:
+    """Tests for the single common resolver resolve_quota_reset_epoch (#1321).
+
+    Every agent-invocation path routes through this one function, so it must
+    recognize all three quota phrasings (GitHub limit, Claude usage cap, Claude
+    session limit) and preserve the ``0`` unknown-reset sentinel.
+    """
+
+    def test_resolves_session_limit_without_timezone(self) -> None:
+        epoch = resolve_quota_reset_epoch("You've hit your session limit \xb7 resets 4:20am")
+        assert epoch is not None
+        assert epoch > int(time.time())
+
+    def test_resolves_github_rest_limit(self) -> None:
+        epoch = resolve_quota_reset_epoch("Limit reached ... resets 2:30pm (America/Los_Angeles)")
+        assert epoch is not None
+        assert epoch > 0
+
+    def test_resolves_claude_usage_cap(self) -> None:
+        epoch = resolve_quota_reset_epoch(
+            "Claude usage limit reached \xb7 resets 9pm (America/Los_Angeles)"
+        )
+        assert epoch is not None
+        assert epoch > 0
+
+    def test_returns_none_when_no_quota_message(self) -> None:
+        assert resolve_quota_reset_epoch("nothing", "to see", "here") is None
+
+    def test_skips_empty_streams_and_scans_all(self) -> None:
+        epoch = resolve_quota_reset_epoch(
+            "", "clean output", "You've hit your session limit \xb7 resets 4:20am"
+        )
+        assert epoch is not None
+        assert epoch > int(time.time())
+
+    def test_preserves_zero_unknown_reset_sentinel(self) -> None:
+        # A bare session-limit message resolves to 0, which must be returned
+        # (not skipped as falsy) so callers back off.
+        assert resolve_quota_reset_epoch("You've hit your session limit") == 0
 
 
 class TestGraphQLRateLimit:

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -541,14 +541,64 @@ class TestGlobalThrottle:
         assert (tmp_path / "hephaestus_gh_rate.json").exists()
 
     def test_rapid_calls_eventually_throttle(self, monkeypatch, tmp_path) -> None:
-        """With burst=2 and rate=10/sec, the third call must wait ~0.1s."""
+        """With burst=2 and rate=10/sec, the third call must request a sleep >= 0.1s.
+
+        The throttle contract: when the token bucket is exhausted, ``time.sleep``
+        is called with ``(1 - tokens) / rate`` seconds. We verify the *contract*
+        deterministically by mocking ``time.sleep`` and ``time.monotonic`` in the
+        production module, rather than measuring real wall-clock elapsed time
+        (which is flaky on fast CI runners).
+
+        ``time.monotonic`` is driven by a scripted sequence:
+
+        * Calls 1 and 2 each consume one iteration of the while-loop; monotonic
+          returns the same ``t0`` for both so zero time appears to pass and no
+          refill occurs between them.
+        * Call 3's first loop iteration also sees ``t0`` → bucket is empty →
+          the throttle records ``wait = 0.1s`` and calls ``time.sleep(0.1)``.
+        * Call 3's *retry* iteration sees ``t0 + 0.2`` → the bucket has refilled
+          by ``0.2 * 10 = 2 tokens``, which is enough to consume one token and
+          return. This lets the loop terminate so the test completes.
+
+        The sleep-call list is the observable contract: we assert that at least
+        one call requested >= 0.09s (not a loose zero-threshold; the expected
+        value is exactly ``(1.0 - 0) / 10 = 0.1s``).
+        """
+        import unittest.mock
+
         monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_RATE", "10")
         monkeypatch.setenv("HEPHAESTUS_GH_GLOBAL_BURST", "2")
         monkeypatch.setenv("HEPHAESTUS_RATE_DIR", str(tmp_path))
-        gh_global_throttle_acquire()
-        gh_global_throttle_acquire()
-        before = time.monotonic()
-        gh_global_throttle_acquire()
-        elapsed = time.monotonic() - before
-        # Refilling 1 token at 10/sec costs ~0.1s. Accept generous bounds for CI noise.
-        assert elapsed >= 0.05
+
+        sleep_calls: list[float] = []
+
+        # Scripted monotonic sequence:
+        #   t0        – iteration for call 1 (succeeds, 2→1 tokens)
+        #   t0        – iteration for call 2 (succeeds, 1→0 tokens)
+        #   t0        – first iteration for call 3 (empty bucket → sleep queued)
+        #   t0 + 0.2  – retry iteration for call 3 (0.2s of refill → 2 tokens → succeed)
+        #   (extra values guard against off-by-one in the iteration count)
+        t0 = 1_000.0
+        mono_values = iter([t0, t0, t0, t0 + 0.2, t0 + 0.2, t0 + 0.2])
+
+        with (
+            unittest.mock.patch(
+                "hephaestus.github.rate_limit.time.sleep",
+                side_effect=lambda s: sleep_calls.append(s),
+            ),
+            unittest.mock.patch(
+                "hephaestus.github.rate_limit.time.monotonic",
+                side_effect=mono_values,
+            ),
+        ):
+            gh_global_throttle_acquire()  # consumes token 1 (burst=2 → 1 left)
+            gh_global_throttle_acquire()  # consumes token 2 (1 → 0 left)
+            gh_global_throttle_acquire()  # bucket empty → must sleep and retry
+
+        # The throttle must have called sleep at least once with a wait that
+        # reflects the cost of refilling 1 token at 10/sec (= 0.1s).
+        assert sleep_calls, "throttle must call time.sleep when bucket is exhausted"
+        assert sleep_calls[0] >= 0.09, (
+            f"throttle sleep was {sleep_calls[0]:.4f}s; expected >= 0.09s "
+            f"(1 token at 10/sec costs 0.1s)"
+        )


### PR DESCRIPTION
The Claude CLI session-limit 429 ("You've hit your session limit · resets 4:20am") has no parenthesized timezone, so neither `RATE_LIMIT_RE` nor `CLAUDE_USAGE_CAP_RE` matched. `_claude_quota_reset_epoch` returned None, the `wait_until` branch was skipped, and the implement phase hard-failed the issue instead of waiting for reset.

## Changes
- Add `CLAUDE_SESSION_LIMIT_RE` + `detect_session_limit()` (timezone optional; bare message returns the 0 "reset unknown" sentinel).
- Add the single common `resolve_quota_reset_epoch(*texts)` running all three detectors; export both.
- Route every agent-invocation call site through it: `_claude_quota_reset_epoch` (implementer), `scan_quota_reset` (planner + plan-reviewer), and the follow-up `is_error` guard.

`client.py`'s narrow `detect_claude_usage_cap` is intentionally left as-is (raises the typed `ClaudeUsageCapError` for gh-surfaced caps).

**Stacked on #1325** (ruff-format drift fix). Tests: 103 rate-limit + follow-up tests pass.

Closes #1321

🤖 Generated with [Claude Code](https://claude.com/claude-code)