### PR TITLE
fix(nats): wire subscriber reconnects to circuit breaker

### DIFF
--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -37,11 +37,27 @@ from typing import Any
 
 from hephaestus.nats.config import NATSConfig
 from hephaestus.nats.events import NATSEvent
+from hephaestus.resilience import (
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitBreakerState,
+)
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_JOIN_TIMEOUT: float = 5.0
 """Default join timeout (seconds) for :meth:`NATSSubscriberThread.stop`."""
+
+NATS_CIRCUIT_BREAKER_NAME = "nats-subscriber"
+"""Circuit breaker name used by :class:`NATSSubscriberThread`."""
+
+NATS_CIRCUIT_BREAKER_FAILURE_THRESHOLD = 5
+"""Consecutive connection failures before the subscriber enters ``ERROR``.
+
+The value matches :class:`hephaestus.resilience.CircuitBreaker`'s default so
+the NATS subscriber adopts the shared resilience behavior without adding a
+NATS-specific tuning surface.
+"""
 
 
 class SubscriberState(enum.Enum):
@@ -55,7 +71,7 @@ class SubscriberState(enum.Enum):
         CONNECTED    → STOPPING     (stop() called while connected)
         DISCONNECTED → STOPPING     (stop() called while in backoff)
         STOPPING     → STOPPED      (thread join completes)
-        any          → ERROR        (unhandled exception propagates out of run())
+        any          → ERROR        (unhandled exception or open circuit breaker)
 
     """
 
@@ -72,6 +88,8 @@ class NATSSubscriberThread(threading.Thread):
 
     The thread creates an isolated asyncio event loop internally.  The NATS
     connection and JetStream subscription live entirely within that loop.
+    Reconnection attempts are guarded by a circuit breaker; sustained
+    connection failures transition the subscriber to :attr:`SubscriberState.ERROR`.
 
     Health observability
     --------------------
@@ -83,7 +101,7 @@ class NATSSubscriberThread(threading.Thread):
     - :attr:`last_message_at` — Unix timestamp of the most recent successfully
       dispatched message, or ``None`` if no message has been processed yet.
     - :meth:`health_dict()` — JSON-serialisable snapshot of the above plus the
-      configured URL, stream, and uptime approximation.
+      configured URL, stream, circuit-breaker state, and uptime approximation.
 
     Delivery semantics
     ------------------
@@ -138,6 +156,11 @@ class NATSSubscriberThread(threading.Thread):
         self._handler = handler
         self._join_timeout = join_timeout
         self._stop_event = threading.Event()
+        self._circuit_breaker = CircuitBreaker(
+            NATS_CIRCUIT_BREAKER_NAME,
+            failure_threshold=NATS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+            recovery_timeout=self._config.max_backoff_seconds,
+        )
 
         # --- health / observability state (guarded by _state_lock) ---
         self._state_lock = threading.Lock()
@@ -189,6 +212,8 @@ class NATSSubscriberThread(threading.Thread):
               timestamp of last dispatched message, or ``None``.
             - ``"url"`` (:class:`str`): configured NATS URL.
             - ``"stream"`` (:class:`str`): configured stream name.
+            - ``"circuit_breaker_state"`` (:class:`str`): current circuit
+              breaker state, e.g. ``"closed"`` or ``"open"``.
             - ``"uptime_seconds"`` (:class:`float`): seconds since thread was
               constructed.
 
@@ -203,6 +228,7 @@ class NATSSubscriberThread(threading.Thread):
             "last_message_at": last_msg,
             "url": self._config.url,
             "stream": self._config.stream,
+            "circuit_breaker_state": self._circuit_breaker.state.value,
             "uptime_seconds": time.monotonic() - self._started_at,
         }
 
@@ -220,6 +246,12 @@ class NATSSubscriberThread(threading.Thread):
         with self._state_lock:
             self._last_error = exc
             self._state = SubscriberState.DISCONNECTED
+
+    def _record_terminal_error(self, exc: BaseException) -> None:
+        """Record *exc* as the latest error and transition to ERROR."""
+        with self._state_lock:
+            self._last_error = exc
+            self._state = SubscriberState.ERROR
 
     def _record_message(self) -> None:
         """Update ``last_message_at`` to the current time."""
@@ -246,7 +278,19 @@ class NATSSubscriberThread(threading.Thread):
                 try:
                     loop = asyncio.new_event_loop()
                     try:
-                        loop.run_until_complete(self._subscribe_loop())
+
+                        def _run_subscribe_once(
+                            event_loop: asyncio.AbstractEventLoop = loop,
+                        ) -> None:
+                            event_loop.run_until_complete(self._subscribe_loop())
+
+                        self._circuit_breaker.call(_run_subscribe_once)
+                    except CircuitBreakerOpenError as exc:
+                        self._record_terminal_error(exc)
+                        logger.error(
+                            "NATS circuit breaker is open; subscriber entering ERROR state"
+                        )
+                        return
                     finally:
                         loop.close()
                     backoff = self._config.initial_backoff_seconds
@@ -254,6 +298,13 @@ class NATSSubscriberThread(threading.Thread):
                     if self._stop_event.is_set():
                         break
                     self._record_error(exc)
+                    if self._circuit_breaker.state is CircuitBreakerState.OPEN:
+                        self._record_terminal_error(exc)
+                        logger.error(
+                            "NATS circuit breaker opened after sustained connection "
+                            "failures; subscriber entering ERROR state"
+                        )
+                        return
                     logger.exception(
                         "NATS connection error, retrying in %.1fs",
                         backoff,

--- a/tests/unit/nats/test_subscriber.py
+++ b/tests/unit/nats/test_subscriber.py
@@ -112,8 +112,13 @@ class TestHealthObservability:
             "last_message_at",
             "url",
             "stream",
+            "circuit_breaker_state",
             "uptime_seconds",
         }
+
+    def test_health_dict_circuit_breaker_state_is_string(self) -> None:
+        thread = NATSSubscriberThread(config=_config(), handler=MagicMock())
+        assert thread.health_dict()["circuit_breaker_state"] == "closed"
 
     def test_health_dict_initial_values(self) -> None:
         config = _config(url="nats://localhost:4222")

--- a/tests/unit/nats/test_subscriber_backoff.py
+++ b/tests/unit/nats/test_subscriber_backoff.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Coroutine
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from hephaestus.nats.config import NATSConfig
@@ -22,7 +24,8 @@ class TestSubscriberReadsBackoffFromConfig:
         # Force one iteration of the reconnect loop, then bail.
         call_count = {"n": 0}
 
-        def _fake_run_until_complete(_coro: object) -> None:
+        def _fake_run_until_complete(coro: Coroutine[Any, Any, Any]) -> None:
+            coro.close()
             call_count["n"] += 1
             if call_count["n"] == 1:
                 raise RuntimeError("boom")
@@ -54,7 +57,8 @@ class TestSubscriberReadsBackoffFromConfig:
         thread = NATSSubscriberThread(config=config, handler=MagicMock())
         iters = {"n": 0}
 
-        def _fake_run_until_complete(_coro: object) -> None:
+        def _fake_run_until_complete(coro: Coroutine[Any, Any, Any]) -> None:
+            coro.close()
             iters["n"] += 1
             if iters["n"] >= 3:
                 thread._stop_event.set()

--- a/tests/unit/nats/test_subscriber_circuit_breaker.py
+++ b/tests/unit/nats/test_subscriber_circuit_breaker.py
@@ -1,0 +1,90 @@
+"""Circuit breaker regression tests for NATSSubscriberThread."""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Coroutine
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from hephaestus.nats.config import NATSConfig
+from hephaestus.nats.subscriber import (
+    NATS_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+    NATSSubscriberThread,
+    SubscriberState,
+)
+from hephaestus.resilience import CircuitBreakerOpenError
+
+
+def _config(**kwargs: object) -> NATSConfig:
+    defaults: dict[str, object] = {
+        "enabled": True,
+        "initial_backoff_seconds": 0.01,
+        "max_backoff_seconds": 0.01,
+    }
+    defaults.update(kwargs)
+    return NATSConfig(**defaults)  # type: ignore[arg-type]
+
+
+class TestNATSSubscriberCircuitBreaker:
+    """Tests for subscriber reconnection circuit-breaker behavior."""
+
+    def test_persistent_connection_failures_open_circuit_and_enter_error(self) -> None:
+        thread = NATSSubscriberThread(config=_config(), handler=MagicMock())
+        loop = MagicMock()
+
+        def fail_subscribe(coro: Coroutine[Any, Any, Any]) -> None:
+            coro.close()
+            raise RuntimeError("nats down")
+
+        loop.run_until_complete.side_effect = fail_subscribe
+
+        waits: list[float] = []
+
+        def stop_after_threshold(timeout: float) -> bool:
+            waits.append(timeout)
+            if len(waits) >= NATS_CIRCUIT_BREAKER_FAILURE_THRESHOLD:
+                thread._stop_event.set()
+            return False
+
+        with (
+            patch("asyncio.new_event_loop", return_value=loop),
+            patch.object(thread._stop_event, "wait", side_effect=stop_after_threshold),
+        ):
+            thread.run()
+
+        assert loop.run_until_complete.call_count == NATS_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+        assert thread.state is SubscriberState.ERROR
+        assert thread.last_error is not None
+        assert "nats down" in str(thread.last_error)
+        health = thread.health_dict()
+        assert health["state"] == "error"
+        assert health["last_error"] is not None
+        assert "nats down" in health["last_error"]
+        assert health["circuit_breaker_state"] == "open"
+
+    def test_open_circuit_fails_fast_without_subscribing(self) -> None:
+        thread = NATSSubscriberThread(
+            config=_config(max_backoff_seconds=60.0),
+            handler=MagicMock(),
+        )
+
+        def fail() -> None:
+            raise RuntimeError("seed failure")
+
+        for _ in range(NATS_CIRCUIT_BREAKER_FAILURE_THRESHOLD):
+            with contextlib.suppress(RuntimeError):
+                thread._circuit_breaker.call(fail)
+
+        loop = MagicMock()
+        with patch("asyncio.new_event_loop", return_value=loop):
+            thread.run()
+
+        loop.run_until_complete.assert_not_called()
+        assert thread.state is SubscriberState.ERROR
+        assert isinstance(thread.last_error, CircuitBreakerOpenError)
+        health = thread.health_dict()
+        assert health["state"] == "error"
+        assert health["last_error"] is not None
+        assert "Circuit breaker 'nats-subscriber' is open" in health["last_error"]
+        assert health["circuit_breaker_state"] == "open"


### PR DESCRIPTION
## Summary
Adds circuit-breaker protection to NATS subscriber reconnection so persistent failures can fail fast instead of looping indefinitely on backoff.

## Changes
- Routes subscriber reconnect attempts through resilience circuit-breaker handling
- Updates subscriber health/state behavior and backoff tests for circuit-breaker failures
- Adds dedicated unit coverage for NATS subscriber circuit-breaker reconnect behavior

## Testing
- Added and updated unit tests for subscriber backoff and circuit-breaker reconnect paths

## Closes
Closes #1486

Generated by Codex via ProjectHephaestus automation.
