### PR TITLE
refactor(automation): extract impl session id loader

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -15,6 +15,8 @@ Provides:
   and ``address_review`` (#599 dedupe).
 - ``instance_log``: Shared body of the per-instance ``_log`` helper used by
   the reviewer classes (#599 dedupe).
+- ``load_impl_session_id``: Shared implementer-session state loader for
+  drive-green and address-review.
 """
 
 from __future__ import annotations
@@ -25,9 +27,10 @@ import logging
 import re
 import threading
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
-from hephaestus.agents.runtime import add_agent_argument
+from hephaestus.agents.runtime import add_agent_argument, session_agent_matches
 from hephaestus.cli.utils import add_dry_run_arg, add_github_throttle_args
 
 from .github_api import _gh_call
@@ -214,6 +217,48 @@ def _discover_prs_simple(
         elif on_missing is not None:
             on_missing(issue_num)
     return pr_map
+
+
+def load_impl_session_id(state_dir: Path, issue_number: int, agent: str) -> str | None:
+    """Load the implementer's agent session ID from on-disk state.
+
+    The implementer persists its state to ``issue-<n>.json`` (see
+    ``ImplementationStateManager.save``), not ``state-<n>.json``. A stored
+    session is only returned when its ``session_agent`` is compatible with the
+    selected ``agent``; legacy files with no ``session_agent`` are treated as
+    Claude sessions by ``session_agent_matches``.
+
+    Args:
+        state_dir: Directory holding the implementer state files.
+        issue_number: GitHub issue number.
+        agent: Selected agent for the current run.
+
+    Returns:
+        Session ID string, or ``None`` if the file is absent, unreadable, has
+        no ``session_id``, or belongs to a different agent.
+
+    """
+    state_file = state_dir / f"issue-{issue_number}.json"
+    if not state_file.exists():
+        logger.debug("No implementer state file for issue #%s", issue_number)
+        return None
+
+    try:
+        data = json.loads(state_file.read_text())
+        session_id: str | None = data.get("session_id")
+        session_agent: str | None = data.get("session_agent")
+        if session_id and not session_agent_matches(session_agent, agent):
+            logger.info(
+                "Skipping impl session for issue #%s: session belongs to %s, selected agent is %s",
+                issue_number,
+                session_agent or "claude",
+                agent,
+            )
+            return None
+        return session_id
+    except Exception as e:
+        logger.warning("Could not load impl session for #%s: %s", issue_number, e)
+        return None
 
 
 def find_pr_for_issue(

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -32,7 +32,6 @@ from hephaestus.agents.runtime import (
     resolve_agent,
     resume_agent_session,
     run_agent_session,
-    session_agent_matches,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import add_json_arg, emit_json_status
@@ -42,6 +41,7 @@ from ._review_utils import (
     build_review_parser,
     find_pr_for_issue,
     instance_log,
+    load_impl_session_id,
     setup_review_logging,
 )
 from ._reviewer_base import BaseReviewer
@@ -729,6 +729,9 @@ class AddressReviewer(BaseReviewer):
     def _load_impl_session_id(self, issue_number: int) -> str | None:
         """Load the implementer's agent session ID from state file.
 
+        Thin wrapper around :func:`._review_utils.load_impl_session_id`, kept
+        as a method so existing patch-by-method test seams hold.
+
         Args:
             issue_number: GitHub issue number
 
@@ -736,29 +739,7 @@ class AddressReviewer(BaseReviewer):
             Session ID string if found, None otherwise
 
         """
-        state_file = self.state_dir / f"issue-{issue_number}.json"
-        if not state_file.exists():
-            logger.warning(
-                "No implementation state for issue #%s, will use fresh session", issue_number
-            )
-            return None
-        try:
-            data = json.loads(state_file.read_text())
-            session_id: str | None = data.get("session_id")
-            session_agent: str | None = data.get("session_agent")
-            if session_id and not session_agent_matches(session_agent, self.options.agent):
-                logger.info(
-                    "Skipping impl session for issue #%s: session belongs to %s, "
-                    "selected agent is %s",
-                    issue_number,
-                    session_agent or "claude",
-                    self.options.agent,
-                )
-                return None
-            return session_id
-        except Exception as e:
-            logger.warning("Could not load impl session for #%s: %s", issue_number, e)
-            return None
+        return load_impl_session_id(self.state_dir, issue_number, self.options.agent)
 
     def _load_review_state(self, issue_number: int) -> ReviewState | None:
         """Load review state from disk.

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -26,7 +26,6 @@ from hephaestus.agents.runtime import (
     direct_agent_model,
     resolve_agent,
     run_agent_session,
-    session_agent_matches,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
@@ -38,7 +37,12 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.utils.file_lock import file_lock
 
-from ._review_utils import _discover_prs_simple, add_max_workers_arg, find_pr_for_issue
+from ._review_utils import (
+    _discover_prs_simple,
+    add_max_workers_arg,
+    find_pr_for_issue,
+    load_impl_session_id,
+)
 from .address_review import (
     _parse_addressed_block,
     resolve_addressed_threads,
@@ -1825,6 +1829,9 @@ class CIDriver:
     def _load_impl_session_id(self, issue_number: int) -> str | None:
         """Load the agent session ID from the implementer's saved state.
 
+        Thin wrapper around :func:`._review_utils.load_impl_session_id`, kept
+        as a method so existing patch-by-method test seams hold.
+
         Args:
             issue_number: GitHub issue number.
 
@@ -1832,35 +1839,7 @@ class CIDriver:
             Session ID string, or None if not found.
 
         """
-        # The implementer persists its state to ``issue-<n>.json`` (see
-        # ImplementationStateManager.save), NOT ``state-<n>.json``. Reading the
-        # wrong name always missed, so this lookup silently never resumed the
-        # implementer's session — masked for Claude (deterministic-UUID resume)
-        # but breaking Codex session continuity on the CI-fix path.
-        state_file = self.state_dir / f"issue-{issue_number}.json"
-        if not state_file.exists():
-            logger.debug("No implementer state file for issue #%s", issue_number)
-            return None
-
-        try:
-            data = json.loads(state_file.read_text())
-            session_id: str | None = data.get("session_id")
-            session_agent: str | None = data.get("session_agent")
-            if session_id and not session_agent_matches(session_agent, self.options.agent):
-                logger.info(
-                    "Skipping impl session for issue #%s: session belongs to %s, "
-                    "selected agent is %s",
-                    issue_number,
-                    session_agent or "claude",
-                    self.options.agent,
-                )
-                return None
-            if session_id:
-                logger.debug("Loaded session_id for issue #%s: %s...", issue_number, session_id[:8])
-            return session_id
-        except Exception as e:
-            logger.warning("Could not load session_id for issue #%s: %s", issue_number, e)
-            return None
+        return load_impl_session_id(self.state_dir, issue_number, self.options.agent)
 
     def _list_unresolved_threads_safe(self, pr_number: int) -> list[dict[str, Any]]:
         """Fetch unresolved review threads, swallowing lookup failures.

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,7 @@ from hephaestus.automation._review_utils import (
     find_merged_closing_pr,
     find_pr_for_issue,
     get_pr_head_branch,
+    load_impl_session_id,
     parse_json_block,
 )
 
@@ -87,6 +89,67 @@ class TestDiscoverPrsSimple:
         assert result == {1: 101, 3: 103}
         assert calls == [1, 2, 3]
         assert missing == [2]
+
+
+# ---------------------------------------------------------------------------
+# load_impl_session_id
+# ---------------------------------------------------------------------------
+
+
+class TestLoadImplSessionId:
+    """Tests for the shared load_impl_session_id helper."""
+
+    def test_returns_session_id_for_matching_claude(self, tmp_path: Path) -> None:
+        """Legacy state without session_agent belongs to Claude."""
+        (tmp_path / "issue-123.json").write_text(json.dumps({"session_id": "abc"}))
+
+        assert load_impl_session_id(tmp_path, 123, "claude") == "abc"
+
+    def test_skips_legacy_claude_session_for_codex(self, tmp_path: Path) -> None:
+        """Legacy Claude session must not resume as Codex."""
+        (tmp_path / "issue-123.json").write_text(json.dumps({"session_id": "abc"}))
+
+        assert load_impl_session_id(tmp_path, 123, "codex") is None
+
+    def test_returns_matching_codex_session(self, tmp_path: Path) -> None:
+        """Codex sessions resume when the selected agent is Codex."""
+        (tmp_path / "issue-123.json").write_text(
+            json.dumps({"session_id": "codex-sess", "session_agent": "codex"})
+        )
+
+        assert load_impl_session_id(tmp_path, 123, "codex") == "codex-sess"
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        """Missing implementer state returns None."""
+        assert load_impl_session_id(tmp_path, 123, "claude") is None
+
+    def test_null_session_id_returns_none(self, tmp_path: Path) -> None:
+        """State with a null session_id returns None."""
+        (tmp_path / "issue-123.json").write_text(json.dumps({"session_id": None}))
+
+        assert load_impl_session_id(tmp_path, 123, "claude") is None
+
+    def test_no_session_id_key_returns_none(self, tmp_path: Path) -> None:
+        """State without session_id returns None."""
+        (tmp_path / "issue-123.json").write_text(json.dumps({"phase": "completed"}))
+
+        assert load_impl_session_id(tmp_path, 123, "claude") is None
+
+    def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        """Unreadable JSON state returns None."""
+        (tmp_path / "issue-123.json").write_text("{not json")
+
+        assert load_impl_session_id(tmp_path, 123, "claude") is None
+
+    def test_reads_issue_filename_not_legacy_state_name(self, tmp_path: Path) -> None:
+        """Only the implementer-written issue filename is read."""
+        (tmp_path / "state-123.json").write_text(json.dumps({"session_id": "legacy"}))
+
+        assert load_impl_session_id(tmp_path, 123, "claude") is None
+
+        (tmp_path / "issue-123.json").write_text(json.dumps({"session_id": "real"}))
+
+        assert load_impl_session_id(tmp_path, 123, "claude") == "real"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extracts shared implementation session ID loading logic for review automation with no intended behavior change.

## Changes
- Added load_impl_session_id helper in _review_utils.py to read issue state and validate the session agent
- Updated CI driver and address reviewer to call the shared helper instead of maintaining duplicate methods
- Added unit coverage for the shared review utility helper

## Testing
- Added tests in tests/unit/automation/test_review_utils.py

## Closes
Closes #1383

Generated by Codex via ProjectHephaestus automation.
