### PR TITLE
[Refactor] Decompose CIDriver into 4 SRP collaborators (combined #1179+#1289)

### DIFF
--- a/hephaestus/automation/ci_check_inspector.py
+++ b/hephaestus/automation/ci_check_inspector.py
@@ -1,0 +1,167 @@
+"""CI check inspection collaborator extracted from CIDriver (refs #1179).
+
+Owns the FAILING_CHECK_CONCLUSIONS constant and all methods that query
+CI check state for a given PR.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from .github_api import _gh_call, gh_pr_checks
+
+logger = logging.getLogger(__name__)
+
+# Conclusion values that indicate a PR's check rollup is failing in a way
+# drive-green can act on. SUCCESS / SKIPPED / NEUTRAL / PENDING are
+# explicitly excluded. Shared with loop_runner._count_failing_prs so the
+# SKIP gate and the actual work list never drift (#819).
+FAILING_CHECK_CONCLUSIONS: frozenset[str] = frozenset({"FAILURE", "CANCELLED", "TIMED_OUT"})
+
+
+class CICheckInspector:
+    """Queries CI check state for a PR using narrow-callable injection.
+
+    Receives ``get_pr_branch`` as a callable instead of the full CIDriver to
+    satisfy DIP and avoid bidirectional coupling (refs #1179 MAJOR finding 2).
+    """
+
+    def __init__(
+        self,
+        *,
+        get_pr_branch: Callable[[int], str],
+        options_provider: Callable[[], Any],
+    ) -> None:
+        """Initialise the inspector with narrow provider callables.
+
+        Args:
+            get_pr_branch: Callable that resolves the head branch for a PR number.
+            options_provider: Returns the current CIDriverOptions.
+
+        """
+        self._get_pr_branch = get_pr_branch
+        self._options = options_provider
+
+    def failing_required_check_names(self, pr_number: int) -> list[str]:
+        """Return names of required checks that are currently failing.
+
+        Used by the no-commit retry path (#846) to name the actual offenders
+        verbatim in the force-engagement prompt. Returns an empty list if
+        the lookup fails — the caller treats that as "cannot prove still
+        red" and skips the retry rather than launching Claude blind.
+
+        Args:
+            pr_number: GitHub PR number.
+
+        Returns:
+            Names of required checks with ``conclusion == "failure"``.
+
+        """
+        options = self._options()
+        try:
+            checks = gh_pr_checks(pr_number, dry_run=options.dry_run)
+        except Exception as exc:
+            logger.info(
+                "PR #%s: failed to re-check CI for no-commit retry decision (%s)",
+                pr_number,
+                exc,
+            )
+            return []
+        if not checks:
+            return []
+        required = [c for c in checks if c.get("required")] or checks
+        return [
+            c.get("name", "")
+            for c in required
+            if c.get("status") == "completed" and c.get("conclusion") == "failure"
+        ]
+
+    def pending_required_check_names(self, pr_number: int) -> list[str]:
+        """Return names of required checks that are still in flight (not completed).
+
+        Used by the BLOCKED early-exit guard in ``_wait_for_pr_terminal`` to
+        distinguish branch-protection blocks (all checks green but conversations
+        unresolved) from pending-CI blocks (checks still running). Returns an
+        empty list on lookup failure — the caller then conservatively assumes no
+        checks are pending and exits the poll.
+
+        Args:
+            pr_number: GitHub PR number.
+
+        Returns:
+            Names of required checks whose ``status != "completed"``.
+
+        """
+        options = self._options()
+        try:
+            checks = gh_pr_checks(pr_number, dry_run=options.dry_run)
+        except Exception as exc:
+            logger.info(
+                "PR #%s: failed to fetch CI checks for BLOCKED pending guard (%s)",
+                pr_number,
+                exc,
+            )
+            return []
+        if not checks:
+            return []
+        required = [c for c in checks if c.get("required")] or checks
+        return [c.get("name", "") for c in required if c.get("status") != "completed"]
+
+    def get_failing_ci_logs(self, pr_number: int) -> str:
+        """Fetch combined failure logs for recent failed CI runs on a PR.
+
+        Scopes the ``gh run list`` query to the PR's head branch so we only
+        see runs that belong to this PR rather than the most-recent repo-wide
+        runs (the previous repo-wide query could return runs for other PRs
+        and even other branches, making the logs useless for fixing *this* PR).
+
+        Args:
+            pr_number: GitHub PR number.
+
+        Returns:
+            Combined log string, truncated to 10 000 characters.
+
+        """
+        try:
+            branch = self._get_pr_branch(pr_number)
+            result2 = _gh_call(
+                [
+                    "run",
+                    "list",
+                    "--branch",
+                    branch,
+                    "--status",
+                    "failure",
+                    "--limit",
+                    "10",
+                    "--json",
+                    "databaseId,conclusion,name,headSha",
+                ],
+                check=False,
+            )
+            runs: list[dict[str, Any]] = json.loads(result2.stdout or "[]")
+            failed_runs = [r for r in runs if r.get("conclusion") == "failure"][:3]
+
+            logs: list[str] = []
+            for run_info in failed_runs:
+                run_id = run_info.get("databaseId")
+                run_name = run_info.get("name", str(run_id))
+                if not run_id:
+                    continue
+                try:
+                    log_result = _gh_call(
+                        ["run", "view", str(run_id), "--log-failed"],
+                        check=False,
+                    )
+                    logs.append(f"=== {run_name} ===\n{log_result.stdout[:3000]}")
+                except Exception as log_err:
+                    logger.debug("Could not fetch log for run %s: %s", run_id, log_err)
+
+            return "\n\n".join(logs)[:10000]
+
+        except Exception as e:
+            logger.warning("Could not fetch CI logs for PR #%s: %s", pr_number, e)
+            return ""

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -18,7 +18,6 @@ import subprocess
 import threading
 import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -26,7 +25,6 @@ from hephaestus.agents.runtime import (
     add_agent_argument,
     is_codex,
     resolve_agent,
-    resume_codex_session,
     run_codex_session,
     session_agent_matches,
 )
@@ -40,48 +38,43 @@ from .address_review import (
 )
 from .advise_runner import run_advise
 from .arming_state import ArmingStateStore
+from .ci_check_inspector import FAILING_CHECK_CONCLUSIONS as FAILING_CHECK_CONCLUSIONS  # re-export
+from .ci_check_inspector import CICheckInspector
+from .ci_fix_orchestrator import CIFixOrchestrator
 from .claude_invoke import invoke_claude_with_session
-from .claude_models import advise_model, implementer_model
+from .claude_models import advise_model
 from .claude_timeouts import (
     advise_claude_timeout,
-    ci_driver_claude_timeout,
     ci_poll_max_wait,
-    learn_claude_timeout,
 )
 from .git_utils import (
-    get_repo_info,
     get_repo_root,
     get_repo_slug,
     issue_ref,
     pr_ref,
-    push_current_branch_with_lease_on_divergence,
-    rebase_worktree_onto,
-    run,
-    sync_worktree_to_remote_branch,
 )
 from .github_api import (
-    GitHubUnavailableError,
     _gh_call,
     gh_issue_json,
     gh_pr_checks,
     gh_pr_list_unresolved_threads,
     gh_pr_resolve_thread,
 )
-from .learn import build_learn_prompt, compact_session, mnemosyne_update_evidence
 from .models import CIDriverOptions, WorkerResult
+from .post_merge_processor import PostMergeProcessor
+from .pr_discovery import PRDiscovery
 from .pr_manager import pr_has_implementation_go_label
 from .prompts import get_advise_prompt_builder
-from .session_naming import AGENT_ADVISE, AGENT_CI_DRIVER
+from .session_naming import AGENT_ADVISE
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
 
-# Conclusion values that indicate a PR's check rollup is failing in a way
-# drive-green can act on. SUCCESS / SKIPPED / NEUTRAL / PENDING are
-# explicitly excluded. Shared with loop_runner._count_failing_prs so the
-# SKIP gate and the actual work list never drift (#819).
-FAILING_CHECK_CONCLUSIONS: frozenset[str] = frozenset({"FAILURE", "CANCELLED", "TIMED_OUT"})
+# FAILING_CHECK_CONCLUSIONS moved to ci_check_inspector.py (#1357) and
+# re-exported from the import block above for backward compatibility — the
+# module-level _pr_is_failing predicate and loop_runner._count_failing_prs
+# both still import it from here.
 
 # Max address-review passes for a green-but-BLOCKED PR before leaving it armed
 # (#1348). The progress guard stops earlier whenever a pass resolves no new
@@ -146,11 +139,51 @@ class CIDriver:
         # arming record (and therefore its own /learn capture once the PR
         # actually merges in a subsequent run). #840 +on top of #834.
         self.shared_pr_issues: dict[int, list[int]] = {}
-        # Viewer login cache (#821). Resolved lazily on first use of the
-        # author filter; empty string means "not yet resolved". When
-        # options.include_all_authors=True the filter is bypassed and this
-        # stays empty so a broken `gh auth` does not block --all runs.
-        self._viewer_login: str = ""
+
+        # Narrow-callable collaborators extracted from CIDriver (#1357 /
+        # refs #1179, #1289). Each receives only the specific Callable[[], T]
+        # providers / bound methods it needs (DIP) — never ``self``. The
+        # injected callables are wrapped in lambdas (or passed as bound methods
+        # that delegate further) so ``patch.object(driver, "_method")`` in tests
+        # still intercepts through the indirection at call time. The viewer-login
+        # cache (#821) now lives inside PRDiscovery.
+        self._pr_discovery = PRDiscovery(
+            options_provider=lambda: self.options,
+            status_tracker_provider=lambda: self.status_tracker,
+            repo_root_provider=lambda: self.repo_root,
+            pr_merge_state_provider=lambda pr_number: self._pr_merge_state(pr_number),
+        )
+        self._check_inspector = CICheckInspector(
+            get_pr_branch=lambda pr_number: self._get_pr_branch(pr_number),
+            options_provider=lambda: self.options,
+        )
+        self._fix_orchestrator = CIFixOrchestrator(
+            options_provider=lambda: self.options,
+            repo_root_provider=lambda: self.repo_root,
+            state_dir_provider=lambda: self.state_dir,
+            status_tracker_provider=lambda: self.status_tracker,
+            get_pr_branch=lambda pr_number: self._get_pr_branch(pr_number),
+            get_worktree_path=lambda issue_number, pr_number: self._get_worktree_path(
+                issue_number, pr_number
+            ),
+            format_review_threads_block=lambda pr_number: self._format_review_threads_block(
+                pr_number
+            ),
+            failing_required_check_names=lambda pr_number: self._failing_required_check_names(
+                pr_number
+            ),
+        )
+        self._post_merge = PostMergeProcessor(
+            options_provider=lambda: self.options,
+            repo_root_provider=lambda: self.repo_root,
+            get_worktree_path=lambda issue_number, pr_number: self._get_worktree_path(
+                issue_number, pr_number
+            ),
+            load_arming_state=lambda issue_number: self._load_arming_state(issue_number),
+            save_arming_state=lambda issue_number, record: self._save_arming_state(
+                issue_number, record
+            ),
+        )
 
     def run(self) -> dict[int, WorkerResult]:  # noqa: C901  # orchestration: thread pool + finally + preserve report across exception paths
         """Run the CI driver on all configured issues.
@@ -300,140 +333,12 @@ class CIDriver:
         return results
 
     def _list_open_prs_remaining(self) -> list[dict[str, Any]]:
-        """Return the list of open PRs left on the repo after the drive (#838).
-
-        A repo is only truly "driven" when there are zero open PRs left. The
-        per-issue ``_drive_issue`` loop's notion of success — every issue's
-        PR moved to green and/or got auto-merge enabled — does NOT imply the
-        repo is clean: PRs that have not yet merged (auto-merge waiting on
-        CI), PRs from issues outside the input set, and PRs opened by
-        humans/other-automation all leave open work behind.
-
-        Uses ``gh api --paginate`` so the result is the FULL set of open PRs,
-        not a capped prefix. A repo with hundreds of dependabot PRs would
-        otherwise pass the done-check after looking at only 100 of them.
-
-        Returns:
-            One dict per open PR with keys ``number``, ``title``,
-            ``headRefName``, ``autoMergeRequest`` (None or the auto-merge
-            metadata blob), and ``mergeStateStatus`` / ``mergeable`` (the
-            per-PR merge-state, fetched separately because the REST list
-            endpoint does not populate ``mergeable`` reliably — see #1328).
-            Empty list iff the repo is clean.
-
-        """
-        try:
-            owner, repo = get_repo_info(self.repo_root)
-        except RuntimeError as exc:
-            logger.error("Could not resolve repo owner/name to list open PRs: %s", exc)
-            # Unknown ownership ⇒ treat as not-done so operators investigate.
-            return [{"number": -1, "title": "(unknown: cannot resolve repo)"}]
-
-        # ``gh api --paginate`` walks ``Link: rel="next"`` headers and emits
-        # a single concatenated JSON array across all pages. ``per_page=100``
-        # is GitHub's max page size; we issue the minimum number of calls.
-        # We use ``gh api`` directly (not ``gh pr list``) because the latter
-        # caps at ``--limit`` even with paginate semantics; gh's REST proxy
-        # paginates without an upper bound.
-        try:
-            result = _gh_call(
-                [
-                    "api",
-                    "--paginate",
-                    f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
-                ],
-                check=False,
-            )
-            raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            # If we cannot determine the open-PR count, the safest default is
-            # to assume the repo is NOT done — surface the unknown state as a
-            # failure so operators don't walk away on a false-green.
-            logger.error("Could not list open PRs to verify repo done-state: %s", exc)
-            return [{"number": -1, "title": "(unknown: gh api pulls failed)"}]
-
-        # The REST shape exposes ``head.ref`` and ``auto_merge`` (snake_case);
-        # normalise to the gh-CLI shape consumers downstream already use.
-        viewer = "" if self.options.include_all_authors else self._resolve_viewer_login()
-        normalised: list[dict[str, Any]] = []
-        for pr in raw_pulls:
-            user = pr.get("user") or {}
-            if viewer and user.get("login") != viewer:
-                if user.get("login") is None:
-                    logger.warning(
-                        "PR #%s has no user.login; skipping under author filter (#821)",
-                        pr.get("number"),
-                        extra={
-                            "missing_field": "user.login",
-                            "filter": "author",
-                            "pr_number": pr.get("number"),
-                        },
-                    )
-                continue  # #821: hide other-author PRs from the done-gate sweep
-            labels = pr.get("labels") or []
-            number = pr.get("number")
-            merge_state, mergeable = self._pr_merge_state(number)
-            normalised.append(
-                {
-                    "number": number,
-                    "title": pr.get("title", ""),
-                    "headRefName": (pr.get("head") or {}).get("ref", ""),
-                    "autoMergeRequest": pr.get("auto_merge"),
-                    "mergeStateStatus": merge_state,
-                    "mergeable": mergeable,
-                    "labels": [
-                        label.get("name", "") for label in labels if isinstance(label, dict)
-                    ],
-                    "isBot": user.get("type") == "Bot",
-                }
-            )
-        return normalised
+        """Delegate to PRDiscovery (extracted #1357)."""
+        return self._pr_discovery.list_open_prs_remaining()
 
     def _pr_merge_state(self, pr_number: Any) -> tuple[str, str]:
-        """Return ``(mergeStateStatus, mergeable)`` for a single PR (#1328).
-
-        The REST ``/pulls`` list endpoint does NOT populate ``mergeable`` /
-        ``mergeable_state`` reliably (GitHub computes the merge-state lazily and
-        omits it from list responses), so the done-gate cannot tell a
-        permanently-CONFLICTING armed PR apart from one that is genuinely still
-        merging. A per-PR ``gh pr view`` forces GitHub to compute the merge
-        state, matching how the rest of this module queries merge-state
-        (``_attempt_mechanical_rebase`` / ``_gh_pr_state``).
-
-        Args:
-            pr_number: PR number to query.
-
-        Returns:
-            ``(mergeStateStatus, mergeable)`` upper-cased. Empty strings when the
-            number is the unknown-marker sentinel or the query fails — an unknown
-            merge-state must never be misread as CONFLICTING.
-
-        """
-        if not isinstance(pr_number, int) or pr_number < 0:
-            return "", ""
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "view",
-                    str(pr_number),
-                    "--json",
-                    "mergeStateStatus,mergeable",
-                ],
-                check=False,
-            )
-            state = dict(json.loads(result.stdout or "{}"))
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            logger.warning(
-                "Could not fetch PR #%s merge-state for done-gate; treating as unknown: %s",
-                pr_number,
-                exc,
-            )
-            return "", ""
-        return (
-            str(state.get("mergeStateStatus") or "").upper(),
-            str(state.get("mergeable") or "").upper(),
-        )
+        """Delegate to PRDiscovery (extracted #1357)."""
+        return self._pr_discovery.pr_merge_state(pr_number)
 
     def _arm_all_unarmed_open_prs(self, open_prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Arm auto-merge on every implementation-GO un-armed open PR (#882).
@@ -473,201 +378,20 @@ class CIDriver:
         return self._list_open_prs_remaining()
 
     def _resolve_viewer_login(self) -> str:
-        """Return the authenticated `gh api user` login. Fail CLOSED on error.
-
-        Lazy + cached: only called when the author filter is active. Raises
-        ``RuntimeError`` with operator guidance on any failure so a broken
-        `gh` auth never silently widens scope to all PRs (#821 POLA).
-        """
-        if self._viewer_login:
-            return self._viewer_login
-        try:
-            result = _gh_call(["api", "user", "-q", ".login"], check=True)
-        except (
-            subprocess.CalledProcessError,
-            FileNotFoundError,
-            GitHubUnavailableError,
-        ) as exc:
-            raise RuntimeError(
-                "Could not resolve viewer login via `gh api user`: "
-                f"{exc}. Re-authenticate with `gh auth login`, or pass "
-                "--all to opt out of the @me filter (#821)."
-            ) from exc
-        login = (result.stdout or "").strip()
-        if not login:
-            raise RuntimeError(
-                "Could not resolve viewer login via `gh api user`: "
-                "empty response. Re-authenticate with `gh auth login`, "
-                "or pass --all to opt out of the @me filter (#821)."
-            )
-        self._viewer_login = login
-        return login
+        """Delegate to PRDiscovery (extracted #1357)."""
+        return self._pr_discovery.resolve_viewer_login()
 
     def _discover_bot_prs(self) -> dict[int, int]:
-        """Enumerate every open ``is_bot=true`` PR on the repo (#848).
-
-        Bot PRs (Dependabot, github-actions, etc.) carry NO ``Closes #N``
-        link to an issue, so the issue-driven discovery path can never see
-        them — they are architecturally invisible. Without this enumeration
-        a repo can sit with dozens of stranded Dependabot PRs forever while
-        the ecosystem script cheerfully reports "driven" because every
-        listed issue had no matching PR.
-
-        Returns a mapping where each bot PR's number is used both as the
-        synthetic issue key AND the PR number. Downstream code is taught
-        (``_is_bot_pr_mode``) to detect the equality and skip issue-data
-        fetches that would 404 on a synthetic key.
-
-        Returns:
-            Mapping of ``pr_number -> pr_number`` for every open bot PR.
-            Empty dict if the ``gh api`` pulls lookup fails or returns
-            nothing — bot discovery must never abort the drive on a list
-            failure.
-
-        Raises:
-            RuntimeError: When the default @me author filter is active
-                (``--all`` not set) and viewer-login resolution fails. This
-                fail-CLOSED abort is intentional per #821 (POLA): a broken
-                ``gh auth`` must never silently widen scope to every author's
-                PRs. Pass ``--all`` to opt out of the filter and bypass the
-                resolver entirely.
-
-        """
-        try:
-            owner, repo = get_repo_info(self.repo_root)
-        except RuntimeError as exc:
-            logger.info("Bot-PR discovery skipped: could not resolve owner/name (%s)", exc)
-            return {}
-
-        try:
-            result = _gh_call(
-                [
-                    "api",
-                    "--paginate",
-                    f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
-                ],
-                check=False,
-            )
-            raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-            OSError,
-            json.JSONDecodeError,
-        ) as exc:
-            logger.info("Bot-PR discovery skipped: gh api failed (%s)", exc)
-            return {}
-
-        viewer = "" if self.options.include_all_authors else self._resolve_viewer_login()
-        bot_prs: dict[int, int] = {}
-        for pr in raw_pulls:
-            user = pr.get("user") or {}
-            if user.get("type") != "Bot":
-                continue
-            if viewer and user.get("login") != viewer:
-                if user.get("login") is None:
-                    logger.warning(
-                        "PR #%s has no user.login; skipping under author filter (#821)",
-                        pr.get("number"),
-                        extra={
-                            "missing_field": "user.login",
-                            "filter": "author",
-                            "pr_number": pr.get("number"),
-                        },
-                    )
-                continue  # #821: not viewer-owned and --all not set
-            number = pr.get("number")
-            if isinstance(number, int):
-                bot_prs[number] = number
-
-        if bot_prs:
-            logger.info(
-                "Discovered %s open bot-authored PR(s): %s",
-                len(bot_prs),
-                sorted(bot_prs),
-            )
-        return bot_prs
+        """Delegate to PRDiscovery (extracted #1357)."""
+        return self._pr_discovery.discover_bot_prs()
 
     def _discover_failing_prs(self) -> dict[int, int]:
-        """Enumerate open non-draft PRs whose checks failed or merge is BLOCKED.
-
-        Symmetrical to ``_discover_bot_prs``: the issue→PR direction (Closes #N)
-        misses every PR with no Closes line and every PR linked to a closed
-        issue (issue body §1, §2). One CLI call, PR-keyed, synthetic-issue
-        invariant (pr_number == issue_number) so downstream ``_is_bot_pr_mode``
-        short-circuits ``gh issue view`` identically to the bot path.
-
-        Bounded by gh's --limit 1000 (its documented hard upper). A repo with
-        more than 1000 failing open PRs is pathological — we log a WARNING
-        so operators see the truncation rather than silently dropping work.
-
-        Returns:
-            Mapping pr_number -> pr_number for every failing open PR.
-            Empty dict on any lookup failure — discovery must never abort
-            the drive.
-
-        """
-        try:
-            owner, repo = get_repo_info(self.repo_root)
-        except RuntimeError as exc:
-            logger.info("Failing-PR discovery skipped: could not resolve owner/name (%s)", exc)
-            return {}
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "list",
-                    "--repo",
-                    f"{owner}/{repo}",
-                    "--state",
-                    "open",
-                    "--limit",
-                    "1000",
-                    "--json",
-                    "number,isDraft,statusCheckRollup,mergeStateStatus",
-                ],
-            )
-            pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-            OSError,
-            json.JSONDecodeError,
-        ) as exc:
-            logger.info("Failing-PR discovery skipped: gh pr list failed (%s)", exc)
-            return {}
-        if len(pulls) >= 1000:
-            logger.warning(
-                "Failing-PR discovery hit gh's 1000-PR cap on %s/%s — "
-                "additional failing PRs may exist and are not visible to this run.",
-                owner,
-                repo,
-            )
-        failing: dict[int, int] = {}
-        for pr in pulls:
-            number = pr.get("number")
-            if not isinstance(number, int):
-                continue
-            if _pr_is_failing(pr):
-                failing[number] = number
-        if failing:
-            logger.info(
-                "Discovered %s open failing PR(s): %s",
-                len(failing),
-                sorted(failing),
-            )
-        return failing
+        """Delegate to PRDiscovery (extracted #1357)."""
+        return self._pr_discovery.discover_failing_prs(_pr_is_failing)
 
     def _is_bot_pr_mode(self, issue_number: int, pr_number: int) -> bool:
-        """Return True iff this work item is a synthetic-issue bot PR (#848).
-
-        The bot-PR enumeration uses the PR number as a stand-in for an
-        issue number because Dependabot PRs have no associated issue.
-        Anywhere we would normally call ``gh issue view <issue_number>``
-        we must instead short-circuit; this helper centralises the check
-        so a single rule (issue == pr) keeps both ends honest.
-        """
-        return issue_number == pr_number
+        """Delegate to PRDiscovery (extracted #1357)."""
+        return self._pr_discovery.is_bot_pr_mode(issue_number, pr_number)
 
     def _discover_prs(self, issue_numbers: list[int]) -> dict[int, int]:  # noqa: C901  # orchestration: multi-PR dedup with fallback discovery across issue/PR mappings
         """Pre-discover open PRs for all issues, deduped by PR.
@@ -1005,122 +729,10 @@ class CIDriver:
         pr_number: int,
         acquired_slot: int,
     ) -> bool:
-        """Rebase a behind/conflicting PR onto its base branch with no agent (#871).
-
-        The cheap, deterministic path: a PR that is merely behind its base (or
-        whose changes don't textually overlap) is rebased and pushed here. Only a
-        PR whose rebase hits real conflicts falls through to the CI-fix agent.
-
-        Flow:
-
-        1. Query ``mergeStateStatus`` / ``mergeable`` / ``baseRefName``. Skip
-           (return ``False``) unless the PR is ``BEHIND`` or ``DIRTY`` /
-           ``CONFLICTING`` — a PR already on top of its base needs no rebase and
-           the normal check-status path handles it.
-        2. Sync the worktree to the PR head, then ``rebase_worktree_onto`` the
-           base branch.
-        3. Clean rebase → push ``HEAD:<pr-head>`` with ``--force-with-lease`` and
-           return ``True``. The push re-triggers CI; the caller's poll loop
-           evaluates the rebased head.
-        4. Conflicts → the rebase is aborted inside ``rebase_worktree_onto``;
-           return ``False`` so the caller continues to the agent path.
-
-        Any unexpected git/subprocess error is logged and swallowed (returns
-        ``False``) — a mechanical-rebase failure must never crash the worker; the
-        agent path is always the safe fallback.
-
-        Args:
-            issue_number: GitHub issue number for the PR.
-            pr_number: PR number to rebase.
-            acquired_slot: Worker slot ID for status tracking.
-
-        Returns:
-            ``True`` if the PR was mechanically rebased and pushed; ``False`` if
-            no rebase was needed, the rebase conflicted, or an error occurred.
-
-        """
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "view",
-                    str(pr_number),
-                    "--json",
-                    "mergeStateStatus,mergeable,headRefName,baseRefName",
-                ],
-                check=False,
-            )
-            state = dict(json.loads(result.stdout or "{}"))
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            logger.warning(
-                "Issue #%s: could not fetch PR #%s merge state for rebase; "
-                "skipping mechanical rebase: %s",
-                issue_number,
-                pr_number,
-                exc,
-            )
-            return False
-
-        merge_state = str(state.get("mergeStateStatus") or "").upper()
-        # Only behind-base / conflicting PRs need a rebase. CLEAN / BLOCKED /
-        # UNSTABLE / HAS_HOOKS PRs are already on top of their base — let the
-        # check-status path handle them. (BLOCKED is the review-gated case.)
-        if merge_state not in ("BEHIND", "DIRTY", "CONFLICTING"):
-            return False
-
-        pr_head_branch = str(state.get("headRefName") or "") or self._get_pr_branch(pr_number)
-        base_branch = str(state.get("baseRefName") or "main") or "main"
-        if not pr_head_branch:
-            logger.warning(
-                "Issue #%s: PR #%s has no resolvable head branch; skipping rebase",
-                issue_number,
-                pr_number,
-            )
-            return False
-
-        self.status_tracker.update_slot(
-            acquired_slot,
-            f"{issue_ref(issue_number)}: mechanical rebase onto {base_branch}",
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.attempt_mechanical_rebase(
+            issue_number, pr_number, acquired_slot
         )
-
-        try:
-            worktree_path = self._get_worktree_path(issue_number, pr_number)
-            # Land on the PR's actual remote head before rebasing so we replay the
-            # PR's commits (not a stale local ref) onto the base (#832).
-            sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
-
-            if not rebase_worktree_onto(worktree_path, base_branch):
-                logger.info(
-                    "Issue #%s: PR #%s (%s) has rebase conflicts onto %s; deferring to agent",
-                    issue_number,
-                    pr_number,
-                    merge_state,
-                    base_branch,
-                )
-                return False
-
-            # Clean rebase rewrote history — lease-push to the PR head. The helper
-            # no-ops cleanly if the rebase was already up to date (HEAD unchanged).
-            push_current_branch_with_lease_on_divergence(
-                worktree_path,
-                branch=pr_head_branch,
-                push_ref=f"HEAD:{pr_head_branch}",
-            )
-            logger.info(
-                "Issue #%s: mechanically rebased PR #%s onto %s and pushed (no agent)",
-                issue_number,
-                pr_number,
-                base_branch,
-            )
-            return True
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "Issue #%s: mechanical rebase of PR #%s failed (%s); falling through to agent",
-                issue_number,
-                pr_number,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return False
 
     def _run_advise(self, issue_number: int) -> str:
         """Pull prior learnings from ProjectMnemosyne before the CI fix loop.
@@ -1648,60 +1260,8 @@ class CIDriver:
         return self.worktree_manager.create_worktree(issue_number, branch)
 
     def _get_failing_ci_logs(self, pr_number: int) -> str:
-        """Fetch combined failure logs for recent failed CI runs on a PR.
-
-        Scopes the ``gh run list`` query to the PR's head branch so we only
-        see runs that belong to this PR rather than the most-recent repo-wide
-        runs (the previous repo-wide query could return runs for other PRs
-        and even other branches, making the logs useless for fixing *this* PR).
-
-        Args:
-            pr_number: GitHub PR number.
-
-        Returns:
-            Combined log string, truncated to 10 000 characters.
-
-        """
-        try:
-            branch = self._get_pr_branch(pr_number)
-            result2 = _gh_call(
-                [
-                    "run",
-                    "list",
-                    "--branch",
-                    branch,
-                    "--status",
-                    "failure",
-                    "--limit",
-                    "10",
-                    "--json",
-                    "databaseId,conclusion,name,headSha",
-                ],
-                check=False,
-            )
-            runs: list[dict[str, Any]] = json.loads(result2.stdout or "[]")
-            failed_runs = [r for r in runs if r.get("conclusion") == "failure"][:3]
-
-            logs: list[str] = []
-            for run_info in failed_runs:
-                run_id = run_info.get("databaseId")
-                run_name = run_info.get("name", str(run_id))
-                if not run_id:
-                    continue
-                try:
-                    log_result = _gh_call(
-                        ["run", "view", str(run_id), "--log-failed"],
-                        check=False,
-                    )
-                    logs.append(f"=== {run_name} ===\n{log_result.stdout[:3000]}")
-                except Exception as log_err:
-                    logger.debug("Could not fetch log for run %s: %s", run_id, log_err)
-
-            return "\n\n".join(logs)[:10000]
-
-        except Exception as e:
-            logger.warning("Could not fetch CI logs for PR #%s: %s", pr_number, e)
-            return ""
+        """Delegate to CICheckInspector (extracted #1357)."""
+        return self._check_inspector.get_failing_ci_logs(pr_number)
 
     # ------------------------------------------------------------------
     # Drive-green arming records (#840)
@@ -1742,33 +1302,8 @@ class CIDriver:
         *,
         succeeded: bool,
     ) -> None:
-        """Persist an explicit attempted/succeeded/failed learn result.
-
-        ``learn_captured_at`` is retained as the success timestamp for older
-        readers, but failure now records ``learn_status=failed`` without
-        claiming Mnemosyne was updated.
-        """
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-        record["learn_attempted_at"] = timestamp
-        if succeeded:
-            record["learn_status"] = "succeeded"
-            record["learn_succeeded_at"] = timestamp
-            record["learn_captured_at"] = timestamp
-            record.update(
-                getattr(self, "_last_drive_green_learn_evidence", mnemosyne_update_evidence(""))
-            )
-        else:
-            record["learn_status"] = "failed"
-            record["learn_succeeded_at"] = None
-            record["learn_captured_at"] = None
-            record.update(
-                {
-                    "mnemosyne_update_status": "failed",
-                    "mnemosyne_update_urls": [],
-                    "mnemosyne_update_pr_numbers": [],
-                }
-            )
-        self._save_arming_state(issue_number, record)
+        """Delegate to PostMergeProcessor (extracted #1357)."""
+        self._post_merge.mark_drive_green_learn_result(issue_number, record, succeeded=succeeded)
 
     def _arm_drive_green(self, pr_number: int, pr_head_branch: str, pr_head_sha: str) -> None:
         """Record arming for every issue that resolved to ``pr_number``.
@@ -2302,72 +1837,16 @@ class CIDriver:
         return resolved
 
     def _failing_required_check_names(self, pr_number: int) -> list[str]:
-        """Return names of required checks that are currently failing.
-
-        Used by the no-commit retry path (#846) to name the actual offenders
-        verbatim in the force-engagement prompt. Returns an empty list if
-        the lookup fails — the caller treats that as "cannot prove still
-        red" and skips the retry rather than launching Claude blind.
-        """
-        try:
-            checks = gh_pr_checks(pr_number, dry_run=self.options.dry_run)
-        except Exception as exc:
-            logger.info(
-                "PR #%s: failed to re-check CI for no-commit retry decision (%s)",
-                pr_number,
-                exc,
-            )
-            return []
-        if not checks:
-            return []
-        required = [c for c in checks if c.get("required")] or checks
-        return [
-            c.get("name", "")
-            for c in required
-            if c.get("status") == "completed" and c.get("conclusion") == "failure"
-        ]
+        """Delegate to CICheckInspector (extracted #1357)."""
+        return self._check_inspector.failing_required_check_names(pr_number)
 
     def _tracked_worktree_changes(self, worktree_path: Path, issue_number: int) -> list[str]:
-        """Return tracked dirty status lines for a post-agent worktree.
-
-        Untracked tool output such as a local ``uv.lock`` is intentionally
-        ignored. A no-commit turn that left tracked files modified is still
-        actionable even when the remote has no red required checks, as happens
-        for merge-conflict/behind-branch repairs where the agent fixed files but
-        forgot the signed commit.
-        """
-        status = self._git_stdout_for_push_guard(
-            worktree_path,
-            issue_number,
-            ["git", "status", "--porcelain"],
-            "failed to inspect worktree status for no-commit retry",
-        )
-        if status is None:
-            return []
-        return [line for line in status.splitlines() if line.strip() and not line.startswith("?? ")]
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator._tracked_worktree_changes(worktree_path, issue_number)
 
     def _pending_required_check_names(self, pr_number: int) -> list[str]:
-        """Return names of required checks that are still in flight (not completed).
-
-        Used by the BLOCKED early-exit guard in ``_wait_for_pr_terminal`` to
-        distinguish branch-protection blocks (all checks green but conversations
-        unresolved) from pending-CI blocks (checks still running).  Returns an
-        empty list on lookup failure — the caller then conservatively assumes no
-        checks are pending and exits the poll.
-        """
-        try:
-            checks = gh_pr_checks(pr_number, dry_run=self.options.dry_run)
-        except Exception as exc:
-            logger.info(
-                "PR #%s: failed to fetch CI checks for BLOCKED pending guard (%s)",
-                pr_number,
-                exc,
-            )
-            return []
-        if not checks:
-            return []
-        required = [c for c in checks if c.get("required")] or checks
-        return [c.get("name", "") for c in required if c.get("status") != "completed"]
+        """Delegate to CICheckInspector (extracted #1357)."""
+        return self._check_inspector.pending_required_check_names(pr_number)
 
     def _force_engagement_prompt(
         self,
@@ -2380,66 +1859,15 @@ class CIDriver:
         review_threads_block: str,
         dirty_tracked_changes: list[str] | None = None,
     ) -> str:
-        """Build the retry prompt when the agent returned without committing (#846).
-
-        The retry must engage the agent enough to either (a) produce a real
-        fix or (b) explicitly say why CI cannot pass / merge. The prompt names
-        the failing checks and/or dirty tracked files verbatim, re-emphasises
-        the existing PR/branch invariant, and re-emphasises signed commits — a
-        no-commit retry is a contract violation that the agent has to address
-        head-on.
-        """
-        failing_block = "\n".join(f"- {n}" for n in failing_check_names) or "- (unknown)"
-        dirty_lines = dirty_tracked_changes or []
-        dirty_block = "\n".join(f"- {line}" for line in dirty_lines)
-        if dirty_block:
-            dirty_block = (
-                "\n\nThe local worktree also contains uncommitted tracked changes "
-                "from the previous turn. Review this existing diff first and either "
-                f"commit it after verification or amend it before committing:\n\n{dirty_block}\n"
-            )
-        remote_block = (
-            "The required CI checks below are STILL failing on the remote"
-            if failing_check_names
-            else "The remote checks may be green, but the PR still needs a committed "
-            "repair before the driver can push"
-        )
-        return (
-            f"{review_threads_block}"
-            f"## Force-Engagement Retry — Previous Turn Produced No Commit\n\n"
-            f"You just returned from a CI-fix session for PR {pr_ref(pr_number)} "
-            f"(issue {issue_ref(issue_number)}) WITHOUT producing a new commit on "
-            f"branch `{pr_head_branch}`. {remote_block}:\n\n"
-            f"{failing_block}\n\n"
-            f"{dirty_block}"
-            f"Returning no commit when required checks are still red is itself a "
-            f"bug; returning no commit after editing tracked files is also a bug. "
-            f"Fix the code so the failing checks pass and the PR can merge. If no "
-            f"code fix is possible, DO NOT commit a 'blocker' file: a new "
-            f"Markdown/docs file will itself fail the repo's lint gates (e.g. "
-            f"markdownlint) and turn one blocker into two. Instead leave the tree "
-            f"unchanged and report the blocker via the `BLOCKED:` line below — do "
-            f"NOT commit any file to document it.\n\n"
-            f"Working directory: {worktree_path}\n"
-            f"Current branch (DO NOT change, DO NOT create a new branch): "
-            f"{pr_head_branch}\n\n"
-            f"Required behaviour:\n"
-            f"1. Re-read the failing check logs for the names listed above.\n"
-            f"2. Make the minimal change that addresses each failure.\n"
-            f"3. Run `pixi run python -m pytest tests/ -v` and "
-            f"`pre-commit run --all-files` locally to verify before committing. "
-            f"This MUST include any markdown/lint hooks — every file you add or "
-            f"edit has to pass the repo's own linters, with no rule disabled.\n"
-            f"4. **Every commit MUST be cryptographically signed (`git commit -S`).** "
-            f"NEVER use `--no-verify`. The repository's CI gate rejects unsigned "
-            f"commits and any commit that bypassed pre-commit hooks.\n"
-            f"5. Do NOT run `git checkout -b`, `git switch -c`, or any command "
-            f"that creates or switches branches — the fix has to land on "
-            f"`{pr_head_branch}`.\n"
-            f"6. Do NOT add a new top-level `CI_BLOCKER.md` or similar doc file to "
-            f"record the blocker — use the `BLOCKED:` line instead.\n\n"
-            f"If after the steps above you still cannot produce a commit, reply "
-            f"with a single line `BLOCKED: <one-sentence reason>` and stop."
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.force_engagement_prompt(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            worktree_path=worktree_path,
+            pr_head_branch=pr_head_branch,
+            failing_check_names=failing_check_names,
+            review_threads_block=review_threads_block,
+            dirty_tracked_changes=dirty_tracked_changes,
         )
 
     def _record_repeated_no_commit(
@@ -2450,36 +1878,13 @@ class CIDriver:
         pr_head_branch: str,
         failing_check_names: list[str],
     ) -> None:
-        """Persist a marker for the next ecosystem run (#846).
-
-        Writes ``state_dir / "repeated-no-commit-<pr>.json"`` so a future
-        run (and the human reading the logs) can see which PRs got stuck
-        in the no-commit loop. We deliberately do NOT delete the arming
-        record here — the PR is still open and may yet land via another
-        actor; the marker file is purely a forensics aid.
-        """
-        marker = self.state_dir / f"repeated-no-commit-{pr_number}.json"
-        try:
-            marker.write_text(
-                json.dumps(
-                    {
-                        "issue_number": issue_number,
-                        "pr_number": pr_number,
-                        "pr_head_branch": pr_head_branch,
-                        "failing_required_checks": failing_check_names,
-                        "recorded_at": datetime.now(timezone.utc).isoformat(),
-                    },
-                    indent=2,
-                )
-                + "\n"
-            )
-        except OSError as exc:
-            logger.warning(
-                "Issue #%s: failed to write repeated-no-commit marker for PR #%s: %s",
-                issue_number,
-                pr_number,
-                exc,
-            )
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        self._fix_orchestrator.record_repeated_no_commit(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_head_branch=pr_head_branch,
+            failing_check_names=failing_check_names,
+        )
 
     def _invoke_agent_session(
         self,
@@ -2490,94 +1895,14 @@ class CIDriver:
         issue_number: int,
         pr_number: int,
     ) -> subprocess.CompletedProcess[str]:
-        """Dispatch a prompt to the configured agent (codex or claude).
-
-        Returns a CompletedProcess whose returncode signals success or failure:
-        - returncode == 0: agent ran successfully (stdout has output)
-        - returncode != 0: agent failed (stderr has details)
-
-        For codex, returncode is synthetic — AgentRunResult has no returncode
-        field; success is "no CalledProcessError" (hephaestus/agents/runtime.py).
-        For claude, returncode comes from the subprocess exit code.
-
-        CalledProcessError is absorbed from all codex paths into a non-zero
-        CompletedProcess. TimeoutExpired propagates to the caller so it can
-        log a distinct timeout message.
-        """
-        if is_codex(self.options.agent):
-            if session_id:
-                try:
-                    result = resume_codex_session(
-                        session_id,
-                        prompt,
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                    )
-                except subprocess.CalledProcessError as exc:
-                    logger.warning(
-                        "Issue #%s: Codex resume session %r failed for PR #%s; "
-                        "falling back to fresh session: %s",
-                        issue_number,
-                        session_id,
-                        pr_number,
-                        (exc.stderr or exc.stdout or "")[:300],
-                    )
-                    try:
-                        result = run_codex_session(
-                            prompt,
-                            cwd=worktree_path,
-                            timeout=ci_driver_claude_timeout(),
-                            sandbox="workspace-write",
-                        )
-                    except subprocess.CalledProcessError as fresh_exc:
-                        return subprocess.CompletedProcess(
-                            args=fresh_exc.cmd,
-                            returncode=fresh_exc.returncode,
-                            stdout=fresh_exc.stdout or "",
-                            stderr=fresh_exc.stderr or "",
-                        )
-            else:
-                try:
-                    result = run_codex_session(
-                        prompt,
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                        sandbox="workspace-write",
-                    )
-                except subprocess.CalledProcessError as exc:
-                    return subprocess.CompletedProcess(
-                        args=exc.cmd,
-                        returncode=exc.returncode,
-                        stdout=exc.stdout or "",
-                        stderr=exc.stderr or "",
-                    )
-            return subprocess.CompletedProcess(
-                args=[], returncode=0, stdout=result.stdout, stderr=result.stderr or ""
-            )
-
-        repo_slug = get_repo_slug(self.repo_root)
-        try:
-            stdout, _ = invoke_claude_with_session(
-                repo=repo_slug,
-                issue=issue_number,
-                agent=AGENT_CI_DRIVER,
-                prompt=prompt,
-                model=implementer_model(),
-                cwd=worktree_path,
-                timeout=ci_driver_claude_timeout(),
-                output_format="json",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                extra_args=["--dangerously-skip-permissions"],
-                input_via_stdin=True,
-            )
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
-        except subprocess.CalledProcessError as exc:
-            return subprocess.CompletedProcess(
-                args=exc.cmd,
-                returncode=exc.returncode,
-                stdout=exc.stdout or "",
-                stderr=exc.stderr or "",
-            )
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.invoke_agent_session(
+            prompt=prompt,
+            session_id=session_id,
+            worktree_path=worktree_path,
+            issue_number=issue_number,
+            pr_number=pr_number,
+        )
 
     def _push_ci_fix(
         self,
@@ -2589,34 +1914,15 @@ class CIDriver:
         pr_head_branch: str,
         session_id: str | None,
     ) -> bool:
-        """Check head advancement, retry if needed, then push CI fixes.
-
-        Shared post-agent contract for both codex and claude providers (#846).
-        Returns True if fixes were pushed, False on any failure or no-commit.
-        """
-        if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):  # noqa: SIM102
-            if not self._retry_no_commit_once(
-                issue_number=issue_number,
-                pr_number=pr_number,
-                worktree_path=worktree_path,
-                pr_head_branch=pr_head_branch,
-                pre_agent_sha=pre_agent_sha,
-                session_id=session_id,
-            ):
-                return False
-        if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
-            return False
-        try:
-            push_current_branch_with_lease_on_divergence(
-                worktree_path,
-                branch=pr_head_branch,
-                push_ref=f"HEAD:{pr_head_branch}",
-            )
-            logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
-            return True
-        except Exception as push_err:
-            logger.error("Issue #%s: git push failed after CI fix: %s", issue_number, push_err)
-            return False
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.push_ci_fix(
+            worktree_path=worktree_path,
+            pre_agent_sha=pre_agent_sha,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_head_branch=pr_head_branch,
+            session_id=session_id,
+        )
 
     def _retry_no_commit_once(
         self,
@@ -2629,123 +1935,16 @@ class CIDriver:
         session_id: str | None,
         max_retries: int = 2,
     ) -> bool:
-        """Re-invoke the agent up to ``max_retries`` times after a no-commit turn (#846).
-
-        A single no-op agent turn used to be terminal: with
-        ``max_fix_iterations=1`` the whole issue failed the instant the first
-        force-engagement retry also returned no commit. That cost real PRs
-        (AchaeanFleet #691/#683, Hermes #643). We now re-engage up to
-        ``max_retries`` times before recording the forensics marker, re-checking
-        between attempts so a PR that goes green (or where a commit lands)
-        short-circuits immediately.
-
-        Only fires when the PR still has failing required checks — a green PR
-        that arrived via concurrent activity should NOT be perturbed. Stays on
-        the same ``(repo, issue, AGENT_CI_DRIVER)`` session so the agent's
-        transcript is continuous; the existing PR and branch are preserved
-        (no new PR, no new branch, no force-push to a new ref).
-
-        Args:
-            issue_number: GitHub issue number for the PR.
-            pr_number: PR number to retry on.
-            worktree_path: Worktree the agent runs in (same as the first turn).
-            pr_head_branch: PR head branch name; the retry must not switch off it.
-            pre_agent_sha: HEAD SHA from before the first turn (used as the
-                no-commit baseline for the retry too — if the retry doesn't
-                advance past this, we treat it as repeated-no-commit).
-            session_id: Codex resume id (Claude resumes by deterministic UUID).
-
-        Returns:
-            True if the retry produced a new commit (caller should push).
-            False if CI is green now, the retry returned no commit again, or
-            any error path fired. On repeated-no-commit, writes a forensics
-            marker to ``state_dir``.
-
-        """
-        failing: list[str] = []
-        for retry in range(1, max_retries + 1):
-            failing = self._failing_required_check_names(pr_number)
-            dirty_tracked_changes = self._tracked_worktree_changes(worktree_path, issue_number)
-            if not failing and not dirty_tracked_changes:
-                logger.info(
-                    "Issue #%s: no-commit turn but PR #%s has no failing required checks "
-                    "and no tracked worktree changes; skipping force-engagement retry",
-                    issue_number,
-                    pr_number,
-                )
-                return False
-
-            review_threads_block = self._format_review_threads_block(pr_number)
-            retry_prompt = self._force_engagement_prompt(
-                issue_number=issue_number,
-                pr_number=pr_number,
-                worktree_path=worktree_path,
-                pr_head_branch=pr_head_branch,
-                failing_check_names=failing,
-                dirty_tracked_changes=dirty_tracked_changes,
-                review_threads_block=review_threads_block,
-            )
-
-            retry_reason = ", ".join(failing) if failing else "tracked worktree changes"
-            logger.warning(
-                "Issue #%s: no-commit on CI fix turn; re-invoking with "
-                "force-engagement prompt (retry %s/%s, reason: %s)",
-                issue_number,
-                retry,
-                max_retries,
-                retry_reason,
-            )
-
-            try:
-                retry_result = self._invoke_agent_session(
-                    prompt=retry_prompt,
-                    session_id=session_id,
-                    worktree_path=worktree_path,
-                    issue_number=issue_number,
-                    pr_number=pr_number,
-                )
-            except subprocess.TimeoutExpired:
-                logger.error(
-                    "Issue #%s: no-commit retry session timed out for PR #%s",
-                    issue_number,
-                    pr_number,
-                )
-                return False
-
-            if retry_result.returncode != 0:
-                logger.error(
-                    "Issue #%s: no-commit retry session failed for PR #%s: %s",
-                    issue_number,
-                    pr_number,
-                    (retry_result.stderr or "")[:300],
-                )
-                return False
-
-            if self._head_advanced(worktree_path, pre_agent_sha, issue_number):
-                return True
-
-            logger.warning(
-                "Issue #%s: still no commit on PR #%s after force-engagement retry %s/%s",
-                issue_number,
-                pr_number,
-                retry,
-                max_retries,
-            )
-
-        logger.error(
-            "Issue #%s: REPEATED no-commit on PR #%s after %s force-engagement "
-            "retries; marking and moving on",
-            issue_number,
-            pr_number,
-            max_retries,
-        )
-        self._record_repeated_no_commit(
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.retry_no_commit_once(
             issue_number=issue_number,
             pr_number=pr_number,
+            worktree_path=worktree_path,
             pr_head_branch=pr_head_branch,
-            failing_check_names=failing,
+            pre_agent_sha=pre_agent_sha,
+            session_id=session_id,
+            max_retries=max_retries,
         )
-        return False
 
     def _head_advanced(
         self,
@@ -2753,43 +1952,8 @@ class CIDriver:
         pre_agent_sha: str,
         issue_number: int,
     ) -> bool:
-        """Return True iff HEAD has moved past ``pre_agent_sha`` after the agent ran.
-
-        Called between the agent session and the push to detect the
-        no-commit-made case (#836). When ``pre_agent_sha`` still matches HEAD
-        the agent did not commit anything, so a force-with-lease push of
-        HEAD:<branch> would be a silent 0-exit no-op and the driver would
-        falsely log "pushed CI fixes". We instead log a warning and return
-        False so the iteration counts as failed.
-
-        Args:
-            worktree_path: Worktree to inspect.
-            pre_agent_sha: HEAD SHA captured right after the pre-agent sync.
-            issue_number: For log context.
-
-        Returns:
-            True if HEAD moved (something to push); False if it did not (or
-            if reading HEAD failed — we treat that as "don't push" too).
-
-        """
-        try:
-            post_agent_sha = run(["git", "rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
-        except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Issue #%s: failed to read HEAD after CI fix session: %s",
-                issue_number,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return False
-        if post_agent_sha == pre_agent_sha:
-            logger.warning(
-                "Issue #%s: agent session produced no new commit (HEAD unchanged "
-                "at %s); skipping push and treating iteration as failed",
-                issue_number,
-                pre_agent_sha[:8],
-            )
-            return False
-        return True
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator._head_advanced(worktree_path, pre_agent_sha, issue_number)
 
     def _git_stdout_for_push_guard(
         self,
@@ -2798,26 +1962,10 @@ class CIDriver:
         argv: list[str],
         failure_message: str,
     ) -> str | None:
-        """Run a git inspection command for the CI pre-push guard."""
-        try:
-            result = run(argv, cwd=worktree_path, capture_output=True, check=False)
-        except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Issue #%s: %s: %s",
-                issue_number,
-                failure_message,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return None
-        if result.returncode != 0:
-            logger.error(
-                "Issue #%s: %s: %s",
-                issue_number,
-                failure_message,
-                (result.stderr or result.stdout or "")[:300],
-            )
-            return None
-        return result.stdout or ""
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator._git_stdout_for_push_guard(
+            worktree_path, issue_number, argv, failure_message
+        )
 
     def _ci_fix_head_is_pushable(
         self,
@@ -2826,106 +1974,18 @@ class CIDriver:
         *,
         base_ref: str = "origin/main",
     ) -> bool:
-        """Return True when the post-agent worktree is safe to push.
-
-        ``_head_advanced`` only proves HEAD changed. A conflict-resolution agent
-        can still leave the index unmerged, leave tracked files uncommitted, or
-        accidentally detach at the base branch itself. None of those states may
-        be pushed to the PR head.
-        """
-        unmerged = self._git_stdout_for_push_guard(
-            worktree_path,
-            issue_number,
-            ["git", "diff", "--name-only", "--diff-filter=U"],
-            "failed to inspect merge state before push",
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator._ci_fix_head_is_pushable(
+            worktree_path, issue_number, base_ref=base_ref
         )
-        if unmerged is None:
-            return False
-        unmerged_paths = [line for line in unmerged.splitlines() if line.strip()]
-        if unmerged_paths:
-            logger.error(
-                "Issue #%s: refusing to push CI fix with unresolved merge paths: %s",
-                issue_number,
-                ", ".join(unmerged_paths[:10]),
-            )
-            return False
-
-        status = self._git_stdout_for_push_guard(
-            worktree_path,
-            issue_number,
-            ["git", "status", "--porcelain"],
-            "failed to inspect worktree status before push",
-        )
-        if status is None:
-            return False
-        tracked_dirty = [
-            line for line in status.splitlines() if line.strip() and not line.startswith("?? ")
-        ]
-        if tracked_dirty:
-            logger.error(
-                "Issue #%s: refusing to push CI fix with uncommitted tracked changes: %s",
-                issue_number,
-                ", ".join(tracked_dirty[:10]),
-            )
-            return False
-
-        ahead = self._git_stdout_for_push_guard(
-            worktree_path,
-            issue_number,
-            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
-            f"failed to inspect HEAD ahead of {base_ref} before push",
-        )
-        if ahead is None:
-            return False
-        try:
-            ahead_count = int(ahead.strip() or "0")
-        except ValueError:
-            logger.error(
-                "Issue #%s: refusing to push CI fix with invalid ahead count: %r",
-                issue_number,
-                ahead,
-            )
-            return False
-        if ahead_count <= 0:
-            logger.error(
-                "Issue #%s: refusing to push CI fix because HEAD has no commits ahead of %s",
-                issue_number,
-                base_ref,
-            )
-            return False
-        return True
 
     def _sync_worktree_and_snapshot_sha(
         self, issue_number: int, worktree_path: Path, pr_head_branch: str
     ) -> str | None:
-        """Sync worktree to remote PR head and snapshot HEAD SHA.
-
-        Returns the pre-agent SHA string, or ``None`` on any subprocess failure
-        (caller should return ``False`` immediately).
-
-        Syncing before the agent prevents the agent from committing on a stale
-        base and failing the force-with-lease push (#832). Snapshotting the SHA
-        lets the push helper detect sessions that return without committing (#836).
-        """
-        try:
-            sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
-        except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Issue #%s: failed to sync worktree to origin/%s before CI fix: %s",
-                issue_number,
-                pr_head_branch,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return None
-        try:
-            return run(["git", "rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
-        except subprocess.CalledProcessError as exc:
-            logger.error(
-                "Issue #%s: failed to snapshot HEAD before CI fix session: %s",
-                issue_number,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return None
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.sync_worktree_and_snapshot_sha(
+            issue_number, worktree_path, pr_head_branch
+        )
 
     def _build_ci_fix_prompt(
         self,
@@ -2936,27 +1996,14 @@ class CIDriver:
         pr_head_branch: str,
         advise_findings: str,
     ) -> str:
-        """Build the CI-fix agent prompt string."""
-        advise_block = ""
-        findings = advise_findings.strip()
-        if findings and not findings.startswith("<!-- advise step skipped"):
-            advise_block = f"## Prior Learnings from Team Knowledge Base\n\n{findings}\n\n---\n\n"
-        review_threads_block = self._format_review_threads_block(pr_number)
-        return (
-            f"{advise_block}{review_threads_block}"
-            f"Fix the CI failures for PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}).\n\n"
-            f"Working directory: {worktree_path}\n"
-            f"Current branch (DO NOT change): {pr_head_branch}\n\n"
-            f"CI failure logs:\n{ci_logs}\n\n"
-            "Fix the code to make the CI checks pass. After fixing:\n"
-            "1. Run: pixi run python -m pytest tests/ -v\n"
-            "2. Run: pre-commit run --all-files\n"
-            "3. Commit changes (do NOT push) on the current branch — DO NOT run "
-            "`git checkout -b`, `git switch -c`, or any other command that creates "
-            "or switches to a different branch\n"
-            "4. Every commit MUST be cryptographically signed (`git commit -S`); "
-            "NEVER use `--no-verify`.\n\n"
-            f"Commit message: fix: Address CI failures for PR {pr_ref(pr_number)}\n"
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.build_ci_fix_prompt(
+            issue_number,
+            pr_number,
+            worktree_path,
+            ci_logs,
+            pr_head_branch,
+            advise_findings,
         )
 
     def _run_ci_fix_session(
@@ -2970,74 +2017,15 @@ class CIDriver:
         *,
         pr_head_branch: str,
     ) -> bool:
-        """Invoke the selected coding agent to fix CI failures, then push the result.
-
-        Args:
-            issue_number: GitHub issue number.
-            pr_number: GitHub PR number.
-            worktree_path: Path to the checked-out worktree.
-            ci_logs: Combined CI failure log text.
-            session_id: Optional agent session ID to resume.
-            advise_findings: Prior learnings from the advise step, prepended to
-                the prompt as context. Empty or a skip marker contributes nothing.
-            pr_head_branch: The PR's head-branch name on the remote. The push
-                uses this as the destination refspec so the fix lands on the
-                actual PR branch even if the agent switched branches locally
-                during the session (#832).
-
-        Returns:
-            True if the fix session succeeded and the branch was pushed.
-
-        """
-        pre_agent_sha = self._sync_worktree_and_snapshot_sha(
-            issue_number, worktree_path, pr_head_branch
-        )
-        if pre_agent_sha is None:
-            return False
-
-        prompt = self._build_ci_fix_prompt(
+        """Delegate to CIFixOrchestrator (extracted #1357)."""
+        return self._fix_orchestrator.run_ci_fix_session(
             issue_number,
             pr_number,
             worktree_path,
             ci_logs,
-            pr_head_branch,
+            session_id,
             advise_findings,
-        )
-
-        try:
-            agent_result = self._invoke_agent_session(
-                prompt=prompt,
-                session_id=session_id,
-                worktree_path=worktree_path,
-                issue_number=issue_number,
-                pr_number=pr_number,
-            )
-        except subprocess.TimeoutExpired:
-            logger.error("Issue #%s: CI fix session timed out for PR #%s", issue_number, pr_number)
-            return False
-        except Exception as e:
-            logger.error(
-                "Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e
-            )
-            return False
-
-        if agent_result.returncode != 0:
-            logger.error(
-                "Issue #%s: CI fix session returned exit code %s: %s",
-                issue_number,
-                agent_result.returncode,
-                (agent_result.stderr or "")[:300],
-            )
-            return False
-
-        logger.debug("Issue #%s: CI fix output: %s", issue_number, agent_result.stdout[:500])
-        return self._push_ci_fix(
-            worktree_path=worktree_path,
-            pre_agent_sha=pre_agent_sha,
-            issue_number=issue_number,
-            pr_number=pr_number,
             pr_head_branch=pr_head_branch,
-            session_id=session_id,
         )
 
     def _enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:
@@ -3115,121 +2103,12 @@ class CIDriver:
             return False
 
     def _run_drive_green_learnings(self, issue_number: int, pr_number: int) -> bool:
-        """Capture drive-green learnings under AGENT_CI_DRIVER (Session 3).
-
-        Runs after a PR reaches green and auto-merge is enabled, mirroring the
-        implementer's post-PR ``/learn`` step but scoped to *this* drive: what
-        made CI fail and how it was fixed. Resumes Session 3 (the
-        ``AGENT_CI_DRIVER`` session the fix session created) so the learnings
-        compound on the same transcript that did the work.
-
-        This is best-effort. Any failure is logged at WARNING and swallowed so
-        a flaky learnings step never flips a successful drive to failure.
-
-        Args:
-            issue_number: GitHub issue number.
-            pr_number: GitHub PR number.
-
-        Returns:
-            True if the learnings session completed, False otherwise.
-
-        """
-        prompt = build_learn_prompt(
-            f"You just drove PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}) "
-            "to green CI. Capture concise learnings about what made CI fail and how "
-            "you fixed it, scoped to this issue/PR."
-        )
-        self._last_drive_green_learn_evidence = mnemosyne_update_evidence("")
-        try:
-            repo_slug = get_repo_slug(self.repo_root)
-            # Best-effort: try to resume in the original worktree (so the
-            # AGENT_CI_DRIVER transcript is found by ``session_jsonl_path``).
-            # In the post-merge code path (#840) the PR's head branch may be
-            # gone from the remote, so ``_get_worktree_path`` could fail. In
-            # that case fall back to ``repo_root`` cwd — the prompt is
-            # self-contained, and a fresh ``--session-id`` create still
-            # captures the lesson.
-            try:
-                cwd = self._get_worktree_path(issue_number, pr_number)
-            except Exception as wt_err:
-                logger.info(
-                    "Issue #%s: no worktree available for /learn (%s); "
-                    "falling back to repo root for a fresh session",
-                    issue_number,
-                    wt_err,
-                )
-                cwd = self.repo_root
-            if is_codex(self.options.agent):
-                codex_result = run_codex_session(
-                    prompt,
-                    cwd=cwd,
-                    timeout=learn_claude_timeout(),
-                    sandbox="workspace-write",
-                )
-                self._last_drive_green_learn_evidence = mnemosyne_update_evidence(
-                    codex_result.stdout or ""
-                )
-                logger.info("Issue #%s: drive-green learnings captured with Codex", issue_number)
-                return True
-            stdout, _ = invoke_claude_with_session(
-                repo=repo_slug,
-                issue=issue_number,
-                agent=AGENT_CI_DRIVER,
-                prompt=prompt,
-                # /learn inherits the parent phase's model. drive-green resumes
-                # the implementer's session, and ``claude --resume`` is locked to
-                # the model that created it, so we must use implementer_model().
-                model=implementer_model(),
-                cwd=cwd,
-                timeout=learn_claude_timeout(),
-                output_format="text",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                extra_args=["--dangerously-skip-permissions"],
-                input_via_stdin=True,
-            )
-            self._last_drive_green_learn_evidence = mnemosyne_update_evidence(stdout or "")
-            logger.info("Issue #%s: drive-green learnings captured", issue_number)
-            return True
-        except Exception as e:  # broad: external claude process; non-blocking
-            logger.warning(
-                "Issue #%s: drive-green learnings failed (non-fatal): %s",
-                issue_number,
-                e,
-            )
-            return False
+        """Delegate to PostMergeProcessor (extracted #1357)."""
+        return self._post_merge.run_drive_green_learnings(issue_number, pr_number)
 
     def _run_drive_green_compact(self, issue_number: int, pr_number: int) -> bool:
-        """Compact the AGENT_CI_DRIVER session transcript after /learn (#842).
-
-        Mirrors the cwd-derivation of ``_run_drive_green_learnings``: try the
-        worktree first so the deterministic JSONL probe in ``session_jsonl_path``
-        finds the transcript, fall back to ``repo_root`` when the branch is
-        already gone post-merge. Non-fatal.
-        """
-        if is_codex(self.options.agent):
-            logger.info(
-                "Issue #%s: skipping /compact (codex has no persisted "
-                "drive-green session to resume)",
-                issue_number,
-            )
-            return False
-        try:
-            cwd = self._get_worktree_path(issue_number, pr_number)
-        except Exception as wt_err:
-            logger.info(
-                "Issue #%s: no worktree available for /compact (%s); using repo root",
-                issue_number,
-                wt_err,
-            )
-            cwd = self.repo_root
-        repo_slug = get_repo_slug(self.repo_root)
-        return compact_session(
-            repo=repo_slug,
-            issue=issue_number,
-            agent=AGENT_CI_DRIVER,
-            cwd=cwd,
-            model=implementer_model(),
-        )
+        """Delegate to PostMergeProcessor (extracted #1357)."""
+        return self._post_merge.run_drive_green_compact(issue_number, pr_number)
 
     def _parse_json_block(self, text: str) -> dict[str, Any]:
         """Extract and parse the first JSON block from a text string.

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -1,0 +1,910 @@
+"""CI fix session orchestrator extracted from CIDriver (refs #1179, #1289).
+
+Owns the methods that run coding-agent sessions to fix CI failures:
+- agent session dispatch (codex/claude) and the post-agent push contract (#846)
+- force-engagement prompts and no-commit retry logic (#846)
+- the main CI fix session (prompt build + invoke + push)
+- mechanical rebase (no-agent fast path, #871)
+
+Receives narrow ``Callable`` providers for the shared state and back-called
+CIDriver methods instead of the full ``CIDriver`` to satisfy DIP and avoid
+bidirectional coupling (refs #1179 MAJOR finding 2). The construction site wraps
+the injected callables in lambdas so ``patch.object`` on the CIDriver method
+continues to intercept through the indirection in tests.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.runtime import (
+    is_codex,
+    resume_codex_session,
+    run_codex_session,
+)
+
+from .claude_invoke import invoke_claude_with_session
+from .claude_models import implementer_model
+from .claude_timeouts import ci_driver_claude_timeout
+from .git_utils import (
+    get_repo_slug,
+    issue_ref,
+    pr_ref,
+    push_current_branch_with_lease_on_divergence,
+    rebase_worktree_onto,
+    run,
+    sync_worktree_to_remote_branch,
+)
+from .github_api import _gh_call
+from .session_naming import AGENT_CI_DRIVER
+
+logger = logging.getLogger(__name__)
+
+
+class CIFixOrchestrator:
+    """Orchestrates CI fix sessions using narrow-callable injection.
+
+    Receives all back-called CIDriver methods as callables instead of the
+    full CIDriver to satisfy DIP and avoid bidirectional coupling
+    (refs #1179 MAJOR finding 2).
+    """
+
+    def __init__(
+        self,
+        *,
+        options_provider: Callable[[], Any],
+        repo_root_provider: Callable[[], Path],
+        state_dir_provider: Callable[[], Path],
+        status_tracker_provider: Callable[[], Any],
+        get_pr_branch: Callable[[int], str],
+        get_worktree_path: Callable[[int, int], Path],
+        format_review_threads_block: Callable[[int], str],
+        failing_required_check_names: Callable[[int], list[str]],
+    ) -> None:
+        """Initialise the orchestrator with narrow provider callables.
+
+        The post-agent push-safety guard (``_head_advanced``,
+        ``_ci_fix_head_is_pushable``, ``_tracked_worktree_changes``, and the
+        shared ``_git_stdout_for_push_guard`` helper) lives on this class — it is
+        part of the CI-fix push contract — so it is NOT injected (#1357).
+
+        Args:
+            options_provider: Returns the current CIDriverOptions.
+            repo_root_provider: Returns the repo root Path.
+            state_dir_provider: Returns the state directory Path.
+            status_tracker_provider: Returns the current StatusTracker.
+            get_pr_branch: Returns the head branch name for a PR number.
+            get_worktree_path: Resolves the worktree path for (issue, pr).
+            format_review_threads_block: Builds the review-threads prompt block.
+            failing_required_check_names: Returns names of failing required checks.
+
+        """
+        self._options = options_provider
+        self._repo_root = repo_root_provider
+        self._state_dir = state_dir_provider
+        self._status = status_tracker_provider
+        self._get_pr_branch = get_pr_branch
+        self._get_worktree_path = get_worktree_path
+        self._format_review_threads_block = format_review_threads_block
+        self._failing_required_check_names = failing_required_check_names
+
+    def force_engagement_prompt(
+        self,
+        *,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        pr_head_branch: str,
+        failing_check_names: list[str],
+        review_threads_block: str,
+        dirty_tracked_changes: list[str] | None = None,
+    ) -> str:
+        """Build the retry prompt when the agent returned without committing (#846).
+
+        The retry must engage the agent enough to either (a) produce a real
+        fix or (b) explicitly say why CI cannot pass / merge. The prompt names
+        the failing checks and/or dirty tracked files verbatim, re-emphasises
+        the existing PR/branch invariant, and re-emphasises signed commits — a
+        no-commit retry is a contract violation that the agent has to address
+        head-on.
+        """
+        failing_block = "\n".join(f"- {n}" for n in failing_check_names) or "- (unknown)"
+        dirty_lines = dirty_tracked_changes or []
+        dirty_block = "\n".join(f"- {line}" for line in dirty_lines)
+        if dirty_block:
+            dirty_block = (
+                "\n\nThe local worktree also contains uncommitted tracked changes "
+                "from the previous turn. Review this existing diff first and either "
+                f"commit it after verification or amend it before committing:\n\n{dirty_block}\n"
+            )
+        remote_block = (
+            "The required CI checks below are STILL failing on the remote"
+            if failing_check_names
+            else "The remote checks may be green, but the PR still needs a committed "
+            "repair before the driver can push"
+        )
+        return (
+            f"{review_threads_block}"
+            f"## Force-Engagement Retry — Previous Turn Produced No Commit\n\n"
+            f"You just returned from a CI-fix session for PR {pr_ref(pr_number)} "
+            f"(issue {issue_ref(issue_number)}) WITHOUT producing a new commit on "
+            f"branch `{pr_head_branch}`. {remote_block}:\n\n"
+            f"{failing_block}\n\n"
+            f"{dirty_block}"
+            f"Returning no commit when required checks are still red is itself a "
+            f"bug; returning no commit after editing tracked files is also a bug. "
+            f"Fix the code so the failing checks pass and the PR can merge. If no "
+            f"code fix is possible, DO NOT commit a 'blocker' file: a new "
+            f"Markdown/docs file will itself fail the repo's lint gates (e.g. "
+            f"markdownlint) and turn one blocker into two. Instead leave the tree "
+            f"unchanged and report the blocker via the `BLOCKED:` line below — do "
+            f"NOT commit any file to document it.\n\n"
+            f"Working directory: {worktree_path}\n"
+            f"Current branch (DO NOT change, DO NOT create a new branch): "
+            f"{pr_head_branch}\n\n"
+            f"Required behaviour:\n"
+            f"1. Re-read the failing check logs for the names listed above.\n"
+            f"2. Make the minimal change that addresses each failure.\n"
+            f"3. Run `pixi run python -m pytest tests/ -v` and "
+            f"`pre-commit run --all-files` locally to verify before committing. "
+            f"This MUST include any markdown/lint hooks — every file you add or "
+            f"edit has to pass the repo's own linters, with no rule disabled.\n"
+            f"4. **Every commit MUST be cryptographically signed (`git commit -S`).** "
+            f"NEVER use `--no-verify`. The repository's CI gate rejects unsigned "
+            f"commits and any commit that bypassed pre-commit hooks.\n"
+            f"5. Do NOT run `git checkout -b`, `git switch -c`, or any command "
+            f"that creates or switches branches — the fix has to land on "
+            f"`{pr_head_branch}`.\n"
+            f"6. Do NOT add a new top-level `CI_BLOCKER.md` or similar doc file to "
+            f"record the blocker — use the `BLOCKED:` line instead.\n\n"
+            f"If after the steps above you still cannot produce a commit, reply "
+            f"with a single line `BLOCKED: <one-sentence reason>` and stop."
+        )
+
+    def record_repeated_no_commit(
+        self,
+        *,
+        issue_number: int,
+        pr_number: int,
+        pr_head_branch: str,
+        failing_check_names: list[str],
+    ) -> None:
+        """Persist a marker for the next ecosystem run (#846).
+
+        Writes ``state_dir / "repeated-no-commit-<pr>.json"`` so a future
+        run (and the human reading the logs) can see which PRs got stuck
+        in the no-commit loop. We deliberately do NOT delete the arming
+        record here — the PR is still open and may yet land via another
+        actor; the marker file is purely a forensics aid.
+        """
+        marker = self._state_dir() / f"repeated-no-commit-{pr_number}.json"
+        try:
+            marker.write_text(
+                json.dumps(
+                    {
+                        "issue_number": issue_number,
+                        "pr_number": pr_number,
+                        "pr_head_branch": pr_head_branch,
+                        "failing_required_checks": failing_check_names,
+                        "recorded_at": datetime.now(timezone.utc).isoformat(),
+                    },
+                    indent=2,
+                )
+                + "\n"
+            )
+        except OSError as exc:
+            logger.warning(
+                "Issue #%s: failed to write repeated-no-commit marker for PR #%s: %s",
+                issue_number,
+                pr_number,
+                exc,
+            )
+
+    def invoke_agent_session(
+        self,
+        *,
+        prompt: str,
+        session_id: str | None,
+        worktree_path: Path,
+        issue_number: int,
+        pr_number: int,
+    ) -> subprocess.CompletedProcess[str]:
+        """Dispatch a prompt to the configured agent (codex or claude).
+
+        Returns a CompletedProcess whose returncode signals success or failure:
+        - returncode == 0: agent ran successfully (stdout has output)
+        - returncode != 0: agent failed (stderr has details)
+
+        For codex, returncode is synthetic — AgentRunResult has no returncode
+        field; success is "no CalledProcessError" (hephaestus/agents/runtime.py).
+        For claude, returncode comes from the subprocess exit code.
+
+        CalledProcessError is absorbed from all codex paths into a non-zero
+        CompletedProcess. TimeoutExpired propagates to the caller so it can
+        log a distinct timeout message.
+        """
+        options = self._options()
+        if is_codex(options.agent):
+            if session_id:
+                try:
+                    result = resume_codex_session(
+                        session_id,
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                    )
+                except subprocess.CalledProcessError as exc:
+                    logger.warning(
+                        "Issue #%s: Codex resume session %r failed for PR #%s; "
+                        "falling back to fresh session: %s",
+                        issue_number,
+                        session_id,
+                        pr_number,
+                        (exc.stderr or exc.stdout or "")[:300],
+                    )
+                    try:
+                        result = run_codex_session(
+                            prompt,
+                            cwd=worktree_path,
+                            timeout=ci_driver_claude_timeout(),
+                            sandbox="workspace-write",
+                        )
+                    except subprocess.CalledProcessError as fresh_exc:
+                        return subprocess.CompletedProcess(
+                            args=fresh_exc.cmd,
+                            returncode=fresh_exc.returncode,
+                            stdout=fresh_exc.stdout or "",
+                            stderr=fresh_exc.stderr or "",
+                        )
+            else:
+                try:
+                    result = run_codex_session(
+                        prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                        sandbox="workspace-write",
+                    )
+                except subprocess.CalledProcessError as exc:
+                    return subprocess.CompletedProcess(
+                        args=exc.cmd,
+                        returncode=exc.returncode,
+                        stdout=exc.stdout or "",
+                        stderr=exc.stderr or "",
+                    )
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=result.stdout, stderr=result.stderr or ""
+            )
+
+        repo_slug = get_repo_slug(self._repo_root())
+        try:
+            stdout, _ = invoke_claude_with_session(
+                repo=repo_slug,
+                issue=issue_number,
+                agent=AGENT_CI_DRIVER,
+                prompt=prompt,
+                model=implementer_model(),
+                cwd=worktree_path,
+                timeout=ci_driver_claude_timeout(),
+                output_format="json",
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                extra_args=["--dangerously-skip-permissions"],
+                input_via_stdin=True,
+            )
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+        except subprocess.CalledProcessError as exc:
+            return subprocess.CompletedProcess(
+                args=exc.cmd,
+                returncode=exc.returncode,
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
+            )
+
+    def push_ci_fix(
+        self,
+        *,
+        worktree_path: Path,
+        pre_agent_sha: str,
+        issue_number: int,
+        pr_number: int,
+        pr_head_branch: str,
+        session_id: str | None,
+    ) -> bool:
+        """Check head advancement, retry if needed, then push CI fixes.
+
+        Shared post-agent contract for both codex and claude providers (#846).
+        Returns True if fixes were pushed, False on any failure or no-commit.
+        """
+        if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):  # noqa: SIM102
+            if not self.retry_no_commit_once(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                worktree_path=worktree_path,
+                pr_head_branch=pr_head_branch,
+                pre_agent_sha=pre_agent_sha,
+                session_id=session_id,
+            ):
+                return False
+        if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
+            return False
+        try:
+            push_current_branch_with_lease_on_divergence(
+                worktree_path,
+                branch=pr_head_branch,
+                push_ref=f"HEAD:{pr_head_branch}",
+            )
+            logger.info("Issue #%s: pushed CI fixes for PR #%s", issue_number, pr_number)
+            return True
+        except Exception as push_err:
+            logger.error("Issue #%s: git push failed after CI fix: %s", issue_number, push_err)
+            return False
+
+    def retry_no_commit_once(
+        self,
+        *,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        pr_head_branch: str,
+        pre_agent_sha: str,
+        session_id: str | None,
+        max_retries: int = 2,
+    ) -> bool:
+        """Re-invoke the agent up to ``max_retries`` times after a no-commit turn (#846).
+
+        A single no-op agent turn used to be terminal: with
+        ``max_fix_iterations=1`` the whole issue failed the instant the first
+        force-engagement retry also returned no commit. That cost real PRs
+        (AchaeanFleet #691/#683, Hermes #643). We now re-engage up to
+        ``max_retries`` times before recording the forensics marker, re-checking
+        between attempts so a PR that goes green (or where a commit lands)
+        short-circuits immediately.
+
+        Only fires when the PR still has failing required checks — a green PR
+        that arrived via concurrent activity should NOT be perturbed. Stays on
+        the same ``(repo, issue, AGENT_CI_DRIVER)`` session so the agent's
+        transcript is continuous; the existing PR and branch are preserved
+        (no new PR, no new branch, no force-push to a new ref).
+
+        Args:
+            issue_number: GitHub issue number for the PR.
+            pr_number: PR number to retry on.
+            worktree_path: Worktree the agent runs in (same as the first turn).
+            pr_head_branch: PR head branch name; the retry must not switch off it.
+            pre_agent_sha: HEAD SHA from before the first turn (used as the
+                no-commit baseline for the retry too — if the retry doesn't
+                advance past this, we treat it as repeated-no-commit).
+            session_id: Codex resume id (Claude resumes by deterministic UUID).
+            max_retries: Maximum number of force-engagement retries.
+
+        Returns:
+            True if the retry produced a new commit (caller should push).
+            False if CI is green now, the retry returned no commit again, or
+            any error path fired. On repeated-no-commit, writes a forensics
+            marker to ``state_dir``.
+
+        """
+        failing: list[str] = []
+        for retry in range(1, max_retries + 1):
+            failing = self._failing_required_check_names(pr_number)
+            dirty_tracked_changes = self._tracked_worktree_changes(worktree_path, issue_number)
+            if not failing and not dirty_tracked_changes:
+                logger.info(
+                    "Issue #%s: no-commit turn but PR #%s has no failing required checks "
+                    "and no tracked worktree changes; skipping force-engagement retry",
+                    issue_number,
+                    pr_number,
+                )
+                return False
+
+            review_threads_block = self._format_review_threads_block(pr_number)
+            retry_prompt = self.force_engagement_prompt(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                worktree_path=worktree_path,
+                pr_head_branch=pr_head_branch,
+                failing_check_names=failing,
+                dirty_tracked_changes=dirty_tracked_changes,
+                review_threads_block=review_threads_block,
+            )
+
+            retry_reason = ", ".join(failing) if failing else "tracked worktree changes"
+            logger.warning(
+                "Issue #%s: no-commit on CI fix turn; re-invoking with "
+                "force-engagement prompt (retry %s/%s, reason: %s)",
+                issue_number,
+                retry,
+                max_retries,
+                retry_reason,
+            )
+
+            try:
+                retry_result = self.invoke_agent_session(
+                    prompt=retry_prompt,
+                    session_id=session_id,
+                    worktree_path=worktree_path,
+                    issue_number=issue_number,
+                    pr_number=pr_number,
+                )
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    "Issue #%s: no-commit retry session timed out for PR #%s",
+                    issue_number,
+                    pr_number,
+                )
+                return False
+
+            if retry_result.returncode != 0:
+                logger.error(
+                    "Issue #%s: no-commit retry session failed for PR #%s: %s",
+                    issue_number,
+                    pr_number,
+                    (retry_result.stderr or "")[:300],
+                )
+                return False
+
+            if self._head_advanced(worktree_path, pre_agent_sha, issue_number):
+                return True
+
+            logger.warning(
+                "Issue #%s: still no commit on PR #%s after force-engagement retry %s/%s",
+                issue_number,
+                pr_number,
+                retry,
+                max_retries,
+            )
+
+        logger.error(
+            "Issue #%s: REPEATED no-commit on PR #%s after %s force-engagement "
+            "retries; marking and moving on",
+            issue_number,
+            pr_number,
+            max_retries,
+        )
+        self.record_repeated_no_commit(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_head_branch=pr_head_branch,
+            failing_check_names=failing,
+        )
+        return False
+
+    def sync_worktree_and_snapshot_sha(
+        self, issue_number: int, worktree_path: Path, pr_head_branch: str
+    ) -> str | None:
+        """Sync worktree to remote PR head and snapshot HEAD SHA.
+
+        Returns the pre-agent SHA string, or ``None`` on any subprocess failure
+        (caller should return ``False`` immediately).
+
+        Syncing before the agent prevents the agent from committing on a stale
+        base and failing the force-with-lease push (#832). Snapshotting the SHA
+        lets the push helper detect sessions that return without committing (#836).
+        """
+        try:
+            sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: failed to sync worktree to origin/%s before CI fix: %s",
+                issue_number,
+                pr_head_branch,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return None
+        try:
+            return run(["git", "rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: failed to snapshot HEAD before CI fix session: %s",
+                issue_number,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return None
+
+    def build_ci_fix_prompt(
+        self,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        ci_logs: str,
+        pr_head_branch: str,
+        advise_findings: str,
+    ) -> str:
+        """Build the CI-fix agent prompt string."""
+        advise_block = ""
+        findings = advise_findings.strip()
+        if findings and not findings.startswith("<!-- advise step skipped"):
+            advise_block = f"## Prior Learnings from Team Knowledge Base\n\n{findings}\n\n---\n\n"
+        review_threads_block = self._format_review_threads_block(pr_number)
+        return (
+            f"{advise_block}{review_threads_block}"
+            f"Fix the CI failures for PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}).\n\n"
+            f"Working directory: {worktree_path}\n"
+            f"Current branch (DO NOT change): {pr_head_branch}\n\n"
+            f"CI failure logs:\n{ci_logs}\n\n"
+            "Fix the code to make the CI checks pass. After fixing:\n"
+            "1. Run: pixi run python -m pytest tests/ -v\n"
+            "2. Run: pre-commit run --all-files\n"
+            "3. Commit changes (do NOT push) on the current branch — DO NOT run "
+            "`git checkout -b`, `git switch -c`, or any other command that creates "
+            "or switches to a different branch\n"
+            "4. Every commit MUST be cryptographically signed (`git commit -S`); "
+            "NEVER use `--no-verify`.\n\n"
+            f"Commit message: fix: Address CI failures for PR {pr_ref(pr_number)}\n"
+        )
+
+    def run_ci_fix_session(
+        self,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        ci_logs: str,
+        session_id: str | None,
+        advise_findings: str = "",
+        *,
+        pr_head_branch: str,
+    ) -> bool:
+        """Invoke the selected coding agent to fix CI failures, then push the result.
+
+        Args:
+            issue_number: GitHub issue number.
+            pr_number: GitHub PR number.
+            worktree_path: Path to the checked-out worktree.
+            ci_logs: Combined CI failure log text.
+            session_id: Optional agent session ID to resume.
+            advise_findings: Prior learnings from the advise step, prepended to
+                the prompt as context. Empty or a skip marker contributes nothing.
+            pr_head_branch: The PR's head-branch name on the remote. The push
+                uses this as the destination refspec so the fix lands on the
+                actual PR branch even if the agent switched branches locally
+                during the session (#832).
+
+        Returns:
+            True if the fix session succeeded and the branch was pushed.
+
+        """
+        pre_agent_sha = self.sync_worktree_and_snapshot_sha(
+            issue_number, worktree_path, pr_head_branch
+        )
+        if pre_agent_sha is None:
+            return False
+
+        prompt = self.build_ci_fix_prompt(
+            issue_number,
+            pr_number,
+            worktree_path,
+            ci_logs,
+            pr_head_branch,
+            advise_findings,
+        )
+
+        try:
+            agent_result = self.invoke_agent_session(
+                prompt=prompt,
+                session_id=session_id,
+                worktree_path=worktree_path,
+                issue_number=issue_number,
+                pr_number=pr_number,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error("Issue #%s: CI fix session timed out for PR #%s", issue_number, pr_number)
+            return False
+        except Exception as e:
+            logger.error(
+                "Issue #%s: CI fix session failed for PR #%s: %s", issue_number, pr_number, e
+            )
+            return False
+
+        if agent_result.returncode != 0:
+            logger.error(
+                "Issue #%s: CI fix session returned exit code %s: %s",
+                issue_number,
+                agent_result.returncode,
+                (agent_result.stderr or "")[:300],
+            )
+            return False
+
+        logger.debug("Issue #%s: CI fix output: %s", issue_number, agent_result.stdout[:500])
+        return self.push_ci_fix(
+            worktree_path=worktree_path,
+            pre_agent_sha=pre_agent_sha,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_head_branch=pr_head_branch,
+            session_id=session_id,
+        )
+
+    def attempt_mechanical_rebase(
+        self,
+        issue_number: int,
+        pr_number: int,
+        acquired_slot: int,
+    ) -> bool:
+        """Rebase a behind/conflicting PR onto its base branch with no agent (#871).
+
+        The cheap, deterministic path: a PR that is merely behind its base (or
+        whose changes don't textually overlap) is rebased and pushed here. Only a
+        PR whose rebase hits real conflicts falls through to the CI-fix agent.
+
+        Flow:
+
+        1. Query ``mergeStateStatus`` / ``mergeable`` / ``baseRefName``. Skip
+           (return ``False``) unless the PR is ``BEHIND`` or ``DIRTY`` /
+           ``CONFLICTING`` — a PR already on top of its base needs no rebase and
+           the normal check-status path handles it.
+        2. Sync the worktree to the PR head, then ``rebase_worktree_onto`` the
+           base branch.
+        3. Clean rebase → push ``HEAD:<pr-head>`` with ``--force-with-lease`` and
+           return ``True``. The push re-triggers CI; the caller's poll loop
+           evaluates the rebased head.
+        4. Conflicts → the rebase is aborted inside ``rebase_worktree_onto``;
+           return ``False`` so the caller continues to the agent path.
+
+        Any unexpected git/subprocess error is logged and swallowed (returns
+        ``False``) — a mechanical-rebase failure must never crash the worker; the
+        agent path is always the safe fallback.
+
+        Args:
+            issue_number: GitHub issue number for the PR.
+            pr_number: PR number to rebase.
+            acquired_slot: Worker slot ID for status tracking.
+
+        Returns:
+            ``True`` if the PR was mechanically rebased and pushed; ``False`` if
+            no rebase was needed, the rebase conflicted, or an error occurred.
+
+        """
+        try:
+            result = _gh_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "mergeStateStatus,mergeable,headRefName,baseRefName",
+                ],
+                check=False,
+            )
+            state = dict(json.loads(result.stdout or "{}"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Issue #%s: could not fetch PR #%s merge state for rebase; "
+                "skipping mechanical rebase: %s",
+                issue_number,
+                pr_number,
+                exc,
+            )
+            return False
+
+        merge_state = str(state.get("mergeStateStatus") or "").upper()
+        # Only behind-base / conflicting PRs need a rebase. CLEAN / BLOCKED /
+        # UNSTABLE / HAS_HOOKS PRs are already on top of their base — let the
+        # check-status path handle them. (BLOCKED is the review-gated case.)
+        if merge_state not in ("BEHIND", "DIRTY", "CONFLICTING"):
+            return False
+
+        pr_head_branch = str(state.get("headRefName") or "") or self._get_pr_branch(pr_number)
+        base_branch = str(state.get("baseRefName") or "main") or "main"
+        if not pr_head_branch:
+            logger.warning(
+                "Issue #%s: PR #%s has no resolvable head branch; skipping rebase",
+                issue_number,
+                pr_number,
+            )
+            return False
+
+        self._status().update_slot(
+            acquired_slot,
+            f"{issue_ref(issue_number)}: mechanical rebase onto {base_branch}",
+        )
+
+        try:
+            worktree_path = self._get_worktree_path(issue_number, pr_number)
+            # Land on the PR's actual remote head before rebasing so we replay the
+            # PR's commits (not a stale local ref) onto the base (#832).
+            sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
+
+            if not rebase_worktree_onto(worktree_path, base_branch):
+                logger.info(
+                    "Issue #%s: PR #%s (%s) has rebase conflicts onto %s; deferring to agent",
+                    issue_number,
+                    pr_number,
+                    merge_state,
+                    base_branch,
+                )
+                return False
+
+            # Clean rebase rewrote history — lease-push to the PR head. The helper
+            # no-ops cleanly if the rebase was already up to date (HEAD unchanged).
+            push_current_branch_with_lease_on_divergence(
+                worktree_path,
+                branch=pr_head_branch,
+                push_ref=f"HEAD:{pr_head_branch}",
+            )
+            logger.info(
+                "Issue #%s: mechanically rebased PR #%s onto %s and pushed (no agent)",
+                issue_number,
+                pr_number,
+                base_branch,
+            )
+            return True
+        except subprocess.CalledProcessError as exc:
+            logger.warning(
+                "Issue #%s: mechanical rebase of PR #%s failed (%s); falling through to agent",
+                issue_number,
+                pr_number,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return False
+
+    def _tracked_worktree_changes(self, worktree_path: Path, issue_number: int) -> list[str]:
+        """Return tracked dirty status lines for a post-agent worktree.
+
+        Untracked tool output such as a local ``uv.lock`` is intentionally
+        ignored. A no-commit turn that left tracked files modified is still
+        actionable even when the remote has no red required checks, as happens
+        for merge-conflict/behind-branch repairs where the agent fixed files but
+        forgot the signed commit.
+        """
+        status = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "status", "--porcelain"],
+            "failed to inspect worktree status for no-commit retry",
+        )
+        if status is None:
+            return []
+        return [line for line in status.splitlines() if line.strip() and not line.startswith("?? ")]
+
+    def _head_advanced(
+        self,
+        worktree_path: Path,
+        pre_agent_sha: str,
+        issue_number: int,
+    ) -> bool:
+        """Return True iff HEAD has moved past ``pre_agent_sha`` after the agent ran.
+
+        Called between the agent session and the push to detect the
+        no-commit-made case (#836). When ``pre_agent_sha`` still matches HEAD
+        the agent did not commit anything, so a force-with-lease push of
+        HEAD:<branch> would be a silent 0-exit no-op and the driver would
+        falsely log "pushed CI fixes". We instead log a warning and return
+        False so the iteration counts as failed.
+
+        Args:
+            worktree_path: Worktree to inspect.
+            pre_agent_sha: HEAD SHA captured right after the pre-agent sync.
+            issue_number: For log context.
+
+        Returns:
+            True if HEAD moved (something to push); False if it did not (or
+            if reading HEAD failed — we treat that as "don't push" too).
+
+        """
+        try:
+            post_agent_sha = run(["git", "rev-parse", "HEAD"], cwd=worktree_path).stdout.strip()
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: failed to read HEAD after CI fix session: %s",
+                issue_number,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return False
+        if post_agent_sha == pre_agent_sha:
+            logger.warning(
+                "Issue #%s: agent session produced no new commit (HEAD unchanged "
+                "at %s); skipping push and treating iteration as failed",
+                issue_number,
+                pre_agent_sha[:8],
+            )
+            return False
+        return True
+
+    def _git_stdout_for_push_guard(
+        self,
+        worktree_path: Path,
+        issue_number: int,
+        argv: list[str],
+        failure_message: str,
+    ) -> str | None:
+        """Run a git inspection command for the CI pre-push guard."""
+        try:
+            result = run(argv, cwd=worktree_path, capture_output=True, check=False)
+        except subprocess.CalledProcessError as exc:
+            logger.error(
+                "Issue #%s: %s: %s",
+                issue_number,
+                failure_message,
+                (exc.stderr or exc.stdout or "")[:300],
+            )
+            return None
+        if result.returncode != 0:
+            logger.error(
+                "Issue #%s: %s: %s",
+                issue_number,
+                failure_message,
+                (result.stderr or result.stdout or "")[:300],
+            )
+            return None
+        return result.stdout or ""
+
+    def _ci_fix_head_is_pushable(
+        self,
+        worktree_path: Path,
+        issue_number: int,
+        *,
+        base_ref: str = "origin/main",
+    ) -> bool:
+        """Return True when the post-agent worktree is safe to push.
+
+        ``_head_advanced`` only proves HEAD changed. A conflict-resolution agent
+        can still leave the index unmerged, leave tracked files uncommitted, or
+        accidentally detach at the base branch itself. None of those states may
+        be pushed to the PR head.
+        """
+        unmerged = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "diff", "--name-only", "--diff-filter=U"],
+            "failed to inspect merge state before push",
+        )
+        if unmerged is None:
+            return False
+        unmerged_paths = [line for line in unmerged.splitlines() if line.strip()]
+        if unmerged_paths:
+            logger.error(
+                "Issue #%s: refusing to push CI fix with unresolved merge paths: %s",
+                issue_number,
+                ", ".join(unmerged_paths[:10]),
+            )
+            return False
+
+        status = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "status", "--porcelain"],
+            "failed to inspect worktree status before push",
+        )
+        if status is None:
+            return False
+        tracked_dirty = [
+            line for line in status.splitlines() if line.strip() and not line.startswith("?? ")
+        ]
+        if tracked_dirty:
+            logger.error(
+                "Issue #%s: refusing to push CI fix with uncommitted tracked changes: %s",
+                issue_number,
+                ", ".join(tracked_dirty[:10]),
+            )
+            return False
+
+        ahead = self._git_stdout_for_push_guard(
+            worktree_path,
+            issue_number,
+            ["git", "rev-list", "--count", f"{base_ref}..HEAD"],
+            f"failed to inspect HEAD ahead of {base_ref} before push",
+        )
+        if ahead is None:
+            return False
+        try:
+            ahead_count = int(ahead.strip() or "0")
+        except ValueError:
+            logger.error(
+                "Issue #%s: refusing to push CI fix with invalid ahead count: %r",
+                issue_number,
+                ahead,
+            )
+            return False
+        if ahead_count <= 0:
+            logger.error(
+                "Issue #%s: refusing to push CI fix because HEAD has no commits ahead of %s",
+                issue_number,
+                base_ref,
+            )
+            return False
+        return True

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -1,0 +1,227 @@
+"""Post-merge processor extracted from CIDriver (refs #1179).
+
+Owns the drive-green /learn and /compact steps that run after a PR
+reaches green CI and auto-merge is enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.runtime import is_codex, run_codex_session
+
+from .claude_invoke import invoke_claude_with_session
+from .claude_models import implementer_model
+from .claude_timeouts import learn_claude_timeout
+from .git_utils import get_repo_slug, issue_ref, pr_ref
+from .learn import build_learn_prompt, compact_session, mnemosyne_update_evidence
+from .session_naming import AGENT_CI_DRIVER
+
+logger = logging.getLogger(__name__)
+
+
+class PostMergeProcessor:
+    """Runs drive-green /learn and /compact after a PR merges.
+
+    Receives all back-called CIDriver methods as callables instead of the
+    full CIDriver to satisfy DIP and avoid bidirectional coupling
+    (refs #1179 MAJOR finding 2).
+    """
+
+    def __init__(
+        self,
+        *,
+        options_provider: Callable[[], Any],
+        repo_root_provider: Callable[[], Path],
+        get_worktree_path: Callable[[int, int], Path],
+        load_arming_state: Callable[[int], dict[str, Any] | None],
+        save_arming_state: Callable[[int, dict[str, Any]], None],
+    ) -> None:
+        """Initialise the processor with narrow provider callables.
+
+        Args:
+            options_provider: Returns the current CIDriverOptions.
+            repo_root_provider: Returns the repo root Path.
+            get_worktree_path: Resolves the worktree path for (issue, pr) pair.
+            load_arming_state: Loads the arming record for an issue number.
+            save_arming_state: Persists the arming record for an issue number.
+
+        """
+        self._options = options_provider
+        self._repo_root = repo_root_provider
+        self._get_worktree_path = get_worktree_path
+        self._load_arming_state = load_arming_state
+        self._save_arming_state = save_arming_state
+        # Ephemeral evidence from the most recent /learn invocation. Reset
+        # before each call and read by mark_drive_green_learn_result.
+        self._last_learn_evidence: dict[str, Any] = mnemosyne_update_evidence("")
+
+    def mark_drive_green_learn_result(
+        self,
+        issue_number: int,
+        record: dict[str, Any],
+        *,
+        succeeded: bool,
+    ) -> None:
+        """Persist an explicit attempted/succeeded/failed learn result.
+
+        ``learn_captured_at`` is retained as the success timestamp for older
+        readers, but failure now records ``learn_status=failed`` without
+        claiming Mnemosyne was updated.
+
+        Args:
+            issue_number: GitHub issue number.
+            record: Mutable arming-state record dict to update in place.
+            succeeded: Whether the learn session completed successfully.
+
+        """
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        record["learn_attempted_at"] = timestamp
+        if succeeded:
+            record["learn_status"] = "succeeded"
+            record["learn_succeeded_at"] = timestamp
+            record["learn_captured_at"] = timestamp
+            record.update(self._last_learn_evidence)
+        else:
+            record["learn_status"] = "failed"
+            record["learn_succeeded_at"] = None
+            record["learn_captured_at"] = None
+            record.update(
+                {
+                    "mnemosyne_update_status": "failed",
+                    "mnemosyne_update_urls": [],
+                    "mnemosyne_update_pr_numbers": [],
+                }
+            )
+        self._save_arming_state(issue_number, record)
+
+    def run_drive_green_learnings(self, issue_number: int, pr_number: int) -> bool:
+        """Capture drive-green learnings under AGENT_CI_DRIVER (Session 3).
+
+        Runs after a PR reaches green and auto-merge is enabled, mirroring the
+        implementer's post-PR ``/learn`` step but scoped to *this* drive: what
+        made CI fail and how it was fixed. Resumes Session 3 (the
+        ``AGENT_CI_DRIVER`` session the fix session created) so the learnings
+        compound on the same transcript that did the work.
+
+        This is best-effort. Any failure is logged at WARNING and swallowed so
+        a flaky learnings step never flips a successful drive to failure.
+
+        Args:
+            issue_number: GitHub issue number.
+            pr_number: GitHub PR number.
+
+        Returns:
+            True if the learnings session completed, False otherwise.
+
+        """
+        options = self._options()
+        repo_root = self._repo_root()
+        prompt = build_learn_prompt(
+            f"You just drove PR {pr_ref(pr_number)} (issue {issue_ref(issue_number)}) "
+            "to green CI. Capture concise learnings about what made CI fail and how "
+            "you fixed it, scoped to this issue/PR."
+        )
+        self._last_learn_evidence = mnemosyne_update_evidence("")
+        try:
+            repo_slug = get_repo_slug(repo_root)
+            # Best-effort: try to resume in the original worktree (so the
+            # AGENT_CI_DRIVER transcript is found by ``session_jsonl_path``).
+            # In the post-merge code path (#840) the PR's head branch may be
+            # gone from the remote, so ``_get_worktree_path`` could fail. In
+            # that case fall back to ``repo_root`` cwd — the prompt is
+            # self-contained, and a fresh ``--session-id`` create still
+            # captures the lesson.
+            try:
+                cwd = self._get_worktree_path(issue_number, pr_number)
+            except Exception as wt_err:
+                logger.info(
+                    "Issue #%s: no worktree available for /learn (%s); "
+                    "falling back to repo root for a fresh session",
+                    issue_number,
+                    wt_err,
+                )
+                cwd = repo_root
+            if is_codex(options.agent):
+                codex_result = run_codex_session(
+                    prompt,
+                    cwd=cwd,
+                    timeout=learn_claude_timeout(),
+                    sandbox="workspace-write",
+                )
+                self._last_learn_evidence = mnemosyne_update_evidence(codex_result.stdout or "")
+                logger.info("Issue #%s: drive-green learnings captured with Codex", issue_number)
+                return True
+            stdout, _ = invoke_claude_with_session(
+                repo=repo_slug,
+                issue=issue_number,
+                agent=AGENT_CI_DRIVER,
+                prompt=prompt,
+                # /learn inherits the parent phase's model. drive-green resumes
+                # the implementer's session, and ``claude --resume`` is locked to
+                # the model that created it, so we must use implementer_model().
+                model=implementer_model(),
+                cwd=cwd,
+                timeout=learn_claude_timeout(),
+                output_format="text",
+                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+                extra_args=["--dangerously-skip-permissions"],
+                input_via_stdin=True,
+            )
+            self._last_learn_evidence = mnemosyne_update_evidence(stdout or "")
+            logger.info("Issue #%s: drive-green learnings captured", issue_number)
+            return True
+        except Exception as e:  # broad: external claude process; non-blocking
+            logger.warning(
+                "Issue #%s: drive-green learnings failed (non-fatal): %s",
+                issue_number,
+                e,
+            )
+            return False
+
+    def run_drive_green_compact(self, issue_number: int, pr_number: int) -> bool:
+        """Compact the AGENT_CI_DRIVER session transcript after /learn (#842).
+
+        Mirrors the cwd-derivation of ``run_drive_green_learnings``: try the
+        worktree first so the deterministic JSONL probe in ``session_jsonl_path``
+        finds the transcript, fall back to ``repo_root`` when the branch is
+        already gone post-merge. Non-fatal.
+
+        Args:
+            issue_number: GitHub issue number.
+            pr_number: GitHub PR number.
+
+        Returns:
+            True if the compact session completed, False otherwise.
+
+        """
+        options = self._options()
+        repo_root = self._repo_root()
+        if is_codex(options.agent):
+            logger.info(
+                "Issue #%s: skipping /compact (codex has no persisted "
+                "drive-green session to resume)",
+                issue_number,
+            )
+            return False
+        try:
+            cwd = self._get_worktree_path(issue_number, pr_number)
+        except Exception as wt_err:
+            logger.info(
+                "Issue #%s: no worktree available for /compact (%s); using repo root",
+                issue_number,
+                wt_err,
+            )
+            cwd = repo_root
+        repo_slug = get_repo_slug(repo_root)
+        return compact_session(
+            repo=repo_slug,
+            issue=issue_number,
+            agent=AGENT_CI_DRIVER,
+            cwd=cwd,
+            model=implementer_model(),
+        )

--- a/hephaestus/automation/pr_discovery.py
+++ b/hephaestus/automation/pr_discovery.py
@@ -1,0 +1,418 @@
+"""PR discovery collaborator extracted from CIDriver (refs #1179).
+
+Owns viewer-login caching and all PR enumeration strategies:
+- issue-driven (Closes #N links)
+- bot-PR (Dependabot, github-actions)
+- failing-PR (any open non-draft PR whose checks are red)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from collections.abc import Callable
+from typing import Any
+
+from .git_utils import get_repo_info
+from .github_api import GitHubUnavailableError, _gh_call
+
+logger = logging.getLogger(__name__)
+
+
+class PRDiscovery:
+    """Discovers open PRs via multiple strategies using narrow-callable injection.
+
+    Receives provider callables instead of the full CIDriver to satisfy DIP and
+    avoid bidirectional coupling (refs #1179 MAJOR finding 2).
+    """
+
+    def __init__(
+        self,
+        *,
+        options_provider: Callable[[], Any],
+        status_tracker_provider: Callable[[], Any],
+        repo_root_provider: Callable[[], Any],
+        pr_merge_state_provider: Callable[[Any], tuple[str, str]] | None = None,
+    ) -> None:
+        """Initialise the collaborator with narrow provider callables.
+
+        Args:
+            options_provider: Returns the current CIDriverOptions.
+            status_tracker_provider: Returns the current StatusTracker.
+            repo_root_provider: Returns the repo root Path.
+            pr_merge_state_provider: Resolves ``(mergeStateStatus, mergeable)``
+                for a single PR. Injected as a lambda wrapping the driver's
+                ``_pr_merge_state`` delegation stub so ``patch.object(driver,
+                "_pr_merge_state")`` intercepts at call time (#1357). Defaults
+                to this collaborator's own :meth:`pr_merge_state` when not wired.
+
+        """
+        self._options = options_provider
+        self._status = status_tracker_provider
+        self._repo_root = repo_root_provider
+        self._pr_merge_state_fn = pr_merge_state_provider
+        # Viewer-login cache owned here (#821). Empty string = not yet resolved.
+        self._viewer_login: str = ""
+
+    def resolve_viewer_login(self) -> str:
+        """Return the authenticated ``gh api user`` login. Fail CLOSED on error.
+
+        Lazy + cached: only called when the author filter is active. Raises
+        ``RuntimeError`` with operator guidance on any failure so a broken
+        ``gh`` auth never silently widens scope to all PRs (#821 POLA).
+
+        Returns:
+            Authenticated GitHub login string.
+
+        Raises:
+            RuntimeError: When ``gh api user`` fails or returns empty output.
+
+        """
+        if self._viewer_login:
+            return self._viewer_login
+        try:
+            result = _gh_call(["api", "user", "-q", ".login"], check=True)
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            GitHubUnavailableError,
+        ) as exc:
+            raise RuntimeError(
+                "Could not resolve viewer login via `gh api user`: "
+                f"{exc}. Re-authenticate with `gh auth login`, or pass "
+                "--all to opt out of the @me filter (#821)."
+            ) from exc
+        login = (result.stdout or "").strip()
+        if not login:
+            raise RuntimeError(
+                "Could not resolve viewer login via `gh api user`: "
+                "empty response. Re-authenticate with `gh auth login`, "
+                "or pass --all to opt out of the @me filter (#821)."
+            )
+        self._viewer_login = login
+        return login
+
+    def discover_bot_prs(self) -> dict[int, int]:
+        """Enumerate every open ``is_bot=true`` PR on the repo (#848).
+
+        Bot PRs (Dependabot, github-actions, etc.) carry NO ``Closes #N``
+        link to an issue, so the issue-driven discovery path can never see
+        them — they are architecturally invisible. Without this enumeration
+        a repo can sit with dozens of stranded Dependabot PRs forever while
+        the ecosystem script cheerfully reports "driven" because every
+        listed issue had no matching PR.
+
+        Returns a mapping where each bot PR's number is used both as the
+        synthetic issue key AND the PR number. Downstream code is taught
+        (``_is_bot_pr_mode``) to detect the equality and skip issue-data
+        fetches that would 404 on a synthetic key.
+
+        Returns:
+            Mapping of ``pr_number -> pr_number`` for every open bot PR.
+            Empty dict if the ``gh api`` pulls lookup fails or returns
+            nothing — bot discovery must never abort the drive on a list
+            failure.
+
+        Raises:
+            RuntimeError: When the default @me author filter is active
+                (``--all`` not set) and viewer-login resolution fails. This
+                fail-CLOSED abort is intentional per #821 (POLA): a broken
+                ``gh auth`` must never silently widen scope to every author's
+                PRs. Pass ``--all`` to opt out of the filter and bypass the
+                resolver entirely.
+
+        """
+        options = self._options()
+        repo_root = self._repo_root()
+        try:
+            owner, repo = get_repo_info(repo_root)
+        except RuntimeError as exc:
+            logger.info("Bot-PR discovery skipped: could not resolve owner/name (%s)", exc)
+            return {}
+
+        try:
+            result = _gh_call(
+                [
+                    "api",
+                    "--paginate",
+                    f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
+                ],
+                check=False,
+            )
+            raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+            json.JSONDecodeError,
+        ) as exc:
+            logger.info("Bot-PR discovery skipped: gh api failed (%s)", exc)
+            return {}
+
+        viewer = "" if options.include_all_authors else self.resolve_viewer_login()
+        bot_prs: dict[int, int] = {}
+        for pr in raw_pulls:
+            user = pr.get("user") or {}
+            if user.get("type") != "Bot":
+                continue
+            if viewer and user.get("login") != viewer:
+                if user.get("login") is None:
+                    logger.warning(
+                        "PR #%s has no user.login; skipping under author filter (#821)",
+                        pr.get("number"),
+                        extra={
+                            "missing_field": "user.login",
+                            "filter": "author",
+                            "pr_number": pr.get("number"),
+                        },
+                    )
+                continue  # #821: not viewer-owned and --all not set
+            number = pr.get("number")
+            if isinstance(number, int):
+                bot_prs[number] = number
+
+        if bot_prs:
+            logger.info(
+                "Discovered %s open bot-authored PR(s): %s",
+                len(bot_prs),
+                sorted(bot_prs),
+            )
+        return bot_prs
+
+    def discover_failing_prs(
+        self, _pr_is_failing: Callable[[dict[str, Any]], bool]
+    ) -> dict[int, int]:
+        """Enumerate open non-draft PRs whose checks failed or merge is BLOCKED.
+
+        Symmetrical to ``discover_bot_prs``: the issue→PR direction (Closes #N)
+        misses every PR with no Closes line and every PR linked to a closed
+        issue. One CLI call, PR-keyed, synthetic-issue invariant (pr_number ==
+        issue_number) so downstream ``is_bot_pr_mode`` short-circuits ``gh issue
+        view`` identically to the bot path.
+
+        Bounded by gh's --limit 1000 (its documented hard upper). A repo with
+        more than 1000 failing open PRs is pathological — we log a WARNING
+        so operators see the truncation rather than silently dropping work.
+
+        Args:
+            _pr_is_failing: Module-level predicate that determines if a PR row
+                should be picked up for driving.
+
+        Returns:
+            Mapping pr_number -> pr_number for every failing open PR.
+            Empty dict on any lookup failure — discovery must never abort
+            the drive.
+
+        """
+        repo_root = self._repo_root()
+        try:
+            owner, repo = get_repo_info(repo_root)
+        except RuntimeError as exc:
+            logger.info("Failing-PR discovery skipped: could not resolve owner/name (%s)", exc)
+            return {}
+        try:
+            result = _gh_call(
+                [
+                    "pr",
+                    "list",
+                    "--repo",
+                    f"{owner}/{repo}",
+                    "--state",
+                    "open",
+                    "--limit",
+                    "1000",
+                    "--json",
+                    "number,isDraft,statusCheckRollup,mergeStateStatus",
+                ],
+            )
+            pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            OSError,
+            json.JSONDecodeError,
+        ) as exc:
+            logger.info("Failing-PR discovery skipped: gh pr list failed (%s)", exc)
+            return {}
+        if len(pulls) >= 1000:
+            logger.warning(
+                "Failing-PR discovery hit gh's 1000-PR cap on %s/%s — "
+                "additional failing PRs may exist and are not visible to this run.",
+                owner,
+                repo,
+            )
+        failing: dict[int, int] = {}
+        for pr in pulls:
+            number = pr.get("number")
+            if not isinstance(number, int):
+                continue
+            if _pr_is_failing(pr):
+                failing[number] = number
+        if failing:
+            logger.info(
+                "Discovered %s open failing PR(s): %s",
+                len(failing),
+                sorted(failing),
+            )
+        return failing
+
+    def is_bot_pr_mode(self, issue_number: int, pr_number: int) -> bool:
+        """Return True iff this work item is a synthetic-issue bot PR (#848).
+
+        The bot-PR enumeration uses the PR number as a stand-in for an
+        issue number because Dependabot PRs have no associated issue.
+        Anywhere we would normally call ``gh issue view <issue_number>``
+        we must instead short-circuit; this helper centralises the check
+        so a single rule (issue == pr) keeps both ends honest.
+
+        Args:
+            issue_number: GitHub issue number (may be synthetic).
+            pr_number: GitHub PR number.
+
+        Returns:
+            True when issue_number equals pr_number (synthetic-issue invariant).
+
+        """
+        return issue_number == pr_number
+
+    def list_open_prs_remaining(self) -> list[dict[str, Any]]:
+        """Return the list of open PRs left on the repo after the drive (#838).
+
+        A repo is only truly "driven" when there are zero open PRs left. The
+        per-issue ``_drive_issue`` loop's notion of success — every issue's
+        PR moved to green and/or got auto-merge enabled — does NOT imply the
+        repo is clean: PRs that have not yet merged (auto-merge waiting on
+        CI), PRs from issues outside the input set, and PRs opened by
+        humans/other-automation all leave open work behind.
+
+        Uses ``gh api --paginate`` so the result is the FULL set of open PRs,
+        not a capped prefix. A repo with hundreds of dependabot PRs would
+        otherwise pass the done-check after looking at only 100 of them.
+
+        Returns:
+            One dict per open PR with keys ``number``, ``title``,
+            ``headRefName``, ``autoMergeRequest`` (None or the auto-merge
+            metadata blob), and ``mergeStateStatus`` / ``mergeable`` (the
+            per-PR merge-state, fetched separately because the REST list
+            endpoint does not populate ``mergeable`` reliably — see #1328).
+            Empty list iff the repo is clean.
+
+        """
+        options = self._options()
+        repo_root = self._repo_root()
+        try:
+            owner, repo = get_repo_info(repo_root)
+        except RuntimeError as exc:
+            logger.error("Could not resolve repo owner/name to list open PRs: %s", exc)
+            # Unknown ownership ⇒ treat as not-done so operators investigate.
+            return [{"number": -1, "title": "(unknown: cannot resolve repo)"}]
+
+        # ``gh api --paginate`` walks ``Link: rel="next"`` headers and emits
+        # a single concatenated JSON array across all pages. ``per_page=100``
+        # is GitHub's max page size; we issue the minimum number of calls.
+        # We use ``gh api`` directly (not ``gh pr list``) because the latter
+        # caps at ``--limit`` even with paginate semantics; gh's REST proxy
+        # paginates without an upper bound.
+        try:
+            result = _gh_call(
+                [
+                    "api",
+                    "--paginate",
+                    f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
+                ],
+                check=False,
+            )
+            raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            # If we cannot determine the open-PR count, the safest default is
+            # to assume the repo is NOT done — surface the unknown state as a
+            # failure so operators don't walk away on a false-green.
+            logger.error("Could not list open PRs to verify repo done-state: %s", exc)
+            return [{"number": -1, "title": "(unknown: gh api pulls failed)"}]
+
+        # The REST shape exposes ``head.ref`` and ``auto_merge`` (snake_case);
+        # normalise to the gh-CLI shape consumers downstream already use.
+        viewer = "" if options.include_all_authors else self.resolve_viewer_login()
+        normalised: list[dict[str, Any]] = []
+        for pr in raw_pulls:
+            user = pr.get("user") or {}
+            if viewer and user.get("login") != viewer:
+                if user.get("login") is None:
+                    logger.warning(
+                        "PR #%s has no user.login; skipping under author filter (#821)",
+                        pr.get("number"),
+                        extra={
+                            "missing_field": "user.login",
+                            "filter": "author",
+                            "pr_number": pr.get("number"),
+                        },
+                    )
+                continue  # #821: hide other-author PRs from the done-gate sweep
+            labels = pr.get("labels") or []
+            number = pr.get("number")
+            # Route through the injected provider (lambda → driver stub) so
+            # ``patch.object(driver, "_pr_merge_state")`` intercepts (#1357);
+            # fall back to the local method when unwired.
+            merge_state_fn = self._pr_merge_state_fn or self.pr_merge_state
+            merge_state, mergeable = merge_state_fn(number)
+            normalised.append(
+                {
+                    "number": number,
+                    "title": pr.get("title", ""),
+                    "headRefName": (pr.get("head") or {}).get("ref", ""),
+                    "autoMergeRequest": pr.get("auto_merge"),
+                    "mergeStateStatus": merge_state,
+                    "mergeable": mergeable,
+                    "labels": [
+                        label.get("name", "") for label in labels if isinstance(label, dict)
+                    ],
+                    "isBot": user.get("type") == "Bot",
+                }
+            )
+        return normalised
+
+    def pr_merge_state(self, pr_number: Any) -> tuple[str, str]:
+        """Return ``(mergeStateStatus, mergeable)`` for a single PR (#1328).
+
+        The REST ``/pulls`` list endpoint does NOT populate ``mergeable`` /
+        ``mergeable_state`` reliably (GitHub computes the merge-state lazily and
+        omits it from list responses), so the done-gate cannot tell a
+        permanently-CONFLICTING armed PR apart from one that is genuinely still
+        merging. A per-PR ``gh pr view`` forces GitHub to compute the merge
+        state, matching how the rest of the driver queries merge-state.
+
+        Args:
+            pr_number: PR number to query.
+
+        Returns:
+            ``(mergeStateStatus, mergeable)`` upper-cased. Empty strings when the
+            number is the unknown-marker sentinel or the query fails — an unknown
+            merge-state must never be misread as CONFLICTING.
+
+        """
+        if not isinstance(pr_number, int) or pr_number < 0:
+            return "", ""
+        try:
+            result = _gh_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "mergeStateStatus,mergeable",
+                ],
+                check=False,
+            )
+            state = dict(json.loads(result.stdout or "{}"))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Could not fetch PR #%s merge-state for done-gate; treating as unknown: %s",
+                pr_number,
+                exc,
+            )
+            return "", ""
+        return (
+            str(state.get("mergeStateStatus") or "").upper(),
+            str(state.get("mergeable") or "").upper(),
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,7 @@ omit = [
     "*/__init__.py",
     # Full orchestration loops require a live claude/gh CLI — integration test territory.
     # Pure-function helpers in these modules are tested in tests/unit/automation/ instead.
-    # The allowlist of these 12 modules is frozen in tests/unit/validation/test_omit_allowlist.py
+    # The allowlist of these 16 modules is frozen in tests/unit/validation/test_omit_allowlist.py
     # to prevent silent growth of the omit list, and their importability is guarded by
     # tests/integration/test_orchestration_smoke.py.
     "hephaestus/automation/implementer.py",
@@ -253,6 +253,13 @@ omit = [
     "hephaestus/automation/planner.py",
     "hephaestus/automation/address_review.py",
     "hephaestus/automation/ci_driver.py",
+    # CIDriver collaborators extracted from ci_driver.py (#1357 / refs #1179, #1289).
+    # Each drives a live gh/claude/codex session, so like ci_driver.py they are
+    # integration-only; their pure helpers are unit-tested in tests/unit/automation/.
+    "hephaestus/automation/pr_discovery.py",
+    "hephaestus/automation/ci_check_inspector.py",
+    "hephaestus/automation/ci_fix_orchestrator.py",
+    "hephaestus/automation/post_merge_processor.py",
     "hephaestus/automation/loop_runner.py",
     # curses_ui.py uses a live terminal; cannot be unit-tested without a real TTY
     "hephaestus/automation/curses_ui.py",

--- a/tests/integration/test_orchestration_smoke.py
+++ b/tests/integration/test_orchestration_smoke.py
@@ -1,16 +1,18 @@
 """Smoke tests for omitted orchestration modules — integration backstop.
 
-These tests validate that the 12 automation modules omitted from coverage
+These tests validate that the 16 automation modules omitted from coverage
 (per pyproject.toml[tool.coverage.run].omit) remain importable and their
 console entry points work correctly.
 
 Module enumeration and entry-point discovery verified at plan time:
-- All 12 modules are importable (guards against import regressions)
+- All 16 modules are importable (guards against import regressions)
 - 5 modules have console scripts: implementer, planner, loop_runner, pr_reviewer, audit_reviewer
 - 2 modules are script-less but have main(): address_review, ci_driver
-- 5 modules lack main() entirely: implementer_cli (only argument parsing /
+- 9 modules lack main() entirely: implementer_cli (only argument parsing /
     logging setup since #714 relocated main() to implementer),
-    implementer_phase_runner, implementer_summary, curses_ui, github_api
+    implementer_phase_runner, implementer_summary, curses_ui, github_api,
+    and the 4 CIDriver collaborators extracted in #1357 (pr_discovery,
+    ci_check_inspector, ci_fix_orchestrator, post_merge_processor)
 """
 
 import subprocess
@@ -18,7 +20,7 @@ import sys
 
 import pytest
 
-# All 12 omitted orchestration modules
+# All 16 omitted orchestration modules
 OMITTED_MODULES = [
     "hephaestus.automation.implementer",
     "hephaestus.automation.implementer_cli",
@@ -27,6 +29,10 @@ OMITTED_MODULES = [
     "hephaestus.automation.planner",
     "hephaestus.automation.address_review",
     "hephaestus.automation.ci_driver",
+    "hephaestus.automation.pr_discovery",
+    "hephaestus.automation.ci_check_inspector",
+    "hephaestus.automation.ci_fix_orchestrator",
+    "hephaestus.automation.post_merge_processor",
     "hephaestus.automation.loop_runner",
     "hephaestus.automation.curses_ui",
     "hephaestus.automation.github_api",

--- a/tests/unit/automation/test_ci_check_inspector_helpers.py
+++ b/tests/unit/automation/test_ci_check_inspector_helpers.py
@@ -1,0 +1,82 @@
+"""Unit tests for CICheckInspector collaborator (refs #1179)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation.ci_check_inspector import (
+    FAILING_CHECK_CONCLUSIONS,
+    CICheckInspector,
+)
+
+
+@pytest.fixture()
+def inspector() -> CICheckInspector:
+    """Return a CICheckInspector wired with test doubles."""
+    return CICheckInspector(
+        get_pr_branch=lambda pr: f"branch-{pr}",
+        options_provider=lambda: MagicMock(dry_run=False),
+    )
+
+
+class TestFailingCheckConclusions:
+    """Tests for the FAILING_CHECK_CONCLUSIONS constant."""
+
+    def test_contains_expected_values(self) -> None:
+        assert "FAILURE" in FAILING_CHECK_CONCLUSIONS
+        assert "CANCELLED" in FAILING_CHECK_CONCLUSIONS
+        assert "TIMED_OUT" in FAILING_CHECK_CONCLUSIONS
+
+    def test_is_frozenset(self) -> None:
+        assert isinstance(FAILING_CHECK_CONCLUSIONS, frozenset)
+
+    def test_success_not_included(self) -> None:
+        assert "SUCCESS" not in FAILING_CHECK_CONCLUSIONS
+        assert "PENDING" not in FAILING_CHECK_CONCLUSIONS
+
+
+class TestFailingRequiredCheckNames:
+    """Tests for CICheckInspector.failing_required_check_names."""
+
+    def test_returns_required_failing_check_names(self, inspector: CICheckInspector) -> None:
+        # gh_pr_checks returns dicts with lowercase "conclusion" and "required" key
+        checks = [
+            {"name": "lint", "conclusion": "failure", "status": "completed", "required": True},
+            {"name": "tests", "conclusion": "success", "status": "completed", "required": True},
+            {"name": "optional", "conclusion": "failure", "status": "completed", "required": False},
+        ]
+        with patch(
+            "hephaestus.automation.ci_check_inspector.gh_pr_checks",
+            return_value=checks,
+        ):
+            result = inspector.failing_required_check_names(42)
+        assert result == ["lint"]
+
+    def test_empty_when_no_required_checks_fail(self, inspector: CICheckInspector) -> None:
+        checks = [
+            {"name": "lint", "conclusion": "success", "status": "completed", "required": True},
+        ]
+        with patch(
+            "hephaestus.automation.ci_check_inspector.gh_pr_checks",
+            return_value=checks,
+        ):
+            result = inspector.failing_required_check_names(42)
+        assert result == []
+
+
+class TestPendingRequiredCheckNames:
+    """Tests for CICheckInspector.pending_required_check_names."""
+
+    def test_returns_pending_required_checks(self, inspector: CICheckInspector) -> None:
+        checks = [
+            {"name": "slow-ci", "conclusion": None, "status": "in_progress", "required": True},
+            {"name": "fast-ci", "conclusion": "success", "status": "completed", "required": True},
+        ]
+        with patch(
+            "hephaestus.automation.ci_check_inspector.gh_pr_checks",
+            return_value=checks,
+        ):
+            result = inspector.pending_required_check_names(42)
+        assert "slow-ci" in result

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -272,17 +272,27 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
     ]
 
     with (
-        patch("hephaestus.automation.ci_driver.resume_codex_session", side_effect=resume_error),
         patch(
-            "hephaestus.automation.ci_driver.run_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
+            side_effect=resume_error,
+        ),
+        patch(
+            "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
             return_value=fresh_result,
         ) as mock_fresh,
         patch(
-            "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+            "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
         ) as mock_push,
-        patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch") as mock_sync,
-        patch.object(driver, "_ci_fix_head_is_pushable", return_value=True),
-        patch("hephaestus.automation.ci_driver.run", side_effect=pre_post_sequence),
+        patch(
+            "hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"
+        ) as mock_sync,
+        patch.object(driver._fix_orchestrator, "_ci_fix_head_is_pushable", return_value=True),
+        # The pre-agent SHA snapshot and the post-agent HEAD read (_head_advanced)
+        # both run inside ci_fix_orchestrator after the decomposition (#1357).
+        patch(
+            "hephaestus.automation.ci_fix_orchestrator.run",
+            side_effect=pre_post_sequence,
+        ),
     ):
         result = driver._run_ci_fix_session(
             issue_number=123,
@@ -323,15 +333,18 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
 
     with (
         patch(
-            "hephaestus.automation.ci_driver.run_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
             return_value=fresh_result,
         ),
         patch(
-            "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+            "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
         ) as mock_push,
-        patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch"),
+        patch("hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"),
+        # Pre-agent SHA snapshot, post-agent HEAD read (_head_advanced) and the
+        # git-status read (_tracked_worktree_changes) all run inside
+        # ci_fix_orchestrator after the decomposition (#1357).
         patch(
-            "hephaestus.automation.ci_driver.run",
+            "hephaestus.automation.ci_fix_orchestrator.run",
             side_effect=[unchanged_sha, unchanged_sha, clean_status],
         ),
         patch(
@@ -339,7 +352,7 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
             return_value=[],
         ),
         patch(
-            "hephaestus.automation.ci_driver.gh_pr_checks",
+            "hephaestus.automation.ci_check_inspector.gh_pr_checks",
             return_value=[],
         ),
     ):
@@ -365,7 +378,7 @@ def test_ci_fix_head_not_pushable_with_unmerged_index(
 ) -> None:
     """A semantic conflict resolution is not pushable until the index is merged."""
     with patch(
-        "hephaestus.automation.ci_driver.run",
+        "hephaestus.automation.ci_fix_orchestrator.run",
         return_value=MagicMock(
             stdout="hephaestus/automation/loop_runner.py\n",
             stderr="",
@@ -385,7 +398,7 @@ def test_ci_fix_head_not_pushable_when_head_is_base_only(
         MagicMock(stdout="?? uv.lock\n", stderr="", returncode=0),  # generated untracked file
         MagicMock(stdout="0\n", stderr="", returncode=0),  # no commits ahead of origin/main
     ]
-    with patch("hephaestus.automation.ci_driver.run", side_effect=responses):
+    with patch("hephaestus.automation.ci_fix_orchestrator.run", side_effect=responses):
         assert driver._ci_fix_head_is_pushable(tmp_path, 993) is False
 
 
@@ -399,7 +412,7 @@ def test_ci_fix_head_pushable_with_clean_committed_pr_head(
         MagicMock(stdout="?? uv.lock\n", stderr="", returncode=0),
         MagicMock(stdout="1\n", stderr="", returncode=0),
     ]
-    with patch("hephaestus.automation.ci_driver.run", side_effect=responses):
+    with patch("hephaestus.automation.ci_fix_orchestrator.run", side_effect=responses):
         assert driver._ci_fix_head_is_pushable(tmp_path, 993) is True
 
 
@@ -496,8 +509,8 @@ class TestOpenPrsRemaining:
         driver.options.include_all_authors = True
         result_mock = MagicMock(stdout="[]")
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
-            patch("hephaestus.automation.ci_driver._gh_call", return_value=result_mock),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery._gh_call", return_value=result_mock),
         ):
             remaining = driver._list_open_prs_remaining()
         assert remaining == []
@@ -527,8 +540,8 @@ class TestOpenPrsRemaining:
         ]
         result_mock = MagicMock(stdout=json.dumps(rest_pulls))
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
-            patch("hephaestus.automation.ci_driver._gh_call", return_value=result_mock),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery._gh_call", return_value=result_mock),
             # #1328: merge-state is fetched per-PR via a separate gh pr view.
             patch.object(driver, "_pr_merge_state", side_effect=[("CLEAN", "MERGEABLE"), ("", "")]),
         ):
@@ -561,7 +574,9 @@ class TestOpenPrsRemaining:
         result_mock = MagicMock(
             stdout=json.dumps({"mergeStateStatus": "dirty", "mergeable": "conflicting"})
         )
-        with patch("hephaestus.automation.ci_driver._gh_call", return_value=result_mock) as mock_gh:
+        with patch(
+            "hephaestus.automation.pr_discovery._gh_call", return_value=result_mock
+        ) as mock_gh:
             merge_state, mergeable = driver._pr_merge_state(42)
         assert (merge_state, mergeable) == ("DIRTY", "CONFLICTING")
         cmd = mock_gh.call_args[0][0]
@@ -570,14 +585,14 @@ class TestOpenPrsRemaining:
 
     def test_pr_merge_state_unknown_marker_skips_query(self, driver: CIDriver) -> None:
         """#1328: the -1 unknown sentinel must not trigger a gh call."""
-        with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh:
+        with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh:
             assert driver._pr_merge_state(-1) == ("", "")
         mock_gh.assert_not_called()
 
     def test_pr_merge_state_gh_failure_returns_unknown(self, driver: CIDriver) -> None:
         """#1328: a failed merge-state query degrades to unknown, never CONFLICTING."""
         with patch(
-            "hephaestus.automation.ci_driver._gh_call",
+            "hephaestus.automation.pr_discovery._gh_call",
             side_effect=subprocess.CalledProcessError(1, "gh"),
         ):
             assert driver._pr_merge_state(7) == ("", "")
@@ -590,9 +605,9 @@ class TestOpenPrsRemaining:
         # #821: this test verifies gh-failure handling, not author scope.
         driver.options.include_all_authors = True
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 side_effect=subprocess.CalledProcessError(1, "gh", stderr="rate limited"),
             ),
         ):
@@ -609,9 +624,9 @@ class TestOpenPrsRemaining:
         driver.options.include_all_authors = True
         result_mock = MagicMock(stdout="[]")
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=result_mock,
             ) as mock_gh,
         ):
@@ -1350,10 +1365,12 @@ class TestDriveGreenLearnings:
         with (
             patch.object(driver, "_get_worktree_path", return_value=tmp_path),
             patch(
-                "hephaestus.automation.ci_driver.run_codex_session",
+                "hephaestus.automation.post_merge_processor.run_codex_session",
                 return_value=mock_codex_result,
             ) as mock_codex,
-            patch("hephaestus.automation.ci_driver.invoke_claude_with_session") as mock_invoke,
+            patch(
+                "hephaestus.automation.post_merge_processor.invoke_claude_with_session"
+            ) as mock_invoke,
         ):
             result = driver._run_drive_green_learnings(123, 456)
 
@@ -1365,7 +1382,8 @@ class TestDriveGreenLearnings:
         assert "Only push skills to ProjectMnemosyne" in prompt
         assert mock_codex.call_args.kwargs["cwd"] == tmp_path
         mock_invoke.assert_not_called()
-        assert driver._last_drive_green_learn_evidence["mnemosyne_update_status"] == "confirmed"
+        # The learn-evidence cache moved into PostMergeProcessor (#1357).
+        assert driver._post_merge._last_learn_evidence["mnemosyne_update_status"] == "confirmed"
 
 
 # ---------------------------------------------------------------------------
@@ -1530,7 +1548,7 @@ class TestGetFailingCiLogs:
         driver.options.dry_run = False
         with (
             patch.object(driver, "_get_pr_branch", return_value="123-auto-impl"),
-            patch("hephaestus.automation.ci_driver._gh_call") as mock_gh,
+            patch("hephaestus.automation.ci_check_inspector._gh_call") as mock_gh,
         ):
             mock_gh.return_value = MagicMock(stdout="[]")
             driver._get_failing_ci_logs(pr_number=456)
@@ -1543,7 +1561,7 @@ class TestGetFailingCiLogs:
         """``gh run list`` must NOT be called without a ``--branch`` filter."""
         with (
             patch.object(driver, "_get_pr_branch", return_value="my-branch"),
-            patch("hephaestus.automation.ci_driver._gh_call") as mock_gh,
+            patch("hephaestus.automation.ci_check_inspector._gh_call") as mock_gh,
         ):
             mock_gh.return_value = MagicMock(stdout="[]")
             driver._get_failing_ci_logs(pr_number=10)
@@ -1653,7 +1671,7 @@ class TestFailingRequiredCheckNames:
 
     def test_all_green_returns_empty(self, driver: CIDriver) -> None:
         checks = [_make_check("lint", conclusion="success")]
-        with patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks):
+        with patch("hephaestus.automation.ci_check_inspector.gh_pr_checks", return_value=checks):
             assert driver._failing_required_check_names(pr_number=1) == []
 
     def test_one_required_failure_returned(self, driver: CIDriver) -> None:
@@ -1662,7 +1680,7 @@ class TestFailingRequiredCheckNames:
             _make_check("test", conclusion="failure"),
             _make_check("non-req", conclusion="failure", required=False),
         ]
-        with patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks):
+        with patch("hephaestus.automation.ci_check_inspector.gh_pr_checks", return_value=checks):
             names = driver._failing_required_check_names(pr_number=1)
         assert names == ["test"]
 
@@ -1671,13 +1689,13 @@ class TestFailingRequiredCheckNames:
         checks = [
             _make_check("only-check", conclusion="failure", required=False),
         ]
-        with patch("hephaestus.automation.ci_driver.gh_pr_checks", return_value=checks):
+        with patch("hephaestus.automation.ci_check_inspector.gh_pr_checks", return_value=checks):
             assert driver._failing_required_check_names(pr_number=1) == ["only-check"]
 
     def test_gh_failure_returns_empty(self, driver: CIDriver) -> None:
         """A gh blip must not promote the no-commit to a retry — empty list = skip."""
         with patch(
-            "hephaestus.automation.ci_driver.gh_pr_checks",
+            "hephaestus.automation.ci_check_inspector.gh_pr_checks",
             side_effect=RuntimeError("api down"),
         ):
             assert driver._failing_required_check_names(pr_number=1) == []
@@ -1757,16 +1775,18 @@ class TestNoCommitRetry:
         """No-commit + green CI + clean tracked tree → no retry."""
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="success")],
             ),
-            patch("hephaestus.automation.ci_driver.invoke_claude_with_session") as mock_invoke,
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session"
+            ) as mock_invoke,
             patch(
                 "hephaestus.automation.ci_driver.gh_pr_list_unresolved_threads",
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_driver.run",
+                "hephaestus.automation.ci_fix_orchestrator.run",
                 return_value=MagicMock(stdout="?? uv.lock\n", stderr="", returncode=0),
             ),
         ):
@@ -1795,7 +1815,7 @@ class TestNoCommitRetry:
         post_sha = MagicMock(stdout="deadbeef\n", stderr="", returncode=0)
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="success")],
             ),
             patch(
@@ -1803,10 +1823,10 @@ class TestNoCommitRetry:
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
                 return_value=("done", "sess"),
             ) as mock_invoke,
-            patch("hephaestus.automation.ci_driver.run", side_effect=[status, post_sha]),
+            patch("hephaestus.automation.ci_fix_orchestrator.run", side_effect=[status, post_sha]),
         ):
             result = driver._retry_no_commit_once(
                 issue_number=993,
@@ -1833,7 +1853,7 @@ class TestNoCommitRetry:
         clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="failure")],
             ),
             patch(
@@ -1841,10 +1861,13 @@ class TestNoCommitRetry:
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
                 return_value=("done", "sess"),
             ) as mock_invoke,
-            patch("hephaestus.automation.ci_driver.run", side_effect=[clean_status, post_sha]),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.run",
+                side_effect=[clean_status, post_sha],
+            ),
         ):
             result = driver._retry_no_commit_once(
                 issue_number=1,
@@ -1870,7 +1893,7 @@ class TestNoCommitRetry:
         clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="failure")],
             ),
             patch(
@@ -1878,11 +1901,11 @@ class TestNoCommitRetry:
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
                 return_value=("nope", "sess"),
             ) as mock_invoke,
             patch(
-                "hephaestus.automation.ci_driver.run",
+                "hephaestus.automation.ci_fix_orchestrator.run",
                 side_effect=[clean_status, unchanged, clean_status, unchanged],
             ),
         ):
@@ -1912,7 +1935,7 @@ class TestNoCommitRetry:
         """A subprocess error during retry → False, no marker (could not prove repeated)."""
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="failure")],
             ),
             patch(
@@ -1920,7 +1943,7 @@ class TestNoCommitRetry:
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
                 side_effect=subprocess.CalledProcessError(1, ["claude"], stderr="boom"),
             ),
         ):
@@ -1944,7 +1967,7 @@ class TestNoCommitRetry:
         clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="failure")],
             ),
             patch(
@@ -1952,11 +1975,14 @@ class TestNoCommitRetry:
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_driver.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
                 return_value=AgentRunResult(stdout="ok", stderr="", session_id="s"),
             ) as mock_resume,
-            patch("hephaestus.automation.ci_driver.run_codex_session") as mock_fresh,
-            patch("hephaestus.automation.ci_driver.run", side_effect=[clean_status, post_sha]),
+            patch("hephaestus.automation.ci_fix_orchestrator.run_codex_session") as mock_fresh,
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.run",
+                side_effect=[clean_status, post_sha],
+            ),
         ):
             result = driver._retry_no_commit_once(
                 issue_number=1,
@@ -1984,11 +2010,11 @@ class TestBotPrDiscovery:
         driver.options.include_all_authors = True
         with (
             patch(
-                "hephaestus.automation.ci_driver.get_repo_info",
+                "hephaestus.automation.pr_discovery.get_repo_info",
                 return_value=("o", "r"),
             ),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout="[]"),
             ),
         ):
@@ -2004,11 +2030,11 @@ class TestBotPrDiscovery:
         ]
         with (
             patch(
-                "hephaestus.automation.ci_driver.get_repo_info",
+                "hephaestus.automation.pr_discovery.get_repo_info",
                 return_value=("o", "r"),
             ),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(raw)),
             ),
         ):
@@ -2021,11 +2047,11 @@ class TestBotPrDiscovery:
         driver.options.include_all_authors = True
         with (
             patch(
-                "hephaestus.automation.ci_driver.get_repo_info",
+                "hephaestus.automation.pr_discovery.get_repo_info",
                 return_value=("o", "r"),
             ),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 side_effect=subprocess.CalledProcessError(1, ["gh"], stderr="boom"),
             ),
         ):
@@ -2035,11 +2061,11 @@ class TestBotPrDiscovery:
         """Discovery returns empty dict when gh api times out (docstring contract)."""
         with (
             patch(
-                "hephaestus.automation.ci_driver.get_repo_info",
+                "hephaestus.automation.pr_discovery.get_repo_info",
                 return_value=("o", "r"),
             ),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30),
             ),
         ):
@@ -2049,11 +2075,11 @@ class TestBotPrDiscovery:
         """Discovery returns empty dict when the gh binary is missing/unexecutable."""
         with (
             patch(
-                "hephaestus.automation.ci_driver.get_repo_info",
+                "hephaestus.automation.pr_discovery.get_repo_info",
                 return_value=("o", "r"),
             ),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 side_effect=FileNotFoundError(2, "No such file or directory", "gh"),
             ),
         ):
@@ -2366,16 +2392,18 @@ class TestMechanicalRebase:
         """A BEHIND PR rebases cleanly → pushes with lease, returns True."""
         with (
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
                 return_value=self._pr_state("BEHIND"),
             ),
             patch.object(driver, "_get_worktree_path", return_value=tmp_path),
-            patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch") as mock_sync,
             patch(
-                "hephaestus.automation.ci_driver.rebase_worktree_onto", return_value=True
+                "hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"
+            ) as mock_sync,
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto", return_value=True
             ) as mock_rebase,
             patch(
-                "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+                "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
             ) as mock_push,
         ):
             result = driver._attempt_mechanical_rebase(
@@ -2391,14 +2419,16 @@ class TestMechanicalRebase:
         """A DIRTY PR whose rebase conflicts must NOT push — it returns False."""
         with (
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
                 return_value=self._pr_state("DIRTY"),
             ),
             patch.object(driver, "_get_worktree_path", return_value=tmp_path),
-            patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch"),
-            patch("hephaestus.automation.ci_driver.rebase_worktree_onto", return_value=False),
+            patch("hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"),
             patch(
-                "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+                "hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto", return_value=False
+            ),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
             ) as mock_push,
         ):
             result = driver._attempt_mechanical_rebase(
@@ -2412,12 +2442,12 @@ class TestMechanicalRebase:
         """A CLEAN/BLOCKED PR is already on its base — no rebase, no push."""
         with (
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
                 return_value=self._pr_state("CLEAN"),
             ),
-            patch("hephaestus.automation.ci_driver.rebase_worktree_onto") as mock_rebase,
+            patch("hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto") as mock_rebase,
             patch(
-                "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+                "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
             ) as mock_push,
         ):
             result = driver._attempt_mechanical_rebase(
@@ -2432,10 +2462,10 @@ class TestMechanicalRebase:
         """BLOCKED (green, waiting on review) is on-base — must not be rebased."""
         with (
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
                 return_value=self._pr_state("BLOCKED"),
             ),
-            patch("hephaestus.automation.ci_driver.rebase_worktree_onto") as mock_rebase,
+            patch("hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto") as mock_rebase,
         ):
             result = driver._attempt_mechanical_rebase(
                 issue_number=5, pr_number=50, acquired_slot=0
@@ -2448,15 +2478,17 @@ class TestMechanicalRebase:
         """The rebase targets the PR's actual baseRefName, not a hardcoded main."""
         with (
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
                 return_value=self._pr_state("BEHIND", base="develop"),
             ),
             patch.object(driver, "_get_worktree_path", return_value=tmp_path),
-            patch("hephaestus.automation.ci_driver.sync_worktree_to_remote_branch"),
+            patch("hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"),
             patch(
-                "hephaestus.automation.ci_driver.rebase_worktree_onto", return_value=True
+                "hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto", return_value=True
             ) as mock_rebase,
-            patch("hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
+            ),
         ):
             driver._attempt_mechanical_rebase(issue_number=5, pr_number=50, acquired_slot=0)
 
@@ -2468,10 +2500,10 @@ class TestMechanicalRebase:
         """A bad/empty gh response must be swallowed → False, never raise."""
         with (
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
                 return_value=MagicMock(stdout="not json"),
             ),
-            patch("hephaestus.automation.ci_driver.rebase_worktree_onto") as mock_rebase,
+            patch("hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto") as mock_rebase,
         ):
             result = driver._attempt_mechanical_rebase(
                 issue_number=5, pr_number=50, acquired_slot=0
@@ -3130,7 +3162,7 @@ class TestRunDriveGreenCompact:
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
         """Verify /compact runs exactly once and respects learn_captured_at gate."""
-        with patch("hephaestus.automation.ci_driver.compact_session") as mock_compact:
+        with patch("hephaestus.automation.post_merge_processor.compact_session") as mock_compact:
             mock_compact.return_value = True
 
             # First pass: should call compact_session
@@ -3145,7 +3177,7 @@ class TestRunDriveGreenCompact:
         self, driver: CIDriver, tmp_path: Path
     ) -> None:
         """Verify compact failure is non-fatal (returns False but doesn't raise)."""
-        with patch("hephaestus.automation.ci_driver.compact_session") as mock_compact:
+        with patch("hephaestus.automation.post_merge_processor.compact_session") as mock_compact:
             mock_compact.return_value = False
 
             # Should return False but not raise
@@ -3156,14 +3188,16 @@ class TestRunDriveGreenCompact:
         """Verify compact is skipped for codex (no persisted session)."""
         driver.options.agent = "codex"
 
-        with patch("hephaestus.automation.ci_driver.compact_session") as mock_compact:
+        with patch("hephaestus.automation.post_merge_processor.compact_session") as mock_compact:
             driver._run_drive_green_compact(842, 100)
             mock_compact.assert_not_called()
 
     def test_drive_green_compact_uses_worktree_path(self, driver: CIDriver, tmp_path: Path) -> None:
         """Verify compact_session is called with the worktree path."""
         with patch.object(driver, "_get_worktree_path", return_value=tmp_path):
-            with patch("hephaestus.automation.ci_driver.compact_session") as mock_compact:
+            with patch(
+                "hephaestus.automation.post_merge_processor.compact_session"
+            ) as mock_compact:
                 mock_compact.return_value = True
 
                 driver._run_drive_green_compact(842, 100)
@@ -3177,7 +3211,9 @@ class TestRunDriveGreenCompact:
     ) -> None:
         """Verify compact_session uses repo_root when worktree is not available."""
         with patch.object(driver, "_get_worktree_path", side_effect=RuntimeError("No worktree")):
-            with patch("hephaestus.automation.ci_driver.compact_session") as mock_compact:
+            with patch(
+                "hephaestus.automation.post_merge_processor.compact_session"
+            ) as mock_compact:
                 mock_compact.return_value = True
 
                 driver._run_drive_green_compact(842, 100)
@@ -3256,7 +3292,7 @@ class TestInvokeAgentSession:
 
     def test_claude_success_returns_rc0(self, driver: CIDriver, tmp_path: Path) -> None:
         with patch(
-            "hephaestus.automation.ci_driver.invoke_claude_with_session",
+            "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
             return_value=("output text", "sess-id"),
         ) as mock_invoke:
             result = driver._invoke_agent_session(
@@ -3272,7 +3308,7 @@ class TestInvokeAgentSession:
 
     def test_claude_error_returns_nonzero_rc(self, driver: CIDriver, tmp_path: Path) -> None:
         with patch(
-            "hephaestus.automation.ci_driver.invoke_claude_with_session",
+            "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
             side_effect=subprocess.CalledProcessError(1, ["claude"], stderr="boom"),
         ):
             result = driver._invoke_agent_session(
@@ -3289,10 +3325,10 @@ class TestInvokeAgentSession:
         driver.options.agent = "codex"
         with (
             patch(
-                "hephaestus.automation.ci_driver.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
                 return_value=AgentRunResult(stdout="ok", stderr="", session_id="s"),
             ) as mock_resume,
-            patch("hephaestus.automation.ci_driver.run_codex_session") as mock_fresh,
+            patch("hephaestus.automation.ci_fix_orchestrator.run_codex_session") as mock_fresh,
         ):
             result = driver._invoke_agent_session(
                 prompt="fix it",
@@ -3311,11 +3347,11 @@ class TestInvokeAgentSession:
         driver.options.agent = "codex"
         with (
             patch(
-                "hephaestus.automation.ci_driver.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
                 side_effect=subprocess.CalledProcessError(1, ["codex"], stderr="resume-fail"),
             ),
             patch(
-                "hephaestus.automation.ci_driver.run_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
                 return_value=AgentRunResult(stdout="fresh ok", stderr="", session_id="s2"),
             ) as mock_fresh,
         ):
@@ -3336,11 +3372,11 @@ class TestInvokeAgentSession:
         driver.options.agent = "codex"
         with (
             patch(
-                "hephaestus.automation.ci_driver.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
                 side_effect=subprocess.CalledProcessError(1, ["codex"], stderr="resume-fail"),
             ),
             patch(
-                "hephaestus.automation.ci_driver.run_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
                 side_effect=subprocess.CalledProcessError(2, ["codex"], stderr="fresh-fail"),
             ),
         ):
@@ -3360,7 +3396,7 @@ class TestInvokeAgentSession:
         """No session_id + fresh codex fails → CompletedProcess(returncode!=0), no exception."""
         driver.options.agent = "codex"
         with patch(
-            "hephaestus.automation.ci_driver.run_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
             side_effect=subprocess.CalledProcessError(3, ["codex"], stderr="fail"),
         ):
             result = driver._invoke_agent_session(
@@ -3375,9 +3411,9 @@ class TestInvokeAgentSession:
     def test_codex_no_session_runs_fresh(self, driver: CIDriver, tmp_path: Path) -> None:
         driver.options.agent = "codex"
         with (
-            patch("hephaestus.automation.ci_driver.resume_codex_session") as mock_resume,
+            patch("hephaestus.automation.ci_fix_orchestrator.resume_codex_session") as mock_resume,
             patch(
-                "hephaestus.automation.ci_driver.run_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
                 return_value=AgentRunResult(stdout="done", stderr="", session_id="s3"),
             ) as mock_fresh,
         ):
@@ -3395,7 +3431,7 @@ class TestInvokeAgentSession:
     def test_timeout_propagates_to_caller(self, driver: CIDriver, tmp_path: Path) -> None:
         """TimeoutExpired escapes the helper so callers can log a distinct timeout message."""
         with patch(
-            "hephaestus.automation.ci_driver.invoke_claude_with_session",
+            "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
             side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=60),
         ):
             with pytest.raises(subprocess.TimeoutExpired):
@@ -3426,11 +3462,11 @@ class TestPushCiFix:
         no_untracked = MagicMock(stdout="", returncode=0)
         with (
             patch(
-                "hephaestus.automation.ci_driver.run",
+                "hephaestus.automation.ci_fix_orchestrator.run",
                 side_effect=[post_sha, clean_status, no_untracked, ahead_count],
             ),
             patch(
-                "hephaestus.automation.ci_driver.push_current_branch_with_lease_on_divergence"
+                "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
             ) as mock_push,
         ):
             result = driver._push_ci_fix(
@@ -3451,7 +3487,7 @@ class TestPushCiFix:
         clean_status = MagicMock(stdout="", stderr="", returncode=0)
         with (
             patch(
-                "hephaestus.automation.ci_driver.gh_pr_checks",
+                "hephaestus.automation.ci_check_inspector.gh_pr_checks",
                 return_value=[_make_check("lint", conclusion="failure")],
             ),
             patch(
@@ -3460,11 +3496,11 @@ class TestPushCiFix:
             ),
             # Agent fails → _retry_no_commit_once returns False immediately
             patch(
-                "hephaestus.automation.ci_driver.invoke_claude_with_session",
+                "hephaestus.automation.ci_fix_orchestrator.invoke_claude_with_session",
                 side_effect=subprocess.CalledProcessError(1, ["claude"], stderr="err"),
             ),
             patch(
-                "hephaestus.automation.ci_driver.run",
+                "hephaestus.automation.ci_fix_orchestrator.run",
                 side_effect=[unchanged, clean_status],
             ),
         ):
@@ -3483,7 +3519,7 @@ class TestPushCiFix:
         # Unmerged index entries → not pushable
         unmerged = MagicMock(stdout="UU conflict.py\n", stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.ci_driver.run",
+            "hephaestus.automation.ci_fix_orchestrator.run",
             side_effect=[post_sha, unmerged],
         ):
             result = driver._push_ci_fix(

--- a/tests/unit/automation/test_ci_driver_author_scope.py
+++ b/tests/unit/automation/test_ci_driver_author_scope.py
@@ -44,7 +44,9 @@ def driver(mock_options: CIDriverOptions, tmp_path: Path) -> CIDriver:
 @pytest.fixture
 def viewer_driver(driver: CIDriver) -> CIDriver:
     """Driver with viewer login pre-cached to 'mvillmow' so filter is deterministic."""
-    driver._viewer_login = "mvillmow"
+    # Viewer-login cache moved into PRDiscovery in the CIDriver decomposition
+    # (#1357 / refs #1179, #1289).
+    driver._pr_discovery._viewer_login = "mvillmow"
     return driver
 
 
@@ -105,9 +107,9 @@ class TestDefaultScopedDiscovery:
     def test_bot_pr_discovery_filters_to_viewer(self, viewer_driver: CIDriver) -> None:
         viewer_driver.options.include_all_authors = False
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
         ):
@@ -116,12 +118,14 @@ class TestDefaultScopedDiscovery:
     def test_open_prs_remaining_filters_to_viewer(self, viewer_driver: CIDriver) -> None:
         viewer_driver.options.include_all_authors = False
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
-            patch.object(viewer_driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
+            patch.object(
+                viewer_driver._pr_discovery, "pr_merge_state", return_value=("CLEAN", "MERGEABLE")
+            ),
         ):
             remaining = viewer_driver._list_open_prs_remaining()
         assert [pr["number"] for pr in remaining] == [100]
@@ -133,9 +137,9 @@ class TestAllFlagScopedDiscovery:
     def test_bot_pr_discovery_returns_all_bots(self, driver: CIDriver) -> None:
         driver.options.include_all_authors = True
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
         ):
@@ -144,12 +148,14 @@ class TestAllFlagScopedDiscovery:
     def test_open_prs_remaining_returns_all_prs(self, driver: CIDriver) -> None:
         driver.options.include_all_authors = True
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
-            patch.object(driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
+            patch.object(
+                driver._pr_discovery, "pr_merge_state", return_value=("CLEAN", "MERGEABLE")
+            ),
         ):
             remaining = driver._list_open_prs_remaining()
         assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]
@@ -171,33 +177,36 @@ class TestResolveViewerLogin:
     """Viewer login resolution is lazy, cached, and fails CLOSED."""
 
     def test_resolve_caches_value(self, driver: CIDriver) -> None:
-        driver._viewer_login = ""  # reset
+        driver._pr_discovery._viewer_login = ""  # reset
         with patch(
-            "hephaestus.automation.ci_driver._gh_call", return_value=MagicMock(stdout="mvillmow\n")
+            "hephaestus.automation.pr_discovery._gh_call",
+            return_value=MagicMock(stdout="mvillmow\n"),
         ) as mock_gh:
             assert driver._resolve_viewer_login() == "mvillmow"
             assert driver._resolve_viewer_login() == "mvillmow"
         assert mock_gh.call_count == 1
 
     def test_resolve_failure_raises_runtimeerror(self, driver: CIDriver) -> None:
-        driver._viewer_login = ""
+        driver._pr_discovery._viewer_login = ""
         with patch(
-            "hephaestus.automation.ci_driver._gh_call",
+            "hephaestus.automation.pr_discovery._gh_call",
             side_effect=subprocess.CalledProcessError(1, ["gh"]),
         ):
             with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
                 driver._resolve_viewer_login()
 
     def test_resolve_empty_stdout_raises(self, driver: CIDriver) -> None:
-        driver._viewer_login = ""
-        with patch("hephaestus.automation.ci_driver._gh_call", return_value=MagicMock(stdout="")):
+        driver._pr_discovery._viewer_login = ""
+        with patch(
+            "hephaestus.automation.pr_discovery._gh_call", return_value=MagicMock(stdout="")
+        ):
             with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
                 driver._resolve_viewer_login()
 
     def test_resolve_gh_not_installed_raises(self, driver: CIDriver) -> None:
-        driver._viewer_login = ""
+        driver._pr_discovery._viewer_login = ""
         with patch(
-            "hephaestus.automation.ci_driver._gh_call",
+            "hephaestus.automation.pr_discovery._gh_call",
             side_effect=FileNotFoundError("gh not on PATH"),
         ):
             with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
@@ -210,9 +219,9 @@ class TestResolveViewerLogin:
         to a ``RuntimeError`` carrying the `gh auth login` / --all guidance
         rather than propagating raw (#821).
         """
-        driver._viewer_login = ""
+        driver._pr_discovery._viewer_login = ""
         with patch(
-            "hephaestus.automation.ci_driver._gh_call",
+            "hephaestus.automation.pr_discovery._gh_call",
             side_effect=GitHubUnavailableError("circuit breaker open"),
         ):
             with pytest.raises(RuntimeError, match="Could not resolve viewer login"):
@@ -226,13 +235,13 @@ class TestAllFlagSkipsViewerResolution:
         driver.options.include_all_authors = True
         with (
             patch.object(
-                driver,
-                "_resolve_viewer_login",
+                driver._pr_discovery,
+                "resolve_viewer_login",
                 side_effect=RuntimeError("should not be called"),
             ),
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
         ):
@@ -248,12 +257,14 @@ class TestAllFlagSkipsViewerResolution:
                 "_resolve_viewer_login",
                 side_effect=RuntimeError("should not be called"),
             ),
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MIXED_PULLS)),
             ),
-            patch.object(driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
+            patch.object(
+                driver._pr_discovery, "pr_merge_state", return_value=("CLEAN", "MERGEABLE")
+            ),
         ):
             remaining = driver._list_open_prs_remaining()
         assert sorted(pr["number"] for pr in remaining) == [100, 101, 102]
@@ -266,12 +277,12 @@ class TestMissingUserLogin:
         self, viewer_driver: CIDriver, caplog: pytest.LogCaptureFixture
     ) -> None:
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_PULLS)),
             ),
-            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.pr_discovery"),
         ):
             result = viewer_driver._list_open_prs_remaining()
 
@@ -285,12 +296,12 @@ class TestMissingUserLogin:
         self, viewer_driver: CIDriver, caplog: pytest.LogCaptureFixture
     ) -> None:
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_BOT_PULLS)),
             ),
-            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.pr_discovery"),
         ):
             result = viewer_driver._discover_bot_prs()
 
@@ -306,13 +317,15 @@ class TestMissingUserLogin:
         """Warning must NOT fire when --all is set (viewer filter bypassed entirely)."""
         driver.options.include_all_authors = True
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_PULLS)),
             ),
-            patch.object(driver, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")),
-            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+            patch.object(
+                driver._pr_discovery, "pr_merge_state", return_value=("CLEAN", "MERGEABLE")
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.pr_discovery"),
         ):
             result = driver._list_open_prs_remaining()
 
@@ -327,12 +340,12 @@ class TestMissingUserLogin:
         """Warning must NOT fire when --all is set (viewer filter bypassed entirely)."""
         driver.options.include_all_authors = True
         with (
-            patch("hephaestus.automation.ci_driver.get_repo_info", return_value=("o", "r")),
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
             patch(
-                "hephaestus.automation.ci_driver._gh_call",
+                "hephaestus.automation.pr_discovery._gh_call",
                 return_value=MagicMock(stdout=json.dumps(_MISSING_LOGIN_BOT_PULLS)),
             ),
-            caplog.at_level(logging.WARNING, logger="hephaestus.automation.ci_driver"),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.pr_discovery"),
         ):
             driver._discover_bot_prs()
 

--- a/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
+++ b/tests/unit/automation/test_ci_driver_failing_pr_discovery.py
@@ -148,9 +148,9 @@ class TestDiscoverFailingPrs:
                 "mergeStateStatus": "CLEAN",
             },
         ]
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.return_value = Mock(stdout=json.dumps(mock_output))
                 result = ci_driver._discover_failing_prs()
         assert result == {1: 1}
@@ -166,9 +166,9 @@ class TestDiscoverFailingPrs:
                 "mergeStateStatus": "BLOCKED",
             },
         ]
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.return_value = Mock(stdout=json.dumps(mock_output))
                 result = ci_driver._discover_failing_prs()
         assert result == {3: 3}
@@ -183,9 +183,9 @@ class TestDiscoverFailingPrs:
                 "mergeStateStatus": "CLEAN",
             },
         ]
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.return_value = Mock(stdout=json.dumps(mock_output))
                 result = ci_driver._discover_failing_prs()
         assert result == {}
@@ -194,9 +194,9 @@ class TestDiscoverFailingPrs:
         """Discovery returns empty dict on gh command failure."""
         import subprocess
 
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.side_effect = subprocess.CalledProcessError(1, "gh")
                 result = ci_driver._discover_failing_prs()
         assert result == {}
@@ -205,9 +205,9 @@ class TestDiscoverFailingPrs:
         """Discovery returns empty dict when gh pr list times out (docstring contract)."""
         import subprocess
 
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=30)
                 result = ci_driver._discover_failing_prs()
         assert result == {}
@@ -216,9 +216,9 @@ class TestDiscoverFailingPrs:
         self, ci_driver: CIDriver
     ) -> None:
         """Discovery returns empty dict when the gh binary is missing/unexecutable."""
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.side_effect = FileNotFoundError(2, "No such file or directory", "gh")
                 result = ci_driver._discover_failing_prs()
         assert result == {}
@@ -234,20 +234,20 @@ class TestDiscoverFailingPrs:
             }
             for i in range(1, 1001)
         ]
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.return_value = Mock(stdout=json.dumps(mock_output))
-                with patch("hephaestus.automation.ci_driver.logger") as mock_logger:
+                with patch("hephaestus.automation.pr_discovery.logger") as mock_logger:
                     result = ci_driver._discover_failing_prs()
         assert len(result) == 1000
         mock_logger.warning.assert_called()
 
     def test_discover_failing_prs_returns_empty_on_invalid_json(self, ci_driver: CIDriver) -> None:
         """Discovery returns empty dict on invalid JSON."""
-        with patch("hephaestus.automation.ci_driver.get_repo_info") as mock_repo_info:
+        with patch("hephaestus.automation.pr_discovery.get_repo_info") as mock_repo_info:
             mock_repo_info.return_value = ("MyOrg", "MyRepo")
-            with patch("hephaestus.automation.ci_driver._gh_call") as mock_gh_call:
+            with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh_call:
                 mock_gh_call.return_value = Mock(stdout="not-json")
                 result = ci_driver._discover_failing_prs()
         assert result == {}
@@ -367,14 +367,22 @@ class TestFailingCheckPredicateSingleDefinition:
         return hits
 
     def test_failing_check_conclusions_defined_exactly_once(self) -> None:
-        """FAILING_CHECK_CONCLUSIONS must have a single canonical definition."""
+        """FAILING_CHECK_CONCLUSIONS must have a single canonical definition.
+
+        The canonical home moved from ci_driver.py to ci_check_inspector.py in
+        the CIDriver decomposition (#1357 / refs #1179, #1289): the constant
+        belongs to the check-inspector that queries CI check state. ci_driver.py
+        re-exports it (an import, not an assignment) for backward compatibility,
+        so the DRY guard from #1345 still holds — exactly one assignment, no
+        drift across the automation package.
+        """
         hits = self._count_assignments("FAILING_CHECK_CONCLUSIONS")
         assert len(hits) == 1, (
             f"Expected exactly 1 definition of FAILING_CHECK_CONCLUSIONS, "
             f"found {len(hits)}: {[str(p) for p in hits]}"
         )
-        assert hits[0].name == "ci_driver.py", (
-            f"Canonical definition must be in ci_driver.py, not {hits[0].name}"
+        assert hits[0].name == "ci_check_inspector.py", (
+            f"Canonical definition must be in ci_check_inspector.py, not {hits[0].name}"
         )
 
     def test_pr_is_failing_defined_exactly_once(self) -> None:

--- a/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
+++ b/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
@@ -1,0 +1,194 @@
+"""Unit tests for the CIFixOrchestrator collaborator (refs #1179, #1289).
+
+Covers the pure / lightly-mocked methods extracted from CIDriver: prompt
+builders, the forensics marker writer, and the mechanical-rebase skip/clean
+decision branches. The full agent-session paths are exercised through
+``CIDriver`` delegation in ``test_ci_driver.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation.ci_fix_orchestrator import CIFixOrchestrator
+
+
+@pytest.fixture()
+def orchestrator(tmp_path: Path) -> CIFixOrchestrator:
+    """Return a CIFixOrchestrator wired with simple test doubles."""
+    options = MagicMock()
+    options.agent = "claude"
+    options.dry_run = False
+    status = MagicMock()
+    return CIFixOrchestrator(
+        options_provider=lambda: options,
+        repo_root_provider=lambda: tmp_path,
+        state_dir_provider=lambda: tmp_path,
+        status_tracker_provider=lambda: status,
+        get_pr_branch=lambda pr: f"{pr}-impl",
+        get_worktree_path=lambda issue, pr: tmp_path,
+        format_review_threads_block=lambda pr: "",
+        failing_required_check_names=lambda pr: [],
+    )
+
+
+class TestForceEngagementPrompt:
+    """The retry prompt must name failing checks/dirty files verbatim."""
+
+    def test_names_failing_checks_and_branch(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        prompt = orchestrator.force_engagement_prompt(
+            issue_number=1,
+            pr_number=2,
+            worktree_path=tmp_path,
+            pr_head_branch="1-fix",
+            failing_check_names=["lint", "test-py310"],
+            review_threads_block="",
+        )
+        assert "- lint" in prompt
+        assert "- test-py310" in prompt
+        assert "1-fix" in prompt
+        assert "BLOCKED:" in prompt
+
+    def test_dirty_changes_block_rendered(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        prompt = orchestrator.force_engagement_prompt(
+            issue_number=1,
+            pr_number=2,
+            worktree_path=tmp_path,
+            pr_head_branch="1-fix",
+            failing_check_names=[],
+            review_threads_block="",
+            dirty_tracked_changes=[" M src/a.py"],
+        )
+        assert "uncommitted tracked changes" in prompt
+        assert "M src/a.py" in prompt
+
+    def test_review_threads_block_prepended(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        prompt = orchestrator.force_engagement_prompt(
+            issue_number=1,
+            pr_number=2,
+            worktree_path=tmp_path,
+            pr_head_branch="1-fix",
+            failing_check_names=["lint"],
+            review_threads_block="## Unresolved PR Review Threads\n\nSee below.\n",
+        )
+        assert prompt.startswith("## Unresolved PR Review Threads")
+
+
+class TestBuildCiFixPrompt:
+    """The fix prompt folds advise findings + review threads + CI logs."""
+
+    def test_includes_advise_and_logs(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        prompt = orchestrator.build_ci_fix_prompt(
+            issue_number=1,
+            pr_number=2,
+            worktree_path=tmp_path,
+            ci_logs="boom: import error",
+            pr_head_branch="1-fix",
+            advise_findings="Prior lesson: pin deps.",
+        )
+        assert "Prior Learnings from Team Knowledge Base" in prompt
+        assert "Prior lesson: pin deps." in prompt
+        assert "boom: import error" in prompt
+        assert "1-fix" in prompt
+
+    def test_skip_marker_advise_contributes_nothing(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        prompt = orchestrator.build_ci_fix_prompt(
+            issue_number=1,
+            pr_number=2,
+            worktree_path=tmp_path,
+            ci_logs="",
+            pr_head_branch="1-fix",
+            advise_findings="<!-- advise step skipped -->",
+        )
+        assert "Prior Learnings from Team Knowledge Base" not in prompt
+
+
+class TestRecordRepeatedNoCommit:
+    """The forensics marker is written into the state dir."""
+
+    def test_writes_marker_with_payload(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        orchestrator.record_repeated_no_commit(
+            issue_number=1,
+            pr_number=2,
+            pr_head_branch="1-fix",
+            failing_check_names=["lint"],
+        )
+        marker = tmp_path / "repeated-no-commit-2.json"
+        assert marker.exists()
+        payload = json.loads(marker.read_text())
+        assert payload["pr_number"] == 2
+        assert payload["pr_head_branch"] == "1-fix"
+        assert payload["failing_required_checks"] == ["lint"]
+
+
+class TestAttemptMechanicalRebase:
+    """Only BEHIND/DIRTY/CONFLICTING PRs are rebased; clean ones are skipped."""
+
+    @staticmethod
+    def _pr_state(merge_state: str, head: str = "5-impl", base: str = "main") -> MagicMock:
+        return MagicMock(
+            stdout=json.dumps(
+                {
+                    "mergeStateStatus": merge_state,
+                    "mergeable": "MERGEABLE",
+                    "headRefName": head,
+                    "baseRefName": base,
+                }
+            )
+        )
+
+    def test_clean_pr_skips_rebase(self, orchestrator: CIFixOrchestrator) -> None:
+        with (
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
+                return_value=self._pr_state("CLEAN"),
+            ),
+            patch("hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto") as mock_rebase,
+        ):
+            assert orchestrator.attempt_mechanical_rebase(5, 50, 0) is False
+        mock_rebase.assert_not_called()
+
+    def test_behind_pr_rebases_clean_and_pushes(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        with (
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator._gh_call",
+                return_value=self._pr_state("BEHIND"),
+            ),
+            patch("hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.rebase_worktree_onto",
+                return_value=True,
+            ) as mock_rebase,
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator."
+                "push_current_branch_with_lease_on_divergence"
+            ) as mock_push,
+        ):
+            assert orchestrator.attempt_mechanical_rebase(5, 50, 0) is True
+        mock_rebase.assert_called_once_with(tmp_path, "main")
+        mock_push.assert_called_once()
+
+    def test_gh_query_failure_swallowed(self, orchestrator: CIFixOrchestrator) -> None:
+        with patch(
+            "hephaestus.automation.ci_fix_orchestrator._gh_call",
+            return_value=MagicMock(stdout="not json"),
+        ):
+            assert orchestrator.attempt_mechanical_rebase(5, 50, 0) is False

--- a/tests/unit/automation/test_phase_agent_wiring.py
+++ b/tests/unit/automation/test_phase_agent_wiring.py
@@ -61,9 +61,17 @@ SELF_AGENT_PHASES: list[tuple[str, str, tuple[str, ...]]] = [
             "_review_phase.py",
         ),
     ),
-    # ci_driver owns Session 3 (AGENT_CI_DRIVER): its fix sessions and its
-    # post-green learnings run on a transcript independent of the implementer.
-    ("ci_driver.py", "AGENT_CI_DRIVER", ()),
+    # ci_driver owns Session 3 (AGENT_CI_DRIVER): the live AGENT_CI_DRIVER
+    # imports moved into the extracted collaborators ci_fix_orchestrator (fix
+    # sessions) and post_merge_processor (post-green /learn + /compact) in the
+    # CIDriver decomposition (#1357 / refs #1179, #1289). ci_driver.py remains
+    # the orchestrating entry point; both run on a transcript independent of the
+    # implementer.
+    (
+        "ci_driver.py",
+        "AGENT_CI_DRIVER",
+        ("ci_fix_orchestrator.py", "post_merge_processor.py"),
+    ),
 ]
 
 

--- a/tests/unit/automation/test_post_merge_helpers.py
+++ b/tests/unit/automation/test_post_merge_helpers.py
@@ -1,0 +1,63 @@
+"""Unit tests for PostMergeProcessor collaborator (refs #1179)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation.post_merge_processor import PostMergeProcessor
+
+
+def _make_processor(tmp_path: Path) -> tuple[PostMergeProcessor, dict[int, dict[str, Any]]]:
+    """Return a PostMergeProcessor and the shared saved-state dict for assertions."""
+    from unittest.mock import MagicMock
+
+    options = MagicMock(dry_run=False, agent="claude")
+    saved: dict[int, dict[str, Any]] = {}
+
+    def load(issue: int) -> dict[str, Any] | None:
+        return saved.get(issue)
+
+    def save(issue: int, record: dict[str, Any]) -> None:
+        saved[issue] = record
+
+    proc = PostMergeProcessor(
+        options_provider=lambda: options,
+        repo_root_provider=lambda: tmp_path,
+        get_worktree_path=lambda issue, pr: tmp_path / f"{issue}-{pr}",
+        load_arming_state=load,
+        save_arming_state=save,
+    )
+    return proc, saved
+
+
+class TestMarkDriveGreenLearnResult:
+    """Tests for PostMergeProcessor.mark_drive_green_learn_result."""
+
+    def test_succeeded_writes_succeeded_status(self, tmp_path: Path) -> None:
+        processor, _ = _make_processor(tmp_path)
+        record: dict[str, Any] = {}
+        processor.mark_drive_green_learn_result(1, record, succeeded=True)
+        assert record["learn_status"] == "succeeded"
+        assert "learn_succeeded_at" in record
+        assert "learn_attempted_at" in record
+
+    def test_failed_writes_failed_status(self, tmp_path: Path) -> None:
+        processor, _ = _make_processor(tmp_path)
+        record: dict[str, Any] = {}
+        processor.mark_drive_green_learn_result(1, record, succeeded=False)
+        assert record["learn_status"] == "failed"
+        assert record["learn_succeeded_at"] is None
+        assert record["learn_captured_at"] is None
+
+    def test_save_called_on_success(self, tmp_path: Path) -> None:
+        processor, saved = _make_processor(tmp_path)
+        record: dict[str, Any] = {}
+        processor.mark_drive_green_learn_result(42, record, succeeded=True)
+        assert saved[42] is record
+
+    def test_save_called_on_failure(self, tmp_path: Path) -> None:
+        processor, saved = _make_processor(tmp_path)
+        record: dict[str, Any] = {}
+        processor.mark_drive_green_learn_result(42, record, succeeded=False)
+        assert saved[42] is record

--- a/tests/unit/automation/test_pr_discovery_helpers.py
+++ b/tests/unit/automation/test_pr_discovery_helpers.py
@@ -1,0 +1,157 @@
+"""Unit tests for PRDiscovery collaborator (refs #1179)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation.pr_discovery import PRDiscovery
+
+
+@pytest.fixture()
+def discovery() -> PRDiscovery:
+    """Return a PRDiscovery wired with test doubles."""
+    options_mock = MagicMock()
+    options_mock.include_all_authors = False
+    return PRDiscovery(
+        options_provider=lambda: options_mock,
+        status_tracker_provider=MagicMock,
+        repo_root_provider=MagicMock(side_effect=MagicMock),
+    )
+
+
+class TestResolveViewerLogin:
+    """Tests for PRDiscovery.resolve_viewer_login."""
+
+    def test_caches_login_on_success(self, discovery: PRDiscovery) -> None:
+        discovery._viewer_login = ""
+        with patch(
+            "hephaestus.automation.pr_discovery._gh_call",
+            return_value=MagicMock(stdout="testuser\n"),
+        ) as mock_gh:
+            assert discovery.resolve_viewer_login() == "testuser"
+            assert discovery.resolve_viewer_login() == "testuser"
+        assert mock_gh.call_count == 1  # cached on second call
+
+    def test_empty_stdout_raises(self, discovery: PRDiscovery) -> None:
+        discovery._viewer_login = ""
+        with (
+            patch(
+                "hephaestus.automation.pr_discovery._gh_call",
+                return_value=MagicMock(stdout=""),
+            ),
+            pytest.raises(RuntimeError, match="empty response"),
+        ):
+            discovery.resolve_viewer_login()
+
+    def test_subprocess_error_raises(self, discovery: PRDiscovery) -> None:
+        discovery._viewer_login = ""
+        with (
+            patch(
+                "hephaestus.automation.pr_discovery._gh_call",
+                side_effect=subprocess.CalledProcessError(1, ["gh"]),
+            ),
+            pytest.raises(RuntimeError, match="Could not resolve viewer login"),
+        ):
+            discovery.resolve_viewer_login()
+
+    def test_already_cached_skips_gh_call(self, discovery: PRDiscovery) -> None:
+        discovery._viewer_login = "cached"
+        with patch("hephaestus.automation.pr_discovery._gh_call") as mock_gh:
+            result = discovery.resolve_viewer_login()
+        assert result == "cached"
+        mock_gh.assert_not_called()
+
+
+class TestIsBotPrMode:
+    """Tests for PRDiscovery.is_bot_pr_mode."""
+
+    def test_equal_numbers_returns_true(self, discovery: PRDiscovery) -> None:
+        assert discovery.is_bot_pr_mode(42, 42) is True
+
+    def test_different_numbers_returns_false(self, discovery: PRDiscovery) -> None:
+        assert discovery.is_bot_pr_mode(1, 42) is False
+
+    def test_zero_zero_returns_true(self, discovery: PRDiscovery) -> None:
+        assert discovery.is_bot_pr_mode(0, 0) is True
+
+
+class TestDiscoverBotPrs:
+    """Tests for PRDiscovery.discover_bot_prs."""
+
+    def test_returns_bot_prs_keyed_by_pr_number(self, discovery: PRDiscovery) -> None:
+        pulls: list[dict[str, Any]] = [
+            {"number": 10, "user": {"type": "Bot", "login": "depbot"}},
+            {"number": 11, "user": {"type": "User", "login": "human"}},
+        ]
+        discovery._options().include_all_authors = True
+        with (
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.pr_discovery._gh_call",
+                return_value=MagicMock(stdout=json.dumps(pulls)),
+            ),
+        ):
+            result = discovery.discover_bot_prs()
+        assert result == {10: 10}
+
+    def test_empty_on_get_repo_info_failure(self, discovery: PRDiscovery) -> None:
+        with patch(
+            "hephaestus.automation.pr_discovery.get_repo_info",
+            side_effect=RuntimeError("no repo"),
+        ):
+            result = discovery.discover_bot_prs()
+        assert result == {}
+
+    def test_empty_on_gh_call_failure(self, discovery: PRDiscovery) -> None:
+        discovery._options().include_all_authors = True
+        with (
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.pr_discovery._gh_call",
+                side_effect=subprocess.CalledProcessError(1, ["gh"]),
+            ),
+        ):
+            result = discovery.discover_bot_prs()
+        assert result == {}
+
+
+class TestDiscoverFailingPrs:
+    """Tests for PRDiscovery.discover_failing_prs."""
+
+    def test_returns_matching_prs(self, discovery: PRDiscovery) -> None:
+        pulls = [
+            {
+                "number": 5,
+                "isDraft": False,
+                "statusCheckRollup": None,
+                "mergeStateStatus": "BLOCKED",
+            },
+            {
+                "number": 7,
+                "isDraft": True,
+                "statusCheckRollup": None,
+                "mergeStateStatus": "BLOCKED",
+            },
+        ]
+        with (
+            patch("hephaestus.automation.pr_discovery.get_repo_info", return_value=("o", "r")),
+            patch(
+                "hephaestus.automation.pr_discovery._gh_call",
+                return_value=MagicMock(stdout=json.dumps(pulls)),
+            ),
+        ):
+            result = discovery.discover_failing_prs(lambda pr: not pr.get("isDraft"))
+        assert result == {5: 5}
+
+    def test_empty_on_repo_info_failure(self, discovery: PRDiscovery) -> None:
+        with patch(
+            "hephaestus.automation.pr_discovery.get_repo_info",
+            side_effect=RuntimeError("no remote"),
+        ):
+            result = discovery.discover_failing_prs(lambda pr: True)
+        assert result == {}

--- a/tests/unit/validation/test_omit_allowlist.py
+++ b/tests/unit/validation/test_omit_allowlist.py
@@ -32,7 +32,7 @@ class TestOmitAllowlist:
 
         omit_list = pyproject.get("tool", {}).get("coverage", {}).get("run", {}).get("omit", [])
 
-        # Expected omit list: test globs + 12 automation modules
+        # Expected omit list: test globs + 16 automation modules
         expected_globs = {
             "*/tests/*",
             "*/__init__.py",
@@ -45,6 +45,11 @@ class TestOmitAllowlist:
             "hephaestus/automation/planner.py",
             "hephaestus/automation/address_review.py",
             "hephaestus/automation/ci_driver.py",
+            # CIDriver collaborators extracted in #1357 (refs #1179, #1289).
+            "hephaestus/automation/pr_discovery.py",
+            "hephaestus/automation/ci_check_inspector.py",
+            "hephaestus/automation/ci_fix_orchestrator.py",
+            "hephaestus/automation/post_merge_processor.py",
             "hephaestus/automation/loop_runner.py",
             "hephaestus/automation/curses_ui.py",
             "hephaestus/automation/github_api.py",


### PR DESCRIPTION
## Summary

Decomposes the `CIDriver` god-class (3,570 lines on current `main`) into four
narrow single-responsibility collaborators, wired by the Dependency Inversion
Principle. `ci_driver.py` drops from **3,570 → 2,449 lines** (delegation stubs
plus the orchestration/arm-flow logic that legitimately stays on the driver).

| Module | Responsibility |
|--------|---------------|
| `hephaestus/automation/pr_discovery.py` | Viewer-login caching + PR enumeration (issue-driven, bot, failing) |
| `hephaestus/automation/ci_check_inspector.py` | Required CI check queries (`gh pr checks`) |
| `hephaestus/automation/ci_fix_orchestrator.py` | CI fix session management (codex + claude paths) |
| `hephaestus/automation/post_merge_processor.py` | Drive-green `/learn` + `/compact` after PR merges |

### Design

- **Narrow-callable injection (DIP):** each collaborator receives only the
  specific `Callable[[], T]` providers it needs — never `self`/`CIDriver`.
- **Lambda-wrapped providers:** every injected callable is a lambda over the
  driver's delegation stub, so `patch.object(driver, "_method")` intercepts
  through the lambda at call time. The merge-state lookup inside
  `PRDiscovery.list_open_prs_remaining` routes through an injected
  `pr_merge_state_provider` for exactly this reason.
- **Delegation stubs preserved:** every existing `patch.object(CIDriver,
  "_method")` test target remains a stub on `CIDriver`.

### Corner-case fix-flow preservation (do-not-regress)

The methods shipped after the two reference PRs are preserved with exact
behavior on `CIDriver`:

- `_resolve_dirty_pr` (#1347) — resolves armed-DIRTY merge conflicts in the
  post-fix re-arm path.
- `_resolve_blocked_pr` + `_address_threads_once` +
  `_BLOCKED_ADDRESS_MAX_ATTEMPTS=2` (#1356) — addresses unresolved review
  threads on green-but-BLOCKED PRs.
- `resolve_dirty: bool = True` recursion guard on
  `_recheck_and_arm_after_fix` (#1355).

Their regression suites (`TestRecheckAndArmAfterFix`, `TestResolveDirtyPr`,
`TestResolveBlockedPr`) pass unchanged.

### Supersedes

This re-implements the two competing reference PRs **#1292** and **#1344**
against current `main` (which grew to 3,570 lines via #1353–#1356). Both are
closed in favor of this combined PR.

## Test plan

- [x] `test_ci_driver.py` + author-scope + failing-pr-discovery + prs-mode +
      phase-agent-wiring suites pass.
- [x] New collaborator unit tests (`test_pr_discovery_helpers.py`,
      `test_ci_check_inspector_helpers.py`, `test_ci_fix_orchestrator_helpers.py`,
      `test_post_merge_helpers.py`) pass — 311 tests total green.
- [x] Omit-allowlist guard + orchestration smoke updated atomically with the
      4 new module paths.
- [x] F1/F2/F4 corner-case regression tests pass.
- [x] `ruff check` clean, `mypy` clean (no new errors), `pre-commit
      --all-files` all hooks pass.

Closes #1357

🤖 Generated with [Claude Code](https://claude.com/claude-code)