### PR TITLE
fix(automation): resolve armed-DIRTY PR conflicts in post-fix re-arm path

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -1155,7 +1155,7 @@ class CIDriver:
         )
 
     def _recheck_and_arm_after_fix(
-        self, issue_number: int, pr_number: int, acquired_slot: int
+        self, issue_number: int, pr_number: int, acquired_slot: int, *, resolve_dirty: bool = True
     ) -> WorkerResult | None:
         """After a CI fix is pushed, re-poll checks and arm if now green.
 
@@ -1164,6 +1164,18 @@ class CIDriver:
         now-green PR sat ``NOT armed`` forever (observed: ProjectHermes #645,
         which ended ``CLEAN`` but un-armed). This re-enters the
         check→arm→wait flow ONCE.
+
+        Args:
+            issue_number: GitHub issue number.
+            pr_number: GitHub PR number.
+            acquired_slot: Worker slot ID for status tracking.
+            resolve_dirty: When True (the default, used by the primary fix paths)
+                an armed PR that goes ``DIRTY`` while we wait is routed to
+                ``_resolve_dirty_pr`` (#1347). ``_resolve_dirty_pr`` calls this
+                method back after a rebase/agent fix; those callbacks pass
+                ``resolve_dirty=False`` so a still-DIRTY PR does NOT re-dispatch
+                into ``_resolve_dirty_pr`` — breaking the
+                resolve→recheck→resolve recursion at depth one.
 
         Returns:
             A terminal ``WorkerResult`` if the PR armed (and we waited on it), or
@@ -1231,7 +1243,14 @@ class CIDriver:
         pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
         pr_head_branch = self._get_pr_branch(pr_number)
         self._arm_drive_green(pr_number, pr_head_branch, pr_head_sha)
-        self._wait_for_pr_terminal(issue_number, pr_number)
+        outcome = self._wait_for_pr_terminal(issue_number, pr_number)
+        # An armed PR can go DIRTY (merge conflict) after the fix push. Mirror
+        # the primary arm path (_arm_and_wait_for_merge) and route it to the
+        # conflict resolver instead of silently reporting success (#1347).
+        # ``resolve_dirty`` gates this so the resolver's own callback into this
+        # method cannot re-trigger resolution and recurse indefinitely.
+        if resolve_dirty and outcome == "DIRTY":
+            return self._resolve_dirty_pr(issue_number, pr_number, acquired_slot)
         return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
     def _resolve_dirty_pr(
@@ -1256,7 +1275,9 @@ class CIDriver:
         # 1. Cheap path: mechanical rebase. Returns True only on a clean
         #    rebase+push, in which case re-poll and arm the rebased head.
         if self._attempt_mechanical_rebase(issue_number, pr_number, acquired_slot):
-            rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+            rearmed = self._recheck_and_arm_after_fix(
+                issue_number, pr_number, acquired_slot, resolve_dirty=False
+            )
             if rearmed is not None:
                 return rearmed
             return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
@@ -1284,7 +1305,9 @@ class CIDriver:
             issue_number, pr_number, acquired_slot, extra_context=conflict_context
         )
         if fix_result is not None and fix_result.success:
-            rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+            rearmed = self._recheck_and_arm_after_fix(
+                issue_number, pr_number, acquired_slot, resolve_dirty=False
+            )
             return rearmed if rearmed is not None else fix_result
         return WorkerResult(
             issue_number=issue_number,

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -2660,6 +2660,79 @@ class TestRecheckAndArmAfterFix:
             assert driver._recheck_and_arm_after_fix(1, 2, 0) is None
         mock_arm.assert_not_called()
 
+    def test_dirty_after_fix_routes_to_resolve_dirty_pr(self, driver: CIDriver) -> None:
+        # A PR that arms green post-fix but then goes DIRTY (merge conflict)
+        # while we wait must be routed to _resolve_dirty_pr, not reported as a
+        # silent success (#1347).
+        green = [_make_check("test", required=True, conclusion="success")]
+        dirty_result = WorkerResult(issue_number=1, success=False, pr_number=2, error="dirty")
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=green),
+            _impl_go(driver),
+            patch.object(driver, "_enable_auto_merge", return_value=True),
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc"}),
+            patch.object(driver, "_get_pr_branch", return_value="b"),
+            patch.object(driver, "_arm_drive_green"),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="DIRTY"),
+            patch.object(driver, "_resolve_dirty_pr", return_value=dirty_result) as mock_resolve,
+        ):
+            result = driver._recheck_and_arm_after_fix(1, 2, 0)
+        assert result is dirty_result
+        mock_resolve.assert_called_once_with(1, 2, 0)
+
+    def test_dirty_with_resolve_dirty_false_does_not_recurse(self, driver: CIDriver) -> None:
+        # _resolve_dirty_pr calls this method back with resolve_dirty=False. A
+        # PR that is STILL DIRTY on that callback must NOT re-dispatch into
+        # _resolve_dirty_pr, otherwise resolve->recheck->resolve recurses
+        # unboundedly (#1347).
+        green = [_make_check("test", required=True, conclusion="success")]
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=green),
+            _impl_go(driver),
+            patch.object(driver, "_enable_auto_merge", return_value=True),
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc"}),
+            patch.object(driver, "_get_pr_branch", return_value="b"),
+            patch.object(driver, "_arm_drive_green"),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="DIRTY"),
+            patch.object(driver, "_resolve_dirty_pr") as mock_resolve,
+        ):
+            result = driver._recheck_and_arm_after_fix(1, 2, 0, resolve_dirty=False)
+        # No re-dispatch; falls back to the success WorkerResult.
+        mock_resolve.assert_not_called()
+        assert result is not None and result.success is True
+
+    def test_resolve_dirty_pr_recursion_is_bounded_when_pr_stays_dirty(
+        self, driver: CIDriver
+    ) -> None:
+        # End-to-end recursion guard: enter via _resolve_dirty_pr with a clean
+        # mechanical rebase that re-arms, but the re-armed PR stays DIRTY. The
+        # callback uses resolve_dirty=False, so _resolve_dirty_pr is entered
+        # exactly once -- no resolve->recheck->resolve loop.
+        green = [_make_check("test", required=True, conclusion="success")]
+        real_resolve = driver._resolve_dirty_pr
+        call_count = {"n": 0}
+
+        def counting_resolve(*args: object, **kwargs: object) -> WorkerResult:
+            call_count["n"] += 1
+            assert call_count["n"] <= 2, "recursion guard failed: _resolve_dirty_pr re-entered"
+            return real_resolve(*args, **kwargs)  # type: ignore[arg-type]
+
+        with (
+            patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=green),
+            _impl_go(driver),
+            patch.object(driver, "_enable_auto_merge", return_value=True),
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc"}),
+            patch.object(driver, "_get_pr_branch", return_value="b"),
+            patch.object(driver, "_arm_drive_green"),
+            patch.object(driver, "_attempt_mechanical_rebase", return_value=True),
+            patch.object(driver, "_wait_for_pr_terminal", return_value="DIRTY"),
+            patch.object(driver, "_resolve_dirty_pr", side_effect=counting_resolve),
+        ):
+            result = driver._resolve_dirty_pr(1, 2, 0)
+        # Entered once (the outer call); the re-arm callback did NOT recurse.
+        assert call_count["n"] == 1
+        assert result is not None and result.success is True
+
 
 class TestResolveDirtyPr:
     """An armed-but-DIRTY PR is rebased, then handed to the agent if still conflicting."""


### PR DESCRIPTION
_recheck_and_arm_after_fix discarded its _wait_for_pr_terminal outcome, so a PR that pushed a CI fix and then went DIRTY (merge conflict) while armed was reported "CI drive completed" without ever resolving the conflict (observed on PR #1332 in the 2026-06-14 output.log). Now routes a DIRTY outcome to the existing _resolve_dirty_pr (mechanical rebase -> implementation agent), with a guard against resolve/recheck recursion.

Recursion guard: _recheck_and_arm_after_fix gains a keyword-only resolve_dirty flag (default True). _resolve_dirty_pr calls back with resolve_dirty=False, so a still-DIRTY PR on the callback does NOT re-dispatch into the resolver -- bounded at depth one.

Based on #1352 (re-greened main); rebased onto main since #1352 has merged.

Closes #1347