### PR TITLE
fix(automation): enforce signed DCO commits

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -420,7 +420,7 @@ jobs:
             # shellcheck disable=SC2086  # word-splitting of $bad is intentional
             printf '  %s\n' $bad
             msg="::error::Every commit MUST be cryptographically signed."
-            msg+=" Re-sign with: git rebase --exec 'git commit --amend --no-edit -S' origin/main"
+            msg+=" Re-sign with: git rebase --exec 'git commit --amend --no-edit -S -s' origin/main"
             echo "$msg"
             exit 1
           fi

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -13,7 +13,7 @@ A piece of work is **done** when every item below is true.
 |---|-------------|-------------|
 | 1 | Branch named `<issue-number>-<description>` | Convention (PR reviewer) |
 | 2 | PR body contains the literal line `Closes #<issue-number>` (capital C, no colon, on its own line) | CI gate `pr-policy` (`.github/workflows/_required.yml`) |
-| 3 | Every commit on the branch is cryptographically signed (`git commit -S`) | CI gate `pr-policy` |
+| 3 | Every commit on the branch is cryptographically signed and DCO-signed (`git commit -S -s`) | CI gate `pr-policy` |
 | 4 | Auto-merge is disabled until `state:implementation-go`, then enabled with `--squash` (NOT `--rebase`; the repo disallows rebase merges) | CI gate `pr-policy` |
 | 5 | Commit messages follow Conventional Commits (`type(scope): description`) | CI gate `pr-policy` (Check 3) + local `commit-msg` hook `conventional-commit-msg` |
 | 6 | `pixi run ruff check hephaestus/ tests/` passes | CI job `lint` |

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -1114,6 +1114,7 @@ class _CIDriverCore:
             issue_number=issue_number,
             pr_number=pr_number,
             pr_head_branch=pr_head_branch,
+            pr_base_branch=self._get_pr_base_branch(pr_number),
             session_id=None,
         )
         if not pushed:
@@ -1192,6 +1193,7 @@ class _CIDriverCore:
             # CI fix push must target THIS remote ref even if Claude switches
             # branches locally during the session (#832).
             pr_head_branch = self._get_pr_branch(pr_number)
+            pr_base_branch = self._get_pr_base_branch(pr_number)
 
             if self.options.dry_run:
                 logger.info(
@@ -1214,6 +1216,7 @@ class _CIDriverCore:
                 session_id,
                 advise_findings,
                 pr_head_branch=pr_head_branch,
+                pr_base_branch=pr_base_branch,
             )
             if fixed:
                 logger.info(
@@ -1322,6 +1325,16 @@ class _CIDriverCore:
         except Exception as e:
             logger.warning("Could not fetch branch for PR #%s: %s", pr_number, e)
             return f"pr-{pr_number}"
+
+    def _get_pr_base_branch(self, pr_number: int) -> str:
+        """Return the PR base branch, defaulting to ``main`` on lookup gaps."""
+        try:
+            gh_state = self._gh_pr_state(pr_number) or {}
+        except Exception as exc:
+            logger.warning("Could not fetch base branch for PR #%s: %s", pr_number, exc)
+            return "main"
+        base_branch = str(gh_state.get("baseRefName") or "main")
+        return base_branch or "main"
 
     def _get_worktree_path(self, issue_number: int, pr_number: int) -> Path:
         """Resolve the worktree path for a given issue/PR.
@@ -1433,7 +1446,7 @@ class _CIDriverCore:
             )
 
     def _gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
-        """Return ``{state, headRefOid, mergedAt, mergeStateStatus}`` or ``None``.
+        """Return ``{state, headRefOid, mergedAt, mergeStateStatus, baseRefName}`` or ``None``.
 
         Used by the on-drive-start check (#840) to detect post-merge so the
         ``/learn`` capture can fire exactly once per issue, and by
@@ -1447,7 +1460,7 @@ class _CIDriverCore:
                     "view",
                     str(pr_number),
                     "--json",
-                    "state,headRefOid,mergedAt,mergeStateStatus",
+                    "state,headRefOid,mergedAt,mergeStateStatus,baseRefName",
                 ],
                 check=False,
             )
@@ -2000,7 +2013,8 @@ class _CIDriverCore:
         issue_number: int,
         pr_number: int,
         pr_head_branch: str,
-        session_id: str | None,
+        session_id: str | None = None,
+        pr_base_branch: str = "main",
     ) -> bool:
         """Delegate to CIFixOrchestrator (extracted #1357)."""
         return self._fix_orchestrator.push_ci_fix(
@@ -2009,6 +2023,7 @@ class _CIDriverCore:
             issue_number=issue_number,
             pr_number=pr_number,
             pr_head_branch=pr_head_branch,
+            pr_base_branch=pr_base_branch,
             session_id=session_id,
         )
 
@@ -2104,6 +2119,7 @@ class _CIDriverCore:
         advise_findings: str = "",
         *,
         pr_head_branch: str,
+        pr_base_branch: str = "main",
     ) -> bool:
         """Delegate to CIFixOrchestrator (extracted #1357)."""
         return self._fix_orchestrator.run_ci_fix_session(
@@ -2114,6 +2130,7 @@ class _CIDriverCore:
             session_id,
             advise_findings,
             pr_head_branch=pr_head_branch,
+            pr_base_branch=pr_base_branch,
         )
 
     def _enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -566,12 +566,8 @@ class CIFixOrchestrator:
             worktree_path: Path to the checked-out worktree.
             ci_logs: Combined CI failure log text.
             session_id: Optional agent session ID to resume.
-            advise_findings: Prior learnings from the advise step, prepended to
-                the prompt as context. Empty or a skip marker contributes nothing.
-            pr_head_branch: The PR's head-branch name on the remote. The push
-                uses this as the destination refspec so the fix lands on the
-                actual PR branch even if the agent switched branches locally
-                during the session (#832).
+            advise_findings: Prior learnings prepended to the prompt.
+            pr_head_branch: Remote PR head branch used as the push destination.
 
         Returns:
             True if the fix session succeeded and the branch was pushed.

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -567,10 +567,9 @@ class CIFixOrchestrator:
             ci_logs: Combined CI failure log text.
             session_id: Optional agent session ID to resume.
             advise_findings: Prior learnings prepended to the prompt.
-            pr_head_branch: Remote PR head branch used as the push destination.
-                Threaded explicitly (not read from the local worktree) because
-                an agent can switch branches mid-session — the push must target
-                the PR's original remote refspec regardless (#832).
+            pr_head_branch: Remote PR head branch the push targets, even if
+                the agent switches branches mid-session (#832).
+            pr_base_branch: PR base branch used for commit-metadata repair.
 
         Returns:
             True if the fix session succeeded and the branch was pushed.

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -292,6 +292,7 @@ class CIFixOrchestrator:
         pr_number: int,
         pr_head_branch: str,
         session_id: str | None,
+        pr_base_branch: str = "main",
     ) -> bool:
         """Check head advancement, retry if needed, then push CI fixes.
 
@@ -308,10 +309,12 @@ class CIFixOrchestrator:
                 session_id=session_id,
             ):
                 return False
-        if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
+        base_ref = f"origin/{pr_base_branch}"
+        if not self._ci_fix_head_is_pushable(worktree_path, issue_number, base_ref=base_ref):
             if not self._ci_fix_residual_commit_is_safe(
                 worktree_path=worktree_path,
                 issue_number=issue_number,
+                base_ref=base_ref,
             ):
                 return False
             if not self._commit_residual_ci_fix_changes(
@@ -319,16 +322,18 @@ class CIFixOrchestrator:
                 issue_number=issue_number,
             ):
                 return False
-            if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
+            if not self._ci_fix_head_is_pushable(worktree_path, issue_number, base_ref=base_ref):
                 return False
         try:
-            ensure_branch_commit_metadata(worktree_path)
+            ensure_branch_commit_metadata(worktree_path, base_branch=pr_base_branch)
         except Exception as metadata_err:
             logger.error(
                 "Issue #%s: failed to enforce signed+DCO commit metadata before push: %s",
                 issue_number,
                 metadata_err,
             )
+            return False
+        if not self._ci_fix_head_is_pushable(worktree_path, issue_number, base_ref=base_ref):
             return False
         try:
             push_current_branch_with_lease_on_divergence(
@@ -551,6 +556,7 @@ class CIFixOrchestrator:
         advise_findings: str = "",
         *,
         pr_head_branch: str,
+        pr_base_branch: str = "main",
     ) -> bool:
         """Invoke the selected coding agent to fix CI failures, then push the result.
 
@@ -619,6 +625,7 @@ class CIFixOrchestrator:
             issue_number=issue_number,
             pr_number=pr_number,
             pr_head_branch=pr_head_branch,
+            pr_base_branch=pr_base_branch,
             session_id=session_id,
         )
 

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -35,6 +35,7 @@ from .claude_invoke import invoke_claude_with_session
 from .claude_models import implementer_model
 from .git_utils import (
     commit_if_changes,
+    ensure_branch_commit_metadata,
     get_repo_slug,
     issue_ref,
     pr_ref,
@@ -207,9 +208,10 @@ class CIFixOrchestrator:
             f"This MUST include any markdown/lint hooks — every file you add or "
             f"edit has to pass the repo's own linters, with no rule disabled.\n"
             f"4. **Every commit MUST be cryptographically signed and DCO signed off "
-            f"(`git commit -S -s`).** NEVER use `--no-verify`. The repository's CI "
-            f"gate rejects unsigned commits, missing sign-offs, and any commit that "
-            f"bypassed pre-commit hooks.\n"
+            f"4. **Every commit MUST be cryptographically signed and DCO-signed "
+            f"(`git commit -S -s`).** NEVER use `--no-verify`. The repository's "
+            f"CI gate rejects unsigned commits, commits without Signed-off-by "
+            f"trailers, and any commit that bypassed pre-commit hooks.\n"
             f"5. Do NOT run `git checkout -b`, `git switch -c`, or any command "
             f"that creates or switches branches — the fix has to land on "
             f"`{pr_head_branch}`.\n"
@@ -320,6 +322,15 @@ class CIFixOrchestrator:
                 return False
             if not self._ci_fix_head_is_pushable(worktree_path, issue_number):
                 return False
+        try:
+            ensure_branch_commit_metadata(worktree_path)
+        except Exception as metadata_err:
+            logger.error(
+                "Issue #%s: failed to enforce signed+DCO commit metadata before push: %s",
+                issue_number,
+                metadata_err,
+            )
+            return False
         try:
             push_current_branch_with_lease_on_divergence(
                 worktree_path,
@@ -526,7 +537,7 @@ class CIFixOrchestrator:
             "3. Commit changes (do NOT push) on the current branch — DO NOT run "
             "`git checkout -b`, `git switch -c`, or any other command that creates "
             "or switches to a different branch\n"
-            "4. Every commit MUST be cryptographically signed and DCO signed off "
+            "4. Every commit MUST be cryptographically signed and DCO-signed "
             "(`git commit -S -s`); NEVER use `--no-verify`.\n\n"
             f"Commit message: fix: Address CI failures for PR {pr_ref(pr_number)}\n"
         )

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -568,6 +568,9 @@ class CIFixOrchestrator:
             session_id: Optional agent session ID to resume.
             advise_findings: Prior learnings prepended to the prompt.
             pr_head_branch: Remote PR head branch used as the push destination.
+                Threaded explicitly (not read from the local worktree) because
+                an agent can switch branches mid-session — the push must target
+                the PR's original remote refspec regardless (#832).
 
         Returns:
             True if the fix session succeeded and the branch was pushed.

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -207,7 +207,6 @@ class CIFixOrchestrator:
             f"`pre-commit run --all-files` locally to verify before committing. "
             f"This MUST include any markdown/lint hooks — every file you add or "
             f"edit has to pass the repo's own linters, with no rule disabled.\n"
-            f"4. **Every commit MUST be cryptographically signed and DCO signed off "
             f"4. **Every commit MUST be cryptographically signed and DCO-signed "
             f"(`git commit -S -s`).** NEVER use `--no-verify`. The repository's "
             f"CI gate rejects unsigned commits, commits without Signed-off-by "

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -539,7 +539,14 @@ def _remove_untracked_files_tracked_by_ref(cwd: Path, ref: str) -> list[Path]:
 
 def _commit_policy_rebase_command(base_ref: str) -> list[str]:
     """Return a rebase command that repairs signature and DCO metadata per commit."""
-    return ["git", "rebase", base_ref, "--exec", COMMIT_POLICY_REWRITE_EXEC]
+    return [
+        "git",
+        "rebase",
+        "--force-rebase",
+        base_ref,
+        "--exec",
+        COMMIT_POLICY_REWRITE_EXEC,
+    ]
 
 
 def ensure_branch_commit_metadata(
@@ -551,7 +558,13 @@ def ensure_branch_commit_metadata(
     """Rewrite branch commits so each carries a verified signature and DCO trailer."""
     base_ref = f"{remote}/{base_branch}"
     run(["git", "fetch", remote, base_branch], cwd=cwd)
-    run(_commit_policy_rebase_command(base_ref), cwd=cwd)
+    try:
+        run(_commit_policy_rebase_command(base_ref), cwd=cwd)
+    except subprocess.CalledProcessError:
+        # Leave the worktree ready for the caller's next automation attempt.
+        # ``check=False`` preserves the original rebase failure signal.
+        run(["git", "rebase", "--abort"], cwd=cwd, check=False)
+        raise
 
 
 def rebase_worktree_onto(
@@ -564,7 +577,7 @@ def rebase_worktree_onto(
 
     This is the cheap, deterministic path for PRs that are merely *behind* the
     base branch (or have textually non-overlapping changes): a policy-aware
-    ``git rebase --exec`` resolves them with no agent involvement while
+    ``git rebase --force-rebase --exec`` resolves them with no agent involvement while
     re-signing each replayed commit and adding a DCO sign-off. Only when the
     rebase hits a real conflict do we hand off to the CI-fix agent.
 
@@ -572,10 +585,11 @@ def rebase_worktree_onto(
 
     1. ``git fetch <remote> <base_branch>`` — refresh the remote-tracking ref so
        the rebase target is current.
-    2. ``git rebase <remote>/<base_branch> --exec ...`` — replay the PR's commits
-       on top of the latest base and run ``git commit --amend --no-edit -S -s``
-       after each replayed commit. On conflict, ``git rebase --abort`` restores
-       the pre-rebase HEAD so the worktree is left clean for the agent path.
+    2. ``git rebase --force-rebase <remote>/<base_branch> --exec ...`` —
+       replay the PR's commits on top of the latest base and run
+       ``git commit --amend --no-edit -S -s`` after each replayed commit. On
+       conflict, ``git rebase --abort`` restores the pre-rebase HEAD so the
+       worktree is left clean for the agent path.
 
     The caller is expected to push the rebased HEAD with
     :func:`push_current_branch_with_lease_on_divergence` (the rebase rewrites
@@ -587,10 +601,9 @@ def rebase_worktree_onto(
         remote: Remote name (default ``origin``).
 
     Returns:
-        ``True`` if the rebase applied cleanly (HEAD may or may not have moved —
-        an already-up-to-date PR rebases cleanly to a no-op). ``False`` if the
-        rebase hit conflicts and was aborted, signalling the caller to fall back
-        to the agent.
+        ``True`` if the rebase applied cleanly. ``False`` if the rebase hit
+        conflicts and was aborted, signalling the caller to fall back to the
+        agent.
 
     Raises:
         subprocess.CalledProcessError: If the ``git fetch`` fails. A fetch

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -558,6 +558,7 @@ def ensure_branch_commit_metadata(
     """Rewrite branch commits so each carries a verified signature and DCO trailer."""
     base_ref = f"{remote}/{base_branch}"
     run(["git", "fetch", remote, base_branch], cwd=cwd)
+    _remove_untracked_files_tracked_by_ref(cwd, base_ref)
     try:
         run(_commit_policy_rebase_command(base_ref), cwd=cwd)
     except subprocess.CalledProcessError:

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -537,6 +537,23 @@ def _remove_untracked_files_tracked_by_ref(cwd: Path, ref: str) -> list[Path]:
     return removed
 
 
+def _commit_policy_rebase_command(base_ref: str) -> list[str]:
+    """Return a rebase command that repairs signature and DCO metadata per commit."""
+    return ["git", "rebase", base_ref, "--exec", COMMIT_POLICY_REWRITE_EXEC]
+
+
+def ensure_branch_commit_metadata(
+    cwd: Path,
+    base_branch: str = "main",
+    *,
+    remote: str = "origin",
+) -> None:
+    """Rewrite branch commits so each carries a verified signature and DCO trailer."""
+    base_ref = f"{remote}/{base_branch}"
+    run(["git", "fetch", remote, base_branch], cwd=cwd)
+    run(_commit_policy_rebase_command(base_ref), cwd=cwd)
+
+
 def rebase_worktree_onto(
     cwd: Path,
     base_branch: str = "main",
@@ -585,7 +602,7 @@ def rebase_worktree_onto(
     run(["git", "fetch", remote, base_branch], cwd=cwd)
     _remove_untracked_files_tracked_by_ref(cwd, base_ref)
     try:
-        run(["git", "rebase", base_ref, "--exec", COMMIT_POLICY_REWRITE_EXEC], cwd=cwd)
+        run(_commit_policy_rebase_command(base_ref), cwd=cwd)
         logger.info("Rebased worktree at %s onto %s/%s cleanly", cwd, remote, base_branch)
         return True
     except subprocess.CalledProcessError:

--- a/hephaestus/automation/prompts/implementation.py
+++ b/hephaestus/automation/prompts/implementation.py
@@ -86,7 +86,7 @@ agent turn returns.
 - When you finish, summarize what changed and what tests you ran.
 
 After you return, the orchestrator will:
-1. Create a cryptographically signed and DCO signed-off commit with `git commit -S -s`.
+1. Create a cryptographically signed and DCO-signed commit with `git commit -S -s`.
 2. Push the branch to origin.
 3. Create or reuse the pull request for this branch.
 4. Ensure the PR body contains the exact policy line `Closes #{issue_number}`.

--- a/scripts/check_dco_signoff.py
+++ b/scripts/check_dco_signoff.py
@@ -104,8 +104,8 @@ def main(argv: list[str] | None = None) -> int:
     if failed:
         print(
             "Every commit MUST carry a 'Signed-off-by: Name <email>' trailer "
-            "(the DCO). Add it with: git commit -s  (re-sign existing commits "
-            "with: git rebase --exec 'git commit --amend --no-edit -s' origin/main). "
+            "(the DCO). Add it with: git commit -S -s  (re-sign existing commits "
+            "with: git rebase --exec 'git commit --amend --no-edit -S -s' origin/main). "
             "See CONTRIBUTING.md, section 'Developer Certificate of Origin (DCO)'."
         )
         return 1

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -328,6 +328,7 @@ def test_codex_ci_fix_session_falls_back_to_fresh_on_resume_failure(
         patch(
             "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
         ) as mock_push,
+        patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
         patch(
             "hephaestus.automation.ci_fix_orchestrator.sync_worktree_to_remote_branch"
         ) as mock_sync,
@@ -3692,6 +3693,7 @@ class TestPushCiFix:
                 "hephaestus.automation.ci_fix_orchestrator.run",
                 side_effect=[post_sha, clean_status, no_untracked, ahead_count],
             ),
+            patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
             patch(
                 "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
             ) as mock_push,
@@ -3706,6 +3708,42 @@ class TestPushCiFix:
             )
         assert result is True
         mock_push.assert_called_once()
+
+    def test_enforces_signature_and_dco_metadata_before_push(
+        self, driver: CIDriver, tmp_path: Path
+    ) -> None:
+        post_sha = MagicMock(stdout="deadbeef\n")
+        clean_status = MagicMock(stdout="", stderr="", returncode=0)
+        ahead_count = MagicMock(stdout="1\n", stderr="", returncode=0)
+        no_untracked = MagicMock(stdout="", returncode=0)
+        events: list[str] = []
+        with (
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.run",
+                side_effect=[post_sha, clean_status, no_untracked, ahead_count],
+            ),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata",
+                create=True,
+            ) as mock_policy,
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.push_current_branch_with_lease_on_divergence"
+            ) as mock_push,
+        ):
+            mock_policy.side_effect = lambda *_args, **_kwargs: events.append("policy")
+            mock_push.side_effect = lambda *_args, **_kwargs: events.append("push")
+            result = driver._push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="cafef00d",
+                issue_number=1,
+                pr_number=2,
+                pr_head_branch="1-fix",
+                session_id=None,
+            )
+
+        assert result is True
+        mock_policy.assert_called_once_with(tmp_path)
+        assert events == ["policy", "push"]
 
     def test_returns_false_when_head_not_advanced_and_retry_fails(
         self, driver: CIDriver, tmp_path: Path

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -95,6 +95,7 @@ def _mock_default_pr_state(monkeypatch: pytest.MonkeyPatch) -> None:
             "state": "OPEN",
             "headRefOid": f"test-head-{pr_number}",
             "mergeStateStatus": "CLEAN",
+            "baseRefName": "main",
         },
     )
     monkeypatch.setattr(
@@ -890,6 +891,37 @@ class TestCiDriverAdvise:
         mock_advise.assert_called_once_with(123)
         # Findings are forwarded as the 6th positional arg to the fix session.
         assert mock_fix.call_args.args[5] == "## Findings\n- mind X"
+
+    def test_attempt_ci_fixes_passes_pr_base_ref_to_fix_session(
+        self, driver: CIDriver, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-main PR base is threaded into the CI-fix push path."""
+        monkeypatch.setattr(
+            CIDriver,
+            "_gh_pr_state",
+            lambda self, pr_number: {
+                "state": "OPEN",
+                "headRefOid": f"test-head-{pr_number}",
+                "mergeStateStatus": "CLEAN",
+                "baseRefName": "release/2.x",
+            },
+        )
+        with (
+            patch.object(driver, "_get_failing_ci_logs", return_value="error log"),
+            patch.object(driver, "_load_impl_session_id", return_value=None),
+            patch.object(driver, "_get_worktree_path", return_value=Path("/tmp/wt")),
+            patch.object(driver, "_run_ci_fix_session", return_value=True) as mock_fix,
+            patch.object(driver, "_record_ci_fix_head"),
+            patch.object(driver, "_reply_and_resolve_bot_threads"),
+        ):
+            driver._attempt_ci_fixes(123, 456, 0)
+
+        assert mock_fix.call_args.kwargs["pr_base_branch"] == "release/2.x"
+
+    def test_get_pr_base_branch_defaults_to_main_on_lookup_error(self, driver: CIDriver) -> None:
+        """Base-branch lookup failures must not abort CI/address fix push paths."""
+        with patch.object(driver, "_gh_pr_state", side_effect=RuntimeError("gh unavailable")):
+            assert driver._get_pr_base_branch(456) == "main"
 
     def test_advise_skipped_when_disabled(self, driver: CIDriver) -> None:
         """enable_advise=False → _run_advise is never called and findings are empty."""
@@ -3691,7 +3723,15 @@ class TestPushCiFix:
         with (
             patch(
                 "hephaestus.automation.ci_fix_orchestrator.run",
-                side_effect=[post_sha, clean_status, no_untracked, ahead_count],
+                side_effect=[
+                    post_sha,
+                    clean_status,
+                    no_untracked,
+                    ahead_count,
+                    clean_status,
+                    no_untracked,
+                    ahead_count,
+                ],
             ),
             patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
             patch(
@@ -3720,7 +3760,15 @@ class TestPushCiFix:
         with (
             patch(
                 "hephaestus.automation.ci_fix_orchestrator.run",
-                side_effect=[post_sha, clean_status, no_untracked, ahead_count],
+                side_effect=[
+                    post_sha,
+                    clean_status,
+                    no_untracked,
+                    ahead_count,
+                    clean_status,
+                    no_untracked,
+                    ahead_count,
+                ],
             ),
             patch(
                 "hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata",
@@ -3742,7 +3790,7 @@ class TestPushCiFix:
             )
 
         assert result is True
-        mock_policy.assert_called_once_with(tmp_path)
+        mock_policy.assert_called_once_with(tmp_path, base_branch="main")
         assert events == ["policy", "push"]
 
     def test_returns_false_when_head_not_advanced_and_retry_fails(

--- a/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
+++ b/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
@@ -193,7 +193,7 @@ class TestPushCiFix:
             patch.object(
                 orchestrator,
                 "_ci_fix_head_is_pushable",
-                side_effect=[False, True],
+                side_effect=[False, True, True],
             ),
             patch.object(orchestrator, "_ci_fix_residual_commit_is_safe", return_value=True),
             patch.object(
@@ -238,7 +238,7 @@ class TestPushCiFix:
             patch.object(
                 orchestrator,
                 "_ci_fix_head_is_pushable",
-                side_effect=[False, True],
+                side_effect=[False, True, True],
             ),
             patch.object(orchestrator, "_ci_fix_residual_commit_is_safe", return_value=True),
             patch.object(
@@ -313,6 +313,67 @@ class TestPushCiFix:
             )
 
         assert pushed is False
+        push.assert_not_called()
+
+    def test_enforces_metadata_against_pr_base_branch(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        with (
+            patch.object(orchestrator, "_head_advanced", return_value=True),
+            patch.object(
+                orchestrator,
+                "_ci_fix_head_is_pushable",
+                side_effect=[True, True],
+            ),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"
+            ) as metadata,
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator."
+                "push_current_branch_with_lease_on_divergence"
+            ),
+        ):
+            pushed = orchestrator.push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="abc123",
+                issue_number=1405,
+                pr_number=1633,
+                pr_head_branch="1405-auto-impl",
+                pr_base_branch="release/2.x",
+                session_id=None,
+            )
+
+        assert pushed is True
+        metadata.assert_called_once_with(tmp_path, base_branch="release/2.x")
+
+    def test_rechecks_pushability_after_metadata_rewrite_before_push(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        with (
+            patch.object(orchestrator, "_head_advanced", return_value=True),
+            patch.object(
+                orchestrator,
+                "_ci_fix_head_is_pushable",
+                side_effect=[True, False],
+            ) as pushable,
+            patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
+            patch(
+                "hephaestus.automation.ci_fix_orchestrator."
+                "push_current_branch_with_lease_on_divergence"
+            ) as push,
+        ):
+            pushed = orchestrator.push_ci_fix(
+                worktree_path=tmp_path,
+                pre_agent_sha="abc123",
+                issue_number=1405,
+                pr_number=1633,
+                pr_head_branch="1405-auto-impl",
+                pr_base_branch="release/2.x",
+                session_id=None,
+            )
+
+        assert pushed is False
+        assert pushable.call_count == 2
         push.assert_not_called()
 
     def test_returns_false_when_residual_commit_does_not_restore_pushability(

--- a/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
+++ b/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
@@ -74,6 +74,8 @@ class TestForceEngagementPrompt:
         assert "- test-py310" in prompt
         assert "1-fix" in prompt
         assert "BLOCKED:" in prompt
+        assert prompt.count("Every commit MUST be cryptographically signed and DCO-signed") == 1
+        assert "DCO signed off 4." not in prompt
 
     def test_dirty_changes_block_rendered(
         self, orchestrator: CIFixOrchestrator, tmp_path: Path
@@ -203,6 +205,7 @@ class TestPushCiFix:
                 "hephaestus.automation.ci_fix_orchestrator.commit_if_changes",
                 return_value=True,
             ) as commit,
+            patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
             patch(
                 "hephaestus.automation.ci_fix_orchestrator."
                 "push_current_branch_with_lease_on_divergence"
@@ -250,6 +253,7 @@ class TestPushCiFix:
                 "hephaestus.automation.ci_fix_orchestrator.commit_if_changes",
                 return_value=True,
             ) as commit,
+            patch("hephaestus.automation.ci_fix_orchestrator.ensure_branch_commit_metadata"),
             patch(
                 "hephaestus.automation.ci_fix_orchestrator."
                 "push_current_branch_with_lease_on_divergence"

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -696,6 +696,49 @@ class TestRebaseWorktreeOnto:
 class TestEnsureBranchCommitMetadata:
     """Tests for policy metadata repair before pushing CI fixes."""
 
+    def test_removes_stale_untracked_files_before_metadata_rebase(
+        self, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        """Metadata repair should not be blocked by stale untracked base files."""
+        tracked_shadow = tmp_path / "scripts" / "generated_ci_fix.py"
+        tracked_shadow.parent.mkdir()
+        tracked_shadow.write_text("leftover from previous agent turn\n")
+        git_utils_mocks.run.side_effect = [
+            Mock(returncode=0),
+            Mock(returncode=0, stdout="scripts/generated_ci_fix.py\0"),
+            Mock(returncode=0),
+            Mock(returncode=0),
+        ]
+
+        ensure_branch_commit_metadata(tmp_path, "main")
+
+        assert not tracked_shadow.exists()
+        assert git_utils_mocks.run.call_count == 4
+        fetch_args, fetch_kwargs = git_utils_mocks.run.call_args_list[0]
+        assert fetch_args[0] == ["git", "fetch", "origin", "main"]
+        assert fetch_kwargs["cwd"] == tmp_path
+        ls_files_args, ls_files_kwargs = git_utils_mocks.run.call_args_list[1]
+        assert ls_files_args[0] == ["git", "ls-files", "--others", "--exclude-standard", "-z"]
+        assert ls_files_kwargs["cwd"] == tmp_path
+        cat_file_args, cat_file_kwargs = git_utils_mocks.run.call_args_list[2]
+        assert cat_file_args[0] == [
+            "git",
+            "cat-file",
+            "-e",
+            "origin/main:scripts/generated_ci_fix.py",
+        ]
+        assert cat_file_kwargs["cwd"] == tmp_path
+        rebase_args, rebase_kwargs = git_utils_mocks.run.call_args_list[3]
+        assert rebase_args[0] == [
+            "git",
+            "rebase",
+            "--force-rebase",
+            "origin/main",
+            "--exec",
+            "git commit --amend --no-edit -S -s",
+        ]
+        assert rebase_kwargs["cwd"] == tmp_path
+
     def test_rebase_failure_aborts_and_reraises(self, git_utils_mocks: Any) -> None:
         """A failed policy rebase is aborted so later automation gets a clean worktree."""
         rebase_err = subprocess.CalledProcessError(
@@ -703,6 +746,7 @@ class TestEnsureBranchCommitMetadata:
         )
         git_utils_mocks.run.side_effect = [
             Mock(returncode=0),
+            Mock(returncode=0, stdout=""),
             rebase_err,
             Mock(returncode=0),
         ]
@@ -712,11 +756,14 @@ class TestEnsureBranchCommitMetadata:
             ensure_branch_commit_metadata(worktree, "main")
 
         assert exc_info.value is rebase_err
-        assert git_utils_mocks.run.call_count == 3
+        assert git_utils_mocks.run.call_count == 4
         fetch_args, fetch_kwargs = git_utils_mocks.run.call_args_list[0]
         assert fetch_args[0] == ["git", "fetch", "origin", "main"]
         assert fetch_kwargs["cwd"] == worktree
-        rebase_args, rebase_kwargs = git_utils_mocks.run.call_args_list[1]
+        ls_files_args, ls_files_kwargs = git_utils_mocks.run.call_args_list[1]
+        assert ls_files_args[0] == ["git", "ls-files", "--others", "--exclude-standard", "-z"]
+        assert ls_files_kwargs["cwd"] == worktree
+        rebase_args, rebase_kwargs = git_utils_mocks.run.call_args_list[2]
         assert rebase_args[0] == [
             "git",
             "rebase",
@@ -726,7 +773,7 @@ class TestEnsureBranchCommitMetadata:
             "git commit --amend --no-edit -S -s",
         ]
         assert rebase_kwargs["cwd"] == worktree
-        abort_args, abort_kwargs = git_utils_mocks.run.call_args_list[2]
+        abort_args, abort_kwargs = git_utils_mocks.run.call_args_list[3]
         assert abort_args[0] == ["git", "rebase", "--abort"]
         assert abort_kwargs["cwd"] == worktree
         assert abort_kwargs.get("check") is False

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -10,9 +10,11 @@ from unittest.mock import Mock, patch
 import pytest
 
 from hephaestus.automation.git_utils import (
+    _commit_policy_rebase_command,
     _remove_untracked_files_tracked_by_ref,
     clear_repo_caches,
     commit_if_changes,
+    ensure_branch_commit_metadata,
     get_current_branch,
     get_repo_info,
     get_repo_root,
@@ -573,6 +575,7 @@ class TestRebaseWorktreeOnto:
         assert rebase_args[0] == [
             "git",
             "rebase",
+            "--force-rebase",
             "origin/main",
             "--exec",
             "git commit --amend --no-edit -S -s",
@@ -592,10 +595,20 @@ class TestRebaseWorktreeOnto:
         assert rebase_args == [
             "git",
             "rebase",
+            "--force-rebase",
             "origin/main",
             "--exec",
             "git commit --amend --no-edit -S -s",
         ]
+
+    def test_policy_rebase_forces_replay_when_branch_already_based_on_target(
+        self,
+    ) -> None:
+        """The metadata-repair command must not fast-forward/no-op before --exec."""
+        command = _commit_policy_rebase_command("origin/main")
+
+        assert "--force-rebase" in command
+        assert command.index("--force-rebase") < command.index("--exec")
 
     def test_conflict_aborts_and_returns_false(self, git_utils_mocks: Any) -> None:
         """A rebase conflict triggers ``git rebase --abort`` and returns False."""
@@ -673,7 +686,47 @@ class TestRebaseWorktreeOnto:
         assert git_utils_mocks.run.call_args_list[2][0][0] == [
             "git",
             "rebase",
+            "--force-rebase",
             "upstream/develop",
             "--exec",
             "git commit --amend --no-edit -S -s",
         ]
+
+
+class TestEnsureBranchCommitMetadata:
+    """Tests for policy metadata repair before pushing CI fixes."""
+
+    def test_rebase_failure_aborts_and_reraises(self, git_utils_mocks: Any) -> None:
+        """A failed policy rebase is aborted so later automation gets a clean worktree."""
+        rebase_err = subprocess.CalledProcessError(
+            1, ["git", "rebase"], output="", stderr="CONFLICT (content)\n"
+        )
+        git_utils_mocks.run.side_effect = [
+            Mock(returncode=0),
+            rebase_err,
+            Mock(returncode=0),
+        ]
+        worktree = Path("/tmp/worktree-xyz")
+
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            ensure_branch_commit_metadata(worktree, "main")
+
+        assert exc_info.value is rebase_err
+        assert git_utils_mocks.run.call_count == 3
+        fetch_args, fetch_kwargs = git_utils_mocks.run.call_args_list[0]
+        assert fetch_args[0] == ["git", "fetch", "origin", "main"]
+        assert fetch_kwargs["cwd"] == worktree
+        rebase_args, rebase_kwargs = git_utils_mocks.run.call_args_list[1]
+        assert rebase_args[0] == [
+            "git",
+            "rebase",
+            "--force-rebase",
+            "origin/main",
+            "--exec",
+            "git commit --amend --no-edit -S -s",
+        ]
+        assert rebase_kwargs["cwd"] == worktree
+        abort_args, abort_kwargs = git_utils_mocks.run.call_args_list[2]
+        assert abort_args[0] == ["git", "rebase", "--abort"]
+        assert abort_kwargs["cwd"] == worktree
+        assert abort_kwargs.get("check") is False

--- a/tests/unit/automation/test_implementer_phase_runner.py
+++ b/tests/unit/automation/test_implementer_phase_runner.py
@@ -229,6 +229,9 @@ class TestCommitDirtyReusedWorktree:
         for c in mock_run.call_args_list:
             assert "-A" not in c[0][0], "'git add -A' must not appear in any git call"
 
+        commit_cmd = mock_run.call_args_list[1][0][0]
+        assert commit_cmd[:4] == ["git", "commit", "-S", "-s"]
+
         assert sha == "abc1234"
 
     def test_git_add_a_never_called_with_untracked_leftover(
@@ -295,6 +298,8 @@ class TestRestoreDirtyReusedWorktreeCommitAfterSync:
         assert mock_run.call_count == 1
         cmd = mock_run.call_args_list[0][0][0]
         assert "cherry-pick" in cmd
+        assert "-S" in cmd
+        assert "-s" in cmd
 
     def test_cherry_pick_conflict_does_not_raise(
         self, impl: IssueImplementer, tmp_path: Path

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -251,6 +251,48 @@ class TestLocalAheadCount:
         assert count == 0
 
 
+class TestRebaseMain:
+    """Tests for loop repo preparation rebase behavior."""
+
+    def test_local_ahead_rebase_resigns_and_signs_off_commits(self, tmp_path: Path) -> None:
+        commands: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+            del kwargs
+            commands.append(cmd)
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = ""
+            if "symbolic-ref" in cmd:
+                m.stdout = "origin/main\n"
+            elif "rev-list" in cmd:
+                m.stdout = "2\n"
+            elif "rev-parse" in cmd:
+                m.stdout = "abc1234\n"
+            return m
+
+        fetch_result = MagicMock(returncode=0, stderr="")
+        with (
+            patch(
+                "hephaestus.automation.loop_repo_manager.resilient_call", return_value=fetch_result
+            ),
+            patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        ):
+            sha, fetch_ok = loop_repo_manager._rebase_main("MyRepo", tmp_path)
+
+        assert (sha, fetch_ok) == ("abc1234", True)
+        assert [
+            "git",
+            "-C",
+            str(tmp_path),
+            "rebase",
+            "origin/main",
+            "--exec",
+            "git commit --amend --no-edit -S -s",
+            "--quiet",
+        ] in commands
+
+
 class TestEnsureClone:
     """Tests for _ensure_clone."""
 

--- a/tests/unit/scripts/test_check_dco_signoff.py
+++ b/tests/unit/scripts/test_check_dco_signoff.py
@@ -161,7 +161,8 @@ class TestMain:
         f.write_text(NO_SIGNOFF_MESSAGE)
         main([str(f)])
         out = capsys.readouterr().out
-        assert "git commit -s" in out
+        assert "git commit -S -s" in out
+        assert "git commit --amend --no-edit -S -s" in out
 
     def test_passes_valid_stdin(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
@@ -179,7 +180,8 @@ class TestMain:
         assert main(["-"]) == 1
         out = capsys.readouterr().out
         assert "FAILED" in out
-        assert "git commit -s" in out
+        assert "git commit -S -s" in out
+        assert "git commit --amend --no-edit -S -s" in out
 
     def test_passes_multiple_valid_messages_stdin(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture


### PR DESCRIPTION
## Summary
- Enforce signed and DCO-signed commits in automation-created commits and mechanical rebases.
- Update CI/prompt remediation text to consistently point operators at git commit -S -s.
- Add unit coverage for commit metadata repair before push and loop rebase behavior.

## Test Plan
- [x] pixi run pytest tests/unit/automation/test_git_utils.py tests/unit/automation/test_loop_repo_manager.py tests/unit/automation/test_pr_manager.py tests/unit/scripts/test_check_dco_signoff.py -q --no-cov
- [x] pixi run ruff check hephaestus/automation/ci_fix_orchestrator.py hephaestus/automation/git_utils.py hephaestus/automation/prompts/implementation.py scripts/check_dco_signoff.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_git_utils.py tests/unit/automation/test_implementer_phase_runner.py tests/unit/automation/test_loop_repo_manager.py tests/unit/scripts/test_check_dco_signoff.py

Closes #1491

Signed-off-by: Micah Villmow <4211002+mvillmow@users.noreply.github.com>