### PR TITLE
refactor(implementer): reduce delegation surface

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -58,9 +58,10 @@ import subprocess
 import sys
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from hephaestus.agents.runtime import (
     agent_cli_name,
@@ -141,6 +142,41 @@ class IssueImplementer:
     - Real-time curses UI for status monitoring
     """
 
+    _PHASE_RUNNER_DELEGATES: ClassVar[frozenset[str]] = frozenset(
+        {
+            "_can_resume_state_session",
+            "_ensure_pr_created",
+            "_learn_needs_rerun",
+            "_load_review_iteration_state",
+            "_parse_follow_up_items",
+            "_rerun_failed_learns",
+            "_run_advise_as_implementer_turn",
+            "_run_claude_impl_session",
+            "_run_codex_code",
+            "_run_follow_up_issues",
+            "_run_learn",
+            "_run_tests_in_worktree",
+            "_save_review_iteration_state",
+            "_save_review_log",
+        }
+    )
+
+    if TYPE_CHECKING:
+        _parse_follow_up_items: Callable[..., list[dict[str, Any]]]
+        _can_resume_state_session: Callable[..., bool]
+        _run_follow_up_issues: Callable[..., None]
+        _learn_needs_rerun: Callable[..., bool]
+        _rerun_failed_learns: Callable[[], dict[int, bool]]
+        _run_learn: Callable[..., bool]
+        _run_advise_as_implementer_turn: Callable[..., str]
+        _save_review_log: Callable[..., None]
+        _save_review_iteration_state: Callable[..., None]
+        _load_review_iteration_state: Callable[..., tuple[int, str | None]]
+        _run_tests_in_worktree: Callable[..., bool]
+        _run_claude_impl_session: Callable[..., str | None]
+        _run_codex_code: Callable[..., str | None]
+        _ensure_pr_created: Callable[..., int]
+
     def __init__(self, options: ImplementerOptions):
         """Initialize issue implementer.
 
@@ -179,6 +215,19 @@ class IssueImplementer:
     def state_lock(self) -> threading.Lock:
         """Return the lock guarding :attr:`states`."""
         return self.state_mgr.lock
+
+    def __getattr__(self, name: str) -> Any:
+        """Resolve audited low-risk phase-runner compatibility delegates."""
+        if name in type(self)._PHASE_RUNNER_DELEGATES:
+            try:
+                phase_runner = object.__getattribute__(self, "phase_runner")
+            except AttributeError as exc:
+                raise AttributeError(
+                    f"{type(self).__name__!r} object has no attribute {name!r}"
+                ) from exc
+            return getattr(phase_runner, name)
+
+        raise AttributeError(f"{type(self).__name__!r} object has no attribute {name!r}")
 
     def _log(self, level: str, msg: str, thread_id: int | None = None) -> None:
         """Log to both standard logger and UI thread buffer.
@@ -486,11 +535,11 @@ class IssueImplementer:
         return results
 
     # ------------------------------------------------------------------
-    # Per-issue phase runner — bodies live in implementer_phase_runner.py.
-    # Each shim here forwards to the runner; the runner dispatches all
-    # cross-method calls back through ``self.impl._xxx`` so test idioms
-    # like ``patch.object(impl, "_has_plan", ...)`` keep intercepting
-    # every call site, including the ones inside ``_implement_issue``.
+    # Explicit phase-runner shims.
+    #
+    # Keep these as real methods because they are central workflow/review
+    # checkpoints or heavily patched in tests. Lower-risk support shims are
+    # resolved by __getattr__ through _PHASE_RUNNER_DELEGATES.
     # ------------------------------------------------------------------
 
     def _finalize_pr(
@@ -528,73 +577,9 @@ class IssueImplementer:
         """Generate plan for an issue using hephaestus-plan-issues."""
         self.phase_runner._generate_plan(issue_number)
 
-    def _parse_follow_up_items(self, text: str) -> list[dict[str, Any]]:
-        """Parse follow-up items from Claude's JSON response."""
-        return self.phase_runner._parse_follow_up_items(text)
-
-    def _can_resume_state_session(self, state: ImplementationState) -> bool:
-        """Return True when the saved session can be resumed by the selected agent."""
-        return self.phase_runner._can_resume_state_session(state)
-
-    def _run_follow_up_issues(
-        self,
-        session_id: str,
-        worktree_path: Path,
-        issue_number: int,
-        slot_id: int | None = None,
-        *,
-        session_agent: str | None = None,
-    ) -> None:
-        """Resume the selected agent session to identify and file follow-up issues."""
-        self.phase_runner._run_follow_up_issues(
-            session_id,
-            worktree_path,
-            issue_number,
-            slot_id,
-            session_agent=session_agent,
-        )
-
-    def _learn_needs_rerun(self, issue_number: int) -> bool:
-        """Check if learn log indicates failure."""
-        return self.phase_runner._learn_needs_rerun(issue_number)
-
-    def _rerun_failed_learns(self) -> dict[int, bool]:
-        """Re-run failed learns for completed issues."""
-        return self.phase_runner._rerun_failed_learns()
-
-    def _run_learn(
-        self,
-        session_id: str,
-        worktree_path: Path,
-        issue_number: int,
-        slot_id: int | None = None,
-        *,
-        session_agent: str | None = None,
-    ) -> bool:
-        """Resume the selected agent session to run /learn."""
-        return self.phase_runner._run_learn(
-            session_id,
-            worktree_path,
-            issue_number,
-            slot_id,
-            session_agent=session_agent,
-        )
-
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
         """Run the advise-first step before implementing (delegates to runner)."""
         return self.phase_runner._run_advise(issue_number, issue_title, issue_body)
-
-    def _run_advise_as_implementer_turn(
-        self,
-        issue_number: int,
-        issue_title: str,
-        issue_body: str,
-        worktree_path: Path,
-    ) -> str:
-        """Compatibility wrapper for the shared advise path (delegates to runner)."""
-        return self.phase_runner._run_advise_as_implementer_turn(
-            issue_number, issue_title, issue_body, worktree_path
-        )
 
     def _run_impl_review_loop(
         self,
@@ -730,55 +715,15 @@ class IssueImplementer:
         """Return a newline-separated list of changed files vs ``origin/main``."""
         return self.phase_runner._collect_changed_files(worktree_path, branch_name)
 
-    def _save_review_log(self, issue_number: int, iteration: int, review_text: str) -> None:
-        """Persist a per-iteration review log for later inspection."""
-        self.phase_runner._save_review_log(issue_number, iteration, review_text)
-
-    def _save_review_iteration_state(
-        self, issue_number: int, iterations_run: int, prior_review: str
-    ) -> None:
-        """Persist review loop progress for ``--resume`` continuity (A2-005)."""
-        self.phase_runner._save_review_iteration_state(issue_number, iterations_run, prior_review)
-
-    def _load_review_iteration_state(self, issue_number: int) -> tuple[int, str | None]:
-        """Load persisted review iteration progress for ``--resume`` (A2-005)."""
-        return self.phase_runner._load_review_iteration_state(issue_number)
-
-    def _run_tests_in_worktree(self, worktree_path: Path, issue_number: int) -> bool:
-        """Run the unit test suite inside the worktree as a pre-PR gate (A2-004)."""
-        return self.phase_runner._run_tests_in_worktree(worktree_path, issue_number)
-
     def _run_claude_code(
         self, issue_number: int, worktree_path: Path, prompt: str, slot_id: int | None = None
     ) -> str | None:
         """Run the selected implementation agent in a worktree."""
         return self.phase_runner._run_claude_code(issue_number, worktree_path, prompt, slot_id)
 
-    def _run_claude_impl_session(
-        self, issue_number: int, worktree_path: Path, prompt: str
-    ) -> str | None:
-        """Run Claude implementation prompt and return its session id."""
-        return self.phase_runner._run_claude_impl_session(issue_number, worktree_path, prompt)
-
-    def _run_codex_code(self, issue_number: int, worktree_path: Path, prompt: str) -> str | None:
-        """Run Codex implementation prompt in a worktree."""
-        return self.phase_runner._run_codex_code(issue_number, worktree_path, prompt)
-
     def _commit_changes(self, issue_number: int, worktree_path: Path) -> None:
         """Commit changes in worktree."""
         commit_changes(issue_number, worktree_path, self.options.agent)
-
-    def _ensure_pr_created(
-        self,
-        issue_number: int,
-        branch_name: str,
-        worktree_path: Path,
-        slot_id: int | None = None,
-    ) -> int:
-        """Ensure an implementation commit is pushed and a PR exists."""
-        return self.phase_runner._ensure_pr_created(
-            issue_number, branch_name, worktree_path, slot_id
-        )
 
     def _create_pr(self, issue_number: int, branch_name: str) -> int:
         """Create pull request for issue."""

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -94,6 +94,43 @@ def dry_run_implementer(tmp_path: Path) -> IssueImplementer:
         return IssueImplementer(options)
 
 
+class TestPhaseRunnerDelegateCompatibility:
+    """Compatibility tests for dynamic IssueImplementer phase-runner delegates."""
+
+    @pytest.mark.parametrize("name", sorted(IssueImplementer._PHASE_RUNNER_DELEGATES))
+    def test_phase_runner_delegate_compatibility_binds_to_phase_runner(
+        self, dry_run_implementer: IssueImplementer, name: str
+    ) -> None:
+        delegate = getattr(dry_run_implementer, name)
+        runner_delegate = getattr(dry_run_implementer.phase_runner, name)
+
+        assert callable(delegate)
+        assert delegate.__self__ is dry_run_implementer.phase_runner
+        assert delegate.__func__ is runner_delegate.__func__
+
+    @pytest.mark.parametrize("name", sorted(IssueImplementer._PHASE_RUNNER_DELEGATES))
+    def test_phase_runner_delegate_compatibility_patch_object_still_intercepts(
+        self, dry_run_implementer: IssueImplementer, name: str
+    ) -> None:
+        sentinel = object()
+
+        with patch.object(dry_run_implementer, name, return_value=sentinel) as mocked:
+            assert getattr(dry_run_implementer, name)("ignored") is sentinel
+
+        mocked.assert_called_once_with("ignored")
+
+        restored = getattr(dry_run_implementer, name)
+        assert restored.__self__ is dry_run_implementer.phase_runner
+
+    def test_phase_runner_delegate_compatibility_unknown_private_name_still_raises_attribute_error(
+        self, dry_run_implementer: IssueImplementer
+    ) -> None:
+        missing_name = "_not_a_phase_runner_delegate"
+
+        with pytest.raises(AttributeError):
+            getattr(dry_run_implementer, missing_name)
+
+
 # ---------------------------------------------------------------------------
 # Issue #371 — dry-run must not create real worktrees or branches
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -179,7 +179,7 @@ def test_implement_phase_run_claude_code_dry_run(tmp_path: Path) -> None:
 def test_implement_phase_run_claude_code_dispatches_claude(tmp_path: Path) -> None:
     """_run_claude_code routes to the Claude session for non-direct agents."""
     ctx = _make_ctx(tmp_path)
-    ctx.impl._run_claude_impl_session = mock.MagicMock(return_value="sess-1")  # type: ignore[method-assign]
+    ctx.impl._run_claude_impl_session = mock.MagicMock(return_value="sess-1")
     phase = ImplementPhase(ctx)
     assert phase._run_claude_code(7, tmp_path, "prompt") == "sess-1"
     ctx.impl._run_claude_impl_session.assert_called_once()
@@ -193,9 +193,9 @@ def test_implement_phase_run_claude_code_dispatches_claude(tmp_path: Path) -> No
 def test_pr_create_finalize_persists_pr_number(tmp_path: Path) -> None:
     """_finalize_pr ensures the PR exists and persists its number on state."""
     ctx = _make_ctx(tmp_path)
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[method-assign]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)
     ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[method-assign]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)
     phase = PRCreatePhase(ctx)
     state = SimpleNamespace(phase=None, pr_number=None)
     with mock.patch(
@@ -214,8 +214,8 @@ def test_pr_create_finalize_commits_dirty_worktree_before_pr(tmp_path: Path) -> 
     """_finalize_pr commits agent edits before push/PR creation."""
     ctx = _make_ctx(tmp_path)
     ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[method-assign]
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)  # type: ignore[method-assign]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)  # type: ignore[method-assign]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=321)
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=True)
     parent = mock.MagicMock()
     parent.attach_mock(ctx.impl._commit_changes, "commit")
     parent.attach_mock(ctx.impl._ensure_pr_created, "ensure")
@@ -240,9 +240,9 @@ def test_pr_create_finalize_commits_dirty_worktree_before_pr(tmp_path: Path) -> 
 def test_pr_create_finalize_runs_pre_pr_tests_when_enabled(tmp_path: Path) -> None:
     """_finalize_pr runs the opt-in pre-PR test gate before creating the PR."""
     ctx = _make_ctx(tmp_path, run_pre_pr_tests=True)
-    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=9)  # type: ignore[method-assign]
+    ctx.impl._ensure_pr_created = mock.MagicMock(return_value=9)
     ctx.impl._commit_changes = mock.MagicMock()  # type: ignore[method-assign]
-    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=False)  # type: ignore[method-assign]
+    ctx.impl._run_tests_in_worktree = mock.MagicMock(return_value=False)
     phase = PRCreatePhase(ctx)
     state = SimpleNamespace(phase=None, pr_number=None)
     with mock.patch(


### PR DESCRIPTION
## Summary
Reduce IssueImplementer pass-through boilerplate while preserving delegation behavior through phase runner routing.

## Changes
- Replaced mechanical IssueImplementer pass-through methods with grouped explicit delegations and dynamic phase runner fallback
- Updated review, PR review, address review, CI driver, and stage phase call sites to use the reduced delegation surface
- Adjusted unit coverage around implementer delegation and removed obsolete review utility tests

## Testing
- Not run (not provided)

## Closes
Closes #1391

Generated by Codex via ProjectHephaestus automation.
