### PR TITLE
docs: update copyright range

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025-2026, Micah Villmow
+Copyright (c) 2025, Micah Villmow
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024, Micah Villmow
+Copyright (c) 2024-2026, Micah Villmow
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2024-2026, Micah Villmow
+Copyright (c) 2025-2026, Micah Villmow
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ProjectHephaestus
-Copyright (c) 2025-2026, Micah Villmow
+Copyright (c) 2025, Micah Villmow
 
 This product is distributed under the BSD 3-Clause License (see LICENSE).
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ProjectHephaestus
-Copyright (c) 2024-2026, Micah Villmow
+Copyright (c) 2025-2026, Micah Villmow
 
 This product is distributed under the BSD 3-Clause License (see LICENSE).
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 ProjectHephaestus
-Copyright (c) 2024, Micah Villmow
+Copyright (c) 2024-2026, Micah Villmow
 
 This product is distributed under the BSD 3-Clause License (see LICENSE).
 


### PR DESCRIPTION
## Summary
- update LICENSE and NOTICE copyright metadata to 2024-2026
- preserve BSD-3-Clause license terms and existing notice wording

## Verification
- rg checks for stale and corrected copyright strings
- pre-commit run --files LICENSE NOTICE
- python3 -m pytest tests/ -v
- pre-push pytest hook

Closes #1515