### PR TITLE
docs(templates): add DoD reference and PR size guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 ## Summary
 
-<!-- Brief description of what this PR accomplishes -->
+<!-- Brief description of what this PR accomplishes.
+     Keep PRs small — prefer one issue per PR (see CONTRIBUTING.md → "Planning artifacts").
+     Rough size guidance: XS <10 lines · S <50 · M <250 · L <500 · XL 500+.
+     PRs over ~500 changed lines should be split unless inherently atomic. -->
 
 ## Changes
 
@@ -47,6 +50,7 @@ Closes #
 - [ ] No new warnings introduced
 - [ ] Conventional commit message format used
 - [ ] Branch named following convention: `<issue-number>-<description>`
+- [ ] Change meets the [Definition of Done](https://github.com/mvillmow/ProjectHephaestus/blob/main/docs/DEFINITION_OF_DONE.md)
 
 ## Additional Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,12 @@ Before opening a PR, locate the work in:
   `pr-policy` CI gate).
 
 Keep PRs small: prefer one issue per PR so each change can be reviewed
-and reverted independently. Releases are cut on demand by pushing a
-signed `vX.Y.Z` git tag (see [`docs/RELEASING.md`](docs/RELEASING.md)).
+and reverted independently. As a rough guide, aim to keep PRs under
+~500 changed lines (XS <10 · S <50 · M <250 · L <500 · XL 500+); split
+larger PRs unless the change is inherently atomic. Every PR is reviewed
+against the [Definition of Done](docs/DEFINITION_OF_DONE.md). Releases
+are cut on demand by pushing a signed `vX.Y.Z` git tag (see
+[`docs/RELEASING.md`](docs/RELEASING.md)).
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary
Add Definition of Done reference to PR template and document PR size guidance in CONTRIBUTING.

## Changes
- Add DoD document reference to PR template
- Document PR size guidance in CONTRIBUTING.md

## Testing
- Verify PR template renders correctly on GitHub
- Confirm DoD link is accessible from template

## Closes
Closes #1552

Generated by Claude Code via ProjectHephaestus automation.
