### PR TITLE
[Fix] Planner: skip issues already covered by an open/merged PR

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -309,6 +309,101 @@ def find_pr_for_issue(
     return None
 
 
+def find_merged_closing_pr(issue_number: int) -> int | None:
+    """Find a MERGED PR that closes ``issue_number`` via an exact ``Closes #N`` line.
+
+    Mirrors Strategy 3 of :func:`find_pr_for_issue` but searches *merged* PRs
+    instead of open ones. This catches the failure mode where a closing PR has
+    already merged with a valid ``Closes #N`` line yet the issue stayed OPEN
+    (GitHub does not always auto-close), causing the loop to re-plan and
+    re-implement an issue whose work has already landed.
+
+    The same exact-line regex discipline as :func:`find_pr_for_issue` applies:
+    GitHub's full-text search returns substring matches, so a merged PR whose
+    body says ``Closes #1234`` must NOT match a query for #12, and a grouped
+    ``Closes #12, #18`` must not match either — only PRs that follow the
+    ``pr-policy`` exact-line format (``^Closes #<N>`` on its own line) match.
+
+    Args:
+        issue_number: GitHub issue number.
+
+    Returns:
+        The merged PR number if one genuinely closes the issue, ``None``
+        otherwise.
+
+    """
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "list",
+                "--state",
+                "merged",
+                "--search",
+                f"Closes #{issue_number} in:body",
+                "--json",
+                "number,body",
+                "--limit",
+                "10",
+            ],
+            check=False,
+        )
+        pr_data = json.loads(result.stdout or "[]")
+        closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
+        for candidate in pr_data:
+            body = candidate.get("body") or ""
+            if closes_pattern.search(body):
+                pr_number = int(candidate["number"])
+                logger.info(
+                    "Found merged PR #%d closing issue #%d via body search",
+                    pr_number,
+                    issue_number,
+                )
+                return pr_number
+    except Exception as e:
+        logger.debug("Merged-PR body search failed for issue #%d: %s", issue_number, e)
+
+    return None
+
+
+def close_issue_as_covered(issue_number: int, pr_number: int) -> bool:
+    """Close an OPEN issue already covered by a merged closing PR (idempotent).
+
+    Used after :func:`find_merged_closing_pr` confirms ``pr_number`` merged with
+    an exact ``Closes #N`` line but the issue stayed OPEN. ``gh issue close`` is
+    a no-op when the issue is already closed, so this is safe to call
+    unconditionally.
+
+    Args:
+        issue_number: GitHub issue number to close.
+        pr_number: The merged PR that closes it (cited in the close comment).
+
+    Returns:
+        True if the close command ran without error, False otherwise.
+
+    """
+    try:
+        _gh_call(
+            [
+                "issue",
+                "close",
+                str(issue_number),
+                "--comment",
+                f"Closed by merged PR #{pr_number} (Closes #{issue_number}).",
+            ],
+            check=False,
+        )
+        logger.info(
+            "Closed issue #%d — covered by merged PR #%d",
+            issue_number,
+            pr_number,
+        )
+        return True
+    except Exception as e:
+        logger.warning("Failed to close issue #%d (merged PR #%d): %s", issue_number, pr_number, e)
+        return False
+
+
 def get_pr_head_branch(pr_number: int) -> str | None:
     """Return the real head branch of ``pr_number`` via ``gh pr view``.
 

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -24,6 +24,11 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 
+from ._review_utils import (
+    close_issue_as_covered,
+    find_merged_closing_pr,
+    find_pr_for_issue,
+)
 from .advise_runner import advise_skipped, ensure_mnemosyne, run_advise
 from .claude_models import advise_model
 from .claude_timeouts import advise_claude_timeout
@@ -138,6 +143,72 @@ class Planner:
         cached_labels = self.state_mgr.get_cached_labels(issue_number)
         return is_plan_review_go(issue_number, issue_labels=cached_labels)
 
+    def _pr_coverage_skip(self, issue_number: int, slot_id: int) -> PlanResult | None:
+        """Skip planning when a PR already covers the issue (FM1 idempotency guard).
+
+        Two gaps closed here, both observed in the 2026-06-15 automation-loop run:
+
+        1. **Open PR exists** — an open PR already closes this issue, so planning
+           it again wastes an agent call and risks a duplicate/zombie PR. Mirrors
+           the implementer's existing open-PR skip via the shared
+           :func:`find_pr_for_issue` (branch-name → review-state → ``Closes #N``
+           body search with the exact ``^Closes #N`` post-filter).
+        2. **Merged closing PR, issue still OPEN** — a closing PR merged with a
+           valid ``Closes #N`` line yet the issue never auto-closed. Close the
+           issue (idempotently) and skip rather than re-implement landed work.
+
+        The merged-PR gate is checked first: a merged PR is the stronger signal
+        (work has landed), and closing the issue prevents the loop from churning
+        on it next run.
+
+        Args:
+            issue_number: Issue under consideration.
+            slot_id: Worker slot for status-tracker updates.
+
+        Returns:
+            A ``PlanResult`` (success, ``plan_already_exists=True``) when the
+            issue should be skipped, or ``None`` when planning should proceed.
+
+        """
+        # Gate A: a merged PR already closed (or should have closed) this issue.
+        merged_pr = find_merged_closing_pr(issue_number)
+        if merged_pr is not None:
+            logger.info(
+                "Issue #%s: merged PR #%s already closes it — closing issue and skipping plan",
+                issue_number,
+                merged_pr,
+            )
+            close_issue_as_covered(issue_number, merged_pr)
+            self.status_tracker.update_slot(
+                slot_id,
+                f"{issue_ref(issue_number)}: merged PR #{merged_pr} covers it, closed + skipped",
+            )
+            return PlanResult(
+                issue_number=issue_number,
+                success=True,
+                plan_already_exists=True,
+            )
+
+        # Gate B: an open PR already covers this issue.
+        open_pr = find_pr_for_issue(issue_number)
+        if open_pr is not None:
+            logger.info(
+                "Issue #%s: open PR #%s already covers it — skipping plan",
+                issue_number,
+                open_pr,
+            )
+            self.status_tracker.update_slot(
+                slot_id,
+                f"{issue_ref(issue_number)}: open PR #{open_pr} covers it, skipped",
+            )
+            return PlanResult(
+                issue_number=issue_number,
+                success=True,
+                plan_already_exists=True,
+            )
+
+        return None
+
     def _plan_issue(self, issue_number: int) -> PlanResult:
         """Plan a single issue.
 
@@ -157,6 +228,18 @@ class Planner:
             )
 
         try:
+            # Idempotency guard (FM1): never (re-)plan an issue whose work is
+            # already covered by a PR. Runs BEFORE the existing-plan/force gates
+            # because an open/merged closing PR makes planning pure churn — the
+            # 2026-06-15 loop burned ~5.5h re-planning #1357/#1289/#1179 while
+            # their PRs were open (and again after they merged). This mirrors the
+            # implementer phase's "Skipped (open PR already exists)" semantics so
+            # plan and implement agree on what to skip. Localized to this guard
+            # block (no _call_claude changes) for FM3 retry-logic coordination.
+            covered = self._pr_coverage_skip(issue_number, slot_id)
+            if covered is not None:
+                return covered
+
             # Skip-if-already-planned moved here from _filter_issues (#548) so
             # the check runs inside the thread pool (parallel, overlapped with
             # actual planning work) instead of as a serial pre-pass that

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -596,3 +596,88 @@ class TestEnsureMnemosyne:
         call_kwargs = mock_run.call_args.kwargs
         assert "timeout" in call_kwargs, "subprocess.run for clone must pass timeout="
         assert call_kwargs["timeout"] == 120
+
+
+class TestPrCoverageSkip:
+    """FM1 idempotency guard: skip planning issues already covered by a PR.
+
+    Regression for the 2026-06-15 loop run that re-planned #1357/#1289/#1179
+    while their PRs were open (and again after PR #1358 merged but the issue
+    stayed OPEN), burning ~5.5h on duplicate/zombie PRs (#1359, #1365).
+    """
+
+    def test_skips_when_open_pr_covers_issue(self, planner: Any) -> None:
+        """find_pr_for_issue returns a PR → skip, no agent call, no plan post."""
+        with (
+            patch(
+                "hephaestus.automation.planner.find_merged_closing_pr",
+                return_value=None,
+            ),
+            patch(
+                "hephaestus.automation.planner.find_pr_for_issue",
+                return_value=42,
+            ),
+            patch.object(planner, "_run_plan_review_loop") as mock_loop,
+            patch.object(planner, "_post_plan") as mock_post,
+            patch.object(planner, "_call_claude") as mock_claude,
+        ):
+            result = planner._plan_issue(123)
+
+        assert result.success is True
+        assert result.plan_already_exists is True
+        mock_loop.assert_not_called()
+        mock_post.assert_not_called()
+        mock_claude.assert_not_called()
+
+    def test_closes_issue_when_merged_pr_covers_and_skips(self, planner: Any) -> None:
+        """Merged closing PR + open issue → close issue, skip, no re-plan."""
+        with (
+            patch(
+                "hephaestus.automation.planner.find_merged_closing_pr",
+                return_value=1358,
+            ),
+            patch(
+                "hephaestus.automation.planner.close_issue_as_covered",
+            ) as mock_close,
+            patch(
+                "hephaestus.automation.planner.find_pr_for_issue",
+            ) as mock_open_pr,
+            patch.object(planner, "_run_plan_review_loop") as mock_loop,
+            patch.object(planner, "_post_plan") as mock_post,
+            patch.object(planner, "_call_claude") as mock_claude,
+        ):
+            result = planner._plan_issue(1357)
+
+        assert result.success is True
+        assert result.plan_already_exists is True
+        mock_close.assert_called_once_with(1357, 1358)
+        # Merged-PR gate short-circuits before the open-PR lookup.
+        mock_open_pr.assert_not_called()
+        mock_loop.assert_not_called()
+        mock_post.assert_not_called()
+        mock_claude.assert_not_called()
+
+    def test_plans_when_no_pr_covers_issue(self, planner: Any) -> None:
+        """No open/merged PR → planning proceeds normally."""
+        with (
+            patch(
+                "hephaestus.automation.planner.find_merged_closing_pr",
+                return_value=None,
+            ),
+            patch(
+                "hephaestus.automation.planner.find_pr_for_issue",
+                return_value=None,
+            ),
+            patch.object(planner, "_has_existing_plan", return_value=False),
+            patch.object(
+                planner,
+                "_run_plan_review_loop",
+                return_value=("# Plan", "GO review", 1, True),
+            ),
+            patch.object(planner, "_post_plan") as mock_post,
+        ):
+            result = planner._plan_issue(123)
+
+        assert result.success is True
+        assert result.plan_already_exists is False
+        mock_post.assert_called_once()

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -9,6 +9,8 @@ import pytest
 
 from hephaestus.automation._review_utils import (
     add_max_workers_arg,
+    close_issue_as_covered,
+    find_merged_closing_pr,
     find_pr_for_issue,
     get_pr_head_branch,
     parse_json_block,
@@ -315,3 +317,119 @@ class TestAddMaxWorkersArg:
         add_max_workers_arg(parser, default=8)
         args = parser.parse_args([])
         assert args.max_workers == 8
+
+
+# ---------------------------------------------------------------------------
+# find_merged_closing_pr
+# ---------------------------------------------------------------------------
+
+
+class TestFindMergedClosingPr:
+    """Tests for find_merged_closing_pr — the merged-PR coverage gate (FM1)."""
+
+    def test_finds_merged_pr_with_exact_closes_line(self) -> None:
+        """A merged PR whose body has ``Closes #N`` on its own line is returned."""
+        captured: dict[str, list[str]] = {}
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            captured["args"] = args
+            return _make_gh_result([{"number": 1358, "body": "Summary.\n\nCloses #1357\n"}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_merged_closing_pr(1357)
+
+        assert result == 1358
+        # Must search the MERGED state, not open.
+        assert "--state" in captured["args"]
+        assert "merged" in captured["args"]
+
+    def test_rejects_substring_match(self) -> None:
+        """``Closes #1234`` must NOT match a query for issue #12."""
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            return _make_gh_result([{"number": 9999, "body": "Closes #1234\n"}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_merged_closing_pr(12)
+
+        assert result is None
+
+    def test_rejects_grouped_closes(self) -> None:
+        """A grouped one-line ``Closes #12, #18, #28`` does not match #28."""
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            return _make_gh_result([{"number": 5000, "body": "Closes #12, #18, #28, #29\n"}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_merged_closing_pr(28)
+
+        assert result is None
+
+    def test_returns_none_when_no_merged_pr(self) -> None:
+        """No merged PR found → None."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result([]),
+        ):
+            result = find_merged_closing_pr(1357)
+
+        assert result is None
+
+    def test_gh_failure_returns_none(self) -> None:
+        """A gh failure is swallowed and returns None (no crash)."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=RuntimeError("gh boom"),
+        ):
+            result = find_merged_closing_pr(1357)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# close_issue_as_covered
+# ---------------------------------------------------------------------------
+
+
+class TestCloseIssueAsCovered:
+    """Tests for close_issue_as_covered."""
+
+    def test_runs_gh_issue_close_with_comment(self) -> None:
+        """Closes the issue with a comment citing the merged PR."""
+        captured: dict[str, list[str]] = {}
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            captured["args"] = args
+            return MagicMock()
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = close_issue_as_covered(1357, 1358)
+
+        assert result is True
+        assert captured["args"][:3] == ["issue", "close", "1357"]
+        assert "--comment" in captured["args"]
+        comment = captured["args"][captured["args"].index("--comment") + 1]
+        assert "PR #1358" in comment
+        assert "Closes #1357" in comment
+
+    def test_gh_failure_returns_false(self) -> None:
+        """A gh failure is swallowed and returns False (no crash)."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=RuntimeError("gh boom"),
+        ):
+            result = close_issue_as_covered(1357, 1358)
+
+        assert result is False


### PR DESCRIPTION
## Summary

Closes the PRIMARY automation-loop failure (FM1): the PLANNER phase re-planned
issues already covered by a PR, causing duplicate-PR churn. Root-caused from the
2026-06-15 output.log, where #1357 was re-planned/re-implemented while open PR
#1358 already closed it (zombie PRs #1359, #1365, ~5.5h burned) and again after
#1358 merged but the issue stayed OPEN.

## Changes

**`hephaestus/automation/_review_utils.py`** (new helpers, next to `find_pr_for_issue`):
- `find_merged_closing_pr(issue_number) -> int | None` — searches MERGED PRs
  (`gh pr list --state merged --search "Closes #N in:body"`) with the same exact
  `^Closes #N` MULTILINE post-filter discipline as the open-PR search, so
  `Closes #1234` never matches #12 and grouped `Closes #12, #18` never matches.
- `close_issue_as_covered(issue_number, pr_number) -> bool` — idempotent
  `gh issue close N --comment "Closed by merged PR #M (Closes #N)."`.
- `find_pr_for_issue` open-PR behavior is **unchanged**.

**`hephaestus/automation/planner.py`** (regions touched, for FM3 coordination):
- New import of `close_issue_as_covered`, `find_merged_closing_pr`,
  `find_pr_for_issue` from `._review_utils`.
- New method `Planner._pr_coverage_skip(issue_number, slot_id)` — merged-PR gate
  (close + skip) then open-PR gate (skip), mirroring the implementer's existing
  open-PR skip semantics.
- A single guard at the **top of `_plan_issue`'s try-body** calling
  `_pr_coverage_skip`. `_call_claude` is **untouched** so FM3's retry/backoff
  work won't collide.

## FM3 coordination note
Only two `planner.py` regions changed: (1) the import block (~L27) and (2) the
new `_pr_coverage_skip` method + a ~3-line guard at the top of `_plan_issue`.
`_call_claude` (~L224-244) is untouched.

## Tests
- `tests/unit/automation/test_review_utils.py`: `TestFindMergedClosingPr` (5),
  `TestCloseIssueAsCovered` (2).
- `tests/unit/automation/test_planner.py`: `TestPrCoverageSkip` (3).

ruff clean, mypy no new errors, pre-commit all pass.

Closes #1370