### PR TITLE
docs(validation): fix coverage threshold mismatch in DEFINITION_OF_DONE.md

### DIFF
--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -20,7 +20,7 @@ A piece of work is **done** when every item below is true.
 | 7 | `pixi run ruff format --check hephaestus/ tests/` passes (no files would be reformatted) | CI job `lint` |
 | 8 | `pixi run mypy` returns `Success: no issues found in N source files` | CI job `lint` |
 | 9 | Full unit suite passes: `pixi run pytest tests/unit` (currently 2,500+ tests across 4 Python versions) | CI jobs `unit-tests`, `test (ubuntu-latest, 3.10/3.11/3.12/3.13, unit)` |
-| 10 | Coverage gate satisfied: `--cov-fail-under=80` (configured in `pyproject.toml [tool.coverage.report].fail_under`) | CI job `unit-tests` |
+| 10 | Coverage gate satisfied: `--cov-fail-under=83` (configured in `pyproject.toml [tool.coverage.report].fail_under`) | CI job `unit-tests` |
 | 11 | No new warnings introduced (pytest, deprecation, ruff) | PR reviewer |
 | 12 | Integration tests pass: `pixi run pytest tests/integration` | CI job `integration-tests` |
 | 13 | Shell tests pass: `pixi run test-shell` | CI job `shell-tests` |
@@ -47,7 +47,7 @@ In addition to the universal checklist:
 | # | Requirement | Enforced by |
 |---|-------------|-------------|
 | F1 | Public functions have Google-style docstrings | Convention (PR reviewer) |
-| F2 | New `main()` entry points have at least smoke tests (one happy-path, one error-path) | Coverage gate (rejects untested code if it drops total under 80%) |
+| F2 | New `main()` entry points have at least smoke tests (one happy-path, one error-path) | Coverage gate (rejects untested code if it drops total under 83%) |
 | F3 | New CLI scripts use `add_json_arg(parser)` and emit `emit_json_status(...)` on exit | CI integration test `TestCLIJsonFlag` in `tests/integration/test_cli_entry_points.py` |
 | F4 | New CLI scripts appear in `pyproject.toml [project.scripts]` AND in the CLI table of `README.md` | CI gate via `scripts/check_cli_table_sync.py` |
 | F5 | If the work touches deprecated APIs, update `COMPATIBILITY.md` | PR reviewer |

--- a/hephaestus/validation/doc_config.py
+++ b/hephaestus/validation/doc_config.py
@@ -3,7 +3,8 @@
 Checks that values documented in CLAUDE.md and README.md match what is configured in
 ``pyproject.toml``:
 
-1. Coverage threshold in CLAUDE.md matches ``fail_under`` in ``[tool.coverage.report]``.
+1. Coverage threshold in CLAUDE.md AND docs/DEFINITION_OF_DONE.md matches ``fail_under``
+   in ``[tool.coverage.report]``.
 2. ``--cov=<path>`` in README.md matches ``addopts`` in ``[tool.pytest.ini_options]``.
 3. If ``--cov-fail-under=N`` is present in ``addopts``, it must match ``fail_under`` in
    ``[tool.coverage.report]``.  Absent is OK — ``[tool.coverage.report].fail_under`` is
@@ -182,6 +183,47 @@ def check_claude_md_threshold(repo_root: Path, expected: int) -> list[str]:
     return errors
 
 
+def check_dod_threshold(repo_root: Path, expected: int) -> list[str]:
+    """Check that docs/DEFINITION_OF_DONE.md documents the correct coverage threshold.
+
+    The DoD references the gate in two distinct phrasings that differ from
+    CLAUDE.md's: ``--cov-fail-under=<N>`` (row 10) and ``drops total under <N>%``
+    (row F2). Both must match the authoritative *expected* value. The match is
+    anchored on these gate-specific shapes rather than a free ``<N>%`` scan so it
+    does not false-positive on unrelated numbers (the 10% tolerance, Python 3.10).
+
+    Args:
+        repo_root: Repository root.
+        expected: Authoritative threshold value from ``pyproject.toml``.
+
+    Returns:
+        List of error strings (empty if all checks pass).
+
+    """
+    dod = repo_root / "docs" / "DEFINITION_OF_DONE.md"
+    if not dod.exists():
+        return [f"DEFINITION_OF_DONE.md not found at {dod}"]
+
+    text = dod.read_text(encoding="utf-8")
+    matches = re.findall(r"--cov-fail-under=(\d+)", text)
+    matches += re.findall(r"drops total under (\d+)%", text)
+    if not matches:
+        return [
+            "DEFINITION_OF_DONE.md: No coverage threshold mention found "
+            "(expected '--cov-fail-under=<N>' or 'drops total under <N>%')"
+        ]
+
+    errors: list[str] = []
+    for raw in matches:
+        found = int(raw)
+        if found != expected:
+            errors.append(
+                f"DEFINITION_OF_DONE.md: Coverage threshold mismatch — "
+                f"DEFINITION_OF_DONE.md says {found}%, pyproject.toml says {expected}%"
+            )
+    return errors
+
+
 def check_readme_cov_path(repo_root: Path, expected_path: str) -> list[str]:
     """Check that all ``--cov=<path>`` occurrences in README.md match *expected_path*.
 
@@ -312,7 +354,8 @@ def check_doc_config_consistency(
     """Run all doc/config consistency checks and return an exit code.
 
     Checks:
-    1. CLAUDE.md coverage threshold vs ``[tool.coverage.report].fail_under``.
+    1. CLAUDE.md AND docs/DEFINITION_OF_DONE.md coverage threshold vs
+       ``[tool.coverage.report].fail_under``.
     2. README.md ``--cov=<path>`` vs ``[tool.pytest.ini_options].addopts``.
     3. ``--cov-fail-under`` in addopts (if present) vs ``fail_under``.
     4. README.md hardcoded test count vs ``pytest --collect-only`` (skipped if
@@ -349,7 +392,7 @@ def check_doc_config_consistency(
 
 
 def _run_threshold_check(repo_root: Path, expected: int, verbose: bool) -> list[str]:
-    """Run CLAUDE.md coverage threshold check and print verbose result.
+    """Run CLAUDE.md and DEFINITION_OF_DONE.md coverage threshold checks.
 
     Args:
         repo_root: Repository root.
@@ -361,8 +404,12 @@ def _run_threshold_check(repo_root: Path, expected: int, verbose: bool) -> list[
 
     """
     errors = check_claude_md_threshold(repo_root, expected)
+    errors += check_dod_threshold(repo_root, expected)
     if not errors and verbose:
-        print(f"PASS: CLAUDE.md coverage threshold matches pyproject.toml ({expected}%)")
+        print(
+            f"PASS: CLAUDE.md and DEFINITION_OF_DONE.md coverage threshold "
+            f"match pyproject.toml ({expected}%)"
+        )
     return errors
 
 
@@ -464,6 +511,7 @@ def main() -> int:
         expected_threshold = load_coverage_threshold(repo_root)
         all_errors: list[str] = []
         all_errors.extend(check_claude_md_threshold(repo_root, expected_threshold))
+        all_errors.extend(check_dod_threshold(repo_root, expected_threshold))
         cov_path = extract_cov_path(repo_root)
         all_errors.extend(check_readme_cov_path(repo_root, cov_path))
         all_errors.extend(check_addopts_cov_fail_under(repo_root, expected_threshold))

--- a/tests/unit/validation/test_doc_config.py
+++ b/tests/unit/validation/test_doc_config.py
@@ -13,6 +13,7 @@ from hephaestus.validation.doc_config import (
     check_addopts_cov_fail_under,
     check_claude_md_threshold,
     check_doc_config_consistency,
+    check_dod_threshold,
     check_readme_cov_path,
     check_readme_test_count,
     collect_actual_test_count,
@@ -145,6 +146,42 @@ class TestCheckClaudeMdThreshold:
         assert check_claude_md_threshold(tmp_path, 80) == []
 
 
+class TestCheckDodThreshold:
+    """Tests for check_dod_threshold()."""
+
+    def _write_dod(self, tmp_path: Path, text: str) -> None:
+        (tmp_path / "docs").mkdir(exist_ok=True)
+        (tmp_path / "docs" / "DEFINITION_OF_DONE.md").write_text(text)
+
+    def test_matching_threshold(self, tmp_path: Path) -> None:
+        self._write_dod(tmp_path, "`--cov-fail-under=83` and drops total under 83%.")
+        assert check_dod_threshold(tmp_path, 83) == []
+
+    def test_mismatch_cov_fail_under(self, tmp_path: Path) -> None:
+        self._write_dod(tmp_path, "`--cov-fail-under=80`")
+        errors = check_dod_threshold(tmp_path, 83)
+        assert len(errors) == 1
+        assert "80%" in errors[0]
+        assert "83%" in errors[0]
+
+    def test_mismatch_drops_under(self, tmp_path: Path) -> None:
+        self._write_dod(tmp_path, "drops total under 80%")
+        errors = check_dod_threshold(tmp_path, 83)
+        assert len(errors) == 1
+        assert "80%" in errors[0]
+
+    def test_no_mention(self, tmp_path: Path) -> None:
+        self._write_dod(tmp_path, "No coverage info here.")
+        errors = check_dod_threshold(tmp_path, 83)
+        assert len(errors) == 1
+        assert "No coverage threshold" in errors[0]
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        errors = check_dod_threshold(tmp_path, 83)
+        assert len(errors) == 1
+        assert "not found" in errors[0]
+
+
 class TestCheckReadmeCovPath:
     """Tests for check_readme_cov_path()."""
 
@@ -251,6 +288,10 @@ class TestCheckDocConfigConsistency:
         _write_pyproject(tmp_path, _minimal_pyproject(fail_under=80))
         (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
         (tmp_path / "README.md").write_text("Run pytest --cov=hephaestus")
+        (tmp_path / "docs").mkdir(exist_ok=True)
+        (tmp_path / "docs" / "DEFINITION_OF_DONE.md").write_text(
+            "`--cov-fail-under=80` and drops total under 80%."
+        )
 
     def test_all_pass(self, tmp_path: Path) -> None:
         self._setup_valid_repo(tmp_path)
@@ -263,6 +304,19 @@ class TestCheckDocConfigConsistency:
         (tmp_path / "README.md").write_text("")
         result = check_doc_config_consistency(tmp_path, skip_test_count=True)
         assert result == 1
+
+    def test_dod_threshold_mismatch_fails(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A stale threshold in DEFINITION_OF_DONE.md fails the consolidated run."""
+        self._setup_valid_repo(tmp_path)
+        # Rewrite the DoD with a threshold that no longer matches fail_under=80.
+        (tmp_path / "docs" / "DEFINITION_OF_DONE.md").write_text(
+            "`--cov-fail-under=83` and drops total under 83%."
+        )
+        result = check_doc_config_consistency(tmp_path, skip_test_count=True)
+        assert result == 1
+        assert "DEFINITION_OF_DONE.md" in capsys.readouterr().err
 
     def test_verbose_on_pass(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
         self._setup_valid_repo(tmp_path)
@@ -289,6 +343,10 @@ class TestMain:
         _write_pyproject(tmp_path, _minimal_pyproject(fail_under=80))
         (tmp_path / "CLAUDE.md").write_text("We maintain 80%+ test coverage.")
         (tmp_path / "README.md").write_text("Run pytest --cov=hephaestus")
+        (tmp_path / "docs").mkdir(exist_ok=True)
+        (tmp_path / "docs" / "DEFINITION_OF_DONE.md").write_text(
+            "`--cov-fail-under=80` and drops total under 80%."
+        )
         monkeypatch.setattr(
             "sys.argv",
             [

--- a/tests/unit/validation/test_validation_cli_contracts.py
+++ b/tests/unit/validation/test_validation_cli_contracts.py
@@ -63,6 +63,7 @@ def test_doc_config_main_uses_shared_repo_root_json_path(
     monkeypatch.setattr(doc_config, "load_coverage_threshold", lambda repo_root: 83.0)
     monkeypatch.setattr(doc_config, "extract_cov_path", lambda repo_root: "hephaestus")
     monkeypatch.setattr(doc_config, "check_claude_md_threshold", lambda *args: [])
+    monkeypatch.setattr(doc_config, "check_dod_threshold", lambda *args: [])
     monkeypatch.setattr(doc_config, "check_readme_cov_path", lambda *args: [])
     monkeypatch.setattr(doc_config, "check_addopts_cov_fail_under", lambda *args: [])
 


### PR DESCRIPTION
## Summary
Align DEFINITION_OF_DONE.md coverage threshold documentation with the actual 83% enforcement in pyproject.toml, and extend the doc-config validator to catch similar mismatches in the future.

## Changes
- Updated docs/DEFINITION_OF_DONE.md to state 83% coverage threshold (was 80%)
- Extended hephaestus/validation/doc_config.py to validate DEFINITION_OF_DONE.md coverage threshold against pyproject.toml
- Added unit tests to verify doc-config validator catches threshold mismatches

## Testing
- doc_config validator correctly identifies 80% → 83% mismatch in DEFINITION_OF_DONE.md
- Validator enforces consistency between DEFINITION_OF_DONE.md, CLAUDE.md, and pyproject.toml coverage thresholds
- Existing documentation passes updated validator checks

## Closes
Closes #1451

Generated by Claude Code via ProjectHephaestus automation.
