### PR TITLE
fix(lint): clear SIM102 violation blocking main

### DIFF
--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -345,9 +345,12 @@ class TestFailingCheckPredicateSingleDefinition:
                     for t in node.targets:
                         if isinstance(t, ast.Name) and t.id == target:
                             hits.append(py_file)
-                elif isinstance(node, ast.AnnAssign):
-                    if isinstance(node.target, ast.Name) and node.target.id == target:
-                        hits.append(py_file)
+                elif (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and node.target.id == target
+                ):
+                    hits.append(py_file)
         return hits
 
     def _count_function_defs(self, name: str) -> list[Path]:


### PR DESCRIPTION
main (HEAD via #1346) fails the repo-wide ruff-check-python pre-commit hook with SIM102 at tests/unit/automation/test_ci_driver_failing_pr_discovery.py:348, blocking every signed commit on every branch (--no-verify is banned). Combine the nested if under the AnnAssign elif into a single condition with and.

Verified: pixi run ruff check hephaestus/ scripts/ tests/ -> All checks passed; 25 tests in the file pass.

Closes #1351