### PR TITLE
feat(agents): add Pi subprocess adapter

### DIFF
--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -50,7 +50,6 @@ def main(argv: list[str] | None = None) -> int:
             cwd=args.cwd,
             timeout=args.timeout,
             model=model,
-            sandbox="read-only",
         )
     except subprocess.CalledProcessError as exc:
         detail = exc.stderr or exc.stdout or f"Pi smoke failed with exit {exc.returncode}"
@@ -59,6 +58,9 @@ def main(argv: list[str] | None = None) -> int:
     except subprocess.TimeoutExpired as exc:
         print(f"ERROR: Pi smoke timed out after {exc.timeout}s", file=sys.stderr)
         return 124
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
     print(redact_pi_private_values(result.stdout, redaction_tokens))
     if result.session_id:
         print(f"SESSION_ID={result.session_id}", file=sys.stderr)

--- a/tests/unit/scripts/test_pi_smoke.py
+++ b/tests/unit/scripts/test_pi_smoke.py
@@ -88,3 +88,17 @@ def test_success_output_redacts_private_values(
     assert "private-test-alias" not in output
     assert "PRIVATE_ENDPOINT_TOKEN" not in output
     assert "<redacted-pi-private-value>" in output
+
+
+def test_reports_pi_runtime_contract_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Pi JSON contract failures should produce an actionable smoke error."""
+    monkeypatch.setenv("HEPH_PI_MODEL", "private-test-alias")
+    run_pi = Mock(side_effect=RuntimeError("missing session id"))
+    monkeypatch.setattr(_mod, "run_pi_session", run_pi)
+
+    assert _mod.main(["--cwd", str(tmp_path)]) == 1
+    assert "missing session id" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
Adds provider-neutral Pi runtime helpers for non-interactive automation with structured JSON event parsing and session handling.

## Changes
- Implemented Pi subprocess helpers for text runs, new sessions, and resumed sessions using JSON-mode event output.
- Extracted Pi session ids from stderr headers and final assistant text from terminal JSON events with privacy-safe environment defaults.
- Updated one-off agent stage and Pi smoke script behavior for the new Pi runtime path.
- Added Pi CLI fixtures and focused unit coverage for runtime parsing, session resume, agent-stage routing, and smoke checks.

## Testing
- tests/unit/agents/test_runtime_pi.py
- tests/unit/automation/test_agent_stage.py
- tests/unit/scripts/test_pi_smoke.py

## Closes
Closes #1577

Generated by Codex via ProjectHephaestus automation.
