### PR TITLE
fix(automation): serialize drive-green orphan sweep across processes (cross-process file lock)

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -35,6 +35,7 @@ from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     emit_json_status,
 )
+from hephaestus.utils.file_lock import file_lock
 
 from ._review_utils import add_max_workers_arg, find_pr_for_issue
 from .address_review import (
@@ -1561,6 +1562,23 @@ class CIDriver:
         whose PR is CLOSED-not-merged, fire ``/learn`` once for records
         whose PR is MERGED (then mark explicit succeeded/failed learn status),
         leave OPEN records alone for the normal per-issue path to handle.
+        """
+        # Serialize the sweep across the issue-major loop's per-issue ci-driver
+        # SUBPROCESSES (#1567). They share one ``state_dir`` and each runs this
+        # sweep on startup; without a cross-process lock, two subprocesses both
+        # find the same MERGED orphan and both fire ``/learn`` +
+        # ``create_worktree`` on the same path → ``fatal: ... already exists``
+        # (the in-process WorktreeManager lock can't see another process). Hold
+        # the lock across the whole sweep so a second sweeper, on acquiring,
+        # re-globs + re-loads records and finds them already terminal/cleared.
+        with file_lock(self.state_dir / "orphan-sweep.lock"):
+            self._sweep_orphaned_arming_records_locked()
+
+    def _sweep_orphaned_arming_records_locked(self) -> None:
+        """Body of :meth:`_sweep_orphaned_arming_records`, run under the lock.
+
+        Globs and processes records inside the cross-process lock so concurrent
+        ci-driver subprocesses never double-process the same arming record.
         """
         try:
             records = sorted(self.state_dir.glob("drive-green-armed-*.json"))

--- a/hephaestus/utils/file_lock.py
+++ b/hephaestus/utils/file_lock.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Cross-process advisory file lock for ProjectHephaestus.
+
+Provides :func:`file_lock`, a context manager that serializes a critical
+section across separate processes using ``fcntl.flock`` on a sentinel file.
+An in-process ``threading.Lock`` only coordinates threads of one interpreter;
+this helper is for the case where independent ``subprocess.run`` children (e.g.
+the issue-major automation loop's per-issue phase subprocesses) must not race on
+a shared on-disk resource such as a git worktree path or a state-record sweep.
+
+The lock is advisory (cooperating processes must all use it) and POSIX-only.
+On platforms without ``fcntl`` (Windows) it degrades to a no-op so callers stay
+portable; the underlying race simply isn't guarded there.
+
+Extracted from the previously-inline ``fcntl.flock`` patterns in
+``hephaestus.github.rate_limit`` and ``hephaestus.automation.advise_runner`` so
+there is a single, tested primitive (DRY).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TextIO
+
+
+class LockUnavailableError(RuntimeError):
+    """Raised by :func:`file_lock` with ``blocking=False`` when held elsewhere."""
+
+
+def _open_secure_lock_file(path: Path) -> TextIO:
+    """Open ``path`` for locking without following symlinks.
+
+    Args:
+        path: Sentinel file to open (created if absent, mode ``0o600``).
+
+    Returns:
+        An open file object whose descriptor backs the advisory lock.
+
+    Raises:
+        RuntimeError: If ``path`` already exists and is a symlink.
+
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.is_symlink():
+        raise RuntimeError(f"Refusing to use symlinked lock file: {path}")
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o600)
+    os.fchmod(fd, 0o600)
+    return os.fdopen(fd, "r+")
+
+
+@contextmanager
+def file_lock(path: Path, *, blocking: bool = True) -> Iterator[None]:
+    """Hold an exclusive cross-process advisory lock on ``path``.
+
+    Acquires ``fcntl.flock(LOCK_EX)`` on a sentinel file for the duration of the
+    ``with`` block, releasing it (and closing the descriptor) on exit even if the
+    body raises. The sentinel file is intentionally NOT unlinked while the lock
+    is held — deleting it would let a second acquirer create a fresh inode and
+    lock that instead, defeating the mutual exclusion (inode-reuse hazard).
+
+    Args:
+        path: Sentinel file backing the lock. Created if absent.
+        blocking: When True (default) block until the lock is free. When False,
+            raise :class:`LockUnavailableError` immediately if another holder exists.
+
+    Yields:
+        None. Use as ``with file_lock(path): ...``.
+
+    Raises:
+        LockUnavailableError: ``blocking=False`` and the lock is already held.
+        RuntimeError: ``path`` exists and is a symlink.
+
+    """
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - Windows path
+        # No advisory locking available; degrade to a no-op so callers stay
+        # portable. The guarded race is simply unprotected on this platform.
+        yield
+        return
+
+    fh = _open_secure_lock_file(path)
+    try:
+        mode = fcntl.LOCK_EX
+        if not blocking:
+            mode |= fcntl.LOCK_NB
+        try:
+            fcntl.flock(fh.fileno(), mode)
+        except OSError as exc:
+            if not blocking:
+                raise LockUnavailableError(f"Lock already held: {path}") from exc
+            raise
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    finally:
+        fh.close()

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -2310,6 +2310,41 @@ class TestArmingSweep:
         assert record["learn_succeeded_at"] is None
         assert record["learn_status"] == "failed"
 
+    def test_sweep_acquires_cross_process_lock(self, driver: CIDriver) -> None:
+        """The sweep serializes via ``file_lock`` on the shared state_dir (#1567).
+
+        Two issue-major ci-driver subprocesses share one ``state_dir``; the lock
+        is what prevents them double-firing ``/learn`` + colliding on the same
+        worktree path. Assert the lock is entered for the orphan-sweep sentinel.
+        """
+        self._write_record(driver, issue=841, pr_number=843)
+        with (
+            patch("hephaestus.automation.ci_driver.file_lock") as mock_lock,
+            patch.object(driver, "_gh_pr_state", return_value={"state": "OPEN"}),
+        ):
+            driver._sweep_orphaned_arming_records()
+        mock_lock.assert_called_once_with(driver.state_dir / "orphan-sweep.lock")
+
+    def test_concurrent_sweep_fires_learn_once(self, driver: CIDriver) -> None:
+        """A second sweep must NOT re-fire ``/learn`` for a terminal record.
+
+        Regression for the cross-process double-``/learn`` + duplicate-worktree
+        race (#1567): once the first sweeper marks a MERGED record terminal, the
+        second must skip it.
+
+        The real ``file_lock`` serializes the two sweeps; here we run them
+        sequentially over the SAME ``state_dir``, which is exactly the state the
+        second process observes once it acquires the lock the first released.
+        """
+        self._write_record(driver, issue=841, pr_number=843)
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"state": "MERGED"}),
+            patch.object(driver, "_run_drive_green_learnings", return_value=True) as mock_learn,
+        ):
+            driver._sweep_orphaned_arming_records()  # first sweeper: fires /learn
+            driver._sweep_orphaned_arming_records()  # second sweeper: record terminal
+        mock_learn.assert_called_once_with(841, 843)
+
 
 class TestRunSweeperWiring:
     """``CIDriver.run()`` invokes the sweeper before any per-issue work."""

--- a/tests/unit/benchmarks/test_compare.py
+++ b/tests/unit/benchmarks/test_compare.py
@@ -4,6 +4,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -56,7 +57,7 @@ class TestExtractTimings:
 
     def test_extract_timings_empty(self) -> None:
         """Test extracting timings from empty results."""
-        results = {"benchmarks": []}
+        results: dict[str, Any] = {"benchmarks": []}
         timings = extract_timings(results)
         assert timings == {}
 
@@ -174,8 +175,8 @@ class TestFormatMarkdownReport:
                 severity="critical",
             )
         ]
-        improvements = []
-        current_results = {
+        improvements: list[dict[str, Any]] = []
+        current_results: dict[str, Any] = {
             "environment": {
                 "os": "Linux",
                 "cpu": "AMD Ryzen",
@@ -183,7 +184,7 @@ class TestFormatMarkdownReport:
                 "git_commit": "abc123",
             }
         }
-        baseline_results = {"environment": {}}
+        baseline_results: dict[str, Any] = {"environment": {}}
 
         report = format_markdown_report(
             regressions, improvements, current_results, baseline_results
@@ -198,8 +199,8 @@ class TestFormatMarkdownReport:
 
     def test_format_markdown_report_with_improvements(self) -> None:
         """Test generating markdown report with improvements."""
-        regressions = []
-        improvements = [
+        regressions: list[Regression] = []
+        improvements: list[dict[str, Any]] = [
             {
                 "benchmark": "bench1",
                 "baseline_ms": 100.0,
@@ -207,8 +208,8 @@ class TestFormatMarkdownReport:
                 "improvement_percent": 20.0,
             }
         ]
-        current_results = {"environment": {}}
-        baseline_results = {"environment": {}}
+        current_results: dict[str, Any] = {"environment": {}}
+        baseline_results: dict[str, Any] = {"environment": {}}
 
         report = format_markdown_report(
             regressions, improvements, current_results, baseline_results
@@ -221,10 +222,10 @@ class TestFormatMarkdownReport:
 
     def test_format_markdown_report_no_changes(self) -> None:
         """Test generating markdown report with no changes."""
-        regressions = []
-        improvements = []
-        current_results = {"environment": {}}
-        baseline_results = {"environment": {}}
+        regressions: list[Regression] = []
+        improvements: list[dict[str, Any]] = []
+        current_results: dict[str, Any] = {"environment": {}}
+        baseline_results: dict[str, Any] = {"environment": {}}
 
         report = format_markdown_report(
             regressions, improvements, current_results, baseline_results

--- a/tests/unit/utils/test_file_lock.py
+++ b/tests/unit/utils/test_file_lock.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Unit tests for ``hephaestus.utils.file_lock``.
+
+Covers the cross-process advisory lock context manager: acquire/release
+round-trip, sequential re-acquisition, non-blocking contention, symlink refusal,
+and graceful no-op when ``fcntl`` is unavailable (Windows).
+"""
+
+from __future__ import annotations
+
+import builtins
+import os
+from pathlib import Path
+
+import pytest
+
+from hephaestus.utils.file_lock import LockUnavailableError, file_lock
+
+
+class TestFileLock:
+    """Behaviour of the ``file_lock`` context manager."""
+
+    def test_acquire_release_round_trip_creates_file(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / "x.lock"
+        with file_lock(lock_path):
+            assert lock_path.exists()
+        # File persists after release (we never unlink while/after holding).
+        assert lock_path.exists()
+
+    def test_sequential_reacquire_succeeds(self, tmp_path: Path) -> None:
+        lock_path = tmp_path / "x.lock"
+        for _ in range(3):
+            with file_lock(lock_path):
+                pass  # released at block exit, so the next acquire succeeds
+
+    def test_non_blocking_raises_when_already_held(self, tmp_path: Path) -> None:
+        """``blocking=False`` raises LockUnavailableError on contention.
+
+        ``fcntl.flock`` is advisory per open file description. Hold the lock on
+        one fd, then a non-blocking acquire on a *separate* fd must fail.
+        """
+        fcntl = pytest.importorskip("fcntl")
+        lock_path = tmp_path / "x.lock"
+        held_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        try:
+            fcntl.flock(held_fd, fcntl.LOCK_EX)
+            with pytest.raises(LockUnavailableError):
+                with file_lock(lock_path, blocking=False):
+                    pass
+        finally:
+            fcntl.flock(held_fd, fcntl.LOCK_UN)
+            os.close(held_fd)
+
+    def test_refuses_symlinked_path(self, tmp_path: Path) -> None:
+        pytest.importorskip("fcntl")
+        target = tmp_path / "real"
+        target.write_text("", encoding="utf-8")
+        link = tmp_path / "link.lock"
+        link.symlink_to(target)
+        with pytest.raises(RuntimeError):
+            with file_lock(link):
+                pass
+
+    def test_no_fcntl_is_noop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``fcntl`` import fails (Windows), the lock degrades to a no-op."""
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "fcntl":
+                raise ImportError("simulated: no fcntl on this platform")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        # Must not raise, and must not require/lock anything.
+        with file_lock(tmp_path / "x.lock"):
+            pass


### PR DESCRIPTION
## Summary

Analysis of `~/ProjectHephaestus/output.log` (run 2026-06-21 22:31, issues 1553,1547) showed the pipeline succeeded end-to-end (PRs #1565/#1566 merged) but exposed a real **cross-process race** in the post-merge drive-green tail.

The issue-major loop (#1560) runs each issue's phases as separate `subprocess.run` calls. With 2+ issues in parallel, two `hephaestus-ci-driver` subprocesses start near-simultaneously and **each** runs `_sweep_orphaned_arming_records`, which globs **all** `drive-green-armed-*.json` records in the shared `build/.issue_implementer` dir. Both find the same MERGED orphan and both fire `/learn` + `create_worktree(same_issue)` on the same `build/.worktrees/issue-<N>` path. The only guard was an in-process `threading.Lock` — useless across subprocesses — so the second collided:

```
ERROR git worktree add .../issue-1547 1547-auto-impl
fatal: '.../build/.worktrees/issue-1547' already exists
INFO no worktree available for /learn (exit 128); falling back to repo root
```

It self-recovered but cascaded into spurious `/compact` "No conversation found" warnings.

## Changes

1. **New `hephaestus/utils/file_lock.py`** — a reusable `fcntl.flock` context manager (secure `O_NOFOLLOW` open, non-blocking option raising `LockUnavailableError`, Windows no-op), extracted from the previously-inline patterns in `rate_limit.py` / `advise_runner.py` (no generic helper existed — DRY).
2. **`ci_driver.py`** — wrap `_sweep_orphaned_arming_records` in `file_lock(state_dir / "orphan-sweep.lock")`. Holding the lock across the sweep serializes the subprocesses; the second re-globs/re-loads records under the lock, sees them already terminal, and no-ops — closing both the double-`/learn` and the worktree collision.
3. **Pre-existing main fix (folded in):** 10 missing type annotations in `tests/unit/benchmarks/test_compare.py` left by #1566. The mypy pre-commit hook checks the whole tree, so these block every PR until fixed.

## Tests

- New `tests/unit/utils/test_file_lock.py` (acquire/release, sequential re-acquire, non-blocking contention, symlink refusal, no-`fcntl` no-op).
- `TestArmingSweep`: `test_sweep_acquires_cross_process_lock` + `test_concurrent_sweep_fires_learn_once` (the double-`/learn`/duplicate-worktree regression).

## Verification

- `pixi run pytest tests/unit/automation tests/unit/utils tests/unit/benchmarks tests/unit/validation/test_import_surface.py tests/unit/validation/test_automation_boundary.py` → **2017 passed**
- `pixi run mypy` → clean (411 source files); `ruff check` / `ruff format --check` clean.

Closes #1567

🤖 Generated with [Claude Code](https://claude.com/claude-code)