### PR TITLE
test(validation): detect ghost package directories (#1447)

### DIFF
--- a/hephaestus/validation/test_structure.py
+++ b/hephaestus/validation/test_structure.py
@@ -42,17 +42,35 @@ SANCTIONED_EXTRA_TEST_DIRS: frozenset[str] = frozenset(
 )
 
 
+def _has_python_source(directory: Path) -> bool:
+    """Return True if *directory* directly contains a Python source file.
+
+    A package directory must hold an ``__init__.py`` or at least one ``*.py``
+    module. A directory whose only remaining content is ``__pycache__`` (stale
+    ``.pyc`` files left after the source was deleted) is a *ghost* package and
+    must NOT be treated as a subpackage — doing so implies an importable
+    subpackage that does not exist (POLA).
+    """
+    if (directory / "__init__.py").exists():
+        return True
+    return any(directory.glob("*.py"))
+
+
 def _get_subpackages(root: Path) -> set[str]:
     """Return the set of direct subpackage names under *root*.
 
-    Ignores directories starting with ``_`` or ``.``.
+    Ignores directories starting with ``_`` or ``.``, and ghost directories
+    that contain no Python source file (only ``__pycache__``/``.pyc``).
     """
     if not root.is_dir():
         return set()
     return {
         d.name
         for d in root.iterdir()
-        if d.is_dir() and not d.name.startswith("_") and not d.name.startswith(".")
+        if d.is_dir()
+        and not d.name.startswith("_")
+        and not d.name.startswith(".")
+        and _has_python_source(d)
     }
 
 

--- a/tests/unit/validation/test_test_structure.py
+++ b/tests/unit/validation/test_test_structure.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from hephaestus.validation.test_structure import (
     SANCTIONED_EXTRA_TEST_DIRS,
     _detect_src_package,
+    _get_subpackages,
     check_no_loose_test_files,
     check_no_unsanctioned_test_dirs,
     check_scripts_coverage,
@@ -22,6 +23,19 @@ def _make_package(root: Path, name: str) -> Path:
     return pkg
 
 
+def _make_test_dir(root: Path, name: str) -> Path:
+    """Create a test subpackage directory with a placeholder ``test_*.py``.
+
+    Real ``tests/unit/`` subpackages always contain at least one test module,
+    so fixtures must too: a bare directory with no Python source is now treated
+    as a ghost by ``_get_subpackages`` and would not be enumerated.
+    """
+    pkg = root / name
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / f"test_{name}.py").touch()
+    return pkg
+
+
 class TestCheckTestDirectoryMirrors:
     """Tests for check_test_directory_mirrors()."""
 
@@ -31,7 +45,7 @@ class TestCheckTestDirectoryMirrors:
         tests = tmp_path / "tests" / "unit"
         for name in ["utils", "config", "io"]:
             _make_package(src, name)
-            (tests / name).mkdir(parents=True)
+            _make_test_dir(tests, name)
         mirrored, missing = check_test_directory_mirrors(src, tests)
         assert mirrored is True
         assert missing == set()
@@ -42,7 +56,7 @@ class TestCheckTestDirectoryMirrors:
         tests = tmp_path / "tests" / "unit"
         _make_package(src, "utils")
         _make_package(src, "config")
-        (tests / "utils").mkdir(parents=True)
+        _make_test_dir(tests, "utils")
         mirrored, missing = check_test_directory_mirrors(src, tests)
         assert mirrored is False
         assert missing == {"config"}
@@ -63,7 +77,7 @@ class TestCheckTestDirectoryMirrors:
         _make_package(src, "utils")
         (src / "__pycache__").mkdir()
         (src / ".hidden").mkdir()
-        (tests / "utils").mkdir(parents=True)
+        _make_test_dir(tests, "utils")
         mirrored, _missing = check_test_directory_mirrors(src, tests)
         assert mirrored is True
 
@@ -127,7 +141,7 @@ class TestCheckNoUnsanctionedTestDirs:
         tests = tmp_path / "tests" / "unit"
         for name in ["utils", "io"]:
             _make_package(src, name)
-            (tests / name).mkdir(parents=True)
+            _make_test_dir(tests, name)
         ok, unsanctioned = check_no_unsanctioned_test_dirs(src, tests, frozenset())
         assert ok is True
         assert unsanctioned == set()
@@ -136,8 +150,8 @@ class TestCheckNoUnsanctionedTestDirs:
         src = tmp_path / "mypackage"
         tests = tmp_path / "tests" / "unit"
         _make_package(src, "utils")
-        (tests / "utils").mkdir(parents=True)
-        (tests / "rogue").mkdir()
+        _make_test_dir(tests, "utils")
+        _make_test_dir(tests, "rogue")
         ok, unsanctioned = check_no_unsanctioned_test_dirs(src, tests, frozenset())
         assert ok is False
         assert unsanctioned == {"rogue"}
@@ -146,8 +160,8 @@ class TestCheckNoUnsanctionedTestDirs:
         src = tmp_path / "mypackage"
         tests = tmp_path / "tests" / "unit"
         _make_package(src, "utils")
-        (tests / "utils").mkdir(parents=True)
-        (tests / "scripts").mkdir()
+        _make_test_dir(tests, "utils")
+        _make_test_dir(tests, "scripts")
         ok, unsanctioned = check_no_unsanctioned_test_dirs(src, tests, frozenset({"scripts"}))
         assert ok is True
         assert unsanctioned == set()
@@ -157,7 +171,7 @@ class TestCheckNoUnsanctionedTestDirs:
         src = tmp_path / "mypackage"
         tests = tmp_path / "tests" / "unit"
         _make_package(src, "utils")
-        (tests / "utils").mkdir(parents=True)
+        _make_test_dir(tests, "utils")
         (tests / "__pycache__").mkdir()
         (tests / ".hidden").mkdir()
         ok, unsanctioned = check_no_unsanctioned_test_dirs(src, tests, frozenset())
@@ -167,6 +181,67 @@ class TestCheckNoUnsanctionedTestDirs:
     def test_real_repo_extras_are_sanctioned(self) -> None:
         """The real tests/unit/ extras are all in the shipped allowlist."""
         assert {"constants", "docs", "plugins", "scripts", "shell"} <= SANCTIONED_EXTRA_TEST_DIRS
+
+
+class TestGetSubpackages:
+    """_get_subpackages must ignore ghost (__pycache__-only) directories."""
+
+    def test_pycache_only_dir_not_counted(self, tmp_path: Path) -> None:
+        # Acceptance: ghost hephaestus/git/ (only __pycache__) is NOT a subpackage.
+        (tmp_path / "real").mkdir()
+        (tmp_path / "real" / "__init__.py").write_text("", encoding="utf-8")
+        ghost = tmp_path / "git"
+        (ghost / "__pycache__").mkdir(parents=True)
+        (ghost / "__pycache__" / "changelog.cpython-314.pyc").write_text("", encoding="utf-8")
+        assert _get_subpackages(tmp_path) == {"real"}
+
+    def test_dir_with_bare_module_counted(self, tmp_path: Path) -> None:
+        # A dir with a *.py but no __init__.py still counts (namespace-style).
+        pkg = tmp_path / "mod"
+        pkg.mkdir()
+        (pkg / "thing.py").write_text("", encoding="utf-8")
+        assert _get_subpackages(tmp_path) == {"mod"}
+
+    def test_empty_dir_not_counted(self, tmp_path: Path) -> None:
+        # A directory with no Python source at all is not a subpackage.
+        (tmp_path / "empty").mkdir()
+        assert _get_subpackages(tmp_path) == set()
+
+
+class TestGhostDirDoesNotMaskMirror:
+    """A ghost source dir must not register as a satisfied/extra mirror."""
+
+    def test_ghost_src_dir_ignored_in_mirror_checks(self, tmp_path: Path) -> None:
+        # Acceptance: a __pycache__-only src dir is not reported as a mirrored
+        # subpackage (would otherwise mask its deletion).
+        src = tmp_path / "src"
+        tests = tmp_path / "tests"
+        _make_package(src, "real")
+        ghost = src / "git"
+        (ghost / "__pycache__").mkdir(parents=True)
+        (ghost / "__pycache__" / "x.pyc").write_text("", encoding="utf-8")
+        (tests / "real").mkdir(parents=True)
+        (tests / "real" / "__init__.py").write_text("", encoding="utf-8")
+
+        mirrored, missing = check_test_directory_mirrors(src, tests)
+        assert mirrored and missing == set()  # ghost git/ not demanded as a mirror
+        ok, unsanctioned = check_no_unsanctioned_test_dirs(src, tests, frozenset())
+        assert ok and unsanctioned == set()
+
+    def test_ghost_src_dir_not_demanded_by_check_test_structure(self, tmp_path: Path) -> None:
+        # Orchestrator altitude: check_test_structure() must pass with a ghost
+        # __pycache__-only src dir present (it must not be counted as a
+        # subpackage requiring a mirror test directory).
+        src = tmp_path / "mypackage"
+        _make_package(src, "real")
+        (src / "__init__.py").touch()
+        ghost = src / "git"
+        (ghost / "__pycache__").mkdir(parents=True)
+        (ghost / "__pycache__" / "changelog.cpython-314.pyc").write_text("", encoding="utf-8")
+        test_root = tmp_path / "tests" / "unit"
+        _make_test_dir(test_root, "real")
+        passed = check_test_structure(tmp_path, src_package="mypackage")
+        assert passed is True
 
 
 class TestCheckTestStructure:
@@ -212,7 +287,7 @@ class TestCheckTestStructure:
         _make_package(src, "utils")
         (src / "__init__.py").touch()
         test_root = tmp_path / "tests" / "unit"
-        (test_root / "utils").mkdir(parents=True)
+        _make_test_dir(test_root, "utils")
         passed = check_test_structure(tmp_path, src_package="mypackage", verbose=True)
         assert passed is True
 
@@ -225,7 +300,7 @@ class TestCheckTestStructure:
         _make_package(src, "core")
         (src / "__init__.py").touch()
         test_root = tmp_path / "tests" / "unit"
-        (test_root / "core").mkdir(parents=True)
+        _make_test_dir(test_root, "core")
         passed = check_test_structure(tmp_path)
         assert passed is True
 
@@ -238,8 +313,8 @@ class TestCheckTestStructure:
         _make_package(src, "utils")
         (src / "__init__.py").touch()
         test_root = tmp_path / "tests" / "unit"
-        (test_root / "utils").mkdir(parents=True)
-        (test_root / "rogue").mkdir()  # no source counterpart, not allowlisted
+        _make_test_dir(test_root, "utils")
+        _make_test_dir(test_root, "rogue")  # no source counterpart, not allowlisted
         passed = check_test_structure(tmp_path, src_package="mypackage")
         assert passed is False
         err = capsys.readouterr().err
@@ -278,7 +353,7 @@ class TestMain:
         _make_package(src, "utils")
         (src / "__init__.py").touch()
         test_root = tmp_path / "tests" / "unit"
-        (test_root / "utils").mkdir(parents=True)
+        _make_test_dir(test_root, "utils")
         monkeypatch.setattr(
             "sys.argv",
             [


### PR DESCRIPTION
## Summary
Add detection for ghost package directories (empty dirs with only __pycache__) that mask deleted source files and confuse tooling.

## Changes
- Add _has_python_source() helper to distinguish real packages from __pycache__-only ghosts (POLA)
- Update _get_subpackages() to filter out directories without Python source files
- Add comprehensive test coverage for ghost-directory scenarios (test_pycache_only_dir_not_counted, test_ghost_src_dir_ignored_in_mirror_checks, test_ghost_src_dir_not_demanded_by_check_test_structure)
- Verify ghost dirs don't satisfy mirror checks or register as extra test directories

## Testing
- hephaestus/git/ (the __pycache__-only ghost) is no longer counted as a valid subpackage
- check_test_structure() passes with ghost directories present (they are ignored)
- Mirror checks do not demand test directories for ghost source directories
- Unsanctioned test-dir checks ignore ghost dirs in both source and test roots

## Closes
Closes #1447

Generated by Claude Code via ProjectHephaestus automation.
