### PR TITLE
docs(migration): bump latest-version line to 0.9.6 to clear drift guard

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-> **Status (as of 2026-06-12):** The latest released version is **0.9.5** (tag-driven
+> **Status (as of 2026-06-16):** The latest released version is **0.9.6** (tag-driven
 > via hatch-vcs). **1.0 has not been released yet** — the section below is the
 > *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
 > prepare. There are currently **no breaking changes between 0.9.x releases**: upgrading


### PR DESCRIPTION
Bumps the `latest released version is **X.Y.Z**` line in `docs/MIGRATION.md` from 0.9.5 to 0.9.6 so the version-currency drift guard (`tests/unit/docs/test_version_currency.py`) passes. The v0.9.6 git tag shipped but the doc still recorded 0.9.5.

Also refreshes the stale "as of" date to 2026-06-16.

Verified locally: `pytest tests/unit/docs/test_version_currency.py` now passes.

Closes #1378