### PR TITLE
refactor(constants): consolidate transient-error signals into TRANSIENT_ERROR_CORE

### DIFF
--- a/hephaestus/constants.py
+++ b/hephaestus/constants.py
@@ -32,6 +32,26 @@ LOG_FORMAT: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 # Base field names included in every JSON log record.
 JSON_LOG_FIELDS: tuple[str, ...] = ("timestamp", "level", "logger", "message")
 
+# Canonical transient-failure substrings shared by the resilience and retry
+# layers. Both ``subprocess_resilience.TRANSIENT_ERROR_PATTERNS`` and
+# ``retry.NETWORK_ERROR_KEYWORDS`` derive from this core so the overlapping
+# signals cannot drift (see issue #1205). Each consumer adds its own
+# layer-specific extras on top: the retry layer additionally treats
+# rate-limit/throttle signals as retryable, which the resilience layer
+# intentionally does NOT retry (rate-limit passthrough is handled by callers).
+TRANSIENT_ERROR_CORE: frozenset[str] = frozenset(
+    {
+        "connection",
+        "timed out",
+        "temporary failure",
+        "could not resolve",
+        "network unreachable",
+        "503",
+        "502",
+        "504",
+    }
+)
+
 # Marker file that identifies the repo root in a dev checkout.
 _REPO_ROOT_MARKER = "pyproject.toml"
 

--- a/hephaestus/resilience/subprocess_resilience.py
+++ b/hephaestus/resilience/subprocess_resilience.py
@@ -13,6 +13,7 @@ import subprocess
 from collections.abc import Callable
 from typing import Any, TypeVar
 
+from hephaestus.constants import TRANSIENT_ERROR_CORE
 from hephaestus.resilience.circuit_breaker import CircuitBreaker, get_circuit_breaker
 from hephaestus.utils.retry import retry_with_backoff
 
@@ -28,25 +29,27 @@ TRANSIENT_SUBPROCESS_ERRORS: tuple[type[Exception], ...] = (
     OSError,
 )
 
-# Patterns in stderr that indicate transient (retryable) failures
-TRANSIENT_ERROR_PATTERNS: list[str] = [
-    "connection reset",
-    "connection refused",
-    "network unreachable",
-    "network is unreachable",
-    "temporary failure",
-    "could not resolve host",
-    "curl 56",
-    "timed out",
-    "early eof",
-    "recv failure",
-    "broken pipe",
-    "connection timed out",
-    "ssl handshake",
-    "503",
-    "502",
-    "504",
-]
+# Patterns in stderr that indicate transient (retryable) failures.
+# Derived from the shared TRANSIENT_ERROR_CORE (issue #1205) plus
+# subprocess-specific signals. The explicit ``connection *`` / ``could not
+# resolve host`` phrases are retained as extras (rather than relying solely on
+# the broader core substrings) so callers and tests asserting exact membership
+# keep working. Kept as a sorted list because call sites iterate it.
+_SUBPROCESS_TRANSIENT_EXTRAS: frozenset[str] = frozenset(
+    {
+        "connection reset",
+        "connection refused",
+        "connection timed out",
+        "network is unreachable",
+        "could not resolve host",
+        "curl 56",
+        "early eof",
+        "recv failure",
+        "broken pipe",
+        "ssl handshake",
+    }
+)
+TRANSIENT_ERROR_PATTERNS: list[str] = sorted(TRANSIENT_ERROR_CORE | _SUBPROCESS_TRANSIENT_EXTRAS)
 
 
 def is_transient_subprocess_error(error: BaseException) -> bool:

--- a/hephaestus/utils/retry.py
+++ b/hephaestus/utils/retry.py
@@ -15,24 +15,25 @@ import time
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
+from hephaestus.constants import TRANSIENT_ERROR_CORE
+
 # Type variable for generic function decoration
 F = TypeVar("F", bound=Callable[..., Any])
 
-# Network error keywords to detect transient failures
-NETWORK_ERROR_KEYWORDS = [
-    "connection",
-    "network",
-    "timeout",
-    "timed out",
-    "temporary failure",
-    "could not resolve",
-    "name resolution",
-    "rate limit",
-    "throttle",
-    "503",
-    "502",
-    "504",
-]
+# Network error keywords to detect transient failures. Derived from the shared
+# TRANSIENT_ERROR_CORE (issue #1205) plus retry-specific signals — including
+# rate-limit/throttle, which (unlike the resilience layer) the retry layer DOES
+# treat as retryable network errors.
+_NETWORK_EXTRA_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "network",
+        "timeout",
+        "name resolution",
+        "rate limit",
+        "throttle",
+    }
+)
+NETWORK_ERROR_KEYWORDS: list[str] = sorted(TRANSIENT_ERROR_CORE | _NETWORK_EXTRA_KEYWORDS)
 
 
 def is_network_error(error: BaseException) -> bool:

--- a/tests/unit/constants/test_constants.py
+++ b/tests/unit/constants/test_constants.py
@@ -1,4 +1,4 @@
-"""Tests for hephaestus.constants path helpers."""
+"""Tests for hephaestus.constants path helpers and shared constants."""
 
 from __future__ import annotations
 
@@ -7,6 +7,62 @@ from pathlib import Path
 import pytest
 
 from hephaestus import constants
+from hephaestus.constants import TRANSIENT_ERROR_CORE
+from hephaestus.resilience.subprocess_resilience import TRANSIENT_ERROR_PATTERNS
+from hephaestus.utils.retry import NETWORK_ERROR_KEYWORDS
+
+# Signals that are genuinely shared by both the resilience and retry layers.
+# These MUST stay present in both consumer lists; the canonical core exists so
+# they cannot drift apart (issue #1205).
+SHARED_TRANSIENT_SIGNALS = (
+    "connection",
+    "timed out",
+    "temporary failure",
+    "could not resolve",
+    "503",
+    "502",
+    "504",
+)
+
+
+class TestTransientErrorCore:
+    """Tests for the canonical TRANSIENT_ERROR_CORE shared by two consumers."""
+
+    def test_is_frozenset(self) -> None:
+        """TRANSIENT_ERROR_CORE must be a frozenset, not a mutable set."""
+        assert isinstance(TRANSIENT_ERROR_CORE, frozenset)
+
+    def test_all_entries_are_strings(self) -> None:
+        """Every entry in the core is a string."""
+        for entry in TRANSIENT_ERROR_CORE:
+            assert isinstance(entry, str)
+
+    def test_all_entries_are_lowercase(self) -> None:
+        """All entries are lowercase for case-insensitive substring matching."""
+        for entry in TRANSIENT_ERROR_CORE:
+            assert entry == entry.lower(), f"not lowercase: {entry}"
+
+    @pytest.mark.parametrize("substring", SHARED_TRANSIENT_SIGNALS)
+    def test_core_contains_shared_signal(self, substring: str) -> None:
+        """Each genuinely-shared transient signal lives in the canonical core."""
+        assert substring in TRANSIENT_ERROR_CORE
+
+    def test_immutability(self) -> None:
+        """Frozenset should reject mutation attempts."""
+        with pytest.raises(AttributeError):
+            TRANSIENT_ERROR_CORE.add("nope")  # type: ignore[attr-defined]
+        with pytest.raises(AttributeError):
+            TRANSIENT_ERROR_CORE.discard("connection")  # type: ignore[attr-defined]
+
+    @pytest.mark.parametrize("substring", SHARED_TRANSIENT_SIGNALS)
+    def test_shared_signal_present_in_subprocess_patterns(self, substring: str) -> None:
+        """Anti-drift: every shared signal is reachable from the subprocess list."""
+        assert any(substring in pattern for pattern in TRANSIENT_ERROR_PATTERNS)
+
+    @pytest.mark.parametrize("substring", SHARED_TRANSIENT_SIGNALS)
+    def test_shared_signal_present_in_network_keywords(self, substring: str) -> None:
+        """Anti-drift: every shared signal is reachable from the network list."""
+        assert any(substring in keyword for keyword in NETWORK_ERROR_KEYWORDS)
 
 
 def test_repo_root_resolves_to_repo_containing_pyproject() -> None:


### PR DESCRIPTION
Consolidates the overlapping transient-failure substring lists in `subprocess_resilience.TRANSIENT_ERROR_PATTERNS` and `retry.NETWORK_ERROR_KEYWORDS` into a canonical `TRANSIENT_ERROR_CORE` frozenset in `hephaestus.constants`, so the shared signals cannot silently drift. Adds anti-drift tests asserting every shared signal is reachable from each consumer list.

Salvaged from an uncommitted worktree during `/worktree-cleanup`.

Closes #1205