### PR TITLE
fix(deps): cap security-pinned transitive deps

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -50,17 +50,18 @@ pip = ">=23.0,<27"
 # It is intentionally NOT in pyproject [project.dependencies] — see issue #1458 /
 # ADR-0001. Kept here so the dev/test env can import hephaestus.automation.
 pydantic = ">=2.12.5,<3"
-pygments = ">=2.20.0"  # CVE-2026-4539
+# Direct floor keeps CVE-2026-4539 fixed; <3 blocks the next untested major.
+pygments = ">=2.20.0,<3"
 pygithub = ">=2.9.1,<3"
 # Transitive via pygithub/requests. Pinned to prevent the lock from
 # downgrading below the fix version for CVE-2026-44431/44432 (fixed in
 # 2.7.0); without this, a future pixi update could silently reintroduce
 # the CVEs. Closes #1004.
-urllib3 = ">=2.7.0"
+urllib3 = ">=2.7.0,<3"
 # Transitive via pygithub. Pinned to pull the security fix for
 # PYSEC-2026-175/177/178/179 (all fixed in 2.13.0); without this the locked
 # env resolves to 2.12.1 and pip-audit fails the dependency scan.
-pyjwt = ">=2.13.0"
+pyjwt = ">=2.13.0,<3"
 # Build backend for the `dev-install` editable install.
 hatchling = ">=1.27.0,<2"
 hatch-vcs = ">=0.4.0,<1"

--- a/tests/unit/scripts/test_dependency_floor_consistency.py
+++ b/tests/unit/scripts/test_dependency_floor_consistency.py
@@ -453,6 +453,37 @@ class TestPipPinning:
         )
 
 
+class TestSecurityFloorTransitivePinning:
+    """Security-fix transitive pins in pixi.toml must keep next-major caps."""
+
+    @pytest.mark.parametrize(
+        ("name", "minimum_floor"),
+        [
+            ("pygments", Version("2.20.0")),
+            ("urllib3", Version("2.7.0")),
+            ("pyjwt", Version("2.13.0")),
+        ],
+    )
+    def test_security_floor_transitives_have_next_major_caps(
+        self, repo_root: Path, name: str, minimum_floor: Version
+    ) -> None:
+        """Named security pins must keep their fix floor and block untested 3.x."""
+        pixi_path = repo_root / "pixi.toml"
+        with open(pixi_path, "rb") as f:
+            pixi = tomllib.load(f)
+
+        spec = pixi["dependencies"][name]
+        floor = Version(_floor(spec))
+        cap = Version(_upper_cap(spec))
+
+        assert floor >= minimum_floor, (
+            f"{name} floor {floor} is below required security floor {minimum_floor}"
+        )
+        assert cap == Version(str(floor.major + 1)), (
+            f"{name} cap {cap} must be the next major after floor {floor}"
+        )
+
+
 class TestAllExtraDocsInSync:
     """Guard that `[all]`'s member extras are documented in both docs.
 


### PR DESCRIPTION
## Summary
Adds upper bounds for security-pinned transitive dependencies and updates dependency policy coverage to enforce consistent cap discipline.

## Changes
- Add upper caps to pygments, urllib3, and pyjwt in pixi.toml while preserving security floor bounds.
- Move dependency floor/cap consistency coverage into the dependency floor consistency tests and simplify base dependency surface validation.

## Testing
- Not run; no test execution was provided.

## Closes
Closes #1478

Generated by Codex via ProjectHephaestus automation.
