### PR TITLE
refactor(prompts): add fenced content helper

### DIFF
--- a/hephaestus/automation/prompts/__init__.py
+++ b/hephaestus/automation/prompts/__init__.py
@@ -28,12 +28,14 @@ importers continue to work unchanged.
 from ._shared import (
     _TERSE_OUTPUT_DIRECTIVE as _TERSE_OUTPUT_DIRECTIVE,
     _UNTRUSTED_NOTICE as _UNTRUSTED_NOTICE,
+    FencedContent as FencedContent,
     _fence_untrusted as _fence_untrusted,
     _iteration_guidance as _iteration_guidance,
     _iteration_label as _iteration_label,
     _prior_review_block as _prior_review_block,
     _prompts_logger as _prompts_logger,
     _relativize_path as _relativize_path,
+    fence_content as fence_content,
 )
 from ._strict_rubric import (
     _FULL_SWEEP_SUFFIX as _FULL_SWEEP_SUFFIX,
@@ -102,7 +104,9 @@ __all__ = [
     "PLAN_PROMPT",
     "PLAN_REVIEW_PROMPT",
     "PR_REVIEW_ANALYSIS_PROMPT",
+    "FencedContent",
     "build_unaddressed_directive",
+    "fence_content",
     "get_address_review_prompt",
     "get_advise_prompt",
     "get_advise_prompt_builder",

--- a/hephaestus/automation/prompts/_shared.py
+++ b/hephaestus/automation/prompts/_shared.py
@@ -9,6 +9,8 @@ build on these primitives.
 """
 
 import logging
+import secrets
+from dataclasses import dataclass
 from pathlib import Path
 
 _prompts_logger = logging.getLogger("hephaestus.automation.prompts")
@@ -70,6 +72,27 @@ def _fence_untrusted(label: str, content: str, nonce: str) -> str:
     each block self-describing in logs.
     """
     return f"BEGIN_{nonce}_{label}\n{content}\nEND_{nonce}_{label}"
+
+
+@dataclass(frozen=True)
+class FencedContent:
+    """Prompt-scoped helper for fencing untrusted fields with one nonce."""
+
+    nonce: str
+
+    @property
+    def untrusted_notice(self) -> str:
+        """Return the standard untrusted-content notice for prompt templates."""
+        return _UNTRUSTED_NOTICE
+
+    def fence(self, label: str, content: str) -> str:
+        """Fence one untrusted prompt field using this prompt's nonce."""
+        return _fence_untrusted(label, content, self.nonce)
+
+
+def fence_content() -> FencedContent:
+    """Create a prompt-scoped fencer with a fresh random nonce."""
+    return FencedContent(secrets.token_hex(8).upper())
 
 
 def _iteration_label(iteration: int) -> str:

--- a/hephaestus/automation/prompts/address_review.py
+++ b/hephaestus/automation/prompts/address_review.py
@@ -1,9 +1,8 @@
 """Address-review prompt: apply fixes for unresolved PR review threads."""
 
-import secrets
 from typing import Any
 
-from ._shared import _TERSE_OUTPUT_DIRECTIVE, _UNTRUSTED_NOTICE, _fence_untrusted
+from ._shared import _TERSE_OUTPUT_DIRECTIVE, _fence_untrusted, fence_content
 
 ADDRESS_REVIEW_PROMPT = """
 You are the COORDINATOR for addressing the review threads on PR #{pr_number}
@@ -223,15 +222,23 @@ def get_address_review_prompt(
         Formatted address review prompt
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     return ADDRESS_REVIEW_PROMPT.format(
         pr_number=pr_number,
         issue_number=issue_number,
         worktree_path=worktree_path,
-        threads_json_block=_fence_untrusted("THREADS_JSON", threads_json, nonce),
-        todo_block=_fence_untrusted("TODO_LIST", todo_block or "_(no todo lines)_", nonce),
-        untrusted_notice=_UNTRUSTED_NOTICE,
-        context_block=_build_context_block(task_block, task_review_block, diff_text, nonce),
-        retry_directive_block=build_unaddressed_directive(unaddressed_findings or [], nonce),
+        threads_json_block=fenced.fence("THREADS_JSON", threads_json),
+        todo_block=fenced.fence("TODO_LIST", todo_block or "_(no todo lines)_"),
+        untrusted_notice=fenced.untrusted_notice,
+        context_block=_build_context_block(
+            task_block,
+            task_review_block,
+            diff_text,
+            fenced.nonce,
+        ),
+        retry_directive_block=build_unaddressed_directive(
+            unaddressed_findings or [],
+            fenced.nonce,
+        ),
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )

--- a/hephaestus/automation/prompts/implementation.py
+++ b/hephaestus/automation/prompts/implementation.py
@@ -4,16 +4,13 @@ Contains the canonical implementation prompt, the iteration-aware impl-loop
 review prompt, and the resume-after-NOGO feedback prompt.
 """
 
-import secrets
-
 from ._shared import (
     _TERSE_OUTPUT_DIRECTIVE,
-    _UNTRUSTED_NOTICE,
-    _fence_untrusted,
     _iteration_guidance,
     _iteration_label,
     _prior_review_block,
     _relativize_path,
+    fence_content,
 )
 from ._strict_rubric import (
     _FULL_SWEEP_SUFFIX,
@@ -223,14 +220,14 @@ def get_implementation_prompt(
 
     """
     safe_worktree_path = _relativize_path(worktree_path, repo_root)
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     return IMPLEMENTATION_PROMPT.format(
         issue_number=issue_number,
         issue_title=issue_title,
-        issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
+        issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
         branch_name=branch_name,
         worktree_path=safe_worktree_path,
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        untrusted_notice=fenced.untrusted_notice,
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
@@ -260,7 +257,7 @@ def get_impl_loop_review_prompt(
         Formatted prompt for a fresh reviewer session.
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     full_sweep_suffix = _FULL_SWEEP_SUFFIX.strip() if iteration == 2 else ""
     return IMPL_LOOP_REVIEW_PROMPT.format(
         rubric=_IMPL_LOOP_STRICT_RUBRIC.strip(),
@@ -269,13 +266,13 @@ def get_impl_loop_review_prompt(
         iteration_guidance=_iteration_guidance(iteration),
         issue_number=issue_number,
         issue_title=issue_title,
-        issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
-        diff_text_block=_fence_untrusted("DIFF_TEXT", diff_text or "_(no diff produced)_", nonce),
+        issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
+        diff_text_block=fenced.fence("DIFF_TEXT", diff_text or "_(no diff produced)_"),
         files_changed=files_changed or "_(no files changed)_",
         prior_review_block=_prior_review_block(prior_review),
         full_sweep_suffix=full_sweep_suffix,
         output_format=_STRICT_REVIEW_OUTPUT_FORMAT.strip(),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        untrusted_notice=fenced.untrusted_notice,
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
@@ -297,16 +294,15 @@ def get_dirty_reused_worktree_decision_prompt(
     Fenced prompt asking for an exact final-line COMMIT/STASH decision.
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     return DIRTY_REUSED_WORKTREE_DECISION_PROMPT.format(
-        branch_block=_fence_untrusted("BRANCH_NAME", branch_name, nonce),
-        status_block=_fence_untrusted("GIT_STATUS", status_text.strip() or "_(empty)_", nonce),
-        diff_block=_fence_untrusted(
+        branch_block=fenced.fence("BRANCH_NAME", branch_name),
+        status_block=fenced.fence("GIT_STATUS", status_text.strip() or "_(empty)_"),
+        diff_block=fenced.fence(
             "GIT_DIFF_HEAD",
             (diff_text or "")[:6000] or "_(empty)_",
-            nonce,
         ),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        untrusted_notice=fenced.untrusted_notice,
     )
 
 

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -4,15 +4,12 @@ Contains the plan-generation prompt, the standalone plan-review prompt, and
 the iteration-aware plan-loop review prompt.
 """
 
-import secrets
-
 from ._shared import (
     _TERSE_OUTPUT_DIRECTIVE,
-    _UNTRUSTED_NOTICE,
-    _fence_untrusted,
     _iteration_guidance,
     _iteration_label,
     _prior_review_block,
+    fence_content,
 )
 from ._strict_rubric import (
     _FULL_SWEEP_SUFFIX,
@@ -249,13 +246,13 @@ def get_plan_review_prompt(
         Formatted plan review prompt
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     return PLAN_REVIEW_PROMPT.format(
         issue_number=issue_number,
         issue_title=issue_title,
-        issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
-        plan_text_block=_fence_untrusted("PLAN_TEXT", plan_text, nonce),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
+        plan_text_block=fenced.fence("PLAN_TEXT", plan_text),
+        untrusted_notice=fenced.untrusted_notice,
         strict_rubric=_PLAN_STRICT_RUBRIC.strip(),
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
@@ -289,7 +286,7 @@ def get_plan_loop_review_prompt(
         Formatted prompt for a fresh reviewer session.
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     full_sweep_suffix = _FULL_SWEEP_SUFFIX.strip() if iteration == 2 else ""
     return PLAN_LOOP_REVIEW_PROMPT.format(
         rubric=_PLAN_LOOP_STRICT_RUBRIC.strip(),
@@ -298,17 +295,16 @@ def get_plan_loop_review_prompt(
         iteration_guidance=_iteration_guidance(iteration),
         issue_number=issue_number,
         issue_title=issue_title,
-        issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
-        advise_findings_block=_fence_untrusted(
+        issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
+        advise_findings_block=fenced.fence(
             "ADVISE_FINDINGS",
             advise_findings or "_(no prior advise findings supplied)_",
-            nonce,
         ),
-        plan_text_block=_fence_untrusted("PLAN_TEXT", plan_text, nonce),
+        plan_text_block=fenced.fence("PLAN_TEXT", plan_text),
         learnings=learnings or "_(no learnings captured this iteration)_",
         prior_review_block=_prior_review_block(prior_review),
         full_sweep_suffix=full_sweep_suffix,
         output_format=_STRICT_REVIEW_OUTPUT_FORMAT.strip(),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        untrusted_notice=fenced.untrusted_notice,
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -4,9 +4,7 @@ Contains the PR review analysis prompt (inline-comment generator) and the
 plain PR description template.
 """
 
-import secrets
-
-from ._shared import _TERSE_OUTPUT_DIRECTIVE, _UNTRUSTED_NOTICE, _fence_untrusted
+from ._shared import _TERSE_OUTPUT_DIRECTIVE, fence_content
 from ._strict_rubric import _PR_STRICT_RUBRIC
 
 PR_REVIEW_ANALYSIS_PROMPT = """
@@ -140,21 +138,20 @@ def get_pr_review_analysis_prompt(
         Formatted PR review analysis prompt
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     nitpick_directive = _NITPICK_INCLUDE if include_nitpicks else _NITPICK_SUPPRESS
     return PR_REVIEW_ANALYSIS_PROMPT.format(
         pr_number=pr_number,
         issue_number=issue_number,
-        pr_diff_block=_fence_untrusted("PR_DIFF", pr_diff, nonce),
-        issue_body_block=_fence_untrusted("ISSUE_BODY", issue_body, nonce),
-        advise_findings_block=_fence_untrusted(
+        pr_diff_block=fenced.fence("PR_DIFF", pr_diff),
+        issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
+        advise_findings_block=fenced.fence(
             "ADVISE_FINDINGS",
             advise_findings or "_(no prior advise findings supplied)_",
-            nonce,
         ),
-        ci_status_block=_fence_untrusted("CI_STATUS", ci_status, nonce),
-        pr_description_block=_fence_untrusted("PR_DESCRIPTION", pr_description, nonce),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        ci_status_block=fenced.fence("CI_STATUS", ci_status),
+        pr_description_block=fenced.fence("PR_DESCRIPTION", pr_description),
+        untrusted_notice=fenced.untrusted_notice,
         strict_rubric=_PR_STRICT_RUBRIC.strip(),
         nitpick_directive=nitpick_directive,
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
@@ -259,13 +256,13 @@ def get_review_validation_prompt(
         Formatted review-validation prompt.
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     return REVIEW_VALIDATION_PROMPT.format(
         pr_number=pr_number,
         issue_number=issue_number,
-        prior_comments_block=_fence_untrusted("PRIOR_COMMENTS", prior_comments_json, nonce),
-        diff_block=_fence_untrusted("DIFF", diff_text, nonce),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        prior_comments_block=fenced.fence("PRIOR_COMMENTS", prior_comments_json),
+        diff_block=fenced.fence("DIFF", diff_text),
+        untrusted_notice=fenced.untrusted_notice,
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 
@@ -330,11 +327,11 @@ def get_comment_difficulty_prompt(
         Formatted comment-difficulty classification prompt.
 
     """
-    nonce = secrets.token_hex(8).upper()
+    fenced = fence_content()
     return COMMENT_DIFFICULTY_PROMPT.format(
         issue_number=issue_number,
-        comments_block=_fence_untrusted("REVIEW_COMMENTS", comments_json, nonce),
-        untrusted_notice=_UNTRUSTED_NOTICE,
+        comments_block=fenced.fence("REVIEW_COMMENTS", comments_json),
+        untrusted_notice=fenced.untrusted_notice,
         terse_output_directive=_TERSE_OUTPUT_DIRECTIVE,
     )
 

--- a/tests/unit/automation/prompts/test_shared.py
+++ b/tests/unit/automation/prompts/test_shared.py
@@ -8,6 +8,7 @@ than WARNING so they do not add routine noise to default runs (#1556).
 from __future__ import annotations
 
 import logging
+import secrets
 
 import pytest
 
@@ -68,3 +69,33 @@ def test_no_repo_root_logs_debug_not_warning(
 def test_empty_path_returned_unchanged() -> None:
     """An empty path short-circuits with no logging."""
     assert _shared._relativize_path("", "/repo") == ""
+
+
+def test_fence_content_generates_uppercase_nonce_and_notice(monkeypatch) -> None:
+    """The convenience helper owns nonce generation and the standard notice."""
+    calls: list[int] = []
+
+    def fake_token_hex(length: int) -> str:
+        calls.append(length)
+        return "abc123def456abcd"
+
+    monkeypatch.setattr(secrets, "token_hex", fake_token_hex)
+
+    fenced = _shared.fence_content()
+
+    assert calls == [8]
+    assert fenced.nonce == "ABC123DEF456ABCD"
+    assert fenced.untrusted_notice == _shared._UNTRUSTED_NOTICE
+    assert fenced.fence("ISSUE_BODY", "payload") == (
+        "BEGIN_ABC123DEF456ABCD_ISSUE_BODY\npayload\nEND_ABC123DEF456ABCD_ISSUE_BODY"
+    )
+
+
+def test_fence_content_reuses_nonce_for_prompt_blocks(monkeypatch) -> None:
+    """One helper instance fences multiple fields with the same prompt nonce."""
+    monkeypatch.setattr(secrets, "token_hex", lambda length: "feedfacecafebeef")
+
+    fenced = _shared.fence_content()
+
+    assert "BEGIN_FEEDFACECAFEBEEF_FIRST" in fenced.fence("FIRST", "one")
+    assert "BEGIN_FEEDFACECAFEBEEF_SECOND" in fenced.fence("SECOND", "two")

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -467,6 +467,99 @@ class TestUntrustedFencing:
         assert self._fence_present(out, "GIT_DIFF_HEAD")
         assert prompts._UNTRUSTED_NOTICE in out
 
+    def test_refactored_prompt_builders_include_untrusted_notice(self) -> None:
+        """Prompt builders using shared fencing still carry the notice."""
+        rendered_prompts = [
+            (
+                "plan_review",
+                prompts.get_plan_review_prompt(
+                    issue_number=1,
+                    issue_title="t",
+                    issue_body=self.INJECTION,
+                    plan_text=self.INJECTION,
+                ),
+            ),
+            (
+                "plan_loop_review",
+                prompts.get_plan_loop_review_prompt(
+                    issue_number=1,
+                    issue_title="t",
+                    issue_body=self.INJECTION,
+                    plan_text=self.INJECTION,
+                    learnings="",
+                    iteration=0,
+                    prior_review=None,
+                    advise_findings=self.INJECTION,
+                ),
+            ),
+            (
+                "implementation",
+                prompts.get_implementation_prompt(
+                    issue_number=1,
+                    issue_title="t",
+                    issue_body=self.INJECTION,
+                ),
+            ),
+            (
+                "impl_loop_review",
+                prompts.get_impl_loop_review_prompt(
+                    issue_number=1,
+                    issue_title="t",
+                    issue_body=self.INJECTION,
+                    diff_text=self.INJECTION,
+                    files_changed="a.py",
+                    iteration=0,
+                    prior_review=None,
+                ),
+            ),
+            (
+                "dirty_reused_worktree_decision",
+                prompts.get_dirty_reused_worktree_decision_prompt(
+                    branch_name="branch",
+                    status_text=" M a.py",
+                    diff_text=self.INJECTION,
+                ),
+            ),
+            (
+                "address_review",
+                prompts.get_address_review_prompt(
+                    pr_number=1,
+                    issue_number=1,
+                    worktree_path="/tmp/wt",
+                    threads_json="[]",
+                    todo_block="",
+                ),
+            ),
+            (
+                "pr_review_analysis",
+                prompts.get_pr_review_analysis_prompt(
+                    pr_number=1,
+                    issue_number=1,
+                    issue_body=self.INJECTION,
+                    advise_findings=self.INJECTION,
+                ),
+            ),
+            (
+                "review_validation",
+                prompts.get_review_validation_prompt(
+                    pr_number=1,
+                    issue_number=1,
+                    prior_comments_json="[]",
+                    diff_text=self.INJECTION,
+                ),
+            ),
+            (
+                "comment_difficulty",
+                prompts.get_comment_difficulty_prompt(
+                    issue_number=1,
+                    comments_json="[]",
+                ),
+            ),
+        ]
+
+        for name, out in rendered_prompts:
+            assert prompts._UNTRUSTED_NOTICE in out, name
+
 
 class TestSharedRubricConstants:
     """Tests for the shared strict-grading and seven-principles rubric blocks.


### PR DESCRIPTION
## Summary
Add a shared prompt fencing helper to reduce nonce, fence, and notice boilerplate across prompt builders.

## Changes
- Added a shared fenced-content convenience API in prompts/_shared.py and exported it from prompts/__init__.py.
- Refactored planning, implementation, PR review, and address-review prompt builders to use the shared fencing helper.
- Adjusted review-stage automation tests and prompt tests for the updated shared prompt-fencing flow.

## Testing
- Updated unit coverage for the shared fencing helper and untrusted-content prompt fencing behavior.

## Closes
Closes #1399

Generated by Codex via ProjectHephaestus automation.
