### PR TITLE
docs(nats): document msg.ack() behavior on handler raise

### DIFF
--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -85,6 +85,15 @@ class NATSSubscriberThread(threading.Thread):
     - :meth:`health_dict()` — JSON-serialisable snapshot of the above plus the
       configured URL, stream, and uptime approximation.
 
+    Delivery semantics
+    ------------------
+    Messages are acked **unconditionally** after the handler returns, including
+    when the handler raises — this is *at-most-once* delivery by design. A
+    failing handler does NOT trigger JetStream redelivery (which would loop
+    forever on a poison message); instead the exception is recorded in
+    :attr:`last_error` and logged via ``logger.exception``. Handlers needing
+    retry semantics must implement them internally.
+
     Configurable stop timeout
     -------------------------
     Pass ``join_timeout`` to the constructor to change the default; or supply a
@@ -365,6 +374,14 @@ class NATSSubscriberThread(threading.Thread):
                         )
                     else:
                         self._record_message()
+                    # Ack unconditionally — even when the handler raised. This is
+                    # AT-MOST-ONCE delivery by design: a handler that fails on a
+                    # given message will fail again on redelivery, so re-queuing it
+                    # would wedge the poll loop on a poison message forever. The
+                    # failure is NOT lost — it is recorded in `last_error` and
+                    # surfaced via logger.exception above. Do NOT move this ack into
+                    # the `else:` branch (that switches to at-least-once and
+                    # reintroduces poison-message redelivery loops). (#1551)
                     await msg.ack()
 
         finally:

--- a/tests/unit/nats/test_subscriber_polling.py
+++ b/tests/unit/nats/test_subscriber_polling.py
@@ -218,3 +218,37 @@ def test_both_timeout_aliases_are_caught(exc_type: type[BaseException]) -> None:
     # asyncio.run; reaching the drain assertion proves it was swallowed.
     _run_loop(thread, nats_module)
     nc.drain.assert_awaited_once()
+
+
+def test_ack_is_awaited_even_when_handler_raises() -> None:
+    """A raising handler must NOT block the ack — at-most-once by design (#1551).
+
+    The message is acked unconditionally so a poison message cannot wedge the
+    poll loop on infinite JetStream redelivery. The failure is surfaced via
+    ``last_error`` and the success counter (``_record_message`` /
+    ``last_message_at``) is left untouched.
+    """
+    boom = RuntimeError("handler exploded")
+
+    def handler(_event: NATSEvent) -> None:
+        raise boom
+
+    thread = NATSSubscriberThread(
+        config=NATSConfig(enabled=True, subjects=["hi.tasks.>"]),
+        handler=handler,
+    )
+
+    msg = _make_msg({"hello": "world"})
+
+    async def next_msg(timeout: float = 0.0) -> MagicMock:
+        # Yield exactly one message, then request shutdown so the loop exits.
+        thread._stop_event.set()
+        return msg
+
+    nats_module, nc = _install_fake_nats(AsyncMock(side_effect=next_msg))
+    _run_loop(thread, nats_module)
+
+    msg.ack.assert_awaited_once()  # acked despite the raise
+    assert thread.last_error is boom  # failure surfaced, not swallowed
+    assert thread.last_message_at is None  # success path NOT taken
+    nc.drain.assert_awaited_once()  # clean drain on loop exit


### PR DESCRIPTION
## Summary
Document that NATSSubscriberThread calls msg.ack() even when the message handler raises an exception, clarifying this is intentional behavior for reliability.

## Changes
- Added docstring clarification to NATSSubscriberThread explaining msg.ack() is called regardless of handler exceptions
- Added unit test verifying msg.ack() is invoked when handler raises

## Testing
- Unit test confirms msg.ack() called on handler exception in test_subscriber_polling.py

## Closes
Closes #1551

Generated by Claude Code via ProjectHephaestus automation.
