### PR TITLE
fix(automation): raise /compact agent timeout 60s -> 300s

### DIFF
--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -368,7 +368,7 @@ def compact_session(
     issue: int | str,
     agent: str,
     cwd: Path,
-    timeout: int = 60,
+    timeout: int = 300,
     model: str | None = None,
 ) -> bool:
     """Send ``/compact`` to the (repo, issue, agent, model) Claude session.
@@ -385,7 +385,7 @@ def compact_session(
         issue: Issue number
         agent: Agent identifier
         cwd: Working directory for session lookup
-        timeout: Subprocess timeout in seconds (default: 60)
+        timeout: Subprocess timeout in seconds (default: 300)
 
     Returns:
         True on a zero-exit subprocess call, False on any failure including

--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -345,9 +345,12 @@ class TestFailingCheckPredicateSingleDefinition:
                     for t in node.targets:
                         if isinstance(t, ast.Name) and t.id == target:
                             hits.append(py_file)
-                elif isinstance(node, ast.AnnAssign):
-                    if isinstance(node.target, ast.Name) and node.target.id == target:
-                        hits.append(py_file)
+                elif (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and node.target.id == target
+                ):
+                    hits.append(py_file)
         return hits
 
     def _count_function_defs(self, name: str) -> list[Path]:

--- a/tests/unit/automation/test_compact.py
+++ b/tests/unit/automation/test_compact.py
@@ -83,6 +83,19 @@ class TestCompactSession:
             output_fmt_idx = cmd.index("--output-format")
             assert cmd[output_fmt_idx + 1] == "text"
 
+    def test_compact_session_default_timeout_is_300(self, tmp_path: Path) -> None:
+        """Verify compact_session uses a 300s default subprocess timeout (#1349).
+
+        The original 60s default silently lost compaction work on slow
+        sessions; this guards the raised default.
+        """
+        with patch("hephaestus.automation.learn.subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0, stderr="")
+
+            compact_session("test-repo", 42, AGENT_CI_DRIVER, tmp_path)
+
+            assert mock_run.call_args[1]["timeout"] == 300
+
     def test_compact_failure_returns_false_on_timeout(self, tmp_path: Path) -> None:
         """Verify compact_session returns False on timeout (non-fatal)."""
         with patch("hephaestus.automation.learn.subprocess.run") as mock_run:


### PR DESCRIPTION
The 2026-06-14 automation-loop run lost session compaction 6x to a 60s timeout. compact_session sends /compact to a long fix-iteration session that needs more than 60s; raised the default to 300s.

The planner-learnings 120s literal from the same run is already fixed on main (uses learn_claude_timeout()=7200s), so no change there.

Note: based on #1352 (SIM102 fix) which must merge first to re-green main; rebases to main once #1352 lands.

Closes #1349