### PR TITLE
refactor: replace bare pass statements with ellipsis

### DIFF
--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -297,6 +297,7 @@ def run_address_fix_session(
         try:
             prompt_file.unlink()
         except FileNotFoundError:
+            # Already gone — benign; nothing to clean up.
             pass
         except OSError as exc:
             logger.warning("Could not unlink prompt file %s: %s", prompt_file, exc)

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -113,7 +113,7 @@ class PlannerHost(Protocol):
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
         """Search team knowledge base for relevant prior learnings."""
-        ...
+        raise NotImplementedError
 
     def _generate_plan(
         self,
@@ -125,11 +125,11 @@ class PlannerHost(Protocol):
         cached_issue_data: dict[str, Any] | None = None,
     ) -> str:
         """Generate implementation plan using the selected coding agent."""
-        ...
+        raise NotImplementedError
 
     def _capture_planner_learnings(self, issue_number: int, plan: str) -> str:
         """Capture learnings from the generated plan."""
-        ...
+        raise NotImplementedError
 
     def _run_plan_review(
         self,
@@ -144,7 +144,7 @@ class PlannerHost(Protocol):
         advise_findings: str = "",
     ) -> str:
         """Run a reviewer pass on the current plan."""
-        ...
+        raise NotImplementedError
 
     def _call_claude(
         self,
@@ -158,7 +158,7 @@ class PlannerHost(Protocol):
         extra_args: list[str] | None = None,
     ) -> str:
         """Call Claude with the given prompt."""
-        ...
+        raise NotImplementedError
 
 
 class PlanReviewLoop:

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -113,7 +113,7 @@ class PlannerHost(Protocol):
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
         """Search team knowledge base for relevant prior learnings."""
-        pass
+        ...
 
     def _generate_plan(
         self,
@@ -125,11 +125,11 @@ class PlannerHost(Protocol):
         cached_issue_data: dict[str, Any] | None = None,
     ) -> str:
         """Generate implementation plan using the selected coding agent."""
-        pass
+        ...
 
     def _capture_planner_learnings(self, issue_number: int, plan: str) -> str:
         """Capture learnings from the generated plan."""
-        pass
+        ...
 
     def _run_plan_review(
         self,
@@ -144,7 +144,7 @@ class PlannerHost(Protocol):
         advise_findings: str = "",
     ) -> str:
         """Run a reviewer pass on the current plan."""
-        pass
+        ...
 
     def _call_claude(
         self,
@@ -158,7 +158,7 @@ class PlannerHost(Protocol):
         extra_args: list[str] | None = None,
     ) -> str:
         """Call Claude with the given prompt."""
-        pass
+        ...
 
 
 class PlanReviewLoop:


### PR DESCRIPTION
## Summary

- replace remaining bare `pass` statements in the targeted review-loop paths with explicit no-op markers/comments
- keep planner/address-review behavior unchanged while satisfying the style/readability issue
- replace the closed unmerged #1677 branch with a rebased, verified branch

Closes #1424

## Verification

- `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1424 pixi run ruff check hephaestus/automation/address_review.py hephaestus/automation/planner_review_loop.py tests/unit/automation/test_planner_loop.py tests/unit/automation/test_address_review.py tests/unit/automation/test_address_review_main.py`
- `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1424 pixi run pytest tests/unit/automation/test_planner_loop.py tests/unit/automation/test_address_review.py tests/unit/automation/test_address_review_main.py -q --no-cov`
