### PR TITLE
fix(automation): suppress ERROR noise for expected "Body is not editable" on bot comments

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -1239,6 +1239,14 @@ def gh_pr_update_review_comment(comment_node_id: str, body: str) -> None:
 
     Used to edit an existing inline comment in place (#1083) instead of posting
     a duplicate on the same line.
+
+    GitHub rejects this mutation when the token does not own the comment
+    ("Body is not editable").  That failure is EXPECTED and fully recovered by
+    :func:`_edit_or_keep_comments` — it catches the exception and posts an
+    editable shadow comment instead (#1327).  We therefore suppress ERROR-level
+    logs for this call (``log_on_error=False``) so routine automation-loop runs
+    are not polluted with misleading error noise for a handled condition.
+    Genuine, unexpected failures still propagate as exceptions to the caller.
     """
     mutation = (
         "mutation($id:ID!,$body:String!){"
@@ -1257,7 +1265,8 @@ def gh_pr_update_review_comment(comment_node_id: str, body: str) -> None:
             f"id={comment_node_id}",
             "-f",
             f"body={body}",
-        ]
+        ],
+        log_on_error=False,
     )
 
 

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -298,6 +298,7 @@ def _gh_call_impl(
     check: bool = True,
     retry_on_rate_limit: bool = True,
     max_retries: int = 6,
+    log_on_error: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Implement gh CLI call with rate limit handling (circuit breaker will wrap this).
 
@@ -306,6 +307,10 @@ def _gh_call_impl(
         check: Whether to raise on non-zero exit
         retry_on_rate_limit: Whether to retry on rate limit
         max_retries: Maximum retry attempts
+        log_on_error: If False, suppress ERROR-level logs when the command
+            fails.  Pass ``False`` when the failure is expected and already
+            handled by the caller (e.g. ``updatePullRequestReviewComment`` on a
+            foreign-authored comment that the caller recovers via a shadow post).
 
     Returns:
         CompletedProcess instance
@@ -324,6 +329,7 @@ def _gh_call_impl(
                 ["gh", *args],
                 check=check,
                 timeout=gh_cli_timeout(),
+                log_on_error=log_on_error,
             )
             return result
         except subprocess.CalledProcessError as e:
@@ -342,7 +348,8 @@ def _gh_call_impl(
                 continue
 
             if _is_non_transient_error(stderr):
-                logger.error("Non-transient error detected: %s", stderr[:200])
+                if log_on_error:
+                    logger.error("Non-transient error detected: %s", stderr[:200])
                 if _is_token_scope_error(stderr):
                     _log_token_scope_remediation(args, stderr)
                 raise
@@ -394,6 +401,7 @@ def _gh_call(
     check: bool = True,
     retry_on_rate_limit: bool = True,
     max_retries: int = 6,
+    log_on_error: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     """Call gh CLI with rate limit handling and circuit breaker protection.
 
@@ -406,6 +414,10 @@ def _gh_call(
         check: Whether to raise on non-zero exit
         retry_on_rate_limit: Whether to retry on rate limit
         max_retries: Maximum retry attempts
+        log_on_error: If False, suppress ERROR-level logs when the command
+            fails.  Pass ``False`` when the failure is expected and already
+            handled by the caller (e.g. ``updatePullRequestReviewComment`` on a
+            foreign-authored comment that the caller recovers via a shadow post).
 
     Returns:
         CompletedProcess instance
@@ -425,6 +437,7 @@ def _gh_call(
             check=check,
             retry_on_rate_limit=retry_on_rate_limit,
             max_retries=max_retries,
+            log_on_error=log_on_error,
         )
     except CircuitBreakerOpenError as exc:
         # Translate to a domain exception (RuntimeError subclass) so existing

--- a/tests/unit/automation/test_gh_call_circuit_breaker.py
+++ b/tests/unit/automation/test_gh_call_circuit_breaker.py
@@ -147,10 +147,13 @@ class TestGhCallCircuitBreaker:
 
         assert result == expected_result
 
-        # Verify the mock was called with correct arguments
+        # Verify the mock was called with correct arguments — log_on_error is now
+        # forwarded by the circuit-breaker passthrough (added in #1368), so it
+        # must appear in the expected call (default value True).
         mock_impl.assert_called_once_with(
             ["issue", "list"],
             check=False,
             retry_on_rate_limit=False,
             max_retries=3,
+            log_on_error=True,
         )

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2698,6 +2698,79 @@ class TestEditOrKeepUneditableComment:
         # The finding was consumed by the shadow comment, not re-posted fresh.
         assert kept == []
 
+    @patch("hephaestus.automation.github_api.gh_pr_wont_fix_line_index", return_value=set())
+    @patch("hephaestus.automation.github_api.gh_pr_update_review_comment")
+    @patch("hephaestus.automation.github_api.gh_pr_review_post")
+    @patch("hephaestus.automation.github_api.gh_pr_inline_comment_index")
+    def test_uneditable_viewer_flag_emits_no_error_log(
+        self,
+        mock_index: Any,
+        mock_post: Any,
+        mock_update: Any,
+        _mock_wont_fix: Any,
+        caplog: Any,
+    ) -> None:
+        """#1368: foreign-comment (viewerCanUpdate=False) path emits no ERROR logs.
+
+        When ``viewerCanUpdate`` is False the proactive path posts a shadow
+        comment directly — the ``updatePullRequestReviewComment`` mutation is
+        NEVER called, so no failure is generated.  This test confirms the update
+        mock is not called AND that no ERROR-level records are emitted.
+        """
+        from hephaestus.automation.github_api import _edit_or_keep_comments
+
+        mock_index.side_effect = [
+            {("a.py", 2, "RIGHT"): ("FOREIGN_NODE", "copilot finding", False)},
+            {("a.py", 2, "RIGHT"): ("OUR_NODE", "our finding", True)},
+        ]
+
+        with caplog.at_level("ERROR"):
+            kept = _edit_or_keep_comments(
+                7, [{"path": "a.py", "line": 2, "side": "RIGHT", "body": "our finding"}]
+            )
+
+        # Proactive path: update mutation must not be called for a foreign comment.
+        mock_update.assert_not_called()
+        # Recovery still happens: shadow comment is posted.
+        mock_post.assert_called_once()
+        # Finding is consumed, not returned for re-post.
+        assert kept == []
+        # No ERROR-level noise for an expected, fully-recovered condition.
+        error_records = [r for r in caplog.records if r.levelno >= 40]
+        assert error_records == [], (
+            f"Expected no ERROR logs but got: {[r.getMessage() for r in error_records]}"
+        )
+
+    @patch("hephaestus.github.client.run_subprocess")
+    def test_update_review_comment_does_not_log_error_on_not_editable(
+        self,
+        mock_run: Any,
+        caplog: Any,
+    ) -> None:
+        """#1368: gh_pr_update_review_comment passes log_on_error=False to _gh_call.
+
+        When GitHub rejects the update with "Body is not editable" the call
+        raises (so the caller can shadow-post), but must NOT emit ERROR-level
+        logs — the failure is expected and the caller recovers it.  Genuine
+        unexpected failures elsewhere should still log at ERROR (checked via
+        the existing test_token_scope_error_is_non_transient test).
+        """
+        from hephaestus.automation.github_api import gh_pr_update_review_comment
+
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, "gh", stderr="gh: Body is not editable"
+        )
+
+        with caplog.at_level("ERROR"):
+            with pytest.raises(subprocess.CalledProcessError):
+                gh_pr_update_review_comment("NODE_ID", "some body")
+
+        error_records = [r for r in caplog.records if r.levelno >= 40]
+        assert error_records == [], (
+            f"Expected no ERROR logs for expected 'not editable' failure but got: "
+            f"{[r.getMessage() for r in error_records]}"
+        )
+
 
 class TestGhPrInlineCommentIndex:
     """gh_pr_inline_comment_index returns (path,line) → (node_id, body) (#1085)."""


### PR DESCRIPTION
## Summary

- `updatePullRequestReviewComment` on a foreign-authored comment (Copilot, CodeQL) raises \"Body is not editable\" — an expected, fully-recovered failure (#1327). Before this change two ERROR-level log lines were emitted every time, making routine runs look broken.
- Add `log_on_error: bool = True` to `gh_call` / `_gh_call_impl` and thread it through to `run_subprocess`. Gate \"Non-transient error detected\" log in `_gh_call_impl` on the same flag.
- `gh_pr_update_review_comment` passes `log_on_error=False` because its sole caller (`_edit_or_keep_comments`) already catches and recovers every failure from it.
- Recovery behaviour (shadow comment posting) is completely unchanged. Genuine unexpected `gh` failures still log at ERROR.

## Files changed

- `hephaestus/github/client.py`: `log_on_error` param added to `_gh_call_impl` and `_gh_call`; non-transient error log gated on flag
- `hephaestus/automation/github_api.py`: `gh_pr_update_review_comment` passes `log_on_error=False`
- `tests/unit/automation/test_github_api.py`: 2 new tests — (a) proactive path emits no ERROR; (b) fallback path emits no ERROR on \"not editable\"

## Test plan

- [ ] `pixi run pytest tests/unit/automation/test_github_api.py` — 149 passed
- [ ] `pixi run ruff check hephaestus/ tests/` — clean
- [ ] `pixi run mypy` — no issues in 404 source files
- [ ] `pre-commit run --files ...` — all hooks passed

Closes #1368