### PR TITLE
refactor(automation): add ReviewerProtocol + abstract BaseReviewer.run for OCP/DIP

### DIFF
--- a/tests/unit/automation/test_interfaces.py
+++ b/tests/unit/automation/test_interfaces.py
@@ -4,47 +4,50 @@ from hephaestus.automation._interfaces import ReviewerProtocol
 
 
 class _ConcreteReviewer:
+    """Stub reviewer that satisfies the protocol."""
+
     def run(self) -> dict:
+        """Return an empty result mapping."""
         return {}
 
 
 class _MissingReviewer:
-    pass
+    """Stub that does not implement run()."""
 
 
 def test_protocol_satisfied_by_stub() -> None:
-    """A class with run() must satisfy ReviewerProtocol via runtime_checkable."""
+    """A class defining run() satisfies ReviewerProtocol."""
     assert isinstance(_ConcreteReviewer(), ReviewerProtocol)
 
 
 def test_protocol_violated_by_stub() -> None:
-    """A class without run() must not satisfy ReviewerProtocol."""
+    """A class missing run() does not satisfy ReviewerProtocol."""
     assert not isinstance(_MissingReviewer(), ReviewerProtocol)
 
 
 def test_pr_reviewer_satisfies_protocol() -> None:
-    """PRReviewer inherits BaseReviewer and defines run() — must satisfy."""
+    """PRReviewer satisfies ReviewerProtocol structurally."""
     from hephaestus.automation.pr_reviewer import PRReviewer
 
     assert issubclass(PRReviewer, ReviewerProtocol)
 
 
 def test_address_reviewer_satisfies_protocol() -> None:
-    """AddressReviewer implements run() and must satisfy ReviewerProtocol."""
+    """AddressReviewer satisfies ReviewerProtocol structurally."""
     from hephaestus.automation.address_review import AddressReviewer
 
     assert issubclass(AddressReviewer, ReviewerProtocol)
 
 
 def test_audit_reviewer_satisfies_protocol() -> None:
-    """AuditReviewer implements run() and must satisfy ReviewerProtocol."""
+    """AuditReviewer satisfies ReviewerProtocol structurally."""
     from hephaestus.automation.audit_reviewer import AuditReviewer
 
     assert issubclass(AuditReviewer, ReviewerProtocol)
 
 
 def test_plan_reviewer_satisfies_protocol() -> None:
-    """PlanReviewer implements run() and must satisfy ReviewerProtocol."""
+    """PlanReviewer satisfies ReviewerProtocol structurally."""
     from hephaestus.automation.plan_reviewer import PlanReviewer
 
     assert issubclass(PlanReviewer, ReviewerProtocol)


### PR DESCRIPTION
## Summary

- Adds `ReviewerProtocol` (a `runtime_checkable` `Protocol`) in `hephaestus/automation/_interfaces.py`, declaring the shared `run()` contract for all four reviewer classes (`PRReviewer`, `AddressReviewer`, `AuditReviewer`, `PlanReviewer`)
- Makes `BaseReviewer` abstract (`ABC`) with `@abstractmethod run()`, statically constraining `PRReviewer` and `AddressReviewer` to implement the entry-point
- Protocol lives in a private `_interfaces` module (not the lazy `__init__` exports) to avoid defeating the automation package's lazy-load design
- Six conformance tests verify all four concrete reviewer classes satisfy `ReviewerProtocol`
- This PR polishes test stub class docstrings and tightens function docstrings to match the approved plan spec exactly (the core implementation was shipped in #1282)

## Verification

### Hard Gate Results

1. `pixi run pytest tests/unit/automation/ --no-cov -q` — 1763 passed, 4 pre-existing failures in test_planner_loop/test_planner_main (confirmed present on origin/main before this change)
2. `pixi run pytest tests/unit/automation/test_interfaces.py -v --no-cov` — **6/6 pass**
3. `pixi run pytest tests/unit/validation/test_import_surface.py -v --no-cov` — **1 pass** (abc is stdlib; no new optional-extra leak)
4. `pixi run mypy` — **Success: no issues found in 403 source files**
5. `pixi run ruff check hephaestus/ tests/` — **All checks passed**
6. Pre-commit hooks — all passed on commit

## Files Changed

- `tests/unit/automation/test_interfaces.py` — added class docstrings on stub classes, tightened function docstrings to match approved plan spec

## Files Already on main (from #1282)

- `hephaestus/automation/_interfaces.py` — ReviewerProtocol declaration
- `hephaestus/automation/_reviewer_base.py` — BaseReviewer(ABC) + @abstractmethod run()

Closes #1193