### PR TITLE
fix(automation): detect cwd repo from github remote

### DIFF
--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -31,10 +31,12 @@ LOG = logging.getLogger(__name__)
 def _detect_cwd_repo() -> tuple[str | None, str | None]:
     """Return ``(org, repo_name)`` for the current working directory.
 
-    Returns ``(None, None)`` when cwd is not inside a git repo or has no
-    parseable github.com origin remote. ``org`` is parsed from
-    ``git remote get-url origin``; ``repo_name`` is the basename of
-    ``git rev-parse --show-toplevel``.
+    Returns ``(None, None)`` when cwd is not inside a git repo. For GitHub
+    origin remotes, both ``org`` and ``repo_name`` come from
+    ``git remote get-url origin`` so automation worktree names such as
+    ``issue-1442`` do not masquerade as repository names. Non-GitHub remotes
+    preserve the historical fallback of returning the local top-level basename
+    with ``org`` set to ``None``.
     """
     try:
         top = subprocess.run(
@@ -74,9 +76,11 @@ def _detect_cwd_repo() -> tuple[str | None, str | None]:
         path = path_part.lstrip("/")
 
     if host == "github.com":
-        parts = path.split("/", 1)
+        parts = path.strip("/").split("/", 1)
         if len(parts) == 2:
             org = parts[0] or None
+            remote_repo = parts[1].removesuffix(".git")
+            repo = remote_repo or repo
 
     return (org, repo)
 

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -51,6 +51,22 @@ class TestDetectCwdRepo:
         assert org == "MyOrg"
         assert repo == "MyRepo"
 
+    def test_parses_repo_name_from_https_remote_not_worktree_dir(self) -> None:
+        """GitHub remote path is authoritative when worktree dir is issue-named."""
+
+        def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+            m = MagicMock()
+            if "rev-parse" in cmd:
+                m.stdout = "/home/user/repos/ProjectHephaestus/build/.worktrees/issue-1442\n"
+            else:
+                m.stdout = "https://github.com/HomericIntelligence/ProjectHephaestus.git\n"
+            return m
+
+        with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+            org, repo = _detect_cwd_repo()
+        assert org == "HomericIntelligence"
+        assert repo == "ProjectHephaestus"
+
     def test_parses_ssh_scp_url(self) -> None:
         def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
             m = MagicMock()
@@ -64,6 +80,22 @@ class TestDetectCwdRepo:
             org, repo = _detect_cwd_repo()
         assert org == "MyOrg"
         assert repo == "ProjectFoo"
+
+    def test_parses_repo_name_from_ssh_remote_not_worktree_dir(self) -> None:
+        """SCP-style GitHub remotes also override local worktree basenames."""
+
+        def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+            m = MagicMock()
+            if "rev-parse" in cmd:
+                m.stdout = "/home/user/repos/ProjectHephaestus/build/.worktrees/issue-1442\n"
+            else:
+                m.stdout = "git@github.com:HomericIntelligence/ProjectHephaestus.git\n"
+            return m
+
+        with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+            org, repo = _detect_cwd_repo()
+        assert org == "HomericIntelligence"
+        assert repo == "ProjectHephaestus"
 
     def test_returns_none_org_for_non_github_remote(self) -> None:
         def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -1395,6 +1395,56 @@ def test_detect_cwd_repo_parses_https_url() -> None:
     assert repo == "R"
 
 
+def test_detect_cwd_repo_uses_remote_repo_when_worktree_dir_differs() -> None:
+    """Automation worktree names like issue-1442 must not become repo names."""
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=0,
+                stdout="/tmp/ProjectHephaestus/build/.worktrees/issue-1442\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout="https://github.com/HomericIntelligence/ProjectHephaestus.git\n",
+            stderr="",
+        )
+
+    with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+        org, repo = loop_runner._detect_cwd_repo()
+    assert org == "HomericIntelligence"
+    assert repo == "ProjectHephaestus"
+
+
+def test_resolve_org_and_repos_cwd_default_uses_remote_repo_not_worktree_dir() -> None:
+    """No flags should scope the loop to the GitHub repo, not worktree basename."""
+    args = loop_runner._parse_args([])
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if "rev-parse" in argv:
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=0,
+                stdout="/tmp/ProjectHephaestus/build/.worktrees/issue-1442\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=argv,
+            returncode=0,
+            stdout="git@github.com:HomericIntelligence/ProjectHephaestus.git\n",
+            stderr="",
+        )
+
+    with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+        org, repos, err = loop_runner._resolve_org_and_repos(args)
+    assert err is None
+    assert org == "HomericIntelligence"
+    assert repos == ["ProjectHephaestus"]
+
+
 def test_detect_cwd_repo_returns_none_when_not_git() -> None:
     """``git rev-parse`` failure → ``(None, None)``."""
     with patch(


### PR DESCRIPTION
## Summary
- Fix automation loop cwd repo detection so GitHub origin remotes provide both org and repo.
- Prevent issue-named worktrees such as issue-1442 from being treated as repository names.
- Add regression coverage for HTTPS, SSH, and the no-flag loop default path.

## Test Plan
- [x] RED regression tests failed with issue-1442 before the fix
- [x] pixi run pytest tests/unit/automation/test_loop_repo_manager.py tests/unit/automation/test_loop_runner.py -q --override-ini=addopts=
- [x] pixi run pytest tests/unit -q
- [x] pixi run python -m mypy hephaestus/ scripts/ tests/
- [x] pixi run ruff check hephaestus/ tests/
- [x] pixi run ruff format --check hephaestus/ tests/
- [x] pixi run pre-commit run --files hephaestus/automation/loop_repo_manager.py tests/unit/automation/test_loop_repo_manager.py tests/unit/automation/test_loop_runner.py
- [x] Live smoke from build/.worktrees/issue-1442 returns HomericIntelligence/ProjectHephaestus

Closes #1733