### PR TITLE
fix(automation): post own editable comment when foreign review comment is uneditable

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1121,7 +1121,7 @@ def _fetch_pr_inline_review_thread_nodes(pr_number: int) -> list[dict[str, Any]]
         "    pullRequest(number:$number){"
         "      reviewThreads(first:100){"
         "        nodes{ isResolved path line side:diffSide "
-        "comments(first:20){ nodes{ id body } } }"
+        "comments(first:20){ nodes{ id body viewerCanUpdate } } }"
         "      }"
         "    }"
         "  }"
@@ -1160,20 +1160,26 @@ def _fetch_pr_inline_review_thread_nodes(pr_number: int) -> list[dict[str, Any]]
     return [node for node in nodes if isinstance(node, dict)]
 
 
-def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tuple[str, str]]:
-    """Map ``(path, line)`` → ``(comment_node_id, body)`` for unresolved bot threads.
+def gh_pr_inline_comment_index(
+    pr_number: int,
+) -> dict[ReviewCommentIndexKey, tuple[str, str, bool]]:
+    """Map ``(path, line)`` → ``(comment_node_id, body, editable)`` for unresolved threads.
 
-    Returns the GraphQL node id AND current body of the FIRST comment of each
-    unresolved review thread, keyed by its ``(path, line)``. Used by
-    :func:`gh_pr_review_post` to detect a line that already has a comment so the
-    new content can be **appended** to the existing body in place rather than
-    posted as a duplicate (#1083). The body is required because the
-    ``updatePullRequestReviewComment`` mutation REPLACES the body — the caller
-    must concatenate ``existing + new`` or the original comment is lost (#1085).
-    Fails open: returns ``{}`` on any API/parse error so the caller posts
-    everything as before.
+    Returns the GraphQL node id, current body, AND ``viewerCanUpdate`` flag of
+    the FIRST comment of each unresolved review thread, keyed by its
+    ``(path, line)``. Used by :func:`gh_pr_review_post` to detect a line that
+    already has a comment so the new content can be **appended** to the existing
+    body in place rather than posted as a duplicate (#1083). The body is required
+    because the ``updatePullRequestReviewComment`` mutation REPLACES the body —
+    the caller must concatenate ``existing + new`` or the original comment is
+    lost (#1085). The ``editable`` flag (``viewerCanUpdate``) is required because
+    the first comment of a thread may belong to another app/account (Copilot,
+    CodeQL); GitHub rejects an in-place edit of such a comment with
+    ``Body is not editable``, so the caller must post its OWN editable shadow
+    comment instead (#1327). Fails open: returns ``{}`` on any API/parse error so
+    the caller posts everything as before.
     """
-    index: dict[ReviewCommentIndexKey, tuple[str, str]] = {}
+    index: dict[ReviewCommentIndexKey, tuple[str, str, bool]] = {}
     for node in _fetch_pr_inline_review_thread_nodes(pr_number):
         if node.get("isResolved"):
             continue
@@ -1184,13 +1190,16 @@ def gh_pr_inline_comment_index(pr_number: int) -> dict[ReviewCommentIndexKey, tu
         if not comment_id:
             continue
         body = comment_nodes[0].get("body") or ""
+        # Default to editable when the field is absent so behaviour is unchanged
+        # for callers/tests that predate the ``viewerCanUpdate`` selection.
+        editable = bool(comment_nodes[0].get("viewerCanUpdate", True))
         path = node.get("path") or ""
         line = node.get("line")
         side = node.get("side") or "RIGHT"
-        index[(path, line, side)] = (comment_id, body)
+        index[(path, line, side)] = (comment_id, body, editable)
         # Preserve the older key shape for callers/tests that predate diff-side
         # support, and as a fallback if GitHub ever omits ``diffSide``.
-        index.setdefault((path, line), (comment_id, body))
+        index.setdefault((path, line), (comment_id, body, editable))
     return index
 
 
@@ -1251,6 +1260,12 @@ def gh_pr_update_review_comment(comment_node_id: str, body: str) -> None:
         ]
     )
 
+
+# GitHub rejects ``updatePullRequestReviewComment`` on a comment the current
+# token does not own ("gh: Body is not editable"). The first comment of a thread
+# may belong to another app (Copilot, CodeQL), so this string is matched as a
+# fallback signal when ``viewerCanUpdate`` was unavailable/stale (#1327).
+_BODY_NOT_EDITABLE_MARKER = "not editable"
 
 _ADDITIONAL_REVIEW_NOTE_DELIMITER = "\n\n---\n_Additional review note (same line):_\n\n"
 
@@ -1354,6 +1369,62 @@ def _review_comment_already_covers(existing_body: str, new_body: str) -> bool:
     return False
 
 
+def _post_shadow_review_comment(pr_number: int, comment: dict[str, Any]) -> tuple[str, str] | None:
+    """Post OUR OWN editable inline comment shadowing a foreign (uneditable) one.
+
+    The first comment of a thread can belong to another app/account (Copilot,
+    CodeQL); GitHub forbids editing it ("Body is not editable"). Rather than
+    silently drop the finding, we post a brand-new inline comment at the same
+    ``(path, line, side)`` that WE own and can edit on every later run (#1327).
+
+    Posting reuses :func:`gh_pr_review_post` with ``dedupe_existing=False`` so it
+    does NOT re-enter the dedupe path (which would re-detect the same foreign
+    comment and loop). ``gh_pr_review_post`` returns thread ids, not the inline
+    comment node id, so we re-fetch the inline-comment index to recover the new
+    comment's editable node id for subsequent same-line updates.
+
+    Returns ``(new_comment_node_id, posted_body)`` on success, or ``None`` if the
+    post or the follow-up lookup failed (the caller then falls back to posting the
+    finding fresh).
+    """
+    path = comment.get("path") or ""
+    line = comment.get("line")
+    side = comment.get("side") or "RIGHT"
+    body = comment.get("body") or ""
+    try:
+        gh_pr_review_post(
+            pr_number,
+            [{"path": path, "line": line, "side": side, "body": body}],
+            summary="",
+            dedupe_existing=False,
+        )
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "PR #%s: could not post editable shadow comment on %s:%s (%s): %s",
+            pr_number,
+            path,
+            line,
+            side,
+            exc,
+        )
+        return None
+    # Re-fetch the index to discover OUR new comment's editable node id. Prefer an
+    # editable entry for this exact line; that is the comment we just posted.
+    refreshed = gh_pr_inline_comment_index(pr_number)
+    entry = refreshed.get((path, line, side)) or refreshed.get((path, line))
+    if entry is None or not entry[2]:
+        logger.warning(
+            "PR #%s: posted editable shadow comment on %s:%s (%s) but could not relocate "
+            "its editable node id",
+            pr_number,
+            path,
+            line,
+            side,
+        )
+        return None
+    return entry[0], entry[1]
+
+
 def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Edit comments whose line already has an UNRESOLVED bot comment; keep the rest.
 
@@ -1361,6 +1432,13 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
     thread, skip it if the existing body already covers the same finding, else
     rewrite that thread's comment to ``existing_body + new_body`` (a single edit
     preserving the original text, #1085) and drop it from the returned list.
+
+    When the existing thread's first comment is NOT editable — it belongs to
+    another app/account such as Copilot or CodeQL (``viewerCanUpdate`` is false,
+    or the update mutation reports "Body is not editable") — we do NOT silently
+    keep the foreign comment. Instead we post OUR OWN editable shadow comment on
+    the same line and from then on edit THAT comment for every re-raise of the
+    finding (#1327). The foreign comment is left untouched.
 
     Findings on fresh lines — including lines whose only prior comment is a
     RESOLVED thread — are returned unchanged for posting. Dedup is deliberately
@@ -1403,10 +1481,7 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
         if editable is None:
             fresh.append(c)
             continue
-        # #1085: updatePullRequestReviewComment REPLACES the body, so concatenate
-        # the existing body + the new note. Passing only the suffix would destroy
-        # the original comment.
-        existing_id, existing_body = editable
+        existing_id, existing_body, can_update = editable
         if _review_comment_already_covers(existing_body, body):
             logger.info(
                 "PR #%s: skipped duplicate same-line review comment on %s:%s (%s)",
@@ -1416,9 +1491,36 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
                 side,
             )
             continue
+
+        # #1327: the existing comment belongs to another app/account and is not
+        # editable. Post our OWN editable shadow comment on the same line, index
+        # it, and edit THAT comment on every later re-raise. Leave the foreign
+        # comment untouched. ``viewerCanUpdate`` is the primary signal.
+        if not can_update:
+            shadow = _post_shadow_review_comment(pr_number, c)
+            if shadow is None:
+                fresh.append(c)
+                continue
+            new_id, new_body = shadow
+            editable_index[(path, line, side)] = (new_id, new_body, True)
+            editable_index[(path, line)] = (new_id, new_body, True)
+            logger.info(
+                "PR #%s: posted editable shadow comment on %s:%s (%s); foreign comment left intact",
+                pr_number,
+                path,
+                line,
+                side,
+            )
+            continue
+
+        # #1085: updatePullRequestReviewComment REPLACES the body, so concatenate
+        # the existing body + the new note. Passing only the suffix would destroy
+        # the original comment.
         combined = f"{existing_body}{_ADDITIONAL_REVIEW_NOTE_DELIMITER}{body}"
         try:
             gh_pr_update_review_comment(existing_id, combined)
+            editable_index[(path, line, side)] = (existing_id, combined, True)
+            editable_index[(path, line)] = (existing_id, combined, True)
             logger.info(
                 "PR #%s: edited existing comment on %s:%s (%s) instead of duplicating",
                 pr_number,
@@ -1427,7 +1529,24 @@ def _edit_or_keep_comments(pr_number: int, comments: list[dict[str, Any]]) -> li
                 side,
             )
         except (OSError, subprocess.SubprocessError) as exc:
-            # If the edit fails, fall back to posting the comment fresh.
+            # A deterministic "Body is not editable" means viewerCanUpdate was
+            # stale/unavailable; recover by posting our own editable shadow
+            # comment (#1327). Any other edit error falls back to posting fresh.
+            if _BODY_NOT_EDITABLE_MARKER in str(exc).lower():
+                shadow = _post_shadow_review_comment(pr_number, c)
+                if shadow is not None:
+                    new_id, new_body = shadow
+                    editable_index[(path, line, side)] = (new_id, new_body, True)
+                    editable_index[(path, line)] = (new_id, new_body, True)
+                    logger.info(
+                        "PR #%s: edit reported not-editable on %s:%s (%s); posted editable "
+                        "shadow comment instead",
+                        pr_number,
+                        path,
+                        line,
+                        side,
+                    )
+                    continue
             logger.warning(
                 "PR #%s: edit-in-place failed for %s:%s (%s): %s; posting fresh",
                 pr_number,

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -159,6 +159,10 @@ _NON_TRANSIENT_PATTERNS = [
         # unused variable can never succeed on retry (#1040).
         r"doesn't accept argument",
         r"is declared by .* but not used",
+        # "Body is not editable": editing a review comment owned by another
+        # app/account (Copilot, CodeQL) is forbidden and never succeeds on
+        # retry. Fail fast so the caller posts its own editable comment (#1327).
+        r"not editable",
     )
 ]
 _NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2206,7 +2206,7 @@ class TestGhPrReviewPost:
         )
         # a.py:2 already has a bot comment (id + existing body); a.py:3 does not.
         mock_index.return_value = {
-            ("a.py", 2): ("COMMENT_NODE_A2", "original note on line 2"),
+            ("a.py", 2): ("COMMENT_NODE_A2", "original note on line 2", True),
         }
 
         gh_pr_review_post(
@@ -2255,6 +2255,7 @@ class TestGhPrReviewPost:
                 "COMMENT_NODE_A2",
                 "This regression coverage only exercises the Claude result-envelope path. "
                 "The production diff also changed the Codex stdout path, so add a Codex test.",
+                True,
             ),
         }
 
@@ -2312,6 +2313,7 @@ class TestGhPrReviewPost:
                 "test where `summary` lacks a verdict and `review_text`/stdout contains "
                 "`Verdict: GO` or `Verdict: NOGO`; otherwise the second producer path can "
                 "regress without this suite catching it.",
+                True,
             ),
         }
 
@@ -2419,6 +2421,7 @@ class TestGhPrReviewPost:
                 "test where `summary` lacks a verdict and `review_text`/stdout contains "
                 "`Verdict: GO` or `Verdict: NOGO`; otherwise the second producer path can "
                 "regress without this suite catching it.",
+                True,
             ),
         }
 
@@ -2493,6 +2496,7 @@ class TestGhPrReviewPost:
                 "`summary` as the review body. Capture this mock and assert "
                 '`gh_pr_review_post(..., summary="a defect (no verdict token here)")` so a '
                 "future regression cannot post the full verdict prose.",
+                True,
             ),
         }
 
@@ -2566,7 +2570,7 @@ class TestGhPrReviewPost:
         mock_gh_call.side_effect = self._gh_call_side_effect(
             "REVIEW_1", [], diff_text=self._SAMPLE_DIFF
         )
-        mock_index.return_value = {("a.py", 2): ("NODE", "old body")}
+        mock_index.return_value = {("a.py", 2): ("NODE", "old body", True)}
         mock_update.side_effect = OSError("network down")
 
         gh_pr_review_post(
@@ -2579,6 +2583,120 @@ class TestGhPrReviewPost:
         mock_update.assert_called_once()
         # Edit failed → the comment is posted as a fresh inline comment.
         assert {c["body"] for c in self._posted_comments(mock_write)} == {"retry me"}
+
+
+class TestEditOrKeepUneditableComment:
+    """#1327: a foreign (uneditable) first comment triggers an editable shadow post.
+
+    When the first comment of an unresolved thread belongs to another app/account
+    (Copilot, CodeQL), GitHub forbids editing it. ``_edit_or_keep_comments`` must
+    NOT silently keep the foreign comment — it posts OUR OWN editable comment on
+    the same line, indexes it, and edits THAT comment on every later re-raise.
+    """
+
+    @patch("hephaestus.automation.github_api.gh_pr_wont_fix_line_index", return_value=set())
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_review_post")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    def test_uneditable_viewer_flag_posts_new_editable_shadow_comment(
+        self,
+        mock_index: Any,
+        mock_post: Any,
+        mock_update: Any,
+        _mock_wont_fix: Any,
+    ) -> None:
+        from hephaestus.automation.github_api import _edit_or_keep_comments
+
+        # First fetch: foreign comment (viewerCanUpdate False). Re-fetch after the
+        # shadow post: our own editable comment now occupies the line.
+        mock_index.side_effect = [
+            {("a.py", 2, "RIGHT"): ("FOREIGN_NODE", "copilot finding", False)},
+            {("a.py", 2, "RIGHT"): ("OUR_NODE", "our finding", True)},
+        ]
+
+        kept = _edit_or_keep_comments(
+            7, [{"path": "a.py", "line": 2, "side": "RIGHT", "body": "our finding"}]
+        )
+
+        # A NEW editable comment was posted (not silently skipped)...
+        mock_post.assert_called_once()
+        posted_comments = mock_post.call_args.args[1]
+        assert posted_comments == [
+            {"path": "a.py", "line": 2, "side": "RIGHT", "body": "our finding"}
+        ]
+        # ...with dedupe disabled so it does not re-enter the dedupe loop.
+        assert mock_post.call_args.kwargs["dedupe_existing"] is False
+        # The foreign comment was left untouched (no edit mutation).
+        mock_update.assert_not_called()
+        # The finding was consumed (edited via shadow), not returned for re-post.
+        assert kept == []
+
+    @patch("hephaestus.automation.github_api.gh_pr_wont_fix_line_index", return_value=set())
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_review_post")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    def test_subsequent_same_line_finding_edits_the_new_shadow_comment(
+        self,
+        mock_index: Any,
+        mock_post: Any,
+        mock_update: Any,
+        _mock_wont_fix: Any,
+    ) -> None:
+        """After shadowing a foreign comment, a second same-line finding edits OUR node."""
+        from hephaestus.automation.github_api import _edit_or_keep_comments
+
+        mock_index.side_effect = [
+            {("a.py", 2, "RIGHT"): ("FOREIGN_NODE", "copilot finding", False)},
+            {("a.py", 2, "RIGHT"): ("OUR_NODE", "first our note", True)},
+        ]
+
+        _edit_or_keep_comments(
+            7,
+            [
+                {"path": "a.py", "line": 2, "side": "RIGHT", "body": "first our note"},
+                {"path": "a.py", "line": 2, "side": "RIGHT", "body": "a wholly different note"},
+            ],
+        )
+
+        # The shadow was posted once for the first finding; the second finding was
+        # an in-place edit of OUR newly-indexed editable comment, not the foreign.
+        mock_post.assert_called_once()
+        mock_update.assert_called_once()
+        assert mock_update.call_args.args[0] == "OUR_NODE"
+        edited_body = mock_update.call_args.args[1]
+        assert "first our note" in edited_body
+        assert "a wholly different note" in edited_body
+
+    @patch("hephaestus.automation.github_api.gh_pr_wont_fix_line_index", return_value=set())
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_review_post")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    def test_not_editable_mutation_error_falls_back_to_shadow_post(
+        self,
+        mock_index: Any,
+        mock_post: Any,
+        mock_update: Any,
+        _mock_wont_fix: Any,
+    ) -> None:
+        """A "Body is not editable" mutation error (stale viewer flag) shadow-posts."""
+        from hephaestus.automation.github_api import _edit_or_keep_comments
+
+        # viewerCanUpdate optimistically True, but the edit mutation rejects it.
+        mock_index.side_effect = [
+            {("a.py", 2, "RIGHT"): ("FOREIGN_NODE", "copilot finding", True)},
+            {("a.py", 2, "RIGHT"): ("OUR_NODE", "our finding", True)},
+        ]
+        mock_update.side_effect = subprocess.SubprocessError("gh: Body is not editable")
+
+        kept = _edit_or_keep_comments(
+            7, [{"path": "a.py", "line": 2, "side": "RIGHT", "body": "our finding"}]
+        )
+
+        # The edit was attempted (probe) then a shadow comment was posted.
+        mock_update.assert_called_once()
+        mock_post.assert_called_once()
+        # The finding was consumed by the shadow comment, not re-posted fresh.
+        assert kept == []
 
 
 class TestGhPrInlineCommentIndex:
@@ -2600,7 +2718,30 @@ class TestGhPrInlineCommentIndex:
                                         "path": "a.py",
                                         "line": 2,
                                         "side": "RIGHT",
-                                        "comments": {"nodes": [{"id": "N1", "body": "keep me"}]},
+                                        "comments": {
+                                            "nodes": [
+                                                {
+                                                    "id": "N1",
+                                                    "body": "keep me",
+                                                    "viewerCanUpdate": True,
+                                                }
+                                            ]
+                                        },
+                                    },
+                                    {  # unresolved but foreign (Copilot) → not editable
+                                        "isResolved": False,
+                                        "path": "c.py",
+                                        "line": 4,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "nodes": [
+                                                {
+                                                    "id": "N3",
+                                                    "body": "copilot note",
+                                                    "viewerCanUpdate": False,
+                                                }
+                                            ]
+                                        },
                                     },
                                     {
                                         "isResolved": True,
@@ -2619,10 +2760,14 @@ class TestGhPrInlineCommentIndex:
 
         index = gh_pr_inline_comment_index(7)
 
-        # Unresolved thread is indexed with id + body; resolved one is excluded.
+        # Unresolved threads are indexed with id + body + viewerCanUpdate; the
+        # resolved thread is excluded. The foreign (Copilot) comment carries
+        # editable=False so the caller posts its own shadow comment (#1327).
         assert index == {
-            ("a.py", 2): ("N1", "keep me"),
-            ("a.py", 2, "RIGHT"): ("N1", "keep me"),
+            ("a.py", 2): ("N1", "keep me", True),
+            ("a.py", 2, "RIGHT"): ("N1", "keep me", True),
+            ("c.py", 4): ("N3", "copilot note", False),
+            ("c.py", 4, "RIGHT"): ("N3", "copilot note", False),
         }
 
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("owner", "repo"))

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -135,3 +135,24 @@ class TestGhCallPublicExports:
         assert github_pkg.GitHubRateLimitError is GitHubRateLimitError
         assert github_pkg.GitHubUnavailableError is GitHubUnavailableError
         assert github_pkg.ClaudeUsageCapError is ClaudeUsageCapError
+
+
+class TestNonTransientErrorClassification:
+    """_is_non_transient_error: deterministic gh failures must not be retried."""
+
+    def test_body_not_editable_is_non_transient(self) -> None:
+        """#1327: editing a foreign-owned comment never succeeds on retry.
+
+        Without this classification the deterministic "Body is not editable"
+        rejection was retried ~6× per finding (66× in one observed run) before
+        the caller could fall back to posting its own editable comment.
+        """
+        from hephaestus.github.client import _is_non_transient_error
+
+        assert _is_non_transient_error("gh: Body is not editable") is True
+
+    def test_transient_5xx_is_not_non_transient(self) -> None:
+        """A 500 is retryable, so it must NOT be flagged non-transient."""
+        from hephaestus.github.client import _is_non_transient_error
+
+        assert _is_non_transient_error("Internal Server Error (HTTP 500)") is False


### PR DESCRIPTION
## Summary

The PR review dedupe loop (`_edit_or_keep_comments`) overwrote the FIRST comment of every unresolved review thread via `gh_pr_update_review_comment`. When that comment belongs to another app/account (Copilot, CodeQL), GitHub rejects the GraphQL `updatePullRequestReviewComment` mutation with `gh: Body is not editable` — observed failing 66× in one run, each retried ~6× because the pattern was not classified non-transient.

## Fix (RC1, #1327)

1. **Surface editability.** `_fetch_pr_inline_review_thread_nodes` now selects `viewerCanUpdate`, and `gh_pr_inline_comment_index` carries it through — the index tuple is now `(comment_node_id, body, editable)`.
2. **Post our own editable shadow comment.** When the existing comment is NOT editable (`viewerCanUpdate` false, OR the edit mutation reports "Body is not editable"), `_edit_or_keep_comments` no longer silently keeps the foreign comment. It posts OUR OWN inline comment at the same `(path, line, side)` via `gh_pr_review_post(dedupe_existing=False)`, records the new node id in the in-memory index, and edits THAT shadow comment on every later re-raise. The foreign (Copilot/CodeQL) comment is left untouched.
3. **Fail fast.** `not editable` added to `_NON_TRANSIENT_PATTERNS` in `hephaestus/github/client.py` so the edit probe fails on attempt 1 instead of retrying 6× before the fallback posts the editable comment.

## Tests

- `tests/unit/automation/test_github_api.py`: uneditable existing comment (viewer flag false) posts a NEW editable comment and indexes it (not skipped); a subsequent same-line finding edits the NEW comment's id; a "Body is not editable" mutation error falls back to a shadow post. Existing index-tuple tests updated to the 3-tuple shape; index test asserts a foreign comment surfaces `editable=False`.
- `tests/unit/github/test_client.py`: `_is_non_transient_error("gh: Body is not editable")` is True; a 5xx is not.

All gh calls mocked; no network. `ruff format`/`ruff check`/`mypy`/`pre-commit` clean; 158 tests pass.

Closes #1327

🤖 Generated with [Claude Code](https://claude.com/claude-code)