### PR TITLE
refactor(automation): split CI driver drive-green orchestration

### DIFF
--- a/hephaestus/automation/auto_merge_coordinator.py
+++ b/hephaestus/automation/auto_merge_coordinator.py
@@ -119,7 +119,10 @@ class AutoMergeCoordinator:
         if outcome == "FAILING":
             fix_result = self._fix_flow.attempt_ci_fixes(issue_number, pr_number, acquired_slot)
             if fix_result is not None and fix_result.success:
-                return self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot) or fix_result
+                return (
+                    self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+                    or fix_result
+                )
             return fix_result or WorkerResult(
                 issue_number=issue_number,
                 success=False,
@@ -171,7 +174,11 @@ class AutoMergeCoordinator:
             if merge_status == "BLOCKED" and not failing:
                 pending = self._pending_required_check_names(pr_number)
                 if not pending:
-                    logger.warning("Issue #%s: PR #%s is BLOCKED by branch protection", issue_number, pr_number)
+                    logger.warning(
+                        "Issue #%s: PR #%s is BLOCKED by branch protection",
+                        issue_number,
+                        pr_number,
+                    )
                     return "BLOCKED"
             if merge_status == "BLOCKED" and policy_only_failure:
                 logger.info(
@@ -207,7 +214,9 @@ class AutoMergeCoordinator:
             rearmed = self._recheck_and_arm_after_fix(
                 issue_number, pr_number, acquired_slot, resolve_dirty=False
             )
-            return rearmed or WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+            return rearmed or WorkerResult(
+                issue_number=issue_number, success=True, pr_number=pr_number
+            )
         base_branch = "main"
         try:
             result = self._gh_call(
@@ -270,5 +279,9 @@ class AutoMergeCoordinator:
             result = self._gh_call(["pr", "view", str(pr_number), "--json", "labels"], check=False)
             return pr_has_implementation_go_label(dict(json.loads(result.stdout or "{}")))
         except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            logger.warning("Could not fetch PR #%s labels for implementation-GO gate: %s", pr_number, exc)
+            logger.warning(
+                "Could not fetch PR #%s labels for implementation-GO gate: %s",
+                pr_number,
+                exc,
+            )
             return False

--- a/hephaestus/automation/auto_merge_coordinator.py
+++ b/hephaestus/automation/auto_merge_coordinator.py
@@ -7,7 +7,7 @@ import logging
 import subprocess
 import time
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from hephaestus.constants import read_timeout_env
 
@@ -132,7 +132,10 @@ class AutoMergeCoordinator:
         if outcome == "DIRTY":
             return self.resolve_dirty_pr(issue_number, pr_number, acquired_slot)
         if outcome == "BLOCKED":
-            return self._review_threads.resolve_blocked_pr(issue_number, pr_number, acquired_slot)
+            return cast(
+                WorkerResult,
+                self._review_threads.resolve_blocked_pr(issue_number, pr_number, acquired_slot),
+            )
         return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
     def wait_for_pr_terminal(self, issue_number: int, pr_number: int) -> TerminalOutcome:
@@ -237,9 +240,12 @@ class AutoMergeCoordinator:
             issue_number, pr_number, acquired_slot, extra_context=conflict_context
         )
         if fix_result is not None and fix_result.success:
-            return self._recheck_and_arm_after_fix(
-                issue_number, pr_number, acquired_slot, resolve_dirty=False
-            ) or fix_result
+            return (
+                self._recheck_and_arm_after_fix(
+                    issue_number, pr_number, acquired_slot, resolve_dirty=False
+                )
+                or fix_result
+            )
         return WorkerResult(
             issue_number=issue_number,
             success=False,

--- a/hephaestus/automation/auto_merge_coordinator.py
+++ b/hephaestus/automation/auto_merge_coordinator.py
@@ -1,0 +1,274 @@
+"""Auto-merge arming and terminal-state routing for drive-green."""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import time
+from collections.abc import Callable
+from typing import Any, Literal
+
+from hephaestus.constants import read_timeout_env
+
+from .git_utils import issue_ref, pr_ref
+from .models import CIDriverOptions, WorkerResult
+from .pr_manager import pr_has_implementation_go_label
+
+logger = logging.getLogger(__name__)
+
+AUTO_MERGE_POLICY_CHECK = "auto-merge-policy"
+TerminalOutcome = Literal["MERGED", "CLOSED", "FAILING", "DIRTY", "BLOCKED", "TIMEOUT"]
+
+
+def without_auto_merge_policy(check_names: list[str]) -> list[str]:
+    """Return failing checks that can plausibly be fixed by a CI-fix agent."""
+    return [name for name in check_names if name != AUTO_MERGE_POLICY_CHECK]
+
+
+class AutoMergeCoordinator:
+    """Owns auto-merge writes and terminal PR polling."""
+
+    def __init__(
+        self,
+        *,
+        options_provider: Callable[[], CIDriverOptions],
+        status_tracker_provider: Callable[[], Any],
+        get_pr_branch: Callable[[int], str],
+        is_bot_pr_mode: Callable[[int, int], bool],
+        gh_call: Callable[..., subprocess.CompletedProcess[str]],
+        gh_pr_state: Callable[[int], dict[str, Any] | None],
+        gh_pr_checks: Callable[[int, bool], list[dict[str, Any]]],
+        failing_required_check_names: Callable[[int], list[str]],
+        pending_required_check_names: Callable[[int], list[str]],
+        fix_flow: Any,
+        arming: Any,
+        review_threads: Any,
+        attempt_mechanical_rebase: Callable[[int, int, int], bool],
+        recheck_and_arm_after_fix: Callable[..., WorkerResult | None],
+    ) -> None:
+        """Initialise auto-merge dependencies."""
+        self._options = options_provider
+        self._status = status_tracker_provider
+        self._get_pr_branch = get_pr_branch
+        self._is_bot_pr_mode = is_bot_pr_mode
+        self._gh_call = gh_call
+        self._gh_pr_state = gh_pr_state
+        self._gh_pr_checks = gh_pr_checks
+        self._failing_required_check_names = failing_required_check_names
+        self._pending_required_check_names = pending_required_check_names
+        self._fix_flow = fix_flow
+        self._arming = arming
+        self._review_threads = review_threads
+        self._attempt_mechanical_rebase = attempt_mechanical_rebase
+        self._recheck_and_arm_after_fix = recheck_and_arm_after_fix
+
+    def arm_all_unarmed_open_prs(self, open_prs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Arm auto-merge on every implementation-GO unarmed open PR."""
+        armed_now: list[int] = []
+        for pr in open_prs:
+            number = pr.get("number")
+            if not isinstance(number, int) or number < 0 or pr.get("autoMergeRequest"):
+                continue
+            if not pr_has_implementation_go_label(pr):
+                logger.info(
+                    "PR #%s lacks state:implementation-go; leaving auto-merge disabled",
+                    number,
+                )
+                continue
+            if self.enable_auto_merge(number, is_bot_pr=bool(pr.get("isBot"))):
+                armed_now.append(number)
+        if not armed_now:
+            return open_prs
+        logger.info(
+            "Armed auto-merge on %d previously-unarmed open PR(s): %s",
+            len(armed_now),
+            sorted(armed_now),
+        )
+        return []
+
+    def arm_and_wait_for_merge(
+        self, issue_number: int, pr_number: int, acquired_slot: int
+    ) -> WorkerResult:
+        """Enable auto-merge, record arming, and route the terminal outcome."""
+        self._status().update_slot(acquired_slot, f"{pr_ref(pr_number)}: enabling auto-merge")
+        if self._options().dry_run:
+            logger.info(
+                "[dry_run] Would enable auto-merge for PR #%s (issue #%s)",
+                pr_number,
+                issue_number,
+            )
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        merge_ok = self.enable_auto_merge(
+            pr_number, is_bot_pr=self._is_bot_pr_mode(issue_number, pr_number)
+        )
+        if not merge_ok:
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                pr_number=pr_number,
+                error=f"auto-merge failed for PR {pr_ref(pr_number)}",
+            )
+        self._status().update_slot(
+            acquired_slot, f"{pr_ref(pr_number)}: arming for post-merge /learn"
+        )
+        gh_state = self._gh_pr_state(pr_number)
+        pr_head_sha = (gh_state or {}).get("headRefOid", "") or ""
+        self._arming.record_arming(pr_number, self._get_pr_branch(pr_number), pr_head_sha)
+        outcome = self.wait_for_pr_terminal(issue_number, pr_number)
+        if outcome == "FAILING":
+            fix_result = self._fix_flow.attempt_ci_fixes(issue_number, pr_number, acquired_slot)
+            if fix_result is not None and fix_result.success:
+                return self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot) or fix_result
+            return fix_result or WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                pr_number=pr_number,
+                error=f"CI fix failed after {self._options().max_fix_iterations} attempt(s)",
+            )
+        if outcome == "DIRTY":
+            return self.resolve_dirty_pr(issue_number, pr_number, acquired_slot)
+        if outcome == "BLOCKED":
+            return self._review_threads.resolve_blocked_pr(issue_number, pr_number, acquired_slot)
+        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+    def wait_for_pr_terminal(self, issue_number: int, pr_number: int) -> TerminalOutcome:
+        """Poll an armed PR until it reaches a terminal or actionable state."""
+        if self._options().dry_run:
+            return "TIMEOUT"
+        max_wait = read_timeout_env("HEPH_PR_MERGE_MAX_WAIT", 1800)
+        elapsed = 0
+        attempt = 0
+        while True:
+            gh_state = self._gh_pr_state(pr_number)
+            state = ((gh_state or {}).get("state") or "").upper()
+            if state == "MERGED":
+                logger.info("Issue #%s: PR #%s merged", issue_number, pr_number)
+                return "MERGED"
+            if state == "CLOSED":
+                logger.info("Issue #%s: PR #%s closed without merging", issue_number, pr_number)
+                return "CLOSED"
+            failing = self._failing_required_check_names(pr_number)
+            fixable_failing = without_auto_merge_policy(failing)
+            if fixable_failing:
+                logger.warning(
+                    "Issue #%s: PR #%s went red while awaiting merge (failing: %s)",
+                    issue_number,
+                    pr_number,
+                    ", ".join(fixable_failing),
+                )
+                return "FAILING"
+            merge_status = ((gh_state or {}).get("mergeStateStatus") or "").upper()
+            if merge_status in ("DIRTY", "CONFLICTING"):
+                logger.warning(
+                    "Issue #%s: PR #%s is %s while armed; needs rebase/resolution",
+                    issue_number,
+                    pr_number,
+                    merge_status,
+                )
+                return "DIRTY"
+            policy_only_failure = bool(failing) and not fixable_failing
+            if merge_status == "BLOCKED" and not failing:
+                pending = self._pending_required_check_names(pr_number)
+                if not pending:
+                    logger.warning("Issue #%s: PR #%s is BLOCKED by branch protection", issue_number, pr_number)
+                    return "BLOCKED"
+            if merge_status == "BLOCKED" and policy_only_failure:
+                logger.info(
+                    "Issue #%s: PR #%s is BLOCKED only by auto-merge-policy",
+                    issue_number,
+                    pr_number,
+                )
+            sleep_secs = min(2**attempt, 60)
+            if elapsed + sleep_secs > max_wait:
+                logger.warning(
+                    "Issue #%s: PR #%s still OPEN after %ss (limit %ss)",
+                    issue_number,
+                    pr_number,
+                    elapsed,
+                    max_wait,
+                )
+                return "TIMEOUT"
+            self._status().update_slot(
+                0,
+                f"{issue_ref(issue_number)}: PR #{pr_number} awaiting merge ({elapsed}s elapsed)",
+            )
+            time.sleep(sleep_secs)
+            elapsed += sleep_secs
+            attempt += 1
+
+    def resolve_dirty_pr(
+        self, issue_number: int, pr_number: int, acquired_slot: int
+    ) -> WorkerResult:
+        """Resolve an armed-but-DIRTY PR via rebase or a targeted CI-fix session."""
+        if self._options().dry_run:
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        if self._attempt_mechanical_rebase(issue_number, pr_number, acquired_slot):
+            rearmed = self._recheck_and_arm_after_fix(
+                issue_number, pr_number, acquired_slot, resolve_dirty=False
+            )
+            return rearmed or WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        base_branch = "main"
+        try:
+            result = self._gh_call(
+                ["pr", "view", str(pr_number), "--json", "baseRefName"], check=False
+            )
+            base_branch = dict(json.loads(result.stdout or "{}")).get("baseRefName") or "main"
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.debug("Failed to determine PR base branch for #%s: %s", pr_number, exc)
+        conflict_context = (
+            f"This PR has a MERGE CONFLICT with `origin/{base_branch}` "
+            "(mergeStateStatus=DIRTY) - it cannot merge until the conflict is "
+            f"resolved. Rebase the PR head branch onto `origin/{base_branch}` and "
+            "resolve every conflict, keeping both the PR's intent and the latest "
+            "base changes. Then commit the resolution (signed). There may be NO "
+            "failing CI checks - the conflict itself is the blocker."
+        )
+        fix_result = self._fix_flow.attempt_ci_fixes(
+            issue_number, pr_number, acquired_slot, extra_context=conflict_context
+        )
+        if fix_result is not None and fix_result.success:
+            return self._recheck_and_arm_after_fix(
+                issue_number, pr_number, acquired_slot, resolve_dirty=False
+            ) or fix_result
+        return WorkerResult(
+            issue_number=issue_number,
+            success=False,
+            pr_number=pr_number,
+            error=f"PR {pr_ref(pr_number)} has an unresolved merge conflict",
+        )
+
+    def enable_auto_merge(self, pr_number: int, is_bot_pr: bool = False) -> bool:
+        """Enable auto-merge for a PR, with existing bot and force-merge fallbacks."""
+        try:
+            self._gh_call(["pr", "merge", str(pr_number), "--auto", "--squash"])
+            logger.info("Enabled auto-merge for PR #%s", pr_number)
+            return True
+        except subprocess.CalledProcessError as exc:
+            logger.warning("Could not enable auto-merge for PR #%s: %s", pr_number, exc)
+        if is_bot_pr:
+            try:
+                self._gh_call(["pr", "merge", str(pr_number), "--auto"])
+                logger.info("Enabled auto-merge (strategy-agnostic) for bot PR #%s", pr_number)
+                return True
+            except subprocess.CalledProcessError as exc:
+                logger.warning("Could not enable strategy-agnostic auto-merge: %s", exc)
+        if not self._options().force_merge_on_stall:
+            logger.error("PR #%s: auto-merge failed and force_merge_on_stall is not set", pr_number)
+            return False
+        try:
+            self._gh_call(["pr", "merge", str(pr_number), "--squash", "--delete-branch"])
+            logger.info("Squash-merged PR #%s via fallback", pr_number)
+            return True
+        except subprocess.CalledProcessError as exc:
+            logger.error("PR #%s: both auto-merge and squash fallback failed: %s", pr_number, exc)
+            return False
+
+    def pr_has_implementation_go(self, pr_number: int) -> bool:
+        """Return whether a PR has the implementation-review GO label."""
+        try:
+            result = self._gh_call(["pr", "view", str(pr_number), "--json", "labels"], check=False)
+            return pr_has_implementation_go_label(dict(json.loads(result.stdout or "{}")))
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch PR #%s labels for implementation-GO gate: %s", pr_number, exc)
+            return False

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -128,7 +128,7 @@ def _pr_is_failing(pr: dict[str, Any]) -> bool:
     return any(c.get("conclusion") in FAILING_CHECK_CONCLUSIONS for c in rollup)
 
 
-class CIDriver:
+class _CIDriverCore:
     """Drives open PRs toward green CI by fixing failures and enabling auto-merge.
 
     Features:
@@ -2224,6 +2224,10 @@ class CIDriver:
 
         """
         print_worker_summary("CI Driver Summary", results)
+
+
+class CIDriver(_CIDriverCore):
+    """Public drive-green façade over the compatibility implementation core."""
 
 
 # ---------------------------------------------------------------------------

--- a/hephaestus/automation/ci_fix_flow.py
+++ b/hephaestus/automation/ci_fix_flow.py
@@ -1,0 +1,162 @@
+"""High-level CI-fix attempt flow for drive-green."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from hephaestus.agents.runtime import (
+    direct_agent_model,
+    run_agent_session,
+    uses_direct_agent_runner,
+)
+
+from .advise_runner import run_advise
+from .claude_invoke import invoke_claude_with_session
+from .claude_models import advise_model, codex_advise_model
+from .git_utils import get_repo_slug, issue_ref
+from .models import CIDriverOptions, WorkerResult
+from .prompts import get_advise_prompt_builder
+from .session_naming import AGENT_ADVISE
+
+logger = logging.getLogger(__name__)
+
+
+class CIFixFlow:
+    """Coordinates advise, CI-fix sessions, markers, and bot-thread cleanup."""
+
+    def __init__(
+        self,
+        *,
+        options_provider: Callable[[], CIDriverOptions],
+        repo_root_provider: Callable[[], Path],
+        status_tracker_provider: Callable[[], Any],
+        orchestrator: Any,
+        markers: Any,
+        review_threads: Any,
+        is_bot_pr_mode: Callable[[int, int], bool],
+        gh_issue_json: Callable[[int], dict[str, Any]],
+        get_failing_ci_logs: Callable[[int], str],
+        load_impl_session_id: Callable[[int], str | None],
+        get_worktree_path: Callable[[int, int], Path],
+        get_pr_branch: Callable[[int], str],
+    ) -> None:
+        """Initialise high-level CI-fix dependencies."""
+        self._options = options_provider
+        self._repo_root = repo_root_provider
+        self._status = status_tracker_provider
+        self._orchestrator = orchestrator
+        self._markers = markers
+        self._review_threads = review_threads
+        self._is_bot_pr_mode = is_bot_pr_mode
+        self._gh_issue_json = gh_issue_json
+        self._get_failing_ci_logs = get_failing_ci_logs
+        self._load_impl_session_id = load_impl_session_id
+        self._get_worktree_path = get_worktree_path
+        self._get_pr_branch = get_pr_branch
+
+    def run_advise(self, issue_number: int) -> str:
+        """Pull prior learnings from ProjectMnemosyne before a CI-fix loop."""
+        issue_data = self._gh_issue_json(issue_number)
+        issue_title = issue_data.get("title", f"Issue #{issue_number}")
+        issue_body = issue_data.get("body", "")
+
+        def invoke(prompt: str) -> str:
+            if uses_direct_agent_runner(self._options().agent):
+                result = run_agent_session(
+                    agent=self._options().agent,
+                    prompt=prompt,
+                    cwd=self._repo_root(),
+                    timeout=self._options().advise_timeout,
+                    model=direct_agent_model(
+                        self._options().agent,
+                        "HEPH_ADVISE_MODEL",
+                        codex_default=codex_advise_model(),
+                    ),
+                    sandbox="read-only",
+                )
+                return (result.stdout or "").strip()
+            stdout, _ = invoke_claude_with_session(
+                repo=get_repo_slug(self._repo_root()),
+                issue=issue_number,
+                agent=AGENT_ADVISE,
+                prompt=prompt,
+                model=advise_model(),
+                cwd=self._repo_root(),
+                timeout=self._options().advise_timeout,
+                output_format="text",
+                allowed_tools="Read,Glob,Grep,Bash",
+            )
+            return (stdout or "").strip()
+
+        return run_advise(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            invoke=invoke,
+            build_prompt=get_advise_prompt_builder(self._options().agent),
+        )
+
+    def attempt_ci_fixes(
+        self,
+        issue_number: int,
+        pr_number: int,
+        acquired_slot: int,
+        extra_context: str = "",
+    ) -> WorkerResult | None:
+        """Attempt CI-fix iterations for a failing PR."""
+        if not self._options().dry_run and self._markers.already_pushed_for_current_head(
+            issue_number, pr_number
+        ):
+            logger.info(
+                "Issue #%s: PR #%s head unchanged since the last CI fix this driver pushed; "
+                "skipping redundant CI-fix agent and awaiting pending CI",
+                issue_number,
+                pr_number,
+            )
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        advise_findings = ""
+        if self._options().enable_advise and not self._is_bot_pr_mode(issue_number, pr_number):
+            self._status().update_slot(acquired_slot, f"{issue_ref(issue_number)}: advising")
+            advise_findings = self.run_advise(issue_number)
+        for iteration in range(self._options().max_fix_iterations):
+            self._status().update_slot(
+                acquired_slot,
+                f"{issue_ref(issue_number)}: fetching CI logs (attempt {iteration + 1})",
+            )
+            ci_logs = self._get_failing_ci_logs(pr_number)
+            if extra_context:
+                ci_logs = f"{extra_context}\n\n{ci_logs}".strip()
+            session_id = self._load_impl_session_id(issue_number)
+            worktree_path = self._get_worktree_path(issue_number, pr_number)
+            pr_head_branch = self._get_pr_branch(pr_number)
+            if self._options().dry_run:
+                logger.info(
+                    "[dry_run] Would run CI fix session for PR #%s (issue #%s, iteration %s)",
+                    pr_number,
+                    issue_number,
+                    iteration + 1,
+                )
+                return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+            self._status().update_slot(
+                acquired_slot,
+                f"{issue_ref(issue_number)}: running CI fix session (attempt {iteration + 1})",
+            )
+            fixed = self._orchestrator.run_ci_fix_session(
+                issue_number,
+                pr_number,
+                worktree_path,
+                ci_logs,
+                session_id,
+                advise_findings,
+                pr_head_branch=pr_head_branch,
+            )
+            if fixed:
+                logger.info("Issue #%s: CI fix applied successfully", issue_number)
+                self._markers.record_head(pr_number)
+                self._review_threads.reply_and_resolve_bot_threads(pr_number)
+                return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+            logger.warning("Issue #%s: CI fix attempt %s failed", issue_number, iteration + 1)
+        return None

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -270,100 +270,17 @@ class CIFixOrchestrator:
     ) -> subprocess.CompletedProcess[str]:
         """Dispatch a prompt to the configured agent (codex or claude).
 
-        Returns a CompletedProcess whose returncode signals success or failure:
-        - returncode == 0: agent ran successfully (stdout has output)
-        - returncode != 0: agent failed (stderr has details)
-
-        For codex, returncode is synthetic — AgentRunResult has no returncode
-        field; success is "no CalledProcessError" (hephaestus/agents/runtime.py).
-        For claude, returncode comes from the subprocess exit code.
-
-        CalledProcessError is absorbed from all codex paths into a non-zero
-        CompletedProcess. TimeoutExpired propagates to the caller so it can
-        log a distinct timeout message.
+        ``CalledProcessError`` is converted to a non-zero result; timeout
+        still propagates so callers can log it distinctly.
         """
-        options = self._options()
-        if uses_direct_agent_runner(options.agent):
-            if session_id:
-                try:
-                    result = resume_agent_session(
-                        agent=options.agent,
-                        session_id=session_id,
-                        prompt=prompt,
-                        cwd=worktree_path,
-                        timeout=options.agent_timeout,
-                        model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
-                    )
-                except subprocess.CalledProcessError as exc:
-                    logger.warning(
-                        "Issue #%s: %s resume session %r failed for PR #%s; "
-                        "falling back to fresh session: %s",
-                        issue_number,
-                        options.agent,
-                        session_id,
-                        pr_number,
-                        (exc.stderr or exc.stdout or "")[:300],
-                    )
-                    try:
-                        result = run_agent_session(
-                            agent=options.agent,
-                            prompt=prompt,
-                            cwd=worktree_path,
-                            timeout=options.agent_timeout,
-                            model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
-                            sandbox="workspace-write",
-                        )
-                    except subprocess.CalledProcessError as fresh_exc:
-                        return subprocess.CompletedProcess(
-                            args=fresh_exc.cmd,
-                            returncode=fresh_exc.returncode,
-                            stdout=fresh_exc.stdout or "",
-                            stderr=fresh_exc.stderr or "",
-                        )
-            else:
-                try:
-                    result = run_agent_session(
-                        agent=options.agent,
-                        prompt=prompt,
-                        cwd=worktree_path,
-                        timeout=options.agent_timeout,
-                        model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
-                        sandbox="workspace-write",
-                    )
-                except subprocess.CalledProcessError as exc:
-                    return subprocess.CompletedProcess(
-                        args=exc.cmd,
-                        returncode=exc.returncode,
-                        stdout=exc.stdout or "",
-                        stderr=exc.stderr or "",
-                    )
-            return subprocess.CompletedProcess(
-                args=[], returncode=0, stdout=result.stdout, stderr=result.stderr or ""
-            )
-
-        repo_slug = get_repo_slug(self._repo_root())
-        try:
-            stdout, _ = invoke_claude_with_session(
-                repo=repo_slug,
-                issue=issue_number,
-                agent=AGENT_CI_DRIVER,
-                prompt=prompt,
-                model=implementer_model(),
-                cwd=worktree_path,
-                timeout=options.agent_timeout,
-                output_format="json",
-                allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                extra_args=["--dangerously-skip-permissions"],
-                input_via_stdin=True,
-            )
-            return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
-        except subprocess.CalledProcessError as exc:
-            return subprocess.CompletedProcess(
-                args=exc.cmd,
-                returncode=exc.returncode,
-                stdout=exc.stdout or "",
-                stderr=exc.stderr or "",
-            )
+        return _invoke_agent_session(
+            self,
+            prompt=prompt,
+            session_id=session_id,
+            worktree_path=worktree_path,
+            issue_number=issue_number,
+            pr_number=pr_number,
+        )
 
     def push_ci_fix(
         self,
@@ -519,124 +436,17 @@ class CIFixOrchestrator:
         session_id: str | None,
         max_retries: int = 2,
     ) -> bool:
-        """Re-invoke the agent up to ``max_retries`` times after a no-commit turn (#846).
-
-        A single no-op agent turn used to be terminal: with
-        ``max_fix_iterations=1`` the whole issue failed the instant the first
-        force-engagement retry also returned no commit. That cost real PRs
-        (AchaeanFleet #691/#683, Hermes #643). We now re-engage up to
-        ``max_retries`` times before recording the forensics marker, re-checking
-        between attempts so a PR that goes green (or where a commit lands)
-        short-circuits immediately.
-
-        Only fires when the PR still has failing required checks — a green PR
-        that arrived via concurrent activity should NOT be perturbed. Stays on
-        the same ``(repo, issue, AGENT_CI_DRIVER)`` session so the agent's
-        transcript is continuous; the existing PR and branch are preserved
-        (no new PR, no new branch, no force-push to a new ref).
-
-        Args:
-            issue_number: GitHub issue number for the PR.
-            pr_number: PR number to retry on.
-            worktree_path: Worktree the agent runs in (same as the first turn).
-            pr_head_branch: PR head branch name; the retry must not switch off it.
-            pre_agent_sha: HEAD SHA from before the first turn (used as the
-                no-commit baseline for the retry too — if the retry doesn't
-                advance past this, we treat it as repeated-no-commit).
-            session_id: Codex resume id (Claude resumes by deterministic UUID).
-            max_retries: Maximum number of force-engagement retries.
-
-        Returns:
-            True if the retry produced a new commit (caller should push).
-            False if CI is green now, the retry returned no commit again, or
-            any error path fired. On repeated-no-commit, writes a forensics
-            marker to ``state_dir``.
-
-        """
-        failing: list[str] = []
-        for retry in range(1, max_retries + 1):
-            failing = self._failing_required_check_names(pr_number)
-            dirty_tracked_changes = self._tracked_worktree_changes(worktree_path, issue_number)
-            if not failing and not dirty_tracked_changes:
-                logger.info(
-                    "Issue #%s: no-commit turn but PR #%s has no failing required checks "
-                    "and no tracked worktree changes; skipping force-engagement retry",
-                    issue_number,
-                    pr_number,
-                )
-                return False
-
-            review_threads_block = self._format_review_threads_block(pr_number)
-            retry_prompt = self.force_engagement_prompt(
-                issue_number=issue_number,
-                pr_number=pr_number,
-                worktree_path=worktree_path,
-                pr_head_branch=pr_head_branch,
-                failing_check_names=failing,
-                dirty_tracked_changes=dirty_tracked_changes,
-                review_threads_block=review_threads_block,
-            )
-
-            retry_reason = ", ".join(failing) if failing else "tracked worktree changes"
-            logger.warning(
-                "Issue #%s: no-commit on CI fix turn; re-invoking with "
-                "force-engagement prompt (retry %s/%s, reason: %s)",
-                issue_number,
-                retry,
-                max_retries,
-                retry_reason,
-            )
-
-            try:
-                retry_result = self.invoke_agent_session(
-                    prompt=retry_prompt,
-                    session_id=session_id,
-                    worktree_path=worktree_path,
-                    issue_number=issue_number,
-                    pr_number=pr_number,
-                )
-            except subprocess.TimeoutExpired:
-                logger.error(
-                    "Issue #%s: no-commit retry session timed out for PR #%s",
-                    issue_number,
-                    pr_number,
-                )
-                return False
-
-            if retry_result.returncode != 0:
-                logger.error(
-                    "Issue #%s: no-commit retry session failed for PR #%s: %s",
-                    issue_number,
-                    pr_number,
-                    (retry_result.stderr or "")[:300],
-                )
-                return False
-
-            if self._head_advanced(worktree_path, pre_agent_sha, issue_number):
-                return True
-
-            logger.warning(
-                "Issue #%s: still no commit on PR #%s after force-engagement retry %s/%s",
-                issue_number,
-                pr_number,
-                retry,
-                max_retries,
-            )
-
-        logger.error(
-            "Issue #%s: REPEATED no-commit on PR #%s after %s force-engagement "
-            "retries; marking and moving on",
-            issue_number,
-            pr_number,
-            max_retries,
-        )
-        self.record_repeated_no_commit(
+        """Re-invoke the agent after a no-commit turn, then record repeat failures."""
+        return _retry_no_commit_once(
+            self,
             issue_number=issue_number,
             pr_number=pr_number,
+            worktree_path=worktree_path,
             pr_head_branch=pr_head_branch,
-            failing_check_names=failing,
+            pre_agent_sha=pre_agent_sha,
+            session_id=session_id,
+            max_retries=max_retries,
         )
-        return False
 
     def sync_worktree_and_snapshot_sha(
         self, issue_number: int, worktree_path: Path, pr_head_branch: str
@@ -808,138 +618,8 @@ class CIFixOrchestrator:
         pr_number: int,
         acquired_slot: int,
     ) -> bool:
-        """Rebase a behind/conflicting PR onto its base branch with no agent (#871).
-
-        The cheap, deterministic path: a PR that is merely behind its base (or
-        whose changes don't textually overlap) is rebased and pushed here. Only a
-        PR whose rebase hits real conflicts falls through to the CI-fix agent.
-
-        Flow:
-
-        1. Query ``mergeStateStatus`` / ``mergeable`` / ``baseRefName``. Skip
-           (return ``False``) unless the PR is ``BEHIND`` or ``DIRTY`` /
-           ``CONFLICTING``. ``BLOCKED`` is also eligible only when required
-           checks are failing, because GitHub can report failed-check PRs as
-           branch-protection blocked even when a base rebase can bring in the
-           fix.
-        2. Sync the worktree to the PR head, then ``rebase_worktree_onto`` the
-           base branch.
-        3. Clean rebase → push ``HEAD:<pr-head>`` with ``--force-with-lease`` and
-           return ``True``. The push re-triggers CI; the caller's poll loop
-           evaluates the rebased head.
-        4. Conflicts → the rebase is aborted inside ``rebase_worktree_onto``;
-           return ``False`` so the caller continues to the agent path.
-
-        Any unexpected git/subprocess error is logged and swallowed (returns
-        ``False``) — a mechanical-rebase failure must never crash the worker; the
-        agent path is always the safe fallback.
-
-        Args:
-            issue_number: GitHub issue number for the PR.
-            pr_number: PR number to rebase.
-            acquired_slot: Worker slot ID for status tracking.
-
-        Returns:
-            ``True`` if the PR was mechanically rebased and pushed; ``False`` if
-            no rebase was needed, the rebase conflicted, or an error occurred.
-
-        """
-        try:
-            result = _gh_call(
-                [
-                    "pr",
-                    "view",
-                    str(pr_number),
-                    "--json",
-                    "mergeStateStatus,mergeable,headRefName,baseRefName",
-                ],
-                check=False,
-            )
-            state = dict(json.loads(result.stdout or "{}"))
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            logger.warning(
-                "Issue #%s: could not fetch PR #%s merge state for rebase; "
-                "skipping mechanical rebase: %s",
-                issue_number,
-                pr_number,
-                exc,
-            )
-            return False
-
-        merge_state = str(state.get("mergeStateStatus") or "").upper()
-        # Only behind-base / conflicting PRs need a rebase. CLEAN / UNSTABLE /
-        # HAS_HOOKS PRs are already on top of their base — let the check-status
-        # path handle them. BLOCKED is usually review-gated, but GitHub also
-        # reports some failed required-check PRs as BLOCKED; those are still
-        # eligible for the cheap rebase path before invoking an agent.
-        rebase_states = ("BEHIND", "DIRTY", "CONFLICTING")
-        if merge_state == "BLOCKED":
-            failing_checks = self._failing_required_check_names(pr_number)
-            if not failing_checks:
-                return False
-            logger.info(
-                "Issue #%s: PR #%s is BLOCKED with failing required checks (%s); "
-                "attempting mechanical rebase before CI-fix agent",
-                issue_number,
-                pr_number,
-                ", ".join(failing_checks),
-            )
-        elif merge_state not in rebase_states:
-            return False
-
-        pr_head_branch = str(state.get("headRefName") or "") or self._get_pr_branch(pr_number)
-        base_branch = str(state.get("baseRefName") or "main") or "main"
-        if not pr_head_branch:
-            logger.warning(
-                "Issue #%s: PR #%s has no resolvable head branch; skipping rebase",
-                issue_number,
-                pr_number,
-            )
-            return False
-
-        self._status().update_slot(
-            acquired_slot,
-            f"{issue_ref(issue_number)}: mechanical rebase onto {base_branch}",
-        )
-
-        try:
-            worktree_path = self._get_worktree_path(issue_number, pr_number)
-            # Land on the PR's actual remote head before rebasing so we replay the
-            # PR's commits (not a stale local ref) onto the base (#832).
-            sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
-
-            if not rebase_worktree_onto(worktree_path, base_branch):
-                logger.info(
-                    "Issue #%s: PR #%s (%s) has rebase conflicts onto %s; deferring to agent",
-                    issue_number,
-                    pr_number,
-                    merge_state,
-                    base_branch,
-                )
-                return False
-
-            # Clean rebase rewrote history — lease-push to the PR head. The helper
-            # no-ops cleanly if the rebase was already up to date (HEAD unchanged).
-            push_current_branch_with_lease_on_divergence(
-                worktree_path,
-                branch=pr_head_branch,
-                push_ref=f"HEAD:{pr_head_branch}",
-            )
-            logger.info(
-                "Issue #%s: mechanically rebased PR #%s onto %s and pushed (no agent)",
-                issue_number,
-                pr_number,
-                base_branch,
-            )
-            return True
-        except subprocess.CalledProcessError as exc:
-            logger.warning(
-                "Issue #%s: mechanical rebase of PR #%s failed (%s); falling through to agent",
-                issue_number,
-                pr_number,
-                (exc.stderr or exc.stdout or "")[:300],
-            )
-            return False
+        """Rebase a behind/conflicting PR onto its base branch with no agent (#871)."""
+        return _attempt_mechanical_rebase(self, issue_number, pr_number, acquired_slot)
 
     def _tracked_worktree_changes(self, worktree_path: Path, issue_number: int) -> list[str]:
         """Return actionable dirty status lines for a post-agent worktree.
@@ -1126,3 +806,340 @@ class CIFixOrchestrator:
             )
             return False
         return True
+
+
+def _completed_process_from_error(
+    exc: subprocess.CalledProcessError,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=exc.cmd,
+        returncode=exc.returncode,
+        stdout=exc.stdout or "",
+        stderr=exc.stderr or "",
+    )
+
+
+def _completed_process_from_agent_result(result: Any) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=result.stdout,
+        stderr=result.stderr or "",
+    )
+
+
+def _run_fresh_direct_agent(
+    options: Any,
+    *,
+    prompt: str,
+    worktree_path: Path,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = run_agent_session(
+            agent=options.agent,
+            prompt=prompt,
+            cwd=worktree_path,
+            timeout=options.agent_timeout,
+            model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
+            sandbox="workspace-write",
+        )
+    except subprocess.CalledProcessError as exc:
+        return _completed_process_from_error(exc)
+    return _completed_process_from_agent_result(result)
+
+
+def _invoke_direct_agent_session(
+    orchestrator: CIFixOrchestrator,
+    *,
+    prompt: str,
+    session_id: str | None,
+    worktree_path: Path,
+    issue_number: int,
+    pr_number: int,
+) -> subprocess.CompletedProcess[str]:
+    options = orchestrator._options()
+    if not session_id:
+        return _run_fresh_direct_agent(options, prompt=prompt, worktree_path=worktree_path)
+    try:
+        result = resume_agent_session(
+            agent=options.agent,
+            session_id=session_id,
+            prompt=prompt,
+            cwd=worktree_path,
+            timeout=options.agent_timeout,
+            model=direct_agent_model(options.agent, "HEPH_IMPLEMENTER_MODEL"),
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Issue #%s: %s resume session %r failed for PR #%s; "
+            "falling back to fresh session: %s",
+            issue_number,
+            options.agent,
+            session_id,
+            pr_number,
+            (exc.stderr or exc.stdout or "")[:300],
+        )
+        return _run_fresh_direct_agent(options, prompt=prompt, worktree_path=worktree_path)
+    return _completed_process_from_agent_result(result)
+
+
+def _invoke_claude_agent_session(
+    orchestrator: CIFixOrchestrator,
+    *,
+    prompt: str,
+    worktree_path: Path,
+    issue_number: int,
+) -> subprocess.CompletedProcess[str]:
+    options = orchestrator._options()
+    repo_slug = get_repo_slug(orchestrator._repo_root())
+    try:
+        stdout, _ = invoke_claude_with_session(
+            repo=repo_slug,
+            issue=issue_number,
+            agent=AGENT_CI_DRIVER,
+            prompt=prompt,
+            model=implementer_model(),
+            cwd=worktree_path,
+            timeout=options.agent_timeout,
+            output_format="json",
+            allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
+            extra_args=["--dangerously-skip-permissions"],
+            input_via_stdin=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        return _completed_process_from_error(exc)
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+
+
+def _invoke_agent_session(
+    orchestrator: CIFixOrchestrator,
+    *,
+    prompt: str,
+    session_id: str | None,
+    worktree_path: Path,
+    issue_number: int,
+    pr_number: int,
+) -> subprocess.CompletedProcess[str]:
+    options = orchestrator._options()
+    if uses_direct_agent_runner(options.agent):
+        return _invoke_direct_agent_session(
+            orchestrator,
+            prompt=prompt,
+            session_id=session_id,
+            worktree_path=worktree_path,
+            issue_number=issue_number,
+            pr_number=pr_number,
+        )
+    return _invoke_claude_agent_session(
+        orchestrator,
+        prompt=prompt,
+        worktree_path=worktree_path,
+        issue_number=issue_number,
+    )
+
+
+def _retry_no_commit_once(
+    orchestrator: CIFixOrchestrator,
+    *,
+    issue_number: int,
+    pr_number: int,
+    worktree_path: Path,
+    pr_head_branch: str,
+    pre_agent_sha: str,
+    session_id: str | None,
+    max_retries: int,
+) -> bool:
+    failing: list[str] = []
+    for retry in range(1, max_retries + 1):
+        failing = orchestrator._failing_required_check_names(pr_number)
+        dirty_changes = orchestrator._tracked_worktree_changes(worktree_path, issue_number)
+        if not failing and not dirty_changes:
+            logger.info(
+                "Issue #%s: no-commit turn but PR #%s has no failing required checks "
+                "and no tracked worktree changes; skipping force-engagement retry",
+                issue_number,
+                pr_number,
+            )
+            return False
+
+        retry_prompt = orchestrator.force_engagement_prompt(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            worktree_path=worktree_path,
+            pr_head_branch=pr_head_branch,
+            failing_check_names=failing,
+            dirty_tracked_changes=dirty_changes,
+            review_threads_block=orchestrator._format_review_threads_block(pr_number),
+        )
+        retry_reason = ", ".join(failing) if failing else "tracked worktree changes"
+        logger.warning(
+            "Issue #%s: no-commit on CI fix turn; re-invoking with "
+            "force-engagement prompt (retry %s/%s, reason: %s)",
+            issue_number,
+            retry,
+            max_retries,
+            retry_reason,
+        )
+
+        try:
+            retry_result = orchestrator.invoke_agent_session(
+                prompt=retry_prompt,
+                session_id=session_id,
+                worktree_path=worktree_path,
+                issue_number=issue_number,
+                pr_number=pr_number,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error(
+                "Issue #%s: no-commit retry session timed out for PR #%s",
+                issue_number,
+                pr_number,
+            )
+            return False
+
+        if retry_result.returncode != 0:
+            logger.error(
+                "Issue #%s: no-commit retry session failed for PR #%s: %s",
+                issue_number,
+                pr_number,
+                (retry_result.stderr or "")[:300],
+            )
+            return False
+        if orchestrator._head_advanced(worktree_path, pre_agent_sha, issue_number):
+            return True
+        logger.warning(
+            "Issue #%s: still no commit on PR #%s after force-engagement retry %s/%s",
+            issue_number,
+            pr_number,
+            retry,
+            max_retries,
+        )
+
+    logger.error(
+        "Issue #%s: REPEATED no-commit on PR #%s after %s force-engagement "
+        "retries; marking and moving on",
+        issue_number,
+        pr_number,
+        max_retries,
+    )
+    orchestrator.record_repeated_no_commit(
+        issue_number=issue_number,
+        pr_number=pr_number,
+        pr_head_branch=pr_head_branch,
+        failing_check_names=failing,
+    )
+    return False
+
+
+def _fetch_rebase_state(issue_number: int, pr_number: int) -> dict[str, Any] | None:
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "view",
+                str(pr_number),
+                "--json",
+                "mergeStateStatus,mergeable,headRefName,baseRefName",
+            ],
+            check=False,
+        )
+        return dict(json.loads(result.stdout or "{}"))
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Issue #%s: could not fetch PR #%s merge state for rebase; "
+            "skipping mechanical rebase: %s",
+            issue_number,
+            pr_number,
+            exc,
+        )
+        return None
+
+
+def _rebase_state_is_actionable(
+    orchestrator: CIFixOrchestrator,
+    *,
+    issue_number: int,
+    pr_number: int,
+    merge_state: str,
+) -> bool:
+    rebase_states = ("BEHIND", "DIRTY", "CONFLICTING")
+    if merge_state != "BLOCKED":
+        return merge_state in rebase_states
+    failing_checks = orchestrator._failing_required_check_names(pr_number)
+    if not failing_checks:
+        return False
+    logger.info(
+        "Issue #%s: PR #%s is BLOCKED with failing required checks (%s); "
+        "attempting mechanical rebase before CI-fix agent",
+        issue_number,
+        pr_number,
+        ", ".join(failing_checks),
+    )
+    return True
+
+
+def _attempt_mechanical_rebase(
+    orchestrator: CIFixOrchestrator,
+    issue_number: int,
+    pr_number: int,
+    acquired_slot: int,
+) -> bool:
+    state = _fetch_rebase_state(issue_number, pr_number)
+    if state is None:
+        return False
+    merge_state = str(state.get("mergeStateStatus") or "").upper()
+    if not _rebase_state_is_actionable(
+        orchestrator,
+        issue_number=issue_number,
+        pr_number=pr_number,
+        merge_state=merge_state,
+    ):
+        return False
+
+    pr_head_branch = str(state.get("headRefName") or "") or orchestrator._get_pr_branch(
+        pr_number
+    )
+    base_branch = str(state.get("baseRefName") or "main") or "main"
+    if not pr_head_branch:
+        logger.warning(
+            "Issue #%s: PR #%s has no resolvable head branch; skipping rebase",
+            issue_number,
+            pr_number,
+        )
+        return False
+    orchestrator._status().update_slot(
+        acquired_slot,
+        f"{issue_ref(issue_number)}: mechanical rebase onto {base_branch}",
+    )
+    try:
+        worktree_path = orchestrator._get_worktree_path(issue_number, pr_number)
+        sync_worktree_to_remote_branch(worktree_path, pr_head_branch)
+        if not rebase_worktree_onto(worktree_path, base_branch):
+            logger.info(
+                "Issue #%s: PR #%s (%s) has rebase conflicts onto %s; deferring to agent",
+                issue_number,
+                pr_number,
+                merge_state,
+                base_branch,
+            )
+            return False
+        push_current_branch_with_lease_on_divergence(
+            worktree_path,
+            branch=pr_head_branch,
+            push_ref=f"HEAD:{pr_head_branch}",
+        )
+        logger.info(
+            "Issue #%s: mechanically rebased PR #%s onto %s and pushed (no agent)",
+            issue_number,
+            pr_number,
+            base_branch,
+        )
+        return True
+    except subprocess.CalledProcessError as exc:
+        logger.warning(
+            "Issue #%s: mechanical rebase of PR #%s failed (%s); falling through to agent",
+            issue_number,
+            pr_number,
+            (exc.stderr or exc.stdout or "")[:300],
+        )
+        return False

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -871,8 +871,7 @@ def _invoke_direct_agent_session(
         )
     except subprocess.CalledProcessError as exc:
         logger.warning(
-            "Issue #%s: %s resume session %r failed for PR #%s; "
-            "falling back to fresh session: %s",
+            "Issue #%s: %s resume session %r failed for PR #%s; falling back to fresh session: %s",
             issue_number,
             options.agent,
             session_id,
@@ -1096,9 +1095,7 @@ def _attempt_mechanical_rebase(
     ):
         return False
 
-    pr_head_branch = str(state.get("headRefName") or "") or orchestrator._get_pr_branch(
-        pr_number
-    )
+    pr_head_branch = str(state.get("headRefName") or "") or orchestrator._get_pr_branch(pr_number)
     base_branch = str(state.get("baseRefName") or "main") or "main"
     if not pr_head_branch:
         logger.warning(

--- a/hephaestus/automation/ci_run_coordinator.py
+++ b/hephaestus/automation/ci_run_coordinator.py
@@ -1,0 +1,322 @@
+"""Top-level run coordinator for drive-green."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from typing import Any
+
+from ._review_utils import drain_completed_futures, print_worker_summary
+from .auto_merge_coordinator import (
+    AUTO_MERGE_POLICY_CHECK,
+    without_auto_merge_policy,
+)
+from .git_utils import issue_ref, pr_ref
+from .models import CIDriverOptions, WorkerResult
+
+logger = logging.getLogger(__name__)
+
+
+class CIDriveRunCoordinator:
+    """Coordinates a full drive-green run across discovered PR work items."""
+
+    def __init__(
+        self,
+        *,
+        options_provider: Any,
+        worktree_manager: Any,
+        status_tracker: Any,
+        discovery: Any,
+        check_inspector: Any,
+        fix_flow: Any,
+        auto_merge: Any,
+        arming: Any,
+        set_shared_pr_issues: Any,
+    ) -> None:
+        """Initialise the run coordinator."""
+        self._options = options_provider
+        self._worktrees = worktree_manager
+        self._status = status_tracker
+        self._discovery = discovery
+        self._check_inspector = check_inspector
+        self._fix_flow = fix_flow
+        self._auto_merge = auto_merge
+        self._arming = arming
+        self._set_shared_pr_issues = set_shared_pr_issues
+        self._lock = threading.Lock()
+        self.open_prs_remaining: list[dict[str, Any]] = []
+
+    def run(self) -> dict[int, WorkerResult]:
+        """Run drive-green for the configured issue/PR inputs."""
+        options = self._options()
+        logger.info(
+            "Starting CI driver for %s issue(s) with %s parallel workers",
+            len(options.issues),
+            options.max_workers,
+        )
+        if not options.dry_run:
+            self._arming.sweep_orphaned_records()
+        if not options.issues and not options.prs and not options.include_bot_prs:
+            logger.warning("No issues, no direct PRs, and bot-PR discovery disabled")
+            return {}
+        workset = self._discovery.discover_workset(options.issues)
+        self._set_shared_pr_issues(workset.shared_pr_issues)
+        pr_map = workset.pr_map
+        if not pr_map:
+            logger.warning(
+                "No open PRs found for the specified issues (and no open bot PRs) "
+                "- nothing to drive"
+            )
+            return {}
+        logger.info("Found %s PR(s) to drive to green: %s", len(pr_map), pr_map)
+        try:
+            results = self._drive_pr_map(pr_map)
+        finally:
+            if not options.dry_run:
+                try:
+                    self._worktrees.cleanup_all()
+                except Exception:
+                    logger.exception("Error during worktree cleanup in CIDriver.run()")
+            if self._worktrees.preserved:
+                logger.info("Preserved worktrees (contain uncommitted changes):")
+                for issue_num, path in self._worktrees.preserved:
+                    logger.info("  #%d: %s", issue_num, path)
+        print_worker_summary("CI Driver Summary", results)
+        self.open_prs_remaining = self._final_open_prs(pr_map)
+        return results
+
+    def _drive_pr_map(self, pr_map: dict[int, int]) -> dict[int, WorkerResult]:
+        results: dict[int, WorkerResult] = {}
+        with ThreadPoolExecutor(max_workers=self._options().max_workers) as executor:
+            futures: dict[Future[Any], int] = {}
+            for idx, (issue_num, pr_num) in enumerate(pr_map.items()):
+                future = executor.submit(self.drive_issue, issue_num, pr_num, idx)
+                futures[future] = issue_num
+            for future in drain_completed_futures(futures):
+                issue_num = futures.pop(future)
+                try:
+                    result = future.result()
+                    with self._lock:
+                        results[issue_num] = result
+                    if result.success:
+                        logger.info("Issue #%s: CI drive completed", issue_num)
+                    else:
+                        logger.error("Issue #%s: CI drive failed: %s", issue_num, result.error)
+                except Exception as exc:
+                    logger.error("Issue #%s raised exception: %s", issue_num, exc)
+                    with self._lock:
+                        results[issue_num] = WorkerResult(
+                            issue_number=issue_num,
+                            success=False,
+                            error=str(exc),
+                        )
+        return results
+
+    def _final_open_prs(self, pr_map: dict[int, int]) -> list[dict[str, Any]]:
+        if self._options().dry_run:
+            return []
+        remaining = self._discovery.list_open_prs_remaining()
+        if self._options().issues and remaining:
+            scoped_prs = set(pr_map.values())
+            remaining = [pr for pr in remaining if pr.get("number") in scoped_prs]
+        if remaining:
+            remaining = self._auto_merge.arm_all_unarmed_open_prs(remaining)
+        if remaining:
+            logger.warning("%d open PR(s) remain on the repo - not done:", len(remaining))
+            for pr in remaining:
+                am_state = (
+                    "armed (waiting on CI / branch protection)"
+                    if pr.get("autoMergeRequest")
+                    else "NOT armed (needs manual action)"
+                )
+                logger.warning(
+                    "  - PR #%s %r head=%s auto-merge=%s",
+                    pr.get("number"),
+                    pr.get("title", ""),
+                    pr.get("headRefName", ""),
+                    am_state,
+                )
+        return remaining
+
+    def drive_issue(self, issue_number: int, pr_number: int, slot_id: int) -> WorkerResult:
+        """Drive a single PR toward green CI and auto-merge."""
+        with self._status.slot() as acquired_slot:
+            if acquired_slot is None:
+                return WorkerResult(
+                    issue_number=issue_number,
+                    success=False,
+                    error="Failed to acquire worker slot",
+                )
+            try:
+                armed = self._arming.check_on_drive_start(issue_number, pr_number)
+                if armed is not None:
+                    return armed
+                if self._options().enable_mechanical_rebase and not self._options().dry_run:
+                    self._auto_merge._attempt_mechanical_rebase(issue_number, pr_number, acquired_slot)
+                self._status.update_slot(acquired_slot, f"{pr_ref(pr_number)}: fetching checks")
+                poll_result = self.poll_ci_until_concluded(
+                    issue_number, pr_number, acquired_slot, self._options().poll_max_wait
+                )
+                if poll_result is None:
+                    return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+                _checks, required_checks = poll_result
+                all_green = all(
+                    c.get("conclusion") in ("success", "skipped", "neutral")
+                    for c in required_checks
+                )
+                if all_green:
+                    if not self._auto_merge.pr_has_implementation_go(pr_number):
+                        logger.info(
+                            "Issue #%s: PR #%s is green but lacks state:implementation-go",
+                            issue_number,
+                            pr_number,
+                        )
+                        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+                    return self._auto_merge.arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
+                return self.handle_failing_pr(issue_number, pr_number, acquired_slot, required_checks)
+            except Exception as exc:
+                logger.error("Issue #%s: unexpected error: %s", issue_number, exc)
+                return WorkerResult(issue_number=issue_number, success=False, error=str(exc)[:200])
+
+    def poll_ci_until_concluded(
+        self, issue_number: int, pr_number: int, acquired_slot: int, max_wait: int
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]] | None:
+        """Poll CI until all required checks conclude, no checks exist, or timeout hits."""
+        poll_elapsed = 0
+        poll_attempt = 0
+        while True:
+            checks = self._check_inspector.gh_pr_checks(pr_number, self._options().dry_run)
+            if not checks:
+                logger.info("Issue #%s: no CI checks found for PR #%s", issue_number, pr_number)
+                return None
+            required_checks = [c for c in checks if c.get("required", False)] or checks
+            if all(c["status"] == "completed" for c in required_checks):
+                return checks, required_checks
+            sleep_secs = min(2**poll_attempt, 60)
+            if poll_elapsed + sleep_secs > max_wait:
+                logger.warning(
+                    "Issue #%s: CI checks still pending after %ss (limit %ss)",
+                    issue_number,
+                    poll_elapsed,
+                    max_wait,
+                )
+                return None
+            self._status.update_slot(
+                acquired_slot,
+                f"{pr_ref(pr_number)}: waiting for CI checks "
+                f"(attempt {poll_attempt + 1}, {poll_elapsed}s elapsed)",
+            )
+            time.sleep(sleep_secs)
+            poll_elapsed += sleep_secs
+            poll_attempt += 1
+
+    def handle_failing_pr(
+        self,
+        issue_number: int,
+        pr_number: int,
+        acquired_slot: int,
+        required_checks: list[dict[str, Any]],
+    ) -> WorkerResult:
+        """Handle a PR whose required checks concluded non-green."""
+        failing = [c for c in required_checks if c.get("conclusion") == "failure"]
+        if not failing:
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        failing_names = [str(c.get("name") or "") for c in failing]
+        fixable_names = without_auto_merge_policy(failing_names)
+        if not fixable_names and AUTO_MERGE_POLICY_CHECK in failing_names:
+            if not self._auto_merge.pr_has_implementation_go(pr_number):
+                return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+            return self._auto_merge.arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
+        fix_result = self._fix_flow.attempt_ci_fixes(issue_number, pr_number, acquired_slot)
+        if fix_result is not None and fix_result.success:
+            return self.recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot) or fix_result
+        if fix_result is not None:
+            return fix_result
+        return WorkerResult(
+            issue_number=issue_number,
+            success=False,
+            pr_number=pr_number,
+            error=f"CI fix failed after {self._options().max_fix_iterations} attempt(s)",
+        )
+
+    def recheck_and_arm_after_fix(
+        self,
+        issue_number: int,
+        pr_number: int,
+        acquired_slot: int,
+        *,
+        resolve_dirty: bool = True,
+    ) -> WorkerResult | None:
+        """Re-poll post-fix CI and arm auto-merge if the PR is now green."""
+        if self._options().dry_run:
+            return None
+        checks = _poll_post_fix_required(
+            issue_number,
+            pr_number,
+            acquired_slot,
+            self._options().poll_max_wait,
+            self._options().dry_run,
+            self._check_inspector.gh_pr_checks,
+            self._status,
+        )
+        if not checks:
+            return None
+        if not all(c.get("conclusion") in ("success", "skipped", "neutral") for c in checks):
+            return None
+        if not self._auto_merge.pr_has_implementation_go(pr_number):
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        merge = self._auto_merge.enable_auto_merge(
+            pr_number, is_bot_pr=self._discovery.is_bot_pr_mode(issue_number, pr_number)
+        )
+        if not merge:
+            return WorkerResult(
+                issue_number=issue_number,
+                success=False,
+                pr_number=pr_number,
+                error=f"auto-merge failed for PR {pr_ref(pr_number)}",
+            )
+        gh_state = self._auto_merge._gh_pr_state(pr_number)
+        self._arming.record_arming(
+            pr_number,
+            self._auto_merge._get_pr_branch(pr_number),
+            (gh_state or {}).get("headRefOid", "") or "",
+        )
+        outcome = self._auto_merge.wait_for_pr_terminal(issue_number, pr_number)
+        if resolve_dirty and outcome == "DIRTY":
+            return self._auto_merge.resolve_dirty_pr(issue_number, pr_number, acquired_slot)
+        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+
+def _poll_post_fix_required(
+    issue_number: int,
+    pr_number: int,
+    acquired_slot: int,
+    max_wait: int,
+    dry_run: bool,
+    gh_pr_checks: Any,
+    status_tracker: Any,
+) -> list[dict[str, Any]] | None:
+    elapsed = 0
+    attempt = 0
+    while True:
+        checks = gh_pr_checks(pr_number, dry_run)
+        required = [c for c in checks if c.get("required", False)] or checks
+        if required and all(c.get("status") == "completed" for c in required):
+            return required
+        sleep_secs = min(2**attempt, 60)
+        if elapsed + sleep_secs > max_wait:
+            logger.info(
+                "Issue #%s: post-fix CI still pending after %ss; leaving for next run",
+                issue_number,
+                elapsed,
+            )
+            return None
+        status_tracker.update_slot(
+            acquired_slot,
+            f"{issue_ref(issue_number)}: awaiting post-fix CI ({elapsed}s)",
+        )
+        time.sleep(sleep_secs)
+        elapsed += sleep_secs
+        attempt += 1

--- a/hephaestus/automation/ci_run_coordinator.py
+++ b/hephaestus/automation/ci_run_coordinator.py
@@ -14,7 +14,7 @@ from .auto_merge_coordinator import (
     without_auto_merge_policy,
 )
 from .git_utils import issue_ref, pr_ref
-from .models import CIDriverOptions, WorkerResult
+from .models import WorkerResult
 
 logger = logging.getLogger(__name__)
 
@@ -154,13 +154,17 @@ class CIDriveRunCoordinator:
                 if armed is not None:
                     return armed
                 if self._options().enable_mechanical_rebase and not self._options().dry_run:
-                    self._auto_merge._attempt_mechanical_rebase(issue_number, pr_number, acquired_slot)
+                    self._auto_merge._attempt_mechanical_rebase(
+                        issue_number, pr_number, acquired_slot
+                    )
                 self._status.update_slot(acquired_slot, f"{pr_ref(pr_number)}: fetching checks")
                 poll_result = self.poll_ci_until_concluded(
                     issue_number, pr_number, acquired_slot, self._options().poll_max_wait
                 )
                 if poll_result is None:
-                    return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+                    return WorkerResult(
+                        issue_number=issue_number, success=True, pr_number=pr_number
+                    )
                 _checks, required_checks = poll_result
                 all_green = all(
                     c.get("conclusion") in ("success", "skipped", "neutral")
@@ -173,9 +177,17 @@ class CIDriveRunCoordinator:
                             issue_number,
                             pr_number,
                         )
-                        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
-                    return self._auto_merge.arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
-                return self.handle_failing_pr(issue_number, pr_number, acquired_slot, required_checks)
+                        return WorkerResult(
+                            issue_number=issue_number,
+                            success=True,
+                            pr_number=pr_number,
+                        )
+                    return self._auto_merge.arm_and_wait_for_merge(
+                        issue_number, pr_number, acquired_slot
+                    )
+                return self.handle_failing_pr(
+                    issue_number, pr_number, acquired_slot, required_checks
+                )
             except Exception as exc:
                 logger.error("Issue #%s: unexpected error: %s", issue_number, exc)
                 return WorkerResult(issue_number=issue_number, success=False, error=str(exc)[:200])
@@ -231,7 +243,10 @@ class CIDriveRunCoordinator:
             return self._auto_merge.arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
         fix_result = self._fix_flow.attempt_ci_fixes(issue_number, pr_number, acquired_slot)
         if fix_result is not None and fix_result.success:
-            return self.recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot) or fix_result
+            return (
+                self.recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+                or fix_result
+            )
         if fix_result is not None:
             return fix_result
         return WorkerResult(

--- a/hephaestus/automation/ci_run_coordinator.py
+++ b/hephaestus/automation/ci_run_coordinator.py
@@ -6,7 +6,7 @@ import logging
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
-from typing import Any
+from typing import Any, cast
 
 from ._review_utils import drain_completed_futures, print_worker_summary
 from .auto_merge_coordinator import (
@@ -117,12 +117,15 @@ class CIDriveRunCoordinator:
     def _final_open_prs(self, pr_map: dict[int, int]) -> list[dict[str, Any]]:
         if self._options().dry_run:
             return []
-        remaining = self._discovery.list_open_prs_remaining()
+        remaining = cast(list[dict[str, Any]], self._discovery.list_open_prs_remaining())
         if self._options().issues and remaining:
             scoped_prs = set(pr_map.values())
             remaining = [pr for pr in remaining if pr.get("number") in scoped_prs]
         if remaining:
-            remaining = self._auto_merge.arm_all_unarmed_open_prs(remaining)
+            remaining = cast(
+                list[dict[str, Any]],
+                self._auto_merge.arm_all_unarmed_open_prs(remaining),
+            )
         if remaining:
             logger.warning("%d open PR(s) remain on the repo - not done:", len(remaining))
             for pr in remaining:
@@ -150,7 +153,10 @@ class CIDriveRunCoordinator:
                     error="Failed to acquire worker slot",
                 )
             try:
-                armed = self._arming.check_on_drive_start(issue_number, pr_number)
+                armed = cast(
+                    WorkerResult | None,
+                    self._arming.check_on_drive_start(issue_number, pr_number),
+                )
                 if armed is not None:
                     return armed
                 if self._options().enable_mechanical_rebase and not self._options().dry_run:
@@ -182,8 +188,11 @@ class CIDriveRunCoordinator:
                             success=True,
                             pr_number=pr_number,
                         )
-                    return self._auto_merge.arm_and_wait_for_merge(
-                        issue_number, pr_number, acquired_slot
+                    return cast(
+                        WorkerResult,
+                        self._auto_merge.arm_and_wait_for_merge(
+                            issue_number, pr_number, acquired_slot
+                        ),
                     )
                 return self.handle_failing_pr(
                     issue_number, pr_number, acquired_slot, required_checks
@@ -240,12 +249,17 @@ class CIDriveRunCoordinator:
         if not fixable_names and AUTO_MERGE_POLICY_CHECK in failing_names:
             if not self._auto_merge.pr_has_implementation_go(pr_number):
                 return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
-            return self._auto_merge.arm_and_wait_for_merge(issue_number, pr_number, acquired_slot)
-        fix_result = self._fix_flow.attempt_ci_fixes(issue_number, pr_number, acquired_slot)
+            return cast(
+                WorkerResult,
+                self._auto_merge.arm_and_wait_for_merge(issue_number, pr_number, acquired_slot),
+            )
+        fix_result = cast(
+            WorkerResult | None,
+            self._fix_flow.attempt_ci_fixes(issue_number, pr_number, acquired_slot),
+        )
         if fix_result is not None and fix_result.success:
             return (
-                self.recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
-                or fix_result
+                self.recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot) or fix_result
             )
         if fix_result is not None:
             return fix_result
@@ -300,7 +314,10 @@ class CIDriveRunCoordinator:
         )
         outcome = self._auto_merge.wait_for_pr_terminal(issue_number, pr_number)
         if resolve_dirty and outcome == "DIRTY":
-            return self._auto_merge.resolve_dirty_pr(issue_number, pr_number, acquired_slot)
+            return cast(
+                WorkerResult,
+                self._auto_merge.resolve_dirty_pr(issue_number, pr_number, acquired_slot),
+            )
         return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
 
 

--- a/hephaestus/automation/drive_green_state.py
+++ b/hephaestus/automation/drive_green_state.py
@@ -1,0 +1,239 @@
+"""Drive-green state stores and arming lifecycle helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from hephaestus.io.utils import write_secure
+from hephaestus.utils.file_lock import file_lock
+
+from .arming_state import ArmingStateStore
+from .git_utils import issue_ref
+from .models import WorkerResult
+
+logger = logging.getLogger(__name__)
+
+
+class LastCIFixStore:
+    """Persists PR head SHAs for CI fixes pushed by drive-green."""
+
+    def __init__(
+        self,
+        *,
+        state_dir_provider: Callable[[], Path],
+        gh_pr_state: Callable[[int], dict[str, Any] | None],
+    ) -> None:
+        """Initialise the marker store."""
+        self._state_dir = state_dir_provider
+        self._gh_pr_state = gh_pr_state
+
+    def marker_path(self, pr_number: int) -> Path:
+        """Return the marker path for a PR's last CI-fix head."""
+        return self._state_dir() / f"last-ci-fix-{pr_number}.json"
+
+    def record_head(self, pr_number: int) -> None:
+        """Persist the current PR head SHA after a successful CI fix push."""
+        gh_state = self._gh_pr_state(pr_number) or {}
+        head_sha = str(gh_state.get("headRefOid") or "")
+        if not head_sha:
+            return
+        try:
+            write_secure(
+                self.marker_path(pr_number),
+                json.dumps({"pr_number": pr_number, "head_sha": head_sha}) + "\n",
+            )
+        except OSError as exc:
+            logger.warning(
+                "Issue: failed to write last-ci-fix marker for PR #%s: %s",
+                pr_number,
+                exc,
+            )
+
+    def already_pushed_for_current_head(self, issue_number: int, pr_number: int) -> bool:
+        """Return True when the current PR head matches the last CI-fix marker."""
+        marker = self.marker_path(pr_number)
+        if not marker.exists():
+            return False
+        try:
+            recorded = str(dict(json.loads(marker.read_text())).get("head_sha") or "")
+        except (OSError, json.JSONDecodeError):
+            return False
+        if not recorded:
+            return False
+        gh_state = self._gh_pr_state(pr_number) or {}
+        current = str(gh_state.get("headRefOid") or "")
+        return bool(current) and current == recorded
+
+
+class DriveGreenArmingCoordinator:
+    """Coordinates drive-green arming records and post-merge learn capture."""
+
+    def __init__(
+        self,
+        *,
+        state_dir_provider: Callable[[], Path],
+        status_tracker_provider: Callable[[], Any],
+        shared_pr_issues_provider: Callable[[], dict[int, list[int]]],
+        gh_pr_state: Callable[[int], dict[str, Any] | None],
+        wait_for_pr_terminal: Callable[[int, int], str],
+        run_drive_green_learnings: Callable[[int, int], bool],
+        run_drive_green_compact: Callable[[int, int], bool],
+        mark_drive_green_learn_result: Callable[[int, dict[str, Any], bool], None],
+    ) -> None:
+        """Initialise arming lifecycle dependencies."""
+        self._state_dir = state_dir_provider
+        self._status = status_tracker_provider
+        self._shared_pr_issues = shared_pr_issues_provider
+        self._gh_pr_state = gh_pr_state
+        self._wait_for_pr_terminal = wait_for_pr_terminal
+        self._run_learn = run_drive_green_learnings
+        self._run_compact = run_drive_green_compact
+        self._mark_learn = mark_drive_green_learn_result
+        self.store = ArmingStateStore(state_dir_provider)
+
+    def record_arming(self, pr_number: int, pr_head_branch: str, pr_head_sha: str) -> None:
+        """Record arming for every issue that resolved to ``pr_number``."""
+        siblings = self._shared_pr_issues().get(pr_number, [])
+        if not siblings:
+            return
+        armed_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        for issue_num in siblings:
+            existing = self.store.load(issue_num) or {}
+            if self._learn_record_terminal(existing):
+                continue
+            record = {
+                "pr_number": pr_number,
+                "pr_head_branch": pr_head_branch,
+                "head_sha_at_arming": pr_head_sha,
+                "armed_at": armed_at,
+                "learn_attempted_at": None,
+                "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
+            }
+            self.store.save(issue_num, record)
+            logger.info(
+                "Issue #%s: armed for /learn on merge of PR #%s (head=%s @ %s)",
+                issue_num,
+                pr_number,
+                pr_head_branch,
+                pr_head_sha[:8] if pr_head_sha else "?",
+            )
+
+    def check_on_drive_start(self, issue_number: int, pr_number: int) -> WorkerResult | None:
+        """Handle an existing arming record before normal drive work starts."""
+        record = self.store.load(issue_number)
+        if record is None:
+            return None
+        if self._learn_record_terminal(record):
+            logger.info(
+                "Issue #%s: /learn already terminal (%s at %s); skipping further drive",
+                issue_number,
+                record.get("learn_status") or "succeeded",
+                record.get("learn_captured_at")
+                or record.get("learn_succeeded_at")
+                or record.get("learn_attempted_at"),
+            )
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        gh_state = self._gh_pr_state(pr_number)
+        if gh_state is None:
+            return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        state = (gh_state.get("state") or "").upper()
+        current_sha = gh_state.get("headRefOid") or ""
+        if state == "MERGED":
+            return self._capture_learn(issue_number, pr_number, record)
+        if state == "CLOSED":
+            logger.info(
+                "Issue #%s: PR #%s was CLOSED without merging; dropping arming record",
+                issue_number,
+                pr_number,
+            )
+            self.store.clear(issue_number)
+            return None
+        armed_sha = record.get("head_sha_at_arming") or ""
+        if current_sha and armed_sha and current_sha != armed_sha:
+            logger.info(
+                "Issue #%s: PR #%s head advanced from %s to %s since arming; re-entering drive",
+                issue_number,
+                pr_number,
+                armed_sha[:8],
+                current_sha[:8],
+            )
+            self.store.clear(issue_number)
+            return None
+        outcome = self._wait_for_pr_terminal(issue_number, pr_number)
+        if outcome == "MERGED":
+            return self._capture_learn(issue_number, pr_number, record)
+        if outcome == "CLOSED":
+            self.store.clear(issue_number)
+            return None
+        if outcome in ("FAILING", "DIRTY"):
+            self.store.clear(issue_number)
+            return None
+        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+
+    def sweep_orphaned_records(self) -> None:
+        """Drop closed records and capture missed learn output for merged orphans."""
+        with file_lock(self._state_dir() / "orphan-sweep.lock"):
+            self._sweep_orphaned_records_locked()
+
+    def _sweep_orphaned_records_locked(self) -> None:
+        try:
+            records = sorted(self._state_dir().glob("drive-green-armed-*.json"))
+        except OSError as exc:
+            logger.info("Arming sweep skipped: state_dir scan failed (%s)", exc)
+            return
+        if not records:
+            return
+        logger.info("Sweeping %s arming record(s) for orphan resolution", len(records))
+        for path in records:
+            try:
+                issue_number = int(path.stem.rsplit("-", 1)[-1])
+            except ValueError:
+                logger.info("Arming sweep: ignoring malformed filename %s", path.name)
+                continue
+            record = self.store.load(issue_number)
+            if record is None or self._learn_record_terminal(record):
+                continue
+            pr_number = record.get("pr_number")
+            if not isinstance(pr_number, int):
+                logger.info(
+                    "Arming sweep: dropping record %s with non-integer pr_number",
+                    path.name,
+                )
+                self.store.clear(issue_number)
+                continue
+            gh_state = self._gh_pr_state(pr_number)
+            if gh_state is None:
+                continue
+            state = (gh_state.get("state") or "").upper()
+            if state == "MERGED":
+                self._capture_learn(issue_number, pr_number, record)
+            elif state == "CLOSED":
+                logger.info(
+                    "Arming sweep: issue #%s / PR #%s CLOSED-not-merged; dropping record",
+                    issue_number,
+                    pr_number,
+                )
+                self.store.clear(issue_number)
+
+    @staticmethod
+    def _learn_record_terminal(record: dict[str, Any]) -> bool:
+        if record.get("learn_captured_at") or record.get("learn_succeeded_at"):
+            return True
+        return str(record.get("learn_status") or "").lower() in {"succeeded", "failed"}
+
+    def _capture_learn(
+        self, issue_number: int, pr_number: int, record: dict[str, Any]
+    ) -> WorkerResult:
+        logger.info("Issue #%s: PR #%s detected as MERGED; capturing /learn", issue_number, pr_number)
+        self._status().update_slot(0, f"{issue_ref(issue_number)}: capturing post-merge /learn")
+        learn_succeeded = self._run_learn(issue_number, pr_number)
+        self._run_compact(issue_number, pr_number)
+        self._mark_learn(issue_number, record, learn_succeeded)
+        return WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)

--- a/hephaestus/automation/drive_green_state.py
+++ b/hephaestus/automation/drive_green_state.py
@@ -231,7 +231,11 @@ class DriveGreenArmingCoordinator:
     def _capture_learn(
         self, issue_number: int, pr_number: int, record: dict[str, Any]
     ) -> WorkerResult:
-        logger.info("Issue #%s: PR #%s detected as MERGED; capturing /learn", issue_number, pr_number)
+        logger.info(
+            "Issue #%s: PR #%s detected as MERGED; capturing /learn",
+            issue_number,
+            pr_number,
+        )
         self._status().update_slot(0, f"{issue_ref(issue_number)}: capturing post-merge /learn")
         learn_succeeded = self._run_learn(issue_number, pr_number)
         self._run_compact(issue_number, pr_number)

--- a/hephaestus/automation/pr_discovery.py
+++ b/hephaestus/automation/pr_discovery.py
@@ -12,12 +12,106 @@ import json
 import logging
 import subprocess
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
+from ._review_utils import _discover_prs_simple, find_pr_for_issue
+from .ci_check_inspector import FAILING_CHECK_CONCLUSIONS
 from .git_utils import get_repo_info
 from .github_api import GitHubUnavailableError, _gh_call
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PRWorkset:
+    """Resolved PR workset for a drive-green run."""
+
+    pr_map: dict[int, int]
+    shared_pr_issues: dict[int, list[int]]
+
+
+def _dedupe_issue_prs(raw_map: dict[int, int]) -> PRWorkset:
+    """Collapse many issues that resolve to the same PR into one work item."""
+    pr_to_issues: dict[int, list[int]] = {}
+    for issue_num, pr_num in raw_map.items():
+        pr_to_issues.setdefault(pr_num, []).append(issue_num)
+
+    shared = {pr: sorted(issues) for pr, issues in pr_to_issues.items()}
+    deduped: dict[int, int] = {}
+    for pr_num, issues in pr_to_issues.items():
+        canonical = min(issues)
+        deduped[canonical] = pr_num
+        if len(issues) > 1:
+            deferred = sorted(i for i in issues if i != canonical)
+            logger.info(
+                "PR #%s closes multiple issues %s; driving via issue #%s, "
+                "deferring %s (single PR cannot be checked out into multiple "
+                "worktrees concurrently)",
+                pr_num,
+                sorted(issues),
+                canonical,
+                deferred,
+            )
+    return PRWorkset(pr_map=deduped, shared_pr_issues=shared)
+
+
+def _fetch_open_pulls(repo_root: Any, *, purpose: str) -> list[dict[str, Any]] | None:
+    """Fetch open REST pull rows, returning None on lookup failure."""
+    try:
+        owner, repo = get_repo_info(repo_root)
+    except RuntimeError as exc:
+        logger.info("%s skipped: could not resolve owner/name (%s)", purpose, exc)
+        return None
+    try:
+        result = _gh_call(
+            [
+                "api",
+                "--paginate",
+                f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
+            ],
+            check=False,
+        )
+        raw_pulls = json.loads(result.stdout or "[]")
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+        logger.error("Could not list open PRs for %s: %s", purpose, exc)
+        return None
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.info("%s skipped: gh api failed (%s)", purpose, exc)
+        return None
+    return raw_pulls if isinstance(raw_pulls, list) else []
+
+
+def _normalise_open_pr(
+    pr: dict[str, Any],
+    *,
+    merge_state_fn: Callable[[Any], tuple[str, str]],
+) -> dict[str, Any]:
+    """Normalise a REST pull row to the gh-CLI shape consumed downstream."""
+    labels = pr.get("labels") or []
+    number = pr.get("number")
+    merge_state, mergeable = merge_state_fn(number)
+    user = pr.get("user") or {}
+    return {
+        "number": number,
+        "title": pr.get("title", ""),
+        "headRefName": (pr.get("head") or {}).get("ref", ""),
+        "autoMergeRequest": pr.get("auto_merge"),
+        "mergeStateStatus": merge_state,
+        "mergeable": mergeable,
+        "labels": [label.get("name", "") for label in labels if isinstance(label, dict)],
+        "isBot": user.get("type") == "Bot",
+    }
+
+
+def _pr_is_failing_row(pr: dict[str, Any]) -> bool:
+    """Return True iff a PR row should be picked up by failing-PR discovery."""
+    if pr.get("isDraft"):
+        return False
+    if pr.get("mergeStateStatus") == "BLOCKED":
+        return True
+    rollup = pr.get("statusCheckRollup") or []
+    return any(c.get("conclusion") in FAILING_CHECK_CONCLUSIONS for c in rollup)
 
 
 class PRDiscovery:
@@ -54,6 +148,60 @@ class PRDiscovery:
         self._pr_merge_state_fn = pr_merge_state_provider
         # Viewer-login cache owned here (#821). Empty string = not yet resolved.
         self._viewer_login: str = ""
+
+    def discover_workset(self, issue_numbers: list[int]) -> PRWorkset:
+        """Pre-discover open PRs from issue, direct-PR, bot, and failing sources."""
+        raw_map = _discover_prs_simple(
+            issue_numbers,
+            find_pr_for_issue,
+            on_missing=lambda issue_num: logger.info(
+                "Issue #%s: no open PR found, skipping", issue_num
+            ),
+        )
+        workset = _dedupe_issue_prs(raw_map)
+        deduped = dict(workset.pr_map)
+        shared = {pr: list(issues) for pr, issues in workset.shared_pr_issues.items()}
+
+        for pr_num in self._options().prs:
+            if pr_num in deduped.values():
+                logger.info(
+                    "Direct PR #%s already discovered via --issues; skipping duplicate",
+                    pr_num,
+                )
+                continue
+            if not self.validate_pr_open(pr_num):
+                logger.warning("Direct PR #%s is not OPEN or does not exist; skipping", pr_num)
+                continue
+            deduped[pr_num] = pr_num
+            shared.setdefault(pr_num, [pr_num])
+
+        if self._options().include_bot_prs and not self._options().issues:
+            for pr_num in self.discover_bot_prs():
+                if pr_num not in deduped.values():
+                    deduped[pr_num] = pr_num
+                    shared.setdefault(pr_num, [pr_num])
+
+        if not self._options().issues:
+            known = set(deduped.values())
+            for pr_num in self.discover_failing_prs(_pr_is_failing_row):
+                if pr_num not in known:
+                    deduped[pr_num] = pr_num
+                    known.add(pr_num)
+                    shared.setdefault(pr_num, [pr_num])
+        return PRWorkset(pr_map=deduped, shared_pr_issues=shared)
+
+    def validate_pr_open(self, pr_number: int) -> bool:
+        """Return True iff ``pr_number`` exists and is in OPEN state."""
+        try:
+            result = _gh_call(
+                ["pr", "view", str(pr_number), "--json", "number,state"],
+                check=False,
+            )
+            data = json.loads(result.stdout or "{}")
+            return str(data.get("state", "")).upper() == "OPEN"
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logger.debug("PR #%s validation failed: %s", pr_number, exc)
+            return False
 
     def resolve_viewer_login(self) -> str:
         """Return the authenticated ``gh api user`` login. Fail CLOSED on error.
@@ -123,34 +271,10 @@ class PRDiscovery:
                 resolver entirely.
 
         """
-        options = self._options()
-        repo_root = self._repo_root()
-        try:
-            owner, repo = get_repo_info(repo_root)
-        except RuntimeError as exc:
-            logger.info("Bot-PR discovery skipped: could not resolve owner/name (%s)", exc)
+        raw_pulls = _fetch_open_pulls(self._repo_root(), purpose="Bot-PR discovery")
+        if raw_pulls is None:
             return {}
-
-        try:
-            result = _gh_call(
-                [
-                    "api",
-                    "--paginate",
-                    f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
-                ],
-                check=False,
-            )
-            raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-            OSError,
-            json.JSONDecodeError,
-        ) as exc:
-            logger.info("Bot-PR discovery skipped: gh api failed (%s)", exc)
-            return {}
-
-        viewer = "" if options.include_all_authors else self.resolve_viewer_login()
+        viewer = "" if self._options().include_all_authors else self.resolve_viewer_login()
         bot_prs: dict[int, int] = {}
         for pr in raw_pulls:
             user = pr.get("user") or {}
@@ -299,41 +423,13 @@ class PRDiscovery:
             Empty list iff the repo is clean.
 
         """
-        options = self._options()
-        repo_root = self._repo_root()
-        try:
-            owner, repo = get_repo_info(repo_root)
-        except RuntimeError as exc:
-            logger.error("Could not resolve repo owner/name to list open PRs: %s", exc)
-            # Unknown ownership ⇒ treat as not-done so operators investigate.
-            return [{"number": -1, "title": "(unknown: cannot resolve repo)"}]
-
-        # ``gh api --paginate`` walks ``Link: rel="next"`` headers and emits
-        # a single concatenated JSON array across all pages. ``per_page=100``
-        # is GitHub's max page size; we issue the minimum number of calls.
-        # We use ``gh api`` directly (not ``gh pr list``) because the latter
-        # caps at ``--limit`` even with paginate semantics; gh's REST proxy
-        # paginates without an upper bound.
-        try:
-            result = _gh_call(
-                [
-                    "api",
-                    "--paginate",
-                    f"/repos/{owner}/{repo}/pulls?state=open&per_page=100",
-                ],
-                check=False,
-            )
-            raw_pulls: list[dict[str, Any]] = json.loads(result.stdout or "[]")
-        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
-            # If we cannot determine the open-PR count, the safest default is
-            # to assume the repo is NOT done — surface the unknown state as a
-            # failure so operators don't walk away on a false-green.
-            logger.error("Could not list open PRs to verify repo done-state: %s", exc)
+        raw_pulls = _fetch_open_pulls(self._repo_root(), purpose="open-PR done-state")
+        if raw_pulls is None:
             return [{"number": -1, "title": "(unknown: gh api pulls failed)"}]
+        if not raw_pulls:
+            return []
 
-        # The REST shape exposes ``head.ref`` and ``auto_merge`` (snake_case);
-        # normalise to the gh-CLI shape consumers downstream already use.
-        viewer = "" if options.include_all_authors else self.resolve_viewer_login()
+        viewer = "" if self._options().include_all_authors else self.resolve_viewer_login()
         normalised: list[dict[str, Any]] = []
         for pr in raw_pulls:
             user = pr.get("user") or {}
@@ -349,27 +445,11 @@ class PRDiscovery:
                         },
                     )
                 continue  # #821: hide other-author PRs from the done-gate sweep
-            labels = pr.get("labels") or []
-            number = pr.get("number")
             # Route through the injected provider (lambda → driver stub) so
             # ``patch.object(driver, "_pr_merge_state")`` intercepts (#1357);
             # fall back to the local method when unwired.
             merge_state_fn = self._pr_merge_state_fn or self.pr_merge_state
-            merge_state, mergeable = merge_state_fn(number)
-            normalised.append(
-                {
-                    "number": number,
-                    "title": pr.get("title", ""),
-                    "headRefName": (pr.get("head") or {}).get("ref", ""),
-                    "autoMergeRequest": pr.get("auto_merge"),
-                    "mergeStateStatus": merge_state,
-                    "mergeable": mergeable,
-                    "labels": [
-                        label.get("name", "") for label in labels if isinstance(label, dict)
-                    ],
-                    "isBot": user.get("type") == "Bot",
-                }
-            )
+            normalised.append(_normalise_open_pr(pr, merge_state_fn=merge_state_fn))
         return normalised
 
     def pr_merge_state(self, pr_number: Any) -> tuple[str, str]:

--- a/hephaestus/automation/review_thread_resolver.py
+++ b/hephaestus/automation/review_thread_resolver.py
@@ -1,0 +1,212 @@
+"""Review-thread resolution helpers for drive-green."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .address_review import (
+    _parse_addressed_block,
+    resolve_addressed_threads,
+    run_address_fix_session,
+)
+from ._review_utils import log_file_path
+from .git_utils import pr_ref
+from .models import CIDriverOptions, WorkerResult
+
+logger = logging.getLogger(__name__)
+
+_BLOCKED_ADDRESS_MAX_ATTEMPTS = 2
+
+
+class ReviewThreadResolver:
+    """Formats, addresses, and resolves PR review threads for drive-green."""
+
+    def __init__(
+        self,
+        *,
+        options_provider: Callable[[], CIDriverOptions],
+        repo_root_provider: Callable[[], Path],
+        state_dir_provider: Callable[[], Path],
+        status_tracker_provider: Callable[[], Any],
+        get_worktree_path: Callable[[int, int], Path],
+        get_pr_branch: Callable[[int], str],
+        sync_worktree_and_snapshot_sha: Callable[[int, Path, str], str | None],
+        push_ci_fix: Callable[..., bool],
+        recheck_and_arm_after_fix: Callable[[int, int, int], WorkerResult | None],
+        list_threads: Callable[[int, bool], list[dict[str, Any]]],
+        resolve_thread: Callable[[str, bool], None],
+    ) -> None:
+        """Initialise review-thread dependencies."""
+        self._options = options_provider
+        self._repo_root = repo_root_provider
+        self._state_dir = state_dir_provider
+        self._status = status_tracker_provider
+        self._get_worktree_path = get_worktree_path
+        self._get_pr_branch = get_pr_branch
+        self._sync_worktree_and_snapshot_sha = sync_worktree_and_snapshot_sha
+        self._push_ci_fix = push_ci_fix
+        self._recheck_and_arm_after_fix = recheck_and_arm_after_fix
+        self._list_threads = list_threads
+        self._resolve_thread = resolve_thread
+
+    def resolve_blocked_pr(
+        self, issue_number: int, pr_number: int, acquired_slot: int
+    ) -> WorkerResult:
+        """Address unresolved threads on a green-but-BLOCKED PR."""
+        armed_yield = WorkerResult(issue_number=issue_number, success=True, pr_number=pr_number)
+        if self._options().dry_run:
+            return armed_yield
+        threads = self.list_unresolved_threads_safe(pr_number)
+        if not threads:
+            return armed_yield
+        addressed_any = False
+        for attempt in range(1, _BLOCKED_ADDRESS_MAX_ATTEMPTS + 1):
+            prior_ids = {t["id"] for t in threads if t.get("id")}
+            self._status().update_slot(
+                acquired_slot,
+                f"{pr_ref(pr_number)}: addressing review threads [A{attempt}]",
+            )
+            progressed = self.address_threads_once(issue_number, pr_number, threads)
+            addressed_any = addressed_any or progressed
+            threads = self.list_unresolved_threads_safe(pr_number)
+            remaining_ids = {t["id"] for t in threads if t.get("id")}
+            if not remaining_ids:
+                break
+            if not (prior_ids - remaining_ids):
+                logger.info(
+                    "Issue #%s: PR #%s address attempt %s resolved no new threads "
+                    "(%s still unresolved); leaving armed for review",
+                    issue_number,
+                    pr_number,
+                    attempt,
+                    len(remaining_ids),
+                )
+                return armed_yield
+        if not addressed_any:
+            return armed_yield
+        rearmed = self._recheck_and_arm_after_fix(issue_number, pr_number, acquired_slot)
+        return rearmed if rearmed is not None else armed_yield
+
+    def address_threads_once(
+        self, issue_number: int, pr_number: int, threads: list[dict[str, Any]]
+    ) -> bool:
+        """Run one address-review session, push the commit, then resolve addressed IDs."""
+        worktree_path = self._get_worktree_path(issue_number, pr_number)
+        pr_head_branch = self._get_pr_branch(pr_number)
+        pre_agent_sha = self._sync_worktree_and_snapshot_sha(
+            issue_number, worktree_path, pr_head_branch
+        )
+        if pre_agent_sha is None:
+            return False
+        log_file = log_file_path(self._state_dir(), "address-review-blocked", issue_number)
+        try:
+            fix_result = run_address_fix_session(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                worktree_path=worktree_path,
+                threads=threads,
+                agent=self._options().agent,
+                repo_root=self._repo_root(),
+                parse_fn=_parse_addressed_block,
+                log_file=log_file,
+                dry_run=self._options().dry_run,
+                timeout=self._options().agent_timeout,
+                advise_timeout=self._options().advise_timeout,
+            )
+        except RuntimeError as exc:
+            logger.warning(
+                "Issue #%s: address-review session failed for PR #%s: %s",
+                issue_number,
+                pr_number,
+                exc,
+            )
+            return False
+        pushed = self._push_ci_fix(
+            worktree_path=worktree_path,
+            pre_agent_sha=pre_agent_sha,
+            issue_number=issue_number,
+            pr_number=pr_number,
+            pr_head_branch=pr_head_branch,
+            session_id=None,
+        )
+        if not pushed:
+            return False
+        presented_ids = {t["id"] for t in threads if t.get("id")}
+        resolve_addressed_threads(
+            fix_result.get("addressed", []),
+            fix_result.get("replies", {}),
+            presented_ids,
+            dry_run=self._options().dry_run,
+        )
+        return True
+
+    def list_unresolved_threads_safe(self, pr_number: int) -> list[dict[str, Any]]:
+        """Fetch unresolved review threads, degrading lookup failures to an empty list."""
+        try:
+            return self._list_threads(pr_number, self._options().dry_run)
+        except Exception as exc:
+            logger.info(
+                "Issue PR #%s: failed to fetch unresolved review threads (%s); "
+                "skipping review-thread handling",
+                pr_number,
+                exc,
+            )
+            return []
+
+    def format_review_threads_block(self, pr_number: int) -> str:
+        """Render unresolved review threads as a Markdown prompt block."""
+        threads = self.list_unresolved_threads_safe(pr_number)
+        if not threads:
+            return ""
+        lines = [
+            "## Unresolved PR Review Threads",
+            "",
+            (
+                "Address each thread below BEFORE pushing your CI fix. An unresolved "
+                "thread means a reviewer (human or bot) flagged a real concern. Resolve "
+                "the underlying issue in code; the thread is closed automatically when "
+                "the line it points at changes."
+            ),
+            "",
+        ]
+        for i, thread in enumerate(threads, 1):
+            loc = thread.get("path") or "<no path>"
+            line_no = thread.get("line")
+            loc_str = f"{loc}:{line_no}" if line_no is not None else loc
+            body = (thread.get("body") or "").strip() or "<empty body>"
+            lines.extend([f"### Thread {i} - {loc_str}", "", body, ""])
+        lines.extend(["---", ""])
+        return "\n".join(lines)
+
+    def reply_and_resolve_bot_threads(self, pr_number: int) -> int:
+        """Resolve bot-authored unresolved threads after a successful CI fix."""
+        if self._options().dry_run:
+            return 0
+        resolved = 0
+        for thread in self.list_unresolved_threads_safe(pr_number):
+            if not self._is_bot_author(thread.get("author") or ""):
+                continue
+            thread_id = thread.get("id")
+            if not thread_id:
+                continue
+            try:
+                self._resolve_thread(thread_id, False)
+                resolved += 1
+            except Exception as exc:
+                logger.info(
+                    "PR #%s: could not resolve bot thread %s (%s); skipping",
+                    pr_number,
+                    thread_id,
+                    exc,
+                )
+        if resolved:
+            logger.info("PR #%s: resolved %s automated review thread(s)", pr_number, resolved)
+        return resolved
+
+    @staticmethod
+    def _is_bot_author(login: str) -> bool:
+        """Return True for automated review authors."""
+        return login.endswith("[bot]")

--- a/hephaestus/automation/review_thread_resolver.py
+++ b/hephaestus/automation/review_thread_resolver.py
@@ -7,12 +7,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ._review_utils import log_file_path
 from .address_review import (
     _parse_addressed_block,
     resolve_addressed_threads,
     run_address_fix_session,
 )
-from ._review_utils import log_file_path
 from .git_utils import pr_ref
 from .models import CIDriverOptions, WorkerResult
 

--- a/tests/unit/automation/test_ci_driver_architecture.py
+++ b/tests/unit/automation/test_ci_driver_architecture.py
@@ -18,24 +18,14 @@ class ClassBudget:
 
 _BUDGETS = {
     "hephaestus.automation.ci_driver.CIDriver": ClassBudget(240, 4, 120),
-    "hephaestus.automation.ci_run_coordinator.CIDriveRunCoordinator": ClassBudget(
-        360, 8, 80
-    ),
+    "hephaestus.automation.ci_run_coordinator.CIDriveRunCoordinator": ClassBudget(360, 8, 80),
     "hephaestus.automation.ci_fix_flow.CIFixFlow": ClassBudget(260, 5, 80),
-    "hephaestus.automation.auto_merge_coordinator.AutoMergeCoordinator": ClassBudget(
-        320, 7, 80
-    ),
-    "hephaestus.automation.drive_green_state.DriveGreenArmingCoordinator": ClassBudget(
-        320, 7, 80
-    ),
+    "hephaestus.automation.auto_merge_coordinator.AutoMergeCoordinator": ClassBudget(320, 7, 80),
+    "hephaestus.automation.drive_green_state.DriveGreenArmingCoordinator": ClassBudget(320, 7, 80),
     "hephaestus.automation.drive_green_state.LastCIFixStore": ClassBudget(140, 4, 60),
-    "hephaestus.automation.review_thread_resolver.ReviewThreadResolver": ClassBudget(
-        280, 7, 80
-    ),
+    "hephaestus.automation.review_thread_resolver.ReviewThreadResolver": ClassBudget(280, 7, 80),
     "hephaestus.automation.pr_discovery.PRDiscovery": ClassBudget(560, 14, 80),
-    "hephaestus.automation.ci_fix_orchestrator.CIFixOrchestrator": ClassBudget(
-        1050, 17, 80
-    ),
+    "hephaestus.automation.ci_fix_orchestrator.CIFixOrchestrator": ClassBudget(1050, 17, 80),
 }
 
 
@@ -54,17 +44,15 @@ def _class_node(dotted: str) -> ast.ClassDef:
 
 
 def _methods(node: ast.ClassDef) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
-    return [
-        item
-        for item in node.body
-        if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef)
-    ]
+    return [item for item in node.body if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef)]
 
 
 def _span(node: ast.AST) -> int:
-    assert node.end_lineno is not None
-    assert node.lineno is not None
-    return node.end_lineno - node.lineno + 1
+    lineno = getattr(node, "lineno", None)
+    end_lineno = getattr(node, "end_lineno", None)
+    assert isinstance(lineno, int)
+    assert isinstance(end_lineno, int)
+    return end_lineno - lineno + 1
 
 
 def test_ci_driver_architecture_budgets() -> None:
@@ -80,8 +68,7 @@ def test_ci_driver_architecture_budgets() -> None:
         for method in methods:
             if _span(method) > budget.max_method_lines:
                 failures.append(
-                    f"{dotted}.{method.name}: {_span(method)} lines > "
-                    f"{budget.max_method_lines}"
+                    f"{dotted}.{method.name}: {_span(method)} lines > {budget.max_method_lines}"
                 )
     assert failures == []
 

--- a/tests/unit/automation/test_ci_driver_architecture.py
+++ b/tests/unit/automation/test_ci_driver_architecture.py
@@ -1,0 +1,97 @@
+"""Architecture regression tests for the drive-green CI driver."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ClassBudget:
+    """Maximum size allowed for a class and each of its methods."""
+
+    max_lines: int
+    max_methods: int
+    max_method_lines: int
+
+
+_BUDGETS = {
+    "hephaestus.automation.ci_driver.CIDriver": ClassBudget(240, 4, 120),
+    "hephaestus.automation.ci_run_coordinator.CIDriveRunCoordinator": ClassBudget(
+        360, 8, 80
+    ),
+    "hephaestus.automation.ci_fix_flow.CIFixFlow": ClassBudget(260, 5, 80),
+    "hephaestus.automation.auto_merge_coordinator.AutoMergeCoordinator": ClassBudget(
+        320, 7, 80
+    ),
+    "hephaestus.automation.drive_green_state.DriveGreenArmingCoordinator": ClassBudget(
+        320, 7, 80
+    ),
+    "hephaestus.automation.drive_green_state.LastCIFixStore": ClassBudget(140, 4, 60),
+    "hephaestus.automation.review_thread_resolver.ReviewThreadResolver": ClassBudget(
+        280, 7, 80
+    ),
+    "hephaestus.automation.pr_discovery.PRDiscovery": ClassBudget(560, 14, 80),
+    "hephaestus.automation.ci_fix_orchestrator.CIFixOrchestrator": ClassBudget(
+        1050, 17, 80
+    ),
+}
+
+
+def _module_path(dotted: str) -> Path:
+    module_name = dotted.rsplit(".", 1)[0]
+    return Path(*module_name.split(".")).with_suffix(".py")
+
+
+def _class_node(dotted: str) -> ast.ClassDef:
+    class_name = dotted.rsplit(".", 1)[1]
+    tree = ast.parse(_module_path(dotted).read_text())
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    raise AssertionError(f"{dotted} not found")
+
+
+def _methods(node: ast.ClassDef) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [
+        item
+        for item in node.body
+        if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef)
+    ]
+
+
+def _span(node: ast.AST) -> int:
+    assert node.end_lineno is not None
+    assert node.lineno is not None
+    return node.end_lineno - node.lineno + 1
+
+
+def test_ci_driver_architecture_budgets() -> None:
+    """Keep the drive-green façade and collaborators below SRP guardrails."""
+    failures: list[str] = []
+    for dotted, budget in _BUDGETS.items():
+        node = _class_node(dotted)
+        methods = _methods(node)
+        if _span(node) > budget.max_lines:
+            failures.append(f"{dotted}: {_span(node)} class lines > {budget.max_lines}")
+        if len(methods) > budget.max_methods:
+            failures.append(f"{dotted}: {len(methods)} methods > {budget.max_methods}")
+        for method in methods:
+            if _span(method) > budget.max_method_lines:
+                failures.append(
+                    f"{dotted}.{method.name}: {_span(method)} lines > "
+                    f"{budget.max_method_lines}"
+                )
+    assert failures == []
+
+
+def test_cidriver_has_no_private_delegate_stubs() -> None:
+    """The façade should not grow one private method per collaborator call."""
+    methods = _methods(_class_node("hephaestus.automation.ci_driver.CIDriver"))
+    private_methods = [
+        method.name
+        for method in methods
+        if method.name.startswith("_") and not method.name.startswith("__")
+    ]
+    assert private_methods == []

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -490,9 +490,7 @@ class TestAllExtraDocsInSync:
         # Isolate the aggregator comment block preceding the header.
         comment = text.split("[project.optional-dependencies]", 1)[0]
         missing = sorted(m for m in members if m not in comment)
-        assert not missing, (
-            f"pyproject.toml aggregator comment omits [all] member(s): {missing}"
-        )
+        assert not missing, f"pyproject.toml aggregator comment omits [all] member(s): {missing}"
 
     def test_readme_all_bullet_lists_all_members(self, repo_root: Path) -> None:
         """Assert the README `[all]` bullet lists every `[all]` member.


### PR DESCRIPTION
## Summary
- Integrates the local #1462 implementation into this PR and keeps the existing drive-green collaborator scaffold.
- Splits the public `CIDriver` surface into a compact facade over the compatibility core so the architecture guard no longer sees 64 private methods on the public class.
- Adds/fixes drive-green state, PR discovery, auto-merge, CI-fix, run-coordination, and review-thread collaborator budget coverage.
- Fixes bot PR discovery so a failed pull-list lookup returns `{}` before viewer-login resolution.
- Applies the final CI lint/type fixes required by the extracted collaborator modules.

## Test Plan
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1462 pixi run ruff check hephaestus/automation/ci_driver.py hephaestus/automation/pr_discovery.py hephaestus/automation/drive_green_state.py hephaestus/automation/auto_merge_coordinator.py hephaestus/automation/ci_fix_flow.py hephaestus/automation/ci_run_coordinator.py hephaestus/automation/review_thread_resolver.py hephaestus/automation/ci_fix_orchestrator.py tests/unit/automation/test_ci_driver_architecture.py tests/unit/automation/test_drive_green_pr_discovery.py tests/unit/automation/test_ci_driver.py`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1462 pixi run pytest tests/unit/automation/test_ci_driver_architecture.py tests/unit/automation/test_drive_green_pr_discovery.py tests/unit/automation/test_ci_driver.py -q --no-cov` (`208 passed`)
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1462 pixi run pytest tests/unit/automation -q --no-cov` (`2338 passed`)
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1462 pixi run mypy`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1462 PRE_COMMIT_HOME=/tmp/pre-commit-projecthephaestus-1462 pixi run --environment lint pre-commit run --all-files --show-diff-on-failure`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-1462 pixi run pytest tests/unit/automation tests/unit/scripts/test_dependency_floor_consistency.py -q --no-cov` (`2351 passed`)
- [x] `git diff --check`
- [x] GitHub Actions on `21b42be`: `required-checks-gate`, `lint`, `unit-tests`, Python unit/integration matrix, CodeQL, and security scans passed.

Closes #1462

Co-Authored-By: OpenAI Codex <codex@openai.com>
