### PR TITLE
[Feat] Issue-major automation loop (plan→implement→merge per issue, skip on exhaustion)

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2336,6 +2336,16 @@ Examples:
             "require the agent for all behind/conflicting PRs."
         ),
     )
+    parser.add_argument(
+        "--max-fix-iterations",
+        type=int,
+        default=1,
+        help=(
+            "Number of CI-fix attempts per failing PR before giving up "
+            "(default: 1). The issue-major loop passes its --max-merge-attempts "
+            "here so a PR that will not go green is abandoned after N tries."
+        ),
+    )
     add_github_throttle_args(parser)
     add_json_arg(parser)
     return parser
@@ -2473,6 +2483,7 @@ def main() -> int:
             include_bot_prs=args.include_bot_prs,
             include_all_authors=args.include_all_authors,
             enable_mechanical_rebase=args.enable_mechanical_rebase,
+            max_fix_iterations=args.max_fix_iterations,
         )
 
         driver = CIDriver(options)

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -248,7 +248,12 @@ class ImplementationPhaseRunner:
             )
 
         self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Creating worktree")
-        worktree_path = self.worktree_manager.create_worktree(issue_number, branch_name)
+        # refresh_base=True: issue-major loop (#1560) — cut this issue's branch
+        # from the freshly-merged trunk so it never conflicts with a sibling
+        # issue's just-merged PR.
+        worktree_path = self.worktree_manager.create_worktree(
+            issue_number, branch_name, refresh_base=True
+        )
         with self.state_lock:
             state.worktree_path = str(worktree_path)
             state.branch_name = branch_name

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1,23 +1,30 @@
-"""Multi-repo, multi-stage automation loop driver.
+"""Multi-repo, ISSUE-MAJOR automation loop driver.
 
 Replaces ``scripts/run_automation_loop.sh``. Iterates over all
-non-archived HomericIntelligence repos. Per loop iteration, runs the
-2-phase iteration body (``plan`` → ``implement``) ``--loops`` times per
-repo. After the loop body finishes (whether by exhaustion or early-exit),
-runs the post-loop terminal stages (``drive-green``) **once per repo**.
+non-archived HomericIntelligence repos. Within each repo, work is
+ISSUE-MAJOR (#1560): each open issue is carried through the FULL selected
+phase sequence (``plan`` → ``implement`` → ``drive-green``) end to end by a
+single worker before that worker takes the next issue. Up to
+``--max-workers`` issues are in flight at once.
 
-Plan-review, PR-review, and address-review are no longer standalone phases —
-the planner owns its review loop and the implementer absorbs PR-review +
-thread-addressing in-loop (#455/#468/#484). ``drive-green`` was promoted
-from "third loop phase, final-loop only" to "post-loop terminal stage" in
-#818 — it is a per-repo terminal action, not an iteration step.
+``drive-green`` is the BLOCKING phase: scoped to one issue's PR it waits for
+the PR to MERGE (driving CI green, bounded by ``--max-merge-attempts``); if
+the PR does not merge within that budget the issue is tagged ``state:skip``
+and the worker frees its slot for a human/another agent. Because each issue's
+worktree is cut from the freshly-merged trunk, the stale-plan and
+sibling-branch merge-conflict classes the old phase-major batching suffered
+are eliminated.
 
-The key correctness invariant — and the reason this replaces the bash
-version — is that each phase is a plain ``subprocess.run`` call inside a
-Python ``for`` loop. Phase N failing returns a ``PhaseResult(rc=N)`` and
-control unconditionally proceeds to phase N+1. No shell-option landmine
-(``set -e`` / ``set -m`` / subshell exec-optimization) can silently skip
-the rest of the pipeline.
+Phase selection still works per issue: ``--phases plan`` runs only plan per
+issue; ``--phases implement`` only implement; etc. Plan-review, PR-review, and
+address-review are not standalone phases — the planner owns its review loop and
+the implementer absorbs PR-review + thread-addressing in-loop (#455/#468/#484).
+
+The key correctness invariant is that each phase is a plain ``subprocess.run``
+call inside a Python ``for`` loop. Phase N failing returns a
+``PhaseResult(rc=N)`` and control unconditionally proceeds to phase N+1. No
+shell-option landmine (``set -e`` / ``set -m`` / subshell exec-optimization)
+can silently skip the rest of the pipeline.
 
 CLI is flag-compatible with the previous bash script so operator muscle
 memory and any pinned callers keep working.
@@ -38,12 +45,13 @@ import sys
 import threading
 import time
 import traceback
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from hephaestus.agents.runtime import add_agent_argument, resolve_agent
 from hephaestus.automation._review_utils import add_max_workers_arg
+from hephaestus.automation.github_api import gh_issue_add_labels
 from hephaestus.automation.loop_repo_manager import (
     _clone_missing_repos as _clone_missing_repos,
     _count_failing_prs as _count_failing_prs,
@@ -58,6 +66,7 @@ from hephaestus.automation.loop_repo_manager import (
     _resolve_repo_dir as _resolve_repo_dir,
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
+from hephaestus.automation.state_labels import STATE_SKIP
 from hephaestus.cli.utils import (
     add_dry_run_arg,
     add_github_throttle_args,
@@ -98,26 +107,22 @@ def _default_phase_timeout_s() -> float:
         return float(default)
 
 
-# Canonical loop-body ordering. The pipeline collapsed from 6 phases to 2
-# session-stable iteration phases (#455/#468/#484/#818): plan-review,
-# PR-review, and address-review fold into plan/implement, and drive-green
-# was promoted from "final-loop-only phase" to a post-loop terminal stage
-# (see ALL_POST_LOOP_STAGES below).
+# The two non-blocking iteration phases. Plan-review, PR-review, and
+# address-review fold into plan/implement (#455/#468/#484).
 ALL_PHASES: tuple[str, ...] = (
     "plan",
     "implement",
 )
 
-# Post-loop terminal stages. Run once per repo AFTER all loop iterations
-# finish (exhaustion or early-exit). Per #818, drive-green belongs here
-# because it polls existing PRs — it is a terminal action, not an iteration
-# step. Operators select it with ``--phases drive-green`` (same flag, no
-# new arg); the runner partitions selected names into loop phases vs.
-# post-loop stages internally.
+# drive-green is the per-issue BLOCKING phase (#1560): scoped to one issue's
+# PR it waits for the merge (bounded by --max-merge-attempts) before the worker
+# moves on. It runs LAST in each issue's sequence. Kept as a distinct tuple
+# (rather than folded into ALL_PHASES) so ``_run_post_loop_stages`` and the
+# explicit ``--phases drive-green`` operator re-run path keep working.
 ALL_POST_LOOP_STAGES: tuple[str, ...] = ("drive-green",)
 
-# Union used by --phases validation. Operators may select any combination
-# of loop phases and post-loop stages on the same flag.
+# Per-issue phase sequence, in order: plan → implement → drive-green. Operators
+# select any subset via --phases; unselected phases are skipped per issue.
 ALL_SELECTABLE: tuple[str, ...] = ALL_PHASES + ALL_POST_LOOP_STAGES
 
 # DEFAULT_PROJECTS_DIR is re-exported from hephaestus.config.paths so existing
@@ -322,14 +327,19 @@ class LoopConfig:
     loops: int = 5
     max_workers: int = 3
     parallel_repos: int = 1
-    # Dataclass default is loop-body-only by design: it covers ONLY the
-    # iteration phases (``ALL_PHASES``), deliberately excluding post-loop
-    # terminal stages like drive-green. This differs from the CLI ``--phases``
-    # default (``ALL_SELECTABLE`` = loop phases + post-loop stages, set in
-    # ``_parse_args``): an operator on the CLI opts into drive-green by default,
-    # but a bare ``LoopConfig()`` (tests/programmatic callers) gets a quiet
-    # loop-only run that never touches existing PRs via ``_run_post_loop_stages``.
+    # Dataclass default covers ONLY the iteration phases (``ALL_PHASES`` =
+    # plan, implement), deliberately excluding drive-green. This differs from
+    # the CLI ``--phases`` default (``ALL_SELECTABLE`` = plan, implement,
+    # drive-green, set in ``_parse_args``): an operator on the CLI opts into
+    # the blocking per-issue drive-green by default, but a bare ``LoopConfig()``
+    # (tests/programmatic callers) gets a quiet plan+implement run that never
+    # drives existing PRs to merge.
     phases: tuple[str, ...] = ALL_PHASES
+    # Bound on per-issue drive-green merge attempts before the issue is tagged
+    # ``state:skip`` and the worker frees its slot for the next issue (#1560).
+    # Defaults to the CIDriver ``max_fix_iterations`` default (1) so behavior
+    # matches the pre-issue-major drive-green retry budget unless overridden.
+    max_merge_attempts: int = 1
     agent: str = "claude"
     issues: list[int] = field(default_factory=list)
     dry_run: bool = False
@@ -422,6 +432,16 @@ def _build_parser() -> argparse.ArgumentParser:
     add_max_workers_arg(
         p,
         help_text="Parallel workers per repo per phase (1-32, default: 3). Passes to child phases.",
+    )
+    p.add_argument(
+        "--max-merge-attempts",
+        type=int,
+        default=1,
+        help=(
+            "Per-issue drive-green merge attempts before the issue is tagged "
+            "state:skip and the worker moves on (default: 1, matching the prior "
+            "drive-green retry budget)."
+        ),
     )
     p.add_argument(
         "--parallel-repos",
@@ -752,6 +772,12 @@ def _build_phase_argv(
     if phase == "drive-green" and cfg.drive_green_all:
         argv.append("--all")
 
+    # Per-issue drive-green is the blocking merge step (#1560): forward the
+    # operator's merge-attempt budget so a PR that will not go green is
+    # abandoned after N tries (the caller then applies state:skip).
+    if phase == "drive-green":
+        argv.extend(["--max-fix-iterations", str(cfg.max_merge_attempts)])
+
     return argv
 
 
@@ -905,22 +931,72 @@ def _process_repo_inner(
     LOG.info("[%s] trunk=%s%s", repo, trunk_sha, stale_suffix)
 
     # Open-issue discovery happens once per repo per loop. When the operator
-    # scopes the loop explicitly, reuse that bounded list for child phases.
+    # scopes the loop explicitly, reuse that bounded list.
     open_issues = cfg.issues or _list_open_issue_numbers(cfg.org, repo)
 
-    for phase in ALL_PHASES:
+    # ISSUE-MAJOR control flow (#1560): iterate issues outermost and run the
+    # FULL selected-phase sequence (plan → implement → drive-green) for each
+    # issue before it is considered done. Up to ``max_workers`` issues are in
+    # flight at once. drive-green per issue blocks on the PR MERGING (see
+    # _process_one_issue), so each subsequent issue's branch is cut from the
+    # freshly-merged trunk — eliminating the stale-plan and sibling-branch
+    # merge-conflict classes the old phase-major batching suffered.
+    if not open_issues:
+        LOG.info("[%s] no open issues to process", repo)
+        return result
+
+    workers = max(1, cfg.max_workers)
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(
+                _process_one_issue,
+                repo=repo,
+                repo_dir=repo_dir,
+                issue=issue,
+                cfg=cfg,
+                loop_idx=loop_idx,
+                trunk_sha=trunk_sha,
+            ): issue
+            for issue in open_issues
+        }
+        for future in as_completed(futures):
+            issue = futures[future]
+            try:
+                result.phases.extend(future.result())
+            except Exception as exc:  # worker boundary: never let one issue crash the repo
+                LOG.error("[%s] issue #%s pipeline crashed: %s", repo, issue, exc)
+                result.phases.append(PhaseResult(name="implement", rc=1, elapsed_s=0.0))
+
+    return result
+
+
+def _process_one_issue(
+    *,
+    repo: str,
+    repo_dir: Path,
+    issue: int,
+    cfg: LoopConfig,
+    loop_idx: int,
+    trunk_sha: str,
+) -> list[PhaseResult]:
+    """Run the full selected-phase sequence for ONE issue, in order.
+
+    Each selected phase (plan, implement, drive-green) runs scoped to this
+    single issue. The ``--phases`` selection is honored per issue: a disabled
+    phase is recorded skipped and the sequence continues. When ``drive-green``
+    is selected it is the BLOCKING phase — ``run_phase`` waits for the issue's
+    PR to merge (or skip on exhaustion) before returning, so the worker only
+    frees its slot once the issue is fully settled.
+    """
+    phases: list[PhaseResult] = []
+    for phase in ALL_SELECTABLE:
         if _shutdown_requested():
-            LOG.warning("[%s] phase %s SKIP (shutdown requested)", repo, phase)
-            result.phases.append(
-                PhaseResult(name=phase, skipped=True, skip_reason="shutdown requested")
-            )
+            LOG.warning("[%s] issue #%s phase %s SKIP (shutdown requested)", repo, issue, phase)
+            phases.append(PhaseResult(name=phase, skipped=True, skip_reason="shutdown requested"))
             continue
 
         if phase not in cfg.phases:
-            LOG.info("[%s] phase %s SKIP (disabled by --phases)", repo, phase)
-            result.phases.append(
-                PhaseResult(name=phase, skipped=True, skip_reason="disabled by --phases")
-            )
+            phases.append(PhaseResult(name=phase, skipped=True, skip_reason="disabled by --phases"))
             continue
 
         phase_result = run_phase(
@@ -929,19 +1005,35 @@ def _process_repo_inner(
             phase=phase,
             cfg=cfg,
             loop_idx=loop_idx,
-            open_issues=open_issues,
+            open_issues=[issue],
             trunk_sha=trunk_sha,
         )
-        result.phases.append(phase_result)
+        phases.append(phase_result)
         if phase_result.failed:
             LOG.warning(
-                "[%s] phase %s FAILED rc=%d — continuing to next phase",
+                "[%s] issue #%s phase %s FAILED rc=%d — continuing to next phase",
                 repo,
+                issue,
                 phase,
                 phase_result.rc,
             )
+            # drive-green is the blocking merge phase: if it fails (the PR did
+            # not merge within --max-merge-attempts), tag the issue state:skip
+            # so it is not re-attempted and a human/another agent can take it
+            # over (#1560). Mirrors the review-loop exhaustion behavior. A
+            # dry-run must not mutate GitHub state.
+            if phase == "drive-green" and not cfg.dry_run:
+                LOG.warning(
+                    "[%s] issue #%s did not merge after %d attempt(s) — tagging %s",
+                    repo,
+                    issue,
+                    cfg.max_merge_attempts,
+                    STATE_SKIP,
+                )
+                with contextlib.suppress(Exception):
+                    gh_issue_add_labels(issue, [STATE_SKIP])
 
-    return result
+    return phases
 
 
 # ---------------------------------------------------------------------------
@@ -1201,10 +1293,12 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
 
         _maybe_sleep_for_rate_budget(loop_idx, cfg.loops)
 
-    # Post-loop terminal stages run once per repo regardless of how the
-    # iteration body exited (exhaustion or early-exit). Per #818.
-    post_loop_results = _run_post_loop_stages(cfg, repos)
-    all_results.extend(post_loop_results)
+    # drive-green is now a per-issue BLOCKING phase inside the issue-major
+    # loop body (#1560) — each issue is driven to merge before its worker
+    # frees the slot. It is no longer a separate once-per-repo post-loop
+    # stage, so nothing runs here. ``_run_post_loop_stages`` is retained for
+    # explicit operator re-runs but the default loop does not invoke it.
+    post_loop_results: list[RepoResult] = []
 
     # Report actual loops run (may be less than cfg.loops due to early
     # exit). Post-loop RepoResults are tagged ``is_post_loop=True`` by
@@ -1317,6 +1411,7 @@ def main(argv: list[str] | None = None) -> int:
     cfg = LoopConfig(
         loops=args.loops,
         max_workers=args.max_workers,
+        max_merge_attempts=args.max_merge_attempts,
         parallel_repos=args.parallel_repos,
         phases=phases,
         agent=agent,

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -106,6 +106,26 @@ class WorktreeManager:
         self._base_branch_resolved = self._detect_base_branch()
         return self._base_branch_resolved
 
+    def refresh_base_branch(self) -> str:
+        """Re-fetch ``origin`` and re-resolve the auto-detected base branch.
+
+        Issue-major loop (#1560): each issue's worktree should branch off the
+        FRESHLY-merged trunk, not a snapshot pinned once per loop. Calling this
+        before creating a worktree fetches the latest ``origin`` and clears the
+        cached ``_base_branch_resolved`` so the next ``base_branch`` access
+        re-detects ``origin/HEAD``.
+
+        A no-op when the base is explicitly pinned (``base_branch=`` or
+        ``HEPH_TRUNK_GITHASH``): the operator chose that snapshot deliberately,
+        so we must not silently move it. Returns the effective base branch.
+        """
+        if self._base_branch_override is not None:
+            return self.base_branch
+        with contextlib.suppress(Exception):
+            run(["git", "fetch", "origin"], cwd=self.repo_root, capture_output=True)
+        self._base_branch_resolved = None  # force re-detect on next access
+        return self.base_branch
+
     def _detect_base_branch(self) -> str:
         try:
             result = run(
@@ -140,12 +160,20 @@ class WorktreeManager:
         self,
         issue_number: int,
         branch_name: str | None = None,
+        *,
+        refresh_base: bool = False,
     ) -> Path:
         """Create a new worktree for an issue.
 
         Args:
             issue_number: Issue number
             branch_name: Branch name (default: {issue_number}-auto)
+            refresh_base: When True, re-fetch origin and re-resolve the
+                auto-detected base branch first, so the new branch is cut from
+                the freshly-merged trunk. Used by the issue-major loop (#1560)
+                so each issue branches off the latest trunk; no-op when the base
+                is explicitly pinned. Default False preserves prior behavior for
+                all other callers (review, address-review, ci-driver).
 
         Returns:
             Path to worktree directory
@@ -158,6 +186,9 @@ class WorktreeManager:
             if issue_number in self.worktrees:
                 logger.warning("Worktree for issue #%s already exists", issue_number)
                 return self.worktrees[issue_number]
+
+            if refresh_base:
+                self.refresh_base_branch()
 
             if branch_name is None:
                 branch_name = f"{issue_number}-auto"

--- a/tests/unit/automation/test_ci_driver_cli.py
+++ b/tests/unit/automation/test_ci_driver_cli.py
@@ -44,6 +44,14 @@ def test_parse_args_accepts_github_throttle_options(monkeypatch: pytest.MonkeyPa
     assert args.gh_global_burst == 11.0
 
 
+def test_parse_args_accepts_max_fix_iterations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--max-fix-iterations is parsed; default is 1 (#1560)."""
+    monkeypatch.setattr(sys, "argv", ["drive_prs_green.py", "--max-fix-iterations", "5"])
+    assert ci_driver._parse_args().max_fix_iterations == 5
+    monkeypatch.setattr(sys, "argv", ["drive_prs_green.py"])
+    assert ci_driver._parse_args().max_fix_iterations == 1
+
+
 def test_parse_args_issues_flag_without_values_exits_2(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -20,6 +20,7 @@ import pytest
 from hephaestus.automation import loop_runner
 from hephaestus.automation.loop_runner import (
     ALL_PHASES,
+    ALL_SELECTABLE,
     LoopConfig,
     PhaseResult,
     RepoResult,
@@ -37,6 +38,7 @@ from hephaestus.automation.loop_runner import (
     run_loop,
     run_phase,
 )
+from hephaestus.automation.state_labels import STATE_SKIP
 from hephaestus.constants import scripts_dir as _scripts_dir
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
@@ -173,6 +175,97 @@ def test_build_phase_argv_forwards_github_throttle_options() -> None:
     assert argv is not None
     assert argv[argv.index("--gh-global-rate") + 1] == "4.5"
     assert argv[argv.index("--gh-global-burst") + 1] == "11"
+
+
+def test_parse_args_accepts_max_merge_attempts() -> None:
+    """--max-merge-attempts is parsed; default is 1 (#1560)."""
+    assert loop_runner._parse_args(["--max-merge-attempts", "3"]).max_merge_attempts == 3
+    assert loop_runner._parse_args([]).max_merge_attempts == 1
+
+
+def test_build_phase_argv_drive_green_forwards_max_merge_attempts() -> None:
+    """drive-green argv carries --max-fix-iterations = cfg.max_merge_attempts (#1560)."""
+    cfg = LoopConfig(max_merge_attempts=4, phases=ALL_SELECTABLE)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/dg", [])):
+        argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[1])
+    assert argv is not None
+    assert argv[argv.index("--max-fix-iterations") + 1] == "4"
+
+
+def test_build_phase_argv_non_drive_green_omits_max_fix_iterations() -> None:
+    """plan/implement argv must not carry the drive-green merge-attempt flag."""
+    cfg = LoopConfig(max_merge_attempts=4)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/p", [])):
+        plan_argv = loop_runner._build_phase_argv("plan", cfg, open_issues=[1])
+    assert plan_argv is not None
+    assert "--max-fix-iterations" not in plan_argv
+
+
+def test_process_one_issue_tags_skip_when_drive_green_fails() -> None:
+    """A failed (non-merged) drive-green tags the issue state:skip (#1560)."""
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE, max_merge_attempts=2)
+
+    def fake_run_phase(**kw: object) -> PhaseResult:
+        name = str(kw["phase"])
+        rc = 1 if name == "drive-green" else 0  # PR never merges
+        return PhaseResult(name=name, rc=rc, elapsed_s=0.1)
+
+    with (
+        patch.object(loop_runner, "run_phase", side_effect=fake_run_phase),
+        patch.object(loop_runner, "gh_issue_add_labels") as add_labels,
+    ):
+        loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=42,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
+
+    add_labels.assert_called_once_with(42, [STATE_SKIP])
+
+
+def test_process_one_issue_no_skip_when_drive_green_merges() -> None:
+    """A successful drive-green (merged) must NOT tag state:skip."""
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE)
+    with (
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+        patch.object(loop_runner, "gh_issue_add_labels") as add_labels,
+    ):
+        loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=42,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
+    add_labels.assert_not_called()
+
+
+def test_process_one_issue_dry_run_does_not_tag_skip() -> None:
+    """dry-run must not mutate GitHub state even when drive-green fails."""
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE, dry_run=True)
+    with (
+        patch.object(
+            loop_runner,
+            "run_phase",
+            side_effect=lambda **kw: PhaseResult(
+                name=str(kw["phase"]), rc=1 if kw["phase"] == "drive-green" else 0
+            ),
+        ),
+        patch.object(loop_runner, "gh_issue_add_labels") as add_labels,
+    ):
+        loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=42,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
+    add_labels.assert_not_called()
 
 
 def test_parse_args_accepts_issue_scope() -> None:
@@ -342,24 +435,50 @@ def repo_inputs(tmp_path: Path) -> tuple[Path, LoopConfig]:
     return projects, cfg
 
 
-def test_process_repo_runs_all_phases_when_all_succeed(
+def test_process_repo_runs_selected_phases_per_issue(
     repo_inputs: tuple[Path, LoopConfig],
 ) -> None:
-    """Process repo runs all phases when all succeed."""
-    _, cfg = repo_inputs
+    """Issue-major (#1560): each issue runs the SELECTED phases; others skip.
+
+    With the default ``--phases`` (plan, implement), drive-green is recorded
+    skipped per issue. Phases that ran are the selected ones, once per issue.
+    """
+    _, cfg = repo_inputs  # default phases = ALL_PHASES = (plan, implement)
     with (
         patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1, 2]),
         patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
     ):
         result = process_repo("r", loop_idx=1, cfg=cfg)
-    assert [p.name for p in result.phases] == list(ALL_PHASES)
+
+    ran = [p.name for p in result.phases if not p.skipped]
+    # Each selected phase runs once per issue (2 issues × {plan, implement}).
+    assert sorted(ran) == ["implement", "implement", "plan", "plan"]
+    # drive-green is not selected by default → recorded skipped, never run.
+    assert all(p.skipped for p in result.phases if p.name == "drive-green")
     assert not result.any_failure
 
 
-def test_process_repo_continues_after_phase_failure(repo_inputs: tuple[Path, LoopConfig]) -> None:
-    """The core regression test: phase 1 failing must NOT stop phases 2-6."""
-    _, cfg = repo_inputs
+def test_process_repo_drive_green_runs_per_issue_when_selected(
+    repo_inputs: tuple[Path, LoopConfig],
+) -> None:
+    """When drive-green is selected it runs per issue (the blocking phase)."""
+    projects, _ = repo_inputs
+    cfg = LoopConfig(loops=1, projects_dir=projects, phases=ALL_SELECTABLE)
+    with (
+        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
+        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[7]),
+        patch.object(loop_runner, "run_phase", side_effect=lambda **kw: _ok(kw["phase"])),
+    ):
+        result = process_repo("r", loop_idx=1, cfg=cfg)
+
+    ran = [p.name for p in result.phases if not p.skipped]
+    # One issue, full selectable sequence in order.
+    assert ran == list(ALL_SELECTABLE)
+
+
+def test_process_one_issue_continues_after_phase_failure() -> None:
+    """Phase isolation per issue: a failed plan must NOT skip later phases."""
     call_order: list[str] = []
 
     def fake_run_phase(**kw: object) -> PhaseResult:
@@ -368,18 +487,44 @@ def test_process_repo_continues_after_phase_failure(repo_inputs: tuple[Path, Loo
         rc = 1 if name == "plan" else 0
         return PhaseResult(name=name, rc=rc, elapsed_s=0.1)
 
-    with (
-        patch.object(loop_runner, "_rebase_main", return_value=("abc1234", True)),
-        patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1]),
-        patch.object(loop_runner, "_count_failing_prs", return_value=1),
-        patch.object(loop_runner, "run_phase", side_effect=fake_run_phase),
-    ):
-        result = process_repo("r", loop_idx=1, cfg=cfg)
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE)
+    with patch.object(loop_runner, "run_phase", side_effect=fake_run_phase):
+        phases = loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=1,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
 
-    assert call_order == list(ALL_PHASES), "phase 1 failure must not skip subsequent phases"
-    assert result.phases[0].failed
-    assert not result.phases[1].failed
-    assert result.any_failure
+    assert call_order == list(ALL_SELECTABLE), "a failed phase must not skip subsequent phases"
+    assert phases[0].failed  # plan
+    assert not phases[1].failed  # implement
+    assert any(p.failed for p in phases)
+
+
+def test_process_one_issue_skips_disabled_phases() -> None:
+    """--phases selection is honored per issue: unselected phases are skipped."""
+    ran: list[str] = []
+
+    def fake_run_phase(**kw: object) -> PhaseResult:
+        ran.append(str(kw["phase"]))
+        return PhaseResult(name=str(kw["phase"]), rc=0, elapsed_s=0.1)
+
+    cfg = LoopConfig(loops=1, phases=("implement",))  # only implement selected
+    with patch.object(loop_runner, "run_phase", side_effect=fake_run_phase):
+        phases = loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=1,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
+
+    assert ran == ["implement"], "only the selected phase runs"
+    assert {p.name for p in phases if p.skipped} == {"plan", "drive-green"}
 
 
 def test_process_repo_swallows_worker_exceptions(repo_inputs: tuple[Path, LoopConfig]) -> None:

--- a/tests/unit/automation/test_loop_runner_post_loop.py
+++ b/tests/unit/automation/test_loop_runner_post_loop.py
@@ -1,4 +1,11 @@
-"""Tests for post-loop terminal stages (drive-green) (#818)."""
+"""Tests for drive-green as a per-issue blocking loop-body phase (#1560).
+
+Supersedes the post-loop-terminal-stage model (#818): drive-green now runs
+INSIDE the issue-major loop body, once per issue per loop (the blocking phase
+that waits for each issue's PR to merge), rather than once per repo after all
+loops. ``_run_post_loop_stages`` is no longer auto-invoked by ``run_loop`` —
+``post_loop_phases`` is therefore always empty in the default path.
+"""
 
 from __future__ import annotations
 
@@ -77,13 +84,18 @@ def test_final_loop_only_symbols_removed() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Acceptance criterion 1: drive-green alone, loops>1
+# drive-green is now a per-issue loop-body phase (#1560)
 # ---------------------------------------------------------------------------
 
 
-def test_drive_green_alone_runs_once_per_repo_loops_5(tmp_path: Path) -> None:
-    """`--phases drive-green --loops 5` → drive-green once per repo, no loop phases."""
-    cfg = _cfg(tmp_path, loops=5, phases=("drive-green",))
+def test_drive_green_alone_runs_per_issue_in_loop_body(tmp_path: Path) -> None:
+    """`--phases drive-green` → drive-green runs per issue in the loop body, no plan/implement.
+
+    With early-exit disabled (drive-green is not a convergence phase, and one
+    issue is discovered each loop), it runs once per issue per loop. The result
+    is recorded under ``phases`` (loop body), never ``post_loop_phases``.
+    """
+    cfg = _cfg(tmp_path, loops=1, phases=("drive-green",))
     repos = ["r1", "r2"]
     _ensure_repo_dirs(cfg, repos)
     calls: list = []
@@ -92,11 +104,13 @@ def test_drive_green_alone_runs_once_per_repo_loops_5(tmp_path: Path) -> None:
         results = loop_runner.run_loop(cfg, repos)
     dg_calls = [c for c in calls if c[2] == "drive-green"]
     loop_phase_calls = [c for c in calls if c[2] in ALL_PHASES]
+    # One issue per repo, one loop → drive-green once per repo's issue.
     assert sorted(c[1] for c in dg_calls) == ["r1", "r2"], dg_calls
     assert loop_phase_calls == [], loop_phase_calls
-    # Recorded under post_loop_phases, not phases
-    post = [(r.repo, p.name) for r in results for p in r.post_loop_phases]
-    assert sorted(post) == [("r1", "drive-green"), ("r2", "drive-green")]
+    # Recorded in the loop body (phases), NOT post_loop_phases (#1560).
+    assert all(not r.post_loop_phases for r in results), results
+    body = [(r.repo, p.name) for r in results for p in r.phases if not p.skipped]
+    assert sorted(body) == [("r1", "drive-green"), ("r2", "drive-green")]
 
 
 # ---------------------------------------------------------------------------
@@ -104,8 +118,12 @@ def test_drive_green_alone_runs_once_per_repo_loops_5(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_drive_green_with_loop_phases_runs_once_per_repo(tmp_path: Path) -> None:
-    """Default `--loops 5` (plan+implement+drive-green) → drive-green once per repo."""
+def test_drive_green_with_loop_phases_runs_per_issue_each_loop(tmp_path: Path) -> None:
+    """`--phases plan,implement,drive-green --loops 3` → all three run per issue, each loop.
+
+    Issue-major (#1560): each loop runs plan→implement→drive-green for the
+    discovered issue, so all three appear once per loop (3 loops → 3 each).
+    """
     cfg = _cfg(tmp_path, loops=3, phases=ALL_SELECTABLE)
     repos = ["r1"]
     _ensure_repo_dirs(cfg, repos)
@@ -130,7 +148,8 @@ def test_drive_green_with_loop_phases_runs_once_per_repo(tmp_path: Path) -> None
     dg = [c for c in calls if c[2] == "drive-green"]
     plan = [c for c in calls if c[2] == "plan"]
     impl = [c for c in calls if c[2] == "implement"]
-    assert len(dg) == 1, dg
+    # One issue, 3 loops, full sequence each loop → 3 of each phase.
+    assert len(dg) == 3, dg
     assert len(plan) == 3, plan
     assert len(impl) == 3, impl
 
@@ -167,25 +186,32 @@ def test_phases_plan_only_does_not_invoke_drive_green(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Acceptance criterion 4: early-exit on loop 1 still runs post-loop drive-green
+# Early-exit interaction: drive-green runs in the loop body of loop 1 (#1560)
 # ---------------------------------------------------------------------------
 
 
-def test_early_exit_loop_1_still_runs_post_loop_drive_green(tmp_path: Path) -> None:
-    """Early-exit (zero-work) on loop 1 still triggers post-loop drive-green per repo."""
+def test_early_exit_loop_1_runs_drive_green_in_loop_body(tmp_path: Path) -> None:
+    """Early-exit (zero-work) after loop 1 still drives each issue green in-body.
+
+    Under issue-major, drive-green runs per issue inside loop 1 (no separate
+    post-loop pass). Early-exit then fires after loop 1, so plan and drive-green
+    each run exactly once per repo.
+    """
     cfg = _cfg(tmp_path, loops=5, phases=ALL_SELECTABLE)
     repos = ["r1", "r2"]
     _ensure_repo_dirs(cfg, repos)
     calls: list = []
     cms = _patch_run_loop_externals(calls)  # all phases report work_units=0
     with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
-        loop_runner.run_loop(cfg, repos)
+        results = loop_runner.run_loop(cfg, repos)
     plan_calls = [c for c in calls if c[2] == "plan"]
     dg_calls = [c for c in calls if c[2] == "drive-green"]
     # Early-exit fires after loop 1 → plan invoked exactly once per repo
     assert sorted(c[1] for c in plan_calls) == ["r1", "r2"], plan_calls
-    # Post-loop drive-green still runs once per repo
+    # drive-green ran in the loop body of loop 1, once per repo's issue
     assert sorted(c[1] for c in dg_calls) == ["r1", "r2"], dg_calls
+    # No post-loop stage records anymore.
+    assert all(not r.post_loop_phases for r in results), results
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -893,3 +893,52 @@ class TestCreateWorktreeBranchCollision:
         ):
             assert manager._worktree_holding_branch("708-auto-impl") == p
             assert manager._worktree_holding_branch("999-auto-impl") is None
+
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_refresh_base_branch_refetches_and_redetects(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
+        """refresh_base_branch fetches origin and clears the cached base (#1560)."""
+        mock_get_root.return_value = tmp_path
+        mock_run.return_value.stdout = "origin/main"
+        manager = WorktreeManager()
+        # Prime the cache via first access.
+        assert manager.base_branch == "origin/main"
+        mock_run.reset_mock()
+
+        result = manager.refresh_base_branch()
+
+        argvs = [c[0][0] for c in mock_run.call_args_list]
+        assert ["git", "fetch", "origin"] in argvs, argvs
+        assert result == "origin/main"
+
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_refresh_base_branch_noop_when_pinned(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
+        """A pinned base (explicit/HEPH_TRUNK_GITHASH) is never moved by refresh."""
+        mock_get_root.return_value = tmp_path
+        manager = WorktreeManager(base_branch="deadbeef")
+        mock_run.reset_mock()
+
+        result = manager.refresh_base_branch()
+
+        argvs = [c[0][0] for c in mock_run.call_args_list]
+        assert all(a[:2] != ["git", "fetch"] for a in argvs), argvs
+        assert result == "deadbeef"
+
+    @patch("hephaestus.automation.worktree_manager.run")
+    @patch("hephaestus.automation.worktree_manager.get_repo_root")
+    def test_create_worktree_refresh_base_fetches(
+        self, mock_get_root: Any, mock_run: Any, tmp_path: Any
+    ) -> None:
+        """create_worktree(refresh_base=True) fetches origin before adding (#1560)."""
+        mock_get_root.return_value = tmp_path
+        mock_run.return_value.stdout = "origin/main"
+        manager = WorktreeManager()
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            manager.create_worktree(123, "123-feature", refresh_base=True)
+        argvs = [c[0][0] for c in mock_run.call_args_list]
+        assert ["git", "fetch", "origin"] in argvs, argvs


### PR DESCRIPTION
Converts the automation loop from **phase-major** (plan-all → implement-all → drive-green-once) to **issue-major**: each worker carries one issue through the full selected-phase sequence (plan → implement → drive-green) before taking the next, with up to `--max-workers` issues in flight.

## Why
Phase-major batching caused **stale plans** (a plan written early in a pass describes a tree that moved before implementation) and **merge conflicts** (all in-flight branches cut from the same base; nothing rebases onto a sibling just-merged commit). Issue-major fixes both: each issue branches off the freshly-merged trunk and is driven to merge before the next starts.

## Behavior
- **drive-green is the per-issue BLOCKING phase** — scoped to one issue it waits for the PR to MERGE.
- **Bounded retries → skip:** if the PR does not merge within `--max-merge-attempts` (default 1, = prior drive-green retry budget), the issue is tagged `state:skip` and the worker frees its slot for a human/another agent.
- **Phase selection preserved:** `--phases plan` runs only plan per issue, etc. The phase topology (`ALL_PHASES`, `run_phase`) is kept as the per-issue building blocks.
- Each issue worktree is re-cut from latest `origin/HEAD` (`worktree_manager.refresh_base_branch`).

## Changes
- `loop_runner`: issue-major `_process_repo_inner` (ThreadPoolExecutor over issues) + new `_process_one_issue` (per-issue phase sequence + skip-on-exhaustion); `--max-merge-attempts` flag + `LoopConfig` field; drive-green argv forwards it; `_run_post_loop_stages` no longer auto-invoked.
- `ci_driver`: `--max-fix-iterations` flag wired into `CIDriverOptions`.
- `worktree_manager`: `refresh_base_branch()` + `create_worktree(refresh_base=True)` (opt-in; default preserves all other callers).
- `implementer_phase_runner`: implement worktree opts into `refresh_base`.

## Verification
- Full automation suite: **1845 passed**.
- `mypy` whole tree: Success, 409 files. `ruff` check + format clean. Pre-commit clean.
- Updated the phase-major order tests to the issue-major contract; added tests for per-issue ordering, phase isolation, `--phases` filtering, `state:skip` on drive-green exhaustion (+ no-skip on merge/dry-run), `--max-merge-attempts` parsing + argv forwarding, and `refresh_base_branch`.

Closes #1560