### PR TITLE
fix(automation): use atomic writes for state and logs

### DIFF
--- a/hephaestus/automation/_implement_phase.py
+++ b/hephaestus/automation/_implement_phase.py
@@ -26,6 +26,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.github.rate_limit import wait_until
+from hephaestus.io.utils import write_secure
 
 from ._review_utils import log_file_path
 from ._stage_context import StageMixin
@@ -166,7 +167,7 @@ class ImplementPhase(StageMixin):
     ) -> str | None:
         """Run Claude implementation prompt and return its session id."""
         prompt_file = worktree_path / f".claude-prompt-{issue_number}.md"
-        prompt_file.write_text(prompt)
+        write_secure(prompt_file, prompt)
 
         repo_slug = get_repo_slug(self.repo_root)
 
@@ -195,7 +196,7 @@ class ImplementPhase(StageMixin):
                 if isinstance(data, dict) and data.get("is_error"):
                     err_text = str(data.get("result") or "")
                     log_file = log_file_path(self.state_dir, "claude", issue_number)
-                    log_file.write_text(result.stdout or "")
+                    write_secure(log_file, result.stdout or "")
                     reset_epoch = _claude_quota_reset_epoch(err_text)
                     if reset_epoch is not None and reset_epoch > 0:
                         logger.warning(
@@ -208,7 +209,7 @@ class ImplementPhase(StageMixin):
 
                 # Save successful output to log file
                 log_file = log_file_path(self.state_dir, "claude", issue_number)
-                log_file.write_text(result.stdout or "")
+                write_secure(log_file, result.stdout or "")
 
                 return cast("str | None", session_id)
             except (json.JSONDecodeError, AttributeError):
@@ -217,7 +218,7 @@ class ImplementPhase(StageMixin):
 
                 # Save output even if JSON parsing failed
                 log_file = log_file_path(self.state_dir, "claude", issue_number)
-                log_file.write_text(result.stdout or "")
+                write_secure(log_file, result.stdout or "")
 
                 return None
         except subprocess.CalledProcessError as e:
@@ -233,7 +234,7 @@ class ImplementPhase(StageMixin):
             stdout = e.stdout or ""
             stderr = e.stderr or ""
             output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-            log_file.write_text(output)
+            write_secure(log_file, output)
 
             # If the failure was a quota cap, block until reset rather than
             # letting the orchestrator burn through every remaining issue in
@@ -249,7 +250,7 @@ class ImplementPhase(StageMixin):
         except subprocess.TimeoutExpired as e:
             # Save timeout info to log file
             log_file = log_file_path(self.state_dir, "claude", issue_number)
-            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+            write_secure(log_file, f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
 
             raise RuntimeError("Claude Code timed out") from e
         finally:
@@ -276,13 +277,13 @@ class ImplementPhase(StageMixin):
                 model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
                 sandbox="workspace-write",
             )
-            log_file.write_text(result.stdout or "")
+            write_secure(log_file, result.stdout or "")
             return result.session_id
         except subprocess.CalledProcessError as e:
             stdout = e.stdout or ""
             stderr = e.stderr or ""
             output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-            log_file.write_text(output)
+            write_secure(log_file, output)
             reset_epoch = _claude_quota_reset_epoch(stderr, stdout)
             if reset_epoch is not None and reset_epoch > 0:
                 logger.warning(
@@ -293,5 +294,5 @@ class ImplementPhase(StageMixin):
                 wait_until(reset_epoch)
             raise RuntimeError(f"{agent} failed: {stderr or stdout}") from e
         except subprocess.TimeoutExpired as e:
-            log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+            write_secure(log_file, f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
             raise RuntimeError(f"{agent} timed out") from e

--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -32,6 +32,7 @@ from hephaestus.agents.runtime import (
 from hephaestus.constants import agent_git_timeout, diff_collect_timeout
 from hephaestus.github.client import ClaudeUsageCapError, gh_call
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
+from hephaestus.io.utils import write_secure
 
 from . import review_state
 from ._review_utils import log_file_path
@@ -1484,9 +1485,10 @@ class ReviewPhase(StageMixin):
         if not matches.get("addressed") and "```json" not in text:
             with contextlib.suppress(Exception):
                 trace_path = self.state_dir / f"address-{issue_number}-r{iteration}.parse-error.log"
-                trace_path.write_text(
+                write_secure(
+                    trace_path,
                     f"reason: no fenced ```json block found in response\n\n"
-                    f"=== full response ===\n{text}"
+                    f"=== full response ===\n{text}",
                 )
         return matches
 
@@ -1573,7 +1575,7 @@ class ReviewPhase(StageMixin):
                     issue_number,
                     iteration=prev_iteration + 1,
                 )
-                log_file.write_text(result.stdout or "")
+                write_secure(log_file, result.stdout or "")
                 return True
             except subprocess.CalledProcessError as e:
                 logger.error(
@@ -1797,7 +1799,7 @@ class ReviewPhase(StageMixin):
                 issue_number,
                 iteration=iteration,
             )
-            log_file.write_text(review_text)
+            write_secure(log_file, review_text)
         except Exception as e:
             logger.warning("#%s: failed to save review log r%s: %s", issue_number, iteration, e)
 
@@ -1807,12 +1809,12 @@ class ReviewPhase(StageMixin):
         """Persist review loop progress for ``--resume`` continuity (A2-005)."""
         try:
             iter_file = self.state_dir / f"review-iter-{issue_number}.json"
-            iter_file.write_text(json.dumps({"iterations_run": iterations_run}))
+            write_secure(iter_file, json.dumps({"iterations_run": iterations_run}))
         except Exception as e:
             logger.warning("#%d: failed to persist review iteration count: %s", issue_number, e)
         try:
             prior_file = self.state_dir / f"review-prior-{issue_number}.txt"
-            prior_file.write_text(prior_review)
+            write_secure(prior_file, prior_review)
         except Exception as e:
             logger.warning("#%d: failed to persist prior review text: %s", issue_number, e)
 

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -45,6 +45,7 @@ from hephaestus.cli.utils import (
     add_json_arg,
     add_version_arg,
 )
+from hephaestus.io.utils import write_secure
 
 from .github_api import _gh_call
 from .models import DEFAULT_STATE_DIR, DEFAULT_WORKER_COUNT
@@ -369,7 +370,8 @@ def _write_json_parse_trace(
     trace_path = trace_dir / trace_name
     try:
         trace_dir.mkdir(parents=True, exist_ok=True)
-        trace_path.write_text(
+        write_secure(
+            trace_path,
             "\n".join(
                 [
                     f"reason: {reason}",
@@ -380,7 +382,7 @@ def _write_json_parse_trace(
                     "=== full response ===",
                     text,
                 ]
-            )
+            ),
         )
         return trace_path, None
     except OSError as exc:

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -34,6 +34,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import emit_json_status
+from hephaestus.io.utils import write_secure
 
 from . import _review_utils
 from ._review_utils import (
@@ -211,7 +212,7 @@ def run_address_fix_session(
     )
 
     prompt_file = worktree_path / f".claude-address-review-{issue_number}.md"
-    prompt_file.write_text(prompt)
+    write_secure(prompt_file, prompt)
 
     try:
         if uses_direct_agent_runner(agent):
@@ -226,7 +227,7 @@ def run_address_fix_session(
             log = direct_result.stdout
             if direct_result.session_id:
                 log = f"SESSION_ID: {direct_result.session_id}\n\n{log}"
-            log_file.write_text(log)
+            write_secure(log_file, log)
             parsed = parse_fn(direct_result.stdout)
             logger.info(
                 "Fix session complete for PR #%s; addressed %s thread(s)",
@@ -254,7 +255,7 @@ def run_address_fix_session(
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash,Task,Skill",
             input_via_stdin=True,
         )
-        log_file.write_text(stdout or "")
+        write_secure(log_file, stdout or "")
 
         # Extract response text from Claude's JSON wrapper
         try:
@@ -275,12 +276,12 @@ def run_address_fix_session(
         stdout = e.stdout or ""
         stderr = e.stderr or ""
         error_output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-        log_file.write_text(error_output)
+        write_secure(log_file, error_output)
         raise RuntimeError(
             f"Fix session failed for PR {pr_ref(pr_number)}: {e.stderr or e.stdout}"
         ) from e
     except subprocess.TimeoutExpired as e:
-        log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+        write_secure(log_file, f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
         raise RuntimeError(f"Fix session timed out for PR {pr_ref(pr_number)}") from e
     finally:
         # Narrow exception: a missing prompt file is benign cleanup,
@@ -890,7 +891,7 @@ class AddressReviewer(BaseReviewer):
                 log = direct_result.stdout
                 if direct_result.session_id:
                     log = f"SESSION_ID: {direct_result.session_id}\n\n{log}"
-                log_file.write_text(log)
+                write_secure(log_file, log)
                 parsed = parse_with_trace(direct_result.stdout)
                 logger.info(
                     "Fix session complete for PR #%s; addressed %s thread(s)",

--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -15,6 +15,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.io.utils import write_secure
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -69,7 +70,7 @@ def read_prompt(prompt_file: Path, skill_file: Path | None, stage: str) -> str:
 def write_log(log_file: Path | None, text: str) -> None:
     """Write a subprocess log when a log path was provided."""
     if log_file is not None:
-        log_file.write_text(text, encoding="utf-8")
+        write_secure(log_file, text)
 
 
 def run_claude(
@@ -95,7 +96,7 @@ def run_claude(
         write_log(log_file, str(exc))
         return 124
 
-    output_file.write_text(result.stdout or "", encoding="utf-8")
+    write_secure(output_file, result.stdout or "")
     write_log(log_file, result.stdout or "")
     return result.returncode
 
@@ -133,7 +134,7 @@ def run_direct_agent(
         write_log(log_file, log_text)
         return exc.returncode
 
-    output_file.write_text(result.stdout, encoding="utf-8")
+    write_secure(output_file, result.stdout)
     log = result.stdout
     if result.session_id:
         log = f"SESSION_ID: {result.session_id}\n\n{log}"

--- a/hephaestus/automation/arming_state.py
+++ b/hephaestus/automation/arming_state.py
@@ -26,6 +26,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from hephaestus.io.utils import write_secure
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,7 +77,7 @@ class ArmingStateStore:
         """Persist the arming record. Best-effort; logs and swallows IO errors."""
         path = self.path(issue_number)
         try:
-            path.write_text(json.dumps(record, indent=2, sort_keys=True))
+            write_secure(path, json.dumps(record, indent=2, sort_keys=True))
         except OSError as exc:
             logger.warning(
                 "Could not write arming record for issue #%s: %s",

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -30,6 +30,7 @@ from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     emit_json_status,
 )
+from hephaestus.io.utils import write_secure
 
 from ._review_utils import build_automation_parser, ensure_state_dir
 from .claude_invoke import invoke_claude_with_session
@@ -71,7 +72,7 @@ def write_audit_report(state_dir: Path, audits: list[dict[str, Any]]) -> Path:
     state_dir.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     path = state_dir / f"audit-report-{ts}.json"
-    path.write_text(json.dumps({"audits": audits, "generated_at": ts}, indent=2))
+    write_secure(path, json.dumps({"audits": audits, "generated_at": ts}, indent=2))
     return path
 
 
@@ -177,12 +178,12 @@ def run_audit_coordinator(
                 response = json.loads(stdout or "{}").get("result", stdout or "")
             except (json.JSONDecodeError, AttributeError):
                 response = stdout or ""
-        log_file.write_text(response)
+        write_secure(log_file, response)
     except subprocess.CalledProcessError as e:
-        log_file.write_text(f"EXIT {e.returncode}\nSTDOUT:\n{e.stdout}\nSTDERR:\n{e.stderr}")
+        write_secure(log_file, f"EXIT {e.returncode}\nSTDOUT:\n{e.stdout}\nSTDERR:\n{e.stderr}")
         raise RuntimeError(f"Audit coordinator failed: {e.stderr or e.stdout}") from e
     except subprocess.TimeoutExpired as e:
-        log_file.write_text(f"TIMEOUT after {e.timeout}s\n{e.output or ''}")
+        write_secure(log_file, f"TIMEOUT after {e.timeout}s\n{e.output or ''}")
         raise RuntimeError("Audit coordinator timed out") from e
 
     audits = _parse_coordinator_results(response)

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -30,6 +30,7 @@ from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     emit_json_status,
 )
+from hephaestus.io.utils import write_secure
 from hephaestus.utils.file_lock import file_lock
 
 from ._review_utils import (
@@ -1243,8 +1244,9 @@ class CIDriver:
         if not head_sha:
             return
         try:
-            self._ci_fix_marker_path(pr_number).write_text(
-                json.dumps({"pr_number": pr_number, "head_sha": head_sha}) + "\n"
+            write_secure(
+                self._ci_fix_marker_path(pr_number),
+                json.dumps({"pr_number": pr_number, "head_sha": head_sha}) + "\n",
             )
         except OSError as exc:
             logger.warning(

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -29,6 +29,7 @@ from hephaestus.agents.runtime import (
     run_agent_session,
     uses_direct_agent_runner,
 )
+from hephaestus.io.utils import write_secure
 
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
@@ -224,7 +225,8 @@ class CIFixOrchestrator:
         """
         marker = self._state_dir() / f"repeated-no-commit-{pr_number}.json"
         try:
-            marker.write_text(
+            write_secure(
+                marker,
                 json.dumps(
                     {
                         "issue_number": issue_number,
@@ -235,7 +237,7 @@ class CIFixOrchestrator:
                     },
                     indent=2,
                 )
-                + "\n"
+                + "\n",
             )
         except OSError as exc:
             logger.warning(

--- a/hephaestus/automation/comment_difficulty.py
+++ b/hephaestus/automation/comment_difficulty.py
@@ -28,6 +28,7 @@ from hephaestus.agents.runtime import (
     run_agent_text,
     uses_direct_agent_runner,
 )
+from hephaestus.io.utils import write_secure
 
 from ._review_utils import log_file_path, parse_json_block
 from .claude_invoke import invoke_claude_with_session
@@ -132,7 +133,7 @@ def _run_classifier_session(
                 model=direct_agent_model(agent, "HEPH_ADVISE_MODEL"),
                 sandbox="read-only",
             )
-            log_file.write_text(result.stdout or "")
+            write_secure(log_file, result.stdout or "")
             parsed = parse_json_block(result.stdout or "")
         else:
             stdout, _ = invoke_claude_with_session(
@@ -148,7 +149,7 @@ def _run_classifier_session(
                 allowed_tools="Read,Glob,Grep",
                 input_via_stdin=True,
             )
-            log_file.write_text(stdout or "")
+            write_secure(log_file, stdout or "")
             try:
                 data = json.loads(stdout or "{}")
                 response_text: str = data.get("result", stdout or "")

--- a/hephaestus/automation/follow_up.py
+++ b/hephaestus/automation/follow_up.py
@@ -39,6 +39,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
+from hephaestus.io.utils import write_secure
 
 from ._review_utils import log_file_path
 from .claude_timeouts import follow_up_claude_timeout
@@ -370,7 +371,7 @@ def _persist_rejected(
     path = state_dir / f"follow-up-rejected-{issue_number}.json"
     payload = [{"title": r.title, "reason": r.reason} for r in rejected]
     with contextlib.suppress(Exception):
-        path.write_text(json.dumps(payload, indent=2) + "\n")
+        write_secure(path, json.dumps(payload, indent=2) + "\n")
 
 
 def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + file paths are unavoidably coupled
@@ -409,11 +410,11 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
             f"but selected agent is {agent}; skipping follow-up resume"
         )
         logger.warning("Follow-up skipped for issue #%d: %s", issue_number, message)
-        follow_up_log.write_text(f"FAILED: {message}\n")
+        write_secure(follow_up_log, f"FAILED: {message}\n")
         return None
 
     prompt_file = worktree_path / f".claude-followup-{issue_number}.md"
-    prompt_file.write_text(get_follow_up_prompt(issue_number))
+    write_secure(prompt_file, get_follow_up_prompt(issue_number))
 
     try:
         if uses_direct_agent_runner(agent):
@@ -441,7 +442,7 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
             )
             stdout = result.stdout or ""
 
-        follow_up_log.write_text(stdout)
+        write_secure(follow_up_log, stdout)
 
         try:
             data = json.loads(stdout)
@@ -531,7 +532,7 @@ def run_follow_up_issues(  # noqa: C901  # orchestration: quota-check + parse + 
             error_output += f"\nSTDERR:\n{e.stderr or ''}"
         error_output += f"\nTRACEBACK:\n{traceback.format_exc()}"
         with contextlib.suppress(Exception):
-            follow_up_log.write_text(error_output)
+            write_secure(follow_up_log, error_output)
         return None
     finally:
         with contextlib.suppress(Exception):

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -24,6 +24,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
+from hephaestus.io.utils import write_secure
 
 from ._review_utils import log_file_path
 from .claude_models import learn_model
@@ -99,7 +100,7 @@ def _write_learn_record(
         record["error"] = error
     record_file = state_dir / f"learn-{issue_number}.json"
     try:
-        record_file.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
+        write_secure(record_file, json.dumps(record, indent=2, sort_keys=True) + "\n")
     except OSError as exc:
         logger.warning("Learn record write failed for issue #%s: %s", issue_number, exc)
 
@@ -124,7 +125,7 @@ def _record_learn_failure(
 ) -> None:
     """Write the FAILED: log + record for a non-recoverable ``/learn`` failure."""
     logger.warning("Learn failed for issue #%s: %s", issue_number, error)
-    log_file.write_text(log_text)
+    write_secure(log_file, log_text)
     _write_learn_record(
         state_dir,
         issue_number,
@@ -138,7 +139,7 @@ def _record_learn_success(
     state_dir: Path, issue_number: int, log_file: Path, *, stdout: str
 ) -> None:
     """Write the log + record for a successful ``/learn`` run."""
-    log_file.write_text(stdout)
+    write_secure(log_file, stdout)
     _write_learn_record(
         state_dir,
         issue_number,
@@ -216,7 +217,7 @@ def run_learn(
             f"but selected agent is {agent}; skipping learn resume"
         )
         logger.warning("Learn skipped for issue #%s: %s", issue_number, message)
-        log_file.write_text(f"FAILED: {message}\n")
+        write_secure(log_file, f"FAILED: {message}\n")
         _write_learn_record(
             state_dir,
             issue_number,
@@ -324,7 +325,7 @@ def _run_learn_with_retry(
             # reset and re-invoke. Only a genuine failure records FAILED:.
             reset_epoch = resolve_quota_reset_epoch(err_stderr, err_stdout, str(e))
             if reset_epoch is not None:
-                log_file.write_text(error_output)
+                write_secure(log_file, error_output)
                 _wait_for_quota_reset(reset_epoch, issue_number)
                 continue
             _record_learn_failure(
@@ -338,7 +339,7 @@ def _run_learn_with_retry(
         # a bogus success.
         reset_epoch = resolve_quota_reset_epoch(stdout)
         if reset_epoch is not None:
-            log_file.write_text(stdout)
+            write_secure(log_file, stdout)
             _wait_for_quota_reset(reset_epoch, issue_number)
             continue
         _record_learn_success(state_dir, issue_number, log_file, stdout=stdout)

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -22,6 +22,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Protocol
 
+from hephaestus.io.utils import write_secure
+
 from ._review_utils import ensure_state_dir, log_file_path
 from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
@@ -667,8 +669,8 @@ class PlanReviewLoop:
                 )
             if error:
                 record["error"] = error
-            record_file.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n")
-            log_file.write_text(output if succeeded else f"FAILED: {error}\n")
+            write_secure(record_file, json.dumps(record, indent=2, sort_keys=True) + "\n")
+            write_secure(log_file, output if succeeded else f"FAILED: {error}\n")
         except OSError as exc:
             logger.warning(
                 "%s: failed to write planner-learnings state (non-fatal): %s",

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -38,6 +38,7 @@ from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     emit_json_status,
 )
+from hephaestus.io.utils import write_secure
 
 from . import _review_utils
 from ._review_utils import (
@@ -122,7 +123,7 @@ def run_pr_review_analysis(
     )
 
     prompt_file = worktree_path / f".claude-pr-review-{issue_number}.md"
-    prompt_file.write_text(prompt)
+    write_secure(prompt_file, prompt)
 
     log_file = log_file_path(state_dir, "pr-review-analysis", issue_number)
 
@@ -136,7 +137,7 @@ def run_pr_review_analysis(
                 model=direct_agent_model(agent, "HEPH_REVIEWER_MODEL"),
                 sandbox="read-only",
             )
-            log_file.write_text(result.stdout or "")
+            write_secure(log_file, result.stdout or "")
             review_text = result.stdout or ""
             parsed = _review_utils.parse_json_block(review_text)
             parsed["review_text"] = review_text
@@ -166,7 +167,7 @@ def run_pr_review_analysis(
             # Matches the plan reviewer / address-review / ci_driver invocations.
             input_via_stdin=True,
         )
-        log_file.write_text(stdout or "")
+        write_secure(log_file, stdout or "")
 
         # The CLI can exit 0 with an ``is_error: true`` envelope carrying a 429
         # quota cap; without this guard the cap message would be parsed as
@@ -197,12 +198,12 @@ def run_pr_review_analysis(
         stdout = e.stdout or ""
         stderr = e.stderr or ""
         error_output = f"EXIT CODE: {e.returncode}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}"
-        log_file.write_text(error_output)
+        write_secure(log_file, error_output)
         raise RuntimeError(
             f"Analysis session failed for PR {pr_ref(pr_number)}: {e.stderr or e.stdout}"
         ) from e
     except subprocess.TimeoutExpired as e:
-        log_file.write_text(f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
+        write_secure(log_file, f"TIMEOUT after {e.timeout}s\n\nOutput:\n{e.output or ''}")
         raise RuntimeError(f"Analysis session timed out for PR {pr_ref(pr_number)}") from e
     finally:
         with contextlib.suppress(Exception):

--- a/hephaestus/automation/review_validator.py
+++ b/hephaestus/automation/review_validator.py
@@ -40,6 +40,7 @@ from hephaestus.agents.runtime import (
     run_agent_text,
     uses_direct_agent_runner,
 )
+from hephaestus.io.utils import write_secure
 
 from ._review_utils import log_file_path, parse_json_block
 from .claude_invoke import invoke_claude_with_session, raise_for_error_envelope
@@ -186,7 +187,7 @@ def _run_validation_session(
                 model=direct_agent_model(agent, "HEPH_REVIEWER_MODEL"),
                 sandbox="read-only",
             )
-            log_file.write_text(result.stdout or "")
+            write_secure(log_file, result.stdout or "")
             parsed = parse_json_block(result.stdout or "")
         else:
             repo_slug = get_repo_slug(get_repo_root())
@@ -203,7 +204,7 @@ def _run_validation_session(
                 allowed_tools="Read,Glob,Grep",
                 input_via_stdin=True,
             )
-            log_file.write_text(stdout or "")
+            write_secure(log_file, stdout or "")
             # Fail loudly on an ``is_error: true`` envelope (e.g. a 429 cap)
             # instead of validating against the cap message as if it were a
             # real review (#1528 follow-up).

--- a/hephaestus/automation/work_report.py
+++ b/hephaestus/automation/work_report.py
@@ -13,6 +13,8 @@ import os
 from collections.abc import Callable, Iterator
 from pathlib import Path
 
+from hephaestus.io.utils import write_secure
+
 
 def write_work_report(work_units: int) -> None:
     """Write the phase's work-unit count to the path in $HEPH_WORK_REPORT.
@@ -29,7 +31,7 @@ def write_work_report(work_units: int) -> None:
         return
     # best-effort; absence ⇒ "unknown" ⇒ treated as work
     with contextlib.suppress(OSError):
-        Path(path).write_text(str(int(work_units)), encoding="utf-8")
+        write_secure(Path(path), str(int(work_units)))
 
 
 @contextlib.contextmanager

--- a/hephaestus/io/utils.py
+++ b/hephaestus/io/utils.py
@@ -175,7 +175,7 @@ def write_secure(
     )
     try:
         os.chmod(tmp_name, permissions)
-        with os.fdopen(fd, "w") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             fh.write(content)
             fh.flush()
             os.fsync(fh.fileno())

--- a/tests/unit/automation/test_atomic_write_guard.py
+++ b/tests/unit/automation/test_atomic_write_guard.py
@@ -1,0 +1,28 @@
+"""Guard automation state/log writes against raw Path.write_text()."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _write_text_calls(root: Path) -> list[str]:
+    """Return Python call sites that invoke an attribute named write_text."""
+    offenders: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "write_text"
+            ):
+                offenders.append(f"{path}:{node.lineno}")
+    return offenders
+
+
+def test_no_raw_write_text_calls_remain_in_automation() -> None:
+    """Automation state, prompt, output, and log files use atomic write_secure."""
+    offenders = _write_text_calls(Path("hephaestus/automation"))
+
+    assert offenders == []

--- a/tests/unit/validation/test_validation_cli_contracts.py
+++ b/tests/unit/validation/test_validation_cli_contracts.py
@@ -1,0 +1,195 @@
+"""CLI contract tests for shared validation parser migrations."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.validation import (
+    cli_tier_docs,
+    doc_config,
+    docstrings,
+    markdown,
+    mypy_per_file,
+    skill_catalog,
+)
+
+
+def test_docstrings_main_accepts_repo_root_and_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """docstrings.main() keeps explicit --repo-root and --json behavior."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hephaestus-check-docstrings",
+            "--repo-root",
+            str(tmp_path),
+            "--directory",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+    monkeypatch.setattr(docstrings, "scan_directory", lambda directory, repo_root: [])
+
+    assert docstrings.main() == 0
+    assert json.loads(capsys.readouterr().out) == []
+
+
+def test_doc_config_main_uses_shared_repo_root_json_path(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """doc_config.main() reads repo_root from the shared parser in JSON mode."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hephaestus-check-doc-config",
+            "--repo-root",
+            str(tmp_path),
+            "--skip-test-count",
+            "--json",
+        ],
+    )
+    monkeypatch.setattr(doc_config, "load_coverage_threshold", lambda repo_root: 83.0)
+    monkeypatch.setattr(doc_config, "extract_cov_path", lambda repo_root: "hephaestus")
+    monkeypatch.setattr(doc_config, "check_claude_md_threshold", lambda *args: [])
+    monkeypatch.setattr(doc_config, "check_readme_cov_path", lambda *args: [])
+    monkeypatch.setattr(doc_config, "check_addopts_cov_fail_under", lambda *args: [])
+
+    assert doc_config.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["expected_threshold"] == 83.0
+    assert payload["passed"] is True
+
+
+def test_mypy_per_file_preserves_unknown_flag_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """mypy_per_file.main() parses --json without swallowing mypy flags."""
+    observed: dict[str, Any] = {}
+
+    def fake_run(files: list[str], flags: list[str] | None = None) -> int:
+        observed["files"] = files
+        observed["flags"] = flags
+        return 0
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hephaestus-mypy-each-file",
+            "--json",
+            "--strict",
+            "--python-version",
+            "3.13",
+            "module.py",
+        ],
+    )
+    monkeypatch.setattr(mypy_per_file, "run_mypy_per_file", fake_run)
+
+    assert mypy_per_file.main() == 0
+    assert observed == {
+        "files": ["module.py"],
+        "flags": ["--strict", "--python-version", "3.13"],
+    }
+    assert json.loads(capsys.readouterr().out)["files_checked"] == 1
+
+
+def test_skill_catalog_defaults_derive_from_repo_root_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """skill_catalog.main() still derives default paths from --repo-root."""
+    docs_dir = tmp_path / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "plugin-installation.md").write_text(
+        "# Plugin\n\n"
+        "| Skill | Invocation | Description |\n"
+        "|-------|------------|-------------|\n"
+        "| alpha | `/alpha` | Test skill |\n",
+        encoding="utf-8",
+    )
+    skill_dir = tmp_path / "skills" / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Test skill\n---\n\n# Alpha\n",
+        encoding="utf-8",
+    )
+
+    assert skill_catalog.main(["--repo-root", str(tmp_path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    assert payload["missing"] == []
+    assert payload["extra"] == []
+
+
+def test_cli_tier_docs_main_accepts_argv_repo_root_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """cli_tier_docs.main(argv) keeps explicit repo-root and JSON behavior."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\n\n[project.scripts]\nhephaestus-demo = "pkg:main"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "COMPATIBILITY.md").write_text(
+        "## Console-Script Stability Tiers\n"
+        "| CLI | Tier |\n"
+        "|-----|------|\n"
+        "| `hephaestus-demo` | Stable |\n",
+        encoding="utf-8",
+    )
+
+    assert cli_tier_docs.main(["--repo-root", str(tmp_path), "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == {"violations": []}
+
+
+def test_markdown_readme_entry_point_does_not_require_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """check_readmes_main() keeps its no-repo-root CLI contract."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hephaestus-check-readmes", "--directory", str(tmp_path), "--json"],
+    )
+
+    assert markdown.check_readmes_main() == 0
+    assert json.loads(capsys.readouterr().out) == {"directory": str(tmp_path), "results": []}
+
+
+def test_markdown_link_entry_point_accepts_repo_root_json(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """markdown.main() keeps explicit --repo-root and --json behavior."""
+    (tmp_path / "README.md").write_text("# Demo\n", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hephaestus-validate-links",
+            str(tmp_path),
+            "--repo-root",
+            str(tmp_path),
+            "--json",
+        ],
+    )
+
+    assert markdown.main() == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["failed"] == []


### PR DESCRIPTION
## Summary
Switches automation state and log file persistence to secure atomic writes while centralizing validation CLI parser setup.

## Changes
- Replaced raw automation state/log file writes with write_secure-backed atomic persistence across review, CI, GitHub API, and implementer flows.
- Added create_validation_parser and updated validation commands to share repo-root, JSON, and version argument handling.
- Adjusted related unit tests and added coverage for atomic write guards and validation CLI contracts.

## Testing
- Not run; only issue, changed-file, and commit metadata were provided.

## Closes
Closes #1410

Generated by Codex via ProjectHephaestus automation.
