### PR TITLE
[Fix] Progress-aware review budget so a productive PR converges instead of state:skip

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -76,7 +76,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Base review-budget: a loop that is NOT making progress (a stuck or oscillating
+# reviewer) terminates after this many iterations and is tagged ``state:skip``.
 MAX_REVIEW_ITERATIONS = 3
+
+# Absolute ceiling on review iterations. A loop that makes genuine progress every
+# round (resolves a fresh finding without the validator re-opening a prior one)
+# earns extra iterations beyond ``MAX_REVIEW_ITERATIONS`` — up to this hard cap —
+# so a steadily-improving PR with more real findings than the base budget can
+# converge to a clean GO instead of being stranded one address-pass short (#1554).
+# The cap bounds a truly non-converging reviewer so it can never spin forever.
+MAX_REVIEW_ITERATIONS_HARD_CAP = MAX_REVIEW_ITERATIONS * 2
 
 # Bounded exponential backoff for transient 529 server-overload responses
 # (5s → 10s → 20s, capped). Unlike a 429 quota cap these carry no reset epoch,
@@ -672,7 +682,12 @@ class ReviewPhase(StageMixin):
 
         Each iteration posts inline PR review threads and returns a verdict; on
         NOGO the implementer session is resumed to address threads. Terminates on
-        GO, zero blocking threads, or :data:`MAX_REVIEW_ITERATIONS`.
+        GO or zero blocking threads, or on budget exhaustion. The budget starts
+        at :data:`MAX_REVIEW_ITERATIONS` and is extended one iteration at a time —
+        up to :data:`MAX_REVIEW_ITERATIONS_HARD_CAP` — for as long as each round
+        keeps making real progress (resolves a fresh finding without the
+        validator re-opening a prior one), so a steadily-improving PR converges
+        instead of being stranded one address-pass short (#1554).
 
         #1328: before the FIRST review iteration, a PR with a merge conflict is
         rebased / handed to the implementation agent to resolve. A conflicted PR
@@ -710,7 +725,39 @@ class ReviewPhase(StageMixin):
             )
             return 0, "NOGO", None
 
-        for iteration in range(MAX_REVIEW_ITERATIONS):
+        # #1554: progress-aware review budget. The loop starts with the base
+        # ``MAX_REVIEW_ITERATIONS`` budget; whenever the PREVIOUS round made
+        # genuine PROGRESS (its address step resolved a fresh finding without the
+        # validator re-opening a prior one) and the loop is about to exhaust the
+        # budget, grant one more iteration — up to ``MAX_REVIEW_ITERATIONS_HARD_CAP``
+        # — so a steadily-improving PR with more real findings than the base
+        # budget converges to a clean GO instead of being stranded one
+        # address-pass short. A stuck or oscillating reviewer makes no progress
+        # and is never extended, so it still terminates at the base budget and is
+        # tagged ``state:skip``. The extension happens at the TOP of the loop
+        # (before the address-step gate that breaks on the final budgeted
+        # iteration), keyed off the prior round's progress.
+        budget = MAX_REVIEW_ITERATIONS
+        prior_round_made_progress = False
+        iteration = 0
+        while iteration < budget:
+            # Extend the budget when the prior round made real progress and this
+            # would otherwise be the last budgeted iteration — so the fix the
+            # prior round landed gets a re-review (and its findings addressed).
+            if (
+                prior_round_made_progress
+                and iteration == budget - 1
+                and budget < MAX_REVIEW_ITERATIONS_HARD_CAP
+            ):
+                budget += 1
+                self.impl._log(
+                    "info",
+                    f"{issue_ref(issue_number)} R{iteration}: prior round resolved "
+                    f"finding(s); extending review budget to "
+                    f"{budget}/{MAX_REVIEW_ITERATIONS_HARD_CAP} iteration(s)",
+                    thread_id,
+                )
+            prior_round_made_progress = False
             (
                 last_verdict,
                 last_grade,
@@ -753,6 +800,7 @@ class ReviewPhase(StageMixin):
                 and validator_clean
             ):
                 prior_review = review_text
+                iteration += 1
                 continue
             prior_review = review_text
             address_result = self._run_address_step_if_needed(
@@ -761,6 +809,7 @@ class ReviewPhase(StageMixin):
                 branch_name=branch_name,
                 worktree_path=worktree_path,
                 iteration=iteration,
+                budget=budget,
                 session_id=session_id,
                 slot_id=slot_id,
                 thread_id=thread_id,
@@ -771,9 +820,18 @@ class ReviewPhase(StageMixin):
                 break
             prior_addressed_threads, addressed = address_result
             if pr_number is None:
+                iteration += 1
                 continue
             if not addressed:
                 break
+            # The address step resolved a fresh finding (``addressed``) without
+            # the validator re-opening a prior one (``validator_clean``): this
+            # round made real progress. Record it so the NEXT iteration can
+            # extend the budget if it would otherwise be the last — letting a PR
+            # that fixes one real bug per round converge instead of being
+            # stranded one pass short of GO and wrongly skipped (#1554).
+            prior_round_made_progress = addressed and validator_clean
+            iteration += 1
 
         self._finalize_review_outcome(
             issue_number=issue_number,
@@ -886,13 +944,14 @@ class ReviewPhase(StageMixin):
         branch_name: str,
         worktree_path: Path,
         iteration: int,
+        budget: int,
         session_id: str | None,
         slot_id: int | None,
         thread_id: int | None,
         issue_title: str,
         issue_body: str,
     ) -> tuple[list[dict[str, Any]], bool] | None:
-        """Run address iteration if not the final iteration.
+        """Run address iteration unless this is the final budgeted iteration.
 
         Args:
             issue_number: GitHub issue number.
@@ -900,6 +959,10 @@ class ReviewPhase(StageMixin):
             branch_name: Git branch name.
             worktree_path: Path to the checked-out worktree.
             iteration: Current zero-based iteration index.
+            budget: Current iteration budget. Addressing is skipped on the final
+                budgeted iteration (``iteration == budget - 1``); a productive
+                round extends ``budget`` in the caller BEFORE the next pass, so a
+                steadily-improving PR still gets its findings addressed (#1554).
             session_id: Optional implementer session ID.
             slot_id: Worker slot for status tracking.
             thread_id: Current thread id for logging.
@@ -907,11 +970,11 @@ class ReviewPhase(StageMixin):
             issue_body: Issue body for context.
 
         Returns:
-            None if this is the final iteration (caller should break).
+            None if this is the final budgeted iteration (caller should break).
             (prior_addressed_threads, addressed) tuple otherwise.
 
         """
-        if iteration == MAX_REVIEW_ITERATIONS - 1:
+        if iteration == budget - 1:
             return None
         prior_addressed_threads, addressed = self._run_address_iteration(
             issue_number=issue_number,
@@ -1019,9 +1082,11 @@ class ReviewPhase(StageMixin):
         unlabeled for re-review / human action.
         """
         # A2-003: Surface AMBIGUOUS verdict distinctly so operators can triage
-        # without inspecting raw log files.
+        # without inspecting raw log files. #1554: the loop may run beyond the
+        # base budget when it keeps making progress, so anchor on ">=" rather
+        # than "==" — an extended run that still ended non-GO must warn too.
         if last_verdict == "AMBIGUOUS" or (
-            iterations_run == MAX_REVIEW_ITERATIONS and last_verdict not in (None, "GO")
+            iterations_run >= MAX_REVIEW_ITERATIONS and last_verdict not in (None, "GO")
         ):
             logger.warning(
                 "#%d: review loop ended without clear GO — "

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -92,7 +92,11 @@ from .implementer_cli import (
     _parse_args as _parse_args,
     _setup_logging as _setup_logging,
 )
-from .implementer_phase_runner import MAX_REVIEW_ITERATIONS, ImplementationPhaseRunner
+from .implementer_phase_runner import (
+    MAX_REVIEW_ITERATIONS,
+    MAX_REVIEW_ITERATIONS_HARD_CAP,
+    ImplementationPhaseRunner,
+)
 from .implementer_state import ImplementationStateManager
 from .implementer_summary import ImplementationSummaryPrinter
 from .models import (
@@ -110,6 +114,7 @@ from .worktree_manager import WorktreeManager
 # tests assert on it as the documented default.
 __all__ = [
     "MAX_REVIEW_ITERATIONS",
+    "MAX_REVIEW_ITERATIONS_HARD_CAP",
     "_CLAUDE_IMPL_TIMEOUT",
     "IssueImplementer",
     "main",

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -40,7 +40,11 @@ from ._followup_phase import FollowUpPhase
 from ._implement_phase import ImplementPhase, _prepend_advise
 from ._plan_phase import PlanPhase
 from ._pr_create_phase import PRCreatePhase
-from ._review_phase import MAX_REVIEW_ITERATIONS, ReviewPhase
+from ._review_phase import (
+    MAX_REVIEW_ITERATIONS,
+    MAX_REVIEW_ITERATIONS_HARD_CAP,
+    ReviewPhase,
+)
 from ._review_utils import find_pr_for_issue, get_pr_head_branch
 from ._stage_context import StageContext
 from .claude_invoke import invoke_claude_with_session
@@ -105,7 +109,11 @@ logger = logging.getLogger(__name__)
 
 # Re-exported for back-compat: ``implementer`` imports ``MAX_REVIEW_ITERATIONS``
 # from this module. The canonical value now lives in ``_review_phase``.
-__all__ = ["MAX_REVIEW_ITERATIONS", "ImplementationPhaseRunner"]
+__all__ = [
+    "MAX_REVIEW_ITERATIONS",
+    "MAX_REVIEW_ITERATIONS_HARD_CAP",
+    "ImplementationPhaseRunner",
+]
 
 DirtyWorktreeDecision = Literal["commit", "stash"]
 

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -53,7 +53,9 @@ ALL_IMPLEMENTATION_STATE_LABELS = (STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTAT
 #: Manual override: when present on an issue OR its PR, automation normally
 #: skips that work item entirely (#1083). Unlike the plan/implementation state
 #: labels this is operator-applied (or auto-applied by the review loop when it
-#: exhausts MAX_REVIEW_ITERATIONS without a GO), and it is independent of all
+#: exhausts its review budget without a GO — the budget starts at
+#: MAX_REVIEW_ITERATIONS and extends up to MAX_REVIEW_ITERATIONS_HARD_CAP while
+#: the loop keeps making progress, #1554), and it is independent of all
 #: other state labels — so it deliberately lives outside the tuples above.
 #: The implementer has one narrow stale-state recovery path for explicitly
 #: selected issues that also carry ``state:plan-go`` and have no open PR.

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation.implementer import MAX_REVIEW_ITERATIONS, IssueImplementer
+from hephaestus.automation.implementer import (
+    MAX_REVIEW_ITERATIONS,
+    MAX_REVIEW_ITERATIONS_HARD_CAP,
+    IssueImplementer,
+)
 from hephaestus.automation.implementer_phase_runner import (
     _parse_dirty_reused_worktree_decision,
 )
@@ -392,22 +396,30 @@ class TestRunImplReviewLoop:
         assert iters == 2  # did NOT accept GO on R0; addressed then re-reviewed
         mock_addr.assert_called()
 
-    def test_runs_3_iterations_on_sustained_nogo(
+    def test_sustained_nogo_with_progress_extends_to_hard_cap(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
+        """A NOGO loop that keeps resolving findings extends to the hard cap.
+
+        #1554: when every round resolves a fresh finding (``addressed`` and
+        validator-clean) but the reviewer never issues a clean GO, the budget
+        extends one iteration at a time up to ``MAX_REVIEW_ITERATIONS_HARD_CAP``,
+        then stops. The hard cap bounds a reviewer that invents an endless stream
+        of new findings so the loop can never spin forever.
+        """
         with (
             patch.object(
                 implementer,
                 "_run_impl_review_step",
+                # One distinct NOGO thread per round, never going clean. Provide
+                # enough side-effects to cover the hard cap.
                 side_effect=[
-                    (_nogo("D"), ["t0"]),
-                    (_nogo("C"), ["t1"]),
-                    (_nogo("B"), ["t2"]),
+                    (_nogo("D"), [f"t{i}"]) for i in range(MAX_REVIEW_ITERATIONS_HARD_CAP)
                 ],
             ) as mock_rev,
             patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
         ):
-            iters, verdict, grade = implementer._run_impl_review_loop(
+            iters, verdict, _grade = implementer._run_impl_review_loop(
                 issue_number=1,
                 worktree_path=tmp_path,
                 branch_name="b",
@@ -419,12 +431,11 @@ class TestRunImplReviewLoop:
                 pr_number=42,
             )
 
-        assert iters == MAX_REVIEW_ITERATIONS == 3
+        assert iters == MAX_REVIEW_ITERATIONS_HARD_CAP == 6
         assert verdict == "NOGO"
-        assert grade == "B"  # last review's grade
-        assert mock_rev.call_count == 3
-        # Address called for iterations 0 and 1 (not after the final R2 review).
-        assert mock_addr.call_count == 2
+        assert mock_rev.call_count == MAX_REVIEW_ITERATIONS_HARD_CAP
+        # Address runs on every iteration EXCEPT the final budgeted one.
+        assert mock_addr.call_count == MAX_REVIEW_ITERATIONS_HARD_CAP - 1
 
     def test_address_resolving_nothing_breaks_loop_early(
         self, implementer: IssueImplementer, tmp_path: Path
@@ -454,13 +465,18 @@ class TestRunImplReviewLoop:
         assert verdict == "NOGO"
         assert mock_rev.call_count == 1
 
-    def test_exhaustion_without_go_applies_state_skip(
+    def test_productive_loop_converges_past_base_budget_no_skip(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:
-        """Exhausting MAX_REVIEW_ITERATIONS without GO applies ``state:skip``.
+        """A PR that fixes one real finding per round converges to GO (#1554).
 
-        #1083 Bug 2: a sustained NOGO run that never reaches GO must label the
-        issue ``state:skip`` so the next loop skips it.
+        Reproduces the #1554 / PR #1570 strand: the reviewer surfaces a NEW
+        distinct finding on each of R0/R1/R2 (one inline comment per pass), the
+        implementer resolves each in turn, and only the FOURTH review is clean.
+        Before the progress-aware budget the loop hit ``MAX_REVIEW_ITERATIONS``
+        (3) one address-pass short — R2's finding was posted but never addressed,
+        forcing a terminal NOGO and ``state:skip``. Now the budget extends while
+        progress is made, so the loop reaches a clean GO and applies NO skip.
         """
         from hephaestus.automation.state_labels import STATE_SKIP
 
@@ -469,15 +485,100 @@ class TestRunImplReviewLoop:
                 implementer,
                 "_run_impl_review_step",
                 side_effect=[
-                    (_nogo("D"), ["t0"]),
-                    (_nogo("C"), ["t1"]),
-                    (_nogo("B"), ["t2"]),
+                    (_nogo("D"), ["t0"]),  # R0: finding #1
+                    (_nogo("C"), ["t1"]),  # R1: finding #2 (fresh)
+                    (_nogo("B"), ["t2"]),  # R2: finding #3 (fresh) — was the strand point
+                    (_go(), []),  # R3: clean — all addressed
+                ],
+            ) as mock_rev,
+            patch.object(implementer, "_run_address_review_step", return_value=True) as mock_addr,
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
+        ):
+            iters, verdict, grade = implementer._run_impl_review_loop(
+                issue_number=1554,
+                worktree_path=tmp_path,
+                branch_name="1554-auto-impl",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=1570,
+            )
+
+        assert verdict == "GO"
+        assert grade == "A"
+        # Converged on the 4th review — one past the base budget of 3.
+        assert iters == 4
+        assert mock_rev.call_count == 4
+        # The final-iteration address-skip off-by-one is fixed: R2's finding was
+        # addressed (address ran on R0, R1, R2 — not on the clean R3).
+        assert mock_addr.call_count == 3
+        # A converged PR must NOT be tagged ``state:skip``.
+        for call in mock_label.call_args_list:
+            assert STATE_SKIP not in call.args[1], f"unexpected state:skip: {call}"
+
+    def test_progress_then_clean_go_does_not_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """One productive round then a clean GO converges without skip (#1554).
+
+        The base budget alone (3) would suffice here, but this guards the common
+        case: progress is made, the next review is clean, and the loop terminates
+        GO well within budget — no extension needed, no ``state:skip``.
+        """
+        from hephaestus.automation.state_labels import STATE_SKIP
+
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo("D"), ["t0"]), (_go(), [])],
+            ),
+            patch.object(implementer, "_run_address_review_step", return_value=True),
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
+        ):
+            iters, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=1,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "GO"
+        assert iters == 2
+        for call in mock_label.call_args_list:
+            assert STATE_SKIP not in call.args[1]
+
+    def test_exhaustion_without_go_applies_state_skip(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """Exhausting the review budget without GO applies ``state:skip``.
+
+        #1083 Bug 2: a sustained NOGO run that never reaches GO must label the
+        issue ``state:skip`` so the next loop skips it. #1554: a progress-making
+        run extends to ``MAX_REVIEW_ITERATIONS_HARD_CAP`` first, but a hard-cap
+        run that still never reaches GO is genuine exhaustion and is skipped.
+        """
+        from hephaestus.automation.state_labels import STATE_SKIP
+
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[
+                    (_nogo("D"), [f"t{i}"]) for i in range(MAX_REVIEW_ITERATIONS_HARD_CAP)
                 ],
             ),
             patch.object(implementer, "_run_address_review_step", return_value=True),
             patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
         ):
-            _, verdict, _ = implementer._run_impl_review_loop(
+            iters, verdict, _ = implementer._run_impl_review_loop(
                 issue_number=7,
                 worktree_path=tmp_path,
                 branch_name="b",
@@ -489,6 +590,7 @@ class TestRunImplReviewLoop:
                 pr_number=42,
             )
 
+        assert iters == MAX_REVIEW_ITERATIONS_HARD_CAP
         assert verdict == "NOGO"
         mock_label.assert_called_once_with(7, [STATE_SKIP])
 


### PR DESCRIPTION
## Summary

The in-loop implementation review (`_review_phase.py::_run_impl_review_loop`) strands a PR that is making genuine progress — resolving one real review finding per round — when the number of distinct findings meets or exceeds the fixed `MAX_REVIEW_ITERATIONS` budget (3). The PR is wrongly tagged `state:skip`, auto-merge is never armed, and `ci_driver` reports `Repo not done: ... needs manual action` indefinitely.

Diagnosed from `output.log` (2026-06-22 run): PR #1570 / issue #1554. The reviewer surfaced one distinct, substantive finding per round (R0 missing `add_version_arg`, R1 tautological empty-name test, R2 overwrite-guard gap); the implementer fixed + pushed each, but R2's finding was posted on the final iteration where the address step is skipped → terminal NOGO → `state:skip`.

## Root cause

`MAX_REVIEW_ITERATIONS = 3` runs iters 0/1/2; `_run_address_step_if_needed` returns `None` on the final iteration, so that round's review is never addressed. The convergence logic has no notion of *progress*: a loop resolving a fresh real finding every round is indistinguishable, at the cap, from a stuck/oscillating one.

## Change

Progress-aware budget in `_run_impl_review_loop`:
- Budget starts at `MAX_REVIEW_ITERATIONS` and extends one iteration at a time, up to `MAX_REVIEW_ITERATIONS_HARD_CAP` (= `MAX_REVIEW_ITERATIONS * 2` = 6), whenever the prior round made real progress (address step resolved a fresh finding **and** the validator did not re-open a prior one).
- The address-step gate now keys off the dynamic `budget` instead of the static cap, fixing the final-iteration off-by-one.
- `state:skip` still applies only on genuine exhaustion (hard cap or a no-progress round), preserving the verified-ci `state:skip`-on-true-exhaustion contract. The hard cap bounds a non-converging reviewer so the loop can never spin forever.
- Constants re-exported through `implementer_phase_runner` / `implementer`; `state_labels` doc comment updated.

## Tests

`tests/unit/automation/test_implementer_loop.py`:
- **New** `test_productive_loop_converges_past_base_budget_no_skip` — reproduces the #1554 strand; now converges to GO at iter 4 with no `state:skip` and the final finding addressed.
- **New** `test_progress_then_clean_go_does_not_skip` — common case, converges within budget.
- **New** `test_sustained_nogo_with_progress_extends_to_hard_cap` — a reviewer that never goes clean extends to the hard cap then stops.
- **Updated** the two prior sustained-NOGO tests to the progress-aware semantics (no-progress stops at base; hard-cap exhaustion still applies `state:skip`).

All 1855 automation unit tests pass; ruff + mypy clean.

## Operator recovery (separate, not in this PR)

The already-stranded PR #1570 needs `state:skip` removed from #1554 and `state:implementation-no-go` removed from #1570 so the next loop re-enters and converges.

Closes #1571