### PR TITLE
refactor(automation): centralize issue log paths

### DIFF
--- a/hephaestus/automation/_implement_phase.py
+++ b/hephaestus/automation/_implement_phase.py
@@ -27,6 +27,7 @@ from hephaestus.agents.runtime import (
 )
 from hephaestus.github.rate_limit import wait_until
 
+from ._review_utils import log_file_path
 from ._stage_context import StageMixin
 from .advise_runner import run_advise
 from .claude_invoke import invoke_claude_with_session
@@ -190,7 +191,7 @@ class ImplementPhase(StageMixin):
                 # silently logging a useless session_id.
                 if isinstance(data, dict) and data.get("is_error"):
                     err_text = str(data.get("result") or "")
-                    log_file = self.state_dir / f"claude-{issue_number}.log"
+                    log_file = log_file_path(self.state_dir, "claude", issue_number)
                     log_file.write_text(result.stdout or "")
                     reset_epoch = _claude_quota_reset_epoch(err_text)
                     if reset_epoch is not None and reset_epoch > 0:
@@ -203,7 +204,7 @@ class ImplementPhase(StageMixin):
                 session_id = data.get("session_id")
 
                 # Save successful output to log file
-                log_file = self.state_dir / f"claude-{issue_number}.log"
+                log_file = log_file_path(self.state_dir, "claude", issue_number)
                 log_file.write_text(result.stdout or "")
 
                 return cast("str | None", session_id)
@@ -212,7 +213,7 @@ class ImplementPhase(StageMixin):
                 logger.debug("Claude stdout: %s", result.stdout[:500])
 
                 # Save output even if JSON parsing failed
-                log_file = self.state_dir / f"claude-{issue_number}.log"
+                log_file = log_file_path(self.state_dir, "claude", issue_number)
                 log_file.write_text(result.stdout or "")
 
                 return None
@@ -225,7 +226,7 @@ class ImplementPhase(StageMixin):
                 logger.error("Stderr: %s", e.stderr[:1000])
 
             # Save failure output to log file
-            log_file = self.state_dir / f"claude-{issue_number}.log"
+            log_file = log_file_path(self.state_dir, "claude", issue_number)
             stdout = e.stdout or ""
             stderr = e.stderr or ""
             output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
@@ -244,7 +245,7 @@ class ImplementPhase(StageMixin):
             raise RuntimeError(f"Claude Code failed: {e.stderr or e.stdout}") from e
         except subprocess.TimeoutExpired as e:
             # Save timeout info to log file
-            log_file = self.state_dir / f"claude-{issue_number}.log"
+            log_file = log_file_path(self.state_dir, "claude", issue_number)
             log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
 
             raise RuntimeError("Claude Code timed out") from e
@@ -262,7 +263,7 @@ class ImplementPhase(StageMixin):
     ) -> str | None:
         """Run a direct-runner implementation prompt in a worktree."""
         agent = self.options.agent
-        log_file = self.state_dir / f"{agent}-{issue_number}.log"
+        log_file = log_file_path(self.state_dir, agent, issue_number)
         try:
             result = run_agent_session(
                 agent=agent,

--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -34,6 +34,7 @@ from hephaestus.github.client import ClaudeUsageCapError, gh_call
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from . import review_state
+from ._review_utils import log_file_path
 from ._stage_context import StageMixin
 from .address_review import run_address_fix_session
 from .claude_invoke import (
@@ -1420,7 +1421,12 @@ class ReviewPhase(StageMixin):
             _, task_review_block = self.runner._fetch_plan_and_review(issue_number)
             diff_text = self.impl._collect_diff(worktree_path, branch_name)
 
-        log_file = self.state_dir / f"address-review-{issue_number}-r{iteration}.log"
+        log_file = log_file_path(
+            self.state_dir,
+            "address-review",
+            issue_number,
+            iteration=iteration,
+        )
         fix_result = run_address_fix_session(
             issue_number=issue_number,
             pr_number=pr_number,
@@ -1561,9 +1567,11 @@ class ReviewPhase(StageMixin):
                     timeout=implementer_claude_timeout(),
                     model=direct_agent_model(self.options.agent, "HEPH_IMPLEMENTER_MODEL"),
                 )
-                log_file = (
-                    self.state_dir
-                    / f"{self.options.agent}-feedback-{issue_number}-r{prev_iteration + 1}.log"
+                log_file = log_file_path(
+                    self.state_dir,
+                    f"{self.options.agent}-feedback",
+                    issue_number,
+                    iteration=prev_iteration + 1,
                 )
                 log_file.write_text(result.stdout or "")
                 return True
@@ -1783,7 +1791,12 @@ class ReviewPhase(StageMixin):
     def _save_review_log(self, issue_number: int, iteration: int, review_text: str) -> None:
         """Persist a per-iteration review log for later inspection."""
         try:
-            log_file = self.state_dir / f"review-{issue_number}-r{iteration}.log"
+            log_file = log_file_path(
+                self.state_dir,
+                "review",
+                issue_number,
+                iteration=iteration,
+            )
             log_file.write_text(review_text)
         except Exception as e:
             logger.warning("#%s: failed to save review log r%s: %s", issue_number, iteration, e)

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -22,6 +22,7 @@ Provides:
   the reviewer classes (#599 dedupe).
 - ``load_impl_session_id``: Shared implementer-session state loader for
   drive-green and address-review.
+- ``log_file_path``: Standard per-issue automation log filename builder.
 """
 
 from __future__ import annotations
@@ -331,6 +332,20 @@ def instance_log(
     prefix = {"error": "ERROR", "warning": "WARN", "info": ""}.get(level, "")
     ui_msg = f"{prefix}: {msg}" if prefix else msg
     log_manager.log(tid, ui_msg)
+
+
+def log_file_path(
+    state_dir: Path,
+    prefix: str,
+    issue_number: int,
+    *,
+    iteration: int | None = None,
+) -> Path:
+    """Return the standard per-issue automation log path."""
+    stem = f"{prefix}-{issue_number}"
+    if iteration is not None:
+        stem = f"{stem}-r{iteration}"
+    return state_dir / f"{stem}.log"
 
 
 def _copy_default(default: Mapping[str, Any]) -> dict[str, Any]:

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -42,6 +42,7 @@ from ._review_utils import (
     find_pr_for_issue,
     instance_log,
     load_impl_session_id,
+    log_file_path,
     print_worker_summary,
     setup_review_logging,
 )
@@ -849,7 +850,7 @@ class AddressReviewer(BaseReviewer):
             Parsed dict with "addressed" and "replies" keys
 
         """
-        log_file = self.state_dir / f"address-review-{issue_number}.log"
+        log_file = log_file_path(self.state_dir, "address-review", issue_number)
 
         def parse_with_trace(text: str) -> dict[str, Any]:
             return _review_utils.parse_json_block(

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -38,6 +38,7 @@ from ._review_utils import (
     ensure_state_dir,
     find_pr_for_issue,
     load_impl_session_id,
+    log_file_path,
     parse_json_block,
     print_worker_summary,
 )
@@ -1080,7 +1081,7 @@ class CIDriver:
         if pre_agent_sha is None:
             return False
 
-        log_file = self.state_dir / f"address-review-blocked-{issue_number}.log"
+        log_file = log_file_path(self.state_dir, "address-review-blocked", issue_number)
         try:
             fix_result = run_address_fix_session(
                 issue_number=issue_number,

--- a/hephaestus/automation/comment_difficulty.py
+++ b/hephaestus/automation/comment_difficulty.py
@@ -29,7 +29,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 
-from ._review_utils import parse_json_block
+from ._review_utils import log_file_path, parse_json_block
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import HAIKU, OPUS, SONNET, advise_model
 from .claude_timeouts import advise_claude_timeout
@@ -121,7 +121,7 @@ def _run_classifier_session(
         issue_number=issue_number,
         comments_json=comments_json,
     )
-    log_file = state_dir / f"comment-difficulty-{issue_number}.log"
+    log_file = log_file_path(state_dir, "comment-difficulty", issue_number)
     try:
         if uses_direct_agent_runner(agent):
             result = run_agent_text(

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -40,6 +40,7 @@ from hephaestus.agents.runtime import (
 )
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
+from ._review_utils import log_file_path
 from .claude_timeouts import follow_up_claude_timeout
 from .git_utils import issue_ref, run
 from .github_api import gh_issue_comment, gh_issue_create
@@ -401,7 +402,7 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
     - In ``dry_run`` mode, all GitHub side effects are suppressed.
     """
     state_dir.mkdir(parents=True, exist_ok=True)
-    follow_up_log = state_dir / f"follow-up-{issue_number}.log"
+    follow_up_log = log_file_path(state_dir, "follow-up", issue_number)
     if not session_agent_matches(session_agent, agent):
         message = (
             f"Session belongs to {session_agent or 'claude'}, "

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -25,6 +25,7 @@ from hephaestus.agents.runtime import (
 )
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
+from ._review_utils import log_file_path
 from .claude_models import learn_model
 from .claude_timeouts import learn_claude_timeout
 from .git_utils import run
@@ -208,7 +209,7 @@ def run_learn(
 
     """
     state_dir.mkdir(parents=True, exist_ok=True)
-    log_file = state_dir / f"learn-{issue_number}.log"
+    log_file = log_file_path(state_dir, "learn", issue_number)
     if not session_agent_matches(session_agent, agent):
         message = (
             f"Session belongs to {session_agent or 'claude'}, "
@@ -363,7 +364,7 @@ def learn_needs_rerun(issue_number: int, state_dir: Path) -> bool:
         True if learn needs to be re-run (missing or failed log)
 
     """
-    log_file = state_dir / f"learn-{issue_number}.log"
+    log_file = log_file_path(state_dir, "learn", issue_number)
     if not log_file.exists():
         return True
     try:

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -22,7 +22,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
-from ._review_utils import ensure_state_dir
+from ._review_utils import ensure_state_dir, log_file_path
 from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
 from .claude_timeouts import (
@@ -647,7 +647,7 @@ class PlanReviewLoop:
             timestamp = datetime.now(timezone.utc).isoformat()
             duration = round(time.monotonic() - start, 3) if start else None
             record_file = state_dir / f"planner-learn-{issue_number}.json"
-            log_file = state_dir / f"planner-learn-{issue_number}.log"
+            log_file = log_file_path(state_dir, "planner-learn", issue_number)
             record = {
                 "issue_number": issue_number,
                 "learn_attempted_at": timestamp,

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -46,7 +46,6 @@ from ._review_utils import (
     find_pr_for_issue,
     instance_log,
     log_file_path,
-    parse_json_block,
     print_worker_summary,
     setup_review_logging,
 )

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -45,6 +45,8 @@ from ._review_utils import (
     build_review_parser,
     find_pr_for_issue,
     instance_log,
+    log_file_path,
+    parse_json_block,
     print_worker_summary,
     setup_review_logging,
 )
@@ -123,7 +125,7 @@ def run_pr_review_analysis(
     prompt_file = worktree_path / f".claude-pr-review-{issue_number}.md"
     prompt_file.write_text(prompt)
 
-    log_file = state_dir / f"pr-review-analysis-{issue_number}.log"
+    log_file = log_file_path(state_dir, "pr-review-analysis", issue_number)
 
     try:
         if uses_direct_agent_runner(agent):

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -41,7 +41,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 
-from ._review_utils import parse_json_block
+from ._review_utils import log_file_path, parse_json_block
 from .claude_invoke import invoke_claude_with_session, raise_for_error_envelope
 from .claude_models import reviewer_model
 from .claude_timeouts import pr_reviewer_claude_timeout
@@ -175,7 +175,7 @@ def _run_validation_session(
         prior_comments_json=prior_comments_json,
         diff_text=diff_text,
     )
-    log_file = state_dir / f"review-validation-{issue_number}.log"
+    log_file = log_file_path(state_dir, "review-validation", issue_number)
     try:
         if uses_direct_agent_runner(agent):
             result = run_agent_text(

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -18,10 +18,32 @@ from hephaestus.automation._review_utils import (
     find_pr_for_issue,
     get_pr_head_branch,
     load_impl_session_id,
+    log_file_path,
     parse_json_block,
     print_worker_summary,
 )
 from hephaestus.automation.models import DEFAULT_WORKER_COUNT, WorkerResult
+
+# ---------------------------------------------------------------------------
+# log_file_path
+# ---------------------------------------------------------------------------
+
+
+class TestLogFilePath:
+    """Tests for standard per-issue automation log paths."""
+
+    def test_without_iteration(self, tmp_path: Path) -> None:
+        assert log_file_path(tmp_path, "learn", 42) == tmp_path / "learn-42.log"
+
+    def test_with_iteration(self, tmp_path: Path) -> None:
+        assert log_file_path(tmp_path, "review", 42, iteration=3) == tmp_path / "review-42-r3.log"
+
+    def test_prefix_can_include_hyphen(self, tmp_path: Path) -> None:
+        assert (
+            log_file_path(tmp_path, "pr-review-analysis", 42)
+            == tmp_path / "pr-review-analysis-42.log"
+        )
+
 
 # ---------------------------------------------------------------------------
 # parse_json_block


### PR DESCRIPTION
## Summary
Centralizes automation issue log filename construction and updates callers to use the shared helper.

## Changes
- Added shared issue log path helpers in automation review utilities
- Replaced duplicated state_dir log filename construction across automation workflows
- Updated review utility unit tests for standardized log path behavior

## Testing
- tests/unit/automation/test_review_utils.py

## Closes
Closes #1397

Generated by Codex via ProjectHephaestus automation.
