### PR TITLE
fix(automation): pre-review conflict gate + done-gate accuracy (RC2)

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -39,7 +39,15 @@ from .claude_invoke import (
 )
 from .claude_models import implementer_model, reviewer_model
 from .claude_timeouts import implementer_claude_timeout
-from .git_utils import get_repo_slug, issue_ref, pr_ref, run
+from .git_utils import (
+    get_repo_slug,
+    issue_ref,
+    pr_ref,
+    push_current_branch_with_lease_on_divergence,
+    rebase_worktree_onto,
+    run,
+    sync_worktree_to_remote_branch,
+)
 from .github_api import (
     gh_current_login,
     gh_issue_add_labels,
@@ -371,6 +379,188 @@ class ReviewPhase(StageMixin):
         impl._save_review_iteration_state(issue_number, iteration + 1, review_text)
         return reopened, review_text, posted_thread_ids, verdict
 
+    # ------------------------------------------------------------------
+    # Pre-review conflict gate (#1328)
+    # ------------------------------------------------------------------
+
+    def _pr_merge_state(self, pr_number: int) -> tuple[str, str]:
+        """Return ``(mergeStateStatus, mergeable)`` upper-cased for *pr_number*.
+
+        Mirrors the merge-state query the CI driver uses
+        (``ci_driver._gh_pr_state`` / ``_attempt_mechanical_rebase``). Returns
+        empty strings on any query failure so an unknown merge-state is never
+        misread as CONFLICTING.
+        """
+        try:
+            result = run(
+                ["gh", "pr", "view", str(pr_number), "--json", "mergeStateStatus,mergeable"],
+                cwd=self.repo_root,
+                capture_output=True,
+            )
+            state = dict(json.loads(result.stdout or "{}"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "#%d: could not fetch PR %s merge-state for conflict gate: %s",
+                pr_number,
+                pr_ref(pr_number),
+                exc,
+            )
+            return "", ""
+        return (
+            str(state.get("mergeStateStatus") or "").upper(),
+            str(state.get("mergeable") or "").upper(),
+        )
+
+    def _resolve_conflict_before_review(
+        self,
+        *,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        branch_name: str,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        state: ImplementationState | None,
+    ) -> bool:
+        """Ensure *pr_number* is conflict-free before the review iterations (#1328).
+
+        Reviewing a PR that has a merge conflict with its base is pointless — a
+        conflicted PR can never merge, so any GO verdict would be wasted spend.
+        Per the user's instruction this resolves the conflict with the
+        IMPLEMENTATION agent BEFORE the first review iteration.
+
+        The flow reuses the SAME primitives the CI driver's ``_resolve_dirty_pr``
+        uses (``rebase_worktree_onto`` / ``push_current_branch_with_lease_on_divergence``
+        from :mod:`git_utils`, and the implementer-session resume in
+        ``_resume_impl_with_feedback``), rather than reinventing conflict
+        resolution. ``ReviewPhase`` runs under ``IssueImplementer`` — a different
+        object than ``CIDriver`` — so the helper cannot be called directly; this
+        is the smallest seam that reuses the underlying rebase/agent primitives.
+
+        Steps:
+
+        1. Query merge-state. If NOT DIRTY/CONFLICTING, return ``True`` (nothing
+           to do — proceed straight to review). An unknown merge-state also
+           returns ``True`` so a transient gh failure never strands a healthy PR.
+        2. Mechanical rebase onto the base. A clean rebase + lease-push
+           re-triggers CI; return ``True`` once the merge-state clears.
+        3. Still conflicting → dispatch the implementation agent with explicit
+           conflict-resolution instructions, commit + push, then re-check.
+        4. Return ``True`` only if the PR is conflict-free afterwards; ``False``
+           if the conflict could not be resolved (caller returns early so the PR
+           is treated as not-GO rather than reviewed).
+
+        Returns:
+            ``True`` if the PR is conflict-free (review may proceed); ``False``
+            if an unresolved merge conflict remains.
+
+        """
+        if self.options.dry_run:
+            return True
+
+        merge_state, mergeable = self._pr_merge_state(pr_number)
+        if merge_state not in ("DIRTY", "CONFLICTING") and mergeable != "CONFLICTING":
+            return True
+
+        impl = self.impl
+        impl._log(
+            "warning",
+            f"{issue_ref(issue_number)}: {pr_ref(pr_number)} is {merge_state or 'CONFLICTING'} "
+            "(merge conflict) before review — resolving with the implementation agent "
+            "before any review iteration",
+            thread_id,
+        )
+        if slot_id is not None:
+            self.status_tracker.update_slot(
+                slot_id, f"{pr_ref(pr_number)}: resolving merge conflict"
+            )
+
+        # Resolve the base branch once for both the rebase target and the agent
+        # prompt. Best-effort: default to ``main`` like ``_resolve_dirty_pr``.
+        base_branch = "main"
+        try:
+            base_result = run(
+                ["gh", "pr", "view", str(pr_number), "--json", "baseRefName"],
+                cwd=self.repo_root,
+                capture_output=True,
+            )
+            base_branch = dict(json.loads(base_result.stdout or "{}")).get("baseRefName") or "main"
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.debug(
+                "#%d: failed to determine base branch for %s; defaulting to 'main': %s",
+                issue_number,
+                pr_ref(pr_number),
+                exc,
+            )
+
+        # 1. Cheap path: mechanical rebase. A clean rebase resolves a PR that is
+        #    merely behind / non-overlapping with no agent spend.
+        with contextlib.suppress(subprocess.CalledProcessError):
+            sync_worktree_to_remote_branch(worktree_path, branch_name)
+            if rebase_worktree_onto(worktree_path, base_branch):
+                push_current_branch_with_lease_on_divergence(
+                    worktree_path,
+                    branch=branch_name,
+                    push_ref=f"HEAD:{branch_name}",
+                )
+                logger.info(
+                    "#%d: mechanically rebased %s onto %s (no agent) for conflict gate",
+                    issue_number,
+                    pr_ref(pr_number),
+                    base_branch,
+                )
+                cleared_state, cleared_mergeable = self._pr_merge_state(pr_number)
+                if cleared_state not in ("DIRTY", "CONFLICTING") and (
+                    cleared_mergeable != "CONFLICTING"
+                ):
+                    return True
+
+        # 2. Rebase still conflicts → the implementation agent resolves it. Reuse
+        #    the same conflict_context wording as ci_driver._resolve_dirty_pr.
+        if session_id is None:
+            # Without an implementer session to resume there is no agent seam in
+            # this phase to drive a code-level conflict resolution; bail so the
+            # PR is treated as not-GO rather than reviewed-while-conflicted.
+            impl._log(
+                "warning",
+                f"{issue_ref(issue_number)}: {pr_ref(pr_number)} still conflicts after rebase and "
+                "has no implementer session to resume — skipping review (not-GO)",
+                thread_id,
+            )
+            return False
+
+        conflict_context = (
+            f"This PR has a MERGE CONFLICT with `origin/{base_branch}` "
+            f"(mergeStateStatus=DIRTY) — it cannot merge until the conflict is "
+            f"resolved. Rebase the PR head branch onto `origin/{base_branch}` and "
+            f"resolve every conflict, keeping both the PR's intent and the latest "
+            f"base changes. Then commit the resolution (signed). There may be NO "
+            f"failing CI checks — the conflict itself is the blocker."
+        )
+        resolved = self._resume_impl_with_feedback(
+            session_id=session_id,
+            worktree_path=worktree_path,
+            issue_number=issue_number,
+            review_text=conflict_context,
+            prev_iteration=-1,
+            verdict="CONFLICT",
+            state=state,
+        )
+        if resolved and self.runner._commit_if_changes(issue_number, worktree_path):
+            self.runner._push_branch(branch_name, worktree_path)
+
+        final_state, final_mergeable = self._pr_merge_state(pr_number)
+        if final_state in ("DIRTY", "CONFLICTING") or final_mergeable == "CONFLICTING":
+            impl._log(
+                "warning",
+                f"{issue_ref(issue_number)}: {pr_ref(pr_number)} still has an unresolved merge "
+                "conflict after agent resolution — skipping review (not-GO)",
+                thread_id,
+            )
+            return False
+        return True
+
     def _run_impl_review_loop(
         self,
         *,
@@ -391,12 +581,38 @@ class ReviewPhase(StageMixin):
         Each iteration posts inline PR review threads and returns a verdict; on
         NOGO the implementer session is resumed to address threads. Terminates on
         GO, zero blocking threads, or :data:`MAX_REVIEW_ITERATIONS`.
+
+        #1328: before the FIRST review iteration, a PR with a merge conflict is
+        rebased / handed to the implementation agent to resolve. A conflicted PR
+        can never merge, so reviewing it would be wasted spend; if the conflict
+        cannot be resolved the loop returns early with a non-GO verdict so the PR
+        is treated as needs-action instead of being reviewed.
         """
         last_verdict: str | None = None
         last_grade: str | None = None
         prior_review: str | None = None
         iterations_run = 0
         prior_addressed_threads: list[dict[str, Any]] = []
+
+        # #1328: resolve any merge conflict BEFORE reviewing. Never review a
+        # conflicted PR — it cannot merge regardless of the verdict.
+        if pr_number is not None and not self._resolve_conflict_before_review(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            session_id=session_id,
+            slot_id=slot_id,
+            thread_id=thread_id,
+            state=state,
+        ):
+            self._finalize_review_outcome(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                last_verdict="NOGO",
+                iterations_run=0,
+            )
+            return 0, "NOGO", None
 
         for iteration in range(MAX_REVIEW_ITERATIONS):
             (

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -303,8 +303,11 @@ class CIDriver:
 
         Returns:
             One dict per open PR with keys ``number``, ``title``,
-            ``headRefName``, and ``autoMergeRequest`` (None or the auto-merge
-            metadata blob). Empty list iff the repo is clean.
+            ``headRefName``, ``autoMergeRequest`` (None or the auto-merge
+            metadata blob), and ``mergeStateStatus`` / ``mergeable`` (the
+            per-PR merge-state, fetched separately because the REST list
+            endpoint does not populate ``mergeable`` reliably — see #1328).
+            Empty list iff the repo is clean.
 
         """
         try:
@@ -356,12 +359,16 @@ class CIDriver:
                     )
                 continue  # #821: hide other-author PRs from the done-gate sweep
             labels = pr.get("labels") or []
+            number = pr.get("number")
+            merge_state, mergeable = self._pr_merge_state(number)
             normalised.append(
                 {
-                    "number": pr.get("number"),
+                    "number": number,
                     "title": pr.get("title", ""),
                     "headRefName": (pr.get("head") or {}).get("ref", ""),
                     "autoMergeRequest": pr.get("auto_merge"),
+                    "mergeStateStatus": merge_state,
+                    "mergeable": mergeable,
                     "labels": [
                         label.get("name", "") for label in labels if isinstance(label, dict)
                     ],
@@ -369,6 +376,52 @@ class CIDriver:
                 }
             )
         return normalised
+
+    def _pr_merge_state(self, pr_number: Any) -> tuple[str, str]:
+        """Return ``(mergeStateStatus, mergeable)`` for a single PR (#1328).
+
+        The REST ``/pulls`` list endpoint does NOT populate ``mergeable`` /
+        ``mergeable_state`` reliably (GitHub computes the merge-state lazily and
+        omits it from list responses), so the done-gate cannot tell a
+        permanently-CONFLICTING armed PR apart from one that is genuinely still
+        merging. A per-PR ``gh pr view`` forces GitHub to compute the merge
+        state, matching how the rest of this module queries merge-state
+        (``_attempt_mechanical_rebase`` / ``_gh_pr_state``).
+
+        Args:
+            pr_number: PR number to query.
+
+        Returns:
+            ``(mergeStateStatus, mergeable)`` upper-cased. Empty strings when the
+            number is the unknown-marker sentinel or the query fails — an unknown
+            merge-state must never be misread as CONFLICTING.
+
+        """
+        if not isinstance(pr_number, int) or pr_number < 0:
+            return "", ""
+        try:
+            result = _gh_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "mergeStateStatus,mergeable",
+                ],
+                check=False,
+            )
+            state = dict(json.loads(result.stdout or "{}"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Could not fetch PR #%s merge-state for done-gate; treating as unknown: %s",
+                pr_number,
+                exc,
+            )
+            return "", ""
+        return (
+            str(state.get("mergeStateStatus") or "").upper(),
+            str(state.get("mergeable") or "").upper(),
+        )
 
     def _arm_all_unarmed_open_prs(self, open_prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Arm auto-merge on every implementation-GO un-armed open PR (#882).
@@ -3257,10 +3310,19 @@ def _evaluate_run_result(
     own) vs ``needs_action`` (un-armed, genuinely stuck) and only fail on the
     latter (or on per-issue failures).
 
+    An armed PR is only "merging on its own" while its merge-state is benign
+    (CLEAN, or BLOCKED/UNSTABLE on in-flight CI). An armed PR whose merge-state
+    is ``DIRTY`` / ``CONFLICTING`` has a permanent merge conflict with its base
+    — it can NEVER merge while armed, so reporting it as "armed and still
+    merging" is a false-green (#1328). Such PRs are reclassified OUT of
+    ``armed_pending`` and INTO ``needs_action`` so the gate returns rc=1 and the
+    JSON status surfaces them. This mirrors ``_wait_for_armed_merge``'s terminal
+    handling, which already treats DIRTY/CONFLICTING as a stop-and-resolve case.
+
     Args:
         results: Per-issue worker results from ``CIDriver.run()``.
         open_prs_remaining: Open PRs left on the repo (each carries
-            ``number`` and ``autoMergeRequest``).
+            ``number``, ``autoMergeRequest``, and ``mergeStateStatus``).
         issues: The input issue list (echoed into JSON status).
         as_json: Whether to emit a machine-readable status line.
 
@@ -3271,8 +3333,29 @@ def _evaluate_run_result(
     """
     log = logging.getLogger(__name__)
     failed = [num for num, result in results.items() if not result.success]
-    armed_pending = [pr.get("number") for pr in open_prs_remaining if pr.get("autoMergeRequest")]
-    needs_action = [pr.get("number") for pr in open_prs_remaining if not pr.get("autoMergeRequest")]
+
+    # Terminal-state vocabulary shared with ``_wait_for_armed_merge``: a PR in
+    # one of these merge-states has a real conflict with its base and can never
+    # merge while armed — it needs manual/agent action, not more waiting.
+    conflict_states = {"DIRTY", "CONFLICTING"}
+
+    def _is_conflicting(pr: dict[str, Any]) -> bool:
+        merge_state = str(pr.get("mergeStateStatus") or "").upper()
+        mergeable = str(pr.get("mergeable") or "").upper()
+        return merge_state in conflict_states or mergeable == "CONFLICTING"
+
+    # Armed AND merge-state benign → genuinely merging on its own (rc=0). Armed
+    # but CONFLICTING → false-green; demote to needs_action below.
+    armed_pending = [
+        pr.get("number")
+        for pr in open_prs_remaining
+        if pr.get("autoMergeRequest") and not _is_conflicting(pr)
+    ]
+    needs_action = [
+        pr.get("number")
+        for pr in open_prs_remaining
+        if not pr.get("autoMergeRequest") or _is_conflicting(pr)
+    ]
     if armed_pending:
         log.warning(
             "%s PR(s) armed and still merging (waited; not a failure): %s",

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -527,6 +527,8 @@ class TestOpenPrsRemaining:
         with (
             patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
             patch("hephaestus.automation.ci_driver._gh_call", return_value=result_mock),
+            # #1328: merge-state is fetched per-PR via a separate gh pr view.
+            patch.object(driver, "_pr_merge_state", side_effect=[("CLEAN", "MERGEABLE"), ("", "")]),
         ):
             remaining = driver._list_open_prs_remaining()
         assert remaining == [
@@ -535,6 +537,8 @@ class TestOpenPrsRemaining:
                 "title": "first",
                 "headRefName": "branch-1",
                 "autoMergeRequest": {"enabled_by": {"login": "bot"}},
+                "mergeStateStatus": "CLEAN",
+                "mergeable": "MERGEABLE",
                 "isBot": False,
                 "labels": ["state:implementation-go"],
             },
@@ -543,10 +547,38 @@ class TestOpenPrsRemaining:
                 "title": "second",
                 "headRefName": "branch-2",
                 "autoMergeRequest": None,
+                "mergeStateStatus": "",
+                "mergeable": "",
                 "isBot": True,
                 "labels": [],
             },
         ]
+
+    def test_pr_merge_state_returns_upper_cased_pair(self, driver: CIDriver) -> None:
+        """#1328: ``_pr_merge_state`` forces a per-PR merge-state computation."""
+        result_mock = MagicMock(
+            stdout=json.dumps({"mergeStateStatus": "dirty", "mergeable": "conflicting"})
+        )
+        with patch("hephaestus.automation.ci_driver._gh_call", return_value=result_mock) as mock_gh:
+            merge_state, mergeable = driver._pr_merge_state(42)
+        assert (merge_state, mergeable) == ("DIRTY", "CONFLICTING")
+        cmd = mock_gh.call_args[0][0]
+        assert cmd[:3] == ["pr", "view", "42"]
+        assert "mergeStateStatus,mergeable" in cmd
+
+    def test_pr_merge_state_unknown_marker_skips_query(self, driver: CIDriver) -> None:
+        """#1328: the -1 unknown sentinel must not trigger a gh call."""
+        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh:
+            assert driver._pr_merge_state(-1) == ("", "")
+        mock_gh.assert_not_called()
+
+    def test_pr_merge_state_gh_failure_returns_unknown(self, driver: CIDriver) -> None:
+        """#1328: a failed merge-state query degrades to unknown, never CONFLICTING."""
+        with patch(
+            "hephaestus.automation.ci_driver._gh_call",
+            side_effect=subprocess.CalledProcessError(1, "gh"),
+        ):
+            assert driver._pr_merge_state(7) == ("", "")
 
     def test_gh_failure_returns_unknown_marker(self, driver: CIDriver) -> None:
         """If gh fails we treat the state as unknown — repo is NOT done."""
@@ -2811,6 +2843,63 @@ class TestEvaluateRunResult:
     def test_failed_issue_is_one(self) -> None:
         results = {1: WorkerResult(issue_number=1, success=False, pr_number=10)}
         assert _evaluate_run_result(results, [], issues=[1], as_json=False) == 1
+
+    def test_armed_but_conflicting_is_needs_action(self) -> None:
+        # #1328: an armed PR with a permanent merge conflict can NEVER merge
+        # while armed; reporting it as "armed and still merging" is a
+        # false-green. It must be reclassified into needs_action → rc=1.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining = [
+            {
+                "number": 10,
+                "autoMergeRequest": {"enabledAt": "now"},
+                "mergeStateStatus": "CONFLICTING",
+                "mergeable": "CONFLICTING",
+            }
+        ]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 1
+
+    def test_armed_but_dirty_is_needs_action(self) -> None:
+        # #1328: DIRTY is the gh-CLI spelling of the same conflict state.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining = [
+            {
+                "number": 10,
+                "autoMergeRequest": {"enabledAt": "now"},
+                "mergeStateStatus": "DIRTY",
+                "mergeable": "",
+            }
+        ]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 1
+
+    def test_armed_and_clean_stays_armed_pending(self) -> None:
+        # #1328: a genuinely-merging armed PR (CLEAN merge-state) must stay in
+        # armed_pending and keep rc=0 — the conflict reclassification must not
+        # red-flag healthy PRs.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining = [
+            {
+                "number": 10,
+                "autoMergeRequest": {"enabledAt": "now"},
+                "mergeStateStatus": "CLEAN",
+                "mergeable": "MERGEABLE",
+            }
+        ]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
+
+    def test_armed_and_blocked_on_ci_stays_armed_pending(self) -> None:
+        # #1328: BLOCKED (branch-protection / in-flight CI) is NOT a conflict —
+        # such PRs are still merging on their own and stay armed_pending (rc=0).
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining = [
+            {
+                "number": 10,
+                "autoMergeRequest": {"enabledAt": "now"},
+                "mergeStateStatus": "BLOCKED",
+                "mergeable": "MERGEABLE",
+            }
+        ]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
 
 
 class TestRunDriveGreenCompact:

--- a/tests/unit/automation/test_ci_driver_author_scope.py
+++ b/tests/unit/automation/test_ci_driver_author_scope.py
@@ -121,6 +121,7 @@ class TestDefaultScopedDiscovery:
                 "hephaestus.automation.ci_driver._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
+            patch.object(viewer_driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
         ):
             remaining = viewer_driver._list_open_prs_remaining()
         assert [pr["number"] for pr in remaining] == [100]
@@ -148,6 +149,7 @@ class TestAllFlagScopedDiscovery:
                 "hephaestus.automation.ci_driver._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
+            patch.object(driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
         ):
             remaining = driver._list_open_prs_remaining()
         assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]
@@ -251,6 +253,7 @@ class TestAllFlagSkipsViewerResolution:
                 "hephaestus.automation.ci_driver._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
+            patch.object(driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
         ):
             remaining = driver._list_open_prs_remaining()
         assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]
@@ -308,6 +311,7 @@ class TestMissingUserLogin:
                 "hephaestus.automation.ci_driver._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_PULLS)),
             ),
+            patch.object(driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
             caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
         ):
             result = driver._list_open_prs_remaining()

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -314,3 +314,206 @@ def test_review_phase_commit_if_changes_clean_returns_false(tmp_path: Path) -> N
     ):
         assert phase._commit_if_changes(7, tmp_path) is False
     mock_commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #1328: pre-review conflict gate
+# ---------------------------------------------------------------------------
+
+
+def _gh_json(payload: dict[str, Any]) -> SimpleNamespace:
+    """Stub a ``run(..., capture_output=True)`` result carrying JSON stdout."""
+    return SimpleNamespace(stdout=json.dumps(payload), stderr="")
+
+
+def test_conflict_gate_clean_pr_proceeds_without_resolution(tmp_path: Path) -> None:
+    """#1328: a non-conflicting PR returns True with no rebase/agent spend."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    with (
+        mock.patch.object(
+            phase, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")
+        ) as merge_state,
+        mock.patch("hephaestus.automation._review_phase.rebase_worktree_onto") as rebase,
+        mock.patch.object(phase, "_resume_impl_with_feedback") as resume,
+    ):
+        result = phase._resolve_conflict_before_review(
+            issue_number=7,
+            pr_number=12,
+            worktree_path=tmp_path,
+            branch_name="b",
+            session_id="sess",
+            slot_id=None,
+            thread_id=None,
+            state=None,
+        )
+    assert result is True
+    merge_state.assert_called_once()
+    rebase.assert_not_called()
+    resume.assert_not_called()
+
+
+def test_conflict_gate_mechanical_rebase_clears_conflict(tmp_path: Path) -> None:
+    """#1328: a clean mechanical rebase clears the conflict without the agent."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    with (
+        mock.patch.object(
+            phase,
+            "_pr_merge_state",
+            side_effect=[("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")],
+        ),
+        mock.patch(
+            "hephaestus.automation._review_phase.run",
+            return_value=_gh_json({"baseRefName": "main"}),
+        ),
+        mock.patch("hephaestus.automation._review_phase.sync_worktree_to_remote_branch"),
+        mock.patch(
+            "hephaestus.automation._review_phase.rebase_worktree_onto", return_value=True
+        ) as rebase,
+        mock.patch(
+            "hephaestus.automation._review_phase.push_current_branch_with_lease_on_divergence"
+        ) as push,
+        mock.patch.object(phase, "_resume_impl_with_feedback") as resume,
+    ):
+        result = phase._resolve_conflict_before_review(
+            issue_number=7,
+            pr_number=12,
+            worktree_path=tmp_path,
+            branch_name="b",
+            session_id="sess",
+            slot_id=None,
+            thread_id=None,
+            state=None,
+        )
+    assert result is True
+    rebase.assert_called_once()
+    push.assert_called_once()
+    resume.assert_not_called()  # agent never needed — rebase cleared it
+
+
+def test_conflict_gate_dispatches_agent_when_rebase_conflicts(tmp_path: Path) -> None:
+    """#1328: a still-conflicting rebase hands off to the implementation agent."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    runner = cast(Any, phase.ctx.runner)
+    runner._commit_if_changes = mock.Mock(return_value=True)
+    runner._push_branch = mock.Mock()
+    with (
+        mock.patch.object(
+            phase,
+            "_pr_merge_state",
+            # initial=DIRTY → rebase fails → agent resolves → final=CLEAN
+            side_effect=[("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")],
+        ),
+        mock.patch(
+            "hephaestus.automation._review_phase.run",
+            return_value=_gh_json({"baseRefName": "main"}),
+        ),
+        mock.patch("hephaestus.automation._review_phase.sync_worktree_to_remote_branch"),
+        mock.patch("hephaestus.automation._review_phase.rebase_worktree_onto", return_value=False),
+        mock.patch.object(phase, "_resume_impl_with_feedback", return_value=True) as resume,
+    ):
+        result = phase._resolve_conflict_before_review(
+            issue_number=7,
+            pr_number=12,
+            worktree_path=tmp_path,
+            branch_name="b",
+            session_id="sess",
+            slot_id=None,
+            thread_id=None,
+            state=None,
+        )
+    assert result is True
+    resume.assert_called_once()
+    runner._commit_if_changes.assert_called_once()
+    runner._push_branch.assert_called_once()
+
+
+def test_conflict_gate_unresolved_returns_false(tmp_path: Path) -> None:
+    """#1328: an unresolved conflict after the agent returns False (not-GO)."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    runner = cast(Any, phase.ctx.runner)
+    runner._commit_if_changes = mock.Mock(return_value=True)
+    runner._push_branch = mock.Mock()
+    with (
+        mock.patch.object(
+            phase,
+            "_pr_merge_state",
+            side_effect=[("DIRTY", "CONFLICTING"), ("DIRTY", "CONFLICTING")],
+        ),
+        mock.patch(
+            "hephaestus.automation._review_phase.run",
+            return_value=_gh_json({"baseRefName": "main"}),
+        ),
+        mock.patch("hephaestus.automation._review_phase.sync_worktree_to_remote_branch"),
+        mock.patch("hephaestus.automation._review_phase.rebase_worktree_onto", return_value=False),
+        mock.patch.object(phase, "_resume_impl_with_feedback", return_value=True),
+    ):
+        result = phase._resolve_conflict_before_review(
+            issue_number=7,
+            pr_number=12,
+            worktree_path=tmp_path,
+            branch_name="b",
+            session_id="sess",
+            slot_id=None,
+            thread_id=None,
+            state=None,
+        )
+    assert result is False
+
+
+def test_review_loop_resolves_conflict_before_first_review(tmp_path: Path) -> None:
+    """#1328: the conflict gate runs BEFORE the first review iteration."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    call_order: list[str] = []
+
+    def _gate(**_kwargs: Any) -> bool:
+        call_order.append("gate")
+        return True
+
+    def _iter(**_kwargs: Any) -> tuple[Any, ...]:
+        call_order.append("review")
+        # verdict, grade, review_text, posted_thread_ids, go_blocked, reopened, should_break
+        return "GO", "A", "ok", [], False, [], True
+
+    with (
+        mock.patch.object(phase, "_resolve_conflict_before_review", side_effect=_gate) as gate,
+        mock.patch.object(phase, "_process_review_iteration", side_effect=_iter),
+        mock.patch.object(phase, "_finalize_review_outcome"),
+    ):
+        phase._run_impl_review_loop(
+            issue_number=7,
+            worktree_path=tmp_path,
+            branch_name="b",
+            issue_title="t",
+            issue_body="body",
+            session_id="sess",
+            slot_id=None,
+            thread_id=None,
+            pr_number=12,
+        )
+    gate.assert_called_once()
+    assert call_order[0] == "gate"
+    assert "review" in call_order
+
+
+def test_review_loop_skips_reviewer_when_conflict_unresolved(tmp_path: Path) -> None:
+    """#1328: an unresolved conflict skips the reviewer entirely (not-GO)."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    with (
+        mock.patch.object(phase, "_resolve_conflict_before_review", return_value=False),
+        mock.patch.object(phase, "_process_review_iteration") as review,
+        mock.patch.object(phase, "_finalize_review_outcome") as finalize,
+    ):
+        iterations, verdict, grade = phase._run_impl_review_loop(
+            issue_number=7,
+            worktree_path=tmp_path,
+            branch_name="b",
+            issue_title="t",
+            issue_body="body",
+            session_id="sess",
+            slot_id=None,
+            thread_id=None,
+            pr_number=12,
+        )
+    review.assert_not_called()  # reviewer never runs on a conflicted PR
+    assert (iterations, verdict, grade) == (0, "NOGO", None)
+    finalize.assert_called_once()


### PR DESCRIPTION
## Summary

RC2 fixes two related bugs (#1328) that let a permanently-conflicting armed PR be reported as healthy and let the impl review loop waste spend reviewing a PR that can never merge.

### Part A — pre-review conflict gate (`_review_phase.py`)
- `_run_impl_review_loop` now resolves any merge conflict **before** the first review iteration via a new `_resolve_conflict_before_review`: it queries `mergeStateStatus`/`mergeable`, attempts a mechanical rebase, and on a still-conflicting PR dispatches the **implementation agent** with the same `conflict_context` wording `ci_driver._resolve_dirty_pr` uses. The reviewer never runs on a conflicted PR; if the conflict cannot be resolved the loop returns a non-GO verdict so the PR is treated as needs-action.
- **Seam:** `ReviewPhase` runs under `IssueImplementer`, a different object than `CIDriver`, so `_resolve_dirty_pr` (which is wired into CIDriver's worktree/recheck machinery) cannot be called directly. Rather than a large, risky refactor extracting that helper, the gate reuses the **same underlying primitives** — `rebase_worktree_onto` / `sync_worktree_to_remote_branch` / `push_current_branch_with_lease_on_divergence` from `git_utils`, and the implementer-session resume in `_resume_impl_with_feedback` — the smallest change that reuses existing conflict-resolution machinery.

### Part B — done-gate accuracy (`ci_driver.py`)
- `_list_open_prs_remaining` now enriches each remaining PR with `mergeStateStatus`/`mergeable` via a per-PR `gh pr view` (the REST list endpoint omits `mergeable`).
- `_evaluate_run_result` reclassifies armed-but-`DIRTY`/`CONFLICTING` PRs **out** of `armed_pending` and **into** `needs_action` (rc=1), matching the terminal-state vocabulary in `_wait_for_armed_merge`. Genuinely-merging armed PRs (`CLEAN`/`BLOCKED`-on-CI) stay in `armed_pending` (rc=0).

## Tests
- Done-gate: armed+`CONFLICTING`/`DIRTY` → `needs_action` (rc=1); armed+`CLEAN` and armed+`BLOCKED` → `armed_pending` (rc=0); `_pr_merge_state` query shape + unknown-marker/failure degradation.
- Conflict gate: clean PR proceeds without spend; mechanical rebase clears conflict; agent dispatch on rebase conflict; unresolved → False; gate runs **before** the first review iteration; reviewer skipped when conflict unresolved.
- All gh/git calls mocked — no network.

## Verification
- `ruff format` + `ruff check`, `mypy` on both modules, and the full `test_ci_driver.py` + `test_stage_phases.py` suites (190 passed) all green. `pre-commit run` clean with no hook-modified files.

Closes #1328

🤖 Generated with [Claude Code](https://claude.com/claude-code)