### PR TITLE
docs(packaging): document automation extra in [all] declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ and intentionally excludes `[dev]` (which carries test/lint tooling such as
 pytest, ruff, and mypy):
 
 - `pip install HomericIntelligence-Hephaestus[all]` — installs all runtime
-  extras: `github`, `nats`, `toml`, `xml`, `schema`.
+  extras: `automation`, `github`, `nats`, `toml`, `xml`, `schema`. Note that
+  `automation` is the product layer (`hephaestus.automation`) and pulls in
+  `pydantic`; see [ADR 0001](docs/adr/0001-automation-library-boundary.md).
 - `pip install HomericIntelligence-Hephaestus[dev]` — installs development and
   testing dependencies. Use this for contributors and CI.
 - `pip install "HomericIntelligence-Hephaestus[all,dev]"` — both, for a full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,11 @@ dependencies = [
 ]
 
 # Optional-dependency groups. The `all` aggregator below intentionally lists
-# only runtime extras (github, nats, toml, xml, schema) — `dev` is kept separate
-# so production installs of `[all]` do not pull pytest/ruff/mypy. If you change
-# this convention, update the "Optional dependencies" section in README.md.
+# all runtime extras (automation, github, nats, toml, xml, schema) — `dev` is
+# kept separate so production installs of `[all]` do not pull pytest/ruff/mypy.
+# `automation` is the product layer (hephaestus.automation) and pulls pydantic;
+# see docs/adr/0001-automation-library-boundary.md. If you change this
+# convention, update the "Optional dependencies" section in README.md.
 [project.optional-dependencies]
 dev = [
     # pytest 9.x and pytest-cov 7.x are the latest majors; tight floors are

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -5,6 +5,7 @@ ensuring the published install contract does not permit API-incompatible
 versions that are never tested.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -450,3 +451,58 @@ class TestPipPinning:
             f"pip cap {cap} must be > 26 (no downgrade) and <= 27 (block untested major); "
             "update when CI tests pip 27.x"
         )
+
+
+class TestAllExtraDocsInSync:
+    """Guard that `[all]`'s member extras are documented in both docs.
+
+    The `[all]` aggregator's member extras must be documented in both the
+    pyproject.toml aggregator comment and the README `[all]` bullet (#1498).
+
+    Guards a DRY/POLA invariant: `[all]` silently included the `automation`
+    product layer (and its pydantic dependency) while both docs omitted it.
+    The truth is derived from the manifest `all = [...]` spec rather than
+    hardcoded, so adding a future extra to `[all]` without documenting it
+    fails this test.
+    """
+
+    @staticmethod
+    def _all_members(repo_root: Path) -> set[str]:
+        """Return the set of extras named inside the `[all]` aggregator spec."""
+        pyproject_path = repo_root / "pyproject.toml"
+        with pyproject_path.open("rb") as f:
+            pyproject = tomllib.load(f)
+        all_specs = pyproject["project"]["optional-dependencies"]["all"]
+        assert all_specs, "[project.optional-dependencies.all] is empty"
+        # all = ["HomericIntelligence-Hephaestus[automation,github,nats,...]"]
+        inner = re.search(r"\[([^\]]+)\]", all_specs[0])
+        assert inner, f"No extras bracket found in [all] spec: {all_specs[0]!r}"
+        return {e.strip() for e in inner.group(1).split(",") if e.strip()}
+
+    def test_pyproject_comment_lists_all_members(self, repo_root: Path) -> None:
+        """Assert the pyproject aggregator comment lists every `[all]` member.
+
+        The comment block preceding [project.optional-dependencies] must
+        enumerate every member extra of `[all]`.
+        """
+        members = self._all_members(repo_root)
+        text = (repo_root / "pyproject.toml").read_text(encoding="utf-8")
+        # Isolate the aggregator comment block preceding the header.
+        comment = text.split("[project.optional-dependencies]", 1)[0]
+        missing = sorted(m for m in members if m not in comment)
+        assert not missing, (
+            f"pyproject.toml aggregator comment omits [all] member(s): {missing}"
+        )
+
+    def test_readme_all_bullet_lists_all_members(self, repo_root: Path) -> None:
+        """Assert the README `[all]` bullet lists every `[all]` member.
+
+        The bullet under "### Optional dependencies" must enumerate every
+        member extra of `[all]`.
+        """
+        members = self._all_members(repo_root)
+        readme = (repo_root / "README.md").read_text(encoding="utf-8")
+        # The `[all]` bullet enumerates the runtime extras just after the header.
+        section = readme.split("### Optional dependencies", 1)[1].split("###", 1)[0]
+        missing = sorted(m for m in members if m not in section)
+        assert not missing, f"README `[all]` section omits member(s): {missing}"


### PR DESCRIPTION
## Summary
Update README and pyproject.toml to explicitly document that the [all] extra includes the automation product layer, fixing a DRY/POLA violation where consumers were unaware of the included pydantic dependency.

## Changes
- Added 'automation' to the documented extras list in README.md [all] description
- Clarified pyproject.toml comment at line 38 to include automation in the [all] extra declaration
- Added test_dependency_floor_consistency.py to validate [all] extra membership and documentation consistency

## Testing
- Unit tests verify [all] extra includes automation, github, nats, toml, xml, schema
- Documentation consistency checks ensure README and pyproject.toml lists match the actual [all] declaration

## Closes
Closes #1498

Generated by Claude Code via ProjectHephaestus automation.
