### PR TITLE
fix(typing): document and remove unjustified type: ignore comments

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -40,6 +40,8 @@ from hephaestus.github.mnemosyne_repo import resolve_mnemosyne_target
 try:
     import fcntl
 except ModuleNotFoundError:  # pragma: no cover - Windows fallback
+    # WHY justified: mypy types the stdlib `fcntl` module, so rebinding the
+    # name to None on the Windows fallback path needs [assignment].
     fcntl = None  # type: ignore[assignment]
 
 from .git_utils import get_repo_root

--- a/hephaestus/automation/curses_ui.py
+++ b/hephaestus/automation/curses_ui.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 try:
     import curses
 except ModuleNotFoundError:  # Windows: stdlib `curses` is not bundled with CPython.
+    # WHY justified: mypy types the imported `curses` module, so rebinding the
+    # name to None on the Windows fallback path needs [assignment].
     curses = None  # type: ignore[assignment]
 
 

--- a/hephaestus/automation/github_api.py
+++ b/hephaestus/automation/github_api.py
@@ -15,6 +15,7 @@ import os
 import re
 import subprocess
 import tempfile
+from collections.abc import Iterator
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, cast
@@ -208,7 +209,7 @@ def gh_issue_remove_labels(issue_number: int, labels: list[str]) -> None:
 
 
 @contextlib.contextmanager
-def _body_file(body: str):  # type: ignore[no-untyped-def]
+def _body_file(body: str) -> Iterator[str]:
     """Yield a path to a temporary file containing *body*, deleted on exit.
 
     Use with ``gh <subcmd> --body-file <path>`` instead of ``--body <body>`` so

--- a/hephaestus/forensics/coredump_handler.py
+++ b/hephaestus/forensics/coredump_handler.py
@@ -52,6 +52,7 @@ import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import BinaryIO
 
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 
@@ -224,7 +225,7 @@ def verify_crash_bundle(log_dir: Path) -> tuple[str, str]:
 
 
 def write_core(
-    stream: object,
+    stream: BinaryIO,
     pid: str,
     exe: str,
     crash_time: str,
@@ -257,7 +258,7 @@ def write_core(
     try:
         with open(out, "wb") as core_file:
             while written < max_bytes:
-                chunk = stream.read(min(chunk_size, max_bytes - written))  # type: ignore[attr-defined]
+                chunk = stream.read(min(chunk_size, max_bytes - written))
                 if not chunk:
                     break
                 core_file.write(chunk)

--- a/hephaestus/github/rate_limit.py
+++ b/hephaestus/github/rate_limit.py
@@ -36,6 +36,8 @@ logger = logging.getLogger(__name__)
 try:
     from zoneinfo import ZoneInfo
 except ImportError:  # pragma: no cover – Python 3.8 backport
+    # WHY justified: the backports.zoneinfo fallback rebinds the same `ZoneInfo`
+    # name as the stdlib import above, which mypy flags as [no-redef].
     from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
 
 # Regex matching GitHub CLI rate-limit messages, e.g.:

--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -39,6 +39,9 @@ _correlation_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar
 )
 
 
+# WHY justified: logging.LoggerAdapter is non-generic at runtime on Python 3.10
+# (PEP 585-style subscription was added in 3.11); parameterizing it would break
+# at import time, so we suppress disallow_any_generics' [type-arg] here.
 class ContextLogger(logging.LoggerAdapter):  # type: ignore[type-arg]
     """Logger adapter that adds context information to log messages."""
 

--- a/hephaestus/scripts_lib/check_cli_table_sync.py
+++ b/hephaestus/scripts_lib/check_cli_table_sync.py
@@ -38,6 +38,9 @@ def _get_tomllib() -> types.ModuleType:
         RuntimeError: When neither ``tomllib`` nor ``tomli`` is importable.
 
     """
+    # WHY justified: tomllib is stdlib only on Python 3.11+; on 3.10 we fall
+    # back to the `tomli` backport. [no-any-return] — the imported module object
+    # is typed Any; [no-redef] — `tomli as tomllib` rebinds the same name.
     try:
         import tomllib  # Python 3.11+
 

--- a/hephaestus/version/manager.py
+++ b/hephaestus/version/manager.py
@@ -22,6 +22,7 @@ Note: pixi.toml intentionally has no version field.
 
 import re
 from pathlib import Path
+from typing import cast
 
 from hephaestus.logging.utils import get_logger
 from hephaestus.utils.helpers import get_repo_root
@@ -102,8 +103,10 @@ class VersionManager:
         if pyproject_file is _UNSET:
             self.pyproject_file: Path | None = self.repo_root / "pyproject.toml"
         else:
-            # At this point pyproject_file is Path | None (not _UnsetType)
-            self.pyproject_file = pyproject_file  # type: ignore[assignment]
+            # The `is _UNSET` check above eliminates the sentinel, but mypy
+            # cannot narrow it out of the union; cast to Path | None so the
+            # assignment type-checks without a blanket suppression.
+            self.pyproject_file = cast("Path | None", pyproject_file)
         self.version_files = version_files or [self.repo_root / "VERSION"]
 
         # Auto-detect init files if not provided


### PR DESCRIPTION
## Summary
Audit all 23 type: ignore suppressions, documenting justified ones (platform-specific imports, Protocol compatibility) and fixing unjustified ones by adding proper type annotations.

## Changes
- Added return type annotation to _body_file in github_api.py
- Fixed type mismatch in version/manager.py pyproject_file assignment
- Documented platform-specific imports in curses_ui.py and advise_runner.py with justification comments
- Added type annotations to coredump_handler.py attr-defined suppression
- Documented tomllib import fallback in check_cli_table_sync.py
- Added explanatory comments for rate_limit.py and logging/utils.py platform guards

## Testing
- Run mypy with warn_unused_ignores = true to verify no false suppressions remain
- Verify type checking passes: pixi run mypy
- Run full test suite: pixi run pytest tests/unit

## Closes
Closes #1423

Generated by Claude Code via ProjectHephaestus automation.
