### PR TITLE
refactor(automation): centralize parser setup

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -13,6 +13,8 @@ Provides:
   CLIs (#599 dedupe).
 - ``print_worker_summary``: Standard worker-run summary logging for reviewer
   and driver classes (#1381 dedupe).
+- ``build_automation_parser``: Argparse parser builder for automation CLIs
+  with opt-in common flags (#1392 dedupe).
 - ``build_review_parser``: Argparse parser builder shared by ``pr_reviewer``
   and ``address_review`` (#599 dedupe).
 - ``instance_log``: Shared body of the per-instance ``_log`` helper used by
@@ -35,7 +37,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from hephaestus.agents.runtime import add_agent_argument, session_agent_matches
-from hephaestus.cli.utils import add_dry_run_arg, add_github_throttle_args
+from hephaestus.cli.utils import (
+    add_dry_run_arg,
+    add_github_throttle_args,
+    add_json_arg,
+    add_version_arg,
+)
 
 from .github_api import _gh_call
 
@@ -135,6 +142,110 @@ def print_worker_summary(
                 logger.info("  #%s: %s", issue_num, result.error)
 
 
+def _automation_parser_kwargs(
+    description: str,
+    epilog: str | None,
+    prog: str | None,
+    formatter_class: type[argparse.HelpFormatter] | None,
+) -> dict[str, Any]:
+    """Build ArgumentParser kwargs while omitting unset optional parameters."""
+    kwargs: dict[str, Any] = {"description": description}
+    if prog is not None:
+        kwargs["prog"] = prog
+    if formatter_class is not None:
+        kwargs["formatter_class"] = formatter_class
+    if epilog is not None:
+        kwargs["epilog"] = epilog
+    return kwargs
+
+
+def build_automation_parser(
+    description: str,
+    epilog: str | None = None,
+    *,
+    prog: str | None = None,
+    formatter_class: type[argparse.HelpFormatter] | None = None,
+    add_agent: bool = True,
+    add_max_workers: bool = True,
+    max_workers_help: str = "Maximum number of parallel workers, 1-32 (default: 3)",
+    add_parallel: bool = False,
+    parallel_help: str = "Number of parallel workers, 1-32 (default: 3)",
+    add_github_throttle: bool = False,
+    add_dry_run: bool = True,
+    dry_run_prefix: str | None = None,
+    dry_run_help: str | None = None,
+    add_no_ui: bool = False,
+    add_json: bool = True,
+    add_version: bool = True,
+    add_verbose: bool = True,
+    verbose_help: str = "Enable verbose logging",
+) -> argparse.ArgumentParser:
+    """Build an automation CLI parser with configurable common options.
+
+    Args:
+        description: Parser description text.
+        epilog: Optional parser epilog, typically an examples block.
+        prog: Optional program name override.
+        formatter_class: Optional argparse formatter class.
+        add_agent: Add the common ``--agent`` provider selector.
+        add_max_workers: Add the common validated ``--max-workers`` flag.
+        max_workers_help: Help text for ``--max-workers``.
+        add_parallel: Add the planner-style ``--parallel`` worker flag.
+        parallel_help: Help text for ``--parallel``.
+        add_github_throttle: Add GitHub global-throttle flags.
+        add_dry_run: Add ``--dry-run``.
+        dry_run_prefix: Prefix passed to the canonical dry-run helper.
+        dry_run_help: Raw ``--dry-run`` help text; bypasses the canonical caveat.
+        add_no_ui: Add ``--no-ui``.
+        add_json: Add ``--json``.
+        add_version: Add ``-V`` / ``--version``.
+        add_verbose: Add ``-v`` / ``--verbose``.
+        verbose_help: Help text for ``-v`` / ``--verbose``.
+
+    Returns:
+        Configured ``argparse.ArgumentParser``.
+
+    """
+    parser = argparse.ArgumentParser(
+        **_automation_parser_kwargs(description, epilog, prog, formatter_class)
+    )
+
+    if add_agent:
+        add_agent_argument(parser)
+    if add_max_workers:
+        add_max_workers_arg(parser, help_text=max_workers_help)
+    if add_parallel:
+        parser.add_argument(
+            "--parallel",
+            type=int,
+            default=3,
+            choices=range(1, 33),
+            metavar="N",
+            help=parallel_help,
+        )
+    if add_github_throttle:
+        add_github_throttle_args(parser)
+    if add_dry_run:
+        if dry_run_help is not None:
+            parser.add_argument("--dry-run", action="store_true", help=dry_run_help)
+        else:
+            add_dry_run_arg(parser, prefix=dry_run_prefix)
+    if add_no_ui:
+        parser.add_argument(
+            "--no-ui",
+            action="store_true",
+            help="Disable curses UI (use plain logging instead)",
+        )
+    if add_verbose:
+        parser.add_argument("-v", "--verbose", action="store_true", help=verbose_help)
+    if add_json:
+        add_json_arg(parser)
+    if add_version:
+        add_version_arg(parser)
+
+    return parser
+
+
 def build_review_parser(
     description: str,
     epilog: str | None = None,
@@ -159,10 +270,14 @@ def build_review_parser(
         Configured ``argparse.ArgumentParser`` — caller invokes ``parse_args``.
 
     """
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         description=description,
-        formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=epilog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        add_github_throttle=True,
+        dry_run_prefix=dry_run_help,
+        add_no_ui=True,
+        add_version=False,
     )
 
     parser.add_argument(
@@ -171,21 +286,6 @@ def build_review_parser(
         nargs="+",
         required=True,
         help=issues_help,
-    )
-    add_agent_argument(parser)
-    add_max_workers_arg(parser)
-    add_github_throttle_args(parser)
-    add_dry_run_arg(parser, prefix=dry_run_help)
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
     )
     return parser
 

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -251,7 +251,7 @@ def build_review_parser(
     epilog: str | None = None,
     *,
     issues_help: str,
-    dry_run_help: str,
+    dry_run_prefix: str,
 ) -> argparse.ArgumentParser:
     """Build the argparse parser shared by ``pr_reviewer`` and ``address_review``.
 
@@ -264,7 +264,8 @@ def build_review_parser(
         description: Parser description text.
         epilog: Parser epilog text (typically an Examples block).
         issues_help: Help text for the ``--issues`` argument.
-        dry_run_help: Help text for the ``--dry-run`` argument.
+        dry_run_prefix: Prefix string for the ``--dry-run`` help text, appended
+            with ``DRY_RUN_HELP_CAVEAT``.
 
     Returns:
         Configured ``argparse.ArgumentParser`` — caller invokes ``parse_args``.
@@ -275,7 +276,7 @@ def build_review_parser(
         epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
         add_github_throttle=True,
-        dry_run_prefix=dry_run_help,
+        dry_run_prefix=dry_run_prefix,
         add_no_ui=True,
         add_version=False,
     )

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -1018,7 +1018,9 @@ Examples:
   %(prog)s --issues 595 596 597 --max-workers 5
         """,
         issues_help="Issue numbers whose linked PRs should have review threads addressed",
-        dry_run_help="Show what would be done without actually resolving threads or pushing code.",
+        dry_run_prefix=(
+            "Show what would be done without actually resolving threads or pushing code."
+        ),
     )
     return parser
 

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -33,7 +33,7 @@ from hephaestus.agents.runtime import (
     run_agent_session,
     uses_direct_agent_runner,
 )
-from hephaestus.cli.utils import add_json_arg, emit_json_status
+from hephaestus.cli.utils import emit_json_status
 
 from . import _review_utils
 from ._review_utils import (
@@ -1020,7 +1020,6 @@ Examples:
         issues_help="Issue numbers whose linked PRs should have review threads addressed",
         dry_run_help="Show what would be done without actually resolving threads or pushing code.",
     )
-    add_json_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -21,20 +21,17 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    add_agent_argument,
     direct_agent_model,
     resolve_agent,
     run_agent_text,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
-    add_github_throttle_args,
-    add_json_arg,
-    add_version_arg,
     configure_github_throttle_from_args,
     emit_json_status,
 )
 
+from ._review_utils import build_automation_parser
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
@@ -246,9 +243,13 @@ class AuditReviewer:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         prog="hephaestus-audit-prs",
         description="Audit ALL open PRs in one coordinator agent invocation.",
+        add_max_workers=False,
+        add_github_throttle=True,
+        dry_run_help="Skip the agent call and the GitHub posting step.",
+        verbose_help="DEBUG-level logging.",
     )
     parser.add_argument(
         "--pr-numbers",
@@ -257,15 +258,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=[],
         help="Audit only these PR numbers (default: all open).",
     )
-    add_agent_argument(parser)
     parser.add_argument("--codex", action="store_true", help="Deprecated alias for --agent codex.")
-    parser.add_argument(
-        "--dry-run", action="store_true", help="Skip the agent call and the GitHub posting step."
-    )
-    parser.add_argument("-v", "--verbose", action="store_true", help="DEBUG-level logging.")
-    add_github_throttle_args(parser)
-    add_json_arg(parser)
-    add_version_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -21,16 +21,12 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    add_agent_argument,
     direct_agent_model,
     resolve_agent,
     run_agent_session,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
-    add_dry_run_arg,
-    add_github_throttle_args,
-    add_json_arg,
     configure_github_throttle_from_args,
     emit_json_status,
 )
@@ -38,7 +34,7 @@ from hephaestus.utils.file_lock import file_lock
 
 from ._review_utils import (
     _discover_prs_simple,
-    add_max_workers_arg,
+    build_automation_parser,
     find_pr_for_issue,
     load_impl_session_id,
     parse_json_block,
@@ -2270,7 +2266,7 @@ def _setup_logging(verbose: bool = False) -> None:
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser for the CI-driver CLI."""
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         description="Drive PRs to green CI: fix failures and enable auto-merge",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -2296,6 +2292,12 @@ Examples:
   # Drive every open PR, including teammates' and bots' (default is @me only)
   %(prog)s --all
         """,
+        add_github_throttle=True,
+        dry_run_prefix=(
+            "Suppress GitHub writes and git pushes (no comments, no merges, no pushes)."
+        ),
+        add_no_ui=True,
+        add_version=False,
     )
 
     parser.add_argument(
@@ -2322,27 +2324,10 @@ Examples:
             "--issues; duplicate PRs are deduped."
         ),
     )
-    add_agent_argument(parser)
-    add_max_workers_arg(parser)
-    add_dry_run_arg(
-        parser,
-        prefix="Suppress GitHub writes and git pushes (no comments, no merges, no pushes).",
-    )
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
     parser.add_argument(
         "--no-advise",
         action="store_true",
         help="Skip the advise step before CI fixing",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
     )
     parser.add_argument(
         "--no-include-bot-prs",
@@ -2393,8 +2378,6 @@ Examples:
             "here so a PR that will not go green is abandoned after N tries."
         ),
     )
-    add_github_throttle_args(parser)
-    add_json_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -33,15 +33,10 @@ import logging
 import subprocess
 import sys
 
-from hephaestus.cli.utils import (
-    add_github_throttle_args,
-    add_json_arg,
-    add_version_arg,
-    configure_github_throttle_from_args,
-    emit_json_status,
-)
+from hephaestus.cli.utils import configure_github_throttle_from_args, emit_json_status
 from hephaestus.github.client import gh_call
 
+from ._review_utils import build_automation_parser
 from .state_labels import STATE_LABEL_SPECS
 
 logger = logging.getLogger(__name__)
@@ -154,12 +149,17 @@ def _detect_current_repo_slug() -> str:
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         prog="hephaestus-ensure-state-labels",
         description=(
             "Idempotently provision automation state:* labels "
             "(plan-state, implementation-review, and skip) on one or more repos."
         ),
+        add_agent=False,
+        add_max_workers=False,
+        add_github_throttle=True,
+        dry_run_help="Print what would happen; mutate nothing.",
+        verbose_help="Enable DEBUG logging.",
     )
     target = parser.add_mutually_exclusive_group()
     target.add_argument(
@@ -172,20 +172,6 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="ORG",
         help="Apply to every non-archived, non-fork repo in the org.",
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Print what would happen; mutate nothing.",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable DEBUG logging.",
-    )
-    add_github_throttle_args(parser)
-    add_json_arg(parser)
-    add_version_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/implementer_cli.py
+++ b/hephaestus/automation/implementer_cli.py
@@ -21,14 +21,7 @@ import argparse
 import logging
 from pathlib import Path
 
-from hephaestus.agents.runtime import add_agent_argument
-from hephaestus.automation._review_utils import add_max_workers_arg
-from hephaestus.cli.utils import (
-    add_dry_run_arg,
-    add_github_throttle_args,
-    add_json_arg,
-    add_version_arg,
-)
+from hephaestus.automation._review_utils import build_automation_parser
 
 
 def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
@@ -54,7 +47,7 @@ def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser for the implementer CLI."""
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         description="Bulk implement GitHub issues using Claude Code or Codex",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -80,6 +73,9 @@ Examples:
   # Dry run
   %(prog)s --issues 595 --dry-run
         """,
+        add_github_throttle=True,
+        dry_run_prefix="Suppress GitHub mutations and git pushes (no PR creation, no commits).",
+        add_no_ui=True,
     )
 
     parser.add_argument(
@@ -93,7 +89,6 @@ Examples:
         nargs="+",
         help="Specific issue numbers to implement (alternative to --epic)",
     )
-    add_agent_argument(parser)
     parser.add_argument(
         "--analyze",
         action="store_true",
@@ -109,7 +104,6 @@ Examples:
         action="store_true",
         help="Resume previous implementation from saved state",
     )
-    add_max_workers_arg(parser)
     parser.add_argument(
         "--no-skip-closed",
         action="store_true",
@@ -119,10 +113,6 @@ Examples:
         "--no-auto-merge",
         action="store_true",
         help="Don't enable auto-merge after implementation-review GO",
-    )
-    add_dry_run_arg(
-        parser,
-        prefix="Suppress GitHub mutations and git pushes (no PR creation, no commits).",
     )
     parser.add_argument(
         "--no-learn",
@@ -144,20 +134,6 @@ Examples:
         action="store_true",
         help="Let the reviewer emit nitpick-severity comments (suppressed by default)",
     )
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
-    )
-    add_github_throttle_args(parser)
-    add_json_arg(parser)
-    add_version_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -50,8 +50,8 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from hephaestus.agents.runtime import add_agent_argument, resolve_agent
-from hephaestus.automation._review_utils import add_max_workers_arg, find_pr_for_issue
+from hephaestus.agents.runtime import resolve_agent
+from hephaestus.automation._review_utils import build_automation_parser, find_pr_for_issue
 from hephaestus.automation.github_api import (
     gh_issue_add_labels,
     is_issue_closed,
@@ -74,10 +74,6 @@ from hephaestus.automation.loop_repo_manager import (
 from hephaestus.automation.pr_manager import pr_is_genuinely_stuck
 from hephaestus.automation.state_labels import STATE_SKIP
 from hephaestus.cli.utils import (
-    add_dry_run_arg,
-    add_github_throttle_args,
-    add_json_arg,
-    add_version_arg,
     configure_github_throttle_from_args,
     emit_json_status,
 )
@@ -435,22 +431,22 @@ def _read_work_report(path: str) -> int | None:
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser for the loop runner."""
-    p = argparse.ArgumentParser(
+    p = build_automation_parser(
         prog="hephaestus-automation-loop",
         description=(
             "Run the 2-stage loop body and post-loop terminal stages across "
             "HomericIntelligence repos."
         ),
-    )
-    add_dry_run_arg(
-        p,
-        prefix="Forward --dry-run to every phase (suppresses GitHub mutations and git pushes).",
+        max_workers_help=(
+            "Parallel workers per repo per phase (1-32, default: 3). Passes to child phases."
+        ),
+        add_github_throttle=True,
+        dry_run_prefix=(
+            "Forward --dry-run to every phase (suppresses GitHub mutations and git pushes)."
+        ),
+        verbose_help="Enable DEBUG logging",
     )
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
-    add_max_workers_arg(
-        p,
-        help_text="Parallel workers per repo per phase (1-32, default: 3). Passes to child phases.",
-    )
     p.add_argument(
         "--max-merge-attempts",
         type=int,
@@ -477,7 +473,6 @@ def _build_parser() -> argparse.ArgumentParser:
             "when selected and also does one final repo-level catch-up sweep)."
         ),
     )
-    add_agent_argument(p)
     p.add_argument(
         "--issues",
         type=_parse_issue_list,
@@ -574,10 +569,6 @@ def _build_parser() -> argparse.ArgumentParser:
             "enumeration. Space-separated input is NOT accepted."
         ),
     )
-    add_github_throttle_args(p)
-    p.add_argument("-v", "--verbose", action="store_true", help="Enable DEBUG logging")
-    add_json_arg(p)
-    add_version_arg(p)
     return p
 
 

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -20,14 +20,13 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    add_agent_argument,
     direct_agent_model,
     resolve_agent,
     run_agent_text,
     uses_direct_agent_runner,
 )
-from hephaestus.automation._review_utils import add_max_workers_arg, print_worker_summary
-from hephaestus.cli.utils import add_dry_run_arg, add_json_arg, emit_json_status
+from hephaestus.automation._review_utils import build_automation_parser, print_worker_summary
+from hephaestus.cli.utils import emit_json_status
 from hephaestus.github.rate_limit import wait_until
 
 from .claude_invoke import invoke_claude_with_session, parse_review_verdict, scan_quota_reset
@@ -614,7 +613,7 @@ def _setup_logging(verbose: bool = False) -> None:
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build the argparse parser for plan_reviewer CLI."""
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         description="Review implementation plans posted to GitHub issues using Claude",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -631,6 +630,10 @@ Examples:
   # Verbose output
   %(prog)s --issues 123 -v
         """,
+        add_github_throttle=False,
+        dry_run_prefix="Suppress GitHub mutations (no review comments posted).",
+        add_no_ui=True,
+        add_version=False,
     )
 
     parser.add_argument(
@@ -640,24 +643,6 @@ Examples:
         required=True,
         help="Issue numbers whose plans should be reviewed",
     )
-    add_agent_argument(parser)
-    add_max_workers_arg(parser)
-    add_dry_run_arg(
-        parser,
-        prefix="Suppress GitHub mutations (no review comments posted).",
-    )
-    parser.add_argument(
-        "--no-ui",
-        action="store_true",
-        help="Disable curses UI (use plain logging instead)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
-    )
-    add_json_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -17,21 +17,17 @@ from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import (
-    add_agent_argument,
     direct_agent_model,
     resolve_agent,
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
-    add_dry_run_arg,
-    add_github_throttle_args,
-    add_json_arg,
-    add_version_arg,
     configure_github_throttle_from_args,
     emit_json_status,
 )
 
 from ._review_utils import (
+    build_automation_parser,
     close_issue_as_covered,
     find_merged_closing_pr,
     find_pr_for_issue,
@@ -569,7 +565,7 @@ def _build_parser() -> argparse.ArgumentParser:
     """
     from pathlib import Path
 
-    parser = argparse.ArgumentParser(
+    parser = build_automation_parser(
         description="Bulk plan GitHub issues using Claude Code or Codex",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
@@ -592,6 +588,11 @@ Examples:
   # Plan with more parallelism
   %(prog)s --issues 123 456 789 --parallel 5
         """,
+        add_max_workers=False,
+        add_parallel=True,
+        parallel_help="Number of parallel workers, 1-32 (default: 3)",
+        add_github_throttle=True,
+        dry_run_prefix="Suppress GitHub mutations and agent calls (no issue comments posted).",
     )
 
     parser.add_argument(
@@ -600,23 +601,10 @@ Examples:
         nargs="+",
         help="Issue numbers to plan (default: all open issues)",
     )
-    add_agent_argument(parser)
-    add_dry_run_arg(
-        parser,
-        prefix="Suppress GitHub mutations and agent calls (no issue comments posted).",
-    )
     parser.add_argument(
         "--force",
         action="store_true",
         help="Force re-planning even if plan already exists",
-    )
-    parser.add_argument(
-        "--parallel",
-        type=int,
-        default=3,
-        choices=range(1, 33),
-        metavar="N",
-        help="Number of parallel workers, 1-32 (default: 3)",
     )
     parser.add_argument(
         "--system-prompt",
@@ -633,15 +621,6 @@ Examples:
         action="store_true",
         help="Skip the advise step (don't search team knowledge base before planning)",
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Enable verbose logging",
-    )
-    add_github_throttle_args(parser)
-    add_json_arg(parser)
-    add_version_arg(parser)
     return parser
 
 

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -34,7 +34,6 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
-    add_json_arg,
     add_version_arg,
     configure_github_throttle_from_args,
     emit_json_status,
@@ -882,7 +881,6 @@ Examples:
         issues_help="Issue numbers whose linked PRs should be reviewed",
         dry_run_help="Show what would be done without actually posting any review comments.",
     )
-    add_json_arg(parser)
     add_version_arg(parser)
     return parser
 

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -879,7 +879,7 @@ Examples:
   %(prog)s --issues 595 596 --max-workers 5
         """,
         issues_help="Issue numbers whose linked PRs should be reviewed",
-        dry_run_help="Show what would be done without actually posting any review comments.",
+        dry_run_prefix="Show what would be done without actually posting any review comments.",
     )
     add_version_arg(parser)
     return parser

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -1,0 +1,717 @@
+"""Characterization tests for automation CLI parser option surfaces."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from hephaestus.automation import (
+    address_review,
+    audit_reviewer,
+    ci_driver,
+    ensure_state_labels,
+    implementer_cli,
+    loop_runner,
+    plan_reviewer,
+    planner,
+    pr_reviewer,
+)
+from hephaestus.automation._review_utils import build_automation_parser
+from hephaestus.cli.utils import DRY_RUN_HELP_CAVEAT
+
+AGENT_CHOICES = ("claude", "codex", "pi")
+WORKER_CHOICES = tuple(range(1, 33))
+SUPPRESS_DEFAULT = "==SUPPRESS=="
+
+AGENT_HELP = (
+    "Agent backend to invoke for model-driven steps "
+    "(default: auto-detect authenticated backend, preferring claude when authenticated)"
+)
+JSON_HELP = "Emit machine-readable JSON output instead of human-readable text"
+NO_UI_HELP = "Disable curses UI (use plain logging instead)"
+THROTTLE_RATE_HELP = (
+    "Global gh token-bucket refill rate in calls/sec (default: 10.0). "
+    "Pass 0 to disable the global throttle."
+)
+THROTTLE_BURST_HELP = "Global gh token-bucket burst size (default: 30.0)."
+VERSION_HELP = "show program's version number and exit"
+
+
+@dataclass(frozen=True)
+class ActionSpec:
+    """Stable subset of argparse action configuration relevant to CLI parity."""
+
+    option_strings: tuple[str, ...]
+    dest: str
+    action: str
+    default: Any
+    required: bool
+    nargs: Any
+    choices: tuple[Any, ...] | None
+    help: str | None
+
+
+def _action_spec(
+    option_strings: tuple[str, ...],
+    dest: str,
+    action: str,
+    default: Any,
+    required: bool = False,
+    nargs: Any = None,
+    choices: tuple[Any, ...] | None = None,
+    help_text: str | None = None,
+) -> ActionSpec:
+    """Build an expected argparse action spec with readable call sites."""
+    return ActionSpec(
+        option_strings=option_strings,
+        dest=dest,
+        action=action,
+        default=default,
+        required=required,
+        nargs=nargs,
+        choices=choices,
+        help=help_text,
+    )
+
+
+def _dry_help(prefix: str) -> str:
+    """Return the exact canonical dry-run help produced by add_dry_run_arg."""
+    return f"{prefix} {DRY_RUN_HELP_CAVEAT}"
+
+
+def _agent_spec() -> ActionSpec:
+    """Return the common --agent action spec."""
+    return _action_spec(
+        ("--agent",),
+        "agent",
+        "_StoreAction",
+        None,
+        choices=AGENT_CHOICES,
+        help_text=AGENT_HELP,
+    )
+
+
+def _max_workers_spec(help_text: str) -> ActionSpec:
+    """Return the common --max-workers action spec."""
+    return _action_spec(
+        ("--max-workers",),
+        "max_workers",
+        "_StoreAction",
+        3,
+        choices=WORKER_CHOICES,
+        help_text=help_text,
+    )
+
+
+def _dry_run_spec(help_text: str) -> ActionSpec:
+    """Return a --dry-run action spec."""
+    return _action_spec(
+        ("--dry-run",),
+        "dry_run",
+        "_StoreTrueAction",
+        False,
+        nargs=0,
+        help_text=help_text,
+    )
+
+
+def _verbose_spec(help_text: str) -> ActionSpec:
+    """Return a -v/--verbose action spec."""
+    return _action_spec(
+        ("-v", "--verbose"),
+        "verbose",
+        "_StoreTrueAction",
+        False,
+        nargs=0,
+        help_text=help_text,
+    )
+
+
+def _no_ui_spec() -> ActionSpec:
+    """Return the common --no-ui action spec."""
+    return _action_spec(
+        ("--no-ui",),
+        "no_ui",
+        "_StoreTrueAction",
+        False,
+        nargs=0,
+        help_text=NO_UI_HELP,
+    )
+
+
+def _github_throttle_specs() -> tuple[ActionSpec, ActionSpec]:
+    """Return the GitHub global-throttle action specs."""
+    return (
+        _action_spec(
+            ("--gh-global-rate",),
+            "gh_global_rate",
+            "_StoreAction",
+            10.0,
+            help_text=THROTTLE_RATE_HELP,
+        ),
+        _action_spec(
+            ("--gh-global-burst",),
+            "gh_global_burst",
+            "_StoreAction",
+            30.0,
+            help_text=THROTTLE_BURST_HELP,
+        ),
+    )
+
+
+def _json_spec() -> ActionSpec:
+    """Return the common --json action spec."""
+    return _action_spec(
+        ("--json",),
+        "json",
+        "_StoreTrueAction",
+        False,
+        nargs=0,
+        help_text=JSON_HELP,
+    )
+
+
+def _version_spec() -> ActionSpec:
+    """Return the common -V/--version action spec."""
+    return _action_spec(
+        ("-V", "--version"),
+        "version",
+        "_VersionAction",
+        SUPPRESS_DEFAULT,
+        nargs=0,
+        help_text=VERSION_HELP,
+    )
+
+
+def _store_true(option: str, dest: str, help_text: str) -> ActionSpec:
+    """Return a single-option store_true spec."""
+    return _action_spec(
+        (option,),
+        dest,
+        "_StoreTrueAction",
+        False,
+        nargs=0,
+        help_text=help_text,
+    )
+
+
+def _specs(parser: argparse.ArgumentParser) -> tuple[ActionSpec, ...]:
+    """Return comparable action specs for a parser, excluding argparse help."""
+    return tuple(
+        ActionSpec(
+            option_strings=tuple(action.option_strings),
+            dest=action.dest,
+            action=type(action).__name__,
+            default=SUPPRESS_DEFAULT if action.default is argparse.SUPPRESS else action.default,
+            required=getattr(action, "required", False),
+            nargs=action.nargs,
+            choices=tuple(action.choices) if action.choices is not None else None,
+            help=action.help,
+        )
+        for action in parser._actions
+        if action.option_strings != ["-h", "--help"]
+    )
+
+
+def _sorted_specs(specs: tuple[ActionSpec, ...]) -> list[ActionSpec]:
+    """Sort specs so tests assert parser surface without pinning help order."""
+    return sorted(specs, key=lambda spec: spec.option_strings)
+
+
+COMMON_REVIEW_MAX_WORKERS = "Maximum number of parallel workers, 1-32 (default: 3)"
+
+EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
+    "planner": (
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            None,
+            nargs="+",
+            help_text="Issue numbers to plan (default: all open issues)",
+        ),
+        _agent_spec(),
+        _dry_run_spec(
+            _dry_help("Suppress GitHub mutations and agent calls (no issue comments posted).")
+        ),
+        _store_true("--force", "force", "Force re-planning even if plan already exists"),
+        _action_spec(
+            ("--parallel",),
+            "parallel",
+            "_StoreAction",
+            3,
+            choices=WORKER_CHOICES,
+            help_text="Number of parallel workers, 1-32 (default: 3)",
+        ),
+        _action_spec(
+            ("--system-prompt",),
+            "system_prompt",
+            "_StoreAction",
+            None,
+            help_text="Path to system prompt file for Claude Code",
+        ),
+        _store_true(
+            "--no-skip-closed",
+            "no_skip_closed",
+            "Plan closed issues (default: skip closed issues)",
+        ),
+        _store_true(
+            "--no-advise",
+            "no_advise",
+            "Skip the advise step (don't search team knowledge base before planning)",
+        ),
+        _verbose_spec("Enable verbose logging"),
+        *_github_throttle_specs(),
+        _json_spec(),
+        _version_spec(),
+    ),
+    "plan_reviewer": (
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            None,
+            required=True,
+            nargs="+",
+            help_text="Issue numbers whose plans should be reviewed",
+        ),
+        _agent_spec(),
+        _max_workers_spec(COMMON_REVIEW_MAX_WORKERS),
+        _dry_run_spec(_dry_help("Suppress GitHub mutations (no review comments posted).")),
+        _no_ui_spec(),
+        _verbose_spec("Enable verbose logging"),
+        _json_spec(),
+    ),
+    "pr_reviewer": (
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            None,
+            required=True,
+            nargs="+",
+            help_text="Issue numbers whose linked PRs should be reviewed",
+        ),
+        _agent_spec(),
+        _max_workers_spec(COMMON_REVIEW_MAX_WORKERS),
+        *_github_throttle_specs(),
+        _dry_run_spec(
+            _dry_help("Show what would be done without actually posting any review comments.")
+        ),
+        _no_ui_spec(),
+        _verbose_spec("Enable verbose logging"),
+        _json_spec(),
+        _version_spec(),
+    ),
+    "address_review": (
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            None,
+            required=True,
+            nargs="+",
+            help_text="Issue numbers whose linked PRs should have review threads addressed",
+        ),
+        _agent_spec(),
+        _max_workers_spec(COMMON_REVIEW_MAX_WORKERS),
+        *_github_throttle_specs(),
+        _dry_run_spec(
+            _dry_help("Show what would be done without actually resolving threads or pushing code.")
+        ),
+        _no_ui_spec(),
+        _verbose_spec("Enable verbose logging"),
+        _json_spec(),
+    ),
+    "ci_driver": (
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            [],
+            nargs="+",
+            help_text=(
+                "Scope to these issue numbers' PRs. Requires at least one issue number when given. "
+                "Omit the flag entirely to drive every failing open PR discovered via gh "
+                "(issue-linked PRs plus bot-authored PRs)."
+            ),
+        ),
+        _action_spec(
+            ("--prs",),
+            "prs",
+            "_StoreAction",
+            [],
+            nargs="*",
+            help_text=(
+                "PR numbers to drive directly, bypassing issue-to-PR discovery (#918). "
+                "Use when the PR body uses 'Refs #N' or the PR is otherwise not reachable "
+                "via the strict Closes-link lookup. May be combined with --issues; "
+                "duplicate PRs are deduped."
+            ),
+        ),
+        _agent_spec(),
+        _max_workers_spec(COMMON_REVIEW_MAX_WORKERS),
+        _dry_run_spec(
+            _dry_help("Suppress GitHub writes and git pushes (no comments, no merges, no pushes).")
+        ),
+        _no_ui_spec(),
+        _store_true("--no-advise", "no_advise", "Skip the advise step before CI fixing"),
+        _verbose_spec("Enable verbose logging"),
+        _action_spec(
+            ("--no-include-bot-prs",),
+            "include_bot_prs",
+            "_StoreFalseAction",
+            True,
+            nargs=0,
+            help_text=(
+                "Suppress the union of open bot-authored PRs (Dependabot, github-actions, "
+                "etc.) into the work set. By default the driver unions every open "
+                "is_bot=true PR with the issue-driven list so Dependabot PRs are not "
+                "architecturally invisible (#848). Pass this flag only when you explicitly "
+                "want issue-driven scope."
+            ),
+        ),
+        _store_true(
+            "--all",
+            "include_all_authors",
+            "Include PRs opened by other actors (teammates, bots). Without this flag, "
+            "only PRs authored by the authenticated viewer (`gh api user`) are driven "
+            "(#821). NOTE: when scoped to issues (--issues N), the resolved PR is processed "
+            "regardless of author — issue-scoped takes precedence.",
+        ),
+        _action_spec(
+            ("--no-mechanical-rebase",),
+            "enable_mechanical_rebase",
+            "_StoreFalseAction",
+            True,
+            nargs=0,
+            help_text=(
+                "Disable the mechanical git rebase that runs before the CI-fix agent. "
+                "By default a PR that is behind/conflicting with its base is rebased and "
+                "pushed with no agent spend; only PRs whose rebase hits real conflicts "
+                "fall through to the agent (#871). Pass this flag to require the agent "
+                "for all behind/conflicting PRs."
+            ),
+        ),
+        _action_spec(
+            ("--max-fix-iterations",),
+            "max_fix_iterations",
+            "_StoreAction",
+            1,
+            help_text=(
+                "Number of CI-fix attempts per failing PR before giving up (default: 1). "
+                "The issue-major loop passes its --max-merge-attempts here so a PR that "
+                "will not go green is abandoned after N tries."
+            ),
+        ),
+        *_github_throttle_specs(),
+        _json_spec(),
+    ),
+    "implementer_cli": (
+        _action_spec(
+            ("--epic",),
+            "epic",
+            "_StoreAction",
+            None,
+            help_text="Epic issue number containing sub-issues",
+        ),
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            None,
+            nargs="+",
+            help_text="Specific issue numbers to implement (alternative to --epic)",
+        ),
+        _agent_spec(),
+        _store_true("--analyze", "analyze", "Analyze dependencies without implementing"),
+        _store_true(
+            "--health-check",
+            "health_check",
+            "Run health check of dependencies and environment",
+        ),
+        _store_true("--resume", "resume", "Resume previous implementation from saved state"),
+        _max_workers_spec(COMMON_REVIEW_MAX_WORKERS),
+        _store_true(
+            "--no-skip-closed",
+            "no_skip_closed",
+            "Implement closed issues (default: skip closed issues)",
+        ),
+        _store_true(
+            "--no-auto-merge",
+            "no_auto_merge",
+            "Don't enable auto-merge after implementation-review GO",
+        ),
+        _dry_run_spec(
+            _dry_help("Suppress GitHub mutations and git pushes (no PR creation, no commits).")
+        ),
+        _store_true(
+            "--no-learn",
+            "no_learn",
+            "Disable /learn after implementation (enabled by default)",
+        ),
+        _store_true(
+            "--no-follow-up",
+            "no_follow_up",
+            "Disable automatic filing of follow-up issues (enabled by default)",
+        ),
+        _store_true("--no-advise", "no_advise", "Skip the advise step before implementation"),
+        _store_true(
+            "--nitpick",
+            "nitpick",
+            "Let the reviewer emit nitpick-severity comments (suppressed by default)",
+        ),
+        _no_ui_spec(),
+        _verbose_spec("Enable verbose logging"),
+        *_github_throttle_specs(),
+        _json_spec(),
+        _version_spec(),
+    ),
+    "loop_runner": (
+        _dry_run_spec(
+            _dry_help(
+                "Forward --dry-run to every phase (suppresses GitHub mutations and git pushes)."
+            )
+        ),
+        _action_spec(
+            ("--loops",),
+            "loops",
+            "_StoreAction",
+            5,
+            help_text="Number of loop iterations (default: 5)",
+        ),
+        _max_workers_spec(
+            "Parallel workers per repo per phase (1-32, default: 3). Passes to child phases."
+        ),
+        _action_spec(
+            ("--max-merge-attempts",),
+            "max_merge_attempts",
+            "_StoreAction",
+            1,
+            help_text=(
+                "Per-issue drive-green merge attempts before the issue is tagged "
+                "state:skip and the worker moves on (default: 1, matching the prior "
+                "drive-green retry budget)."
+            ),
+        ),
+        _action_spec(
+            ("--parallel-repos",),
+            "parallel_repos",
+            "_StoreAction",
+            1,
+            help_text="Repos processed in parallel per loop iteration (default: 1)",
+        ),
+        _action_spec(
+            ("--phases",),
+            "phases",
+            "_StoreAction",
+            "plan,implement,drive-green",
+            help_text=(
+                "Comma-separated subset of phases/stages to run. Valid: "
+                "plan,implement,drive-green (plan/implement are loop-body phases; "
+                "drive-green runs per issue when selected and also does one final "
+                "repo-level catch-up sweep)."
+            ),
+        ),
+        _agent_spec(),
+        _action_spec(
+            ("--issues",),
+            "issues",
+            "_StoreAction",
+            None,
+            help_text=(
+                "Comma-separated issue numbers to pass to issue-scoped phases "
+                "(plan, implement, drive-green). Default: phase auto-discovery."
+            ),
+        ),
+        _store_true(
+            "--no-advise",
+            "no_advise",
+            "Pass --no-advise to phases that support the advise preflight",
+        ),
+        _store_true(
+            "--nitpick",
+            "nitpick",
+            "Pass --nitpick to review phases (reviewer emits nitpick comments)",
+        ),
+        _store_true(
+            "--drive-green-all",
+            "drive_green_all",
+            "Pass --all to the drive-green phase: drive every open PR, including those "
+            "opened by teammates and bots. By default drive-green operates only on PRs "
+            "authored by the authenticated viewer (#821).",
+        ),
+        _store_true(
+            "--allow-unsafe-phase-order",
+            "allow_unsafe_phase_order",
+            "Silence dependency-ordering warnings when --phases skips a recommended predecessor",
+        ),
+        _action_spec(
+            ("--model",),
+            "model",
+            "_StoreAction",
+            "",
+            help_text=(
+                "Model ID applied to every phase (planner, reviewer, implementer, advise) "
+                "for child processes, so no HEPH_*_MODEL env vars are required. The /learn "
+                "step inherits its parent phase's model automatically. A per-phase flag below "
+                "overrides this for that phase."
+            ),
+        ),
+        _action_spec(
+            ("--planner-model",),
+            "planner_model",
+            "_StoreAction",
+            "",
+            help_text="HEPH_PLANNER_MODEL for child processes",
+        ),
+        _action_spec(
+            ("--reviewer-model",),
+            "reviewer_model",
+            "_StoreAction",
+            "",
+            help_text="HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review)",
+        ),
+        _action_spec(
+            ("--implementer-model",),
+            "implementer_model",
+            "_StoreAction",
+            "",
+            help_text=(
+                "HEPH_IMPLEMENTER_MODEL for child processes (implement, address-review, ci-driver)"
+            ),
+        ),
+        _action_spec(
+            ("--org",),
+            "org",
+            "_StoreAction",
+            None,
+            nargs="?",
+            help_text=(
+                "Enumerate non-fork, non-archived repos in a GitHub org. Pass `--org NAME` "
+                "for a specific org, or `--org` alone to auto-detect the org from the "
+                "current repo's git remote. Default (no flag): run only for the current repo."
+            ),
+        ),
+        _action_spec(
+            ("--projects-dir",),
+            "projects_dir",
+            "_StoreAction",
+            None,
+            help_text=(
+                "Local directory containing repo clones. When omitted, resolved from the "
+                "``PROJECTS_ROOT`` env var (if set and existing), otherwise the current "
+                "checkout parent when available, then "
+                "``/mnt/weka/home/micah.villmow/Projects``."
+            ),
+        ),
+        _action_spec(
+            ("--phase-timeout",),
+            "phase_timeout",
+            "_StoreAction",
+            7800.0,
+            help_text=(
+                "Per-phase timeout in seconds (default: HEPH_PHASE_TIMEOUT or 7800s). "
+                "Pass 0 or a negative value to disable."
+            ),
+        ),
+        _action_spec(
+            ("--repos",),
+            "repos",
+            "_StoreAction",
+            None,
+            help_text=(
+                "Comma-separated repo list (e.g. `--repos foo,bar`). Overrides org "
+                "enumeration. Space-separated input is NOT accepted."
+            ),
+        ),
+        *_github_throttle_specs(),
+        _verbose_spec("Enable DEBUG logging"),
+        _json_spec(),
+        _version_spec(),
+    ),
+    "audit_reviewer": (
+        _action_spec(
+            ("--pr-numbers",),
+            "pr_numbers",
+            "_StoreAction",
+            [],
+            nargs="+",
+            help_text="Audit only these PR numbers (default: all open).",
+        ),
+        _agent_spec(),
+        _store_true("--codex", "codex", "Deprecated alias for --agent codex."),
+        _dry_run_spec("Skip the agent call and the GitHub posting step."),
+        _verbose_spec("DEBUG-level logging."),
+        *_github_throttle_specs(),
+        _json_spec(),
+        _version_spec(),
+    ),
+    "ensure_state_labels": (
+        _action_spec(
+            ("--repo",),
+            "repo",
+            "_StoreAction",
+            None,
+            help_text="Single target repo (default: the current git checkout's origin).",
+        ),
+        _action_spec(
+            ("--org",),
+            "org",
+            "_StoreAction",
+            None,
+            help_text="Apply to every non-archived, non-fork repo in the org.",
+        ),
+        _dry_run_spec("Print what would happen; mutate nothing."),
+        _verbose_spec("Enable DEBUG logging."),
+        *_github_throttle_specs(),
+        _json_spec(),
+        _version_spec(),
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    ("name", "factory"),
+    [
+        ("planner", planner._build_parser),
+        ("plan_reviewer", plan_reviewer._build_parser),
+        ("pr_reviewer", pr_reviewer._build_parser),
+        ("address_review", address_review._build_parser),
+        ("ci_driver", ci_driver._build_parser),
+        ("implementer_cli", implementer_cli._build_parser),
+        ("loop_runner", loop_runner._build_parser),
+        ("audit_reviewer", audit_reviewer._build_parser),
+        ("ensure_state_labels", ensure_state_labels._build_parser),
+    ],
+)
+def test_parser_action_specs_are_preserved(
+    name: str,
+    factory: Callable[[], argparse.ArgumentParser],
+) -> None:
+    """Affected parsers keep their current action specs after common-helper extraction."""
+    assert _sorted_specs(_specs(factory())) == _sorted_specs(EXPECTED_SPECS[name])
+
+
+def test_build_automation_parser_does_not_add_throttle_by_default() -> None:
+    """The shared helper does not expose GitHub throttle flags unless opted in."""
+    flags = {
+        flag for spec in _specs(build_automation_parser("demo")) for flag in spec.option_strings
+    }
+
+    assert "--gh-global-rate" not in flags
+    assert "--gh-global-burst" not in flags
+
+
+def test_plan_reviewer_still_has_no_throttle_or_version_flags() -> None:
+    """Plan review keeps its historical absence of throttle and version flags."""
+    flags = {flag for spec in _specs(plan_reviewer._build_parser()) for flag in spec.option_strings}
+
+    assert "--gh-global-rate" not in flags
+    assert "--gh-global-burst" not in flags
+    assert "--version" not in flags
+    assert "-V" not in flags

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -22,6 +22,7 @@ from hephaestus.automation import (
 )
 from hephaestus.automation._review_utils import build_automation_parser
 from hephaestus.cli.utils import DRY_RUN_HELP_CAVEAT
+from hephaestus.config.paths import DEFAULT_PROJECTS_DIR
 
 AGENT_CHOICES = ("claude", "codex", "pi")
 WORKER_CHOICES = tuple(range(1, 33))
@@ -606,7 +607,7 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
                 "Local directory containing repo clones. When omitted, resolved from the "
                 "``PROJECTS_ROOT`` env var (if set and existing), otherwise the current "
                 "checkout parent when available, then "
-                "``/mnt/weka/home/micah.villmow/Projects``."
+                f"``{DEFAULT_PROJECTS_DIR}``."
             ),
         ),
         _action_spec(


### PR DESCRIPTION
## Summary
Centralize automation CLI parser construction so stage parsers share common argument wiring and keep only stage-specific options locally.

## Changes
- Add shared automation parser helpers in _review_utils for common agent, parallelism, dry-run, JSON, version, and verbose options
- Refactor planner, reviewer, implementer, CI driver, loop runner, and state-label CLIs to use the shared parser setup
- Add parser regression coverage for the refactored automation CLI argument behavior

## Testing
- Added unit coverage in tests/unit/automation/test_automation_parsers.py

## Closes
Closes #1392

Generated by Codex via ProjectHephaestus automation.
