### PR TITLE
[Fix] Detect is_error 429 envelope centrally for reviewer paths

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -28,7 +28,7 @@ from hephaestus.agents.runtime import (
     resume_codex_session,
     run_codex_text,
 )
-from hephaestus.github.client import gh_call
+from hephaestus.github.client import ClaudeUsageCapError, gh_call
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from . import review_state
@@ -98,7 +98,9 @@ def _handle_reviewer_quota_or_overload(
 
     The reviewer subprocess surfaces the 429/529 text inside the ``RuntimeError``
     message (``Analysis session failed for PR …: <CLI output>``), so the
-    classifiers read ``str(error)``.
+    classifiers read ``str(error)``. A :class:`ClaudeUsageCapError` raised by the
+    central ``is_error`` envelope guard carries the reset epoch as an attribute
+    instead (its message has no reset phrasing), so that is honored first.
 
     Args:
         error: The exception raised by the reviewer invocation.
@@ -106,8 +108,12 @@ def _handle_reviewer_quota_or_overload(
         iteration: Current review iteration; also drives the overload backoff.
 
     """
+    # A typed cap carries the reset epoch directly — prefer it over text scanning.
+    cap_reset = (
+        getattr(error, "reset_epoch", None) if isinstance(error, ClaudeUsageCapError) else None
+    )
     text = str(error)
-    reset_epoch = resolve_quota_reset_epoch(text)
+    reset_epoch = cap_reset if cap_reset is not None else resolve_quota_reset_epoch(text)
     if reset_epoch is not None and reset_epoch > 0:
         logger.warning(
             "#%s R%s: in-loop PR review hit Claude usage cap; waiting for reset",

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -18,6 +18,7 @@ What lives here:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
@@ -27,6 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from hephaestus.automation.session_naming import session_jsonl_path, session_name
+from hephaestus.github.client import ClaudeUsageCapError
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch
 
 logger = logging.getLogger(__name__)
@@ -184,6 +186,47 @@ def invoke_claude_with_session(
         cwd=str(cwd),
     )
     return result.stdout, sid
+
+
+def raise_for_error_envelope(stdout: str) -> None:
+    """Raise if ``stdout`` is an ``is_error: true`` Claude JSON envelope.
+
+    The Claude CLI can exit 0 while returning a JSON envelope whose
+    ``is_error`` is true — e.g. a 429 quota cap or another fatal API error
+    surfaced inside the ``result`` field. Callers that pass
+    ``output_format="json"`` and would otherwise treat that envelope as a real
+    result (``pr_reviewer``, ``review_validator``) call this to fail loudly
+    instead of forwarding the cap message downstream (#1528 follow-up).
+
+    A quota cap becomes a :class:`ClaudeUsageCapError` carrying the reset epoch
+    (a ``RuntimeError`` subclass, so existing ``except RuntimeError`` handlers
+    still catch it); any other ``is_error`` envelope becomes a plain
+    ``RuntimeError``. Non-JSON or non-error stdout is left untouched.
+
+    Args:
+        stdout: The raw stdout returned by :func:`invoke_claude_with_session`.
+
+    Raises:
+        ClaudeUsageCapError: If the envelope signals a 429 quota cap.
+        RuntimeError: If the envelope is ``is_error`` for any other reason.
+
+    """
+    if not stdout:
+        return
+    try:
+        data = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return
+    if not (isinstance(data, dict) and data.get("is_error")):
+        return
+    err_text = str(data.get("result") or "")
+    reset_epoch = resolve_quota_reset_epoch(err_text)
+    if reset_epoch is not None:
+        raise ClaudeUsageCapError(
+            "Claude usage cap reached",
+            reset_epoch=reset_epoch if reset_epoch > 0 else None,
+        )
+    raise RuntimeError(f"Claude Code failed: {err_text or 'is_error=true'}")
 
 
 def scan_quota_reset(*texts: str) -> int | None:

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -43,7 +43,7 @@ from ._review_utils import (
     setup_review_logging,
 )
 from ._reviewer_base import BaseReviewer
-from .claude_invoke import invoke_claude_with_session
+from .claude_invoke import invoke_claude_with_session, raise_for_error_envelope
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
 from .curses_ui import CursesUI
@@ -177,6 +177,13 @@ def run_pr_review_analysis(
             input_via_stdin=True,
         )
         log_file.write_text(stdout or "")
+
+        # The CLI can exit 0 with an ``is_error: true`` envelope carrying a 429
+        # quota cap; without this guard the cap message would be parsed as
+        # review text and silently produce a bogus verdict (#1528 follow-up).
+        # Raises ClaudeUsageCapError (a RuntimeError) so the review-phase handler
+        # waits for reset before recording ERROR.
+        raise_for_error_envelope(stdout or "")
 
         # Extract the response text from Claude's JSON wrapper
         try:

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -38,7 +38,7 @@ from typing import Any
 from hephaestus.agents.runtime import is_codex, run_codex_text
 
 from ._review_utils import parse_json_block
-from .claude_invoke import invoke_claude_with_session
+from .claude_invoke import invoke_claude_with_session, raise_for_error_envelope
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
 from .git_utils import get_repo_root, get_repo_slug, pr_ref
@@ -198,6 +198,10 @@ def _run_validation_session(
                 input_via_stdin=True,
             )
             log_file.write_text(stdout or "")
+            # Fail loudly on an ``is_error: true`` envelope (e.g. a 429 cap)
+            # instead of validating against the cap message as if it were a
+            # real review (#1528 follow-up).
+            raise_for_error_envelope(stdout or "")
             try:
                 data = json.loads(stdout or "{}")
                 response_text: str = data.get("result", stdout or "")

--- a/tests/unit/automation/test_claude_invoke.py
+++ b/tests/unit/automation/test_claude_invoke.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from hephaestus.automation.claude_invoke import (
     INFRA_ERROR_REVIEW_TEXT,
     ReviewVerdict,
@@ -144,3 +146,53 @@ class TestInfraErrorVerdict:
         """A GO verdict is not an error."""
         v = parse_review_verdict("Grade: A\nVerdict: GO")
         assert v.is_error is False
+
+
+class TestRaiseForErrorEnvelope:
+    """Tests for the central is_error JSON envelope guard (#1528 follow-up)."""
+
+    def test_429_envelope_raises_usage_cap_with_reset(self) -> None:
+        """A 429 envelope raises ClaudeUsageCapError carrying the reset epoch."""
+        import json
+
+        from hephaestus.automation.claude_invoke import raise_for_error_envelope
+        from hephaestus.github.client import ClaudeUsageCapError
+
+        stdout = json.dumps(
+            {
+                "is_error": True,
+                "api_error_status": 429,
+                "result": "You've hit your session limit · resets 5pm (America/Los_Angeles)",
+            }
+        )
+        with pytest.raises(ClaudeUsageCapError) as exc:
+            raise_for_error_envelope(stdout)
+        assert exc.value.reset_epoch is not None and exc.value.reset_epoch > 0
+
+    def test_non_quota_error_envelope_raises_runtime_error(self) -> None:
+        """A non-quota is_error envelope raises a plain RuntimeError."""
+        import json
+
+        from hephaestus.automation.claude_invoke import raise_for_error_envelope
+        from hephaestus.github.client import ClaudeUsageCapError
+
+        stdout = json.dumps({"is_error": True, "result": "tool execution failed"})
+        with pytest.raises(RuntimeError) as exc:
+            raise_for_error_envelope(stdout)
+        assert not isinstance(exc.value, ClaudeUsageCapError)
+
+    def test_success_envelope_does_not_raise(self) -> None:
+        """A normal (is_error absent/false) result is left untouched."""
+        import json
+
+        from hephaestus.automation.claude_invoke import raise_for_error_envelope
+
+        raise_for_error_envelope(json.dumps({"result": "Grade: A\nVerdict: GO"}))
+        raise_for_error_envelope(json.dumps({"is_error": False, "result": "ok"}))
+
+    def test_non_json_stdout_does_not_raise(self) -> None:
+        """Plain-text or empty stdout is ignored (not every caller uses json)."""
+        from hephaestus.automation.claude_invoke import raise_for_error_envelope
+
+        raise_for_error_envelope("just some prose")
+        raise_for_error_envelope("")

--- a/tests/unit/automation/test_review_phase.py
+++ b/tests/unit/automation/test_review_phase.py
@@ -73,6 +73,26 @@ class TestHandleReviewerQuotaOrOverload:
         assert waited == []
         assert slept == []
 
+    def test_usage_cap_error_reset_epoch_attr_is_honored(self, monkeypatch):
+        """A ClaudeUsageCapError's reset_epoch attribute drives wait_until.
+
+        The central is_error guard raises ClaudeUsageCapError whose message has
+        no reset phrasing, so resolve_quota_reset_epoch(str(e)) would miss it —
+        the attribute must be used instead (#1528 follow-up).
+        """
+        from hephaestus.github.client import ClaudeUsageCapError
+
+        waited: list[int] = []
+        monkeypatch.setattr(_review_phase, "wait_until", lambda epoch: waited.append(epoch))
+        # str(error) carries no reset phrasing, so text scanning returns None.
+        monkeypatch.setattr(_review_phase, "resolve_quota_reset_epoch", lambda *t: None)
+
+        future = int(time.time()) + 3600
+        err = ClaudeUsageCapError("Claude usage cap reached", reset_epoch=future)
+        _review_phase._handle_reviewer_quota_or_overload(err, issue_number=5, iteration=0)
+
+        assert waited == [future]
+
     def test_zero_reset_epoch_does_not_wait(self, monkeypatch):
         """A 0 reset-epoch sentinel (reset unknown) must not call wait_until."""
         waited: list[int] = []


### PR DESCRIPTION
Stacked on #1531. The Claude CLI can exit 0 while returning an `is_error: true` JSON envelope carrying a 429 quota cap. `pr_reviewer.run_pr_review_analysis` and `review_validator` parsed that envelope as review text, silently producing a bogus verdict against the cap message instead of waiting.

## Fix

Add opt-in `raise_for_error_envelope(stdout)` to `claude_invoke`: raises `ClaudeUsageCapError` (with reset epoch) on a 429 envelope, or a plain `RuntimeError` otherwise. It does NOT change `invoke_claude_with_session`'s contract, so retry-aware callers (`planner_claude`, `_implement_phase`) keep their `CalledProcessError` flows.

Wired into `pr_reviewer` and `review_validator`; the review-phase handler now honors `ClaudeUsageCapError.reset_epoch`.

## Verification

- `pixi run pytest` (claude_invoke, review_phase, pr_reviewer, review_validator) => 62 passed
- `pixi run mypy` => Success; `ruff check`/`format` => clean

> Note: base is the #1531 branch (stacked). Rebase onto main after #1531 merges.

Closes #1536