### PR TITLE
docs(compatibility): document hephaestus.utils and hephaestus.config stable tables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,19 @@ repos:
         pass_filenames: false
         files: ^(pyproject\.toml|COMPATIBILITY\.md)$
 
+  # Per-symbol API table documentation enforcement (#1507)
+  - repo: local
+    hooks:
+      - id: hephaestus-check-api-table-docs
+        name: Every guarded subpackage __all__ must be documented in COMPATIBILITY.md
+        description: Fails the build if a guarded subpackage's __all__ and its API table in COMPATIBILITY.md drift apart
+        # --environment default is explicit because the pre-commit CI job runs
+        # in the lint env; the hephaestus-* console scripts live in default.
+        entry: pixi run --environment default hephaestus-check-api-table-docs
+        language: system
+        pass_filenames: false
+        files: ^(hephaestus/(config|utils)/__init__\.py|COMPATIBILITY\.md)$
+
   # Complexity check
   - repo: local
     hooks:

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -81,7 +81,7 @@ may change incompatibly in a minor release.
 
 ## Console-Script Stability Tiers
 
-ProjectHephaestus installs 49 console scripts via `[project.scripts]` in
+ProjectHephaestus installs 50 console scripts via `[project.scripts]` in
 `pyproject.toml`. Each is classified into one of three tiers:
 
 - **Stable** — covered by the [deprecation policy](#deprecation-policy). CLI
@@ -158,6 +158,7 @@ bypass a misfiring hook locally use
 | `hephaestus-validate-agents` | Internal | Repo CI agent-frontmatter validator |
 | `hephaestus-check-repo-analyze-skills` | Internal | Repo CI repo-analyze skill generator validator |
 | `hephaestus-check-cli-tier-docs` | Internal | Enforces this very table; added in #766 |
+| `hephaestus-check-api-table-docs` | Internal | Enforces per-symbol __all__ documentation in COMPATIBILITY.md |
 
 ## Public API
 
@@ -207,11 +208,19 @@ removal):
 
 | Symbol | Added | Notes |
 |--------|-------|-------|
+| `check_dep_sync` | 0.3.0 | Check pixi.toml ↔ requirements drift |
+| `check_requirements_up_to_date` | 0.3.0 | Verify requirements file is current |
+| `generate_requirements_content` | 0.3.0 | Render requirements.txt content from pixi deps |
 | `get_config_value` | 0.2.0 | High-level config lookup with env overlay — **(deprecated)**, use `load_config` + `merge_with_env` + `get_setting` |
 | `get_setting` | 0.1.0 | Dot-notation access to nested config dict |
 | `load_config` | 0.1.0 | Load YAML/JSON config file |
+| `load_yaml_config` | 0.1.0 | Load a YAML config file |
 | `merge_configs` | 0.1.0 | Deep-merge multiple config dicts |
 | `merge_with_env` | 0.2.0 | Overlay env vars onto config |
+| `parse_pixi_toml` | 0.3.0 | Parse pixi.toml dependency tables |
+| `parse_requirements` | 0.3.0 | Parse a requirements.txt file |
+| `sync_requirements` | 0.3.0 | Sync requirements.txt from pixi deps |
+| `validate_config` | 0.1.0 | Validate a config dict against a schema |
 
 **Deprecated symbols** (covered by the deprecation policy until removal):
 
@@ -236,10 +245,19 @@ removal):
 | Symbol | Added | Notes |
 |--------|-------|-------|
 | `flatten_dict` | 0.1.0 | Flatten nested dict |
+| `get_proj_root` | 0.1.0 | Locate the project root directory |
+| `get_repo_root` | 0.1.0 | Locate the git repository root |
 | `human_readable_size` | 0.1.0 | Format byte count as human-readable string |
+| `install_package` | 0.2.0 | Install a Python package at runtime via pip |
+| `install_signal_handlers` | 0.3.0 | Register terminal-restoring signal handlers |
+| `is_network_error` | 0.2.0 | Classify an exception as a transient network error |
+| `restore_terminal` | 0.3.0 | Restore terminal state after a raw-mode session |
+| `retry_on_network_error` | 0.2.0 | Retry decorator scoped to network errors |
 | `retry_with_backoff` | 0.1.0 | Exponential backoff retry decorator |
+| `retry_with_jitter` | 0.1.0 | Jittered backoff retry decorator — **(deprecated)**, use `retry_with_backoff(jitter=True, max_delay=...)` |
 | `run_subprocess` | 0.1.0 | Execute shell commands with error handling |
 | `slugify` | 0.1.0 | Convert text to URL-friendly slug |
+| `terminal_guard` | 0.3.0 | Context manager that saves/restores terminal state |
 
 ## Deprecation Policy
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -158,7 +158,7 @@ bypass a misfiring hook locally use
 | `hephaestus-validate-agents` | Internal | Repo CI agent-frontmatter validator |
 | `hephaestus-check-repo-analyze-skills` | Internal | Repo CI repo-analyze skill generator validator |
 | `hephaestus-check-cli-tier-docs` | Internal | Enforces this very table; added in #766 |
-| `hephaestus-check-api-table-docs` | Internal | Enforces per-symbol __all__ documentation in COMPATIBILITY.md |
+| `hephaestus-check-api-table-docs` | Internal | Enforces per-symbol `__all__` documentation in COMPATIBILITY.md |
 
 ## Public API
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -81,7 +81,7 @@ may change incompatibly in a minor release.
 
 ## Console-Script Stability Tiers
 
-ProjectHephaestus installs 50 console scripts via `[project.scripts]` in
+ProjectHephaestus installs 51 console scripts via `[project.scripts]` in
 `pyproject.toml`. Each is classified into one of three tiers:
 
 - **Stable** — covered by the [deprecation policy](#deprecation-policy). CLI

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ config = merge_with_env({}, convert_bools=True)
 <!-- CLI table generated from pyproject.toml [project.scripts]. Keep in sync via
      `python3 scripts/check_cli_table_sync.py` (also enforced in pre-commit). -->
 
-50 console scripts are installed when you install the package.  Run any command
+51 console scripts are installed when you install the package.  Run any command
 with `--help` to see full usage.
 
 ### Automation
@@ -400,6 +400,7 @@ sync (#993).
 | Command | Description |
 |---|---|
 | `hephaestus-audit-doc-policy` | Audit documentation command examples for policy violations |
+| `hephaestus-check-api-table-docs` | Enforce per-symbol `__all__` documentation in COMPATIBILITY.md |
 | `hephaestus-check-cli-tier-docs` | Enforce console-script stability-tier documentation in COMPATIBILITY.md |
 | `hephaestus-check-complexity` | Check cyclomatic complexity against a threshold |
 | `hephaestus-check-coverage` | Check test coverage against configurable thresholds |

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ just docs        # outputs to docs/api/
 ```
 
 The generated `docs/api/` directory is git-ignored; run the command locally to browse
-full function signatures, docstrings, and type annotations for all 50 CLI entry points.
+full function signatures, docstrings, and type annotations for all 51 CLI entry points.
 
 ## Setup
 

--- a/hephaestus/validation/api_table_docs.py
+++ b/hephaestus/validation/api_table_docs.py
@@ -1,0 +1,199 @@
+"""Enforce per-symbol API stability-table documentation.
+
+Every member of a documented subpackage's __all__ MUST have a matching row in
+that subpackage's "### `hephaestus.<pkg>`" table in COMPATIBILITY.md, and every
+documented row MUST correspond to a live __all__ member. Only TABLE MEMBERSHIP
+is validated — the "Added" version column is a best-effort historical anchor
+and is intentionally NOT asserted.
+
+If this hook misfires in a way you cannot fix locally, bypass it with
+``SKIP=hephaestus-check-api-table-docs git commit -S -s`` (do NOT use
+``--no-verify``, which skips ALL hooks including signing).
+
+Usage::
+    hephaestus-check-api-table-docs
+    hephaestus-check-api-table-docs --json
+    hephaestus-check-api-table-docs --repo-root /path/to/repo
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from hephaestus.cli.utils import add_json_arg, add_version_arg
+from hephaestus.utils.helpers import get_repo_root
+
+# Subpackages whose API tables are completeness-guarded. Add a name here only
+# after authoring its table in COMPATIBILITY.md.
+GUARDED_PACKAGES: tuple[str, ...] = ("hephaestus.config", "hephaestus.utils")
+
+_HEADER_RE = re.compile(r"^###\s+`(hephaestus\.[a-z_]+)`\s*$")
+_SEPARATOR_RE = re.compile(r"^\|[\s\-:|]+\|?\s*$")
+_ROW_RE = re.compile(r"^\|\s*`([A-Za-z_][A-Za-z0-9_]*)`\s*\|")
+
+
+@dataclass
+class ApiTableFinding:
+    """A single violation found while cross-checking API table documentation."""
+
+    package: str
+    # kind values: "missing-from-docs" | "missing-from-all"
+    #              | "table-not-found" | "parser-found-no-rows"
+    kind: str
+    detail: str
+
+
+def load_documented_symbols(compatibility_path: Path) -> dict[str, set[str]]:
+    """Return ``{package: {symbol, ...}}`` parsed from each ``### `hephaestus.<pkg>``` table.
+
+    Scans all ``### `hephaestus.<pkg>``` headings, reading table rows until
+    the next heading (``###`` or ``##``) or the end of the file. Separator
+    rows and the column header row are skipped.
+
+    Args:
+        compatibility_path: Path to ``COMPATIBILITY.md``.
+
+    Returns:
+        Mapping from fully-qualified package name to the set of symbol names
+        parsed from that package's table.
+
+    """
+    tables: dict[str, set[str]] = {}
+    current: str | None = None
+    text = compatibility_path.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        header = _HEADER_RE.match(line)
+        if header:
+            current = header.group(1)
+            tables.setdefault(current, set())
+            continue
+        if line.startswith("### ") or line.startswith("## "):
+            current = None
+            continue
+        if current is None:
+            continue
+        if _SEPARATOR_RE.match(line) or line.lower().startswith("| symbol"):
+            continue
+        m = _ROW_RE.match(line)
+        if m:
+            tables[current].add(m.group(1))
+    return tables
+
+
+def live_all(package: str) -> set[str]:
+    """Return the live ``__all__`` of *package* as a set.
+
+    Args:
+        package: Fully-qualified package name (e.g. ``hephaestus.utils``).
+
+    Returns:
+        Set of public symbol names exported by the package.
+
+    """
+    mod = importlib.import_module(package)
+    return set(getattr(mod, "__all__", ()))
+
+
+def find_violations(
+    documented: dict[str, set[str]],
+    packages: tuple[str, ...] = GUARDED_PACKAGES,
+) -> list[ApiTableFinding]:
+    """Cross-check *packages* live ``__all__`` against *documented* table rows.
+
+    For each package in *packages*:
+
+    - ``table-not-found`` if the package has no ``### `hephaestus.<pkg>``` heading.
+    - ``parser-found-no-rows`` if the heading exists but zero rows were parsed.
+    - ``missing-from-docs`` for each ``__all__`` symbol with no table row.
+    - ``missing-from-all`` for each table row whose symbol is not in ``__all__``.
+
+    The "Added" version column is deliberately NOT validated — those values are
+    best-effort historical anchors and asserting them would lend false authority
+    to inferred data.
+
+    Args:
+        documented: Output of :func:`load_documented_symbols`.
+        packages: Tuple of package names to check; defaults to
+            :data:`GUARDED_PACKAGES`.
+
+    Returns:
+        List of :class:`ApiTableFinding` objects. Empty list means full alignment.
+
+    """
+    findings: list[ApiTableFinding] = []
+    for pkg in packages:
+        if pkg not in documented:
+            findings.append(
+                ApiTableFinding(
+                    pkg,
+                    "table-not-found",
+                    f"No '### `{pkg}`' API table found in COMPATIBILITY.md",
+                )
+            )
+            continue
+        doc_syms = documented[pkg]
+        all_syms = live_all(pkg)
+        if all_syms and not doc_syms:
+            findings.append(
+                ApiTableFinding(
+                    pkg,
+                    "parser-found-no-rows",
+                    f"'### `{pkg}`' table parsed zero rows; format may have changed",
+                )
+            )
+            continue
+        for sym in sorted(all_syms - doc_syms):
+            findings.append(
+                ApiTableFinding(
+                    pkg,
+                    "missing-from-docs",
+                    f"{pkg}.{sym} is in __all__ but has no row in COMPATIBILITY.md",
+                )
+            )
+        for sym in sorted(doc_syms - all_syms):
+            findings.append(
+                ApiTableFinding(
+                    pkg,
+                    "missing-from-all",
+                    f"{pkg}: '{sym}' has a row in COMPATIBILITY.md but is not in __all__",
+                )
+            )
+    return findings
+
+
+def format_report(findings: list[ApiTableFinding]) -> str:
+    """Render *findings* as a human-readable text report."""
+    if not findings:
+        return "OK: every guarded subpackage's __all__ is fully documented in COMPATIBILITY.md."
+    lines = [f"FAIL: {len(findings)} API-table violation(s):"]
+    lines.extend(f"  [{f.kind}] {f.detail}" for f in findings)
+    return "\n".join(lines)
+
+
+def format_json(findings: list[ApiTableFinding]) -> str:
+    """Render *findings* as a JSON string."""
+    return json.dumps({"violations": [asdict(f) for f in findings]}, indent=2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``hephaestus-check-api-table-docs``."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=None)
+    add_json_arg(parser)
+    add_version_arg(parser)
+    args = parser.parse_args(argv)
+    repo_root = args.repo_root or get_repo_root()
+    documented = load_documented_symbols(repo_root / "COMPATIBILITY.md")
+    findings = find_violations(documented)
+    print(format_json(findings) if args.json else format_report(findings))
+    return 0 if not findings else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ hephaestus-github-stats = "hephaestus.github.stats:main"
 hephaestus-agent-stats = "hephaestus.agents.stats:main"
 hephaestus-validate-agents = "hephaestus.agents.frontmatter:validate_agents_main"
 hephaestus-check-cli-tier-docs = "hephaestus.validation.cli_tier_docs:main"
+hephaestus-check-api-table-docs = "hephaestus.validation.api_table_docs:main"
 
 [project.urls]
 Homepage = "https://github.com/HomericIntelligence/ProjectHephaestus"

--- a/tests/unit/validation/test_api_table_docs.py
+++ b/tests/unit/validation/test_api_table_docs.py
@@ -1,0 +1,199 @@
+"""Tests for hephaestus/validation/api_table_docs.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hephaestus.utils.helpers import get_repo_root
+from hephaestus.validation.api_table_docs import (
+    ApiTableFinding,
+    find_violations,
+    load_documented_symbols,
+    main,
+)
+
+_CONFIG_DOC = """\
+### `hephaestus.config`
+
+| Symbol | Added | Notes |
+|--------|-------|-------|
+| `load_config` | 0.1.0 | Load YAML/JSON config file |
+"""
+
+_UTILS_DOC = """\
+### `hephaestus.utils`
+
+| Symbol | Added | Notes |
+|--------|-------|-------|
+| `slugify` | 0.1.0 | Convert text to URL-friendly slug |
+"""
+
+_BOTH_DOC = _CONFIG_DOC + "\n" + _UTILS_DOC
+
+
+class TestLoadDocumentedSymbols:
+    """Tests for load_documented_symbols()."""
+
+    def test_parses_single_table(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(_CONFIG_DOC, encoding="utf-8")
+        tables = load_documented_symbols(p)
+        assert tables["hephaestus.config"] == {"load_config"}
+
+    def test_parses_multiple_tables(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(_BOTH_DOC, encoding="utf-8")
+        tables = load_documented_symbols(p)
+        assert tables["hephaestus.config"] == {"load_config"}
+        assert tables["hephaestus.utils"] == {"slugify"}
+
+    def test_skips_separator_rows(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(
+            "### `hephaestus.config`\n\n"
+            "| Symbol | Added | Notes |\n"
+            "|--------|-------|-------|\n"  # separator — must be skipped
+            "| `load_config` | 0.1.0 | x |\n",
+            encoding="utf-8",
+        )
+        tables = load_documented_symbols(p)
+        assert tables["hephaestus.config"] == {"load_config"}
+
+    def test_stops_at_next_heading(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(
+            "### `hephaestus.config`\n"
+            "| `load_config` | 0.1.0 | x |\n"
+            "### `hephaestus.utils`\n"
+            "| `slugify` | 0.1.0 | y |\n",
+            encoding="utf-8",
+        )
+        tables = load_documented_symbols(p)
+        assert "hephaestus.config" in tables
+        assert "hephaestus.utils" in tables
+        assert tables["hephaestus.config"] == {"load_config"}
+        assert tables["hephaestus.utils"] == {"slugify"}
+
+    def test_empty_doc_returns_empty(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text("# No tables here\n", encoding="utf-8")
+        assert load_documented_symbols(p) == {}
+
+
+class TestFindViolations:
+    """Tests for find_violations()."""
+
+    def test_table_not_found(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text("# no tables here\n", encoding="utf-8")
+        documented = load_documented_symbols(p)
+        findings = find_violations(documented, packages=("hephaestus.utils",))
+        assert len(findings) == 1
+        assert findings[0].kind == "table-not-found"
+        assert "hephaestus.utils" in findings[0].detail
+
+    def test_missing_from_docs_detected(self, tmp_path: Path) -> None:
+        """A symbol in __all__ but absent from docs raises missing-from-docs."""
+        p = tmp_path / "COMPATIBILITY.md"
+        # Only one symbol documented, but hephaestus.config.__all__ has more
+        p.write_text(
+            "### `hephaestus.config`\n\n"
+            "| Symbol | Added | Notes |\n"
+            "|--------|-------|-------|\n"
+            "| `load_config` | 0.1.0 | x |\n",
+            encoding="utf-8",
+        )
+        documented = load_documented_symbols(p)
+        findings = find_violations(documented, packages=("hephaestus.config",))
+        kinds = {f.kind for f in findings}
+        assert "missing-from-docs" in kinds
+        # validate_config is one of the symbols that was missing before this PR
+        assert any("validate_config" in f.detail for f in findings)
+
+    def test_missing_from_all_detected(self, tmp_path: Path) -> None:
+        """A docs row with no corresponding __all__ symbol raises missing-from-all."""
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(
+            "### `hephaestus.config`\n\n"
+            "| Symbol | Added | Notes |\n"
+            "|--------|-------|-------|\n"
+            "| `nonexistent_symbol_xyz` | 0.1.0 | x |\n",
+            encoding="utf-8",
+        )
+        documented = load_documented_symbols(p)
+        findings = find_violations(documented, packages=("hephaestus.config",))
+        kinds = {f.kind for f in findings}
+        assert "missing-from-all" in kinds
+        assert any("nonexistent_symbol_xyz" in f.detail for f in findings)
+
+    def test_clean_when_aligned(self, tmp_path: Path) -> None:
+        """No findings when documented symbols exactly match __all__."""
+        import hephaestus.config as cfg
+
+        doc_lines = "\n".join(f"| `{sym}` | 0.1.0 | x |" for sym in cfg.__all__)
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(
+            "### `hephaestus.config`\n\n"
+            "| Symbol | Added | Notes |\n"
+            "|--------|-------|-------|\n"
+            + doc_lines
+            + "\n",
+            encoding="utf-8",
+        )
+        documented = load_documented_symbols(p)
+        findings = find_violations(documented, packages=("hephaestus.config",))
+        assert findings == []
+
+    def test_empty_packages_tuple_returns_no_findings(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text("# empty\n", encoding="utf-8")
+        documented = load_documented_symbols(p)
+        assert find_violations(documented, packages=()) == []
+
+    def test_finding_is_dataclass(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text("# no tables\n", encoding="utf-8")
+        documented = load_documented_symbols(p)
+        findings = find_violations(documented, packages=("hephaestus.utils",))
+        assert isinstance(findings[0], ApiTableFinding)
+        assert findings[0].package == "hephaestus.utils"
+
+
+class TestLiveTreeAlignment:
+    """Live guard: COMPATIBILITY.md must stay aligned with the actual __all__."""
+
+    def test_real_compatibility_md_is_aligned(self) -> None:
+        """After completing both tables, there must be ZERO drift for guarded packages."""
+        root = get_repo_root()
+        documented = load_documented_symbols(root / "COMPATIBILITY.md")
+        findings = find_violations(documented)
+        assert findings == [], "\n".join(f.detail for f in findings)
+
+
+class TestMain:
+    """Tests for the main() entry point."""
+
+    def test_main_returns_zero_on_real_repo(self) -> None:
+        assert main([]) == 0
+
+    def test_main_returns_one_on_missing_table(self, tmp_path: Path) -> None:
+        (tmp_path / "COMPATIBILITY.md").write_text("# no tables\n", encoding="utf-8")
+        # Need a real repo structure for get_repo_root; override via --repo-root
+        result = main(["--repo-root", str(tmp_path)])
+        assert result == 1
+
+    def test_main_json_output_is_valid_json(self, tmp_path: Path) -> None:
+        import json
+
+        (tmp_path / "COMPATIBILITY.md").write_text("# no tables\n", encoding="utf-8")
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            main(["--repo-root", str(tmp_path), "--json"])
+        data = json.loads(buf.getvalue())
+        assert "violations" in data
+        assert isinstance(data["violations"], list)

--- a/tests/unit/validation/test_api_table_docs.py
+++ b/tests/unit/validation/test_api_table_docs.py
@@ -135,9 +135,7 @@ class TestFindViolations:
         p.write_text(
             "### `hephaestus.config`\n\n"
             "| Symbol | Added | Notes |\n"
-            "|--------|-------|-------|\n"
-            + doc_lines
-            + "\n",
+            "|--------|-------|-------|\n" + doc_lines + "\n",
             encoding="utf-8",
         )
         documented = load_documented_symbols(p)

--- a/tests/unit/validation/test_api_table_docs.py
+++ b/tests/unit/validation/test_api_table_docs.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from hephaestus.utils.helpers import get_repo_root
 from hephaestus.validation.api_table_docs import (
     ApiTableFinding,


### PR DESCRIPTION
## Summary
Add comprehensive API documentation for all __all__ symbols in hephaestus.utils and hephaestus.config stable modules in COMPATIBILITY.md, resolving audit finding S14. Previously 9 utils symbols and 8 config symbols were undocumented. Includes new validator to enforce continuous coverage.

## Changes
- Added 9 missing hephaestus.utils symbols to COMPATIBILITY.md API table (install_package, install_signal_handlers, is_network_error, restore_terminal, retry_on_network_error, terminal_guard, get_proj_root, get_repo_root, and retry_with_jitter deprecated marker)
- Added 8 missing hephaestus.config symbols to COMPATIBILITY.md API table (validate_config, load_yaml_config, check_dep_sync, parse_pixi_toml, sync_requirements, check_requirements_up_to_date, generate_requirements_content, parse_requirements)
- Created hephaestus/validation/api_table_docs.py validator to ensure __all__ membership stays synchronized with COMPATIBILITY.md tables
- Added hephaestus-check-api-table-docs pre-commit hook and console script to enforce API documentation completeness
- Added test suite (tests/unit/validation/test_api_table_docs.py) to verify validator logic and table integrity

## Testing
- Run hephaestus-check-api-table-docs to verify all hephaestus.utils and hephaestus.config symbols are documented
- Run tests/unit/validation/test_api_table_docs.py to verify table parsing and validation logic
- Verify pre-commit hook runs on commit and rejects undocumented symbols

## Closes
Closes #1507

Generated by Claude Code via ProjectHephaestus automation.
