### PR TITLE
[Docs] Bump MIGRATION.md latest-version to 0.9.9 ahead of the release tag

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide
 
-> **Status (as of 2026-06-20):** The latest released version is **0.9.7** (tag-driven
+> **Status (as of 2026-07-03):** The latest released version is **0.9.9** (tag-driven
 > via hatch-vcs). **1.0 has not been released yet** — the section below is the
 > *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
 > prepare. There are currently **no breaking changes between 0.9.x releases**: upgrading

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -32,8 +32,13 @@ Before triggering the workflow, ensure:
 - [ ] All changes merged to `main` and CI is green.
 - [ ] `pixi.lock` is up to date (`pixi install` produces no changes).
 - [ ] No open issues in the milestone you are releasing.
+- [ ] `docs/MIGRATION.md`'s "latest released version is **X.Y.Z**" line already names
+  the version you are about to tag. The Release workflow's test job runs
+  `test_migration_md_version_does_not_trail_latest_git_tag`, and tags are immutable —
+  tagging before the doc bump strands the tag unreleased (this broke the first
+  v0.9.7 attempt and all of v0.9.8; see #1802). Bump the doc, merge, then tag.
 
-The version itself does **not** need to be edited in any file: this project uses
+The package version itself does **not** need to be edited in any file: this project uses
 hatch-vcs dynamic versioning, so the package version is derived from the git tag the
 `auto-tag` workflow pushes. There is no `[project].version` field to bump.
 


### PR DESCRIPTION
## Summary

Bumps `docs/MIGRATION.md`'s "latest released version" line to **0.9.9** so the Release workflow's `test_migration_md_version_does_not_trail_latest_git_tag` guard passes on the upcoming v0.9.9 tag. The v0.9.8 tag is stranded unreleasable: its (immutable) tree still documents 0.9.7, which is exactly how this guard failed the v0.9.8 release run (28693531484).

Also adds the bump-doc-then-tag step to the RELEASING.md Pre-Release Checklist so the trap is documented instead of rediscovered each release (it previously broke the first v0.9.7 attempt too; cf. #1542).

## Test plan

- `pixi run pytest tests/unit/docs/test_version_currency.py` passes with the doc claiming 0.9.9 (guard is `documented >= latest tag`; 0.9.9 > 0.9.8 tag).
- Markdown lint via pre-commit passed.

Closes #1802