### PR TITLE
fix(automation): count loop plan work by work_units + warn on all-filtered explicit issues

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -278,10 +278,18 @@ class RepoResult:
 def _summarize_loop(loop_results: list[RepoResult], loop_idx: int, elapsed_s: float) -> str:
     """Generate a one-line summary of loop execution for logs.
 
-    Counts: planned (non-skipped plan stages), implemented (non-skipped
-    implement stages), skipped (all skipped stages). Plan-review and PR-review
-    are now in-loop steps of plan/implement, so they no longer have their own
-    count.
+    Counts: planned (issues actually planned, from the plan phase's
+    ``work_units``; falls back to 1 per un-instrumented plan phase whose
+    ``work_units`` is unknown), implemented (non-skipped implement stages —
+    the implement phase reports no ``work_units``), skipped (all skipped
+    stages). Plan-review and PR-review are now in-loop steps of plan/implement,
+    so they no longer have their own count.
+
+    Counting plan by ``work_units`` keeps this human-facing summary consistent
+    with the machine convergence signal (``produced_work``): a plan phase that
+    ran but planned 0 issues now reads ``planned=0`` instead of inflating to
+    ``planned=1`` (the 2026-06-21 output.log regression — closed-issue runs
+    logged ``planned=N`` directly above ``produced 0 new plans``).
 
     Args:
         loop_results: Results from all repos in this loop iteration.
@@ -301,7 +309,10 @@ def _summarize_loop(loop_results: list[RepoResult], loop_idx: int, elapsed_s: fl
             if phase.skipped:
                 total_skipped += 1
             elif phase.name == "plan":
-                total_planned += 1
+                # Count issues actually planned. ``work_units is None`` means the
+                # phase didn't report (un-instrumented) → count it as 1
+                # conservatively, matching ``produced_work``'s unknown→work rule.
+                total_planned += phase.work_units if phase.work_units is not None else 1
             elif phase.name == "implement":
                 total_implemented += 1
 

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -146,6 +146,11 @@ class PlannerOptions(BaseModel):
     """Options for the Planner."""
 
     issues: list[int]
+    # True when ``issues`` came from an explicit ``--issues`` flag rather than
+    # auto-discovery. Drives the "all issues filtered out" warning so a
+    # mis-scoped explicit run is visible, while a converged auto-discovery pass
+    # (legitimately empty) stays quiet.
+    issues_explicit: bool = False
     agent: str = "claude"
     dry_run: bool = False
     force: bool = False

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -674,6 +674,9 @@ def main() -> int:
     log.info("Starting issue planner")
     agent = resolve_agent(args.agent)
 
+    # Capture explicitness before auto-discovery overwrites ``args.issues``.
+    issues_explicit = bool(args.issues)
+
     if not args.issues:
         try:
             discovered = gh_list_open_issues()
@@ -702,6 +705,7 @@ def main() -> int:
     try:
         options = PlannerOptions(
             issues=args.issues,
+            issues_explicit=issues_explicit,
             agent=agent,
             dry_run=args.dry_run,
             force=args.force,

--- a/hephaestus/automation/planner_state.py
+++ b/hephaestus/automation/planner_state.py
@@ -122,6 +122,19 @@ class PlannerStateManager:
 
             issues_to_plan.append(issue_num)
 
+        # Make a mis-scoped explicit run obvious. An explicit ``--issues`` set
+        # that fully filters out (all closed and/or already-planned) otherwise
+        # no-ops with only INFO-level per-issue "... skipping" lines. Stay quiet
+        # for auto-discovery (issues_explicit=False): a converged repo
+        # legitimately yields an empty set every pass and must not spam.
+        if self.options.issues_explicit and self.options.issues and not issues_to_plan:
+            logger.warning(
+                "All %d explicitly-requested issue(s) were filtered out "
+                "(closed or already planned); nothing to plan. Requested: %s",
+                len(self.options.issues),
+                self.options.issues,
+            )
+
         return issues_to_plan
 
     def get_cached_labels(self, issue_number: int) -> list[str] | None:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -1215,11 +1215,45 @@ class TestSummarizeLoop:
         assert "loop 2" in summary
 
     def test_counts_plan_phase(self) -> None:
-        """Non-skipped plan phase counted in planned."""
+        """Plan phase with unknown work_units falls back to counting as 1.
+
+        ``work_units is None`` means the phase did not report (un-instrumented),
+        so it is counted conservatively as 1 — matching ``produced_work``'s
+        "unknown counts as work" convention.
+        """
         repo_result = RepoResult(repo="TestRepo", loop_idx=1)
         repo_result.phases = [PhaseResult("plan", rc=0)]
         summary = _summarize_loop([repo_result], 1, 3.0)
         assert "planned=1" in summary
+
+    def test_plan_counts_work_units(self) -> None:
+        """Plan count reflects the issues actually planned (work_units)."""
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        repo_result.phases = [PhaseResult("plan", rc=0, work_units=3)]
+        summary = _summarize_loop([repo_result], 1, 3.0)
+        assert "planned=3" in summary
+
+    def test_plan_zero_work_units_counts_zero(self) -> None:
+        """A plan phase that ran but planned 0 issues must not inflate the count.
+
+        Regression for the 2026-06-21 output.log: a run scoped to closed issues
+        logged ``planned=4`` directly above ``produced 0 new plans``. With
+        ``work_units == 0`` the count must read ``planned=0`` so the human
+        summary agrees with the convergence signal.
+        """
+        repo_result = RepoResult(repo="TestRepo", loop_idx=1)
+        repo_result.phases = [PhaseResult("plan", rc=0, work_units=0)]
+        summary = _summarize_loop([repo_result], 1, 3.0)
+        assert "planned=0" in summary
+
+    def test_multiple_repos_sum_plan_work_units(self) -> None:
+        """Plan work_units are summed across repos."""
+        repo1 = RepoResult(repo="Repo1", loop_idx=1)
+        repo1.phases = [PhaseResult("plan", rc=0, work_units=2)]
+        repo2 = RepoResult(repo="Repo2", loop_idx=1)
+        repo2.phases = [PhaseResult("plan", rc=0, work_units=0)]
+        summary = _summarize_loop([repo1, repo2], 1, 10.0)
+        assert "planned=2" in summary
 
     def test_counts_implement_phases(self) -> None:
         """Non-skipped implement phases counted in implemented."""
@@ -1234,6 +1268,7 @@ class TestSummarizeLoop:
         """Mix of skipped, planned, and implemented phases."""
         repo_result = RepoResult(repo="TestRepo", loop_idx=1)
         repo_result.phases = [
+            # No work_units → counted as 1 via the unknown-fallback path.
             PhaseResult("plan", rc=0),
             PhaseResult("implement", rc=1),  # failed but still counted as implemented
             PhaseResult("drive-green", skipped=True, skip_reason="no issues"),

--- a/tests/unit/automation/test_planner_state.py
+++ b/tests/unit/automation/test_planner_state.py
@@ -227,6 +227,76 @@ class TestFilterDropsPlanGoIssues:
         assert mgr.get_cached_labels(1) is None
 
 
+class TestFilterAllFilteredWarning:
+    """``filter()`` warns when an explicit ``--issues`` set fully filters out.
+
+    A run scoped to closed / already-planned issues otherwise no-ops with only
+    INFO-level per-issue ``... skipping`` lines, making a mis-scoped run easy to
+    miss (the 2026-06-21 ``--issues 123,456,789,101`` all-closed run). The
+    warning only fires for explicit sets — auto-discovery legitimately yields an
+    empty work set on a converged repo and must stay quiet.
+    """
+
+    def test_warns_when_explicit_set_fully_filtered(self, caplog: Any) -> None:
+        from hephaestus.automation.state_labels import STATE_PLAN_GO
+
+        opts = _make_options(issues=[10, 11])
+        opts.skip_closed = False
+        opts.issues_explicit = True
+        mgr = PlannerStateManager(opts)
+
+        with (
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={10: [STATE_PLAN_GO], 11: [STATE_PLAN_GO]},
+            ),
+            caplog.at_level("WARNING", logger="hephaestus.automation.planner_state"),
+        ):
+            kept = mgr.filter()
+
+        assert kept == []
+        assert any("filtered out" in r.message and r.levelname == "WARNING" for r in caplog.records)
+
+    def test_no_warning_when_explicit_set_keeps_issues(self, caplog: Any) -> None:
+        opts = _make_options(issues=[10, 11])
+        opts.skip_closed = False
+        opts.issues_explicit = True
+        mgr = PlannerStateManager(opts)
+
+        with (
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={10: [], 11: []},
+            ),
+            caplog.at_level("WARNING", logger="hephaestus.automation.planner_state"),
+        ):
+            kept = mgr.filter()
+
+        assert kept == [10, 11]
+        assert not any("filtered out" in r.message for r in caplog.records)
+
+    def test_no_warning_when_discovered_set_fully_filtered(self, caplog: Any) -> None:
+        """Auto-discovery (issues_explicit=False) empties quietly — no warning."""
+        from hephaestus.automation.state_labels import STATE_PLAN_GO
+
+        opts = _make_options(issues=[10, 11])
+        opts.skip_closed = False
+        opts.issues_explicit = False
+        mgr = PlannerStateManager(opts)
+
+        with (
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={10: [STATE_PLAN_GO], 11: [STATE_PLAN_GO]},
+            ),
+            caplog.at_level("WARNING", logger="hephaestus.automation.planner_state"),
+        ):
+            kept = mgr.filter()
+
+        assert kept == []
+        assert not any("filtered out" in r.message for r in caplog.records)
+
+
 # ---------------------------------------------------------------------------
 # has_existing_plan — fallback (no cache)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Analyzed two `hephaestus-automation-loop` `output.log` files to find what went wrong:

- **Old log (2026-06-10):** malformed GraphQL batch-label query (single-quoted `owner`), retry-masked. **Already fixed by #1148** — its regression test is present and passing. No change needed.
- **New log (2026-06-21):** run scoped to `--issues 123,456,789,101` (all closed). Everything filtered correctly, but the summary read `loop 1: planned=4 implemented=4` directly above `produced 0 new plans` — a contradiction, plus the mis-scope was only visible via INFO-level lines.

## Changes

1. **`_summarize_loop`** now counts `planned` by the plan phase's `work_units` (already reported via the work-report file), falling back to 1 only for an un-instrumented phase whose `work_units` is unknown — matching `produced_work`'s unknown→work convention. Implement counting is left as-is (it reports no `work_units`). The human summary now agrees with the convergence signal.
2. **`PlannerStateManager.filter`** emits a WARNING when an explicit `--issues` set fully filters out (all closed / already-planned), so a mis-scoped run is obvious. Auto-discovery stays quiet (a converged repo legitimately empties every pass). Gated by a new `PlannerOptions.issues_explicit` flag set in `planner.main`.

## Tests

- `TestSummarizeLoop`: added `test_plan_counts_work_units`, `test_plan_zero_work_units_counts_zero` (the regression), `test_multiple_repos_sum_plan_work_units`; updated existing tests' intent.
- `TestFilterAllFilteredWarning`: warns on explicit fully-filtered set; no warning when issues kept; no warning for auto-discovery.

## Verification

- `pixi run pytest tests/unit/automation` → **1851 passed**
- `pixi run ruff check` / `ruff format --check` / `pixi run mypy` → clean (mypy: 409 source files, no issues)
- End-to-end dry-run on the closed-issue set now logs `loop 1: planned=0 ...` and the all-filtered WARNING.

Closes #1563

🤖 Generated with [Claude Code](https://claude.com/claude-code)