### PR TITLE
[Fix] Harden advise selector-JSON parse + quiet benign fallback warnings

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shutil
 import subprocess
 import threading
@@ -227,22 +228,54 @@ def resolve_marketplace(mnemosyne_root: Path) -> tuple[Path | None, str]:
     return marketplace_path, ""
 
 
+def _repair_json_text(text: str) -> str:
+    """Best-effort repair of near-JSON the selector model commonly emits.
+
+    Handles two non-fatal shapes seen in real automation-loop runs (#1556):
+
+    - Python-style single-quoted objects (``{'skills': []}``), which json
+      rejects at char 1 with "Expecting property name enclosed in double
+      quotes".
+    - Trailing commas before ``]`` or ``}`` (``[{"a": 1},]``).
+
+    Quotes are only flipped when the text contains no double quotes, so a
+    valid JSON string that legitimately contains an apostrophe is never
+    corrupted. The result is *attempted* JSON, not guaranteed valid — the
+    caller still parses and validates it.
+    """
+    repaired = text
+    if "'" in repaired and '"' not in repaired:
+        repaired = repaired.replace("'", '"')
+    # Drop trailing commas: `, ]` / `, }` (optionally with whitespace between).
+    repaired = re.sub(r",(\s*[\]}])", r"\1", repaired)
+    return repaired
+
+
 def _extract_json_object(text: str) -> dict[str, object]:
-    """Parse the selector's JSON object, allowing fenced or prefixed output."""
+    """Parse the selector's JSON object, allowing fenced or prefixed output.
+
+    Recovers from the common malformed shapes the selector model emits:
+    markdown code fences, prose prefixes, Python-style single quotes, and
+    trailing commas (#1556). Strict JSON is always tried first.
+    """
     stripped = text.strip()
     if not stripped:
         raise ValueError("empty selector output")
     try:
-        data = json.loads(stripped)
+        data: object = json.loads(stripped)
     except json.JSONDecodeError:
         start = stripped.find("{")
         end = stripped.rfind("}")
         if start < 0 or end < start:
             raise ValueError("selector output did not contain a JSON object") from None
+        candidate = stripped[start : end + 1]
         try:
-            data = json.loads(stripped[start : end + 1])
-        except json.JSONDecodeError as exc:
-            raise ValueError(f"invalid selector JSON: {exc}") from exc
+            data = json.loads(candidate)
+        except json.JSONDecodeError:
+            try:
+                data = json.loads(_repair_json_text(candidate))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid selector JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError("selector JSON must be an object")
     return data

--- a/hephaestus/automation/prompts/_shared.py
+++ b/hephaestus/automation/prompts/_shared.py
@@ -33,14 +33,19 @@ def _relativize_path(path: str, repo_root: str | None) -> str:
     if not path:
         return path
     if repo_root is None:
-        _prompts_logger.warning(
+        # Benign: an absolute path is a correct, working fallback. Logged at
+        # DEBUG so it only surfaces under -v/--verbose rather than as routine
+        # WARNING noise on every default run (#1556).
+        _prompts_logger.debug(
             "repo_root not provided; injecting absolute path into prompt: %s", path
         )
         return path
     try:
         return str(Path(path).relative_to(repo_root))
     except ValueError:
-        _prompts_logger.warning(
+        # Benign: cross-repo paths (e.g. the ProjectMnemosyne marketplace) are
+        # expected and the absolute path works. DEBUG, not WARNING (#1556).
+        _prompts_logger.debug(
             "Path %r is not under repo_root %r; injecting absolute path into prompt.",
             path,
             repo_root,

--- a/hephaestus/config/paths.py
+++ b/hephaestus/config/paths.py
@@ -66,7 +66,11 @@ def resolve_projects_dir(override: str | None = None) -> Path:
         return DEFAULT_PROJECTS_DIR
 
     if key not in _warned_keys:
-        logger.warning(
+        # Benign: an unset PROJECTS_ROOT with no override is the normal case;
+        # the default is a correct fallback. DEBUG (visible under -v) rather
+        # than routine WARNING noise (#1556). A *nonexistent* PROJECTS_ROOT
+        # (above) stays at WARNING — that is operator misconfiguration.
+        logger.debug(
             "PROJECTS_ROOT not set and no --projects-dir given; falling back to default: %s",
             DEFAULT_PROJECTS_DIR,
         )

--- a/tests/unit/automation/prompts/test_shared.py
+++ b/tests/unit/automation/prompts/test_shared.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``hephaestus.automation.prompts._shared._relativize_path``.
+
+Covers the repo-relative happy path and the two benign absolute-path
+fallbacks, which are logged at DEBUG (visible only under -v/--verbose) rather
+than WARNING so they do not add routine noise to default runs (#1556).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hephaestus.automation.prompts import _shared
+
+_LOGGER_NAME = _shared._prompts_logger.name
+
+
+def test_path_under_repo_root_is_relativized(tmp_path) -> None:
+    """A path inside repo_root is returned relative, with no log output."""
+    repo_root = tmp_path
+    target = tmp_path / "worktrees" / "123-fix"
+    result = _shared._relativize_path(str(target), str(repo_root))
+    assert result == "worktrees/123-fix"
+
+
+def test_path_outside_repo_root_logs_debug_not_warning(
+    tmp_path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A cross-repo path keeps the absolute path and logs at DEBUG only (#1556)."""
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    outside = tmp_path / "other" / "marketplace.json"
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        result_info = _shared._relativize_path(str(outside), str(repo_root))
+    assert result_info == str(outside)
+    # Nothing at INFO or above — the benign fallback is quiet on default runs.
+    assert caplog.records == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        result_debug = _shared._relativize_path(str(outside), str(repo_root))
+    assert result_debug == str(outside)
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert "is not under repo_root" in caplog.records[0].getMessage()
+
+
+def test_no_repo_root_logs_debug_not_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """repo_root=None returns the path unchanged and logs at DEBUG only (#1556)."""
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        result_info = _shared._relativize_path("/abs/path", None)
+    assert result_info == "/abs/path"
+    assert caplog.records == []
+
+    caplog.clear()
+    with caplog.at_level(logging.DEBUG, logger=_LOGGER_NAME):
+        result_debug = _shared._relativize_path("/abs/path", None)
+    assert result_debug == "/abs/path"
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.DEBUG
+    assert "repo_root not provided" in caplog.records[0].getMessage()
+
+
+def test_empty_path_returned_unchanged() -> None:
+    """An empty path short-circuits with no logging."""
+    assert _shared._relativize_path("", "/repo") == ""

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -11,6 +11,8 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from hephaestus.automation import advise_runner
 
 
@@ -289,3 +291,60 @@ class TestRunAdvise:
 
         assert "[truncated]" in result
         assert len(result) <= 260
+
+
+# ---------------------------------------------------------------------------
+# _extract_json_object — robustness against common malformed selector output
+# ---------------------------------------------------------------------------
+
+
+class TestExtractJsonObject:
+    """The selector model sometimes returns JSON that is not strictly valid.
+
+    These cover the shapes seen in real automation-loop runs (issue #1556):
+    markdown fences, Python-style single quotes, and trailing commas. The
+    extractor must recover rather than raising ``invalid selector JSON``.
+    """
+
+    def test_plain_object(self) -> None:
+        assert advise_runner._extract_json_object('{"skills": []}') == {"skills": []}
+
+    def test_json_fenced_block(self) -> None:
+        text = '```json\n{"skills": [{"name": "a"}]}\n```'
+        assert advise_runner._extract_json_object(text) == {"skills": [{"name": "a"}]}
+
+    def test_bare_fenced_block(self) -> None:
+        text = '```\n{"skills": []}\n```'
+        assert advise_runner._extract_json_object(text) == {"skills": []}
+
+    def test_prose_prefix_before_object(self) -> None:
+        text = 'Here is the selection:\n{"skills": []}'
+        assert advise_runner._extract_json_object(text) == {"skills": []}
+
+    def test_single_quoted_object(self) -> None:
+        # Python-style dict literal: the failure shape from issue #1556's log
+        # ("Expecting property name enclosed in double quotes ... char 1").
+        text = "{'skills': [{'name': 'a', 'reason': 'b'}]}"
+        assert advise_runner._extract_json_object(text) == {
+            "skills": [{"name": "a", "reason": "b"}]
+        }
+
+    def test_trailing_comma_object(self) -> None:
+        text = '{"skills": [{"name": "a"},],}'
+        assert advise_runner._extract_json_object(text) == {"skills": [{"name": "a"}]}
+
+    def test_single_quoted_inside_fence(self) -> None:
+        text = "```json\n{'skills': []}\n```"
+        assert advise_runner._extract_json_object(text) == {"skills": []}
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError, match="empty selector output"):
+            advise_runner._extract_json_object("   ")
+
+    def test_no_object_raises(self) -> None:
+        with pytest.raises(ValueError, match="did not contain a JSON object"):
+            advise_runner._extract_json_object("no braces here")
+
+    def test_non_object_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="must be an object"):
+            advise_runner._extract_json_object("[1, 2, 3]")

--- a/tests/unit/config/test_paths.py
+++ b/tests/unit/config/test_paths.py
@@ -67,25 +67,37 @@ def test_env_var_dir_missing_warns_and_falls_back(
     assert str(nonexistent) in caplog.records[0].getMessage()
 
 
-def test_no_override_no_env_warns_and_uses_default(
+def test_no_override_no_env_no_warning_at_info(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Unset PROJECTS_ROOT + no override emits the 'not set' warning + default."""
+    """Unset PROJECTS_ROOT is benign: nothing at INFO/WARNING, only DEBUG (#1556)."""
     monkeypatch.delenv("PROJECTS_ROOT", raising=False)
-    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+    with caplog.at_level(logging.INFO, logger="hephaestus.config.paths"):
+        result = resolve_projects_dir()
+    assert result == DEFAULT_PROJECTS_DIR
+    # Benign fallback must not surface at INFO or above on a default run.
+    assert caplog.records == []
+
+
+def test_no_override_no_env_emits_debug_under_verbose(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The 'not set' fallback message is still available at DEBUG (verbose mode)."""
+    monkeypatch.delenv("PROJECTS_ROOT", raising=False)
+    with caplog.at_level(logging.DEBUG, logger="hephaestus.config.paths"):
         result = resolve_projects_dir()
     assert result == DEFAULT_PROJECTS_DIR
     assert len(caplog.records) == 1
-    assert caplog.records[0].levelno == logging.WARNING
+    assert caplog.records[0].levelno == logging.DEBUG
     assert "PROJECTS_ROOT not set" in caplog.records[0].getMessage()
 
 
-def test_warning_deduplicated_within_process(
+def test_debug_deduplicated_within_process(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Calling resolve twice with the same (override, env) key warns only once."""
+    """Calling resolve twice with the same (override, env) key logs only once."""
     monkeypatch.delenv("PROJECTS_ROOT", raising=False)
-    with caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"):
+    with caplog.at_level(logging.DEBUG, logger="hephaestus.config.paths"):
         first = resolve_projects_dir()
         second = resolve_projects_dir()
     assert first == DEFAULT_PROJECTS_DIR


### PR DESCRIPTION
Detected from `output.log` analysis of a 2026-06-20 automation-loop run.

## Changes

**1. Harden advise selector-JSON parsing (non-fatal robustness)**
`advise_runner._extract_json_object` now recovers from the malformed selector output the model commonly emits — Python-style single-quoted objects (`{'skills': []}`) and trailing commas — via a best-effort `_repair_json_text` pass after strict JSON fails (fences/prose were already handled). Fixes the log error:
```
Advise step failed for issue #1383: invalid selector JSON: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```
The failure was already caught (advise degraded to `advise_skipped`), so this recovers context that was being dropped unnecessarily.

**2. Quiet benign fallback warnings (per request: only show in verbose)**
Downgraded WARNING -> DEBUG so they appear only under `-v/--verbose`:
- `config/paths.py` — `PROJECTS_ROOT not set ... falling back to default`
- `prompts/_shared.py` — `Path ... is not under repo_root ...; injecting absolute path` (fired once per issue)

The *nonexistent* `PROJECTS_ROOT` case is intentionally kept at WARNING — a wrong explicit path is real misconfiguration, not a benign fallback.

## Verification
- TDD: failing tests added first (reproduced the exact `char 1` error), then the fix.
- `pytest tests/unit/automation/test_advise_runner.py tests/unit/config/ tests/unit/automation/prompts/` -> 258 passed
- `mypy` whole tree -> Success, no issues (409 files); `ruff check`/`format` clean
- Liveness confirmed: the editable install reproduces the log shape and now recovers

Closes #1556