### PR TITLE
fix(automation): complete GraphQL variable migration + harden non-transient patterns

### DIFF
--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -284,42 +284,45 @@ def fetch_all_issue_comments_graphql(
 
     owner, name = get_repo_info(get_repo_root())
 
-    # Build one aliased fragment per issue: issueN: issue(number: <n>) { ... }
-    fragments = [
+    # owner/name AND each issue number MUST be passed as GraphQL variables, not
+    # interpolated. A {owner!r} repr produces single-quoted literals
+    # (owner:'Owner'), which is invalid GraphQL (only double quotes are accepted)
+    # and gh rejects with "Expected VALUE, actual: UNKNOWN_CHAR". Mirror
+    # github_api._fetch_batch_states: declare $owner/$name/$nN and pass via -F.
+    var_decls = ",".join(f"$n{idx}:Int!" for idx in range(len(issue_numbers)))
+    fragments = " ".join(
         (
-            f"issue{idx}: issue(number: {int(num)}){{"
+            f"issue{idx}: issue(number:$n{idx}){{"
             "comments(last: 100, orderBy: {field: UPDATED_AT, direction: DESC})"
             "{nodes{body updatedAt url}}"
-            "}}"
+            "}"
         )
-        for idx, num in enumerate(issue_numbers)
-    ]
-    # owner/name MUST be passed as GraphQL variables, not interpolated. The
-    # {owner!r} repr produces single-quoted literals (owner:'Owner'), which is
-    # invalid GraphQL (only double quotes are accepted) and gh rejects with
-    # "Expected VALUE, actual: UNKNOWN_CHAR". Mirror fetch_issue_review_comments.
+        for idx in range(len(issue_numbers))
+    )
     query = (
-        f"query($owner:String!,$name:String!)"
-        f"{{repository(owner:$owner,name:$name){{{' '.join(fragments)}}}}}"
+        f"query($owner:String!,$name:String!,{var_decls})"
+        f"{{repository(owner:$owner,name:$name){{{fragments}}}}}"
     )
 
     # Map alias index back to issue number for result assembly.
     idx_to_num = dict(enumerate(issue_numbers))
     result_map: dict[int, list[dict[str, Any]]] = {num: [] for num in issue_numbers}
 
+    args = [
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+    ]
+    for idx, issue_num in enumerate(issue_numbers):
+        args.extend(["-F", f"n{idx}={int(issue_num)}"])
+
     try:
-        result = _gh_call(
-            [
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-F",
-                f"owner={owner}",
-                "-F",
-                f"name={name}",
-            ],
-        )
+        result = _gh_call(args)
         data = json.loads(result.stdout)
         repo_data = data.get("data", {}).get("repository", {})
         for alias, issue_data in repo_data.items():
@@ -372,32 +375,36 @@ def fetch_all_issue_labels_graphql(
 
     owner, name = get_repo_info(get_repo_root())
 
-    fragments = [
-        (f"issue{idx}: issue(number: {int(num)}){{labels(first: 50){{nodes{{name}}}}}}")
-        for idx, num in enumerate(issue_numbers)
-    ]
-    # owner/name as GraphQL variables (see fetch_all_issue_comments_graphql).
+    # owner/name and each issue number as GraphQL variables (never interpolated);
+    # see fetch_all_issue_comments_graphql and github_api._fetch_batch_states.
+    var_decls = ",".join(f"$n{idx}:Int!" for idx in range(len(issue_numbers)))
+    fragments = " ".join(
+        f"issue{idx}: issue(number:$n{idx}){{labels(first: 50){{nodes{{name}}}}}}"
+        for idx in range(len(issue_numbers))
+    )
     query = (
-        f"query($owner:String!,$name:String!)"
-        f"{{repository(owner:$owner,name:$name){{{' '.join(fragments)}}}}}"
+        f"query($owner:String!,$name:String!,{var_decls})"
+        f"{{repository(owner:$owner,name:$name){{{fragments}}}}}"
     )
 
     idx_to_num = dict(enumerate(issue_numbers))
     result_map: dict[int, list[str]] = {num: [] for num in issue_numbers}
 
+    args = [
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+    ]
+    for idx, issue_num in enumerate(issue_numbers):
+        args.extend(["-F", f"n{idx}={int(issue_num)}"])
+
     try:
-        result = _gh_call(
-            [
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-F",
-                f"owner={owner}",
-                "-F",
-                f"name={name}",
-            ],
-        )
+        result = _gh_call(args)
         data = json.loads(result.stdout)
         repo_data = data.get("data", {}).get("repository", {})
         for alias, issue_data in repo_data.items():

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -159,6 +159,12 @@ _NON_TRANSIENT_PATTERNS = [
         # unused variable can never succeed on retry (#1040).
         r"doesn't accept argument",
         r"is declared by .* but not used",
+        # A malformed GraphQL query (e.g. a single-quoted string literal from a
+        # stray repr) is a syntax error that can never parse on retry. gh surfaces
+        # these as "Expected VALUE, actual: UNKNOWN_CHAR" / "Parse error" (#1350).
+        r"Expected VALUE",
+        r"UNKNOWN_CHAR",
+        r"Parse error",
         # "Body is not editable": editing a review comment owned by another
         # app/account (Copilot, CodeQL) is forbidden and never succeeds on
         # retry. Fail fast so the caller posts its own editable comment (#1327).

--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -345,9 +345,12 @@ class TestFailingCheckPredicateSingleDefinition:
                     for t in node.targets:
                         if isinstance(t, ast.Name) and t.id == target:
                             hits.append(py_file)
-                elif isinstance(node, ast.AnnAssign):
-                    if isinstance(node.target, ast.Name) and node.target.id == target:
-                        hits.append(py_file)
+                elif (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and node.target.id == target
+                ):
+                    hits.append(py_file)
         return hits
 
     def _count_function_defs(self, name: str) -> list[Path]:

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -480,9 +480,14 @@ class TestFetchAllIssueLabelsGraphql:
         assert "'HomericIntelligence'" not in query_arg
         assert "'ProjectHephaestus'" not in query_arg
         # owner/name supplied as declared variables, passed via -F.
+        assert query_arg.startswith("query=query($owner:String!,$name:String!")
         assert "$owner" in query_arg and "$name" in query_arg
         assert "owner=HomericIntelligence" in argv
         assert "name=ProjectHephaestus" in argv
+        # Issue numbers are GraphQL variables too, not interpolated inline.
+        assert "owner:'" not in query_arg
+        assert "n0=10" in argv and "n1=11" in argv
+        assert "issue(number:$n0)" in query_arg
 
     def test_comments_owner_name_passed_as_graphql_variables(self) -> None:
         """Same regression guard for the batched comments fetch."""
@@ -504,6 +509,11 @@ class TestFetchAllIssueLabelsGraphql:
         argv = mock_gh.call_args.args[0]
         query_arg = next(a for a in argv if a.startswith("query="))
         assert "'HomericIntelligence'" not in query_arg
+        assert query_arg.startswith("query=query($owner:String!,$name:String!")
         assert "$owner" in query_arg and "$name" in query_arg
         assert "owner=HomericIntelligence" in argv
         assert "name=ProjectHephaestus" in argv
+        # Issue number passed as a variable, not interpolated inline.
+        assert "owner:'" not in query_arg
+        assert "n0=10" in argv
+        assert "issue(number:$n0)" in query_arg

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -156,3 +156,20 @@ class TestNonTransientErrorClassification:
         from hephaestus.github.client import _is_non_transient_error
 
         assert _is_non_transient_error("Internal Server Error (HTTP 500)") is False
+
+    def test_graphql_syntax_error_is_non_transient(self) -> None:
+        """#1350: a malformed GraphQL query is a parse error, never retryable.
+
+        A stray ``repr()`` once emitted single-quoted string literals
+        (``owner:'H...'``), which gh rejected with
+        ``Expected VALUE, actual: UNKNOWN_CHAR``. Such syntax errors can never
+        succeed on retry, so they must fail fast instead of being retried ~6×.
+        """
+        from hephaestus.github.client import _is_non_transient_error
+
+        assert (
+            _is_non_transient_error(
+                'gh: Expected VALUE, actual: UNKNOWN_CHAR ("H") at [1, 24]',
+            )
+            is True
+        )


### PR DESCRIPTION
The owner/name repr->variable fix already landed (#1148); current main no longer reproduces the UNKNOWN_CHAR crash. This completes the migration (per-issue number -> $nN:Int! variable in both batch fetch functions) and adds GraphQL syntax errors to _NON_TRANSIENT_PATTERNS so malformed queries fail fast (1 attempt) instead of 6 retries.

Verified: 54 tests pass; live smoke check of the new query shape returns labels with no UNKNOWN_CHAR.

Note: based on #1352 (SIM102 fix); rebases to main once it lands.

Closes #1350