### PR TITLE
fix(agents): map codex model tiers

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -20,6 +20,13 @@ DEFAULT_AGENT: AgentName = "claude"
 AGENT_AUTH_STATUS_TIMEOUT = 10
 CODEX_FINAL_MESSAGE_GRACE_ENV = "HEPH_CODEX_FINAL_MESSAGE_GRACE"
 CODEX_FINAL_MESSAGE_GRACE_SECONDS = 5.0
+CODEX_OPUS_MODEL = "gpt-5.5"
+CODEX_OPUS_REASONING_EFFORT = "xhigh"
+CODEX_SONNET_MODEL = "gpt-5.5"
+CODEX_SONNET_REASONING_EFFORT = "medium"
+CODEX_HAIKU_MODEL = "gpt-5.4-mini"
+CODEX_DEFAULT_MODEL = CODEX_OPUS_MODEL
+CODEX_DEFAULT_REASONING_EFFORT = CODEX_OPUS_REASONING_EFFORT
 PI_MODEL_ENV = "HEPH_PI_MODEL"
 PI_MODEL_CONFIG_RELATIVE_PATH = Path(".pi") / "agent" / "models.json"
 PI_READ_ONLY_TOOLS = "read,grep,find,ls"
@@ -69,6 +76,14 @@ AGENT_CAPABILITIES: dict[AgentName, AgentCapabilities] = {
         supports_sessions=True,
     ),
 }
+
+
+@dataclass(frozen=True)
+class CodexModelConfig:
+    """Codex-native model selection derived from a provider-neutral tier."""
+
+    model: str
+    reasoning_effort: str = ""
 
 
 def add_agent_argument(parser: argparse.ArgumentParser) -> None:
@@ -266,6 +281,39 @@ def codex_approval_args(approval: str) -> list[str]:
     return []
 
 
+def _codex_model_config(model: str, *, use_default: bool = False) -> CodexModelConfig:
+    """Translate Claude tier IDs into Codex-native model/reasoning settings."""
+    normalized = model.strip()
+    if not normalized:
+        if use_default:
+            return CodexModelConfig(CODEX_DEFAULT_MODEL, CODEX_DEFAULT_REASONING_EFFORT)
+        return CodexModelConfig("")
+    lower_model = normalized.lower()
+    if lower_model == "opus" or lower_model.startswith("claude-opus-"):
+        return CodexModelConfig(CODEX_OPUS_MODEL, CODEX_OPUS_REASONING_EFFORT)
+    if lower_model == "sonnet" or lower_model.startswith("claude-sonnet-"):
+        return CodexModelConfig(CODEX_SONNET_MODEL, CODEX_SONNET_REASONING_EFFORT)
+    if lower_model == "haiku" or lower_model.startswith("claude-haiku-"):
+        return CodexModelConfig(CODEX_HAIKU_MODEL)
+    return CodexModelConfig(normalized)
+
+
+def _codex_model_args(model: str, *, use_default: bool = False) -> list[str]:
+    """Return Codex CLI arguments for the requested model tier."""
+    model_config = _codex_model_config(model, use_default=use_default)
+    args: list[str] = []
+    if model_config.model:
+        args.extend(["--model", model_config.model])
+    if model_config.reasoning_effort:
+        args.extend(
+            [
+                "-c",
+                f"model_reasoning_effort={json.dumps(model_config.reasoning_effort)}",
+            ]
+        )
+    return args
+
+
 def run_codex_text(
     prompt: str,
     *,
@@ -314,8 +362,7 @@ def _codex_base_cmd(
             "exec",
         ]
     )
-    if model:
-        cmd.extend(["--model", model])
+    cmd.extend(_codex_model_args(model, use_default=resume_id is None))
     if resume_id is None:
         if cwd is None:
             raise ValueError("cwd is required for new Codex exec sessions")
@@ -800,8 +847,7 @@ def codex_exec_resume_args(
 ) -> list[str]:
     """Return the Codex command prefix used to resume a non-interactive session."""
     cmd = ["codex", "exec", "resume", session_id]
-    if model:
-        cmd.extend(["--model", model])
+    cmd.extend(_codex_model_args(model))
     return cmd
 
 

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -260,6 +261,63 @@ def test_codex_approval_args_preserves_legacy_flag() -> None:
             "--approval-policy",
             "never",
         ]
+
+
+@pytest.mark.parametrize(
+    ("claude_model", "expected_model", "expected_reasoning"),
+    [
+        ("claude-opus-4-7", "gpt-5.5", "xhigh"),
+        ("claude-sonnet-4-6", "gpt-5.5", "medium"),
+    ],
+)
+def test_codex_base_cmd_maps_claude_reasoning_tiers(
+    tmp_path: Path,
+    claude_model: str,
+    expected_model: str,
+    expected_reasoning: str,
+) -> None:
+    """Codex must receive Codex model IDs plus tier-specific reasoning config."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model=claude_model)
+
+    assert cmd[cmd.index("--model") + 1] == expected_model
+    assert cmd[cmd.index("-c") + 1] == (f"model_reasoning_effort={json.dumps(expected_reasoning)}")
+
+
+def test_codex_base_cmd_maps_haiku_to_mini_without_reasoning_override(
+    tmp_path: Path,
+) -> None:
+    """Haiku-tier Codex work should use GPT-5.4-Mini without forcing reasoning."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model="claude-haiku-4-5")
+
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.4-mini"
+    assert "model_reasoning_effort" not in cmd
+
+
+def test_codex_base_cmd_keeps_native_codex_model_ids(tmp_path: Path) -> None:
+    """Explicit native Codex model overrides should still pass through unchanged."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model="gpt-5.4-mini")
+
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.4-mini"
+    assert "model_reasoning_effort" not in cmd
+
+
+def test_codex_base_cmd_defaults_new_sessions_to_gpt_55_xhigh(tmp_path: Path) -> None:
+    """A fresh Codex session should not depend on the operator's CLI default."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path)
+
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.5"
+    assert cmd[cmd.index("-c") + 1] == 'model_reasoning_effort="xhigh"'
+
+
+def test_codex_base_cmd_resume_without_model_preserves_session_model() -> None:
+    """Resume should not force the default model unless a model is requested."""
+    cmd = agent_runtime._codex_base_cmd(resume_id="session-123", sandbox=None)
+
+    assert cmd == ["codex", "exec", "resume", "session-123", "--json"]
 
 
 def test_resume_codex_session_uses_exec_resume(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Translate Claude-tier model selections at the Codex runtime boundary: opus to gpt-5.5 with xhigh reasoning, sonnet to gpt-5.5 with medium reasoning, and haiku to gpt-5.4-mini.
- Default fresh Codex sessions to gpt-5.5 with xhigh reasoning while preserving resumed session models unless an explicit model is supplied.
- Add runtime regression tests for tier mapping, native Codex model pass-through, fresh-session defaults, and resume behavior.

## Test Plan
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-pixi-cache pixi run pytest -o cache_dir=/tmp/heph-pytest-cache tests/unit/agents/test_runtime.py -q --no-cov
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-pixi-cache pixi run pytest -o cache_dir=/tmp/heph-pytest-cache tests/unit/automation/test_planner.py -q --no-cov
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-pixi-cache pixi run pytest -o cache_dir=/tmp/heph-pytest-cache tests/unit/automation/test_ci_driver.py::test_codex_ci_advise_uses_codex_prompt_builder -q --no-cov
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-pixi-cache pixi run python -m mypy --cache-dir /tmp/heph-mypy-cache hephaestus/
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-ruff-cache pixi run ruff check --cache-dir /tmp/heph-ruff-cache hephaestus/ tests/
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-pixi-cache pixi run ruff format --check --cache-dir /tmp/heph-ruff-cache hephaestus/ tests/
- [x] env PIXI_HOME=/tmp/heph-pixi-home PIXI_CACHE_DIR=/tmp/heph-pixi-cache PRE_COMMIT_HOME=/tmp/heph-pre-commit pixi run pre-commit run --files hephaestus/agents/runtime.py tests/unit/agents/test_runtime.py

## Notes
- Full tests/unit was attempted and failed due workspace ENOSPC while tests wrote temporary files under build/ and rewrote generated skill files; test-induced file changes were restored.
- Per operator request, the policy marker below is fenced to avoid closing any GitHub issue.

```text
Closes #1591
```
