### PR TITLE
fix(validation): flag vestigial test directories

### DIFF
--- a/hephaestus/validation/test_structure.py
+++ b/hephaestus/validation/test_structure.py
@@ -1,6 +1,6 @@
 """Validate unit test directory structure.
 
-Provides four complementary checks:
+Provides six complementary checks:
 
 1. **Mirror check**: Every subpackage in the source directory has a corresponding
    directory under ``tests/unit/``.
@@ -14,7 +14,9 @@ Provides four complementary checks:
    ``hephaestus/<name>/`` subpackage where both are content-free (source has
    no module beyond ``__init__.py`` AND the test dir has no ``test_*.py``) —
    the name-only mirror check would otherwise treat the pair as valid.
-5. **No-stray-tests-root-files check**: No ``test_*.py`` files exist directly
+5. **No-phantom-test-dirs check**: No direct ``tests/unit/<name>/`` dir is
+   content-free, such as a stale directory containing only ``__pycache__``.
+6. **No-stray-tests-root-files check**: No ``test_*.py`` files exist directly
    under ``tests/`` root. Such files fall outside
    ``testpaths = ["tests/unit", "tests/integration"]`` and are silently never
    collected by pytest (issue #1467).
@@ -125,6 +127,26 @@ def check_no_ghost_packages(
         if not _has_source_modules(src_root / name) and not _has_test_files(test_root / name)
     }
     return len(ghosts) == 0, ghosts
+
+
+def check_no_phantom_test_dirs(test_root: Path) -> tuple[bool, set[str]]:
+    """Flag direct ``tests/unit`` dirs with no Python source at all.
+
+    This catches stale skeletons such as ``tests/unit/git/`` containing only
+    ``__pycache__`` after the corresponding tests were removed.
+    """
+    if not test_root.is_dir():
+        return True, set()
+
+    phantoms = {
+        d.name
+        for d in test_root.iterdir()
+        if d.is_dir()
+        and not d.name.startswith("_")
+        and not d.name.startswith(".")
+        and not _has_python_source(d)
+    }
+    return len(phantoms) == 0, phantoms
 
 
 def check_test_directory_mirrors(
@@ -364,6 +386,23 @@ def _report_ghost_packages_check(
     return False
 
 
+def _report_phantom_test_dirs_check(test_root: Path, verbose: bool) -> bool:
+    ok, phantoms = check_no_phantom_test_dirs(test_root)
+    if ok:
+        if verbose:
+            print("OK: No phantom test directories under tests/unit/.")
+        return True
+
+    print(
+        "ERROR: tests/unit/ has content-free directories. Remove stale dirs, "
+        "or add real test files if the directory is intentional.\nPhantom(s):",
+        file=sys.stderr,
+    )
+    for name in sorted(phantoms):
+        print(f"  tests/unit/{name}/ (no Python source)", file=sys.stderr)
+    return False
+
+
 def _report_stray_tests_root_files_check(tests_root: Path, verbose: bool) -> bool:
     no_stray, violations = check_no_stray_tests_root_files(tests_root)
     if no_stray:
@@ -419,6 +458,7 @@ def check_test_structure(
         _report_loose_files_check(test_root, verbose),
         _report_unsanctioned_dirs_check(src_root, test_root, verbose),
         _report_ghost_packages_check(src_root, test_root, verbose),
+        _report_phantom_test_dirs_check(test_root, verbose),
         _report_stray_tests_root_files_check(tests_root, verbose),
     ]
     return all(results)

--- a/tests/unit/validation/test_test_structure.py
+++ b/tests/unit/validation/test_test_structure.py
@@ -8,6 +8,7 @@ from hephaestus.validation.test_structure import (
     _get_subpackages,
     check_no_ghost_packages,
     check_no_loose_test_files,
+    check_no_phantom_test_dirs,
     check_no_stray_tests_root_files,
     check_no_unsanctioned_test_dirs,
     check_scripts_coverage,
@@ -290,6 +291,39 @@ class TestCheckNoGhostPackages:
         assert ok is True, f"ghost dirs present: {ghosts}"
 
 
+class TestCheckNoPhantomTestDirs:
+    """Tests for check_no_phantom_test_dirs()."""
+
+    def test_pycache_only_test_dir_flagged(self, tmp_path: Path) -> None:
+        """Regression for #1468: tests/unit/git/ with only __pycache__ is phantom."""
+        test_root = tmp_path / "tests" / "unit"
+        ghost = test_root / "git"
+        (ghost / "__pycache__").mkdir(parents=True)
+        (ghost / "__pycache__" / "test_git.cpython-314.pyc").write_text("", encoding="utf-8")
+
+        ok, phantoms = check_no_phantom_test_dirs(test_root)
+
+        assert ok is False
+        assert phantoms == {"git"}
+
+    def test_test_module_dir_not_phantom(self, tmp_path: Path) -> None:
+        """A test dir with a real test module is not phantom."""
+        test_root = tmp_path / "tests" / "unit"
+        (test_root / "github").mkdir(parents=True)
+        (test_root / "github" / "test_client.py").write_text("", encoding="utf-8")
+
+        ok, phantoms = check_no_phantom_test_dirs(test_root)
+
+        assert ok is True
+        assert phantoms == set()
+
+    def test_real_repo_has_no_phantom_test_dirs(self) -> None:
+        """The shipped tests/unit tree must not contain pycache-only skeletons."""
+        repo_root = Path(__file__).resolve().parents[3]
+        ok, phantoms = check_no_phantom_test_dirs(repo_root / "tests" / "unit")
+        assert ok is True, f"phantom test dirs present: {phantoms}"
+
+
 class TestGetSubpackages:
     """_get_subpackages must ignore ghost (__pycache__-only) directories."""
 
@@ -355,7 +389,7 @@ class TestCheckTestStructure:
     """Tests for check_test_structure()."""
 
     def test_passing_structure(self, tmp_path: Path) -> None:
-        """Correctly structured project passes both checks."""
+        """Correctly structured project passes all checks."""
         # Create source package
         src = tmp_path / "mypackage"
         _make_package(src, "utils")
@@ -446,10 +480,27 @@ class TestCheckTestStructure:
         assert "tests/unit/git/ (no tests)" in err
         assert "hephaestus/git/ (no modules)" in err
 
+    def test_pycache_only_test_dir_fails(self, tmp_path: Path, capsys) -> None:
+        """check_test_structure fails when tests/unit/git/ is only stale bytecode."""
+        src = tmp_path / "mypackage"
+        _make_package(src, "real")
+        (src / "__init__.py").touch()
+
+        test_root = tmp_path / "tests" / "unit"
+        _make_test_dir(test_root, "real")
+        ghost = test_root / "git"
+        (ghost / "__pycache__").mkdir(parents=True)
+        (ghost / "__pycache__" / "test_git.cpython-314.pyc").write_text("", encoding="utf-8")
+
+        passed = check_test_structure(tmp_path, src_package="mypackage")
+
+        assert passed is False
+        assert "tests/unit/git/ (no Python source)" in capsys.readouterr().err
+
     def test_stray_tests_root_file_fails(self, tmp_path: Path, capsys) -> None:
         """check_test_structure fails and prints when a test_*.py sits at tests/ root.
 
-        Exercises Check 5's failure branch (the stray-file print loop). The
+        Exercises Check 6's failure branch (the stray-file print loop). The
         structure passes every other check; only a stray ``test_*.py`` at
         ``tests/`` root (outside testpaths) triggers the failure — the #1467
         regression.


### PR DESCRIPTION
## Summary
Extends test-structure validation to catch empty vestigial test directories and adds unit coverage for the new checks.

## Changes
- Detect test directories that contain only generated cache artifacts instead of real test files.
- Add validation unit tests covering vestigial test-directory reporting.

## Testing
- Not run; no test command output was provided.

## Closes
Closes #1468

Generated by Codex via ProjectHephaestus automation.
