### PR TITLE
[Fix] Retry no-commit address turn with an informed directive

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -739,6 +739,12 @@ class ReviewPhase(StageMixin):
         # iteration), keyed off the prior round's progress.
         budget = MAX_REVIEW_ITERATIONS
         prior_round_made_progress = False
+        # #1554: still-unresolved threads from a prior address turn that produced
+        # NO commit. Injected into the NEXT address invocation as a "Make sure to
+        # handle <finding>" directive to re-ground a resumed session that
+        # self-reported success without editing code. Empty except on the round
+        # immediately following a no-commit turn.
+        pending_unaddressed: list[dict[str, Any]] = []
         iteration = 0
         while iteration < budget:
             # Extend the budget when the prior round made real progress and this
@@ -815,6 +821,7 @@ class ReviewPhase(StageMixin):
                 thread_id=thread_id,
                 issue_title=issue_title,
                 issue_body=issue_body,
+                unaddressed_findings=pending_unaddressed,
             )
             if address_result is None:
                 break
@@ -823,13 +830,34 @@ class ReviewPhase(StageMixin):
                 iteration += 1
                 continue
             if not addressed:
+                # #1554: the address step produced NO commit (the fix agent
+                # punted or self-reported a phantom fix). If fixable threads
+                # remain AND iterations are left, do NOT give up — re-review and
+                # retry, carrying the still-unresolved threads forward as a "Make
+                # sure to handle <finding>" directive to re-ground the next
+                # address attempt. ``prior_addressed_threads`` is the snapshot the
+                # address step already took (its current unresolved set), so we
+                # reuse it instead of issuing another network call. Only when
+                # there is nothing fixable left OR no iterations remain do we
+                # break to the existing terminal/skip handling (unchanged).
+                still_unresolved = prior_addressed_threads
+                if still_unresolved and iteration < budget - 1:
+                    pending_unaddressed = still_unresolved
+                    iteration += 1
+                    continue
                 break
+            # A committed round: clear the retry directive (it only follows an
+            # immediately-preceding no-commit turn).
+            pending_unaddressed = []
             # The address step resolved a fresh finding (``addressed``) without
             # the validator re-opening a prior one (``validator_clean``): this
             # round made real progress. Record it so the NEXT iteration can
             # extend the budget if it would otherwise be the last — letting a PR
             # that fixes one real bug per round converge instead of being
-            # stranded one pass short of GO and wrongly skipped (#1554).
+            # stranded one pass short of GO and wrongly skipped (#1554). A
+            # no-commit round has ``addressed=False`` and never reaches here, so
+            # it can never set progress or extend the budget — the hard cap
+            # (MAX_REVIEW_ITERATIONS_HARD_CAP) still bounds total iterations.
             prior_round_made_progress = addressed and validator_clean
             iteration += 1
 
@@ -950,6 +978,7 @@ class ReviewPhase(StageMixin):
         thread_id: int | None,
         issue_title: str,
         issue_body: str,
+        unaddressed_findings: list[dict[str, Any]] | None = None,
     ) -> tuple[list[dict[str, Any]], bool] | None:
         """Run address iteration unless this is the final budgeted iteration.
 
@@ -968,6 +997,9 @@ class ReviewPhase(StageMixin):
             thread_id: Current thread id for logging.
             issue_title: Issue title for context.
             issue_body: Issue body for context.
+            unaddressed_findings: Still-unresolved threads from a prior no-commit
+                turn, injected as a "Make sure to handle <finding>" directive to
+                re-ground a resumed session (#1554).
 
         Returns:
             None if this is the final budgeted iteration (caller should break).
@@ -987,6 +1019,7 @@ class ReviewPhase(StageMixin):
             thread_id=thread_id,
             issue_title=issue_title,
             issue_body=issue_body,
+            unaddressed_findings=unaddressed_findings,
         )
         return prior_addressed_threads, addressed
 
@@ -1003,6 +1036,7 @@ class ReviewPhase(StageMixin):
         thread_id: int | None,
         issue_title: str,
         issue_body: str,
+        unaddressed_findings: list[dict[str, Any]] | None = None,
     ) -> tuple[list[dict[str, Any]], bool]:
         """Run the address step for one iteration.
 
@@ -1044,6 +1078,7 @@ class ReviewPhase(StageMixin):
             include_bootstrap_context=session_id is None,
             issue_title=issue_title,
             issue_body=issue_body,
+            unaddressed_findings=unaddressed_findings,
         )
         if not addressed:
             impl._log(
@@ -1295,6 +1330,7 @@ class ReviewPhase(StageMixin):
         include_bootstrap_context: bool = False,
         issue_title: str = "",
         issue_body: str = "",
+        unaddressed_findings: list[dict[str, Any]] | None = None,
     ) -> bool:
         """Address the posted PR threads in-loop, resuming Session 2.
 
@@ -1309,6 +1345,10 @@ class ReviewPhase(StageMixin):
         Returns:
             ``True`` if at least one thread was addressed (so the loop should
             re-review); ``False`` when nothing was addressable (the loop stops).
+
+        ``unaddressed_findings`` carries the still-unresolved threads from a
+        prior no-commit turn; they are injected into the prompt as a "Make sure
+        to handle <finding>" directive to re-ground a resumed session (#1554).
 
         """
         threads = gh_pr_list_unresolved_threads(pr_number, dry_run=False)
@@ -1348,6 +1388,7 @@ class ReviewPhase(StageMixin):
             task_block=task_block,
             task_review_block=task_review_block,
             diff_text=diff_text,
+            unaddressed_findings=unaddressed_findings,
         )
         addressed: list[str] = fix_result.get("addressed", [])
 

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -103,6 +103,7 @@ def run_address_fix_session(
     task_block: str = "",
     task_review_block: str = "",
     diff_text: str = "",
+    unaddressed_findings: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Run the address-review fix session and return the agent's parsed result.
 
@@ -135,6 +136,9 @@ def run_address_fix_session(
             session can read the task and continue the work.
         task_review_block: Optional plan-review verdict text for the context.
         diff_text: Optional current implementation diff for the context.
+        unaddressed_findings: Optional still-unresolved threads from a prior
+            no-commit turn (#1554); injected as a "Make sure to handle <finding>"
+            directive to re-ground a resumed session on what it failed to fix.
 
     Returns:
         Parsed dict with ``"addressed"`` and ``"replies"`` keys.
@@ -181,6 +185,7 @@ def run_address_fix_session(
         task_block=task_block,
         task_review_block=task_review_block,
         diff_text=diff_text,
+        unaddressed_findings=unaddressed_findings,
     )
 
     prompt_file = worktree_path / f".claude-address-review-{issue_number}.md"

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -684,6 +684,7 @@ class IssueImplementer:
         include_bootstrap_context: bool = False,
         issue_title: str = "",
         issue_body: str = "",
+        unaddressed_findings: list[dict[str, Any]] | None = None,
     ) -> bool:
         """Address the posted PR threads in-loop, resuming Session 2."""
         return self.phase_runner._run_address_review_step(
@@ -695,6 +696,7 @@ class IssueImplementer:
             include_bootstrap_context=include_bootstrap_context,
             issue_title=issue_title,
             issue_body=issue_body,
+            unaddressed_findings=unaddressed_findings,
         )
 
     def _resume_impl_with_feedback(

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -1198,6 +1198,7 @@ class ImplementationPhaseRunner:
         include_bootstrap_context: bool = False,
         issue_title: str = "",
         issue_body: str = "",
+        unaddressed_findings: list[dict[str, Any]] | None = None,
     ) -> bool:
         """Delegate to :meth:`ReviewPhase._run_address_review_step`."""
         return self.review_phase._run_address_review_step(
@@ -1209,6 +1210,7 @@ class ImplementationPhaseRunner:
             include_bootstrap_context=include_bootstrap_context,
             issue_title=issue_title,
             issue_body=issue_body,
+            unaddressed_findings=unaddressed_findings,
         )
 
     def _resume_impl_with_feedback(

--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -47,7 +47,11 @@ from ._strict_rubric import (
     _STRICT_REVIEW_OUTPUT_FORMAT as _STRICT_REVIEW_OUTPUT_FORMAT,
     _STRICT_REVIEW_RUBRIC as _STRICT_REVIEW_RUBRIC,
 )
-from .address_review import ADDRESS_REVIEW_PROMPT, get_address_review_prompt
+from .address_review import (
+    ADDRESS_REVIEW_PROMPT,
+    build_unaddressed_directive,
+    get_address_review_prompt,
+)
 from .advise import (
     ADVISE_PROMPT,
     CODEX_ADVISE_PROMPT,
@@ -98,6 +102,7 @@ __all__ = [
     "PLAN_PROMPT",
     "PLAN_REVIEW_PROMPT",
     "PR_REVIEW_ANALYSIS_PROMPT",
+    "build_unaddressed_directive",
     "get_address_review_prompt",
     "get_advise_prompt",
     "get_advise_prompt_builder",

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -1,6 +1,7 @@
 """Address-review prompt: apply fixes for unresolved PR review threads."""
 
 import secrets
+from typing import Any
 
 from ._shared import _TERSE_OUTPUT_DIRECTIVE, _UNTRUSTED_NOTICE, _fence_untrusted
 
@@ -19,6 +20,7 @@ These threads live on the PR, not on the issue.
 
 {untrusted_notice}
 {context_block}
+{retry_directive_block}
 **Review Threads to Address (untrusted):**
 {threads_json_block}
 
@@ -100,6 +102,45 @@ Rules for the JSON block:
 """
 
 
+def build_unaddressed_directive(threads: list[dict[str, Any]], nonce: str) -> str:
+    """Render a "Make sure to handle <finding>" directive from unresolved threads.
+
+    Used on a retry after the previous address turn produced NO commit (the fix
+    session resumed a stale transcript and self-reported success without editing
+    code, #1554). The directive re-grounds the resumed session on the concrete
+    findings it still has to fix, naming each by location and reviewer body.
+
+    Each ``body`` is verbatim untrusted reviewer text (GitHub-sourced), so the
+    whole block is fenced as untrusted. The thread dicts use the snapshot shape
+    returned by :func:`gh_pr_list_unresolved_threads` (``id`` / ``path`` /
+    ``line`` / ``body``).
+
+    Args:
+        threads: Still-unresolved review thread dicts from the prior turn.
+        nonce: Per-prompt nonce used to delimit the untrusted fence (shared with
+            the rest of the prompt so all fences use one nonce).
+
+    Returns:
+        The rendered directive block, or ``""`` when ``threads`` is empty.
+
+    """
+    if not threads:
+        return ""
+    lines: list[str] = []
+    for t in threads:
+        loc = t.get("path") or "<no path>"
+        line_no = t.get("line")
+        loc_str = f"{loc}:{line_no}" if line_no is not None else loc
+        body = (t.get("body") or "").strip() or "<empty body>"
+        lines.append(f"- Make sure to handle {loc_str} — {body}")
+    directive = _fence_untrusted("UNADDRESSED", "\n".join(lines), nonce)
+    return (
+        "**You produced NO commit on the previous turn, so these findings are "
+        "STILL unaddressed. Fix each one in code now — do not report success "
+        "without an actual edit (untrusted):**\n" + directive + "\n"
+    )
+
+
 def _build_context_block(
     task_block: str,
     task_review_block: str,
@@ -147,6 +188,7 @@ def get_address_review_prompt(
     task_block: str = "",
     task_review_block: str = "",
     diff_text: str = "",
+    unaddressed_findings: list[dict[str, Any]] | None = None,
 ) -> str:
     """Get the address review prompt for fixing inline review thread feedback.
 
@@ -172,6 +214,10 @@ def get_address_review_prompt(
             untrusted context section.
         diff_text: Optional current implementation diff, rendered as an untrusted
             context section.
+        unaddressed_findings: Optional still-unresolved review threads from a
+            prior address turn that produced NO commit (#1554). When supplied,
+            a "Make sure to handle <finding>" directive is rendered above the
+            thread list to re-ground a resumed session on what it failed to fix.
 
     Returns:
         Formatted address review prompt
@@ -186,5 +232,6 @@ def get_address_review_prompt(
         todo_block=_fence_untrusted("TODO_LIST", todo_block or "_(no todo lines)_", nonce),
         untrusted_notice=_UNTRUSTED_NOTICE,
         context_block=_build_context_block(task_block, task_review_block, diff_text, nonce),
+        retry_directive_block=build_unaddressed_directive(unaddressed_findings or [], nonce),
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -1059,6 +1059,209 @@ class TestRunImplReviewLoop:
         # No PR → in-loop address step is never invoked.
         mock_addr.assert_not_called()
 
+    def test_no_commit_with_iterations_left_continues_not_break(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A no-commit address step does not end the loop while fixable work remains.
+
+        #1554 regression: the address agent can resume a stale session and
+        self-report success without committing. The #1083 guard returns
+        ``addressed=False``; previously the loop hit ``if not addressed: break``
+        and stopped at R0, wasting its remaining budget. Now, with unresolved
+        threads still present and iterations left, the loop re-reviews and the
+        next address attempt lands the fix → GO.
+        """
+        # Automation-owned thread (github-actions[bot]) so a GO with it still
+        # open downgrades to NOGO (re-review) rather than HUMAN_BLOCKED.
+        snapshot = [
+            {
+                "id": "t0",
+                "path": "a.py",
+                "line": 5,
+                "body": "fix the guard",
+                "author": "github-actions[bot]",
+            }
+        ]
+        # The thread stays open until the address step commits (R1 returns True),
+        # after which the list-threads helper reports it resolved so R1's GO
+        # can finally stand. ``committed`` is flipped by the address side_effect.
+        committed = {"done": False}
+
+        def _addr(*_args: object, **_kwargs: object) -> bool:
+            if committed["done"]:
+                return True
+            committed["done"] = True  # this turn lands the fix
+            return False  # ...but reports no commit on the FIRST turn
+
+        def _threads(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+            return [] if committed["done"] else snapshot
+
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo("D"), ["t0"]), (_go(), [])],
+            ) as mock_rev,
+            patch.object(implementer, "_run_address_review_step", side_effect=_addr) as mock_addr,
+            patch(
+                "hephaestus.automation._review_phase.gh_pr_list_unresolved_threads",
+                side_effect=_threads,
+            ),
+        ):
+            iters, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=1554,
+                worktree_path=tmp_path,
+                branch_name="1554-auto-impl",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=1570,
+            )
+
+        # The loop did NOT break at R0's no-commit address step — it re-reviewed
+        # (mock_rev twice) and converged on GO. (R1 was a clean GO, so the
+        # address step ran only on R0; the key assertion is that the loop did
+        # not stop after the first no-commit turn.)
+        assert verdict == "GO"
+        assert iters >= 2
+        assert mock_rev.call_count >= 2
+        assert mock_addr.call_count >= 1
+
+    def test_no_commit_retry_injects_directive(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """After a no-commit turn, the NEXT address call carries the directive.
+
+        #1554: the still-unresolved threads from the no-commit round are passed
+        to the next address invocation via ``unaddressed_findings`` so the prompt
+        names what to fix. The FIRST call (no prior no-commit turn) carries none.
+
+        Both R0 and R1 stay NOGO with an open thread and the address step never
+        commits, so two address turns occur: the second must carry the directive.
+        """
+        snapshot = [{"id": "t0", "path": "a.py", "line": 5, "body": "fix the guard"}]
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo("D"), ["t0"]), (_nogo("C"), ["t1"]), (_go(), [])],
+            ),
+            # Never commits → each round is a no-commit retry.
+            patch.object(implementer, "_run_address_review_step", return_value=False) as mock_addr,
+            patch(
+                "hephaestus.automation._review_phase.gh_pr_list_unresolved_threads",
+                return_value=snapshot,
+            ),
+        ):
+            implementer._run_impl_review_loop(
+                issue_number=1554,
+                worktree_path=tmp_path,
+                branch_name="1554-auto-impl",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=1570,
+            )
+
+        assert mock_addr.call_count >= 2
+        # First address turn: no prior no-commit, so empty/no directive.
+        first = mock_addr.call_args_list[0]
+        assert not first.kwargs.get("unaddressed_findings")
+        # Second address turn: re-grounded with the still-unresolved snapshot.
+        second = mock_addr.call_args_list[1]
+        assert second.kwargs.get("unaddressed_findings") == snapshot
+
+    def test_no_commit_then_commit_clears_directive(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A committed round clears the retry directive for the following turn.
+
+        #1554: the directive must only follow an immediately-preceding no-commit
+        turn. Sequence: R0 no-commit → R1 commits (clears) → R2 no-commit again →
+        R3 should re-inject. We assert R2's address call (after the R1 commit)
+        carries NO directive.
+        """
+        snapshot = [{"id": "t0", "path": "a.py", "line": 5, "body": "fix the guard"}]
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                # Stay NOGO so the loop keeps addressing; budget extends while
+                # progress is made, so provide enough reviews up to the hard cap.
+                side_effect=[
+                    (_nogo("D"), [f"t{i}"]) for i in range(MAX_REVIEW_ITERATIONS_HARD_CAP)
+                ],
+            ),
+            # R0 no-commit, R1 commit, R2 no-commit, then commits.
+            patch.object(
+                implementer,
+                "_run_address_review_step",
+                side_effect=[False, True, False, True, True],
+            ) as mock_addr,
+            patch(
+                "hephaestus.automation._review_phase.gh_pr_list_unresolved_threads",
+                return_value=snapshot,
+            ),
+        ):
+            implementer._run_impl_review_loop(
+                issue_number=1,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        # Address call 0 (R0): no directive. Call 1 (R1, after R0 no-commit):
+        # directive present. Call 2 (R2, after R1 commit): directive CLEARED.
+        calls = mock_addr.call_args_list
+        assert not calls[0].kwargs.get("unaddressed_findings")
+        assert calls[1].kwargs.get("unaddressed_findings") == snapshot
+        assert not calls[2].kwargs.get("unaddressed_findings")
+
+    def test_normal_converging_run_reaches_go_unchanged(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """Regression: a normal NOGO→GO run with committing fixes still converges.
+
+        Guards against behavior drift from the no-commit-retry change: when the
+        address step commits (``True``), the loop behaves exactly as before.
+        """
+        from hephaestus.automation.state_labels import STATE_SKIP
+
+        with (
+            patch.object(
+                implementer,
+                "_run_impl_review_step",
+                side_effect=[(_nogo("D"), ["t0"]), (_go(), [])],
+            ),
+            patch.object(implementer, "_run_address_review_step", return_value=True),
+            patch("hephaestus.automation._review_phase.gh_issue_add_labels") as mock_label,
+        ):
+            iters, verdict, _ = implementer._run_impl_review_loop(
+                issue_number=1,
+                worktree_path=tmp_path,
+                branch_name="b",
+                issue_title="t",
+                issue_body="ib",
+                session_id="sess",
+                slot_id=0,
+                thread_id=None,
+                pr_number=42,
+            )
+
+        assert verdict == "GO"
+        assert iters == 2
+        for call in mock_label.call_args_list:
+            assert STATE_SKIP not in call.args[1]
+
 
 class TestRunImplReviewFailsSafe:
     """When the reviewer call itself fails, surface a distinct ERROR verdict.

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -842,6 +842,38 @@ class TestAddressReviewPrompt:
         assert "_TASK_REVIEW\n" in out
         assert "_DIFF\n" in out
 
+    def test_no_retry_directive_by_default(self) -> None:
+        """Without unaddressed_findings, no 'Make sure to handle' directive appears."""
+        out = self._build()
+        assert "Make sure to handle" not in out
+        assert "_UNADDRESSED\n" not in out
+
+    def test_retry_directive_contains_finding_body(self) -> None:
+        """#1554: the no-commit retry directive names each unaddressed finding."""
+        out = prompts.get_address_review_prompt(
+            pr_number=42,
+            issue_number=7,
+            worktree_path="/tmp/wt",
+            threads_json='[{"thread_id": "T1", "path": "a.py", "line": 1, "body": "fix"}]',
+            todo_block="@ a.py Line 1 - simple - fix",
+            unaddressed_findings=[
+                {"id": "t0", "path": "scaffold.py", "line": 175, "body": "FIX THE NULL DEREF"}
+            ],
+        )
+        assert "Make sure to handle scaffold.py:175 — FIX THE NULL DEREF" in out
+        assert "produced NO commit on the previous turn" in out
+        # The directive body is reviewer text → fenced as untrusted.
+        assert "_UNADDRESSED\n" in out
+
+    def test_build_unaddressed_directive_empty_is_blank(self) -> None:
+        """An empty findings list renders no directive block."""
+        assert prompts.build_unaddressed_directive([], "NONCE") == ""
+
+    def test_build_unaddressed_directive_handles_missing_fields(self) -> None:
+        """Missing path/line/body degrade gracefully, not crash."""
+        out = prompts.build_unaddressed_directive([{"id": "t0"}], "NONCE")
+        assert "Make sure to handle <no path> — <empty body>" in out
+
 
 class TestReviewValidationPrompt:
     """The review-validation prompt re-checks prior comments against the diff."""


### PR DESCRIPTION
## Summary

The in-loop implementation review gave up after a single no-commit address turn. When the fix agent resumed a stale session and **self-reported success without committing** (the `#1083` anti-fabrication guard correctly returns `addressed=False`), the loop hit `if not addressed: break` and stopped at iteration 0 — wasting its remaining budget. With no GO, auto-merge never armed, drive-green returned rc=1, and the issue was tagged `state:skip`.

Diagnosed from `output.log` (2026-06-23 run on issue #1554 / PR #1570): R0 reviewer GO'd with a residual *minor* finding (`scaffold_subpackage.py:175` overwrite guard); the unresolved thread downgraded GO→NOGO; the address agent reported *"Signed commit verified"* but made zero edits; the loop stopped and `state:skip` was applied.

## Change

Per the maintainer policy — "if there is something to fix and there are loop iterations left, then fix it; if there are no iterations left, the next run will fix it":

1. **Retry instead of break** (`_review_phase.py::_run_impl_review_loop`): when an address step produces no commit but unresolved threads remain AND iterations are left, re-review and retry rather than stopping. Only break when nothing fixable remains or the budget is exhausted (existing terminal/skip behavior unchanged). A no-commit round still never counts as progress, so it cannot extend the budget; `MAX_REVIEW_ITERATIONS_HARD_CAP` continues to bound total iterations.
2. **Informed retry directive**: carry the still-unresolved threads forward into the next address invocation via a new optional `unaddressed_findings` parameter, rendered as a `Make sure to handle <finding>` prompt block (`build_unaddressed_directive`, fenced untrusted) to re-ground a resumed session on the concrete work it failed to land. Threaded through `get_address_review_prompt` → `run_address_fix_session` → `_run_address_review_step` → `_run_address_iteration` → `_run_address_step_if_needed` (plus the `implementer` / `implementer_phase_runner` delegators).

**Out of scope (intentionally):** the exhaustion `state:skip` policy is unchanged — stranded PRs are triaged manually.

## Tests

- `tests/unit/automation/test_implementer_loop.py`: no-commit-with-iterations-left continues (not break, the #1570 regression); the retry injects the directive on the next address call; a committed round clears the directive; a normal converging run reaches GO unchanged.
- `tests/unit/automation/test_prompts.py`: directive contains the finding body and is fenced untrusted; no directive by default; empty findings → blank; missing fields degrade gracefully.

All automation unit tests pass; ruff + mypy clean.

Closes #1574