### PR TITLE
fix(automation): ignore stale armed PR failures

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -2425,7 +2425,7 @@ def _evaluate_run_result(
 
     """
     log = logging.getLogger(__name__)
-    failed = [num for num, result in results.items() if not result.success]
+    raw_failed = {num: result for num, result in results.items() if not result.success}
 
     # Terminal-state vocabulary shared with ``_wait_for_armed_merge``: a PR in
     # one of these merge-states has a real conflict with its base and can never
@@ -2460,6 +2460,13 @@ def _evaluate_run_result(
         for pr in open_prs_remaining
         if pr.get("autoMergeRequest") and not _is_conflicting(pr)
     ]
+    armed_pending_prs = set(armed_pending)
+    stale_failed = [
+        num
+        for num, result in raw_failed.items()
+        if result.pr_number is not None and result.pr_number in armed_pending_prs
+    ]
+    failed = [num for num in raw_failed if num not in stale_failed]
     # #1576: un-armed-because-awaiting-review PRs are neither armed nor stuck.
     pending_review = [pr.get("number") for pr in open_prs_remaining if _is_pending_review(pr)]
     # needs_action = genuinely stuck: un-armed for a reason OTHER than pending
@@ -2475,6 +2482,12 @@ def _evaluate_run_result(
             "%s PR(s) armed and still merging (waited; not a failure): %s",
             len(armed_pending),
             armed_pending,
+        )
+    if stale_failed:
+        log.info(
+            "%s issue failure(s) correspond to armed pending PRs and are no longer actionable: %s",
+            len(stale_failed),
+            stale_failed,
         )
     if pending_review:
         log.info(

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -3192,6 +3192,28 @@ class TestEvaluateRunResult:
         remaining = [{"number": 10, "autoMergeRequest": {"enabledAt": "now"}}]
         assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
 
+    def test_failed_issue_same_armed_pending_pr_is_zero(self) -> None:
+        # A no-commit CI-fix turn can leave a stale failed WorkerResult after
+        # the same PR has become armed and is only waiting on GitHub. The final
+        # repo gate should trust the current PR state and not fail the loop.
+        results = {
+            1: WorkerResult(
+                issue_number=1,
+                success=False,
+                pr_number=10,
+                error="CI fix failed after 1 attempt(s)",
+            )
+        }
+        remaining = [
+            {
+                "number": 10,
+                "autoMergeRequest": {"enabledAt": "now"},
+                "mergeStateStatus": "BLOCKED",
+                "mergeable": "MERGEABLE",
+            }
+        ]
+        assert _evaluate_run_result(results, remaining, issues=[1], as_json=False) == 0
+
     def test_unarmed_go_labeled_pr_is_needs_action(self) -> None:
         # #1576: an un-armed PR that HAS state:implementation-go (review approved
         # but somehow not armed) is a genuine anomaly needing action → rc=1.


### PR DESCRIPTION
## Summary
- Treat armed PRs with no failing required checks as non-failures even when an earlier no-commit CI fix attempt returned failure.
- Add a Python 3.10 tomli fallback for the mypy incremental config guard that was failing unit-test collection on main.

## Test Plan
- [x] /tmp/heph-py310-1617/bin/pytest tests/unit/validation/test_mypy_incremental_config.py --override-ini=addopts= -q
- [x] pixi run pytest --no-cov tests/unit/validation/test_mypy_incremental_config.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_options_contract.py -q
- [x] pixi run ruff check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py tests/unit/validation/test_mypy_incremental_config.py
- [x] pixi run ruff format --check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py tests/unit/validation/test_mypy_incremental_config.py
- [x] pixi run pre-commit run --files hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py tests/unit/validation/test_mypy_incremental_config.py

Closes #1386

Co-authored-by: Codex <noreply@openai.com>