### PR TITLE
test(automation): add unit tests for run_drive_green_learnings and run_drive_green_compact

### DIFF
--- a/tests/unit/automation/test_post_merge_helpers.py
+++ b/tests/unit/automation/test_post_merge_helpers.py
@@ -4,14 +4,20 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 from hephaestus.automation.post_merge_processor import PostMergeProcessor
+
+_MOD = "hephaestus.automation.post_merge_processor"
+
+
+def _raise_no_worktree(issue: int, pr: int) -> Path:
+    """get_worktree_path stub that raises, to exercise the repo_root fallback."""
+    raise RuntimeError("worktree gone post-merge")
 
 
 def _make_processor(tmp_path: Path) -> tuple[PostMergeProcessor, dict[int, dict[str, Any]]]:
     """Return a PostMergeProcessor and the shared saved-state dict for assertions."""
-    from unittest.mock import MagicMock
-
     options = MagicMock(dry_run=False, agent="claude")
     saved: dict[int, dict[str, Any]] = {}
 
@@ -29,6 +35,19 @@ def _make_processor(tmp_path: Path) -> tuple[PostMergeProcessor, dict[int, dict[
         save_arming_state=save,
     )
     return proc, saved
+
+
+def _make_codex_processor(tmp_path: Path) -> PostMergeProcessor:
+    """PostMergeProcessor whose options report agent='codex'."""
+    options = MagicMock(dry_run=False, agent="codex")
+    saved: dict[int, dict[str, Any]] = {}
+    return PostMergeProcessor(
+        options_provider=lambda: options,
+        repo_root_provider=lambda: tmp_path,
+        get_worktree_path=lambda issue, pr: tmp_path / f"{issue}-{pr}",
+        load_arming_state=lambda i: saved.get(i),
+        save_arming_state=lambda i, r: saved.__setitem__(i, r),
+    )
 
 
 class TestMarkDriveGreenLearnResult:
@@ -61,3 +80,99 @@ class TestMarkDriveGreenLearnResult:
         record: dict[str, Any] = {}
         processor.mark_drive_green_learn_result(42, record, succeeded=False)
         assert saved[42] is record
+
+
+class TestRunDriveGreenLearnings:
+    """Tests for PostMergeProcessor.run_drive_green_learnings (post_merge_processor.py:102)."""
+
+    def test_claude_path_returns_true_and_captures_evidence(self, tmp_path: Path) -> None:
+        processor, _ = _make_processor(tmp_path)
+        sentinel = {"mnemosyne_update_status": "ok", "mnemosyne_update_urls": ["u"]}
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(f"{_MOD}.invoke_claude_with_session", return_value=("learn-stdout", None)) as inv,
+            patch(f"{_MOD}.mnemosyne_update_evidence", return_value=sentinel),
+        ):
+            result = processor.run_drive_green_learnings(1, 2)
+        assert result is True
+        assert inv.called
+        assert processor._last_learn_evidence == sentinel
+
+    def test_codex_path_uses_run_codex_session(self, tmp_path: Path) -> None:
+        processor = _make_codex_processor(tmp_path)
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(f"{_MOD}.run_codex_session", return_value=MagicMock(stdout="codex-out")) as codex,
+            patch(f"{_MOD}.invoke_claude_with_session") as inv,
+        ):
+            result = processor.run_drive_green_learnings(3, 4)
+        assert result is True
+        assert codex.called
+        assert not inv.called
+
+    def test_worktree_failure_falls_back_to_repo_root(self, tmp_path: Path) -> None:
+        options = MagicMock(dry_run=False, agent="claude")
+        proc = PostMergeProcessor(
+            options_provider=lambda: options,
+            repo_root_provider=lambda: tmp_path,
+            get_worktree_path=_raise_no_worktree,
+            load_arming_state=lambda i: None,
+            save_arming_state=lambda i, r: None,
+        )
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(f"{_MOD}.invoke_claude_with_session", return_value=("ok", None)) as inv,
+        ):
+            result = proc.run_drive_green_learnings(5, 6)
+        assert result is True
+        assert inv.call_args.kwargs["cwd"] == tmp_path
+
+    def test_subprocess_exception_is_swallowed_returns_false(self, tmp_path: Path) -> None:
+        processor, _ = _make_processor(tmp_path)
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(
+                f"{_MOD}.invoke_claude_with_session",
+                side_effect=RuntimeError("claude boom"),
+            ),
+        ):
+            result = processor.run_drive_green_learnings(7, 8)
+        assert result is False
+
+
+class TestRunDriveGreenCompact:
+    """Tests for PostMergeProcessor.run_drive_green_compact (post_merge_processor.py:186)."""
+
+    def test_codex_short_circuits_without_compact(self, tmp_path: Path) -> None:
+        processor = _make_codex_processor(tmp_path)
+        with patch(f"{_MOD}.compact_session") as compact:
+            result = processor.run_drive_green_compact(1, 2)
+        assert result is False
+        assert not compact.called
+
+    def test_claude_path_calls_compact_session(self, tmp_path: Path) -> None:
+        processor, _ = _make_processor(tmp_path)
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(f"{_MOD}.compact_session", return_value=True) as compact,
+        ):
+            result = processor.run_drive_green_compact(3, 4)
+        assert result is True
+        assert compact.call_args.kwargs["cwd"] == tmp_path / "3-4"
+
+    def test_worktree_failure_falls_back_to_repo_root(self, tmp_path: Path) -> None:
+        options = MagicMock(dry_run=False, agent="claude")
+        proc = PostMergeProcessor(
+            options_provider=lambda: options,
+            repo_root_provider=lambda: tmp_path,
+            get_worktree_path=_raise_no_worktree,
+            load_arming_state=lambda i: None,
+            save_arming_state=lambda i, r: None,
+        )
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(f"{_MOD}.compact_session", return_value=True) as compact,
+        ):
+            result = proc.run_drive_green_compact(5, 6)
+        assert result is True
+        assert compact.call_args.kwargs["cwd"] == tmp_path


### PR DESCRIPTION
Adds 7 new tests to `tests/unit/automation/test_post_merge_helpers.py` covering the two previously-untested public methods of `PostMergeProcessor` (extracted in #1357, refs #1179):

- `TestRunDriveGreenLearnings` (4 tests): claude happy-path + evidence capture, codex path uses `run_codex_session`, worktree failure falls back to `repo_root`, subprocess exception is swallowed and returns `False`
- `TestRunDriveGreenCompact` (3 tests): codex short-circuits without calling `compact_session`, claude path calls `compact_session` with worktree `cwd`, worktree failure falls back to `repo_root`

All external touch-points (`invoke_claude_with_session`, `run_codex_session`, `compact_session`, `get_repo_slug`, `mnemosyne_update_evidence`) are patched in the consumer module namespace. No live subprocess is invoked. `pyproject.toml` omit-allowlist is unchanged.

Closes #1362