### PR TITLE
fix(automation): remove Claude permission bypass flag

### DIFF
--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -902,7 +902,6 @@ def _invoke_claude_agent_session(
             timeout=options.agent_timeout,
             output_format="json",
             allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-            extra_args=["--dangerously-skip-permissions"],
             input_via_stdin=True,
         )
     except subprocess.CalledProcessError as exc:

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -421,7 +421,6 @@ def compact_session(
                 sid,
                 "--output-format",
                 "text",
-                "--dangerously-skip-permissions",
                 "--print",
                 "/compact",
             ],

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -178,7 +178,6 @@ class PostMergeProcessor:
                 timeout=options.learn_timeout,
                 output_format="text",
                 allowed_tools="Read,Write,Edit,Glob,Grep,Bash",
-                extra_args=["--dangerously-skip-permissions"],
                 input_via_stdin=True,
             )
             self._last_learn_evidence = mnemosyne_update_evidence(stdout or "")

--- a/tests/unit/automation/test_ci_driver.py
+++ b/tests/unit/automation/test_ci_driver.py
@@ -3495,6 +3495,9 @@ class TestInvokeAgentSession:
         assert result.returncode == 0
         assert result.stdout == "output text"
         mock_invoke.assert_called_once()
+        kwargs = mock_invoke.call_args.kwargs
+        assert kwargs["allowed_tools"] == "Read,Write,Edit,Glob,Grep,Bash"
+        assert "extra_args" not in kwargs
 
     def test_claude_error_returns_nonzero_rc(self, driver: CIDriver, tmp_path: Path) -> None:
         with patch(

--- a/tests/unit/automation/test_claude_permission_flags.py
+++ b/tests/unit/automation/test_claude_permission_flags.py
@@ -1,0 +1,24 @@
+"""Regression guard for Claude permission bypass flags."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[3]
+AUTOMATION_DIR = REPO_ROOT / "hephaestus" / "automation"
+DANGEROUS_PERMISSION_FLAG = "--dangerously-skip-permissions"
+
+
+def test_automation_sources_do_not_pass_dangerously_skip_permissions() -> None:
+    """Verify automation source does not bypass Claude permission prompts."""
+    offenders: list[str] = []
+    for path in sorted(AUTOMATION_DIR.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and node.value == DANGEROUS_PERMISSION_FLAG:
+                offenders.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+
+    assert not offenders, "Claude automation must not bypass permission prompts: " + ", ".join(
+        offenders
+    )

--- a/tests/unit/automation/test_compact.py
+++ b/tests/unit/automation/test_compact.py
@@ -70,17 +70,17 @@ class TestCompactSession:
             assert "cwd" in call_kwargs
             assert call_kwargs["cwd"] == str(test_cwd)
 
-    def test_compact_session_passes_dangerously_skip_permissions_and_text_output(
+    def test_compact_session_omits_dangerously_skip_permissions_and_uses_text_output(
         self, tmp_path: Path
     ) -> None:
-        """Verify all required CLI flags are present."""
+        """Verify compact keeps text output without bypassing permissions."""
         with patch("hephaestus.automation.learn.subprocess.run") as mock_run:
             mock_run.return_value = Mock(returncode=0, stderr="")
 
             compact_session("test-repo", 42, AGENT_CI_DRIVER, tmp_path)
 
             cmd = mock_run.call_args[0][0]
-            assert "--dangerously-skip-permissions" in cmd
+            assert "--dangerously-skip-permissions" not in cmd
             assert "--output-format" in cmd
             output_fmt_idx = cmd.index("--output-format")
             assert cmd[output_fmt_idx + 1] == "text"

--- a/tests/unit/automation/test_post_merge_helpers.py
+++ b/tests/unit/automation/test_post_merge_helpers.py
@@ -96,6 +96,9 @@ class TestRunDriveGreenLearnings:
             result = processor.run_drive_green_learnings(1, 2)
         assert result is True
         assert inv.called
+        kwargs = inv.call_args.kwargs
+        assert kwargs["allowed_tools"] == "Read,Write,Edit,Glob,Grep,Bash"
+        assert "extra_args" not in kwargs
         assert processor._last_learn_evidence == sentinel
 
     def test_codex_path_uses_run_agent_session(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Removes the Claude CLI permission bypass flag from automation subprocess paths and adds regression coverage to prevent it from returning.

## Changes
- Removed --dangerously-skip-permissions from CI fix orchestration, learning, and post-merge Claude invocations.
- Added focused regression coverage for Claude permission flag handling.
- Updated affected automation helper tests to match the safer Claude invocation behavior.

## Testing
- Added/updated unit tests under tests/unit/automation for permission flags, CI driver, compaction, and post-merge helpers.

## Closes
Closes #1480

Generated by Codex via ProjectHephaestus automation.
