### PR TITLE
refactor(automation): consolidate JSON block parsing

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -24,11 +24,13 @@ Provides:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import logging
 import re
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -41,6 +43,15 @@ if TYPE_CHECKING:
     from .models import WorkerResult
 
 logger = logging.getLogger(__name__)
+
+ParseJsonErrorCallback = Callable[[str, Path | None, OSError | None], None]
+
+_JSON_BLOCK_RE = re.compile(r"```json\s*(.*?)\s*```", re.DOTALL)
+_REVIEW_PARSE_MISSING = {"comments": [], "summary": "No structured output from analysis"}
+_REVIEW_PARSE_FAILED = {
+    "comments": [],
+    "summary": "Failed to parse structured output from analysis",
+}
 
 
 def setup_review_logging(verbose: bool = False) -> None:
@@ -212,23 +223,118 @@ def instance_log(
     log_manager.log(tid, ui_msg)
 
 
-def parse_json_block(text: str) -> dict[str, Any]:
-    """Extract the last ```json ... ``` block from an agent response.
+def _copy_default(default: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(default))
+
+
+def _format_parse_error(exc: Exception) -> str:
+    if isinstance(exc, json.JSONDecodeError):
+        return f"json.JSONDecodeError: {exc}"
+    return f"{type(exc).__name__}: {exc}"
+
+
+def _write_json_parse_trace(
+    *,
+    trace_dir: Path,
+    trace_name: str,
+    reason: str,
+    text: str,
+    last_block: str | None,
+) -> tuple[Path, OSError | None]:
+    trace_path = trace_dir / trace_name
+    try:
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        trace_path.write_text(
+            "\n".join(
+                [
+                    f"reason: {reason}",
+                    "",
+                    "=== last fenced block (if any) ===",
+                    last_block or "(none)",
+                    "",
+                    "=== full response ===",
+                    text,
+                ]
+            )
+        )
+        return trace_path, None
+    except OSError as exc:
+        return trace_path, exc
+
+
+def parse_json_block(
+    text: str,
+    *,
+    default: Mapping[str, Any] | None = None,
+    parse_error_default: Mapping[str, Any] | None = None,
+    trace_dir: Path | None = None,
+    trace_name: str = "parse-error.log",
+    raw_json_fallback: bool = False,
+    use_last_block: bool = True,
+    on_error: ParseJsonErrorCallback | None = None,
+) -> dict[str, Any]:
+    """Extract a JSON object from an agent response.
 
     Args:
         text: Agent response text.
+        default: Result shape for missing JSON, and for parse errors unless
+            ``parse_error_default`` is supplied.
+        parse_error_default: Result shape for malformed/non-object JSON.
+        trace_dir: Optional directory for parse-failure diagnostics.
+        trace_name: Diagnostic filename when ``trace_dir`` is supplied.
+        raw_json_fallback: Try parsing the full response as raw JSON.
+        use_last_block: When true, parse the last fenced block; otherwise the
+            first. Reviewers use the last block, CI repair uses the first.
+        on_error: Optional callback receiving the reason, trace path, and trace
+            write error.
 
     Returns:
-        Parsed dict, or a default dict with empty collections on failure.
+        Parsed dict, or a caller-provided/default dict on failure.
 
     """
-    matches = re.findall(r"```json\s*(.*?)\s*```", text, re.DOTALL)
-    if not matches:
-        return {"comments": [], "summary": "No structured output from analysis"}
-    try:
-        return dict(json.loads(matches[-1]))
-    except json.JSONDecodeError:
-        return {"comments": [], "summary": "Failed to parse structured output from analysis"}
+    missing_default = _REVIEW_PARSE_MISSING if default is None else default
+    if parse_error_default is not None:
+        failed_default = parse_error_default
+    elif default is None:
+        failed_default = _REVIEW_PARSE_FAILED
+    else:
+        failed_default = missing_default
+
+    def record_error(reason: str, last_block: str | None) -> None:
+        trace_path: Path | None = None
+        trace_error: OSError | None = None
+        if trace_dir is not None:
+            trace_path, trace_error = _write_json_parse_trace(
+                trace_dir=trace_dir,
+                trace_name=trace_name,
+                reason=reason,
+                text=text,
+                last_block=last_block,
+            )
+        if on_error is not None:
+            on_error(reason, trace_path, trace_error)
+
+    matches = _JSON_BLOCK_RE.findall(text)
+    if matches:
+        block = matches[-1 if use_last_block else 0]
+        try:
+            return dict(json.loads(block))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            if raw_json_fallback:
+                with contextlib.suppress(json.JSONDecodeError, TypeError, ValueError):
+                    return dict(json.loads(text))
+            record_error(_format_parse_error(exc), block)
+            return _copy_default(failed_default)
+
+    if raw_json_fallback:
+        try:
+            return dict(json.loads(text))
+        except (json.JSONDecodeError, TypeError, ValueError) as exc:
+            record_error(_format_parse_error(exc), None)
+            return _copy_default(failed_default)
+
+    record_error("no fenced ```json block found in response", None)
+    return _copy_default(missing_default)
 
 
 def _discover_prs_simple(

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import re
 import subprocess
 import threading
 import time
@@ -36,6 +35,7 @@ from hephaestus.agents.runtime import (
 )
 from hephaestus.cli.utils import add_json_arg, emit_json_status
 
+from . import _review_utils
 from ._review_utils import (
     _discover_prs_simple,
     build_review_parser,
@@ -68,12 +68,14 @@ from .session_naming import AGENT_IMPLEMENTER
 
 logger = logging.getLogger(__name__)
 
+_ADDRESS_PARSE_DEFAULT: dict[str, Any] = {"addressed": [], "replies": {}}
+
 
 def _parse_addressed_block(text: str) -> dict[str, Any]:
     """Extract the last ```json``` block as an ``{"addressed", "replies"}`` dict.
 
     Trace-free parser shared by the in-loop address step (#28). The standalone
-    :meth:`AddressReviewer._parse_json_block` wraps this with a diagnostic
+    :class:`AddressReviewer` path wraps the same parser with a diagnostic
     trace-file writer; callers that don't need the trace use this directly.
 
     Args:
@@ -84,13 +86,28 @@ def _parse_addressed_block(text: str) -> dict[str, Any]:
         if no parseable ``json`` block is present.
 
     """
-    matches = re.findall(r"```json\s*(.*?)\s*```", text, re.DOTALL)
-    if not matches:
-        return {"addressed": [], "replies": {}}
-    try:
-        return dict(json.loads(matches[-1]))
-    except json.JSONDecodeError:
-        return {"addressed": [], "replies": {}}
+    return _review_utils.parse_json_block(text, default=_ADDRESS_PARSE_DEFAULT)
+
+
+def _log_address_parse_error(
+    issue_number: int,
+    reason: str,
+    trace_path: Path | None,
+    trace_error: OSError | None,
+) -> None:
+    if trace_error is not None:
+        logger.warning(
+            "Issue #%d: address-review JSON parse failed and trace write also failed: %s",
+            issue_number,
+            trace_error,
+        )
+    elif trace_path is not None:
+        logger.warning(
+            "Issue #%d: address-review JSON parse failed (%s); trace at %s",
+            issue_number,
+            reason,
+            trace_path,
+        )
 
 
 def run_address_fix_session(
@@ -131,7 +148,7 @@ def run_address_fix_session(
         agent: Selected implementation agent (``"claude"`` / ``"codex"``).
         repo_root: Repo root used for session-naming githash + slug.
         parse_fn: Callable ``(text) -> dict`` used to parse the agent's output.
-            The standalone path passes its trace-writing method; the in-loop
+            The standalone path passes its trace-writing closure; the in-loop
             path passes :func:`_parse_addressed_block`.
         log_file: Path to write the raw session log to.
         dry_run: When True, skip the agent call and return empty result.
@@ -834,6 +851,20 @@ class AddressReviewer(BaseReviewer):
         """
         log_file = self.state_dir / f"address-review-{issue_number}.log"
 
+        def parse_with_trace(text: str) -> dict[str, Any]:
+            return _review_utils.parse_json_block(
+                text,
+                default=_ADDRESS_PARSE_DEFAULT,
+                trace_dir=self.state_dir,
+                trace_name=f"address-{issue_number}.parse-error.log",
+                on_error=lambda reason, path, error: _log_address_parse_error(
+                    issue_number,
+                    reason,
+                    path,
+                    error,
+                ),
+            )
+
         if not self.options.dry_run and uses_direct_agent_runner(self.options.agent) and session_id:
             threads_json = json.dumps(
                 [
@@ -876,7 +907,7 @@ class AddressReviewer(BaseReviewer):
                 if direct_result.session_id:
                     log = f"SESSION_ID: {direct_result.session_id}\n\n{log}"
                 log_file.write_text(log)
-                parsed = self._parse_json_block(direct_result.stdout, issue_number=issue_number)
+                parsed = parse_with_trace(direct_result.stdout)
                 logger.info(
                     "Fix session complete for PR #%s; addressed %s thread(s)",
                     pr_number,
@@ -891,84 +922,10 @@ class AddressReviewer(BaseReviewer):
             threads=threads,
             agent=self.options.agent,
             repo_root=self.repo_root,
-            parse_fn=lambda text: self._parse_json_block(text, issue_number=issue_number),
+            parse_fn=parse_with_trace,
             log_file=log_file,
             dry_run=self.options.dry_run,
         )
-
-    def _parse_json_block(self, text: str, issue_number: int | None = None) -> dict[str, Any]:
-        """Extract the last ```json ... ``` block from an agent response.
-
-        On parse failure or missing block, writes a trace file under the state
-        dir so an empty ``addressed`` list is distinguishable from "the agent
-        reviewed and decided no fixes were warranted". Without this the two
-        cases looked identical in logs and it was hard to know whether to
-        retry, escalate, or trust the result.
-
-        Args:
-            text: Claude's full response text
-            issue_number: Issue number for diagnostic filenames; if None, no
-                trace is written (used by tests).
-
-        Returns:
-            Parsed dict with "addressed" and "replies" keys, or defaults if not found
-
-        """
-        matches = re.findall(r"```json\s*(.*?)\s*```", text, re.DOTALL)
-        if not matches:
-            self._write_parse_trace(
-                issue_number,
-                reason="no fenced ```json block found in response",
-                text=text,
-            )
-            return {"addressed": [], "replies": {}}
-        try:
-            return dict(json.loads(matches[-1]))
-        except json.JSONDecodeError as e:
-            self._write_parse_trace(
-                issue_number,
-                reason=f"json.JSONDecodeError: {e}",
-                text=text,
-                last_block=matches[-1],
-            )
-            return {"addressed": [], "replies": {}}
-
-    def _write_parse_trace(
-        self,
-        issue_number: int | None,
-        *,
-        reason: str,
-        text: str,
-        last_block: str | None = None,
-    ) -> None:
-        """Persist a diagnostic file describing why JSON parsing failed."""
-        if issue_number is None:
-            logger.warning("Parse trace skipped (no issue_number): %s", reason)
-            return
-        trace_path = self.state_dir / f"address-{issue_number}.parse-error.log"
-        try:
-            payload = [
-                f"reason: {reason}",
-                "",
-                "=== last fenced block (if any) ===",
-                last_block or "(none)",
-                "",
-                "=== full response ===",
-                text,
-            ]
-            trace_path.write_text("\n".join(payload))
-            logger.warning(
-                "Issue #%d: address-review JSON parse failed (%s); trace at %s",
-                issue_number,
-                reason,
-                trace_path,
-            )
-        except OSError as exc:
-            logger.warning(
-                "Issue #%d: address-review JSON parse failed and trace write also failed: %s",
-                issue_number,
-                exc,
-            )
 
     def _resolve_addressed_threads(
         self,

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -10,7 +10,6 @@ Provides:
 from __future__ import annotations
 
 import argparse
-import contextlib
 import json
 import logging
 import os
@@ -42,6 +41,7 @@ from ._review_utils import (
     add_max_workers_arg,
     find_pr_for_issue,
     load_impl_session_id,
+    parse_json_block,
     print_worker_summary,
 )
 from .address_review import (
@@ -2221,7 +2221,7 @@ class CIDriver:
         return self._post_merge.run_drive_green_compact(issue_number, pr_number)
 
     def _parse_json_block(self, text: str) -> dict[str, Any]:
-        """Extract and parse the first JSON block from a text string.
+        """Extract and parse the first JSON block or raw JSON object.
 
         Args:
             text: Input text that may contain a JSON block.
@@ -2230,18 +2230,13 @@ class CIDriver:
             Parsed dictionary, or empty dict if no valid JSON found.
 
         """
-        import re
-
-        match = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
-        if match:
-            with contextlib.suppress(json.JSONDecodeError):
-                return dict(json.loads(match.group(1)))
-
-        # Try raw JSON
-        with contextlib.suppress(json.JSONDecodeError):
-            return dict(json.loads(text))
-
-        return {}
+        return parse_json_block(
+            text,
+            default={},
+            parse_error_default={},
+            raw_json_fallback=True,
+            use_last_block=False,
+        )
 
     def _print_summary(self, results: dict[int, WorkerResult]) -> None:
         """Print a summary of CI drive results.

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -40,12 +40,12 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 
+from . import _review_utils
 from ._review_utils import (
     _discover_prs_simple,
     build_review_parser,
     find_pr_for_issue,
     instance_log,
-    parse_json_block,
     print_worker_summary,
     setup_review_logging,
 )
@@ -61,22 +61,6 @@ from .prompts import get_pr_review_analysis_prompt
 from .session_naming import AGENT_PR_REVIEWER, reviewer_agent
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_json_block(text: str) -> dict[str, Any]:
-    """Extract the last ```json ... ``` block from an agent response.
-
-    Thin wrapper around :func:`_review_utils.parse_json_block` kept for
-    backward compatibility with existing callers and tests.
-
-    Args:
-        text: Agent response text
-
-    Returns:
-        Parsed dict with keys "comments" and "summary", or defaults if not found
-
-    """
-    return parse_json_block(text)
 
 
 def run_pr_review_analysis(
@@ -154,7 +138,7 @@ def run_pr_review_analysis(
             )
             log_file.write_text(result.stdout or "")
             review_text = result.stdout or ""
-            parsed = _parse_json_block(review_text)
+            parsed = _review_utils.parse_json_block(review_text)
             parsed["review_text"] = review_text
             logger.info(
                 "Analysis complete for PR #%s; found %s inline comment(s)",
@@ -198,7 +182,7 @@ def run_pr_review_analysis(
         except (json.JSONDecodeError, AttributeError):
             response_text = stdout or ""
 
-        parsed = _parse_json_block(response_text)
+        parsed = _review_utils.parse_json_block(response_text)
         # The Verdict:/Grade: line lives in the reviewer prose, not the JSON
         # summary block. Surface it so callers parse the real verdict.
         parsed["review_text"] = response_text

--- a/tests/unit/automation/test_address_review.py
+++ b/tests/unit/automation/test_address_review.py
@@ -3,6 +3,7 @@
 import json
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -132,36 +133,58 @@ class TestLoadImplSessionId:
 
 
 # ---------------------------------------------------------------------------
-# _parse_json_block (instance method on AddressReviewer)
+# Address-review parse tracing
 # ---------------------------------------------------------------------------
 
 
-class TestParseJsonBlock:
-    """Tests for AddressReviewer._parse_json_block."""
+class TestAddressReviewParseTracing:
+    """AddressReviewer keeps standalone trace diagnostics through the shared parser."""
 
-    def test_extracts_last_json_block(self, reviewer: AddressReviewer) -> None:
-        """Returns last parsed JSON block from Claude output."""
-        payload = {"addressed": ["thread-1", "thread-2"], "replies": {"thread-1": "Fixed"}}
-        text = (
-            "Some output\n"
-            "```json\n"
-            '{"addressed": ["old"], "replies": {}}\n'
-            "```\n"
-            "More output\n"
-            "```json\n" + json.dumps(payload) + "\n```"
-        )
-        result = reviewer._parse_json_block(text)
-        assert result["addressed"] == ["thread-1", "thread-2"]
+    def test_missing_block_writes_address_trace_and_warning(
+        self,
+        reviewer: AddressReviewer,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        reviewer.state_dir = tmp_path
 
-    def test_no_block_returns_defaults(self, reviewer: AddressReviewer) -> None:
-        """No json block → returns defaults with empty addressed list."""
-        result = reviewer._parse_json_block("No json here.")
+        def fake_run_address_fix_session(**kwargs: Any) -> dict[str, Any]:
+            return kwargs["parse_fn"]("No json here.")
+
+        with patch(
+            "hephaestus.automation.address_review.run_address_fix_session",
+            side_effect=fake_run_address_fix_session,
+        ):
+            result = reviewer._run_fix_session(123, 456, tmp_path, [], session_id=None)
+
         assert result == {"addressed": [], "replies": {}}
+        trace = tmp_path / "address-123.parse-error.log"
+        assert trace.exists()
+        assert "reason: no fenced ```json block found in response" in trace.read_text()
+        assert "Issue #123: address-review JSON parse failed" in caplog.text
 
-    def test_invalid_json_returns_defaults(self, reviewer: AddressReviewer) -> None:
-        """Invalid json block → returns defaults."""
-        result = reviewer._parse_json_block("```json\n{broken!!}\n```")
+    def test_invalid_block_writes_last_block_in_address_trace(
+        self,
+        reviewer: AddressReviewer,
+        tmp_path: Path,
+    ) -> None:
+        reviewer.state_dir = tmp_path
+        text = "```json\n{broken!!}\n```"
+
+        def fake_run_address_fix_session(**kwargs: Any) -> dict[str, Any]:
+            return kwargs["parse_fn"](text)
+
+        with patch(
+            "hephaestus.automation.address_review.run_address_fix_session",
+            side_effect=fake_run_address_fix_session,
+        ):
+            result = reviewer._run_fix_session(123, 456, tmp_path, [], session_id=None)
+
         assert result == {"addressed": [], "replies": {}}
+        payload = (tmp_path / "address-123.parse-error.log").read_text()
+        assert "reason: json.JSONDecodeError:" in payload
+        assert "=== last fenced block (if any) ===\n{broken!!}" in payload
+        assert "=== full response ===\n" in payload
 
 
 def test_codex_fix_session_falls_back_to_fresh_on_resume_failure(

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -251,6 +251,15 @@ class TestParseJsonBlock:
         result = driver._parse_json_block("not json at all")
         assert result == {}
 
+    def test_first_invalid_block_does_not_parse_later_valid_block(self, driver: CIDriver) -> None:
+        """First-block mode does not skip ahead to a later valid block."""
+        text = '```json\n{bad}\n```\n```json\n{"fixed": true}\n```'
+        assert driver._parse_json_block(text) == {}
+
+    def test_raw_json_scalar_returns_empty_dict(self, driver: CIDriver) -> None:
+        """Raw JSON fallback must still return a dict shape."""
+        assert driver._parse_json_block("42") == {}
+
 
 def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
     driver: CIDriver,

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -11,57 +11,10 @@ from hephaestus.automation.claude_invoke import parse_review_verdict
 from hephaestus.automation.models import ReviewerOptions
 from hephaestus.automation.pr_reviewer import (
     PRReviewer,
-    _parse_json_block,
     gather_impl_review_context,
     review_pr_inline,
     run_pr_review_analysis,
 )
-
-# ---------------------------------------------------------------------------
-# _parse_json_block (module-level function)
-# ---------------------------------------------------------------------------
-
-
-class TestParseJsonBlock:
-    """Tests for the module-level _parse_json_block function."""
-
-    def test_parse_json_block_extracts_last_block(self) -> None:
-        """Multiple ```json blocks → returns last one parsed."""
-        text = (
-            "Some analysis\n"
-            "```json\n"
-            '{"comments": ["first"], "summary": "first"}\n'
-            "```\n"
-            "More text\n"
-            "```json\n"
-            '{"comments": ["second"], "summary": "second"}\n'
-            "```"
-        )
-        result = _parse_json_block(text)
-        assert result["summary"] == "second"
-        assert result["comments"] == ["second"]
-
-    def test_parse_json_block_no_block(self) -> None:
-        """No json block → returns defaults with empty comments."""
-        result = _parse_json_block("No json here at all.")
-        assert result["comments"] == []
-        assert "No structured output" in result["summary"]
-
-    def test_parse_json_block_invalid_json(self) -> None:
-        """Malformed json block → returns default dict."""
-        text = "```json\n{invalid json!!!}\n```"
-        result = _parse_json_block(text)
-        assert result["comments"] == []
-        assert "Failed to parse" in result["summary"]
-
-    def test_parse_json_block_single_valid_block(self) -> None:
-        """Single valid json block → returns parsed content."""
-        comments = [{"path": "foo.py", "line": 10, "body": "Fix this"}]
-        text = "```json\n" + json.dumps({"comments": comments, "summary": "Looks good"}) + "\n```"
-        result = _parse_json_block(text)
-        assert len(result["comments"]) == 1
-        assert result["summary"] == "Looks good"
-
 
 # ---------------------------------------------------------------------------
 # PRReviewer fixtures
@@ -542,6 +495,34 @@ class TestRunPrReviewAnalysis:
         assert out["summary"] == "Needs fixes."
         assert "Verdict: NOGO" in out["review_text"]
         assert parse_review_verdict(out["review_text"]).verdict == "NOGO"
+
+    def test_uses_canonical_review_utils_parser_patch_target(self, tmp_path: Path) -> None:
+        """PR-review parsing goes through the canonical patch target."""
+        stdout = 'review prose\n```json\n{"comments": [], "summary": "real"}\n```'
+
+        with (
+            patch(
+                "hephaestus.automation.pr_reviewer.run_agent_text",
+                return_value=MagicMock(stdout=stdout),
+            ),
+            patch(
+                "hephaestus.automation._review_utils.parse_json_block",
+                return_value={"comments": [], "summary": "patched"},
+            ) as parse_json,
+        ):
+            out = run_pr_review_analysis(
+                pr_number=1,
+                issue_number=1,
+                worktree_path=tmp_path,
+                context={"pr_diff": "diff"},
+                agent="codex",
+                state_dir=tmp_path,
+                dry_run=False,
+            )
+
+        parse_json.assert_called_once_with(stdout)
+        assert out["summary"] == "patched"
+        assert out["review_text"] == stdout
 
     def test_prompt_passed_via_stdin_not_argv(self, tmp_path: Path) -> None:
         """The reviewer prompt is piped via stdin, never embedded in argv.

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -156,8 +156,8 @@ class TestPRReviewAnalysisPrompt:
     def test_pr_review_prompt_preserves_json_block(self) -> None:
         """The trailing JSON fenced block must remain byte-exact.
 
-        `pr_reviewer.py:_parse_json_block` extracts the LAST fenced JSON
-        block — any change to the schema or fence ordering breaks parsing.
+        `_review_utils.parse_json_block` extracts the LAST fenced JSON block — any
+        change to the schema or fence ordering breaks parsing.
         """
         out = prompts.get_pr_review_analysis_prompt(pr_number=1, issue_number=1)
         # The schema example object must appear verbatim (now on its own line so

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -60,6 +60,43 @@ class TestParseJsonBlock:
         assert result["summary"] == "ok"
         assert len(result["comments"]) == 1
 
+    def test_invalid_json_with_custom_default_writes_trace(self, tmp_path: Path) -> None:
+        """Malformed JSON with trace_dir writes the diagnostic payload."""
+        default: dict[str, Any] = {"addressed": [], "replies": {}}
+        text = "before\n```json\n{broken!!}\n```\nafter"
+
+        result = parse_json_block(
+            text,
+            default=default,
+            trace_dir=tmp_path,
+            trace_name="address-123.parse-error.log",
+        )
+
+        assert result == default
+        trace = tmp_path / "address-123.parse-error.log"
+        assert trace.exists()
+        payload = trace.read_text()
+        assert "reason: json.JSONDecodeError:" in payload
+        assert "=== last fenced block (if any) ===\n{broken!!}" in payload
+        assert "=== full response ===\n" in payload
+        assert text in payload
+
+    def test_raw_json_fallback_invalid_returns_custom_default(self) -> None:
+        """Invalid raw JSON fallback returns the caller's shape."""
+        assert parse_json_block("{bad", default={}, raw_json_fallback=True) == {}
+
+    def test_first_block_invalid_with_raw_fallback_does_not_use_later_block(self) -> None:
+        """First-block mode preserves CI-driver semantics on invalid first blocks."""
+        text = '```json\n{bad}\n```\n```json\n{"fixed": true}\n```'
+        assert (
+            parse_json_block(text, default={}, raw_json_fallback=True, use_last_block=False) == {}
+        )
+
+    def test_scalar_json_returns_parse_error_default(self) -> None:
+        """Scalar JSON is not a dict result and uses the parse-error default."""
+        result = parse_json_block("```json\n42\n```")
+        assert result["summary"].startswith("Failed to parse")
+
 
 class TestPrintWorkerSummary:
     """Tests for the shared worker summary logger."""


### PR DESCRIPTION
## Summary
Consolidates duplicated JSON block parsing paths behind the shared review utility while preserving error tracing and CI diagnostics behavior.

## Changes
- Extended `_review_utils.parse_json_block` to support shared failure handling and optional trace output
- Removed duplicate parser wrappers from PR review, address review, and CI driver flows
- Updated automation unit tests to patch and validate the shared parser path

## Testing
- Updated unit coverage for review utils, address review, CI driver, PR reviewer posting, and prompt behavior

## Closes
Closes #1385

Generated by Codex via ProjectHephaestus automation.
