### PR TITLE
[Release] Bump MIGRATION.md to 0.9.7 (release prep)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-> **Status (as of 2026-06-16):** The latest released version is **0.9.6** (tag-driven
+> **Status (as of 2026-06-20):** The latest released version is **0.9.7** (tag-driven
 > via hatch-vcs). **1.0 has not been released yet** — the section below is the
 > *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
 > prepare. There are currently **no breaking changes between 0.9.x releases**: upgrading


### PR DESCRIPTION
Bumps the `latest released version` line in `docs/MIGRATION.md` from 0.9.6 to 0.9.7 and refreshes the status date to 2026-06-20.

This clears the `test_version_currency` drift guard so the tag-driven Release workflow can publish v0.9.7 to PyPI and create the GitHub release. Follows the established release order (cf. #1379, #1233): land the doc bump on main, then cut the signed tag on the merge commit.

Closes #1541