### PR TITLE
refactor(pr-merge): reuse shared subprocess helper

### DIFF
--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -150,12 +150,12 @@ def local_branch_exists(branch_name: str) -> bool:
 
     """
     try:
-        out = subprocess.check_output(
+        result = run_subprocess(
             ["git", "branch", "--list", branch_name],
-            stderr=subprocess.DEVNULL,
             timeout=METADATA_TIMEOUT,
+            log_on_error=False,
         )
-        return bool(out.strip())
+        return bool(result.stdout.strip())
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return False
 

--- a/tests/unit/github/test_github_utils.py
+++ b/tests/unit/github/test_github_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Tests for GitHub utilities."""
 
-from subprocess import CalledProcessError
+from subprocess import CalledProcessError, CompletedProcess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,31 +67,46 @@ class TestDetectRepoFromRemote:
 class TestLocalBranchExists:
     """Tests for local_branch_exists."""
 
-    @patch("subprocess.check_output")
-    def test_branch_exists(self, mock_check_output):
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_branch_exists(self, mock_run):
         """Returns True when branch exists."""
-        mock_check_output.return_value = b"  feature-branch\n"
+        mock_run.return_value = CompletedProcess(
+            ["git", "branch", "--list", "feature-branch"],
+            0,
+            stdout="  feature-branch\n",
+            stderr="",
+        )
         result = local_branch_exists("feature-branch")
         assert result is True
 
-    @patch("subprocess.check_output")
-    def test_branch_not_exists(self, mock_check_output):
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_branch_not_exists(self, mock_run):
         """Returns False when branch doesn't exist (empty output)."""
-        mock_check_output.return_value = b""
+        mock_run.return_value = CompletedProcess(
+            ["git", "branch", "--list", "non-existent-branch"],
+            0,
+            stdout="",
+            stderr="",
+        )
         result = local_branch_exists("non-existent-branch")
         assert result is False
 
-    @patch("subprocess.check_output")
-    def test_branch_check_error_returns_false(self, mock_check_output):
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_branch_check_error_returns_false(self, mock_run):
         """Returns False on CalledProcessError."""
-        mock_check_output.side_effect = CalledProcessError(1, ["git", "branch"])
+        mock_run.side_effect = CalledProcessError(1, ["git", "branch"])
         result = local_branch_exists("any-branch")
         assert result is False
 
-    @patch("subprocess.check_output")
-    def test_branch_with_whitespace_output(self, mock_check_output):
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_branch_with_whitespace_output(self, mock_run):
         """Branch name with whitespace in output still returns True."""
-        mock_check_output.return_value = b"  main  \n"
+        mock_run.return_value = CompletedProcess(
+            ["git", "branch", "--list", "main"],
+            0,
+            stdout="  main  \n",
+            stderr="",
+        )
         result = local_branch_exists("main")
         assert result is True
 
@@ -99,17 +114,21 @@ class TestLocalBranchExists:
 class TestRunGitCmd:
     """Tests for run_git_cmd."""
 
-    def test_dry_run_does_not_call_subprocess(self):
-        """In dry-run mode, no subprocess is called."""
-        with patch("subprocess.run") as mock_run:
-            run_git_cmd(["git", "push", "origin", "main"], dry_run=True)
-            mock_run.assert_not_called()
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_dry_run_delegates_to_shared_helper(self, mock_run):
+        """Dry-run handling is delegated to the shared subprocess helper."""
+        run_git_cmd(["git", "push", "origin", "main"], dry_run=True)
+        mock_run.assert_called_once_with(
+            ["git", "push", "origin", "main"],
+            cwd=None,
+            dry_run=True,
+        )
 
-    def test_non_dry_run_calls_subprocess(self):
-        """In non-dry-run mode, subprocess is called."""
-        with patch("subprocess.run") as mock_run:
-            run_git_cmd(["git", "status"], dry_run=False)
-            mock_run.assert_called_once()
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_non_dry_run_delegates_to_shared_helper(self, mock_run):
+        """Non-dry-run execution is delegated to the shared subprocess helper."""
+        run_git_cmd(["git", "status"], dry_run=False)
+        mock_run.assert_called_once_with(["git", "status"], cwd=None, dry_run=False)
 
 
 class TestChecksSuccessAndPrint:

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -240,35 +240,51 @@ class TestLegacyStatusAndPrint:
 class TestLocalBranchExists:
     """Tests for local_branch_exists."""
 
-    @patch("hephaestus.github.pr_merge.subprocess.check_output")
-    def test_returns_true_when_branch_exists(self, mock_check) -> None:
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_returns_true_when_branch_exists(self, mock_run) -> None:
         """Returns True when git branch --list output is non-empty."""
-        mock_check.return_value = b"  my-feature\n"
+        mock_run.return_value = subprocess.CompletedProcess(
+            ["git", "branch", "--list", "my-feature"],
+            0,
+            stdout="  my-feature\n",
+            stderr="",
+        )
         assert local_branch_exists("my-feature") is True
 
-    @patch("hephaestus.github.pr_merge.subprocess.check_output")
-    def test_returns_false_when_branch_absent(self, mock_check) -> None:
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_returns_false_when_branch_absent(self, mock_run) -> None:
         """Returns False when git branch --list output is empty."""
-        mock_check.return_value = b""
+        mock_run.return_value = subprocess.CompletedProcess(
+            ["git", "branch", "--list", "nonexistent"],
+            0,
+            stdout="",
+            stderr="",
+        )
         assert local_branch_exists("nonexistent") is False
 
-    @patch("hephaestus.github.pr_merge.subprocess.check_output")
-    def test_returns_false_on_subprocess_error(self, mock_check) -> None:
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_returns_false_on_subprocess_error(self, mock_run) -> None:
         """Returns False when subprocess raises CalledProcessError."""
-        mock_check.side_effect = subprocess.CalledProcessError(1, "git")
+        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
         assert local_branch_exists("branch") is False
 
-    @patch("hephaestus.github.pr_merge.subprocess.check_output")
-    def test_passes_timeout(self, mock_check) -> None:
-        """The git branch lookup is bounded by METADATA_TIMEOUT (#684)."""
-        mock_check.return_value = b"  my-feature\n"
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_passes_timeout_and_suppresses_expected_error_logs(self, mock_run) -> None:
+        """The git branch lookup is bounded and avoids noisy expected-error logs."""
+        mock_run.return_value = subprocess.CompletedProcess(
+            ["git", "branch", "--list", "my-feature"],
+            0,
+            stdout="  my-feature\n",
+            stderr="",
+        )
         local_branch_exists("my-feature")
-        assert mock_check.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+        assert mock_run.call_args.kwargs["log_on_error"] is False
 
-    @patch("hephaestus.github.pr_merge.subprocess.check_output")
-    def test_returns_false_on_timeout(self, mock_check) -> None:
+    @patch("hephaestus.github.pr_merge.run_subprocess")
+    def test_returns_false_on_timeout(self, mock_run) -> None:
         """A hung ``git branch --list`` degrades to False instead of hanging (#684)."""
-        mock_check.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
         assert local_branch_exists("branch") is False
 
 
@@ -570,3 +586,18 @@ class TestSquashOnlyInvariant:
         source = inspect.getsource(pr_merge)
         assert "merge_method=rebase" not in source
         assert "merge_method=squash" in source
+
+
+class TestCanonicalRunSubprocess:
+    """Source-level regressions for subprocess helper consolidation."""
+
+    def test_pr_merge_uses_canonical_run_subprocess(self) -> None:
+        import inspect
+
+        from hephaestus.github import pr_merge
+        from hephaestus.utils import helpers
+
+        source = inspect.getsource(pr_merge)
+        assert vars(pr_merge)["run_subprocess"] is helpers.run_subprocess
+        assert "def run_subprocess(" not in source
+        assert "subprocess.check_output" not in source


### PR DESCRIPTION
## Summary
Refactors PR merge subprocess handling to rely on the shared helper and updates related automation/GitHub utilities and tests.

## Changes
- Replaced the local pr_merge subprocess wrapper with the canonical shared helper.
- Adjusted related automation review, CI, GitHub API, and git utility code/tests after removing duplicated helper paths.

## Testing
- Unit test coverage updated for pr_merge, GitHub utilities, GitHub API, address review, and stage phases.

## Closes
Closes #1414

Generated by Codex via ProjectHephaestus automation.
