### PR TITLE
[Fix] Honor Claude 429/529 caps in in-loop PR review

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import subprocess
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -28,6 +29,7 @@ from hephaestus.agents.runtime import (
     run_codex_text,
 )
 from hephaestus.github.client import gh_call
+from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from . import review_state
 from ._stage_context import StageMixin
@@ -35,6 +37,7 @@ from .address_review import run_address_fix_session
 from .claude_invoke import (
     INFRA_ERROR_REVIEW_TEXT,
     SESSION_EXPIRED_PHRASES,
+    detect_server_overload,
     invoke_claude_with_session,
     parse_review_verdict,
 )
@@ -74,6 +77,57 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MAX_REVIEW_ITERATIONS = 3
+
+# Bounded exponential backoff for transient 529 server-overload responses
+# (5s → 10s → 20s, capped). Unlike a 429 quota cap these carry no reset epoch,
+# so the correct response is a short backoff, not a wait-until-reset.
+_OVERLOAD_BACKOFF_BASE_SECONDS = 5
+_OVERLOAD_BACKOFF_MAX_SECONDS = 20
+
+
+def _handle_reviewer_quota_or_overload(
+    error: Exception, *, issue_number: int, iteration: int
+) -> None:
+    """Block on a Claude quota cap / server overload before recording ERROR.
+
+    The in-loop PR-review path used to catch a 429 session-limit failure, record
+    a synthetic ``Verdict=ERROR``, and immediately re-review — firing fresh
+    reviewer sessions against an exhausted quota (issue #1528). The implement
+    phase already detects the cap and blocks; this helper gives the review path
+    the same behavior so both honor the same transient-failure families.
+
+    The reviewer subprocess surfaces the 429/529 text inside the ``RuntimeError``
+    message (``Analysis session failed for PR …: <CLI output>``), so the
+    classifiers read ``str(error)``.
+
+    Args:
+        error: The exception raised by the reviewer invocation.
+        issue_number: Issue under review (for log context).
+        iteration: Current review iteration; also drives the overload backoff.
+
+    """
+    text = str(error)
+    reset_epoch = resolve_quota_reset_epoch(text)
+    if reset_epoch is not None and reset_epoch > 0:
+        logger.warning(
+            "#%s R%s: in-loop PR review hit Claude usage cap; waiting for reset",
+            issue_number,
+            iteration,
+        )
+        wait_until(reset_epoch)
+        return
+    if detect_server_overload(text):
+        delay = min(
+            _OVERLOAD_BACKOFF_BASE_SECONDS * (2**iteration),
+            _OVERLOAD_BACKOFF_MAX_SECONDS,
+        )
+        logger.warning(
+            "#%s R%s: in-loop PR review hit server overload; backing off %ss",
+            issue_number,
+            iteration,
+            delay,
+        )
+        time.sleep(delay)
 
 
 def _is_automation_owned_thread(thread: dict[str, Any], current_login: str | None) -> bool:
@@ -1142,6 +1196,11 @@ class ReviewPhase(StageMixin):
                 dry_run=False,
             )
         except Exception as e:
+            # A 429 quota cap / 529 overload must pause the loop, not spin fresh
+            # reviewer sessions against an exhausted quota (issue #1528). After
+            # any wait, still record ERROR so a transient infra failure re-reviews
+            # next loop and is never mistaken for a NOGO.
+            _handle_reviewer_quota_or_overload(e, issue_number=issue_number, iteration=iteration)
             logger.error(
                 "#%s R%s: in-loop PR review failed: %s; recording ERROR (re-review next "
                 "loop, no skip/label) so an infra failure isn't mistaken for a NOGO",
@@ -1501,6 +1560,10 @@ class ReviewPhase(StageMixin):
                 raise RuntimeError("reviewer returned empty output")
             return output
         except Exception as e:
+            # Mirror the in-loop path: pause on a Claude 429 cap / 529 overload
+            # before recording ERROR so the diff-only fallback does not burn
+            # sessions against an exhausted quota either (issue #1528).
+            _handle_reviewer_quota_or_overload(e, issue_number=issue_number, iteration=iteration)
             logger.error(
                 "#%s R%s: impl reviewer call failed: %s; recording ERROR (re-review next "
                 "loop, no skip/label) so an infra failure isn't mistaken for a NOGO",

--- a/tests/unit/automation/test_review_phase.py
+++ b/tests/unit/automation/test_review_phase.py
@@ -1,0 +1,106 @@
+"""Tests for :mod:`hephaestus.automation._review_phase`.
+
+Focus: the in-loop PR-review path must honor Claude 429 session-limit caps
+(block until reset) and 529 server-overload (bounded backoff) before recording
+an ERROR verdict, matching the implement-phase behavior. Regression guard for
+the asymmetry where the review path burned doomed sessions against an exhausted
+quota (issue #1528).
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from hephaestus.automation import _review_phase
+
+
+class TestHandleReviewerQuotaOrOverload:
+    """Unit tests for the shared quota/overload handler."""
+
+    def test_session_limit_429_waits_until_reset(self, monkeypatch):
+        """A 429 session-limit message blocks via wait_until(reset_epoch)."""
+        waited: list[int] = []
+        monkeypatch.setattr(_review_phase, "wait_until", lambda epoch: waited.append(epoch))
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+
+        # A realistic reset epoch in the future so reset_epoch > 0.
+        future = int(time.time()) + 3600
+        monkeypatch.setattr(
+            _review_phase,
+            "resolve_quota_reset_epoch",
+            lambda *texts: future,
+        )
+
+        err = RuntimeError(
+            "Analysis session failed for PR Foo#1: "
+            '{"is_error":true,"api_error_status":429,'
+            '"result":"You\'ve hit your session limit · resets 5pm (America/Los_Angeles)"}'
+        )
+        _review_phase._handle_reviewer_quota_or_overload(err, issue_number=42, iteration=0)
+
+        assert waited == [future], "must block until the parsed reset epoch"
+        assert slept == [], "429 waits until reset, it does not backoff-sleep"
+
+    def test_529_overload_backs_off(self, monkeypatch):
+        """A 529 overload (no reset epoch) triggers a bounded backoff sleep."""
+        waited: list[int] = []
+        monkeypatch.setattr(_review_phase, "wait_until", lambda epoch: waited.append(epoch))
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+        # No quota reset epoch for a server-overload error.
+        monkeypatch.setattr(_review_phase, "resolve_quota_reset_epoch", lambda *t: None)
+
+        err = RuntimeError("Analysis session failed for PR Foo#1: API Error: 529 Overloaded")
+        _review_phase._handle_reviewer_quota_or_overload(err, issue_number=7, iteration=2)
+
+        assert waited == [], "overload carries no reset epoch; must not wait_until"
+        assert len(slept) == 1 and slept[0] > 0, "overload must back off once"
+
+    def test_plain_failure_neither_waits_nor_sleeps(self, monkeypatch):
+        """A non-transient failure returns immediately with no wait/sleep."""
+        waited: list[int] = []
+        monkeypatch.setattr(_review_phase, "wait_until", lambda epoch: waited.append(epoch))
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+        monkeypatch.setattr(_review_phase, "resolve_quota_reset_epoch", lambda *t: None)
+
+        err = RuntimeError("reviewer returned empty output")
+        _review_phase._handle_reviewer_quota_or_overload(err, issue_number=9, iteration=0)
+
+        assert waited == []
+        assert slept == []
+
+    def test_zero_reset_epoch_does_not_wait(self, monkeypatch):
+        """A 0 reset-epoch sentinel (reset unknown) must not call wait_until."""
+        waited: list[int] = []
+        monkeypatch.setattr(_review_phase, "wait_until", lambda epoch: waited.append(epoch))
+        slept: list[float] = []
+        monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+        # 0 sentinel = rate-limited but reset time unknown; guarded by epoch > 0.
+        monkeypatch.setattr(_review_phase, "resolve_quota_reset_epoch", lambda *t: 0)
+        monkeypatch.setattr(_review_phase, "detect_server_overload", lambda *t: False)
+
+        err = RuntimeError("session limit")
+        _review_phase._handle_reviewer_quota_or_overload(err, issue_number=1, iteration=0)
+
+        assert waited == []
+        assert slept == []
+
+
+@pytest.mark.parametrize("backoff_iteration,expected_max", [(0, 5), (1, 10), (5, 20)])
+def test_overload_backoff_is_bounded(monkeypatch, backoff_iteration, expected_max):
+    """Overload backoff grows with iteration but is capped at 20s."""
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", lambda s: slept.append(s))
+    monkeypatch.setattr(_review_phase, "resolve_quota_reset_epoch", lambda *t: None)
+
+    err = RuntimeError("overloaded")
+    _review_phase._handle_reviewer_quota_or_overload(
+        err, issue_number=1, iteration=backoff_iteration
+    )
+
+    assert len(slept) == 1
+    assert 0 < slept[0] <= expected_max


### PR DESCRIPTION
Analysis of an automation-loop output.log run (2026-06-19) found 48 `api_error_status:429` "You've hit your session limit" errors cascading into 30 in-loop PR-review ERRORs — **39 doomed reviewer sessions fired in a single hour** against a quota that does not reset until 5pm.

## Root cause

The detect-quota-then-`wait_until` pattern exists in `_implement_phase` but was **absent from the in-loop PR-review path**. Both review catch sites (`_run_impl_review_step`, `_run_impl_review`) caught the 429 RuntimeError, recorded a synthetic `Verdict=ERROR`, and immediately re-reviewed — never blocking. The 529 server-overload backoff (`detect_server_overload`) was likewise only wired into `planner_claude.py`.

Same structural family as the verified-ci learning `automation-529-overload-not-retried-classifier-gap` (PR #1375).

## Fix

Add a shared `_handle_reviewer_quota_or_overload` helper that, before recording ERROR:
1. detects a reset epoch via `resolve_quota_reset_epoch(str(e))` and blocks with `wait_until`, or
2. applies a bounded exponential backoff (5s/10s/20s) for 529 overload via `detect_server_overload`.

Wired into both catch sites, reusing `hephaestus/github/rate_limit.py`. New `test_review_phase.py` (7 tests) covers 429-wait, 529-backoff, plain-failure no-op, and the 0-epoch sentinel.

## Verification

- `pixi run pytest tests/unit/automation/test_review_phase.py` → 7 passed
- `pixi run mypy` → Success; `ruff check` → clean

Closes #1528