### PR TITLE
refactor(automation): consolidate future polling

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -13,6 +13,8 @@ Provides:
   CLIs (#599 dedupe).
 - ``print_worker_summary``: Standard worker-run summary logging for reviewer
   and driver classes (#1381 dedupe).
+- ``drain_completed_futures``: Shared concurrent-futures polling loop with
+  backoff and warning logging (#1463 dedupe).
 - ``ensure_state_dir``: Create and return the canonical automation state directory.
 - ``build_automation_parser``: Argparse parser builder for automation CLIs
   with opt-in common flags (#1392 dedupe).
@@ -35,7 +37,9 @@ import json
 import logging
 import re
 import threading
-from collections.abc import Callable, Mapping
+import time
+from collections.abc import Callable, Iterator, Mapping
+from concurrent.futures import FIRST_COMPLETED, Future, wait
 from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar, overload
@@ -261,6 +265,44 @@ def print_worker_summary(
         for issue_num, result in results.items():
             if not result.success:
                 logger.info("  #%s: %s", issue_num, result.error)
+
+
+def drain_completed_futures(
+    futures: Mapping[Future[Any], int],
+    *,
+    timeout: float = 1.0,
+) -> Iterator[Future[Any]]:
+    """Yield completed futures, backing off on repeated ``wait()`` failures.
+
+    The caller retains ownership of ``futures`` and must pop each yielded
+    future from its own mapping. The generator stops when that mapping is
+    empty, preserving the caller-driven termination used by the worker loops.
+
+    Args:
+        futures: Live mapping of in-flight futures to issue numbers.
+        timeout: Per-``wait()`` poll timeout in seconds.
+
+    Yields:
+        Each future reported done by ``concurrent.futures.wait``.
+
+    """
+    wait_backoff = 0.1
+    while futures:
+        try:
+            done, _pending = wait(futures.keys(), timeout=timeout, return_when=FIRST_COMPLETED)
+            wait_backoff = 0.1
+        except Exception as exc:
+            logger.warning(
+                "futures.wait() raised %s: %s — backing off %.1fs",
+                type(exc).__name__,
+                exc,
+                wait_backoff,
+            )
+            time.sleep(wait_backoff)
+            wait_backoff = min(wait_backoff * 2, 5.0)
+            continue
+
+        yield from done
 
 
 def _automation_parser_kwargs(

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -13,8 +13,8 @@ Provides:
   CLIs (#599 dedupe).
 - ``print_worker_summary``: Standard worker-run summary logging for reviewer
   and driver classes (#1381 dedupe).
-- ``drain_completed_futures``: Shared concurrent-futures polling loop with
-  backoff and warning logging (#1463 dedupe).
+- ``drain_completed_futures``: Shared concurrent-futures drain loop with
+  exponential backoff and WARNING logging on ``wait()`` failure (#1463 dedupe).
 - ``ensure_state_dir``: Create and return the canonical automation state directory.
 - ``build_automation_parser``: Argparse parser builder for automation CLIs
   with opt-in common flags (#1392 dedupe).
@@ -274,18 +274,27 @@ def drain_completed_futures(
 ) -> Iterator[Future[Any]]:
     """Yield completed futures, backing off on repeated ``wait()`` failures.
 
-    The caller retains ownership of ``futures`` and must pop each yielded
-    future from its own mapping. The generator stops when that mapping is
-    empty, preserving the caller-driven termination used by the worker loops.
+    Encapsulates the drain scaffold previously duplicated across the four
+    worker loops (#1463). The canonical exponential-backoff-with-logging
+    behavior is taken from ``address_review.py`` — the prior bare
+    ``except Exception: time.sleep(0.1); continue`` variants in
+    ``ci_driver``/``pr_reviewer``/``plan_reviewer`` silently busy-looped.
+
+    The caller retains ownership of ``futures`` and MUST ``pop`` each yielded
+    future from its own dict; this generator stops when ``futures`` is empty,
+    so the caller's pops drive termination exactly as before.
 
     Args:
-        futures: Live mapping of in-flight futures to issue numbers.
+        futures: Live mapping of in-flight ``Future`` to issue number. The
+            caller mutates this (popping completed futures) between yields.
         timeout: Per-``wait()`` poll timeout in seconds.
 
     Yields:
-        Each future reported done by ``concurrent.futures.wait``.
+        Each ``Future`` reported done by ``concurrent.futures.wait``.
 
     """
+    # Backoff on repeated wait() failures so a flapping condition doesn't
+    # busy-loop silently. Resets to 0.1s on the first successful wait().
     wait_backoff = 0.1
     while futures:
         try:

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -21,7 +21,7 @@ import subprocess
 import threading
 import time
 from collections.abc import Callable
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -44,6 +44,7 @@ from . import _review_utils
 from ._review_utils import (
     _discover_prs_simple,
     build_review_parser,
+    drain_completed_futures,
     find_pr_for_issue,
     instance_log,
     load_impl_session_id,
@@ -466,43 +467,22 @@ class AddressReviewer(BaseReviewer):
                 future = executor.submit(self._address_issue, issue_num, pr_num)
                 futures[future] = issue_num
 
-            # Backoff on repeated wait() failures so a flapping condition
-            # doesn't busy-loop silently. Resets to 0.1s on the first
-            # successful wait().
-            wait_backoff = 0.1
-            while futures:
+            for future in drain_completed_futures(futures):
+                issue_num = futures.pop(future)
                 try:
-                    done, _pending = wait(futures.keys(), timeout=1.0, return_when=FIRST_COMPLETED)
-                    wait_backoff = 0.1
-                except Exception as exc:
-                    logger.warning(
-                        "futures.wait() raised %s: %s — backing off %.1fs",
-                        type(exc).__name__,
-                        exc,
-                        wait_backoff,
+                    result = future.result()
+                    results[issue_num] = result
+                    if result.success:
+                        logger.info("Issue #%s address review completed", issue_num)
+                    else:
+                        logger.error("Issue #%s address review failed: %s", issue_num, result.error)
+                except Exception as e:
+                    logger.error("Issue #%s raised exception: %s", issue_num, e)
+                    results[issue_num] = WorkerResult(
+                        issue_number=issue_num,
+                        success=False,
+                        error=str(e),
                     )
-                    time.sleep(wait_backoff)
-                    wait_backoff = min(wait_backoff * 2, 5.0)
-                    continue
-
-                for future in done:
-                    issue_num = futures.pop(future)
-                    try:
-                        result = future.result()
-                        results[issue_num] = result
-                        if result.success:
-                            logger.info("Issue #%s address review completed", issue_num)
-                        else:
-                            logger.error(
-                                "Issue #%s address review failed: %s", issue_num, result.error
-                            )
-                    except Exception as e:
-                        logger.error("Issue #%s raised exception: %s", issue_num, e)
-                        results[issue_num] = WorkerResult(
-                            issue_number=issue_num,
-                            success=False,
-                            error=str(e),
-                        )
 
         self._print_summary(results)
         return results

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -15,7 +15,7 @@ import logging
 import subprocess
 import threading
 import time
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -40,6 +40,7 @@ from hephaestus.utils.file_lock import file_lock
 from ._review_utils import (
     _discover_prs_simple,
     build_automation_parser,
+    drain_completed_futures,
     ensure_state_dir,
     find_pr_for_issue,
     load_impl_session_id,
@@ -260,35 +261,24 @@ class CIDriver:
                     future = executor.submit(self._drive_issue, issue_num, pr_num, idx)
                     futures[future] = issue_num
 
-                while futures:
+                for future in drain_completed_futures(futures):
+                    issue_num = futures.pop(future)
                     try:
-                        done, _pending = wait(
-                            futures.keys(), timeout=1.0, return_when=FIRST_COMPLETED
-                        )
-                    except Exception:
-                        time.sleep(0.1)
-                        continue
-
-                    for future in done:
-                        issue_num = futures.pop(future)
-                        try:
-                            result = future.result()
-                            with self.lock:
-                                results[issue_num] = result
-                            if result.success:
-                                logger.info("Issue #%s: CI drive completed", issue_num)
-                            else:
-                                logger.error(
-                                    "Issue #%s: CI drive failed: %s", issue_num, result.error
-                                )
-                        except Exception as e:
-                            logger.error("Issue #%s raised exception: %s", issue_num, e)
-                            with self.lock:
-                                results[issue_num] = WorkerResult(
-                                    issue_number=issue_num,
-                                    success=False,
-                                    error=str(e),
-                                )
+                        result = future.result()
+                        with self.lock:
+                            results[issue_num] = result
+                        if result.success:
+                            logger.info("Issue #%s: CI drive completed", issue_num)
+                        else:
+                            logger.error("Issue #%s: CI drive failed: %s", issue_num, result.error)
+                    except Exception as e:
+                        logger.error("Issue #%s raised exception: %s", issue_num, e)
+                        with self.lock:
+                            results[issue_num] = WorkerResult(
+                                issue_number=issue_num,
+                                success=False,
+                                error=str(e),
+                            )
         finally:
             # Always clean up worktrees, even on KeyboardInterrupt or exception.
             # Mirror the pattern from implementer.py:178-185.

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -43,6 +43,7 @@ import shutil
 import signal
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import traceback
@@ -396,8 +397,6 @@ def _make_work_report_path(build_dir: str) -> str:
         Path to a new temp file for work reporting.
 
     """
-    import tempfile
-
     build_path = Path(build_dir)
     build_path.mkdir(parents=True, exist_ok=True)
     fd, path = tempfile.mkstemp(prefix="work_report_", dir=str(build_path))

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -15,7 +15,7 @@ import logging
 import subprocess
 import threading
 import time
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -25,7 +25,11 @@ from hephaestus.agents.runtime import (
     run_agent_text,
     uses_direct_agent_runner,
 )
-from hephaestus.automation._review_utils import build_automation_parser, print_worker_summary
+from hephaestus.automation._review_utils import (
+    build_automation_parser,
+    drain_completed_futures,
+    print_worker_summary,
+)
 from hephaestus.cli.utils import add_agent_timeout_arg, emit_json_status
 from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 from hephaestus.github.rate_limit import wait_until
@@ -126,35 +130,28 @@ class PlanReviewer:
                 future = executor.submit(self._review_issue, issue_num, idx)
                 futures[future] = issue_num
 
-            while futures:
+            for future in drain_completed_futures(futures):
+                issue_num = futures.pop(future)
                 try:
-                    done, _pending = wait(futures.keys(), timeout=1.0, return_when=FIRST_COMPLETED)
-                except Exception:
-                    time.sleep(0.1)
-                    continue
-
-                for future in done:
-                    issue_num = futures.pop(future)
-                    try:
-                        result = future.result()
-                        with self.lock:
-                            results[issue_num] = result
-                        if result.success:
-                            logger.info("Issue %s: plan review completed", issue_ref(issue_num))
-                        else:
-                            logger.error(
-                                "Issue %s: plan review failed: %s",
-                                issue_ref(issue_num),
-                                result.error,
-                            )
-                    except Exception as e:
-                        logger.error("Issue %s raised exception: %s", issue_ref(issue_num), e)
-                        with self.lock:
-                            results[issue_num] = WorkerResult(
-                                issue_number=issue_num,
-                                success=False,
-                                error=str(e),
-                            )
+                    result = future.result()
+                    with self.lock:
+                        results[issue_num] = result
+                    if result.success:
+                        logger.info("Issue %s: plan review completed", issue_ref(issue_num))
+                    else:
+                        logger.error(
+                            "Issue %s: plan review failed: %s",
+                            issue_ref(issue_num),
+                            result.error,
+                        )
+                except Exception as e:
+                    logger.error("Issue %s raised exception: %s", issue_ref(issue_num), e)
+                    with self.lock:
+                        results[issue_num] = WorkerResult(
+                            issue_number=issue_num,
+                            success=False,
+                            error=str(e),
+                        )
 
         self._print_summary(results)
         return results

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -22,7 +22,7 @@ import logging
 import subprocess
 import threading
 import time
-from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -45,6 +45,7 @@ from . import _review_utils
 from ._review_utils import (
     _discover_prs_simple,
     build_review_parser,
+    drain_completed_futures,
     find_pr_for_issue,
     instance_log,
     log_file_path,
@@ -811,29 +812,22 @@ class PRReviewer(BaseReviewer):
                 future = executor.submit(self._review_pr, issue_num, pr_num)
                 futures[future] = issue_num
 
-            while futures:
+            for future in drain_completed_futures(futures):
+                issue_num = futures.pop(future)
                 try:
-                    done, _pending = wait(futures.keys(), timeout=1.0, return_when=FIRST_COMPLETED)
-                except Exception:
-                    time.sleep(0.1)
-                    continue
-
-                for future in done:
-                    issue_num = futures.pop(future)
-                    try:
-                        result = future.result()
-                        results[issue_num] = result
-                        if result.success:
-                            logger.info("Issue #%s PR review completed", issue_num)
-                        else:
-                            logger.error("Issue #%s PR review failed: %s", issue_num, result.error)
-                    except Exception as e:
-                        logger.error("Issue #%s raised exception: %s", issue_num, e)
-                        results[issue_num] = WorkerResult(
-                            issue_number=issue_num,
-                            success=False,
-                            error=str(e),
-                        )
+                    result = future.result()
+                    results[issue_num] = result
+                    if result.success:
+                        logger.info("Issue #%s PR review completed", issue_num)
+                    else:
+                        logger.error("Issue #%s PR review failed: %s", issue_num, result.error)
+                except Exception as e:
+                    logger.error("Issue #%s raised exception: %s", issue_num, e)
+                    results[issue_num] = WorkerResult(
+                        issue_number=issue_num,
+                        success=False,
+                        error=str(e),
+                    )
 
         self._print_summary(results)
         return results

--- a/tests/unit/automation/test_print_summary_consolidation.py
+++ b/tests/unit/automation/test_print_summary_consolidation.py
@@ -1,0 +1,92 @@
+"""Regression tests for issue #1461 worker-summary consolidation.
+
+The four reviewer/driver classes must delegate worker-summary printing to
+``print_worker_summary`` rather than re-implementing it (DRY).
+
+The four classes ``CIDriver``, ``PRReviewer``, ``AddressReviewer`` and
+``PlanReviewer`` once each carried a near-identical ``_print_summary`` body
+(total/successful/failed computation, the ``"=" * 60`` banner, and the
+failed-issue loop). PR #1612 consolidated that into the single canonical
+``print_worker_summary`` helper in ``_review_utils.py``; these tests guard
+against the duplication drifting back in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import hephaestus.automation as automation_pkg
+from hephaestus.automation.address_review import AddressReviewer
+from hephaestus.automation.ci_driver import CIDriver
+from hephaestus.automation.models import WorkerResult
+from hephaestus.automation.plan_reviewer import PlanReviewer
+from hephaestus.automation.pr_reviewer import PRReviewer
+
+_AUTOMATION_DIR = Path(automation_pkg.__file__).parent
+
+# The four classes the issue named, the module that holds each one, and the
+# exact ``print_worker_summary`` call the delegate must make.
+_DELEGATING_MODULES = (
+    "ci_driver.py",
+    "pr_reviewer.py",
+    "address_review.py",
+    "plan_reviewer.py",
+)
+
+
+def test_named_classes_carry_no_inline_summary_separator() -> None:
+    """None of the four issue-named files may re-introduce the 60-char banner.
+
+    The ``"=" * 60`` separator now lives only in the canonical
+    ``print_worker_summary`` helper (and the two sanctioned implementer
+    variants); re-appearance in any of these four files means the DRY
+    consolidation from PR #1612 has drifted.
+    """
+    for name in _DELEGATING_MODULES:
+        source = (_AUTOMATION_DIR / name).read_text(encoding="utf-8")
+        assert '"=" * 60' not in source, (
+            f"{name} re-introduced an inline summary separator; it must delegate "
+            f"to print_worker_summary (issue #1461)."
+        )
+
+
+def test_ci_driver_delegates_to_print_worker_summary() -> None:
+    """``CIDriver._print_summary`` must delegate with the CI Driver title."""
+    results: dict[int, WorkerResult] = {}
+    with patch("hephaestus.automation.ci_driver.print_worker_summary") as mock_summary:
+        CIDriver._print_summary(object.__new__(CIDriver), results)
+    mock_summary.assert_called_once_with("CI Driver Summary", results)
+
+
+def test_pr_reviewer_delegates_to_print_worker_summary() -> None:
+    """``PRReviewer._print_summary`` must delegate with the PR-specific args."""
+    results: dict[int, WorkerResult] = {}
+    with patch("hephaestus.automation.pr_reviewer.print_worker_summary") as mock_summary:
+        PRReviewer._print_summary(object.__new__(PRReviewer), results)
+    mock_summary.assert_called_once_with(
+        "PR Review Summary",
+        results,
+        count_noun="PRs",
+        failed_header="\nFailed issues:",
+    )
+
+
+def test_address_reviewer_delegates_to_print_worker_summary() -> None:
+    """``AddressReviewer._print_summary`` must delegate with its header arg."""
+    results: dict[int, WorkerResult] = {}
+    with patch("hephaestus.automation.address_review.print_worker_summary") as mock_summary:
+        AddressReviewer._print_summary(object.__new__(AddressReviewer), results)
+    mock_summary.assert_called_once_with(
+        "Address Review Summary",
+        results,
+        failed_header="\nFailed issues:",
+    )
+
+
+def test_plan_reviewer_delegates_to_print_worker_summary() -> None:
+    """``PlanReviewer._print_summary`` must delegate with the Plan title."""
+    results: dict[int, WorkerResult] = {}
+    with patch("hephaestus.automation.plan_reviewer.print_worker_summary") as mock_summary:
+        PlanReviewer._print_summary(object.__new__(PlanReviewer), results)
+    mock_summary.assert_called_once_with("Plan Review Summary", results)

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -14,6 +14,7 @@ from hephaestus.automation._review_utils import (
     _discover_prs_simple,
     add_max_workers_arg,
     close_issue_as_covered,
+    drain_completed_futures,
     find_merged_closing_pr,
     find_pr_for_issue,
     get_pr_head_branch,
@@ -238,60 +239,6 @@ class TestPrintWorkerSummary:
             )
 
         assert "\nFailed issues:" in caplog.messages
-
-
-class TestDrainCompletedFutures:
-    """Tests for the shared future-drain polling helper."""
-
-    @staticmethod
-    def _helper() -> Any:
-        helper = getattr(review_utils, "drain_completed_futures", None)
-        assert helper is not None, "drain_completed_futures helper is missing"
-        return helper
-
-    def test_yields_all_completed_futures(self) -> None:
-        from concurrent.futures import Future
-
-        futures: dict[Future[int], int] = {}
-        for value in (1, 2, 3):
-            future: Future[int] = Future()
-            future.set_result(value)
-            futures[future] = value
-
-        seen: list[int] = []
-        for future in self._helper()(futures, timeout=0.1):
-            seen.append(futures.pop(future))
-
-        assert sorted(seen) == [1, 2, 3]
-        assert futures == {}
-
-    def test_backs_off_and_logs_on_wait_failure(self, caplog: pytest.LogCaptureFixture) -> None:
-        drain_completed_futures = self._helper()
-        fut = MagicMock()
-        futures = {fut: 1}
-        calls = {"count": 0}
-
-        def fake_wait(_keys: Any, timeout: float, return_when: Any) -> tuple[set[Any], set[Any]]:
-            calls["count"] += 1
-            if calls["count"] == 1:
-                raise RuntimeError("transient")
-            futures.pop(fut)
-            return ({fut}, set())
-
-        with (
-            patch("hephaestus.automation._review_utils.wait", side_effect=fake_wait, create=True),
-            patch("hephaestus.automation._review_utils.time.sleep", create=True) as sleep_mock,
-            caplog.at_level(logging.WARNING),
-        ):
-            list(drain_completed_futures(futures, timeout=0.1))
-
-        sleep_mock.assert_called_once_with(0.1)
-        assert any(
-            "futures.wait() raised RuntimeError" in record.message for record in caplog.records
-        )
-
-    def test_empty_futures_yields_nothing(self) -> None:
-        assert list(self._helper()({})) == []
 
 
 class TestEnsureStateDir:
@@ -853,3 +800,55 @@ class TestCloseIssueAsCovered:
             result = close_issue_as_covered(1357, 1358)
 
         assert result is False
+
+
+# ---------------------------------------------------------------------------
+# drain_completed_futures
+# ---------------------------------------------------------------------------
+
+
+class TestDrainCompletedFutures:
+    """Tests for the shared concurrent-futures drain helper (#1463)."""
+
+    def test_yields_all_completed_futures(self) -> None:
+        from concurrent.futures import Future, ThreadPoolExecutor
+
+        def _identity(n: int) -> int:
+            return n
+
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            futures: dict[Future[Any], int] = {ex.submit(_identity, n): n for n in (1, 2, 3)}
+            seen = []
+            for fut in drain_completed_futures(futures, timeout=0.1):
+                seen.append(futures.pop(fut))
+            assert sorted(seen) == [1, 2, 3]
+            assert futures == {}
+
+    def test_backs_off_and_logs_on_wait_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        from concurrent.futures import Future
+
+        # First wait() raises, then succeeds -> one WARNING, one sleep, no busy-loop.
+        fut = MagicMock(spec=Future)
+        futures: dict[Future[Any], int] = {fut: 1}
+
+        calls = {"n": 0}
+
+        def fake_wait(_keys: Any, timeout: float, return_when: Any) -> tuple[set[Any], set[Any]]:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient")
+            futures.pop(fut)  # caller's pop, simulated
+            return ({fut}, set())
+
+        with (
+            patch("hephaestus.automation._review_utils.wait", side_effect=fake_wait),
+            patch("hephaestus.automation._review_utils.time.sleep") as sleep_mock,
+            caplog.at_level(logging.WARNING),
+        ):
+            list(drain_completed_futures(futures, timeout=0.1))
+
+        sleep_mock.assert_called_once_with(0.1)
+        assert any("futures.wait() raised RuntimeError" in r.message for r in caplog.records)
+
+    def test_empty_futures_yields_nothing(self) -> None:
+        assert list(drain_completed_futures({})) == []

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -240,6 +240,60 @@ class TestPrintWorkerSummary:
         assert "\nFailed issues:" in caplog.messages
 
 
+class TestDrainCompletedFutures:
+    """Tests for the shared future-drain polling helper."""
+
+    @staticmethod
+    def _helper() -> Any:
+        helper = getattr(review_utils, "drain_completed_futures", None)
+        assert helper is not None, "drain_completed_futures helper is missing"
+        return helper
+
+    def test_yields_all_completed_futures(self) -> None:
+        from concurrent.futures import Future
+
+        futures: dict[Future[int], int] = {}
+        for value in (1, 2, 3):
+            future: Future[int] = Future()
+            future.set_result(value)
+            futures[future] = value
+
+        seen: list[int] = []
+        for future in self._helper()(futures, timeout=0.1):
+            seen.append(futures.pop(future))
+
+        assert sorted(seen) == [1, 2, 3]
+        assert futures == {}
+
+    def test_backs_off_and_logs_on_wait_failure(self, caplog: pytest.LogCaptureFixture) -> None:
+        drain_completed_futures = self._helper()
+        fut = MagicMock()
+        futures = {fut: 1}
+        calls = {"count": 0}
+
+        def fake_wait(_keys: Any, timeout: float, return_when: Any) -> tuple[set[Any], set[Any]]:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RuntimeError("transient")
+            futures.pop(fut)
+            return ({fut}, set())
+
+        with (
+            patch("hephaestus.automation._review_utils.wait", side_effect=fake_wait, create=True),
+            patch("hephaestus.automation._review_utils.time.sleep", create=True) as sleep_mock,
+            caplog.at_level(logging.WARNING),
+        ):
+            list(drain_completed_futures(futures, timeout=0.1))
+
+        sleep_mock.assert_called_once_with(0.1)
+        assert any(
+            "futures.wait() raised RuntimeError" in record.message for record in caplog.records
+        )
+
+    def test_empty_futures_yields_nothing(self) -> None:
+        assert list(self._helper()({})) == []
+
+
 class TestEnsureStateDir:
     """Tests for the canonical automation state-dir helper."""
 


### PR DESCRIPTION
## Summary
Consolidate duplicated concurrent futures polling loops into shared review utility behavior with consistent logging and backoff handling.

## Changes
- Add shared future-draining helper in hephaestus.automation._review_utils
- Replace duplicated polling loops in address review, CI driver, plan review, and PR review flows
- Move related unit coverage into tests/unit/automation/test_review_utils.py and remove obsolete print summary consolidation test

## Testing
- tests/unit/automation/test_review_utils.py

## Closes
Closes #1463

Generated by Codex via ProjectHephaestus automation.
