### PR TITLE
fix(github): stop retrying unresolved issue errors

### DIFF
--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -152,6 +152,8 @@ _NON_TRANSIENT_PATTERNS = [
     for p in (
         r"(?:^|\s)403(?:\s|$)|forbidden|permission denied",
         r"(?:^|\s)404(?:\s|$)|not found",
+        # gh sometimes phrases missing issue/PR targets without 404/not found.
+        r"could not resolve to (?:an? )?(?:issue|pull request)\b",
         r"(?:^|\s)400(?:\s|$)|bad request",
         r"(?:^|\s)401(?:\s|$)|unauthorized",
         r"(?:^|\s)422(?:\s|$)|unprocessable entity",

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -502,6 +502,21 @@ class TestGhCall:
         assert mock_run.call_count == 1
 
     @patch("hephaestus.github.client.run_subprocess")
+    @patch("hephaestus.github.client.time.sleep")
+    def test_fail_fast_on_could_not_resolve_issue(self, _mock_sleep: Any, mock_run: Any) -> None:
+        """A permanent GitHub issue-resolution failure must not retry."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1,
+            "gh",
+            stderr="gh: Could not resolve to an Issue with the number of 119.",
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            _gh_call(["issue", "view", "119"], max_retries=6)
+
+        assert mock_run.call_count == 1
+
+    @patch("hephaestus.github.client.run_subprocess")
     def test_fail_fast_on_bad_request(self, mock_run: Any) -> None:
         """Test that 400 errors fail fast without retry."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr="400 Bad Request")

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -501,15 +501,20 @@ class TestGhCall:
 
         assert mock_run.call_count == 1
 
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "gh: Could not resolve to an Issue with the number of 119.",
+            "GraphQL: Could not resolve to an issue or pull request with the number of 5528.",
+        ],
+    )
     @patch("hephaestus.github.client.run_subprocess")
     @patch("hephaestus.github.client.time.sleep")
-    def test_fail_fast_on_could_not_resolve_issue(self, _mock_sleep: Any, mock_run: Any) -> None:
+    def test_fail_fast_on_could_not_resolve_issue(
+        self, _mock_sleep: Any, mock_run: Any, stderr: str
+    ) -> None:
         """A permanent GitHub issue-resolution failure must not retry."""
-        mock_run.side_effect = subprocess.CalledProcessError(
-            1,
-            "gh",
-            stderr="gh: Could not resolve to an Issue with the number of 119.",
-        )
+        mock_run.side_effect = subprocess.CalledProcessError(1, "gh", stderr=stderr)
 
         with pytest.raises(subprocess.CalledProcessError):
             _gh_call(["issue", "view", "119"], max_retries=6)


### PR DESCRIPTION
## Summary
Treat GitHub CLI "Could not resolve" issue or pull request errors as permanent failures so they do not consume the retry backoff budget.

## Changes
- Add a non-transient error pattern for unresolved GitHub issue or pull request stderr messages.
- Add retry classifier coverage asserting unresolved issue errors fail after one attempt.
- Remove obsolete NATS subscriber circuit breaker coverage and adjust subscriber backoff tests.

## Testing
- Not run; no test execution was provided.

## Closes
Closes #1796

Generated by Codex via ProjectHephaestus automation.
