### PR TITLE
refactor(automation): centralize state directory initialization

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -4,6 +4,8 @@ Extracts utilities that were previously duplicated across
 ``pr_reviewer.py`` and ``address_review.py``.
 
 Provides:
+- ``DEFAULT_STATE_DIR`` / ``ensure_state_dir``: Canonical automation state
+  directory path and creation helper.
 - ``parse_json_block``: Extract the last ```json``` block from Claude output.
 - ``find_pr_for_issue``: Locate the open PR for a GitHub issue (two or three
   lookup strategies depending on the caller's needs).
@@ -22,6 +24,7 @@ import json
 import logging
 import re
 import threading
+from pathlib import Path
 from typing import Any
 
 from hephaestus.agents.runtime import add_agent_argument
@@ -30,6 +33,24 @@ from hephaestus.cli.utils import add_dry_run_arg, add_github_throttle_args
 from .github_api import _gh_call
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_STATE_DIR = "build/.issue_implementer"
+
+
+def ensure_state_dir(repo_root: Path, subdir: str = DEFAULT_STATE_DIR) -> Path:
+    """Return the repo-local automation state directory, creating it if needed.
+
+    Args:
+        repo_root: Repository root path.
+        subdir: Repo-relative state directory path.
+
+    Returns:
+        The created state directory path.
+
+    """
+    state_dir = repo_root / subdir
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir
 
 
 def setup_review_logging(verbose: bool = False) -> None:

--- a/hephaestus/automation/_reviewer_base.py
+++ b/hephaestus/automation/_reviewer_base.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ._review_utils import instance_log
+from ._review_utils import ensure_state_dir, instance_log
 from .curses_ui import CursesUI, ThreadLogManager
 from .git_utils import get_repo_root as _default_get_repo_root, issue_ref
 from .github_api import write_secure
@@ -78,8 +78,7 @@ class BaseReviewer(ABC):
         """
         self.options = options
         self.repo_root: Path = Path(get_repo_root())
-        self.state_dir: Path = self.repo_root / "build" / ".issue_implementer"
-        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.state_dir: Path = ensure_state_dir(self.repo_root)
 
         self.worktree_manager: WorktreeManager = worktree_manager_factory()
         self.status_tracker: StatusTracker = status_tracker_factory(options.max_workers)

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -35,6 +35,7 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 
+from ._review_utils import ensure_state_dir
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
@@ -206,7 +207,7 @@ class AuditReviewer:
     def __post_init__(self) -> None:
         """Set default state_dir if not provided."""
         if self.state_dir is None:
-            self.state_dir = get_repo_root() / "build" / ".issue_implementer"
+            self.state_dir = ensure_state_dir(get_repo_root())
 
     def run(self) -> tuple[int, list[dict[str, Any]]]:
         """Run the coordinator audit and post a summary review per PR."""

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -38,7 +38,7 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.utils.file_lock import file_lock
 
-from ._review_utils import add_max_workers_arg, find_pr_for_issue
+from ._review_utils import add_max_workers_arg, ensure_state_dir, find_pr_for_issue
 from .address_review import (
     _parse_addressed_block,
     resolve_addressed_threads,
@@ -138,8 +138,7 @@ class CIDriver:
         """
         self.options = options
         self.repo_root = get_repo_root()
-        self.state_dir = self.repo_root / "build" / ".issue_implementer"
-        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.state_dir = ensure_state_dir(self.repo_root)
         self._arming_store = ArmingStateStore(lambda: self.state_dir)
 
         self.worktree_manager = WorktreeManager()

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -67,6 +67,8 @@ from hephaestus.agents.runtime import (
     agent_display_name,
 )
 
+from ._review_utils import ensure_state_dir
+
 # Imports for the Test-Patch Contract — see module docstring for the full table.
 # Each symbol here is either a real call site in IssueImplementer/main or an
 # explicit re-export required by tests or the public API.
@@ -150,8 +152,7 @@ class IssueImplementer:
         """
         self.options = options
         self.repo_root = get_repo_root()
-        self.state_dir = self.repo_root / "build" / ".issue_implementer"
-        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.state_dir = ensure_state_dir(self.repo_root)
 
         self.resolver = DependencyResolver(skip_closed=options.skip_closed)
         self.worktree_manager = WorktreeManager()
@@ -833,7 +834,7 @@ def main() -> int:
     configure_github_throttle_from_args(args)
     agent = resolve_agent(args.agent)
 
-    state_dir = get_repo_root() / "build" / ".issue_implementer"
+    state_dir = ensure_state_dir(get_repo_root())
     _setup_logging(args.verbose, log_dir=state_dir)
 
     log = logging.getLogger(__name__)

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
+from ._review_utils import ensure_state_dir
 from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
 from .claude_timeouts import learn_claude_timeout, planner_claude_timeout
@@ -620,9 +621,7 @@ class PlanReviewLoop:
             return ""
 
     def _planner_learn_state_dir(self) -> Path:
-        state_dir = get_repo_root() / "build" / ".issue_implementer"
-        state_dir.mkdir(parents=True, exist_ok=True)
-        return state_dir
+        return ensure_state_dir(get_repo_root())
 
     def _write_planner_learn_record(
         self,

--- a/tests/integration/test_audit_reviewer_integration.py
+++ b/tests/integration/test_audit_reviewer_integration.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.audit_reviewer import (
     AuditReviewer,
     _parse_coordinator_results,
@@ -119,13 +120,18 @@ Overall, we have 2 PRs ready to review."""
         assert any("#100" in line and "GO" in line for line in lines)
         assert any("#101" in line and "NOGO" in line for line in lines)
 
-    def test_auditreviewer_construction_default(self) -> None:
+    def test_auditreviewer_construction_default(self, tmp_path: Path) -> None:
         """Verify AuditReviewer initializes with sensible defaults."""
-        reviewer = AuditReviewer()
+        with mock.patch(
+            "hephaestus.automation.audit_reviewer.get_repo_root",
+            return_value=tmp_path,
+        ):
+            reviewer = AuditReviewer()
         assert reviewer.agent == "claude"
         assert reviewer.pr_numbers == []
         assert reviewer.dry_run is False
-        assert reviewer.state_dir is not None
+        assert reviewer.state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert reviewer.state_dir.is_dir()
 
     def test_auditreviewer_construction_codex(self) -> None:
         """Verify AuditReviewer accepts codex agent."""

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.audit_reviewer import (
     AuditReviewer,
     _build_coordinator_prompt,
@@ -409,8 +410,14 @@ class TestAuditReviewerRun:
         assert mock_post.call_args[1]["dry_run"] is True
 
     def test_state_dir_default_under_build(self, tmp_path: Path) -> None:
-        reviewer = AuditReviewer()
-        assert "build" in str(reviewer.state_dir)
+        with mock.patch(
+            "hephaestus.automation.audit_reviewer.get_repo_root",
+            return_value=tmp_path,
+        ):
+            reviewer = AuditReviewer()
+
+        assert reviewer.state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert reviewer.state_dir.is_dir()
 
 
 class TestParser:

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -11,6 +11,7 @@ import pytest
 
 from hephaestus.agents.runtime import AgentRunResult
 from hephaestus.automation import ci_driver
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.ci_driver import CIDriver, _evaluate_run_result
 from hephaestus.automation.models import CIDriverOptions, WorkerResult
 
@@ -81,6 +82,21 @@ def driver(mock_options: CIDriverOptions, tmp_path: Path) -> CIDriver:
         d = CIDriver(mock_options)
         d.state_dir = tmp_path
         return d
+
+
+def test_default_state_dir_uses_canonical_path(
+    mock_options: CIDriverOptions, tmp_path: Path
+) -> None:
+    """CIDriver creates the shared default automation state directory."""
+    with (
+        patch("hephaestus.automation.ci_driver.get_repo_root", return_value=tmp_path),
+        patch("hephaestus.automation.ci_driver.WorktreeManager"),
+        patch("hephaestus.automation.ci_driver.StatusTracker"),
+    ):
+        d = CIDriver(mock_options)
+
+    assert d.state_dir == tmp_path / DEFAULT_STATE_DIR
+    assert d.state_dir.is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation import implementer
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.implementer import (
     _CLAUDE_IMPL_TIMEOUT,
     IssueImplementer,
@@ -92,6 +93,12 @@ def dry_run_implementer(tmp_path: Path) -> IssueImplementer:
     )
     with patch("hephaestus.automation.implementer.get_repo_root", return_value=tmp_path):
         return IssueImplementer(options)
+
+
+def test_default_state_dir_uses_canonical_path(dry_run_implementer: IssueImplementer) -> None:
+    """IssueImplementer creates the shared default automation state directory."""
+    assert dry_run_implementer.state_dir == dry_run_implementer.repo_root / DEFAULT_STATE_DIR
+    assert dry_run_implementer.state_dir.is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -24,6 +24,8 @@ from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
+
 
 def test_main_returns_zero_when_no_open_issues(
     monkeypatch: pytest.MonkeyPatch,
@@ -91,3 +93,24 @@ def test_no_ui_flag_skips_curses(
 
     assert rc == 0
     mock_curses.assert_not_called()
+
+
+def test_main_configures_logging_under_default_state_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``main`` passes the canonical state directory to logging setup."""
+    from hephaestus.automation import implementer
+
+    monkeypatch.setattr(sys, "argv", ["impl", "--dry-run", "--no-ui", "--agent", "claude"])
+
+    with (
+        patch.object(implementer, "gh_list_open_issues", return_value=[]),
+        patch.object(implementer, "get_repo_root", return_value=tmp_path),
+        patch.object(implementer, "_setup_logging") as mock_setup_logging,
+    ):
+        rc = implementer.main()
+
+    assert rc == 0
+    mock_setup_logging.assert_called_once()
+    assert mock_setup_logging.call_args.kwargs["log_dir"] == tmp_path / DEFAULT_STATE_DIR

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.models import PLAN_COMMENT_MARKER, PlannerOptions
 from hephaestus.automation.planner import MAX_REVIEW_ITERATIONS, Planner
 from hephaestus.automation.review_state import PLAN_REVIEW_PREFIX, is_plan_review_go
@@ -679,7 +680,7 @@ class TestCapturePlannerLearnings:
         ):
             out = planner._capture_planner_learnings(123, "plan text")
 
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         record = json.loads((state_dir / "planner-learn-123.json").read_text())
         assert out == "- learning A\n"
         assert record["issue_number"] == 123
@@ -704,7 +705,7 @@ class TestCapturePlannerLearnings:
         ):
             out = planner._capture_planner_learnings(123, "plan text")
 
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         record = json.loads((state_dir / "planner-learn-123.json").read_text())
         assert out == ""
         assert record["issue_number"] == 123

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.claude_invoke import parse_review_verdict
 from hephaestus.automation.models import ReviewerOptions
 from hephaestus.automation.pr_reviewer import (
@@ -225,7 +226,7 @@ class TestIdempotencyGuard:
         from hephaestus.automation.models import ReviewPhase, ReviewState
 
         # Write a completed review state to disk
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         state_dir.mkdir(parents=True)
         completed_state = ReviewState(issue_number=123, pr_number=42, phase=ReviewPhase.COMPLETED)
         (state_dir / "review-123.json").write_text(completed_state.model_dump_json())
@@ -251,7 +252,7 @@ class TestIdempotencyGuard:
         self, mock_options: ReviewerOptions, tmp_path: Path
     ) -> None:
         """Malformed state file → warning logged, fresh state created."""
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         state_dir.mkdir(parents=True)
         (state_dir / "review-123.json").write_text("{not valid json!!!}")
 

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -2,19 +2,74 @@
 
 import argparse
 import json
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hephaestus.automation._review_utils import (
+    DEFAULT_STATE_DIR,
     add_max_workers_arg,
     close_issue_as_covered,
+    ensure_state_dir,
     find_merged_closing_pr,
     find_pr_for_issue,
     get_pr_head_branch,
     parse_json_block,
 )
+
+# ---------------------------------------------------------------------------
+# ensure_state_dir
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStateDir:
+    """Tests for the shared automation state directory helper."""
+
+    def test_default_state_dir_literal(self) -> None:
+        """Default state directory path remains the existing on-disk layout."""
+        assert DEFAULT_STATE_DIR == "build/.issue_implementer"
+
+    def test_creates_default_state_dir(self, tmp_path: Path) -> None:
+        """Default helper creates and returns the repo-local state directory."""
+        state_dir = ensure_state_dir(tmp_path)
+
+        assert state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert state_dir.is_dir()
+
+    def test_creates_custom_subdir(self, tmp_path: Path) -> None:
+        """A custom subdir keeps the helper reusable for alternate state roots."""
+        state_dir = ensure_state_dir(tmp_path, "custom/state")
+
+        assert state_dir == tmp_path / "custom/state"
+        assert state_dir.is_dir()
+
+
+def test_issue_implementer_state_dir_literal_is_centralized() -> None:
+    """Only the canonical helper and literal-pin test may spell issue_implementer."""
+    import ast
+
+    allowed = {
+        Path("hephaestus/automation/_review_utils.py"),
+        Path("tests/unit/automation/test_review_utils.py"),
+    }
+    hits: list[tuple[Path, int, str]] = []
+    for base in (Path("hephaestus/automation"), Path("tests/unit/automation")):
+        for path in base.rglob("*.py"):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and "issue_implementer" in node.value
+                ):
+                    hits.append((path, node.lineno, node.value))
+
+    bad = [hit for hit in hits if hit[0] not in allowed]
+    assert not bad
+    assert {path for path, _, _ in hits} == allowed
+
 
 # ---------------------------------------------------------------------------
 # parse_json_block

--- a/tests/unit/automation/test_reviewer_base_contract.py
+++ b/tests/unit/automation/test_reviewer_base_contract.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from hephaestus.automation import _reviewer_base
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 
 
 def _make_options(max_workers: int = 2) -> object:
@@ -36,6 +37,14 @@ def test_injection_wires_repo_root(tmp_path: Path) -> None:
     deps = _make_deps(tmp_path)
     r = ConcreteReviewer(_make_options(), **deps)
     assert r.repo_root == tmp_path
+
+
+def test_injection_wires_default_state_dir(tmp_path: Path) -> None:
+    """Constructor injection must create the canonical default state directory."""
+    deps = _make_deps(tmp_path)
+    r = ConcreteReviewer(_make_options(), **deps)
+    assert r.state_dir == tmp_path / DEFAULT_STATE_DIR
+    assert r.state_dir.is_dir()
 
 
 def test_injection_calls_factories(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Centralizes the automation state directory path and creation logic so reviewers, implementers, and CI drivers share one helper instead of repeating the build/.issue_implementer setup.

## Changes
- Added shared state directory initialization in automation review utilities with a centralized default path.
- Updated reviewer, implementer, CI driver, PR review, planner review, and address-review flows to use the shared helper.
- Expanded unit and integration coverage around state directory handling across affected automation components.

## Testing
- Not run; test execution was not provided.

## Closes
Closes #1394

Generated by Codex via ProjectHephaestus automation.
