### PR TITLE
docs(roadmap): Define explicit iteration cadence and release process

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,25 @@ We also capture session learnings in ProjectMnemosyne via the `/learn` skill, pr
 
 ## Updating This Roadmap
 
-This roadmap is reviewed and updated at the end of each release cycle (typically monthly). As new Epics are created or project priorities shift, the roadmap is refreshed to reflect current focus areas. To propose changes, open an issue and reference this document.
+**Cadence — release-driven, not date-driven.** A "release cycle" is not a
+calendar interval; it is each `vX.Y.Z` release cut through the **Auto Tag
+Release** workflow (see [RELEASING.md](RELEASING.md)). Because that workflow is
+triggered manually when a batch of features/fixes is ready — not on a fixed
+schedule — releases (and therefore roadmap reviews) are **feature/fix-driven,
+not date-driven**. Cadence in practice tracks release frequency rather than a
+fixed monthly rhythm.
 
-Last updated: 2026-06-12
+**Trigger.** The roadmap is reviewed as part of the pre-release checklist,
+whenever a release is cut. Any Epic being opened or closed, or a shift in
+priorities, is also a valid trigger to refresh it between releases.
+
+**Responsibility.** The maintainer cutting the release owns the roadmap review
+for that cycle: confirming the "Current Focus" section still reflects open
+Epics and updating the "Last updated" date below. In this solo/small-team repo
+that is the release maintainer; there is no separate roadmap committee.
+
+**How to propose changes.** Open an issue that references this document (or a
+PR editing it directly). The roadmap is refreshed to reflect current focus
+areas as Epics are created or priorities shift.
+
+Last updated: 2026-07-01

--- a/tests/unit/docs/test_roadmap_cadence.py
+++ b/tests/unit/docs/test_roadmap_cadence.py
@@ -1,0 +1,56 @@
+"""Regression test: ROADMAP.md must define an explicit iteration cadence.
+
+Issue #1493 (S10 Planning, MODULARITY): the roadmap previously said it was
+"reviewed and updated at the end of each release cycle (typically monthly)"
+without defining the trigger, whether releases are date- or feature-driven,
+or who owns the review. This guard fails if that section regresses to vague
+prose. It asserts the HARD invariant (required phrases are present), never an
+unverifiable cadence value like "monthly".
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ROADMAP_MD = REPO_ROOT / "docs" / "ROADMAP.md"
+
+_SECTION_RE = re.compile(
+    r"^##\s+Updating This Roadmap\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _updating_section() -> str:
+    text = ROADMAP_MD.read_text(encoding="utf-8")
+    match = _SECTION_RE.search(text)
+    assert match is not None, (
+        "ROADMAP.md no longer has an '## Updating This Roadmap' section; "
+        "restore it or update this test's heading regex."
+    )
+    return match.group(1)
+
+
+def test_cadence_is_release_driven_not_vague_monthly() -> None:
+    """Fail if the roadmap's cadence section lacks the explicit trigger/driver/owner."""
+    # Collapse whitespace so phrase checks are robust to line wrapping in the
+    # source markdown (e.g. "auto tag\nrelease" wraps across two lines).
+    section = re.sub(r"\s+", " ", _updating_section().lower())
+    # The vague phrasing this issue removed must not come back.
+    assert "typically monthly" not in section, (
+        "ROADMAP.md reverted to the vague 'typically monthly' cadence "
+        "(issue #1493); state the release-driven trigger explicitly instead."
+    )
+    # Trigger: tied to the Auto Tag Release pipeline, not a calendar.
+    assert "auto tag release" in section, (
+        "The cadence section must reference the 'Auto Tag Release' workflow "
+        "as the release-cycle trigger (see docs/RELEASING.md)."
+    )
+    # Driver: explicitly feature/fix-driven, not date-driven.
+    assert "not date-driven" in section, (
+        "The cadence section must state releases are feature/fix-driven, not date-driven."
+    )
+    # Responsible party must be named.
+    assert "maintainer" in section, (
+        "The cadence section must name who is responsible for the review "
+        "(the maintainer cutting the release)."
+    )

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -490,9 +490,7 @@ class TestAllExtraDocsInSync:
         # Isolate the aggregator comment block preceding the header.
         comment = text.split("[project.optional-dependencies]", 1)[0]
         missing = sorted(m for m in members if m not in comment)
-        assert not missing, (
-            f"pyproject.toml aggregator comment omits [all] member(s): {missing}"
-        )
+        assert not missing, f"pyproject.toml aggregator comment omits [all] member(s): {missing}"
 
     def test_readme_all_bullet_lists_all_members(self, repo_root: Path) -> None:
         """Assert the README `[all]` bullet lists every `[all]` member.


### PR DESCRIPTION
## Summary
Replace vague 'typically monthly' cadence with explicit release-driven process definition. Clarify that releases are feature/fix-driven (not date-driven), triggered by the Auto Tag Release workflow, and owned by the release maintainer. Add regression test to guard against reversion to vague phrasing.

## Changes
- Replace 'typically monthly' with explicit release-driven cadence definition in docs/ROADMAP.md
- Document that releases are feature/fix-driven, not calendar-driven, triggered by the Auto Tag Release workflow
- Name the maintainer as responsible party for pre-release roadmap review
- Add regression test test_roadmap_cadence.py to enforce cadence clarity (guards against 'typically monthly', requires 'Auto Tag Release', 'not date-driven', 'maintainer')
- Verify dependency floor consistency test still passes

## Testing
- test_roadmap_cadence.py asserts vague 'typically monthly' phrasing is absent
- test_roadmap_cadence.py verifies 'Auto Tag Release' workflow is documented as the trigger
- test_roadmap_cadence.py confirms releases are explicitly feature/fix-driven, not date-driven
- test_roadmap_cadence.py verifies maintainer responsibility is named
- dependency_floor_consistency tests still pass

## Closes
Closes #1493

Generated by Claude Code via ProjectHephaestus automation.
