### PR TITLE
[Fix] Loop self-inflicted CI failures + memoize repeated issue-state queries

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -481,7 +481,25 @@ def run_advise(
         )
         logger.info("Running advise skill selection for issue #%s...", issue_number)
         selector_output = invoke(advise_prompt)
-        selected = parse_selected_skills(selector_output, mnemosyne_root)
+        try:
+            selected = parse_selected_skills(selector_output, mnemosyne_root)
+        except ValueError as parse_err:
+            # #1587: the selector model occasionally returns prose with no JSON
+            # object. Retry ONCE with an explicit JSON-only reminder before
+            # degrading to a skip — a malformed first response is usually
+            # transient and a single re-ask recovers it.
+            logger.warning(
+                "Advise selector output for issue #%s was unparseable (%s); retrying once",
+                issue_number,
+                parse_err,
+            )
+            retry_prompt = (
+                advise_prompt
+                + "\n\nIMPORTANT: Return ONLY a JSON object of the form "
+                + '{"skills": [...]}. No prose, no code fences, no commentary.'
+            )
+            selector_output = invoke(retry_prompt)
+            selected = parse_selected_skills(selector_output, mnemosyne_root)
         return format_selected_skill_context(selected)
     except Exception as e:
         logger.warning("Advise step failed for issue #%s: %s", issue_number, e)

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -1158,6 +1158,24 @@ class CIDriver:
         # (#848): the issue number is synthetic (equals the PR number) so
         # ``gh issue view`` would 404; there is also no human-authored issue
         # body that would meaningfully steer the advise prompt.
+        # #1587: a prior drive-green pass may have already pushed a CI fix whose
+        # CI simply had not concluded when that pass gave up ("post-fix CI still
+        # pending ... leaving for next run"). Re-dispatching a full CI-fix agent
+        # against the SAME tip just re-derives "the fix is already in place" after
+        # a multi-minute, multi-turn session. If the PR head is unchanged since
+        # the last fix this driver recorded, skip the agent and let the
+        # recheck/arm poll wait for the pending CI instead.
+        if not self.options.dry_run and self._ci_fix_already_pushed_for_current_head(
+            issue_number, pr_number
+        ):
+            logger.info(
+                "Issue #%s: PR #%s head unchanged since the last CI fix this driver pushed; "
+                "skipping redundant CI-fix agent and awaiting pending CI",
+                issue_number,
+                pr_number,
+            )
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
         advise_findings = ""
         if self.options.enable_advise and not self._is_bot_pr_mode(issue_number, pr_number):
             self.status_tracker.update_slot(acquired_slot, f"{issue_ref(issue_number)}: advising")
@@ -1206,6 +1224,10 @@ class CIDriver:
                     issue_number,
                     iteration + 1,
                 )
+                # #1587: record the pushed head SHA so a later drive-green pass can
+                # detect "fix already pushed, CI still pending" and skip a
+                # redundant agent re-run.
+                self._record_ci_fix_head(pr_number)
                 # Acknowledge automated review comments the fix addressed by
                 # replying + resolving the bot threads (human threads untouched).
                 self._reply_and_resolve_bot_threads(pr_number)
@@ -1214,6 +1236,47 @@ class CIDriver:
             logger.warning("Issue #%s: CI fix attempt %s failed", issue_number, iteration + 1)
 
         return None
+
+    def _ci_fix_marker_path(self, pr_number: int) -> Path:
+        """Path of the marker recording the head SHA of this PR's last CI fix (#1587)."""
+        return self.state_dir / f"last-ci-fix-{pr_number}.json"
+
+    def _record_ci_fix_head(self, pr_number: int) -> None:
+        """Persist the current PR head SHA after a successful CI fix push (#1587)."""
+        gh_state = self._gh_pr_state(pr_number) or {}
+        head_sha = str(gh_state.get("headRefOid") or "")
+        if not head_sha:
+            return
+        try:
+            self._ci_fix_marker_path(pr_number).write_text(
+                json.dumps({"pr_number": pr_number, "head_sha": head_sha}) + "\n"
+            )
+        except OSError as exc:
+            logger.warning(
+                "Issue: failed to write last-ci-fix marker for PR #%s: %s", pr_number, exc
+            )
+
+    def _ci_fix_already_pushed_for_current_head(self, issue_number: int, pr_number: int) -> bool:
+        """Return True if the PR head is unchanged since this driver's last CI fix (#1587).
+
+        Reads the ``last-ci-fix-<pr>.json`` marker and compares its recorded head
+        SHA to the PR's current ``headRefOid``. When they match, the fix this
+        driver already pushed is still the tip — CI is merely pending — so a fresh
+        CI-fix agent would only re-derive "already fixed". Any missing marker,
+        missing SHA, or lookup failure returns False (do not skip on uncertainty).
+        """
+        marker = self._ci_fix_marker_path(pr_number)
+        if not marker.exists():
+            return False
+        try:
+            recorded = str(dict(json.loads(marker.read_text())).get("head_sha") or "")
+        except (OSError, json.JSONDecodeError):
+            return False
+        if not recorded:
+            return False
+        gh_state = self._gh_pr_state(pr_number) or {}
+        current = str(gh_state.get("headRefOid") or "")
+        return bool(current) and current == recorded
 
     def _find_pr_for_issue(self, issue_number: int) -> int | None:
         """Find the open PR for a single issue.

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 
 _label_cache: set[str] | None = None
 
+# #1587: in-process memo for issue states so repeated prefetch_issue_states
+# calls within ONE process (e.g. the parent loop's in-loop + post-loop
+# closed-filter, and any phase that prefetches more than once) reuse the result
+# of one gh GraphQL round-trip instead of re-querying. Process-scoped: it dies
+# with the subprocess, so cross-phase staleness is bounded by the subprocess
+# lifetime, and ``refresh=True`` forces a fresh read when a caller needs it.
+_issue_state_cache: dict[int, IssueState] = {}
+
 # Module-level aliases so existing test patches keep resolving.
 # unittest.mock.patch walks the dotted path's module attributes at patch
 # time; these names exist as attributes of this module after the
@@ -819,38 +827,57 @@ def _fetch_batch_states(batch: list[int], owner: str, repo: str) -> dict[int, Is
     return states
 
 
-def prefetch_issue_states(issue_numbers: list[int]) -> dict[int, IssueState]:
-    """Batch fetch issue states using GraphQL.
+def prefetch_issue_states(
+    issue_numbers: list[int], *, refresh: bool = False
+) -> dict[int, IssueState]:
+    """Batch fetch issue states using GraphQL, memoized in-process (#1587).
+
+    Results are cached per process in :data:`_issue_state_cache`, so repeated
+    calls within one process only query the numbers not already seen. The gh
+    GraphQL round-trip is the most expensive of the loop's repeated lookups and
+    previously had no caching at all (it ran once per phase-subprocess AND twice
+    in the parent's closed-filter).
 
     Args:
-        issue_numbers: List of issue numbers
+        issue_numbers: List of issue numbers.
+        refresh: When True, ignore the cache and re-query every number (and
+            update the cache with fresh values). Use when a state may have
+            changed mid-process and a stale read is unacceptable.
 
     Returns:
-        Dictionary mapping issue number to state
+        Dictionary mapping issue number to state (only the requested numbers).
 
     """
     if not issue_numbers:
         return {}
 
+    if not refresh:
+        missing = [n for n in issue_numbers if n not in _issue_state_cache]
+    else:
+        missing = list(issue_numbers)
+    if not missing:
+        return {n: _issue_state_cache[n] for n in issue_numbers if n in _issue_state_cache}
+
     try:
         owner, repo = get_repo_info()
     except RuntimeError as e:
         logger.warning("Failed to get repo info: %s", e)
-        return {}
+        return {n: _issue_state_cache[n] for n in issue_numbers if n in _issue_state_cache}
 
     # Sanitize owner and repo to prevent GraphQL injection
     # Owner and repo should be alphanumeric with hyphens/underscores
     if not re.match(r"^[a-zA-Z0-9_-]+$", owner) or not re.match(r"^[a-zA-Z0-9_-]+$", repo):
         logger.error("Invalid owner/repo format: %s/%s", owner, repo)
-        return {}
+        return {n: _issue_state_cache[n] for n in issue_numbers if n in _issue_state_cache}
 
     batch_size = 100
-    all_states: dict[int, IssueState] = {}
-    for i in range(0, len(issue_numbers), batch_size):
-        batch = issue_numbers[i : i + batch_size]
-        all_states.update(_fetch_batch_states(batch, owner, repo))
+    for i in range(0, len(missing), batch_size):
+        batch = missing[i : i + batch_size]
+        _issue_state_cache.update(_fetch_batch_states(batch, owner, repo))
 
-    return all_states
+    # Return only the requested numbers (those that resolved); a number that
+    # failed to fetch is simply absent, matching the prior contract.
+    return {n: _issue_state_cache[n] for n in issue_numbers if n in _issue_state_cache}
 
 
 def is_issue_closed(issue_number: int, cached_states: dict[int, IssueState] | None = None) -> bool:
@@ -2012,7 +2039,15 @@ def gh_pr_checks(
         return []
 
     try:
-        result = _gh_call(["pr", "checks", str(pr_number), "--json", "name,state,bucket,workflow"])
+        # #1587: "no checks reported" is the expected empty state right after a
+        # push. ``log_on_error=False`` suppresses the spurious ERROR log for that
+        # case; the "no checks reported" non-transient pattern (github.client)
+        # makes _gh_call fail FAST (no exponential-backoff retry) so we reach the
+        # except below immediately. A genuine failure still raises after retries.
+        result = _gh_call(
+            ["pr", "checks", str(pr_number), "--json", "name,state,bucket,workflow"],
+            log_on_error=False,
+        )
     except subprocess.CalledProcessError as exc:
         if _is_gh_pr_checks_no_checks_error(exc):
             logger.info(

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -449,12 +449,26 @@ def compact_session(
         return False
 
     if result.returncode != 0:
+        stderr = result.stderr or ""
+        # #1587: "No conversation found with session ID" is the EXPECTED case
+        # when this (agent, issue) never created a session this run (e.g. the
+        # arming sweep firing /compact for agent=ci-driver on a PR the driver
+        # didn't fix). There is simply nothing to compact — log at DEBUG, not
+        # WARNING, so it doesn't read as a failure.
+        if "No conversation found with session ID" in stderr:
+            logger.debug(
+                "Issue #%s: no %s session to compact (session %s); skipping",
+                issue,
+                agent,
+                sid,
+            )
+            return False
         logger.warning(
             "Issue #%s: /compact for agent=%s exited %s (non-fatal); stderr=%s",
             issue,
             agent,
             result.returncode,
-            (result.stderr or "")[:200],
+            stderr[:200],
         )
         return False
 

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -55,6 +55,50 @@ _RESERVED_MESSAGE_LINE = re.compile(
 )
 _GIT_MESSAGE_MODEL_ENV = "HEPH_GIT_MESSAGE_MODEL"
 
+# Conventional-commit types the ``pr-policy`` CI gate accepts. MUST stay in sync
+# with ``ALLOWED_TYPES`` in ``scripts/check_conventional_commit.py`` (the gate's
+# source of truth); ``tests/.../test_pr_manager.py`` asserts the two sets match,
+# so drift fails CI rather than silently re-introducing #1587 (the automation
+# generating a ``security(audit):`` prefix the gate then rejects). The script is
+# not imported here to avoid inverting the scripts→library dependency direction.
+ALLOWED_CONVENTIONAL_TYPES = frozenset(
+    {"feat", "fix", "docs", "refactor", "test", "chore", "ci", "build", "perf", "style", "revert"}
+)
+
+# Leading ``type(scope)?: `` token of a conventional-commit subject. Scope is
+# optional; only the bare type is validated against the allowlist.
+_CONVENTIONAL_PREFIX = re.compile(r"^(?P<type>[a-z]+)(?P<scope>\([^)]*\))?(?P<bang>!)?:\s")
+
+
+def _normalize_conventional_type(subject: str, *, default: str = "chore") -> str:
+    """Rewrite a subject's leading type to an allowlisted one if it is not already.
+
+    The commit/PR-message agent can emit a ``type(scope):`` whose type the
+    pr-policy gate forbids (e.g. ``security(audit):``), which blocks the PR and
+    triggers an expensive self-cleanup (#1587). This normalizes ONLY the leading
+    type token — scope, ``!``, and the description are preserved — to ``default``
+    when the type is not in :data:`ALLOWED_CONVENTIONAL_TYPES`. A subject with no
+    recognizable conventional prefix is prefixed with ``f"{default}: "`` so the
+    gate always sees a valid type.
+
+    Args:
+        subject: The one-line commit/PR subject from the agent.
+        default: The fallback type (must be in the allowlist).
+
+    Returns:
+        A subject whose leading type is allowlisted.
+
+    """
+    match = _CONVENTIONAL_PREFIX.match(subject)
+    if match is None:
+        return f"{default}: {subject.strip()}" if subject.strip() else f"{default}: update"
+    if match.group("type") in ALLOWED_CONVENTIONAL_TYPES:
+        return subject
+    scope = match.group("scope") or ""
+    bang = match.group("bang") or ""
+    rest = subject[match.end() :]
+    return f"{default}{scope}{bang}: {rest}"
+
 
 @dataclass(frozen=True)
 class _CommitMessageParts:
@@ -210,6 +254,9 @@ Return JSON only, with exactly:
 {{"subject":"type(scope): concise summary","body":"short explanatory body"}}
 
 Rules:
+- The subject MUST start with one of these conventional-commit types ONLY:
+  {", ".join(sorted(ALLOWED_CONVENTIONAL_TYPES))}. Any other type (e.g.
+  "security") will be REJECTED by CI. Pick the closest allowed type.
 - Do not modify files, run git, push, or create a PR.
 - Do not include Closes, Implemented-By, or Co-Authored-By lines.
 - Base the message only on the issue and changed files below.
@@ -249,6 +296,9 @@ Return JSON only, with exactly:
 }}
 
 Rules:
+- The title MUST start with one of these conventional-commit types ONLY:
+  {", ".join(sorted(ALLOWED_CONVENTIONAL_TYPES))}. Any other type (e.g.
+  "security") will be REJECTED by CI. Pick the closest allowed type.
 - Do not modify files, run git, push, or create a PR.
 - Do not include Closes lines; the orchestrator adds the required policy line.
 - Base the message only on the issue, changed files, and commits below.
@@ -377,6 +427,10 @@ def _generate_commit_message(
             fallback=f"feat: Implement #{issue_number}",
             max_len=120,
         )
+        # #1587: the agent can emit a type the pr-policy gate forbids
+        # (e.g. ``security(audit):``). Normalize it locally so the automation
+        # never produces a commit that fails its own required CI.
+        subject = _normalize_conventional_type(subject)
         body = _strip_reserved_lines(_message_text(data.get("body")))
         parts = _CommitMessageParts(subject=subject, body=body)
         return _format_commit_message(
@@ -440,7 +494,12 @@ def _generate_pr_message(
         if data is None:
             raise ValueError("message agent returned no JSON object")
         return _PrMessageParts(
-            title=_single_line(data.get("title"), fallback=fallback.title, max_len=120),
+            # #1587: normalize the PR title's conventional-commit type too — a
+            # squash merge uses the PR title as the commit subject, so a forbidden
+            # type here fails pr-policy exactly like a commit subject does.
+            title=_normalize_conventional_type(
+                _single_line(data.get("title"), fallback=fallback.title, max_len=120)
+            ),
             summary=_strip_reserved_lines(_message_text(data.get("summary"))) or fallback.summary,
             changes=_strip_reserved_lines(_message_text(data.get("changes"))) or fallback.changes,
             testing=_strip_reserved_lines(_message_text(data.get("testing"))) or fallback.testing,

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -171,6 +171,12 @@ _NON_TRANSIENT_PATTERNS = [
         # app/account (Copilot, CodeQL) is forbidden and never succeeds on
         # retry. Fail fast so the caller posts its own editable comment (#1327).
         r"not editable",
+        # "no checks reported on the '<branch>' branch": the EXPECTED empty state
+        # right after a push, before any check run registers. ``gh pr checks``
+        # exits non-zero for it, but it is not a failure and never "succeeds" on
+        # retry — fail fast so ``gh_pr_checks`` converts it to [] without burning
+        # exponential backoff or logging spurious ERRORs (#1587).
+        r"no checks reported",
     )
 ]
 _NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -210,6 +210,66 @@ class TestRunAdvise:
         # The marketplace path is threaded into the prompt builder + invoker.
         assert captured and "marketplace.json" in captured[0]
 
+    def test_retries_once_on_unparseable_selector_output(self, tmp_path: Path) -> None:
+        """#1587: a non-JSON first selector response is re-asked once, then parsed."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        skills_dir = mnemosyne_root / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "debugging.md").write_text("# Debugging\n", encoding="utf-8")
+
+        with (
+            patch.object(advise_runner, "get_repo_root", return_value=Path("/repo")),
+            patch.object(advise_runner, "default_mnemosyne_root", return_value=mnemosyne_root),
+            patch.object(
+                advise_runner,
+                "resolve_marketplace",
+                return_value=(mnemosyne_root / ".claude-plugin" / "marketplace.json", ""),
+            ),
+        ):
+            calls: list[str] = []
+
+            def invoke(prompt: str) -> str:
+                calls.append(prompt)
+                if len(calls) == 1:
+                    return "Sure! Here are the skills you should use: (prose, no JSON)"
+                return (
+                    '{"skills": [{"name": "debugging", '
+                    '"source": "./skills/debugging.md", "reason": "r"}]}'
+                )
+
+            result = advise_runner.run_advise(
+                issue_number=7,
+                issue_title="t",
+                issue_body="b",
+                invoke=invoke,
+                build_prompt=_build_prompt,
+            )
+        assert len(calls) == 2  # retried once
+        assert "JSON object" in calls[1]  # retry prompt carries the JSON-only reminder
+        assert "### debugging" in result
+
+    def test_unparseable_twice_degrades_to_skip(self, tmp_path: Path) -> None:
+        """#1587: if the retry is ALSO unparseable, degrade to a skip (no abort)."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        (mnemosyne_root / "skills").mkdir(parents=True)
+        with (
+            patch.object(advise_runner, "get_repo_root", return_value=Path("/repo")),
+            patch.object(advise_runner, "default_mnemosyne_root", return_value=mnemosyne_root),
+            patch.object(
+                advise_runner,
+                "resolve_marketplace",
+                return_value=(mnemosyne_root / ".claude-plugin" / "marketplace.json", ""),
+            ),
+        ):
+            result = advise_runner.run_advise(
+                issue_number=7,
+                issue_title="t",
+                issue_body="b",
+                invoke=lambda _p: "still no json",
+                build_prompt=_build_prompt,
+            )
+        assert result.startswith("<!-- advise step skipped:")
+
     def test_skips_when_marketplace_unresolved(self) -> None:
         with (
             patch.object(advise_runner, "get_repo_root", return_value=Path("/repo")),

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -3802,3 +3802,57 @@ class TestHandleFailingPr:
         mock_fix.assert_not_called()
         assert result.success is True
         assert result.pr_number == 42
+
+
+class TestCiFixRedispatchGuard:
+    """#1587: don't re-run a CI-fix agent when the fix is already pushed."""
+
+    def test_skips_agent_when_head_unchanged_since_last_fix(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        driver.state_dir = tmp_path
+        # Record a prior fix at SHA "abc123".
+        (tmp_path / "last-ci-fix-42.json").write_text('{"pr_number": 42, "head_sha": "abc123"}')
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc123"}),
+            patch.object(driver, "_run_ci_fix_session") as mock_session,
+            patch.object(driver, "_run_advise", return_value=""),
+        ):
+            result = driver._attempt_ci_fixes(1, 42, 0)
+        # No expensive agent session spawned; treated as success (let recheck arm).
+        mock_session.assert_not_called()
+        assert result is not None and result.success is True
+
+    def test_runs_agent_when_head_advanced(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.state_dir = tmp_path
+        (tmp_path / "last-ci-fix-42.json").write_text('{"pr_number": 42, "head_sha": "old999"}')
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "new111"}),
+            patch.object(driver, "_run_advise", return_value=""),
+            patch.object(driver, "_get_failing_ci_logs", return_value="logs"),
+            patch.object(driver, "_load_impl_session_id", return_value=None),
+            patch.object(driver, "_get_worktree_path", return_value=tmp_path),
+            patch.object(driver, "_get_pr_branch", return_value="42-auto-impl"),
+            patch.object(driver, "_run_ci_fix_session", return_value=True) as mock_session,
+            patch.object(driver, "_record_ci_fix_head"),
+            patch.object(driver, "_reply_and_resolve_bot_threads"),
+        ):
+            driver._attempt_ci_fixes(1, 42, 0)
+        # Head advanced → genuine new state → agent runs.
+        mock_session.assert_called()
+
+    def test_no_marker_runs_agent(self, driver: CIDriver, tmp_path: Path) -> None:
+        driver.state_dir = tmp_path  # no marker file written
+        with (
+            patch.object(driver, "_gh_pr_state", return_value={"headRefOid": "abc123"}),
+            patch.object(driver, "_run_advise", return_value=""),
+            patch.object(driver, "_get_failing_ci_logs", return_value="logs"),
+            patch.object(driver, "_load_impl_session_id", return_value=None),
+            patch.object(driver, "_get_worktree_path", return_value=tmp_path),
+            patch.object(driver, "_get_pr_branch", return_value="42-auto-impl"),
+            patch.object(driver, "_run_ci_fix_session", return_value=True) as mock_session,
+            patch.object(driver, "_record_ci_fix_head"),
+            patch.object(driver, "_reply_and_resolve_bot_threads"),
+        ):
+            driver._attempt_ci_fixes(1, 42, 0)
+        mock_session.assert_called()

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -190,6 +190,19 @@ class TestIsIssueClosed:
 class TestPrefetchIssueStates:
     """Tests for prefetch_issue_states function."""
 
+    @pytest.fixture(autouse=True)
+    def _clear_state_cache(self) -> Any:
+        """Reset the #1587 in-process issue-state memo between tests.
+
+        The memo persists module-level, so without this a state cached by one
+        test would satisfy another test's request and skip its mocked gh call.
+        """
+        from hephaestus.automation import github_api
+
+        github_api._issue_state_cache.clear()
+        yield
+        github_api._issue_state_cache.clear()
+
     def test_empty_list(self) -> None:
         """Test with empty issue list."""
         states = prefetch_issue_states([])
@@ -218,6 +231,64 @@ class TestPrefetchIssueStates:
 
         assert states[123] == IssueState.OPEN
         assert states[456] == IssueState.CLOSED
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_memoizes_in_process(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        """#1587: a second call for cached numbers does not re-query gh."""
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {"data": {"repository": {"issue0": {"number": 123, "state": "OPEN"}}}}
+        )
+        mock_gh_call.return_value = mock_result
+
+        first = prefetch_issue_states([123])
+        second = prefetch_issue_states([123])
+
+        assert first == second == {123: IssueState.OPEN}
+        # One network round-trip total despite two calls.
+        assert mock_gh_call.call_count == 1
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_refresh_forces_requery(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        """#1587: refresh=True bypasses the memo and re-queries."""
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {"data": {"repository": {"issue0": {"number": 123, "state": "OPEN"}}}}
+        )
+        mock_gh_call.return_value = mock_result
+
+        prefetch_issue_states([123])
+        prefetch_issue_states([123], refresh=True)
+
+        assert mock_gh_call.call_count == 2
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    def test_only_missing_numbers_queried(self, mock_repo_info: Any, mock_gh_call: Any) -> None:
+        """#1587: a follow-up call only queries numbers not already cached."""
+        mock_repo_info.return_value = ("owner", "repo")
+        mock_gh_call.side_effect = [
+            Mock(
+                stdout=json.dumps(
+                    {"data": {"repository": {"issue0": {"number": 1, "state": "OPEN"}}}}
+                )
+            ),
+            Mock(
+                stdout=json.dumps(
+                    {"data": {"repository": {"issue0": {"number": 2, "state": "CLOSED"}}}}
+                )
+            ),
+        ]
+
+        prefetch_issue_states([1])
+        states = prefetch_issue_states([1, 2])
+
+        assert states == {1: IssueState.OPEN, 2: IssueState.CLOSED}
+        assert mock_gh_call.call_count == 2  # second call fetched only #2
 
     @patch("hephaestus.automation.github_api.get_repo_info")
     def test_repo_info_failure(self, mock_repo_info: Any) -> None:
@@ -1832,6 +1903,22 @@ class TestGhPrChecks:
         )
 
         assert gh_pr_checks(289) == []
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_no_checks_path_suppresses_error_logging(self, mock_gh_call: Any) -> None:
+        """#1587: gh_pr_checks calls _gh_call with log_on_error=False.
+
+        Combined with the 'no checks reported' non-transient pattern in
+        github.client, this makes the expected post-push empty state fail FAST
+        with no ERROR log and no exponential-backoff retry.
+        """
+        mock_result = Mock()
+        mock_result.stdout = "[]"
+        mock_gh_call.return_value = mock_result
+
+        gh_pr_checks(289)
+
+        assert mock_gh_call.call_args.kwargs.get("log_on_error") is False
 
     @patch("hephaestus.automation.github_api._gh_call")
     def test_other_called_process_error_still_raises(self, mock_gh_call: Any) -> None:

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -645,3 +645,39 @@ class TestPrIsGenuinelyStuck:
         gh_mock = _status("not json")
         with patch.object(pr_manager, "_gh_call", return_value=gh_mock):
             assert pr_manager.pr_is_genuinely_stuck(7) is False
+
+
+class TestNormalizeConventionalType:
+    """``_normalize_conventional_type`` keeps the commit/PR type pr-policy-legal (#1587)."""
+
+    def test_disallowed_type_normalized_scope_preserved(self) -> None:
+        assert (
+            pr_manager._normalize_conventional_type("security(audit): add threat model")
+            == "chore(audit): add threat model"
+        )
+
+    def test_allowed_type_unchanged(self) -> None:
+        assert (
+            pr_manager._normalize_conventional_type("fix(io): handle EOF") == "fix(io): handle EOF"
+        )
+
+    def test_no_prefix_gets_default(self) -> None:
+        assert (
+            pr_manager._normalize_conventional_type("add threat model") == "chore: add threat model"
+        )
+
+    def test_breaking_bang_preserved(self) -> None:
+        assert pr_manager._normalize_conventional_type("security!: drop API") == "chore!: drop API"
+
+    def test_disallowed_no_scope(self) -> None:
+        assert pr_manager._normalize_conventional_type("wip: stuff") == "chore: stuff"
+
+    def test_allowlist_matches_pr_policy_gate(self) -> None:
+        """The mirrored allowlist MUST equal the pr-policy gate's source of truth."""
+        import sys
+        from pathlib import Path
+
+        sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
+        from check_conventional_commit import ALLOWED_TYPES
+
+        assert set(pr_manager.ALLOWED_CONVENTIONAL_TYPES) == set(ALLOWED_TYPES)

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -151,6 +151,17 @@ class TestNonTransientErrorClassification:
 
         assert _is_non_transient_error("gh: Body is not editable") is True
 
+    def test_no_checks_reported_is_non_transient(self) -> None:
+        """#1587: 'no checks reported' is the expected post-push empty state.
+
+        It exits non-zero but never succeeds on retry; classifying it
+        non-transient makes gh_pr_checks fail fast and convert it to [] without
+        burning exponential backoff or logging spurious ERRORs.
+        """
+        from hephaestus.github.client import _is_non_transient_error
+
+        assert _is_non_transient_error("no checks reported on the '45-foo' branch") is True
+
     def test_transient_5xx_is_not_non_transient(self) -> None:
         """A 500 is retryable, so it must NOT be flagged non-transient."""
         from hephaestus.github.client import _is_non_transient_error


### PR DESCRIPTION
## Summary

Found by analyzing an automation-loop run made AFTER the `state:skip` cycle fix (#1583). That cycle is resolved (PRs merge, no spurious skips); this PR fixes the **remaining bugs** that run surfaced and the **redundant-query** problem ("the same thing is queried over and over").

## Bugs

- **Bug 2 (highest value):** the commit/PR-message agent emitted `security(audit):`, a conventional-commit type the `pr-policy` gate forbids — blocking the PR and triggering a ~10-min CI-fix agent to fix the automation's own output (the PR title stayed wrong). Now the commit + PR prompts list the allowed types AND `_normalize_conventional_type` rewrites a disallowed leading type to a safe default locally (scope/`!`/description preserved: `security(audit):` → `chore(audit):`) before commit and PR-title. `ALLOWED_CONVENTIONAL_TYPES` mirrors the gate's `ALLOWED_TYPES` with a sync test so drift fails CI.
- **Bug 1:** "no checks reported on the '<branch>' branch" right after a push is the expected empty state, not a transient error. Classified non-transient (fail fast) + `gh_pr_checks` calls with `log_on_error=False` → returns `[]` with no ERROR log and no exponential-backoff retry.
- **Bug 4:** don't re-dispatch a full CI-fix agent when the PR head is unchanged since the last fix this driver pushed (CI merely pending) — record the fixed head SHA (`last-ci-fix-<pr>.json`) and skip the redundant ~40-min no-op agent, letting the recheck/arm poll wait.
- **Bug 5a:** retry the advise selector once on non-JSON output before degrading to a skip.
- **Bug 5b:** downgrade the `/compact` "No conversation found" expected case from WARNING to DEBUG.

## Redundant queries ("query once")

Root cause: the loop runs a subprocess per (issue, phase), wiping in-memory caches each child. `prefetch_issue_states` (gh GraphQL) had no memoization and was even double-called in the parent's closed-filter. Now memoized in-process with a `refresh=` escape hatch. The per-branch `git fetch` is a correctness-critical fresh-base-before-agent step (#832/#836) and is **intentionally not** deduped; Bug 4 already removes the biggest source of repeat syncs.

## Tests

`test_github_api.py` (memo + no-checks log suppression), `test_pr_manager.py` (normalize + allowlist sync), `test_advise_runner.py` (retry + degrade), `test_ci_driver.py` (re-dispatch guard), `test_client.py` (non-transient). Full unit suite passes (4664); pre-commit ruff/format/mypy clean.

Closes #1588