### PR TITLE
fix(automation): isolate loop resume state

### DIFF
--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -344,8 +344,13 @@ class IssueImplementer:
         if self.options.analyze_only:
             return self._analyze_dependencies()
 
-        # Always load state to detect failed learns
-        self._load_state()
+        # Keep issue-scoped runs from hydrating stale state for unrelated
+        # historical issues. Epic/global runs still load all state so the
+        # failed-learn sweep can see their full dependency context.
+        if self.options.issues:
+            self.state_mgr.load_only(self.options.issues)
+        else:
+            self._load_state()
 
         # Re-run failed learns before normal processing
         if self.options.enable_learn:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -789,7 +789,12 @@ def _build_phase_argv(
 
     worker_arg = flags.get("worker_arg")
     if isinstance(worker_arg, str):
-        argv.extend([worker_arg, str(cfg.max_workers)])
+        # _process_one_issue already provides the outer issue-level
+        # concurrency. When a child phase receives exactly one issue, letting it
+        # create its own worker pool only multiplies git/GitHub contention
+        # against the same repo and can race shared .git metadata.
+        child_workers = 1 if len(open_issues) == 1 else cfg.max_workers
+        argv.extend([worker_arg, str(child_workers)])
 
     argv.extend(
         [

--- a/hephaestus/automation/state/implementer.py
+++ b/hephaestus/automation/state/implementer.py
@@ -102,3 +102,20 @@ class ImplementationStateManager:
             with self._lock:
                 self.states[state.issue_number] = state
             logger.info("Loaded state for issue #%s", state.issue_number)
+
+    def load_only(self, issue_numbers: list[int]) -> None:
+        """Load only state files for the current run's issue scope."""
+        for issue_number in issue_numbers:
+            state = load_state_file(
+                self.state_dir,
+                "issue",
+                issue_number,
+                ImplementationState,
+                state_logger=logger,
+            )
+            if state is None:
+                continue
+
+            with self._lock:
+                self.states[state.issue_number] = state
+            logger.info("Loaded state for issue #%s", state.issue_number)

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -29,6 +29,8 @@ import shutil
 import threading
 from pathlib import Path
 
+from hephaestus.utils.file_lock import file_lock
+
 from .git_utils import get_repo_root, is_clean_working_tree, rebase_worktree_onto, run
 
 logger = logging.getLogger(__name__)
@@ -103,6 +105,10 @@ class WorktreeManager:
 
         logger.debug("Initialized WorktreeManager at %s", self.base_dir)
 
+    def _git_metadata_lock_path(self) -> Path:
+        """Return the cross-process lock guarding shared git worktree metadata."""
+        return self.base_dir / ".git-metadata.lock"
+
     @property
     def base_branch(self) -> str:
         """The base branch, auto-detected on first access."""
@@ -133,10 +139,11 @@ class WorktreeManager:
         if self._base_branch_override_source == "loop_trunk":
             self._base_branch_override = None
             self._base_branch_override_source = None
-        with contextlib.suppress(Exception):
-            run(["git", "fetch", "origin"], cwd=self.repo_root, capture_output=True)
-        self._base_branch_resolved = None  # force re-detect on next access
-        return self.base_branch
+        with file_lock(self._git_metadata_lock_path()):
+            with contextlib.suppress(Exception):
+                run(["git", "fetch", "origin"], cwd=self.repo_root, capture_output=True)
+            self._base_branch_resolved = None  # force re-detect on next access
+            return self.base_branch
 
     def _detect_base_branch(self) -> str:
         try:
@@ -254,11 +261,12 @@ class WorktreeManager:
                     logger.debug("git worktree prune failed: %s", e)
 
             try:
-                self._add_worktree_for_branch(
-                    worktree_path,
-                    branch_name,
-                    refresh_base=refresh_base,
-                )
+                with file_lock(self._git_metadata_lock_path()):
+                    self._add_worktree_for_branch(
+                        worktree_path,
+                        branch_name,
+                        refresh_base=refresh_base,
+                    )
                 self.worktrees[issue_number] = worktree_path
                 logger.info("Created worktree for issue #%s at %s", issue_number, worktree_path)
                 return worktree_path
@@ -594,7 +602,8 @@ class WorktreeManager:
                 if force:
                     cmd.append("--force")
 
-                run(cmd, cwd=self.repo_root)
+                with file_lock(self._git_metadata_lock_path()):
+                    run(cmd, cwd=self.repo_root)
 
                 del self.worktrees[issue_number]
                 logger.info("Removed worktree for issue #%s", issue_number)

--- a/hephaestus/config/paths.py
+++ b/hephaestus/config/paths.py
@@ -40,7 +40,24 @@ def _current_checkout_parent() -> Path | None:
     checkout = Path(result.stdout.strip())
     if not checkout.name:
         return None
-    parent = checkout.parent
+    # Automation issue worktrees live under
+    # ``<repo>/build/.worktrees/issue-N``. When the loop is launched from one,
+    # the projects root is still the parent of ``<repo>``, not
+    # ``<repo>/build/.worktrees``; otherwise repo resolution nests clones and
+    # worktrees under the issue worktree area.
+    if (
+        checkout.parent.name == ".worktrees"
+        and checkout.parent.parent.name == "build"
+        and checkout.parent.parent.parent.is_dir()
+    ):
+        parent = checkout.parent.parent.parent.parent
+        logger.warning(
+            "Current checkout %s is an automation issue worktree; using %s as projects root",
+            checkout,
+            parent,
+        )
+    else:
+        parent = checkout.parent
     return parent if parent.is_dir() else None
 
 

--- a/tests/unit/automation/state/test_implementer.py
+++ b/tests/unit/automation/state/test_implementer.py
@@ -51,3 +51,17 @@ def test_load_all_loads_valid_state_and_skips_corrupt_file(tmp_path: Path) -> No
 
     assert manager.states[123].phase is ImplementationPhase.TESTING
     assert 456 not in manager.states
+
+
+def test_load_only_hydrates_requested_issue_states(tmp_path: Path) -> None:
+    """Issue-scoped runs should not load every stale issue state file."""
+    current = ImplementationState(issue_number=123, phase=ImplementationPhase.TESTING)
+    stale = ImplementationState(issue_number=456, phase=ImplementationPhase.FOLLOW_UP_ISSUES)
+    (tmp_path / "issue-123.json").write_text(current.model_dump_json())
+    (tmp_path / "issue-456.json").write_text(stale.model_dump_json())
+
+    manager = ImplementationStateManager(tmp_path)
+    manager.load_only([123])
+
+    assert set(manager.states) == {123}
+    assert manager.states[123].phase is ImplementationPhase.TESTING

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -887,6 +887,47 @@ def test_build_phase_argv_implement_has_single_max_workers() -> None:
     assert argv.count("--max-workers") == 1
 
 
+@pytest.mark.parametrize(
+    ("phase", "worker_arg"),
+    [
+        ("plan", "--parallel"),
+        ("implement", "--max-workers"),
+        ("drive-green", "--max-workers"),
+    ],
+)
+def test_build_phase_argv_issue_scoped_phases_use_single_child_worker(
+    phase: str, worker_arg: str
+) -> None:
+    """Issue-major outer workers should not fan out again inside one-issue phases."""
+    cfg = LoopConfig(max_workers=8)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/phase", [])):
+        argv = loop_runner._build_phase_argv(phase, cfg, open_issues=[1577])
+
+    assert argv is not None
+    assert argv[argv.index(worker_arg) + 1] == "1"
+
+
+@pytest.mark.parametrize("open_issues", ([1, 2], []))
+@pytest.mark.parametrize(
+    ("phase", "worker_arg"),
+    [
+        ("plan", "--parallel"),
+        ("implement", "--max-workers"),
+        ("drive-green", "--max-workers"),
+    ],
+)
+def test_build_phase_argv_multi_issue_or_unscoped_phases_keep_configured_workers(
+    phase: str, worker_arg: str, open_issues: list[int]
+) -> None:
+    """Only exactly-one-issue child invocations are narrowed to one worker."""
+    cfg = LoopConfig(max_workers=8)
+    with patch.object(loop_runner, "_resolve_phase_bin", return_value=("/x/phase", [])):
+        argv = loop_runner._build_phase_argv(phase, cfg, open_issues=open_issues)
+
+    assert argv is not None
+    assert argv[argv.index(worker_arg) + 1] == "8"
+
+
 def test_build_phase_argv_plan_omits_no_ui() -> None:
     """Regression: plan does NOT receive --no-ui (per _PHASE_FLAGS)."""
     cfg = LoopConfig()

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -1,6 +1,8 @@
 """Tests for worktree manager."""
 
 import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
@@ -61,6 +63,28 @@ class TestWorktreeManager:
         call_args = worktree_mocks.run.call_args[0][0]
         assert call_args[0:2] == ["git", "worktree"]
         assert "123-feature" in call_args
+
+    def test_create_worktree_serializes_git_metadata_mutation(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """Independent subprocesses must not race on shared git worktree metadata."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        worktree_mocks.run.return_value.stdout = "origin/main"
+        manager = WorktreeManager()
+        lock_paths: list[Path] = []
+
+        @contextmanager
+        def fake_file_lock(path: Path) -> Iterator[None]:
+            lock_paths.append(path)
+            yield
+
+        with (
+            patch.object(manager, "_worktree_holding_branch", return_value=None),
+            patch("hephaestus.automation.worktree_manager.file_lock", side_effect=fake_file_lock),
+        ):
+            manager.create_worktree(123, "123-feature")
+
+        assert lock_paths == [manager.base_dir / ".git-metadata.lock"]
 
     def test_create_worktree_default_branch_name(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test worktree creation with default branch name."""

--- a/tests/unit/config/test_paths.py
+++ b/tests/unit/config/test_paths.py
@@ -88,6 +88,29 @@ def test_prefer_cwd_parent_uses_current_checkout_parent(
     assert caplog.records == []
 
 
+def test_prefer_cwd_parent_unwraps_automation_issue_worktree(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """Loop defaults must not treat build/.worktrees as the projects root."""
+    checkout = tmp_path / "projects" / "ProjectHephaestus"
+    issue_worktree = checkout / "build" / ".worktrees" / "issue-1442"
+    issue_worktree.mkdir(parents=True)
+    monkeypatch.delenv("PROJECTS_ROOT", raising=False)
+    result_mock = MagicMock(stdout=f"{issue_worktree}\n")
+
+    with (
+        patch("hephaestus.config.paths.subprocess.run", return_value=result_mock),
+        caplog.at_level(logging.WARNING, logger="hephaestus.config.paths"),
+    ):
+        result = resolve_projects_dir(prefer_cwd_parent=True)
+
+    assert result == checkout.parent
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelno == logging.WARNING
+    assert "automation issue worktree" in caplog.records[0].getMessage()
+    assert str(issue_worktree) in caplog.records[0].getMessage()
+
+
 def test_prefer_cwd_parent_falls_back_when_git_root_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- unwrap automation issue worktree checkouts when resolving the projects root
- clamp one-issue child phase invocations to a single worker to avoid nested contention
- hydrate only scoped implementation state on issue-specific resumes
- serialize git worktree metadata mutations across subprocesses

## Test Plan
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-loop-resume pixi run python -m pytest tests/unit/config/test_paths.py tests/unit/automation/test_loop_runner.py tests/unit/automation/state/test_implementer.py tests/unit/automation/test_worktree_manager.py -q --no-cov` (`212 passed`)
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-loop-resume pixi run pytest tests/unit -v` (`5390 passed, 23 skipped`, coverage `83.79%`)
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-loop-resume pixi run python -m mypy hephaestus/`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-loop-resume pixi run ruff check hephaestus/ tests/`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-loop-resume pixi run ruff format --check hephaestus/ tests/`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-projecthephaestus-loop-resume pixi run pre-commit run --files hephaestus/automation/implementer.py hephaestus/automation/loop_runner.py hephaestus/automation/state/implementer.py hephaestus/automation/worktree_manager.py hephaestus/config/paths.py tests/unit/automation/state/test_implementer.py tests/unit/automation/test_loop_runner.py tests/unit/automation/test_worktree_manager.py tests/unit/config/test_paths.py`

Closes #1778

Co-Authored-By: OpenAI Codex <codex@openai.com>