### PR TITLE
[Feature] Exclude epic/roadmap issues from the planning loop

### DIFF
--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -35,6 +35,7 @@ from hephaestus.utils.helpers import strip_null_bytes
 
 from .git_utils import get_repo_info, run
 from .models import IssueInfo, IssueState
+from .state_labels import STATE_SKIP, is_skipped
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +141,27 @@ def gh_issue_add_labels(issue_number: int, labels: list[str]) -> None:
         cmd += ["--add-label", label]
     _gh_call(cmd)
     logger.info("Added labels %s to issue #%s", labels, issue_number)
+
+
+def skip_epics(epics_labels: dict[int, list[str]]) -> None:
+    """Tag excluded epic/roadmap issues with ``state:skip``, idempotently.
+
+    Called by the discovery chokepoints after :func:`~hephaestus.automation.
+    state_labels.partition_epics` separates the epics out. Applies the
+    ``state:skip`` override so dashboards and other tooling see the epic as
+    intentionally bypassed and the loop never re-attempts it. An epic that
+    already carries ``state:skip`` is left untouched — no redundant API write
+    each loop.
+
+    Args:
+        epics_labels: Mapping of epic issue number → its current label names.
+
+    """
+    for number, labels in epics_labels.items():
+        if is_skipped(labels):
+            continue
+        gh_issue_add_labels(number, [STATE_SKIP])
+        logger.info("Issue #%s is an epic/roadmap tracking issue; tagged state:skip", number)
 
 
 def gh_issue_remove_labels(issue_number: int, labels: list[str]) -> None:

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -19,6 +19,8 @@ from urllib.parse import urlparse
 
 from hephaestus.automation.ci_driver import _pr_is_failing
 from hephaestus.automation.git_utils import COMMIT_POLICY_REWRITE_EXEC
+from hephaestus.automation.github_api import skip_epics
+from hephaestus.automation.state_labels import partition_epics
 from hephaestus.github.client import gh_call
 from hephaestus.resilience.subprocess_resilience import resilient_call
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
@@ -110,7 +112,7 @@ def _gh_list_repos(org: str) -> list[str]:
 
 
 def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
-    """Return ALL open issue numbers in ``org/repo``, sorted ascending.
+    """Return open NON-epic issue numbers in ``org/repo``, sorted ascending.
 
     This is the loop's single canonical issue-discovery call: the result is
     passed down to the plan/implement child phases via ``--issues`` so they do
@@ -118,6 +120,14 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
     (no ``@me`` author/assignee filter) so it matches the child phases'
     ``gh_list_open_issues`` semantics exactly — the loop's convergence and
     failing-PR gates then agree with the work the phases actually do.
+
+    Epic/roadmap **tracking** issues are excluded (#1669): they are checklists
+    of child work, not code tasks, so the loop must never plan/implement them.
+    Each excluded epic is tagged ``state:skip`` (best-effort) via
+    :func:`skip_epics` so dashboards see it as intentionally bypassed; that
+    tagging never raises and never affects the returned list. Detection uses
+    label names + title because native GitHub issue types are not exposed by the
+    installed ``gh`` — see :func:`~hephaestus.automation.state_labels.is_epic`.
 
     Sorted ascending so the implementer phase processes oldest-first. Returns
     an empty list on any failure (rate limit, auth error, timeout) so callers
@@ -135,14 +145,38 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
                 "--limit",
                 "500",
                 "--json",
-                "number",
-                "--jq",
-                ".[].number",
+                "number,labels,title",
             ],
         )
-    except (subprocess.SubprocessError, RuntimeError, OSError):
+        entries = json.loads(out.stdout or "[]")
+    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
         return []
-    return sorted(int(x) for x in out.stdout.split() if x.strip().isdigit())
+
+    meta = [
+        {
+            "number": e["number"],
+            "labels": [lbl["name"] for lbl in e.get("labels", [])],
+            "title": e.get("title", ""),
+        }
+        for e in entries
+        if isinstance(e, dict) and "number" in e
+    ]
+    kept, epics = partition_epics(meta)
+    if epics:
+        epic_set = set(epics)
+        for num in epics:
+            LOG.info(
+                "[%s] issue #%s is an epic/roadmap tracking issue; excluding from planning loop",
+                repo,
+                num,
+            )
+        epic_labels = {m["number"]: m["labels"] for m in meta if m["number"] in epic_set}
+        # Best-effort skip-tagging: never let a label write break discovery.
+        try:
+            skip_epics(epic_labels)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOG.warning("[%s] could not tag excluded epics state:skip: %s", repo, exc)
+    return kept
 
 
 def _count_open_issues(org: str, repo: str) -> int:

--- a/hephaestus/automation/planner_state.py
+++ b/hephaestus/automation/planner_state.py
@@ -20,14 +20,15 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from .git_utils import issue_ref
-from .github_api import _gh_call, prefetch_issue_states
+from .github_api import _gh_call, prefetch_issue_states, skip_epics
 from .models import PLAN_COMMENT_MARKER
 from .review_state import (
     PLAN_REVIEW_PREFIX,
     fetch_all_issue_comments_graphql,
     fetch_all_issue_labels_graphql,
+    fetch_all_issue_titles_graphql,
 )
-from .state_labels import STATE_PLAN_GO
+from .state_labels import STATE_PLAN_GO, is_epic
 
 if TYPE_CHECKING:
     from .models import PlannerOptions
@@ -78,10 +79,12 @@ class PlannerStateManager:
     def filter(self) -> list[int]:
         """Filter issues based on options.
 
-        Two cheap, batched checks here, each one GraphQL call per 100 issues:
+        Cheap, batched checks here, each one GraphQL call per 100 issues:
 
         1. Skip **closed** issues (:func:`prefetch_issue_states`).
-        2. Skip issues already in ``state:plan-go`` (:func:`fetch_all_issue_labels_graphql`).
+        2. Skip **epic/roadmap** tracking issues (:func:`is_epic`) and tag them
+           ``state:skip`` (#1669) — they are checklists, not code tasks.
+        3. Skip issues already in ``state:plan-go`` (:func:`fetch_all_issue_labels_graphql`).
 
         Dropping ``state:plan-go`` issues up front means the loop stops
         re-evaluating every open issue every pass — previously each surviving
@@ -102,7 +105,10 @@ class PlannerStateManager:
         # Batch-fetch labels so we can cheaply drop already-GO issues here and
         # also serve them to is_plan_review_go inside the worker (no extra call).
         self._labels_cache = fetch_all_issue_labels_graphql(self.options.issues)
+        # Titles back the epic title-signal (catches epics carrying no label).
+        titles = fetch_all_issue_titles_graphql(self.options.issues)
 
+        skip_epics_meta: dict[int, list[str]] = {}
         issues_to_plan = []
         for issue_num in self.options.issues:
             if self.options.skip_closed:
@@ -111,16 +117,37 @@ class PlannerStateManager:
                     logger.info("Issue #%s is closed, skipping", issue_num)
                     continue
 
+            labels = self._labels_cache.get(issue_num) or []
+
+            # Epic/roadmap tracking issues are never planned (#1669). Collect
+            # them for one idempotent state:skip tagging pass after the loop.
+            if is_epic(labels, titles.get(issue_num, "")):
+                logger.info(
+                    "Issue #%s is an epic/roadmap tracking issue; excluding from planning",
+                    issue_num,
+                )
+                skip_epics_meta[issue_num] = labels
+                continue
+
             # Already-planned fast path: a state:plan-go label is the single
             # source of truth (#704). Drop it now without a per-issue round-trip.
             # ``force`` re-plans everything, so don't pre-filter then.
-            if not self.options.force:
-                labels = self._labels_cache.get(issue_num)
-                if labels is not None and STATE_PLAN_GO in labels:
-                    logger.info("Issue #%s already has a plan (state:plan-go), skipping", issue_num)
-                    continue
+            if (
+                not self.options.force
+                and self._labels_cache.get(issue_num) is not None
+                and STATE_PLAN_GO in labels
+            ):
+                logger.info("Issue #%s already has a plan (state:plan-go), skipping", issue_num)
+                continue
 
             issues_to_plan.append(issue_num)
+
+        # Best-effort skip-tagging of excluded epics; never block planning on it.
+        if skip_epics_meta:
+            try:
+                skip_epics(skip_epics_meta)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("Could not tag excluded epics state:skip: %s", exc)
 
         # Make a mis-scoped explicit run obvious. An explicit ``--issues`` set
         # that fully filters out (all closed and/or already-planned) otherwise

--- a/hephaestus/automation/review_state.py
+++ b/hephaestus/automation/review_state.py
@@ -428,6 +428,84 @@ def fetch_all_issue_labels_graphql(
     return result_map
 
 
+def fetch_all_issue_titles_graphql(
+    issue_numbers: list[int],
+) -> dict[int, str]:
+    """Batch-fetch issue titles in one aliased GraphQL call.
+
+    Sibling of :func:`fetch_all_issue_labels_graphql`. The planner uses it
+    alongside the labels fetch so :func:`~hephaestus.automation.state_labels.
+    is_epic` can apply its title-based signal (catching epics/roadmaps that
+    carry no label) without a per-issue ``gh issue view`` (#1669).
+
+    Falls back to an empty string per issue on any failure (caller then treats
+    the title as "unknown" and relies on labels alone).
+
+    Args:
+        issue_numbers: List of GitHub issue numbers to fetch.
+
+    Returns:
+        Mapping of ``issue_number → title``. Issues that could not be fetched
+        map to ``""``.
+
+    """
+    if not issue_numbers:
+        return {}
+
+    owner, name = get_repo_info(get_repo_root())
+
+    # owner/name and each issue number as GraphQL variables (never interpolated);
+    # mirrors fetch_all_issue_labels_graphql.
+    var_decls = ",".join(f"$n{idx}:Int!" for idx in range(len(issue_numbers)))
+    fragments = " ".join(
+        f"issue{idx}: issue(number:$n{idx}){{title}}" for idx in range(len(issue_numbers))
+    )
+    query = (
+        f"query($owner:String!,$name:String!,{var_decls})"
+        f"{{repository(owner:$owner,name:$name){{{fragments}}}}}"
+    )
+
+    idx_to_num = dict(enumerate(issue_numbers))
+    result_map: dict[int, str] = dict.fromkeys(issue_numbers, "")
+
+    args = [
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"name={name}",
+    ]
+    for idx, issue_num in enumerate(issue_numbers):
+        args.extend(["-F", f"n{idx}={int(issue_num)}"])
+
+    try:
+        result = _gh_call(args)
+        data = json.loads(result.stdout)
+        repo_data = data.get("data", {}).get("repository", {})
+        for alias, issue_data in repo_data.items():
+            if not alias.startswith("issue"):
+                continue
+            try:
+                idx = int(alias[len("issue") :])
+            except ValueError:
+                continue
+            num = idx_to_num.get(idx)
+            if num is None or issue_data is None:
+                continue
+            result_map[num] = issue_data.get("title", "") or ""
+    except Exception as exc:  # pragma: no cover - logged, callers get empty strings
+        logger.warning(
+            "Failed to batch-fetch titles for issues %s: %s",
+            issue_numbers,
+            exc,
+        )
+
+    return result_map
+
+
 def is_plan_review_go(  # noqa: C901  # validation: labels-first gate with comment-scan backfill; many independent rule checks
     issue_number: int,
     comments: list[dict[str, Any]] | None = None,

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -31,7 +31,8 @@ each apply-state helper removes the other two as it sets its own.
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 # Single source of truth for the three plan-state labels. All label-aware code
 # in the pipeline imports these constants; do not hard-code the names.
@@ -60,6 +61,14 @@ ALL_IMPLEMENTATION_STATE_LABELS = (STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTAT
 #: The implementer has one narrow stale-state recovery path for explicitly
 #: selected issues that also carry ``state:plan-go`` and have no open PR.
 STATE_SKIP = "state:skip"
+
+#: Label names that mark a TRACKING issue (an epic / roadmap) rather than a code
+#: task. Epics and roadmaps are checklists of child work; the planning loop must
+#: not plan or implement them directly (their deliverable is a body edit, not a
+#: PR). Matched case-insensitively. Native GitHub issue types are not exposed by
+#: the installed ``gh`` CLI, so a label name or a title substring is the only
+#: available signal — see :func:`is_epic`.
+EPIC_LABELS = ("epic", "roadmap")
 
 #: Per-label colour (hex without leading ``#``) and short description. The
 #: provisioning script (``hephaestus-ensure-state-labels``) uses these when
@@ -137,6 +146,65 @@ def is_skipped(labels: Iterable[str]) -> bool:
     policy where they have enough context.
     """
     return has_label(labels, STATE_SKIP)
+
+
+def is_epic(labels: Iterable[str], title: str = "") -> bool:
+    """Return ``True`` iff the issue is an epic/roadmap tracking issue.
+
+    An issue is treated as an epic when **either** signal matches (both
+    case-insensitive):
+
+    * it carries a label whose name is in :data:`EPIC_LABELS`
+      (``epic`` / ``roadmap``), **or**
+    * its ``title`` contains one of those markers as a substring.
+
+    The title fallback catches the convention even when the label was not
+    applied. Pure function (no I/O) so both discovery paths and unit tests can
+    call it directly.
+
+    Args:
+        labels: Label names on the issue.
+        title: The issue title (optional; empty disables the title signal).
+
+    Returns:
+        ``True`` if the issue should be excluded from the planning loop.
+
+    """
+    if {label.lower() for label in labels} & set(EPIC_LABELS):
+        return True
+    lowered_title = title.lower()
+    return any(marker in lowered_title for marker in EPIC_LABELS)
+
+
+def partition_epics(
+    issues_meta: Sequence[dict[str, Any]],
+) -> tuple[list[int], list[int]]:
+    """Split issue metadata into ``(kept, epics)`` by :func:`is_epic`.
+
+    Pure helper shared by both discovery chokepoints so the loop and the
+    standalone planner exclude epics identically (DRY). Each element is a
+    metadata dict with ``number`` and the optional ``labels`` / ``title``
+    signals; missing keys are treated as absent (an issue with no labels and
+    no title is simply kept).
+
+    Args:
+        issues_meta: Issue metadata dicts, each with at least ``number`` and
+            optionally ``labels`` (list of names) and ``title``.
+
+    Returns:
+        ``(kept_numbers, epic_numbers)``, both sorted ascending. ``kept`` are
+        the real work items the loop should plan; ``epics`` are the tracking
+        issues to exclude (and tag ``state:skip``).
+
+    """
+    kept: list[int] = []
+    epics: list[int] = []
+    for meta in issues_meta:
+        number = int(meta["number"])
+        labels = meta.get("labels") or []
+        title = meta.get("title") or ""
+        (epics if is_epic(labels, title) else kept).append(number)
+    return sorted(kept), sorted(epics)
 
 
 def needs_plan(labels: Iterable[str]) -> bool:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -32,6 +32,7 @@ from hephaestus.automation.github_api import (
     is_issue_closed,
     parse_issue_dependencies,
     prefetch_issue_states,
+    skip_epics,
 )
 from hephaestus.automation.models import IssueState
 from hephaestus.io import utils as io_utils
@@ -1205,6 +1206,37 @@ class TestGhIssueAddLabels:
         assert args.count("--add-label") == 2
         assert "state:plan-go" in args
         assert "state:plan-no-go" in args
+
+
+class TestSkipEpics:
+    """Tests for skip_epics — idempotent ``state:skip`` tagging of excluded epics."""
+
+    def teardown_method(self) -> None:
+        _github_api_module._label_cache = None
+
+    @patch("hephaestus.automation.github_api.gh_issue_add_labels")
+    def test_tags_unskipped_epics(self, mock_add: Any) -> None:
+        """Each epic without state:skip gets exactly one add-label call."""
+        skip_epics({10: ["epic"], 11: ["roadmap", "bug"]})
+        assert mock_add.call_count == 2
+        mock_add.assert_any_call(10, ["state:skip"])
+        mock_add.assert_any_call(11, ["state:skip"])
+
+    @patch("hephaestus.automation.github_api.gh_issue_add_labels")
+    def test_skips_already_skipped_epic(self, mock_add: Any) -> None:
+        """An epic already carrying state:skip is not re-tagged (no API write)."""
+        skip_epics({10: ["epic", "state:skip"]})
+        mock_add.assert_not_called()
+
+    @patch("hephaestus.automation.github_api.gh_issue_add_labels")
+    def test_mixed_skipped_and_unskipped(self, mock_add: Any) -> None:
+        skip_epics({10: ["epic", "state:skip"], 11: ["roadmap"]})
+        mock_add.assert_called_once_with(11, ["state:skip"])
+
+    @patch("hephaestus.automation.github_api.gh_issue_add_labels")
+    def test_empty_mapping_is_noop(self, mock_add: Any) -> None:
+        skip_epics({})
+        mock_add.assert_not_called()
 
 
 class TestGhIssueRemoveLabels:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -9,6 +9,7 @@ subsequent phases from being attempted.
 
 from __future__ import annotations
 
+import json
 import signal
 import subprocess
 import sys
@@ -1124,15 +1125,78 @@ def test_gh_list_repos_does_not_filter_by_name() -> None:
     assert sorted(names) == ["AnyName", "Hephaestus", "Odysseus"]
 
 
+def _issue_json(*issues: dict[str, object]) -> str:
+    """Render a ``gh issue list --json number,labels,title`` style payload."""
+    return json.dumps(list(issues))
+
+
 def test_list_open_issue_numbers_returns_all_open_sorted() -> None:
-    """A single all-open query is parsed and sorted ascending."""
+    """A single all-open query is parsed (as JSON) and sorted ascending."""
+    payload = _issue_json(
+        {"number": 12, "labels": [], "title": "c"},
+        {"number": 7, "labels": [], "title": "a"},
+        {"number": 10, "labels": [], "title": "b"},
+    )
 
     def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
-        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="12\n7\n10\n", stderr="")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=payload, stderr="")
 
     with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
         nums = loop_runner._list_open_issue_numbers("MyOrg", "MyRepo")
     assert nums == [7, 10, 12]
+
+
+def test_list_open_issue_numbers_excludes_epics_and_tags_skip() -> None:
+    """Epic/roadmap issues (by label or title) are excluded and tagged state:skip (#1669)."""
+    payload = _issue_json(
+        {"number": 5, "labels": [{"name": "bug"}], "title": "Fix crash"},
+        {"number": 6, "labels": [{"name": "epic"}], "title": "Umbrella"},
+        {"number": 7, "labels": [{"name": "feature"}], "title": "Q3 Roadmap rollup"},
+    )
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=payload, stderr="")
+
+    with (
+        patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        patch("hephaestus.automation.loop_repo_manager.skip_epics") as mock_skip,
+    ):
+        nums = loop_runner._list_open_issue_numbers("Org", "Repo")
+
+    assert nums == [5]
+    # Both the epic-labelled (#6) and roadmap-titled (#7) issues were handed to skip_epics.
+    mock_skip.assert_called_once()
+    tagged = mock_skip.call_args[0][0]
+    assert set(tagged.keys()) == {6, 7}
+
+
+def test_list_open_issue_numbers_no_epics_skips_nothing() -> None:
+    """When there are no epics, skip_epics is never invoked."""
+    payload = _issue_json(
+        {"number": 1, "labels": [{"name": "bug"}], "title": "a"},
+        {"number": 2, "labels": [], "title": "b"},
+    )
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout=payload, stderr="")
+
+    with (
+        patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        patch("hephaestus.automation.loop_repo_manager.skip_epics") as mock_skip,
+    ):
+        nums = loop_runner._list_open_issue_numbers("Org", "Repo")
+    assert nums == [1, 2]
+    mock_skip.assert_not_called()
+
+
+def test_list_open_issue_numbers_returns_empty_on_bad_json() -> None:
+    """Malformed JSON yields the safe-fallback empty list."""
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="not json", stderr="")
+
+    with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+        assert loop_runner._list_open_issue_numbers("Org", "Repo") == []
 
 
 def test_list_open_issue_numbers_queries_all_open_no_me_filter() -> None:
@@ -1145,7 +1209,7 @@ def test_list_open_issue_numbers_queries_all_open_no_me_filter() -> None:
 
     def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         seen_argv.extend(argv)
-        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="[]", stderr="")
 
     with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
         loop_runner._list_open_issue_numbers("Org", "Repo")
@@ -1155,6 +1219,8 @@ def test_list_open_issue_numbers_queries_all_open_no_me_filter() -> None:
     assert "--repo" in seen_argv
     assert "Org/Repo" in seen_argv
     assert seen_argv[seen_argv.index("--state") + 1] == "open"
+    # Discovery now fetches labels + title so epics can be filtered (#1669).
+    assert seen_argv[seen_argv.index("--json") + 1] == "number,labels,title"
 
 
 def test_resolve_org_and_repos_cwd_default() -> None:
@@ -1470,7 +1536,9 @@ class TestSubprocessTimeouts:
     def test_gh_issue_numbers_passes_timeout(self) -> None:
         """``gh issue list`` is routed through gh_call's bounded adapter."""
         with patch("hephaestus.automation.loop_repo_manager.gh_call") as mock_gh_call:
-            mock_gh_call.return_value = _completed(stdout="1\n2\n")
+            mock_gh_call.return_value = _completed(
+                stdout='[{"number": 1, "labels": [], "title": "a"}]'
+            )
             loop_runner._list_open_issue_numbers("Org", "Repo")
         assert mock_gh_call.call_args.kwargs.get("timeout") is None
 

--- a/tests/unit/automation/test_planner_state.py
+++ b/tests/unit/automation/test_planner_state.py
@@ -20,6 +20,26 @@ from hephaestus.automation.planner_state import PlannerStateManager
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _default_title_and_skip_patches() -> Any:
+    """Default the epic-detection helpers to no-ops (#1669).
+
+    ``PlannerStateManager.filter`` now also batch-fetches titles and may tag
+    excluded epics ``state:skip``. Tests that don't care about epics get a
+    safe default: no titles (so nothing reads as an epic by title) and a
+    no-op skip-tagging call. Tests that DO exercise epic exclusion override
+    these with their own ``patch`` context.
+    """
+    with (
+        patch(
+            "hephaestus.automation.planner_state.fetch_all_issue_titles_graphql",
+            return_value={},
+        ),
+        patch("hephaestus.automation.planner_state.skip_epics"),
+    ):
+        yield
+
+
 def _make_options(issues: list[int] | None = None) -> PlannerOptions:
     return PlannerOptions(
         issues=issues or [1, 2, 3],
@@ -225,6 +245,57 @@ class TestFilterDropsPlanGoIssues:
     def test_labels_cache_none_before_filter(self) -> None:
         mgr = PlannerStateManager(_make_options())
         assert mgr.get_cached_labels(1) is None
+
+
+class TestFilterEpicExclusion:
+    """``filter()`` drops epic/roadmap issues and tags them state:skip (#1669)."""
+
+    def test_drops_epic_by_label_and_title_and_tags_skip(self) -> None:
+        opts = _make_options(issues=[10, 11, 12])
+        opts.skip_closed = False
+        mgr = PlannerStateManager(opts)
+
+        labels = {10: ["bug"], 11: ["epic"], 12: ["feature"]}
+        titles = {10: "Fix crash", 11: "Umbrella", 12: "Q3 Roadmap rollup"}
+
+        with (
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value=labels,
+            ),
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_titles_graphql",
+                return_value=titles,
+            ),
+            patch("hephaestus.automation.planner_state.skip_epics") as mock_skip,
+        ):
+            kept = mgr.filter()
+
+        assert kept == [10]  # 11 (epic label) and 12 (roadmap title) excluded
+        mock_skip.assert_called_once()
+        tagged = mock_skip.call_args[0][0]
+        assert set(tagged.keys()) == {11, 12}
+
+    def test_no_epics_does_not_tag(self) -> None:
+        opts = _make_options(issues=[10, 11])
+        opts.skip_closed = False
+        mgr = PlannerStateManager(opts)
+
+        with (
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_labels_graphql",
+                return_value={10: ["bug"], 11: []},
+            ),
+            patch(
+                "hephaestus.automation.planner_state.fetch_all_issue_titles_graphql",
+                return_value={10: "a", 11: "b"},
+            ),
+            patch("hephaestus.automation.planner_state.skip_epics") as mock_skip,
+        ):
+            kept = mgr.filter()
+
+        assert kept == [10, 11]
+        mock_skip.assert_not_called()
 
 
 class TestFilterAllFilteredWarning:

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -489,6 +489,91 @@ class TestFetchAllIssueLabelsGraphql:
         assert "n0=10" in argv and "n1=11" in argv
         assert "issue(number:$n0)" in query_arg
 
+
+class TestFetchAllIssueTitlesGraphql:
+    """Batched title fetch used by the planner to detect epic/roadmap issues (#1669)."""
+
+    def test_empty_input_returns_empty(self) -> None:
+        from hephaestus.automation.review_state import fetch_all_issue_titles_graphql
+
+        assert fetch_all_issue_titles_graphql([]) == {}
+
+    def test_parses_aliased_titles(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from hephaestus.automation.review_state import fetch_all_issue_titles_graphql
+
+        payload = {
+            "data": {
+                "repository": {
+                    "issue0": {"title": "Epic: pipeline overhaul"},
+                    "issue1": {"title": "Fix crash"},
+                }
+            }
+        }
+        with (
+            patch("hephaestus.automation.review_state.get_repo_root", return_value="/tmp/repo"),
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("owner", "repo"),
+            ),
+            patch("hephaestus.automation.review_state._gh_call") as mock_gh,
+        ):
+            mock_gh.return_value = MagicMock(stdout=json.dumps(payload))
+            result = fetch_all_issue_titles_graphql([10, 11])
+
+        assert result == {10: "Epic: pipeline overhaul", 11: "Fix crash"}
+
+    def test_fetch_failure_returns_empty_strings(self) -> None:
+        from unittest.mock import patch
+
+        from hephaestus.automation.review_state import fetch_all_issue_titles_graphql
+
+        with (
+            patch("hephaestus.automation.review_state.get_repo_root", return_value="/tmp/repo"),
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("owner", "repo"),
+            ),
+            patch(
+                "hephaestus.automation.review_state._gh_call",
+                side_effect=RuntimeError("gh down"),
+            ),
+        ):
+            result = fetch_all_issue_titles_graphql([10, 11])
+
+        assert result == {10: "", 11: ""}
+
+    def test_owner_name_passed_as_graphql_variables_not_interpolated(self) -> None:
+        """Title fetch must parameterize owner/name/numbers (no injection)."""
+        from unittest.mock import MagicMock, patch
+
+        from hephaestus.automation.review_state import fetch_all_issue_titles_graphql
+
+        with (
+            patch("hephaestus.automation.review_state.get_repo_root", return_value="/tmp/repo"),
+            patch(
+                "hephaestus.automation.review_state.get_repo_info",
+                return_value=("HomericIntelligence", "ProjectHephaestus"),
+            ),
+            patch("hephaestus.automation.review_state._gh_call") as mock_gh,
+        ):
+            mock_gh.return_value = MagicMock(stdout=json.dumps({"data": {"repository": {}}}))
+            fetch_all_issue_titles_graphql([10, 11])
+
+        argv = mock_gh.call_args.args[0]
+        query_arg = next(a for a in argv if a.startswith("query="))
+        assert "'HomericIntelligence'" not in query_arg
+        assert query_arg.startswith("query=query($owner:String!,$name:String!")
+        assert "owner=HomericIntelligence" in argv
+        assert "name=ProjectHephaestus" in argv
+        assert "n0=10" in argv and "n1=11" in argv
+        assert "issue(number:$n0)" in query_arg
+
+
+class TestFetchAllIssueCommentsGraphqlVars:
+    """Regression guard for the batched comments fetch's GraphQL parameterization."""
+
     def test_comments_owner_name_passed_as_graphql_variables(self) -> None:
         """Same regression guard for the batched comments fetch."""
         from unittest.mock import MagicMock, patch

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -12,6 +12,7 @@ import pytest
 from hephaestus.automation.state_labels import (
     ALL_IMPLEMENTATION_STATE_LABELS,
     ALL_STATE_LABELS,
+    EPIC_LABELS,
     STATE_IMPLEMENTATION_GO,
     STATE_IMPLEMENTATION_NO_GO,
     STATE_LABEL_SPECS,
@@ -20,11 +21,13 @@ from hephaestus.automation.state_labels import (
     STATE_PLAN_NO_GO,
     STATE_SKIP,
     has_label,
+    is_epic,
     is_implementation_go,
     is_plan_go,
     is_plan_no_go,
     is_skipped,
     needs_plan,
+    partition_epics,
 )
 
 
@@ -164,3 +167,94 @@ class TestNeedsPlan:
         False even when ``state:needs-plan`` was not yet removed.
         """
         assert needs_plan(labels) is False
+
+
+class TestIsEpic:
+    """``is_epic`` excludes epic/roadmap TRACKING issues from the planning loop.
+
+    An issue is an epic iff it carries an ``epic``/``roadmap`` label
+    (case-insensitive) OR its title contains ``epic``/``roadmap``. Native
+    GitHub issue types are not exposed by the installed ``gh``, so label +
+    title are the only available signals.
+    """
+
+    def test_epic_label_marks_epic(self) -> None:
+        assert is_epic(["epic"]) is True
+
+    def test_roadmap_label_marks_epic(self) -> None:
+        assert is_epic(["roadmap"]) is True
+
+    def test_label_match_is_case_insensitive(self) -> None:
+        assert is_epic(["Epic"]) is True
+        assert is_epic(["ROADMAP"]) is True
+
+    def test_title_substring_marks_epic(self) -> None:
+        """Belt-and-suspenders: catch the convention even when unlabelled."""
+        assert is_epic([], title="Epic: ship the new pipeline") is True
+        assert is_epic([], title="Q3 Roadmap tracking") is True
+
+    def test_title_match_is_case_insensitive(self) -> None:
+        assert is_epic([], title="EPIC umbrella issue") is True
+
+    def test_plain_bug_is_not_epic(self) -> None:
+        assert is_epic(["bug", "severity:major"], title="Fix crash in parser") is False
+
+    def test_empty_inputs_not_epic(self) -> None:
+        assert is_epic([]) is False
+        assert is_epic([], title="") is False
+
+    def test_other_state_labels_not_epic(self) -> None:
+        assert is_epic([STATE_NEEDS_PLAN, STATE_PLAN_GO]) is False
+
+    def test_epic_labels_constant_contents(self) -> None:
+        assert set(EPIC_LABELS) == {"epic", "roadmap"}
+
+
+class TestPartitionEpics:
+    """``partition_epics`` splits issue metadata into (kept, epics).
+
+    Pure function shared by both discovery chokepoints (the loop's
+    ``_list_open_issue_numbers`` and the planner's ``filter``). Input is a list
+    of ``{"number", "labels", "title"}`` dicts; output is two ascending number
+    lists so callers stay deterministic.
+    """
+
+    def test_keeps_real_issues_and_extracts_epics(self) -> None:
+        meta = [
+            {"number": 3, "labels": ["bug"], "title": "Fix crash"},
+            {"number": 1, "labels": ["epic"], "title": "Umbrella"},
+            {"number": 2, "labels": ["feature"], "title": "Q3 Roadmap"},
+        ]
+        kept, epics = partition_epics(meta)
+        assert kept == [3]
+        assert epics == [1, 2]
+
+    def test_no_epics_returns_all_kept(self) -> None:
+        meta = [
+            {"number": 5, "labels": ["bug"], "title": "a"},
+            {"number": 4, "labels": [], "title": "b"},
+        ]
+        kept, epics = partition_epics(meta)
+        assert kept == [4, 5]
+        assert epics == []
+
+    def test_results_sorted_ascending(self) -> None:
+        meta = [
+            {"number": 30, "labels": [], "title": "x"},
+            {"number": 10, "labels": ["epic"], "title": "y"},
+            {"number": 20, "labels": [], "title": "z"},
+            {"number": 5, "labels": ["roadmap"], "title": "w"},
+        ]
+        kept, epics = partition_epics(meta)
+        assert kept == [20, 30]
+        assert epics == [5, 10]
+
+    def test_empty_input(self) -> None:
+        assert partition_epics([]) == ([], [])
+
+    def test_missing_keys_default_safely(self) -> None:
+        """Missing labels/title must not raise — treat as absent signals."""
+        meta = [{"number": 7}]
+        kept, epics = partition_epics(meta)
+        assert kept == [7]
+        assert epics == []


### PR DESCRIPTION
## Summary

The automation/planning loop now excludes **epic/roadmap tracking** issues. They are checklists of child work, not code tasks, so the loop must never plan or implement them directly (their deliverable is a body edit, not a PR). Previously the loop fetched all open issues with no issue-type filter, so an epic would be fed into plan → implement and wrongly receive a code PR.

## What changed

- **`is_epic(labels, title)`** + **`partition_epics`** (pure) in `state_labels.py`. An issue is an epic iff it carries an `epic`/`roadmap` label (case-insensitive) **or** its title contains one of those markers. Native `gh issueType` is not exposed by the installed gh, so label + title are the only available signals.
- **Loop discovery** (`_list_open_issue_numbers`) now fetches `number,labels,title`, partitions, and excludes epics. `_count_open_issues` inherits this, so convergence/open-issue gates stop counting epics too.
- **Standalone planner** (`PlannerStateManager.filter`) drops epics using its cached labels plus a new batched `fetch_all_issue_titles_graphql` (sibling of the labels fetch).
- **Excluded epics are tagged `state:skip`** idempotently via a new `skip_epics` helper (guards with `is_skipped`, reuses `gh_issue_add_labels`). Best-effort — never breaks the safe-fallback discovery contract.

## Notes

- Explicit `--issues` loop runs bypass the loop's discovery filter (`cfg.issues or _list_open_issue_numbers(...)`); the planner `filter()` path covers those.
- The manual `--epic` implementer expansion path (`dependency_resolver.load_epic`) is an explicit operator action and is intentionally unchanged.

## Testing

- New unit tests for `is_epic`, `partition_epics`, `skip_epics`, `fetch_all_issue_titles_graphql`, and the epic-exclusion behavior of both chokepoints (RED-GREEN TDD).
- Full automation suite: **2217 passed**. Whole-tree mypy clean (447 files). ruff clean. pre-commit clean.

Closes #1669