### PR TITLE
[Fix] Make worktree removal idempotent and alias-safe

### DIFF
--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -22,6 +22,7 @@ that runs the automation. Recovery procedure for a force-killed loop:
     rm -rf <repo>/build/.worktrees/issue-N                    # last resort
 """
 
+import contextlib
 import logging
 import os
 import shutil
@@ -460,6 +461,23 @@ class WorktreeManager:
                 return
 
             worktree_path = self.worktrees[issue_number]
+
+            # Idempotent removal: when several issues share one branch they alias
+            # the same path (see create_worktree's branch-reuse), so cleanup_all
+            # may reach this with the directory already gone after the first key
+            # removed it. Treat an absent directory as already-removed rather than
+            # raising [Errno 2] — drop the key and prune stale git metadata (#1532).
+            if not worktree_path.exists():
+                logger.info(
+                    "Worktree directory for issue #%s already gone (%s); pruning metadata",
+                    issue_number,
+                    worktree_path,
+                )
+                del self.worktrees[issue_number]
+                with contextlib.suppress(Exception):
+                    run(["git", "worktree", "prune"], cwd=self.repo_root, check=False)
+                return
+
             self._cleanup_automation_prompt_artifacts(worktree_path)
 
             if not force and not is_clean_working_tree(worktree_path):
@@ -510,9 +528,28 @@ class WorktreeManager:
         with self.lock:
             issue_numbers = list(self.worktrees.keys())
 
+        # Several issues can alias the same path when they share a branch (see
+        # create_worktree's branch-reuse). Remove each distinct directory once;
+        # for aliased keys whose path was already removed, just drop the stale
+        # registration instead of re-running `git worktree remove` on a gone dir
+        # (which logged "[Errno 2]" failures before #1532).
+        removed_paths: set[Path] = set()
         for issue_num in issue_numbers:
+            with self.lock:
+                path = self.worktrees.get(issue_num)
+            if path is not None and path in removed_paths:
+                with self.lock:
+                    self.worktrees.pop(issue_num, None)
+                logger.debug(
+                    "Issue #%s aliases already-removed worktree %s; dropping registration",
+                    issue_num,
+                    path,
+                )
+                continue
             try:
                 self.remove_worktree(issue_num, force=force)
+                if path is not None:
+                    removed_paths.add(path)
             except WorktreeDirtyError as e:
                 logger.info("Preserved dirty worktree for issue #%s at %s", e.issue_number, e.path)
                 self.preserved.append((e.issue_number, e.path))

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -303,8 +303,10 @@ class TestWorktreeManager:
         mock_run.return_value.stdout = "origin/main"
         manager = WorktreeManager()
 
-        # Add worktree to tracked list
+        # Add worktree to tracked list (directory must exist on disk so removal
+        # runs `git worktree remove` rather than the idempotent already-gone path).
         worktree_path = manager.base_dir / "issue-123"
+        worktree_path.mkdir(parents=True)
         manager.worktrees[123] = worktree_path
 
         manager.remove_worktree(123)
@@ -326,6 +328,7 @@ class TestWorktreeManager:
         manager = WorktreeManager()
 
         worktree_path = manager.base_dir / "issue-123"
+        worktree_path.mkdir(parents=True)
         manager.worktrees[123] = worktree_path
 
         manager.remove_worktree(123, force=True)
@@ -362,6 +365,7 @@ class TestWorktreeManager:
         manager = WorktreeManager()
 
         worktree_path = manager.base_dir / "issue-123"
+        worktree_path.mkdir(parents=True)
         manager.worktrees[123] = worktree_path
 
         mock_run.side_effect = subprocess.CalledProcessError(1, "git")
@@ -380,6 +384,7 @@ class TestWorktreeManager:
         manager = WorktreeManager()
 
         worktree_path = manager.base_dir / "issue-42"
+        worktree_path.mkdir(parents=True)
         manager.worktrees[42] = worktree_path
 
         with pytest.raises(WorktreeDirtyError) as exc_info:
@@ -406,6 +411,7 @@ class TestWorktreeManager:
         manager = WorktreeManager()
 
         dirty_path = manager.base_dir / "issue-1"
+        dirty_path.mkdir(parents=True)
         manager.worktrees[1] = dirty_path
 
         manager.cleanup_all()
@@ -437,10 +443,11 @@ class TestWorktreeManager:
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
 
-        # Add multiple worktrees
-        manager.worktrees[123] = manager.base_dir / "issue-123"
-        manager.worktrees[456] = manager.base_dir / "issue-456"
-        manager.worktrees[789] = manager.base_dir / "issue-789"
+        # Add multiple worktrees (dirs must exist so each runs a real removal).
+        for num in (123, 456, 789):
+            path = manager.base_dir / f"issue-{num}"
+            path.mkdir(parents=True)
+            manager.worktrees[num] = path
 
         manager.cleanup_all()
 
@@ -459,8 +466,10 @@ class TestWorktreeManager:
         mock_get_root.return_value = tmp_path
         manager = WorktreeManager()
 
-        manager.worktrees[123] = manager.base_dir / "issue-123"
-        manager.worktrees[456] = manager.base_dir / "issue-456"
+        for num in (123, 456):
+            path = manager.base_dir / f"issue-{num}"
+            path.mkdir(parents=True)
+            manager.worktrees[num] = path
 
         # First removal fails, second succeeds
         mock_run.side_effect = [
@@ -470,6 +479,67 @@ class TestWorktreeManager:
 
         # Should not crash
         manager.cleanup_all()
+
+    @patch("hephaestus.automation.worktree_manager.is_clean_working_tree", return_value=True)
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_remove_worktree_missing_dir_is_idempotent(
+        self, mock_get_root: Any, mock_run: Any, mock_clean: Any, tmp_path: Any
+    ) -> None:
+        """Removing a worktree whose directory is already gone succeeds (#1532).
+
+        Regression for the `[Errno 2] No such file or directory` failures: a
+        missing directory must be treated as already-removed (drop the key,
+        prune metadata) rather than running `git worktree remove` on a gone dir.
+        """
+        mock_get_root.return_value = tmp_path
+        manager = WorktreeManager()
+
+        # Registered but never created on disk (the post-first-removal alias case).
+        gone_path = manager.base_dir / "issue-28"
+        manager.worktrees[28] = gone_path
+
+        manager.remove_worktree(28)
+
+        assert 28 not in manager.worktrees
+        # No `git worktree remove` fired; only the metadata prune.
+        assert all(
+            call.args[0][0:3] != ["git", "worktree", "remove"] for call in mock_run.call_args_list
+        )
+        assert any(call.args[0] == ["git", "worktree", "prune"] for call in mock_run.call_args_list)
+
+    @patch("hephaestus.automation.worktree_manager.is_clean_working_tree", return_value=True)
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_cleanup_all_dedups_aliased_paths(
+        self, mock_get_root: Any, mock_run: Any, mock_clean: Any, tmp_path: Any
+    ) -> None:
+        """Several issue keys aliasing one path remove it once, no errors (#1532).
+
+        Reproduces the branch-reuse aliasing (issues #12/#29/#65 sharing the
+        issue-28 worktree): the shared directory is removed exactly once and the
+        aliased registrations are dropped without re-running removal on a gone dir.
+        """
+        mock_get_root.return_value = tmp_path
+        manager = WorktreeManager()
+
+        shared = manager.base_dir / "issue-28"
+        shared.mkdir(parents=True)
+        # 28 owns the dir; 12/29/65 alias the same path (branch-reuse).
+        for num in (28, 12, 29, 65):
+            manager.worktrees[num] = shared
+
+        manager.cleanup_all()
+
+        assert manager.worktrees == {}
+        assert manager.preserved == []
+        # `git worktree remove` runs exactly once for the shared directory.
+        remove_calls = [
+            call
+            for call in mock_run.call_args_list
+            if call.args[0][0:3] == ["git", "worktree", "remove"]
+        ]
+        assert len(remove_calls) == 1
 
     @patch("hephaestus.automation.worktree_manager.run")
     @patch("hephaestus.automation.worktree_manager.get_repo_root")


### PR DESCRIPTION
output.log showed cleanup errors where several issue numbers all tried to remove the SAME stale path, raising `[Errno 2] No such file or directory`:

```
Failed to remove worktree for issue #12: [Errno 2] ...issue-28
Failed to remove worktree for issue #29: [Errno 2] ...issue-28
Failed to remove worktree for issue #65: [Errno 2] ...issue-28
```

## Root cause

When issues share one branch/PR, `create_worktree`'s branch-reuse path aliases multiple issue keys onto the same path (`self.worktrees[29] = self.worktrees[12] = .../issue-28`). `cleanup_all` called `remove_worktree` once per key — the first deleted the directory, the rest hit `[Errno 2]`. `remove_worktree` had no existence check and re-wrapped every error as fatal.

## Fix

- `remove_worktree`: missing directory => already-removed (drop key, prune metadata, return).
- `cleanup_all`: dedup by resolved path so a shared directory is removed exactly once; aliased keys dropped cleanly.

Existing remove/cleanup tests now create the dir on disk so they exercise real removal; new tests cover the idempotent missing-dir path and aliased-key cleanup.

## Verification

- `pixi run pytest tests/unit/automation/test_worktree_manager.py` => 39 passed
- `pixi run mypy` => Success; `ruff check`/`format` => clean

Closes #1532