### PR TITLE
refactor(validation): share parser boilerplate

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -281,10 +281,12 @@ removal):
 | `configure_github_throttle_from_args` | 0.9.0 | Apply parsed throttle args to the GitHub client |
 | `confirm_action` | 0.1.0 | Interactive yes/no confirmation prompt |
 | `create_parser` | 0.1.0 | Build a standard `ArgumentParser` |
+| `create_validation_parser` | 0.9.8 | Build a standardized parser for validation-style CLIs |
 | `emit_json_status` | 0.6.0 | Emit a structured JSON status envelope |
 | `format_output` | 0.1.0 | Format a value for human-readable output |
 | `format_table` | 0.1.0 | Render rows as an aligned text table |
 | `register_command` | 0.1.0 | Decorator registering a CLI subcommand |
+| `resolve_repo_root` | 0.9.8 | Return the explicit CLI repo-root arg or auto-detect it |
 
 ### `hephaestus.system`
 

--- a/hephaestus/cli/__init__.py
+++ b/hephaestus/cli/__init__.py
@@ -13,10 +13,12 @@ from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     confirm_action,
     create_parser,
+    create_validation_parser,
     emit_json_status,
     format_output,
     format_table,
     register_command,
+    resolve_repo_root,
 )
 
 __all__ = [
@@ -32,8 +34,10 @@ __all__ = [
     "configure_github_throttle_from_args",
     "confirm_action",
     "create_parser",
+    "create_validation_parser",
     "emit_json_status",
     "format_output",
     "format_table",
     "register_command",
+    "resolve_repo_root",
 ]

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -15,9 +15,11 @@ import json
 import math
 import sys
 from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Any
 
 from hephaestus._version_lookup import get_version
+from hephaestus.utils.helpers import get_repo_root
 
 __version__ = get_version()
 
@@ -33,10 +35,12 @@ __all__ = [
     "configure_github_throttle_from_args",
     "confirm_action",
     "create_parser",
+    "create_validation_parser",
     "emit_json_status",
     "format_output",
     "format_table",
     "register_command",
+    "resolve_repo_root",
 ]
 
 
@@ -145,6 +149,53 @@ def add_json_arg(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Emit machine-readable JSON output instead of human-readable text",
     )
+
+
+def create_validation_parser(
+    description: str | None = None,
+    *,
+    include_repo_root: bool = True,
+    prog: str | None = None,
+    usage: str | None = None,
+    epilog: str | None = None,
+    formatter_class: type[argparse.HelpFormatter] = argparse.HelpFormatter,
+) -> argparse.ArgumentParser:
+    """Create a standardized parser for validation-style CLIs.
+
+    Args:
+        description: Parser description text.
+        include_repo_root: Whether to add the standard ``--repo-root`` option.
+        prog: Optional program name override.
+        usage: Optional usage string override.
+        epilog: Optional parser epilog text.
+        formatter_class: Argparse help formatter class.
+
+    Returns:
+        Configured ArgumentParser instance with shared validation flags.
+
+    """
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        usage=usage,
+        description=description,
+        epilog=epilog,
+        formatter_class=formatter_class,
+    )
+    if include_repo_root:
+        parser.add_argument(
+            "--repo-root",
+            type=Path,
+            default=None,
+            help="Repository root (default: auto-detect)",
+        )
+    add_json_arg(parser)
+    add_version_arg(parser)
+    return parser
+
+
+def resolve_repo_root(args: argparse.Namespace) -> Path:
+    """Return the explicit CLI repository root or auto-detect it."""
+    return args.repo_root if args.repo_root is not None else get_repo_root()
 
 
 DRY_RUN_HELP_CAVEAT = (

--- a/hephaestus/validation/audit.py
+++ b/hephaestus/validation/audit.py
@@ -20,7 +20,7 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status, format_output
+from hephaestus.cli.utils import create_validation_parser, emit_json_status, format_output
 from hephaestus.utils.helpers import get_repo_root
 
 HIGH_THRESHOLD: float = 7.0
@@ -157,8 +157,6 @@ def main() -> int:
 
     """
     parser = _build_parser()
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args()
 
     ignore_ids = load_ignore_list(args.ignore_file)
@@ -233,8 +231,9 @@ def _emit_audit_json(blocking: list[AuditEntry], suppressed: list[AuditEntry]) -
 
 def _build_parser() -> argparse.ArgumentParser:
     """Build argument parser for the filter-audit CLI."""
-    parser = argparse.ArgumentParser(
-        description="Filter pip-audit JSON to fail only on HIGH/CRITICAL vulnerabilities",
+    parser = create_validation_parser(
+        "Filter pip-audit JSON to fail only on HIGH/CRITICAL vulnerabilities",
+        include_repo_root=False,
         epilog="Usage: pip-audit --format json | %(prog)s",
     )
     parser.add_argument(

--- a/hephaestus/validation/cli_tier_docs.py
+++ b/hephaestus/validation/cli_tier_docs.py
@@ -16,16 +16,14 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import json
 import re
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg
+from hephaestus.cli.utils import create_validation_parser, resolve_repo_root
 from hephaestus.io.toml import import_tomllib
-from hephaestus.utils.helpers import get_repo_root
 
 VALID_TIERS: frozenset[str] = frozenset({"Stable", "Provisional", "Internal"})
 _SECTION_HEADER_RE = re.compile(r"^##\s+Console-Script Stability Tiers", re.IGNORECASE)
@@ -230,12 +228,9 @@ def format_json(findings: list[TierDocFinding]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     """Entry point for ``hephaestus-check-cli-tier-docs``."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--repo-root", type=Path, default=None)
-    add_json_arg(parser)
-    add_version_arg(parser)
+    parser = create_validation_parser(__doc__)
     args = parser.parse_args(argv)
-    repo_root = args.repo_root or get_repo_root()
+    repo_root = resolve_repo_root(args)
     scripts = load_pyproject_scripts(repo_root / "pyproject.toml")
     tiers, occurrences, section_count = load_documented_tiers(repo_root / "COMPATIBILITY.md")
     duplicates = find_duplicate_tiers(occurrences)

--- a/hephaestus/validation/complexity.py
+++ b/hephaestus/validation/complexity.py
@@ -11,13 +11,12 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import json
 import subprocess
 import sys
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, format_output
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
 from hephaestus.utils.helpers import NETWORK_TIMEOUT, get_repo_root
 
 
@@ -122,8 +121,8 @@ def main() -> int:
         Exit code (0 if clean, 1 if violations found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Check cyclomatic complexity against threshold",
+    parser = create_validation_parser(
+        "Check cyclomatic complexity against threshold",
         epilog="Example: %(prog)s --path mypackage/ --threshold 10",
     )
     parser.add_argument(
@@ -139,21 +138,13 @@ def main() -> int:
         help="Path to source code to check (default: .)",
     )
     parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detect)",
-    )
-    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Enable verbose output",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args()
 
-    repo_root = args.repo_root or get_repo_root()
+    repo_root = resolve_repo_root(args)
 
     if args.json:
         violations = run_ruff_complexity_check(args.path, args.threshold, repo_root)

--- a/hephaestus/validation/coverage.py
+++ b/hephaestus/validation/coverage.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status, format_output
+from hephaestus.cli.utils import create_validation_parser, emit_json_status, format_output
 from hephaestus.io.toml import import_tomllib
 from hephaestus.utils.helpers import get_repo_root
 
@@ -314,8 +314,9 @@ def main() -> int:
         Exit code (0 if coverage meets threshold, 1 otherwise).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Check test coverage against threshold",
+    parser = create_validation_parser(
+        "Check test coverage against threshold",
+        include_repo_root=False,
         epilog="Example: %(prog)s --threshold 80 --path mypackage/",
     )
     parser.add_argument(
@@ -347,8 +348,6 @@ def main() -> int:
         action="store_true",
         help="Enable verbose output",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
 

--- a/hephaestus/validation/doc_config.py
+++ b/hephaestus/validation/doc_config.py
@@ -22,14 +22,13 @@ Exit codes:
 
 from __future__ import annotations
 
-import argparse
 import re
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, cast
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, format_output
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
 from hephaestus.io.toml import import_tomllib
 from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
@@ -442,15 +441,9 @@ def main() -> int:
         Exit code (0 if all checks pass, 1 if any fail).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Enforce consistency between doc metric values and pyproject.toml",
+    parser = create_validation_parser(
+        "Enforce consistency between doc metric values and pyproject.toml",
         epilog="Example: %(prog)s --repo-root /path/to/repo --verbose",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: auto-detected via git)",
     )
     parser.add_argument(
         "--verbose",
@@ -463,17 +456,9 @@ def main() -> int:
         action="store_true",
         help="Skip the live pytest --collect-only test count check",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-
-    if args.repo_root is not None:
-        repo_root: Path = args.repo_root
-    else:
-        from hephaestus.utils.helpers import get_repo_root
-
-        repo_root = get_repo_root()
+    repo_root = resolve_repo_root(args)
 
     if args.json:
         expected_threshold = load_coverage_threshold(repo_root)

--- a/hephaestus/validation/doc_policy.py
+++ b/hephaestus/validation/doc_policy.py
@@ -35,7 +35,6 @@ Exit codes:
 
 from __future__ import annotations
 
-import argparse
 import json
 import re
 import sys
@@ -43,8 +42,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg
-from hephaestus.utils.helpers import get_repo_root
+from hephaestus.cli.utils import create_validation_parser, resolve_repo_root
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -347,8 +345,8 @@ def main() -> int:
         Exit code (0 if no violations, 1 if violations found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Audit documentation command examples for policy violations",
+    parser = create_validation_parser(
+        "Audit documentation command examples for policy violations",
         epilog="Example: %(prog)s --directory docs/ --verbose",
     )
     parser.add_argument(
@@ -356,12 +354,6 @@ def main() -> int:
         type=Path,
         default=None,
         help="Directory to scan (default: repository root)",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: auto-detect)",
     )
     parser.add_argument(
         "--verbose",
@@ -376,11 +368,9 @@ def main() -> int:
         default=None,
         help="Additional path prefix to exclude (may be repeated)",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-    repo_root: Path = args.repo_root or get_repo_root()
+    repo_root: Path = resolve_repo_root(args)
     scan_root: Path = args.directory or repo_root
 
     excluded: tuple[str, ...] = EXCLUDED_PREFIXES

--- a/hephaestus/validation/docstrings.py
+++ b/hephaestus/validation/docstrings.py
@@ -13,15 +13,13 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import ast
 import json
 import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg
-from hephaestus.utils.helpers import get_repo_root
+from hephaestus.cli.utils import create_validation_parser, resolve_repo_root
 
 _CONTINUATION_STARTERS = frozenset(
     {
@@ -282,8 +280,8 @@ def main() -> int:
         Exit code (0 if no violations, 1 if violations found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Check Python docstrings for genuine sentence fragments",
+    parser = create_validation_parser(
+        "Check Python docstrings for genuine sentence fragments",
         epilog="Example: %(prog)s --directory mypackage/",
     )
     parser.add_argument(
@@ -293,21 +291,13 @@ def main() -> int:
         help="Directory to scan (default: auto-detect source package)",
     )
     parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: auto-detect)",
-    )
-    parser.add_argument(
         "--verbose",
         action="store_true",
         help="Print detailed output",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-    repo_root = args.repo_root or get_repo_root()
+    repo_root = resolve_repo_root(args)
     directory = args.directory or repo_root
 
     findings = scan_directory(directory, repo_root)

--- a/hephaestus/validation/markdown.py
+++ b/hephaestus/validation/markdown.py
@@ -12,7 +12,6 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import json
 import re
 import sys
@@ -21,7 +20,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, format_output
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
 from hephaestus.logging.utils import get_logger
 from hephaestus.markdown.utils import find_markdown_files
 
@@ -480,8 +479,9 @@ def check_readmes_main() -> int:
         Exit code (0 if all pass, 1 if any failures).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Validate README files for required sections and formatting",
+    parser = create_validation_parser(
+        "Validate README files for required sections and formatting",
+        include_repo_root=False,
     )
     parser.add_argument(
         "--directory",
@@ -501,8 +501,6 @@ def check_readmes_main() -> int:
         action="store_true",
         help="Print each README path as it is checked",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
     directory = args.directory or Path.cwd()
@@ -712,10 +710,8 @@ def main() -> int:
         Exit code (0 if all links valid, 1 if broken links found).
 
     """
-    from hephaestus.utils.helpers import get_repo_root
-
-    parser = argparse.ArgumentParser(
-        description="Validate markdown links in documentation",
+    parser = create_validation_parser(
+        "Validate markdown links in documentation",
         epilog="Example: %(prog)s docs/ --verbose",
     )
     parser.add_argument(
@@ -726,22 +722,14 @@ def main() -> int:
         help="Directory to scan (default: repo root)",
     )
     parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detect)",
-    )
-    parser.add_argument(
         "--verbose",
         "-v",
         action="store_true",
         help="Print verbose output",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-    repo_root = args.repo_root or get_repo_root()
+    repo_root = resolve_repo_root(args)
     directory = args.directory or repo_root
 
     if not directory.exists():

--- a/hephaestus/validation/mypy_per_file.py
+++ b/hephaestus/validation/mypy_per_file.py
@@ -19,12 +19,11 @@ Exit codes:
 
 from __future__ import annotations
 
-import argparse
 import subprocess
 import sys
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import create_validation_parser, emit_json_status
 from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 # mypy flags that consume the next argument as their value.
@@ -140,13 +139,11 @@ def main() -> int:
         Aggregated exit code from all mypy runs.
 
     """
-    parser = argparse.ArgumentParser(
-        description="Run mypy on each file individually (avoids duplicate-module-name errors)",
+    parser = create_validation_parser(
+        "Run mypy on each file individually (avoids duplicate-module-name errors)",
+        include_repo_root=False,
         usage="%(prog)s [mypy-flags...] file1.py file2.py ...",
-        add_help=True,
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
     # We parse just --help / -h / --json normally; all remaining args are passed through.
     parser.parse_known_args(sys.argv[1:])
 

--- a/hephaestus/validation/python_version.py
+++ b/hephaestus/validation/python_version.py
@@ -13,14 +13,12 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import re
 import sys
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, format_output
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
 from hephaestus.io.toml import import_tomllib
-from hephaestus.utils.helpers import get_repo_root
 
 tomllib = import_tomllib()
 
@@ -486,15 +484,9 @@ def main() -> int:
         Exit code (0 if consistent, 1 if mismatch).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Check Python version consistency across config files",
+    parser = create_validation_parser(
+        "Check Python version consistency across config files",
         epilog="Example: %(prog)s --repo-root /path/to/repo --verbose",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detect)",
     )
     parser.add_argument(
         "--check-dockerfile",
@@ -507,11 +499,9 @@ def main() -> int:
         action="store_true",
         help="Print parsed versions even when consistent",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-    repo_root = args.repo_root or get_repo_root()
+    repo_root = resolve_repo_root(args)
 
     consistent, versions = check_python_version_consistency(
         repo_root,

--- a/hephaestus/validation/repo_analyze_skills.py
+++ b/hephaestus/validation/repo_analyze_skills.py
@@ -8,7 +8,6 @@ Entry point: ``hephaestus-check-repo-analyze-skills`` (see pyproject.toml).
 
 from __future__ import annotations
 
-import argparse
 import re
 import sys
 from pathlib import Path
@@ -16,7 +15,7 @@ from string import Template
 
 import yaml
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import create_validation_parser, emit_json_status
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 COMMON_DIR = REPO_ROOT / "skills" / "_repo_analyze_common"
@@ -134,8 +133,9 @@ def _render(variant: dict[str, str]) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     """Generate repo-analyze* skill SKILL.md files from partials."""
-    parser = argparse.ArgumentParser(
-        description="Generate repo-analyze* skill SKILL.md files from partials"
+    parser = create_validation_parser(
+        "Generate repo-analyze* skill SKILL.md files from partials",
+        include_repo_root=False,
     )
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument(
@@ -149,8 +149,6 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Regenerate SKILL.md files in place",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args(argv)
 
     spec = yaml.safe_load((COMMON_DIR / "variants.yaml").read_text(encoding="utf-8"))

--- a/hephaestus/validation/schema.py
+++ b/hephaestus/validation/schema.py
@@ -11,7 +11,6 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import json
 import re
 import sys
@@ -20,7 +19,7 @@ from typing import Any
 
 import yaml
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import create_validation_parser, emit_json_status, resolve_repo_root
 
 SchemaMapping = list[tuple[re.Pattern[str], Path]]
 
@@ -176,8 +175,8 @@ def main() -> int:
         Exit code (0 if clean or ``--dry-run``, 1 if violations found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Validate config files against their JSON schemas",
+    parser = create_validation_parser(
+        "Validate config files against their JSON schemas",
         epilog="Example: %(prog)s --schema-map schemas.json config/*.yaml",
     )
     parser.add_argument(
@@ -199,18 +198,10 @@ def main() -> int:
         help="Print passing file names",
     )
     parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: auto-detect)",
-    )
-    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print errors but exit 0",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
 
@@ -219,9 +210,7 @@ def main() -> int:
             emit_json_status(0, message="no files to validate", error_count=0)
         return 0
 
-    from hephaestus.utils.helpers import get_repo_root as _get_repo_root
-
-    repo_root = args.repo_root or _get_repo_root()
+    repo_root = resolve_repo_root(args)
 
     if args.schema_map is None:
         if args.json:

--- a/hephaestus/validation/skill_catalog.py
+++ b/hephaestus/validation/skill_catalog.py
@@ -24,15 +24,13 @@ Exit codes:
 
 from __future__ import annotations
 
-import argparse
 import re
 import sys
 from pathlib import Path
 
 from hephaestus.agents.frontmatter import check_agent_file, extract_frontmatter_parsed
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
+from hephaestus.cli.utils import create_validation_parser, emit_json_status, resolve_repo_root
 from hephaestus.discovery.skills import discover_skills
-from hephaestus.utils.helpers import get_repo_root
 
 # Matches a markdown table row of the form ``| cell | cell | ... |``. We pull
 # out the leftmost non-empty cell as the skill name. Table header and the
@@ -216,9 +214,9 @@ def main(argv: list[str] | None = None) -> int:
         Exit code (0 on match, 1 on mismatch).
 
     """
-    parser = argparse.ArgumentParser(
+    parser = create_validation_parser(
+        "Verify docs/plugin-installation.md lists every shipped skill.",
         prog="hephaestus-check-skill-catalog",
-        description=("Verify docs/plugin-installation.md lists every shipped skill."),
     )
     parser.add_argument(
         "--table",
@@ -232,17 +230,9 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="Path to the skills directory (default: skills/)",
     )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: auto-detect)",
-    )
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args(argv)
 
-    repo_root: Path = args.repo_root or get_repo_root()
+    repo_root: Path = resolve_repo_root(args)
     table_path: Path = args.table or (repo_root / "docs" / "plugin-installation.md")
     skills_dir: Path = args.skills_dir or (repo_root / "skills")
 

--- a/hephaestus/validation/stale_scripts.py
+++ b/hephaestus/validation/stale_scripts.py
@@ -24,12 +24,11 @@ Exit codes:
 
 from __future__ import annotations
 
-import argparse
 import re
 import sys
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, format_output
+from hephaestus.cli.utils import create_validation_parser, format_output, resolve_repo_root
 
 # Scripts that are imported by other scripts (not invoked directly) — always active.
 _ALWAYS_ACTIVE: frozenset[str] = frozenset(
@@ -257,15 +256,9 @@ def main() -> int:
         Exit code (0 unless ``--strict`` and stale scripts are found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Detect scripts/ files with no references in CI configs or other scripts",
+    parser = create_validation_parser(
+        "Detect scripts/ files with no references in CI configs or other scripts",
         epilog="Example: %(prog)s --strict --verbose",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root (default: auto-detected via git)",
     )
     parser.add_argument(
         "--strict",
@@ -284,17 +277,9 @@ def main() -> int:
         default=None,
         help="Exclude scripts whose name contains PATTERN (e.g. 'test_')",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-
-    if args.repo_root is not None:
-        repo_root: Path = args.repo_root
-    else:
-        from hephaestus.utils.helpers import get_repo_root
-
-        repo_root = get_repo_root()
+    repo_root = resolve_repo_root(args)
 
     if args.json:
         stale = find_stale_scripts(repo_root, exclude_pattern=args.exclude)

--- a/hephaestus/validation/test_structure.py
+++ b/hephaestus/validation/test_structure.py
@@ -20,12 +20,10 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
 import sys
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
-from hephaestus.utils.helpers import get_repo_root
+from hephaestus.cli.utils import create_validation_parser, emit_json_status, resolve_repo_root
 
 ALLOWED_ROOT_FILES: frozenset[str] = frozenset({"__init__.py", "conftest.py"})
 
@@ -311,15 +309,9 @@ def main() -> int:
         Exit code (0 if clean, 1 if violations found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Validate unit test directory structure",
+    parser = create_validation_parser(
+        "Validate unit test directory structure",
         epilog="Example: %(prog)s --src-package mypackage --verbose",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detect)",
     )
     parser.add_argument(
         "--src-package",
@@ -333,11 +325,9 @@ def main() -> int:
         action="store_true",
         help="Print detailed output",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
-    repo_root = args.repo_root or get_repo_root()
+    repo_root = resolve_repo_root(args)
 
     passed = check_test_structure(repo_root, src_package=args.src_package, verbose=args.verbose)
     exit_code = 0 if passed else 1

--- a/hephaestus/validation/tier_labels.py
+++ b/hephaestus/validation/tier_labels.py
@@ -36,8 +36,7 @@ import sys
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg
-from hephaestus.utils.helpers import get_repo_root
+from hephaestus.cli.utils import create_validation_parser, resolve_repo_root
 
 # ---------------------------------------------------------------------------
 # Canonical mapping (source of truth)
@@ -308,8 +307,8 @@ def main() -> int:
         Exit code: 0 clean, 1 mismatches found, 2 I/O error.
 
     """
-    parser = argparse.ArgumentParser(
-        description=(
+    parser = create_validation_parser(
+        (
             "Enforce tier label consistency in Markdown files.  "
             "By default scans all *.md files in the repository."
         ),
@@ -330,12 +329,6 @@ def main() -> int:
         help="Directory to scan (default: repository root).",
     )
     parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root to scan from (default: auto-detect via git).",
-    )
-    parser.add_argument(
         "--glob",
         default="**/*.md",
         help="Glob pattern to match Markdown files (default: **/*.md).",
@@ -354,14 +347,12 @@ def main() -> int:
         action="store_true",
         help="Print details for each mismatch found.",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
 
     # Resolve repository root.
     try:
-        repo_root = args.repo_root if args.repo_root is not None else get_repo_root()
+        repo_root = resolve_repo_root(args)
     except Exception as exc:
         print(f"ERROR: Could not determine repository root: {exc}", file=sys.stderr)
         return 2

--- a/hephaestus/validation/type_aliases.py
+++ b/hephaestus/validation/type_aliases.py
@@ -16,12 +16,11 @@ Examples of allowed patterns::
 
 from __future__ import annotations
 
-import argparse
 import re
 import sys
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, format_output
+from hephaestus.cli.utils import create_validation_parser, format_output
 
 
 def is_shadowing_pattern(alias: str, target: str) -> bool:
@@ -163,8 +162,9 @@ def main() -> int:
         Exit code (0 if clean, 1 if violations found).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Detect type alias shadowing patterns in Python code",
+    parser = create_validation_parser(
+        "Detect type alias shadowing patterns in Python code",
+        include_repo_root=False,
         epilog="Example: %(prog)s src/ tests/ scripts/",
     )
     parser.add_argument(
@@ -179,8 +179,6 @@ def main() -> int:
         action="store_true",
         help="Print verbose output",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
 
     args = parser.parse_args()
 

--- a/hephaestus/version/consistency.py
+++ b/hephaestus/version/consistency.py
@@ -23,16 +23,19 @@ Usage:
     hephaestus-bump-version {major,minor,patch} [--repo-root PATH] [--dry-run] [--verbose]
 """
 
-import argparse
 import re
 import subprocess
 import sys
 from importlib.metadata import PackageNotFoundError, version as _dist_version
 from pathlib import Path
 
-from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status, format_output
+from hephaestus.cli.utils import (
+    create_validation_parser,
+    emit_json_status,
+    format_output,
+    resolve_repo_root,
+)
 from hephaestus.io.toml import import_tomllib
-from hephaestus.utils.helpers import get_repo_root
 from hephaestus.version.manager import VersionManager, parse_version
 from hephaestus.version.parsing import parse_version_tuple
 
@@ -503,15 +506,9 @@ def check_version_consistency_main() -> int:
         Exit code (0 if consistent, 1 on mismatch).
 
     """
-    parser = argparse.ArgumentParser(
-        description="Detect version drift between pyproject.toml and pixi.toml",
+    parser = create_validation_parser(
+        "Detect version drift between pyproject.toml and pixi.toml",
         epilog="Example: %(prog)s --repo-root /path/to/repo --verbose",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detected from pyproject.toml)",
     )
     parser.add_argument(
         "--verbose",
@@ -519,10 +516,8 @@ def check_version_consistency_main() -> int:
         action="store_true",
         help="Print parsed versions even when they match",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args()
-    root = args.repo_root or get_repo_root()
+    root = resolve_repo_root(args)
     if args.json:
         canonical = _version_from_git_tag(root) or _version_from_metadata()
         pixi_version = _get_pixi_version(root)
@@ -544,15 +539,9 @@ def check_package_versions_main() -> int:
         Exit code (0 if all checks pass, 1 otherwise).
 
     """
-    parser = argparse.ArgumentParser(
-        description=("Enforce package version consistency across all version declaration sites"),
+    parser = create_validation_parser(
+        "Enforce package version consistency across all version declaration sites",
         epilog="Example: %(prog)s --scan-skills --verbose",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detected)",
     )
     parser.add_argument(
         "--package-init",
@@ -574,10 +563,8 @@ def check_package_versions_main() -> int:
         action="store_true",
         help="Print passing check names and canonical version",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args()
-    root = args.repo_root or get_repo_root()
+    root = resolve_repo_root(args)
     init_path: Path | None = args.package_init
     if init_path is not None and not init_path.is_absolute():
         init_path = root / init_path
@@ -613,20 +600,14 @@ def bump_version_main() -> int:
         Exit code (0 on success, 1 on failure).
 
     """
-    parser = argparse.ArgumentParser(
-        description=("Bump project version in pyproject.toml (and secondary files) atomically"),
+    parser = create_validation_parser(
+        "Bump project version in pyproject.toml (and secondary files) atomically",
         epilog="Example: %(prog)s patch --verbose",
     )
     parser.add_argument(
         "part",
         choices=["major", "minor", "patch"],
         help="Which version part to bump",
-    )
-    parser.add_argument(
-        "--repo-root",
-        type=Path,
-        default=None,
-        help="Repository root directory (default: auto-detected)",
     )
     parser.add_argument(
         "--dry-run",
@@ -639,10 +620,8 @@ def bump_version_main() -> int:
         action="store_true",
         help="Print additional details",
     )
-    add_json_arg(parser)
-    add_version_arg(parser)
     args = parser.parse_args()
-    root = args.repo_root or get_repo_root()
+    root = resolve_repo_root(args)
     if args.json:
         exit_code = bump_version(root, part=args.part, dry_run=args.dry_run, verbose=False)
         emit_json_status(

--- a/tests/unit/cli/test_validation_parser.py
+++ b/tests/unit/cli/test_validation_parser.py
@@ -1,0 +1,123 @@
+"""Tests for validation-style CLI parser helpers."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hephaestus.cli.utils import create_validation_parser, resolve_repo_root
+
+ISSUE_1418_FILES = [
+    Path("hephaestus/validation/docstrings.py"),
+    Path("hephaestus/validation/doc_config.py"),
+    Path("hephaestus/validation/type_aliases.py"),
+    Path("hephaestus/validation/skill_catalog.py"),
+    Path("hephaestus/validation/complexity.py"),
+    Path("hephaestus/validation/audit.py"),
+    Path("hephaestus/validation/stale_scripts.py"),
+    Path("hephaestus/validation/test_structure.py"),
+    Path("hephaestus/validation/mypy_per_file.py"),
+    Path("hephaestus/validation/cli_tier_docs.py"),
+    Path("hephaestus/validation/coverage.py"),
+    Path("hephaestus/validation/doc_policy.py"),
+    Path("hephaestus/validation/python_version.py"),
+    Path("hephaestus/validation/schema.py"),
+    Path("hephaestus/validation/tier_labels.py"),
+    Path("hephaestus/validation/markdown.py"),
+    Path("hephaestus/validation/repo_analyze_skills.py"),
+    Path("hephaestus/version/consistency.py"),
+]
+
+
+def test_create_validation_parser_adds_standard_validation_flags() -> None:
+    """Validation parsers include repo-root and JSON flags by default."""
+    parser = create_validation_parser("check things")
+
+    args = parser.parse_args(["--repo-root", "/tmp/project", "--json"])
+
+    assert args.repo_root == Path("/tmp/project")
+    assert args.json is True
+
+
+def test_create_validation_parser_adds_version_flag(capsys: pytest.CaptureFixture[str]) -> None:
+    """Validation parsers include the shared version flag."""
+    parser = create_validation_parser("check things", prog="demo")
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--version"])
+
+    assert exc.value.code == 0
+    assert "demo" in capsys.readouterr().out
+
+
+def test_create_validation_parser_can_skip_repo_root() -> None:
+    """No-repo-root validation CLIs can opt out of the standard root flag."""
+    parser = create_validation_parser("check things", include_repo_root=False)
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["--repo-root", "/tmp/project"])
+
+    assert exc.value.code == 2
+
+
+def test_create_validation_parser_preserves_parser_customization() -> None:
+    """Call sites can preserve existing help metadata while sharing standard flags."""
+    parser = create_validation_parser(
+        "check things",
+        prog="custom-check",
+        usage="%(prog)s [flags] path",
+        epilog="Example: %(prog)s path",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    help_text = parser.format_help()
+
+    assert parser.prog == "custom-check"
+    assert "usage: custom-check [flags] path" in help_text
+    assert "Example: custom-check path" in help_text
+
+
+def test_resolve_repo_root_prefers_explicit_path() -> None:
+    """Explicit CLI roots take precedence over auto-detection."""
+    explicit = Path("/tmp/project")
+
+    with patch("hephaestus.cli.utils.get_repo_root") as mocked:
+        assert resolve_repo_root(argparse.Namespace(repo_root=explicit)) == explicit
+
+    mocked.assert_not_called()
+
+
+def test_resolve_repo_root_auto_detects_when_missing() -> None:
+    """Missing CLI roots fall back to the shared repository root detector."""
+    detected = Path("/tmp/detected")
+
+    with patch("hephaestus.cli.utils.get_repo_root", return_value=detected):
+        assert resolve_repo_root(argparse.Namespace(repo_root=None)) == detected
+
+
+def test_issue_1418_clis_use_canonical_validation_parser() -> None:
+    """Issue-listed CLIs should not reintroduce parser boilerplate."""
+    violations: list[str] = []
+    for path in ISSUE_1418_FILES:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+
+            func = node.func
+            name = func.id if isinstance(func, ast.Name) else ""
+            attr = func.attr if isinstance(func, ast.Attribute) else ""
+            if name in {"add_json_arg", "add_version_arg"}:
+                violations.append(f"{path}:{node.lineno}: direct {name} call")
+            if name == "ArgumentParser" or attr == "ArgumentParser":
+                violations.append(f"{path}:{node.lineno}: direct ArgumentParser call")
+            if attr == "add_argument" and node.args:
+                first = node.args[0]
+                if isinstance(first, ast.Constant) and first.value == "--repo-root":
+                    violations.append(f"{path}:{node.lineno}: direct --repo-root registration")
+
+    assert violations == []


### PR DESCRIPTION
## Summary
Extract shared validation CLI parser and repository-root resolution helpers, then update validation and version consistency entrypoints to use them.

## Changes
- Added create_validation_parser and resolve_repo_root helpers in hephaestus.cli.utils and exported them from hephaestus.cli.
- Refactored validation scripts and version consistency main functions to reuse the shared parser/root-resolution boilerplate.
- Updated related unit tests, including new coverage for the shared validation parser helpers.

## Testing
- Not run; PR message generated from provided issue, changed-file list, diff stat, and commit metadata only.

## Closes
Closes #1418

Generated by Codex via ProjectHephaestus automation.
