### PR TITLE
fix(automation): converge review loop on documented by-design re-opens (#1329)

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -168,19 +168,26 @@ class ReviewPhase(StageMixin):
         prior_threads: list[dict[str, Any]],
         iteration: int,
         thread_id: int | None,
-    ) -> list[str]:
+        prior_reopened_keys: set[str],
+    ) -> tuple[list[str], bool, set[str]]:
         """Re-open prior review comments the current diff does not address.
 
         Runs the read-only validation sub-agent
         (:func:`review_validator.validate_prior_comments_addressed`) against the
-        previous iteration's threads. Returns the IDs of any threads it
-        re-opened (empty when there is no PR, no prior threads, on the first
-        iteration, in dry-run, or when everything was addressed).
+        previous iteration's threads.
+
+        Returns ``(reopened_ids, is_clean, reopened_keys)``: the IDs of any
+        inline threads it re-opened (empty when there is no PR, no prior threads,
+        on the first iteration, in dry-run, or when everything was addressed);
+        ``is_clean`` False when at least one finding was re-opened (including
+        PR-level findings that produce no inline thread id, #1329); and the
+        cumulative set of stable re-open keys to thread forward (#1329) so a
+        documented by-design recurrence is accepted once and never re-added.
         """
         if pr_number is None or not prior_threads or self.options.dry_run:
-            return []
+            return [], True, prior_reopened_keys
         diff_text = self.impl._collect_diff(worktree_path, branch_name)
-        reopened, is_clean = validate_prior_comments_addressed(
+        reopened, is_clean, reopened_keys = validate_prior_comments_addressed(
             pr_number=pr_number,
             issue_number=issue_number,
             worktree_path=worktree_path,
@@ -190,6 +197,7 @@ class ReviewPhase(StageMixin):
             iteration=iteration,
             state_dir=self.state_dir,
             dry_run=False,
+            prior_reopened_keys=prior_reopened_keys,
         )
         if not is_clean:
             self.impl._log(
@@ -198,7 +206,7 @@ class ReviewPhase(StageMixin):
                 f"{len(reopened)} prior review comment(s) the diff did not address",
                 thread_id,
             )
-        return reopened
+        return reopened, is_clean, reopened_keys
 
     # ------------------------------------------------------------------
     # Strict review loop
@@ -294,8 +302,9 @@ class ReviewPhase(StageMixin):
         iteration: int,
         prior_review: str | None,
         prior_addressed_threads: list[dict[str, Any]],
+        prior_reopened_keys: set[str],
         advise_findings: str,
-    ) -> tuple[list[str], str, list[str], Any]:
+    ) -> tuple[list[str], str, list[str], Any, bool, set[str]]:
         """Validate prior threads, run one review, and parse the verdict.
 
         Step 1 (#1152): before the fresh review, verify (via the read-only
@@ -314,8 +323,11 @@ class ReviewPhase(StageMixin):
         there would wrongly validate not-yet-addressed comments against an empty
         diff.
 
-        Returns ``(reopened, review_text, posted_thread_ids, verdict)`` for the
-        caller to drive convergence on.
+        Returns ``(reopened, review_text, posted_thread_ids, verdict,
+        validator_clean, reopened_keys)`` for the caller to drive convergence
+        on. ``validator_clean`` is False whenever the validator re-opened a
+        finding (inline OR PR-level), and ``reopened_keys`` threads the
+        recurrence state forward across rounds (#1329).
         """
         impl = self.impl
         threads_to_validate = prior_addressed_threads
@@ -327,7 +339,7 @@ class ReviewPhase(StageMixin):
         ):
             with contextlib.suppress(Exception):
                 threads_to_validate = gh_pr_list_unresolved_threads(pr_number, dry_run=False)
-        reopened = self.runner._validate_prior_threads(
+        reopened, validator_clean, reopened_keys = self.runner._validate_prior_threads(
             issue_number=issue_number,
             pr_number=pr_number,
             branch_name=branch_name,
@@ -335,6 +347,7 @@ class ReviewPhase(StageMixin):
             prior_threads=threads_to_validate,
             iteration=iteration,
             thread_id=thread_id,
+            prior_reopened_keys=prior_reopened_keys,
         )
 
         # Review step: a fresh reviewer session posts inline PR threads and
@@ -369,7 +382,7 @@ class ReviewPhase(StageMixin):
         # already-completed iterations.  Persist BEFORE the caller may break out
         # so the final iteration's data is always on disk.
         impl._save_review_iteration_state(issue_number, iteration + 1, review_text)
-        return reopened, review_text, posted_thread_ids, verdict
+        return reopened, review_text, posted_thread_ids, verdict, validator_clean, reopened_keys
 
     def _run_impl_review_loop(
         self,
@@ -397,6 +410,10 @@ class ReviewPhase(StageMixin):
         prior_review: str | None = None
         iterations_run = 0
         prior_addressed_threads: list[dict[str, Any]] = []
+        # #1329: stable keys of findings the validator re-opened, carried across
+        # rounds so a re-open recurring on an already-documented design decision
+        # is accepted once and never re-added (converging the loop toward GO).
+        prior_reopened_keys: set[str] = set()
 
         for iteration in range(MAX_REVIEW_ITERATIONS):
             (
@@ -407,6 +424,8 @@ class ReviewPhase(StageMixin):
                 go_blocked_by_automation,
                 reopened,
                 should_break,
+                prior_reopened_keys,
+                validator_clean,
             ) = self._process_review_iteration(
                 issue_number=issue_number,
                 issue_title=issue_title,
@@ -420,16 +439,23 @@ class ReviewPhase(StageMixin):
                 iteration=iteration,
                 prior_review=prior_review,
                 prior_addressed_threads=prior_addressed_threads,
+                prior_reopened_keys=prior_reopened_keys,
                 advise_findings=advise_findings,
             )
             iterations_run = iteration + 1
             if should_break:
                 break
+            # An unclean validator pass (#1329) — including a PR-level-only
+            # re-open that posts no inline thread id — means a prior comment is
+            # still unaddressed and must run the address step. This is distinct
+            # from a zero-thread REVIEWER non-GO (validator clean), which must
+            # simply re-review (the loop's zero-thread convergence contract).
             if (
                 pr_number is not None
                 and not posted_thread_ids
                 and not reopened
                 and not go_blocked_by_automation
+                and validator_clean
             ):
                 prior_review = review_text
                 continue
@@ -477,8 +503,9 @@ class ReviewPhase(StageMixin):
         iteration: int,
         prior_review: str | None,
         prior_addressed_threads: list[dict[str, Any]],
+        prior_reopened_keys: set[str],
         advise_findings: str,
-    ) -> tuple[str | None, str | None, str, list[str], bool, list[str], bool]:
+    ) -> tuple[str | None, str | None, str, list[str], bool, list[str], bool, set[str], bool]:
         """Run one review+verdict iteration.
 
         Args:
@@ -494,14 +521,24 @@ class ReviewPhase(StageMixin):
             iteration: Zero-based iteration index.
             prior_review: Previous review text for context.
             prior_addressed_threads: Threads addressed in previous iteration.
+            prior_reopened_keys: Stable keys re-opened in earlier rounds, threaded
+                forward so a documented by-design recurrence is accepted (#1329).
             advise_findings: Prior learnings from the advise step.
 
         Returns:
             Tuple of (last_verdict, last_grade, review_text, posted_thread_ids,
-                      go_blocked_by_automation, reopened, should_break).
+                      go_blocked_by_automation, reopened, should_break,
+                      reopened_keys, validator_clean).
 
         """
-        reopened, review_text, posted_thread_ids, verdict = self._validate_and_review(
+        (
+            reopened,
+            review_text,
+            posted_thread_ids,
+            verdict,
+            validator_clean,
+            reopened_keys,
+        ) = self._validate_and_review(
             issue_number=issue_number,
             issue_title=issue_title,
             issue_body=issue_body,
@@ -514,6 +551,7 @@ class ReviewPhase(StageMixin):
             iteration=iteration,
             prior_review=prior_review,
             prior_addressed_threads=prior_addressed_threads,
+            prior_reopened_keys=prior_reopened_keys,
             advise_findings=advise_findings,
         )
         last_verdict = verdict.verdict
@@ -521,7 +559,10 @@ class ReviewPhase(StageMixin):
 
         go_blocked_by_automation = False
         should_break = False
-        if reopened:
+        # A validator re-open (inline thread id present) OR an unclean pass with
+        # only PR-level findings (#1329, no thread id) both mean prior comments
+        # are unaddressed → force NOGO so the address step runs.
+        if reopened or not validator_clean:
             last_verdict = "NOGO"
         elif verdict.is_go:
             last_verdict, go_blocked_by_automation, should_break = self._evaluate_go_verdict(
@@ -538,6 +579,8 @@ class ReviewPhase(StageMixin):
             go_blocked_by_automation,
             reopened,
             should_break,
+            reopened_keys,
+            validator_clean,
         )
 
     def _run_address_step_if_needed(
@@ -1259,7 +1302,12 @@ class ReviewPhase(StageMixin):
             logger.warning("diff collection failed for %s: %s", branch_name, e)
             return ""
 
-        max_chars = 200_000
+        # #1329: a 200k cap routinely truncated the diff the validator inspects,
+        # so it could not SEE the fix/documentation at a later hunk and re-opened
+        # comments it judged "unaddressed" — an unwinnable loop. Raise the cap an
+        # order of magnitude so the whole diff is normally fed; only a genuinely
+        # huge diff is still bounded (to protect the model context window).
+        max_chars = 2_000_000
         if len(diff) > max_chars:
             diff = diff[:max_chars] + f"\n\n[... diff truncated at {max_chars} chars ...]\n"
         return diff

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1281,7 +1281,8 @@ class ImplementationPhaseRunner:
         prior_threads: list[dict[str, Any]],
         iteration: int,
         thread_id: int | None,
-    ) -> list[str]:
+        prior_reopened_keys: set[str] | None = None,
+    ) -> tuple[list[str], bool, set[str]]:
         """Delegate to :meth:`ReviewPhase._validate_prior_threads`."""
         return self.review_phase._validate_prior_threads(
             issue_number=issue_number,
@@ -1291,6 +1292,7 @@ class ImplementationPhaseRunner:
             prior_threads=prior_threads,
             iteration=iteration,
             thread_id=thread_id,
+            prior_reopened_keys=prior_reopened_keys or set(),
         )
 
     def _count_unresolved_threads_blocking_go(

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -47,6 +48,103 @@ from .protocol import WONT_FIX_MARKER
 from .session_naming import AGENT_PR_REVIEWER, reviewer_agent
 
 logger = logging.getLogger(__name__)
+
+# Number of source lines on EACH side of a comment's line to scan for a
+# documenting comment/docstring when deciding whether a recurring re-open is
+# an accepted by-design decision (#1329). Kept small and local so the heuristic
+# only honours documentation that sits AT the cited code, not a stray comment
+# elsewhere in the file.
+_SOURCE_DOC_WINDOW = 6
+
+# Phrases that, when present in a code comment/docstring near the cited line,
+# signal the reviewer's suggestion was intentionally NOT taken (#1329). The
+# match is case-insensitive and deliberately conservative — a recurring re-open
+# is suppressed only when the SOURCE itself documents the design decision.
+_BY_DESIGN_PHRASES = (
+    "by design",
+    "intentional",
+    "intentionally",
+    "on purpose",
+    "deliberate",
+    "deliberately",
+    "wont-fix",
+    "won't fix",
+    "wont fix",
+    "do not change",
+    "do not remove",
+    "keep this",
+    "noqa",
+    "nosec",
+    "type: ignore",
+)
+
+
+def _thread_key(*, path: Any, line: Any, body: Any) -> str:
+    """Build a stable cross-round identity for a prior review thread (#1329).
+
+    Keying on ``path:line`` plus a normalized body lets the loop recognize when
+    the SAME finding is being re-opened round after round (the GraphQL
+    ``thread_id`` changes every time the validator posts a fresh re-open thread,
+    so it cannot identify recurrence on its own). Whitespace is collapsed and
+    the body lower-cased so cosmetic differences between a reviewer's original
+    text and the validator's echo do not defeat the match.
+
+    Args:
+        path: File path the comment targets (may be empty for PR-level).
+        line: Line number (int or None).
+        body: The comment / original_body text.
+
+    Returns:
+        A normalized ``"path:line:body"`` key string.
+
+    """
+    norm_body = re.sub(r"\s+", " ", str(body or "")).strip().lower()
+    line_part = "" if line is None else str(line)
+    return f"{path or ''!s}:{line_part}:{norm_body}"
+
+
+def _source_documents_decision(worktree_path: Path, path: str, line: Any) -> bool:
+    """Return True when the source at *path*:*line* documents a by-design choice.
+
+    The "documented in source" heuristic for #1329: when a recurring re-open
+    keeps flagging the same spot, read the current source in the worktree around
+    the cited line and look for a code comment / docstring that justifies why
+    the reviewer's suggestion was intentionally not taken. If such a marker sits
+    within :data:`_SOURCE_DOC_WINDOW` lines of the cited line, the decision is
+    treated as accepted-by-design and the comment is NOT re-added.
+
+    Deliberately simple and conservative: only an explicit by-design phrase
+    (see :data:`_BY_DESIGN_PHRASES`) counts, and only when it sits next to the
+    cited code — a generic comment elsewhere in the file does not qualify. Any
+    read error (missing file, bad path, non-int line) returns False so a genuine
+    unaddressed finding is never silently suppressed.
+
+    Args:
+        worktree_path: Worktree root the cited path is relative to.
+        path: File path the comment targets.
+        line: 1-based line number the comment pointed at.
+
+    Returns:
+        True when a by-design marker is found at/near the cited line.
+
+    """
+    if not path or not isinstance(line, int) or line < 1:
+        return False
+    try:
+        # Guard against path traversal / absolute paths escaping the worktree.
+        source = (worktree_path / path).resolve()
+        if not source.is_relative_to(worktree_path.resolve()):
+            return False
+        text = source.read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return False
+    lines = text.splitlines()
+    if not lines:
+        return False
+    lo = max(0, line - 1 - _SOURCE_DOC_WINDOW)
+    hi = min(len(lines), line + _SOURCE_DOC_WINDOW)
+    window = "\n".join(lines[lo:hi]).lower()
+    return any(phrase in window for phrase in _BY_DESIGN_PHRASES)
 
 
 def _run_validation_session(
@@ -138,7 +236,8 @@ def validate_prior_comments_addressed(
     iteration: int,
     state_dir: Path,
     dry_run: bool = False,
-) -> tuple[list[str], bool]:
+    prior_reopened_keys: set[str] | None = None,
+) -> tuple[list[str], bool, set[str]]:
     """Re-open prior review comments the current diff does not address.
 
     Runs a fresh read-only sub-agent that compares each ``prior_threads`` comment
@@ -146,6 +245,15 @@ def validate_prior_comments_addressed(
     inline review thread on the same path/line citing the original comment, then
     reports the validation as not-clean so the caller drives another address
     iteration.
+
+    Convergence (#1329): an unaddressed finding that was ALREADY re-opened in a
+    prior round (same :func:`_thread_key`) is treated as RECURRING. A recurring
+    finding is accepted-by-design and NOT re-added when either (a) the validator
+    marked it won't-fix, or (b) the current source at its ``path``:``line``
+    documents the design decision (:func:`_source_documents_decision`). Only a
+    genuinely unaddressed AND undocumented finding still re-opens — converting
+    the formerly unwinnable re-open loop into convergence so the review loop can
+    reach GO.
 
     Args:
         pr_number: GitHub PR number.
@@ -158,20 +266,27 @@ def validate_prior_comments_addressed(
         iteration: Zero-based review-loop iteration (selects a fresh token).
         state_dir: Directory for the validation log file.
         dry_run: When True, skip the agent call and posting.
+        prior_reopened_keys: Stable keys (:func:`_thread_key`) of findings the
+            validator re-opened in EARLIER rounds, threaded forward by the loop
+            so recurrence can be detected. ``None`` on the first round.
 
     Returns:
-        ``(reopened_thread_ids, is_clean)``. ``is_clean`` is True when nothing
-        was re-opened (every prior comment is addressed, or there was nothing to
-        validate); False when at least one comment was re-opened. As a side
+        ``(reopened_thread_ids, is_clean, reopened_keys)``. ``is_clean`` is True
+        when nothing was re-opened (every prior comment is addressed, dismissed
+        as documented-by-design, or there was nothing to validate); False when
+        at least one comment was re-opened. ``reopened_keys`` is the set of
+        stable keys re-opened across this and all prior rounds — the caller
+        passes it back in as ``prior_reopened_keys`` next round. As a side
         effect, every prior thread the validator confirms addressed is resolved
         in place (#1083).
 
     """
+    seen_keys: set[str] = set(prior_reopened_keys or set())
     if not prior_threads:
-        return [], True
+        return [], True, seen_keys
     if dry_run:
         logger.info("[DRY RUN] Would validate prior comments on PR #%s", pr_number)
-        return [], True
+        return [], True, seen_keys
 
     prior_comments_json = json.dumps(
         [
@@ -222,48 +337,96 @@ def validate_prior_comments_addressed(
     _resolve_addressed_prior_threads(prior_threads, unaddressed_ids | wont_fix_ids)
 
     if not unaddressed:
-        return [], True
+        return [], True, seen_keys
 
     comments: list[dict[str, Any]] = []
+    pathless: list[dict[str, Any]] = []
+    new_keys: set[str] = set()
     for item in unaddressed:
         path = item.get("path") or ""
-        if not path:
-            # Inline threads require a path; skip PR-level re-opens (the reviewer
-            # will resurface those on its next pass).
-            continue
+        line = item.get("line")
         original = (item.get("original_body") or "").strip()
+        # Stable cross-round identity (#1329): a finding re-opened last round
+        # carries the SAME key even though its GraphQL thread_id was renewed.
+        key = _thread_key(path=path, line=line, body=original or item.get("detail"))
+        recurring = key in seen_keys
+
+        if recurring and _source_documents_decision(worktree_path, path, line):
+            # The same finding was re-opened before AND the current source at
+            # that location documents why the reviewer's suggestion was
+            # intentionally not taken — accept the design decision and stop
+            # re-adding it, so a documented by-design choice no longer makes the
+            # loop unwinnable (#1329). The key stays in ``seen_keys`` (carried
+            # forward) so any later round keeps recognising it as
+            # recurring-and-documented and keeps suppressing it.
+            logger.info(
+                "PR %s R%s: recurring finding at %s:%s is documented as by-design "
+                "in source — not re-adding (accepted design decision)",
+                pr_ref(pr_number),
+                iteration,
+                path or "(PR-level)",
+                line if isinstance(line, int) else "?",
+            )
+            continue
+
         detail = (item.get("detail") or "").strip() or "prior review comment not addressed"
-        body = f"Re-opening: prior review comment not addressed — {detail}"
+        prefix = (
+            "Still unaddressed (recurring; not documented as by-design)"
+            if recurring
+            else "prior review comment not addressed"
+        )
+        body = f"Re-opening: {prefix} — {detail}"
         if original:
             quoted = "\n".join(f"> {ln}" for ln in original.splitlines())
             body = f"{body}\n\n{quoted}"
+
+        new_keys.add(key)
+        if not path:
+            # PR-level (pathless) findings cannot be inline threads. Rather than
+            # silently dropping them (#1329), surface them at PR level in the
+            # review summary so the loop still treats the pass as not-clean and
+            # the finding stays visible.
+            pathless.append({"body": body})
+            continue
+
         comment: dict[str, Any] = {"path": path, "body": body, "side": "RIGHT"}
-        line = item.get("line")
         if isinstance(line, int):
             comment["line"] = line
         comments.append(comment)
 
-    if not comments:
-        return [], True
+    if not comments and not pathless:
+        # Everything unaddressed was a documented-by-design recurrence → clean.
+        return [], True, seen_keys
+
+    summary_parts = []
+    if comments:
+        summary_parts.append(
+            f"Re-opening {len(comments)} prior review comment(s) the current diff does not address."
+        )
+    if pathless:
+        # Append the PR-level findings to the summary so they are not lost.
+        bullets = "\n".join(f"- {p['body']}" for p in pathless)
+        summary_parts.append(
+            f"{len(pathless)} unaddressed PR-level review comment(s) remain:\n{bullets}"
+        )
 
     thread_ids = gh_pr_review_post(
         pr_number=pr_number,
         comments=comments,
-        summary=(
-            f"Re-opening {len(comments)} prior review comment(s) the current diff does not address."
-        ),
+        summary="\n\n".join(summary_parts),
         dry_run=False,
         # #1083: if the line already carries a bot comment, edit it in place
         # rather than stacking a duplicate re-open thread.
         dedupe_existing=True,
     )
     logger.info(
-        "PR %s R%s: re-opened %s unaddressed review comment(s)",
+        "PR %s R%s: re-opened %s inline + %s PR-level unaddressed review comment(s)",
         pr_ref(pr_number),
         iteration,
         len(thread_ids),
+        len(pathless),
     )
-    return thread_ids, False
+    return thread_ids, False, seen_keys | new_keys
 
 
 def _dismiss_wont_fix_prior_threads(

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -98,7 +98,7 @@ class TestRunImplReviewLoop:
             ),
             patch(
                 "hephaestus.automation._review_phase.validate_prior_comments_addressed",
-                return_value=([], True),
+                return_value=([], True, set()),
             ),
             patch(
                 "hephaestus.automation._review_phase.gh_issue_add_labels",
@@ -725,6 +725,58 @@ class TestRunImplReviewLoop:
         mock_addr.assert_not_called()
         assert mock_rev.call_count == 3
 
+    def test_documented_by_design_recurrence_converges_to_go(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """#1329: once the validator accepts a documented by-design finding, GO stands.
+
+        R0 the validator re-opens a finding (NO-GO → address). R1 the validator
+        accepts it as documented-by-design (clean, nothing re-opened) and the
+        reviewer says GO with a clean board → the loop converges to GO instead of
+        spinning to exhaustion and labeling state:skip.
+        """
+        with (
+            patch.object(implementer, "_collect_diff", return_value="diff"),
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo("D"), []), (_go(), [])],
+            ) as mock_rev,
+            patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
+            patch(
+                "hephaestus.automation._review_phase.gh_pr_list_unresolved_threads",
+                return_value=[],
+            ),
+            patch("hephaestus.automation.github_api.gh_pr_resolve_thread"),
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
+            # R0: re-opens the finding (unclean). R1: documented by-design now →
+            # clean, nothing re-opened, key dropped.
+            patch.object(
+                implementer.phase_runner,
+                "_validate_prior_threads",
+                side_effect=[(["RE1"], False, {"k1"}), ([], True, set())],
+            ) as mock_validate,
+        ):
+            iters, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=1,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "GO"
+        assert iters == 2
+        assert mock_rev.call_count == 2
+        # Addressed only after R0's re-open; R1 converged clean.
+        assert mock_addr.call_count == 1
+        assert mock_validate.call_count == 2
+        mock_label.assert_not_called()  # converged to GO → no state:skip
+
     def test_no_session_id_still_addresses(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
@@ -832,11 +884,12 @@ class TestRunImplReviewLoop:
                 return_value="mvillmow",
             ),
             patch("hephaestus.automation.github_api.gh_pr_resolve_thread"),
-            # R0 clean, R1 re-opens (overrides GO), R2 clean.
+            # R0 clean, R1 re-opens (overrides GO), R2 clean. Each pass returns
+            # the new (reopened_ids, is_clean, reopened_keys) tuple (#1329).
             patch.object(
                 implementer.phase_runner,
                 "_validate_prior_threads",
-                side_effect=[[], ["RE1"], []],
+                side_effect=[([], True, set()), (["RE1"], False, {"k1"}), ([], True, {"k1"})],
             ) as mock_validate,
         ):
             iters, verdict, _ = implementer._run_impl_review_loop(

--- a/tests/unit/automation/test_review_validator.py
+++ b/tests/unit/automation/test_review_validator.py
@@ -25,7 +25,7 @@ class TestValidatePriorCommentsAddressed:
 
     def test_no_prior_threads_is_clean_noop(self, tmp_path: Path) -> None:
         with patch.object(review_validator, "gh_pr_review_post") as post:
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=1,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -44,7 +44,7 @@ class TestValidatePriorCommentsAddressed:
             patch.object(review_validator, "_run_validation_session") as run,
             patch.object(review_validator, "gh_pr_review_post") as post,
         ):
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=1,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -70,7 +70,7 @@ class TestValidatePriorCommentsAddressed:
             patch.object(review_validator, "gh_pr_review_post") as post,
             patch.object(review_validator, "gh_pr_resolve_thread") as resolve,
         ):
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=1,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -111,7 +111,7 @@ class TestValidatePriorCommentsAddressed:
             patch.object(review_validator, "gh_pr_review_post", return_value=["NEW"]),
             patch.object(review_validator, "gh_pr_resolve_thread") as resolve,
         ):
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=42,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -207,7 +207,7 @@ class TestValidatePriorCommentsAddressed:
             # real gh call (which would trip the github-api circuit breaker).
             patch.object(review_validator, "gh_pr_resolve_thread"),
         ):
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=42,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -230,19 +230,27 @@ class TestValidatePriorCommentsAddressed:
         # The original comment is quoted into the re-open body.
         assert "> guard the null case" in posted[0]["body"]
 
-    def test_pr_level_unaddressed_without_path_is_skipped(self, tmp_path: Path) -> None:
-        """An item with no path can't be an inline thread → skipped, stays clean."""
+    def test_pr_level_unaddressed_without_path_is_surfaced_not_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        """#1329: a pathless (PR-level) unaddressed item is surfaced, not dropped.
+
+        Previously a pathless item was silently skipped and the pass stayed
+        "clean". Now it is surfaced at PR level via a summary-only review (no
+        inline comment), and the pass is reported NOT clean so the loop addresses
+        it.
+        """
         unaddressed = [{"path": "", "line": None, "original_body": "x", "detail": "y"}]
         with (
             patch.object(
                 review_validator, "_run_validation_session", return_value=(unaddressed, [])
             ),
-            patch.object(review_validator, "gh_pr_review_post") as post,
+            patch.object(review_validator, "gh_pr_review_post", return_value=[]) as post,
             # Both real threads are "addressed" (the unaddressed item has no
             # path) → the validator resolves them; mock to avoid real gh calls.
             patch.object(review_validator, "gh_pr_resolve_thread"),
         ):
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=42,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -252,9 +260,14 @@ class TestValidatePriorCommentsAddressed:
                 iteration=1,
                 state_dir=tmp_path,
             )
+        # No inline thread id (summary-only review), but NOT clean — the loop
+        # still treats the pass as having unaddressed work.
         assert reopened == []
-        assert is_clean is True
-        post.assert_not_called()
+        assert is_clean is False
+        post.assert_called_once()
+        # Posted with no inline comments; the PR-level finding rides the summary.
+        assert post.call_args.kwargs["comments"] == []
+        assert "PR-level" in post.call_args.kwargs["summary"]
 
     def test_wont_fix_dismisses_with_marker_reply_and_no_reopen(self, tmp_path: Path) -> None:
         """#1163: a won't-fix finding resolves with the marker reply, never re-opens.
@@ -272,7 +285,7 @@ class TestValidatePriorCommentsAddressed:
             patch.object(review_validator, "gh_pr_review_post") as post,
             patch.object(review_validator, "gh_pr_resolve_thread") as resolve,
         ):
-            reopened, is_clean = review_validator.validate_prior_comments_addressed(
+            reopened, is_clean, _ = review_validator.validate_prior_comments_addressed(
                 pr_number=1,
                 issue_number=1,
                 worktree_path=tmp_path,
@@ -292,6 +305,176 @@ class TestValidatePriorCommentsAddressed:
         assert calls["T1"] is not None and calls["T1"].startswith(WONT_FIX_MARKER)
         assert "NotImplementedError by design" in calls["T1"]
         assert calls["T2"] is None  # addressed → bare resolve
+
+
+class TestRecurringByDesignConvergence:
+    """#1329: a recurring re-open documented as by-design in source is not re-added."""
+
+    def _unaddressed(self) -> list[dict[str, object]]:
+        return [
+            {
+                "thread_id": "T1",
+                "path": "a.py",
+                "line": 3,
+                "original_body": "guard the null case",
+                "detail": "still dereferences x",
+            }
+        ]
+
+    def test_recurring_documented_in_source_is_not_readded(self, tmp_path: Path) -> None:
+        """Round N+1: same finding, source now documents it by-design → no re-open.
+
+        The finding's key was re-opened in a prior round (passed in via
+        ``prior_reopened_keys``); the worktree source at a.py:3 carries a
+        by-design comment. The validator must NOT re-add the comment and the pass
+        is clean — converging the loop.
+        """
+        (tmp_path / "a.py").write_text(
+            "def f(x):\n"
+            "    # We intentionally skip the null guard here by design: callers\n"
+            "    return x.value  # noqa — see contract in docstring\n"
+        )
+        prior_key = review_validator._thread_key(path="a.py", line=3, body="guard the null case")
+        with (
+            patch.object(
+                review_validator,
+                "_run_validation_session",
+                return_value=(self._unaddressed(), []),
+            ),
+            patch.object(review_validator, "gh_pr_review_post") as post,
+            patch.object(review_validator, "gh_pr_resolve_thread"),
+        ):
+            reopened, is_clean, keys = review_validator.validate_prior_comments_addressed(
+                pr_number=42,
+                issue_number=1,
+                worktree_path=tmp_path,
+                prior_threads=_threads(),
+                diff_text="diff",
+                agent="claude",
+                iteration=2,
+                state_dir=tmp_path,
+                prior_reopened_keys={prior_key},
+            )
+        assert reopened == []
+        assert is_clean is True
+        post.assert_not_called()  # documented by-design → not re-added
+        # The key stays in the carried set so later rounds keep suppressing it.
+        assert prior_key in keys
+
+    def test_recurring_undocumented_still_reopens(self, tmp_path: Path) -> None:
+        """Round N+1: same finding, but source does NOT document it → still re-opens."""
+        (tmp_path / "a.py").write_text("def f(x):\n    return x.value\n")
+        prior_key = review_validator._thread_key(path="a.py", line=3, body="guard the null case")
+        with (
+            patch.object(
+                review_validator,
+                "_run_validation_session",
+                return_value=(self._unaddressed(), []),
+            ),
+            patch.object(review_validator, "gh_pr_review_post", return_value=["NEW"]) as post,
+            patch.object(review_validator, "gh_pr_resolve_thread"),
+        ):
+            reopened, is_clean, keys = review_validator.validate_prior_comments_addressed(
+                pr_number=42,
+                issue_number=1,
+                worktree_path=tmp_path,
+                prior_threads=_threads(),
+                diff_text="diff",
+                agent="claude",
+                iteration=2,
+                state_dir=tmp_path,
+                prior_reopened_keys={prior_key},
+            )
+        assert reopened == ["NEW"]
+        assert is_clean is False
+        post.assert_called_once()
+        # The recurring body is marked as such in the re-open.
+        assert "recurring" in post.call_args.kwargs["comments"][0]["body"].lower()
+        # The key is carried forward so a later documented round can converge.
+        assert prior_key in keys
+
+    def test_first_round_documented_source_still_reopens(self, tmp_path: Path) -> None:
+        """A FIRST-round finding (not yet recurring) still re-opens even if documented.
+
+        The by-design source-skip only applies to RECURRING re-opens — on the
+        first occurrence the comment is posted so the implementer/reviewer gets a
+        chance to engage. (Without a prior key the finding isn't recurring.)
+        """
+        (tmp_path / "a.py").write_text(
+            "def f(x):\n    # intentional by design\n    return x.value\n"
+        )
+        with (
+            patch.object(
+                review_validator,
+                "_run_validation_session",
+                return_value=(self._unaddressed(), []),
+            ),
+            patch.object(review_validator, "gh_pr_review_post", return_value=["NEW"]) as post,
+            patch.object(review_validator, "gh_pr_resolve_thread"),
+        ):
+            reopened, is_clean, keys = review_validator.validate_prior_comments_addressed(
+                pr_number=42,
+                issue_number=1,
+                worktree_path=tmp_path,
+                prior_threads=_threads(),
+                diff_text="diff",
+                agent="claude",
+                iteration=0,
+                state_dir=tmp_path,
+                prior_reopened_keys=set(),
+            )
+        assert reopened == ["NEW"]
+        assert is_clean is False
+        post.assert_called_once()
+        # Its key is recorded so a NEXT round can recognise the recurrence.
+        assert review_validator._thread_key(path="a.py", line=3, body="guard the null case") in keys
+
+
+class TestThreadKey:
+    """#1329: stable cross-round identity for prior review threads."""
+
+    def test_normalizes_whitespace_and_case(self) -> None:
+        a = review_validator._thread_key(path="a.py", line=3, body="Guard  the\nnull case")
+        b = review_validator._thread_key(path="a.py", line=3, body="guard the null case")
+        assert a == b
+
+    def test_distinguishes_path_and_line(self) -> None:
+        a = review_validator._thread_key(path="a.py", line=3, body="x")
+        b = review_validator._thread_key(path="b.py", line=3, body="x")
+        c = review_validator._thread_key(path="a.py", line=4, body="x")
+        assert a != b
+        assert a != c
+
+    def test_none_line_is_stable(self) -> None:
+        a = review_validator._thread_key(path="", line=None, body="pr level")
+        b = review_validator._thread_key(path="", line=None, body="pr level")
+        assert a == b
+
+
+class TestSourceDocumentsDecision:
+    """#1329: the 'documented in source' heuristic reads source near the line."""
+
+    def test_finds_by_design_marker_near_line(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text(
+            "line1\nline2\n# this is intentional by design\nline4\nline5\n"
+        )
+        assert review_validator._source_documents_decision(tmp_path, "a.py", 4) is True
+
+    def test_marker_far_from_line_does_not_count(self, tmp_path: Path) -> None:
+        body = "\n".join(["# by design"] + [f"code{i}" for i in range(30)])
+        (tmp_path / "a.py").write_text(body + "\n")
+        # The marker is at line 1, the cited line is 25 — outside the window.
+        assert review_validator._source_documents_decision(tmp_path, "a.py", 25) is False
+
+    def test_missing_file_returns_false(self, tmp_path: Path) -> None:
+        assert review_validator._source_documents_decision(tmp_path, "missing.py", 1) is False
+
+    def test_pathless_or_bad_line_returns_false(self, tmp_path: Path) -> None:
+        assert review_validator._source_documents_decision(tmp_path, "", 1) is False
+        assert review_validator._source_documents_decision(tmp_path, "a.py", None) is False
+
+    def test_path_traversal_returns_false(self, tmp_path: Path) -> None:
+        assert review_validator._source_documents_decision(tmp_path, "../escape.py", 1) is False
 
 
 class TestDismissWontFixPriorThreads:


### PR DESCRIPTION
## Summary

The implementation review loop never reached GO when the validator kept
re-opening the same comments. A hard `MAX_REVIEW_ITERATIONS = 3` counter plus a
read-only validator that re-opened any comment it could not see fixed made the
loop **unwinnable**: the diff it inspected was truncated at 200k chars (so a fix
at a later hunk was invisible) and pathless (PR-level) unaddressed comments were
silently dropped. One run re-opened 9 comments at R0 — unwinnable in 3 rounds;
4 PRs ended labeled `state:implementation-no-go` needing a human.

Per the explicit instruction: detect repeated re-adds, and if the same comment
keeps getting added, accept it once the design decision is properly documented
in the source — do not re-add it.

## Changes

- **`review_validator.py`**: key each prior thread by a stable `path:line` +
  normalized-body identity (`_thread_key`) and thread "already re-opened" keys
  across rounds. A finding re-opened in a prior round is **RECURRING**; if the
  current source at its `path:line` documents the design decision
  (`_source_documents_decision` scans a small window for an explicit by-design
  marker) it is accepted-by-design and **not re-added**. Only genuinely
  unaddressed **and** undocumented findings still re-open.
  `validate_prior_comments_addressed` now returns the carried-forward key set.
- **Supporting fixes** so the validator can actually *see* the fix/doc: raise
  the diff-truncation cap 200k → 2M; surface pathless unaddressed comments at PR
  level (summary-only review) instead of dropping them.
- **`_review_phase.py` / `implementer_phase_runner.py`**: thread
  `prior_reopened_keys` through `_run_impl_review_loop` →
  `_process_review_iteration` → `_validate_and_review` →
  `_validate_prior_threads`, and force NOGO (run the address step) on an unclean
  validator pass even when it posts no inline thread id.

## Semantics preserved (per pr-review-loop skill, item 13)

`MAX_REVIEW_ITERATIONS` and `state:skip`-on-true-exhaustion are intact. A
zero-thread **reviewer** non-GO still re-reviews (does not address); only an
**unclean validator** pass drives the address step. Convergence still requires
an explicit `Verdict: GO`.

## "Documented in source" heuristic

`_source_documents_decision` reads the current worktree source at the comment's
`path`:`line`, scans ±6 lines, and matches a small conservative list of
by-design markers (`by design`, `intentional`, `noqa`, `nosec`, `type: ignore`,
`do not change`, …). It only applies to a **recurring** re-open (a first-round
finding still posts so the reviewer engages), is case-insensitive, guards
against path traversal, and fails closed (returns False on any read error) so a
genuine unaddressed finding is never silently suppressed.

## Tests

- Recurrence + documented-source → not re-added; undocumented recurrence still
  re-opens; first-round documented finding still re-opens.
- Pathless items surfaced (summary-only review), not dropped.
- `_thread_key` / `_source_documents_decision` helper coverage (window,
  far-marker, missing file, traversal, bad line).
- Loop-level documented by-design recurrence converging to GO with no
  `state:skip`.

Full automation unit suite: 1631 passed. ruff format + check, mypy, and
`pre-commit run` all clean with no hook-modified files.

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)