### PR TITLE
feat(automation): dispatch Pi through shared runtime

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -183,11 +183,31 @@ def uses_direct_agent_runner(agent: str) -> bool:
     return AGENT_CAPABILITIES[agent].direct_runner
 
 
-def direct_agent_model(agent: str, phase_env_var: str) -> str:
+def direct_agent_model(agent: str, phase_env_var: str, *, codex_default: str = "") -> str:
     """Return a model override appropriate for a direct-runner provider."""
     if is_pi(agent):
         return os.environ.get(PI_MODEL_ENV, "")
-    return os.environ.get(phase_env_var, "")
+    return os.environ.get(phase_env_var, codex_default)
+
+
+def agent_cli_name(agent: str) -> str:
+    """Return the executable name for a supported agent backend."""
+    if agent not in AGENT_CAPABILITIES:
+        raise ValueError(f"Unsupported agent: {agent}")
+    return agent
+
+
+def agent_display_name(agent: str) -> str:
+    """Return a short human-facing name for a supported agent backend."""
+    names = {
+        "claude": "Claude Code",
+        "codex": "Codex",
+        "pi": "Pi",
+    }
+    try:
+        return names[agent]
+    except KeyError as e:
+        raise ValueError(f"Unsupported agent: {agent}") from e
 
 
 def session_agent_matches(session_agent: str | None, selected_agent: str) -> bool:
@@ -805,8 +825,8 @@ def codex_exec_resume_args(
     return cmd
 
 
-def codex_json_stdout(text: str, session_id: str | None = None) -> str:
-    """Wrap Codex text output in the JSON shape expected by Claude callers."""
+def agent_json_stdout(text: str, session_id: str | None = None) -> str:
+    """Wrap direct-agent text output in the JSON shape expected by Claude callers."""
     return json.dumps({"result": text, "session_id": session_id, "is_error": False})
 
 

--- a/hephaestus/automation/_implement_phase.py
+++ b/hephaestus/automation/_implement_phase.py
@@ -21,10 +21,8 @@ from typing import TYPE_CHECKING, cast
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     run_agent_session,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.github.rate_limit import wait_until
@@ -82,22 +80,17 @@ class ImplementPhase(StageMixin):
         """Select ProjectMnemosyne skills and return prompt-ready context."""
 
         def _invoke(prompt: str) -> str:
-            if is_codex(self.options.agent):
-                result = run_codex_text(
-                    prompt,
-                    cwd=self.repo_root,
-                    timeout=advise_claude_timeout(),
-                    model=codex_advise_model(),
-                    sandbox="read-only",
-                )
-                return (result.stdout or "").strip()
             if uses_direct_agent_runner(self.options.agent):
                 result = run_agent_text(
                     agent=self.options.agent,
                     prompt=prompt,
                     cwd=self.repo_root,
                     timeout=advise_claude_timeout(),
-                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
+                    model=direct_agent_model(
+                        self.options.agent,
+                        "HEPH_ADVISE_MODEL",
+                        codex_default=codex_advise_model(),
+                    ),
                     sandbox="read-only",
                 )
                 return (result.stdout or "").strip()
@@ -276,9 +269,7 @@ class ImplementPhase(StageMixin):
                 prompt=prompt,
                 cwd=worktree_path,
                 timeout=implementer_claude_timeout(),
-                model=(
-                    "" if is_codex(agent) else direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL")
-                ),
+                model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
                 sandbox="workspace-write",
             )
             log_file.write_text(result.stdout or "")

--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -25,11 +25,8 @@ from typing import TYPE_CHECKING, Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     resume_agent_session,
-    resume_codex_session,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.github.client import ClaudeUsageCapError, gh_call
@@ -1532,36 +1529,6 @@ class ReviewPhase(StageMixin):
             verdict=verdict,
             review_text=review_text,
         )
-        if is_codex(self.options.agent):
-            try:
-                result = resume_codex_session(
-                    session_id,
-                    prompt,
-                    cwd=worktree_path,
-                    timeout=implementer_claude_timeout(),
-                )
-                log_file = (
-                    self.state_dir / f"codex-feedback-{issue_number}-r{prev_iteration + 1}.log"
-                )
-                log_file.write_text(result.stdout or "")
-                return True
-            except subprocess.CalledProcessError as e:
-                logger.error(
-                    "#%d: Codex failed to address R%d feedback (exit=%d): %s",
-                    issue_number,
-                    prev_iteration + 1,
-                    e.returncode,
-                    (e.stderr or e.stdout or "")[:500],
-                )
-                return False
-            except subprocess.TimeoutExpired:
-                logger.error(
-                    "#%d: Codex timed out addressing R%d feedback",
-                    issue_number,
-                    prev_iteration + 1,
-                )
-                return False
-
         if uses_direct_agent_runner(self.options.agent):
             try:
                 result = resume_agent_session(
@@ -1676,17 +1643,6 @@ class ReviewPhase(StageMixin):
             prior_review=prior_review,
         )
         try:
-            if is_codex(self.options.agent):
-                result = run_codex_text(
-                    prompt,
-                    cwd=self.repo_root,
-                    timeout=600,
-                    sandbox="read-only",
-                )
-                output = (result.stdout or "").strip()
-                if not output:
-                    raise RuntimeError("reviewer returned empty output")
-                return output
             if uses_direct_agent_runner(self.options.agent):
                 result = run_agent_text(
                     agent=self.options.agent,

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -29,12 +29,9 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     resolve_agent,
     resume_agent_session,
-    resume_codex_session,
     run_agent_session,
-    run_codex_session,
     session_agent_matches,
     uses_direct_agent_runner,
 )
@@ -196,24 +193,6 @@ def run_address_fix_session(
     prompt_file.write_text(prompt)
 
     try:
-        if is_codex(agent):
-            codex_result = run_codex_session(
-                prompt,
-                cwd=worktree_path,
-                timeout=address_review_claude_timeout(),
-                sandbox="workspace-write",
-            )
-            log = codex_result.stdout
-            if codex_result.session_id:
-                log = f"SESSION_ID: {codex_result.session_id}\n\n{log}"
-            log_file.write_text(log)
-            parsed = parse_fn(codex_result.stdout)
-            logger.info(
-                "Fix session complete for PR #%s; addressed %s thread(s)",
-                pr_number,
-                len(parsed.get("addressed", [])),
-            )
-            return parsed
         if uses_direct_agent_runner(agent):
             direct_result = run_agent_session(
                 agent=agent,
@@ -872,62 +851,7 @@ class AddressReviewer(BaseReviewer):
         """
         log_file = self.state_dir / f"address-review-{issue_number}.log"
 
-        # Codex retains the resume-then-fallback behavior because it cannot
-        # derive a deterministic session UUID; run the resume attempt here and
-        # delegate the prompt build + parse to the shared core via a fresh run.
-        if not self.options.dry_run and is_codex(self.options.agent) and session_id:
-            threads_json = json.dumps(
-                [
-                    {
-                        "thread_id": t["id"],
-                        "path": t["path"],
-                        "line": t.get("line"),
-                        "body": t["body"],
-                    }
-                    for t in threads
-                ]
-            )
-            prompt = get_address_review_prompt(
-                pr_number=pr_number,
-                issue_number=issue_number,
-                worktree_path=str(worktree_path),
-                threads_json=threads_json,
-            )
-            try:
-                codex_result = resume_codex_session(
-                    session_id,
-                    prompt,
-                    cwd=worktree_path,
-                    timeout=address_review_claude_timeout(),
-                )
-            except subprocess.CalledProcessError as e:
-                logger.warning(
-                    "Issue #%s: Codex resume session %r failed for PR #%s; "
-                    "falling back to fresh session: %s",
-                    issue_number,
-                    session_id,
-                    pr_number,
-                    (e.stderr or e.stdout or "")[:300],
-                )
-            else:
-                log = codex_result.stdout
-                if codex_result.session_id:
-                    log = f"SESSION_ID: {codex_result.session_id}\n\n{log}"
-                log_file.write_text(log)
-                parsed = self._parse_json_block(codex_result.stdout, issue_number=issue_number)
-                logger.info(
-                    "Fix session complete for PR #%s; addressed %s thread(s)",
-                    pr_number,
-                    len(parsed.get("addressed", [])),
-                )
-                return parsed
-
-        if (
-            not self.options.dry_run
-            and not is_codex(self.options.agent)
-            and uses_direct_agent_runner(self.options.agent)
-            and session_id
-        ):
+        if not self.options.dry_run and uses_direct_agent_runner(self.options.agent) and session_id:
             threads_json = json.dumps(
                 [
                     {

--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -10,9 +10,9 @@ from pathlib import Path
 from hephaestus.agents.runtime import (
     add_agent_argument,
     resolve_agent,
+    run_agent_session,
     run_claude_text,
-    run_codex_session,
-    run_pi_session,
+    uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 
@@ -100,60 +100,21 @@ def run_claude(
     return result.returncode
 
 
-def run_codex(
+def run_direct_agent(
     args: argparse.Namespace,
     prompt: str,
     repo_root: Path,
     output_file: Path,
     log_file: Path | None,
 ) -> int:
-    """Run one stage with Codex."""
+    """Run one stage with a provider-neutral direct agent."""
     if args.debug:
-        print("Running: codex exec", file=sys.stderr)
+        print(f"Running: {args.agent} direct session", file=sys.stderr)
 
     try:
-        result = run_codex_session(
-            prompt,
-            cwd=repo_root,
-            timeout=args.timeout,
-            model=args.model,
-            sandbox=args.sandbox,
-            approval=args.approval,
-        )
-    except subprocess.TimeoutExpired as exc:
-        write_log(log_file, str(exc))
-        return 124
-    except subprocess.CalledProcessError as exc:
-        log_text = (
-            f"EXIT CODE: {exc.returncode}\n\n"
-            f"STDOUT:\n{exc.stdout or ''}\n\n"
-            f"STDERR:\n{exc.stderr or ''}"
-        )
-        write_log(log_file, log_text)
-        return exc.returncode
-
-    output_file.write_text(result.stdout, encoding="utf-8")
-    log = result.stdout
-    if result.session_id:
-        log = f"SESSION_ID: {result.session_id}\n\n{log}"
-    write_log(log_file, log)
-    return 0
-
-
-def run_pi(
-    args: argparse.Namespace,
-    prompt: str,
-    repo_root: Path,
-    output_file: Path,
-    log_file: Path | None,
-) -> int:
-    """Run one stage with Pi."""
-    if args.debug:
-        print("Running: pi --mode json", file=sys.stderr)
-
-    try:
-        result = run_pi_session(
-            prompt,
+        result = run_agent_session(
+            agent=args.agent,
+            prompt=prompt,
             cwd=repo_root,
             timeout=args.timeout,
             model=args.model,
@@ -241,10 +202,8 @@ def run_agent(args: argparse.Namespace) -> int:
 
     if agent == "claude":
         return run_claude(args, prompt, repo_root, output_file, log_file)
-    if agent == "codex":
-        return run_codex(args, prompt, repo_root, output_file, log_file)
-    if agent == "pi":
-        return run_pi(args, prompt, repo_root, output_file, log_file)
+    if uses_direct_agent_runner(agent):
+        return run_direct_agent(args, prompt, repo_root, output_file, log_file)
     raise ValueError(f"Unsupported agent: {agent}")
 
 

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -277,7 +277,8 @@ def main(argv: list[str] | None = None) -> int:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
-    agent = resolve_agent("codex" if args.codex else args.agent)
+    selected_agent = "codex" if args.codex else args.agent
+    agent = (selected_agent or "claude") if args.dry_run else resolve_agent(selected_agent)
     reviewer = AuditReviewer(
         agent=agent,
         pr_numbers=args.pr_numbers,

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -21,10 +21,10 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
+    add_agent_argument,
     direct_agent_model,
-    is_codex,
+    resolve_agent,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
@@ -149,15 +149,7 @@ def run_audit_coordinator(
     state_dir.mkdir(parents=True, exist_ok=True)
     log_file = state_dir / "audit-coordinator.log"
     try:
-        if is_codex(agent):
-            result = run_codex_text(
-                prompt,
-                cwd=get_repo_root(),
-                timeout=pr_reviewer_claude_timeout(),
-                sandbox="read-only",
-            )
-            response = result.stdout or ""
-        elif uses_direct_agent_runner(agent):
+        if uses_direct_agent_runner(agent):
             result = run_agent_text(
                 agent=agent,
                 prompt=prompt,
@@ -265,7 +257,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
         help="Audit only these PR numbers (default: all open).",
     )
-    parser.add_argument("--codex", action="store_true", help="Use Codex instead of Claude.")
+    add_agent_argument(parser)
+    parser.add_argument("--codex", action="store_true", help="Deprecated alias for --agent codex.")
     parser.add_argument(
         "--dry-run", action="store_true", help="Skip the agent call and the GitHub posting step."
     )
@@ -284,8 +277,9 @@ def main(argv: list[str] | None = None) -> int:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
     )
+    agent = resolve_agent("codex" if args.codex else args.agent)
     reviewer = AuditReviewer(
-        agent="codex" if args.codex else "claude",
+        agent=agent,
         pr_numbers=args.pr_numbers,
         dry_run=args.dry_run,
     )

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -24,10 +24,8 @@ from typing import Any
 from hephaestus.agents.runtime import (
     add_agent_argument,
     direct_agent_model,
-    is_codex,
     resolve_agent,
     run_agent_session,
-    run_codex_session,
     session_agent_matches,
     uses_direct_agent_runner,
 )
@@ -785,22 +783,17 @@ class CIDriver:
         issue_body = issue_data.get("body", "")
 
         def _invoke(prompt: str) -> str:
-            if is_codex(self.options.agent):
-                result = run_codex_session(
-                    prompt,
-                    cwd=self.repo_root,
-                    timeout=advise_claude_timeout(),
-                    model=codex_advise_model(),
-                    sandbox="read-only",
-                )
-                return (result.stdout or "").strip()
             if uses_direct_agent_runner(self.options.agent):
                 result = run_agent_session(
                     agent=self.options.agent,
                     prompt=prompt,
                     cwd=self.repo_root,
                     timeout=advise_claude_timeout(),
-                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
+                    model=direct_agent_model(
+                        self.options.agent,
+                        "HEPH_ADVISE_MODEL",
+                        codex_default=codex_advise_model(),
+                    ),
                     sandbox="read-only",
                 )
                 return (result.stdout or "").strip()

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -25,11 +25,8 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     resume_agent_session,
-    resume_codex_session,
     run_agent_session,
-    run_codex_session,
     uses_direct_agent_runner,
 )
 
@@ -271,57 +268,6 @@ class CIFixOrchestrator:
         log a distinct timeout message.
         """
         options = self._options()
-        if is_codex(options.agent):
-            if session_id:
-                try:
-                    result = resume_codex_session(
-                        session_id,
-                        prompt,
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                    )
-                except subprocess.CalledProcessError as exc:
-                    logger.warning(
-                        "Issue #%s: Codex resume session %r failed for PR #%s; "
-                        "falling back to fresh session: %s",
-                        issue_number,
-                        session_id,
-                        pr_number,
-                        (exc.stderr or exc.stdout or "")[:300],
-                    )
-                    try:
-                        result = run_codex_session(
-                            prompt,
-                            cwd=worktree_path,
-                            timeout=ci_driver_claude_timeout(),
-                            sandbox="workspace-write",
-                        )
-                    except subprocess.CalledProcessError as fresh_exc:
-                        return subprocess.CompletedProcess(
-                            args=fresh_exc.cmd,
-                            returncode=fresh_exc.returncode,
-                            stdout=fresh_exc.stdout or "",
-                            stderr=fresh_exc.stderr or "",
-                        )
-            else:
-                try:
-                    result = run_codex_session(
-                        prompt,
-                        cwd=worktree_path,
-                        timeout=ci_driver_claude_timeout(),
-                        sandbox="workspace-write",
-                    )
-                except subprocess.CalledProcessError as exc:
-                    return subprocess.CompletedProcess(
-                        args=exc.cmd,
-                        returncode=exc.returncode,
-                        stdout=exc.stdout or "",
-                        stderr=exc.stderr or "",
-                    )
-            return subprocess.CompletedProcess(
-                args=[], returncode=0, stdout=result.stdout, stderr=result.stderr or ""
-            )
-
         if uses_direct_agent_runner(options.agent):
             if session_id:
                 try:

--- a/hephaestus/automation/comment_difficulty.py
+++ b/hephaestus/automation/comment_difficulty.py
@@ -25,9 +25,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 
@@ -125,16 +123,7 @@ def _run_classifier_session(
     )
     log_file = state_dir / f"comment-difficulty-{issue_number}.log"
     try:
-        if is_codex(agent):
-            result = run_codex_text(
-                prompt,
-                cwd=worktree_path,
-                timeout=advise_claude_timeout(),
-                sandbox="read-only",
-            )
-            log_file.write_text(result.stdout or "")
-            parsed = parse_json_block(result.stdout or "")
-        elif uses_direct_agent_runner(agent):
+        if uses_direct_agent_runner(agent):
             result = run_agent_text(
                 agent=agent,
                 prompt=prompt,

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -32,10 +32,9 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    codex_json_stdout,
+    agent_json_stdout,
     direct_agent_model,
     resume_agent_session,
-    resume_codex_session,
     session_agent_matches,
     uses_direct_agent_runner,
 )
@@ -416,15 +415,7 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
     prompt_file.write_text(get_follow_up_prompt(issue_number))
 
     try:
-        if agent == "codex":
-            codex_result = resume_codex_session(
-                session_id,
-                prompt_file.read_text(),
-                cwd=worktree_path,
-                timeout=follow_up_claude_timeout(),
-            )
-            stdout = codex_json_stdout(codex_result.stdout, codex_result.session_id)
-        elif uses_direct_agent_runner(agent):
+        if uses_direct_agent_runner(agent):
             direct_result = resume_agent_session(
                 agent=agent,
                 session_id=session_id,
@@ -433,7 +424,7 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
                 timeout=follow_up_claude_timeout(),
                 model=direct_agent_model(agent, "HEPH_LEARN_MODEL"),
             )
-            stdout = codex_json_stdout(direct_result.stdout, direct_result.session_id)
+            stdout = agent_json_stdout(direct_result.stdout, direct_result.session_id)
         else:
             result = run(
                 [

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -63,8 +63,8 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    is_codex,
-    is_pi,
+    agent_cli_name,
+    agent_display_name,
 )
 
 # Imports for the Test-Patch Contract — see module docstring for the full table.
@@ -340,15 +340,8 @@ class IssueImplementer:
             logger.error("git not available: %s", e)
 
         # Check selected agent runtime
-        if is_codex(self.options.agent):
-            agent_binary = "codex"
-            agent_name = "Codex"
-        elif is_pi(self.options.agent):
-            agent_binary = "pi"
-            agent_name = "Pi"
-        else:
-            agent_binary = "claude"
-            agent_name = "Claude Code"
+        agent_binary = agent_cli_name(self.options.agent)
+        agent_name = agent_display_name(self.options.agent)
         try:
             run([agent_binary, "--version"], check=True)
             logger.info("%s available", agent_name)

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -35,9 +35,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 
@@ -886,15 +884,7 @@ class ImplementationPhaseRunner:
                 status_text=status.stdout or "",
                 diff_text=diff.stdout or "",
             )
-            if is_codex(self.options.agent):
-                result = run_codex_text(
-                    prompt,
-                    cwd=worktree_path,
-                    timeout=advise_claude_timeout(),
-                    sandbox="read-only",
-                )
-                output = result.stdout or ""
-            elif uses_direct_agent_runner(self.options.agent):
+            if uses_direct_agent_runner(self.options.agent):
                 result = run_agent_text(
                     agent=self.options.agent,
                     prompt=prompt,

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -20,7 +20,6 @@ from typing import Any
 from hephaestus.agents.runtime import (
     direct_agent_model,
     resume_agent_session,
-    resume_codex_session,
     session_agent_matches,
     uses_direct_agent_runner,
 )
@@ -225,23 +224,6 @@ def run_learn(
             error=message,
         )
         return False
-
-    if agent == "codex":
-
-        def _invoke_codex() -> str:
-            return (
-                resume_codex_session(
-                    session_id,
-                    build_learn_prompt(""),
-                    cwd=worktree_path,
-                    timeout=learn_claude_timeout(),
-                ).stdout
-                or ""
-            )
-
-        return _run_learn_with_retry(
-            _invoke_codex, state_dir=state_dir, issue_number=issue_number, log_file=log_file
-        )
 
     if uses_direct_agent_runner(agent):
 

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -209,6 +209,7 @@ class ReviewState(BaseModel):
     branch_name: str | None = None
     plan_path: str | None = None
     session_id: str | None = None
+    session_agent: str | None = None
     started_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     completed_at: datetime | None = None
     error: str | None = None

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -22,10 +22,8 @@ from typing import Any
 from hephaestus.agents.runtime import (
     add_agent_argument,
     direct_agent_model,
-    is_codex,
     resolve_agent,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.automation._review_utils import add_max_workers_arg
@@ -440,8 +438,6 @@ class PlanReviewer:
             plan_text=plan_text,
         )
 
-        if is_codex(self.options.agent):
-            return self._run_codex_analysis(issue_number, prompt, max_retries=max_retries)
         if uses_direct_agent_runner(self.options.agent):
             return self._run_direct_agent_analysis(issue_number, prompt, max_retries=max_retries)
 
@@ -499,56 +495,6 @@ class PlanReviewer:
             return None
         except Exception as e:
             logger.error("Unexpected error calling Claude for issue #%s: %s", issue_number, e)
-            return None
-
-    def _run_codex_analysis(
-        self,
-        issue_number: int,
-        prompt: str,
-        max_retries: int = 3,
-    ) -> str | None:
-        """Run Codex to produce a plan review."""
-        try:
-            result = run_codex_text(
-                prompt,
-                cwd=Path.cwd(),
-                timeout=plan_reviewer_claude_timeout(),
-                sandbox="read-only",
-            )
-            output = (result.stdout or "").strip()
-            if not output:
-                logger.error("Codex returned empty output for issue #%s", issue_number)
-                return None
-            return output
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr or ""
-            stdout = e.stdout or ""
-            reset_epoch = scan_quota_reset(stderr, stdout)
-            if reset_epoch is not None and max_retries > 0:
-                if reset_epoch > 0:
-                    wait_until(reset_epoch)
-                else:
-                    time.sleep(5)
-                return self._run_codex_analysis(
-                    issue_number,
-                    prompt,
-                    max_retries=max_retries - 1,
-                )
-            logger.error(
-                "Codex returned exit code %s for issue #%s: %s",
-                e.returncode,
-                issue_number,
-                (stderr or stdout)[:200],
-            )
-            return None
-        except subprocess.TimeoutExpired:
-            logger.error("Codex timed out reviewing plan for issue #%s", issue_number)
-            return None
-        except FileNotFoundError:
-            logger.error("'codex' CLI not found in PATH; cannot run plan review")
-            return None
-        except Exception as e:
-            logger.error("Unexpected error calling Codex for issue #%s: %s", issue_number, e)
             return None
 
     def _run_direct_agent_analysis(

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -19,7 +19,6 @@ from typing import Any
 from hephaestus.agents.runtime import (
     add_agent_argument,
     direct_agent_model,
-    is_codex,
     resolve_agent,
     uses_direct_agent_runner,
 )
@@ -334,24 +333,6 @@ class Planner:
             extra_args=extra_args,
         )
 
-    def _call_codex(
-        self,
-        prompt: str,
-        *,
-        model: str,
-        max_retries: int = 3,
-        timeout: int = 300,
-        sandbox: str = "workspace-write",
-    ) -> str:
-        """Call Codex (delegates to claude_runner)."""
-        return self.claude_runner.call_codex(
-            prompt,
-            model=model,
-            max_retries=max_retries,
-            timeout=timeout,
-            sandbox=sandbox,
-        )
-
     def _ensure_mnemosyne(self, mnemosyne_root: Path) -> bool:
         """Clone or refresh ProjectMnemosyne (delegates to the shared runner).
 
@@ -389,17 +370,14 @@ class Planner:
         """
 
         def _invoke(prompt: str) -> str:
-            if is_codex(self.options.agent):
-                return self._call_codex(
-                    prompt,
-                    model=codex_advise_model(),
-                    timeout=advise_claude_timeout(),
-                    sandbox="read-only",
-                )
             if uses_direct_agent_runner(self.options.agent):
                 return self.claude_runner.call_direct_agent(
                     prompt,
-                    model=direct_agent_model(self.options.agent, "HEPH_ADVISE_MODEL"),
+                    model=direct_agent_model(
+                        self.options.agent,
+                        "HEPH_ADVISE_MODEL",
+                        codex_default=codex_advise_model(),
+                    ),
                     timeout=advise_claude_timeout(),
                     sandbox="read-only",
                 )

--- a/hephaestus/automation/planner_claude.py
+++ b/hephaestus/automation/planner_claude.py
@@ -16,9 +16,7 @@ from typing import TYPE_CHECKING
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.github.rate_limit import wait_until
@@ -96,12 +94,14 @@ class PlannerClaudeRunner:
             RuntimeError: If Claude call fails.
 
         """
-        if is_codex(self.options.agent):
-            return self.call_codex(prompt, model=model, max_retries=max_retries, timeout=timeout)
         if uses_direct_agent_runner(self.options.agent):
             return self.call_direct_agent(
                 prompt,
-                model=direct_agent_model(self.options.agent, "HEPH_PLANNER_MODEL"),
+                model=direct_agent_model(
+                    self.options.agent,
+                    "HEPH_PLANNER_MODEL",
+                    codex_default=model,
+                ),
                 max_retries=max_retries,
                 timeout=timeout,
             )
@@ -182,48 +182,6 @@ class PlannerClaudeRunner:
 
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(f"Claude timed out after {timeout}s") from e
-
-    def call_codex(
-        self,
-        prompt: str,
-        *,
-        model: str,
-        max_retries: int = 3,
-        timeout: int = 300,
-        sandbox: str = "workspace-write",
-    ) -> str:
-        """Call Codex CLI with retry logic for rate limits."""
-        try:
-            result = run_codex_text(
-                prompt,
-                cwd=get_repo_root(),
-                timeout=timeout,
-                model=model,
-                sandbox=sandbox,
-            )
-        except subprocess.CalledProcessError as e:
-            stderr = e.stderr or ""
-            stdout = e.stdout or ""
-            reset_epoch = scan_quota_reset(stderr, stdout)
-            if reset_epoch is not None and reset_epoch > 0 and max_retries > 0:
-                logger.warning("Codex usage cap hit; waiting for reset")
-                wait_until(reset_epoch)
-                return self.call_codex(
-                    prompt,
-                    model=model,
-                    max_retries=max_retries - 1,
-                    timeout=timeout,
-                    sandbox=sandbox,
-                )
-            detail = stderr or stdout or str(e)
-            raise RuntimeError(f"Codex failed: {detail}") from e
-        except subprocess.TimeoutExpired as e:
-            raise RuntimeError(f"Codex timed out after {timeout}s") from e
-
-        response = (result.stdout or "").strip()
-        if not response:
-            raise RuntimeError("Codex returned empty response")
-        return response
 
     def call_direct_agent(
         self,

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -14,9 +14,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     run_agent_session,
-    run_codex_session,
     uses_direct_agent_runner,
 )
 
@@ -152,16 +150,6 @@ class PostMergeProcessor:
                     wt_err,
                 )
                 cwd = repo_root
-            if is_codex(options.agent):
-                codex_result = run_codex_session(
-                    prompt,
-                    cwd=cwd,
-                    timeout=learn_claude_timeout(),
-                    sandbox="workspace-write",
-                )
-                self._last_learn_evidence = mnemosyne_update_evidence(codex_result.stdout or "")
-                logger.info("Issue #%s: drive-green learnings captured with Codex", issue_number)
-                return True
             if uses_direct_agent_runner(options.agent):
                 direct_result = run_agent_session(
                     agent=options.agent,

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -10,17 +10,15 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from hephaestus.agents.runtime import (
-    is_codex,
-    is_pi,
+    agent_display_name,
+    direct_agent_model,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 
@@ -54,6 +52,11 @@ _RESERVED_MESSAGE_LINE = re.compile(
     re.IGNORECASE,
 )
 _GIT_MESSAGE_MODEL_ENV = "HEPH_GIT_MESSAGE_MODEL"
+_AGENT_COMMIT_IDENTITIES = {
+    "claude": ("Claude Code", "noreply@anthropic.com"),
+    "codex": ("Codex", "noreply@openai.com"),
+    "pi": ("Pi", "noreply@earendil.works"),
+}
 
 # Conventional-commit types the ``pr-policy`` CI gate accepts. MUST stay in sync
 # with ``ALLOWED_TYPES`` in ``scripts/check_conventional_commit.py`` (the gate's
@@ -120,11 +123,7 @@ class _PrMessageParts:
 
 def _agent_display_name(agent: str) -> str:
     """Return a short human-facing name for generated commits/PR bodies."""
-    if is_codex(agent):
-        return "Codex"
-    if is_pi(agent):
-        return "Pi"
-    return "Claude Code"
+    return agent_display_name(agent)
 
 
 def _coauthor_for_agent(agent: str) -> tuple[str, str]:
@@ -134,29 +133,18 @@ def _coauthor_for_agent(agent: str) -> tuple[str, str]:
     ``Co-Authored-By:`` git trailer. Model identifiers are intentionally NOT
     placed in the name slot — see ``_provenance_for_agent`` for that.
     """
-    if is_codex(agent):
-        return ("Codex", "noreply@openai.com")
-    if is_pi(agent):
-        return ("Pi", "noreply@earendil.works")
-    return ("Claude Code", "noreply@anthropic.com")
+    return _AGENT_COMMIT_IDENTITIES.get(agent, _AGENT_COMMIT_IDENTITIES["claude"])
 
 
 def _provenance_for_agent(agent: str) -> str:
     """Return the value for an ``Implemented-By:`` trailer.
 
     For Claude agents this is the resolved model id (honoring
-    ``HEPH_IMPLEMENTER_MODEL``); for Codex it is the literal ``"Codex"``.
+    ``HEPH_IMPLEMENTER_MODEL``); for direct agents it is the provider display name.
     """
-    if is_codex(agent):
-        return "Codex"
-    if is_pi(agent):
-        return "Pi"
+    if uses_direct_agent_runner(agent):
+        return agent_display_name(agent)
     return implementer_model()
-
-
-def _codex_git_message_model() -> str:
-    """Return the optional Codex model override for git-message generation."""
-    return os.environ.get(_GIT_MESSAGE_MODEL_ENV, "")
 
 
 def _issue_body(issue: Any) -> str:
@@ -329,22 +317,13 @@ def _invoke_git_message_agent(
 ) -> str:
     """Run the lightweight message agent in a separate read-only session."""
     timeout = git_message_agent_timeout()
-    if is_codex(agent):
-        result = run_codex_text(
-            prompt,
-            cwd=worktree_path,
-            timeout=timeout,
-            model=_codex_git_message_model(),
-            sandbox="read-only",
-        )
-        return (result.stdout or "").strip()
     if uses_direct_agent_runner(agent):
         result = run_agent_text(
             agent=agent,
             prompt=prompt,
             cwd=worktree_path,
             timeout=timeout,
-            model=_codex_git_message_model(),
+            model=direct_agent_model(agent, _GIT_MESSAGE_MODEL_ENV),
             sandbox="read-only",
         )
         return (result.stdout or "").strip()

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -29,10 +29,8 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     resolve_agent,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
@@ -143,26 +141,6 @@ def run_pr_review_analysis(
     log_file = state_dir / f"pr-review-analysis-{issue_number}.log"
 
     try:
-        if is_codex(agent):
-            result = run_codex_text(
-                prompt,
-                cwd=worktree_path,
-                timeout=pr_reviewer_claude_timeout(),
-                sandbox="read-only",
-            )
-            log_file.write_text(result.stdout or "")
-            review_text = result.stdout or ""
-            parsed = _parse_json_block(review_text)
-            # The Verdict:/Grade: line lives in the reviewer prose, not the JSON
-            # summary block. Surface the raw output so callers parse the real
-            # verdict instead of the verdict-free summary.
-            parsed["review_text"] = review_text
-            logger.info(
-                "Analysis complete for PR #%s; found %s inline comment(s)",
-                pr_number,
-                len(parsed.get("comments", [])),
-            )
-            return parsed
         if uses_direct_agent_runner(agent):
             result = run_agent_text(
                 agent=agent,

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -37,9 +37,7 @@ from typing import Any
 
 from hephaestus.agents.runtime import (
     direct_agent_model,
-    is_codex,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 
@@ -179,16 +177,7 @@ def _run_validation_session(
     )
     log_file = state_dir / f"review-validation-{issue_number}.log"
     try:
-        if is_codex(agent):
-            result = run_codex_text(
-                prompt,
-                cwd=worktree_path,
-                timeout=pr_reviewer_claude_timeout(),
-                sandbox="read-only",
-            )
-            log_file.write_text(result.stdout or "")
-            parsed = parse_json_block(result.stdout or "")
-        elif uses_direct_agent_runner(agent):
+        if uses_direct_agent_runner(agent):
             result = run_agent_text(
                 agent=agent,
                 prompt=prompt,

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -43,10 +43,8 @@ from typing import Any
 from hephaestus.agents.runtime import (
     add_agent_argument,
     direct_agent_model,
-    is_codex,
     resolve_agent,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
@@ -697,16 +695,6 @@ def rebase_and_resign(
 
 def _run_conflict_agent(agent: str, prompt: str, work: Path, pr_number: int) -> bool:
     """Run the selected conflict-resolution agent."""
-    if is_codex(agent):
-        result = run_codex_text(
-            prompt,
-            cwd=work,
-            timeout=2400,
-            sandbox="workspace-write",
-        )
-        if result.stdout:
-            logger.debug("  agent: %s", result.stdout[:200])
-        return True
     if uses_direct_agent_runner(agent):
         result = run_agent_text(
             agent=agent,

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -26,10 +26,8 @@ from typing import Any
 from hephaestus.agents.runtime import (
     add_agent_argument,
     direct_agent_model,
-    is_codex,
     resolve_agent,
     run_agent_text,
-    run_codex_text,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
@@ -379,14 +377,6 @@ async def _dispatch_swarm(
                 return
 
             logger.info("Spawning agent for branch: %s", branch)
-            if is_codex(agent):
-                results[branch] = await asyncio.to_thread(
-                    _run_codex_rebase_agent,
-                    prompt,
-                    branch,
-                    repo_path,
-                )
-                return
             if uses_direct_agent_runner(agent):
                 results[branch] = await asyncio.to_thread(
                     _run_direct_rebase_agent,
@@ -403,23 +393,6 @@ async def _dispatch_swarm(
 
     await asyncio.gather(*(_run_one(b) for b in branches))
     return results
-
-
-def _run_codex_rebase_agent(prompt: str, branch: str, repo_path: Path) -> str:
-    """Run one Codex rebase-fix agent and return its status marker."""
-    try:
-        result = run_codex_text(
-            prompt,
-            cwd=repo_path,
-            timeout=2400,
-            sandbox="workspace-write",
-        )
-        text = result.stdout or ""
-        logger.debug("[%s] agent: %s", branch, text[:300])
-        return _status_from_agent_text(text) or "failed"
-    except Exception as e:
-        logger.error("[%s] agent exception: %s", branch, e)
-        return "failed"
 
 
 def _run_direct_rebase_agent(agent: str, prompt: str, branch: str, repo_path: Path) -> str:

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -407,8 +407,8 @@ def test_resume_pi_session_passes_resume_id(tmp_path: Path) -> None:
     assert result.session_id == "pi-session-789"
 
 
-def test_direct_agent_model_uses_operator_pi_alias() -> None:
-    """Pi uses its own local alias env var instead of phase-specific model names."""
+def test_direct_agent_model_uses_operator_pi_alias_and_codex_default() -> None:
+    """Direct-runner model defaults are provider-aware and explicit."""
     with patch.dict(
         "os.environ",
         {
@@ -420,9 +420,33 @@ def test_direct_agent_model_uses_operator_pi_alias() -> None:
         assert agent_runtime.direct_agent_model("pi", "HEPH_IMPLEMENTER_MODEL") == (
             "operator-local-alias"
         )
+        assert (
+            agent_runtime.direct_agent_model(
+                "codex",
+                "HEPH_IMPLEMENTER_MODEL",
+                codex_default="fallback-model",
+            )
+            == "phase-model"
+        )
+        assert (
+            agent_runtime.direct_agent_model(
+                "codex",
+                "HEPH_UNSET_MODEL",
+                codex_default="fallback-model",
+            )
+            == "fallback-model"
+        )
+        assert agent_runtime.direct_agent_model("codex", "HEPH_UNSET_MODEL") == ""
         assert agent_runtime.direct_agent_model("claude", "HEPH_IMPLEMENTER_MODEL") == (
             "phase-model"
         )
+
+
+def test_agent_json_stdout_wraps_direct_agent_text() -> None:
+    """Direct-agent text output should use a provider-neutral JSON wrapper."""
+    assert agent_runtime.agent_json_stdout("learned", "pi-session") == (
+        '{"result": "learned", "session_id": "pi-session", "is_error": false}'
+    )
 
 
 def test_run_claude_text_builds_stage_command(tmp_path: Path) -> None:

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -184,11 +184,11 @@ def test_codex_fix_session_falls_back_to_fresh_on_resume_failure(
 
     with (
         patch(
-            "hephaestus.automation.address_review.resume_codex_session",
+            "hephaestus.automation.address_review.resume_agent_session",
             side_effect=resume_error,
         ),
         patch(
-            "hephaestus.automation.address_review.run_codex_session",
+            "hephaestus.automation.address_review.run_agent_session",
             return_value=fresh_result,
         ) as mock_fresh,
     ):

--- a/tests/unit/automation/test_agent_stage.py
+++ b/tests/unit/automation/test_agent_stage.py
@@ -70,10 +70,11 @@ def test_run_agent_dispatches_codex_and_logs_session(
 ) -> None:
     """Codex stages should persist the captured session id in the log."""
 
-    def fake_run_codex_session(*args: object, **kwargs: object) -> AgentRunResult:
+    def fake_run_agent_session(*args: object, **kwargs: object) -> AgentRunResult:
+        assert kwargs["agent"] == "codex"
         return AgentRunResult(stdout="codex output", stderr="", session_id="session-123")
 
-    monkeypatch.setattr(agent_stage, "run_codex_session", fake_run_codex_session)
+    monkeypatch.setattr(agent_stage, "run_agent_session", fake_run_agent_session)
     # resolve_agent now pre-flights install+auth (#1175); codex is not on PATH in
     # CI, so stub the resolution like the other codex stage tests below.
     monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "codex")
@@ -94,10 +95,11 @@ def test_run_agent_dispatches_pi_and_logs_session(
 ) -> None:
     """Pi stages should use the Pi JSON-mode runner and persist session metadata."""
 
-    def fake_run_pi_session(*args: object, **kwargs: object) -> AgentRunResult:
+    def fake_run_agent_session(*args: object, **kwargs: object) -> AgentRunResult:
+        assert kwargs["agent"] == "pi"
         return AgentRunResult(stdout="pi output", stderr="", session_id="pi-session-123")
 
-    monkeypatch.setattr(agent_stage, "run_pi_session", fake_run_pi_session)
+    monkeypatch.setattr(agent_stage, "run_agent_session", fake_run_agent_session)
     monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "pi")
 
     args = _args(tmp_path, agent="pi")
@@ -239,10 +241,11 @@ def test_main_allows_approval_with_codex_agent(
 ) -> None:
     """Codex honors --approval, so validation must not fire."""
 
-    def fake_run_codex_session(*a: object, **kw: object) -> AgentRunResult:
+    def fake_run_agent_session(*a: object, **kw: object) -> AgentRunResult:
+        assert kw["agent"] == "codex"
         return AgentRunResult(stdout="ok", stderr="", session_id=None)
 
-    monkeypatch.setattr(agent_stage, "run_codex_session", fake_run_codex_session)
+    monkeypatch.setattr(agent_stage, "run_agent_session", fake_run_agent_session)
     monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "codex")
     prompt_file = tmp_path / "prompt.md"
     prompt_file.write_text("p", encoding="utf-8")

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -437,6 +437,29 @@ class TestParser:
             main(["--codex", "--dry-run"])
             assert mock_cls.call_args[1]["agent"] == "codex"
 
+    def test_codex_flag_resolves_codex_for_live_run(self) -> None:
+        with mock.patch(
+            "hephaestus.automation.audit_reviewer.resolve_agent",
+            return_value="codex",
+        ) as mock_resolve:
+            with mock.patch("hephaestus.automation.audit_reviewer.AuditReviewer") as mock_cls:
+                mock_instance = mock.Mock()
+                mock_instance.run.return_value = (0, [])
+                mock_cls.return_value = mock_instance
+                main(["--codex"])
+                mock_resolve.assert_called_once_with("codex")
+                assert mock_cls.call_args[1]["agent"] == "codex"
+
+    def test_dry_run_skips_resolve_agent(self) -> None:
+        with mock.patch("hephaestus.automation.audit_reviewer.resolve_agent") as mock_resolve:
+            with mock.patch("hephaestus.automation.audit_reviewer.AuditReviewer") as mock_cls:
+                mock_instance = mock.Mock()
+                mock_instance.run.return_value = (0, [])
+                mock_cls.return_value = mock_instance
+                main(["--dry-run"])
+                mock_resolve.assert_not_called()
+                assert mock_cls.call_args[1]["agent"] == "claude"
+
     def test_json_flag_emits_envelope_on_exit(self) -> None:
         with mock.patch("hephaestus.automation.audit_reviewer.AuditReviewer") as mock_cls:
             mock_instance = mock.Mock()

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -264,21 +264,21 @@ class TestRunAuditCoordinator:
         run_audit_coordinator(prs=prs, agent="claude", state_dir=tmp_path)
         assert mock_invoke.called
 
-    @mock.patch("hephaestus.automation.audit_reviewer.run_codex_text")
+    @mock.patch("hephaestus.automation.audit_reviewer.run_agent_text")
     @mock.patch("hephaestus.automation.audit_reviewer.get_repo_root")
     def test_codex_path_invokes_runtime(
         self,
         mock_root: mock.Mock,
-        mock_codex: mock.Mock,
+        mock_agent: mock.Mock,
         tmp_path: Path,
     ) -> None:
         prs = [{"number": 100, "title": "Test"}]
         mock_root.return_value = Path(".")
-        mock_codex.return_value = mock.Mock(
+        mock_agent.return_value = mock.Mock(
             stdout='```json\n{"audits": [{"pr_number": 100, "verdict": "GO"}]}\n```'
         )
         run_audit_coordinator(prs=prs, agent="codex", state_dir=tmp_path)
-        assert mock_codex.called
+        assert mock_agent.call_args.kwargs["agent"] == "codex"
 
     @mock.patch("hephaestus.automation.audit_reviewer.invoke_claude_with_session")
     @mock.patch("hephaestus.automation.audit_reviewer.get_repo_root")

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -273,11 +273,11 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
 
     with (
         patch(
-            "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.resume_agent_session",
             side_effect=resume_error,
         ),
         patch(
-            "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.run_agent_session",
             return_value=fresh_result,
         ) as mock_fresh,
         patch(
@@ -333,7 +333,7 @@ def test_codex_ci_fix_session_skips_push_when_head_did_not_advance(
 
     with (
         patch(
-            "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.run_agent_session",
             return_value=fresh_result,
         ),
         patch(
@@ -426,7 +426,7 @@ def test_codex_ci_advise_uses_codex_prompt_builder(driver: CIDriver) -> None:
             return_value={"title": "Test Issue", "body": "Issue body"},
         ),
         patch("hephaestus.automation.ci_driver.run_advise", return_value="findings") as run,
-        patch("hephaestus.automation.ci_driver.run_codex_session") as codex,
+        patch("hephaestus.automation.ci_driver.run_agent_session") as codex,
     ):
         codex.return_value = MagicMock(stdout='{"skills": []}')
         result = driver._run_advise(123)
@@ -1371,7 +1371,7 @@ class TestDriveGreenLearnings:
         with (
             patch.object(driver, "_get_worktree_path", return_value=tmp_path),
             patch(
-                "hephaestus.automation.post_merge_processor.run_codex_session",
+                "hephaestus.automation.post_merge_processor.run_agent_session",
                 return_value=mock_codex_result,
             ) as mock_codex,
             patch(
@@ -1382,7 +1382,8 @@ class TestDriveGreenLearnings:
 
         assert result is True
         mock_codex.assert_called_once()
-        prompt = mock_codex.call_args.args[0]
+        assert mock_codex.call_args.kwargs["agent"] == "codex"
+        prompt = mock_codex.call_args.kwargs["prompt"]
         assert prompt.startswith("/learn ")
         assert "/skills-registry-commands:learn" not in prompt
         assert "Only push skills to ProjectMnemosyne" in prompt
@@ -1967,7 +1968,7 @@ class TestNoCommitRetry:
         assert not (driver.state_dir / "repeated-no-commit-2.json").exists()
 
     def test_retry_codex_path_resumes_session(self, driver: CIDriver, tmp_path: Path) -> None:
-        """Codex agent + session_id → resume_codex_session called once with the session."""
+        """Codex agent + session_id → resume_agent_session called once with the session."""
         driver.options.agent = "codex"
         post_sha = MagicMock(stdout="deadbeef\n")
         clean_status = MagicMock(stdout="", stderr="", returncode=0)
@@ -1981,10 +1982,10 @@ class TestNoCommitRetry:
                 return_value=[],
             ),
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_agent_session",
                 return_value=AgentRunResult(stdout="ok", stderr="", session_id="s"),
             ) as mock_resume,
-            patch("hephaestus.automation.ci_fix_orchestrator.run_codex_session") as mock_fresh,
+            patch("hephaestus.automation.ci_fix_orchestrator.run_agent_session") as mock_fresh,
             patch(
                 "hephaestus.automation.ci_fix_orchestrator.run",
                 side_effect=[clean_status, post_sha],
@@ -3470,10 +3471,10 @@ class TestInvokeAgentSession:
         driver.options.agent = "codex"
         with (
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_agent_session",
                 return_value=AgentRunResult(stdout="ok", stderr="", session_id="s"),
             ) as mock_resume,
-            patch("hephaestus.automation.ci_fix_orchestrator.run_codex_session") as mock_fresh,
+            patch("hephaestus.automation.ci_fix_orchestrator.run_agent_session") as mock_fresh,
         ):
             result = driver._invoke_agent_session(
                 prompt="fix it",
@@ -3492,11 +3493,11 @@ class TestInvokeAgentSession:
         driver.options.agent = "codex"
         with (
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_agent_session",
                 side_effect=subprocess.CalledProcessError(1, ["codex"], stderr="resume-fail"),
             ),
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.run_agent_session",
                 return_value=AgentRunResult(stdout="fresh ok", stderr="", session_id="s2"),
             ) as mock_fresh,
         ):
@@ -3517,11 +3518,11 @@ class TestInvokeAgentSession:
         driver.options.agent = "codex"
         with (
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.resume_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.resume_agent_session",
                 side_effect=subprocess.CalledProcessError(1, ["codex"], stderr="resume-fail"),
             ),
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.run_agent_session",
                 side_effect=subprocess.CalledProcessError(2, ["codex"], stderr="fresh-fail"),
             ),
         ):
@@ -3541,7 +3542,7 @@ class TestInvokeAgentSession:
         """No session_id + fresh codex fails → CompletedProcess(returncode!=0), no exception."""
         driver.options.agent = "codex"
         with patch(
-            "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
+            "hephaestus.automation.ci_fix_orchestrator.run_agent_session",
             side_effect=subprocess.CalledProcessError(3, ["codex"], stderr="fail"),
         ):
             result = driver._invoke_agent_session(
@@ -3556,9 +3557,9 @@ class TestInvokeAgentSession:
     def test_codex_no_session_runs_fresh(self, driver: CIDriver, tmp_path: Path) -> None:
         driver.options.agent = "codex"
         with (
-            patch("hephaestus.automation.ci_fix_orchestrator.resume_codex_session") as mock_resume,
+            patch("hephaestus.automation.ci_fix_orchestrator.resume_agent_session") as mock_resume,
             patch(
-                "hephaestus.automation.ci_fix_orchestrator.run_codex_session",
+                "hephaestus.automation.ci_fix_orchestrator.run_agent_session",
                 return_value=AgentRunResult(stdout="done", stderr="", session_id="s3"),
             ) as mock_fresh,
         ):

--- a/tests/unit/automation/test_follow_up.py
+++ b/tests/unit/automation/test_follow_up.py
@@ -283,7 +283,7 @@ class TestRunFollowUpIssues:
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
-        with patch("hephaestus.automation.follow_up.resume_codex_session") as mock_resume:
+        with patch("hephaestus.automation.follow_up.resume_agent_session") as mock_resume:
             response = run_follow_up_issues(
                 "sess",
                 worktree_path,

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -68,9 +68,9 @@ def test_codex_implementer_advise_uses_codex_prompt_builder(
 
     with (
         patch("hephaestus.automation._implement_phase.run_advise", return_value="findings") as run,
-        patch("hephaestus.automation._implement_phase.run_codex_text") as codex,
+        patch("hephaestus.automation._implement_phase.run_agent_text") as direct_agent,
     ):
-        codex.return_value = subprocess.CompletedProcess(
+        direct_agent.return_value = subprocess.CompletedProcess(
             args=["codex", "exec"], returncode=0, stdout='{"skills": []}', stderr=""
         )
         result = implementer._run_advise(123, "Test Issue", "Issue body")
@@ -79,8 +79,9 @@ def test_codex_implementer_advise_uses_codex_prompt_builder(
 
     assert result == "findings"
     assert run.call_args.kwargs["build_prompt"].__name__ == "get_codex_advise_prompt"
-    assert codex.call_args.kwargs["model"] == "gpt-5.4-mini"
-    assert codex.call_args.kwargs["sandbox"] == "read-only"
+    assert direct_agent.call_args.kwargs["agent"] == "codex"
+    assert direct_agent.call_args.kwargs["model"] == "gpt-5.4-mini"
+    assert direct_agent.call_args.kwargs["sandbox"] == "read-only"
 
 
 class TestRunImplReviewLoop:

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -138,7 +138,7 @@ class TestRunLearn:
         worktree_path = tmp_path / "worktree"
         worktree_path.mkdir()
 
-        with patch("hephaestus.automation.learn.resume_codex_session") as mock_resume:
+        with patch("hephaestus.automation.learn.resume_agent_session") as mock_resume:
             result = run_learn(
                 "session-abc",
                 worktree_path,
@@ -163,7 +163,7 @@ class TestRunLearn:
         mock_result.stdout = "learned"
 
         with patch(
-            "hephaestus.automation.learn.resume_codex_session", return_value=mock_result
+            "hephaestus.automation.learn.resume_agent_session", return_value=mock_result
         ) as mock_resume:
             result = run_learn(
                 "session-abc",
@@ -175,7 +175,8 @@ class TestRunLearn:
             )
 
         assert result is True
-        prompt = mock_resume.call_args.args[1]
+        assert mock_resume.call_args.kwargs["agent"] == "codex"
+        prompt = mock_resume.call_args.kwargs["prompt"]
         assert prompt.startswith("/learn")
         assert "/skills-registry-commands:learn" not in prompt
         assert (tmp_path / "learn-42.log").read_text() == "learned"
@@ -395,7 +396,7 @@ class TestRunLearnRateLimitRetry:
 
         with (
             patch(
-                "hephaestus.automation.learn.resume_codex_session",
+                "hephaestus.automation.learn.resume_agent_session",
                 side_effect=[first, second],
             ) as mock_resume,
             patch("hephaestus.automation.learn.wait_until") as mock_wait,

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -11,6 +11,8 @@ from hephaestus.automation.models import (
     IssueState,
     PlannerOptions,
     PlanResult,
+    ReviewPhase,
+    ReviewState,
     WorkerResult,
 )
 
@@ -275,6 +277,25 @@ class TestWorkerResult:
         assert result.success is False
         assert result.error == "Implementation failed"
         assert result.pr_number is None
+
+
+class TestReviewState:
+    """Tests for ReviewState model."""
+
+    def test_session_agent_serialization(self) -> None:
+        """Review state files preserve provider metadata with session ids."""
+        state = ReviewState(
+            issue_number=123,
+            pr_number=456,
+            phase=ReviewPhase.FIXING,
+            session_id="pi-session-123",
+            session_agent="pi",
+        )
+
+        restored = ReviewState.model_validate_json(state.model_dump_json())
+
+        assert restored.session_id == "pi-session-123"
+        assert restored.session_agent == "pi"
 
 
 class TestPlannerOptions:

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -331,7 +331,11 @@ class TestRunAdvise:
 
         with (
             patch("hephaestus.automation.planner.run_advise", return_value="findings") as run,
-            patch.object(planner, "_call_codex", return_value='{"skills": []}') as call_codex,
+            patch.object(
+                planner.claude_runner,
+                "call_direct_agent",
+                return_value='{"skills": []}',
+            ) as call_direct,
         ):
             result = planner._run_advise(123, "Test Issue", "Issue body")
             invoke = run.call_args.kwargs["invoke"]
@@ -339,8 +343,8 @@ class TestRunAdvise:
 
         assert result == "findings"
         assert run.call_args.kwargs["build_prompt"].__name__ == "get_codex_advise_prompt"
-        assert call_codex.call_args.kwargs["model"] == "gpt-5.4-mini"
-        assert call_codex.call_args.kwargs["sandbox"] == "read-only"
+        assert call_direct.call_args.kwargs["model"] == "gpt-5.4-mini"
+        assert call_direct.call_args.kwargs["sandbox"] == "read-only"
 
     def test_graceful_failure_on_error(self, planner: Any) -> None:
         """When advise errors, return a sentinel-comment (not silent ``""``).

--- a/tests/unit/automation/test_post_merge_helpers.py
+++ b/tests/unit/automation/test_post_merge_helpers.py
@@ -98,16 +98,16 @@ class TestRunDriveGreenLearnings:
         assert inv.called
         assert processor._last_learn_evidence == sentinel
 
-    def test_codex_path_uses_run_codex_session(self, tmp_path: Path) -> None:
+    def test_codex_path_uses_run_agent_session(self, tmp_path: Path) -> None:
         processor = _make_codex_processor(tmp_path)
         with (
             patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
-            patch(f"{_MOD}.run_codex_session", return_value=MagicMock(stdout="codex-out")) as codex,
+            patch(f"{_MOD}.run_agent_session", return_value=MagicMock(stdout="codex-out")) as agent,
             patch(f"{_MOD}.invoke_claude_with_session") as inv,
         ):
             result = processor.run_drive_green_learnings(3, 4)
         assert result is True
-        assert codex.called
+        assert agent.call_args.kwargs["agent"] == "codex"
         assert not inv.called
 
     def test_worktree_failure_falls_back_to_repo_root(self, tmp_path: Path) -> None:

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -338,7 +338,6 @@ class TestMessageAgentInvocation:
 
     def test_claude_message_agent_uses_separate_session(self) -> None:
         with (
-            patch.object(pr_manager, "is_codex", return_value=False),
             patch.object(pr_manager, "get_repo_slug", return_value="ProjectHephaestus"),
             patch.object(pr_manager, "git_message_model", return_value="claude-haiku-4-5"),
             patch.object(pr_manager, "git_message_agent_timeout", return_value=120),
@@ -370,10 +369,9 @@ class TestMessageAgentInvocation:
             args=["codex", "exec"], returncode=0, stdout="{}", stderr=""
         )
         with (
-            patch.object(pr_manager, "is_codex", return_value=True),
-            patch.object(pr_manager, "_codex_git_message_model", return_value="gpt-5.4-mini"),
+            patch.dict("os.environ", {"HEPH_GIT_MESSAGE_MODEL": "gpt-5.4-mini"}),
             patch.object(pr_manager, "git_message_agent_timeout", return_value=120),
-            patch.object(pr_manager, "run_codex_text", return_value=completed) as run_codex,
+            patch.object(pr_manager, "run_agent_text", return_value=completed) as run_agent,
         ):
             assert (
                 pr_manager._invoke_git_message_agent(
@@ -386,7 +384,8 @@ class TestMessageAgentInvocation:
                 == "{}"
             )
 
-        kwargs = run_codex.call_args.kwargs
+        kwargs = run_agent.call_args.kwargs
+        assert kwargs["agent"] == "codex"
         assert kwargs["cwd"] == Path("/tmp/wt")
         assert kwargs["sandbox"] == "read-only"
         assert kwargs["model"] == "gpt-5.4-mini"
@@ -395,7 +394,6 @@ class TestMessageAgentInvocation:
         completed = subprocess.CompletedProcess(args=["pi"], returncode=0, stdout="{}", stderr="")
         with (
             patch.object(pr_manager, "uses_direct_agent_runner", return_value=True),
-            patch.object(pr_manager, "is_codex", return_value=False),
             patch.object(pr_manager, "git_message_agent_timeout", return_value=120),
             patch.object(pr_manager, "run_agent_text", return_value=completed) as run_agent,
         ):

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -472,9 +472,9 @@ class TestRunPrReviewAnalysis:
                 "hephaestus.automation.pr_reviewer.get_pr_review_analysis_prompt",
                 side_effect=_fake_prompt,
             ),
-            patch("hephaestus.automation.pr_reviewer.run_codex_text") as mock_codex,
+            patch("hephaestus.automation.pr_reviewer.run_agent_text") as mock_agent,
         ):
-            mock_codex.return_value = MagicMock(
+            mock_agent.return_value = MagicMock(
                 stdout='Verdict: GO\n```json\n{"comments": [], "summary": "ok"}\n```'
             )
             run_pr_review_analysis(
@@ -526,7 +526,7 @@ class TestRunPrReviewAnalysis:
         )
 
         with patch(
-            "hephaestus.automation.pr_reviewer.run_codex_text",
+            "hephaestus.automation.pr_reviewer.run_agent_text",
             return_value=MagicMock(stdout=stdout),
         ):
             out = run_pr_review_analysis(

--- a/tests/unit/automation/test_provider_neutral_direct_dispatch.py
+++ b/tests/unit/automation/test_provider_neutral_direct_dispatch.py
@@ -1,0 +1,78 @@
+"""Static guards for provider-neutral direct-agent automation dispatch."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PROVIDER_NEUTRAL_FILES = [
+    "hephaestus/automation/agent_stage.py",
+    "hephaestus/automation/planner.py",
+    "hephaestus/automation/planner_claude.py",
+    "hephaestus/automation/plan_reviewer.py",
+    "hephaestus/automation/_implement_phase.py",
+    "hephaestus/automation/implementer_phase_runner.py",
+    "hephaestus/automation/implementer.py",
+    "hephaestus/automation/_review_phase.py",
+    "hephaestus/automation/pr_reviewer.py",
+    "hephaestus/automation/audit_reviewer.py",
+    "hephaestus/automation/review_validator.py",
+    "hephaestus/automation/comment_difficulty.py",
+    "hephaestus/automation/address_review.py",
+    "hephaestus/automation/ci_driver.py",
+    "hephaestus/automation/ci_fix_orchestrator.py",
+    "hephaestus/automation/post_merge_processor.py",
+    "hephaestus/automation/learn.py",
+    "hephaestus/automation/follow_up.py",
+    "hephaestus/automation/pr_manager.py",
+    "hephaestus/github/tidy.py",
+    "hephaestus/github/fleet_sync.py",
+]
+
+CODEX_ONLY_NAMES = {
+    "is_codex",
+    "run_codex_text",
+    "run_codex_session",
+    "resume_codex_session",
+    "codex_json_stdout",
+}
+
+
+def _node_name(node: ast.AST) -> str:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
+
+
+def _codex_string_compare(node: ast.Compare) -> bool:
+    comparators = [node.left, *node.comparators]
+    return any(isinstance(item, ast.Constant) and item.value == "codex" for item in comparators)
+
+
+@pytest.mark.parametrize("relative_path", PROVIDER_NEUTRAL_FILES)
+def test_direct_agent_dispatch_has_no_codex_only_runtime_branches(relative_path: str) -> None:
+    """Automation call sites must route Codex and Pi through neutral runtime helpers."""
+    path = REPO_ROOT / relative_path
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            imported = {alias.name for alias in node.names}
+            offenders = imported & CODEX_ONLY_NAMES
+            if offenders:
+                violations.append(f"line {node.lineno}: imports {sorted(offenders)}")
+        elif isinstance(node, ast.Call):
+            name = _node_name(node.func)
+            if name in CODEX_ONLY_NAMES:
+                violations.append(f"line {node.lineno}: calls {name}()")
+        elif isinstance(node, ast.Compare) and _codex_string_compare(node):
+            violations.append(f"line {node.lineno}: compares against 'codex'")
+
+    assert violations == []

--- a/tests/unit/automation/test_session_agent_resume_matrix.py
+++ b/tests/unit/automation/test_session_agent_resume_matrix.py
@@ -1,0 +1,129 @@
+"""Regression matrix for persisted session provider metadata."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hephaestus.agents.runtime import session_agent_matches
+from hephaestus.automation.address_review import AddressReviewer
+from hephaestus.automation.ci_driver import CIDriver
+from hephaestus.automation.models import AddressReviewOptions, CIDriverOptions
+
+
+@pytest.mark.parametrize("selected_agent", ["claude", "codex", "pi"])
+@pytest.mark.parametrize("saved_agent", [None, "claude", "codex", "pi"])
+def test_session_agent_matches_matrix(
+    saved_agent: str | None,
+    selected_agent: str,
+) -> None:
+    """Missing metadata remains Claude-only; explicit metadata must match exactly."""
+    expected = (saved_agent or "claude") == selected_agent
+    assert session_agent_matches(saved_agent, selected_agent) is expected
+
+
+@pytest.fixture
+def address_reviewer_factory(tmp_path: Path) -> Callable[[str], AddressReviewer]:
+    """Create address-review instances with isolated state dirs."""
+
+    def _make(agent: str) -> AddressReviewer:
+        reviewer = AddressReviewer(
+            AddressReviewOptions(
+                issues=[1578],
+                agent=agent,
+                max_workers=1,
+                dry_run=False,
+                enable_ui=False,
+            ),
+            get_repo_root=lambda: tmp_path,
+            worktree_manager_factory=MagicMock(return_value=MagicMock()),
+            status_tracker_factory=MagicMock(return_value=MagicMock()),
+            log_manager_factory=MagicMock(return_value=MagicMock()),
+        )
+        reviewer.state_dir = tmp_path
+        return reviewer
+
+    return _make
+
+
+@pytest.fixture
+def ci_driver_factory(tmp_path: Path) -> Callable[[str], CIDriver]:
+    """Create CI-driver instances with isolated state dirs."""
+
+    def _make(agent: str) -> CIDriver:
+        driver = CIDriver(
+            CIDriverOptions(
+                issues=[1578],
+                agent=agent,
+                max_workers=1,
+                dry_run=False,
+                enable_ui=False,
+            )
+        )
+        driver.repo_root = tmp_path
+        driver.state_dir = tmp_path
+        return driver
+
+    return _make
+
+
+@pytest.mark.parametrize(
+    ("selected_agent", "saved_agent", "expected"),
+    [
+        ("pi", "pi", "session-1578"),
+        ("pi", "codex", None),
+        ("pi", "claude", None),
+        ("pi", None, None),
+        ("codex", "pi", None),
+        ("claude", "pi", None),
+    ],
+)
+def test_address_review_load_impl_session_id_rejects_cross_provider_state(
+    address_reviewer_factory: Callable[[str], AddressReviewer],
+    tmp_path: Path,
+    selected_agent: str,
+    saved_agent: str | None,
+    expected: str | None,
+) -> None:
+    """Address-review must never resume an implementer session from another provider."""
+    payload = {"session_id": "session-1578"}
+    if saved_agent is not None:
+        payload["session_agent"] = saved_agent
+    (tmp_path / "issue-1578.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    reviewer = address_reviewer_factory(selected_agent)
+
+    assert reviewer._load_impl_session_id(1578) == expected
+
+
+@pytest.mark.parametrize(
+    ("selected_agent", "saved_agent", "expected"),
+    [
+        ("pi", "pi", "session-1578"),
+        ("pi", "codex", None),
+        ("pi", "claude", None),
+        ("pi", None, None),
+        ("codex", "pi", None),
+        ("claude", "pi", None),
+    ],
+)
+def test_ci_driver_load_impl_session_id_rejects_cross_provider_state(
+    ci_driver_factory: Callable[[str], CIDriver],
+    tmp_path: Path,
+    selected_agent: str,
+    saved_agent: str | None,
+    expected: str | None,
+) -> None:
+    """CI repair must respect persisted provider metadata before resuming."""
+    payload = {"session_id": "session-1578"}
+    if saved_agent is not None:
+        payload["session_agent"] = saved_agent
+    (tmp_path / "issue-1578.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    driver = ci_driver_factory(selected_agent)
+
+    assert driver._load_impl_session_id(1578) == expected

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -177,12 +177,11 @@ def test_implement_phase_run_claude_code_dry_run(tmp_path: Path) -> None:
 
 
 def test_implement_phase_run_claude_code_dispatches_claude(tmp_path: Path) -> None:
-    """_run_claude_code routes to the Claude session for non-codex agents."""
+    """_run_claude_code routes to the Claude session for non-direct agents."""
     ctx = _make_ctx(tmp_path)
     ctx.impl._run_claude_impl_session = mock.MagicMock(return_value="sess-1")  # type: ignore[method-assign]
     phase = ImplementPhase(ctx)
-    with mock.patch("hephaestus.automation._implement_phase.is_codex", return_value=False):
-        assert phase._run_claude_code(7, tmp_path, "prompt") == "sess-1"
+    assert phase._run_claude_code(7, tmp_path, "prompt") == "sess-1"
     ctx.impl._run_claude_impl_session.assert_called_once()
 
 

--- a/tests/unit/github/test_tidy.py
+++ b/tests/unit/github/test_tidy.py
@@ -174,7 +174,8 @@ def test_dispatch_swarm_runs_codex_agents_in_threads(
 
     assert result == {"feature/a": "fixed"}
     assert calls
-    assert calls[0][0] is tidy_module._run_codex_rebase_agent
+    assert calls[0][0] is tidy_module._run_direct_rebase_agent
+    assert calls[0][1][0] == "codex"
 
 
 class TestMain:


### PR DESCRIPTION
## Summary
Wire Pi into provider-neutral automation dispatch while preserving session-agent metadata and resume safety.

## Changes
- Routes planner, implementer, review, CI, PR-management, tidy, and fleet automation paths through shared runtime dispatch instead of Claude/Codex-specific branching.
- Adds Pi as a supported session_agent value and blocks resuming sessions with a different provider.
- Removes provider-specific helper paths now covered by shared runtime dispatch.

## Testing
- Added regression coverage for provider-neutral direct dispatch and session-agent resume compatibility matrix.

## Closes
Closes #1578

Generated by Codex via ProjectHephaestus automation.
