### PR TITLE
[Fix] Repair mypy 2.1.0 errors blocking main lint gate

### DIFF
--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation import pr_manager
+from hephaestus.automation.session_naming import AGENT_COMMIT_MESSAGE, AGENT_PR_MESSAGE
 
 
 def _status(stdout: str = "", returncode: int = 0) -> MagicMock:
@@ -350,7 +351,7 @@ class TestMessageAgentInvocation:
             assert (
                 pr_manager._invoke_git_message_agent(
                     issue_number=9,
-                    agent_kind=pr_manager.AGENT_COMMIT_MESSAGE,
+                    agent_kind=AGENT_COMMIT_MESSAGE,
                     prompt="prompt",
                     worktree_path=Path("/tmp/wt"),
                     agent="claude",
@@ -359,7 +360,7 @@ class TestMessageAgentInvocation:
             )
 
         kwargs = invoke.call_args.kwargs
-        assert kwargs["agent"] == pr_manager.AGENT_COMMIT_MESSAGE
+        assert kwargs["agent"] == AGENT_COMMIT_MESSAGE
         assert kwargs["model"] == "claude-haiku-4-5"
         assert kwargs["allowed_tools"] == "Read,Glob,Grep"
         assert kwargs["timeout"] == 120
@@ -377,7 +378,7 @@ class TestMessageAgentInvocation:
             assert (
                 pr_manager._invoke_git_message_agent(
                     issue_number=9,
-                    agent_kind=pr_manager.AGENT_PR_MESSAGE,
+                    agent_kind=AGENT_PR_MESSAGE,
                     prompt="prompt",
                     worktree_path=Path("/tmp/wt"),
                     agent="codex",

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -194,9 +194,9 @@ def test_implement_phase_run_claude_code_dispatches_claude(tmp_path: Path) -> No
 def test_pr_create_finalize_persists_pr_number(tmp_path: Path) -> None:
     """_finalize_pr ensures the PR exists and persists its number on state."""
     ctx = _make_ctx(tmp_path)
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[attr-defined]
-    ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[attr-defined]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[attr-defined]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[method-assign]
+    ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[method-assign]
     phase = PRCreatePhase(ctx)
     state = SimpleNamespace(phase=None, pr_number=None)
     with mock.patch(
@@ -214,9 +214,9 @@ def test_pr_create_finalize_persists_pr_number(tmp_path: Path) -> None:
 def test_pr_create_finalize_commits_dirty_worktree_before_pr(tmp_path: Path) -> None:
     """_finalize_pr commits agent edits before push/PR creation."""
     ctx = _make_ctx(tmp_path)
-    ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[attr-defined]
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[attr-defined]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[attr-defined]
+    ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[method-assign]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[method-assign]
     parent = mock.MagicMock()
     parent.attach_mock(ctx.impl._commit_changes, "commit")
     parent.attach_mock(ctx.impl._ensure_pr_created, "ensure")
@@ -241,9 +241,9 @@ def test_pr_create_finalize_commits_dirty_worktree_before_pr(tmp_path: Path) -> 
 def test_pr_create_finalize_runs_pre_pr_tests_when_enabled(tmp_path: Path) -> None:
     """_finalize_pr runs the opt-in pre-PR test gate before creating the PR."""
     ctx = _make_ctx(tmp_path, run_pre_pr_tests=True)
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=9)  # type: ignore[attr-defined]
-    ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[attr-defined]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=False)  # type: ignore[attr-defined]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=9)  # type: ignore[method-assign]
+    ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=False)  # type: ignore[method-assign]
     phase = PRCreatePhase(ctx)
     state = SimpleNamespace(phase=None, pr_number=None)
     with mock.patch(


### PR DESCRIPTION
The required lint job on main is red: the whole-tree mypy pre-commit hook fails with 21 errors (introduced via mypy 2.1.0 sensitivity in #1525), blocking all new PRs.

## Changes

- `test_stage_phases.py`: method monkeypatch assignments used `# type: ignore[attr-defined]`, but mypy 2.1.0 emits `[method-assign]` here. With `warn_unused_ignores=true` each line errored twice. Corrected to `[method-assign]`.
- `test_pr_manager.py`: referenced `pr_manager.AGENT_COMMIT_MESSAGE` / `AGENT_PR_MESSAGE`, which `pr_manager` only imports. `implicit_reexport=false` rejects that — now imported from canonical `session_naming`.

## Verification

- `pixi run mypy` → `Success: no issues found in 406 source files`
- Affected tests still pass (58 passed)

Closes #1529