### PR TITLE
fix(config): raise clear error when PyYAML missing for YAML files

### DIFF
--- a/hephaestus/config/utils.py
+++ b/hephaestus/config/utils.py
@@ -45,7 +45,8 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
 
     Raises:
         FileNotFoundError: If config file doesn't exist
-        ValueError: If config file format is unsupported
+        ValueError: If config file format is unsupported (e.g. .toml)
+        RuntimeError: If a .yaml/.yml file is given but PyYAML is not installed
 
     """
     config_path = Path(config_path)
@@ -53,10 +54,13 @@ def load_config(config_path: str | Path) -> dict[str, Any]:
     if not config_path.exists():
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
+    suffix = config_path.suffix.lower()
     with open(config_path) as f:
-        if config_path.suffix.lower() in [".yml", ".yaml"] and YAML_AVAILABLE:
+        if suffix in (".yml", ".yaml"):
+            if not YAML_AVAILABLE:
+                raise RuntimeError("PyYAML is required for YAML config support")
             return cast(dict[str, Any], yaml.safe_load(f) or {})
-        elif config_path.suffix.lower() == ".json":
+        elif suffix == ".json":
             return cast(dict[str, Any], json.load(f))
         else:
             raise ValueError(f"Unsupported config format: {config_path.suffix}")

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -281,6 +281,8 @@ def _load_fleet_config(config_path: str | None) -> tuple[str | None, list[str] |
                 raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
             except ValueError as e:
                 raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
+            except RuntimeError as e:
+                raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
 
     return file_org, file_repos
 

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -277,11 +277,7 @@ def _load_fleet_config(config_path: str | None) -> tuple[str | None, list[str] |
                 file_repos_raw = cfg.get("repos")
                 if isinstance(file_repos_raw, list):
                     file_repos = file_repos_raw
-            except FileNotFoundError as e:
-                raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
-            except ValueError as e:
-                raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
-            except RuntimeError as e:
+            except (FileNotFoundError, ValueError, RuntimeError) as e:
                 raise RuntimeError(f"Failed to load fleet config from {config_path}: {e}") from e
 
     return file_org, file_repos

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -62,6 +62,34 @@ class TestLoadConfig:
         config = load_config(config_file)
         assert config["key"] == "value"
 
+    def test_load_yaml_without_pyyaml_raises_runtime_error(self, tmp_path, monkeypatch):
+        """Missing PyYAML on a .yaml file raises RuntimeError, not ValueError (issue #1510)."""
+        monkeypatch.setattr("hephaestus.config.utils.YAML_AVAILABLE", False)
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text("key: value\n")
+        with pytest.raises(RuntimeError, match="PyYAML is required for YAML config support"):
+            load_config(yaml_file)
+
+    def test_load_yml_without_pyyaml_raises_runtime_error(self, tmp_path, monkeypatch):
+        """The .yml extension also reports the missing dependency, not a format error."""
+        monkeypatch.setattr("hephaestus.config.utils.YAML_AVAILABLE", False)
+        yml_file = tmp_path / "config.yml"
+        yml_file.write_text("key: value\n")
+        with pytest.raises(RuntimeError, match="PyYAML is required for YAML config support"):
+            load_config(yml_file)
+
+    def test_load_yaml_without_pyyaml_is_not_value_error(self, tmp_path, monkeypatch):
+        """Regression (issue #1510): missing-PyYAML must NOT raise 'Unsupported config format'."""
+        monkeypatch.setattr("hephaestus.config.utils.YAML_AVAILABLE", False)
+        yaml_file = tmp_path / "config.yaml"
+        yaml_file.write_text("key: value\n")
+        try:
+            load_config(yaml_file)
+        except ValueError as exc:
+            pytest.fail(f"Got misleading ValueError instead of RuntimeError: {exc}")
+        except RuntimeError:
+            pass
+
 
 class TestGetSetting:
     """Tests for get_setting."""

--- a/tests/unit/config/test_utils.py
+++ b/tests/unit/config/test_utils.py
@@ -83,12 +83,8 @@ class TestLoadConfig:
         monkeypatch.setattr("hephaestus.config.utils.YAML_AVAILABLE", False)
         yaml_file = tmp_path / "config.yaml"
         yaml_file.write_text("key: value\n")
-        try:
+        with pytest.raises(RuntimeError):
             load_config(yaml_file)
-        except ValueError as exc:
-            pytest.fail(f"Got misleading ValueError instead of RuntimeError: {exc}")
-        except RuntimeError:
-            pass
 
 
 class TestGetSetting:

--- a/tests/unit/github/test_fleet_sync_config.py
+++ b/tests/unit/github/test_fleet_sync_config.py
@@ -177,9 +177,7 @@ class TestResolveFleetConfig:
         assert org == "CwdOrg"
         assert repos == ["cwdrepo"]
 
-    def test_fleet_config_missing_pyyaml_wraps_with_context(
-        self, tmp_path, monkeypatch
-    ) -> None:
+    def test_fleet_config_missing_pyyaml_wraps_with_context(self, tmp_path, monkeypatch) -> None:
         """A .yaml fleet config with PyYAML absent preserves the path context wrapper.
 
         Regression for issue #1510: the ValueError→RuntimeError type flip in load_config

--- a/tests/unit/github/test_fleet_sync_config.py
+++ b/tests/unit/github/test_fleet_sync_config.py
@@ -176,3 +176,19 @@ class TestResolveFleetConfig:
         org, repos = resolve_fleet_config(cli_org=None, cli_repos=None, config_path=None)
         assert org == "CwdOrg"
         assert repos == ["cwdrepo"]
+
+    def test_fleet_config_missing_pyyaml_wraps_with_context(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A .yaml fleet config with PyYAML absent preserves the path context wrapper.
+
+        Regression for issue #1510: the ValueError→RuntimeError type flip in load_config
+        must not cause the 'Failed to load fleet config from {path}' wrapper to be lost.
+        """
+        from hephaestus.github import fleet_sync
+
+        monkeypatch.setattr("hephaestus.config.utils.YAML_AVAILABLE", False)
+        cfg = tmp_path / ".fleet.yml"
+        cfg.write_text("org: acme\nrepos: [a, b]\n")
+        with pytest.raises(RuntimeError, match=r"Failed to load fleet config from .*\.fleet\.yml"):
+            fleet_sync._load_fleet_config(str(cfg))


### PR DESCRIPTION
## Summary
When PyYAML is not installed and a .yaml/.yml file is passed to load_config(), raise a clear RuntimeError explaining the missing dependency instead of a misleading ValueError about unsupported format. This aligns the error message with load_yaml_config() and improves user experience by indicating the actual problem (missing optional dependency) rather than implying the format is never supported.

## Changes
- Raise RuntimeError with clear message when PyYAML is missing for YAML files in load_config()
- Match error handling consistency between load_config() and load_yaml_config() entry points
- Add test coverage for missing PyYAML error path in config utils tests

## Testing
- Unit tests verify RuntimeError is raised with correct message when PyYAML unavailable
- Integration tests confirm package imports work correctly
- Config utils tests cover YAML file handling with missing dependency

## Closes
Closes #1510

Generated by Claude Code via ProjectHephaestus automation.
