### PR TITLE
docs(runbooks): add operational recovery guides for automation pipeline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ See the [README](../README.md) for installation and development setup instructio
 - [Plugin Installation Guide](plugin-installation.md) — Install the Claude Code or Codex plugin and enable skills in your project
 - [Audit Reviewer](audit-reviewer.md) — `hephaestus-audit-prs`: coordinator-pattern auditor for ALL open PRs (issue #994)
 - [MCP Configuration](mcp.md) — Project-scoped `.mcp.json` and how to add a Model Context Protocol server
+- [Operations Runbooks](runbooks/index.md) — Operator recovery procedures for the automation pipeline (loop crash, corrupted worktree, CI-driver stall, quota exhaustion)
 
 ## Contributing
 

--- a/docs/runbooks/automation-loop-crash.md
+++ b/docs/runbooks/automation-loop-crash.md
@@ -1,0 +1,72 @@
+# Runbook: Automation Loop Crashed Mid-Issue
+
+Use this when the `hephaestus-automation-loop` process dies partway through
+processing an issue, or a phase times out, and you need to resume safely.
+
+## Symptoms
+
+- The loop process exited unexpectedly (force-kill, OOM, terminal closed).
+- The log shows one of these crash markers (emitted from
+  `hephaestus/automation/loop_runner.py`):
+  - `[{repo}] issue #{issue} pipeline crashed: {exc}` — a single issue's
+    pipeline raised.
+  - `[{repo}] runner crashed: {exc}` — the per-repo runner raised.
+  - `[{repo}] phase {phase} TIMEOUT after {N}s` — a stage exceeded its timeout.
+- An issue is left in an intermediate `state:*` label (see the
+  [runbooks index](index.md) state-label table).
+
+## Diagnose
+
+1. Read the current label state of the affected issue — phases are
+   driven entirely by the `state:*` label, so the label tells you where the
+   pipeline was:
+
+   ```bash
+   gh issue view <N> --json labels --jq '.labels[].name'
+   ```
+
+2. Check whether an in-progress worktree was left on disk for that issue:
+
+   ```bash
+   git -C <repo> worktree list
+   ls -la <repo>/build/.worktrees/issue-<N>
+   ```
+
+   A leftover worktree is expected after a force-kill — the loop keeps
+   worktrees inside the repo precisely so an interrupted run survives on disk
+   for the next invocation to resume or surface. If the worktree is dirty or
+   suspect, recover it with the
+   [corrupted-worktree runbook](corrupted-worktree.md) before re-running.
+
+## Recover
+
+The loop is idempotent per issue: it re-discovers open issues with a fresh
+`gh issue list` every loop iteration and re-reads each issue's `state:*` label,
+so re-running resumes from the last-known label state. There is no per-issue
+crash checkpoint — the label *is* the checkpoint.
+
+```bash
+hephaestus-automation-loop --issues <N> --loops <K> --repos <REPO>
+```
+
+The shared checkout is reset between turns, so any uncommitted in-flight edit
+from the crashed turn is discarded; this is by design — the loop runner owns
+worktree isolation and resets the shared checkout each turn.
+
+## When `state:skip` applies
+
+`state:skip` is the only label that takes an issue out of the loop entirely. It
+is **operator-applied**, or **auto-applied** when a PR is genuinely stuck after
+the merge budget (`--max-merge-attempts`) is exhausted. A crash alone does
+**not** apply `state:skip`;
+re-running the loop is the correct first response to a crash. Apply
+`state:skip` yourself only when an issue is genuinely stuck after repeated
+attempts (for a stuck-but-green PR, see the
+[CI-driver stall runbook](ci-driver-stall.md)).
+
+## See also
+
+- [Corrupted worktree state](corrupted-worktree.md)
+- [CI-driver stall (green-but-BLOCKED)](ci-driver-stall.md)
+- [Claude quota exhausted (429)](claude-quota-exhausted.md)
+- Stage → module → console-script mapping: [`../../AGENTS.md`](../../AGENTS.md)

--- a/docs/runbooks/ci-driver-stall.md
+++ b/docs/runbooks/ci-driver-stall.md
@@ -1,0 +1,67 @@
+# Runbook: CI-Driver Stall (Green-but-BLOCKED PR)
+
+Use this when the CI driver keeps exiting cleanly each loop but PRs never
+merge — they sit armed for auto-merge with all checks green, yet stay
+un-mergeable. Grounded in `hephaestus/automation/ci_driver.py`.
+
+## Symptom
+
+- The drive-green stage exits `0` every loop, but open PRs pile up
+  un-mergeable.
+- The log shows (from `ci_driver.py`):
+
+  > Issue #N: PR #M is BLOCKED by branch protection (unresolved conversations
+  > or required review) — cannot auto-merge; leaving armed and exiting poll
+  > early
+
+- `mergeStateStatus` for the PR is `BLOCKED` even though every check is green
+  and auto-merge is armed.
+
+## Root cause
+
+The driver treats `mergeStateStatus == "BLOCKED"` as failing-to-merge. The
+common cause is **required-context drift**: an org ruleset requires a check
+context that the repo's CI never emits, so the PR is `BLOCKED` permanently.
+A second cause is an unresolved review thread when the ruleset requires
+`required_review_thread_resolution`. The driver attempts to address
+green-but-BLOCKED PRs at most `_BLOCKED_ADDRESS_MAX_ATTEMPTS = 2` times, then
+**leaves the PR armed** and exits the poll early — it does not loop forever, so
+the loop's clean exit hides the stall.
+
+## Diagnose
+
+```bash
+gh pr view <N> --json mergeStateStatus,statusCheckRollup,autoMergeRequest
+```
+
+Armed (`autoMergeRequest` present) + all checks green + `mergeStateStatus`
+`BLOCKED` = a gating condition CI cannot satisfy on its own. Then inspect what
+is actually required:
+
+```bash
+# Org/repo ruleset: which check contexts are REQUIRED?
+gh api repos/{owner}/{repo}/rulesets
+gh api repos/{owner}/{repo}/rulesets/{id}
+
+# Any unresolved review threads holding the merge?
+gh pr view <N> --json reviewDecision,reviewRequests
+```
+
+## Fix
+
+1. **Required-context drift** — reconcile the ruleset's required check contexts
+   with the contexts CI actually emits. Either remove the obsolete required
+   context from the ruleset, or add a CI job that emits it. A push to re-run CI
+   then re-queues the (now-present) required context.
+2. **Unresolved threads** — if the ruleset requires
+   `required_review_thread_resolution`, resolve the lingering (often bot)
+   review threads, then the armed auto-merge proceeds on its own.
+
+After the gate is satisfied, the already-armed PR merges without re-running the
+driver; re-run `hephaestus-automation-loop` only if you need to drive other
+issues.
+
+## See also
+
+- [Automation loop crashed mid-issue](automation-loop-crash.md)
+- PR / state-label policy: [`../../CLAUDE.md`](../../CLAUDE.md)

--- a/docs/runbooks/claude-quota-exhausted.md
+++ b/docs/runbooks/claude-quota-exhausted.md
@@ -1,0 +1,56 @@
+# Runbook: Claude Quota Exhausted (429)
+
+Use this when a stage stops making progress because the Claude API session
+limit / quota was hit (HTTP 429). Grounded in
+`hephaestus/automation/claude_invoke.py` and
+`hephaestus/github/rate_limit.py`.
+
+## Symptom
+
+- A stage emits `Verdict: ERROR` — an **infrastructure-failure** sentinel,
+  **not** a `NOGO`. `claude_invoke.py` reserves `"ERROR"` for
+  reviewer-infrastructure failures and keeps it *deliberately distinct from*
+  `"NOGO"` so the loop does not mistake "the reviewer never ran" for "the code
+  is bad."
+- Stderr/output carries `429` / quota / rate-limit phrasing, wrapped as a
+  `ClaudeUsageCapError`.
+- The issue is left **unlabeled and not skipped** — a quota cap is not a stuck
+  work item, so the loop does not apply `state:skip` for it.
+
+## ERROR ≠ NOGO
+
+This is the single most important distinction: a `Verdict: ERROR` from a quota
+cap means the reviewer/implementer **never got to run**, not that your change
+failed review. Do not treat it as a `state:implementation-no-go`. There is
+nothing to fix in the code — only the quota to wait out.
+
+## Confirm quota was the cause
+
+Look for `ClaudeUsageCapError` or 429 / rate-limit phrasing in the stage
+output. When a reset time is present, `scan_quota_reset` (which delegates to
+`resolve_quota_reset_epoch`) extracts the reset epoch from the error text; not
+every 429 carries one.
+
+## Do NOT delete sessions
+
+The cap is enforced **API-side**, not session-side. Deleting Claude sessions
+does not restore quota and only discards resumable context — leave sessions
+intact.
+
+## When to re-run
+
+Wait for the Pacific-time session reset, then re-run the **same** invocation —
+the issue was never mis-labeled, so no cleanup is needed:
+
+```bash
+# Check the current Pacific time to gauge the reset window:
+TZ=America/Los_Angeles date
+
+# After the reset, re-run the SAME issues — nothing else to clean up:
+hephaestus-automation-loop --issues <N>
+```
+
+## See also
+
+- [Automation loop crashed mid-issue](automation-loop-crash.md)
+- [CI-driver stall (green-but-BLOCKED)](ci-driver-stall.md)

--- a/docs/runbooks/corrupted-worktree.md
+++ b/docs/runbooks/corrupted-worktree.md
@@ -1,0 +1,82 @@
+# Runbook: Recover a Corrupted Worktree State
+
+Use this when an issue's worktree under `<repo>/build/.worktrees/issue-<N>` is
+dirty, abandoned, or blocking a clean re-run. Recovery commands here come
+directly from the worktree-manager module docstring
+(`hephaestus/automation/worktree_manager.py`).
+
+## Background
+
+The automation pipeline creates one worktree per issue at
+`<repo_root>/build/.worktrees/issue-{N}`. Worktrees live inside the repo (not in
+`~/.tmp`) so an interrupted run leaves the worktree on disk for a later
+invocation to resume or surface. A non-forced removal of a worktree with
+uncommitted changes raises `WorktreeDirtyError`.
+
+## Locate
+
+```bash
+git -C <repo> worktree list --porcelain
+ls -la <repo>/build/.worktrees/issue-<N>
+```
+
+### Cross-repo hazard — check before any delete
+
+A `build/.worktrees/` directory can belong to a **different** repository and be
+invisible to this repo's `git worktree list`. Always confirm ownership before
+removing anything:
+
+```bash
+git -C <repo>/build/.worktrees/issue-<N> remote get-url origin
+```
+
+If `origin` points at a repo other than the one you are recovering, **stop** —
+that worktree belongs to another repo's automation.
+
+## Inspect dirty state
+
+```bash
+git -C <repo>/build/.worktrees/issue-<N> status
+git -C <repo>/build/.worktrees/issue-<N> diff --stat
+```
+
+Uncommitted changes are what cause a non-forced `worktree remove` to raise
+`WorktreeDirtyError`. Decide whether the in-flight work is worth keeping before
+you discard it.
+
+## Remove cleanly
+
+```bash
+# Refuses if the worktree is dirty (preserves uncommitted work):
+git -C <repo> worktree remove build/.worktrees/issue-<N>
+
+# Discards uncommitted work and removes anyway:
+git -C <repo> worktree remove --force build/.worktrees/issue-<N>
+```
+
+## Last resort
+
+If `git worktree remove` itself fails (corrupted git metadata), delete the
+directory and prune the stale administrative entry:
+
+```bash
+rm -rf <repo>/build/.worktrees/issue-<N>
+git -C <repo> worktree prune
+```
+
+## After worktree churn
+
+If the recovered worktree (or its removal) touched `pyproject.toml`, the pixi
+environment may have re-solved and dropped the editable install, leaving
+`hephaestus-*` console scripts dangling. Restore it:
+
+```bash
+pixi run dev-install
+```
+
+## See also
+
+- [Automation loop crashed mid-issue](automation-loop-crash.md)
+- `hephaestus:worktree-cleanup` skill — audit + prune git worktrees
+  (never deletes branches).
+- `hephaestus:tidy` skill — rebase all local branches.

--- a/docs/runbooks/index.md
+++ b/docs/runbooks/index.md
@@ -1,0 +1,38 @@
+# Operations Runbooks
+
+Operator recovery procedures for the `hephaestus.automation` pipeline. Start
+here when the automation loop, a worktree, the CI driver, or a Claude stage
+needs hands-on recovery.
+
+## Runbooks
+
+| Runbook | Use when |
+| ------- | -------- |
+| [Automation loop crashed mid-issue](automation-loop-crash.md) | The `hephaestus-automation-loop` process died or a phase timed out and you need to resume safely. |
+| [Recover a corrupted worktree state](corrupted-worktree.md) | An issue's `build/.worktrees/issue-<N>` worktree is dirty, abandoned, or blocking a clean re-run. |
+| [CI-driver stall (green-but-BLOCKED)](ci-driver-stall.md) | The CI driver exits cleanly each loop but PRs stay armed, green, and un-mergeable (`mergeStateStatus == BLOCKED`). |
+| [Claude quota exhausted (429)](claude-quota-exhausted.md) | A stage emits `Verdict: ERROR` and the issue is left unlabeled because the Claude API quota / session limit was hit. |
+| [No silent failures](no-silent-failures.md) | Policy reference: why `\|\| true`, `continue-on-error`, and advisory `::warning::` are forbidden, and how to fix a tripped hook. |
+
+## Before you start
+
+- **Pipeline stages** — the stage → module → console-script mapping lives in
+  [`../../AGENTS.md`](../../AGENTS.md). Use it to identify which module owns the
+  behavior you are recovering.
+- **PR & state-label policy** — the PR policy (signed commits, `Closes #N`,
+  auto-merge gating) lives in [`../../CLAUDE.md`](../../CLAUDE.md).
+
+## State-label reference
+
+The pipeline drives every issue through `state:*` labels (defined in
+`hephaestus/automation/state_labels.py`). This table is a manual quick-reference
+copy — the module is the source of truth.
+
+| Label | Meaning |
+| ----- | ------- |
+| `state:needs-plan` | Issue is queued for the planner (also the implicit state when no `state:*` label is present). |
+| `state:plan-go` | Plan reviewed and approved; ready for implementation. |
+| `state:plan-no-go` | Plan reviewed and rejected; needs re-planning. |
+| `state:implementation-go` | Implementation reviewed and approved; PR may arm auto-merge. |
+| `state:implementation-no-go` | Implementation reviewed and rejected; needs re-work. |
+| `state:skip` | Work item taken out of the loop entirely — operator-applied, or auto-applied when the review loop exhausts its budget without a GO. Independent of all other state labels. |


### PR DESCRIPTION
## Summary
Add four operator-focused runbooks for the automation pipeline covering crash recovery, CI driver stalls, quota exhaustion, and worktree corruption — addressing POLA principle gap in docs/runbooks/.

## Changes
- Add docs/runbooks/automation-loop-crash.md with recovery steps for mid-issue crashes
- Add docs/runbooks/ci-driver-stall.md with diagnosis and recovery for infinite loops
- Add docs/runbooks/claude-quota-exhausted.md with mitigation and resume procedures
- Add docs/runbooks/corrupted-worktree.md with detection and repair workflows
- Add docs/runbooks/index.md navigation for runbooks directory
- Update docs/index.md to link runbooks section

## Testing
- Verify all runbooks render correctly in markdown (no syntax errors)
- Check that runbook procedures reference correct paths and commands for current codebase
- Confirm all four recovery scenarios are documented with sufficient detail for operator execution

## Closes
Closes #1454

Generated by Claude Code via ProjectHephaestus automation.
