### PR TITLE
test(automation): regression-guard FAILING_CHECK_CONCLUSIONS / _pr_is_failing as single definitions

### DIFF
--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import ast
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -317,3 +319,68 @@ class TestIsBotPrModeForSyntheticKey:
     def test_is_bot_pr_mode_false_for_real_issue(self, ci_driver: CIDriver) -> None:
         """Real issue-PR mappings return False."""
         assert not ci_driver._is_bot_pr_mode(100, 200)
+
+
+class TestFailingCheckPredicateSingleDefinition:
+    """Regression guard: FAILING_CHECK_CONCLUSIONS and _pr_is_failing must not be duplicated.
+
+    The DRY goal is satisfied when there is exactly one assignment to
+    FAILING_CHECK_CONCLUSIONS and exactly one function named _pr_is_failing
+    across the entire automation package.  This test catches future drift that
+    would re-introduce the three-copy situation described in issue #1345.
+    """
+
+    _AUTOMATION_DIR = Path(__file__).parents[3] / "hephaestus" / "automation"
+
+    def _count_assignments(self, target: str) -> list[Path]:
+        """Return paths of automation modules that assign to *target* at module level."""
+        hits: list[Path] = []
+        for py_file in self._AUTOMATION_DIR.rglob("*.py"):
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Assign):
+                    for t in node.targets:
+                        if isinstance(t, ast.Name) and t.id == target:
+                            hits.append(py_file)
+                elif isinstance(node, ast.AnnAssign):
+                    if isinstance(node.target, ast.Name) and node.target.id == target:
+                        hits.append(py_file)
+        return hits
+
+    def _count_function_defs(self, name: str) -> list[Path]:
+        """Return paths of automation modules that define a function named *name*."""
+        hits: list[Path] = []
+        for py_file in self._AUTOMATION_DIR.rglob("*.py"):
+            try:
+                tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.FunctionDef) and node.name == name:
+                    hits.append(py_file)
+        return hits
+
+    def test_failing_check_conclusions_defined_exactly_once(self) -> None:
+        """FAILING_CHECK_CONCLUSIONS must have a single canonical definition."""
+        hits = self._count_assignments("FAILING_CHECK_CONCLUSIONS")
+        assert len(hits) == 1, (
+            f"Expected exactly 1 definition of FAILING_CHECK_CONCLUSIONS, "
+            f"found {len(hits)}: {[str(p) for p in hits]}"
+        )
+        assert hits[0].name == "ci_driver.py", (
+            f"Canonical definition must be in ci_driver.py, not {hits[0].name}"
+        )
+
+    def test_pr_is_failing_defined_exactly_once(self) -> None:
+        """_pr_is_failing must have a single canonical definition."""
+        hits = self._count_function_defs("_pr_is_failing")
+        assert len(hits) == 1, (
+            f"Expected exactly 1 definition of _pr_is_failing, "
+            f"found {len(hits)}: {[str(p) for p in hits]}"
+        )
+        assert hits[0].name == "ci_driver.py", (
+            f"Canonical definition must be in ci_driver.py, not {hits[0].name}"
+        )


### PR DESCRIPTION
## Summary

Issue #1345 describes two follow-up items from a PR (#1289) that was never merged:

1. **Safety**: Guard `CICheckInspector` None-slot callable fields — the class does not exist anywhere in the repo.
2. **Core library**: Deduplicate `FAILING_CHECK_CONCLUSIONS` / `_pr_is_failing` across three modules — only one copy has ever existed (in `ci_driver.py`); the three-copy state described in the issue was never introduced.

Every concrete premise of the issue is factually false against `main`. The correct action is not to fabricate the modules the issue presupposes, but to lock in the already-satisfied DRY invariant as a machine-checkable regression guard.

This PR adds `TestFailingCheckPredicateSingleDefinition` to the failing-PR discovery test suite. The two new tests use `ast.parse` to scan every `.py` file under `hephaestus/automation/` and assert:

- `FAILING_CHECK_CONCLUSIONS` is assigned exactly once (in `ci_driver.py`)
- `_pr_is_failing` is defined exactly once (in `ci_driver.py`)

If a future PR re-introduces duplicate copies, CI will catch it immediately.

## Verification evidence

```
find hephaestus -name ci_check_inspector.py -o -name pr_discovery.py -o -name post_merge_processor.py
# → no output (modules do not exist)

grep -rln "CICheckInspector" hephaestus tests --include="*.py"
# → no output (class does not exist)

grep -rn "FAILING_CHECK_CONCLUSIONS\|def _pr_is_failing" hephaestus/
# → exactly: ci_driver.py:79 and ci_driver.py:82
```

## Test plan

- [x] `pixi run pytest tests/unit/automation/test_ci_driver_failing_pr_discovery.py -v` — all 25 tests pass (2 new)
- [x] `pixi run pytest tests/unit/automation -q` — 1659 tests pass, no regressions

Closes #1345