### PR TITLE
refactor(automation): hoist deferred tempfile import to module level

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -43,6 +43,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -396,8 +397,6 @@ def _make_work_report_path(build_dir: str) -> str:
         Path to a new temp file for work reporting.
 
     """
-    import tempfile
-
     build_path = Path(build_dir)
     build_path.mkdir(parents=True, exist_ok=True)
     fd, path = tempfile.mkstemp(prefix="work_report_", dir=str(build_path))


### PR DESCRIPTION
## Summary
Move deferred 'import tempfile' from inside _make_work_report_path() to module-level imports in loop_runner.py, improving code clarity and eliminating micro-overhead on repeated function calls.

## Changes
- Hoisted 'import tempfile' from function body to module-level imports in hephaestus/automation/loop_runner.py
- Follows PEP 8 import ordering and POLA principle for stdlib modules

## Testing
- Existing unit tests for loop_runner module pass without modification
- Verify _make_work_report_path() behavior unchanged by running automation tests

## Closes
Closes #1465

Generated by Claude Code via ProjectHephaestus automation.
