### PR TITLE
[Fix] Fall back to default model on model-specific usage cap

### DIFF
--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -164,6 +164,17 @@ def git_message_model() -> str:
     return _resolve_model("HEPH_GIT_MESSAGE_MODEL", HAIKU)
 
 
+def fallback_model() -> str:
+    """Model substituted when a model-specific usage cap is detected (#1793).
+
+    A "reached your <model> limit … switch models with /model" 429 carries no
+    reset epoch, so waiting cannot help — the invoke chokepoint retries on
+    this model instead. Honors ``HEPH_FALLBACK_MODEL``; defaults to
+    :data:`OPUS` (the current Opus).
+    """
+    return _resolve_model("HEPH_FALLBACK_MODEL", OPUS)
+
+
 # ── Subprocess timeouts ──────────────────────────────────────────────────────
 
 PLAN_STAGE_TIMEOUT = 7200
@@ -537,6 +548,7 @@ __all__ = [
     "ci_poll_max_wait",
     "codex_advise_model",
     "current_trunk_githash",
+    "fallback_model",
     "follow_up_claude_timeout",
     "gh_cli_timeout",
     "git_message_agent_timeout",

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -7,13 +7,18 @@ What lives here:
 - :func:`parse_review_verdict` — verdict parser used by the strict review loops
 - :func:`scan_quota_reset` — shared cross-stream rate-limit scanner so all
   phases get identical 429 handling.
+- :func:`detect_model_usage_cap` — classifier for the model-specific
+  "reached your <model> limit … switch models with /model" 429, which carries
+  no reset epoch and is remediated by a model switch, not a wait (#1793).
 - :data:`SESSION_EXPIRED_PHRASES` — substrings the Claude CLI returns when
   ``--resume`` targets a session that no longer exists locally.
 - :func:`invoke_claude_with_session` — the single entry point every
   automation phase must use. Picks ``--session-id`` (first call) vs
   ``--resume`` (subsequent calls) based on whether the model-keyed JSONL
   transcript already exists. No recreate-on-failure cascade — a create/resume
-  error propagates (#1168).
+  error propagates (#1168). On a model-specific usage cap it retries the same
+  request once on :func:`agent_config.fallback_model` and pins the fallback
+  for the rest of the process (#1793).
 """
 
 from __future__ import annotations
@@ -27,7 +32,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-from hephaestus.automation.agent_config import session_jsonl_path, session_name
+from hephaestus.automation.agent_config import fallback_model, session_jsonl_path, session_name
 from hephaestus.github.client import ClaudeUsageCapError
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch
 from hephaestus.utils.helpers import strip_null_bytes
@@ -53,6 +58,35 @@ def _session_expired(stderr: str, stdout: str) -> bool:
     """Return True if either stream indicates the resume target is gone."""
     blob = (stderr + "\n" + stdout).lower()
     return any(phrase in blob for phrase in SESSION_EXPIRED_PHRASES)
+
+
+# Models observed to be usage-capped in THIS process. Consulted by
+# :func:`invoke_claude_with_session` so later calls skip the doomed attempt and
+# go straight to the fallback (a capped model stays capped for hours; without
+# stickiness an exhausted quota once fired ~39 doomed sessions in an hour).
+# Deliberately per-process: phase subprocesses spawned by the loop each
+# re-detect once, which costs one ~0.5s failed call per phase (#1793).
+_capped_models: set[str] = set()
+
+
+def is_model_capped(model: str) -> bool:
+    """Return True if *model* hit a model-specific usage cap in this process."""
+    return model in _capped_models
+
+
+def reset_capped_models() -> None:
+    """Clear the capped-model registry (test hook)."""
+    _capped_models.clear()
+
+
+def _record_model_cap(capped: str, fallback: str) -> None:
+    """Mark *capped* as unusable for this process and log the switch."""
+    _capped_models.add(capped)
+    logger.warning(
+        "model %s usage cap hit; falling back to %s for the rest of this run",
+        capped,
+        fallback,
+    )
 
 
 def invoke_claude_with_session(
@@ -90,6 +124,19 @@ def invoke_claude_with_session(
     The session is scoped to the artifact (issue/PR), not a commit SHA, so the
     transcript persists across main-bumps for the issue's lifetime (#841).
 
+    Model-specific usage caps (#1793): a 429 whose message says "reached your
+    <model> limit … switch models with /model" carries no reset epoch, so the
+    wait-until-reset handlers cannot help. When such a cap is detected — via a
+    non-zero exit OR an exit-0 ``is_error: true`` JSON envelope (json format
+    only; plain-text output is never scanned, since agent prose can
+    legitimately contain the phrases) — the same request is retried once on
+    :func:`agent_config.fallback_model`, and the capped model is pinned to the
+    fallback for the rest of this process. The fallback runs under its own
+    session lineage (the model is part of the session key), so the capped
+    model's cached context is re-sent once. No retry happens when the
+    effective model already IS the fallback; the error propagates so callers'
+    existing quota/overload handling takes over.
+
     Args:
         repo: Repository slug (e.g. ``"ProjectScylla"``).
         issue: Issue number — leading ``#`` is stripped by
@@ -116,14 +163,75 @@ def invoke_claude_with_session(
 
     Returns:
         ``(stdout, session_uuid)`` — the deterministic id derived from
-        ``(repo, issue, agent, model)``.
+        ``(repo, issue, agent, model)`` — for the model actually used (the
+        fallback's id when a cap forced a switch).
 
     Raises:
-        subprocess.CalledProcessError: If the create/resume call exits non-zero.
+        subprocess.CalledProcessError: If the create/resume call exits non-zero
+            (after the one fallback retry, when applicable).
         subprocess.TimeoutExpired: If the call exceeds ``timeout``.
 
     """
     del recreate_on_resume_failure  # back-compat shim only; no recreate cascade
+
+    def _attempt(effective_model: str) -> tuple[str, str]:
+        return _invoke_claude_once(
+            repo=repo,
+            issue=issue,
+            agent=agent,
+            prompt=prompt,
+            model=effective_model,
+            cwd=cwd,
+            timeout=timeout,
+            system_prompt_file=system_prompt_file,
+            allowed_tools=allowed_tools,
+            permission_mode=permission_mode,
+            extra_args=extra_args,
+            output_format=output_format,
+            input_via_stdin=input_via_stdin,
+        )
+
+    fallback = fallback_model()
+    effective = model
+    if model != fallback and is_model_capped(model):
+        logger.info("model %s previously capped; using fallback %s", model, fallback)
+        effective = fallback
+    try:
+        stdout, sid = _attempt(effective)
+    except subprocess.CalledProcessError as e:
+        if effective == fallback or not detect_model_usage_cap(e.stderr or "", e.stdout or ""):
+            raise
+        _record_model_cap(effective, fallback)
+        return _attempt(fallback)
+    if output_format == "json" and effective != fallback:
+        err_text = _envelope_error_text(stdout)
+        if err_text is not None and detect_model_usage_cap(err_text):
+            _record_model_cap(effective, fallback)
+            return _attempt(fallback)
+    return stdout, sid
+
+
+def _invoke_claude_once(
+    *,
+    repo: str,
+    issue: int | str,
+    agent: str,
+    prompt: str,
+    model: str,
+    cwd: Path,
+    timeout: int,
+    system_prompt_file: Path | None,
+    allowed_tools: str | None,
+    permission_mode: str | None,
+    extra_args: list[str] | None,
+    output_format: str,
+    input_via_stdin: bool,
+) -> tuple[str, str]:
+    """Run one ``claude`` create/resume call for the given model (no fallback).
+
+    The single-attempt body of :func:`invoke_claude_with_session`; see its
+    docstring for the session-key semantics.
+    """
     display_name = session_name(repo, issue, agent, model)
     sid = str(uuid.uuid5(uuid.NAMESPACE_DNS, display_name))
 
@@ -203,6 +311,25 @@ def invoke_claude_with_session(
     return result.stdout, sid
 
 
+def _envelope_error_text(stdout: str) -> str | None:
+    """Extract the error text from an ``is_error: true`` Claude JSON envelope.
+
+    Returns ``None`` when ``stdout`` is empty, not JSON, or not an error
+    envelope; otherwise the (possibly empty) ``result`` field as a string.
+    Shared by :func:`raise_for_error_envelope` and the model-cap fallback in
+    :func:`invoke_claude_with_session` so the envelope decode exists once.
+    """
+    if not stdout:
+        return None
+    try:
+        data = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not (isinstance(data, dict) and data.get("is_error")):
+        return None
+    return str(data.get("result") or "")
+
+
 def raise_for_error_envelope(stdout: str) -> None:
     """Raise if ``stdout`` is an ``is_error: true`` Claude JSON envelope.
 
@@ -226,15 +353,9 @@ def raise_for_error_envelope(stdout: str) -> None:
         RuntimeError: If the envelope is ``is_error`` for any other reason.
 
     """
-    if not stdout:
+    err_text = _envelope_error_text(stdout)
+    if err_text is None:
         return
-    try:
-        data = json.loads(stdout)
-    except (json.JSONDecodeError, ValueError):
-        return
-    if not (isinstance(data, dict) and data.get("is_error")):
-        return
-    err_text = str(data.get("result") or "")
     reset_epoch = resolve_quota_reset_epoch(err_text)
     if reset_epoch is not None:
         raise ClaudeUsageCapError(
@@ -309,6 +430,56 @@ def detect_server_overload(*texts: str) -> bool:
         if any(phrase in lowered for phrase in _SERVER_OVERLOAD_PHRASES):
             return True
         if _SERVER_OVERLOAD_STATUS_RE.search(text):
+            return True
+    return False
+
+
+# Signals for the MODEL-SPECIFIC usage cap, e.g.:
+#   "You've reached your Fable 5 limit. Run /usage-credits to continue or
+#    switch models with /model."
+# Unlike the session-limit / usage-cap 429s (rate_limit.py), this carries NO
+# reset epoch — waiting cannot help; the remediation is a model switch. The
+# negative lookahead keeps "session limit" / "usage limit" owned by the
+# wait-until-reset detectors so the two families never overlap (#1793).
+_MODEL_USAGE_CAP_RE = re.compile(
+    r"reached\s+your\s+(?!session\b|usage\b)[\w .-]{1,40}?\s+limit",
+    re.IGNORECASE,
+)
+_MODEL_USAGE_CAP_PHRASES: tuple[str, ...] = (
+    "/usage-credits",
+    "switch models with /model",
+)
+
+
+def detect_model_usage_cap(*texts: str) -> bool:
+    """Return True if any stream carries a model-specific usage-cap message.
+
+    Recognizes the "You've reached your <model> limit … switch models with
+    /model" 429 the Claude CLI emits when one model tier's quota is exhausted
+    while others remain available. Three independent signals are ORed (the
+    "reached your <model> limit" regex plus each remediation-hint phrase) so a
+    partial rewording still matches. Session-limit and generic usage-cap
+    phrasings are deliberately NOT matched — those carry a reset epoch and stay
+    with :func:`scan_quota_reset`'s wait-until-reset handling.
+
+    Only failure streams (stderr of a non-zero exit, or the ``result`` field of
+    an ``is_error: true`` JSON envelope) should be passed here — never plain
+    successful output, which can legitimately mention these phrases (#1793).
+
+    Args:
+        *texts: One or more output streams to inspect (stderr and/or stdout).
+
+    Returns:
+        True if a model-specific usage-cap signal is present in any stream.
+
+    """
+    for text in texts:
+        if not text:
+            continue
+        lowered = text.lower()
+        if any(phrase in lowered for phrase in _MODEL_USAGE_CAP_PHRASES):
+            return True
+        if _MODEL_USAGE_CAP_RE.search(text):
             return True
     return False
 

--- a/tests/unit/automation/test_claude_invoke.py
+++ b/tests/unit/automation/test_claude_invoke.py
@@ -8,9 +8,70 @@ from hypothesis import given, strategies as st
 from hephaestus.automation.claude_invoke import (
     INFRA_ERROR_REVIEW_TEXT,
     ReviewVerdict,
+    detect_model_usage_cap,
     detect_server_overload,
     parse_review_verdict,
 )
+
+# The exact model-cap phrasing observed in output2.log (2026-07-03). Unlike a
+# session-limit 429 it carries NO reset time — the remediation is a model
+# switch, not a wait (#1793).
+MODEL_CAP_MESSAGE = (
+    "You've reached your Fable 5 limit. "
+    "Run /usage-credits to continue or switch models with /model."
+)
+
+
+class TestDetectModelUsageCap:
+    """Tests for the model-specific usage-cap classifier (#1793)."""
+
+    def test_production_phrasing(self) -> None:
+        """The exact envelope text from the 2026-07-03 loop run is detected."""
+        assert detect_model_usage_cap(MODEL_CAP_MESSAGE) is True
+
+    def test_other_model_name(self) -> None:
+        """The regex generalizes to any model tier name, not just Fable."""
+        assert detect_model_usage_cap("You've reached your Opus 4.8 limit.") is True
+
+    def test_phrase_signals_alone(self) -> None:
+        """Each remediation-hint phrase is an independent signal."""
+        assert detect_model_usage_cap("Run /usage-credits to continue") is True
+        assert detect_model_usage_cap("switch models with /model") is True
+
+    def test_session_limit_not_matched(self) -> None:
+        """Session-limit phrasings stay owned by detect_session_limit (wait path)."""
+        assert (
+            detect_model_usage_cap(
+                "You've hit your session limit · resets 12:30pm (America/Los_Angeles)"
+            )
+            is False
+        )
+        assert detect_model_usage_cap("You've reached your session limit") is False
+
+    def test_usage_cap_not_matched(self) -> None:
+        """Generic usage-cap phrasings stay owned by detect_claude_usage_cap."""
+        assert (
+            detect_model_usage_cap(
+                "You're out of extra usage · resets May 8, 5pm (America/Los_Angeles)"
+            )
+            is False
+        )
+        assert detect_model_usage_cap("You've reached your usage limit") is False
+
+    def test_scans_multiple_streams(self) -> None:
+        """Detection spans both stderr and stdout streams."""
+        assert detect_model_usage_cap("clean stderr", MODEL_CAP_MESSAGE) is True
+
+    def test_empty_and_no_streams(self) -> None:
+        """Empty or absent streams are skipped without error."""
+        assert detect_model_usage_cap("", "") is False
+        assert detect_model_usage_cap() is False
+
+    def test_model_cap_has_no_reset_epoch(self) -> None:
+        """Documents WHY fallback (not wait): the message yields no reset epoch."""
+        from hephaestus.github.rate_limit import resolve_quota_reset_epoch
+
+        assert resolve_quota_reset_epoch(MODEL_CAP_MESSAGE) is None
 
 
 class TestDetectServerOverload:

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from collections.abc import Generator
@@ -11,7 +12,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation.claude_invoke import invoke_claude_with_session
+from hephaestus.automation.agent_config import OPUS_48
+from hephaestus.automation.claude_invoke import (
+    invoke_claude_with_session,
+    is_model_capped,
+    reset_capped_models,
+)
 from hephaestus.automation.session_naming import (
     AGENT_PLAN_REVIEWER,
     AGENT_PLANNER,
@@ -348,6 +354,279 @@ class TestEndToEndSessionResume:
         assert expected_sid in argv
         assert "--session-id" not in argv
         assert "--session-id" not in argv
+
+
+MODEL_CAP_MESSAGE = (
+    "You've reached your Fable 5 limit. "
+    "Run /usage-credits to continue or switch models with /model."
+)
+
+
+def _cap_error(stderr: str = MODEL_CAP_MESSAGE, stdout: str = "") -> subprocess.CalledProcessError:
+    return subprocess.CalledProcessError(returncode=1, cmd=["claude"], output=stdout, stderr=stderr)
+
+
+def _cap_envelope() -> str:
+    return json.dumps({"is_error": True, "api_error_status": 429, "result": MODEL_CAP_MESSAGE})
+
+
+class TestModelCapFallback:
+    """#1793: a model-specific usage cap falls back to the default model.
+
+    The "reached your <model> limit … switch models with /model" 429 carries no
+    reset epoch, so the wait-until-reset handlers can't help — the correct
+    remediation is to retry once on :func:`agent_config.fallback_model` and pin
+    the fallback for the rest of the process (sticky registry).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_registry(self) -> Generator[None, None, None]:
+        reset_capped_models()
+        yield
+        reset_capped_models()
+
+    def test_called_process_error_falls_back_once(
+        self, fake_home: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A cap CalledProcessError retries the SAME request on the fallback."""
+        import logging
+
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        ok = MagicMock(stdout="fallback-ok", stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[_cap_error(), ok],
+        ) as m:
+            with caplog.at_level(logging.WARNING, logger="hephaestus.automation.claude_invoke"):
+                out, _sid = invoke_claude_with_session(
+                    repo="R",
+                    issue=1,
+                    agent=AGENT_PLANNER,
+                    prompt="hi",
+                    model="claude-fable-5",
+                    cwd=cwd,
+                )
+        assert out == "fallback-ok"
+        assert m.call_count == 2
+        first_argv = _argv(m.call_args_list[0])
+        second_argv = _argv(m.call_args_list[1])
+        assert first_argv[first_argv.index("--model") + 1] == "claude-fable-5"
+        assert second_argv[second_argv.index("--model") + 1] == OPUS_48
+        # Same prompt on both attempts — the request is retried, not dropped.
+        assert first_argv[-1] == second_argv[-1] == "hi"
+        assert any(
+            "claude-fable-5" in r.getMessage() and OPUS_48 in r.getMessage() for r in caplog.records
+        )
+
+    def test_error_envelope_falls_back_once(self, fake_home: Path) -> None:
+        """An exit-0 is_error:true cap envelope (json format) also falls back."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        capped = MagicMock(stdout=_cap_envelope(), stderr="", returncode=0)
+        ok = MagicMock(stdout='{"result": "ok"}', stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[capped, ok],
+        ) as m:
+            out, _sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+                output_format="json",
+            )
+        assert out == '{"result": "ok"}'
+        assert m.call_count == 2
+        second_argv = _argv(m.call_args_list[1])
+        assert second_argv[second_argv.index("--model") + 1] == OPUS_48
+
+    def test_registry_is_sticky_across_calls(self, fake_home: Path) -> None:
+        """After a cap, later calls go straight to the fallback (1 attempt)."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        ok = MagicMock(stdout="ok", stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[_cap_error(), ok],
+        ):
+            invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+            )
+        assert is_model_capped("claude-fable-5") is True
+        with patch("hephaestus.automation.claude_invoke.subprocess.run", return_value=ok) as m2:
+            invoke_claude_with_session(
+                repo="R",
+                issue=2,
+                agent=AGENT_PLANNER,
+                prompt="next",
+                model="claude-fable-5",
+                cwd=cwd,
+            )
+        assert m2.call_count == 1
+        argv = _argv(m2.call_args)
+        assert argv[argv.index("--model") + 1] == OPUS_48
+
+    def test_no_fallback_loop_when_model_is_already_fallback(self, fake_home: Path) -> None:
+        """A cap on the fallback model itself propagates — no retry loop."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=_cap_error(),
+        ) as m:
+            with pytest.raises(subprocess.CalledProcessError):
+                invoke_claude_with_session(
+                    repo="R",
+                    issue=1,
+                    agent=AGENT_PLANNER,
+                    prompt="hi",
+                    model=OPUS_48,
+                    cwd=cwd,
+                )
+        assert m.call_count == 1
+        assert is_model_capped(OPUS_48) is False
+
+    def test_fallback_also_capped_envelope_returned_verbatim(self, fake_home: Path) -> None:
+        """If the fallback retry ALSO returns a cap envelope it is returned as-is.
+
+        Callers' existing ``raise_for_error_envelope`` guards remain the
+        backstop; the fallback model is never added to the registry.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        capped = MagicMock(stdout=_cap_envelope(), stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[capped, capped],
+        ) as m:
+            out, _sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+                output_format="json",
+            )
+        assert m.call_count == 2
+        assert out == _cap_envelope()
+        assert is_model_capped(OPUS_48) is False
+
+    def test_non_cap_failure_propagates_untouched(self, fake_home: Path) -> None:
+        """A 529 overload (or any non-cap error) is NOT a fallback trigger."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        boom = subprocess.CalledProcessError(
+            returncode=1, cmd=["claude"], output="", stderr="API Error: 529 Overloaded"
+        )
+        with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom) as m:
+            with pytest.raises(subprocess.CalledProcessError):
+                invoke_claude_with_session(
+                    repo="R",
+                    issue=1,
+                    agent=AGENT_PLANNER,
+                    prompt="hi",
+                    model="claude-fable-5",
+                    cwd=cwd,
+                )
+        assert m.call_count == 1
+
+    def test_non_cap_error_envelope_returned_untouched(self, fake_home: Path) -> None:
+        """A non-cap is_error envelope is returned verbatim (callers handle it)."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        envelope = json.dumps({"is_error": True, "result": "tool execution failed"})
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            return_value=MagicMock(stdout=envelope, stderr="", returncode=0),
+        ) as m:
+            out, _sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+                output_format="json",
+            )
+        assert m.call_count == 1
+        assert out == envelope
+
+    def test_text_format_stdout_not_scanned(self, fake_home: Path) -> None:
+        """Plain-text exit-0 output mentioning /usage-credits is NOT a cap.
+
+        Agent prose can legitimately contain the phrase (e.g. this repo's own
+        code under review); only the json error envelope is trusted on exit 0.
+        """
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            return_value=MagicMock(
+                stdout="the fix mentions /usage-credits handling", stderr="", returncode=0
+            ),
+        ) as m:
+            out, _sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+            )
+        assert m.call_count == 1
+        assert "usage-credits" in out
+        assert is_model_capped("claude-fable-5") is False
+
+    def test_fallback_gets_its_own_session_lineage(self, fake_home: Path) -> None:
+        """The returned sid is the FALLBACK model's uuid (resume is model-locked)."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        ok = MagicMock(stdout="ok", stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[_cap_error(), ok],
+        ):
+            _, sid = invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+            )
+        assert sid == session_uuid("R", 1, AGENT_PLANNER, OPUS_48)
+
+    def test_heph_fallback_model_env_override(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """HEPH_FALLBACK_MODEL redirects the fallback target."""
+        cwd = fake_home / "work"
+        cwd.mkdir()
+        monkeypatch.setenv("HEPH_FALLBACK_MODEL", "claude-haiku-4-5")
+        ok = MagicMock(stdout="ok", stderr="", returncode=0)
+        with patch(
+            "hephaestus.automation.claude_invoke.subprocess.run",
+            side_effect=[_cap_error(), ok],
+        ) as m:
+            invoke_claude_with_session(
+                repo="R",
+                issue=1,
+                agent=AGENT_PLANNER,
+                prompt="hi",
+                model="claude-fable-5",
+                cwd=cwd,
+            )
+        second_argv = _argv(m.call_args_list[1])
+        assert second_argv[second_argv.index("--model") + 1] == "claude-haiku-4-5"
 
 
 class TestPromptNullByteSanitization:

--- a/tests/unit/automation/test_claude_models.py
+++ b/tests/unit/automation/test_claude_models.py
@@ -31,6 +31,11 @@ class TestDefaults:
         monkeypatch.delenv("HEPH_GIT_MESSAGE_MODEL", raising=False)
         assert claude_models.git_message_model() == claude_models.HAIKU
 
+    def test_fallback_defaults_to_current_opus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The usage-cap fallback model is the current Opus (#1793)."""
+        monkeypatch.delenv("HEPH_FALLBACK_MODEL", raising=False)
+        assert claude_models.fallback_model() == claude_models.OPUS_48
+
 
 class TestEnvOverride:
     """An operator can flip a phase's model without code changes.
@@ -52,6 +57,21 @@ class TestEnvOverride:
         monkeypatch.setenv("HEPH_GIT_MESSAGE_MODEL", "claude-fable-5")
         assert claude_models.git_message_model() == "claude-fable-5"
 
+    def test_fallback_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEPH_FALLBACK_MODEL", "claude-sonnet-4-6")
+        assert claude_models.fallback_model() == "claude-sonnet-4-6"
+
+    def test_fallback_unknown_override_warns_but_returns_value(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        monkeypatch.setenv("HEPH_FALLBACK_MODEL", "claude-preview-99-99")
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.agent_config"):
+            result = claude_models.fallback_model()
+        assert result == "claude-preview-99-99"
+        assert any("Unknown model" in r.message for r in caplog.records)
+
 
 class TestModuleStable:
     """Module reimport stability guard.
@@ -62,7 +82,7 @@ class TestModuleStable:
 
     def test_reimport_idempotent(self) -> None:
         importlib.reload(claude_models)
-        assert claude_models.OPUS == "claude-opus-4-7"
+        assert claude_models.OPUS == "claude-opus-4-8"
         assert claude_models.HAIKU == "claude-haiku-4-5"
         assert claude_models.SONNET == "claude-sonnet-4-6"
         assert claude_models.CODEX_ADVISE == "gpt-5.4-mini"


### PR DESCRIPTION
## Summary

When the Claude CLI hits a **model-specific** usage cap ("You've reached your Fable 5 limit. Run /usage-credits to continue or switch models with /model.") the message carries no reset epoch, so the existing wait-until-reset quota handlers can't act on it and every agent call path (planner, plan-reviewer, implementer, advise, learnings-capture) hard-failed — ~48 doomed calls in the 2026-07-03 loop run.

This PR teaches the single invoke chokepoint (`invoke_claude_with_session`) to:

- classify the model-cap phrasing via a new `detect_model_usage_cap()` (regex + two remediation-hint phrase signals, ORed for rewording resilience; negative lookahead keeps session-limit/usage-limit phrasings with the wait-path detectors),
- retry the **same request once** on `agent_config.fallback_model()` (`HEPH_FALLBACK_MODEL` env override, default `claude-opus-4-8`),
- pin the capped model to the fallback for the rest of the process (sticky registry — avoids repeated doomed calls),
- cover **both** failure shapes: non-zero exits and exit-0 `is_error:true` JSON envelopes (json output format only; plain-text output is never scanned since agent prose can legitimately contain the phrases),
- never loop: when the effective model already IS the fallback, the error propagates and callers' existing quota/overload handling takes over unchanged.

Zero caller changes — all 16 call sites go through the chokepoint. Also fixes the stale `OPUS == "claude-opus-4-7"` assertion in `test_reimport_idempotent` (broken on main since the fable-support bump in 268a6f8).

## Test plan

- 33 new unit tests: classifier positives/negatives (incl. verbatim production phrasing + no-reset-epoch cross-check), CalledProcessError fallback, envelope fallback, sticky registry, no-loop edge case, fallback-also-capped backstop, 529/non-cap untouched, text-format not scanned, fallback session lineage, env override, `fallback_model()` resolver defaults/override/unknown-warning.
- Full suite: 5432 passed, coverage 83.86% (gate 83%). mypy clean. pre-commit hooks pass.

Closes #1793