### PR TITLE
refactor(automation): extract shared worker options base

### DIFF
--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -142,34 +142,28 @@ class PlanResult(BaseModel):
     plan_already_exists: bool = False
 
 
-_DEFAULT_WORKERS = 3
+DEFAULT_WORKER_COUNT = 3
 
 
 class WorkerOptionsBase(BaseModel):
-    """Shared fields for automation worker option models."""
+    """Shared options for automation worker stages."""
 
     dry_run: bool = False
 
 
-class _MaxWorkerOptionsBase(WorkerOptionsBase):
-    """Shared fields for commands that expose --max-workers."""
+class ParallelWorkerOptionsBase(WorkerOptionsBase):
+    """Shared options for stages that expose ``max_workers``."""
 
-    max_workers: int = _DEFAULT_WORKERS
-
-
-class _ParallelWorkerOptionsBase(WorkerOptionsBase):
-    """Shared fields for planner commands that expose --parallel."""
-
-    parallel: int = _DEFAULT_WORKERS
+    max_workers: int = DEFAULT_WORKER_COUNT
 
 
-class _VerboseWorkerOptionsBase(_MaxWorkerOptionsBase):
-    """Shared fields for worker commands that expose --verbose."""
+class VerboseParallelWorkerOptionsBase(ParallelWorkerOptionsBase):
+    """Shared worker options for stages with verbose logging."""
 
     verbose: bool = False
 
 
-class PlannerOptions(_ParallelWorkerOptionsBase):
+class PlannerOptions(WorkerOptionsBase):
     """Options for the Planner."""
 
     issues: list[int]
@@ -180,12 +174,13 @@ class PlannerOptions(_ParallelWorkerOptionsBase):
     issues_explicit: bool = False
     agent: str = "claude"
     force: bool = False
+    parallel: int = DEFAULT_WORKER_COUNT
     system_prompt_file: Path | None = None
     skip_closed: bool = True
     enable_advise: bool = True
 
 
-class ImplementerOptions(_MaxWorkerOptionsBase):
+class ImplementerOptions(ParallelWorkerOptionsBase):
     """Options for the Implementer."""
 
     epic_number: int = 0
@@ -240,7 +235,7 @@ class ReviewState(BaseModel):
     addressed_thread_ids: list[str] = Field(default_factory=list)  # thread IDs Claude addressed
 
 
-class ReviewerOptions(_MaxWorkerOptionsBase):
+class ReviewerOptions(ParallelWorkerOptionsBase):
     """Options for the PRReviewer."""
 
     issues: list[int] = Field(default_factory=list)
@@ -249,7 +244,7 @@ class ReviewerOptions(_MaxWorkerOptionsBase):
     enable_ui: bool = True
 
 
-class PlanReviewerOptions(_VerboseWorkerOptionsBase):
+class PlanReviewerOptions(VerboseParallelWorkerOptionsBase):
     """Options for the PlanReviewer."""
 
     issues: list[int] = Field(default_factory=list)
@@ -257,7 +252,7 @@ class PlanReviewerOptions(_VerboseWorkerOptionsBase):
     enable_ui: bool = True
 
 
-class AddressReviewOptions(_VerboseWorkerOptionsBase):
+class AddressReviewOptions(VerboseParallelWorkerOptionsBase):
     """Options for the AddressReview workflow."""
 
     issues: list[int] = Field(default_factory=list)
@@ -266,7 +261,7 @@ class AddressReviewOptions(_VerboseWorkerOptionsBase):
     resume_impl_session: bool = True  # attempt to resume implementer's saved agent session
 
 
-class CIDriverOptions(_VerboseWorkerOptionsBase):
+class CIDriverOptions(VerboseParallelWorkerOptionsBase):
     """Options for the CIDriver workflow."""
 
     issues: list[int] = Field(default_factory=list)

--- a/hephaestus/automation/models.py
+++ b/hephaestus/automation/models.py
@@ -142,7 +142,34 @@ class PlanResult(BaseModel):
     plan_already_exists: bool = False
 
 
-class PlannerOptions(BaseModel):
+_DEFAULT_WORKERS = 3
+
+
+class WorkerOptionsBase(BaseModel):
+    """Shared fields for automation worker option models."""
+
+    dry_run: bool = False
+
+
+class _MaxWorkerOptionsBase(WorkerOptionsBase):
+    """Shared fields for commands that expose --max-workers."""
+
+    max_workers: int = _DEFAULT_WORKERS
+
+
+class _ParallelWorkerOptionsBase(WorkerOptionsBase):
+    """Shared fields for planner commands that expose --parallel."""
+
+    parallel: int = _DEFAULT_WORKERS
+
+
+class _VerboseWorkerOptionsBase(_MaxWorkerOptionsBase):
+    """Shared fields for worker commands that expose --verbose."""
+
+    verbose: bool = False
+
+
+class PlannerOptions(_ParallelWorkerOptionsBase):
     """Options for the Planner."""
 
     issues: list[int]
@@ -152,15 +179,13 @@ class PlannerOptions(BaseModel):
     # (legitimately empty) stays quiet.
     issues_explicit: bool = False
     agent: str = "claude"
-    dry_run: bool = False
     force: bool = False
-    parallel: int = 3
     system_prompt_file: Path | None = None
     skip_closed: bool = True
     enable_advise: bool = True
 
 
-class ImplementerOptions(BaseModel):
+class ImplementerOptions(_MaxWorkerOptionsBase):
     """Options for the Implementer."""
 
     epic_number: int = 0
@@ -169,10 +194,8 @@ class ImplementerOptions(BaseModel):
     analyze_only: bool = False
     health_check: bool = False
     resume: bool = False
-    max_workers: int = 3
     skip_closed: bool = True
     auto_merge: bool = True
-    dry_run: bool = False
     enable_advise: bool = True
     enable_learn: bool = True
     enable_follow_up: bool = True
@@ -217,41 +240,33 @@ class ReviewState(BaseModel):
     addressed_thread_ids: list[str] = Field(default_factory=list)  # thread IDs Claude addressed
 
 
-class ReviewerOptions(BaseModel):
+class ReviewerOptions(_MaxWorkerOptionsBase):
     """Options for the PRReviewer."""
 
     issues: list[int] = Field(default_factory=list)
     agent: str = "claude"
-    max_workers: int = 3
-    dry_run: bool = False
     enable_learn: bool = True
     enable_ui: bool = True
 
 
-class PlanReviewerOptions(BaseModel):
+class PlanReviewerOptions(_VerboseWorkerOptionsBase):
     """Options for the PlanReviewer."""
 
     issues: list[int] = Field(default_factory=list)
     agent: str = "claude"
-    max_workers: int = 3
-    dry_run: bool = False
     enable_ui: bool = True
-    verbose: bool = False
 
 
-class AddressReviewOptions(BaseModel):
+class AddressReviewOptions(_VerboseWorkerOptionsBase):
     """Options for the AddressReview workflow."""
 
     issues: list[int] = Field(default_factory=list)
     agent: str = "claude"
-    max_workers: int = 3
-    dry_run: bool = False
     enable_ui: bool = True
-    verbose: bool = False
     resume_impl_session: bool = True  # attempt to resume implementer's saved agent session
 
 
-class CIDriverOptions(BaseModel):
+class CIDriverOptions(_VerboseWorkerOptionsBase):
     """Options for the CIDriver workflow."""
 
     issues: list[int] = Field(default_factory=list)
@@ -260,12 +275,9 @@ class CIDriverOptions(BaseModel):
     # PRs do not use a strict ``Closes #N`` link (e.g. ``Refs #N``).
     prs: list[int] = Field(default_factory=list)
     agent: str = "claude"
-    max_workers: int = 3
-    dry_run: bool = False
     enable_advise: bool = True
     enable_learn: bool = True
     enable_ui: bool = True
-    verbose: bool = False
     max_fix_iterations: int = 1  # number of fix attempts before giving up
     force_merge_on_stall: bool = False  # attempt squash-merge fallback if auto-merge fails
     # When True, _discover_prs unions the issue-driven set with every open

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -1,8 +1,13 @@
 """Tests for automation Pydantic models."""
 
+import ast
 from datetime import datetime
+from pathlib import Path
 
 from hephaestus.automation.models import (
+    _DEFAULT_WORKERS,
+    AddressReviewOptions,
+    CIDriverOptions,
     DependencyGraph,
     ImplementationPhase,
     ImplementationState,
@@ -11,9 +16,15 @@ from hephaestus.automation.models import (
     IssueState,
     PlannerOptions,
     PlanResult,
+    PlanReviewerOptions,
+    ReviewerOptions,
     ReviewPhase,
     ReviewState,
+    WorkerOptionsBase,
     WorkerResult,
+    _MaxWorkerOptionsBase,
+    _ParallelWorkerOptionsBase,
+    _VerboseWorkerOptionsBase,
 )
 
 
@@ -296,6 +307,74 @@ class TestReviewState:
 
         assert restored.session_id == "pi-session-123"
         assert restored.session_agent == "pi"
+
+
+_MODELS_PATH = Path(__file__).parents[3] / "hephaestus" / "automation" / "models.py"
+
+
+def _annotated_field_owners(field_name: str) -> list[str]:
+    module = ast.parse(_MODELS_PATH.read_text())
+    owners: list[str] = []
+    for node in module.body:
+        if isinstance(node, ast.ClassDef):
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.AnnAssign)
+                    and isinstance(stmt.target, ast.Name)
+                    and stmt.target.id == field_name
+                ):
+                    owners.append(node.name)
+    return owners
+
+
+def _field_default_expr(class_name: str, field_name: str) -> str:
+    module = ast.parse(_MODELS_PATH.read_text())
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.AnnAssign)
+                    and isinstance(stmt.target, ast.Name)
+                    and stmt.target.id == field_name
+                    and stmt.value is not None
+                ):
+                    return ast.unparse(stmt.value)
+    raise AssertionError(f"{class_name}.{field_name} not found")
+
+
+class TestWorkerOptionsBase:
+    """Tests for shared automation option model fields."""
+
+    def test_all_worker_options_inherit_common_base(self) -> None:
+        for options_cls in (
+            PlannerOptions,
+            ImplementerOptions,
+            ReviewerOptions,
+            PlanReviewerOptions,
+            AddressReviewOptions,
+            CIDriverOptions,
+        ):
+            assert issubclass(options_cls, WorkerOptionsBase)
+
+    def test_shared_fields_are_declared_only_on_intended_bases(self) -> None:
+        assert _annotated_field_owners("dry_run") == ["WorkerOptionsBase"]
+        assert _annotated_field_owners("max_workers") == ["_MaxWorkerOptionsBase"]
+        assert _annotated_field_owners("parallel") == ["_ParallelWorkerOptionsBase"]
+        assert _annotated_field_owners("verbose") == ["_VerboseWorkerOptionsBase"]
+
+    def test_worker_defaults_route_through_default_workers(self) -> None:
+        assert _field_default_expr("_MaxWorkerOptionsBase", "max_workers") == "_DEFAULT_WORKERS"
+        assert _field_default_expr("_ParallelWorkerOptionsBase", "parallel") == "_DEFAULT_WORKERS"
+        assert _MaxWorkerOptionsBase.model_fields["max_workers"].default == _DEFAULT_WORKERS
+        assert _ParallelWorkerOptionsBase.model_fields["parallel"].default == _DEFAULT_WORKERS
+
+    def test_verbose_only_exists_on_current_verbose_option_models(self) -> None:
+        assert issubclass(PlanReviewerOptions, _VerboseWorkerOptionsBase)
+        assert issubclass(AddressReviewOptions, _VerboseWorkerOptionsBase)
+        assert issubclass(CIDriverOptions, _VerboseWorkerOptionsBase)
+        assert "verbose" not in PlannerOptions.model_fields
+        assert "verbose" not in ImplementerOptions.model_fields
+        assert "verbose" not in ReviewerOptions.model_fields
 
 
 class TestPlannerOptions:

--- a/tests/unit/automation/test_models.py
+++ b/tests/unit/automation/test_models.py
@@ -1,11 +1,9 @@
 """Tests for automation Pydantic models."""
 
-import ast
 from datetime import datetime
-from pathlib import Path
 
 from hephaestus.automation.models import (
-    _DEFAULT_WORKERS,
+    DEFAULT_WORKER_COUNT,
     AddressReviewOptions,
     CIDriverOptions,
     DependencyGraph,
@@ -14,17 +12,16 @@ from hephaestus.automation.models import (
     ImplementerOptions,
     IssueInfo,
     IssueState,
+    ParallelWorkerOptionsBase,
     PlannerOptions,
     PlanResult,
     PlanReviewerOptions,
     ReviewerOptions,
     ReviewPhase,
     ReviewState,
+    VerboseParallelWorkerOptionsBase,
     WorkerOptionsBase,
     WorkerResult,
-    _MaxWorkerOptionsBase,
-    _ParallelWorkerOptionsBase,
-    _VerboseWorkerOptionsBase,
 )
 
 
@@ -290,6 +287,85 @@ class TestWorkerResult:
         assert result.pr_number is None
 
 
+class TestWorkerOptionsBase:
+    """Tests for shared worker option defaults."""
+
+    def test_base_defaults_and_model_dump(self) -> None:
+        """WorkerOptionsBase exposes only the dry-run field."""
+        options = WorkerOptionsBase()
+
+        assert WorkerOptionsBase.model_fields["dry_run"].default is False
+        assert "verbose" not in WorkerOptionsBase.model_fields
+        assert options.model_dump() == {"dry_run": False}
+
+    def test_parallel_and_verbose_base_defaults(self) -> None:
+        """Narrow worker base classes expose only their shared fields."""
+        assert ParallelWorkerOptionsBase.model_fields["max_workers"].default == DEFAULT_WORKER_COUNT
+        assert VerboseParallelWorkerOptionsBase.model_fields["verbose"].default is False
+
+    def test_all_option_models_inherit_shared_fields(self) -> None:
+        """Every automation option model inherits dry-run and omits state_dir."""
+        for model_cls in (
+            PlannerOptions,
+            ImplementerOptions,
+            ReviewerOptions,
+            PlanReviewerOptions,
+            AddressReviewOptions,
+            CIDriverOptions,
+        ):
+            assert issubclass(model_cls, WorkerOptionsBase)
+            assert "dry_run" in model_cls.model_fields
+            assert "state_dir" not in model_cls.model_fields
+
+    def test_worker_count_defaults_use_shared_constant(self) -> None:
+        """Worker-count fields all use DEFAULT_WORKER_COUNT without renaming."""
+        assert PlannerOptions.model_fields["parallel"].default == DEFAULT_WORKER_COUNT
+        for model_cls in (
+            ImplementerOptions,
+            ReviewerOptions,
+            PlanReviewerOptions,
+            AddressReviewOptions,
+            CIDriverOptions,
+        ):
+            assert model_cls.model_fields["max_workers"].default == DEFAULT_WORKER_COUNT
+
+    def test_constructor_keywords_and_model_dump_are_compatible(self) -> None:
+        """Existing constructor keyword shapes still validate and dump correctly."""
+        cases = (
+            (
+                PlannerOptions,
+                {"issues": [1], "parallel": 5, "dry_run": True},
+                "parallel",
+            ),
+            (
+                ImplementerOptions,
+                {"max_workers": 5, "dry_run": True},
+                "max_workers",
+            ),
+            (ReviewerOptions, {"max_workers": 5, "dry_run": True}, "max_workers"),
+            (
+                PlanReviewerOptions,
+                {"max_workers": 5, "dry_run": True, "verbose": True},
+                "max_workers",
+            ),
+            (
+                AddressReviewOptions,
+                {"max_workers": 5, "dry_run": True, "verbose": True},
+                "max_workers",
+            ),
+            (CIDriverOptions, {"max_workers": 5, "dry_run": True, "verbose": True}, "max_workers"),
+        )
+
+        for model_cls, kwargs, worker_field in cases:
+            options = model_cls(**kwargs)
+            dumped = options.model_dump(include={worker_field, "dry_run", "verbose"})
+            expected = {worker_field: 5, "dry_run": True}
+            if "verbose" in model_cls.model_fields:
+                expected["verbose"] = True
+
+            assert dumped == expected
+
+
 class TestReviewState:
     """Tests for ReviewState model."""
 
@@ -309,74 +385,6 @@ class TestReviewState:
         assert restored.session_agent == "pi"
 
 
-_MODELS_PATH = Path(__file__).parents[3] / "hephaestus" / "automation" / "models.py"
-
-
-def _annotated_field_owners(field_name: str) -> list[str]:
-    module = ast.parse(_MODELS_PATH.read_text())
-    owners: list[str] = []
-    for node in module.body:
-        if isinstance(node, ast.ClassDef):
-            for stmt in node.body:
-                if (
-                    isinstance(stmt, ast.AnnAssign)
-                    and isinstance(stmt.target, ast.Name)
-                    and stmt.target.id == field_name
-                ):
-                    owners.append(node.name)
-    return owners
-
-
-def _field_default_expr(class_name: str, field_name: str) -> str:
-    module = ast.parse(_MODELS_PATH.read_text())
-    for node in module.body:
-        if isinstance(node, ast.ClassDef) and node.name == class_name:
-            for stmt in node.body:
-                if (
-                    isinstance(stmt, ast.AnnAssign)
-                    and isinstance(stmt.target, ast.Name)
-                    and stmt.target.id == field_name
-                    and stmt.value is not None
-                ):
-                    return ast.unparse(stmt.value)
-    raise AssertionError(f"{class_name}.{field_name} not found")
-
-
-class TestWorkerOptionsBase:
-    """Tests for shared automation option model fields."""
-
-    def test_all_worker_options_inherit_common_base(self) -> None:
-        for options_cls in (
-            PlannerOptions,
-            ImplementerOptions,
-            ReviewerOptions,
-            PlanReviewerOptions,
-            AddressReviewOptions,
-            CIDriverOptions,
-        ):
-            assert issubclass(options_cls, WorkerOptionsBase)
-
-    def test_shared_fields_are_declared_only_on_intended_bases(self) -> None:
-        assert _annotated_field_owners("dry_run") == ["WorkerOptionsBase"]
-        assert _annotated_field_owners("max_workers") == ["_MaxWorkerOptionsBase"]
-        assert _annotated_field_owners("parallel") == ["_ParallelWorkerOptionsBase"]
-        assert _annotated_field_owners("verbose") == ["_VerboseWorkerOptionsBase"]
-
-    def test_worker_defaults_route_through_default_workers(self) -> None:
-        assert _field_default_expr("_MaxWorkerOptionsBase", "max_workers") == "_DEFAULT_WORKERS"
-        assert _field_default_expr("_ParallelWorkerOptionsBase", "parallel") == "_DEFAULT_WORKERS"
-        assert _MaxWorkerOptionsBase.model_fields["max_workers"].default == _DEFAULT_WORKERS
-        assert _ParallelWorkerOptionsBase.model_fields["parallel"].default == _DEFAULT_WORKERS
-
-    def test_verbose_only_exists_on_current_verbose_option_models(self) -> None:
-        assert issubclass(PlanReviewerOptions, _VerboseWorkerOptionsBase)
-        assert issubclass(AddressReviewOptions, _VerboseWorkerOptionsBase)
-        assert issubclass(CIDriverOptions, _VerboseWorkerOptionsBase)
-        assert "verbose" not in PlannerOptions.model_fields
-        assert "verbose" not in ImplementerOptions.model_fields
-        assert "verbose" not in ReviewerOptions.model_fields
-
-
 class TestPlannerOptions:
     """Tests for PlannerOptions model."""
 
@@ -387,7 +395,7 @@ class TestPlannerOptions:
         assert options.issues == [123, 456]
         assert options.dry_run is False
         assert options.force is False
-        assert options.parallel == 3
+        assert options.parallel == DEFAULT_WORKER_COUNT
         assert options.system_prompt_file is None
         assert options.skip_closed is True
         assert options.enable_advise is True
@@ -424,7 +432,7 @@ class TestImplementerOptions:
         assert options.analyze_only is False
         assert options.health_check is False
         assert options.resume is False
-        assert options.max_workers == 3
+        assert options.max_workers == DEFAULT_WORKER_COUNT
         assert options.skip_closed is True
         assert options.auto_merge is True
         assert options.dry_run is False

--- a/tests/unit/validation/test_mypy_incremental_config.py
+++ b/tests/unit/validation/test_mypy_incremental_config.py
@@ -8,23 +8,30 @@ silently disable it.
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 
 import pytest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
 
 PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
 
 
 @pytest.fixture(scope="module")
 def mypy_config() -> dict[str, object]:
+    """Return the project mypy configuration table."""
     data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
     return data["tool"]["mypy"]
 
 
 def test_incremental_enabled(mypy_config: dict[str, object]) -> None:
+    """Mypy incremental mode stays explicitly enabled."""
     assert mypy_config.get("incremental") is True
 
 
 def test_cache_dir_pinned(mypy_config: dict[str, object]) -> None:
+    """Mypy cache location stays pinned for stable pre-commit reuse."""
     assert mypy_config.get("cache_dir") == ".mypy_cache"


### PR DESCRIPTION
## Summary
Consolidates shared automation options into a common base model and cleans up related validation/test-structure plumbing.

## Changes
- Added WorkerOptionsBase in hephaestus/automation/models.py and updated automation option classes to inherit shared fields.
- Expanded automation model tests for inherited worker option defaults and overrides.
- Removed obsolete validation wiring and adjusted unit-test structure checking configuration.

## Testing
- Updated tests/unit/automation/test_models.py and unit-test structure validation coverage.

## Closes
Closes #1387

Generated by Codex via ProjectHephaestus automation.
