### PR TITLE
refactor(automation): centralize state dir initialization

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -4,6 +4,8 @@ Extracts utilities that were previously duplicated across
 ``pr_reviewer.py`` and ``address_review.py``.
 
 Provides:
+- ``DEFAULT_STATE_DIR`` / ``ensure_state_dir``: Canonical automation state
+  directory path and creation helper.
 - ``parse_json_block``: Extract the last ```json``` block from Claude output.
 - ``_discover_prs_simple``: Shared issue-to-PR discovery loop for reviewer
   callers that supply their own single-issue lookup function.

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -63,7 +63,7 @@ from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 from hephaestus.io.utils import write_secure
 
 from .github_api import _gh_call
-from .models import DEFAULT_STATE_DIR, DEFAULT_WORKER_COUNT
+from .models import DEFAULT_STATE_DIR as DEFAULT_STATE_DIR, DEFAULT_WORKER_COUNT
 
 if TYPE_CHECKING:
     from .models import WorkerResult

--- a/tests/integration/test_audit_reviewer_integration.py
+++ b/tests/integration/test_audit_reviewer_integration.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.audit_reviewer import (
     AuditReviewer,
     _parse_coordinator_results,
@@ -119,13 +120,18 @@ Overall, we have 2 PRs ready to review."""
         assert any("#100" in line and "GO" in line for line in lines)
         assert any("#101" in line and "NOGO" in line for line in lines)
 
-    def test_auditreviewer_construction_default(self) -> None:
+    def test_auditreviewer_construction_default(self, tmp_path: Path) -> None:
         """Verify AuditReviewer initializes with sensible defaults."""
-        reviewer = AuditReviewer()
+        with mock.patch(
+            "hephaestus.automation.audit_reviewer.get_repo_root",
+            return_value=tmp_path,
+        ):
+            reviewer = AuditReviewer()
         assert reviewer.agent == "claude"
         assert reviewer.pr_numbers == []
         assert reviewer.dry_run is False
-        assert reviewer.state_dir is not None
+        assert reviewer.state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert reviewer.state_dir.is_dir()
 
     def test_auditreviewer_construction_codex(self) -> None:
         """Verify AuditReviewer accepts codex agent."""

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 from hypothesis import given, strategies as st
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.audit_reviewer import (
     AuditReviewer,
     _build_coordinator_prompt,
@@ -429,8 +430,14 @@ class TestAuditReviewerRun:
         assert mock_post.call_args[1]["dry_run"] is True
 
     def test_state_dir_default_under_build(self, tmp_path: Path) -> None:
-        reviewer = AuditReviewer()
-        assert "build" in str(reviewer.state_dir)
+        with mock.patch(
+            "hephaestus.automation.audit_reviewer.get_repo_root",
+            return_value=tmp_path,
+        ):
+            reviewer = AuditReviewer()
+
+        assert reviewer.state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert reviewer.state_dir.is_dir()
 
 
 class TestParser:

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -11,6 +11,7 @@ import pytest
 
 from hephaestus.agents.runtime import AgentRunResult
 from hephaestus.automation import ci_driver
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.ci_driver import CIDriver, _evaluate_run_result
 from hephaestus.automation.models import CIDriverOptions, WorkerResult
 
@@ -101,6 +102,21 @@ def _mock_default_pr_state(monkeypatch: pytest.MonkeyPatch) -> None:
         "_get_pr_branch",
         lambda self, pr_number: f"test-branch-{pr_number}",
     )
+
+
+def test_default_state_dir_uses_canonical_path(
+    mock_options: CIDriverOptions, tmp_path: Path
+) -> None:
+    """CIDriver creates the shared default automation state directory."""
+    with (
+        patch("hephaestus.automation.ci_driver.get_repo_root", return_value=tmp_path),
+        patch("hephaestus.automation.ci_driver.WorktreeManager"),
+        patch("hephaestus.automation.ci_driver.StatusTracker"),
+    ):
+        d = CIDriver(mock_options)
+
+    assert d.state_dir == tmp_path / DEFAULT_STATE_DIR
+    assert d.state_dir.is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_claude_models.py
+++ b/tests/unit/automation/test_claude_models.py
@@ -62,7 +62,7 @@ class TestModuleStable:
 
     def test_reimport_idempotent(self) -> None:
         importlib.reload(claude_models)
-        assert claude_models.OPUS == "claude-opus-4-7"
+        assert claude_models.OPUS == "claude-opus-4-8"
         assert claude_models.HAIKU == "claude-haiku-4-5"
         assert claude_models.SONNET == "claude-sonnet-4-6"
         assert claude_models.CODEX_ADVISE == "gpt-5.4-mini"

--- a/tests/unit/automation/test_implementer.py
+++ b/tests/unit/automation/test_implementer.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation import implementer
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.implementer import (
     _CLAUDE_IMPL_TIMEOUT,
     IssueImplementer,
@@ -218,6 +219,12 @@ class TestIssueImplementerDynamicDelegates:
         ):
             missing_name = "_sav_state"
             getattr(dry_run_implementer, missing_name)
+
+
+def test_default_state_dir_uses_canonical_path(dry_run_implementer: IssueImplementer) -> None:
+    """IssueImplementer creates the shared default automation state directory."""
+    assert dry_run_implementer.state_dir == dry_run_implementer.repo_root / DEFAULT_STATE_DIR
+    assert dry_run_implementer.state_dir.is_dir()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -24,6 +24,8 @@ from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
+
 
 def test_main_returns_zero_when_no_open_issues(
     monkeypatch: pytest.MonkeyPatch,
@@ -91,3 +93,24 @@ def test_no_ui_flag_skips_curses(
 
     assert rc == 0
     mock_curses.assert_not_called()
+
+
+def test_main_configures_logging_under_default_state_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``main`` passes the canonical state directory to logging setup."""
+    from hephaestus.automation import implementer
+
+    monkeypatch.setattr(sys, "argv", ["impl", "--dry-run", "--no-ui", "--agent", "claude"])
+
+    with (
+        patch.object(implementer, "gh_list_open_issues", return_value=[]),
+        patch.object(implementer, "get_repo_root", return_value=tmp_path),
+        patch.object(implementer, "_setup_logging") as mock_setup_logging,
+    ):
+        rc = implementer.main()
+
+    assert rc == 0
+    mock_setup_logging.assert_called_once()
+    assert mock_setup_logging.call_args.kwargs["log_dir"] == tmp_path / DEFAULT_STATE_DIR

--- a/tests/unit/automation/test_planner_loop.py
+++ b/tests/unit/automation/test_planner_loop.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.models import PLAN_COMMENT_MARKER, PlannerOptions
 from hephaestus.automation.planner import MAX_REVIEW_ITERATIONS, Planner
 from hephaestus.automation.review_state import PLAN_REVIEW_PREFIX, is_plan_review_go
@@ -679,7 +680,7 @@ class TestCapturePlannerLearnings:
         ):
             out = planner._capture_planner_learnings(123, "plan text")
 
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         record = json.loads((state_dir / "planner-learn-123.json").read_text())
         assert out == "- learning A\n"
         assert record["issue_number"] == 123
@@ -704,7 +705,7 @@ class TestCapturePlannerLearnings:
         ):
             out = planner._capture_planner_learnings(123, "plan text")
 
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         record = json.loads((state_dir / "planner-learn-123.json").read_text())
         assert out == ""
         assert record["issue_number"] == 123

--- a/tests/unit/automation/test_pr_reviewer_posting.py
+++ b/tests/unit/automation/test_pr_reviewer_posting.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.claude_invoke import parse_review_verdict
 from hephaestus.automation.models import ReviewerOptions
 from hephaestus.automation.pr_reviewer import (
@@ -178,7 +179,7 @@ class TestIdempotencyGuard:
         from hephaestus.automation.models import ReviewPhase, ReviewState
 
         # Write a completed review state to disk
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         state_dir.mkdir(parents=True)
         completed_state = ReviewState(issue_number=123, pr_number=42, phase=ReviewPhase.COMPLETED)
         (state_dir / "review-123.json").write_text(completed_state.model_dump_json())
@@ -204,7 +205,7 @@ class TestIdempotencyGuard:
         self, mock_options: ReviewerOptions, tmp_path: Path
     ) -> None:
         """Malformed state file → warning logged, fresh state created."""
-        state_dir = tmp_path / "build" / ".issue_implementer"
+        state_dir = tmp_path / DEFAULT_STATE_DIR
         state_dir.mkdir(parents=True)
         (state_dir / "review-123.json").write_text("{not valid json!!!}")
 

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -9,9 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation import _review_utils as review_utils
+from hephaestus.automation import _review_utils as review_utils, models
 from hephaestus.automation._review_utils import (
-    DEFAULT_STATE_DIR,
     _discover_prs_simple,
     add_max_workers_arg,
     close_issue_as_covered,
@@ -39,13 +38,13 @@ class TestEnsureStateDir:
 
     def test_default_state_dir_literal(self) -> None:
         """Default state directory path remains the existing on-disk layout."""
-        assert DEFAULT_STATE_DIR == "build/.issue_implementer"
+        assert models.DEFAULT_STATE_DIR == "build/.issue_implementer"
 
     def test_creates_default_state_dir(self, tmp_path: Path) -> None:
         """Default helper creates and returns the repo-local state directory."""
         state_dir = ensure_state_dir(tmp_path)
 
-        assert state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert state_dir == tmp_path / models.DEFAULT_STATE_DIR
         assert state_dir.is_dir()
 
     def test_creates_custom_subdir(self, tmp_path: Path) -> None:
@@ -134,6 +133,7 @@ class TestSetupReviewLogging:
         review_utils.setup_review_logging(verbose=True)
 
         assert captured["level"] == logging.DEBUG
+
 
 # ---------------------------------------------------------------------------
 # parse_json_block
@@ -292,6 +292,7 @@ class TestPrintWorkerSummary:
             )
 
         assert "\nFailed issues:" in caplog.messages
+
 
 # ---------------------------------------------------------------------------
 # _discover_prs_simple

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -9,12 +9,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation import _review_utils as review_utils, models
+from hephaestus.automation import _review_utils as review_utils
 from hephaestus.automation._review_utils import (
+    DEFAULT_STATE_DIR,
     _discover_prs_simple,
     add_max_workers_arg,
     close_issue_as_covered,
     drain_completed_futures,
+    ensure_state_dir,
     find_merged_closing_pr,
     find_pr_for_issue,
     get_pr_head_branch,
@@ -26,6 +28,58 @@ from hephaestus.automation._review_utils import (
     save_state_file,
 )
 from hephaestus.automation.models import DEFAULT_WORKER_COUNT, ImplementationState, WorkerResult
+
+# ---------------------------------------------------------------------------
+# ensure_state_dir
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureStateDir:
+    """Tests for the shared automation state directory helper."""
+
+    def test_default_state_dir_literal(self) -> None:
+        """Default state directory path remains the existing on-disk layout."""
+        assert DEFAULT_STATE_DIR == "build/.issue_implementer"
+
+    def test_creates_default_state_dir(self, tmp_path: Path) -> None:
+        """Default helper creates and returns the repo-local state directory."""
+        state_dir = ensure_state_dir(tmp_path)
+
+        assert state_dir == tmp_path / DEFAULT_STATE_DIR
+        assert state_dir.is_dir()
+
+    def test_creates_custom_subdir(self, tmp_path: Path) -> None:
+        """A custom subdir keeps the helper reusable for alternate state roots."""
+        state_dir = ensure_state_dir(tmp_path, "custom/state")
+
+        assert state_dir == tmp_path / "custom/state"
+        assert state_dir.is_dir()
+
+
+def test_issue_implementer_state_dir_literal_is_centralized() -> None:
+    """Only the canonical helper and literal-pin test may spell issue_implementer."""
+    import ast
+
+    expected_paths = {
+        Path("hephaestus/automation/models.py"),
+        Path("tests/unit/automation/test_review_utils.py"),
+    }
+    hits: list[tuple[Path, int, str]] = []
+    for base in (Path("hephaestus/automation"), Path("tests/unit/automation")):
+        for path in base.rglob("*.py"):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Constant)
+                    and isinstance(node.value, str)
+                    and "issue_implementer" in node.value
+                ):
+                    hits.append((path, node.lineno, node.value))
+
+    bad = [hit for hit in hits if hit[0] not in expected_paths]
+    assert not bad
+    assert {path for path, _, _ in hits} == expected_paths
+
 
 # ---------------------------------------------------------------------------
 # log_file_path
@@ -80,7 +134,6 @@ class TestSetupReviewLogging:
         review_utils.setup_review_logging(verbose=True)
 
         assert captured["level"] == logging.DEBUG
-
 
 # ---------------------------------------------------------------------------
 # parse_json_block
@@ -239,28 +292,6 @@ class TestPrintWorkerSummary:
             )
 
         assert "\nFailed issues:" in caplog.messages
-
-
-class TestEnsureStateDir:
-    """Tests for the canonical automation state-dir helper."""
-
-    def test_ensure_state_dir_creates_default_state_dir_under_repo_root(
-        self, tmp_path: Path
-    ) -> None:
-        """Default state dir is created under the provided repo root."""
-        state_dir = review_utils.ensure_state_dir(tmp_path)
-
-        assert models.DEFAULT_STATE_DIR == "build/.issue_implementer"
-        assert state_dir == tmp_path / Path(models.DEFAULT_STATE_DIR)
-        assert state_dir.is_dir()
-
-    def test_ensure_state_dir_accepts_custom_subdir(self, tmp_path: Path) -> None:
-        """Callers can override the subdir while reusing mkdir behavior."""
-        state_dir = review_utils.ensure_state_dir(tmp_path, subdir="custom/state")
-
-        assert state_dir == tmp_path / "custom" / "state"
-        assert state_dir.is_dir()
-
 
 # ---------------------------------------------------------------------------
 # _discover_prs_simple

--- a/tests/unit/automation/test_reviewer_base_contract.py
+++ b/tests/unit/automation/test_reviewer_base_contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from hephaestus.automation import _reviewer_base
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR
 from hephaestus.automation.models import ReviewState
 from hephaestus.io import utils as io_utils
 
@@ -39,6 +40,14 @@ def test_injection_wires_repo_root(tmp_path: Path) -> None:
     deps = _make_deps(tmp_path)
     r = ConcreteReviewer(_make_options(), **deps)
     assert r.repo_root == tmp_path
+
+
+def test_injection_wires_default_state_dir(tmp_path: Path) -> None:
+    """Constructor injection must create the canonical default state directory."""
+    deps = _make_deps(tmp_path)
+    r = ConcreteReviewer(_make_options(), **deps)
+    assert r.state_dir == tmp_path / DEFAULT_STATE_DIR
+    assert r.state_dir.is_dir()
 
 
 def test_injection_calls_factories(tmp_path: Path) -> None:
@@ -83,7 +92,7 @@ def test_save_state_persists_review_state_with_secure_permissions(tmp_path: Path
 
     reviewer._save_state(state)
 
-    state_file = tmp_path / "build" / ".issue_implementer" / "review-1402.json"
+    state_file = tmp_path / DEFAULT_STATE_DIR / "review-1402.json"
     restored = ReviewState.model_validate_json(state_file.read_text())
     assert restored.issue_number == 1402
     assert restored.pr_number == 2402


### PR DESCRIPTION
## Summary

- preserve the canonical automation state directory helper behavior on current `main`
- add regression coverage for reviewer, driver, implementer, planner, and audit-reviewer state-dir initialization
- replace the closed unmerged #1622 branch with a rebased, verified branch

Closes #1394

## Verification

- `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1394 pixi run ruff check hephaestus/automation/_review_utils.py hephaestus/automation/_reviewer_base.py hephaestus/automation/audit_reviewer.py hephaestus/automation/ci_driver.py hephaestus/automation/planner_review_loop.py tests/unit/automation/test_review_utils.py tests/unit/automation/test_reviewer_base_contract.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_implementer.py tests/unit/automation/test_audit_reviewer.py tests/integration/test_audit_reviewer_integration.py`
- `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1394 pixi run pytest tests/unit/automation/test_review_utils.py tests/unit/automation/test_reviewer_base_contract.py tests/unit/automation/test_ci_driver.py tests/unit/automation/test_implementer.py tests/unit/automation/test_audit_reviewer.py tests/integration/test_audit_reviewer_integration.py -q --no-cov`
