### PR TITLE
feat(github): resolve ProjectMnemosyne target per gh user (fork-or-upstream)

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 from hephaestus.constants import agent_clone_timeout, agent_git_timeout
 from hephaestus.github.client import gh_call
+from hephaestus.github.mnemosyne_repo import resolve_mnemosyne_target
 
 # fcntl is POSIX-only; CPython does not bundle it on Windows. Import lazily so
 # this module stays importable on Windows for tests that only need its
@@ -81,21 +82,28 @@ def default_mnemosyne_root() -> Path:
 
 
 def _clone_mnemosyne(mnemosyne_root: Path) -> bool:
-    """Clone the ProjectMnemosyne repository into ``mnemosyne_root``."""
+    """Clone the resolved ProjectMnemosyne repository into ``mnemosyne_root``.
+
+    The clone target is resolved via
+    :func:`hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target`, which
+    prefers the gh-authenticated user's own fork (creating it if needed) and
+    falls back to the upstream ``HomericIntelligence/ProjectMnemosyne``.
+    """
     timeout_s = agent_clone_timeout()
+    target = resolve_mnemosyne_target()
     try:
-        logger.info("Cloning ProjectMnemosyne to %s...", mnemosyne_root)
+        logger.info("Cloning %s to %s...", target.slug, mnemosyne_root)
         gh_call(
             [
                 "repo",
                 "clone",
-                "HomericIntelligence/ProjectMnemosyne",
+                target.slug,
                 str(mnemosyne_root),
             ],
             check=True,
             timeout=timeout_s,
         )
-        logger.info("ProjectMnemosyne cloned successfully")
+        logger.info("%s cloned successfully", target.slug)
         return True
     except subprocess.TimeoutExpired:
         logger.warning(

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -42,10 +42,13 @@ _LEARN_RATE_LIMIT_MAX_RETRIES = 5
 # transient/secondary limit clear without busy-looping on an unknown deadline.
 _LEARN_UNKNOWN_RESET_BACKOFF_SECONDS = 300
 
+# Owner-agnostic: the Mnemosyne target may be the upstream
+# (HomericIntelligence/ProjectMnemosyne) or any user's fork
+# (<login>/ProjectMnemosyne). Only the repo name is fixed.
 _MNEMOSYNE_URL_RE = re.compile(
-    r"https://github\.com/HomericIntelligence/ProjectMnemosyne/(?:pull|commit)/[A-Za-z0-9._/-]+"
+    r"https://github\.com/[A-Za-z0-9._-]+/ProjectMnemosyne/(?:pull|commit)/[A-Za-z0-9._/-]+"
 )
-_MNEMOSYNE_PR_REF_RE = re.compile(r"\bHomericIntelligence/ProjectMnemosyne#(?P<number>\d+)\b")
+_MNEMOSYNE_PR_REF_RE = re.compile(r"\b[A-Za-z0-9._-]+/ProjectMnemosyne#(?P<number>\d+)\b")
 
 
 def mnemosyne_update_evidence(output: str) -> dict[str, Any]:
@@ -112,7 +115,9 @@ def build_learn_prompt(context: str) -> str:
         " EXECUTE the /learn skill-creation workflow for ProjectMnemosyne."
         " Do NOT return a plan. Do NOT ask for approval."
         " Commit the results and create a PR."
-        " IMPORTANT: Only push skills to ProjectMnemosyne."
+        " IMPORTANT: Only push skills to the resolved ProjectMnemosyne"
+        " repository (the gh user's own fork when available, else upstream),"
+        " and open the PR against that same repository."
         " Do NOT create files under .claude-plugin/ in this repo."
         f"{suffix}"
     )

--- a/hephaestus/github/__init__.py
+++ b/hephaestus/github/__init__.py
@@ -40,6 +40,14 @@ from hephaestus.github.client import (
     GitHubUnavailableError,
     gh_call,
 )
+from hephaestus.github.mnemosyne_repo import (
+    UPSTREAM_SLUG,
+    MnemosyneTarget,
+    fork_upstream,
+    gh_authenticated_login,
+    remote_repo_exists,
+    resolve_mnemosyne_target,
+)
 from hephaestus.github.pr_merge import detect_repo_from_remote, local_branch_exists
 from hephaestus.github.rate_limit import (
     detect_claude_usage_cap,
@@ -61,23 +69,29 @@ from hephaestus.github.stats import (
 )
 
 __all__ = [
+    "UPSTREAM_SLUG",
     "ClaudeUsageCapError",
     "GitHubRateLimitError",
     "GitHubUnavailableError",
+    "MnemosyneTarget",
     "collect_stats",
     "detect_claude_usage_cap",
     "detect_claude_usage_limit",
     "detect_rate_limit",
     "detect_repo_from_remote",
     "detect_session_limit",
+    "fork_upstream",
     "format_stats_table",
     "get_commits_stats",
     "get_current_repo",
     "get_issues_stats",
     "get_prs_stats",
+    "gh_authenticated_login",
     "gh_call",
     "local_branch_exists",
     "parse_reset_epoch",
+    "remote_repo_exists",
+    "resolve_mnemosyne_target",
     "resolve_quota_reset_epoch",
     "validate_date",
     "wait_until",

--- a/hephaestus/github/mnemosyne_repo.py
+++ b/hephaestus/github/mnemosyne_repo.py
@@ -1,0 +1,246 @@
+"""Resolve which ProjectMnemosyne repository to clone, push to, and PR against.
+
+Historically every path that touched ProjectMnemosyne hardcoded
+``HomericIntelligence/ProjectMnemosyne`` as the remote, which meant only
+members of that org could use the ``/advise`` and ``/learn`` skills (and the
+automation pipeline) against a knowledge base.
+
+This module makes the target portable. The resolution ladder is:
+
+1. An ``override_owner`` (explicit arg or the ``HEPH_MNEMOSYNE_OWNER`` env var)
+   always wins.
+2. Otherwise use the ``gh``-authenticated login. If that login *is*
+   ``HomericIntelligence`` (the upstream itself), clone upstream directly — you
+   cannot fork a repo into its own org. If ``<login>/ProjectMnemosyne`` already
+   exists on GitHub, use it. Otherwise fork
+   ``HomericIntelligence/ProjectMnemosyne`` into the login's namespace and use
+   the resulting fork.
+3. If the login cannot be determined, fall back to the upstream slug.
+
+``/learn`` pushes branches and opens PRs against the *resolved* slug (the fork
+itself), making each user's knowledge base self-contained.
+
+All ``gh`` invocations route through :func:`hephaestus.github.client.gh_call`
+so they stay behind the rate-limit / circuit-breaker adapter. The resolver is
+the single source of truth shared by ``hephaestus.automation.advise_runner`` and
+mirrored (in bash) by the ``advise``/``learn`` skill definitions.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+
+from hephaestus.github.client import gh_call
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
+
+logger = logging.getLogger(__name__)
+
+UPSTREAM_OWNER = "HomericIntelligence"
+MNEMOSYNE_REPO = "ProjectMnemosyne"
+UPSTREAM_SLUG = f"{UPSTREAM_OWNER}/{MNEMOSYNE_REPO}"
+
+#: Environment variable that overrides the resolved owner. Mirrored by the
+#: skill bash blocks so interactive and automated paths agree.
+OWNER_ENV_VAR = "HEPH_MNEMOSYNE_OWNER"
+
+
+@dataclass(frozen=True)
+class MnemosyneTarget:
+    """The resolved ProjectMnemosyne repository to clone, push to, and PR against.
+
+    Attributes:
+        owner: The resolved owner (the ``gh`` login, an override, or
+            ``HomericIntelligence`` when falling back to upstream).
+        slug: ``owner/ProjectMnemosyne`` — the clone / push / PR target.
+        is_fork_of_upstream: True when ``owner`` is a fork of the upstream repo
+            (i.e. not ``HomericIntelligence`` itself).
+
+    """
+
+    owner: str
+    slug: str
+    is_fork_of_upstream: bool
+
+
+def _slug_for(owner: str) -> str:
+    """Return ``owner/ProjectMnemosyne`` for the given owner."""
+    return f"{owner}/{MNEMOSYNE_REPO}"
+
+
+def gh_authenticated_login(*, timeout: int = METADATA_TIMEOUT) -> str | None:
+    """Return the ``gh``-authenticated user's login, or None on failure.
+
+    Args:
+        timeout: Per-call timeout for the ``gh api user`` probe.
+
+    Returns:
+        The login string (e.g. ``"mvillmow"``), or None if ``gh`` is not
+        authenticated or the call fails.
+
+    """
+    try:
+        result = gh_call(
+            ["api", "user", "--jq", ".login"],
+            check=False,
+            timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+        logger.warning("Failed to determine gh-authenticated login: %s", exc)
+        return None
+    if result.returncode != 0:
+        logger.warning(
+            "gh api user failed (rc=%s); cannot determine login: %s",
+            result.returncode,
+            (result.stderr or "").strip(),
+        )
+        return None
+    login = (result.stdout or "").strip()
+    return login or None
+
+
+def remote_repo_exists(slug: str, *, timeout: int = METADATA_TIMEOUT) -> bool:
+    """Return True when ``slug`` (``owner/repo``) exists on GitHub.
+
+    Args:
+        slug: The ``owner/repo`` slug to probe.
+        timeout: Per-call timeout for the ``gh repo view`` probe.
+
+    Returns:
+        True if the repo is visible to the authenticated user, else False.
+
+    """
+    try:
+        result = gh_call(
+            ["repo", "view", slug, "--json", "name"],
+            check=False,
+            log_on_error=False,
+            timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+        logger.warning("Failed to check existence of %s: %s", slug, exc)
+        return False
+    return result.returncode == 0
+
+
+def fork_upstream(owner: str, *, timeout: int = NETWORK_TIMEOUT) -> bool:
+    """Fork ``HomericIntelligence/ProjectMnemosyne`` into the gh user's namespace.
+
+    ``gh repo fork`` always forks into the *authenticated* user's account, so
+    ``owner`` is used only for logging/sanity — the caller is expected to pass
+    the gh-authenticated login.
+
+    Args:
+        owner: The login the fork is expected to land under (for logging).
+        timeout: Per-call timeout for the fork operation.
+
+    Returns:
+        True if the fork was created (or already existed), else False.
+
+    """
+    try:
+        logger.info("Forking %s into %s...", UPSTREAM_SLUG, owner)
+        result = gh_call(
+            ["repo", "fork", UPSTREAM_SLUG, "--clone=false"],
+            check=False,
+            timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError, RuntimeError) as exc:
+        logger.warning("Failed to fork %s: %s", UPSTREAM_SLUG, exc)
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "gh repo fork %s failed (rc=%s): %s",
+            UPSTREAM_SLUG,
+            result.returncode,
+            (result.stderr or "").strip(),
+        )
+        return False
+    logger.info("Fork of %s available under %s", UPSTREAM_SLUG, owner)
+    return True
+
+
+def _validate_owner(owner: str) -> str | None:
+    """Return ``owner`` if it is a plausible GitHub login, else None.
+
+    Guards against an override or login that contains a slash (already a slug)
+    or whitespace, which would corrupt the constructed clone/push slug.
+    """
+    candidate = owner.strip()
+    if not candidate or "/" in candidate or any(c.isspace() for c in candidate):
+        logger.warning("Ignoring invalid Mnemosyne owner %r", owner)
+        return None
+    return candidate
+
+
+def resolve_mnemosyne_target(
+    *,
+    override_owner: str | None = None,
+    allow_fork: bool = True,
+) -> MnemosyneTarget:
+    """Decide which ProjectMnemosyne repository to clone, push to, and PR against.
+
+    See the module docstring for the full precedence ladder.
+
+    Args:
+        override_owner: Explicit owner to use. Falls back to the
+            ``HEPH_MNEMOSYNE_OWNER`` env var when None. An override that resolves
+            to ``HomericIntelligence`` (or any owner) is used verbatim, with no
+            fork attempt.
+        allow_fork: When True (default), fork the upstream repo if the gh user
+            has no existing ``<login>/ProjectMnemosyne``. When False, skip
+            forking and fall back to upstream.
+
+    Returns:
+        The resolved :class:`MnemosyneTarget`.
+
+    """
+    raw_override = override_owner if override_owner is not None else os.environ.get(OWNER_ENV_VAR)
+    if raw_override:
+        owner = _validate_owner(raw_override)
+        if owner:
+            return MnemosyneTarget(
+                owner=owner,
+                slug=_slug_for(owner),
+                is_fork_of_upstream=owner != UPSTREAM_OWNER,
+            )
+
+    login = gh_authenticated_login()
+    if login:
+        login = _validate_owner(login)
+
+    if not login:
+        logger.info("gh login unavailable; defaulting Mnemosyne target to %s", UPSTREAM_SLUG)
+        return MnemosyneTarget(
+            owner=UPSTREAM_OWNER,
+            slug=UPSTREAM_SLUG,
+            is_fork_of_upstream=False,
+        )
+
+    if login == UPSTREAM_OWNER:
+        # Cannot fork a repo into its own org; clone upstream directly.
+        return MnemosyneTarget(
+            owner=UPSTREAM_OWNER,
+            slug=UPSTREAM_SLUG,
+            is_fork_of_upstream=False,
+        )
+
+    user_slug = _slug_for(login)
+    if remote_repo_exists(user_slug):
+        return MnemosyneTarget(owner=login, slug=user_slug, is_fork_of_upstream=True)
+
+    if allow_fork and fork_upstream(login):
+        return MnemosyneTarget(owner=login, slug=user_slug, is_fork_of_upstream=True)
+
+    logger.info(
+        "No %s and fork unavailable; defaulting Mnemosyne target to %s",
+        user_slug,
+        UPSTREAM_SLUG,
+    )
+    return MnemosyneTarget(
+        owner=UPSTREAM_OWNER,
+        slug=UPSTREAM_SLUG,
+        is_fork_of_upstream=False,
+    )

--- a/plugins/hephaestus/skills/advise/SKILL.md
+++ b/plugins/hephaestus/skills/advise/SKILL.md
@@ -11,11 +11,25 @@ Search the skills registry for relevant prior learnings before starting work.
 
 ## Target Repository
 
-**Repository**: `HomericIntelligence/ProjectMnemosyne`
+**Repository**: resolved per gh-authenticated user — the user's own
+`<gh-login>/ProjectMnemosyne` fork when available, otherwise upstream
+`HomericIntelligence/ProjectMnemosyne`.
 **Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-Single shared clone in user's home directory. Automatically updated before searches.
-Automatically skipped if already running in the ProjectMnemosyne repository.
+Single shared clone in the user's home directory. Automatically updated before
+searches. Automatically skipped if already running inside a ProjectMnemosyne
+checkout.
+
+Resolution ladder (mirrors `hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target`):
+
+1. Reuse an existing `$HOME/.agent-brain/ProjectMnemosyne` checkout as-is.
+2. Else clone `<gh-login>/ProjectMnemosyne` if it exists on GitHub.
+3. Else fork `HomericIntelligence/ProjectMnemosyne` into the gh user's
+   namespace, then clone the fork. If the gh user **is** `HomericIntelligence`,
+   clone upstream directly (cannot fork a repo into its own org).
+
+Override the resolved owner with the `HEPH_MNEMOSYNE_OWNER` environment
+variable. PRs target the resolved repository (the fork itself).
 
 ## Instructions
 
@@ -26,19 +40,50 @@ When the user invokes this command:
 1. **Setup repository** (if not already cloned):
 
    ```bash
-   # Detect if already in ProjectMnemosyne
+   # ensure_precommit_installed: do NOT test [ -f .git/hooks/pre-commit ] — in a worktree .git
+   # is a file, and a stray core.hooksPath can fake the path. Ask the resolved hook instead:
+   ensure_precommit_installed() {
+     local hooks_dir; hooks_dir="$(git rev-parse --git-path hooks)"
+     grep -qs 'pre-commit' "$hooks_dir/pre-commit" || pre-commit install --install-hooks
+     pre-commit validate-config >/dev/null 2>&1 \
+       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' here"
+   }
+
+   # resolve_mnemosyne_target: pick the owner/ProjectMnemosyne slug to clone/PR
+   # against. Mirrors hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target.
+   # 1) HEPH_MNEMOSYNE_OWNER override; 2) gh login's own fork (create if needed);
+   # 3) upstream when login is HomericIntelligence or undeterminable.
+   resolve_mnemosyne_target() {
+     local upstream="HomericIntelligence/ProjectMnemosyne"
+     local owner="${HEPH_MNEMOSYNE_OWNER:-$(gh api user --jq .login 2>/dev/null)}"
+     if [ -z "$owner" ] || [ "$owner" = "HomericIntelligence" ]; then
+       echo "$upstream"; return
+     fi
+     if gh repo view "$owner/ProjectMnemosyne" --json name >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     # No personal fork yet — create one (forks into the gh user's namespace).
+     if gh repo fork "$upstream" --clone=false >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     echo "$upstream"  # fork failed — fall back to upstream
+   }
+
+   # Detect if already inside a ProjectMnemosyne checkout (fast path).
    CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
      # Already in ProjectMnemosyne - use current directory
      MNEMOSYNE_DIR="."
+     TARGET_SLUG="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)"
    else
      # Use shared home directory location
      MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+     TARGET_SLUG="$(resolve_mnemosyne_target)"
 
      if [ ! -d "$MNEMOSYNE_DIR" ]; then
-       # Clone fresh
+       # Clone fresh (existing checkout is reused as-is, regardless of remote)
        mkdir -p "$HOME/.agent-brain"
-       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       gh repo clone "$TARGET_SLUG" "$MNEMOSYNE_DIR"
        ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )  # so any later /learn has hooks
      fi
 
@@ -50,16 +95,10 @@ When the user invokes this command:
      # Verify pre-commit is genuinely installed; (re)install if not.
      ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )
    fi
-
-   # ensure_precommit_installed: do NOT test [ -f .git/hooks/pre-commit ] — in a worktree .git
-   # is a file, and a stray core.hooksPath can fake the path. Ask the resolved hook instead:
-   ensure_precommit_installed() {
-     local hooks_dir; hooks_dir="$(git rev-parse --git-path hooks)"
-     grep -qs 'pre-commit' "$hooks_dir/pre-commit" || pre-commit install --install-hooks
-     pre-commit validate-config >/dev/null 2>&1 \
-       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' here"
-   }
    ```
+
+   `$TARGET_SLUG` holds the resolved `owner/ProjectMnemosyne` for any later
+   `gh pr ...` calls in this skill.
 
 2. **Parse the user's goal** from $ARGUMENTS
 3. **Read `.claude-plugin/marketplace.json`** to find available plugins
@@ -128,9 +167,9 @@ for the most relevant matches.
 >
 > ```bash
 > # For each matched skill <name>, surface open PRs already amending it:
-> gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+> gh pr list --repo "$TARGET_SLUG" --state open \
 >   --search "<name> in:title" --json number,headRefName,title
-> gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+> gh pr list --repo "$TARGET_SLUG" --state open \
 >   --json number,headRefName,files \
 >   --jq '.[] | select(.files[].path == "skills/<name>.md") | {number, headRefName}'
 > ```

--- a/plugins/hephaestus/skills/learn/SKILL.md
+++ b/plugins/hephaestus/skills/learn/SKILL.md
@@ -11,14 +11,27 @@ Capture session learnings and amend an existing skill or create a new one in the
 
 ## Target Repository
 
-**Repository**: `HomericIntelligence/ProjectMnemosyne`
+**Repository**: resolved per gh-authenticated user — the user's own
+`<gh-login>/ProjectMnemosyne` fork when available, otherwise upstream
+`HomericIntelligence/ProjectMnemosyne`. Branches are pushed and PRs are opened
+against the **resolved repository (the fork itself)**, not upstream.
 **Base branch**: `main`
 **Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-Single shared clone in user's home directory. Skill branches are created in temporary
-worktrees (`/tmp/mnemosyne-skill-<name>`) for isolation — the shared clone stays on main.
-Worktrees are cleaned up after PR creation. Automatically detected if already running in
-the ProjectMnemosyne repository.
+Single shared clone in the user's home directory. Skill branches are created in
+temporary worktrees (`/tmp/mnemosyne-skill-<name>`) for isolation — the shared
+clone stays on main. Worktrees are cleaned up after PR creation. Automatically
+detected if already running inside a ProjectMnemosyne checkout.
+
+Resolution ladder (mirrors `hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target`):
+
+1. Reuse an existing `$HOME/.agent-brain/ProjectMnemosyne` checkout as-is.
+2. Else clone `<gh-login>/ProjectMnemosyne` if it exists on GitHub.
+3. Else fork `HomericIntelligence/ProjectMnemosyne` into the gh user's
+   namespace, then clone the fork. If the gh user **is** `HomericIntelligence`,
+   clone upstream directly (cannot fork a repo into its own org).
+
+Override the resolved owner with the `HEPH_MNEMOSYNE_OWNER` environment variable.
 
 ## Execution Model
 
@@ -41,11 +54,14 @@ Agent(
     description="Create/amend skill in ProjectMnemosyne",
     isolation="worktree",  # Isolated copy — no branch conflicts
     prompt="""Execute the /learn workflow for ProjectMnemosyne:
-    1. Clone/update ProjectMnemosyne at $HOME/.agent-brain/ProjectMnemosyne
+    1. Resolve the target repo (the gh user's own <login>/ProjectMnemosyne fork,
+       created if needed, else upstream) and clone/update it at
+       $HOME/.agent-brain/ProjectMnemosyne — see the Setup step's
+       resolve_mnemosyne_target helper
     2. Search for existing skills to amend
     3. Create/amend the skill file in a worktree branch
     4. Validate with scripts/validate_plugins.py
-    5. Commit, push, create PR, enable auto-merge
+    5. Commit, push, create PR against the resolved repo, enable auto-merge
     6. Clean up the worktree
 
     Session learnings to capture: <extracted learnings from conversation>"""
@@ -105,8 +121,19 @@ Agent(description="Create skill C", prompt="...skill C content...")
    Before creating a new file, search the registry for skills covering the same topic:
 
    ```bash
+   # Resolve the target slug (defined in the Setup step below) so the amend-lock
+   # check queries the same repo we will push to. The clone itself is created in
+   # the Setup step; if it already exists, search it now.
+   TARGET_SLUG="${TARGET_SLUG:-$(
+     owner="${HEPH_MNEMOSYNE_OWNER:-$(gh api user --jq .login 2>/dev/null)}"
+     if [ -z "$owner" ] || [ "$owner" = "HomericIntelligence" ]; then
+       echo "HomericIntelligence/ProjectMnemosyne"
+     else
+       echo "$owner/ProjectMnemosyne"
+     fi
+   )}"
    MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
-   # Search by keywords from the skill name
+   # Search by keywords from the skill name (only if the clone is already present)
    ls "$MNEMOSYNE_DIR/skills/" | grep -i "<keyword1>\|<keyword2>\|<keyword3>" | grep -v ".notes.md" | grep -v ".history"
    # Also search descriptions in frontmatter
    grep -l "<keyword>" "$MNEMOSYNE_DIR/skills/"*.md 2>/dev/null | head -20
@@ -121,10 +148,10 @@ Agent(description="Create skill C", prompt="...skill C content...")
 
    ```bash
    # (a) Open PRs whose title names the skill
-   gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+   gh pr list --repo "$TARGET_SLUG" --state open \
      --search "<name> in:title" --json number,headRefName,title
    # (b) Open PRs that touch the file even if the title differs
-   gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+   gh pr list --repo "$TARGET_SLUG" --state open \
      --json number,headRefName,files \
      --jq '.[] | select(.files[].path == "skills/<name>.md") | {number, headRefName}'
    ```
@@ -229,7 +256,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
    (`validate` **and** `markdownlint`) is observed **green** on the open PR:
 
    ```bash
-   gh pr view <PR> --repo HomericIntelligence/ProjectMnemosyne \
+   gh pr view <PR> --repo "$TARGET_SLUG" \
      --json mergeStateStatus,statusCheckRollup \
      --jq '{state: .mergeStateStatus, failing: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name]}'
    ```
@@ -250,19 +277,40 @@ Agent(description="Create skill C", prompt="...skill C content...")
 5. **Setup repository using worktrees** (CRITICAL — always use worktrees for branch isolation):
 
    ```bash
-   # Detect if already in ProjectMnemosyne
+   # resolve_mnemosyne_target: pick the owner/ProjectMnemosyne slug to clone/PR
+   # against. Mirrors hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target.
+   # 1) HEPH_MNEMOSYNE_OWNER override; 2) gh login's own fork (create if needed);
+   # 3) upstream when login is HomericIntelligence or undeterminable.
+   resolve_mnemosyne_target() {
+     local upstream="HomericIntelligence/ProjectMnemosyne"
+     local owner="${HEPH_MNEMOSYNE_OWNER:-$(gh api user --jq .login 2>/dev/null)}"
+     if [ -z "$owner" ] || [ "$owner" = "HomericIntelligence" ]; then
+       echo "$upstream"; return
+     fi
+     if gh repo view "$owner/ProjectMnemosyne" --json name >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     if gh repo fork "$upstream" --clone=false >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     echo "$upstream"  # fork failed — fall back to upstream
+   }
+
+   # Detect if already inside a ProjectMnemosyne checkout (fast path).
    CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
      # Already in ProjectMnemosyne - use worktree from current repo
      MNEMOSYNE_DIR="."
+     TARGET_SLUG="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)"
    else
      # Use shared home directory location
      MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+     TARGET_SLUG="${TARGET_SLUG:-$(resolve_mnemosyne_target)}"
 
      if [ ! -d "$MNEMOSYNE_DIR" ]; then
-       # Clone fresh
+       # Clone fresh (existing checkout is reused as-is, regardless of remote)
        mkdir -p "$HOME/.agent-brain"
-       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       gh repo clone "$TARGET_SLUG" "$MNEMOSYNE_DIR"
        ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )  # see helper below
      fi
 
@@ -502,7 +550,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
 9. **Create PR** (only if push succeeded):
 
     ```bash
-    gh pr create --repo HomericIntelligence/ProjectMnemosyne --base main \
+    gh pr create --repo "$TARGET_SLUG" --base main \
       --title "feat: <add|amend> <name> skill" \
       --body "## Summary
 
@@ -539,7 +587,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
 
     # Enable auto-merge so the PR merges automatically once CI passes
     # Note: gh pr merge requires a PR number when using --repo
-    PR_NUMBER=$(gh pr list --repo HomericIntelligence/ProjectMnemosyne --head "skill/<name>" --json number --jq '.[0].number')
+    PR_NUMBER=$(gh pr list --repo "$TARGET_SLUG" --head "skill/<name>" --json number --jq '.[0].number')
     HELPER=""
     for cand in \
         "${HEPHAESTUS_REPO_ROOT:-}/scripts/choose_merge_flag.sh" \
@@ -549,11 +597,11 @@ Agent(description="Create skill C", prompt="...skill C content...")
     done
     if [ -n "$HELPER" ]; then
         . "$HELPER"
-        MERGE_FLAG=$(choose_merge_flag HomericIntelligence/ProjectMnemosyne) || MERGE_FLAG="--squash"
+        MERGE_FLAG=$(choose_merge_flag "$TARGET_SLUG") || MERGE_FLAG="--squash"
     else
         MERGE_FLAG="--squash"
     fi
-    gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
+    gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo "$TARGET_SLUG"
     ```
 
 10. **Cleanup worktree** (always clean up after PR creation):
@@ -571,7 +619,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
     checks — never assume success because auto-merge was armed:
 
     ```bash
-    gh pr view "$PR_NUMBER" --repo HomericIntelligence/ProjectMnemosyne \
+    gh pr view "$PR_NUMBER" --repo "$TARGET_SLUG" \
       --json mergeStateStatus,statusCheckRollup \
       --jq '{state: .mergeStateStatus, failing: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name]}'
     ```

--- a/plugins/hephaestus/skills/myrmidon-swarm/SKILL.md
+++ b/plugins/hephaestus/skills/myrmidon-swarm/SKILL.md
@@ -255,7 +255,10 @@ Instruct sub-agents to report back (not attempt to fix) when they encounter:
 
 **During Phase 3 (per agent)**: Each spawned agent invokes `/hephaestus:learn` as its mandatory final step, capturing its own fixes, patterns, pitfalls, and parameters where the context is freshest. The commander does NOT run `/hephaestus:learn` afterward — learning is delegated, not centralized.
 
-**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
+**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/` — the repository is
+resolved per gh-authenticated user (the user's own `<gh-login>/ProjectMnemosyne`
+fork when available, else upstream `HomericIntelligence/ProjectMnemosyne`) by
+`/advise` and `/learn`; override with `HEPH_MNEMOSYNE_OWNER`.
 
 ## AI Maestro (Optional)
 

--- a/skills/advise/SKILL.md
+++ b/skills/advise/SKILL.md
@@ -11,11 +11,25 @@ Search the skills registry for relevant prior learnings before starting work.
 
 ## Target Repository
 
-**Repository**: `HomericIntelligence/ProjectMnemosyne`
+**Repository**: resolved per gh-authenticated user — the user's own
+`<gh-login>/ProjectMnemosyne` fork when available, otherwise upstream
+`HomericIntelligence/ProjectMnemosyne`.
 **Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-Single shared clone in user's home directory. Automatically updated before searches.
-Automatically skipped if already running in the ProjectMnemosyne repository.
+Single shared clone in the user's home directory. Automatically updated before
+searches. Automatically skipped if already running inside a ProjectMnemosyne
+checkout.
+
+Resolution ladder (mirrors `hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target`):
+
+1. Reuse an existing `$HOME/.agent-brain/ProjectMnemosyne` checkout as-is.
+2. Else clone `<gh-login>/ProjectMnemosyne` if it exists on GitHub.
+3. Else fork `HomericIntelligence/ProjectMnemosyne` into the gh user's
+   namespace, then clone the fork. If the gh user **is** `HomericIntelligence`,
+   clone upstream directly (cannot fork a repo into its own org).
+
+Override the resolved owner with the `HEPH_MNEMOSYNE_OWNER` environment
+variable. PRs target the resolved repository (the fork itself).
 
 ## Instructions
 
@@ -26,19 +40,50 @@ When the user invokes this command:
 1. **Setup repository** (if not already cloned):
 
    ```bash
-   # Detect if already in ProjectMnemosyne
+   # ensure_precommit_installed: do NOT test [ -f .git/hooks/pre-commit ] — in a worktree .git
+   # is a file, and a stray core.hooksPath can fake the path. Ask the resolved hook instead:
+   ensure_precommit_installed() {
+     local hooks_dir; hooks_dir="$(git rev-parse --git-path hooks)"
+     grep -qs 'pre-commit' "$hooks_dir/pre-commit" || pre-commit install --install-hooks
+     pre-commit validate-config >/dev/null 2>&1 \
+       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' here"
+   }
+
+   # resolve_mnemosyne_target: pick the owner/ProjectMnemosyne slug to clone/PR
+   # against. Mirrors hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target.
+   # 1) HEPH_MNEMOSYNE_OWNER override; 2) gh login's own fork (create if needed);
+   # 3) upstream when login is HomericIntelligence or undeterminable.
+   resolve_mnemosyne_target() {
+     local upstream="HomericIntelligence/ProjectMnemosyne"
+     local owner="${HEPH_MNEMOSYNE_OWNER:-$(gh api user --jq .login 2>/dev/null)}"
+     if [ -z "$owner" ] || [ "$owner" = "HomericIntelligence" ]; then
+       echo "$upstream"; return
+     fi
+     if gh repo view "$owner/ProjectMnemosyne" --json name >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     # No personal fork yet — create one (forks into the gh user's namespace).
+     if gh repo fork "$upstream" --clone=false >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     echo "$upstream"  # fork failed — fall back to upstream
+   }
+
+   # Detect if already inside a ProjectMnemosyne checkout (fast path).
    CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
      # Already in ProjectMnemosyne - use current directory
      MNEMOSYNE_DIR="."
+     TARGET_SLUG="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)"
    else
      # Use shared home directory location
      MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+     TARGET_SLUG="$(resolve_mnemosyne_target)"
 
      if [ ! -d "$MNEMOSYNE_DIR" ]; then
-       # Clone fresh
+       # Clone fresh (existing checkout is reused as-is, regardless of remote)
        mkdir -p "$HOME/.agent-brain"
-       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       gh repo clone "$TARGET_SLUG" "$MNEMOSYNE_DIR"
        ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )  # so any later /learn has hooks
      fi
 
@@ -50,16 +95,10 @@ When the user invokes this command:
      # Verify pre-commit is genuinely installed; (re)install if not.
      ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )
    fi
-
-   # ensure_precommit_installed: do NOT test [ -f .git/hooks/pre-commit ] — in a worktree .git
-   # is a file, and a stray core.hooksPath can fake the path. Ask the resolved hook instead:
-   ensure_precommit_installed() {
-     local hooks_dir; hooks_dir="$(git rev-parse --git-path hooks)"
-     grep -qs 'pre-commit' "$hooks_dir/pre-commit" || pre-commit install --install-hooks
-     pre-commit validate-config >/dev/null 2>&1 \
-       || echo "WARNING: pre-commit config invalid — run 'pre-commit install --install-hooks' here"
-   }
    ```
+
+   `$TARGET_SLUG` holds the resolved `owner/ProjectMnemosyne` for any later
+   `gh pr ...` calls in this skill.
 
 2. **Parse the user's goal** from $ARGUMENTS
 3. **Read `.claude-plugin/marketplace.json`** to find available plugins
@@ -128,9 +167,9 @@ for the most relevant matches.
 >
 > ```bash
 > # For each matched skill <name>, surface open PRs already amending it:
-> gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+> gh pr list --repo "$TARGET_SLUG" --state open \
 >   --search "<name> in:title" --json number,headRefName,title
-> gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+> gh pr list --repo "$TARGET_SLUG" --state open \
 >   --json number,headRefName,files \
 >   --jq '.[] | select(.files[].path == "skills/<name>.md") | {number, headRefName}'
 > ```

--- a/skills/learn/SKILL.md
+++ b/skills/learn/SKILL.md
@@ -11,14 +11,27 @@ Capture session learnings and amend an existing skill or create a new one in the
 
 ## Target Repository
 
-**Repository**: `HomericIntelligence/ProjectMnemosyne`
+**Repository**: resolved per gh-authenticated user — the user's own
+`<gh-login>/ProjectMnemosyne` fork when available, otherwise upstream
+`HomericIntelligence/ProjectMnemosyne`. Branches are pushed and PRs are opened
+against the **resolved repository (the fork itself)**, not upstream.
 **Base branch**: `main`
 **Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
 
-Single shared clone in user's home directory. Skill branches are created in temporary
-worktrees (`/tmp/mnemosyne-skill-<name>`) for isolation — the shared clone stays on main.
-Worktrees are cleaned up after PR creation. Automatically detected if already running in
-the ProjectMnemosyne repository.
+Single shared clone in the user's home directory. Skill branches are created in
+temporary worktrees (`/tmp/mnemosyne-skill-<name>`) for isolation — the shared
+clone stays on main. Worktrees are cleaned up after PR creation. Automatically
+detected if already running inside a ProjectMnemosyne checkout.
+
+Resolution ladder (mirrors `hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target`):
+
+1. Reuse an existing `$HOME/.agent-brain/ProjectMnemosyne` checkout as-is.
+2. Else clone `<gh-login>/ProjectMnemosyne` if it exists on GitHub.
+3. Else fork `HomericIntelligence/ProjectMnemosyne` into the gh user's
+   namespace, then clone the fork. If the gh user **is** `HomericIntelligence`,
+   clone upstream directly (cannot fork a repo into its own org).
+
+Override the resolved owner with the `HEPH_MNEMOSYNE_OWNER` environment variable.
 
 ## Execution Model
 
@@ -41,11 +54,14 @@ Agent(
     description="Create/amend skill in ProjectMnemosyne",
     isolation="worktree",  # Isolated copy — no branch conflicts
     prompt="""Execute the /learn workflow for ProjectMnemosyne:
-    1. Clone/update ProjectMnemosyne at $HOME/.agent-brain/ProjectMnemosyne
+    1. Resolve the target repo (the gh user's own <login>/ProjectMnemosyne fork,
+       created if needed, else upstream) and clone/update it at
+       $HOME/.agent-brain/ProjectMnemosyne — see the Setup step's
+       resolve_mnemosyne_target helper
     2. Search for existing skills to amend
     3. Create/amend the skill file in a worktree branch
     4. Validate with scripts/validate_plugins.py
-    5. Commit, push, create PR, enable auto-merge
+    5. Commit, push, create PR against the resolved repo, enable auto-merge
     6. Clean up the worktree
 
     Session learnings to capture: <extracted learnings from conversation>"""
@@ -105,8 +121,19 @@ Agent(description="Create skill C", prompt="...skill C content...")
    Before creating a new file, search the registry for skills covering the same topic:
 
    ```bash
+   # Resolve the target slug (defined in the Setup step below) so the amend-lock
+   # check queries the same repo we will push to. The clone itself is created in
+   # the Setup step; if it already exists, search it now.
+   TARGET_SLUG="${TARGET_SLUG:-$(
+     owner="${HEPH_MNEMOSYNE_OWNER:-$(gh api user --jq .login 2>/dev/null)}"
+     if [ -z "$owner" ] || [ "$owner" = "HomericIntelligence" ]; then
+       echo "HomericIntelligence/ProjectMnemosyne"
+     else
+       echo "$owner/ProjectMnemosyne"
+     fi
+   )}"
    MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
-   # Search by keywords from the skill name
+   # Search by keywords from the skill name (only if the clone is already present)
    ls "$MNEMOSYNE_DIR/skills/" | grep -i "<keyword1>\|<keyword2>\|<keyword3>" | grep -v ".notes.md" | grep -v ".history"
    # Also search descriptions in frontmatter
    grep -l "<keyword>" "$MNEMOSYNE_DIR/skills/"*.md 2>/dev/null | head -20
@@ -121,10 +148,10 @@ Agent(description="Create skill C", prompt="...skill C content...")
 
    ```bash
    # (a) Open PRs whose title names the skill
-   gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+   gh pr list --repo "$TARGET_SLUG" --state open \
      --search "<name> in:title" --json number,headRefName,title
    # (b) Open PRs that touch the file even if the title differs
-   gh pr list --repo HomericIntelligence/ProjectMnemosyne --state open \
+   gh pr list --repo "$TARGET_SLUG" --state open \
      --json number,headRefName,files \
      --jq '.[] | select(.files[].path == "skills/<name>.md") | {number, headRefName}'
    ```
@@ -229,7 +256,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
    (`validate` **and** `markdownlint`) is observed **green** on the open PR:
 
    ```bash
-   gh pr view <PR> --repo HomericIntelligence/ProjectMnemosyne \
+   gh pr view <PR> --repo "$TARGET_SLUG" \
      --json mergeStateStatus,statusCheckRollup \
      --jq '{state: .mergeStateStatus, failing: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name]}'
    ```
@@ -250,19 +277,40 @@ Agent(description="Create skill C", prompt="...skill C content...")
 5. **Setup repository using worktrees** (CRITICAL — always use worktrees for branch isolation):
 
    ```bash
-   # Detect if already in ProjectMnemosyne
+   # resolve_mnemosyne_target: pick the owner/ProjectMnemosyne slug to clone/PR
+   # against. Mirrors hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target.
+   # 1) HEPH_MNEMOSYNE_OWNER override; 2) gh login's own fork (create if needed);
+   # 3) upstream when login is HomericIntelligence or undeterminable.
+   resolve_mnemosyne_target() {
+     local upstream="HomericIntelligence/ProjectMnemosyne"
+     local owner="${HEPH_MNEMOSYNE_OWNER:-$(gh api user --jq .login 2>/dev/null)}"
+     if [ -z "$owner" ] || [ "$owner" = "HomericIntelligence" ]; then
+       echo "$upstream"; return
+     fi
+     if gh repo view "$owner/ProjectMnemosyne" --json name >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     if gh repo fork "$upstream" --clone=false >/dev/null 2>&1; then
+       echo "$owner/ProjectMnemosyne"; return
+     fi
+     echo "$upstream"  # fork failed — fall back to upstream
+   }
+
+   # Detect if already inside a ProjectMnemosyne checkout (fast path).
    CURRENT_REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
    if [[ "$CURRENT_REMOTE" == *"ProjectMnemosyne"* ]] && [[ "$CURRENT_REMOTE" != *"ProjectMnemosyne-"* ]]; then
      # Already in ProjectMnemosyne - use worktree from current repo
      MNEMOSYNE_DIR="."
+     TARGET_SLUG="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null)"
    else
      # Use shared home directory location
      MNEMOSYNE_DIR="$HOME/.agent-brain/ProjectMnemosyne"
+     TARGET_SLUG="${TARGET_SLUG:-$(resolve_mnemosyne_target)}"
 
      if [ ! -d "$MNEMOSYNE_DIR" ]; then
-       # Clone fresh
+       # Clone fresh (existing checkout is reused as-is, regardless of remote)
        mkdir -p "$HOME/.agent-brain"
-       gh repo clone HomericIntelligence/ProjectMnemosyne "$MNEMOSYNE_DIR"
+       gh repo clone "$TARGET_SLUG" "$MNEMOSYNE_DIR"
        ( cd "$MNEMOSYNE_DIR" && ensure_precommit_installed )  # see helper below
      fi
 
@@ -502,7 +550,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
 9. **Create PR** (only if push succeeded):
 
     ```bash
-    gh pr create --repo HomericIntelligence/ProjectMnemosyne --base main \
+    gh pr create --repo "$TARGET_SLUG" --base main \
       --title "feat: <add|amend> <name> skill" \
       --body "## Summary
 
@@ -539,7 +587,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
 
     # Enable auto-merge so the PR merges automatically once CI passes
     # Note: gh pr merge requires a PR number when using --repo
-    PR_NUMBER=$(gh pr list --repo HomericIntelligence/ProjectMnemosyne --head "skill/<name>" --json number --jq '.[0].number')
+    PR_NUMBER=$(gh pr list --repo "$TARGET_SLUG" --head "skill/<name>" --json number --jq '.[0].number')
     HELPER=""
     for cand in \
         "${HEPHAESTUS_REPO_ROOT:-}/scripts/choose_merge_flag.sh" \
@@ -549,11 +597,11 @@ Agent(description="Create skill C", prompt="...skill C content...")
     done
     if [ -n "$HELPER" ]; then
         . "$HELPER"
-        MERGE_FLAG=$(choose_merge_flag HomericIntelligence/ProjectMnemosyne) || MERGE_FLAG="--squash"
+        MERGE_FLAG=$(choose_merge_flag "$TARGET_SLUG") || MERGE_FLAG="--squash"
     else
         MERGE_FLAG="--squash"
     fi
-    gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
+    gh pr merge "$PR_NUMBER" --auto "$MERGE_FLAG" --repo "$TARGET_SLUG"
     ```
 
 10. **Cleanup worktree** (always clean up after PR creation):
@@ -571,7 +619,7 @@ Agent(description="Create skill C", prompt="...skill C content...")
     checks — never assume success because auto-merge was armed:
 
     ```bash
-    gh pr view "$PR_NUMBER" --repo HomericIntelligence/ProjectMnemosyne \
+    gh pr view "$PR_NUMBER" --repo "$TARGET_SLUG" \
       --json mergeStateStatus,statusCheckRollup \
       --jq '{state: .mergeStateStatus, failing: [.statusCheckRollup[] | select(.conclusion=="FAILURE") | .name]}'
     ```

--- a/skills/myrmidon-swarm/SKILL.md
+++ b/skills/myrmidon-swarm/SKILL.md
@@ -255,7 +255,10 @@ Instruct sub-agents to report back (not attempt to fix) when they encounter:
 
 **During Phase 3 (per agent)**: Each spawned agent invokes `/hephaestus:learn` as its mandatory final step, capturing its own fixes, patterns, pitfalls, and parameters where the context is freshest. The commander does NOT run `/hephaestus:learn` afterward — learning is delegated, not centralized.
 
-**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/`
+**Clone location**: `$HOME/.agent-brain/ProjectMnemosyne/` — the repository is
+resolved per gh-authenticated user (the user's own `<gh-login>/ProjectMnemosyne`
+fork when available, else upstream `HomericIntelligence/ProjectMnemosyne`) by
+`/advise` and `/learn`; override with `HEPH_MNEMOSYNE_OWNER`.
 
 ## AI Maestro (Optional)
 

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import pytest
 
 from hephaestus.automation import advise_runner
+from hephaestus.github.mnemosyne_repo import MnemosyneTarget
 
 
 def _build_prompt(**kwargs: object) -> str:
@@ -91,14 +92,27 @@ class TestEnsureMnemosyne:
         """ProjectMnemosyne clone calls use the centralized clone timeout."""
         monkeypatch.setenv("HEPH_AGENT_CLONE_TIMEOUT", "55")
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        target = MnemosyneTarget(
+            owner="HomericIntelligence",
+            slug="HomericIntelligence/ProjectMnemosyne",
+            is_fork_of_upstream=False,
+        )
 
-        with patch("hephaestus.automation.advise_runner.gh_call") as gh_call:
+        with (
+            patch("hephaestus.automation.advise_runner.gh_call") as gh_call,
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=target,
+            ),
+        ):
             gh_call.return_value = subprocess.CompletedProcess(
                 ["gh", "repo", "clone"], 0, stdout="", stderr=""
             )
             assert advise_runner._clone_mnemosyne(mnemosyne_root) is True
 
         assert gh_call.call_args.kwargs["timeout"] == 55
+        # The clone targets the resolved slug, not a hardcoded upstream literal.
+        assert gh_call.call_args[0][0][:3] == ["repo", "clone", target.slug]
 
     def test_existing_corrupt_checkout_is_removed_and_recloned(self, tmp_path: Path) -> None:
         mnemosyne_root = tmp_path / "ProjectMnemosyne"

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -1395,7 +1395,7 @@ class TestDriveGreenLearnings:
         prompt = mock_codex.call_args.kwargs["prompt"]
         assert prompt.startswith("/learn ")
         assert "/skills-registry-commands:learn" not in prompt
-        assert "Only push skills to ProjectMnemosyne" in prompt
+        assert "Only push skills to the resolved ProjectMnemosyne" in prompt
         assert mock_codex.call_args.kwargs["cwd"] == tmp_path
         mock_invoke.assert_not_called()
         # The learn-evidence cache moved into PostMergeProcessor (#1357).

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -74,13 +74,26 @@ class TestRunLearn:
         ]
         assert evidence["mnemosyne_update_pr_numbers"] == [46]
 
+    def test_mnemosyne_update_evidence_recognizes_fork_owner(self) -> None:
+        """A push to a user's fork (<login>/ProjectMnemosyne) still counts."""
+        evidence = mnemosyne_update_evidence(
+            "Opened https://github.com/mvillmow/ProjectMnemosyne/pull/7 "
+            "and referenced mvillmow/ProjectMnemosyne#8"
+        )
+
+        assert evidence["mnemosyne_update_status"] == "confirmed"
+        assert evidence["mnemosyne_update_urls"] == [
+            "https://github.com/mvillmow/ProjectMnemosyne/pull/7"
+        ]
+        assert evidence["mnemosyne_update_pr_numbers"] == [8]
+
     def test_build_learn_prompt_uses_user_facing_command(self) -> None:
         prompt = build_learn_prompt("Capture what happened.")
 
         assert prompt.startswith("/learn EXECUTE")
         assert "Capture what happened." in prompt
         assert "/skills-registry-commands:learn" not in prompt
-        assert "Only push skills to ProjectMnemosyne" in prompt
+        assert "Only push skills to the resolved ProjectMnemosyne" in prompt
         # Directives must appear before the context detail
         assert prompt.index("Do NOT return a plan") < prompt.index("Capture what happened.")
 

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -10,6 +10,7 @@ import pytest
 
 from hephaestus.automation.models import PlannerOptions
 from hephaestus.automation.planner import Planner
+from hephaestus.github.mnemosyne_repo import MnemosyneTarget
 
 
 @pytest.fixture
@@ -533,10 +534,21 @@ class TestEnsureMnemosyne:
     """Tests for _ensure_mnemosyne method."""
 
     def test_clone_success(self, planner: Any, tmp_path: Any) -> None:
-        """Test successful clone returns True and runs correct command."""
+        """Test successful clone returns True and clones the resolved slug."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        target = MnemosyneTarget(
+            owner="HomericIntelligence",
+            slug="HomericIntelligence/ProjectMnemosyne",
+            is_fork_of_upstream=False,
+        )
 
-        with patch("hephaestus.automation.advise_runner.gh_call") as mock_gh:
+        with (
+            patch("hephaestus.automation.advise_runner.gh_call") as mock_gh,
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=target,
+            ),
+        ):
             mock_gh.return_value = MagicMock(returncode=0)
 
             result = planner._ensure_mnemosyne(mnemosyne_root)
@@ -546,7 +558,7 @@ class TestEnsureMnemosyne:
         cmd = mock_gh.call_args[0][0]
         assert "repo" in cmd
         assert "clone" in cmd
-        assert "HomericIntelligence/ProjectMnemosyne" in cmd
+        assert target.slug in cmd
         assert str(mnemosyne_root) in cmd
 
     def test_clone_failure(self, planner: Any, tmp_path: Any) -> None:

--- a/tests/unit/github/test_mnemosyne_repo.py
+++ b/tests/unit/github/test_mnemosyne_repo.py
@@ -1,0 +1,202 @@
+"""Tests for hephaestus.github.mnemosyne_repo.
+
+The resolver picks which ``owner/ProjectMnemosyne`` to clone, push to, and PR
+against. All ``gh`` calls are mocked at the module namespace so no live network
+or ``gh`` auth is required.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.github import mnemosyne_repo
+from hephaestus.github.mnemosyne_repo import (
+    UPSTREAM_SLUG,
+    MnemosyneTarget,
+    fork_upstream,
+    gh_authenticated_login,
+    remote_repo_exists,
+    resolve_mnemosyne_target,
+)
+
+
+def _completed(returncode: int = 0, stdout: str = "", stderr: str = "") -> MagicMock:
+    m = MagicMock()
+    m.returncode = returncode
+    m.stdout = stdout
+    m.stderr = stderr
+    return m
+
+
+@pytest.fixture(autouse=True)
+def _clear_owner_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the HEPH_MNEMOSYNE_OWNER override never leaks in from the host env."""
+    monkeypatch.delenv(mnemosyne_repo.OWNER_ENV_VAR, raising=False)
+
+
+class TestGhAuthenticatedLogin:
+    """Tests for gh_authenticated_login()."""
+
+    def test_returns_login(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(0, "mvillmow\n")):
+            assert gh_authenticated_login() == "mvillmow"
+
+    def test_nonzero_returns_none(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(1, "", "no auth")):
+            assert gh_authenticated_login() is None
+
+    def test_empty_stdout_returns_none(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(0, "   \n")):
+            assert gh_authenticated_login() is None
+
+    def test_exception_returns_none(self) -> None:
+        with patch.object(
+            mnemosyne_repo, "gh_call", side_effect=subprocess.TimeoutExpired("gh", 10)
+        ):
+            assert gh_authenticated_login() is None
+
+
+class TestRemoteRepoExists:
+    """Tests for remote_repo_exists()."""
+
+    def test_exists(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(0, '{"name":"x"}')):
+            assert remote_repo_exists("me/ProjectMnemosyne") is True
+
+    def test_missing(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(1, "", "not found")):
+            assert remote_repo_exists("me/ProjectMnemosyne") is False
+
+    def test_exception_returns_false(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", side_effect=RuntimeError("boom")):
+            assert remote_repo_exists("me/ProjectMnemosyne") is False
+
+
+class TestForkUpstream:
+    """Tests for fork_upstream()."""
+
+    def test_success(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(0)) as gh:
+            assert fork_upstream("me") is True
+        args = gh.call_args[0][0]
+        assert args[:2] == ["repo", "fork"]
+        assert UPSTREAM_SLUG in args
+        assert "--clone=false" in args
+
+    def test_failure_returns_false(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(1, "", "denied")):
+            assert fork_upstream("me") is False
+
+    def test_exception_returns_false(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_call", side_effect=OSError("boom")):
+            assert fork_upstream("me") is False
+
+
+class TestResolveMnemosyneTarget:
+    """Tests for resolve_mnemosyne_target() precedence ladder."""
+
+    def test_upstream_login_clones_upstream_no_fork(self) -> None:
+        with (
+            patch.object(
+                mnemosyne_repo, "gh_authenticated_login", return_value="HomericIntelligence"
+            ),
+            patch.object(mnemosyne_repo, "remote_repo_exists") as exists,
+            patch.object(mnemosyne_repo, "fork_upstream") as fork,
+        ):
+            target = resolve_mnemosyne_target()
+        assert target == MnemosyneTarget(
+            owner="HomericIntelligence",
+            slug=UPSTREAM_SLUG,
+            is_fork_of_upstream=False,
+        )
+        exists.assert_not_called()
+        fork.assert_not_called()
+
+    def test_existing_user_fork_used_no_fork_created(self) -> None:
+        with (
+            patch.object(mnemosyne_repo, "gh_authenticated_login", return_value="mvillmow"),
+            patch.object(mnemosyne_repo, "remote_repo_exists", return_value=True),
+            patch.object(mnemosyne_repo, "fork_upstream") as fork,
+        ):
+            target = resolve_mnemosyne_target()
+        assert target.slug == "mvillmow/ProjectMnemosyne"
+        assert target.is_fork_of_upstream is True
+        fork.assert_not_called()
+
+    def test_missing_fork_is_created(self) -> None:
+        with (
+            patch.object(mnemosyne_repo, "gh_authenticated_login", return_value="mvillmow"),
+            patch.object(mnemosyne_repo, "remote_repo_exists", return_value=False),
+            patch.object(mnemosyne_repo, "fork_upstream", return_value=True) as fork,
+        ):
+            target = resolve_mnemosyne_target()
+        assert target.slug == "mvillmow/ProjectMnemosyne"
+        assert target.is_fork_of_upstream is True
+        fork.assert_called_once_with("mvillmow")
+
+    def test_fork_disabled_falls_back_to_upstream(self) -> None:
+        with (
+            patch.object(mnemosyne_repo, "gh_authenticated_login", return_value="mvillmow"),
+            patch.object(mnemosyne_repo, "remote_repo_exists", return_value=False),
+            patch.object(mnemosyne_repo, "fork_upstream") as fork,
+        ):
+            target = resolve_mnemosyne_target(allow_fork=False)
+        assert target.slug == UPSTREAM_SLUG
+        assert target.is_fork_of_upstream is False
+        fork.assert_not_called()
+
+    def test_fork_failure_falls_back_to_upstream(self) -> None:
+        with (
+            patch.object(mnemosyne_repo, "gh_authenticated_login", return_value="mvillmow"),
+            patch.object(mnemosyne_repo, "remote_repo_exists", return_value=False),
+            patch.object(mnemosyne_repo, "fork_upstream", return_value=False),
+        ):
+            target = resolve_mnemosyne_target()
+        assert target.slug == UPSTREAM_SLUG
+
+    def test_no_login_falls_back_to_upstream(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_authenticated_login", return_value=None):
+            target = resolve_mnemosyne_target()
+        assert target.slug == UPSTREAM_SLUG
+        assert target.is_fork_of_upstream is False
+
+    def test_explicit_override_owner_wins(self) -> None:
+        with (
+            patch.object(mnemosyne_repo, "gh_authenticated_login") as login,
+            patch.object(mnemosyne_repo, "remote_repo_exists") as exists,
+        ):
+            target = resolve_mnemosyne_target(override_owner="acme")
+        assert target == MnemosyneTarget(
+            owner="acme",
+            slug="acme/ProjectMnemosyne",
+            is_fork_of_upstream=True,
+        )
+        login.assert_not_called()
+        exists.assert_not_called()
+
+    def test_env_override_owner_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(mnemosyne_repo.OWNER_ENV_VAR, "acme")
+        with patch.object(mnemosyne_repo, "gh_authenticated_login") as login:
+            target = resolve_mnemosyne_target()
+        assert target.slug == "acme/ProjectMnemosyne"
+        login.assert_not_called()
+
+    def test_override_equal_to_upstream_is_not_marked_fork(self) -> None:
+        target = resolve_mnemosyne_target(override_owner="HomericIntelligence")
+        assert target.slug == UPSTREAM_SLUG
+        assert target.is_fork_of_upstream is False
+
+    def test_invalid_override_is_ignored(self) -> None:
+        # An override that is already a slug (contains "/") is rejected; falls
+        # through to gh login resolution.
+        with patch.object(mnemosyne_repo, "gh_authenticated_login", return_value=None):
+            target = resolve_mnemosyne_target(override_owner="bad/owner")
+        assert target.slug == UPSTREAM_SLUG
+
+    def test_login_with_slash_is_ignored(self) -> None:
+        with patch.object(mnemosyne_repo, "gh_authenticated_login", return_value="weird/login"):
+            target = resolve_mnemosyne_target()
+        assert target.slug == UPSTREAM_SLUG


### PR DESCRIPTION
## Summary

Make the ProjectMnemosyne knowledge base portable. Previously `/advise`,
`/learn`, and the automation pipeline hardcoded
`HomericIntelligence/ProjectMnemosyne`, so only that org could use them.

New shared resolver `hephaestus/github/mnemosyne_repo.py` —
`resolve_mnemosyne_target()`:

1. `HEPH_MNEMOSYNE_OWNER` override wins.
2. Else the gh-authenticated login's own `<login>/ProjectMnemosyne` fork
   (created via `gh repo fork` if absent). If the login is
   `HomericIntelligence`, clone upstream directly (cannot self-fork).
3. Else fall back to upstream.

Existing local `~/.agent-brain/ProjectMnemosyne` checkouts are reused as-is.
`/learn` pushes branches and opens PRs against the resolved fork.

## Changes

- **New**: `hephaestus/github/mnemosyne_repo.py` (resolver + `gh_authenticated_login` / `remote_repo_exists` / `fork_upstream`, all via the rate-limit-safe `gh_call`); exported from `hephaestus/github/__init__.py`.
- `advise_runner._clone_mnemosyne` clones the resolved slug.
- `learn.py`: evidence regexes broadened to any owner; `/learn` prompt pushes/PRs against the resolved fork.
- `advise` / `learn` / `myrmidon-swarm` `SKILL.md` bash rewritten to mirror the same ladder (canonical + plugin mirrors kept byte-identical).
- New `tests/unit/github/test_mnemosyne_repo.py`; updated advise_runner / learn / planner / ci_driver tests.

## Verification

- `pixi run ruff check` + format ✅ · `pixi run mypy` (440 files) ✅ · `pre-commit run --all-files` ✅
- Full unit suite: coverage 83.01% (gate met); import-surface + automation-boundary guards pass.

Closes #1667