### PR TITLE
refactor(automation): share PR discovery helper

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -5,6 +5,8 @@ Extracts utilities that were previously duplicated across
 
 Provides:
 - ``parse_json_block``: Extract the last ```json``` block from Claude output.
+- ``_discover_prs_simple``: Shared issue-to-PR discovery loop for reviewer
+  callers that supply their own single-issue lookup function.
 - ``find_pr_for_issue``: Locate the open PR for a GitHub issue (two or three
   lookup strategies depending on the caller's needs).
 - ``setup_review_logging``: Standard logging configuration for the reviewer
@@ -22,6 +24,7 @@ import json
 import logging
 import re
 import threading
+from collections.abc import Callable
 from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument
@@ -184,6 +187,33 @@ def parse_json_block(text: str) -> dict[str, Any]:
         return dict(json.loads(matches[-1]))
     except json.JSONDecodeError:
         return {"comments": [], "summary": "Failed to parse structured output from analysis"}
+
+
+def _discover_prs_simple(
+    issue_numbers: list[int],
+    find_fn: Callable[[int], int | None],
+    *,
+    on_missing: Callable[[int], None] | None = None,
+) -> dict[int, int]:
+    """Map issue numbers to open PR numbers using ``find_fn``.
+
+    Args:
+        issue_numbers: Issue numbers to resolve.
+        find_fn: Callable that returns a PR number for one issue, or ``None``.
+        on_missing: Optional callback invoked for each issue without an open PR.
+
+    Returns:
+        Mapping of issue number to PR number for found PRs.
+
+    """
+    pr_map: dict[int, int] = {}
+    for issue_num in issue_numbers:
+        pr_number = find_fn(issue_num)
+        if pr_number is not None:
+            pr_map[issue_num] = pr_number
+        elif on_missing is not None:
+            on_missing(issue_num)
+    return pr_map
 
 
 def find_pr_for_issue(

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -38,6 +38,7 @@ from hephaestus.agents.runtime import (
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 
 from ._review_utils import (
+    _discover_prs_simple,
     build_review_parser,
     find_pr_for_issue,
     instance_log,
@@ -402,14 +403,13 @@ class AddressReviewer(BaseReviewer):
             Mapping of issue_number -> pr_number for issues that have an open PR
 
         """
-        pr_map: dict[int, int] = {}
-        for issue_num in issue_numbers:
-            pr_number = self._find_pr_for_issue(issue_num)
-            if pr_number is not None:
-                pr_map[issue_num] = pr_number
-            else:
-                logger.info("Issue #%s: no open PR found, skipping", issue_num)
-        return pr_map
+        return _discover_prs_simple(
+            issue_numbers,
+            self._find_pr_for_issue,
+            on_missing=lambda issue_num: logger.info(
+                "Issue #%s: no open PR found, skipping", issue_num
+            ),
+        )
 
     def _address_all(self, pr_map: dict[int, int]) -> dict[int, WorkerResult]:
         """Address all issues in parallel.

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -38,7 +38,7 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.utils.file_lock import file_lock
 
-from ._review_utils import add_max_workers_arg, find_pr_for_issue
+from ._review_utils import _discover_prs_simple, add_max_workers_arg, find_pr_for_issue
 from .address_review import (
     _parse_addressed_block,
     resolve_addressed_threads,
@@ -441,13 +441,13 @@ class CIDriver:
         # Per-issue lookup first; preserve insertion order so the "lowest
         # numbered issue wins" tie-break is stable across runs given the same
         # input list.
-        raw_map: dict[int, int] = {}
-        for issue_num in issue_numbers:
-            pr_number = self._find_pr_for_issue(issue_num)
-            if pr_number is not None:
-                raw_map[issue_num] = pr_number
-            else:
-                logger.info("Issue #%s: no open PR found, skipping", issue_num)
+        raw_map = _discover_prs_simple(
+            issue_numbers,
+            self._find_pr_for_issue,
+            on_missing=lambda issue_num: logger.info(
+                "Issue #%s: no open PR found, skipping", issue_num
+            ),
+        )
 
         # Group by PR, then pick a canonical issue per PR (the smallest one)
         # and log the deferred siblings so operators can see the dedupe.

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -41,6 +41,7 @@ from hephaestus.cli.utils import (
 )
 
 from ._review_utils import (
+    _discover_prs_simple,
     build_review_parser,
     find_pr_for_issue,
     instance_log,
@@ -448,16 +449,13 @@ class PRReviewer(BaseReviewer):
             Mapping of issue_number -> pr_number for found PRs
 
         """
-        pr_map: dict[int, int] = {}
-
-        for issue_num in issue_numbers:
-            pr_number = self._find_pr_for_issue(issue_num)
-            if pr_number is not None:
-                pr_map[issue_num] = pr_number
-            else:
-                logger.warning("No open PR found for issue #%s", issue_num)
-
-        return pr_map
+        return _discover_prs_simple(
+            issue_numbers,
+            self._find_pr_for_issue,
+            on_missing=lambda issue_num: logger.warning(
+                "No open PR found for issue #%s", issue_num
+            ),
+        )
 
     def _find_pr_for_issue(self, issue_number: int) -> int | None:
         """Find the open PR for a single issue.

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation._review_utils import (
+    _discover_prs_simple,
     add_max_workers_arg,
     close_issue_as_covered,
     find_merged_closing_pr,
@@ -53,6 +54,39 @@ class TestParseJsonBlock:
         result = parse_json_block(text)
         assert result["summary"] == "ok"
         assert len(result["comments"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# _discover_prs_simple
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverPrsSimple:
+    """Tests for the shared issue-to-PR discovery helper."""
+
+    def test_empty_input_returns_empty_without_calling_find(self) -> None:
+        """Empty issue list returns an empty map without lookup calls."""
+        find_fn = MagicMock(return_value=123)
+
+        result = _discover_prs_simple([], find_fn)
+
+        assert result == {}
+        find_fn.assert_not_called()
+
+    def test_discovers_prs_and_reports_missing_issues_in_order(self) -> None:
+        """Found PRs are mapped while missing issues invoke the callback."""
+        calls: list[int] = []
+        missing: list[int] = []
+
+        def find_fn(issue_number: int) -> int | None:
+            calls.append(issue_number)
+            return {1: 101, 3: 103}.get(issue_number)
+
+        result = _discover_prs_simple([1, 2, 3], find_fn, on_missing=missing.append)
+
+        assert result == {1: 101, 3: 103}
+        assert calls == [1, 2, 3]
+        assert missing == [2]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extracts the duplicated simple issue-to-PR discovery flow into a shared review utility and updates reviewers to use it without changing behavior.

## Changes
- Added `_discover_prs_simple` in `hephaestus/automation/_review_utils.py` for mapping issue numbers to PR numbers via a supplied finder
- Updated PR reviewer, address reviewer, and CI driver discovery code to reuse the shared helper while preserving CI-specific deduplication logic
- Added unit tests covering the shared discovery helper

## Testing
- Added coverage in `tests/unit/automation/test_review_utils.py`

## Closes
Closes #1380

Generated by Codex via ProjectHephaestus automation.
