### PR TITLE
docs(skills): add argument-hint to python-repo-modernization

### DIFF
--- a/skills/python-repo-modernization/SKILL.md
+++ b/skills/python-repo-modernization/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: python-repo-modernization
 description: Bring a partially modernized Python repo to production-grade quality by fixing bugs, restructuring tests, enhancing CI/pre-commit, and preparing for PyPI publishing
+argument-hint: <path to Python repo to modernize>
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 ---
 


### PR DESCRIPTION
## Summary
Add missing argument-hint frontmatter field to python-repo-modernization skill definition.

## Changes
- Added argument-hint field to skills/python-repo-modernization/SKILL.md frontmatter

## Testing
- Verify skill frontmatter is valid with argument-hint present
- Confirm skill loads correctly in Claude Code

## Closes
Closes #1553

Generated by Claude Code via ProjectHephaestus automation.
