### PR TITLE
fix(automation): log claude stderr on resume failures

### DIFF
--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -44,6 +44,7 @@ except ModuleNotFoundError:  # pragma: no cover - Windows fallback
     # name to None on the Windows fallback path needs [assignment].
     fcntl = None  # type: ignore[assignment]
 
+from .claude_invoke import format_called_process_error
 from .git_utils import get_repo_root
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,13 @@ class SelectedSkill:
     source: str
     reason: str
     path: Path
+
+
+def _advise_failure_detail(exc: Exception) -> str:
+    """Return the diagnostic string for a failed advise run."""
+    if isinstance(exc, subprocess.CalledProcessError):
+        return format_called_process_error(exc)
+    return str(exc)
 
 
 def advise_skipped(reason: str) -> str:
@@ -515,5 +523,12 @@ def run_advise(
             selected = parse_selected_skills(selector_output, mnemosyne_root)
         return format_selected_skill_context(selected)
     except Exception as e:
-        logger.warning("Advise step failed for issue #%s: %s", issue_number, e)
+        detail = _advise_failure_detail(e)
+        logger.warning(
+            "Advise step failed for issue #%s: %s",
+            issue_number,
+            detail,
+            extra={"exception_type": type(e).__name__},
+            exc_info=True,
+        )
         return advise_skipped(f"unexpected error: {e}")

--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -44,7 +44,7 @@ except ModuleNotFoundError:  # pragma: no cover - Windows fallback
     # name to None on the Windows fallback path needs [assignment].
     fcntl = None  # type: ignore[assignment]
 
-from .claude_invoke import format_called_process_error
+from .claude_invoke import describe_claude_failure
 from .git_utils import get_repo_root
 
 logger = logging.getLogger(__name__)
@@ -67,13 +67,6 @@ class SelectedSkill:
     source: str
     reason: str
     path: Path
-
-
-def _advise_failure_detail(exc: Exception) -> str:
-    """Return the diagnostic string for a failed advise run."""
-    if isinstance(exc, subprocess.CalledProcessError):
-        return format_called_process_error(exc)
-    return str(exc)
 
 
 def advise_skipped(reason: str) -> str:
@@ -523,7 +516,7 @@ def run_advise(
             selected = parse_selected_skills(selector_output, mnemosyne_root)
         return format_selected_skill_context(selected)
     except Exception as e:
-        detail = _advise_failure_detail(e)
+        detail = describe_claude_failure(e)
         logger.warning(
             "Advise step failed for issue #%s: %s",
             issue_number,
@@ -531,4 +524,7 @@ def run_advise(
             extra={"exception_type": type(e).__name__},
             exc_info=True,
         )
-        return advise_skipped(f"unexpected error: {e}")
+        # The marker gets embedded in downstream prompts/plan bodies, so it
+        # must carry the stderr detail too — a bare str(e) is just an exit
+        # code for CalledProcessError (#1799).
+        return advise_skipped(f"unexpected error: {detail}")

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -44,10 +44,45 @@ from hephaestus.utils.helpers import strip_null_bytes
 
 logger = logging.getLogger(__name__)
 
+_MAX_SUBPROCESS_FAILURE_DETAIL_CHARS = 500
+
+
+def _subprocess_stream_text(value: object) -> str:
+    """Return subprocess stream content as text for diagnostic logging."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode(errors="replace")
+    return str(value)
+
+
+def _truncate_subprocess_detail(text: str, max_chars: int) -> str:
+    """Bound subprocess diagnostics before writing them to shared logs."""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "... [truncated]"
+
+
+def format_called_process_error(
+    exc: subprocess.CalledProcessError,
+    *,
+    max_chars: int = _MAX_SUBPROCESS_FAILURE_DETAIL_CHARS,
+) -> str:
+    """Format a ``CalledProcessError`` with bounded stdout/stderr diagnostics."""
+    parts = [str(exc)]
+    stderr = _subprocess_stream_text(exc.stderr).strip()
+    if stderr:
+        parts.append(f"stderr={_truncate_subprocess_detail(stderr, max_chars)!r}")
+    stdout = _subprocess_stream_text(exc.stdout).strip()
+    if stdout:
+        parts.append(f"stdout={_truncate_subprocess_detail(stdout, max_chars)!r}")
+    return "; ".join(parts)
+
 
 # Substrings the Claude CLI returns when ``--resume`` targets a session that
 # no longer exists in local persistence.
 SESSION_EXPIRED_PHRASES: tuple[str, ...] = (
+    "no conversation found",
     "session not found",
     "invalid session",
     "session expired",

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -79,6 +79,19 @@ def format_called_process_error(
     return "; ".join(parts)
 
 
+def describe_claude_failure(exc: BaseException) -> str:
+    """Return a bounded diagnostic string for a failed ``claude`` invocation.
+
+    ``CalledProcessError`` carries the CLI's stderr/stdout, which is the only
+    place the actual failure reason lives (#1799) — surface it via
+    :func:`format_called_process_error`. Any other exception degrades to
+    ``str(exc)``.
+    """
+    if isinstance(exc, subprocess.CalledProcessError):
+        return format_called_process_error(exc)
+    return str(exc)
+
+
 # Substrings the Claude CLI returns when ``--resume`` targets a session that
 # no longer exists in local persistence.
 SESSION_EXPIRED_PHRASES: tuple[str, ...] = (

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -51,7 +51,7 @@ from ._review_phase import (
 )
 from ._review_utils import find_pr_for_issue, get_pr_head_branch
 from ._stage_context import StageContext
-from .claude_invoke import format_called_process_error, invoke_claude_with_session
+from .claude_invoke import describe_claude_failure, invoke_claude_with_session
 from .claude_models import advise_model
 from .git_utils import (
     commit_if_changes,
@@ -909,11 +909,7 @@ class ImplementationPhaseRunner:
                 )
             decision = _parse_dirty_reused_worktree_decision(output)
         except Exception as e:
-            detail = (
-                format_called_process_error(e)
-                if isinstance(e, subprocess.CalledProcessError)
-                else str(e)
-            )
+            detail = describe_claude_failure(e)
             self.impl._log(
                 "warning",
                 f"Issue #{issue_number}: dirty-worktree decision failed ({detail}); "

--- a/hephaestus/automation/implementer_phase_runner.py
+++ b/hephaestus/automation/implementer_phase_runner.py
@@ -51,7 +51,7 @@ from ._review_phase import (
 )
 from ._review_utils import find_pr_for_issue, get_pr_head_branch
 from ._stage_context import StageContext
-from .claude_invoke import invoke_claude_with_session
+from .claude_invoke import format_called_process_error, invoke_claude_with_session
 from .claude_models import advise_model
 from .git_utils import (
     commit_if_changes,
@@ -909,9 +909,15 @@ class ImplementationPhaseRunner:
                 )
             decision = _parse_dirty_reused_worktree_decision(output)
         except Exception as e:
+            detail = (
+                format_called_process_error(e)
+                if isinstance(e, subprocess.CalledProcessError)
+                else str(e)
+            )
             self.impl._log(
                 "warning",
-                f"Issue #{issue_number}: dirty-worktree decision failed ({e}); defaulting to stash",
+                f"Issue #{issue_number}: dirty-worktree decision failed ({detail}); "
+                "defaulting to stash",
                 thread_id,
             )
 

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -7,6 +7,7 @@ reaches green CI and auto-merge is enabled.
 from __future__ import annotations
 
 import logging
+import subprocess
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -18,7 +19,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 
-from .claude_invoke import invoke_claude_with_session
+from .claude_invoke import format_called_process_error, invoke_claude_with_session
 from .claude_models import implementer_model
 from .git_utils import get_repo_slug, issue_ref, pr_ref
 from .learn import build_learn_prompt, compact_session, mnemosyne_update_evidence
@@ -184,10 +185,17 @@ class PostMergeProcessor:
             logger.info("Issue #%s: drive-green learnings captured", issue_number)
             return True
         except Exception as e:  # broad: external claude process; non-blocking
+            detail = (
+                format_called_process_error(e)
+                if isinstance(e, subprocess.CalledProcessError)
+                else str(e)
+            )
             logger.warning(
                 "Issue #%s: drive-green learnings failed (non-fatal): %s",
                 issue_number,
-                e,
+                detail,
+                extra={"exception_type": type(e).__name__},
+                exc_info=True,
             )
             return False
 

--- a/hephaestus/automation/post_merge_processor.py
+++ b/hephaestus/automation/post_merge_processor.py
@@ -7,7 +7,6 @@ reaches green CI and auto-merge is enabled.
 from __future__ import annotations
 
 import logging
-import subprocess
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -19,7 +18,7 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 
-from .claude_invoke import format_called_process_error, invoke_claude_with_session
+from .claude_invoke import describe_claude_failure, invoke_claude_with_session
 from .claude_models import implementer_model
 from .git_utils import get_repo_slug, issue_ref, pr_ref
 from .learn import build_learn_prompt, compact_session, mnemosyne_update_evidence
@@ -185,11 +184,7 @@ class PostMergeProcessor:
             logger.info("Issue #%s: drive-green learnings captured", issue_number)
             return True
         except Exception as e:  # broad: external claude process; non-blocking
-            detail = (
-                format_called_process_error(e)
-                if isinstance(e, subprocess.CalledProcessError)
-                else str(e)
-            )
+            detail = describe_claude_failure(e)
             logger.warning(
                 "Issue #%s: drive-green learnings failed (non-fatal): %s",
                 issue_number,

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -8,6 +8,7 @@ suite; here we exercise the shared logic with a stub invoker.
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -372,6 +373,38 @@ class TestRunAdvise:
             )
         assert result.startswith("<!-- advise step skipped:")
         assert "git boom" in result
+
+    def test_called_process_error_warning_includes_stderr(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        err = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude", "--resume", "abc"],
+            stderr="No conversation found with session ID abc",
+        )
+        with (
+            patch.object(advise_runner, "get_repo_root", return_value=Path("/repo")),
+            patch.object(advise_runner, "default_mnemosyne_root", return_value=Path("/mnemosyne")),
+            patch.object(
+                advise_runner,
+                "resolve_marketplace",
+                return_value=(Path("/mnemosyne/.claude-plugin/marketplace.json"), ""),
+            ),
+            patch.object(
+                advise_runner, "marketplace_prompt_payload", return_value='{"plugins": []}'
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.advise_runner"),
+        ):
+            result = advise_runner.run_advise(
+                issue_number=121,
+                issue_title="t",
+                issue_body="b",
+                invoke=lambda _prompt: (_ for _ in ()).throw(err),
+                build_prompt=_build_prompt,
+            )
+
+        assert result.startswith("<!-- advise step skipped:")
+        assert "No conversation found with session ID abc" in caplog.text
 
     def test_rejects_selected_skill_outside_skills_tree(self, tmp_path: Path) -> None:
         mnemosyne_root = tmp_path / "ProjectMnemosyne"

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -405,6 +405,9 @@ class TestRunAdvise:
 
         assert result.startswith("<!-- advise step skipped:")
         assert "No conversation found with session ID abc" in caplog.text
+        # The prompt-embedded skip marker must carry the stderr detail too —
+        # a bare str(e) is just an exit code for CalledProcessError (#1799).
+        assert "No conversation found with session ID abc" in result
 
     def test_called_process_error_warning_includes_log_safe_stderr(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -406,6 +406,43 @@ class TestRunAdvise:
         assert result.startswith("<!-- advise step skipped:")
         assert "No conversation found with session ID abc" in caplog.text
 
+    def test_called_process_error_warning_includes_log_safe_stderr(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Multiline/control-char stderr is repr-escaped, never raw, in logs+marker."""
+        err = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude", "--resume", "abc"],
+            stderr="No conversation found\nretry later\x00",
+        )
+        with (
+            patch.object(advise_runner, "get_repo_root", return_value=Path("/repo")),
+            patch.object(advise_runner, "default_mnemosyne_root", return_value=Path("/mnemosyne")),
+            patch.object(
+                advise_runner,
+                "resolve_marketplace",
+                return_value=(Path("/mnemosyne/.claude-plugin/marketplace.json"), ""),
+            ),
+            patch.object(
+                advise_runner, "marketplace_prompt_payload", return_value='{"plugins": []}'
+            ),
+            caplog.at_level(logging.WARNING, logger="hephaestus.automation.advise_runner"),
+        ):
+            result = advise_runner.run_advise(
+                issue_number=121,
+                issue_title="t",
+                issue_body="b",
+                invoke=lambda _prompt: (_ for _ in ()).throw(err),
+                build_prompt=_build_prompt,
+            )
+
+        # The !r formatting in format_called_process_error escapes newlines
+        # and control characters, so neither the log record nor the
+        # prompt-embedded marker carries raw multiline/NUL content.
+        assert "\\nretry later\\x00" in caplog.text
+        assert "\x00" not in result
+        assert "No conversation found" in result
+
     def test_rejects_selected_skill_outside_skills_tree(self, tmp_path: Path) -> None:
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
         (mnemosyne_root / "skills").mkdir(parents=True)

--- a/tests/unit/automation/test_claude_invoke.py
+++ b/tests/unit/automation/test_claude_invoke.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 from hypothesis import given, strategies as st
 
 from hephaestus.automation.claude_invoke import (
     INFRA_ERROR_REVIEW_TEXT,
     ReviewVerdict,
+    describe_claude_failure,
     detect_model_usage_cap,
     detect_server_overload,
+    format_called_process_error,
     parse_review_verdict,
 )
 
@@ -258,6 +262,76 @@ class TestRaiseForErrorEnvelope:
 
         raise_for_error_envelope("just some prose")
         raise_for_error_envelope("")
+
+
+class TestFormatCalledProcessError:
+    """Edge cases for the bounded stdout/stderr formatter (#1799)."""
+
+    @staticmethod
+    def _error(
+        output: str | bytes | None = None, stderr: str | bytes | None = None
+    ) -> subprocess.CalledProcessError:
+        return subprocess.CalledProcessError(
+            returncode=1, cmd=["claude", "-p"], output=output, stderr=stderr
+        )
+
+    def test_bytes_streams_are_decoded(self) -> None:
+        """Bytes stdout/stderr (non-text subprocess mode) decode into the message."""
+        err = self._error(stderr=b"boom stderr", output=b"boom stdout")
+        detail = format_called_process_error(err)
+        assert "stderr='boom stderr'" in detail
+        assert "stdout='boom stdout'" in detail
+
+    def test_invalid_utf8_bytes_are_replaced_not_raised(self) -> None:
+        """Undecodable bytes degrade via errors='replace' instead of raising."""
+        err = self._error(stderr=b"\xff\xfe bad")
+        detail = format_called_process_error(err)
+        assert "stderr=" in detail
+        assert "�" in detail
+
+    def test_truncates_beyond_500_chars(self) -> None:
+        """Each stream is bounded at 500 chars plus an explicit truncation marker."""
+        err = self._error(stderr="x" * 501)
+        detail = format_called_process_error(err)
+        assert "x" * 500 + "... [truncated]" in detail
+        assert "x" * 501 not in detail
+
+    def test_exactly_500_chars_is_not_truncated(self) -> None:
+        err = self._error(stderr="y" * 500)
+        detail = format_called_process_error(err)
+        assert "y" * 500 in detail
+        assert "[truncated]" not in detail
+
+    def test_stdout_only_when_stderr_absent(self) -> None:
+        """With no stderr, stdout still surfaces (some CLIs report errors there)."""
+        err = self._error(output="only stdout detail")
+        detail = format_called_process_error(err)
+        assert "stdout='only stdout detail'" in detail
+        assert "stderr=" not in detail
+
+    def test_no_streams_falls_back_to_str(self) -> None:
+        err = self._error()
+        assert format_called_process_error(err) == str(err)
+
+    def test_custom_max_chars(self) -> None:
+        err = self._error(stderr="abcdef")
+        detail = format_called_process_error(err, max_chars=3)
+        assert "abc... [truncated]" in detail
+
+
+class TestDescribeClaudeFailure:
+    """Dispatch helper shared by the advise/implementer/post-merge call sites."""
+
+    def test_called_process_error_gets_stream_detail(self) -> None:
+        err = subprocess.CalledProcessError(
+            returncode=1, cmd=["claude"], stderr="No conversation found"
+        )
+        detail = describe_claude_failure(err)
+        assert detail == format_called_process_error(err)
+        assert "No conversation found" in detail
+
+    def test_other_exceptions_fall_back_to_str(self) -> None:
+        assert describe_claude_failure(TimeoutError("too slow")) == "too slow"
 
 
 # Verdict fragments Hypothesis interleaves with arbitrary text to exercise the

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -14,6 +14,7 @@ import pytest
 
 from hephaestus.automation.agent_config import OPUS_48
 from hephaestus.automation.claude_invoke import (
+    _session_expired,
     invoke_claude_with_session,
     is_model_capped,
     reset_capped_models,
@@ -164,6 +165,9 @@ class TestCreateThenResume:
                 )
         # Exactly one attempt — no recreate/fresh cascade.
         assert m.call_count == 1
+
+    def test_session_expired_detects_no_conversation_found(self) -> None:
+        assert _session_expired("No conversation found with session ID abc", "") is True
 
 
 class TestArgvAssembly:

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -2700,6 +2700,44 @@ class TestResolveDirtyReusedWorktree:
         assert any(a[:3] == ["git", "rev-parse", "HEAD"] for a in argvs)
         assert not any(a[:2] == ["git", "stash"] for a in argvs)
 
+    def test_decision_agent_called_process_error_log_includes_stderr(
+        self, implementer: IssueImplementer, tmp_path: Path
+    ) -> None:
+        """A failed decision-agent call logs subprocess stderr before stashing."""
+        wt = tmp_path / "worktree"
+        wt.mkdir(exist_ok=True)
+        implementer.options.agent = "claude"
+        err = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude", "--resume", "abc"],
+            stderr="No conversation found with session ID abc",
+        )
+
+        with (
+            patch(
+                "hephaestus.automation.implementer_phase_runner.invoke_claude_with_session",
+                side_effect=err,
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.get_repo_slug",
+                return_value="o/r",
+            ),
+            patch(
+                "hephaestus.automation.implementer_phase_runner.run",
+                return_value=MagicMock(stdout="", returncode=0),
+            ),
+            patch.object(implementer, "_log") as log,
+        ):
+            implementer.phase_runner._resolve_dirty_reused_worktree(
+                issue_number=1,
+                worktree_path=wt,
+                branch_name="708-auto-impl",
+                thread_id=None,
+            )
+
+        messages = [call.args[1] for call in log.call_args_list]
+        assert any("No conversation found with session ID abc" in msg for msg in messages)
+
     def test_stash_failure_raises_instead_of_best_effort(
         self, implementer: IssueImplementer, tmp_path: Path
     ) -> None:

--- a/tests/unit/automation/test_post_merge_helpers.py
+++ b/tests/unit/automation/test_post_merge_helpers.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+import subprocess
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from hephaestus.automation.post_merge_processor import PostMergeProcessor
 
@@ -141,6 +145,25 @@ class TestRunDriveGreenLearnings:
         ):
             result = processor.run_drive_green_learnings(7, 8)
         assert result is False
+
+    def test_called_process_error_log_includes_stderr(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        processor, _ = _make_processor(tmp_path)
+        err = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["claude", "--resume", "abc"],
+            stderr="No conversation found with session ID abc",
+        )
+        with (
+            patch(f"{_MOD}.get_repo_slug", return_value="o/r"),
+            patch(f"{_MOD}.invoke_claude_with_session", side_effect=err),
+            caplog.at_level(logging.WARNING, logger=_MOD),
+        ):
+            result = processor.run_drive_green_learnings(7, 8)
+
+        assert result is False
+        assert "No conversation found with session ID abc" in caplog.text
 
 
 class TestRunDriveGreenCompact:


### PR DESCRIPTION
## Summary
Expose the underlying Claude CLI stderr/stdout when resume-mode automation calls fail, so advise, implementer, and post-merge runners log the real diagnostic reason instead of a bare `CalledProcessError` exit-code string.

## Changes
- `hephaestus/automation/claude_invoke.py`: add `format_called_process_error` — a bounded (500-char truncated), bytes-safe stderr/stdout formatter — and `describe_claude_failure(exc)`, a shared helper that dispatches `CalledProcessError` to the detailed formatter and everything else to `str(exc)` (DRY: replaces three copies of the same inline `isinstance` pattern).
- `hephaestus/automation/advise_runner.py`: use `describe_claude_failure` for the failure warning, and embed the detailed failure in the `advise_skipped` prompt marker too (previously a bare `str(e)`, which for `CalledProcessError` is just an exit code).
- `hephaestus/automation/implementer_phase_runner.py`: dirty-worktree decision failure log now carries stderr detail via the shared helper.
- `hephaestus/automation/post_merge_processor.py`: drive-green `/learn` failure log now carries stderr detail via the shared helper.
- Extend Claude session-expired detection coverage ("No conversation found").

## Testing
- New direct edge tests for `format_called_process_error` (bytes streams, invalid UTF-8 replacement, 500-char truncation boundary, stdout-only, no-stream fallback, custom `max_chars`) and for `describe_claude_failure` dispatch in `tests/unit/automation/test_claude_invoke.py`.
- Call-site tests assert the stderr text reaches the warning logs (advise, implementer loop, post-merge) and the advise skip marker itself.
- `pixi run pytest tests/unit/automation -k "claude_invoke or advise or post_merge or implementer_loop"`: 251 passed. `pixi run mypy`, `pixi run ruff check`, and `pre-commit run --all-files` all clean.

Closes #1799

Generated by Codex via ProjectHephaestus automation; consolidated per strict-audit review.
