### PR TITLE
fix(test): update _process_review_iteration mock to 9-tuple signature (unblocks main)

### DIFF
--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -471,8 +471,9 @@ def test_review_loop_resolves_conflict_before_first_review(tmp_path: Path) -> No
 
     def _iter(**_kwargs: Any) -> tuple[Any, ...]:
         call_order.append("review")
-        # verdict, grade, review_text, posted_thread_ids, go_blocked, reopened, should_break
-        return "GO", "A", "ok", [], False, [], True
+        # verdict, grade, review_text, posted_thread_ids, go_blocked, reopened,
+        # should_break, reopened_keys, validator_clean
+        return "GO", "A", "ok", [], False, [], True, set(), True
 
     with (
         mock.patch.object(phase, "_resolve_conflict_before_review", side_effect=_gate) as gate,


### PR DESCRIPTION
main is RED: test_review_loop_resolves_conflict_before_first_review fails with `ValueError: not enough values to unpack (expected 9, got 7)`.

#1336 (RC3) made _process_review_iteration return 9 values; #1337 (RC2) added a test whose _iter mock returns 7. Independent merges → inconsistent union. One-line fix: mock returns 9 (append reopened_keys + validator_clean).

29/29 test_stage_phases.py pass. Unblocks the trailing PR queue (#1282/#1283/#1292/#1332) which inherited the breakage.

Closes #1339

🤖 Generated with [Claude Code](https://claude.com/claude-code)