### PR TITLE
refactor(nats): decouple config from pydantic

### DIFF
--- a/hephaestus/nats/config.py
+++ b/hephaestus/nats/config.py
@@ -31,6 +31,7 @@ DeliverPolicyStr = Literal[
 _DELIVER_POLICIES = frozenset(
     {"all", "last", "new", "by_start_sequence", "by_start_time", "last_per_subject"}
 )
+_FLOAT_FIELDS = frozenset({"initial_backoff_seconds", "max_backoff_seconds", "backoff_multiplier"})
 
 
 @dataclass
@@ -125,12 +126,12 @@ class NATSConfig:
         return cls(**data)
 
 
-def _coerce_float(name: str, raw: str) -> float:
+def _coerce_float(name: str, raw: Any) -> float:
     """Coerce an env var string to ``float`` with a variable-named error.
 
     Args:
         name: Environment variable name (used in the error message).
-        raw: Raw string value to coerce.
+        raw: Raw value to coerce.
 
     Returns:
         The parsed float value.
@@ -141,7 +142,7 @@ def _coerce_float(name: str, raw: str) -> float:
     """
     try:
         return float(raw)
-    except ValueError:
+    except (TypeError, ValueError):
         raise ValueError(f"{name} must be a number, got {raw!r}") from None
 
 
@@ -220,4 +221,7 @@ def load_nats_config(
     # remain strict, which is the desired behavior for code callers.
     known = {f.name for f in dataclass_fields(NATSConfig)}
     filtered = {k: v for k, v in data.items() if k in known}
+    for field_name in _FLOAT_FIELDS:
+        if field_name in filtered:
+            filtered[field_name] = _coerce_float(field_name, filtered[field_name])
     return NATSConfig(**filtered)

--- a/tests/unit/nats/test_config.py
+++ b/tests/unit/nats/test_config.py
@@ -33,7 +33,7 @@ class TestNATSConfig:
         assert config.subjects == ["my.subject.>"]
 
     def test_invalid_extra_field_ignored(self) -> None:
-        config = NATSConfig(enabled=True)
+        config = load_nats_config({"enabled": True, "unknown_key": "ignored"})
         assert config.enabled is True
 
     def test_backoff_defaults_preserve_historical_constants(self) -> None:
@@ -127,6 +127,10 @@ class TestLoadNATSConfig:
         # unknown kwargs). load_nats_config must keep dropping unknown keys.
         config = load_nats_config({"url": "nats://x:4222", "unknown_key": "ignored"})
         assert config.url == "nats://x:4222"
+
+    def test_yaml_string_backoff_coerced_to_float(self) -> None:
+        config = load_nats_config({"initial_backoff_seconds": "0.5"})
+        assert config.initial_backoff_seconds == 0.5
 
 
 class TestFromEnv:


### PR DESCRIPTION
## Summary
Remove the NATS config path's dependency on pydantic to make the automation-only dependency boundary clearer.

## Changes
- Refactored hephaestus.nats.config to avoid relying on pydantic for configuration handling.
- Updated NATS config unit tests to cover the pydantic-free behavior.

## Testing
- Updated tests/unit/nats/test_config.py

## Closes
Closes #1500

Generated by Codex via ProjectHephaestus automation.
