### PR TITLE
fix(automation): stabilize Codex and Pi loop execution

### DIFF
--- a/.github/actions/setup-pi-cli/action.yml
+++ b/.github/actions/setup-pi-cli/action.yml
@@ -1,0 +1,17 @@
+name: Setup Pi CLI
+description: Install the real Earendil Works Pi coding-agent CLI for tests.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js for Pi
+      uses: actions/setup-node@v6
+      with:
+        node-version: 22.19.0
+
+    - name: Install Pi CLI
+      shell: bash
+      run: |
+        set -euo pipefail
+        npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.2
+        pi --version

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -550,6 +550,9 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Pi CLI
+        uses: ./.github/actions/setup-pi-cli
+
       - name: Cache pip packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Pi CLI
+        if: matrix.test-type == 'unit'
+        uses: ./.github/actions/setup-pi-cli
+
       - name: Cache pip packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5
         with:

--- a/docs/pi-private-provider.md
+++ b/docs/pi-private-provider.md
@@ -11,6 +11,14 @@ Use placeholders in documentation:
 - `<private-provider-url>`
 - `<private-model-name>`
 
+Install the real Pi CLI in the automation environment; do not substitute a fake
+`pi` binary for adapter validation:
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.2
+pi --version
+```
+
 Set the local alias at runtime:
 
 ```bash

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -384,6 +384,46 @@ def _codex_model_args(model: str, *, use_default: bool = False) -> list[str]:
     return args
 
 
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    """Return whether ``path`` is inside ``parent`` without requiring Python 3.12 APIs."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _codex_extra_writable_dirs(cwd: Path, sandbox: str | None) -> list[Path]:
+    """Return extra writable roots Codex needs for git worktree metadata."""
+    if sandbox != "workspace-write":
+        return []
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), "rev-parse", "--git-common-dir"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+
+    raw_common_dir = result.stdout.strip()
+    if not raw_common_dir:
+        return []
+
+    common_dir = Path(raw_common_dir)
+    if not common_dir.is_absolute():
+        common_dir = cwd / common_dir
+    common_dir = common_dir.resolve(strict=False)
+    cwd_resolved = cwd.resolve(strict=False)
+    if _is_relative_to(common_dir, cwd_resolved):
+        return []
+    return [common_dir]
+
+
 def run_codex_text(
     prompt: str,
     *,
@@ -439,6 +479,8 @@ def _codex_base_cmd(
         cmd.extend(["--cd", str(cwd)])
         if sandbox is not None:
             cmd.extend(["--sandbox", sandbox])
+        for writable_dir in _codex_extra_writable_dirs(cwd, sandbox):
+            cmd.extend(["--add-dir", str(writable_dir)])
         cmd.extend(codex_approval_args(approval))
     cmd.extend(["--json"])
     return cmd

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -7,13 +7,14 @@ phase sequence (``plan`` → ``implement`` → ``drive-green``) end to end by a
 single worker before that worker takes the next issue. Up to
 ``--max-workers`` issues are in flight at once.
 
-``drive-green`` is the BLOCKING phase: scoped to one issue's PR it waits for
-the PR to MERGE (driving CI green, bounded by ``--max-merge-attempts``); if
-the PR does not merge within that budget the issue is tagged ``state:skip``
-and the worker frees its slot for a human/another agent. Because each issue's
-worktree is cut from the freshly-merged trunk, the stale-plan and
-sibling-branch merge-conflict classes the old phase-major batching suffered
-are eliminated.
+``drive-green`` is the BLOCKING per-worker phase: scoped to one issue's PR it
+waits for the PR to MERGE (driving CI green, bounded by
+``--max-merge-attempts``); if the PR does not merge within that budget and is
+genuinely stuck, the issue is tagged ``state:skip`` and the worker frees its
+slot for a human/another agent. Because each worker drives only its current
+issue, sibling workers never touch each other's PR worktrees. After all
+workers finish, one final repo-level drive-green catch-up sweep handles PRs
+left behind by transient or cross-issue ordering effects.
 
 Phase selection still works per issue: ``--phases plan`` runs only plan per
 issue; ``--phases implement`` only implement; etc. Plan-review, PR-review, and
@@ -119,11 +120,12 @@ ALL_PHASES: tuple[str, ...] = (
     "implement",
 )
 
-# drive-green is the per-issue BLOCKING phase (#1560): scoped to one issue's
-# PR it waits for the merge (bounded by --max-merge-attempts) before the worker
-# moves on. It runs LAST in each issue's sequence. Kept as a distinct tuple
-# (rather than folded into ALL_PHASES) so ``_run_post_loop_stages`` and the
-# explicit ``--phases drive-green`` operator re-run path keep working.
+# drive-green is both the per-issue BLOCKING phase (#1560) and the final
+# catch-up stage. Per-issue workers pass exactly one issue; the catch-up pass
+# deliberately passes no issue scope so the CI driver can use PR discovery.
+# Kept as a distinct tuple (rather than folded into ALL_PHASES) so
+# ``_run_post_loop_stages`` and the explicit ``--phases drive-green`` operator
+# re-run path keep working.
 ALL_POST_LOOP_STAGES: tuple[str, ...] = ("drive-green",)
 
 # Per-issue phase sequence, in order: plan → implement → drive-green. Operators
@@ -471,8 +473,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Comma-separated subset of phases/stages to run. "
             f"Valid: {','.join(ALL_SELECTABLE)} "
-            "(plan/implement are loop-body phases; drive-green is a "
-            "post-loop terminal stage that runs once per repo)."
+            "(plan/implement are loop-body phases; drive-green runs per issue "
+            "when selected and also does one final repo-level catch-up sweep)."
         ),
     )
     add_agent_argument(p)
@@ -549,8 +551,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Local directory containing repo clones. When omitted, resolved from "
-            "the ``PROJECTS_ROOT`` env var (if set and existing), otherwise "
-            f"falls back to ``{DEFAULT_PROJECTS_DIR}``."
+            "the ``PROJECTS_ROOT`` env var (if set and existing), otherwise the "
+            "current checkout parent when available, then "
+            f"``{DEFAULT_PROJECTS_DIR}``."
         ),
     )
     p.add_argument(
@@ -596,9 +599,9 @@ def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
 
     Plan-review and PR-review/address-review fold into plan/implement; the
     only remaining ordering hazard is selecting plan without implement
-    (planning-only, produces no PRs). Per #818, drive-green is a post-loop
-    terminal stage and intentionally supports being run without implement
-    ("drive existing PRs without opening new work").
+    (planning-only, produces no PRs). drive-green intentionally supports being
+    run without implement so operators can drive existing PRs without opening
+    new work.
     """
     warnings: list[str] = []
     selected = set(cfg.phases)
@@ -713,8 +716,9 @@ def _resolve_phase_bin(phase: str) -> tuple[str, list[str]] | None:
 _PHASE_FLAGS: dict[str, dict[str, object]] = {
     # plan/implement use "open": forward the loop-discovered open-issue list so
     # the child phase does NOT re-run its own ``gh issue list`` every phase /
-    # every loop. drive-green stays "explicit" — #819 made it discover failing
-    # PRs directly (not via the issue list), so it must NOT receive open_issues.
+    # every loop. Per-issue drive-green also uses "open" because
+    # _process_one_issue passes exactly [issue]; the final catch-up pass passes
+    # [] so drive-green can fall back to PR discovery.
     "plan": {"worker_arg": "--parallel", "no_ui": False, "issues": "open", "advise": True},
     "implement": {
         "worker_arg": "--max-workers",
@@ -727,7 +731,7 @@ _PHASE_FLAGS: dict[str, dict[str, object]] = {
     "drive-green": {
         "worker_arg": "--max-workers",
         "no_ui": True,
-        "issues": "explicit",
+        "issues": "open",
         "advise": True,
         "nitpick": True,
     },
@@ -1235,12 +1239,14 @@ def _post_loop_stage_skip_reason(
 
 
 def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
-    """Run post-loop terminal stages (drive-green) once per repo.
+    """Run final catch-up stages (drive-green) once per repo.
 
     Iterates ``repos`` sequentially (no thread pool) — post-loop stages are
     terminal and per-repo, so concurrent execution offers no benefit and
-    risks two workers hitting the same PRs. Returns a list of RepoResult
-    with ``loop_idx=cfg.loops`` and ``post_loop_phases`` populated. Any
+    risks two workers hitting the same PRs. Per-issue workers already passed
+    their issue scopes; this catch-up pass intentionally leaves drive-green
+    unscoped so the CI driver can discover any remaining open PRs. Returns a
+    list of RepoResult with ``loop_idx=cfg.loops`` and ``post_loop_phases`` populated. Any
     repo-level exception is captured in ``runner_error`` so the helper
     never raises to the caller (parity with ``process_repo``).
 
@@ -1288,7 +1294,7 @@ def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]
                     phase=stage,
                     cfg=cfg,
                     loop_idx=cfg.loops,
-                    open_issues=open_issues,
+                    open_issues=[] if stage == "drive-green" else open_issues,
                     trunk_sha=trunk_sha,
                 )
                 result.post_loop_phases.append(stage_result)
@@ -1384,12 +1390,11 @@ def run_loop(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]:
 
         _maybe_sleep_for_rate_budget(loop_idx, cfg.loops)
 
-    # drive-green is now a per-issue BLOCKING phase inside the issue-major
-    # loop body (#1560) — each issue is driven to merge before its worker
-    # frees the slot. It is no longer a separate once-per-repo post-loop
-    # stage, so nothing runs here. ``_run_post_loop_stages`` is retained for
-    # explicit operator re-runs but the default loop does not invoke it.
-    post_loop_results: list[RepoResult] = []
+    # Each worker already ran drive-green for only its current issue. Run one
+    # final sequential catch-up sweep per repo so transient CI or ordering
+    # leftovers are reported and driven without cross-worker worktree races.
+    post_loop_results = _run_post_loop_stages(cfg, repos)
+    all_results.extend(post_loop_results)
 
     # Report actual loops run (may be less than cfg.loops due to early
     # exit). Post-loop RepoResults are tagged ``is_post_loop=True`` by
@@ -1519,7 +1524,7 @@ def main(argv: list[str] | None = None) -> int:
         gh_global_rate=args.gh_global_rate,
         gh_global_burst=args.gh_global_burst,
         org=org,
-        projects_dir=resolve_projects_dir(args.projects_dir),
+        projects_dir=resolve_projects_dir(args.projects_dir, prefer_cwd_parent=True),
         # A non-positive --phase-timeout explicitly disables the bound; any
         # positive value (including the env-overridable default) applies it.
         phase_timeout_s=(

--- a/hephaestus/config/paths.py
+++ b/hephaestus/config/paths.py
@@ -5,13 +5,14 @@ parent directory under which sibling HomericIntelligence repositories
 are checked out. Historically this was hardcoded to ``~/Projects``;
 callers now resolve it via :func:`resolve_projects_dir`, which honors
 an explicit override, the ``PROJECTS_ROOT`` environment variable, or
-falls back to the historical default with a warning.
+falls back to the current checkout's parent or the historical default.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -23,13 +24,38 @@ DEFAULT_PROJECTS_DIR: Path = Path.home() / "Projects"
 _warned_keys: set[tuple[str | None, str | None]] = set()
 
 
-def resolve_projects_dir(override: str | None = None) -> Path:
+def _current_checkout_parent() -> Path | None:
+    """Return the parent of the current git checkout, if one can be detected."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+
+    checkout = Path(result.stdout.strip())
+    if not checkout.name:
+        return None
+    parent = checkout.parent
+    return parent if parent.is_dir() else None
+
+
+def resolve_projects_dir(
+    override: str | None = None,
+    *,
+    prefer_cwd_parent: bool = False,
+) -> Path:
     """Resolve the projects root directory.
 
     Priority:
       1. explicit ``override`` argument (e.g. from a CLI flag)
       2. ``$PROJECTS_ROOT`` environment variable, IFF that directory exists
-      3. :data:`DEFAULT_PROJECTS_DIR` (``~/Projects``)
+      3. current checkout parent, when ``prefer_cwd_parent`` is true
+      4. :data:`DEFAULT_PROJECTS_DIR` (``~/Projects``)
 
     A warning is emitted when the fallback path is taken because neither
     an override nor a usable ``PROJECTS_ROOT`` was supplied. A distinct
@@ -41,6 +67,10 @@ def resolve_projects_dir(override: str | None = None) -> Path:
         override: Optional explicit path (e.g. from a ``--projects-dir`` CLI
             flag). When provided, the env var and default are skipped and no
             warning is emitted.
+        prefer_cwd_parent: When true, use the parent of the current git
+            checkout as the default projects root before falling back to
+            :data:`DEFAULT_PROJECTS_DIR`. This is useful for automation loops
+            launched from a checkout inside a nonstandard projects directory.
 
     Returns:
         The resolved projects-root directory as a :class:`pathlib.Path`.
@@ -64,6 +94,11 @@ def resolve_projects_dir(override: str | None = None) -> Path:
             )
             _warned_keys.add(key)
         return DEFAULT_PROJECTS_DIR
+
+    if prefer_cwd_parent:
+        cwd_parent = _current_checkout_parent()
+        if cwd_parent is not None:
+            return cwd_parent
 
     if key not in _warned_keys:
         # Benign: an unset PROJECTS_ROOT with no override is the normal case;

--- a/scripts/shell/install.sh
+++ b/scripts/shell/install.sh
@@ -143,6 +143,8 @@ readonly JUST_SHA256_LINUX_AARCH64="bb3886b15e2cbcb9c0eb19956297d36de4eaef45b89d
 readonly JUST_SHA256_DARWIN_X86_64="30aacf9cbf021c2ff36fff5a05c800360e2020e527916e1c0960452ef5a8568c"
 readonly JUST_SHA256_DARWIN_AARCH64="e7a824c4d92cdea270b61474bd48e851aedc4c65f9c5245c12b32df6de9b536f"
 
+readonly PI_CODING_AGENT_NPM_PACKAGE="@earendil-works/pi-coding-agent@0.80.2"
+
 # Portable SHA-256: GNU coreutils on Linux, BSD `shasum -a 256` on macOS.
 _sha256_cmd() {
     if command -v sha256sum >/dev/null 2>&1; then
@@ -939,6 +941,37 @@ if has_cmd claude; then
             fi
         fi
     done
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Section 8b: Pi coding agent (all roles)
+# ═════════════════════════════════════════════════════════════════════════════
+section "Pi Coding Agent"
+
+if has_cmd pi; then
+    check_pass "pi $(pi --version 2>&1 | head -1)"
+else
+    check_fail "pi — NOT FOUND"
+    if $INSTALL; then
+        if has_cmd npm; then
+            echo -e "    ${BLUE}→${NC} Installing Pi coding agent via npm..."
+            # ─────────────────────────────────────────────────────────────────────
+            # TRUST MODEL — Pi coding-agent via npm
+            #
+            # npm verifies tarball SHA-512 integrity against the registry on every
+            # install (built-in, no flag needed). The package version is pinned in
+            # PI_CODING_AGENT_NPM_PACKAGE. --ignore-scripts follows upstream Pi
+            # install guidance and avoids executing package lifecycle hooks.
+            # ─────────────────────────────────────────────────────────────────────
+            if npm install -g --ignore-scripts "$PI_CODING_AGENT_NPM_PACKAGE" >/dev/null 2>&1; then
+                check_pass "pi installed (npm integrity-checked)"
+            else
+                check_fail "pi — install failed (see https://github.com/earendil-works/pi)"
+            fi
+        else
+            check_fail "pi — skipped (npm not found; install Node.js first)"
+        fi
+    fi
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -168,14 +168,17 @@ def test_run_codex_session_returns_session_id_and_last_message(tmp_path: Path) -
         )
         return _FakeCodexPopen(cmd, proc_stdout=stdout, final_message="final answer", **kwargs)
 
-    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
-        with patch("subprocess.Popen", side_effect=fake_popen):
-            result = agent_runtime.run_codex_session(
-                "prompt",
-                cwd=tmp_path,
-                timeout=30,
-                sandbox="workspace-write",
-            )
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        result = agent_runtime.run_codex_session(
+            "prompt",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
 
     assert result.session_id == "019e1e57-7652-7892-b1ca-c31c93d4b160"
     assert result.stdout == "final answer"
@@ -199,6 +202,7 @@ def test_run_codex_session_recovers_last_message_on_wrapper_timeout(tmp_path: Pa
 
     with (
         patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
         patch.dict("os.environ", {"HEPH_CODEX_FINAL_MESSAGE_GRACE": "0"}),
         patch("subprocess.Popen", side_effect=fake_popen),
     ):
@@ -220,15 +224,18 @@ def test_run_codex_session_timeout_without_last_message_still_raises(tmp_path: P
     def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
         return _FakeCodexPopen(cmd, proc_stdout="", final_message="", hang=True, **kwargs)
 
-    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
-        with patch("subprocess.Popen", side_effect=fake_popen):
-            with pytest.raises(subprocess.TimeoutExpired):
-                agent_runtime.run_codex_session(
-                    "prompt",
-                    cwd=tmp_path,
-                    timeout=1,
-                    sandbox="workspace-write",
-                )
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        with pytest.raises(subprocess.TimeoutExpired):
+            agent_runtime.run_codex_session(
+                "prompt",
+                cwd=tmp_path,
+                timeout=1,
+                sandbox="workspace-write",
+            )
 
 
 def test_codex_approval_args_uses_config_override_for_current_cli() -> None:
@@ -311,6 +318,64 @@ def test_codex_base_cmd_defaults_new_sessions_to_gpt_55_xhigh(tmp_path: Path) ->
 
     assert cmd[cmd.index("--model") + 1] == "gpt-5.5"
     assert cmd[cmd.index("-c") + 1] == 'model_reasoning_effort="xhigh"'
+
+
+def test_codex_base_cmd_adds_git_common_dir_for_worktree_metadata(tmp_path: Path) -> None:
+    """Codex worktree sessions need write access to the main clone's git dir."""
+    worktree = tmp_path / "repo" / "build" / ".worktrees" / "issue-1"
+    git_common_dir = tmp_path / "repo" / ".git"
+    worktree.mkdir(parents=True)
+    git_common_dir.mkdir(parents=True)
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert cmd == ["git", "-C", str(worktree), "rev-parse", "--git-common-dir"]
+        return subprocess.CompletedProcess(cmd, 0, stdout=f"{git_common_dir}\n", stderr="")
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime.subprocess.run", side_effect=fake_run),
+    ):
+        cmd = agent_runtime._codex_base_cmd(cwd=worktree)
+
+    assert "--add-dir" in cmd
+    add_dir_index = cmd.index("--add-dir")
+    assert cmd[add_dir_index + 1] == str(git_common_dir)
+
+
+def test_codex_base_cmd_does_not_add_git_common_dir_for_read_only(
+    tmp_path: Path,
+) -> None:
+    """Read-only Codex sessions must not receive writable git metadata roots."""
+    worktree = tmp_path / "repo" / "build" / ".worktrees" / "issue-1"
+    worktree.mkdir(parents=True)
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime.subprocess.run") as run_mock,
+    ):
+        cmd = agent_runtime._codex_base_cmd(cwd=worktree, sandbox="read-only")
+
+    assert "--add-dir" not in cmd
+    run_mock.assert_not_called()
+
+
+def test_codex_base_cmd_omits_add_dir_when_git_common_dir_is_inside_cwd(
+    tmp_path: Path,
+) -> None:
+    """Normal checkouts already have their git dir inside the writable root."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 0, stdout=".git\n", stderr="")
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime.subprocess.run", side_effect=fake_run),
+    ):
+        cmd = agent_runtime._codex_base_cmd(cwd=repo)
+
+    assert "--add-dir" not in cmd
 
 
 def test_codex_base_cmd_resume_without_model_preserves_session_model() -> None:

--- a/tests/unit/automation/test_drive_green_pr_discovery.py
+++ b/tests/unit/automation/test_drive_green_pr_discovery.py
@@ -120,8 +120,8 @@ class TestCountFailingPrs:
 class TestBuildPhaseArgv:
     """Tests for _build_phase_argv with drive-green."""
 
-    def test_build_phase_argv_drive_green_omits_issues_when_unscoped(self) -> None:
-        """--issues is NOT passed when cfg.issues is empty and no-args discovery is intended."""
+    def test_build_phase_argv_drive_green_passes_worker_issue_scope(self) -> None:
+        """Per-issue drive-green forwards the worker's current issue scope."""
         cfg = LoopConfig(
             org="MyOrg",
             agent="claude-opus-4-8",
@@ -137,10 +137,29 @@ class TestBuildPhaseArgv:
             mock_bin.return_value = ("/py", ["script.py"])
             argv = _build_phase_argv("drive-green", cfg, open_issues)
         assert argv is not None
+        issues_idx = argv.index("--issues")
+        assert argv[issues_idx + 1 : issues_idx + 3] == ["7", "8"]
+
+    def test_build_phase_argv_drive_green_omits_issues_for_final_catchup(self) -> None:
+        """Final catch-up drive-green can omit --issues and use PR discovery."""
+        cfg = LoopConfig(
+            org="MyOrg",
+            agent="claude-opus-4-8",
+            issues=[],
+            max_workers=3,
+            dry_run=False,
+            no_advise=False,
+            phases=("drive-green",),
+            loops=1,
+        )
+        with patch("hephaestus.automation.loop_runner._resolve_phase_bin") as mock_bin:
+            mock_bin.return_value = ("/py", ["script.py"])
+            argv = _build_phase_argv("drive-green", cfg, [])
+        assert argv is not None
         assert "--issues" not in argv
 
-    def test_build_phase_argv_drive_green_passes_explicit_issues(self) -> None:
-        """--issues is passed with explicit issue numbers when cfg.issues is provided."""
+    def test_build_phase_argv_drive_green_prefers_worker_scope_over_cfg_issues(self) -> None:
+        """Worker drive-green must not inherit the loop's full explicit issue list."""
         cfg = LoopConfig(
             org="MyOrg",
             agent="claude-opus-4-8",
@@ -157,17 +176,11 @@ class TestBuildPhaseArgv:
             argv = _build_phase_argv("drive-green", cfg, open_issues)
         assert argv is not None
         issues_idx = argv.index("--issues")
-        assert argv[issues_idx + 1 : issues_idx + 3] == ["123", "456"]
+        assert argv[issues_idx + 1 : issues_idx + 3] == ["7", "8"]
 
 
 class TestPostLoopDriveGreenSkipLogic:
-    """Tests for drive-green SKIP logic in ``_run_post_loop_stages`` (post-#818).
-
-    drive-green moved out of the loop body and into the post-loop terminal
-    stage. The same work-discovery gate (``_count_failing_prs``, --issues
-    override) now lives in ``_run_post_loop_stages`` rather than
-    ``process_repo``; these tests pin that invariant at the new home.
-    """
+    """Tests for the final drive-green catch-up gate in ``_run_post_loop_stages``."""
 
     def test_drive_green_skips_with_reason_no_failing_prs(
         self, repo_inputs: tuple[Path, LoopConfig]

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -13,6 +13,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,10 +49,11 @@ from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 
 def test_all_phases_is_three_stage_pipeline() -> None:
-    """The loop body collapsed to exactly (plan, implement); drive-green moved post-loop.
+    """Default phases stay plan+implement; drive-green remains separately selectable.
 
     Plan-review, PR-review, and address-review fold into plan/implement
-    (#455/#468/#484); drive-green moved to ALL_POST_LOOP_STAGES (#818).
+    (#455/#468/#484). drive-green is both the per-issue blocking phase when
+    selected and the final catch-up stage (#1560/#1577/#1580).
     """
     from hephaestus.automation.loop_runner import ALL_POST_LOOP_STAGES
 
@@ -562,6 +564,33 @@ def test_process_repo_drive_green_runs_per_issue_when_selected(
     assert ran == list(ALL_SELECTABLE)
 
 
+def test_process_one_issue_drive_green_receives_only_current_issue() -> None:
+    """Worker drive-green must not inherit the loop's full explicit issue list."""
+    seen: list[tuple[str, list[int]]] = []
+
+    def fake_run_phase(**kw: object) -> PhaseResult:
+        open_issues = cast(list[int], kw["open_issues"])
+        seen.append((str(kw["phase"]), list(open_issues)))
+        return PhaseResult(name=str(kw["phase"]), rc=0, elapsed_s=0.1)
+
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE, issues=[1577, 1580])
+    with patch.object(loop_runner, "run_phase", side_effect=fake_run_phase):
+        loop_runner._process_one_issue(
+            repo="r",
+            repo_dir=Path("/tmp/r"),
+            issue=1577,
+            cfg=cfg,
+            loop_idx=1,
+            trunk_sha="abc1234",
+        )
+
+    assert seen == [
+        ("plan", [1577]),
+        ("implement", [1577]),
+        ("drive-green", [1577]),
+    ]
+
+
 def test_process_one_issue_continues_after_phase_failure() -> None:
     """Phase isolation per issue: a failed plan must NOT skip later phases."""
     call_order: list[str] = []
@@ -705,6 +734,31 @@ def test_run_loop_continues_when_one_repo_fails(repo_inputs: tuple[Path, LoopCon
     assert not by_repo["ok2"].any_failure
 
 
+def test_run_loop_appends_final_drive_green_catchup(
+    repo_inputs: tuple[Path, LoopConfig],
+) -> None:
+    """After issue workers finish, run one final repo-level drive-green sweep."""
+    _, cfg = repo_inputs
+    cfg = LoopConfig(loops=1, phases=ALL_SELECTABLE, projects_dir=cfg.projects_dir)
+    worker_result = RepoResult(repo="r", loop_idx=1)
+    worker_result.phases.append(PhaseResult(name="plan", rc=0, work_units=1))
+    catchup_result = RepoResult(repo="r", loop_idx=1, is_post_loop=True)
+    catchup_result.post_loop_phases.append(PhaseResult(name="drive-green", rc=0))
+
+    with (
+        patch.object(loop_runner, "process_repo", return_value=worker_result),
+        patch.object(
+            loop_runner,
+            "_run_post_loop_stages",
+            return_value=[catchup_result],
+        ) as catchup,
+    ):
+        results = run_loop(cfg, repos=["r"])
+
+    catchup.assert_called_once_with(cfg, ["r"])
+    assert results == [worker_result, catchup_result]
+
+
 # ---------------------------------------------------------------------------
 # Argv construction
 # ---------------------------------------------------------------------------
@@ -775,28 +829,34 @@ def test_build_phase_argv_forwards_resolved_agent() -> None:
     assert argv[argv.index("--agent") + 1] == "codex"
 
 
-def test_build_phase_argv_drive_green_includes_issues() -> None:
-    """drive-green passes explicit cfg.issues, but not open_issues (uses PR-discovery by default).
-
-    PR-discovery auto-discovers failing PRs; open_issues is only used by other phases.
-    """
+def test_build_phase_argv_drive_green_scopes_to_worker_issue() -> None:
+    """Per-issue drive-green forwards only the current worker issue."""
     cfg = LoopConfig(issues=[7, 8])
     with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
         argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[1, 2])
     assert argv is not None
     assert "--issues" in argv
-    assert "7" in argv and "8" in argv
-    # Important: the open_issues passed to _build_phase_argv are NOT used for drive-green
-    # when cfg.issues is empty; only explicit cfg.issues are forwarded.
+    issue_idx = argv.index("--issues")
+    assert argv[issue_idx + 1 : issue_idx + 3] == ["1", "2"]
+    assert "7" not in argv and "8" not in argv
 
 
-def test_build_phase_argv_drive_green_omits_issues_when_unscoped() -> None:
-    """drive-green omits --issues when cfg.issues is empty (uses PR-discovery mode)."""
+def test_build_phase_argv_drive_green_omits_issues_for_final_catchup() -> None:
+    """Final catch-up drive-green can pass no issue scope to use PR discovery."""
     cfg = LoopConfig(issues=[])
     with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
-        argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[7, 8])
+        argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[])
     assert argv is not None
     assert "--issues" not in argv
+
+
+def test_build_phase_argv_drive_green_uses_worker_issue_even_unscoped() -> None:
+    """An auto-discovered issue worker still scopes drive-green to its issue."""
+    cfg = LoopConfig(issues=[])
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/py", ["script.py"])):
+        argv = loop_runner._build_phase_argv("drive-green", cfg, open_issues=[1577])
+    assert argv is not None
+    assert argv[argv.index("--issues") + 1] == "1577"
 
 
 def test_build_phase_argv_passes_dry_run() -> None:
@@ -1721,6 +1781,37 @@ class TestDefaultPhaseTimeout:
         ):
             main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
         assert captured["cfg"].phase_timeout_s == _default_phase_timeout_s()
+
+    def test_main_prefers_current_checkout_parent_for_projects_dir_default(
+        self, tmp_path: Path
+    ) -> None:
+        """Loop defaults should use the cwd checkout's projects root when available."""
+        captured: dict[str, LoopConfig] = {}
+        projects_dir = tmp_path / "projects"
+
+        def _capture(cfg: LoopConfig, _repos: list[str]) -> list[RepoResult]:
+            captured["cfg"] = cfg
+            return []
+
+        with (
+            patch.object(
+                loop_runner,
+                "_resolve_org_and_repos",
+                return_value=("Org", ["Repo"], None),
+            ),
+            patch.object(loop_runner, "_preflight_token_scopes"),
+            patch.object(loop_runner, "_clone_missing_repos"),
+            patch.object(
+                loop_runner,
+                "resolve_projects_dir",
+                return_value=projects_dir,
+            ) as resolve_projects_dir,
+            patch.object(loop_runner, "run_loop", side_effect=_capture),
+        ):
+            main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
+
+        resolve_projects_dir.assert_called_once_with(None, prefer_cwd_parent=True)
+        assert captured["cfg"].projects_dir == projects_dir
 
     def test_main_resolves_agent_before_building_config(self) -> None:
         """LoopConfig stores the concrete auto-detected provider."""

--- a/tests/unit/automation/test_loop_runner_post_loop.py
+++ b/tests/unit/automation/test_loop_runner_post_loop.py
@@ -1,14 +1,8 @@
-"""Tests for drive-green as a per-issue blocking loop-body phase (#1560).
-
-Supersedes the post-loop-terminal-stage model (#818): drive-green now runs
-INSIDE the issue-major loop body, once per issue per loop (the blocking phase
-that waits for each issue's PR to merge), rather than once per repo after all
-loops. ``_run_post_loop_stages`` is no longer auto-invoked by ``run_loop`` —
-``post_loop_phases`` is therefore always empty in the default path.
-"""
+"""Tests for per-issue drive-green plus the final catch-up sweep (#1560)."""
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from unittest.mock import patch
 
@@ -56,6 +50,7 @@ def _patch_run_loop_externals(calls: list):
         ),
         patch.object(loop_runner, "_clone_missing_repos"),
         patch.object(loop_runner, "_preflight_token_scopes"),
+        patch.object(loop_runner, "_maybe_sleep_for_rate_budget"),
         patch.object(loop_runner, "run_phase", side_effect=_record),
     ]
 
@@ -89,28 +84,33 @@ def test_final_loop_only_symbols_removed() -> None:
 
 
 def test_drive_green_alone_runs_per_issue_in_loop_body(tmp_path: Path) -> None:
-    """`--phases drive-green` → drive-green runs per issue in the loop body, no plan/implement.
-
-    With early-exit disabled (drive-green is not a convergence phase, and one
-    issue is discovered each loop), it runs once per issue per loop. The result
-    is recorded under ``phases`` (loop body), never ``post_loop_phases``.
-    """
+    """`--phases drive-green` runs per issue, then one repo-level catch-up sweep."""
     cfg = _cfg(tmp_path, loops=1, phases=("drive-green",))
     repos = ["r1", "r2"]
     _ensure_repo_dirs(cfg, repos)
     calls: list = []
     cms = _patch_run_loop_externals(calls)
-    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+    with contextlib.ExitStack() as stack:
+        for cm in cms:
+            stack.enter_context(cm)
         results = loop_runner.run_loop(cfg, repos)
     dg_calls = [c for c in calls if c[2] == "drive-green"]
     loop_phase_calls = [c for c in calls if c[2] in ALL_PHASES]
-    # One issue per repo, one loop → drive-green once per repo's issue.
-    assert sorted(c[1] for c in dg_calls) == ["r1", "r2"], dg_calls
+    # One issue per repo, one loop, plus one final catch-up run per repo.
+    assert sorted(c[1] for c in dg_calls) == ["r1", "r1", "r2", "r2"], dg_calls
     assert loop_phase_calls == [], loop_phase_calls
-    # Recorded in the loop body (phases), NOT post_loop_phases (#1560).
-    assert all(not r.post_loop_phases for r in results), results
-    body = [(r.repo, p.name) for r in results for p in r.phases if not p.skipped]
+    body = [
+        (r.repo, p.name) for r in results if not r.is_post_loop for p in r.phases if not p.skipped
+    ]
     assert sorted(body) == [("r1", "drive-green"), ("r2", "drive-green")]
+    catchup = [
+        (r.repo, p.name)
+        for r in results
+        if r.is_post_loop
+        for p in r.post_loop_phases
+        if not p.skipped
+    ]
+    assert sorted(catchup) == [("r1", "drive-green"), ("r2", "drive-green")]
 
 
 # ---------------------------------------------------------------------------
@@ -119,11 +119,7 @@ def test_drive_green_alone_runs_per_issue_in_loop_body(tmp_path: Path) -> None:
 
 
 def test_drive_green_with_loop_phases_runs_per_issue_each_loop(tmp_path: Path) -> None:
-    """`--phases plan,implement,drive-green --loops 3` → all three run per issue, each loop.
-
-    Issue-major (#1560): each loop runs plan→implement→drive-green for the
-    discovered issue, so all three appear once per loop (3 loops → 3 each).
-    """
+    """Full phase selection runs per issue each loop plus final drive-green catch-up."""
     cfg = _cfg(tmp_path, loops=3, phases=ALL_SELECTABLE)
     repos = ["r1"]
     _ensure_repo_dirs(cfg, repos)
@@ -142,14 +138,16 @@ def test_drive_green_with_loop_phases_runs_per_issue_each_loop(tmp_path: Path) -
         patch.object(loop_runner, "_resolve_repo_dir", side_effect=lambda pd, r: pd / r),
         patch.object(loop_runner, "_clone_missing_repos"),
         patch.object(loop_runner, "_preflight_token_scopes"),
+        patch.object(loop_runner, "_maybe_sleep_for_rate_budget"),
         patch.object(loop_runner, "run_phase", side_effect=_record),
     ):
         loop_runner.run_loop(cfg, repos)
     dg = [c for c in calls if c[2] == "drive-green"]
     plan = [c for c in calls if c[2] == "plan"]
     impl = [c for c in calls if c[2] == "implement"]
-    # One issue, 3 loops, full sequence each loop → 3 of each phase.
-    assert len(dg) == 3, dg
+    # One issue, 3 loops, full sequence each loop → plan/implement 3 each,
+    # with one additional repo-level drive-green catch-up at the end.
+    assert [c[0] for c in dg] == [1, 2, 3, 3], dg
     assert len(plan) == 3, plan
     assert len(impl) == 3, impl
 
@@ -166,7 +164,9 @@ def test_phases_plan_implement_does_not_invoke_drive_green(tmp_path: Path) -> No
     _ensure_repo_dirs(cfg, repos)
     calls: list = []
     cms = _patch_run_loop_externals(calls)
-    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+    with contextlib.ExitStack() as stack:
+        for cm in cms:
+            stack.enter_context(cm)
         results = loop_runner.run_loop(cfg, repos)
     assert all(c[2] != "drive-green" for c in calls), calls
     assert all(not r.post_loop_phases for r in results), results
@@ -179,7 +179,9 @@ def test_phases_plan_only_does_not_invoke_drive_green(tmp_path: Path) -> None:
     _ensure_repo_dirs(cfg, repos)
     calls: list = []
     cms = _patch_run_loop_externals(calls)
-    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+    with contextlib.ExitStack() as stack:
+        for cm in cms:
+            stack.enter_context(cm)
         results = loop_runner.run_loop(cfg, repos)
     assert all(c[2] != "drive-green" for c in calls), calls
     assert all(not r.post_loop_phases for r in results), results
@@ -191,27 +193,39 @@ def test_phases_plan_only_does_not_invoke_drive_green(tmp_path: Path) -> None:
 
 
 def test_early_exit_loop_1_runs_drive_green_in_loop_body(tmp_path: Path) -> None:
-    """Early-exit (zero-work) after loop 1 still drives each issue green in-body.
-
-    Under issue-major, drive-green runs per issue inside loop 1 (no separate
-    post-loop pass). Early-exit then fires after loop 1, so plan and drive-green
-    each run exactly once per repo.
-    """
+    """Early-exit after loop 1 still runs worker drive-green and catch-up."""
     cfg = _cfg(tmp_path, loops=5, phases=ALL_SELECTABLE)
     repos = ["r1", "r2"]
     _ensure_repo_dirs(cfg, repos)
     calls: list = []
     cms = _patch_run_loop_externals(calls)  # all phases report work_units=0
-    with cms[0], cms[1], cms[2], cms[3], cms[4], cms[5], cms[6]:
+    with contextlib.ExitStack() as stack:
+        for cm in cms:
+            stack.enter_context(cm)
         results = loop_runner.run_loop(cfg, repos)
     plan_calls = [c for c in calls if c[2] == "plan"]
     dg_calls = [c for c in calls if c[2] == "drive-green"]
     # Early-exit fires after loop 1 → plan invoked exactly once per repo
     assert sorted(c[1] for c in plan_calls) == ["r1", "r2"], plan_calls
-    # drive-green ran in the loop body of loop 1, once per repo's issue
-    assert sorted(c[1] for c in dg_calls) == ["r1", "r2"], dg_calls
-    # No post-loop stage records anymore.
-    assert all(not r.post_loop_phases for r in results), results
+    # drive-green ran in the loop body once per repo's issue, then once more
+    # per repo in the final catch-up sweep.
+    assert sorted(c[1] for c in dg_calls) == ["r1", "r1", "r2", "r2"], dg_calls
+    loop_body_dg = [
+        r.repo
+        for r in results
+        if not r.is_post_loop
+        for p in r.phases
+        if p.name == "drive-green" and not p.skipped
+    ]
+    catchup_dg = [
+        r.repo
+        for r in results
+        if r.is_post_loop
+        for p in r.post_loop_phases
+        if p.name == "drive-green" and not p.skipped
+    ]
+    assert sorted(loop_body_dg) == ["r1", "r2"], results
+    assert sorted(catchup_dg) == ["r1", "r2"], results
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -22,6 +22,8 @@ AUTO_MERGE_ON_GO_WORKFLOW = (
     REPO_ROOT / ".github" / "workflows" / "enable-auto-merge-on-implementation-go.yml"
 )
 REQUIRED_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_required.yml"
+TEST_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
+SETUP_PI_ACTION = REPO_ROOT / ".github" / "actions" / "setup-pi-cli" / "action.yml"
 
 
 class TestCollectYmlFiles:
@@ -256,6 +258,30 @@ class TestEnableAutoMergeOnImplementationGoWorkflow:
         assert "--json body\n" in text or "--json body \\" in text
         # The auto-merge error lives in the advisory job, which is present.
         assert "Auto-merge is enabled before implementation review GO." in text
+
+
+class TestPiCliSetup:
+    """Regression tests for installing the real Pi CLI in test environments."""
+
+    def test_required_unit_tests_install_real_pi_cli(self) -> None:
+        text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+        assert "uses: ./.github/actions/setup-pi-cli" in text
+        unit_section = text[text.index("  unit-tests:") : text.index("  integration-tests:")]
+        assert "Install Pi CLI" in unit_section
+        assert "Run unit tests" in unit_section
+        assert unit_section.index("Install Pi CLI") < unit_section.index("Run unit tests")
+
+    def test_matrix_unit_tests_install_real_pi_cli(self) -> None:
+        text = TEST_WORKFLOW.read_text(encoding="utf-8")
+        assert "uses: ./.github/actions/setup-pi-cli" in text
+        assert text.index("uses: ./.github/actions/setup-pi-cli") < text.index("Run unit tests")
+
+    def test_setup_pi_action_pins_real_npm_package(self) -> None:
+        text = SETUP_PI_ACTION.read_text(encoding="utf-8")
+        assert "actions/setup-node@" in text
+        assert "node-version: 22.19.0" in text
+        assert "npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.2" in text
+        assert "pi --version" in text
 
 
 class TestCollectWorkflowFiles:

--- a/tests/unit/config/test_paths.py
+++ b/tests/unit/config/test_paths.py
@@ -8,8 +8,10 @@ per-process de-duplication guard.
 from __future__ import annotations
 
 import logging
+import subprocess
 from collections.abc import Iterator
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -65,6 +67,40 @@ def test_env_var_dir_missing_warns_and_falls_back(
     assert caplog.records[0].levelno == logging.WARNING
     assert "does not exist" in caplog.records[0].getMessage()
     assert str(nonexistent) in caplog.records[0].getMessage()
+
+
+def test_prefer_cwd_parent_uses_current_checkout_parent(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """Loop callers can default to the projects root that owns the cwd checkout."""
+    checkout = tmp_path / "projects" / "ProjectHephaestus"
+    checkout.mkdir(parents=True)
+    monkeypatch.delenv("PROJECTS_ROOT", raising=False)
+    result_mock = MagicMock(stdout=f"{checkout}\n")
+
+    with (
+        patch("hephaestus.config.paths.subprocess.run", return_value=result_mock),
+        caplog.at_level(logging.INFO, logger="hephaestus.config.paths"),
+    ):
+        result = resolve_projects_dir(prefer_cwd_parent=True)
+
+    assert result == checkout.parent
+    assert caplog.records == []
+
+
+def test_prefer_cwd_parent_falls_back_when_git_root_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The cwd-parent preference is best-effort and keeps the historical fallback."""
+    monkeypatch.delenv("PROJECTS_ROOT", raising=False)
+
+    with patch(
+        "hephaestus.config.paths.subprocess.run",
+        side_effect=subprocess.CalledProcessError(128, ["git"]),
+    ):
+        result = resolve_projects_dir(prefer_cwd_parent=True)
+
+    assert result == DEFAULT_PROJECTS_DIR
 
 
 def test_no_override_no_env_no_warning_at_info(

--- a/tests/unit/shell/test_install_pinning.py
+++ b/tests/unit/shell/test_install_pinning.py
@@ -77,6 +77,14 @@ def test_trust_model_documented_for_unpinned(install_script: str) -> None:
     )
 
 
+def test_installer_can_install_real_pi_cli(install_script: str) -> None:
+    """The bootstrap path must install the real Pi CLI, not a fake binary."""
+    assert "has_cmd pi" in install_script
+    assert "@earendil-works/pi-coding-agent@0.80.2" in install_script
+    assert "npm install -g --ignore-scripts" in install_script
+    assert "pi --version" in install_script
+
+
 def test_podman_socket_uses_secure_runtime_directory(install_script: str) -> None:
     """Podman socket setup uses a hardened TMPDIR subtree."""
     assert "XDG_RUNTIME_DIR" not in install_script


### PR DESCRIPTION
## Summary

Stabilizes the automation loop after the Codex worktree commit failure investigation, and ensures Pi integration tests exercise the real Pi CLI.

## Changes

- Allow Codex workspace-write sessions in git worktrees to write the main clone git metadata required for commits.
- Default the automation loop projects root to the current checkout parent before falling back to the historical default.
- Keep worker drive-green scoped to the current issue and add a final repo-level catch-up sweep.
- Install the real pinned Pi CLI in CI/unit-test environments and document the runtime install path.

## Related Issues

Closes #1610

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (code improvement without changing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] CI/CD or infrastructure change
- [x] Test coverage improvement

## Testing

- [x] All existing tests pass: `pixi run pytest tests/unit -q` (`4772 passed, 20 skipped`, coverage `86.20%`)
- [x] Type check passes: `pixi run mypy`
- [x] Linter clean: `pixi run ruff check hephaestus/ tests/`
- [x] Format check passes: `pixi run ruff format --check hephaestus/ tests/`
- [x] Pre-commit hooks pass: `PRE_COMMIT_HOME=/tmp/pre-commit-cache PIP_CACHE_DIR=/tmp/pip-cache pixi run pre-commit run --files ...`

## Checklist

- [x] Code follows project style guidelines (ruff, mypy)
- [x] Self-review of code completed
- [x] Comments added in hard-to-understand areas
- [x] Documentation updated (if needed)
- [x] No new warnings introduced
- [x] Conventional commit message format used
- [x] Branch named following convention: `<issue-number>-<description>`
- [x] Change meets the [Definition of Done](https://github.com/mvillmow/ProjectHephaestus/blob/main/docs/DEFINITION_OF_DONE.md)

## Additional Notes

- Checked staged content for the internal endpoint/model-name patterns from the Pi provider planning work; none were committed.
- PR #1609 was separately salvaged and its visible CodeQL checks were passing when last checked.

Generated by Codex.
