### PR TITLE
refactor(nats): remove pydantic from base dependency via dataclass migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ ProjectHephaestus ships two layers from one distribution:
   reviewers, loop runner, curses TUI).
 
 `import hephaestus` does **not** load `hephaestus.automation`, `curses`,
-`fcntl`, or `pydantic`. The boundary is enforced by
+`fcntl`, or `pydantic`, and a base `pip install` no longer pulls `pydantic`
+(it ships only in the `[automation]` extra). The boundary is enforced by
 `tests/unit/test_import_surface.py` and
 `tests/unit/test_automation_boundary.py`. See
 [`docs/adr/0001-automation-library-boundary.md`](docs/adr/0001-automation-library-boundary.md).

--- a/docs/adr/0001-automation-library-boundary.md
+++ b/docs/adr/0001-automation-library-boundary.md
@@ -39,9 +39,9 @@ Adopt a **dual-layer package** with four guarantees:
    `hephaestus-implement-issues`, `hephaestus-review-prs`,
    `hephaestus-agent-stage`, `hephaestus-ensure-state-labels`. They require
    the `[automation]` extra to be honest about their dependency surface.
-   Today they happen to run from a base install because `pydantic` is
-   currently also a base dependency (via `hephaestus.nats`); this is a
-   transitional state.
+   As of issue #1458, `pydantic` is no longer a base dependency — it ships
+   only in the `[automation]` extra, so a base install does not provide it
+   and these scripts genuinely require `[automation]`.
 
 4. **Boundary contract** — `hephaestus.automation` may import from any
    library subpackage; library subpackages MUST NOT import from
@@ -72,6 +72,8 @@ Adopt a **dual-layer package** with four guarantees:
   `sys.modules`.
 - `tests/unit/test_automation_boundary.py` fails CI if any library
   subpackage gains a `from hephaestus.automation` import.
-- If `hephaestus.nats` is ever stripped of its pydantic use (or moved
-  out), the base dependency list can drop pydantic and `[automation]`
-  becomes load-bearing rather than transitional.
+- `hephaestus.nats` was migrated off pydantic to stdlib dataclasses
+  (issue #1458; `load_nats_config` filters unknown keys to preserve the
+  prior tolerant-YAML behavior), so pydantic was dropped from the base
+  dependency list and `[automation]` is now load-bearing: a base install
+  no longer pulls pydantic.

--- a/hephaestus/nats/config.py
+++ b/hephaestus/nats/config.py
@@ -1,6 +1,6 @@
 """NATS connection configuration.
 
-Provides the :class:`NATSConfig` Pydantic model and a loader function that
+Provides the :class:`NATSConfig` dataclass and a loader function that
 reads from a YAML dict with optional environment variable overrides.
 
 Usage::
@@ -15,9 +15,8 @@ Usage::
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass, field as dataclass_field, fields as dataclass_fields
 from typing import Any, Literal
-
-from pydantic import BaseModel, Field, model_validator
 
 # Valid JetStream first-subscription deliver policies. These string values match
 # nats.js.api.DeliverPolicy's enum values, so the subscriber can build the enum
@@ -26,8 +25,16 @@ DeliverPolicyStr = Literal[
     "all", "last", "new", "by_start_sequence", "by_start_time", "last_per_subject"
 ]
 
+# Runtime allowlist mirroring DeliverPolicyStr. pydantic enforced the Literal at
+# construction; a stdlib dataclass does not, so __post_init__ checks membership
+# explicitly (subscriber.py builds a DeliverPolicy enum from this string).
+_DELIVER_POLICIES = frozenset(
+    {"all", "last", "new", "by_start_sequence", "by_start_time", "last_per_subject"}
+)
 
-class NATSConfig(BaseModel):
+
+@dataclass
+class NATSConfig:
     """NATS JetStream connection configuration.
 
     Attributes:
@@ -56,45 +63,43 @@ class NATSConfig(BaseModel):
 
     """
 
-    enabled: bool = Field(default=False, description="Enable NATS event subscription")
-    url: str = Field(default="nats://localhost:4222", description="NATS server URL")
-    stream: str = Field(default="TASKS", description="JetStream stream name")
-    subjects: list[str] = Field(
-        default_factory=list,
-        description="Subject patterns to subscribe to",
-    )
-    durable_name: str = Field(
-        default="hephaestus-subscriber",
-        description="Durable consumer name for at-least-once delivery",
-    )
-    deliver_policy: DeliverPolicyStr = Field(
-        default="new",
-        description="JetStream deliver policy (new, all, last, etc.)",
-    )
-    initial_backoff_seconds: float = Field(
-        default=1.0,
-        gt=0.0,
-        description="Initial wait (seconds) before the first reconnect attempt.",
-    )
-    max_backoff_seconds: float = Field(
-        default=60.0,
-        gt=0.0,
-        description="Upper bound (seconds) for exponential reconnect backoff.",
-    )
-    backoff_multiplier: float = Field(
-        default=2.0,
-        gt=1.0,
-        description="Multiplier applied to the current backoff after each failed reconnect.",
-    )
+    enabled: bool = False
+    url: str = "nats://localhost:4222"
+    stream: str = "TASKS"
+    subjects: list[str] = dataclass_field(default_factory=list)
+    durable_name: str = "hephaestus-subscriber"
+    deliver_policy: DeliverPolicyStr = "new"
+    initial_backoff_seconds: float = 1.0
+    max_backoff_seconds: float = 60.0
+    backoff_multiplier: float = 2.0
 
-    @model_validator(mode="after")
-    def _check_backoff_bounds(self) -> NATSConfig:
+    def __post_init__(self) -> None:
+        """Validate deliver-policy membership and backoff bounds.
+
+        Raises:
+            ValueError: If ``deliver_policy`` is not a known policy, a backoff
+                field is out of range, or ``max_backoff_seconds`` is below
+                ``initial_backoff_seconds``.
+
+        """
+        if self.deliver_policy not in _DELIVER_POLICIES:
+            raise ValueError(
+                f"deliver_policy must be one of {sorted(_DELIVER_POLICIES)}, "
+                f"got {self.deliver_policy!r}"
+            )
+        if self.initial_backoff_seconds <= 0.0:
+            raise ValueError(
+                f"initial_backoff_seconds must be > 0, got {self.initial_backoff_seconds}"
+            )
+        if self.max_backoff_seconds <= 0.0:
+            raise ValueError(f"max_backoff_seconds must be > 0, got {self.max_backoff_seconds}")
+        if self.backoff_multiplier <= 1.0:
+            raise ValueError(f"backoff_multiplier must be > 1, got {self.backoff_multiplier}")
         if self.max_backoff_seconds < self.initial_backoff_seconds:
             raise ValueError(
                 "max_backoff_seconds must be >= initial_backoff_seconds "
                 f"(got max={self.max_backoff_seconds}, initial={self.initial_backoff_seconds})"
             )
-        return self
 
     @classmethod
     def from_env(cls, **overrides: Any) -> NATSConfig:
@@ -208,4 +213,11 @@ def load_nats_config(
     if env_override:
         data = _apply_env_overrides(data)
 
-    return NATSConfig(**data)
+    # Pydantic's BaseModel silently dropped unknown keys; a stdlib dataclass
+    # raises TypeError on them. Preserve the historical tolerant-YAML contract
+    # (issue #1458): drop keys that are not NATSConfig fields so a typo'd or
+    # forward-compatible config block still loads. Direct NATSConfig(...) calls
+    # remain strict, which is the desired behavior for code callers.
+    known = {f.name for f in dataclass_fields(NATSConfig)}
+    filtered = {k: v for k, v in data.items() if k in known}
+    return NATSConfig(**filtered)

--- a/hephaestus/nats/events.py
+++ b/hephaestus/nats/events.py
@@ -15,9 +15,8 @@ Usage::
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, NamedTuple
-
-from pydantic import BaseModel, Field
 
 
 class SubjectParts(NamedTuple):
@@ -35,7 +34,8 @@ class SubjectParts(NamedTuple):
     verb: str
 
 
-class NATSEvent(BaseModel):
+@dataclass
+class NATSEvent:
     """Incoming NATS JetStream message payload.
 
     Attributes:
@@ -46,10 +46,20 @@ class NATSEvent(BaseModel):
 
     """
 
-    subject: str = Field(..., description="Full NATS subject string")
-    data: dict[str, Any] = Field(..., description="Decoded JSON message body")
-    timestamp: str = Field(..., description="ISO-8601 timestamp")
-    sequence: int = Field(..., ge=0, description="JetStream sequence number")
+    subject: str
+    data: dict[str, Any]
+    timestamp: str
+    sequence: int
+
+    def __post_init__(self) -> None:
+        """Validate the JetStream sequence number.
+
+        Raises:
+            ValueError: If ``sequence`` is negative.
+
+        """
+        if self.sequence < 0:
+            raise ValueError(f"sequence must be >= 0, got {self.sequence}")
 
 
 def parse_subject(subject: str, prefix: str = "hi.tasks") -> SubjectParts:

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,6 +46,9 @@ python = ">=3.10,<3.14"
 # Floor 23.0: first stable PEP 660 editable-install release; cap blocks the
 # next untested major (installed 26.x in CI). Bump cap after testing 27.x.
 pip = ">=23.0,<27"
+# pydantic is the runtime dep of hephaestus.automation (the [automation] extra).
+# It is intentionally NOT in pyproject [project.dependencies] — see issue #1458 /
+# ADR-0001. Kept here so the dev/test env can import hephaestus.automation.
 pydantic = ">=2.12.5,<3"
 pygments = ">=2.20.0"  # CVE-2026-4539
 pygithub = ">=2.9.1,<3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ keywords = ["utilities", "helpers", "tooling", "homericintelligence"]
 dependencies = [
     "packaging>=21.0,<27",
     "pyyaml>=6.0,<7",
-    "pydantic>=2.12.5,<3",
     # IANA timezone data is bundled with Python on POSIX but not on Windows;
     # rate_limit.py uses ZoneInfo which needs it on Windows.
     "tzdata; platform_system == 'Windows'",
@@ -84,11 +83,11 @@ nats = [
     "nats-py>=2.6,<3",
 ]
 # Product layer (hephaestus.automation). See docs/adr/0001-automation-library-boundary.md.
-# Explicitly declares the deps automation needs at runtime even though some are
-# also currently base deps (pydantic is pulled in transitionally via hephaestus.nats).
-# Listing them here means the extra is honest and forward-compatible: when the
-# base dep list shrinks, this extra remains load-bearing. CI verifies the
-# library-side import surface stays clean via tests/unit/test_import_surface.py.
+# pydantic is the runtime dependency of hephaestus/automation/models.py. As of
+# issue #1458 it is NO LONGER a base dependency (hephaestus.nats moved to stdlib
+# dataclasses), so this extra is now load-bearing: a base install does not get
+# pydantic. CI verifies the library-side import surface stays clean via
+# tests/unit/validation/test_import_surface.py.
 automation = [
     "pydantic>=2.12.5,<3",
 ]

--- a/tests/unit/nats/test_config.py
+++ b/tests/unit/nats/test_config.py
@@ -121,6 +121,13 @@ class TestLoadNATSConfig:
         config = load_nats_config({}, env_override=False)
         assert config.initial_backoff_seconds == 1.0
 
+    def test_extra_yaml_keys_ignored(self) -> None:
+        # Regression for issue #1458: NATSConfig moved from pydantic (which
+        # silently ignored extras) to a stdlib dataclass (which raises on
+        # unknown kwargs). load_nats_config must keep dropping unknown keys.
+        config = load_nats_config({"url": "nats://x:4222", "unknown_key": "ignored"})
+        assert config.url == "nats://x:4222"
+
 
 class TestFromEnv:
     """Tests for NATSConfig.from_env()."""

--- a/tests/unit/nats/test_events.py
+++ b/tests/unit/nats/test_events.py
@@ -16,9 +16,7 @@ class TestNATSEvent:
         assert event.sequence == 0
 
     def test_sequence_non_negative(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValueError):
             NATSEvent(subject="s", data={}, timestamp="", sequence=-1)
 
     def test_data_dict(self) -> None:

--- a/tests/unit/validation/test_base_dep_surface.py
+++ b/tests/unit/validation/test_base_dep_surface.py
@@ -1,0 +1,45 @@
+"""Regression test for ADR-0001 install-boundary resolution (issue #1458).
+
+`pip install HomericIntelligence-Hephaestus` (no [automation]) must NOT pull
+pydantic. pydantic now lives only in the [automation] extra; hephaestus.nats
+uses stdlib dataclasses. Companion to tests/unit/validation/test_import_surface.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+_PYPROJECT = Path(__file__).resolve().parents[3] / "pyproject.toml"
+
+
+def _data() -> dict:
+    return tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _name(spec: str) -> str:
+    for sep in ("<", ">", "=", "!", "~", ";", "["):
+        spec = spec.split(sep)[0]
+    return spec.strip()
+
+
+def test_pydantic_not_a_base_dependency() -> None:
+    """A base install (no [automation]) must not pull pydantic (issue #1458)."""
+    base = _data()["project"]["dependencies"]
+    offenders = [d for d in base if _name(d) == "pydantic"]
+    assert offenders == [], (
+        f"pydantic must not be a base dependency (ADR-0001 / issue #1458); found {offenders}"
+    )
+
+
+def test_pydantic_is_declared_in_automation_extra() -> None:
+    """Pydantic must stay declared in the [automation] extra (load-bearing)."""
+    extras = _data()["project"]["optional-dependencies"]["automation"]
+    assert any(_name(d) == "pydantic" for d in extras), (
+        "pydantic must remain declared in the [automation] extra (load-bearing per ADR-0001)"
+    )


### PR DESCRIPTION
## Summary
Migrates hephaestus.nats from pydantic models to Python dataclasses, removing pydantic as a transitive base dependency. This resolves the documented architectural boundary violation in ADR-0001, allowing pip install HomericIntelligence-Hephaestus to install without pydantic.

## Changes
- Replaced pydantic BaseModel with @dataclass in hephaestus/nats/config.py and events.py
- Updated ADR-0001 to reflect pydantic removal from the base dependency boundary
- Added test_base_dep_surface.py to enforce that base package imports do not pull pydantic
- Updated pyproject.toml and pixi.toml to move pydantic to [automation] extra only
- Updated documentation in README.md to reflect the cleaned dependency boundary

## Testing
- Existing unit tests for nats config and events pass with dataclass implementation
- New validation test (test_base_dep_surface.py) confirms pydantic is not imported in base surface
- Verify pip install HomericIntelligence-Hephaestus does not include pydantic

## Closes
Closes #1458

Generated by Claude Code via ProjectHephaestus automation.
