### PR TITLE
docs(contributing): add release-notes pattern and onboarding guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,28 @@ Thank you for considering contributing to ProjectHephaestus! We welcome contribu
 
 This project follows the [HomericIntelligence Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
 
+## Your first day
+
+New here? This is the shortest path from a fresh clone to a merged PR. Each step
+links to the full section below.
+
+1. **Set up the environment** ([Development Setup](#development-setup)) — install
+   Pixi, then `just bootstrap` (one command: deps + editable install + pre-commit
+   hooks).
+2. **Confirm the toolchain works** — run `just check` (lint + format-check +
+   typecheck) and `pixi run pytest tests/unit`. Green here means your machine is
+   ready.
+3. **Pick an issue** ([Code Contributions](#code-contributions)) — pick or open a
+   GitHub issue, then branch as `<issue-number>-description`.
+4. **Make the change test-first** ([Testing](#testing)) — write a failing test,
+   make it pass, keep coverage at 83%+ (target 90%).
+5. **Open the PR** ([Pull Request Process](#pull-request-process)) — sign every
+   commit (`git commit -S`), put `Closes #<issue-number>` on its own line in the
+   body, and enable auto-merge (`gh pr merge --auto --squash`).
+
+If anything in steps 1–2 fails, see [Platform Support](#platform-support) — the
+pixi dev environment is `linux-64` only by design.
+
 ## Planning artifacts
 
 Before opening a PR, locate the work in:

--- a/docs/release-notes/README.md
+++ b/docs/release-notes/README.md
@@ -1,0 +1,42 @@
+# Release notes (operational)
+
+This directory holds **component-scoped operational notes** that ride along with
+a specific PR or PR bundle — one-time migration warnings, behavior-change
+call-outs, and "what to run after this lands" guidance for fleet operators.
+
+> These are **not** the project's user-facing release notes. ProjectHephaestus
+> generates those from commit history at tag time via
+> `gh release create --generate-notes` (see [`../RELEASING.md`](../RELEASING.md)).
+> There is intentionally **no `CHANGELOG.md`** in this repo.
+
+## When to add a note here
+
+Add a file when a change has an operational consequence a commit message cannot
+convey on its own, for example:
+
+- A behavior tightening that triggers a one-time cost or work burst across the
+  fleet on first run (see `plan-reviewer-final-verdict.md`).
+- A migration step operators must run manually after the PR merges.
+- A correctness change whose blast radius spans repos in the
+  HomericIntelligence ecosystem.
+
+If the change needs none of the above, a conventional-commit message is enough —
+do **not** add a file here.
+
+## File format
+
+- **Filename**: kebab-case, component-scoped — `<component>-<change-summary>.md`.
+- **First line**: a single `# <Title>` H1 summarizing the operational change.
+- **Header block**: the existing example (`plan-reviewer-final-verdict.md`)
+  opens with `**Affected component:**`, `**Issues:**`, and `**Ships with:**`
+  lines. Reuse those keys when they fit; they are a convention by example, not a
+  hard schema.
+
+## Required sections
+
+1. `## What changed` — before/after behavior in plain language.
+2. `## Operational impact` — what operators must do or expect (cost, migration,
+   re-runs), including any copy-pasteable commands.
+
+See [`plan-reviewer-final-verdict.md`](plan-reviewer-final-verdict.md) for a
+worked example.


### PR DESCRIPTION
## Summary
Add explicit release-notes documentation pattern and day-one onboarding path for new contributors to ProjectHephaestus.

## Changes
- Added `docs/release-notes/README.md` documenting the release-notes pattern and how to write systematic release notes
- Updated `CONTRIBUTING.md` with a 'productive in a day' onboarding path for new contributors
- Established release-notes as a documented, repeatable process (not ad-hoc)

## Testing
- Verify release-notes README exists and is formatted correctly
- Confirm CONTRIBUTING.md onboarding section is discoverable and clear
- Check that the release-notes pattern aligns with existing `plan-reviewer-final-verdict.md` example

## Closes
Closes #1544

Generated by Claude Code via ProjectHephaestus automation.
