### PR TITLE
fix(security): include NOTICE in license-scan path filter

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,7 @@ on:
       - "pixi.toml"
       - "pixi.lock"
       - "pyproject.toml"
+      - "NOTICE"
       - "**/*.py"
       - ".github/workflows/security.yml"
   schedule:


### PR DESCRIPTION
## Summary
Add NOTICE file to the security.yml pull_request trigger paths filter so that license-scan runs when NOTICE is updated, closing a compliance blind spot.

## Changes
- Added NOTICE to the paths filter in .github/workflows/security.yml so PRs updating NOTICE trigger license-scan

## Testing
- Verify security.yml paths filter now includes NOTICE alongside pixi.toml, pyproject.toml, and **/*.py

## Closes
Closes #1517

Generated by Claude Code via ProjectHephaestus automation.
