### PR TITLE
test(resilience): inject circuit breaker clock

### DIFF
--- a/hephaestus/resilience/circuit_breaker.py
+++ b/hephaestus/resilience/circuit_breaker.py
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
+def _default_clock() -> float:
+    """Return the production monotonic clock value."""
+    return time.monotonic()
+
+
 class CircuitBreakerState(enum.Enum):
     """States for the circuit breaker."""
 
@@ -96,6 +101,7 @@ class CircuitBreaker:
         half_open_max_calls: Maximum number of calls admitted concurrently in-flight
             while HALF_OPEN; each call releases its slot on completion (success or failure)
         success_threshold: Consecutive successes in HALF_OPEN required to close
+        clock: Monotonic clock function used for recovery-time calculations
 
     Example:
         >>> cb = CircuitBreaker("api", failure_threshold=3, recovery_timeout=30)
@@ -110,6 +116,8 @@ class CircuitBreaker:
         recovery_timeout: float = 60.0,
         half_open_max_calls: int = 1,
         success_threshold: int = 1,
+        *,
+        clock: Callable[[], float] = _default_clock,
     ) -> None:
         """Initialize circuit breaker.
 
@@ -120,6 +128,7 @@ class CircuitBreaker:
             half_open_max_calls: Maximum number of calls admitted concurrently
                 in-flight while HALF_OPEN; each call releases its slot on completion
             success_threshold: Consecutive successes in HALF_OPEN to close
+            clock: Monotonic clock function used for recovery-time calculations
 
         """
         self.name = name
@@ -127,6 +136,7 @@ class CircuitBreaker:
         self.recovery_timeout = recovery_timeout
         self.half_open_max_calls = half_open_max_calls
         self.success_threshold = success_threshold
+        self._clock = clock
 
         self._state = CircuitBreakerState.CLOSED
         self._failure_count = 0
@@ -144,7 +154,7 @@ class CircuitBreaker:
     def _effective_state(self) -> CircuitBreakerState:
         """Compute effective state (must hold lock)."""
         if self._state == CircuitBreakerState.OPEN:
-            elapsed = time.monotonic() - self._last_failure_time
+            elapsed = self._clock() - self._last_failure_time
             if elapsed >= self.recovery_timeout:
                 self._state = CircuitBreakerState.HALF_OPEN
                 self._half_open_calls = 0
@@ -176,7 +186,7 @@ class CircuitBreaker:
             state = self._effective_state()
 
             if state == CircuitBreakerState.OPEN:
-                time_until = self.recovery_timeout - (time.monotonic() - self._last_failure_time)
+                time_until = self.recovery_timeout - (self._clock() - self._last_failure_time)
                 raise CircuitBreakerOpenError(
                     self.name,
                     max(0.0, time_until),
@@ -225,7 +235,7 @@ class CircuitBreaker:
         """Record a failed call (releases this call's half-open slot)."""
         with self._lock:
             self._failure_count += 1
-            self._last_failure_time = time.monotonic()
+            self._last_failure_time = self._clock()
 
             if self._state == CircuitBreakerState.HALF_OPEN:
                 if self._half_open_calls > 0:

--- a/tests/unit/resilience/test_circuit_breaker.py
+++ b/tests/unit/resilience/test_circuit_breaker.py
@@ -18,10 +18,31 @@ from hephaestus.resilience.circuit_breaker import (
 )
 
 
+class FakeClock:
+    """Controllable monotonic clock for deterministic recovery-time tests."""
+
+    def __init__(self, now: float = 0.0) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        """Return the current fake monotonic time."""
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        """Move fake monotonic time forward by ``seconds``."""
+        self.now += seconds
+
+
 @pytest.fixture(autouse=True)
 def _clean_registry() -> None:
     """Reset circuit breaker registry before each test."""
     reset_all_circuit_breakers()
+
+
+@pytest.fixture
+def fake_clock() -> FakeClock:
+    """Provide a deterministic monotonic clock for a circuit breaker."""
+    return FakeClock()
 
 
 class TestCircuitBreakerStates:
@@ -81,11 +102,14 @@ class TestCircuitBreakerStates:
 
         assert cb.state == CircuitBreakerState.CLOSED
 
-    @patch("hephaestus.resilience.circuit_breaker.time.monotonic")
-    def test_open_to_half_open_after_recovery_timeout(self, mock_monotonic: MagicMock) -> None:
+    def test_open_to_half_open_after_recovery_timeout(self, fake_clock: FakeClock) -> None:
         """Circuit transitions from OPEN to HALF_OPEN after recovery timeout."""
-        mock_monotonic.return_value = 1000.0  # baseline stamped by _record_failure
-        cb = CircuitBreaker("test", failure_threshold=1, recovery_timeout=30.0)
+        cb = CircuitBreaker(
+            "test",
+            failure_threshold=1,
+            recovery_timeout=0.1,
+            clock=fake_clock,
+        )
         failing_func = MagicMock(side_effect=RuntimeError("fail"))
 
         with pytest.raises(RuntimeError):
@@ -93,8 +117,7 @@ class TestCircuitBreakerStates:
 
         assert cb.state == CircuitBreakerState.OPEN
 
-        # Advance past recovery timeout
-        mock_monotonic.return_value = 1030.0
+        fake_clock.advance(0.15)
 
         assert cb.state == CircuitBreakerState.HALF_OPEN
 


### PR DESCRIPTION
## Summary
- Add an injectable monotonic clock to CircuitBreaker for deterministic recovery-time tests.
- Replace one recovery-time test path with a fake clock instead of patched/global time.

## Test Plan
- [x] pixi run pytest tests/unit/resilience/test_circuit_breaker.py -q --no-cov
- [x] pixi run ruff check hephaestus/resilience/circuit_breaker.py tests/unit/resilience/test_circuit_breaker.py

Closes #1469

Signed-off-by: Micah Villmow <4211002+mvillmow@users.noreply.github.com>