### PR TITLE
fix(automation): strip NUL bytes before claude invoke

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from hephaestus.utils.helpers import strip_null_bytes
+
 AgentName = Literal["claude", "codex", "pi"]
 SubprocessCommandPart = str | bytes | os.PathLike[str] | os.PathLike[bytes]
 SubprocessCommand = SubprocessCommandPart | Sequence[SubprocessCommandPart]
@@ -314,9 +316,12 @@ def run_claude_text(
     cid = get_current_correlation_id()
     if cid:
         env["GH_TRACE_ID"] = cid
+    # A NUL in the prompt would make subprocess.run raise ``ValueError: embedded
+    # null byte`` while marshaling text stdin, before the child runs (#1661). The
+    # prompt is assembled from untrusted multi-source text; strip defensively.
     return subprocess.run(
         cmd,
-        input=prompt,
+        input=strip_null_bytes(prompt),
         cwd=cwd,
         text=True,
         stdout=subprocess.PIPE,
@@ -904,7 +909,10 @@ def _communicate_codex_process(
     )
     started_at = time.monotonic()
     final_seen_at: float | None = None
-    input_text: str | None = prompt
+    # Strip NUL bytes: proc.communicate(input=...) marshals text stdin and would
+    # raise ``ValueError: embedded null byte`` on a stray NUL, before Codex runs
+    # (#1661) — the same crash the Claude path guards against.
+    input_text: str | None = strip_null_bytes(prompt)
     grace_seconds = _codex_final_message_grace_seconds()
 
     while True:

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from hephaestus.automation.session_naming import session_jsonl_path, session_name
 from hephaestus.github.client import ClaudeUsageCapError
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch
+from hephaestus.utils.helpers import strip_null_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -152,6 +153,20 @@ def invoke_claude_with_session(
         cmd += ["--permission-mode", permission_mode]
     if extra_args:
         cmd += extra_args
+    # subprocess.run rejects any argv element (or text stdin) containing a NUL
+    # with ``ValueError: embedded null byte``. The prompt is assembled from
+    # untrusted multi-source text (issue body + agent/advise output + prior
+    # review) and a single stray NUL would otherwise permanently strand the
+    # issue. Strip defensively here — the one chokepoint every agent phase
+    # (planner, implementer, advise, reviewer) passes through (#1661).
+    sanitized = strip_null_bytes(prompt)
+    if sanitized != prompt:
+        logger.warning(
+            "Stripped NUL byte(s) from %s prompt for issue %s before invoking claude",
+            agent,
+            issue,
+        )
+        prompt = sanitized
     cmd.append("--print")
     if not input_via_stdin:
         cmd.append(prompt)

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -31,6 +31,7 @@ from hephaestus.github.rate_limit import (
     gh_rate_limit_reset_epoch,
 )
 from hephaestus.io.utils import write_secure
+from hephaestus.utils.helpers import strip_null_bytes
 
 from .git_utils import get_repo_info, run
 from .models import IssueInfo, IssueState
@@ -252,7 +253,15 @@ def gh_issue_json(issue_number: int) -> dict[str, Any]:
         result = _gh_call(
             ["issue", "view", str(issue_number), "--json", "number,title,state,labels,body"],
         )
-        return cast(dict[str, Any], json.loads(result.stdout))
+        data = cast(dict[str, Any], json.loads(result.stdout))
+        # Strip stray NUL bytes at the source so downstream prompt assembly never
+        # feeds an embedded null into a subprocess argv (#1661). Title/body are the
+        # only free-text fields consumed by the planner/implementer prompts.
+        for field in ("title", "body"):
+            value = data.get(field)
+            if isinstance(value, str):
+                data[field] = strip_null_bytes(value)
+        return data
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to fetch issue #{issue_number}: {e}") from e
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -256,11 +256,17 @@ def gh_issue_json(issue_number: int) -> dict[str, Any]:
         data = cast(dict[str, Any], json.loads(result.stdout))
         # Strip stray NUL bytes at the source so downstream prompt assembly never
         # feeds an embedded null into a subprocess argv (#1661). Title/body are the
-        # only free-text fields consumed by the planner/implementer prompts.
+        # free-text fields consumed by the planner/implementer prompts; warn on a
+        # strip so the (rare) mutation of a user-visible field is never silent.
         for field in ("title", "body"):
             value = data.get(field)
             if isinstance(value, str):
-                data[field] = strip_null_bytes(value)
+                cleaned = strip_null_bytes(value)
+                if cleaned != value:
+                    logger.warning(
+                        "Stripped NUL byte(s) from issue #%s %s field", issue_number, field
+                    )
+                    data[field] = cleaned
         return data
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to fetch issue #{issue_number}: {e}") from e
@@ -470,7 +476,9 @@ def gh_issue_create(title: str, body: str, labels: list[str] | None = None) -> i
             _ensure_labels_exist(labels)
 
         with _body_file(body) as body_path:
-            cmd = ["issue", "create", "--title", title, "--body-file", body_path]
+            # Title is a direct argv element; a stray NUL would make gh's
+            # subprocess invocation raise ``ValueError: embedded null byte`` (#1661).
+            cmd = ["issue", "create", "--title", strip_null_bytes(title), "--body-file", body_path]
             if labels:
                 for label in labels:
                     cmd.extend(["--label", label])
@@ -754,7 +762,9 @@ def gh_pr_create(
                     "--base",
                     base,
                     "--title",
-                    title,
+                    # NUL in argv → ``ValueError: embedded null byte`` from gh's
+                    # subprocess call before the child runs (#1661).
+                    strip_null_bytes(title),
                     "--body-file",
                     body_path,
                 ]

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -50,6 +50,26 @@ def slugify(text: str) -> str:
     return text
 
 
+def strip_null_bytes(text: str) -> str:
+    r"""Remove NUL (``\x00``) bytes from text destined for a subprocess.
+
+    :func:`subprocess.run` raises ``ValueError: embedded null byte`` if any argv
+    element (or text passed via stdin) contains a NUL. Agent output and malformed
+    GitHub issue bodies can carry stray NULs, which would otherwise permanently
+    strand the affected work item in the automation loop. Strip them defensively
+    at the invoke/data boundary.
+
+    Args:
+        text: Text that may contain embedded NUL bytes.
+
+    Returns:
+        ``text`` with every NUL byte removed; the same object when none are
+        present (clean text is byte-identical).
+
+    """
+    return text.replace("\x00", "") if "\x00" in text else text
+
+
 def human_readable_size(size_bytes: int | float) -> str:
     """Convert byte size to human readable format.
 

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -124,6 +124,7 @@ class _FakeCodexPopen:
         final_message: str = "",
         hang: bool = False,
         returncode: int = 0,
+        captured_input: list[str | None] | None = None,
         **_: Any,
     ) -> None:
         self.cmd = cmd
@@ -133,13 +134,16 @@ class _FakeCodexPopen:
         self.returncode = returncode
         self.killed = False
         self.terminated = False
+        self._captured_input = captured_input
         output_path = Path(cmd[cmd.index("--output-last-message") + 1])
         output_path.write_text(final_message, encoding="utf-8")
 
     def communicate(
         self, input: str | None = None, timeout: float | None = None
     ) -> tuple[str, str]:
-        del input, timeout
+        if self._captured_input is not None:
+            self._captured_input.append(input)
+        del timeout
         if self.hang and not (self.killed or self.terminated):
             raise subprocess.TimeoutExpired(self.cmd, 1)
         return self.stdout, self.stderr
@@ -182,6 +186,58 @@ def test_run_codex_session_returns_session_id_and_last_message(tmp_path: Path) -
 
     assert result.session_id == "019e1e57-7652-7892-b1ca-c31c93d4b160"
     assert result.stdout == "final answer"
+
+
+def test_run_claude_text_strips_null_byte_from_stdin(tmp_path: Path) -> None:
+    """#1661: a NUL in the prompt must not crash the Claude-text stdin path.
+
+    subprocess.run marshals ``input=`` as text stdin and raises
+    ``ValueError: embedded null byte`` on a stray NUL — the same crash the
+    claude_invoke chokepoint guards against, on a sibling runner path.
+    """
+    captured: dict[str, Any] = {}
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        captured["input"] = kwargs.get("input")
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    with patch("hephaestus.agents.runtime.subprocess.run", side_effect=fake_run):
+        agent_runtime.run_claude_text("plan this\x00issue", cwd=tmp_path, timeout=30)
+
+    assert captured["input"] == "plan thisissue"
+    assert "\x00" not in captured["input"]
+
+
+def test_run_codex_session_strips_null_byte_from_stdin(tmp_path: Path) -> None:
+    """#1661: a NUL in the prompt must not crash the Codex stdin path."""
+    captured_input: list[str | None] = []
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        stdout = (
+            '{"type":"session_meta","payload":{"id":"019e1e57-7652-7892-b1ca-c31c93d4b160"}}\n'
+            '{"type":"agent_message","message":"fallback"}\n'
+        )
+        return _FakeCodexPopen(
+            cmd,
+            proc_stdout=stdout,
+            final_message="final answer",
+            captured_input=captured_input,
+            **kwargs,
+        )
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        agent_runtime.run_codex_session(
+            "plan this\x00issue",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+    assert captured_input == ["plan thisissue"]
 
 
 def test_run_codex_session_recovers_last_message_on_wrapper_timeout(tmp_path: Path) -> None:

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
@@ -397,19 +398,22 @@ class TestPromptNullByteSanitization:
     ) -> None:
         """End-to-end regression: the real subprocess.run path tolerates a NUL.
 
-        Reproduces the #1509 crash. We point the invoked binary at ``true`` so
-        the call succeeds; before the fix, argv marshaling raised
-        ``ValueError: embedded null byte`` and never reached the child.
+        Reproduces the #1509 crash. We point the invoked binary at a portable
+        no-op (``sys.executable -c ""``, always present — unlike ``true``) so the
+        call succeeds; WITHOUT the fix, argv marshaling raises
+        ``ValueError: embedded null byte`` here and never reaches the child.
         """
         cwd = fake_home / "work"
         cwd.mkdir()
 
         real_run = subprocess.run
+        noop = [sys.executable, "-c", ""]
 
         def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-            # Replace the "claude" binary with a harmless no-op; keep the real
-            # argv-marshaling behaviour (which is what raised the ValueError).
-            return real_run(["true", *cmd[1:]], **kwargs)
+            # Swap the "claude" binary for a guaranteed no-op while preserving the
+            # rest of argv verbatim — so the real argv/stdin marshaling (which
+            # raised the original ValueError) is still exercised.
+            return real_run([*noop, *cmd[1:]], **kwargs)
 
         monkeypatch.setattr("hephaestus.automation.claude_invoke.subprocess.run", fake_run)
 

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -347,3 +347,78 @@ class TestEndToEndSessionResume:
         assert expected_sid in argv
         assert "--session-id" not in argv
         assert "--session-id" not in argv
+
+
+class TestPromptNullByteSanitization:
+    r"""#1661: a NUL byte in the prompt must not crash the invoke.
+
+    subprocess.run raises ``ValueError: embedded null byte`` if any argv element
+    (or text stdin) contains ``\x00``. The prompt is assembled from untrusted
+    multi-source text (issue body + advise/agent output + prior review), so a
+    single stray NUL would otherwise permanently strand the issue.
+    """
+
+    def test_argv_prompt_has_no_null_byte(self, stub_run: MagicMock, fake_home: Path) -> None:
+        """A NUL in the prompt is stripped before it reaches the argv."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        invoke_claude_with_session(
+            repo="R",
+            issue=1509,
+            agent=AGENT_PLANNER,
+            prompt="plan this\x00issue",
+            model="sonnet",
+            cwd=cwd,
+        )
+        argv = _argv(stub_run.call_args)
+        assert all("\x00" not in arg for arg in argv)
+        # The prompt is the last positional argv element (after --print).
+        assert argv[-1] == "plan thisissue"
+
+    def test_stdin_prompt_has_no_null_byte(self, stub_run: MagicMock, fake_home: Path) -> None:
+        """A NUL is stripped on the stdin path too (input_via_stdin=True)."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        invoke_claude_with_session(
+            repo="R",
+            issue=1509,
+            agent=AGENT_PLANNER,
+            prompt="plan this\x00issue",
+            model="sonnet",
+            cwd=cwd,
+            input_via_stdin=True,
+        )
+        kwargs = stub_run.call_args.kwargs
+        assert kwargs["input"] == "plan thisissue"
+        assert "\x00" not in kwargs["input"]
+
+    def test_real_subprocess_does_not_raise_with_null_byte(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end regression: the real subprocess.run path tolerates a NUL.
+
+        Reproduces the #1509 crash. We point the invoked binary at ``true`` so
+        the call succeeds; before the fix, argv marshaling raised
+        ``ValueError: embedded null byte`` and never reached the child.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+
+        real_run = subprocess.run
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            # Replace the "claude" binary with a harmless no-op; keep the real
+            # argv-marshaling behaviour (which is what raised the ValueError).
+            return real_run(["true", *cmd[1:]], **kwargs)
+
+        monkeypatch.setattr("hephaestus.automation.claude_invoke.subprocess.run", fake_run)
+
+        out, _sid = invoke_claude_with_session(
+            repo="R",
+            issue=1509,
+            agent=AGENT_PLANNER,
+            prompt="plan this\x00issue",
+            model="sonnet",
+            cwd=cwd,
+        )
+        assert out == ""

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -95,6 +95,30 @@ class TestGhIssueJson:
         assert "\x00" not in data["title"]
         assert "\x00" not in data["body"]
 
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_strip_tolerates_missing_and_non_string_fields(self, mock_gh_call: Any) -> None:
+        """#1661: the .get/isinstance guard skips missing or non-string fields.
+
+        Exercises the defensive branch — a payload with ``body`` absent and a
+        non-string ``title`` must not raise (None/int have no ``.replace``).
+        """
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {
+                "number": 1509,
+                "title": 123,  # non-string — isinstance guard must skip it
+                "state": "OPEN",
+                "labels": [],
+                # body intentionally omitted — .get returns None, guard skips it
+            }
+        )
+        mock_gh_call.return_value = mock_result
+
+        data = gh_issue_json(1509)
+
+        assert data["title"] == 123
+        assert "body" not in data
+
 
 class TestParseIssueDependencies:
     """Tests for parse_issue_dependencies function."""
@@ -945,6 +969,19 @@ class TestGhIssueCreate:
         assert call_args[4] == "--body-file"
         assert isinstance(call_args[5], str) and call_args[5]
         assert "Test body" not in call_args
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_title_null_byte_stripped_from_argv(self, mock_gh_call: Any) -> None:
+        """#1661: a NUL in the title must not reach the --title argv element."""
+        mock_result = Mock()
+        mock_result.stdout = "https://github.com/owner/repo/issues/791"
+        mock_gh_call.return_value = mock_result
+
+        gh_issue_create(title="bad\x00title", body="Body")
+
+        call_args = mock_gh_call.call_args[0][0]
+        assert call_args[:4] == ["issue", "create", "--title", "badtitle"]
+        assert all("\x00" not in str(arg) for arg in call_args)
 
     @patch("hephaestus.automation.github_api.gh_list_labels", return_value={"bug", "enhancement"})
     @patch("hephaestus.automation.github_api._gh_call")

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -73,6 +73,28 @@ class TestGhIssueJson:
         with pytest.raises(RuntimeError, match="Failed to fetch issue"):
             gh_issue_json(123)
 
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_strips_null_bytes_from_title_and_body(self, mock_gh_call: Any) -> None:
+        """#1661: NUL bytes in title/body are stripped at the source."""
+        mock_result = Mock()
+        mock_result.stdout = json.dumps(
+            {
+                "number": 1509,
+                "title": "bad\x00title",
+                "state": "OPEN",
+                "labels": [],
+                "body": "bad\x00body",
+            }
+        )
+        mock_gh_call.return_value = mock_result
+
+        data = gh_issue_json(1509)
+
+        assert data["title"] == "badtitle"
+        assert data["body"] == "badbody"
+        assert "\x00" not in data["title"]
+        assert "\x00" not in data["body"]
+
 
 class TestParseIssueDependencies:
     """Tests for parse_issue_dependencies function."""

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -23,28 +23,42 @@ from hephaestus.utils.helpers import (
 class TestStripNullBytes:
     """Tests for strip_null_bytes (#1661)."""
 
-    def test_removes_embedded_null(self):
+    def test_removes_embedded_null(self) -> None:
         """An embedded NUL byte is removed, surrounding text preserved."""
         assert strip_null_bytes("a\x00b") == "ab"
 
-    def test_removes_leading_and_trailing_null(self):
+    def test_removes_leading_and_trailing_null(self) -> None:
         """Leading and trailing NULs are stripped."""
         assert strip_null_bytes("\x00abc\x00") == "abc"
 
-    def test_removes_multiple_nulls(self):
+    def test_removes_multiple_nulls(self) -> None:
         """Every NUL is removed regardless of count or position."""
         assert strip_null_bytes("\x00a\x00\x00b\x00c") == "abc"
 
-    def test_clean_text_unchanged(self):
-        """Text without NULs is returned byte-identical (same object)."""
+    def test_nul_adjacent_to_multibyte_unicode(self) -> None:
+        """A NUL next to multibyte characters is removed without corrupting them."""
+        assert strip_null_bytes("✓\x00é\x00中") == "✓é中"
+
+    def test_clean_text_unchanged(self) -> None:
+        """Text without NULs compares equal (value contract, not identity)."""
         text = "no nulls here — just unicode ✓"
+        assert strip_null_bytes(text) == text
+
+    def test_clean_text_is_not_copied(self) -> None:
+        """Micro-optimization: clean text is returned without allocating a copy.
+
+        Separated from the value-equality contract above so a conformant
+        implementation that always calls ``.replace`` would fail only this
+        explicitly-labeled optimization test, not the behavioral one.
+        """
+        text = "no nulls here"
         assert strip_null_bytes(text) is text
 
-    def test_empty_string(self):
+    def test_empty_string(self) -> None:
         """An empty string is handled without error."""
         assert strip_null_bytes("") == ""
 
-    def test_only_nulls(self):
+    def test_only_nulls(self) -> None:
         """A string of only NULs becomes empty."""
         assert strip_null_bytes("\x00\x00\x00") == ""
 

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -16,7 +16,37 @@ from hephaestus.utils.helpers import (
     install_package,
     run_subprocess,
     slugify,
+    strip_null_bytes,
 )
+
+
+class TestStripNullBytes:
+    """Tests for strip_null_bytes (#1661)."""
+
+    def test_removes_embedded_null(self):
+        """An embedded NUL byte is removed, surrounding text preserved."""
+        assert strip_null_bytes("a\x00b") == "ab"
+
+    def test_removes_leading_and_trailing_null(self):
+        """Leading and trailing NULs are stripped."""
+        assert strip_null_bytes("\x00abc\x00") == "abc"
+
+    def test_removes_multiple_nulls(self):
+        """Every NUL is removed regardless of count or position."""
+        assert strip_null_bytes("\x00a\x00\x00b\x00c") == "abc"
+
+    def test_clean_text_unchanged(self):
+        """Text without NULs is returned byte-identical (same object)."""
+        text = "no nulls here — just unicode ✓"
+        assert strip_null_bytes(text) is text
+
+    def test_empty_string(self):
+        """An empty string is handled without error."""
+        assert strip_null_bytes("") == ""
+
+    def test_only_nulls(self):
+        """A string of only NULs becomes empty."""
+        assert strip_null_bytes("\x00\x00\x00") == ""
 
 
 class TestSlugify:


### PR DESCRIPTION
## Summary

The automation loop crashed with `ValueError: embedded null byte` whenever a NUL (`\x00`) byte appeared in an agent prompt or an agent-generated title. `subprocess.run` (and `Popen.communicate`) reject any argv element or text stdin containing a NUL during marshaling — before the child runs. A single stray NUL — observed permanently stranding **issue #1509 on every loop** — failed the issue with no recovery.

## Fix — NUL stripped at every subprocess boundary that carries untrusted text

- New shared helper `strip_null_bytes` in `hephaestus/utils/helpers.py` (library layer; imported by automation/agents — the allowed dependency direction).
- **Claude invoke chokepoint** (`claude_invoke.invoke_claude_with_session`): sanitize the prompt for both the argv and stdin paths; warn on removal.
- **Direct-runner paths** (`agents/runtime.py`): strip on the Claude-text stdin and Codex stdin paths. (Pi writes the prompt to a temp file and passes only the clean path as argv, so a NUL there is harmless file content — left as-is.)
- **Title argv** (`gh_issue_create` / `gh_pr_create`): strip the `--title` argv element so agent-generated titles can't crash `gh`.
- **Issue data source** (`gh_issue_json`): strip `title`/`body` and **warn** on a strip (no silent mutation of a user-visible field; CLAUDE.md:173 "log suspicious inputs").

## Tests (TDD, all RED-verified before the fix)

- Helper unit coverage incl. NUL adjacent to multibyte unicode; value-equality contract plus a separate explicitly-labeled no-copy test.
- Claude argv + stdin sanitization; an **end-to-end regression** driving the real `subprocess.run` path with a NUL-bearing prompt (portable `sys.executable -c ""` no-op).
- Codex and Claude-text stdin stripping in `agents/runtime.py`.
- `gh_issue_create` `--title` argv stripping; `gh_issue_json` missing-key / non-string guard branch.

All `tests/unit/{agents,utils}` + the touched automation tests pass; ruff, mypy, pre-commit, and the import-surface / automation-boundary tests are clean.

## Scope note

A prior revision's wording ("every agent phase in one place") was too strong — the original commit covered only the Claude path. This PR closes the gap by stripping at **all** subprocess boundaries that carry untrusted issue/agent text (Claude + Codex stdin, title argv, issue-data source), found via a strict adversarial review.

Closes #1661