### PR TITLE
ci(workflows): enforce workflow inventory documentation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,15 @@
+# GitHub Workflows
+
+## Workflow Summary
+
+| Workflow | Purpose | Triggers |
+| --- | --- | --- |
+| _required.yml | Required branch-protection checks, policy gates, tests, coverage, schema, and security gates. | pull_request, push to main |
+| auto-label-needs-plan.yml | Applies `state:needs-plan` to opened or reopened issues and exposes the reusable issue-label workflow. | workflow_call, issues opened/reopened |
+| auto-label-severity.yml | Reconciles `severity:*` labels from issue form content. | issues opened/edited |
+| auto-tag.yml | Manually computes and pushes the next signed release tag. | workflow_dispatch |
+| enable-auto-merge-on-implementation-go.yml | Enables squash auto-merge when an eligible PR receives `state:implementation-go`. | pull_request_target labeled |
+| hol-plugin-scanner.yml | Runs the Hashgraph Online plugin scanner and uploads SARIF. | push to main, pull_request, workflow_dispatch |
+| release.yml | Builds, tests, publishes, and creates releases for tags. | push tags `v*`, workflow_dispatch |
+| security.yml | Runs scheduled/manual security scans and PR-time security checks for dependency-sensitive changes. | pull_request paths, schedule, workflow_dispatch |
+| test.yml | Runs the cross-Python unit/integration test matrix not duplicated by `_required.yml`. | pull_request, push to main |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -224,6 +224,19 @@ repos:
         pass_filenames: false
         files: ^(\.pre-commit-config\.yaml|pixi\.toml)$
 
+  # GitHub workflow inventory documentation enforcement (#1474)
+  - repo: local
+    hooks:
+      - id: hephaestus-check-workflow-inventory
+        name: hephaestus check workflow inventory
+        description: Ensure .github/workflows/README.md documents every .github/workflows/*.yml file
+        # --environment default is explicit because the pre-commit CI job runs
+        # in the lint env; the hephaestus-* console scripts live in default.
+        entry: pixi run --environment default hephaestus-check-workflow-inventory
+        language: system
+        pass_filenames: false
+        files: ^(\.pre-commit-config\.yaml|\.github/workflows/(README\.md|.*\.yml))$
+
   # Version single source of truth check
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -235,6 +235,7 @@ repos:
         entry: pixi run --environment default hephaestus-check-workflow-inventory
         language: system
         pass_filenames: false
+        always_run: true
         files: ^(\.pre-commit-config\.yaml|\.github/workflows/(README\.md|.*\.yml))$
 
   # Version single source of truth check

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -135,6 +135,7 @@ class TestWorkflowInventoryLiveTree:
         assert hook is not None
         assert hook["entry"] == "pixi run --environment default hephaestus-check-workflow-inventory"
         assert hook["pass_filenames"] is False
+        assert hook["always_run"] is True
         assert (
             hook["files"]
             == r"^(\.pre-commit-config\.yaml|\.github/workflows/(README\.md|.*\.yml))$"

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -110,6 +110,37 @@ class TestCheckInventory:
         assert "phantom.yml" in missing
 
 
+class TestWorkflowInventoryLiveTree:
+    """Live-tree regression tests for workflow inventory enforcement."""
+
+    def test_real_repo_workflow_inventory_is_in_sync(self) -> None:
+        undocumented, missing = check_inventory(REPO_ROOT)
+        assert undocumented == []
+        assert missing == []
+
+    def test_workflow_inventory_hook_is_wired_in_precommit(self) -> None:
+        from hephaestus.ci.precommit import load_precommit_config
+
+        repos = load_precommit_config(REPO_ROOT / ".pre-commit-config.yaml")
+        hook = next(
+            (
+                hook
+                for repo in repos
+                for hook in repo.get("hooks", [])
+                if hook.get("id") == "hephaestus-check-workflow-inventory"
+            ),
+            None,
+        )
+
+        assert hook is not None
+        assert hook["entry"] == "pixi run --environment default hephaestus-check-workflow-inventory"
+        assert hook["pass_filenames"] is False
+        assert (
+            hook["files"]
+            == r"^(\.pre-commit-config\.yaml|\.github/workflows/(README\.md|.*\.yml))$"
+        )
+
+
 class TestIsCheckoutStep:
     """Tests for _is_checkout_step()."""
 
@@ -356,6 +387,21 @@ class TestCLIEntryPoints:
             "sys.argv", ["hephaestus-check-workflow-inventory", "--repo-root", str(tmp_path)]
         )
         assert check_workflow_inventory_main() == 1
+
+    def test_inventory_default_repo_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hephaestus.ci.workflows import check_workflow_inventory_main
+
+        workflows = tmp_path / ".github" / "workflows"
+        workflows.mkdir(parents=True)
+        (workflows / "ci.yml").write_text("name: CI")
+        (workflows / "README.md").write_text("| ci.yml | CI workflow |\n")
+
+        monkeypatch.setattr("hephaestus.utils.helpers.get_repo_root", lambda: tmp_path)
+        monkeypatch.setattr("sys.argv", ["hephaestus-check-workflow-inventory"])
+
+        assert check_workflow_inventory_main() == 0
 
     def test_checkout_valid(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture


### PR DESCRIPTION
## Summary
Adds workflow inventory documentation and wires the existing inventory checker into pre-commit enforcement.

## Changes
- Added .github/workflows/README.md documenting workflow files in an inventory table.
- Added a pre-commit hook for hephaestus-check-workflow-inventory.
- Extended CI workflow inventory tests to cover README presence and enforcement wiring.

## Testing
- Updated tests/unit/ci/test_workflows.py with coverage for workflow inventory documentation and pre-commit configuration.

## Closes
Closes #1474

Generated by Codex via ProjectHephaestus automation.
