### PR TITLE
fix(github): throttle rate-limit countdown to 10-min in non-TTY

### DIFF
--- a/hephaestus/github/rate_limit.py
+++ b/hephaestus/github/rate_limit.py
@@ -20,6 +20,7 @@ import os
 import re
 import signal
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -512,8 +513,18 @@ def resolve_quota_reset_epoch(*texts: str) -> int | None:
     return None
 
 
+# Non-TTY progress is throttled to this interval (seconds) so a redirected
+# log file gets one line per 10 minutes instead of one line per 1Hz tick.
+_NON_TTY_EMIT_INTERVAL_S = 600
+
+
 def _countdown_loop(epoch: int, is_interrupted: Callable[[], bool]) -> None:
-    """Print a 1Hz countdown until ``epoch``, or until ``is_interrupted`` is true.
+    r"""Display a countdown until ``epoch``, or until ``is_interrupted`` is true.
+
+    On an interactive terminal (``sys.stdout.isatty()``), a 1Hz ``\\r``
+    spinner is printed. When stdout is redirected to a non-TTY (e.g. a log
+    file), the spinner is suppressed and a progress line is logged at most
+    once every 10 minutes to avoid flooding the log with one line per tick.
 
     Args:
         epoch: Target Unix timestamp to wait for.
@@ -532,21 +543,34 @@ def _countdown_loop(epoch: int, is_interrupted: Callable[[], bool]) -> None:
     iterations = 0
     iteration_cap = 100_000  # ~27hrs at 1Hz; well above any real countdown
 
+    is_tty = sys.stdout.isatty()
+    # Track last non-TTY emission with the monotonic clock; ``time.time`` is
+    # heavily mocked in tests, so monotonic keeps the throttle honest. ``None``
+    # forces an emission on the first iteration so even a short wait logs once.
+    last_emit_mono: float | None = None
+
     while True:
         if is_interrupted():
             print("\n[INFO] Wait interrupted by user")
             raise KeyboardInterrupt
         remaining = epoch - int(time.time())
         if remaining <= 0:
-            print()
+            if is_tty:
+                print()
             return
         h, r = divmod(remaining, 3600)
         m, s = divmod(r, 60)
-        print(
-            f"\r[INFO] Rate limit resets in {h:02d}:{m:02d}:{s:02d}",
-            end="",
-            flush=True,
-        )
+        if is_tty:
+            print(
+                f"\r[INFO] Rate limit resets in {h:02d}:{m:02d}:{s:02d}",
+                end="",
+                flush=True,
+            )
+        else:
+            now_mono = time.monotonic()
+            if last_emit_mono is None or now_mono - last_emit_mono >= _NON_TTY_EMIT_INTERVAL_S:
+                logger.info("Rate limit resets in %02d:%02d:%02d", h, m, s)
+                last_emit_mono = now_mono
         time.sleep(1)
         iterations += 1
         if iterations >= iteration_cap:
@@ -554,7 +578,8 @@ def _countdown_loop(epoch: int, is_interrupted: Callable[[], bool]) -> None:
             # either way, stop spinning and let the caller proceed.
             elapsed_s = (time.monotonic_ns() - start_mono) / 1e9
             logger.warning("wait_until iteration cap reached after %.2fs; bailing out", elapsed_s)
-            print()
+            if is_tty:
+                print()
             return
 
 

--- a/tests/unit/github/test_rate_limit.py
+++ b/tests/unit/github/test_rate_limit.py
@@ -11,6 +11,7 @@ from hephaestus.github.rate_limit import (
     GRAPHQL_RATE_LIMIT_RE,
     RATE_LIMIT_RE,
     SECONDARY_RATE_LIMIT_RE,
+    _countdown_loop,
     _rate_limit_probe_cache,
     detect_claude_usage_cap,
     detect_claude_usage_limit,
@@ -602,3 +603,87 @@ class TestGlobalThrottle:
             f"throttle sleep was {sleep_calls[0]:.4f}s; expected >= 0.09s "
             f"(1 token at 10/sec costs 0.1s)"
         )
+
+
+class TestCountdownThrottle:
+    """Tests for _countdown_loop TTY vs non-TTY emission throttling (#1330)."""
+
+    @patch("hephaestus.github.rate_limit.logger")
+    @patch("hephaestus.github.rate_limit.print")
+    @patch("hephaestus.github.rate_limit.sys.stdout")
+    @patch("hephaestus.github.rate_limit.time.monotonic")
+    @patch("hephaestus.github.rate_limit.time.sleep")
+    @patch("hephaestus.github.rate_limit.time.time")
+    def test_non_tty_throttles_to_ten_minute_emissions(
+        self,
+        mock_time: object,
+        mock_sleep: object,
+        mock_monotonic: object,
+        mock_stdout: object,
+        mock_print: object,
+        mock_logger: object,
+    ) -> None:
+        """Non-TTY: a ~30-minute wait logs ~3 lines (one per 10 min), not ~1800."""
+        import unittest.mock
+
+        assert isinstance(mock_time, unittest.mock.MagicMock)
+        assert isinstance(mock_monotonic, unittest.mock.MagicMock)
+        assert isinstance(mock_stdout, unittest.mock.MagicMock)
+        assert isinstance(mock_logger, unittest.mock.MagicMock)
+        assert isinstance(mock_print, unittest.mock.MagicMock)
+
+        mock_stdout.isatty.return_value = False
+
+        # Wall-clock and monotonic both advance 1 second per iteration so the
+        # 600s throttle window maps cleanly onto a 1800-iteration countdown.
+        target = 1800
+        mock_time.side_effect = list(range(0, target + 2))
+        mock_monotonic.side_effect = [float(i) for i in range(0, target + 2)]
+
+        _countdown_loop(target, lambda: False)
+
+        # Non-TTY must never use the \r spinner.
+        mock_print.assert_not_called()
+        # Emissions at t=0, 600, 1200 → exactly 3 over a 30-minute wait.
+        info_calls = list(mock_logger.info.call_args_list)
+        assert len(info_calls) == 3, f"expected 3 throttled emissions, got {len(info_calls)}"
+
+    @patch("hephaestus.github.rate_limit.logger")
+    @patch("hephaestus.github.rate_limit.print")
+    @patch("hephaestus.github.rate_limit.sys.stdout")
+    @patch("hephaestus.github.rate_limit.time.sleep")
+    @patch("hephaestus.github.rate_limit.time.time")
+    def test_tty_uses_one_hz_spinner(
+        self,
+        mock_time: object,
+        mock_sleep: object,
+        mock_stdout: object,
+        mock_print: object,
+        mock_logger: object,
+    ) -> None:
+        r"""TTY mode prints the \r spinner per tick and does not log progress."""
+        import unittest.mock
+
+        assert isinstance(mock_time, unittest.mock.MagicMock)
+        assert isinstance(mock_stdout, unittest.mock.MagicMock)
+        assert isinstance(mock_print, unittest.mock.MagicMock)
+        assert isinstance(mock_logger, unittest.mock.MagicMock)
+
+        mock_stdout.isatty.return_value = True
+
+        target = 1000
+        # now, now, now, then past-epoch → two spinner ticks then return.
+        mock_time.side_effect = [997, 998, 999, 1001]
+
+        _countdown_loop(target, lambda: False)
+
+        # Spinner printed each tick (plus the trailing newline on completion).
+        assert mock_print.call_count >= 2
+        spinner_calls = [
+            c
+            for c in mock_print.call_args_list
+            if c.args and "Rate limit resets in" in str(c.args[0])
+        ]
+        assert spinner_calls, "expected at least one \\r spinner print on a TTY"
+        # TTY mode must not emit throttled INFO progress lines.
+        mock_logger.info.assert_not_called()


### PR DESCRIPTION
## Summary

`_countdown_loop` in `hephaestus/github/rate_limit.py` printed a 1Hz `\r`
countdown spinner unconditionally. On a TTY the carriage return overwrites a
single line, but when stdout is redirected to a non-TTY log file every
1-second tick becomes a brand-new line — thousands of lines per wait.

## Fix

- Detect non-TTY via `sys.stdout.isatty()`.
- **Non-TTY**: suppress the spinner; log a progress line via the module
  `logger` at most once every 600s (10 minutes). The last-emit time is
  tracked with `time.monotonic()` (not `time.time`, which is heavily mocked
  in tests), and one line is emitted at the start so even short waits log
  something.
- **TTY**: unchanged 1Hz `\r` spinner.
- The `time.sleep(1)` tick and the iteration-cap safety logic are left
  intact, so the wait stays responsive and KeyboardInterrupt handling is
  unchanged.

## Tests

Added `TestCountdownThrottle` in `tests/unit/github/test_rate_limit.py`:
- Non-TTY + a ~30-minute mocked wait emits exactly 3 logging lines (one per
  10 min), not ~1800, and never calls `print`.
- TTY mode still prints the `\r` spinner per tick and logs no progress lines.

All 60 tests in the file pass; ruff format/check, mypy, and pre-commit are
clean.

Closes #1330

🤖 Generated with [Claude Code](https://claude.com/claude-code)