### PR TITLE
[Fix] Robust follow-up JSON extraction + drop diagnostic

### DIFF
--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -92,26 +92,49 @@ class FollowUpResponse:
 def _extract_json_object(text: str) -> dict[str, Any] | None:
     """Extract the first JSON object from ``text``.
 
-    Looks for a fenced ```json ... ``` block first, then falls back to
-    ``json.JSONDecoder.raw_decode`` over the bare text starting at the
-    first ``{``. Returns ``None`` if nothing parseable is found.
-    """
-    fenced = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
-    if fenced is not None:
-        candidate = fenced.group(1)
-    else:
-        start = text.find("{")
-        if start == -1:
-            return None
-        candidate = text[start:]
+    Prefers a fenced ```json ... ``` block, then falls back to scanning the
+    bare text. Both paths use ``json.JSONDecoder.raw_decode`` from each ``{``
+    so a valid object is found even when:
 
-    try:
-        parsed, _ = json.JSONDecoder().raw_decode(candidate)
-    except json.JSONDecodeError:
-        return None
-    if not isinstance(parsed, dict):
-        return None
-    return parsed
+    * the object contains nested braces — a non-greedy ``{.*?}`` regex would
+      truncate at the first ``}`` and fail to parse (#1534); and
+    * the first ``{`` in the text is prose (an example or stray brace) rather
+      than the start of the JSON — earlier ``{`` candidates are skipped until
+      one decodes.
+
+    Returns ``None`` if nothing parseable is found.
+    """
+    # Greedy capture inside the fence (not the non-greedy `{.*?}`): the
+    # _decode_first_object scan below validates and trims to the real object,
+    # so capturing too much is harmless but capturing too little drops data.
+    fenced = re.search(r"```(?:json)?\s*(\{.*\})\s*```", text, re.DOTALL)
+    if fenced is not None:
+        parsed = _decode_first_object(fenced.group(1))
+        if parsed is not None:
+            return parsed
+
+    return _decode_first_object(text)
+
+
+def _decode_first_object(text: str) -> dict[str, Any] | None:
+    """Return the first JSON object decodable from any ``{`` position in ``text``.
+
+    Tries ``raw_decode`` at each ``{`` in order, so a leading prose brace does
+    not mask a valid object that appears later. Returns ``None`` if no ``{``
+    starts a decodable JSON object (or the decoded value is not an object).
+    """
+    decoder = json.JSONDecoder()
+    start = text.find("{")
+    while start != -1:
+        try:
+            parsed, _ = decoder.raw_decode(text[start:])
+        except json.JSONDecodeError:
+            start = text.find("{", start + 1)
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+        start = text.find("{", start + 1)
+    return None
 
 
 def _classify_follow_up_entry(
@@ -161,7 +184,15 @@ def parse_follow_up_response(text: str) -> FollowUpResponse:
     """
     obj = _extract_json_object(text)
     if obj is None:
-        logger.warning("No JSON object found in follow-up response")
+        # Surface a snippet so a dropped follow-up batch is diagnosable rather
+        # than vanishing silently (#1534). The text is the agent's `result`
+        # field, which may be empty (truncated/soft-capped session) or prose.
+        snippet = text.strip().replace("\n", " ")[:200]
+        logger.warning(
+            "No JSON object found in follow-up response (%d chars); first 200: %r",
+            len(text),
+            snippet,
+        )
         return FollowUpResponse()
 
     raw_follow_ups = obj.get("follow_ups", [])

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -105,6 +105,50 @@ class TestParseFollowUpResponse:
         assert len(response.follow_ups) == 1
         assert response.follow_ups[0].category == "security"
 
+    def test_parses_when_prose_brace_precedes_real_json(self) -> None:
+        """A stray ``{`` in prose before the JSON must not mask the real object.
+
+        Regression for #1534: decoding only from the first ``{`` failed when an
+        example brace appeared earlier in the text; the scan now skips it.
+        """
+        text = (
+            "Here is an example shape like {category, title, body} for reference.\n"
+            '{"follow_ups": [{"category": "core", "title": "Real",'
+            ' "body": "B"}], "rejected": []}'
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].title == "Real"
+
+    def test_parses_fenced_json_with_deeply_nested_object(self) -> None:
+        """Greedy fenced capture must span multiple levels of nested braces."""
+        text = (
+            "```json\n"
+            '{"follow_ups": [{"category": "core", "title": "T", "body": "B",'
+            ' "meta": {"a": {"b": {"c": 1}}}}], "rejected": []}\n'
+            "```"
+        )
+        response = parse_follow_up_response(text)
+        assert len(response.follow_ups) == 1
+        assert response.follow_ups[0].title == "T"
+
+    def test_empty_response_logs_diagnostic_snippet(self) -> None:
+        """An empty/truncated session result logs length + snippet, not a bare warning.
+
+        The 37 ``No JSON object found`` warnings in the loop log carried no
+        context; #1534 surfaces the response length and a snippet so a dropped
+        follow-up batch is diagnosable.
+        """
+        with patch("hephaestus.automation.follow_up.logger") as mock_logger:
+            response = parse_follow_up_response("")
+        assert response.follow_ups == []
+        assert response.rejected == []
+        mock_logger.warning.assert_called_once()
+        fmt = mock_logger.warning.call_args.args[0]
+        assert "No JSON object found" in fmt
+        # length arg and snippet arg are passed for diagnosis
+        assert mock_logger.warning.call_args.args[1] == 0
+
     def test_caps_at_three_items(self) -> None:
         items = [{"category": "core", "title": f"T{i}", "body": f"B{i}"} for i in range(10)]
         text = json.dumps({"follow_ups": items, "rejected": []})


### PR DESCRIPTION
The follow-up parser logged `No JSON object found in follow-up response` 37 times in one loop run and silently returned an empty result, dropping any follow-up items the agent intended to file — with no context on what arrived.

## Root cause

`_extract_json_object` decoded only from the first `{` in the text and used a non-greedy fenced regex. A leading prose brace masked a valid object later, and the no-JSON path gave a context-free warning.

## Fix

- Capture the fenced block greedily and validate via a new `_decode_first_object` scan that tries `raw_decode` at each `{` position (handles nested braces; skips a leading prose `{`).
- On no-JSON, log the response length + a 200-char snippet so a dropped batch (often an empty/truncated session) is diagnosable.

New tests: prose brace before real JSON, deeply nested fenced object, diagnostic snippet on empty response.

## Verification

- `pixi run pytest tests/unit/automation/test_follow_up.py` => 37 passed
- `pixi run mypy` => Success; `ruff check`/`format` => clean

Closes #1534