### PR TITLE
refactor(validation): remove bare pass in extract_cvss_score

### DIFF
--- a/hephaestus/validation/audit.py
+++ b/hephaestus/validation/audit.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
-import re
 import sys
 from pathlib import Path
 from typing import Any, cast
@@ -24,8 +23,6 @@ from hephaestus.cli.utils import create_validation_parser, emit_json_status, for
 from hephaestus.utils.helpers import get_repo_root
 
 HIGH_THRESHOLD: float = 7.0
-
-CVSS_PATTERN = re.compile(r"CVSS:\d+\.\d+/.*")
 
 
 def load_ignore_list(path: Path | None = None) -> frozenset[str]:
@@ -74,8 +71,6 @@ def extract_cvss_score(severity_list: list[dict[str, Any]]) -> float | None:
         score_str = entry.get("score", "")
         if isinstance(score_str, (int, float)):
             scores.append(float(score_str))
-        elif isinstance(score_str, str) and CVSS_PATTERN.match(score_str):
-            pass
         numeric = entry.get("base_score") or entry.get("cvss_score")
         if numeric is not None:
             with contextlib.suppress(TypeError, ValueError):


### PR DESCRIPTION
## Summary
Remove the bare `pass` statement in the CVSS vector string branch of `extract_cvss_score()`. The branch intentionally does nothing — it recognizes CVSS vector strings (e.g., 'CVSS:3.1/AV:N/...') but delegates numeric extraction to the subsequent base_score/cvss_score lookup. The bare `pass` created ambiguity about incomplete parsing; deleting it clarifies the intentional control flow.

## Changes
- Removed bare `pass` statement from elif branch that matches CVSS vector strings in extract_cvss_score()
- Simplifies control flow by eliminating the do-nothing branch; numeric score extraction now flows directly to base_score/cvss_score logic

## Testing
- Existing test at line 61 confirms pure CVSS-vector entries return None (intentional behavior preserved)
- No functional change to extract_cvss_score() return values or behavior

## Closes
Closes #1466

Generated by Claude Code via ProjectHephaestus automation.
