### PR TITLE
fix(config): document get_config_value deprecation in COMPATIBILITY.md and MIGRATION.md

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -207,11 +207,17 @@ removal):
 
 | Symbol | Added | Notes |
 |--------|-------|-------|
-| `get_config_value` | 0.2.0 | High-level config lookup with env overlay |
+| `get_config_value` | 0.2.0 | High-level config lookup with env overlay — **(deprecated)**, use `load_config` + `merge_with_env` + `get_setting` |
 | `get_setting` | 0.1.0 | Dot-notation access to nested config dict |
 | `load_config` | 0.1.0 | Load YAML/JSON config file |
 | `merge_configs` | 0.1.0 | Deep-merge multiple config dicts |
 | `merge_with_env` | 0.2.0 | Overlay env vars onto config |
+
+**Deprecated symbols** (covered by the deprecation policy until removal):
+
+- `get_config_value` — superseded by the explicit pipeline `load_config()` →
+  `merge_with_env()` → `get_setting()`. Emits a `DeprecationWarning` when called.
+  Scheduled for removal no earlier than the next major version after 1.0.
 
 ### `hephaestus.io`
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -62,6 +62,10 @@ behavior (you should not have), review these:
   max_delay=...)`. It still works and emits a `DeprecationWarning`; it is retained for
   backwards compatibility and is not removed in 1.0. See the
   [deprecation policy](../COMPATIBILITY.md#deprecation-policy).
+- `get_config_value` — deprecated in favor of the explicit pipeline `load_config()`
+  → `merge_with_env()` → `get_setting()`. It still works and emits a
+  `DeprecationWarning`; it is retained for backwards compatibility and is not removed
+  in 1.0. See the [deprecation policy](../COMPATIBILITY.md#deprecation-policy).
 
 ### Questions
 

--- a/tests/unit/config/test_docs_deprecation_sync.py
+++ b/tests/unit/config/test_docs_deprecation_sync.py
@@ -25,20 +25,41 @@ def test_get_config_value_emits_deprecation_warning() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         get_config_value("nonexistent.key", default=None)
-    assert any(
-        issubclass(w.category, DeprecationWarning) for w in caught
-    ), "get_config_value must emit a DeprecationWarning"
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught), (
+        "get_config_value must emit a DeprecationWarning"
+    )
 
 
 def test_compatibility_md_annotates_get_config_value_deprecated() -> None:
-    """COMPATIBILITY.md must flag get_config_value as (deprecated)."""
+    """COMPATIBILITY.md table must flag get_config_value as (deprecated)."""
     text = COMPATIBILITY.read_text(encoding="utf-8")
-    for line in text.splitlines():
-        if "get_config_value" in line and "deprecated" in line.lower():
-            return
-    raise AssertionError(
-        "COMPATIBILITY.md must annotate get_config_value as deprecated "
-        "(inline '(deprecated)' marker or a Deprecated-symbols callout)"
+    # Find the hephaestus.config section
+    marker = "### `hephaestus.config`"
+    assert marker in text, "COMPATIBILITY.md must have a 'hephaestus.config' section"
+    section = text.split(marker, 1)[1]
+    # Extract just the table (stop at the next section heading)
+    for stop in ("### ", "## "):
+        if stop in section:
+            section = section.split(stop, 1)[0]
+    # Verify inline annotation in table row
+    assert "get_config_value" in section and "deprecated" in section.lower(), (
+        "COMPATIBILITY.md 'hephaestus.config' table must have a row with "
+        "get_config_value and (deprecated)"
+    )
+
+
+def test_compatibility_md_deprecated_symbols_callout_has_get_config_value() -> None:
+    """COMPATIBILITY.md 'Deprecated symbols' callout must list get_config_value."""
+    text = COMPATIBILITY.read_text(encoding="utf-8")
+    marker = "**Deprecated symbols**"
+    assert marker in text, "COMPATIBILITY.md must have a 'Deprecated symbols' callout"
+    callout = text.split(marker, 1)[1]
+    # Extract just the callout (stop at the next section or list marker at column 0)
+    for stop in ("### ", "## ", "\n| "):
+        if stop in callout:
+            callout = callout.split(stop, 1)[0]
+    assert "get_config_value" in callout, (
+        "COMPATIBILITY.md 'Deprecated symbols' callout must list get_config_value"
     )
 
 

--- a/tests/unit/config/test_docs_deprecation_sync.py
+++ b/tests/unit/config/test_docs_deprecation_sync.py
@@ -1,0 +1,55 @@
+"""Regression guard: deprecated config symbols must be annotated in the docs.
+
+Property: a public config symbol that emits a ``DeprecationWarning`` when called
+MUST be annotated ``(deprecated)`` in COMPATIBILITY.md's ``hephaestus.config``
+table AND listed in docs/MIGRATION.md's "Deprecated symbols" section.
+
+Guards issue #1508: ``get_config_value`` was deprecated in code (utils.py:329-335)
+but undocumented in COMPATIBILITY.md and MIGRATION.md.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+from hephaestus.config.utils import get_config_value
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+COMPATIBILITY = REPO_ROOT / "COMPATIBILITY.md"
+MIGRATION = REPO_ROOT / "docs" / "MIGRATION.md"
+
+
+def test_get_config_value_emits_deprecation_warning() -> None:
+    """Source-of-truth: the symbol really does emit a DeprecationWarning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        get_config_value("nonexistent.key", default=None)
+    assert any(
+        issubclass(w.category, DeprecationWarning) for w in caught
+    ), "get_config_value must emit a DeprecationWarning"
+
+
+def test_compatibility_md_annotates_get_config_value_deprecated() -> None:
+    """COMPATIBILITY.md must flag get_config_value as (deprecated)."""
+    text = COMPATIBILITY.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if "get_config_value" in line and "deprecated" in line.lower():
+            return
+    raise AssertionError(
+        "COMPATIBILITY.md must annotate get_config_value as deprecated "
+        "(inline '(deprecated)' marker or a Deprecated-symbols callout)"
+    )
+
+
+def test_migration_md_lists_get_config_value_as_deprecated() -> None:
+    """MIGRATION.md's 'Deprecated symbols' section must list get_config_value."""
+    text = MIGRATION.read_text(encoding="utf-8")
+    marker = "### Deprecated symbols"
+    assert marker in text, "MIGRATION.md must have a 'Deprecated symbols' section"
+    section = text.split(marker, 1)[1]
+    for stop in ("\n## ", "\n### "):
+        section = section.split(stop, 1)[0]
+    assert "get_config_value" in section, (
+        "MIGRATION.md 'Deprecated symbols' section must list get_config_value"
+    )


### PR DESCRIPTION
## Summary
Added deprecation annotations to COMPATIBILITY.md's hephaestus.config API table and expanded MIGRATION.md's deprecated symbols section to include get_config_value, ensuring users see the deprecation status in official documentation. Added test to enforce ongoing sync between code deprecations and docs.

## Changes
- Marked get_config_value as deprecated in COMPATIBILITY.md stable API table
- Added get_config_value to MIGRATION.md's 'Deprecated symbols' section with migration path
- Added test_docs_deprecation_sync.py to verify deprecated symbols are documented in COMPATIBILITY.md and MIGRATION.md

## Testing
- test_docs_deprecation_sync.py validates that get_config_value deprecation is present in both COMPATIBILITY.md and MIGRATION.md
- Verify COMPATIBILITY.md line 207 shows deprecation status
- Verify MIGRATION.md 'Deprecated symbols' section includes get_config_value with migration guidance

## Closes
Closes #1508

Generated by Claude Code via ProjectHephaestus automation.
