### PR TITLE
feat(agents): add Pi automation backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 # Secrets
 .env
 .env.local
+.heph-private-denylist
 *.pem
 credentials.json
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -252,6 +252,16 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: check-private-denylist
+        name: Check local private denylist
+        description: >
+          If .heph-private-denylist exists locally, reject changed text files
+          containing any fixed string listed there. The denylist itself is
+          gitignored and must never be committed.
+        entry: python3 scripts/check_private_denylist.py
+        language: system
+        pass_filenames: true
+        types: [text]
 
   # Conventional Commits enforcement (DoD row 5; issue #1209).
   # commit-msg stage: pre-commit passes the message file path as the only arg.

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -1,8 +1,9 @@
-"""Shared Claude/Codex process helpers for agent-driven CLIs."""
+"""Shared process helpers for agent-driven CLIs."""
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import shutil
@@ -13,15 +14,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
-AgentName = Literal["claude", "codex"]
-AGENT_CHOICES: tuple[AgentName, ...] = ("claude", "codex")
+AgentName = Literal["claude", "codex", "pi"]
+AGENT_CHOICES: tuple[AgentName, ...] = ("claude", "codex", "pi")
 DEFAULT_AGENT: AgentName = "claude"
 AGENT_AUTH_STATUS_TIMEOUT = 10
 CODEX_FINAL_MESSAGE_GRACE_ENV = "HEPH_CODEX_FINAL_MESSAGE_GRACE"
 CODEX_FINAL_MESSAGE_GRACE_SECONDS = 5.0
+PI_MODEL_ENV = "HEPH_PI_MODEL"
+PI_READ_ONLY_TOOLS = "read,grep,find,ls"
 AGENT_AUTH_STATUS_COMMANDS: dict[AgentName, tuple[tuple[str, ...], ...]] = {
     "claude": (("claude", "auth", "status"),),
     "codex": (("codex", "login", "status"),),
+    "pi": (("pi", "--version"),),
 }
 
 
@@ -32,6 +36,38 @@ class AgentRunResult:
     stdout: str
     stderr: str
     session_id: str | None = None
+
+
+@dataclass(frozen=True)
+class AgentCapabilities:
+    """Backend capabilities used by provider-neutral call sites."""
+
+    direct_runner: bool
+    supports_approval: bool
+    supports_sandbox: bool
+    supports_sessions: bool
+
+
+AGENT_CAPABILITIES: dict[AgentName, AgentCapabilities] = {
+    "claude": AgentCapabilities(
+        direct_runner=False,
+        supports_approval=False,
+        supports_sandbox=True,
+        supports_sessions=True,
+    ),
+    "codex": AgentCapabilities(
+        direct_runner=True,
+        supports_approval=True,
+        supports_sandbox=True,
+        supports_sessions=True,
+    ),
+    "pi": AgentCapabilities(
+        direct_runner=True,
+        supports_approval=False,
+        supports_sandbox=True,
+        supports_sessions=True,
+    ),
+}
 
 
 def add_agent_argument(parser: argparse.ArgumentParser) -> None:
@@ -69,17 +105,7 @@ def is_agent_authenticated(agent: AgentName) -> bool:
 
 
 def resolve_agent(agent: str | None) -> AgentName:
-    """Resolve an optional provider selection into a concrete backend.
-
-    When the operator omits ``--agent``, choose an installed provider that also
-    reports authenticated status. Claude still wins ties when both providers are
-    authenticated.
-
-    When the operator explicitly passes ``--agent``, the selected provider must
-    still be installed and authenticated — an unauthenticated backend would
-    silently produce empty output, causing every automation phase to report
-    success while doing no work.
-    """
+    """Resolve an optional provider selection into a concrete backend."""
     if agent is not None:
         if agent not in AGENT_CHOICES:
             raise ValueError(f"Unsupported agent: {agent}")
@@ -90,17 +116,21 @@ def resolve_agent(agent: str | None) -> AgentName:
                     f"Install the '{agent}' CLI and try again, "
                     f"or omit --agent to auto-detect an authenticated backend."
                 )
+            status_hint = (
+                "`pi --version` and check ~/.pi/agent/models.json"
+                if agent == "pi"
+                else f"`{agent} auth status` (or `{agent} login status`)"
+            )
             raise RuntimeError(
                 f"Agent '{agent}' is installed but not authenticated. "
-                f"Run `{agent} auth status` (or `{agent} login status`) "
-                f"and log in before running automation."
+                f"Run {status_hint} before running automation."
             )
         return agent
 
     installed_agents = tuple(agent_name for agent_name in AGENT_CHOICES if shutil.which(agent_name))
     if not installed_agents:
         raise RuntimeError(
-            "No supported agent backend found on PATH. Install `claude` or `codex`, "
+            "No supported agent backend found on PATH. Install `claude`, `codex`, or `pi`, "
             "or pass --agent after installing the selected backend."
         )
 
@@ -110,14 +140,33 @@ def resolve_agent(agent: str | None) -> AgentName:
 
     raise RuntimeError(
         "Supported agent backends are installed but none are authenticated. "
-        "Run `claude auth status` or `codex login status`, then log in to the "
-        "provider you want automation to use."
+        "Run `claude auth status`, `codex login status`, or `pi --version`, then "
+        "log in/configure the provider you want automation to use."
     )
 
 
 def is_codex(agent: str) -> bool:
     """Return True when the selected provider is Codex."""
     return agent == "codex"
+
+
+def is_pi(agent: str) -> bool:
+    """Return True when the selected provider is Pi."""
+    return agent == "pi"
+
+
+def uses_direct_agent_runner(agent: str) -> bool:
+    """Return True when the provider is invoked through runtime text/session helpers."""
+    if agent not in AGENT_CAPABILITIES:
+        return False
+    return AGENT_CAPABILITIES[agent].direct_runner
+
+
+def direct_agent_model(agent: str, phase_env_var: str) -> str:
+    """Return a model override appropriate for a direct-runner provider."""
+    if is_pi(agent):
+        return os.environ.get(PI_MODEL_ENV, "")
+    return os.environ.get(phase_env_var, "")
 
 
 def session_agent_matches(session_agent: str | None, selected_agent: str) -> bool:
@@ -154,7 +203,6 @@ def run_claude_text(
 
     env = os.environ.copy()
     env["CLAUDECODE"] = ""
-    # Propagate correlation ID to subprocess if set (for gh tracing).
     from hephaestus.logging.utils import get_current_correlation_id
 
     cid = get_current_correlation_id()
@@ -288,6 +336,60 @@ def _parse_codex_json_events(text: str) -> tuple[str | None, str]:
     return session_id, "\n".join(messages).strip()
 
 
+def _pi_message_text(message: Any) -> str:
+    """Extract assistant text from a Pi message object."""
+    if not isinstance(message, dict):
+        return ""
+    if message.get("role") not in (None, "assistant"):
+        return ""
+    content = message.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+                elif isinstance(item.get("delta"), str):
+                    parts.append(item["delta"])
+        return "".join(parts).strip()
+    text = message.get("text")
+    return text.strip() if isinstance(text, str) else ""
+
+
+def _parse_pi_json_events(text: str) -> tuple[str | None, str]:
+    """Extract Pi session id and final assistant text from JSONL output."""
+    session_id: str | None = None
+    final_message = ""
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            event: Any = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") == "session" and isinstance(event.get("id"), str):
+            session_id = event["id"]
+        if event.get("type") in {"message_end", "turn_end"}:
+            message_text = _pi_message_text(event.get("message"))
+            if message_text:
+                final_message = message_text
+        if event.get("type") == "agent_end":
+            raw_messages = event.get("messages")
+            if isinstance(raw_messages, list):
+                for message in raw_messages:
+                    message_text = _pi_message_text(message)
+                    if message_text:
+                        final_message = message_text
+    return session_id, final_message.strip()
+
+
 def run_codex_session(
     prompt: str,
     *,
@@ -353,6 +455,223 @@ def _run_codex_command(
     session_id, event_message = _parse_codex_json_events(stdout_text)
     stdout = (last_message or event_message or stdout_text or "").strip()
     return AgentRunResult(stdout=stdout, stderr=stderr_text, session_id=session_id)
+
+
+def _pi_base_cmd(*, model: str = "", session_id: str | None = None) -> list[str]:
+    """Build a Pi JSON-mode command."""
+    resolved_model = model or os.environ.get(PI_MODEL_ENV, "")
+    cmd = ["pi", "--mode", "json"]
+    if session_id:
+        cmd.extend(["--session", session_id])
+    if resolved_model:
+        cmd.extend(["--model", resolved_model])
+    return cmd
+
+
+def _pi_sandbox_args(sandbox: str) -> list[str]:
+    """Return Pi tool restrictions for the requested sandbox mode."""
+    if sandbox == "read-only":
+        return ["--tools", PI_READ_ONLY_TOOLS]
+    if sandbox in {"workspace-write", "danger-full-access"}:
+        return []
+    raise ValueError(f"Unsupported Pi sandbox mode: {sandbox}")
+
+
+def _pi_env() -> dict[str, str]:
+    """Return a privacy-biased environment for Pi subprocesses."""
+    env = os.environ.copy()
+    env.setdefault("PI_TELEMETRY", "0")
+    env.setdefault("PI_SKIP_VERSION_CHECK", "1")
+    return env
+
+
+def _run_pi_command(
+    cmd: list[str],
+    *,
+    prompt: str,
+    cwd: Path,
+    timeout: int,
+    sandbox: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run Pi with prompt content attached via an ephemeral file, not argv."""
+    prompt_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            prefix="pi-prompt-",
+            suffix=".md",
+            encoding="utf-8",
+            delete=False,
+        ) as prompt_file:
+            prompt_file.write(prompt)
+            prompt_path = Path(prompt_file.name)
+        prompt_path.chmod(0o600)
+        cmd.extend(_pi_sandbox_args(sandbox))
+        cmd.append(f"@{prompt_path}")
+        return subprocess.run(
+            cmd,
+            cwd=cwd,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            env=_pi_env(),
+            check=True,
+        )
+    finally:
+        if prompt_path is not None:
+            with contextlib.suppress(OSError):
+                prompt_path.unlink()
+
+
+def run_pi_text(
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: int,
+    model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
+) -> subprocess.CompletedProcess[str]:
+    """Run Pi non-interactively and return a text completed process."""
+    del approval
+    result = run_pi_session(prompt, cwd=cwd, timeout=timeout, model=model, sandbox=sandbox)
+    return subprocess.CompletedProcess(
+        args=["pi", "--mode", "json"],
+        returncode=0,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+
+
+def run_pi_session(
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: int,
+    model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
+) -> AgentRunResult:
+    """Run a new Pi JSON-mode session and capture its id."""
+    del approval
+    cmd = _pi_base_cmd(model=model)
+    result = _run_pi_command(
+        cmd,
+        prompt=prompt,
+        cwd=cwd,
+        timeout=timeout,
+        sandbox=sandbox,
+    )
+    session_id, event_message = _parse_pi_json_events(result.stdout or "")
+    stdout = (event_message or result.stdout or "").strip()
+    return AgentRunResult(stdout=stdout, stderr=result.stderr or "", session_id=session_id)
+
+
+def resume_pi_session(
+    session_id: str,
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: int,
+    model: str = "",
+) -> AgentRunResult:
+    """Resume a Pi JSON-mode session by id."""
+    cmd = _pi_base_cmd(model=model, session_id=session_id)
+    result = _run_pi_command(
+        cmd,
+        prompt=prompt,
+        cwd=cwd,
+        timeout=timeout,
+        sandbox="workspace-write",
+    )
+    parsed_session_id, event_message = _parse_pi_json_events(result.stdout or "")
+    stdout = (event_message or result.stdout or "").strip()
+    return AgentRunResult(
+        stdout=stdout,
+        stderr=result.stderr or "",
+        session_id=parsed_session_id or session_id,
+    )
+
+
+def run_agent_text(
+    agent: str,
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: int,
+    model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
+) -> subprocess.CompletedProcess[str]:
+    """Run a direct-runner agent non-interactively and return text output."""
+    if is_codex(agent):
+        return run_codex_text(
+            prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            sandbox=sandbox,
+            approval=approval,
+        )
+    if is_pi(agent):
+        return run_pi_text(
+            prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            sandbox=sandbox,
+            approval=approval,
+        )
+    raise ValueError(f"Agent '{agent}' does not support direct text execution")
+
+
+def run_agent_session(
+    agent: str,
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: int,
+    model: str = "",
+    sandbox: str = "workspace-write",
+    approval: str = "never",
+) -> AgentRunResult:
+    """Run a direct-runner agent session and return output plus session id."""
+    if is_codex(agent):
+        return run_codex_session(
+            prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            sandbox=sandbox,
+            approval=approval,
+        )
+    if is_pi(agent):
+        return run_pi_session(
+            prompt,
+            cwd=cwd,
+            timeout=timeout,
+            model=model,
+            sandbox=sandbox,
+            approval=approval,
+        )
+    raise ValueError(f"Agent '{agent}' does not support direct session execution")
+
+
+def resume_agent_session(
+    agent: str,
+    session_id: str,
+    prompt: str,
+    *,
+    cwd: Path,
+    timeout: int,
+    model: str = "",
+) -> AgentRunResult:
+    """Resume a direct-runner agent session."""
+    if is_codex(agent):
+        return resume_codex_session(session_id, prompt, cwd=cwd, timeout=timeout, model=model)
+    if is_pi(agent):
+        return resume_pi_session(session_id, prompt, cwd=cwd, timeout=timeout, model=model)
+    raise ValueError(f"Agent '{agent}' does not support direct session resume")
 
 
 def _communicate_codex_process(
@@ -471,7 +790,7 @@ def codex_json_stdout(text: str, session_id: str | None = None) -> str:
 
 
 def extract_agent_text(stdout: str) -> str:
-    """Extract model text from either Claude JSON output or raw Codex text."""
+    """Extract model text from either Claude JSON output or raw direct-agent text."""
     try:
         payload: Any = json.loads(stdout or "{}")
     except json.JSONDecodeError:

--- a/hephaestus/automation/_followup_phase.py
+++ b/hephaestus/automation/_followup_phase.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from hephaestus.agents.runtime import is_codex, session_agent_matches
+from hephaestus.agents.runtime import session_agent_matches, uses_direct_agent_runner
 
 from ._stage_context import StageMixin
 from .claude_models import implementer_model
@@ -70,7 +70,7 @@ class FollowUpPhase(StageMixin):
             with self.state_lock:
                 state.learn_completed = retro_success
             impl._save_state(state)
-            if retro_success and not is_codex(self.options.agent):
+            if retro_success and not uses_direct_agent_runner(self.options.agent):
                 self.runner._compact_implementer_session(issue_number, worktree_path)
 
         # Follow-up issues phase (after LEARN, before COMPLETED)

--- a/hephaestus/automation/_implement_phase.py
+++ b/hephaestus/automation/_implement_phase.py
@@ -20,9 +20,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from hephaestus.agents.runtime import (
+    direct_agent_model,
     is_codex,
-    run_codex_session,
+    run_agent_session,
+    run_agent_text,
     run_codex_text,
+    uses_direct_agent_runner,
 )
 from hephaestus.github.rate_limit import wait_until
 
@@ -88,6 +91,16 @@ class ImplementPhase(StageMixin):
                     sandbox="read-only",
                 )
                 return (result.stdout or "").strip()
+            if uses_direct_agent_runner(self.options.agent):
+                result = run_agent_text(
+                    agent=self.options.agent,
+                    prompt=prompt,
+                    cwd=self.repo_root,
+                    timeout=advise_claude_timeout(),
+                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
+                    sandbox="read-only",
+                )
+                return (result.stdout or "").strip()
             repo_slug = get_repo_slug(self.repo_root)
             stdout, _ = invoke_claude_with_session(
                 repo=repo_slug,
@@ -146,8 +159,8 @@ class ImplementPhase(StageMixin):
 
         self.state_dir.mkdir(parents=True, exist_ok=True)
 
-        if is_codex(self.options.agent):
-            return self.impl._run_codex_code(issue_number, worktree_path, prompt)
+        if uses_direct_agent_runner(self.options.agent):
+            return self._run_direct_agent_code(issue_number, worktree_path, prompt)
 
         return self.impl._run_claude_impl_session(issue_number, worktree_path, prompt)
 
@@ -249,12 +262,23 @@ class ImplementPhase(StageMixin):
 
     def _run_codex_code(self, issue_number: int, worktree_path: Path, prompt: str) -> str | None:
         """Run Codex implementation prompt in a worktree."""
-        log_file = self.state_dir / f"codex-{issue_number}.log"
+        return self._run_direct_agent_code(issue_number, worktree_path, prompt)
+
+    def _run_direct_agent_code(
+        self, issue_number: int, worktree_path: Path, prompt: str
+    ) -> str | None:
+        """Run a direct-runner implementation prompt in a worktree."""
+        agent = self.options.agent
+        log_file = self.state_dir / f"{agent}-{issue_number}.log"
         try:
-            result = run_codex_session(
-                prompt,
+            result = run_agent_session(
+                agent=agent,
+                prompt=prompt,
                 cwd=worktree_path,
                 timeout=implementer_claude_timeout(),
+                model=(
+                    "" if is_codex(agent) else direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL")
+                ),
                 sandbox="workspace-write",
             )
             log_file.write_text(result.stdout or "")
@@ -266,9 +290,13 @@ class ImplementPhase(StageMixin):
             log_file.write_text(output)
             reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
             if reset_epoch is not None and reset_epoch > 0:
-                logger.warning("Codex usage cap hit for issue #%s; waiting for reset", issue_number)
+                logger.warning(
+                    "%s usage cap hit for issue #%s; waiting for reset",
+                    agent,
+                    issue_number,
+                )
                 wait_until(reset_epoch)
-            raise RuntimeError(f"Codex failed: {stderr or stdout}") from e
+            raise RuntimeError(f"{agent} failed: {stderr or stdout}") from e
         except subprocess.TimeoutExpired as e:
             log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
-            raise RuntimeError("Codex timed out") from e
+            raise RuntimeError(f"{agent} timed out") from e

--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -24,9 +24,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hephaestus.agents.runtime import (
+    direct_agent_model,
     is_codex,
+    resume_agent_session,
     resume_codex_session,
+    run_agent_text,
     run_codex_text,
+    uses_direct_agent_runner,
 )
 from hephaestus.github.client import ClaudeUsageCapError, gh_call
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
@@ -1558,6 +1562,41 @@ class ReviewPhase(StageMixin):
                 )
                 return False
 
+        if uses_direct_agent_runner(self.options.agent):
+            try:
+                result = resume_agent_session(
+                    agent=self.options.agent,
+                    session_id=session_id,
+                    prompt=prompt,
+                    cwd=worktree_path,
+                    timeout=implementer_claude_timeout(),
+                    model=direct_agent_model(self.options.agent, "HEPH_IMPLEMENTER_MODEL"),
+                )
+                log_file = (
+                    self.state_dir
+                    / f"{self.options.agent}-feedback-{issue_number}-r{prev_iteration + 1}.log"
+                )
+                log_file.write_text(result.stdout or "")
+                return True
+            except subprocess.CalledProcessError as e:
+                logger.error(
+                    "#%d: %s failed to address R%d feedback (exit=%d): %s",
+                    issue_number,
+                    self.options.agent,
+                    prev_iteration + 1,
+                    e.returncode,
+                    (e.stderr or e.stdout or "")[:500],
+                )
+                return False
+            except subprocess.TimeoutExpired:
+                logger.error(
+                    "#%d: %s timed out addressing R%d feedback",
+                    issue_number,
+                    self.options.agent,
+                    prev_iteration + 1,
+                )
+                return False
+
         # Route through the centralized helper so create/resume semantics and
         # the SESSION_EXPIRED phrase list stay in one place. The deterministic
         # UUID matches what the initial impl session was created with, so the
@@ -1642,6 +1681,19 @@ class ReviewPhase(StageMixin):
                     prompt,
                     cwd=self.repo_root,
                     timeout=600,
+                    sandbox="read-only",
+                )
+                output = (result.stdout or "").strip()
+                if not output:
+                    raise RuntimeError("reviewer returned empty output")
+                return output
+            if uses_direct_agent_runner(self.options.agent):
+                result = run_agent_text(
+                    agent=self.options.agent,
+                    prompt=prompt,
+                    cwd=self.repo_root,
+                    timeout=600,
+                    model=direct_agent_model(self.options.agent, "HEPH_REVIEWER_MODEL"),
                     sandbox="read-only",
                 )
                 output = (result.stdout or "").strip()

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -28,11 +28,15 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
+    direct_agent_model,
     is_codex,
     resolve_agent,
+    resume_agent_session,
     resume_codex_session,
+    run_agent_session,
     run_codex_session,
     session_agent_matches,
+    uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 
@@ -204,6 +208,26 @@ def run_address_fix_session(
                 log = f"SESSION_ID: {codex_result.session_id}\n\n{log}"
             log_file.write_text(log)
             parsed = parse_fn(codex_result.stdout)
+            logger.info(
+                "Fix session complete for PR #%s; addressed %s thread(s)",
+                pr_number,
+                len(parsed.get("addressed", [])),
+            )
+            return parsed
+        if uses_direct_agent_runner(agent):
+            direct_result = run_agent_session(
+                agent=agent,
+                prompt=prompt,
+                cwd=worktree_path,
+                timeout=address_review_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
+                sandbox="workspace-write",
+            )
+            log = direct_result.stdout
+            if direct_result.session_id:
+                log = f"SESSION_ID: {direct_result.session_id}\n\n{log}"
+            log_file.write_text(log)
+            parsed = parse_fn(direct_result.stdout)
             logger.info(
                 "Fix session complete for PR #%s; addressed %s thread(s)",
                 pr_number,
@@ -891,6 +915,61 @@ class AddressReviewer(BaseReviewer):
                     log = f"SESSION_ID: {codex_result.session_id}\n\n{log}"
                 log_file.write_text(log)
                 parsed = self._parse_json_block(codex_result.stdout, issue_number=issue_number)
+                logger.info(
+                    "Fix session complete for PR #%s; addressed %s thread(s)",
+                    pr_number,
+                    len(parsed.get("addressed", [])),
+                )
+                return parsed
+
+        if (
+            not self.options.dry_run
+            and not is_codex(self.options.agent)
+            and uses_direct_agent_runner(self.options.agent)
+            and session_id
+        ):
+            threads_json = json.dumps(
+                [
+                    {
+                        "thread_id": t["id"],
+                        "path": t["path"],
+                        "line": t.get("line"),
+                        "body": t["body"],
+                    }
+                    for t in threads
+                ]
+            )
+            prompt = get_address_review_prompt(
+                pr_number=pr_number,
+                issue_number=issue_number,
+                worktree_path=str(worktree_path),
+                threads_json=threads_json,
+            )
+            try:
+                direct_result = resume_agent_session(
+                    agent=self.options.agent,
+                    session_id=session_id,
+                    prompt=prompt,
+                    cwd=worktree_path,
+                    timeout=address_review_claude_timeout(),
+                    model=direct_agent_model(self.options.agent, "HEPH_IMPLEMENTER_MODEL"),
+                )
+            except subprocess.CalledProcessError as e:
+                logger.warning(
+                    "Issue #%s: %s resume session %r failed for PR #%s; "
+                    "falling back to fresh session: %s",
+                    issue_number,
+                    self.options.agent,
+                    session_id,
+                    pr_number,
+                    (e.stderr or e.stdout or "")[:300],
+                )
+            else:
+                log = direct_result.stdout
+                if direct_result.session_id:
+                    log = f"SESSION_ID: {direct_result.session_id}\n\n{log}"
+                log_file.write_text(log)
+                parsed = self._parse_json_block(direct_result.stdout, issue_number=issue_number)
                 logger.info(
                     "Fix session complete for PR #%s; addressed %s thread(s)",
                     pr_number,

--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -12,6 +12,7 @@ from hephaestus.agents.runtime import (
     resolve_agent,
     run_claude_text,
     run_codex_session,
+    run_pi_session,
 )
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 
@@ -139,6 +140,46 @@ def run_codex(
     return 0
 
 
+def run_pi(
+    args: argparse.Namespace,
+    prompt: str,
+    repo_root: Path,
+    output_file: Path,
+    log_file: Path | None,
+) -> int:
+    """Run one stage with Pi."""
+    if args.debug:
+        print("Running: pi --mode json", file=sys.stderr)
+
+    try:
+        result = run_pi_session(
+            prompt,
+            cwd=repo_root,
+            timeout=args.timeout,
+            model=args.model,
+            sandbox=args.sandbox,
+            approval=args.approval,
+        )
+    except subprocess.TimeoutExpired as exc:
+        write_log(log_file, str(exc))
+        return 124
+    except subprocess.CalledProcessError as exc:
+        log_text = (
+            f"EXIT CODE: {exc.returncode}\n\n"
+            f"STDOUT:\n{exc.stdout or ''}\n\n"
+            f"STDERR:\n{exc.stderr or ''}"
+        )
+        write_log(log_file, log_text)
+        return exc.returncode
+
+    output_file.write_text(result.stdout, encoding="utf-8")
+    log = result.stdout
+    if result.session_id:
+        log = f"SESSION_ID: {result.session_id}\n\n{log}"
+    write_log(log_file, log)
+    return 0
+
+
 # Flag values that silently no-op when --agent=claude is selected.
 # - `approval` is not a parameter of run_claude_text at all, so any
 #   non-default value (i.e. != "never") is a no-op.
@@ -149,6 +190,14 @@ _CLAUDE_NOOP_VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
     ("approval", "--approval", frozenset({"untrusted", "on-request"})),
     ("sandbox", "--sandbox", frozenset({"danger-full-access"})),
 )
+_PI_NOOP_VALUES: tuple[tuple[str, str, frozenset[str]], ...] = (
+    ("approval", "--approval", frozenset({"untrusted", "on-request"})),
+    ("sandbox", "--sandbox", frozenset({"danger-full-access"})),
+)
+_NOOP_VALUES_BY_AGENT: dict[str, tuple[tuple[str, str, frozenset[str]], ...]] = {
+    "claude": _CLAUDE_NOOP_VALUES,
+    "pi": _PI_NOOP_VALUES,
+}
 
 
 def validate_agent_flags(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
@@ -158,18 +207,19 @@ def validate_agent_flags(parser: argparse.ArgumentParser, args: argparse.Namespa
     ``--agent`` is omitted, ``resolve_agent`` will auto-detect at run time and
     that path keeps its existing semantics. See issue #773.
     """
-    if args.agent != "claude":
+    noop_values = _NOOP_VALUES_BY_AGENT.get(args.agent)
+    if not noop_values:
         return
     offending: list[str] = []
-    for attr, flag, noop_values in _CLAUDE_NOOP_VALUES:
+    for attr, flag, noops in noop_values:
         value = getattr(args, attr)
-        if value in noop_values:
+        if value in noops:
             offending.append(f"{flag}={value}")
     if offending:
         parser.error(
-            "--agent=claude does not honor "
+            f"--agent={args.agent} does not honor "
             + ", ".join(offending)
-            + " (these flag values are not supported by the claude agent)"
+            + f" (these flag values are not supported by the {args.agent} agent)"
         )
 
 
@@ -193,6 +243,8 @@ def run_agent(args: argparse.Namespace) -> int:
         return run_claude(args, prompt, repo_root, output_file, log_file)
     if agent == "codex":
         return run_codex(args, prompt, repo_root, output_file, log_file)
+    if agent == "pi":
+        return run_pi(args, prompt, repo_root, output_file, log_file)
     raise ValueError(f"Unsupported agent: {agent}")
 
 

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -20,7 +20,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 from hephaestus.cli.utils import (
     add_github_throttle_args,
     add_json_arg,
@@ -148,6 +154,16 @@ def run_audit_coordinator(
                 prompt,
                 cwd=get_repo_root(),
                 timeout=pr_reviewer_claude_timeout(),
+                sandbox="read-only",
+            )
+            response = result.stdout or ""
+        elif uses_direct_agent_runner(agent):
+            result = run_agent_text(
+                agent=agent,
+                prompt=prompt,
+                cwd=get_repo_root(),
+                timeout=pr_reviewer_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_REVIEWER_MODEL"),
                 sandbox="read-only",
             )
             response = result.stdout or ""

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -23,10 +23,13 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     add_agent_argument,
+    direct_agent_model,
     is_codex,
     resolve_agent,
+    run_agent_session,
     run_codex_session,
     session_agent_matches,
+    uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
     add_dry_run_arg,
@@ -788,6 +791,16 @@ class CIDriver:
                     cwd=self.repo_root,
                     timeout=advise_claude_timeout(),
                     model=codex_advise_model(),
+                    sandbox="read-only",
+                )
+                return (result.stdout or "").strip()
+            if uses_direct_agent_runner(self.options.agent):
+                result = run_agent_session(
+                    agent=self.options.agent,
+                    prompt=prompt,
+                    cwd=self.repo_root,
+                    timeout=advise_claude_timeout(),
+                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
                     sandbox="read-only",
                 )
                 return (result.stdout or "").strip()

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -24,9 +24,13 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
+    direct_agent_model,
     is_codex,
+    resume_agent_session,
     resume_codex_session,
+    run_agent_session,
     run_codex_session,
+    uses_direct_agent_runner,
 )
 
 from .claude_invoke import invoke_claude_with_session
@@ -305,6 +309,64 @@ class CIFixOrchestrator:
                         prompt,
                         cwd=worktree_path,
                         timeout=ci_driver_claude_timeout(),
+                        sandbox="workspace-write",
+                    )
+                except subprocess.CalledProcessError as exc:
+                    return subprocess.CompletedProcess(
+                        args=exc.cmd,
+                        returncode=exc.returncode,
+                        stdout=exc.stdout or "",
+                        stderr=exc.stderr or "",
+                    )
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=result.stdout, stderr=result.stderr or ""
+            )
+
+        if uses_direct_agent_runner(options.agent):
+            if session_id:
+                try:
+                    result = resume_agent_session(
+                        agent=options.agent,
+                        session_id=session_id,
+                        prompt=prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                        model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
+                    )
+                except subprocess.CalledProcessError as exc:
+                    logger.warning(
+                        "Issue #%s: %s resume session %r failed for PR #%s; "
+                        "falling back to fresh session: %s",
+                        issue_number,
+                        options.agent,
+                        session_id,
+                        pr_number,
+                        (exc.stderr or exc.stdout or "")[:300],
+                    )
+                    try:
+                        result = run_agent_session(
+                            agent=options.agent,
+                            prompt=prompt,
+                            cwd=worktree_path,
+                            timeout=ci_driver_claude_timeout(),
+                            model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
+                            sandbox="workspace-write",
+                        )
+                    except subprocess.CalledProcessError as fresh_exc:
+                        return subprocess.CompletedProcess(
+                            args=fresh_exc.cmd,
+                            returncode=fresh_exc.returncode,
+                            stdout=fresh_exc.stdout or "",
+                            stderr=fresh_exc.stderr or "",
+                        )
+            else:
+                try:
+                    result = run_agent_session(
+                        agent=options.agent,
+                        prompt=prompt,
+                        cwd=worktree_path,
+                        timeout=ci_driver_claude_timeout(),
+                        model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
                         sandbox="workspace-write",
                     )
                 except subprocess.CalledProcessError as exc:

--- a/hephaestus/automation/comment_difficulty.py
+++ b/hephaestus/automation/comment_difficulty.py
@@ -23,7 +23,13 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 
 from ._review_utils import parse_json_block
 from .claude_invoke import invoke_claude_with_session
@@ -124,6 +130,17 @@ def _run_classifier_session(
                 prompt,
                 cwd=worktree_path,
                 timeout=advise_claude_timeout(),
+                sandbox="read-only",
+            )
+            log_file.write_text(result.stdout or "")
+            parsed = parse_json_block(result.stdout or "")
+        elif uses_direct_agent_runner(agent):
+            result = run_agent_text(
+                agent=agent,
+                prompt=prompt,
+                cwd=worktree_path,
+                timeout=advise_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_ADVISE_MODEL"),
                 sandbox="read-only",
             )
             log_file.write_text(result.stdout or "")

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -31,7 +31,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import codex_json_stdout, resume_codex_session, session_agent_matches
+from hephaestus.agents.runtime import (
+    codex_json_stdout,
+    direct_agent_model,
+    resume_agent_session,
+    resume_codex_session,
+    session_agent_matches,
+    uses_direct_agent_runner,
+)
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from .claude_timeouts import follow_up_claude_timeout
@@ -417,6 +424,16 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
                 timeout=follow_up_claude_timeout(),
             )
             stdout = codex_json_stdout(codex_result.stdout, codex_result.session_id)
+        elif uses_direct_agent_runner(agent):
+            direct_result = resume_agent_session(
+                agent=agent,
+                session_id=session_id,
+                prompt=prompt_file.read_text(),
+                cwd=worktree_path,
+                timeout=follow_up_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_LEARN_MODEL"),
+            )
+            stdout = codex_json_stdout(direct_result.stdout, direct_result.session_id)
         else:
             result = run(
                 [

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -64,6 +64,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     is_codex,
+    is_pi,
 )
 
 # Imports for the Test-Patch Contract — see module docstring for the full table.
@@ -361,8 +362,15 @@ class IssueImplementer:
             logger.error("git not available: %s", e)
 
         # Check selected agent runtime
-        agent_binary = "codex" if is_codex(self.options.agent) else "claude"
-        agent_name = "Codex" if is_codex(self.options.agent) else "Claude Code"
+        if is_codex(self.options.agent):
+            agent_binary = "codex"
+            agent_name = "Codex"
+        elif is_pi(self.options.agent):
+            agent_binary = "pi"
+            agent_name = "Pi"
+        else:
+            agent_binary = "claude"
+            agent_name = "Claude Code"
         try:
             run([agent_binary, "--version"], check=True)
             logger.info("%s available", agent_name)

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -33,7 +33,13 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
-from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 
 from . import review_state  # noqa: F401  # patch surface — see #714 cycle-break note
 from ._followup_phase import FollowUpPhase
@@ -885,6 +891,16 @@ class ImplementationPhaseRunner:
                     prompt,
                     cwd=worktree_path,
                     timeout=advise_claude_timeout(),
+                    sandbox="read-only",
+                )
+                output = result.stdout or ""
+            elif uses_direct_agent_runner(self.options.agent):
+                result = run_agent_text(
+                    agent=self.options.agent,
+                    prompt=prompt,
+                    cwd=worktree_path,
+                    timeout=advise_claude_timeout(),
+                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
                     sandbox="read-only",
                 )
                 output = result.stdout or ""

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -17,7 +17,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import resume_codex_session, session_agent_matches
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    resume_agent_session,
+    resume_codex_session,
+    session_agent_matches,
+    uses_direct_agent_runner,
+)
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from .claude_models import learn_model
@@ -235,6 +241,28 @@ def run_learn(
 
         return _run_learn_with_retry(
             _invoke_codex, state_dir=state_dir, issue_number=issue_number, log_file=log_file
+        )
+
+    if uses_direct_agent_runner(agent):
+
+        def _invoke_direct_agent() -> str:
+            return (
+                resume_agent_session(
+                    agent=agent,
+                    session_id=session_id,
+                    prompt=build_learn_prompt(""),
+                    cwd=worktree_path,
+                    timeout=learn_claude_timeout(),
+                    model=direct_agent_model(agent, "HEPH_LEARN_MODEL"),
+                ).stdout
+                or ""
+            )
+
+        return _run_learn_with_retry(
+            _invoke_direct_agent,
+            state_dir=state_dir,
+            issue_number=issue_number,
+            log_file=log_file,
         )
 
     # /learn is a SIMPLE-complexity task (summarization + file writes), so we

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -19,7 +19,15 @@ from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
+from hephaestus.agents.runtime import (
+    add_agent_argument,
+    direct_agent_model,
+    is_codex,
+    resolve_agent,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 from hephaestus.automation._review_utils import add_max_workers_arg
 from hephaestus.cli.utils import add_dry_run_arg, add_json_arg, emit_json_status
 from hephaestus.github.rate_limit import wait_until
@@ -434,6 +442,8 @@ class PlanReviewer:
 
         if is_codex(self.options.agent):
             return self._run_codex_analysis(issue_number, prompt, max_retries=max_retries)
+        if uses_direct_agent_runner(self.options.agent):
+            return self._run_direct_agent_analysis(issue_number, prompt, max_retries=max_retries)
 
         repo_root = get_repo_root()
         repo = get_repo_slug(repo_root)
@@ -539,6 +549,60 @@ class PlanReviewer:
             return None
         except Exception as e:
             logger.error("Unexpected error calling Codex for issue #%s: %s", issue_number, e)
+            return None
+
+    def _run_direct_agent_analysis(
+        self,
+        issue_number: int,
+        prompt: str,
+        max_retries: int = 3,
+    ) -> str | None:
+        """Run a non-Claude direct agent to produce a plan review."""
+        agent = self.options.agent
+        try:
+            result = run_agent_text(
+                agent=agent,
+                prompt=prompt,
+                cwd=Path.cwd(),
+                timeout=plan_reviewer_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_REVIEWER_MODEL"),
+                sandbox="read-only",
+            )
+            output = (result.stdout or "").strip()
+            if not output:
+                logger.error("%s returned empty output for issue #%s", agent, issue_number)
+                return None
+            return output
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ""
+            stdout = e.stdout or ""
+            reset_epoch = scan_quota_reset(stderr, stdout)
+            if reset_epoch is not None and max_retries > 0:
+                if reset_epoch > 0:
+                    wait_until(reset_epoch)
+                else:
+                    time.sleep(5)
+                return self._run_direct_agent_analysis(
+                    issue_number,
+                    prompt,
+                    max_retries=max_retries - 1,
+                )
+            logger.error(
+                "%s returned exit code %s for issue #%s: %s",
+                agent,
+                e.returncode,
+                issue_number,
+                (stderr or stdout)[:200],
+            )
+            return None
+        except subprocess.TimeoutExpired:
+            logger.error("%s timed out reviewing plan for issue #%s", agent, issue_number)
+            return None
+        except FileNotFoundError:
+            logger.error("'%s' CLI not found in PATH; cannot run plan review", agent)
+            return None
+        except Exception as e:
+            logger.error("Unexpected error calling %s for issue #%s: %s", agent, issue_number, e)
             return None
 
     def _post_review(self, issue_number: int, review_text: str) -> None:

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -16,7 +16,13 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent
+from hephaestus.agents.runtime import (
+    add_agent_argument,
+    direct_agent_model,
+    is_codex,
+    resolve_agent,
+    uses_direct_agent_runner,
+)
 from hephaestus.cli.utils import (
     add_dry_run_arg,
     add_github_throttle_args,
@@ -387,6 +393,13 @@ class Planner:
                 return self._call_codex(
                     prompt,
                     model=codex_advise_model(),
+                    timeout=advise_claude_timeout(),
+                    sandbox="read-only",
+                )
+            if uses_direct_agent_runner(self.options.agent):
+                return self.claude_runner.call_direct_agent(
+                    prompt,
+                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
                     timeout=advise_claude_timeout(),
                     sandbox="read-only",
                 )

--- a/hephaestus/automation/planner_claude.py
+++ b/hephaestus/automation/planner_claude.py
@@ -14,7 +14,13 @@ import subprocess
 import time
 from typing import TYPE_CHECKING
 
-from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 from hephaestus.github.rate_limit import wait_until
 
 from .claude_invoke import detect_server_overload, invoke_claude_with_session, scan_quota_reset
@@ -92,6 +98,13 @@ class PlannerClaudeRunner:
         """
         if is_codex(self.options.agent):
             return self.call_codex(prompt, model=model, max_retries=max_retries, timeout=timeout)
+        if uses_direct_agent_runner(self.options.agent):
+            return self.call_direct_agent(
+                prompt,
+                model=direct_agent_model(self.options.agent, "HEPH_PLANNER_MODEL"),
+                max_retries=max_retries,
+                timeout=timeout,
+            )
 
         repo_root = get_repo_root()
         repo = get_repo_slug(repo_root)
@@ -210,4 +223,48 @@ class PlannerClaudeRunner:
         response = (result.stdout or "").strip()
         if not response:
             raise RuntimeError("Codex returned empty response")
+        return response
+
+    def call_direct_agent(
+        self,
+        prompt: str,
+        *,
+        model: str,
+        max_retries: int = 3,
+        timeout: int = 300,
+        sandbox: str = "workspace-write",
+    ) -> str:
+        """Call a non-Claude direct agent with retry logic for rate limits."""
+        agent = self.options.agent
+        try:
+            result = run_agent_text(
+                agent=agent,
+                prompt=prompt,
+                cwd=get_repo_root(),
+                timeout=timeout,
+                model=model,
+                sandbox=sandbox,
+            )
+        except subprocess.CalledProcessError as e:
+            stderr = e.stderr or ""
+            stdout = e.stdout or ""
+            reset_epoch = scan_quota_reset(stderr, stdout)
+            if reset_epoch is not None and reset_epoch > 0 and max_retries > 0:
+                logger.warning("%s usage cap hit; waiting for reset", agent)
+                wait_until(reset_epoch)
+                return self.call_direct_agent(
+                    prompt,
+                    model=model,
+                    max_retries=max_retries - 1,
+                    timeout=timeout,
+                    sandbox=sandbox,
+                )
+            detail = stderr or stdout or str(e)
+            raise RuntimeError(f"{agent} failed: {detail}") from e
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(f"{agent} timed out after {timeout}s") from e
+
+        response = (result.stdout or "").strip()
+        if not response:
+            raise RuntimeError(f"{agent} returned empty response")
         return response

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -12,7 +12,13 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import is_codex, run_codex_session
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    run_agent_session,
+    run_codex_session,
+    uses_direct_agent_runner,
+)
 
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
@@ -156,6 +162,22 @@ class PostMergeProcessor:
                 self._last_learn_evidence = mnemosyne_update_evidence(codex_result.stdout or "")
                 logger.info("Issue #%s: drive-green learnings captured with Codex", issue_number)
                 return True
+            if uses_direct_agent_runner(options.agent):
+                direct_result = run_agent_session(
+                    agent=options.agent,
+                    prompt=prompt,
+                    cwd=cwd,
+                    timeout=learn_claude_timeout(),
+                    model=direct_agent_model(options.agent, "HEPH_LEARN_MODEL"),
+                    sandbox="workspace-write",
+                )
+                self._last_learn_evidence = mnemosyne_update_evidence(direct_result.stdout or "")
+                logger.info(
+                    "Issue #%s: drive-green learnings captured with %s",
+                    issue_number,
+                    options.agent,
+                )
+                return True
             stdout, _ = invoke_claude_with_session(
                 repo=repo_slug,
                 issue=issue_number,
@@ -201,11 +223,11 @@ class PostMergeProcessor:
         """
         options = self._options()
         repo_root = self._repo_root()
-        if is_codex(options.agent):
+        if uses_direct_agent_runner(options.agent):
             logger.info(
-                "Issue #%s: skipping /compact (codex has no persisted "
-                "drive-green session to resume)",
+                "Issue #%s: skipping /compact (%s does not use Claude compact sessions)",
                 issue_number,
+                options.agent,
             )
             return False
         try:

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -16,7 +16,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
-from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.agents.runtime import (
+    is_codex,
+    is_pi,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 
 from ._secret_patterns import SECRET_FILE_EXTENSIONS, SECRET_FILE_NAMES
 from .claude_invoke import invoke_claude_with_session
@@ -69,7 +75,11 @@ class _PrMessageParts:
 
 def _agent_display_name(agent: str) -> str:
     """Return a short human-facing name for generated commits/PR bodies."""
-    return "Codex" if is_codex(agent) else "Claude Code"
+    if is_codex(agent):
+        return "Codex"
+    if is_pi(agent):
+        return "Pi"
+    return "Claude Code"
 
 
 def _coauthor_for_agent(agent: str) -> tuple[str, str]:
@@ -81,6 +91,8 @@ def _coauthor_for_agent(agent: str) -> tuple[str, str]:
     """
     if is_codex(agent):
         return ("Codex", "noreply@openai.com")
+    if is_pi(agent):
+        return ("Pi", "noreply@earendil.works")
     return ("Claude Code", "noreply@anthropic.com")
 
 
@@ -92,6 +104,8 @@ def _provenance_for_agent(agent: str) -> str:
     """
     if is_codex(agent):
         return "Codex"
+    if is_pi(agent):
+        return "Pi"
     return implementer_model()
 
 
@@ -267,6 +281,16 @@ def _invoke_git_message_agent(
     if is_codex(agent):
         result = run_codex_text(
             prompt,
+            cwd=worktree_path,
+            timeout=timeout,
+            model=_codex_git_message_model(),
+            sandbox="read-only",
+        )
+        return (result.stdout or "").strip()
+    if uses_direct_agent_runner(agent):
+        result = run_agent_text(
+            agent=agent,
+            prompt=prompt,
             cwd=worktree_path,
             timeout=timeout,
             model=_codex_git_message_model(),

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -27,7 +27,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import is_codex, resolve_agent, run_codex_text
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    resolve_agent,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 from hephaestus.cli.utils import (
     add_json_arg,
     add_version_arg,
@@ -149,6 +156,25 @@ def run_pr_review_analysis(
             # The Verdict:/Grade: line lives in the reviewer prose, not the JSON
             # summary block. Surface the raw output so callers parse the real
             # verdict instead of the verdict-free summary.
+            parsed["review_text"] = review_text
+            logger.info(
+                "Analysis complete for PR #%s; found %s inline comment(s)",
+                pr_number,
+                len(parsed.get("comments", [])),
+            )
+            return parsed
+        if uses_direct_agent_runner(agent):
+            result = run_agent_text(
+                agent=agent,
+                prompt=prompt,
+                cwd=worktree_path,
+                timeout=pr_reviewer_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_REVIEWER_MODEL"),
+                sandbox="read-only",
+            )
+            log_file.write_text(result.stdout or "")
+            review_text = result.stdout or ""
+            parsed = _parse_json_block(review_text)
             parsed["review_text"] = review_text
             logger.info(
                 "Analysis complete for PR #%s; found %s inline comment(s)",

--- a/hephaestus/automation/prompts/advise.py
+++ b/hephaestus/automation/prompts/advise.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 
-from hephaestus.agents.runtime import is_codex
+from hephaestus.agents.runtime import uses_direct_agent_runner
 
 from ._shared import _TERSE_OUTPUT_DIRECTIVE, _relativize_path
 
@@ -51,16 +51,17 @@ If no relevant skills are found, return:
 **Important:** Only select skills from the actual marketplace. Do not speculate or invent skills.
 """
 
-CODEX_ADVISE_PROMPT = (
+DIRECT_AGENT_ADVISE_PROMPT = (
     ADVISE_PROMPT
     + """
 
-**Codex automation constraints:**
+**Direct-agent automation constraints:**
 - Do not invoke `$advise`; this prompt is already the advise step.
 - Do not clone or update ProjectMnemosyne yourself; use the marketplace path above.
 - Do not implement, commit, push, create a PR, or modify files.
 """
 )
+CODEX_ADVISE_PROMPT = DIRECT_AGENT_ADVISE_PROMPT
 
 
 def get_advise_prompt(
@@ -116,7 +117,7 @@ def get_codex_advise_prompt(
     read-only and non-recursive.
     """
     safe_marketplace_path = _relativize_path(marketplace_path, repo_root)
-    return CODEX_ADVISE_PROMPT.format(
+    return DIRECT_AGENT_ADVISE_PROMPT.format(
         issue_number=issue_number,
         issue_title=issue_title,
         issue_body=issue_body,
@@ -128,6 +129,6 @@ def get_codex_advise_prompt(
 
 def get_advise_prompt_builder(agent: str) -> Callable[..., str]:
     """Return the provider-specific advise prompt builder."""
-    if is_codex(agent):
+    if uses_direct_agent_runner(agent):
         return get_codex_advise_prompt
     return get_advise_prompt

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -35,7 +35,13 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import is_codex, run_codex_text
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    is_codex,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 
 from ._review_utils import parse_json_block
 from .claude_invoke import invoke_claude_with_session, raise_for_error_envelope
@@ -178,6 +184,17 @@ def _run_validation_session(
                 prompt,
                 cwd=worktree_path,
                 timeout=pr_reviewer_claude_timeout(),
+                sandbox="read-only",
+            )
+            log_file.write_text(result.stdout or "")
+            parsed = parse_json_block(result.stdout or "")
+        elif uses_direct_agent_runner(agent):
+            result = run_agent_text(
+                agent=agent,
+                prompt=prompt,
+                cwd=worktree_path,
+                timeout=pr_reviewer_claude_timeout(),
+                model=direct_agent_model(agent, "HEPH_REVIEWER_MODEL"),
                 sandbox="read-only",
             )
             log_file.write_text(result.stdout or "")

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -40,7 +40,15 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
+from hephaestus.agents.runtime import (
+    add_agent_argument,
+    direct_agent_model,
+    is_codex,
+    resolve_agent,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 from hephaestus.cli.utils import (
     add_github_throttle_args,
     add_json_arg,
@@ -694,6 +702,18 @@ def _run_conflict_agent(agent: str, prompt: str, work: Path, pr_number: int) -> 
             prompt,
             cwd=work,
             timeout=2400,
+            sandbox="workspace-write",
+        )
+        if result.stdout:
+            logger.debug("  agent: %s", result.stdout[:200])
+        return True
+    if uses_direct_agent_runner(agent):
+        result = run_agent_text(
+            agent=agent,
+            prompt=prompt,
+            cwd=work,
+            timeout=2400,
+            model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
             sandbox="workspace-write",
         )
         if result.stdout:

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -23,7 +23,15 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument, is_codex, resolve_agent, run_codex_text
+from hephaestus.agents.runtime import (
+    add_agent_argument,
+    direct_agent_model,
+    is_codex,
+    resolve_agent,
+    run_agent_text,
+    run_codex_text,
+    uses_direct_agent_runner,
+)
 from hephaestus.cli.utils import (
     add_github_throttle_args,
     add_json_arg,
@@ -355,8 +363,8 @@ async def _dispatch_swarm(
 
     Returns a dict of branch -> status string.
     """
-    claude_swarm = None if is_codex(agent) else _load_claude_swarm()
-    if not is_codex(agent) and claude_swarm is None:
+    claude_swarm = None if uses_direct_agent_runner(agent) else _load_claude_swarm()
+    if not uses_direct_agent_runner(agent) and claude_swarm is None:
         return dict.fromkeys(branches, "failed (claude_code_sdk missing)")
 
     results: dict[str, str] = {}
@@ -379,6 +387,15 @@ async def _dispatch_swarm(
                     repo_path,
                 )
                 return
+            if uses_direct_agent_runner(agent):
+                results[branch] = await asyncio.to_thread(
+                    _run_direct_rebase_agent,
+                    agent,
+                    prompt,
+                    branch,
+                    repo_path,
+                )
+                return
 
             results[branch] = await _run_claude_rebase_agent(
                 prompt, branch, repo_path, claude_swarm
@@ -395,6 +412,25 @@ def _run_codex_rebase_agent(prompt: str, branch: str, repo_path: Path) -> str:
             prompt,
             cwd=repo_path,
             timeout=2400,
+            sandbox="workspace-write",
+        )
+        text = result.stdout or ""
+        logger.debug("[%s] agent: %s", branch, text[:300])
+        return _status_from_agent_text(text) or "failed"
+    except Exception as e:
+        logger.error("[%s] agent exception: %s", branch, e)
+        return "failed"
+
+
+def _run_direct_rebase_agent(agent: str, prompt: str, branch: str, repo_path: Path) -> str:
+    """Run one direct rebase-fix agent and return its status marker."""
+    try:
+        result = run_agent_text(
+            agent=agent,
+            prompt=prompt,
+            cwd=repo_path,
+            timeout=2400,
+            model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
             sandbox="workspace-write",
         )
         text = result.stdout or ""

--- a/scripts/check_private_denylist.py
+++ b/scripts/check_private_denylist.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Reject local private tokens in tracked or staged text files.
+
+Operators can create an untracked ``.heph-private-denylist`` at the repository
+root with one fixed string per line. When present, this guard scans supplied
+paths (pre-commit mode) or git-tracked files (manual mode) and fails if any
+denylisted string appears.
+
+Usage:
+    python scripts/check_private_denylist.py [paths...]
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+DENYLIST_FILENAME = ".heph-private-denylist"
+
+
+class Finding(NamedTuple):
+    """One denylist match in a text file."""
+
+    path: Path
+    line_number: int
+    token: str
+
+
+def get_repo_root() -> Path:
+    """Return the repository root by walking up to the nearest ``pyproject.toml``."""
+    path = Path(__file__).resolve().parent
+    while path != path.parent:
+        if (path / "pyproject.toml").exists():
+            return path
+        path = path.parent
+    return Path(__file__).resolve().parent.parent
+
+
+def load_denylist(repo_root: Path) -> list[str]:
+    """Return local denylist tokens, ignoring blank lines and comments."""
+    path = repo_root / DENYLIST_FILENAME
+    if not path.exists():
+        return []
+    tokens: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        token = line.strip()
+        if token and not token.startswith("#"):
+            tokens.append(token)
+    return tokens
+
+
+def tracked_files(repo_root: Path) -> list[Path]:
+    """Return git-tracked files for manual scans."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [repo_root / line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _relative(repo_root: Path, path: Path) -> Path:
+    try:
+        return path.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return path
+
+
+def scan_paths(repo_root: Path, paths: list[Path], tokens: list[str]) -> list[Finding]:
+    """Return denylist matches in text files under *paths*."""
+    findings: list[Finding] = []
+    if not tokens:
+        return findings
+    denylist_path = (repo_root / DENYLIST_FILENAME).resolve()
+    for path in paths:
+        candidate = path if path.is_absolute() else repo_root / path
+        if candidate.resolve() == denylist_path or not candidate.is_file():
+            continue
+        try:
+            lines = candidate.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        except OSError:
+            continue
+        rel_path = _relative(repo_root, candidate)
+        for line_number, line in enumerate(lines, start=1):
+            for token in tokens:
+                if token in line:
+                    findings.append(Finding(rel_path, line_number, token))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Fail (exit 1) if a scanned text file contains a local denylist token."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] in ("--help", "-h"):
+        print(__doc__)
+        return 0
+
+    repo_root = get_repo_root()
+    tokens = load_denylist(repo_root)
+    if not tokens:
+        return 0
+    paths = [Path(arg) for arg in args] if args else tracked_files(repo_root)
+    findings = scan_paths(repo_root, paths, tokens)
+    if not findings:
+        return 0
+
+    print("ERROR: local private denylist token(s) found. Remove these values before committing:")
+    for finding in findings:
+        print(f"  {finding.path}:{finding.line_number}")
+    print(f"\nDenylist source: {DENYLIST_FILENAME} (local, untracked)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Run a sanitized Pi smoke prompt against an operator-local model alias.
+
+The model/provider configuration must live outside the repository in Pi's local
+configuration. This script accepts only a model alias from ``HEPH_PI_MODEL`` and
+never stores private endpoints, hostnames, or model identifiers in source.
+
+Usage:
+    HEPH_PI_MODEL=<operator-local-alias> python scripts/pi_smoke.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from hephaestus.agents.runtime import run_pi_session
+
+DEFAULT_PROMPT = "Reply with exactly: OK"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the Pi smoke parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Read-only smoke prompt")
+    parser.add_argument("--cwd", type=Path, default=Path.cwd(), help="Working directory for Pi")
+    parser.add_argument("--timeout", type=int, default=300, help="Pi subprocess timeout")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the smoke prompt against the model alias in ``HEPH_PI_MODEL``."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    model = os.environ.get("HEPH_PI_MODEL", "").strip()
+    if not model:
+        print("ERROR: HEPH_PI_MODEL must name an operator-local Pi model alias.", file=sys.stderr)
+        return 2
+    try:
+        result = run_pi_session(
+            args.prompt,
+            cwd=args.cwd,
+            timeout=args.timeout,
+            model=model,
+            sandbox="read-only",
+        )
+    except subprocess.CalledProcessError as exc:
+        print(exc.stderr or exc.stdout or str(exc), file=sys.stderr)
+        return exc.returncode
+    except subprocess.TimeoutExpired as exc:
+        print(f"ERROR: Pi smoke timed out after {exc.timeout}s", file=sys.stderr)
+        return 124
+    print(result.stdout)
+    if result.session_id:
+        print(f"SESSION_ID={result.session_id}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/slurm/pi_smoke.sbatch
+++ b/scripts/slurm/pi_smoke.sbatch
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=pi-smoke
+#SBATCH --output=pi-smoke-%j.out
+#SBATCH --error=pi-smoke-%j.err
+#SBATCH --time=00:30:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+
+set -euo pipefail
+
+: "${HEPH_PI_MODEL:?Set HEPH_PI_MODEL to an operator-local Pi model alias}"
+
+python3 scripts/pi_smoke.py --cwd "${SLURM_SUBMIT_DIR:-$PWD}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ def _agents_authenticated_by_default(
 ) -> None:
     """Stub the agent install+auth pre-flight (#1175) to pass by default.
 
-    ``resolve_agent`` now refuses a ``--agent claude|codex`` selection unless the
+    ``resolve_agent`` now refuses a ``--agent claude|codex|pi`` selection unless the
     CLI is installed AND reports authenticated (#1175) — a real guard so an
-    unauthenticated backend cannot silently produce empty output. But neither CLI
+    unauthenticated backend cannot silently produce empty output. But these CLIs
     is installed in CI, so every test that dispatches a named agent through
     automation, fleet-sync, tidy, etc. (mocking the actual run_* call) would
     otherwise hit ``RuntimeError: Agent '...' is not installed``. Default the

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -43,6 +43,69 @@ def test_parse_codex_json_events_extracts_nested_agent_message() -> None:
     assert output == "nested"
 
 
+def test_parse_pi_json_events_extracts_session_id_and_final_message() -> None:
+    """Pi JSON mode starts with a session header and emits final assistant messages."""
+    text = "\n".join(
+        [
+            '{"type":"session","version":3,"id":"pi-session-123","cwd":"/repo"}',
+            (
+                '{"type":"message_end","message":{"role":"assistant",'
+                '"content":[{"type":"text","text":"final answer"}]}}'
+            ),
+        ]
+    )
+
+    session_id, output = agent_runtime._parse_pi_json_events(text)
+
+    assert session_id == "pi-session-123"
+    assert output == "final answer"
+
+
+def test_parse_pi_json_events_prefers_turn_end_message() -> None:
+    """The parser should handle the canonical turn_end event shape too."""
+    text = "\n".join(
+        [
+            '{"type":"session","id":"pi-session-456"}',
+            (
+                '{"type":"turn_end","message":{"role":"assistant",'
+                '"content":[{"type":"text","text":"turn answer"}]},'
+                '"toolResults":[]}'
+            ),
+        ]
+    )
+
+    session_id, output = agent_runtime._parse_pi_json_events(text)
+
+    assert session_id == "pi-session-456"
+    assert output == "turn answer"
+
+
+def test_parse_pi_json_events_keeps_final_message_once() -> None:
+    """Pi may emit the same assistant response at multiple terminal event levels."""
+    text = "\n".join(
+        [
+            '{"type":"session","id":"pi-session-456"}',
+            (
+                '{"type":"message_end","message":{"role":"assistant",'
+                '"content":[{"type":"text","text":"draft answer"}]}}'
+            ),
+            (
+                '{"type":"turn_end","message":{"role":"assistant",'
+                '"content":[{"type":"text","text":"final answer"}]}}'
+            ),
+            (
+                '{"type":"agent_end","messages":[{"role":"assistant",'
+                '"content":[{"type":"text","text":"final answer"}]}]}'
+            ),
+        ]
+    )
+
+    session_id, output = agent_runtime._parse_pi_json_events(text)
+
+    assert session_id == "pi-session-456"
+    assert output == "final answer"
+
+
 class _FakeCodexPopen:
     def __init__(
         self,
@@ -219,6 +282,142 @@ def test_resume_codex_session_uses_exec_resume(tmp_path: Path) -> None:
     assert result.session_id == "019e1e57-7652-7892-b1ca-c31c93d4b160"
 
 
+def test_run_pi_session_uses_json_mode_and_captures_session(tmp_path: Path) -> None:
+    """Pi stage execution should consume JSONL and preserve the session id."""
+    captured: dict[str, Any] = {}
+    stdout = "\n".join(
+        [
+            '{"type":"session","id":"pi-session-789"}',
+            '{"type":"message_end","message":{"role":"assistant","content":"pi output"}}',
+        ]
+    )
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["cmd"] = cmd
+        captured["kwargs"] = kwargs
+        prompt_arg = next(arg for arg in cmd if arg.startswith("@"))
+        prompt_path = Path(prompt_arg[1:])
+        captured["prompt_text"] = prompt_path.read_text(encoding="utf-8")
+        captured["prompt_mode"] = prompt_path.stat().st_mode & 0o777
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    with (
+        patch.dict("os.environ", {"HEPH_PI_MODEL": ""}),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
+        result = agent_runtime.run_pi_session(
+            "private prompt content",
+            cwd=tmp_path,
+            timeout=30,
+            model="private-alias",
+        )
+
+    assert result.session_id == "pi-session-789"
+    assert result.stdout == "pi output"
+    assert captured["cmd"][:-1] == [
+        "pi",
+        "--mode",
+        "json",
+        "--model",
+        "private-alias",
+    ]
+    assert captured["cmd"][-1].startswith("@")
+    assert "private prompt content" not in captured["cmd"]
+    assert captured["prompt_text"] == "private prompt content"
+    assert captured["prompt_mode"] == 0o600
+    assert captured["kwargs"]["cwd"] == tmp_path
+    assert captured["kwargs"]["timeout"] == 30
+    assert captured["kwargs"]["check"] is True
+    assert captured["kwargs"]["env"]["PI_TELEMETRY"] == "0"
+    assert captured["kwargs"]["env"]["PI_SKIP_VERSION_CHECK"] == "1"
+
+
+def test_run_pi_session_read_only_restricts_tools(tmp_path: Path) -> None:
+    """Read-only Pi stages should request a read-only tool surface."""
+    captured_cmd: list[str] = []
+    stdout = "\n".join(
+        [
+            '{"type":"session","id":"pi-session-789"}',
+            '{"type":"message_end","message":{"role":"assistant","content":"pi output"}}',
+        ]
+    )
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        captured_cmd.extend(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    with (
+        patch.dict("os.environ", {"HEPH_PI_MODEL": ""}),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
+        result = agent_runtime.run_pi_session(
+            "review prompt",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="read-only",
+        )
+
+    assert result.stdout == "pi output"
+    tools_index = captured_cmd.index("--tools")
+    assert captured_cmd[tools_index + 1] == agent_runtime.PI_READ_ONLY_TOOLS
+    assert captured_cmd[-1].startswith("@")
+    assert "review prompt" not in captured_cmd
+
+
+def test_resume_pi_session_passes_resume_id(tmp_path: Path) -> None:
+    """Pi feedback loops should resume the captured session id."""
+    captured: dict[str, Any] = {}
+    stdout = "\n".join(
+        [
+            '{"type":"session","id":"pi-session-789"}',
+            '{"type":"turn_end","message":{"role":"assistant","content":"resumed"}}',
+        ]
+    )
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        del kwargs
+        captured["cmd"] = cmd
+        prompt_arg = next(arg for arg in cmd if arg.startswith("@"))
+        captured["prompt_text"] = Path(prompt_arg[1:]).read_text(encoding="utf-8")
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    with (
+        patch.dict("os.environ", {"HEPH_PI_MODEL": ""}),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
+        result = agent_runtime.resume_pi_session(
+            "pi-session-789",
+            "private feedback content",
+            cwd=tmp_path,
+            timeout=30,
+        )
+
+    assert captured["cmd"][:-1] == ["pi", "--mode", "json", "--session", "pi-session-789"]
+    assert captured["cmd"][-1].startswith("@")
+    assert "private feedback content" not in captured["cmd"]
+    assert captured["prompt_text"] == "private feedback content"
+    assert result.stdout == "resumed"
+    assert result.session_id == "pi-session-789"
+
+
+def test_direct_agent_model_uses_operator_pi_alias() -> None:
+    """Pi uses its own local alias env var instead of phase-specific model names."""
+    with patch.dict(
+        "os.environ",
+        {
+            "HEPH_PI_MODEL": "operator-local-alias",
+            "HEPH_IMPLEMENTER_MODEL": "phase-model",
+        },
+        clear=True,
+    ):
+        assert agent_runtime.direct_agent_model("pi", "HEPH_IMPLEMENTER_MODEL") == (
+            "operator-local-alias"
+        )
+        assert agent_runtime.direct_agent_model("claude", "HEPH_IMPLEMENTER_MODEL") == (
+            "phase-model"
+        )
+
+
 def test_run_claude_text_builds_stage_command(tmp_path: Path) -> None:
     """Claude stage execution should share the agents runtime boundary."""
     captured: dict[str, Any] = {}
@@ -326,6 +525,32 @@ def test_resolve_agent_uses_codex_when_only_codex_is_authenticated() -> None:
             assert agent_runtime.resolve_agent(None) == "codex"
 
 
+def test_resolve_agent_uses_pi_when_claude_and_codex_absent() -> None:
+    """Pi is the third auto-detected backend after Claude and Codex."""
+    with patch("hephaestus.agents.runtime.shutil.which") as mock_which:
+        mock_which.side_effect = lambda name: "/bin/pi" if name == "pi" else None
+
+        with patch(
+            "subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["pi", "--version"], 0, stdout="pi 1.0.0", stderr=""
+            ),
+        ):
+            assert agent_runtime.resolve_agent(None) == "pi"
+
+
+def test_resolve_agent_explicit_pi() -> None:
+    """An explicit Pi backend should be accepted when the CLI preflight succeeds."""
+    with patch("hephaestus.agents.runtime.shutil.which", return_value="/bin/pi"):
+        with patch(
+            "subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                ["pi", "--version"], 0, stdout="pi 1.0.0", stderr=""
+            ),
+        ):
+            assert agent_runtime.resolve_agent("pi") == "pi"
+
+
 def test_resolve_agent_explicit_codex_overrides_claude() -> None:
     """An explicit --agent value wins over auto-detection when authenticated."""
     with patch("hephaestus.agents.runtime.shutil.which", return_value="/bin/codex"):
@@ -391,3 +616,4 @@ def test_add_agent_argument_defaults_to_auto_detect() -> None:
 
     assert parser.parse_args([]).agent is None
     assert parser.parse_args(["--agent", "codex"]).agent == "codex"
+    assert parser.parse_args(["--agent", "pi"]).agent == "pi"

--- a/tests/unit/automation/test_agent_stage.py
+++ b/tests/unit/automation/test_agent_stage.py
@@ -88,6 +88,28 @@ def test_run_agent_dispatches_codex_and_logs_session(
     )
 
 
+def test_run_agent_dispatches_pi_and_logs_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pi stages should use the Pi JSON-mode runner and persist session metadata."""
+
+    def fake_run_pi_session(*args: object, **kwargs: object) -> AgentRunResult:
+        return AgentRunResult(stdout="pi output", stderr="", session_id="pi-session-123")
+
+    monkeypatch.setattr(agent_stage, "run_pi_session", fake_run_pi_session)
+    monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "pi")
+
+    args = _args(tmp_path, agent="pi")
+    rc = agent_stage.run_agent(args)
+
+    assert rc == 0
+    assert Path(args.output).read_text(encoding="utf-8") == "pi output"
+    assert Path(args.log_file).read_text(encoding="utf-8") == (
+        "SESSION_ID: pi-session-123\n\npi output"
+    )
+
+
 def test_run_agent_rejects_unsupported_direct_agent_value(tmp_path: Path) -> None:
     """Direct API callers should not silently route unknown providers to Codex."""
     args = _args(tmp_path, agent="bogus")
@@ -239,3 +261,30 @@ def test_main_allows_approval_with_codex_agent(
         "on-request",
     ]
     assert agent_stage.main(argv) == 0
+
+
+def test_main_rejects_approval_with_pi_agent(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pi does not honor Codex approval policies; reject instead of no-oping."""
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "pi",
+        "--approval",
+        "on-request",
+    ]
+    with pytest.raises(SystemExit) as exc:
+        agent_stage.main(argv)
+    assert exc.value.code == 2
+    assert "--approval=on-request" in capsys.readouterr().err

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -391,6 +391,30 @@ class TestMessageAgentInvocation:
         assert kwargs["sandbox"] == "read-only"
         assert kwargs["model"] == "gpt-5.4-mini"
 
+    def test_pi_message_agent_uses_read_only_pi_exec(self) -> None:
+        completed = subprocess.CompletedProcess(args=["pi"], returncode=0, stdout="{}", stderr="")
+        with (
+            patch.object(pr_manager, "uses_direct_agent_runner", return_value=True),
+            patch.object(pr_manager, "is_codex", return_value=False),
+            patch.object(pr_manager, "git_message_agent_timeout", return_value=120),
+            patch.object(pr_manager, "run_agent_text", return_value=completed) as run_agent,
+        ):
+            assert (
+                pr_manager._invoke_git_message_agent(
+                    issue_number=9,
+                    agent_kind=AGENT_PR_MESSAGE,
+                    prompt="prompt",
+                    worktree_path=Path("/tmp/wt"),
+                    agent="pi",
+                )
+                == "{}"
+            )
+
+        kwargs = run_agent.call_args.kwargs
+        assert kwargs["agent"] == "pi"
+        assert kwargs["cwd"] == Path("/tmp/wt")
+        assert kwargs["sandbox"] == "read-only"
+
 
 # ---------------------------------------------------------------------------
 # #717: Co-Authored-By uses a human-shaped name; model id moves to Implemented-By
@@ -515,6 +539,36 @@ class TestCoAuthorLine:
         assert coauthor_line == "Co-Authored-By: Codex <noreply@openai.com>"
         assert _COAUTHOR_HUMAN_NAME_RE.match(coauthor_line)
         assert "Implemented-By: Codex" in commit_msg
+        mock_model.assert_not_called()
+
+    def test_pi_coauthor_and_provenance_are_pi(self) -> None:
+        porcelain = " M foo.py\n"
+        run_mock = MagicMock(
+            side_effect=[
+                _status(porcelain),  # git status
+                _status(""),  # git add
+                _status("M\tfoo.py\n"),  # changed files context
+                _status(" foo.py | 1 +\n"),  # stat context
+                _status(""),  # git commit
+            ]
+        )
+        issue = MagicMock(title="pi fallback commit")
+
+        with (
+            patch.object(pr_manager, "run", run_mock),
+            patch.object(pr_manager, "fetch_issue_info", return_value=issue),
+            patch.object(pr_manager, "implementer_model") as mock_model,
+            patch.object(pr_manager, "_invoke_git_message_agent", return_value="not json"),
+        ):
+            pr_manager.commit_changes(31, Path("/tmp/wt"), agent="pi")
+
+        commit_msg = run_mock.call_args_list[-1].args[0][-1]
+        coauthor_line = next(
+            line for line in commit_msg.splitlines() if line.startswith("Co-Authored-By:")
+        )
+        assert coauthor_line == "Co-Authored-By: Pi <noreply@earendil.works>"
+        assert _COAUTHOR_HUMAN_NAME_RE.match(coauthor_line)
+        assert "Implemented-By: Pi" in commit_msg
         mock_model.assert_not_called()
 
 

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -329,6 +329,7 @@ class TestAdvisePrompt:
     def test_advise_prompt_builder_selects_codex_prompt(self) -> None:
         """Provider-specific advise prompt selection keeps stage callers simple."""
         assert prompts.get_advise_prompt_builder("codex") is prompts.get_codex_advise_prompt
+        assert prompts.get_advise_prompt_builder("pi") is prompts.get_codex_advise_prompt
         assert prompts.get_advise_prompt_builder("claude") is prompts.get_advise_prompt
 
 

--- a/tests/unit/scripts/test_check_private_denylist.py
+++ b/tests/unit/scripts/test_check_private_denylist.py
@@ -1,0 +1,65 @@
+"""Tests for scripts/check_private_denylist.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "check_private_denylist.py"
+_spec = importlib.util.spec_from_file_location("check_private_denylist", _SCRIPT)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_missing_denylist_is_noop(tmp_path: Path) -> None:
+    """The guard should not affect contributors without local private tokens."""
+    assert _mod.load_denylist(tmp_path) == []
+
+
+def test_load_denylist_ignores_blank_lines_and_comments(tmp_path: Path) -> None:
+    """Operators can annotate the local denylist without creating patterns."""
+    (tmp_path / ".heph-private-denylist").write_text(
+        "\n# local only\nPRIVATE_ENDPOINT_TOKEN\n\nPRIVATE_MODEL_ALIAS\n",
+        encoding="utf-8",
+    )
+
+    assert _mod.load_denylist(tmp_path) == ["PRIVATE_ENDPOINT_TOKEN", "PRIVATE_MODEL_ALIAS"]
+
+
+def test_scan_paths_reports_fake_private_token(tmp_path: Path) -> None:
+    """A tracked text file containing a denylisted token is reported."""
+    source = tmp_path / "hephaestus" / "example.py"
+    source.parent.mkdir()
+    source.write_text('TOKEN = "PRIVATE_ENDPOINT_TOKEN"\n', encoding="utf-8")
+
+    findings = _mod.scan_paths(tmp_path, [source], ["PRIVATE_ENDPOINT_TOKEN"])
+
+    assert findings == [_mod.Finding(source.relative_to(tmp_path), 1, "PRIVATE_ENDPOINT_TOKEN")]
+
+
+def test_main_returns_nonzero_when_fake_token_found(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """main() should fail when any scanned file contains a local denylist token."""
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "docs" / "example.md"
+    source.parent.mkdir()
+    source.write_text("This mentions PRIVATE_ENDPOINT_TOKEN.\n", encoding="utf-8")
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: tmp_path)
+
+    assert _mod.main([str(source)]) == 1
+
+
+def test_help_flag_prints_doc_and_exits_zero(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--help must be a zero-exit smoke path."""
+    monkeypatch.setattr("sys.argv", ["check_private_denylist.py", "--help"])
+    assert _mod.main() == 0
+    assert capsys.readouterr().out.strip()

--- a/tests/unit/scripts/test_pi_smoke.py
+++ b/tests/unit/scripts/test_pi_smoke.py
@@ -1,0 +1,38 @@
+"""Tests for scripts/pi_smoke.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from hephaestus.agents.runtime import AgentRunResult
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "pi_smoke.py"
+_spec = importlib.util.spec_from_file_location("pi_smoke", _SCRIPT)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def test_model_alias_is_required_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The smoke harness must not bake model aliases into source."""
+    monkeypatch.delenv("HEPH_PI_MODEL", raising=False)
+
+    assert _mod.main([]) == 2
+
+
+def test_runs_pi_with_env_model_alias(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The smoke harness forwards only the operator-provided model alias."""
+    monkeypatch.setenv("HEPH_PI_MODEL", "private-test-alias")
+    run_pi = Mock(return_value=AgentRunResult(stdout="OK", stderr="", session_id="pi-smoke"))
+    monkeypatch.setattr(_mod, "run_pi_session", run_pi)
+
+    assert _mod.main(["--cwd", str(tmp_path), "--prompt", "Say OK"]) == 0
+
+    kwargs = run_pi.call_args.kwargs
+    assert kwargs["cwd"] == tmp_path
+    assert kwargs["model"] == "private-test-alias"
+    assert run_pi.call_args.args == ("Say OK",)


### PR DESCRIPTION
## Summary

Adds Pi as a third supported automation backend while keeping private provider details out of tracked source and public GitHub artifacts.

The plan issues remain open for the automation loop.

## Changes

- Add `pi` to the shared agent runtime registry, auth probing, provider capabilities, direct text/session helpers, and session ownership checks.
- Route Pi/direct-runner dispatch through the planner, implementer, review, follow-up, CI, PR manager, tidy, and related automation paths.
- Add a local private-denylist scanner and pre-commit hook wiring for operator-only sensitive strings.
- Add a sanitized Pi smoke harness plus a placeholder-only Slurm wrapper for private environment validation.
- Add regression coverage for Pi runtime parsing, CLI dispatch, PR metadata, private-denylist scanning, and smoke command construction.

## Related Issues

Informational references only: #1576, #1577, #1578, #1579, #1580.

Policy line for this PR only:

Closes #1581

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (code improvement without changing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] CI/CD or infrastructure change
- [x] Test coverage improvement

## Testing

- [ ] All existing tests pass
- [x] New tests added to cover changes
- [ ] Manual testing performed

Passing checks:

- `pixi run ruff check hephaestus tests scripts/check_private_denylist.py scripts/pi_smoke.py`
- `pixi run ruff format --check hephaestus tests scripts/check_private_denylist.py scripts/pi_smoke.py`
- `pixi run mypy`
- `pixi run pytest --no-cov tests/unit/agents/test_runtime.py tests/unit/automation/test_agent_stage.py tests/unit/automation/test_pr_manager.py tests/unit/automation/test_prompts.py tests/unit/scripts/test_check_private_denylist.py tests/unit/scripts/test_pi_smoke.py` (`153 passed`)
- `pixi run python scripts/check_private_denylist.py`
- `git diff --check`
- Staged/private-string scan for internal endpoint, host, checkpoint, and model-name patterns found no branch content matches.

Known local blockers:

- `pixi run pytest --no-cov tests/unit/markdown/test_link_fixer.py -q` fails 3 existing link-fixer assertions in untouched files.
- `pixi run pre-commit run --files ...` could not be completed in this sandbox after hook setup required cache relocation and the final rerun was blocked by the escalation reviewer. The direct ruff, mypy, denylist, and focused pytest checks above passed.

## Checklist

- [x] Code follows project style guidelines (ruff, mypy)
- [x] Self-review of code completed
- [x] Comments added in hard-to-understand areas
- [ ] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Conventional commit message format used
- [ ] Branch named following convention: `<issue-number>-<description>`
- [ ] Change meets the [Definition of Done](https://github.com/mvillmow/ProjectHephaestus/blob/main/docs/DEFINITION_OF_DONE.md)

## Additional Notes

The filed issues already use the feature-request issue template sections: Motivation, Proposed Solution, Alternatives Considered, Severity, and Parent Epic.

No live private endpoint smoke run was performed locally; the added smoke harness accepts only operator-local environment variables and keeps logs/config out of source.

---

Generated by ProjectHephaestus automation.
