### PR TITLE
[Fix] Stop wrongly applying state:skip in a self-perpetuating cycle

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2438,6 +2438,22 @@ def _evaluate_run_result(
         mergeable = str(pr.get("mergeable") or "").upper()
         return merge_state in conflict_states or mergeable == "CONFLICTING"
 
+    def _is_pending_review(pr: dict[str, Any]) -> bool:
+        """Return True for an un-armed, non-conflicting PR awaiting review.
+
+        #1576: such a PR is green but un-armed ONLY because it lacks
+        ``state:implementation-go`` — the review gate has not approved it yet.
+        That is NOT a merge failure (it is the system working as designed), so it
+        must not count toward ``needs_action`` / rc=1, or the loop runner tags
+        the owning issue ``state:skip`` every loop. A conflicting PR is excluded
+        (it is genuinely stuck and stays in ``needs_action``).
+        """
+        return (
+            not pr.get("autoMergeRequest")
+            and not _is_conflicting(pr)
+            and not pr_has_implementation_go_label(pr)
+        )
+
     # Armed AND merge-state benign → genuinely merging on its own (rc=0). Armed
     # but CONFLICTING → false-green; demote to needs_action below.
     armed_pending = [
@@ -2445,16 +2461,27 @@ def _evaluate_run_result(
         for pr in open_prs_remaining
         if pr.get("autoMergeRequest") and not _is_conflicting(pr)
     ]
+    # #1576: un-armed-because-awaiting-review PRs are neither armed nor stuck.
+    pending_review = [pr.get("number") for pr in open_prs_remaining if _is_pending_review(pr)]
+    # needs_action = genuinely stuck: un-armed for a reason OTHER than pending
+    # review (e.g. conflicting), or armed-but-conflicting. Pending-review PRs are
+    # explicitly excluded so they never force rc=1.
     needs_action = [
         pr.get("number")
         for pr in open_prs_remaining
-        if not pr.get("autoMergeRequest") or _is_conflicting(pr)
+        if (not pr.get("autoMergeRequest") or _is_conflicting(pr)) and not _is_pending_review(pr)
     ]
     if armed_pending:
         log.warning(
             "%s PR(s) armed and still merging (waited; not a failure): %s",
             len(armed_pending),
             armed_pending,
+        )
+    if pending_review:
+        log.info(
+            "%s open PR(s) awaiting implementation review (not a failure): %s",
+            len(pending_review),
+            pending_review,
         )
     if failed or needs_action:
         if failed:
@@ -2472,12 +2499,20 @@ def _evaluate_run_result(
                 failed=failed,
                 needs_action=needs_action,
                 armed_pending=armed_pending,
+                pending_review=pending_review,
             )
         return 1
 
     log.info("CI driver complete")
     if as_json:
-        emit_json_status(0, issues=issues, failed=[], needs_action=[], armed_pending=armed_pending)
+        emit_json_status(
+            0,
+            issues=issues,
+            failed=[],
+            needs_action=[],
+            armed_pending=armed_pending,
+            pending_review=pending_review,
+        )
     return 0
 
 

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -70,7 +70,6 @@ from hephaestus.agents.runtime import (
 # Imports for the Test-Patch Contract — see module docstring for the full table.
 # Each symbol here is either a real call site in IssueImplementer/main or an
 # explicit re-export required by tests or the public API.
-from ._review_utils import find_pr_for_issue
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
 
@@ -106,7 +105,7 @@ from .models import (
     WorkerResult,
 )
 from .pr_manager import commit_changes, create_pr
-from .state_labels import is_plan_go, is_skipped
+from .state_labels import is_skipped
 from .status_tracker import StatusTracker
 from .worktree_manager import WorktreeManager
 
@@ -292,10 +291,13 @@ class IssueImplementer:
                 # issue from all phases. Treat it as completed so dependents are
                 # not blocked, and never add it to the work graph.
                 #
-                # Stale-skip recovery: if an explicitly selected issue also has
-                # an approved plan and no PR, load it anyway so a manual/old
-                # skip label cannot strand ready implementation work forever.
-                if is_skipped(issue.labels) and not self._should_recover_stale_skip(issue):
+                # ``state:skip`` is operator-only and ABSOLUTE (#1576): the
+                # automation never removes it and never auto-recovers a skipped
+                # issue — it is the operator's responsibility to remove the label
+                # between runs. ``issue.labels`` comes from the live
+                # ``fetch_issue_info`` (``gh issue view``) call above, never a
+                # cache, so the decision always reflects current GitHub state.
+                if is_skipped(issue.labels):
                     logger.info("Skipping #%s (state:skip)", issue_num)
                     self.resolver.completed.add(issue_num)
                     continue
@@ -311,30 +313,6 @@ class IssueImplementer:
                 logger.error("Failed to load issue #%s: %s", issue_num, e)
 
         logger.info("Loaded %s issues", len(self.resolver.graph.issues))
-
-    @staticmethod
-    def _should_recover_stale_skip(issue: Any) -> bool:
-        """Return True for a skipped, plan-approved issue that has no PR yet."""
-        if not is_plan_go(issue.labels):
-            return False
-        try:
-            pr_number = find_pr_for_issue(issue.number)
-        except Exception as exc:
-            logger.warning(
-                "Issue #%s has state:skip + state:plan-go, but PR lookup failed; "
-                "honoring state:skip (%s)",
-                issue.number,
-                exc,
-            )
-            return False
-        if pr_number is not None:
-            return False
-        logger.warning(
-            "Issue #%s has state:skip + state:plan-go but no open PR; "
-            "treating state:skip as stale and loading for implementation",
-            issue.number,
-        )
-        return True
 
     def _health_check(self) -> dict[int, WorkerResult]:
         """Perform health check of dependencies and environment.

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -50,8 +50,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from hephaestus.agents.runtime import add_agent_argument, resolve_agent
-from hephaestus.automation._review_utils import add_max_workers_arg
-from hephaestus.automation.github_api import gh_issue_add_labels
+from hephaestus.automation._review_utils import add_max_workers_arg, find_pr_for_issue
+from hephaestus.automation.github_api import (
+    gh_issue_add_labels,
+    is_issue_closed,
+    prefetch_issue_states,
+)
 from hephaestus.automation.loop_repo_manager import (
     _clone_missing_repos as _clone_missing_repos,
     _count_failing_prs as _count_failing_prs,
@@ -66,6 +70,7 @@ from hephaestus.automation.loop_repo_manager import (
     _resolve_repo_dir as _resolve_repo_dir,
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
+from hephaestus.automation.pr_manager import pr_is_genuinely_stuck
 from hephaestus.automation.state_labels import STATE_SKIP
 from hephaestus.cli.utils import (
     add_dry_run_arg,
@@ -942,8 +947,13 @@ def _process_repo_inner(
     LOG.info("[%s] trunk=%s%s", repo, trunk_sha, stale_suffix)
 
     # Open-issue discovery happens once per repo per loop. When the operator
-    # scopes the loop explicitly, reuse that bounded list.
+    # scopes the loop explicitly, reuse that bounded list — but drop any that are
+    # CLOSED (#1576): an explicit ``--issues`` list bypasses the open-state
+    # filter that ``_list_open_issue_numbers`` applies, so a closed issue would
+    # otherwise be driven (and wrongly tagged ``state:skip``) every loop.
     open_issues = cfg.issues or _list_open_issue_numbers(cfg.org, repo)
+    if cfg.issues:
+        open_issues = _filter_open_issues(repo, open_issues)
 
     # ISSUE-MAJOR control flow (#1560): iterate issues outermost and run the
     # FULL selected-phase sequence (plan → implement → drive-green) for each
@@ -979,6 +989,66 @@ def _process_repo_inner(
                 result.phases.append(PhaseResult(name="implement", rc=1, elapsed_s=0.0))
 
     return result
+
+
+def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
+    """Drop CLOSED issues from an explicit ``--issues`` list (#1576).
+
+    An operator-pinned ``cfg.issues`` list bypasses the ``--state open`` filter
+    that auto-discovery applies, so a closed issue would otherwise be driven
+    every loop and wrongly tagged ``state:skip`` by drive-green. States are
+    fetched once via :func:`prefetch_issue_states` and checked with
+    :func:`is_issue_closed`. On any lookup failure an issue is KEPT (fail-open:
+    never silently drop work over a transient API blip).
+
+    Args:
+        repo: Repository name (for logging).
+        issue_numbers: The explicit issue list.
+
+    Returns:
+        The subset that is not closed (order preserved).
+
+    """
+    try:
+        cached_states = prefetch_issue_states(issue_numbers)
+    except Exception as exc:  # transient API failure → keep all, don't drop work
+        LOG.warning("[%s] could not prefetch issue states for closed-filter: %s", repo, exc)
+        return issue_numbers
+    kept: list[int] = []
+    for num in issue_numbers:
+        if is_issue_closed(num, cached_states):
+            LOG.info("[%s] issue #%s is closed — excluding from phase loop", repo, num)
+            continue
+        kept.append(num)
+    return kept
+
+
+def _issue_owns_genuinely_failing_pr(issue: int) -> bool:
+    """Return True iff *issue* has a PR that is genuinely stuck (#1576).
+
+    Guards the drive-green ``state:skip`` tag so the loop tags an issue ONLY when
+    that issue's OWN PR genuinely cannot merge (conflict or red CI) — never for a
+    PR that is merely awaiting implementation review, and never for an issue with
+    no PR at all (which covers closed / no-PR issues that share the repo-wide
+    drive-green rc). The PR state is fetched LIVE via
+    :func:`pr_is_genuinely_stuck`. A missing PR or any lookup failure yields
+    False (never tag on uncertainty).
+
+    Args:
+        issue: GitHub issue number.
+
+    Returns:
+        True only when the issue owns a genuinely-stuck PR.
+
+    """
+    try:
+        pr_number = find_pr_for_issue(issue)
+    except Exception as exc:
+        LOG.warning("Could not resolve PR for issue #%s before skip-tagging: %s", issue, exc)
+        return False
+    if pr_number is None:
+        return False
+    return pr_is_genuinely_stuck(pr_number)
 
 
 def _process_one_issue(
@@ -1028,12 +1098,20 @@ def _process_one_issue(
                 phase,
                 phase_result.rc,
             )
-            # drive-green is the blocking merge phase: if it fails (the PR did
-            # not merge within --max-merge-attempts), tag the issue state:skip
-            # so it is not re-attempted and a human/another agent can take it
-            # over (#1560). Mirrors the review-loop exhaustion behavior. A
-            # dry-run must not mutate GitHub state.
-            if phase == "drive-green" and not cfg.dry_run:
+            # drive-green is the blocking merge phase. Its rc is REPO-LEVEL (one
+            # CI-driver run over the whole batch), so a non-zero rc does NOT mean
+            # THIS issue's PR failed — it may be a sibling's PR, or merely a
+            # PR awaiting implementation review. Tag ``state:skip`` ONLY when this
+            # issue OWNS a genuinely-stuck PR (conflict / red CI), verified LIVE
+            # (#1576). This stops the self-perpetuating skip cycle where an
+            # awaiting-review PR (or a closed / no-PR issue sharing the rc) was
+            # re-tagged every loop. ``state:skip`` is operator-only thereafter.
+            # A dry-run must not mutate GitHub state.
+            if (
+                phase == "drive-green"
+                and not cfg.dry_run
+                and _issue_owns_genuinely_failing_pr(issue)
+            ):
                 LOG.warning(
                     "[%s] issue #%s did not merge after %d attempt(s) — tagging %s",
                     repo,
@@ -1194,6 +1272,8 @@ def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]
         try:
             trunk_sha, _fetch_ok = _rebase_main(repo, repo_dir)
             open_issues = cfg.issues or _list_open_issue_numbers(cfg.org, repo)
+            if cfg.issues:
+                open_issues = _filter_open_issues(repo, open_issues)
             for stage in selected_post:
                 skip_reason = _post_loop_stage_skip_reason(cfg, repo, stage, open_issues)
                 if skip_reason is not None:

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -25,6 +25,7 @@ from hephaestus.agents.runtime import (
 )
 
 from ._secret_patterns import SECRET_FILE_EXTENSIONS, SECRET_FILE_NAMES
+from .ci_check_inspector import FAILING_CHECK_CONCLUSIONS
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import git_message_model, implementer_model
 from .claude_timeouts import git_message_agent_timeout
@@ -537,6 +538,65 @@ def pr_has_implementation_go_label(pr: dict[str, object]) -> bool:
             if isinstance(name, str):
                 names.append(name)
     return is_implementation_go(names)
+
+
+def pr_is_genuinely_stuck(pr_number: int) -> bool:
+    """Return True iff a PR genuinely cannot merge without manual/agent action.
+
+    "Genuinely stuck" means a merge CONFLICT (``mergeStateStatus`` DIRTY or
+    CONFLICTING, or ``mergeable`` CONFLICTING) OR a red required check
+    (any ``statusCheckRollup`` conclusion in
+    :data:`~hephaestus.automation.ci_check_inspector.FAILING_CHECK_CONCLUSIONS`).
+
+    Crucially, a PR that is merely **pending implementation review** — green CI,
+    unarmed, ``mergeStateStatus == "BLOCKED"`` only because branch protection
+    requires a review that has not happened yet — is NOT stuck. Returning False
+    for that case is what stops the automation loop from wrongly tagging an
+    awaiting-review PR ``state:skip`` (#1576). ``BLOCKED`` alone is deliberately
+    NOT treated as stuck here (unlike ``_pr_is_failing`` in the CI driver, which
+    intentionally picks BLOCKED PRs up to drive).
+
+    This is the single source of truth shared by the CI driver's needs-action
+    partition and the loop runner's skip-ownership guard, fetched LIVE from
+    GitHub. Any query/parse failure yields ``False`` (safe default: never
+    misclassify an unknown PR as stuck and strand it).
+
+    Args:
+        pr_number: GitHub PR number.
+
+    Returns:
+        True if the PR is conflicting or has a red required check; False for a
+        green/pending/awaiting-review PR or on any lookup failure.
+
+    """
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "mergeStateStatus,mergeable,statusCheckRollup",
+            ],
+            check=False,
+        )
+        pr = cast(dict[str, object], json.loads(result.stdout or "{}"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Could not fetch PR #%s state for stuck-check: %s", pr_number, exc)
+        return False
+
+    merge_state = str(pr.get("mergeStateStatus") or "").upper()
+    mergeable = str(pr.get("mergeable") or "").upper()
+    if merge_state in {"DIRTY", "CONFLICTING"} or mergeable == "CONFLICTING":
+        return True
+
+    rollup = pr.get("statusCheckRollup")
+    if isinstance(rollup, list):
+        return any(
+            isinstance(check, dict) and check.get("conclusion") in FAILING_CHECK_CONCLUSIONS
+            for check in rollup
+        )
+    return False
 
 
 def _pr_label_names(pr_number: int) -> list[str]:

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -3182,10 +3182,43 @@ class TestEvaluateRunResult:
         remaining = [{"number": 10, "autoMergeRequest": {"enabledAt": "now"}}]
         assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
 
-    def test_needs_action_pr_is_one(self) -> None:
-        # An un-armed PR genuinely needs manual action → failure.
+    def test_unarmed_go_labeled_pr_is_needs_action(self) -> None:
+        # #1576: an un-armed PR that HAS state:implementation-go (review approved
+        # but somehow not armed) is a genuine anomaly needing action → rc=1.
+        # (An un-armed PR that LACKS the GO label is pending-review, not a
+        # failure — see test_unarmed_pending_review_pr_is_not_failure.)
         results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
-        remaining = [{"number": 11, "autoMergeRequest": None}]
+        remaining = [
+            {
+                "number": 11,
+                "autoMergeRequest": None,
+                "labels": [{"name": "state:implementation-go"}],
+            }
+        ]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 1
+
+    def test_unarmed_pending_review_pr_is_not_failure(self) -> None:
+        # #1576: an un-armed, non-conflicting PR that lacks
+        # state:implementation-go is merely awaiting review — NOT a merge
+        # failure. It must be classified pending_review and keep rc=0, so the
+        # loop runner never tags the owning issue state:skip.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining: list[dict[str, Any]] = [{"number": 11, "autoMergeRequest": None, "labels": []}]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
+
+    def test_unarmed_pending_review_but_conflicting_is_needs_action(self) -> None:
+        # #1576: a conflicting PR is genuinely stuck even without the GO label —
+        # it stays needs_action (rc=1), never pending_review.
+        results = {1: WorkerResult(issue_number=1, success=True, pr_number=10)}
+        remaining: list[dict[str, Any]] = [
+            {
+                "number": 11,
+                "autoMergeRequest": None,
+                "labels": [],
+                "mergeStateStatus": "DIRTY",
+                "mergeable": "CONFLICTING",
+            }
+        ]
         assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 1
 
     def test_failed_issue_is_one(self) -> None:

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -817,6 +817,8 @@ class TestStateSkipLabel:
         assert 43 not in impl.resolver.completed
 
     def test_plan_go_skip_with_existing_pr_still_skips(self, impl: IssueImplementer) -> None:
+        # #1576: state:skip is ABSOLUTE and operator-only — no auto-recovery,
+        # even with state:plan-go + an open PR. The label is honored verbatim.
         from hephaestus.automation.models import IssueInfo
 
         skipped = IssueInfo(number=44, title="t", labels=["state:skip", "state:plan-go"])
@@ -829,22 +831,20 @@ class TestStateSkipLabel:
                 "hephaestus.automation.implementer.fetch_issue_info",
                 return_value=skipped,
             ),
-            patch(
-                "hephaestus.automation.implementer.find_pr_for_issue",
-                return_value=777,
-            ) as mock_find_pr,
             patch.object(impl.resolver, "add_issue") as mock_add,
         ):
             impl._load_issues([44])
 
-        mock_find_pr.assert_called_once_with(44)
         mock_add.assert_not_called()
         assert 44 in impl.resolver.completed
 
-    def test_plan_go_skip_without_pr_is_loaded(self, impl: IssueImplementer) -> None:
+    def test_plan_go_skip_without_pr_also_skips_no_recovery(self, impl: IssueImplementer) -> None:
+        # #1576: removed the no-PR stale-skip recovery escape hatch — a
+        # state:skip issue is ALWAYS skipped, even plan-go with no PR. It is the
+        # operator's responsibility to remove the label between runs.
         from hephaestus.automation.models import IssueInfo
 
-        ready = IssueInfo(number=45, title="t", labels=["state:skip", "state:plan-go"])
+        skipped = IssueInfo(number=45, title="t", labels=["state:skip", "state:plan-go"])
         with (
             patch(
                 "hephaestus.automation.github_api.prefetch_issue_states",
@@ -852,20 +852,14 @@ class TestStateSkipLabel:
             ),
             patch(
                 "hephaestus.automation.implementer.fetch_issue_info",
-                return_value=ready,
+                return_value=skipped,
             ),
-            patch(
-                "hephaestus.automation.implementer.find_pr_for_issue",
-                return_value=None,
-            ) as mock_find_pr,
-            patch.object(impl.resolver, "_load_dependencies"),
             patch.object(impl.resolver, "add_issue") as mock_add,
         ):
             impl._load_issues([45])
 
-        mock_find_pr.assert_called_once_with(45)
-        mock_add.assert_called_once_with(ready)
-        assert 45 not in impl.resolver.completed
+        mock_add.assert_not_called()
+        assert 45 in impl.resolver.completed
 
 
 class TestNoChangesProducedAppliesStateSkip:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -201,8 +201,12 @@ def test_build_phase_argv_non_drive_green_omits_max_fix_iterations() -> None:
     assert "--max-fix-iterations" not in plan_argv
 
 
-def test_process_one_issue_tags_skip_when_drive_green_fails() -> None:
-    """A failed (non-merged) drive-green tags the issue state:skip (#1560)."""
+def test_process_one_issue_tags_skip_when_issue_owns_failing_pr() -> None:
+    """A failed drive-green tags state:skip ONLY when the issue owns a stuck PR.
+
+    #1560 + #1576: drive-green's rc is repo-level, so the tag is gated on the
+    issue actually owning a genuinely-stuck PR (verified live).
+    """
     cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE, max_merge_attempts=2)
 
     def fake_run_phase(**kw: object) -> PhaseResult:
@@ -212,6 +216,7 @@ def test_process_one_issue_tags_skip_when_drive_green_fails() -> None:
 
     with (
         patch.object(loop_runner, "run_phase", side_effect=fake_run_phase),
+        patch.object(loop_runner, "_issue_owns_genuinely_failing_pr", return_value=True),
         patch.object(loop_runner, "gh_issue_add_labels") as add_labels,
     ):
         loop_runner._process_one_issue(
@@ -224,6 +229,35 @@ def test_process_one_issue_tags_skip_when_drive_green_fails() -> None:
         )
 
     add_labels.assert_called_once_with(42, [STATE_SKIP])
+
+
+def test_process_one_issue_no_skip_when_pr_pending_review() -> None:
+    """#1576: a failed drive-green does NOT tag skip when the PR isn't stuck.
+
+    A green-but-awaiting-review PR (or no PR / sibling's PR) makes the ownership
+    guard return False, so the issue is never tagged despite the repo-level rc=1.
+    """
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE, max_merge_attempts=2)
+
+    def fake_run_phase(**kw: object) -> PhaseResult:
+        name = str(kw["phase"])
+        return PhaseResult(name=name, rc=1 if name == "drive-green" else 0, elapsed_s=0.1)
+
+    with (
+        patch.object(loop_runner, "run_phase", side_effect=fake_run_phase),
+        patch.object(loop_runner, "_issue_owns_genuinely_failing_pr", return_value=False),
+        patch.object(loop_runner, "gh_issue_add_labels") as add_labels,
+    ):
+        loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=42,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
+
+    add_labels.assert_not_called()
 
 
 def test_process_one_issue_no_skip_when_drive_green_merges() -> None:
@@ -266,6 +300,57 @@ def test_process_one_issue_dry_run_does_not_tag_skip() -> None:
             trunk_sha="abc1234",
         )
     add_labels.assert_not_called()
+
+
+def test_filter_open_issues_drops_closed() -> None:
+    """#1576: explicit --issues list drops closed issues before the phase loop."""
+
+    def fake_is_closed(num: int, _cache: object) -> bool:
+        return num == 1552
+
+    with (
+        patch.object(loop_runner, "prefetch_issue_states", return_value={}),
+        patch.object(loop_runner, "is_issue_closed", side_effect=fake_is_closed),
+    ):
+        kept = loop_runner._filter_open_issues("r", [1554, 1552])
+    assert kept == [1554]
+
+
+def test_filter_open_issues_keeps_all_on_prefetch_failure() -> None:
+    """Fail-open: a prefetch error keeps every issue (never silently drop work)."""
+    with patch.object(loop_runner, "prefetch_issue_states", side_effect=RuntimeError("boom")):
+        kept = loop_runner._filter_open_issues("r", [1554, 1552])
+    assert kept == [1554, 1552]
+
+
+def test_issue_owns_genuinely_failing_pr_true_when_stuck() -> None:
+    """#1576: an issue owning a genuinely-stuck PR is tag-eligible."""
+    with (
+        patch.object(loop_runner, "find_pr_for_issue", return_value=1570),
+        patch.object(loop_runner, "pr_is_genuinely_stuck", return_value=True),
+    ):
+        assert loop_runner._issue_owns_genuinely_failing_pr(1554) is True
+
+
+def test_issue_owns_genuinely_failing_pr_false_when_pending_review() -> None:
+    """#1576: a PR awaiting review is not stuck, so the issue is not tag-eligible."""
+    with (
+        patch.object(loop_runner, "find_pr_for_issue", return_value=1570),
+        patch.object(loop_runner, "pr_is_genuinely_stuck", return_value=False),
+    ):
+        assert loop_runner._issue_owns_genuinely_failing_pr(1554) is False
+
+
+def test_issue_owns_genuinely_failing_pr_false_when_no_pr() -> None:
+    """#1576: an issue with no PR (e.g. closed / no-PR) is never tag-eligible."""
+    with patch.object(loop_runner, "find_pr_for_issue", return_value=None):
+        assert loop_runner._issue_owns_genuinely_failing_pr(1552) is False
+
+
+def test_issue_owns_genuinely_failing_pr_false_on_lookup_error() -> None:
+    """#1576: a PR-lookup failure is treated as not-stuck (never tag on uncertainty)."""
+    with patch.object(loop_runner, "find_pr_for_issue", side_effect=RuntimeError("boom")):
+        assert loop_runner._issue_owns_genuinely_failing_pr(1554) is False
 
 
 def test_parse_args_accepts_issue_scope() -> None:

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -599,3 +599,49 @@ class TestImplementationStateLabel:
         gh_mock = _status("not json")
         with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
             assert pr_manager.pr_has_implementation_state_label(7) == (False, False)
+
+
+class TestPrIsGenuinelyStuck:
+    """``pr_is_genuinely_stuck`` distinguishes stuck PRs from pending ones (#1576)."""
+
+    def test_dirty_merge_state_is_stuck(self) -> None:
+        gh_mock = _status('{"mergeStateStatus": "DIRTY", "mergeable": "", "statusCheckRollup": []}')
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_is_genuinely_stuck(7) is True
+
+    def test_conflicting_mergeable_is_stuck(self) -> None:
+        gh_mock = _status(
+            '{"mergeStateStatus": "BLOCKED", "mergeable": "CONFLICTING", "statusCheckRollup": []}'
+        )
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_is_genuinely_stuck(7) is True
+
+    def test_red_check_is_stuck(self) -> None:
+        gh_mock = _status(
+            '{"mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE", '
+            '"statusCheckRollup": [{"conclusion": "FAILURE"}]}'
+        )
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_is_genuinely_stuck(7) is True
+
+    def test_blocked_on_review_is_not_stuck(self) -> None:
+        # Green CI, BLOCKED only because review hasn't approved → NOT stuck.
+        gh_mock = _status(
+            '{"mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE", '
+            '"statusCheckRollup": [{"conclusion": "SUCCESS"}]}'
+        )
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_is_genuinely_stuck(7) is False
+
+    def test_clean_green_is_not_stuck(self) -> None:
+        gh_mock = _status(
+            '{"mergeStateStatus": "CLEAN", "mergeable": "MERGEABLE", "statusCheckRollup": []}'
+        )
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_is_genuinely_stuck(7) is False
+
+    def test_malformed_json_is_not_stuck(self) -> None:
+        # Safe default: never misclassify an unknown PR as stuck.
+        gh_mock = _status("not json")
+        with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
+            assert pr_manager.pr_is_genuinely_stuck(7) is False


### PR DESCRIPTION
## Summary

A run made AFTER the no-commit-retry fix (#1574) "kept skipping everything": 5 loops on `[1554 OPEN, 1552 CLOSED]` accomplished nothing — both were re-tagged `state:skip` every loop. This is a **structural `state:skip` cycle**, not a review-loop bug; the retry fix was unreachable because the issue never re-entered the implementer.

Diagnosed from `output.log` (2026-06-23 08:41). Three stacked defects:

1. **`state:skip` was sticky** — the only escape (`_should_recover_stale_skip`) refused to recover when an open PR exists, so #1554 (plan-go + open PR #1570) was skipped forever.
2. **drive-green's repo-level rc was attributed per-issue** — a green-but-unarmed PR awaiting implementation review (#1570 lacks `state:implementation-go`) landed in `needs_action` → rc=1, and every per-issue worker tagged ITS OWN issue `state:skip` with no check it owned the failing PR.
3. **A pinned `--issues` batch bypasses the open filter** — closed #1552 reached the per-issue loop and was tagged too.

## Change (prevention-only)

`state:skip` is **operator-only and absolute**: the automation never removes it and never auto-recovers; it is read **live** from the GitHub issue. The fix stops the script from wrongly *adding* it:

- **implementer:** removed `_should_recover_stale_skip`; a live `state:skip` is always honored (the operator removes it between runs).
- **ci_driver:** a green-but-unarmed PR that only lacks `state:implementation-go` (awaiting review) is a new `pending_review` bucket that does NOT force rc=1.
- **loop_runner:** filter closed issues out of an explicit `--issues` batch before the phase loop; gate the drive-green `state:skip` tag on the issue actually OWNING a genuinely-stuck PR (conflict / red CI), verified live.
- **pr_manager:** new shared `pr_is_genuinely_stuck` classifier — the single source of truth for stuck-vs-pending-review, used by both ci_driver and loop_runner.

Already-stranded issues (#1554, #1552) stay skipped until the operator clears their labels; this only prevents fresh runs from re-stranding them.

## Tests

`tests/unit/automation/test_implementer.py` (always-honor / no-recovery), `test_loop_runner.py` (closed filter + ownership guard), `test_ci_driver.py` (pending_review partition), `test_pr_manager.py` (`pr_is_genuinely_stuck`). Full automation suite passes (1882); ruff + mypy clean.

Closes #1583