### PR TITLE
refactor(automation): use shared loader for arming state

### DIFF
--- a/hephaestus/automation/arming_state.py
+++ b/hephaestus/automation/arming_state.py
@@ -28,6 +28,8 @@ from typing import Any
 
 from hephaestus.io.utils import write_secure
 
+from ._review_utils import load_state_file
+
 logger = logging.getLogger(__name__)
 
 
@@ -59,19 +61,19 @@ class ArmingStateStore:
         return self._state_dir_provider() / f"drive-green-armed-{issue_number}.json"
 
     def load(self, issue_number: int) -> dict[str, Any] | None:
-        """Return the parsed arming record for ``issue_number`` or ``None``."""
-        path = self.path(issue_number)
-        if not path.exists():
-            return None
-        try:
-            return dict(json.loads(path.read_text()))
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning(
-                "Could not read arming record for issue #%s: %s; ignoring",
-                issue_number,
-                exc,
-            )
-            return None
+        """Return the parsed arming record for ``issue_number`` or ``None``.
+
+        Routes through the canonical ``load_state_file`` helper (raw-dict
+        overload) so malformed-file handling matches the rest of the
+        automation state stores (#1432).
+        """
+        record = load_state_file(
+            self._state_dir_provider(),
+            "drive-green-armed",
+            issue_number,
+            state_logger=logger,
+        )
+        return dict(record) if record is not None else None
 
     def save(self, issue_number: int, record: dict[str, Any]) -> None:
         """Persist the arming record. Best-effort; logs and swallows IO errors."""

--- a/tests/unit/automation/test_arming_state.py
+++ b/tests/unit/automation/test_arming_state.py
@@ -58,7 +58,9 @@ def test_load_corrupt_json_returns_none(tmp_path: Path, caplog: pytest.LogCaptur
     store.path(5).write_text("{not json")
     with caplog.at_level("WARNING"):
         assert store.load(5) is None
-    assert "Could not read arming record" in caplog.text
+    # load() now routes through the canonical load_state_file helper (#1432),
+    # which emits the unified "Malformed <prefix> state" warning.
+    assert "Malformed drive-green-armed state" in caplog.text
 
 
 def test_save_unwritable_dir_swallows_and_warns(


### PR DESCRIPTION
Closes #1432

Replaces closed PR #1687. Current main already contains the broader protocol contracts in `_interfaces.py`, so this carries forward the remaining relevant persistence change from the old branch: `ArmingStateStore.load()` now routes through the shared `load_state_file` helper and its malformed-record warning follows the shared state-file path.

Verification:
- `pixi run pytest tests/unit/automation/test_arming_state.py tests/unit/automation/test_interfaces.py -v --override-ini=addopts=`
- `python3 scripts/check_conventional_commit.py -` on the PR commit subject
- `python3 scripts/check_dco_signoff.py -` on the PR commit message
