### PR TITLE
feat(pi): add private provider safety rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ ENV/
 .DS_Store
 Thumbs.db
 
-# Secrets
+# Secrets and local privacy guards
 .env
 .env.local
 .heph-private-denylist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -262,13 +262,14 @@ repos:
       - id: check-private-denylist
         name: Check local private denylist
         description: >
-          If .heph-private-denylist exists locally, reject changed text files
-          containing any fixed string listed there. The denylist itself is
-          gitignored and must never be committed.
-        entry: python3 scripts/check_private_denylist.py
+          If .heph-private-denylist exists locally, reject staged or tracked
+          text containing any fixed string listed there. The denylist itself is
+          gitignored and must never be committed. Diagnostics print only
+          source/path/line, never matched values.
+        entry: python3 scripts/check_private_denylist.py --staged --tracked
         language: system
-        pass_filenames: true
-        types: [text]
+        pass_filenames: false
+        always_run: true
 
   # Conventional Commits enforcement (DoD row 5; issue #1209).
   # commit-msg stage: pre-commit passes the message file path as the only arg.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,15 @@ with `--help` to see full usage.
 | `hephaestus-ensure-state-labels` | Idempotently provision `state:needs-plan` / `state:plan-no-go` / `state:plan-go` labels on one or more repos |
 | `hephaestus-audit-prs` | Audit ALL open PRs in one coordinator agent invocation |
 
+#### Private Pi provider setup
+
+Pi uses operator-local provider configuration only. Do not commit Pi provider
+config, endpoint URLs, hostnames, checkpoint names, model identifiers, or local
+aliases. Configure the OpenAI-compatible provider in the local Pi config, set
+`HEPH_PI_MODEL=<operator-local-alias>`, and see
+[`docs/pi-private-provider.md`](docs/pi-private-provider.md) for the sanitized
+setup and denylist guard.
+
 #### Running the automation loop from a source checkout (macOS / Codex)
 
 When `hephaestus-automation-loop` is not installed on `PATH` (fresh source

--- a/docs/pi-private-provider.md
+++ b/docs/pi-private-provider.md
@@ -1,0 +1,32 @@
+# Private Pi Provider Setup
+
+Configure private OpenAI-compatible providers only in the operator-local Pi
+configuration, for example under `~/.pi/agent/models.json`. Do not commit Pi
+provider config, endpoint URLs, hostnames, checkpoint names, model identifiers,
+or operator-local aliases.
+
+Use placeholders in documentation:
+
+- `<operator-local-alias>`
+- `<private-provider-url>`
+- `<private-model-name>`
+
+Set the local alias at runtime:
+
+```bash
+export HEPH_PI_MODEL=<operator-local-alias>
+python3 scripts/pi_smoke.py
+```
+
+Create `.heph-private-denylist` at the repository root on machines that know
+private values. Add one fixed string per line, including any private alias,
+hostname, endpoint, checkpoint, or model identifier. The file is gitignored.
+
+Before committing, run:
+
+```bash
+python3 scripts/check_private_denylist.py --staged --tracked
+```
+
+The guard prints only file paths and line numbers. It intentionally never prints
+matched values or source lines.

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -22,6 +23,8 @@ CODEX_FINAL_MESSAGE_GRACE_ENV = "HEPH_CODEX_FINAL_MESSAGE_GRACE"
 CODEX_FINAL_MESSAGE_GRACE_SECONDS = 5.0
 PI_MODEL_ENV = "HEPH_PI_MODEL"
 PI_MODEL_CONFIG_RELATIVE_PATH = Path(".pi") / "agent" / "models.json"
+PI_PRIVATE_DENYLIST_FILENAME = ".heph-private-denylist"
+PI_PRIVATE_REDACTION = "<redacted-pi-private-value>"
 PI_READ_ONLY_TOOLS = "read,grep,find,ls"
 AGENT_AUTH_STATUS_COMMANDS: dict[AgentName, tuple[tuple[str, ...], ...]] = {
     "claude": (("claude", "auth", "status"),),
@@ -188,6 +191,39 @@ def direct_agent_model(agent: str, phase_env_var: str) -> str:
     if is_pi(agent):
         return os.environ.get(PI_MODEL_ENV, "")
     return os.environ.get(phase_env_var, "")
+
+
+def pi_private_redaction_tokens(cwd: Path, model: str = "") -> tuple[str, ...]:
+    """Return local Pi values that must be redacted from publishable diagnostics."""
+    tokens: list[str] = []
+    resolved_model = (model or os.environ.get(PI_MODEL_ENV, "")).strip()
+    if resolved_model:
+        tokens.append(resolved_model)
+
+    resolved_cwd = cwd.resolve()
+    for parent in (resolved_cwd, *resolved_cwd.parents):
+        denylist = parent / PI_PRIVATE_DENYLIST_FILENAME
+        if not denylist.is_file():
+            continue
+        try:
+            lines = denylist.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            break
+        for line in lines:
+            token = line.strip()
+            if token and not token.startswith("#"):
+                tokens.append(token)
+        break
+
+    return tuple(dict.fromkeys(tokens))
+
+
+def redact_pi_private_values(text: str, tokens: Iterable[str]) -> str:
+    """Replace local Pi aliases, endpoints, and model identifiers in text."""
+    redacted = text
+    for token in sorted((token for token in tokens if token), key=len, reverse=True):
+        redacted = redacted.replace(token, PI_PRIVATE_REDACTION)
+    return redacted
 
 
 def session_agent_matches(session_agent: str | None, selected_agent: str) -> bool:
@@ -489,6 +525,17 @@ def _pi_base_cmd(*, model: str = "", session_id: str | None = None) -> list[str]
     return cmd
 
 
+def _model_from_pi_cmd(cmd: list[str]) -> str:
+    """Extract the Pi model value from a command list when present."""
+    try:
+        model_index = cmd.index("--model")
+    except ValueError:
+        return ""
+    if model_index + 1 >= len(cmd):
+        return ""
+    return cmd[model_index + 1]
+
+
 def _pi_sandbox_args(sandbox: str) -> list[str]:
     """Return Pi tool restrictions for the requested sandbox mode."""
     if sandbox == "read-only":
@@ -529,15 +576,32 @@ def _run_pi_command(
         prompt_path.chmod(0o600)
         cmd.extend(_pi_sandbox_args(sandbox))
         cmd.append(f"@{prompt_path}")
-        return subprocess.run(
-            cmd,
-            cwd=cwd,
-            text=True,
-            capture_output=True,
-            timeout=timeout,
-            env=_pi_env(),
-            check=True,
-        )
+        try:
+            return subprocess.run(
+                cmd,
+                cwd=cwd,
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+                env=_pi_env(),
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            tokens = pi_private_redaction_tokens(cwd, _model_from_pi_cmd(cmd))
+            redacted_cmd = (
+                redact_pi_private_values(exc.cmd, tokens)
+                if isinstance(exc.cmd, str)
+                else [
+                    redact_pi_private_values(part, tokens) if isinstance(part, str) else part
+                    for part in exc.cmd
+                ]
+            )
+            raise subprocess.CalledProcessError(
+                exc.returncode,
+                redacted_cmd,
+                output=redact_pi_private_values(exc.stdout or "", tokens),
+                stderr=redact_pi_private_values(exc.stderr or "", tokens),
+            ) from exc
     finally:
         if prompt_path is not None:
             with contextlib.suppress(OSError):

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -10,12 +10,14 @@ import shutil
 import subprocess
 import tempfile
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
 AgentName = Literal["claude", "codex", "pi"]
+SubprocessCommandPart = str | bytes | os.PathLike[str] | os.PathLike[bytes]
+SubprocessCommand = SubprocessCommandPart | Sequence[SubprocessCommandPart]
 AGENT_CHOICES: tuple[AgentName, ...] = ("claude", "codex", "pi")
 DEFAULT_AGENT: AgentName = "claude"
 AGENT_AUTH_STATUS_TIMEOUT = 10
@@ -224,6 +226,18 @@ def redact_pi_private_values(text: str, tokens: Iterable[str]) -> str:
     for token in sorted((token for token in tokens if token), key=len, reverse=True):
         redacted = redacted.replace(token, PI_PRIVATE_REDACTION)
     return redacted
+
+
+def _redact_pi_command_args(cmd: SubprocessCommand, tokens: Iterable[str]) -> SubprocessCommand:
+    """Redact Pi private values from a subprocess command payload."""
+    if isinstance(cmd, str):
+        return redact_pi_private_values(cmd, tokens)
+    if isinstance(cmd, Sequence) and not isinstance(cmd, bytes):
+        return [
+            redact_pi_private_values(part, tokens) if isinstance(part, str) else part
+            for part in cmd
+        ]
+    return cmd
 
 
 def session_agent_matches(session_agent: str | None, selected_agent: str) -> bool:
@@ -588,19 +602,20 @@ def _run_pi_command(
             )
         except subprocess.CalledProcessError as exc:
             tokens = pi_private_redaction_tokens(cwd, _model_from_pi_cmd(cmd))
-            redacted_cmd = (
-                redact_pi_private_values(exc.cmd, tokens)
-                if isinstance(exc.cmd, str)
-                else [
-                    redact_pi_private_values(part, tokens) if isinstance(part, str) else part
-                    for part in exc.cmd
-                ]
-            )
+            redacted_cmd = _redact_pi_command_args(exc.cmd, tokens)
             raise subprocess.CalledProcessError(
                 exc.returncode,
                 redacted_cmd,
                 output=redact_pi_private_values(exc.stdout or "", tokens),
                 stderr=redact_pi_private_values(exc.stderr or "", tokens),
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            tokens = pi_private_redaction_tokens(cwd, _model_from_pi_cmd(cmd))
+            raise subprocess.TimeoutExpired(
+                _redact_pi_command_args(exc.cmd, tokens),
+                exc.timeout,
+                output=redact_pi_private_values(_coerce_timeout_output(exc.output), tokens),
+                stderr=redact_pi_private_values(_coerce_timeout_output(exc.stderr), tokens),
             ) from exc
     finally:
         if prompt_path is not None:

--- a/scripts/check_private_denylist.py
+++ b/scripts/check_private_denylist.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 DENYLIST_FILENAME = ".heph-private-denylist"
+PRIVATE_DENYLIST_REDACTION = "<redacted-private-denylist-value>"
 ScanSource = Literal["working-tree", "tracked", "staged"]
 
 
@@ -111,6 +112,14 @@ def _scan_text(source: ScanSource, rel_path: Path, text: str, tokens: list[str])
     return findings
 
 
+def _redact_private_tokens(text: str, tokens: list[str]) -> str:
+    """Replace local denylist values before emitting diagnostics."""
+    redacted = text
+    for token in sorted((token for token in tokens if token), key=len, reverse=True):
+        redacted = redacted.replace(token, PRIVATE_DENYLIST_REDACTION)
+    return redacted
+
+
 def scan_paths(
     repo_root: Path,
     paths: list[Path],
@@ -182,7 +191,8 @@ def main(argv: list[str] | None = None) -> int:
 
     print("ERROR: local private denylist match(es) found. Remove the value before committing:")
     for finding in findings:
-        print(f"  {finding.source} {finding.path}:{finding.line_number}")
+        redacted_path = _redact_private_tokens(str(finding.path), tokens)
+        print(f"  {finding.source} {redacted_path}:{finding.line_number}")
     print("\nMatched values and line contents are intentionally not printed.")
     print(f"\nDenylist source: {DENYLIST_FILENAME} (local, untracked)")
     return 1

--- a/scripts/check_private_denylist.py
+++ b/scripts/check_private_denylist.py
@@ -3,29 +3,32 @@
 
 Operators can create an untracked ``.heph-private-denylist`` at the repository
 root with one fixed string per line. When present, this guard scans supplied
-paths (pre-commit mode) or git-tracked files (manual mode) and fails if any
-denylisted string appears.
+paths (working-tree mode), git-tracked files, or staged index content and fails
+if any denylisted string appears. Diagnostics intentionally print only
+source/path/line, never the matched value or source line.
 
 Usage:
-    python scripts/check_private_denylist.py [paths...]
+    python scripts/check_private_denylist.py [--staged] [--tracked] [paths...]
 """
 
 from __future__ import annotations
 
+import argparse
 import subprocess
 import sys
 from pathlib import Path
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 DENYLIST_FILENAME = ".heph-private-denylist"
+ScanSource = Literal["working-tree", "tracked", "staged"]
 
 
 class Finding(NamedTuple):
     """One denylist match in a text file."""
 
+    source: ScanSource
     path: Path
     line_number: int
-    token: str
 
 
 def get_repo_root() -> Path:
@@ -51,16 +54,45 @@ def load_denylist(repo_root: Path) -> list[str]:
     return tokens
 
 
-def tracked_files(repo_root: Path) -> list[Path]:
+def _git_paths(repo_root: Path, cmd: list[str]) -> list[Path]:
+    """Return null-delimited git path output as relative paths."""
+    result = subprocess.run(cmd, cwd=repo_root, capture_output=True, check=True)
+    return [Path(raw.decode()) for raw in result.stdout.split(b"\0") if raw]
+
+
+def tracked_files(repo_root: Path, pathspecs: list[str] | None = None) -> list[Path]:
     """Return git-tracked files for manual scans."""
+    cmd = ["git", "ls-files", "-z", "--", *(pathspecs or [])]
+    return [repo_root / path for path in _git_paths(repo_root, cmd)]
+
+
+def staged_files(repo_root: Path, pathspecs: list[str] | None = None) -> list[Path]:
+    """Return staged paths from the git index without reading the worktree."""
+    cmd = [
+        "git",
+        "diff",
+        "--cached",
+        "--name-only",
+        "-z",
+        "--diff-filter=ACMR",
+        "--",
+        *(pathspecs or []),
+    ]
+    return _git_paths(repo_root, cmd)
+
+
+def staged_text(repo_root: Path, rel_path: Path) -> str | None:
+    """Return staged UTF-8 text for *rel_path*, or None for non-text blobs."""
     result = subprocess.run(
-        ["git", "ls-files"],
+        ["git", "show", f":{rel_path.as_posix()}"],
         cwd=repo_root,
         capture_output=True,
-        text=True,
         check=True,
     )
-    return [repo_root / line for line in result.stdout.splitlines() if line.strip()]
+    try:
+        return result.stdout.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
 
 
 def _relative(repo_root: Path, path: Path) -> Path:
@@ -70,7 +102,22 @@ def _relative(repo_root: Path, path: Path) -> Path:
         return path
 
 
-def scan_paths(repo_root: Path, paths: list[Path], tokens: list[str]) -> list[Finding]:
+def _scan_text(source: ScanSource, rel_path: Path, text: str, tokens: list[str]) -> list[Finding]:
+    """Return redacted findings for denylist tokens in text content."""
+    findings: list[Finding] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        if any(token in line for token in tokens):
+            findings.append(Finding(source, rel_path, line_number))
+    return findings
+
+
+def scan_paths(
+    repo_root: Path,
+    paths: list[Path],
+    tokens: list[str],
+    *,
+    source: ScanSource = "working-tree",
+) -> list[Finding]:
     """Return denylist matches in text files under *paths*."""
     findings: list[Finding] = []
     if not tokens:
@@ -87,32 +134,56 @@ def scan_paths(repo_root: Path, paths: list[Path], tokens: list[str]) -> list[Fi
         except OSError:
             continue
         rel_path = _relative(repo_root, candidate)
-        for line_number, line in enumerate(lines, start=1):
-            for token in tokens:
-                if token in line:
-                    findings.append(Finding(rel_path, line_number, token))
+        findings.extend(_scan_text(source, rel_path, "\n".join(lines), tokens))
     return findings
 
 
 def main(argv: list[str] | None = None) -> int:
     """Fail (exit 1) if a scanned text file contains a local denylist token."""
-    args = list(sys.argv[1:] if argv is None else argv)
-    if args and args[0] in ("--help", "-h"):
-        print(__doc__)
+    raw_args = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tracked", action="store_true", help="scan tracked working-tree text")
+    parser.add_argument("--staged", action="store_true", help="scan staged index text")
+    parser.add_argument("paths", nargs="*", help="optional pathspecs or working-tree paths")
+    if any(arg in ("--help", "-h") for arg in raw_args):
+        parser.print_help()
         return 0
+    args = parser.parse_args(raw_args)
 
     repo_root = get_repo_root()
     tokens = load_denylist(repo_root)
     if not tokens:
         return 0
-    paths = [Path(arg) for arg in args] if args else tracked_files(repo_root)
-    findings = scan_paths(repo_root, paths, tokens)
+    pathspecs = list(args.paths)
+    findings: list[Finding] = []
+
+    if not args.tracked and not args.staged and pathspecs:
+        findings.extend(scan_paths(repo_root, [Path(p) for p in pathspecs], tokens))
+    else:
+        if not args.tracked and not args.staged:
+            args.tracked = True
+        if args.tracked:
+            findings.extend(
+                scan_paths(
+                    repo_root,
+                    tracked_files(repo_root, pathspecs),
+                    tokens,
+                    source="tracked",
+                )
+            )
+        if args.staged:
+            for rel_path in staged_files(repo_root, pathspecs):
+                text = staged_text(repo_root, rel_path)
+                if text is not None:
+                    findings.extend(_scan_text("staged", rel_path, text, tokens))
+
     if not findings:
         return 0
 
-    print("ERROR: local private denylist token(s) found. Remove these values before committing:")
+    print("ERROR: local private denylist match(es) found. Remove the value before committing:")
     for finding in findings:
-        print(f"  {finding.path}:{finding.line_number}")
+        print(f"  {finding.source} {finding.path}:{finding.line_number}")
+    print("\nMatched values and line contents are intentionally not printed.")
     print(f"\nDenylist source: {DENYLIST_FILENAME} (local, untracked)")
     return 1
 

--- a/scripts/pi_smoke.py
+++ b/scripts/pi_smoke.py
@@ -17,7 +17,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from hephaestus.agents.runtime import run_pi_session
+from hephaestus.agents.runtime import (
+    pi_private_redaction_tokens,
+    redact_pi_private_values,
+    run_pi_session,
+)
 
 DEFAULT_PROMPT = "Reply with exactly: OK"
 
@@ -39,6 +43,7 @@ def main(argv: list[str] | None = None) -> int:
     if not model:
         print("ERROR: HEPH_PI_MODEL must name an operator-local Pi model alias.", file=sys.stderr)
         return 2
+    redaction_tokens = pi_private_redaction_tokens(args.cwd, model)
     try:
         result = run_pi_session(
             args.prompt,
@@ -48,12 +53,13 @@ def main(argv: list[str] | None = None) -> int:
             sandbox="read-only",
         )
     except subprocess.CalledProcessError as exc:
-        print(exc.stderr or exc.stdout or str(exc), file=sys.stderr)
+        detail = exc.stderr or exc.stdout or f"Pi smoke failed with exit {exc.returncode}"
+        print(redact_pi_private_values(detail, redaction_tokens), file=sys.stderr)
         return exc.returncode
     except subprocess.TimeoutExpired as exc:
         print(f"ERROR: Pi smoke timed out after {exc.timeout}s", file=sys.stderr)
         return 124
-    print(result.stdout)
+    print(redact_pi_private_values(result.stdout, redaction_tokens))
     if result.session_id:
         print(f"SESSION_ID={result.session_id}", file=sys.stderr)
     return 0

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -370,6 +370,40 @@ def test_run_pi_session_redacts_private_values_from_failures(tmp_path: Path) -> 
     assert agent_runtime.PI_PRIVATE_REDACTION in (exc.stderr or "")
 
 
+def test_run_pi_session_redacts_private_values_from_timeouts(tmp_path: Path) -> None:
+    """Pi timeout diagnostics should redact cmd, partial stdout, and stderr."""
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(
+            cmd,
+            7,
+            output="private-test-alias PRIVATE_ENDPOINT_TOKEN",
+            stderr="PRIVATE_ENDPOINT_TOKEN private-test-alias",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with pytest.raises(subprocess.TimeoutExpired) as exc_info:
+            agent_runtime.run_pi_session(
+                "prompt",
+                cwd=tmp_path,
+                timeout=30,
+                model="private-test-alias",
+            )
+
+    exc = exc_info.value
+    assert "private-test-alias" not in str(exc)
+    assert "private-test-alias" not in str(exc.cmd)
+    assert "PRIVATE_ENDPOINT_TOKEN" not in (exc.output or "")
+    assert "PRIVATE_ENDPOINT_TOKEN" not in (exc.stdout or "")
+    assert "PRIVATE_ENDPOINT_TOKEN" not in (exc.stderr or "")
+    assert agent_runtime.PI_PRIVATE_REDACTION in (exc.output or "")
+    assert agent_runtime.PI_PRIVATE_REDACTION in (exc.stderr or "")
+
+
 def test_redact_pi_private_values_replaces_all_tokens() -> None:
     """The standalone redactor should replace each configured private value."""
     text = "private-test-alias uses PRIVATE_ENDPOINT_TOKEN"

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -339,6 +339,51 @@ def test_run_pi_session_uses_json_mode_and_captures_session(tmp_path: Path) -> N
     assert captured["kwargs"]["env"]["PI_SKIP_VERSION_CHECK"] == "1"
 
 
+def test_run_pi_session_redacts_private_values_from_failures(tmp_path: Path) -> None:
+    """Pi subprocess failure diagnostics should not leak local aliases or tokens."""
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    def fake_run(cmd: list[str], **_: Any) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(
+            7,
+            cmd,
+            output="PRIVATE_ENDPOINT_TOKEN",
+            stderr="private-test-alias PRIVATE_ENDPOINT_TOKEN",
+        )
+
+    with patch("subprocess.run", side_effect=fake_run):
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            agent_runtime.run_pi_session(
+                "prompt",
+                cwd=tmp_path,
+                timeout=30,
+                model="private-test-alias",
+            )
+
+    exc = exc_info.value
+    assert "private-test-alias" not in str(exc.cmd)
+    assert "PRIVATE_ENDPOINT_TOKEN" not in (exc.stdout or "")
+    assert "PRIVATE_ENDPOINT_TOKEN" not in (exc.stderr or "")
+    assert agent_runtime.PI_PRIVATE_REDACTION in (exc.stderr or "")
+
+
+def test_redact_pi_private_values_replaces_all_tokens() -> None:
+    """The standalone redactor should replace each configured private value."""
+    text = "private-test-alias uses PRIVATE_ENDPOINT_TOKEN"
+
+    redacted = agent_runtime.redact_pi_private_values(
+        text,
+        ("private-test-alias", "PRIVATE_ENDPOINT_TOKEN"),
+    )
+
+    assert redacted == (
+        f"{agent_runtime.PI_PRIVATE_REDACTION} uses {agent_runtime.PI_PRIVATE_REDACTION}"
+    )
+
+
 def test_run_pi_session_read_only_restricts_tools(tmp_path: Path) -> None:
     """Read-only Pi stages should request a read-only tool surface."""
     captured_cmd: list[str] = []

--- a/tests/unit/ci/test_private_denylist_hook.py
+++ b/tests/unit/ci/test_private_denylist_hook.py
@@ -1,0 +1,25 @@
+"""Tests for the local private denylist pre-commit hook."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_private_denylist_hook_scans_staged_and_tracked() -> None:
+    """The hook should run the whole-repo/index privacy guard."""
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    hook = next(
+        h
+        for repo in config["repos"]
+        for h in repo.get("hooks", [])
+        if h.get("id") == "check-private-denylist"
+    )
+
+    assert hook["entry"] == "python3 scripts/check_private_denylist.py --staged --tracked"
+    assert hook["pass_filenames"] is False
+    assert hook["always_run"] is True
+    assert "types" not in hook

--- a/tests/unit/docs/test_pi_private_provider_docs.py
+++ b/tests/unit/docs/test_pi_private_provider_docs.py
@@ -1,0 +1,46 @@
+"""Tests for sanitized Pi private-provider documentation."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PI_DOC = REPO_ROOT / "docs" / "pi-private-provider.md"
+CONFIG_SUFFIXES = {".json", ".toml", ".yaml", ".yml", ".env", ".ini", ".cfg"}
+
+
+def _is_pi_config_surface(path: str) -> bool:
+    p = Path(path)
+    parts = {part.lower() for part in p.parts}
+    stem_tokens = set(re.split(r"[-_.]+", p.stem.lower()))
+    return p.suffix.lower() in CONFIG_SUFFIXES and (
+        ".pi" in parts or "pi" in parts or "pi" in stem_tokens
+    )
+
+
+def test_pi_private_provider_docs_are_sanitized() -> None:
+    """Docs should describe local setup using placeholders only."""
+    text = PI_DOC.read_text(encoding="utf-8")
+
+    assert "~/.pi/agent/models.json" in text
+    assert "HEPH_PI_MODEL" in text
+    assert ".heph-private-denylist" in text
+    assert "--staged --tracked" in text
+    assert "<operator-local-alias>" in text
+    assert "https://" not in text
+    assert "http://" not in text
+
+
+def test_no_tracked_pi_provider_config_surfaces_exist() -> None:
+    """Tracked config-like Pi paths would invite private provider details."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    paths = [p.decode() for p in result.stdout.split(b"\0") if p]
+
+    assert [p for p in paths if _is_pi_config_surface(p)] == []

--- a/tests/unit/scripts/test_check_private_denylist.py
+++ b/tests/unit/scripts/test_check_private_denylist.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -29,15 +30,22 @@ def test_load_denylist_ignores_blank_lines_and_comments(tmp_path: Path) -> None:
     assert _mod.load_denylist(tmp_path) == ["PRIVATE_ENDPOINT_TOKEN", "PRIVATE_MODEL_ALIAS"]
 
 
-def test_scan_paths_reports_fake_private_token(tmp_path: Path) -> None:
-    """A tracked text file containing a denylisted token is reported."""
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repository for index scan tests."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def test_scan_paths_reports_fake_private_token_without_storing_it(tmp_path: Path) -> None:
+    """A tracked text file containing a denylisted token is reported redacted."""
     source = tmp_path / "hephaestus" / "example.py"
     source.parent.mkdir()
     source.write_text('TOKEN = "PRIVATE_ENDPOINT_TOKEN"\n', encoding="utf-8")
 
     findings = _mod.scan_paths(tmp_path, [source], ["PRIVATE_ENDPOINT_TOKEN"])
 
-    assert findings == [_mod.Finding(source.relative_to(tmp_path), 1, "PRIVATE_ENDPOINT_TOKEN")]
+    assert findings == [_mod.Finding("working-tree", source.relative_to(tmp_path), 1)]
+    assert "PRIVATE_ENDPOINT_TOKEN" not in repr(findings)
 
 
 def test_main_returns_nonzero_when_fake_token_found(
@@ -54,6 +62,47 @@ def test_main_returns_nonzero_when_fake_token_found(
     monkeypatch.setattr(_mod, "get_repo_root", lambda: tmp_path)
 
     assert _mod.main([str(source)]) == 1
+
+
+def test_main_redacts_private_tokens_from_output(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Diagnostics should identify location without printing private values."""
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "docs" / "example.md"
+    source.parent.mkdir()
+    source.write_text("This mentions PRIVATE_ENDPOINT_TOKEN.\n", encoding="utf-8")
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: tmp_path)
+
+    assert _mod.main([str(source)]) == 1
+
+    output = capsys.readouterr().out
+    assert "docs/example.md:1" in output
+    assert "PRIVATE_ENDPOINT_TOKEN" not in output
+    assert "intentionally not printed" in output
+
+
+def test_staged_scan_reads_index_content_not_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--staged should scan index blobs instead of mutable working-tree files."""
+    repo = _init_repo(tmp_path)
+    (repo / ".heph-private-denylist").write_text("PRIVATE_MODEL_ALIAS\n", encoding="utf-8")
+    source = repo / "docs" / "pi.md"
+    source.parent.mkdir()
+    source.write_text("PRIVATE_MODEL_ALIAS\n", encoding="utf-8")
+    subprocess.run(["git", "add", "docs/pi.md"], cwd=repo, check=True)
+    source.write_text("clean working tree copy\n", encoding="utf-8")
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: repo)
+
+    assert _mod.main(["--staged"]) == 1
+
+    output = capsys.readouterr().out
+    assert "staged docs/pi.md:1" in output
+    assert "PRIVATE_MODEL_ALIAS" not in output
 
 
 def test_help_flag_prints_doc_and_exits_zero(

--- a/tests/unit/scripts/test_check_private_denylist.py
+++ b/tests/unit/scripts/test_check_private_denylist.py
@@ -85,6 +85,31 @@ def test_main_redacts_private_tokens_from_output(
     assert "intentionally not printed" in output
 
 
+def test_main_redacts_private_tokens_from_staged_diagnostic_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Staged diagnostics should not leak private values embedded in filenames."""
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+    rel_path = Path("docs") / "PRIVATE_ENDPOINT_TOKEN-example.md"
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(_mod, "staged_files", lambda _repo_root, _pathspecs=None: [rel_path])
+    monkeypatch.setattr(
+        _mod,
+        "staged_text",
+        lambda _repo_root, _rel_path: "This mentions PRIVATE_ENDPOINT_TOKEN.\n",
+    )
+
+    assert _mod.main(["--staged"]) == 1
+
+    output = capsys.readouterr().out
+    assert f"staged docs/{_mod.PRIVATE_DENYLIST_REDACTION}-example.md:1" in output
+    assert "PRIVATE_ENDPOINT_TOKEN" not in output
+    assert "intentionally not printed" in output
+
+
 def test_staged_scan_reads_index_content_not_worktree(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/unit/scripts/test_pi_smoke.py
+++ b/tests/unit/scripts/test_pi_smoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -36,3 +37,54 @@ def test_runs_pi_with_env_model_alias(monkeypatch: pytest.MonkeyPatch, tmp_path:
     assert kwargs["cwd"] == tmp_path
     assert kwargs["model"] == "private-test-alias"
     assert run_pi.call_args.args == ("Say OK",)
+
+
+def test_failure_output_redacts_private_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Smoke failures should redact the local alias and denylist tokens."""
+    monkeypatch.setenv("HEPH_PI_MODEL", "private-test-alias")
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+    err = subprocess.CalledProcessError(
+        9,
+        ["pi"],
+        output="PRIVATE_ENDPOINT_TOKEN",
+        stderr="private-test-alias PRIVATE_ENDPOINT_TOKEN",
+    )
+    monkeypatch.setattr(_mod, "run_pi_session", Mock(side_effect=err))
+
+    assert _mod.main(["--cwd", str(tmp_path)]) == 9
+
+    output = capsys.readouterr().err
+    assert "private-test-alias" not in output
+    assert "PRIVATE_ENDPOINT_TOKEN" not in output
+    assert "<redacted-pi-private-value>" in output
+
+
+def test_success_output_redacts_private_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Smoke success output should also be safe for publication."""
+    monkeypatch.setenv("HEPH_PI_MODEL", "private-test-alias")
+    (tmp_path / ".heph-private-denylist").write_text(
+        "PRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+    run_pi = Mock(
+        return_value=AgentRunResult(
+            stdout="private-test-alias PRIVATE_ENDPOINT_TOKEN",
+            stderr="",
+            session_id=None,
+        )
+    )
+    monkeypatch.setattr(_mod, "run_pi_session", run_pi)
+
+    assert _mod.main(["--cwd", str(tmp_path)]) == 0
+
+    output = capsys.readouterr().out
+    assert "private-test-alias" not in output
+    assert "PRIVATE_ENDPOINT_TOKEN" not in output
+    assert "<redacted-pi-private-value>" in output


### PR DESCRIPTION
## Summary
Add documentation and validation safeguards for operator-local private Pi provider configuration without committing private provider details.

## Changes
- Document sanitized private Pi provider setup and link it from the README
- Add ignored local denylist support with a staged/tracked text scanner and pre-commit hook
- Update Pi runtime and smoke-test behavior for local private provider aliases

## Testing
- Added unit coverage for runtime provider handling, denylist scanning, pre-commit hook wiring, Pi smoke behavior, and private-provider docs

## Closes
Closes #1579

Generated by Codex via ProjectHephaestus automation.
