### PR TITLE
refactor(automation): share worker summary printing

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -11,6 +11,8 @@ Provides:
   lookup strategies depending on the caller's needs).
 - ``setup_review_logging``: Standard logging configuration for the reviewer
   CLIs (#599 dedupe).
+- ``print_worker_summary``: Standard worker-run summary logging for reviewer
+  and driver classes (#1381 dedupe).
 - ``build_review_parser``: Argparse parser builder shared by ``pr_reviewer``
   and ``address_review`` (#599 dedupe).
 - ``instance_log``: Shared body of the per-instance ``_log`` helper used by
@@ -28,12 +30,15 @@ import re
 import threading
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from hephaestus.agents.runtime import add_agent_argument, session_agent_matches
 from hephaestus.cli.utils import add_dry_run_arg, add_github_throttle_args
 
 from .github_api import _gh_call
+
+if TYPE_CHECKING:
+    from .models import WorkerResult
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +88,40 @@ def add_max_workers_arg(
         metavar="N",
         help=help_text,
     )
+
+
+def print_worker_summary(
+    title: str,
+    results: dict[int, WorkerResult],
+    *,
+    count_noun: str = "issues",
+    failed_header: str = "Failed issues:",
+) -> None:
+    """Log the standard worker-run summary.
+
+    Args:
+        title: Summary banner to log between separator lines.
+        results: Mapping of issue or PR number to worker result.
+        count_noun: Noun used in the total-count line.
+        failed_header: Header logged before the per-failure list.
+
+    """
+    total = len(results)
+    successful = sum(1 for result in results.values() if result.success)
+    failed = total - successful
+
+    logger.info("=" * 60)
+    logger.info(title)
+    logger.info("=" * 60)
+    logger.info("Total %s: %s", count_noun, total)
+    logger.info("Successful: %s", successful)
+    logger.info("Failed: %s", failed)
+
+    if failed > 0:
+        logger.info(failed_header)
+        for issue_num, result in results.items():
+            if not result.success:
+                logger.info("  #%s: %s", issue_num, result.error)
 
 
 def build_review_parser(

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -42,6 +42,7 @@ from ._review_utils import (
     find_pr_for_issue,
     instance_log,
     load_impl_session_id,
+    print_worker_summary,
     setup_review_logging,
 )
 from ._reviewer_base import BaseReviewer
@@ -1034,22 +1035,11 @@ class AddressReviewer(BaseReviewer):
             results: Mapping of issue number to WorkerResult
 
         """
-        total = len(results)
-        successful = sum(1 for r in results.values() if r.success)
-        failed = total - successful
-
-        logger.info("=" * 60)
-        logger.info("Address Review Summary")
-        logger.info("=" * 60)
-        logger.info("Total issues: %s", total)
-        logger.info("Successful: %s", successful)
-        logger.info("Failed: %s", failed)
-
-        if failed > 0:
-            logger.info("\nFailed issues:")
-            for issue_num, result in results.items():
-                if not result.success:
-                    logger.info("  #%s: %s", issue_num, result.error)
+        print_worker_summary(
+            "Address Review Summary",
+            results,
+            failed_header="\nFailed issues:",
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -42,6 +42,7 @@ from ._review_utils import (
     add_max_workers_arg,
     find_pr_for_issue,
     load_impl_session_id,
+    print_worker_summary,
 )
 from .address_review import (
     _parse_addressed_block,
@@ -2249,22 +2250,7 @@ class CIDriver:
             results: Mapping of issue number to WorkerResult.
 
         """
-        total = len(results)
-        successful = sum(1 for r in results.values() if r.success)
-        failed = total - successful
-
-        logger.info("=" * 60)
-        logger.info("CI Driver Summary")
-        logger.info("=" * 60)
-        logger.info("Total issues: %s", total)
-        logger.info("Successful: %s", successful)
-        logger.info("Failed: %s", failed)
-
-        if failed > 0:
-            logger.info("Failed issues:")
-            for issue_num, result in results.items():
-                if not result.success:
-                    logger.info("  #%s: %s", issue_num, result.error)
+        print_worker_summary("CI Driver Summary", results)
 
 
 # ---------------------------------------------------------------------------

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -26,7 +26,7 @@ from hephaestus.agents.runtime import (
     run_agent_text,
     uses_direct_agent_runner,
 )
-from hephaestus.automation._review_utils import add_max_workers_arg
+from hephaestus.automation._review_utils import add_max_workers_arg, print_worker_summary
 from hephaestus.cli.utils import add_dry_run_arg, add_json_arg, emit_json_status
 from hephaestus.github.rate_limit import wait_until
 
@@ -589,22 +589,7 @@ class PlanReviewer:
             results: Mapping of issue number to WorkerResult.
 
         """
-        total = len(results)
-        successful = sum(1 for r in results.values() if r.success)
-        failed = total - successful
-
-        logger.info("=" * 60)
-        logger.info("Plan Review Summary")
-        logger.info("=" * 60)
-        logger.info("Total issues: %s", total)
-        logger.info("Successful: %s", successful)
-        logger.info("Failed: %s", failed)
-
-        if failed > 0:
-            logger.info("Failed issues:")
-            for issue_num, result in results.items():
-                if not result.success:
-                    logger.info("  #%s: %s", issue_num, result.error)
+        print_worker_summary("Plan Review Summary", results)
 
 
 # ---------------------------------------------------------------------------

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -46,6 +46,7 @@ from ._review_utils import (
     find_pr_for_issue,
     instance_log,
     parse_json_block,
+    print_worker_summary,
     setup_review_logging,
 )
 from ._reviewer_base import BaseReviewer
@@ -868,22 +869,12 @@ class PRReviewer(BaseReviewer):
             results: Mapping of issue number to WorkerResult
 
         """
-        total = len(results)
-        successful = sum(1 for r in results.values() if r.success)
-        failed = total - successful
-
-        logger.info("=" * 60)
-        logger.info("PR Review Summary")
-        logger.info("=" * 60)
-        logger.info("Total PRs: %s", total)
-        logger.info("Successful: %s", successful)
-        logger.info("Failed: %s", failed)
-
-        if failed > 0:
-            logger.info("\nFailed issues:")
-            for issue_num, result in results.items():
-                if not result.success:
-                    logger.info("  #%s: %s", issue_num, result.error)
+        print_worker_summary(
+            "PR Review Summary",
+            results,
+            count_noun="PRs",
+            failed_header="\nFailed issues:",
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -2,12 +2,14 @@
 
 import argparse
 import json
+import logging
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import hephaestus.automation._review_utils as review_utils
 from hephaestus.automation._review_utils import (
     _discover_prs_simple,
     add_max_workers_arg,
@@ -18,6 +20,7 @@ from hephaestus.automation._review_utils import (
     load_impl_session_id,
     parse_json_block,
 )
+from hephaestus.automation.models import WorkerResult
 
 # ---------------------------------------------------------------------------
 # parse_json_block
@@ -56,6 +59,89 @@ class TestParseJsonBlock:
         result = parse_json_block(text)
         assert result["summary"] == "ok"
         assert len(result["comments"]) == 1
+
+
+class TestPrintWorkerSummary:
+    """Tests for the shared worker summary logger."""
+
+    @staticmethod
+    def _worker_result(issue_number: int, success: bool, error: str | None = None) -> WorkerResult:
+        return WorkerResult(issue_number=issue_number, success=success, error=error)
+
+    def test_empty_results_logs_zero_counts_without_failures(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Empty result sets log zero totals and omit the failure block."""
+        with caplog.at_level(logging.INFO):
+            review_utils.print_worker_summary("PR Review Summary", {})
+
+        text = "\n".join(caplog.messages)
+        assert "PR Review Summary" in text
+        assert "Total issues: 0" in text
+        assert "Successful: 0" in text
+        assert "Failed: 0" in text
+        assert "Failed issues:" not in text
+
+    def test_all_successful_results_log_success_count(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Successful result sets log the expected success tally."""
+        results = {
+            1: self._worker_result(1, True),
+            2: self._worker_result(2, True),
+        }
+
+        with caplog.at_level(logging.INFO):
+            review_utils.print_worker_summary("Plan Review Summary", results)
+
+        text = "\n".join(caplog.messages)
+        assert "Plan Review Summary" in text
+        assert "Total issues: 2" in text
+        assert "Successful: 2" in text
+        assert "Failed: 0" in text
+
+    def test_mixed_results_log_failed_errors(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Failed results are listed with their issue numbers and error text."""
+        results = {
+            1: self._worker_result(1, True),
+            2: self._worker_result(2, False, "boom"),
+        }
+
+        with caplog.at_level(logging.INFO):
+            review_utils.print_worker_summary("CI Driver Summary", results)
+
+        text = "\n".join(caplog.messages)
+        assert "CI Driver Summary" in text
+        assert "Successful: 1" in text
+        assert "Failed: 1" in text
+        assert "Failed issues:" in text
+        assert "  #2: boom" in text
+
+    def test_custom_count_noun_preserves_pr_summary_text(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Callers can preserve the existing PR-specific total label."""
+        results = {1: self._worker_result(1, True)}
+
+        with caplog.at_level(logging.INFO):
+            review_utils.print_worker_summary("PR Review Summary", results, count_noun="PRs")
+
+        assert "Total PRs: 1" in caplog.messages
+
+    def test_custom_failed_header_preserves_leading_newline(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Callers can preserve summary methods that logged a blank line first."""
+        results = {1: self._worker_result(1, False, "x")}
+
+        with caplog.at_level(logging.INFO):
+            review_utils.print_worker_summary(
+                "Address Review Summary",
+                results,
+                failed_header="\nFailed issues:",
+            )
+
+        assert "\nFailed issues:" in caplog.messages
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -9,7 +9,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import hephaestus.automation._review_utils as review_utils
 from hephaestus.automation._review_utils import (
     _discover_prs_simple,
     add_max_workers_arg,
@@ -19,6 +18,7 @@ from hephaestus.automation._review_utils import (
     get_pr_head_branch,
     load_impl_session_id,
     parse_json_block,
+    print_worker_summary,
 )
 from hephaestus.automation.models import WorkerResult
 
@@ -73,7 +73,7 @@ class TestPrintWorkerSummary:
     ) -> None:
         """Empty result sets log zero totals and omit the failure block."""
         with caplog.at_level(logging.INFO):
-            review_utils.print_worker_summary("PR Review Summary", {})
+            print_worker_summary("PR Review Summary", {})
 
         text = "\n".join(caplog.messages)
         assert "PR Review Summary" in text
@@ -92,7 +92,7 @@ class TestPrintWorkerSummary:
         }
 
         with caplog.at_level(logging.INFO):
-            review_utils.print_worker_summary("Plan Review Summary", results)
+            print_worker_summary("Plan Review Summary", results)
 
         text = "\n".join(caplog.messages)
         assert "Plan Review Summary" in text
@@ -108,7 +108,7 @@ class TestPrintWorkerSummary:
         }
 
         with caplog.at_level(logging.INFO):
-            review_utils.print_worker_summary("CI Driver Summary", results)
+            print_worker_summary("CI Driver Summary", results)
 
         text = "\n".join(caplog.messages)
         assert "CI Driver Summary" in text
@@ -124,7 +124,7 @@ class TestPrintWorkerSummary:
         results = {1: self._worker_result(1, True)}
 
         with caplog.at_level(logging.INFO):
-            review_utils.print_worker_summary("PR Review Summary", results, count_noun="PRs")
+            print_worker_summary("PR Review Summary", results, count_noun="PRs")
 
         assert "Total PRs: 1" in caplog.messages
 
@@ -135,7 +135,7 @@ class TestPrintWorkerSummary:
         results = {1: self._worker_result(1, False, "x")}
 
         with caplog.at_level(logging.INFO):
-            review_utils.print_worker_summary(
+            print_worker_summary(
                 "Address Review Summary",
                 results,
                 failed_header="\nFailed issues:",


### PR DESCRIPTION
## Summary
Extract duplicated worker summary logging into a shared automation review utility.

## Changes
- Added print_worker_summary in hephaestus.automation._review_utils for consistent result counting and logging.
- Replaced duplicated _print_summary implementations in PR review, plan review, address review, and CI driver workers.
- Added unit coverage for the shared summary helper.

## Testing
- Added tests/unit/automation/test_review_utils.py coverage for print_worker_summary.

## Closes
Closes #1381

Generated by Codex via ProjectHephaestus automation.
