### PR TITLE
test(github): harden throttle disabled test

### DIFF
--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1597,15 +1597,12 @@ class TestGhCallThrottle:
         monkeypatch.setenv("GH_RATE_LIMIT_PER_SEC", "0")
         mock_run.return_value = Mock(stdout="", stderr="", returncode=0)
 
-        import time as _time
+        with patch("hephaestus.github.client.time.sleep") as mock_sleep:
+            for _ in range(5):
+                _gh_call(["api", "/rate_limit"])
 
-        t0 = _time.monotonic()
-        for _ in range(5):
-            _gh_call(["api", "/rate_limit"])
-        elapsed = _time.monotonic() - t0
-
-        # 5 calls with no throttle should finish well under one min-interval.
-        assert elapsed < 0.05, f"unexpected delay with throttle off; elapsed={elapsed:.3f}s"
+        assert mock_run.call_count == 5
+        mock_sleep.assert_not_called()
 
     @patch("hephaestus.github.client.run_subprocess")
     def test_buckets_are_per_thread(self, mock_run: Any) -> None:


### PR DESCRIPTION
Summary:
- Replace the throttle-disabled test's wall-clock threshold with a direct assertion that the throttle sleep path is not called.
- Keep the regression coverage for five successful mocked gh calls with GH_RATE_LIMIT_PER_SEC=0.

Tests:
- pixi run pytest --no-cov tests/unit/automation/test_github_api.py::TestGhCallThrottle::test_throttle_disabled_when_rate_zero -q
- pixi run pytest --no-cov tests/unit/automation/test_github_api.py::TestGhCallThrottle tests/unit/automation/test_ci_driver.py tests/unit/automation/test_options_contract.py -q
- env RUFF_CACHE_DIR=/tmp/heph-ruff-local-fix pixi run ruff check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_github_api.py
- env RUFF_CACHE_DIR=/tmp/heph-ruff-local-fix pixi run ruff format --check hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_github_api.py
- env RUFF_CACHE_DIR=/tmp/heph-ruff-local-fix pixi run pre-commit run --files hephaestus/automation/ci_driver.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_github_api.py

Closes #1653