### PR TITLE
docs(readme): standardize CI/CD badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # ProjectHephaestus
 
-[![Test](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml)
+[![Test](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/test.yml)
+[![Pre-commit](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/pre-commit.yml)
+[![Security](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/security.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/security.yml)
+[![Release](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/release.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/release.yml)
+[![Auto Tag](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/auto-tag.yml/badge.svg)](https://github.com/HomericIntelligence/ProjectHephaestus/actions/workflows/auto-tag.yml)
 [![PyPI](https://img.shields.io/pypi/v/HomericIntelligence-Hephaestus.svg)](https://pypi.org/project/HomericIntelligence-Hephaestus/)
 [![Python](https://img.shields.io/pypi/pyversions/HomericIntelligence-Hephaestus.svg)](https://pypi.org/project/HomericIntelligence-Hephaestus/)
 [![License: BSD-3-Clause](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)


### PR DESCRIPTION
Part of HomericIntelligence/Odysseus#352

Standardize CI/CD workflow badges in ProjectHephaestus README to match the ecosystem-wide convention:
- Add Pre-commit, Security, Release, and Auto Tag workflow badges
- Normalize existing Test badge URL (remove `?branch=main` query param)
- Preserve existing PyPI, Python version, and License metadata badges

Generated with [Claude Code](https://claude.com/claude-code)