### PR TITLE
refactor(agents): centralize agent timeout constants

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -15,12 +15,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from hephaestus.constants import AGENT_AUTH_STATUS_TIMEOUT
+
 AgentName = Literal["claude", "codex", "pi"]
 SubprocessCommandPart = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 SubprocessCommand = SubprocessCommandPart | Sequence[SubprocessCommandPart]
 AGENT_CHOICES: tuple[AgentName, ...] = ("claude", "codex", "pi")
 DEFAULT_AGENT: AgentName = "claude"
-AGENT_AUTH_STATUS_TIMEOUT = 10
 CODEX_FINAL_MESSAGE_GRACE_ENV = "HEPH_CODEX_FINAL_MESSAGE_GRACE"
 CODEX_FINAL_MESSAGE_GRACE_SECONDS = 5.0
 CODEX_OPUS_MODEL = "gpt-5.5"
@@ -335,7 +336,7 @@ def codex_approval_args(approval: str) -> list[str]:
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            timeout=10,
+            timeout=AGENT_AUTH_STATUS_TIMEOUT,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired):

--- a/hephaestus/automation/_pr_create_phase.py
+++ b/hephaestus/automation/_pr_create_phase.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ._stage_context import StageMixin
+from .claude_timeouts import AGENT_PRE_PR_TEST_TIMEOUT
 from .git_utils import issue_ref, run
 from .models import ImplementationPhase, ImplementationState
 from .pr_manager import ensure_pr_created
@@ -80,7 +81,7 @@ class PRCreatePhase(StageMixin):
                 cwd=worktree_path,
                 capture_output=True,
                 text=True,
-                timeout=600,
+                timeout=AGENT_PRE_PR_TEST_TIMEOUT,
             )
             if result.returncode == 0:
                 logger.info("#%d: pre-PR tests passed", issue_number)
@@ -93,7 +94,11 @@ class PRCreatePhase(StageMixin):
             )
             return False
         except subprocess.TimeoutExpired:
-            logger.warning("#%d: pre-PR tests timed out after 600s", issue_number)
+            logger.warning(
+                "#%d: pre-PR tests timed out after %ds",
+                issue_number,
+                AGENT_PRE_PR_TEST_TIMEOUT,
+            )
             return False
         except Exception as e:
             logger.warning("#%d: pre-PR tests could not run: %s", issue_number, e)

--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -43,7 +43,12 @@ from .claude_invoke import (
     parse_review_verdict,
 )
 from .claude_models import implementer_model, reviewer_model
-from .claude_timeouts import implementer_claude_timeout
+from .claude_timeouts import (
+    AGENT_DIFF_TIMEOUT,
+    AGENT_GIT_TIMEOUT,
+    AGENT_REVIEW_TIMEOUT,
+    implementer_claude_timeout,
+)
 from .git_utils import (
     commit_if_changes,
     get_repo_info,
@@ -1626,7 +1631,7 @@ class ReviewPhase(StageMixin):
                     agent=self.options.agent,
                     prompt=prompt,
                     cwd=self.repo_root,
-                    timeout=600,
+                    timeout=AGENT_REVIEW_TIMEOUT,
                     model=direct_agent_model(self.options.agent, "HEPH_REVIEWER_MODEL"),
                     sandbox="read-only",
                 )
@@ -1650,7 +1655,7 @@ class ReviewPhase(StageMixin):
                 capture_output=True,
                 text=True,
                 check=True,
-                timeout=600,
+                timeout=AGENT_REVIEW_TIMEOUT,
                 env=env,
             )
             output = (result.stdout or "").strip()
@@ -1682,7 +1687,7 @@ class ReviewPhase(StageMixin):
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
-                timeout=60,
+                timeout=AGENT_DIFF_TIMEOUT,
             )
             diff = result.stdout or ""
             if not diff.strip():
@@ -1691,7 +1696,7 @@ class ReviewPhase(StageMixin):
                     cwd=worktree_path,
                     capture_output=True,
                     check=False,
-                    timeout=60,
+                    timeout=AGENT_DIFF_TIMEOUT,
                 )
                 diff = fb.stdout or ""
         except Exception as e:
@@ -1716,7 +1721,7 @@ class ReviewPhase(StageMixin):
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
-                timeout=30,
+                timeout=AGENT_GIT_TIMEOUT,
             )
             files = (result.stdout or "").strip()
             if files:
@@ -1726,7 +1731,7 @@ class ReviewPhase(StageMixin):
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
-                timeout=30,
+                timeout=AGENT_GIT_TIMEOUT,
             )
             return (fb.stdout or "").strip()
         except Exception as e:

--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -31,6 +31,8 @@ from pathlib import Path
 
 from hephaestus.github.client import gh_call
 
+from .claude_timeouts import AGENT_CLONE_TIMEOUT, AGENT_GIT_TIMEOUT
+
 # fcntl is POSIX-only; CPython does not bundle it on Windows. Import lazily so
 # this module stays importable on Windows for tests that only need its
 # pure-Python helpers. The cross-process file lock that uses fcntl is only
@@ -49,8 +51,6 @@ logger = logging.getLogger(__name__)
 # stage) serializes against the same lock — previously this lived on the
 # Planner class, which left the implementer/CI-driver advise paths unguarded.
 _MNEMOSYNE_LOCK = threading.Lock()
-_MNEMOSYNE_GIT_TIMEOUT = 30
-_MNEMOSYNE_CLONE_TIMEOUT = 120
 _MAX_SELECTED_SKILLS = 5
 _MAX_SKILL_CONTEXT_CHARS = 40_000
 _MAX_MARKETPLACE_PROMPT_CHARS = 80_000
@@ -93,14 +93,14 @@ def _clone_mnemosyne(mnemosyne_root: Path) -> bool:
                 str(mnemosyne_root),
             ],
             check=True,
-            timeout=_MNEMOSYNE_CLONE_TIMEOUT,
+            timeout=AGENT_CLONE_TIMEOUT,
         )
         logger.info("ProjectMnemosyne cloned successfully")
         return True
     except subprocess.TimeoutExpired:
         logger.warning(
             "gh repo clone timed out after %s s; ProjectMnemosyne unavailable this run",
-            _MNEMOSYNE_CLONE_TIMEOUT,
+            AGENT_CLONE_TIMEOUT,
         )
         return False
     except subprocess.CalledProcessError as e:
@@ -119,7 +119,7 @@ def _is_valid_mnemosyne_checkout(mnemosyne_root: Path) -> bool:
             check=False,
             capture_output=True,
             text=True,
-            timeout=_MNEMOSYNE_GIT_TIMEOUT,
+            timeout=AGENT_GIT_TIMEOUT,
         )
     except (subprocess.SubprocessError, OSError) as e:
         logger.warning("Failed to validate ProjectMnemosyne checkout at %s: %s", mnemosyne_root, e)
@@ -173,7 +173,7 @@ def ensure_mnemosyne(mnemosyne_root: Path) -> bool:
                                 check=True,
                                 capture_output=True,
                                 text=True,
-                                timeout=_MNEMOSYNE_GIT_TIMEOUT,
+                                timeout=AGENT_GIT_TIMEOUT,
                             )
                             logger.debug("ProjectMnemosyne refreshed at %s", mnemosyne_root)
                         except Exception as e:

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -31,6 +31,8 @@ from hephaestus.automation.session_naming import session_jsonl_path, session_nam
 from hephaestus.github.client import ClaudeUsageCapError
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch
 
+from .claude_timeouts import AGENT_DEFAULT_TIMEOUT
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +64,7 @@ def invoke_claude_with_session(
     prompt: str,
     model: str,
     cwd: Path,
-    timeout: int = 300,
+    timeout: int = AGENT_DEFAULT_TIMEOUT,
     system_prompt_file: Path | None = None,
     allowed_tools: str | None = None,
     permission_mode: str | None = None,

--- a/hephaestus/automation/claude_timeouts.py
+++ b/hephaestus/automation/claude_timeouts.py
@@ -16,6 +16,20 @@ from __future__ import annotations
 import logging
 import os
 
+from hephaestus.constants import (
+    AGENT_AUTH_STATUS_TIMEOUT,
+    AGENT_CLONE_TIMEOUT,
+    AGENT_DEFAULT_TIMEOUT,
+    AGENT_DIFF_TIMEOUT,
+    AGENT_GIT_TIMEOUT,
+    AGENT_IMPL_TIMEOUT,
+    AGENT_LEARN_TIMEOUT,
+    AGENT_PLAN_TIMEOUT,
+    AGENT_PRE_PR_TEST_TIMEOUT,
+    AGENT_REBASE_TIMEOUT,
+    AGENT_REVIEW_TIMEOUT,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -86,6 +100,17 @@ def git_message_agent_timeout() -> int:
 from hephaestus.github.client import gh_cli_timeout  # noqa: E402
 
 __all__ = [
+    "AGENT_AUTH_STATUS_TIMEOUT",
+    "AGENT_CLONE_TIMEOUT",
+    "AGENT_DEFAULT_TIMEOUT",
+    "AGENT_DIFF_TIMEOUT",
+    "AGENT_GIT_TIMEOUT",
+    "AGENT_IMPL_TIMEOUT",
+    "AGENT_LEARN_TIMEOUT",
+    "AGENT_PLAN_TIMEOUT",
+    "AGENT_PRE_PR_TEST_TIMEOUT",
+    "AGENT_REBASE_TIMEOUT",
+    "AGENT_REVIEW_TIMEOUT",
     "address_review_claude_timeout",
     "advise_claude_timeout",
     "ci_driver_claude_timeout",

--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -42,7 +42,6 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.github.client import gh_call
 
-from .claude_timeouts import AGENT_GIT_TIMEOUT
 from .state_labels import STATE_LABEL_SPECS
 
 logger = logging.getLogger(__name__)
@@ -119,7 +118,7 @@ def ensure_labels_on_repo(repo: str, *, dry_run: bool = False) -> int:
             "--force",  # upsert: create-or-update
         ]
         try:
-            gh_call(cmd, timeout=AGENT_GIT_TIMEOUT)
+            gh_call(cmd)
         except subprocess.CalledProcessError as exc:
             logger.warning(
                 "%s: failed to ensure label %r (rc=%s): %s",
@@ -139,7 +138,6 @@ def _detect_current_repo_slug() -> str:
     try:
         proc = gh_call(
             ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-            timeout=AGENT_GIT_TIMEOUT,
         )
     except subprocess.CalledProcessError as exc:
         raise SystemExit(

--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -42,6 +42,7 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.github.client import gh_call
 
+from .claude_timeouts import AGENT_GIT_TIMEOUT
 from .state_labels import STATE_LABEL_SPECS
 
 logger = logging.getLogger(__name__)
@@ -118,7 +119,7 @@ def ensure_labels_on_repo(repo: str, *, dry_run: bool = False) -> int:
             "--force",  # upsert: create-or-update
         ]
         try:
-            gh_call(cmd, timeout=30)
+            gh_call(cmd, timeout=AGENT_GIT_TIMEOUT)
         except subprocess.CalledProcessError as exc:
             logger.warning(
                 "%s: failed to ensure label %r (rc=%s): %s",
@@ -138,7 +139,7 @@ def _detect_current_repo_slug() -> str:
     try:
         proc = gh_call(
             ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
-            timeout=30,
+            timeout=AGENT_GIT_TIMEOUT,
         )
     except subprocess.CalledProcessError as exc:
         raise SystemExit(

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from hephaestus.utils.helpers import get_repo_root as get_repo_root, run_subprocess
 from hephaestus.utils.retry import retry_with_backoff
 
+from .claude_timeouts import AGENT_GIT_TIMEOUT
+
 logger = logging.getLogger(__name__)
 
 
@@ -253,7 +255,7 @@ def safe_git_fetch(repo_root: Path, retries: int = 3) -> bool:
         run(
             ["git", "fetch", "origin"],
             cwd=repo_root,
-            timeout=30,
+            timeout=AGENT_GIT_TIMEOUT,
         )
         logger.debug("Git fetch succeeded")
         return True

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -70,6 +70,7 @@ from hephaestus.agents.runtime import (
 # Imports for the Test-Patch Contract — see module docstring for the full table.
 # Each symbol here is either a real call site in IssueImplementer/main or an
 # explicit re-export required by tests or the public API.
+from .claude_timeouts import AGENT_IMPL_TIMEOUT
 from .curses_ui import CursesUI, ThreadLogManager
 from .dependency_resolver import CyclicDependencyError, DependencyResolver
 
@@ -120,11 +121,9 @@ __all__ = [
     "main",
 ]
 
-# Default implementation timeout in seconds. Actual runtime value is read from
-# ``HEPH_IMPLEMENTER_AGENT_TIMEOUT`` by
-# :func:`.claude_timeouts.implementer_claude_timeout`; this constant serves as
-# the documented default and can be used in tests.
-_CLAUDE_IMPL_TIMEOUT: int = 1800
+# Default implementation timeout in seconds. Preserved as a compatibility seam
+# for tests and older callers; the canonical value lives in hephaestus.constants.
+_CLAUDE_IMPL_TIMEOUT: int = AGENT_IMPL_TIMEOUT
 
 
 logger = logging.getLogger(__name__)

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -26,7 +26,7 @@ from hephaestus.agents.runtime import (
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 
 from .claude_models import learn_model
-from .claude_timeouts import learn_claude_timeout
+from .claude_timeouts import AGENT_LEARN_TIMEOUT, learn_claude_timeout
 from .git_utils import run
 from .session_naming import session_uuid
 
@@ -378,7 +378,7 @@ def compact_session(
     issue: int | str,
     agent: str,
     cwd: Path,
-    timeout: int = 300,
+    timeout: int = AGENT_LEARN_TIMEOUT,
     model: str | None = None,
 ) -> bool:
     """Send ``/compact`` to the (repo, issue, agent, model) Claude session.

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -38,7 +38,7 @@ from ._review_utils import (
 )
 from .advise_runner import advise_skipped, ensure_mnemosyne, run_advise
 from .claude_models import advise_model, codex_advise_model
-from .claude_timeouts import advise_claude_timeout
+from .claude_timeouts import AGENT_PLAN_TIMEOUT, advise_claude_timeout
 from .git_utils import issue_ref
 from .github_api import (
     GitHubRateLimitError,
@@ -319,7 +319,7 @@ class Planner:
         agent: str,
         issue_number: int | str,
         max_retries: int = 3,
-        timeout: int = 300,
+        timeout: int = AGENT_PLAN_TIMEOUT,
         extra_args: list[str] | None = None,
     ) -> str:
         """Call Claude (delegates to claude_runner)."""

--- a/hephaestus/automation/planner_claude.py
+++ b/hephaestus/automation/planner_claude.py
@@ -22,6 +22,7 @@ from hephaestus.agents.runtime import (
 from hephaestus.github.rate_limit import wait_until
 
 from .claude_invoke import detect_server_overload, invoke_claude_with_session, scan_quota_reset
+from .claude_timeouts import AGENT_PLAN_TIMEOUT
 from .git_utils import get_repo_root, get_repo_slug
 
 if TYPE_CHECKING:
@@ -65,7 +66,7 @@ class PlannerClaudeRunner:
         agent: str,
         issue_number: int | str,
         max_retries: int = 3,
-        timeout: int = 300,
+        timeout: int = AGENT_PLAN_TIMEOUT,
         extra_args: list[str] | None = None,
     ) -> str:
         """Call Claude CLI on a deterministic session with rate-limit retry.
@@ -189,7 +190,7 @@ class PlannerClaudeRunner:
         *,
         model: str,
         max_retries: int = 3,
-        timeout: int = 300,
+        timeout: int = AGENT_PLAN_TIMEOUT,
         sandbox: str = "workspace-write",
     ) -> str:
         """Call a non-Claude direct agent with retry logic for rate limits."""

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -24,7 +24,7 @@ from typing import Any, Protocol
 
 from .claude_invoke import INFRA_ERROR_REVIEW_TEXT, parse_review_verdict
 from .claude_models import planner_model, reviewer_model
-from .claude_timeouts import learn_claude_timeout, planner_claude_timeout
+from .claude_timeouts import AGENT_PLAN_TIMEOUT, learn_claude_timeout, planner_claude_timeout
 from .git_utils import get_repo_root, issue_ref
 from .github_api import (
     gh_issue_add_labels,
@@ -147,7 +147,7 @@ class PlannerHost(Protocol):
         agent: str,
         issue_number: int | str,
         max_retries: int = 3,
-        timeout: int = 300,
+        timeout: int = AGENT_PLAN_TIMEOUT,
         extra_args: list[str] | None = None,
     ) -> str:
         """Call Claude with the given prompt."""

--- a/hephaestus/constants.py
+++ b/hephaestus/constants.py
@@ -32,6 +32,31 @@ LOG_FORMAT: str = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 # Base field names included in every JSON log record.
 JSON_LOG_FIELDS: tuple[str, ...] = ("timestamp", "level", "logger", "message")
 
+
+def _read_timeout_env(name: str, default: int) -> int:
+    """Return an integer timeout override or the documented default."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        _logger.warning("Ignoring non-integer %s=%r; using default %ds", name, raw, default)
+        return default
+
+
+AGENT_AUTH_STATUS_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_AUTH_STATUS_TIMEOUT", 10)
+AGENT_GIT_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_GIT_TIMEOUT", 30)
+AGENT_DIFF_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_DIFF_TIMEOUT", 60)
+AGENT_CLONE_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_CLONE_TIMEOUT", 120)
+AGENT_DEFAULT_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_DEFAULT_TIMEOUT", 300)
+AGENT_PLAN_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_PLAN_TIMEOUT", 300)
+AGENT_LEARN_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_LEARN_TIMEOUT", 300)
+AGENT_REVIEW_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_REVIEW_TIMEOUT", 600)
+AGENT_PRE_PR_TEST_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_PRE_PR_TEST_TIMEOUT", 600)
+AGENT_IMPL_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_IMPL_TIMEOUT", 1800)
+AGENT_REBASE_TIMEOUT: int = _read_timeout_env("HEPH_AGENT_REBASE_TIMEOUT", 2400)
+
 # Canonical transient-failure substrings shared by the resilience and retry
 # layers. Both ``subprocess_resilience.TRANSIENT_ERROR_PATTERNS`` and
 # ``retry.NETWORK_ERROR_KEYWORDS`` derive from this core so the overlapping

--- a/hephaestus/github/fleet_sync.py
+++ b/hephaestus/github/fleet_sync.py
@@ -55,6 +55,7 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 from hephaestus.config.utils import load_config
+from hephaestus.constants import AGENT_REBASE_TIMEOUT
 from hephaestus.github.client import gh_call
 from hephaestus.logging.utils import get_logger
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
@@ -700,7 +701,7 @@ def _run_conflict_agent(agent: str, prompt: str, work: Path, pr_number: int) -> 
             agent=agent,
             prompt=prompt,
             cwd=work,
-            timeout=2400,
+            timeout=AGENT_REBASE_TIMEOUT,
             model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
             sandbox="workspace-write",
         )

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -37,6 +37,7 @@ from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     emit_json_status,
 )
+from hephaestus.constants import AGENT_REBASE_TIMEOUT
 from hephaestus.github.client import gh_call
 from hephaestus.github.pr_merge import detect_repo_from_remote
 from hephaestus.logging.utils import get_logger
@@ -402,7 +403,7 @@ def _run_direct_rebase_agent(agent: str, prompt: str, branch: str, repo_path: Pa
             agent=agent,
             prompt=prompt,
             cwd=repo_path,
-            timeout=2400,
+            timeout=AGENT_REBASE_TIMEOUT,
             model=direct_agent_model(agent, "HEPH_IMPLEMENTER_MODEL"),
             sandbox="workspace-write",
         )

--- a/tests/unit/automation/test_claude_timeouts.py
+++ b/tests/unit/automation/test_claude_timeouts.py
@@ -7,9 +7,30 @@ from collections.abc import Callable
 
 import pytest
 
+from hephaestus import constants
 from hephaestus.automation import claude_timeouts
 
 TWO_HOURS_S = 7200
+
+AGENT_TIMEOUT_CONSTANT_NAMES = (
+    "AGENT_AUTH_STATUS_TIMEOUT",
+    "AGENT_GIT_TIMEOUT",
+    "AGENT_DIFF_TIMEOUT",
+    "AGENT_CLONE_TIMEOUT",
+    "AGENT_DEFAULT_TIMEOUT",
+    "AGENT_PLAN_TIMEOUT",
+    "AGENT_LEARN_TIMEOUT",
+    "AGENT_REVIEW_TIMEOUT",
+    "AGENT_PRE_PR_TEST_TIMEOUT",
+    "AGENT_IMPL_TIMEOUT",
+    "AGENT_REBASE_TIMEOUT",
+)
+
+
+@pytest.mark.parametrize("constant_name", AGENT_TIMEOUT_CONSTANT_NAMES)
+def test_agent_timeout_constants_are_reexported(constant_name: str) -> None:
+    """Automation modules can import agent timeout constants from claude_timeouts."""
+    assert getattr(claude_timeouts, constant_name) == getattr(constants, constant_name)
 
 
 def _clear_planner_timeout_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation import implementer
+from hephaestus.automation import claude_timeouts, implementer
 from hephaestus.automation.implementer import (
     _CLAUDE_IMPL_TIMEOUT,
     IssueImplementer,
@@ -139,7 +139,7 @@ class TestClaudeImplTimeoutConstant:
         assert hasattr(implementer, "_CLAUDE_IMPL_TIMEOUT")
 
     def test_constant_value(self) -> None:
-        assert _CLAUDE_IMPL_TIMEOUT == 1800
+        assert _CLAUDE_IMPL_TIMEOUT == claude_timeouts.AGENT_IMPL_TIMEOUT == 1800
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +182,9 @@ class TestRunTestsInWorktree:
     def test_returns_false_on_timeout(self, impl: IssueImplementer, tmp_path: Path) -> None:
         with patch(
             "hephaestus.automation.implementer.subprocess.run",
-            side_effect=subprocess.TimeoutExpired(["pixi"], 600),
+            side_effect=subprocess.TimeoutExpired(
+                ["pixi"], claude_timeouts.AGENT_PRE_PR_TEST_TIMEOUT
+            ),
         ):
             assert impl._run_tests_in_worktree(tmp_path, issue_number=1) is False
 

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation.claude_timeouts import AGENT_CLONE_TIMEOUT, AGENT_PLAN_TIMEOUT
 from hephaestus.automation.models import PlannerOptions
 from hephaestus.automation.planner import Planner
 
@@ -123,7 +124,7 @@ class TestCallClaude:
             self._patch_repo(),
             patch("hephaestus.automation.claude_invoke.subprocess.run") as mock_run,
         ):
-            mock_run.side_effect = subprocess.TimeoutExpired("claude", 300)
+            mock_run.side_effect = subprocess.TimeoutExpired("claude", AGENT_PLAN_TIMEOUT)
 
             with pytest.raises(RuntimeError, match="timed out"):
                 planner._call_claude(
@@ -131,7 +132,7 @@ class TestCallClaude:
                     model="claude-opus-4-7",
                     agent="planner",
                     issue_number=1,
-                    timeout=300,
+                    timeout=AGENT_PLAN_TIMEOUT,
                 )
 
     def test_rate_limit_retry(self, planner: Any) -> None:
@@ -679,7 +680,7 @@ class TestEnsureMnemosyne:
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
         with patch("hephaestus.automation.advise_runner.gh_call") as mock_gh:
-            mock_gh.side_effect = subprocess.TimeoutExpired("gh", 120)
+            mock_gh.side_effect = subprocess.TimeoutExpired("gh", AGENT_CLONE_TIMEOUT)
 
             result = planner._ensure_mnemosyne(mnemosyne_root)
 
@@ -700,7 +701,7 @@ class TestEnsureMnemosyne:
 
         call_kwargs = mock_gh.call_args.kwargs
         assert "timeout" in call_kwargs, "gh_call for clone must pass timeout="
-        assert call_kwargs["timeout"] == 120
+        assert call_kwargs["timeout"] == AGENT_CLONE_TIMEOUT
 
 
 class TestPrCoverageSkip:

--- a/tests/unit/constants/test_constants.py
+++ b/tests/unit/constants/test_constants.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import importlib
+import logging
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
@@ -23,6 +26,66 @@ SHARED_TRANSIENT_SIGNALS = (
     "502",
     "504",
 )
+
+AGENT_TIMEOUT_CONSTANTS = (
+    ("AGENT_AUTH_STATUS_TIMEOUT", "HEPH_AGENT_AUTH_STATUS_TIMEOUT", 10),
+    ("AGENT_GIT_TIMEOUT", "HEPH_AGENT_GIT_TIMEOUT", 30),
+    ("AGENT_DIFF_TIMEOUT", "HEPH_AGENT_DIFF_TIMEOUT", 60),
+    ("AGENT_CLONE_TIMEOUT", "HEPH_AGENT_CLONE_TIMEOUT", 120),
+    ("AGENT_DEFAULT_TIMEOUT", "HEPH_AGENT_DEFAULT_TIMEOUT", 300),
+    ("AGENT_PLAN_TIMEOUT", "HEPH_AGENT_PLAN_TIMEOUT", 300),
+    ("AGENT_LEARN_TIMEOUT", "HEPH_AGENT_LEARN_TIMEOUT", 300),
+    ("AGENT_REVIEW_TIMEOUT", "HEPH_AGENT_REVIEW_TIMEOUT", 600),
+    ("AGENT_PRE_PR_TEST_TIMEOUT", "HEPH_AGENT_PRE_PR_TEST_TIMEOUT", 600),
+    ("AGENT_IMPL_TIMEOUT", "HEPH_AGENT_IMPL_TIMEOUT", 1800),
+    ("AGENT_REBASE_TIMEOUT", "HEPH_AGENT_REBASE_TIMEOUT", 2400),
+)
+
+
+def _reload_constants_module() -> ModuleType:
+    return importlib.reload(constants)
+
+
+class TestAgentTimeoutConstants:
+    """Tests for canonical agent subprocess timeout constants."""
+
+    @pytest.mark.parametrize(("constant_name", "_env_name", "default"), AGENT_TIMEOUT_CONSTANTS)
+    def test_defaults(self, constant_name: str, _env_name: str, default: int) -> None:
+        """Agent timeout constants expose the documented default values."""
+        assert getattr(constants, constant_name) == default
+
+    @pytest.mark.parametrize(("constant_name", "env_name", "_default"), AGENT_TIMEOUT_CONSTANTS)
+    def test_env_overrides(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        constant_name: str,
+        env_name: str,
+        _default: int,
+    ) -> None:
+        """Each timeout can be tuned through its own HEPH_* env var."""
+        monkeypatch.setenv(env_name, "77")
+        try:
+            reloaded = _reload_constants_module()
+            assert getattr(reloaded, constant_name) == 77
+        finally:
+            monkeypatch.delenv(env_name, raising=False)
+            _reload_constants_module()
+
+    def test_invalid_env_logs_and_uses_default(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Malformed timeout overrides warn and fall back to the default."""
+        monkeypatch.setenv("HEPH_AGENT_IMPL_TIMEOUT", "slow")
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="hephaestus.constants"):
+                reloaded = _reload_constants_module()
+        finally:
+            monkeypatch.delenv("HEPH_AGENT_IMPL_TIMEOUT", raising=False)
+            _reload_constants_module()
+
+        assert reloaded.AGENT_IMPL_TIMEOUT == 1800
+        assert any("HEPH_AGENT_IMPL_TIMEOUT" in record.message for record in caplog.records)
 
 
 class TestTransientErrorCore:


### PR DESCRIPTION
## Summary
Centralizes scattered agent subprocess timeout values behind named constants with environment overrides, then updates automation and GitHub workflows to use them.

## Changes
- Added importable agent timeout constants for implementation, review, planning, learning, GitHub operations, auth status, and long-running commands.
- Replaced hardcoded timeout values across agent runtime, planner, implementer, review, learn, advise, tidy, and fleet sync paths.
- Updated affected unit tests for the centralized timeout constants and revised automation helper behavior.

## Testing
- Not run (not provided).

## Closes
Closes #1415

Generated by Codex via ProjectHephaestus automation.
