### PR TITLE
test(automation): add property-based testing for LLM output parsers

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -47,10 +47,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/coverage-7.13.5-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
@@ -64,6 +66,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.29.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-1.2.2-py_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
@@ -93,6 +96,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.5.22.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260408-pyhcf101f3_1.conda
@@ -110,7 +114,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/bb/6dfa7e6f4eeed22d3311af76256615da637f821d584cf7b7aab5f4cbffc5/pdoc-14.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/30/09/fe0e3bc32bd33707c519b102fc064ad2a2ce5a1b53e2be38b86936b476b1/cyclonedx_python_lib-11.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/d3/36a46a8ed992b781acbc05928bd5bee3c810cb0c3563bf81a7b0c04a1a76/msgpack-1.2.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
@@ -132,10 +135,12 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.6.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.3-pyhcf101f3_0.conda
@@ -147,6 +152,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.30.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/identify-2.6.19-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.18-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
@@ -175,6 +181,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pyyaml-6.0.12.20260518-pyhcf101f3_0.conda
@@ -226,7 +233,6 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/22/f3/56ccb2884aaa3db5622368e5191a3384b15f35392aa93df8b2f508c660d2/cyclonedx_python_lib-11.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/bb/6dfa7e6f4eeed22d3311af76256615da637f821d584cf7b7aab5f4cbffc5/pdoc-14.7.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/d0/d04f1d1e064ac901439699ee097f58688caadea42498ec9c4b4ad2ef84ab/pip_requirements_parser-32.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/71/fbcfa83a1d6a9c6091942d1cfd070962244664b87427a9a49a6897b1b219/msgpack-1.2.1-cp313-cp313-macosx_11_0_arm64.whl
@@ -966,6 +972,19 @@ packages:
   run_exports: {}
   size: 18074
   timestamp: 1733247158254
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+  sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
+  md5: c6b0543676ecb1fb2d7643941fe375f2
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/attrs?source=hash-mapping
+  run_exports: {}
+  size: 64927
+  timestamp: 1773935801332
 - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
   sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
   md5: e18ad67cf881dcadee8b8d9e2f8e5f73
@@ -1030,6 +1049,20 @@ packages:
   run_exports: {}
   size: 58872
   timestamp: 1775127203018
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
+  sha256: c253a41cdf898b651a0786cbb76c6d5fc101d0dbbe719f93a124bc4fde5cdd6a
+  md5: 554304a07e581a85891b15e39ea9f268
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click?source=compressed-mapping
+  run_exports: {}
+  size: 104999
+  timestamp: 1779900548735
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -1240,6 +1273,23 @@ packages:
   run_exports: {}
   size: 17397
   timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.155.7-pyha770c72_0.conda
+  sha256: 2e875ba47b4453c372d5cd6ab8233b14d4d5319fe1be70378aff9425ca25ee0e
+  md5: 699483c625c9ed7e43b766777ea3721d
+  depends:
+  - attrs >=22.2.0
+  - click >=7.0
+  - exceptiongroup >=1.0.0
+  - python >=3.10
+  - setuptools
+  - sortedcontainers >=2.1.0,<3.0.0
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls:
+  - pkg:pypi/hypothesis?source=hash-mapping
+  run_exports: {}
+  size: 395304
+  timestamp: 1782032214440
 - conda: https://conda.anaconda.org/conda-forge/noarch/identify-1.2.2-py_0.tar.bz2
   sha256: 8b7a313fb8a50936b32054a01dd044874616e35b4e239bb7d2a42e30e7ab0a5d
   md5: 4b64d3379406ae93336bbc6ea9f5128a
@@ -1763,6 +1813,18 @@ packages:
   run_exports: {}
   size: 18455
   timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+  sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
+  md5: 0401a17ae845fa72c7210e206ec5647d
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/sortedcontainers?source=hash-mapping
+  run_exports: {}
+  size: 28657
+  timestamp: 1738440459037
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
   md5: b5325cf06a000c5b14970462ff5e4d58

--- a/pixi.toml
+++ b/pixi.toml
@@ -86,6 +86,8 @@ msgpack = ">=1.2.1,<2"
 [feature.dev.dependencies]
 pytest = ">=9.0.0,<10"
 pytest-cov = ">=7.0.0,<8"
+# Property-based fuzz testing of LLM-output parsers (issue #1470).
+hypothesis = ">=6.0,<7"
 just = ">=1.25.0,<2"
 bats-core = ">=1.11.0,<2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ dev = [
     "hatchling>=1.27.0,<2",
     "hatch-vcs>=0.4.0,<1",
     "pip-audit>=2.7,<3",
+    # Property-based fuzz testing of LLM-output parsers (issue #1470). Floor
+    # kept in lockstep with pixi.toml [feature.dev]. hypothesis is on conda-forge,
+    # so the matching pixi entry is a conda dependency, not pypi-dependencies.
+    "hypothesis>=6.0,<7",
     "tomli>=2.0,<3;python_version<'3.11'",
 ]
 github = [

--- a/tests/unit/automation/test_address_review_property.py
+++ b/tests/unit/automation/test_address_review_property.py
@@ -1,0 +1,47 @@
+"""Property-based (Hypothesis) fuzz tests for the address-review JSON parser.
+
+Covers issue #1470 — ``_parse_addressed_block`` consumes free-form LLM output
+and must never raise; on malformed/absent JSON it returns the documented
+default shape. See hephaestus/automation/address_review.py:81.
+"""
+
+from __future__ import annotations
+
+import json
+
+from hypothesis import given, strategies as st
+
+from hephaestus.automation.address_review import (
+    _ADDRESS_PARSE_DEFAULT,
+    _parse_addressed_block,
+)
+
+
+class TestParseAddressedBlockProperties:
+    """Property-based fuzz coverage for _parse_addressed_block (#1470)."""
+
+    @given(st.text())
+    def test_never_raises_and_returns_dict(self, text: str) -> None:
+        assert isinstance(_parse_addressed_block(text), dict)
+
+    @given(st.text())
+    def test_non_json_input_returns_default_shape(self, text: str) -> None:
+        # Inputs with no ```json fence resolve to the documented default.
+        if "```json" not in text:
+            assert _parse_addressed_block(text) == _ADDRESS_PARSE_DEFAULT
+
+    @given(st.text())
+    def test_malformed_json_fence_does_not_raise(self, junk: str) -> None:
+        body = f"prefix\n```json\n{junk}\n```\nsuffix"
+        assert isinstance(_parse_addressed_block(body), dict)
+
+    @given(
+        st.dictionaries(st.text(), st.text(), max_size=5),
+        st.dictionaries(st.text(), st.text(), max_size=5),
+    )
+    def test_wellformed_json_block_is_parsed(
+        self, addressed: dict[str, str], replies: dict[str, str]
+    ) -> None:
+        payload = {"addressed": list(addressed), "replies": replies}
+        body = f"```json\n{json.dumps(payload)}\n```"
+        assert _parse_addressed_block(body)["replies"] == replies

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -8,6 +8,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from hypothesis import given, strategies as st
 
 from hephaestus.automation.audit_reviewer import (
     AuditReviewer,
@@ -492,3 +493,30 @@ class TestParser:
         with pytest.raises(SystemExit) as exc_info:
             parser.parse_args(["--help"])
         assert exc_info.value.code == 0
+
+
+class TestParseCoordinatorResultsProperties:
+    """Property-based fuzz coverage for _parse_coordinator_results (#1470)."""
+
+    @given(st.text())
+    def test_never_raises_returns_list_of_dicts(self, text: str) -> None:
+        result = _parse_coordinator_results(text)
+        assert isinstance(result, list)
+        assert all(isinstance(item, dict) for item in result)
+
+    @given(st.text())
+    def test_no_json_fence_returns_empty(self, text: str) -> None:
+        if "```json" not in text:
+            assert _parse_coordinator_results(text) == []
+
+    @given(st.text(max_size=200))
+    def test_malformed_fence_is_skipped_not_raised(self, junk: str) -> None:
+        # A malformed JSON fence must be dropped, never raise (audit_reviewer.py:60).
+        body = f"```json\n{junk}\n```"
+        assert isinstance(_parse_coordinator_results(body), list)
+
+    @given(st.integers(), st.text(max_size=120))
+    def test_wellformed_pr_block_parsed(self, pr_number: int, summary: str) -> None:
+        body = f'```json\n{{"pr_number": {pr_number}, "summary": {json.dumps(summary)}}}\n```'
+        result = _parse_coordinator_results(body)
+        assert result and result[0]["pr_number"] == pr_number

--- a/tests/unit/automation/test_claude_invoke.py
+++ b/tests/unit/automation/test_claude_invoke.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from hypothesis import given, strategies as st
 
 from hephaestus.automation.claude_invoke import (
     INFRA_ERROR_REVIEW_TEXT,
@@ -196,3 +197,32 @@ class TestRaiseForErrorEnvelope:
 
         raise_for_error_envelope("just some prose")
         raise_for_error_envelope("")
+
+
+# Verdict fragments Hypothesis interleaves with arbitrary text to exercise the
+# structured branches of the parser, not just unicode noise (issue #1470).
+_VERDICT_TOKENS = ["GO", "NOGO", "NO-GO", "NO GO", "ERROR"]
+
+
+class TestParseReviewVerdictProperties:
+    """Property-based fuzz coverage for parse_review_verdict (#1470)."""
+
+    @given(st.text())
+    def test_never_raises_and_preserves_raw(self, text: str) -> None:
+        result = parse_review_verdict(text)
+        assert isinstance(result, ReviewVerdict)
+        assert result.raw == text
+        assert result.verdict in {"GO", "NOGO", "ERROR", "AMBIGUOUS"}
+
+    @given(st.text())
+    def test_no_verdict_marker_is_ambiguous(self, text: str) -> None:
+        # Text with no "verdict" token must resolve to AMBIGUOUS (fail-safe).
+        if "verdict" not in text.lower():
+            assert parse_review_verdict(text).verdict == "AMBIGUOUS"
+
+    @given(st.sampled_from(_VERDICT_TOKENS), st.text(max_size=200))
+    def test_anchored_verdict_line_classifies(self, token: str, noise: str) -> None:
+        body = f"{noise}\nVerdict: {token}\n"
+        normalized = token.replace("-", "").replace(" ", "")
+        expected = {"GO": "GO", "ERROR": "ERROR"}.get(normalized, "NOGO")
+        assert parse_review_verdict(body).verdict == expected

--- a/tests/unit/automation/test_review_state.py
+++ b/tests/unit/automation/test_review_state.py
@@ -17,6 +17,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from hypothesis import given, strategies as st
 
 from hephaestus.automation.review_state import (
     MAX_UNPARSEABLE_VERDICT_PASSES,
@@ -641,3 +642,24 @@ class TestFetchAllIssueCommentsGraphqlVars:
         assert "owner:'" not in query_arg
         assert "n0=10" in argv
         assert "issue(number:$n0)" in query_arg
+
+
+class TestLatestVerdictProperties:
+    """Property-based fuzz coverage for latest_verdict (#1470)."""
+
+    @given(st.text())
+    def test_never_raises_returns_go_nogo_or_none(self, body: str) -> None:
+        assert latest_verdict(body) in {"GO", "NOGO", None}
+
+    @given(st.text())
+    def test_no_verdict_line_is_none(self, body: str) -> None:
+        if "verdict" not in body.lower():
+            assert latest_verdict(body) is None
+
+    @given(st.lists(st.sampled_from(["GO", "NOGO", "NO-GO"]), min_size=1, max_size=6))
+    def test_last_matching_line_wins(self, tokens: list[str]) -> None:
+        # Contract: a body with several Verdict lines resolves to the LAST one
+        # (review_state.py:92 — _GATE_VERDICT_RE.findall(...)[-1]).
+        body = "\n".join(f"Verdict: {t}" for t in tokens) + "\n"
+        last = tokens[-1].replace("-", "")
+        assert latest_verdict(body) == ("GO" if last == "GO" else "NOGO")


### PR DESCRIPTION
## Summary
Add Hypothesis-based property testing for string-parsing functions that consume LLM output (parse_review_verdict, _parse_coordinator_results, latest_verdict, _parse_addressed_block). Validates parser robustness against malformed and adversarial input.

## Changes
- Add hypothesis to test dependencies in pixi.toml and pyproject.toml
- Create test_address_review_property.py with property-based tests for address-review parsers
- Add property-based tests to test_audit_reviewer.py for verdict parsing
- Add property-based tests to test_claude_invoke.py for LLM output parsing
- Add property-based tests to test_review_state.py for state parsing

## Testing
- Property-based tests using Hypothesis for malformed LLM output
- Parametric coverage of edge cases in string parsing functions
- Run full test suite: pixi run pytest tests/unit/automation/ -v

## Closes
Closes #1470

Generated by Claude Code via ProjectHephaestus automation.
