### PR TITLE
ci(markdownlint): consolidate duplicate lint job into pre-commit hook

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -41,7 +41,7 @@ Builds and publishes the package to PyPI on version tag push (`v*`).
 ### Required Checks Workflow (`workflows/_required.yml`)
 
 The consolidated required-status-check gate that runs on every pull request to
-`main` (and on push to `main`). It aggregates lint, markdownlint, `pixi-check`,
+`main` (and on push to `main`). It aggregates lint, `pixi-check`,
 shellcheck, the `pr-policy` gate (enforces `Closes #N` and signed commits),
 unit/integration/shell tests, wheel build, security scans (pip-audit, Gitleaks,
 bandit), workflow-schema validation, and version-sync. It also runs the

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -191,7 +191,7 @@ jobs:
           restore-keys: |
             pre-commit-${{ runner.os }}-
 
-      - name: Run pre-commit (ruff, mypy, yamllint, markdownlint + all hooks)
+      - name: Run pre-commit (all hooks)
         run: |
           # Several hooks (check-dep-sync, check-unit-test-structure, the
           # hephaestus-* catalog checks) invoke `pixi run hephaestus-*`, which
@@ -208,24 +208,6 @@ jobs:
           retention-days: 7
           path: |
             .git/pre-commit-*
-
-  markdownlint:
-    name: markdownlint
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    needs: [lint, changes-gate]
-    if: needs.changes-gate.outputs.code_event == 'true'
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - name: Run markdownlint-cli2
-        uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd  # v20.0.0
-        with:
-          globs: |
-            **/*.md
-            !.claude/**
-          config: ".markdownlint.yaml"
 
   pixi-check:
     name: pixi-check
@@ -867,7 +849,6 @@ jobs:
       - changes-gate
       - forbid-suppressions
       - lint
-      - markdownlint
       - pixi-check
       - justfile-check
       - symlink-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,11 @@ repos:
       - id: markdownlint-cli2
         name: Markdown Lint
         description: Lint markdown files for consistency
-        exclude: ^(build/|docs/)
+        # docs/ is intentionally IN scope (consolidated from the former
+        # standalone `markdownlint` CI job, #1199). .claude/ stays excluded:
+        # its two tracked .md files (security/guidelines.md,
+        # workflows/development.md) were never linted by that job — keep parity.
+        exclude: ^(build/|\.claude/)
         args: ['--config', '.markdownlint.yaml', '--fix']
 
   # YAML linting

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -28,7 +28,7 @@ A piece of work is **done** when every item below is true.
 | 15 | Dep sync check passes (pyproject.toml then pixi.toml then pixi.lock) | CI job `deps/version-sync` |
 | 16 | Secrets scan finds no leaks | CI jobs `security/secrets-scan`, gitleaks in `_required.yml` |
 | 17 | Dependency vulnerability scan passes | CI jobs `security/dependency-scan`, `pip-audit` in `_required.yml` |
-| 18 | Markdownlint passes on all `.md` changes | CI job `markdownlint` |
+| 18 | Markdownlint passes on all `.md` changes | CI job `lint` (pre-commit hook) |
 | 19 | Shellcheck passes on all shell scripts | CI job `shellcheck` |
 | 20 | Yamllint passes on all YAML changes | CI job `lint` |
 | 21 | Pre-commit hooks pass on the diff | CI job `lint` (pre-commit suite folded into `lint` per #1173) |


### PR DESCRIPTION
## Summary

markdownlint-cli2 ran **twice** with divergent scope: the lint job's pre-commit run excluded `^(build/|docs/)`, while a separate standalone `markdownlint` CI job linted `**/*.md` except `.claude/**`. Net effect: `docs/*.md` was linted in CI but **not** by the local hook — a silent local↔CI gap. This consolidates to one source of truth (the pre-commit hook).

## Changes

- **`.pre-commit-config.yaml`** — markdownlint hook `exclude: ^(build/|docs/)` → `^(build/|\.claude/)`. `docs/` is now in scope; `.claude/` is excluded to match the removed job's intent (its two tracked `.md` files — `security/guidelines.md`, `workflows/development.md` — were never linted by that job).
- **`.github/workflows/_required.yml`** — delete the standalone `markdownlint` job and remove it from `required-checks-gate.needs` (symmetric removal keeps the aggregator guard test green); rename the pre-commit step to `Run pre-commit (all hooks)`.
- **`docs/DEFINITION_OF_DONE.md`** / **`.github/README.md`** — re-point the removed `markdownlint` job name to the `lint` (pre-commit) job.

## Safety: not a required-check context

Audited branch protection before deleting the job — `markdownlint` is **not** in the legacy required contexts nor any ruleset, so removing it does not permanently block PRs. The single required gate is `required-checks-gate`, which still aggregates `lint` (which runs the markdownlint hook).

## Verification

- `pixi run --environment lint npx markdownlint-cli2 --config .markdownlint.yaml "docs/**/*.md"` → **0 errors** (16 files) under the new scope
- `.claude/` files excluded: `pre-commit run markdownlint-cli2 --files .claude/...` → `(no files to check) Skipped`
- `pixi run --environment lint pre-commit run --all-files` → **all hooks Passed**
- `pixi run pytest tests/unit/ci/test_required_checks_gate.py` → **6 passed** (aggregator invariant intact)
- No standalone job, no dangling `needs:`, no stale `markdownlint` job-name refs remain

Closes #1199

🤖 Generated with [Claude Code](https://claude.com/claude-code)