### PR TITLE
chore(claude-config): Broaden git reset --hard deny rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
       "Bash(curl * | bash)",
       "Bash(git push --force*)",
       "Bash(git push -f*)",
-      "Bash(git reset --hard origin/main)",
+      "Bash(git reset --hard*)",
       "Bash(git push * --no-verify*)",
       "Bash(git commit * --no-verify*)",
       "Bash(gh pr merge * --admin*)",


### PR DESCRIPTION
## Summary
Expand the Bash deny rule to block all `git reset --hard` invocations, not just resets to main. This closes the gap where agents could destructively reset feature branches.

## Changes
- Updated `.claude/settings.json` deny rule from `git reset --hard origin/main` to `git reset --hard*` to prevent destructive resets to any branch or ref

## Testing
- Verify deny rule blocks `git reset --hard origin/feature-branch`
- Verify deny rule blocks `git reset --hard HEAD~3`
- Verify deny rule still blocks `git reset --hard origin/main`

## Closes
Closes #1497

Generated by Claude Code via ProjectHephaestus automation.
