### PR TITLE
feat(pipeline): worker pool with job execution and git/agent isolation

### DIFF
--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -13,6 +13,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .jobs import GIT_OPS, AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
     from .queues import CompletionQueue, StageQueue
     from .routing import (
         ROUTES,
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
         StageOutcome,
     )
     from .work_item import HistoryEvent, ItemKind, ItemResult, WorkItem
+    from .worker_pool import WorkerPool
 
 __all__ = [
     "GIT_OPS",

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -25,33 +25,47 @@ if TYPE_CHECKING:
     from .work_item import HistoryEvent, ItemKind, ItemResult, WorkItem
 
 __all__ = [
+    "GIT_OPS",
     "ROUTES",
+    "AgentJob",
+    "BuildTestJob",
     "CompletionQueue",
     "Disposition",
+    "GitJob",
     "HistoryEvent",
     "ItemKind",
     "ItemResult",
+    "JobHandle",
+    "JobResult",
     "PipelineScope",
     "Route",
     "StageName",
     "StageOutcome",
     "StageQueue",
     "WorkItem",
+    "WorkerPool",
 ]
 
 _LAZY_EXPORTS: dict[str, str] = {
-    "ROUTES": "hephaestus.automation.pipeline.routing",
+    "AgentJob": "hephaestus.automation.pipeline.jobs",
+    "BuildTestJob": "hephaestus.automation.pipeline.jobs",
     "CompletionQueue": "hephaestus.automation.pipeline.queues",
     "Disposition": "hephaestus.automation.pipeline.routing",
+    "GIT_OPS": "hephaestus.automation.pipeline.jobs",
+    "GitJob": "hephaestus.automation.pipeline.jobs",
     "HistoryEvent": "hephaestus.automation.pipeline.work_item",
     "ItemKind": "hephaestus.automation.pipeline.work_item",
     "ItemResult": "hephaestus.automation.pipeline.work_item",
+    "JobHandle": "hephaestus.automation.pipeline.jobs",
+    "JobResult": "hephaestus.automation.pipeline.jobs",
     "PipelineScope": "hephaestus.automation.pipeline.routing",
+    "ROUTES": "hephaestus.automation.pipeline.routing",
     "Route": "hephaestus.automation.pipeline.routing",
     "StageName": "hephaestus.automation.pipeline.routing",
     "StageOutcome": "hephaestus.automation.pipeline.routing",
     "StageQueue": "hephaestus.automation.pipeline.queues",
     "WorkItem": "hephaestus.automation.pipeline.work_item",
+    "WorkerPool": "hephaestus.automation.pipeline.worker_pool",
 }
 
 

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -1,0 +1,86 @@
+"""Frozen job specs and results for the pipeline worker pool.
+
+Jobs are immutable value objects the coordinator freezes and hands to
+:class:`~hephaestus.automation.pipeline.worker_pool.WorkerPool`. Prompts are
+built IN the worker (several builders fetch diffs / issue bodies via ``gh`` and
+must stay off the coordinator thread), so :class:`AgentJob` carries a
+``prompt_builder`` callable rather than a pre-rendered string.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation.pipeline.routing import StageName
+
+GIT_OPS: frozenset[str] = frozenset(
+    {"clone", "create_worktree", "remove_worktree", "rebase", "push", "commit_push"}
+)
+
+
+@dataclass(frozen=True)
+class AgentJob:
+    """Job to invoke an agent (Claude or other)."""
+
+    repo: str
+    issue: int | str
+    agent: str
+    model: str
+    prompt_builder: Callable[..., str]
+    cwd: Path
+    timeout_s: int
+    prompt_kwargs: dict[str, Any] = field(default_factory=dict)
+    output_format: str = "text"
+    parse: Callable[[str], Any] | None = None  # e.g. claude_invoke.parse_review_verdict
+    descr: str = ""
+
+
+@dataclass(frozen=True)
+class BuildTestJob:
+    """Job to run build/test commands."""
+
+    repo: str
+    cwd: Path
+    argv: tuple[str, ...] | list[str]  # e.g. ("pixi","run","pytest","tests/unit","-q")
+    timeout_s: int
+    descr: str = ""
+
+
+@dataclass(frozen=True)
+class GitJob:
+    """Job to perform a git operation."""
+
+    repo: str
+    op: str
+    timeout_s: int
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    descr: str = ""
+
+    def __post_init__(self) -> None:
+        """Validate that op is a recognized git operation."""
+        if self.op not in GIT_OPS:
+            raise ValueError(f"unknown git op {self.op!r}; expected one of {sorted(GIT_OPS)}")
+
+
+@dataclass(frozen=True)
+class JobResult:
+    """Result of a completed job."""
+
+    ok: bool
+    value: Any = None
+    stdout_tail: str = ""
+    stderr_tail: str = ""
+    error: str | None = None
+    interrupted: bool = False
+    duration_s: float = 0.0
+
+
+@dataclass(frozen=True)
+class JobHandle:
+    """Handle to a submitted job paired with its completion result."""
+
+    job: AgentJob | BuildTestJob | GitJob
+    on_done_state: StageName

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -40,18 +40,34 @@ class AgentJob:
 
 @dataclass(frozen=True)
 class BuildTestJob:
-    """Job to run build/test commands."""
+    """Job to run build/test commands.
+
+    Security: ``argv`` MUST NOT carry untrusted (issue-body-derived) strings.
+    It is executed directly as a subprocess argument vector, so only the
+    coordinator may construct these jobs, from vetted command templates.
+    """
 
     repo: str
     cwd: Path
-    argv: tuple[str, ...] | list[str]  # e.g. ("pixi","run","pytest","tests/unit","-q")
+    argv: tuple[str, ...]  # e.g. ("pixi","run","pytest","tests/unit","-q")
     timeout_s: int
     descr: str = ""
+
+    def __post_init__(self) -> None:
+        """Normalize argv to a tuple so the job is deeply immutable/hashable."""
+        if not isinstance(self.argv, tuple):
+            # frozen dataclass: bypass the frozen __setattr__ for normalization
+            object.__setattr__(self, "argv", tuple(self.argv))
 
 
 @dataclass(frozen=True)
 class GitJob:
-    """Job to perform a git operation."""
+    """Job to perform a git operation.
+
+    Security: ``kwargs`` values are forwarded to git/worktree helpers that
+    shell out, so they MUST NOT carry untrusted (issue-body-derived) strings.
+    Only the coordinator may construct these jobs, from vetted values.
+    """
 
     repo: str
     op: str
@@ -78,9 +94,17 @@ class JobResult:
     duration_s: float = 0.0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class JobHandle:
-    """Handle to a submitted job paired with its completion result."""
+    """Handle to a submitted job, used to correlate its completion.
+
+    Identity semantics (``eq=False``): each ``submit()`` mints a distinct
+    handle that hashes and compares by object identity, NOT by field value.
+    Two submissions of identical job specs therefore produce two distinct
+    handles, so the coordinator can key dicts/sets by handle without
+    collisions, and unhashable field values (``dict`` kwargs, callables)
+    never break hashing.
+    """
 
     job: AgentJob | BuildTestJob | GitJob
     on_done_state: StageName

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -167,11 +167,12 @@ class WorkerPool:
     def _run(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
         """Execute a job and return its result.
 
-        Catches all exceptions so a single job failure does not crash the
-        worker thread. After every job, post-checks the shutdown event and
-        marks interrupted=True if it was set (SIGINT to the process group
-        makes children return normally; the interrupt flag prevents misreading
-        a killed job as success).
+        Catches Exception subclasses so a single job failure does not crash the
+        worker thread; BaseException escapes (KeyboardInterrupt, SystemExit) are
+        caught in _on_future_done's BaseException handler. After every job,
+        post-checks the shutdown event and marks interrupted=True if it was set
+        (SIGINT to the process group makes children return normally; the
+        interrupt flag prevents misreading a killed job as success).
         """
         start = time.monotonic()
 

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -1,0 +1,315 @@
+"""Worker pool: the only place agent, build/test, and git/network work runs.
+
+The coordinator submits frozen jobs and drains ``(handle, result)`` tuples from
+the completion queue. Workers never touch WorkItems or stage queues and never
+perform GitHub API mutations (enforced by test_pipeline_architecture.py).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import time
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import replace
+from pathlib import Path
+
+from hephaestus.agents.runtime import resolve_agent, run_agent_session
+from hephaestus.automation import claude_invoke, git_utils
+from hephaestus.automation._review_utils import DEFAULT_STATE_DIR, ensure_state_dir
+from hephaestus.automation.pipeline.jobs import (
+    AgentJob,
+    BuildTestJob,
+    GitJob,
+    JobHandle,
+    JobResult,
+)
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.worktree_manager import WorktreeManager
+from hephaestus.resilience import (
+    CircuitBreakerOpenError,
+)
+
+logger = logging.getLogger(__name__)
+
+_TAIL = 4000  # chars of stdout/stderr retained in a JobResult
+
+
+def _repo_lock_path(repo: str) -> Path:
+    """Cross-process advisory lock file for *repo*, under the automation state dir."""
+    state_dir = ensure_state_dir(Path.cwd(), DEFAULT_STATE_DIR)
+    locks_dir = state_dir / "locks"
+    locks_dir.mkdir(parents=True, exist_ok=True)
+    return locks_dir / f"git-{repo.replace('/', '_')}.lock"
+
+
+class WorkerPool:
+    """Thread pool executor for submitting and tracking frozen jobs.
+
+    Jobs are executed via :meth:`submit`; a future callback drains results to
+    the completion queue. Workers never look up PR numbers, build prompts, or
+    call the GitHub API — those are coordinator responsibilities.
+    """
+
+    def __init__(self, size: int, shutdown: threading.Event, completion_q: CompletionQueue) -> None:
+        """Initialize the pool.
+
+        Args:
+            size: Number of worker threads.
+            shutdown: Event that signals pool shutdown; workers check it before
+                starting and after completing each job.
+            completion_q: Queue to which ``(JobHandle, JobResult)`` tuples are
+                sent when jobs complete.
+
+        """
+        self._executor = ThreadPoolExecutor(max_workers=size)
+        self._shutdown = shutdown
+        self._completion_q = completion_q
+        self._repo_locks: dict[str, threading.Lock] = {}
+        self._repo_locks_guard = threading.Lock()
+
+    def _repo_lock(self, repo: str) -> threading.Lock:
+        """Get or create a per-repo lock (held during git operations)."""
+        with self._repo_locks_guard:
+            return self._repo_locks.setdefault(repo, threading.Lock())
+
+    def submit(self, job: AgentJob | BuildTestJob | GitJob, on_done_state: StageName) -> JobHandle:
+        """Submit a job for execution.
+
+        Args:
+            job: Immutable frozen job spec.
+            on_done_state: Pipeline stage the item should transition to when
+                this job completes.
+
+        Returns:
+            JobHandle carrying the submitted job and target state; the
+            coordinator uses the handle to route the completion back to the
+            work item.
+
+        """
+        handle = JobHandle(job=job, on_done_state=on_done_state)
+        future = self._executor.submit(self._run, job)
+        future.add_done_callback(lambda f: self._on_future_done(handle, f))
+        return handle
+
+    def shutdown(self) -> None:
+        """Shut down the pool.
+
+        Sets the shutdown event and cancels pending futures. Running tasks
+        finish but post-check them for interruption.
+        """
+        self._shutdown.set()
+        self._executor.shutdown(wait=False, cancel_futures=True)
+
+    def _on_future_done(self, handle: JobHandle, future: Future[JobResult]) -> None:
+        """Drain result to completion queue when a job future completes.
+
+        If the future was cancelled, do not emit a completion (the coordinator
+        synthesizes one later).
+        """
+        if future.cancelled():
+            return  # cancel_futures synthesizes NO completion
+        try:
+            result = future.result()
+            self._completion_q.put((handle, result))
+        except BaseException:
+            # future.result() can raise BaseException (e.g. a bug in _run),
+            # but the _run wrapper catches everything so this should be rare.
+            logger.exception("Future result() raised, discarding")
+
+    def _run(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
+        """Execute a job and return its result.
+
+        Catches all exceptions so a single job failure does not crash the
+        worker thread. After every job, post-checks the shutdown event and
+        marks interrupted=True if it was set (SIGINT to the process group
+        makes children return normally; the interrupt flag prevents misreading
+        a killed job as success).
+        """
+        start = time.monotonic()
+
+        # Pre-check: do not start a queued job if shutdown is set.
+        if self._shutdown.is_set():
+            return JobResult(ok=False, interrupted=True, error="interrupted_before_start")
+
+        try:
+            if isinstance(job, AgentJob):
+                result = self._run_agent(job)
+            elif isinstance(job, BuildTestJob):
+                result = self._run_build_test(job)
+            elif isinstance(job, GitJob):
+                result = self._run_git(job)
+            else:
+                raise TypeError(f"unknown job type {type(job)}")
+        except BaseException as exc:
+            # Worker isolates ALL failures (including KeyboardInterrupt) into
+            # a result so the callback never re-raises into its thread.
+            logger.exception("Job %s raised, returning error result", job)
+            result = JobResult(
+                ok=False,
+                error=f"{type(exc).__name__}: {exc!s}"[:500],
+                duration_s=time.monotonic() - start,
+            )
+
+        # Mandatory post-check: SIGINT to the process group makes subprocess
+        # children return "normally" (rc=0 or some other code), so an
+        # interrupted job must never read as success.
+        if self._shutdown.is_set():
+            result = replace(result, interrupted=True, ok=False)
+
+        return replace(
+            result,
+            duration_s=time.monotonic() - start,
+            stdout_tail=result.stdout_tail[-_TAIL:] if result.stdout_tail else "",
+            stderr_tail=result.stderr_tail[-_TAIL:] if result.stderr_tail else "",
+        )
+
+    def _run_agent(self, job: AgentJob) -> JobResult:
+        """Run an agent job (Claude or other runtime)."""
+        try:
+            agent = resolve_agent(job.agent)
+            is_claude = agent == "claude"
+
+            if is_claude:
+                # Claude: invoke via claude_invoke.invoke_claude_with_session
+                prompt = job.prompt_builder(**job.prompt_kwargs)
+                stdout, _ = claude_invoke.invoke_claude_with_session(
+                    repo=job.repo,
+                    issue=job.issue,
+                    agent=job.agent,
+                    prompt=prompt,
+                    model=job.model,
+                    cwd=job.cwd,
+                    timeout=job.timeout_s,
+                    output_format=job.output_format,
+                )
+            else:
+                # Non-Claude: invoke via run_agent_session (e.g. codex, pi)
+                prompt = job.prompt_builder(**job.prompt_kwargs)
+                agent_result = run_agent_session(
+                    agent=agent,
+                    prompt=prompt,
+                    cwd=job.cwd,
+                    timeout=job.timeout_s,
+                    model=job.model,
+                    sandbox="workspace-write",
+                    approval="never",
+                )
+                stdout = agent_result.stdout or ""
+
+            value = None
+            if job.parse is not None:
+                try:
+                    value = job.parse(stdout)
+                except Exception as exc:
+                    logger.exception("Parse callable raised for agent job")
+                    return JobResult(
+                        ok=False,
+                        error=f"parse failed: {type(exc).__name__}: {exc!s}"[:500],
+                        stdout_tail=stdout[-_TAIL:],
+                    )
+
+            return JobResult(
+                ok=True,
+                value=value if value is not None else stdout,
+                stdout_tail=stdout[-_TAIL:],
+            )
+
+        except CircuitBreakerOpenError:
+            return JobResult(ok=False, error="circuit_open")
+        except subprocess.TimeoutExpired:
+            return JobResult(ok=False, error="timeout")
+        except subprocess.CalledProcessError as exc:
+            return JobResult(
+                ok=False,
+                error=f"rc={exc.returncode}",
+                stdout_tail=(exc.stdout or "")[-_TAIL:],
+                stderr_tail=(exc.stderr or "")[-_TAIL:],
+            )
+
+    def _run_build_test(self, job: BuildTestJob) -> JobResult:
+        """Run a build/test job (subprocess with argv)."""
+        try:
+            result = subprocess.run(
+                job.argv,
+                cwd=str(job.cwd),
+                capture_output=True,
+                text=True,
+                timeout=job.timeout_s,
+                check=False,  # we inspect rc below
+            )
+            return JobResult(
+                ok=result.returncode == 0,
+                value=None,
+                stdout_tail=result.stdout[-_TAIL:],
+                stderr_tail=result.stderr[-_TAIL:],
+                error=None if result.returncode == 0 else f"rc={result.returncode}",
+            )
+        except subprocess.TimeoutExpired as exc:
+            return JobResult(
+                ok=False,
+                error="timeout",
+                stdout_tail=str(exc.stdout or "")[-_TAIL:],
+                stderr_tail=str(exc.stderr or "")[-_TAIL:],
+            )
+
+    def _run_git(self, job: GitJob) -> JobResult:
+        """Run a git job (serialized per-repo via a shared lock).
+
+        The per-repo lock is held for the entire operation to ensure
+        worktree-manager calls (which share .git) do not race.
+        """
+        lock = self._repo_lock(job.repo)
+        try:
+            with lock:
+                return self._dispatch_git_op(job)
+        except subprocess.TimeoutExpired as exc:
+            return JobResult(
+                ok=False,
+                error="timeout",
+                stdout_tail=str(exc.stdout or "")[-_TAIL:],
+                stderr_tail=str(exc.stderr or "")[-_TAIL:],
+            )
+
+    def _dispatch_git_op(self, job: GitJob) -> JobResult:
+        """Dispatch a git operation to its handler."""
+        if job.op == "create_worktree":
+            manager = WorktreeManager()
+            manager.create_worktree(**job.kwargs)
+            return JobResult(ok=True)
+
+        elif job.op == "remove_worktree":
+            manager = WorktreeManager()
+            manager.remove_worktree(**job.kwargs)
+            return JobResult(ok=True)
+
+        elif job.op == "rebase":
+            result = git_utils.rebase_worktree_onto(**job.kwargs)
+            return JobResult(ok=result, value=result)
+
+        elif job.op == "push":
+            git_utils.push_current_branch_with_lease_on_divergence(**job.kwargs)
+            return JobResult(ok=True)
+
+        elif job.op == "commit_push":
+            # commit_if_changes returns True if changes were committed
+            git_utils.commit_if_changes(**job.kwargs)
+            # extract worktree_path for push
+            worktree_path = job.kwargs.get("worktree_path")
+            branch = job.kwargs.get("branch", "HEAD")
+            if worktree_path:
+                git_utils.push_branch(branch, worktree_path)
+            return JobResult(ok=True)
+
+        elif job.op == "clone":
+            # gh repo clone <repo> <dest>
+            repo = job.kwargs.get("repo") or ""
+            dest = job.kwargs.get("dest") or ""
+            git_utils.run(["gh", "repo", "clone", repo, dest], cwd=None)
+            return JobResult(ok=True)
+
+        else:
+            # Should be impossible due to GitJob.__post_init__ validation
+            return JobResult(ok=False, error=f"unknown op {job.op!r}")

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -30,6 +30,7 @@ from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.worktree_manager import WorktreeManager
 from hephaestus.resilience import (
     CircuitBreakerOpenError,
+    resilient_call,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,9 +115,10 @@ class WorkerPool:
         try:
             result = future.result()
             self._completion_q.put((handle, result))
-        except BaseException:
-            # future.result() can raise BaseException (e.g. a bug in _run),
-            # but the _run wrapper catches everything so this should be rare.
+        except Exception:
+            # _run catches all job failures and returns them in a JobResult,
+            # so future.result() should rarely raise. This handles only
+            # unexpected runtime errors from the callback machinery.
             logger.exception("Future result() raised, discarding")
 
     def _run(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
@@ -143,14 +145,14 @@ class WorkerPool:
                 result = self._run_git(job)
             else:
                 raise TypeError(f"unknown job type {type(job)}")
-        except BaseException as exc:
-            # Worker isolates ALL failures (including KeyboardInterrupt) into
-            # a result so the callback never re-raises into its thread.
+        except Exception as exc:
+            # Convert job execution failures into a JobResult so the callback
+            # never re-raises into its thread. This catches normal runtime errors
+            # but allows process-control exceptions to propagate normally.
             logger.exception("Job %s raised, returning error result", job)
             result = JobResult(
                 ok=False,
                 error=f"{type(exc).__name__}: {exc!s}"[:500],
-                duration_s=time.monotonic() - start,
             )
 
         # Mandatory post-check: SIGINT to the process group makes subprocess
@@ -171,33 +173,37 @@ class WorkerPool:
         try:
             agent = resolve_agent(job.agent)
             is_claude = agent == "claude"
+            prompt = job.prompt_builder(**job.prompt_kwargs)
 
-            if is_claude:
-                # Claude: invoke via claude_invoke.invoke_claude_with_session
-                prompt = job.prompt_builder(**job.prompt_kwargs)
-                stdout, _ = claude_invoke.invoke_claude_with_session(
-                    repo=job.repo,
-                    issue=job.issue,
-                    agent=job.agent,
-                    prompt=prompt,
-                    model=job.model,
-                    cwd=job.cwd,
-                    timeout=job.timeout_s,
-                    output_format=job.output_format,
-                )
-            else:
-                # Non-Claude: invoke via run_agent_session (e.g. codex, pi)
-                prompt = job.prompt_builder(**job.prompt_kwargs)
-                agent_result = run_agent_session(
-                    agent=agent,
-                    prompt=prompt,
-                    cwd=job.cwd,
-                    timeout=job.timeout_s,
-                    model=job.model,
-                    sandbox="workspace-write",
-                    approval="never",
-                )
-                stdout = agent_result.stdout or ""
+            def _invoke() -> str:
+                if is_claude:
+                    stdout, _ = claude_invoke.invoke_claude_with_session(
+                        repo=job.repo,
+                        issue=job.issue,
+                        agent=job.agent,
+                        prompt=prompt,
+                        model=job.model,
+                        cwd=job.cwd,
+                        timeout=job.timeout_s,
+                        output_format=job.output_format,
+                    )
+                    return stdout
+                else:
+                    agent_result = run_agent_session(
+                        agent=agent,
+                        prompt=prompt,
+                        cwd=job.cwd,
+                        timeout=job.timeout_s,
+                        model=job.model,
+                        sandbox="workspace-write",
+                        approval="never",
+                    )
+                    return agent_result.stdout or ""
+
+            stdout = resilient_call(
+                _invoke,
+                circuit_breaker_name=f"agent:{agent}:{job.model}",
+            )
 
             value = None
             if job.parse is not None:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from hephaestus.agents.runtime import resolve_agent, run_agent_session
 from hephaestus.automation import claude_invoke, git_utils
-from hephaestus.automation._review_utils import DEFAULT_STATE_DIR, ensure_state_dir
+from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
@@ -32,18 +32,35 @@ from hephaestus.resilience import (
     CircuitBreakerOpenError,
     resilient_call,
 )
+from hephaestus.utils.file_lock import file_lock
+from hephaestus.utils.helpers import get_repo_root
 
 logger = logging.getLogger(__name__)
 
 _TAIL = 4000  # chars of stdout/stderr retained in a JobResult
 
 
-def _repo_lock_path(repo: str) -> Path:
-    """Cross-process advisory lock file for *repo*, under the automation state dir."""
-    state_dir = ensure_state_dir(Path.cwd(), DEFAULT_STATE_DIR)
-    locks_dir = state_dir / "locks"
-    locks_dir.mkdir(parents=True, exist_ok=True)
-    return locks_dir / f"git-{repo.replace('/', '_')}.lock"
+def _repo_lock_path(repo: str, lock_dir: Path | None = None) -> Path:
+    """Cross-process advisory lock file for *repo*.
+
+    Anchored at ``<repo_root>/<DEFAULT_STATE_DIR>/locks`` (the shared
+    automation state dir) rather than the bare CWD, so every process that
+    operates on this checkout resolves the SAME sentinel file regardless of
+    which subdirectory it was launched from. ``file_lock`` creates the parent
+    directory on first acquisition.
+
+    Args:
+        repo: Repository slug (``owner/name``); slashes are flattened.
+        lock_dir: Override directory for the sentinel files (tests inject a
+            temp dir here).
+
+    Returns:
+        Path of the sentinel lock file for *repo*.
+
+    """
+    if lock_dir is None:
+        lock_dir = get_repo_root() / DEFAULT_STATE_DIR / "locks"
+    return lock_dir / f"git-{repo.replace('/', '_')}.lock"
 
 
 class WorkerPool:
@@ -52,9 +69,23 @@ class WorkerPool:
     Jobs are executed via :meth:`submit`; a future callback drains results to
     the completion queue. Workers never look up PR numbers, build prompts, or
     call the GitHub API — those are coordinator responsibilities.
+
+    Completion contract: every non-cancelled :meth:`submit` produces EXACTLY
+    ONE ``(handle, result)`` tuple on the completion queue — normal job
+    failures are converted to error results in :meth:`_run`, and any exception
+    that still escapes the future is converted to a ``worker_crash`` result in
+    :meth:`_on_future_done`. Only futures cancelled before starting (via
+    :meth:`shutdown`'s ``cancel_futures=True``) emit no completion; the
+    coordinator synthesizes those.
     """
 
-    def __init__(self, size: int, shutdown: threading.Event, completion_q: CompletionQueue) -> None:
+    def __init__(
+        self,
+        size: int,
+        shutdown: threading.Event,
+        completion_q: CompletionQueue,
+        lock_dir: Path | None = None,
+    ) -> None:
         """Initialize the pool.
 
         Args:
@@ -63,6 +94,9 @@ class WorkerPool:
                 starting and after completing each job.
             completion_q: Queue to which ``(JobHandle, JobResult)`` tuples are
                 sent when jobs complete.
+            lock_dir: Optional override for the cross-process git lock
+                directory (tests inject a temp dir; defaults to the shared
+                automation state dir — see :func:`_repo_lock_path`).
 
         """
         self._executor = ThreadPoolExecutor(max_workers=size)
@@ -70,6 +104,7 @@ class WorkerPool:
         self._completion_q = completion_q
         self._repo_locks: dict[str, threading.Lock] = {}
         self._repo_locks_guard = threading.Lock()
+        self._lock_dir = lock_dir
 
     def _repo_lock(self, repo: str) -> threading.Lock:
         """Get or create a per-repo lock (held during git operations)."""
@@ -108,18 +143,26 @@ class WorkerPool:
         """Drain result to completion queue when a job future completes.
 
         If the future was cancelled, do not emit a completion (the coordinator
-        synthesizes one later).
+        synthesizes one later). For every OTHER outcome a completion MUST be
+        queued: ``_run`` already converts normal job failures into error
+        results, and anything that still escapes ``future.result()`` — up to
+        and including ``BaseException`` — is converted here to a
+        ``worker_crash`` result so a non-cancelled submit never silently loses
+        its completion. ``KeyboardInterrupt`` is intentionally NOT re-raised
+        after queuing: this callback runs on an executor worker thread where a
+        re-raise would only print a traceback, not stop the process.
         """
         if future.cancelled():
             return  # cancel_futures synthesizes NO completion
         try:
             result = future.result()
-            self._completion_q.put((handle, result))
-        except Exception:
-            # _run catches all job failures and returns them in a JobResult,
-            # so future.result() should rarely raise. This handles only
-            # unexpected runtime errors from the callback machinery.
-            logger.exception("Future result() raised, discarding")
+        except BaseException as exc:
+            logger.exception("Worker future raised; converting to worker_crash result")
+            result = JobResult(
+                ok=False,
+                error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:500],
+            )
+        self._completion_q.put((handle, result))
 
     def _run(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
         """Execute a job and return its result.
@@ -169,7 +212,19 @@ class WorkerPool:
         )
 
     def _run_agent(self, job: AgentJob) -> JobResult:
-        """Run an agent job (Claude or other runtime)."""
+        """Run an agent job (Claude or other runtime).
+
+        Retry tradeoff: the whole agent invocation is wrapped in
+        :func:`resilient_call`, so a *transient* failure (network reset, gh
+        flake) re-runs the ENTIRE agent session — expensive, and the retried
+        session may redo work the failed one partially completed. We accept
+        that because agent invocations are idempotent-by-design at the
+        workflow level (plan/review comments upsert; implementation re-runs
+        converge on the same branch), and the alternative — no retry — turns
+        every blip into a failed pipeline stage. Non-transient errors (rc!=0
+        with non-transient stderr, timeouts) are NOT retried; they surface
+        immediately as error results.
+        """
         try:
             agent = resolve_agent(job.agent)
             is_claude = agent == "claude"
@@ -262,14 +317,21 @@ class WorkerPool:
             )
 
     def _run_git(self, job: GitJob) -> JobResult:
-        """Run a git job (serialized per-repo via a shared lock).
+        """Run a git job (serialized per-repo, in-process AND cross-process).
 
-        The per-repo lock is held for the entire operation to ensure
-        worktree-manager calls (which share .git) do not race.
+        Lock layering (documented invariant): the in-process
+        ``threading.Lock`` is OUTER and the cross-process
+        :func:`~hephaestus.utils.file_lock.file_lock` is INNER. The thread
+        lock elects a single thread per process first, so at most one thread
+        per process ever opens/holds the flock descriptor — sidestepping
+        flock's confusing same-process semantics (multiple fds on one file
+        within one process can still exclude each other) and keeping the
+        blocking flock wait to one thread. Both locks are held for the entire
+        operation because worktrees share ``.git``.
         """
         lock = self._repo_lock(job.repo)
         try:
-            with lock:
+            with lock, file_lock(_repo_lock_path(job.repo, self._lock_dir)):
                 return self._dispatch_git_op(job)
         except subprocess.TimeoutExpired as exc:
             return JobResult(
@@ -280,42 +342,91 @@ class WorkerPool:
             )
 
     def _dispatch_git_op(self, job: GitJob) -> JobResult:
-        """Dispatch a git operation to its handler."""
+        """Dispatch a git operation to its handler.
+
+        ``job.timeout_s`` is threaded into every dispatch whose helper accepts
+        a timeout (currently only ``clone`` via ``git_utils.run``). The
+        remaining helpers (``WorktreeManager.create_worktree`` /
+        ``remove_worktree``, ``rebase_worktree_onto``,
+        ``push_current_branch_with_lease_on_divergence``, ``commit_if_changes``,
+        ``push_branch``) expose no timeout parameter today; each call site
+        below documents that gap rather than silently dropping the budget.
+        """
         if job.op == "create_worktree":
             manager = WorktreeManager()
+            # WorktreeManager.create_worktree has no timeout parameter;
+            # job.timeout_s cannot be enforced here.
             manager.create_worktree(**job.kwargs)
             return JobResult(ok=True)
 
         elif job.op == "remove_worktree":
             manager = WorktreeManager()
+            # WorktreeManager.remove_worktree has no timeout parameter;
+            # job.timeout_s cannot be enforced here.
             manager.remove_worktree(**job.kwargs)
             return JobResult(ok=True)
 
         elif job.op == "rebase":
+            # rebase_worktree_onto(cwd, base_branch="main", *, remote) has no
+            # timeout parameter; job.timeout_s cannot be enforced here.
             result = git_utils.rebase_worktree_onto(**job.kwargs)
             return JobResult(ok=result, value=result)
 
         elif job.op == "push":
+            # push_current_branch_with_lease_on_divergence(cwd, *, branch,
+            # remote, push_ref) has no timeout parameter; job.timeout_s
+            # cannot be enforced here.
             git_utils.push_current_branch_with_lease_on_divergence(**job.kwargs)
             return JobResult(ok=True)
 
         elif job.op == "commit_push":
-            # commit_if_changes returns True if changes were committed
-            git_utils.commit_if_changes(**job.kwargs)
-            # extract worktree_path for push
-            worktree_path = job.kwargs.get("worktree_path")
-            branch = job.kwargs.get("branch", "HEAD")
-            if worktree_path:
-                git_utils.push_branch(branch, worktree_path)
-            return JobResult(ok=True)
+            return self._git_commit_push(job)
 
         elif job.op == "clone":
             # gh repo clone <repo> <dest>
-            repo = job.kwargs.get("repo") or ""
-            dest = job.kwargs.get("dest") or ""
-            git_utils.run(["gh", "repo", "clone", repo, dest], cwd=None)
+            repo = str(job.kwargs.get("repo") or "")
+            dest = str(job.kwargs.get("dest") or "")
+            if not repo or not dest:
+                return JobResult(
+                    ok=False,
+                    error="clone requires non-empty 'repo' and 'dest' kwargs",
+                )
+            git_utils.run(["gh", "repo", "clone", repo, dest], cwd=None, timeout=job.timeout_s)
             return JobResult(ok=True)
 
         else:
             # Should be impossible due to GitJob.__post_init__ validation
             return JobResult(ok=False, error=f"unknown op {job.op!r}")
+
+    def _git_commit_push(self, job: GitJob) -> JobResult:
+        """Commit pending changes in a worktree, then push its branch.
+
+        Only the keys ``commit_if_changes`` actually accepts are forwarded —
+        passing ``job.kwargs`` wholesale would crash on routing-only keys such
+        as ``branch``. A missing ``worktree_path`` (or ``issue_number``) is a
+        hard error result, never a silent skip: the coordinator submitted this
+        op expecting a push to happen.
+        """
+        worktree_path = job.kwargs.get("worktree_path")
+        issue_number = job.kwargs.get("issue_number")
+        if not worktree_path or issue_number is None:
+            return JobResult(
+                ok=False,
+                error="commit_push requires non-empty 'worktree_path' and 'issue_number' kwargs",
+            )
+        # NOTE: commit_if_changes returns False BOTH for "worktree clean,
+        # nothing to commit" AND for "commit attempted but failed" (it logs
+        # and swallows the RuntimeError). value=False is therefore ambiguous;
+        # a failed commit still reaches the push below, which pushes whatever
+        # HEAD already holds. commit_if_changes has no timeout parameter;
+        # job.timeout_s cannot be enforced here.
+        changed = git_utils.commit_if_changes(
+            int(issue_number),
+            Path(worktree_path),
+            str(job.kwargs.get("agent", "claude")),
+            allowed_paths=job.kwargs.get("allowed_paths"),
+        )
+        # push_branch has no timeout parameter; job.timeout_s cannot be
+        # enforced here.
+        git_utils.push_branch(str(job.kwargs.get("branch", "HEAD")), Path(worktree_path))
+        return JobResult(ok=True, value=changed)

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -110,6 +110,11 @@ class FakeWorkerPool:
             return JobResult(ok=True, value="fake agent output")
         if isinstance(job, BuildTestJob):
             return JobResult(ok=True, value=0)
+        # GitJob: mirror the real _dispatch_git_op value semantics so
+        # coordinator tests reading result.value see the same shapes —
+        # rebase reports clean-rebase True, commit_push reports changed True.
+        if job.op in ("rebase", "commit_push"):
+            return JobResult(ok=True, value=True)
         return JobResult(ok=True)
 
     def shutdown(self) -> None:

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import queue
 import threading
 from collections import deque
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -47,6 +48,7 @@ class FakeWorkerPool:
         size: int = 1,
         shutdown: threading.Event | None = None,
         completion_q: CompletionQueue | None = None,
+        lock_dir: Path | None = None,
     ) -> None:
         """Initialize the fake pool.
 
@@ -54,6 +56,7 @@ class FakeWorkerPool:
             size: Accepted for signature parity with WorkerPool; unused.
             shutdown: Accepted for signature parity with WorkerPool; unused.
             completion_q: Queue to drain results to (created if omitted).
+            lock_dir: Accepted for signature parity with WorkerPool; unused.
 
         """
         self.size = size

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -1,0 +1,209 @@
+"""Shared test fixtures for pipeline tests.
+
+Provides FakeWorkerPool (synchronous inline executor) and FakeGitHub (dict-backed
+GitHub state mutations) for deterministic testing without threads or real API calls.
+"""
+
+from __future__ import annotations
+
+import queue
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline.jobs import (
+    AgentJob,
+    BuildTestJob,
+    GitJob,
+    JobHandle,
+    JobResult,
+)
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.routing import StageName
+
+
+@dataclass
+class FakeGitHub:
+    """Mock GitHub state for deterministic testing.
+
+    Tracks labels, PR facts, comments, reviews, and all mutations in
+    append-only mutation_log.
+    """
+
+    issues: dict[int, dict[str, Any]] = field(default_factory=dict)
+    prs: dict[int, dict[str, Any]] = field(default_factory=dict)
+    labels: dict[str, dict[str, Any]] = field(default_factory=dict)
+    comments: dict[int, list[dict[str, Any]]] = field(
+        default_factory=lambda: {}  # issue -> comments
+    )
+    reviews: dict[int, list[dict[str, Any]]] = field(
+        default_factory=lambda: {}  # PR -> reviews
+    )
+    mutation_log: list[tuple[str, Any]] = field(default_factory=list)
+
+    def add_issue_label(self, issue_num: int, label: str) -> None:
+        """Add a label to an issue."""
+        if issue_num not in self.issues:
+            self.issues[issue_num] = {}
+        labels = self.issues[issue_num].setdefault("labels", [])
+        if label not in labels:
+            labels.append(label)
+        self.mutation_log.append(("add_issue_label", {"issue": issue_num, "label": label}))
+
+    def remove_issue_label(self, issue_num: int, label: str) -> None:
+        """Remove a label from an issue."""
+        if issue_num in self.issues:
+            labels = self.issues[issue_num].get("labels", [])
+            if label in labels:
+                labels.remove(label)
+        self.mutation_log.append(("remove_issue_label", {"issue": issue_num, "label": label}))
+
+    def add_issue_comment(self, issue_num: int, comment_text: str) -> int:
+        """Add a comment to an issue. Returns comment ID."""
+        if issue_num not in self.comments:
+            self.comments[issue_num] = []
+        comment_id = len(self.comments[issue_num]) + 1
+        self.comments[issue_num].append({"id": comment_id, "body": comment_text})
+        self.mutation_log.append(
+            ("add_issue_comment", {"issue": issue_num, "comment_id": comment_id})
+        )
+        return comment_id
+
+    def update_issue_comment(self, comment_id: int, issue_num: int, comment_text: str) -> None:
+        """Update an existing comment."""
+        if issue_num in self.comments:
+            for comment in self.comments[issue_num]:
+                if comment["id"] == comment_id:
+                    comment["body"] = comment_text
+        self.mutation_log.append(
+            ("update_issue_comment", {"issue": issue_num, "comment_id": comment_id})
+        )
+
+    def create_pr(self, pr_num: int, title: str, body: str) -> None:
+        """Create a PR."""
+        self.prs[pr_num] = {"number": pr_num, "title": title, "body": body, "state": "open"}
+        self.mutation_log.append(("create_pr", {"pr": pr_num}))
+
+    def update_pr(self, pr_num: int, title: str | None = None, body: str | None = None) -> None:
+        """Update PR metadata."""
+        if pr_num in self.prs:
+            if title is not None:
+                self.prs[pr_num]["title"] = title
+            if body is not None:
+                self.prs[pr_num]["body"] = body
+        self.mutation_log.append(("update_pr", {"pr": pr_num}))
+
+    def add_pr_review(self, pr_num: int, review_text: str) -> int:
+        """Add a review to a PR. Returns review ID."""
+        if pr_num not in self.reviews:
+            self.reviews[pr_num] = []
+        review_id = len(self.reviews[pr_num]) + 1
+        self.reviews[pr_num].append({"id": review_id, "body": review_text, "state": "PENDING"})
+        self.mutation_log.append(("add_pr_review", {"pr": pr_num, "review_id": review_id}))
+        return review_id
+
+    def submit_pr_review(self, pr_num: int, review_id: int, event: str = "APPROVE") -> None:
+        """Submit a pending review."""
+        if pr_num in self.reviews:
+            for review in self.reviews[pr_num]:
+                if review["id"] == review_id:
+                    review["state"] = event
+        self.mutation_log.append(
+            ("submit_pr_review", {"pr": pr_num, "review_id": review_id, "event": event})
+        )
+
+    def create_label(self, name: str, description: str = "") -> None:
+        """Create a label."""
+        self.labels[name] = {"name": name, "description": description}
+        self.mutation_log.append(("create_label", {"label": name}))
+
+    def clear_mutations(self) -> None:
+        """Clear the mutation log (for testing phases in isolation)."""
+        self.mutation_log.clear()
+
+
+class FakeWorkerPool:
+    """Synchronous inline executor for deterministic testing.
+
+    Submits are executed immediately on the calling thread, draining results
+    to the completion queue without any threading or sleeps. No concurrency
+    issues, deterministic ordering, easy to mock/spy.
+    """
+
+    def __init__(
+        self,
+        shutdown: object = None,  # unused, for compatibility
+        completion_q: CompletionQueue | None = None,
+    ) -> None:
+        """Initialize.
+
+        Args:
+            shutdown: Unused (for API compatibility with WorkerPool).
+            completion_q: Queue to drain results to (optional; if not provided,
+                a fresh one is created).
+
+        """
+        self._completion_q = completion_q or queue.Queue()
+        self._results: dict[JobHandle, JobResult] = {}
+
+    @property
+    def completion_q(self) -> CompletionQueue:
+        """Access the completion queue."""
+        return self._completion_q
+
+    def submit(self, job: AgentJob | BuildTestJob | GitJob, on_done_state: StageName) -> JobHandle:
+        """Submit a job for immediate synchronous execution.
+
+        Args:
+            job: Frozen job spec.
+            on_done_state: Target stage on completion.
+
+        Returns:
+            JobHandle to track the job.
+
+        """
+        handle = JobHandle(job=job, on_done_state=on_done_state)
+        # Execute immediately and synchronously
+        result = self._execute_job(job)
+        self._results[handle] = result
+        self._completion_q.put((handle, result))
+        return handle
+
+    def _execute_job(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
+        """Execute a job and return its result. Subclasses can override."""
+        # Default: return ok=True for all jobs (suitable for smoke tests)
+        if isinstance(job, AgentJob):
+            return JobResult(ok=True, value="fake agent output")
+        elif isinstance(job, BuildTestJob):
+            return JobResult(ok=True, stdout_tail="0")
+        elif isinstance(job, GitJob):
+            return JobResult(ok=True)
+        else:
+            return JobResult(ok=False, error="unknown job type")
+
+    def set_job_result(self, handle: JobHandle, result: JobResult) -> None:
+        """Override the result for a handle (for mocking specific job outcomes)."""
+        self._results[handle] = result
+
+    def shutdown(self) -> None:
+        """Shutdown (no-op for fake pool)."""
+        pass
+
+
+@pytest.fixture
+def fake_github() -> FakeGitHub:
+    """Fresh FakeGitHub instance for each test."""
+    return FakeGitHub()
+
+
+@pytest.fixture
+def fake_pool(completion_q: CompletionQueue | None = None) -> FakeWorkerPool:
+    """Fresh FakeWorkerPool instance for each test."""
+    return FakeWorkerPool(completion_q=completion_q)
+
+
+@pytest.fixture
+def completion_q() -> CompletionQueue:
+    """Fresh completion queue for tests."""
+    return queue.Queue()

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -182,10 +182,6 @@ class FakeWorkerPool:
         else:
             return JobResult(ok=False, error="unknown job type")
 
-    def set_job_result(self, handle: JobHandle, result: JobResult) -> None:
-        """Override the result for a handle (for mocking specific job outcomes)."""
-        self._results[handle] = result
-
     def shutdown(self) -> None:
         """Shutdown (no-op for fake pool)."""
         pass
@@ -198,8 +194,8 @@ def fake_github() -> FakeGitHub:
 
 
 @pytest.fixture
-def fake_pool(completion_q: CompletionQueue | None = None) -> FakeWorkerPool:
-    """Fresh FakeWorkerPool instance for each test."""
+def fake_pool(completion_q: CompletionQueue) -> FakeWorkerPool:
+    """Fresh FakeWorkerPool instance for each test, wired to the provided completion queue."""
     return FakeWorkerPool(completion_q=completion_q)
 
 

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -1,13 +1,17 @@
-"""Shared test fixtures for pipeline tests.
+"""Shared test doubles for pipeline stage/coordinator tests.
 
-Provides FakeWorkerPool (synchronous inline executor) and FakeGitHub (dict-backed
-GitHub state mutations) for deterministic testing without threads or real API calls.
+FakeWorkerPool runs jobs synchronously and inline (no threads, no sleeps) so
+stage/coordinator tests are deterministic. FakeGitHub is a dict-backed stand-in
+for github_api mutators with an append-only mutation_log; its method names and
+signatures mirror the real ``hephaestus.automation.github_api`` mutator surface
+so later coordinator tests can swap it in without renaming call sites.
 """
 
 from __future__ import annotations
 
 import queue
-from dataclasses import dataclass, field
+import threading
+from collections import deque
 from typing import Any
 
 import pytest
@@ -23,168 +27,224 @@ from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
 
 
-@dataclass
-class FakeGitHub:
-    """Mock GitHub state for deterministic testing.
-
-    Tracks labels, PR facts, comments, reviews, and all mutations in
-    append-only mutation_log.
-    """
-
-    issues: dict[int, dict[str, Any]] = field(default_factory=dict)
-    prs: dict[int, dict[str, Any]] = field(default_factory=dict)
-    labels: dict[str, dict[str, Any]] = field(default_factory=dict)
-    comments: dict[int, list[dict[str, Any]]] = field(
-        default_factory=lambda: {}  # issue -> comments
-    )
-    reviews: dict[int, list[dict[str, Any]]] = field(
-        default_factory=lambda: {}  # PR -> reviews
-    )
-    mutation_log: list[tuple[str, Any]] = field(default_factory=list)
-
-    def add_issue_label(self, issue_num: int, label: str) -> None:
-        """Add a label to an issue."""
-        if issue_num not in self.issues:
-            self.issues[issue_num] = {}
-        labels = self.issues[issue_num].setdefault("labels", [])
-        if label not in labels:
-            labels.append(label)
-        self.mutation_log.append(("add_issue_label", {"issue": issue_num, "label": label}))
-
-    def remove_issue_label(self, issue_num: int, label: str) -> None:
-        """Remove a label from an issue."""
-        if issue_num in self.issues:
-            labels = self.issues[issue_num].get("labels", [])
-            if label in labels:
-                labels.remove(label)
-        self.mutation_log.append(("remove_issue_label", {"issue": issue_num, "label": label}))
-
-    def add_issue_comment(self, issue_num: int, comment_text: str) -> int:
-        """Add a comment to an issue. Returns comment ID."""
-        if issue_num not in self.comments:
-            self.comments[issue_num] = []
-        comment_id = len(self.comments[issue_num]) + 1
-        self.comments[issue_num].append({"id": comment_id, "body": comment_text})
-        self.mutation_log.append(
-            ("add_issue_comment", {"issue": issue_num, "comment_id": comment_id})
-        )
-        return comment_id
-
-    def update_issue_comment(self, comment_id: int, issue_num: int, comment_text: str) -> None:
-        """Update an existing comment."""
-        if issue_num in self.comments:
-            for comment in self.comments[issue_num]:
-                if comment["id"] == comment_id:
-                    comment["body"] = comment_text
-        self.mutation_log.append(
-            ("update_issue_comment", {"issue": issue_num, "comment_id": comment_id})
-        )
-
-    def create_pr(self, pr_num: int, title: str, body: str) -> None:
-        """Create a PR."""
-        self.prs[pr_num] = {"number": pr_num, "title": title, "body": body, "state": "open"}
-        self.mutation_log.append(("create_pr", {"pr": pr_num}))
-
-    def update_pr(self, pr_num: int, title: str | None = None, body: str | None = None) -> None:
-        """Update PR metadata."""
-        if pr_num in self.prs:
-            if title is not None:
-                self.prs[pr_num]["title"] = title
-            if body is not None:
-                self.prs[pr_num]["body"] = body
-        self.mutation_log.append(("update_pr", {"pr": pr_num}))
-
-    def add_pr_review(self, pr_num: int, review_text: str) -> int:
-        """Add a review to a PR. Returns review ID."""
-        if pr_num not in self.reviews:
-            self.reviews[pr_num] = []
-        review_id = len(self.reviews[pr_num]) + 1
-        self.reviews[pr_num].append({"id": review_id, "body": review_text, "state": "PENDING"})
-        self.mutation_log.append(("add_pr_review", {"pr": pr_num, "review_id": review_id}))
-        return review_id
-
-    def submit_pr_review(self, pr_num: int, review_id: int, event: str = "APPROVE") -> None:
-        """Submit a pending review."""
-        if pr_num in self.reviews:
-            for review in self.reviews[pr_num]:
-                if review["id"] == review_id:
-                    review["state"] = event
-        self.mutation_log.append(
-            ("submit_pr_review", {"pr": pr_num, "review_id": review_id, "event": event})
-        )
-
-    def create_label(self, name: str, description: str = "") -> None:
-        """Create a label."""
-        self.labels[name] = {"name": name, "description": description}
-        self.mutation_log.append(("create_label", {"label": name}))
-
-    def clear_mutations(self) -> None:
-        """Clear the mutation log (for testing phases in isolation)."""
-        self.mutation_log.clear()
-
-
 class FakeWorkerPool:
-    """Synchronous inline executor for deterministic testing.
+    """Synchronous inline stand-in for :class:`WorkerPool`.
 
-    Submits are executed immediately on the calling thread, draining results
-    to the completion queue without any threading or sleeps. No concurrency
-    issues, deterministic ordering, easy to mock/spy.
+    Matches the real constructor signature ``(size, shutdown, completion_q)``
+    (all defaulted so tests can construct it bare). ``submit`` completes the
+    job immediately on the calling thread and puts ``(handle, result)`` on the
+    completion queue — no threads, no sleeps, deterministic ordering.
+
+    Scriptable outcomes (FIFO): :meth:`script` / :meth:`queue_result` /
+    :meth:`queue_exception` enqueue outcomes consumed one per ``submit`` in
+    order. A scripted ``Exception`` is converted to an error ``JobResult``
+    (mirroring how the real pool isolates job failures). When the FIFO is
+    empty, a per-job-type ok result is synthesized.
     """
 
     def __init__(
         self,
-        shutdown: object = None,  # unused, for compatibility
+        size: int = 1,
+        shutdown: threading.Event | None = None,
         completion_q: CompletionQueue | None = None,
     ) -> None:
-        """Initialize.
+        """Initialize the fake pool.
 
         Args:
-            shutdown: Unused (for API compatibility with WorkerPool).
-            completion_q: Queue to drain results to (optional; if not provided,
-                a fresh one is created).
+            size: Accepted for signature parity with WorkerPool; unused.
+            shutdown: Accepted for signature parity with WorkerPool; unused.
+            completion_q: Queue to drain results to (created if omitted).
 
         """
-        self._completion_q = completion_q or queue.Queue()
-        self._results: dict[JobHandle, JobResult] = {}
+        self.size = size
+        self.shutdown_event = shutdown if shutdown is not None else threading.Event()
+        self.completion_q: CompletionQueue = (
+            completion_q if completion_q is not None else (queue.Queue())
+        )
+        self.submitted: list[JobHandle] = []
+        self._scripted: deque[JobResult | Exception] = deque()
 
-    @property
-    def completion_q(self) -> CompletionQueue:
-        """Access the completion queue."""
-        return self._completion_q
+    def script(self, *outcomes: JobResult | Exception) -> None:
+        """FIFO-enqueue scripted outcomes for subsequent :meth:`submit` calls."""
+        self._scripted.extend(outcomes)
+
+    def queue_result(self, result: JobResult) -> None:
+        """FIFO-enqueue a single scripted result."""
+        self._scripted.append(result)
+
+    def queue_exception(self, exc: Exception) -> None:
+        """FIFO-enqueue an exception, delivered as an error JobResult."""
+        self._scripted.append(exc)
 
     def submit(self, job: AgentJob | BuildTestJob | GitJob, on_done_state: StageName) -> JobHandle:
-        """Submit a job for immediate synchronous execution.
+        """Execute *job* inline and put its completion on the queue.
 
         Args:
-            job: Frozen job spec.
+            job: Frozen job spec (any of the three job types).
             on_done_state: Target stage on completion.
 
         Returns:
-            JobHandle to track the job.
+            The JobHandle also recorded in :attr:`submitted`.
 
         """
         handle = JobHandle(job=job, on_done_state=on_done_state)
-        # Execute immediately and synchronously
-        result = self._execute_job(job)
-        self._results[handle] = result
-        self._completion_q.put((handle, result))
+        self.submitted.append(handle)
+        outcome: JobResult | Exception = (
+            self._scripted.popleft() if self._scripted else self._default_result(job)
+        )
+        if isinstance(outcome, Exception):
+            outcome = JobResult(
+                ok=False,
+                error=f"{type(outcome).__name__}: {outcome!s}",
+            )
+        self.completion_q.put((handle, outcome))
         return handle
 
-    def _execute_job(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
-        """Execute a job and return its result. Subclasses can override."""
-        # Default: return ok=True for all jobs (suitable for smoke tests)
+    @staticmethod
+    def _default_result(job: AgentJob | BuildTestJob | GitJob) -> JobResult:
+        """Synthesize a per-job-type ok result when nothing is scripted."""
         if isinstance(job, AgentJob):
             return JobResult(ok=True, value="fake agent output")
-        elif isinstance(job, BuildTestJob):
-            return JobResult(ok=True, stdout_tail="0")
-        elif isinstance(job, GitJob):
-            return JobResult(ok=True)
-        else:
-            return JobResult(ok=False, error="unknown job type")
+        if isinstance(job, BuildTestJob):
+            return JobResult(ok=True, value=0)
+        return JobResult(ok=True)
 
     def shutdown(self) -> None:
-        """Shutdown (no-op for fake pool)."""
-        pass
+        """Match the real pool's API (sets the shutdown event; nothing to cancel)."""
+        self.shutdown_event.set()
+
+
+class FakeGitHub:
+    """Dict-backed GitHub state with an append-only ``mutation_log``.
+
+    Method names and signatures mirror the 12 real
+    ``hephaestus.automation.github_api`` mutators the pipeline stages call
+    (``gh_issue_add_labels``, ``gh_issue_remove_labels``, ``gh_create_label``,
+    ``skip_epics``, ``gh_issue_comment``, ``gh_issue_upsert_comment``,
+    ``gh_issue_create``, ``gh_issue_delete_comment``, ``gh_pr_create``,
+    ``gh_pr_review_post``, ``gh_pr_update_review_comment``,
+    ``gh_pr_resolve_thread``), so coordinator tests can inject this double
+    without adapting call sites.
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty GitHub state."""
+        self.labels: dict[int, set[str]] = {}
+        self.defined_labels: dict[str, dict[str, str]] = {}
+        self.comments: dict[int, list[str]] = {}
+        self.issues: dict[int, dict[str, Any]] = {}
+        self.prs: dict[int, dict[str, Any]] = {}
+        self.reviews: dict[int, list[dict[str, Any]]] = {}
+        self.resolved_threads: set[str] = set()
+        self.mutation_log: list[tuple[str, tuple[Any, ...]]] = []
+        self._next_issue = 900
+        self._next_pr = 1000
+
+    def _log(self, name: str, *args: Any) -> None:
+        self.mutation_log.append((name, args))
+
+    # -- label mutators ----------------------------------------------------
+    def gh_create_label(self, name: str, color: str = "ededed", description: str = "") -> None:
+        """Mirror github_api.gh_create_label."""
+        self.defined_labels[name] = {"color": color, "description": description}
+        self._log("gh_create_label", name)
+
+    def gh_issue_add_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Mirror github_api.gh_issue_add_labels."""
+        self.labels.setdefault(issue_number, set()).update(labels)
+        self._log("gh_issue_add_labels", issue_number, tuple(labels))
+
+    def gh_issue_remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Mirror github_api.gh_issue_remove_labels."""
+        self.labels.setdefault(issue_number, set()).difference_update(labels)
+        self._log("gh_issue_remove_labels", issue_number, tuple(labels))
+
+    def skip_epics(self, epics_labels: dict[int, list[str]]) -> None:
+        """Mirror github_api.skip_epics (tags each epic state:skip)."""
+        for issue_number in epics_labels:
+            self.labels.setdefault(issue_number, set()).add("state:skip")
+        self._log("skip_epics", tuple(sorted(epics_labels)))
+
+    # -- issue/comment mutators --------------------------------------------
+    def gh_issue_comment(self, issue_number: int, body: str) -> None:
+        """Mirror github_api.gh_issue_comment."""
+        self.comments.setdefault(issue_number, []).append(body)
+        self._log("gh_issue_comment", issue_number)
+
+    def gh_issue_upsert_comment(self, issue_number: int, marker_prefix: str, body: str) -> int:
+        """Mirror github_api.gh_issue_upsert_comment (returns a comment id)."""
+        self.comments.setdefault(issue_number, []).append(body)
+        self._log("gh_issue_upsert_comment", issue_number, marker_prefix)
+        return len(self.comments[issue_number])
+
+    def gh_issue_create(self, title: str, body: str, labels: list[str] | None = None) -> int:
+        """Mirror github_api.gh_issue_create (returns the new issue number)."""
+        self._next_issue += 1
+        self.issues[self._next_issue] = {"title": title, "body": body}
+        if labels:
+            self.labels.setdefault(self._next_issue, set()).update(labels)
+        self._log("gh_issue_create", self._next_issue)
+        return self._next_issue
+
+    def gh_issue_delete_comment(self, comment_id: int) -> None:
+        """Mirror github_api.gh_issue_delete_comment."""
+        self._log("gh_issue_delete_comment", comment_id)
+
+    # -- PR + review mutators ------------------------------------------------
+    def gh_pr_create(
+        self,
+        branch: str,
+        title: str,
+        body: str,
+        auto_merge: bool = False,
+        base: str = "main",
+    ) -> int:
+        """Mirror github_api.gh_pr_create (returns the new PR number)."""
+        self._next_pr += 1
+        self.prs[self._next_pr] = {
+            "branch": branch,
+            "title": title,
+            "body": body,
+            "auto_merge": auto_merge,
+            "base": base,
+        }
+        self._log("gh_pr_create", self._next_pr, branch)
+        return self._next_pr
+
+    def gh_pr_review_post(
+        self,
+        pr_number: int,
+        comments: list[dict[str, Any]],
+        summary: str,
+        event: str = "COMMENT",
+        dry_run: bool = False,
+        dedupe_existing: bool = False,
+    ) -> list[str]:
+        """Mirror github_api.gh_pr_review_post (returns fake thread ids)."""
+        del dedupe_existing  # signature parity only
+        if dry_run:
+            return []
+        review = {"comments": comments, "summary": summary, "event": event}
+        self.reviews.setdefault(pr_number, []).append(review)
+        self._log("gh_pr_review_post", pr_number, event)
+        return [f"thread-{pr_number}-{i}" for i in range(len(comments))]
+
+    def gh_pr_update_review_comment(self, comment_node_id: str, body: str) -> None:
+        """Mirror github_api.gh_pr_update_review_comment."""
+        del body  # state not modelled; the log entry is the observable
+        self._log("gh_pr_update_review_comment", comment_node_id)
+
+    def gh_pr_resolve_thread(
+        self,
+        thread_id: str,
+        reply_body: str | None = None,
+        dry_run: bool = False,
+    ) -> None:
+        """Mirror github_api.gh_pr_resolve_thread."""
+        if dry_run:
+            return
+        self.resolved_threads.add(thread_id)
+        self._log("gh_pr_resolve_thread", thread_id, reply_body)
 
 
 @pytest.fixture
@@ -194,12 +254,12 @@ def fake_github() -> FakeGitHub:
 
 
 @pytest.fixture
-def fake_pool(completion_q: CompletionQueue) -> FakeWorkerPool:
-    """Fresh FakeWorkerPool instance for each test, wired to the provided completion queue."""
-    return FakeWorkerPool(completion_q=completion_q)
-
-
-@pytest.fixture
 def completion_q() -> CompletionQueue:
     """Fresh completion queue for tests."""
     return queue.Queue()
+
+
+@pytest.fixture
+def fake_pool(completion_q: CompletionQueue) -> FakeWorkerPool:
+    """Fresh FakeWorkerPool wired to the shared completion queue."""
+    return FakeWorkerPool(completion_q=completion_q)

--- a/tests/unit/automation/pipeline/test_fakes.py
+++ b/tests/unit/automation/pipeline/test_fakes.py
@@ -1,0 +1,170 @@
+"""Direct tests for the shared pipeline test doubles in conftest.py.
+
+FakeWorkerPool must work for all three job types and honor scripted
+results/exceptions; FakeGitHub must record every mutation in mutation_log.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hephaestus.automation.pipeline.jobs import (
+    AgentJob,
+    BuildTestJob,
+    GitJob,
+    JobResult,
+)
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.routing import StageName
+
+from .conftest import FakeGitHub, FakeWorkerPool
+
+
+def _jobs() -> tuple[AgentJob, BuildTestJob, GitJob]:
+    """One job of each of the three types."""
+    agent = AgentJob(
+        repo="test/repo",
+        issue=1,
+        agent="claude",
+        model="opus-4-8",
+        prompt_builder=lambda: "prompt",
+        cwd=Path("/tmp"),
+        timeout_s=60,
+    )
+    build = BuildTestJob(repo="test/repo", cwd=Path("/tmp"), argv=("true",), timeout_s=60)
+    git = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+    return agent, build, git
+
+
+class TestFakeWorkerPool:
+    """FakeWorkerPool completes inline for all three job types."""
+
+    def test_matches_real_constructor_signature(self) -> None:
+        """Positional (size, shutdown, completion_q) construction works."""
+        import queue
+        import threading
+
+        q: CompletionQueue = queue.Queue()
+        event = threading.Event()
+        fake = FakeWorkerPool(2, event, q)
+        assert fake.size == 2
+        assert fake.shutdown_event is event
+        assert fake.completion_q is q
+
+    def test_all_three_job_types_complete_inline(self) -> None:
+        """Every job type produces exactly one immediate ok completion."""
+        fake = FakeWorkerPool()
+        for job in _jobs():
+            handle = fake.submit(job, StageName.CI)
+            got_handle, result = fake.completion_q.get_nowait()
+            assert got_handle is handle
+            assert result.ok is True
+        assert len(fake.submitted) == 3
+        assert fake.completion_q.empty()
+
+    def test_scripted_results_consumed_fifo(self) -> None:
+        """script() outcomes are consumed in FIFO order across job types."""
+        fake = FakeWorkerPool()
+        agent, build, git = _jobs()
+        fake.script(
+            JobResult(ok=True, value="first"),
+            JobResult(ok=False, error="second failed"),
+        )
+
+        fake.submit(agent, StageName.PLANNING)
+        _, r1 = fake.completion_q.get_nowait()
+        fake.submit(build, StageName.CI)
+        _, r2 = fake.completion_q.get_nowait()
+        fake.submit(git, StageName.MERGE_WAIT)
+        _, r3 = fake.completion_q.get_nowait()
+
+        assert r1.value == "first"
+        assert r2.ok is False
+        assert r2.error == "second failed"
+        assert r3.ok is True  # FIFO exhausted -> default ok result
+
+    def test_scripted_failure_for_each_job_type(self) -> None:
+        """A scripted failing JobResult is delivered for every job type."""
+        for job in _jobs():
+            fake = FakeWorkerPool()
+            fake.queue_result(JobResult(ok=False, error="scripted failure"))
+            fake.submit(job, StageName.CI)
+            _, result = fake.completion_q.get_nowait()
+            assert result.ok is False
+            assert result.error == "scripted failure"
+
+    def test_scripted_exception_becomes_error_result(self) -> None:
+        """queue_exception() delivers an error JobResult, mirroring the pool."""
+        fake = FakeWorkerPool()
+        fake.queue_exception(RuntimeError("kaboom"))
+        agent, _, _ = _jobs()
+        fake.submit(agent, StageName.PLANNING)
+        _, result = fake.completion_q.get_nowait()
+        assert result.ok is False
+        assert result.error == "RuntimeError: kaboom"
+
+    def test_handles_are_unique_per_submit(self) -> None:
+        """Identical job specs still yield distinct, dict-keyable handles."""
+        fake = FakeWorkerPool()
+        _, _, git = _jobs()
+        h1 = fake.submit(git, StageName.CI)
+        h2 = fake.submit(git, StageName.CI)
+        assert h1 is not h2
+        assert h1 != h2  # identity equality (eq=False)
+        assert len({h1: 1, h2: 2}) == 2
+
+    def test_shutdown_sets_event(self) -> None:
+        """shutdown() flips the shutdown event like the real pool."""
+        fake = FakeWorkerPool()
+        fake.shutdown()
+        assert fake.shutdown_event.is_set()
+
+
+class TestFakeGitHub:
+    """FakeGitHub mirrors the real mutator surface and logs every mutation."""
+
+    def test_label_and_comment_mutators_update_state_and_log(self, fake_github: FakeGitHub) -> None:
+        """Label/comment mutators mutate dict state and append to the log."""
+        fake_github.gh_create_label("state:needs-plan")
+        fake_github.gh_issue_add_labels(7, ["state:needs-plan"])
+        fake_github.gh_issue_comment(7, "planning started")
+        fake_github.gh_issue_remove_labels(7, ["state:needs-plan"])
+        fake_github.skip_epics({9: ["epic"]})
+
+        assert fake_github.labels[7] == set()
+        assert fake_github.labels[9] == {"state:skip"}
+        assert fake_github.comments[7] == ["planning started"]
+        assert [name for name, _ in fake_github.mutation_log] == [
+            "gh_create_label",
+            "gh_issue_add_labels",
+            "gh_issue_comment",
+            "gh_issue_remove_labels",
+            "skip_epics",
+        ]
+
+    def test_pr_and_review_mutators(self, fake_github: FakeGitHub) -> None:
+        """PR/review mutators return ids and record resolved threads."""
+        pr = fake_github.gh_pr_create("7-auto", "title", "body\n\nCloses #7\n")
+        threads = fake_github.gh_pr_review_post(
+            pr, [{"path": "a.py", "line": 1, "side": "RIGHT", "body": "nit"}], "summary"
+        )
+        assert len(threads) == 1
+        fake_github.gh_pr_resolve_thread(threads[0], reply_body="done")
+        fake_github.gh_pr_update_review_comment("comment-node", "edited")
+        issue = fake_github.gh_issue_create("t", "b", labels=["bug"])
+        comment_id = fake_github.gh_issue_upsert_comment(issue, "<!-- marker -->", "hello")
+        fake_github.gh_issue_delete_comment(comment_id)
+
+        assert pr in fake_github.prs
+        assert threads[0] in fake_github.resolved_threads
+        assert "bug" in fake_github.labels[issue]
+        mutated = [name for name, _ in fake_github.mutation_log]
+        assert mutated == [
+            "gh_pr_create",
+            "gh_pr_review_post",
+            "gh_pr_resolve_thread",
+            "gh_pr_update_review_comment",
+            "gh_issue_create",
+            "gh_issue_upsert_comment",
+            "gh_issue_delete_comment",
+        ]

--- a/tests/unit/automation/pipeline/test_jobs.py
+++ b/tests/unit/automation/pipeline/test_jobs.py
@@ -79,6 +79,45 @@ class TestJobDataclassesFrozen:
             handle.on_done_state = StageName.CI  # type: ignore[misc]
 
 
+class TestBuildTestJobArgv:
+    """Tests that BuildTestJob.argv is always a tuple."""
+
+    def test_argv_tuple_preserved(self) -> None:
+        job = BuildTestJob(repo="test/repo", cwd=Path("/tmp"), argv=("pytest", "-q"), timeout_s=60)
+        assert job.argv == ("pytest", "-q")
+        assert isinstance(job.argv, tuple)
+
+    def test_argv_list_normalized_to_tuple(self) -> None:
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=["pytest", "-q"],  # type: ignore[arg-type]
+            timeout_s=60,
+        )
+        assert job.argv == ("pytest", "-q")
+        assert isinstance(job.argv, tuple)
+
+
+class TestJobHandleIdentity:
+    """Tests for JobHandle's identity-based hashing and equality (eq=False)."""
+
+    def test_identical_specs_produce_distinct_handles(self) -> None:
+        """Two handles over the same job spec are neither equal nor colliding."""
+        job = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+        h1 = JobHandle(job=job, on_done_state=StageName.CI)
+        h2 = JobHandle(job=job, on_done_state=StageName.CI)
+        assert h1 != h2
+        assert h1 == h1
+        assert len({h1: "a", h2: "b"}) == 2
+
+    def test_handle_hashable_with_unhashable_job_fields(self) -> None:
+        """Handles hash by identity even when the job carries dict kwargs."""
+        job = GitJob(repo="test/repo", op="rebase", timeout_s=60, kwargs={"cwd": Path("/tmp")})
+        handle = JobHandle(job=job, on_done_state=StageName.CI)
+        tracked = {handle: "pending"}
+        assert tracked[handle] == "pending"
+
+
 class TestDefaultFactories:
     """Tests that default factory fields are independent per instance."""
 

--- a/tests/unit/automation/pipeline/test_jobs.py
+++ b/tests/unit/automation/pipeline/test_jobs.py
@@ -1,0 +1,110 @@
+"""Tests for job dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from hephaestus.automation.pipeline.jobs import (
+    GIT_OPS,
+    AgentJob,
+    BuildTestJob,
+    GitJob,
+    JobHandle,
+    JobResult,
+)
+from hephaestus.automation.pipeline.routing import StageName
+
+
+class TestGitJobValidation:
+    """Tests for GitJob op validation."""
+
+    @pytest.mark.parametrize("op", sorted(GIT_OPS))
+    def test_valid_ops_construct(self, op: str) -> None:
+        job = GitJob(repo="test/repo", op=op, timeout_s=60)
+        assert job.op == op
+        assert job.repo == "test/repo"
+
+    def test_invalid_op_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown git op"):
+            GitJob(repo="test/repo", op="bogus", timeout_s=60)
+
+    def test_invalid_op_suggests_valid_ops(self) -> None:
+        with pytest.raises(ValueError, match=r"clone.*commit_push.*create_worktree"):
+            GitJob(repo="test/repo", op="invalid", timeout_s=60)
+
+
+class TestJobDataclassesFrozen:
+    """Tests that job dataclasses are frozen."""
+
+    def test_agent_job_frozen(self) -> None:
+        job = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
+        with pytest.raises(FrozenInstanceError):
+            job.timeout_s = 120  # type: ignore[misc]
+
+    def test_build_test_job_frozen(self) -> None:
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=("pytest",),
+            timeout_s=60,
+        )
+        with pytest.raises(FrozenInstanceError):
+            job.timeout_s = 120  # type: ignore[misc]
+
+    def test_git_job_frozen(self) -> None:
+        job = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+        with pytest.raises(FrozenInstanceError):
+            job.timeout_s = 120  # type: ignore[misc]
+
+    def test_job_result_frozen(self) -> None:
+        result = JobResult(ok=True)
+        with pytest.raises(FrozenInstanceError):
+            result.ok = False  # type: ignore[misc]
+
+    def test_job_handle_frozen(self) -> None:
+        job = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+        handle = JobHandle(job=job, on_done_state=StageName.IMPLEMENTATION)
+        with pytest.raises(FrozenInstanceError):
+            handle.on_done_state = StageName.CI  # type: ignore[misc]
+
+
+class TestDefaultFactories:
+    """Tests that default factory fields are independent per instance."""
+
+    def test_agent_job_prompt_kwargs_independent(self) -> None:
+        job1 = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
+        job2 = AgentJob(
+            repo="test/repo",
+            issue=124,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
+        # Verify they are separate dicts
+        assert job1.prompt_kwargs is not job2.prompt_kwargs
+
+    def test_git_job_kwargs_independent(self) -> None:
+        job1 = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+        job2 = GitJob(repo="test/repo", op="rebase", timeout_s=60)
+        assert job1.kwargs is not job2.kwargs

--- a/tests/unit/automation/pipeline/test_jobs.py
+++ b/tests/unit/automation/pipeline/test_jobs.py
@@ -107,7 +107,7 @@ class TestJobHandleIdentity:
         h1 = JobHandle(job=job, on_done_state=StageName.CI)
         h2 = JobHandle(job=job, on_done_state=StageName.CI)
         assert h1 != h2
-        assert h1 == h1
+        assert h1 is h1
         assert len({h1: "a", h2: "b"}) == 2
 
     def test_handle_hashable_with_unhashable_job_fields(self) -> None:

--- a/tests/unit/automation/pipeline/test_pipeline_architecture.py
+++ b/tests/unit/automation/pipeline/test_pipeline_architecture.py
@@ -3,6 +3,14 @@
 Models tests/unit/automation/test_ci_driver_architecture.py. Enforces via AST
 walk that pipeline/* modules never import or call github_api mutator functions,
 with an explicit allowlist for documented interim offenders awaiting refactor.
+Worker-side modules (worker_pool.py, jobs.py) are held to a stricter bar: they
+may not import ``hephaestus.automation.github_api`` or
+``hephaestus.automation.pr_manager`` AT ALL, in any form — this also catches
+non-obvious mutators such as ``skip_epics``, ``gh_call``, and ``run``.
+
+Caveat: this is a static, import/attribute-level guard. Subprocess-level ``gh``
+calls (e.g. building a ``["gh", ...]`` argv and running it directly) are OUT OF
+SCOPE here and must be caught in code review.
 """
 
 from __future__ import annotations
@@ -46,6 +54,12 @@ _MUTATORS = _PUBLIC_MUTATORS | _PRIVATE_MUTATORS
 # only when fuse-pattern is unavoidable. Empty on day one per issue #1812.
 _ALLOWLIST: frozenset[str] = frozenset()
 
+# Worker-side modules: code that executes ON worker threads. These may not
+# import github_api or pr_manager at all (not even non-mutator helpers) so
+# that gh_call/run/skip_epics-style mutators can never sneak in.
+_WORKER_SIDE_MODULES = ("worker_pool.py", "jobs.py")
+_FORBIDDEN_WORKER_MODULES = ("github_api", "pr_manager")
+
 
 def _imported_mutators(path: Path) -> set[str]:
     """Find github_api mutators imported or called in a Python file (AST walk)."""
@@ -63,14 +77,36 @@ def _imported_mutators(path: Path) -> set[str]:
     return found
 
 
+def _forbidden_module_imports(path: Path) -> set[str]:
+    """Find any-form imports of forbidden modules (github_api, pr_manager)."""
+
+    def _is_forbidden(dotted: str) -> bool:
+        return any(part in _FORBIDDEN_WORKER_MODULES for part in dotted.split("."))
+
+    tree = ast.parse(path.read_text())
+    hits: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            hits |= {a.name for a in node.names if _is_forbidden(a.name)}
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if _is_forbidden(module):
+                hits.add(module)
+            else:
+                # e.g. `from hephaestus.automation import github_api`
+                hits |= {f"{module}.{a.name}" for a in node.names if _is_forbidden(a.name)}
+    return hits
+
+
 def test_no_worker_module_imports_github_mutators() -> None:
-    """Ensure pipeline/* modules do not import/call github_api mutators.
+    """Ensure pipeline modules (recursively) do not import/call github_api mutators.
 
     Workers execute on thread pool with no coordinator access; all GitHub
     state changes must go through the coordinator to maintain consistency.
+    Subprocess-level ``gh`` invocations are out of scope for this AST guard.
     """
     violations = []
-    for py in _PIPELINE.glob("*.py"):
+    for py in sorted(_PIPELINE.rglob("*.py")):
         if py.stem == "__init__":
             continue
         offenders = _imported_mutators(py) - _ALLOWLIST
@@ -79,6 +115,26 @@ def test_no_worker_module_imports_github_mutators() -> None:
 
     assert not violations, "worker code must not call github_api mutators:\n" + "\n".join(
         violations
+    )
+
+
+def test_worker_side_modules_never_import_github_api_or_pr_manager() -> None:
+    """Worker-side modules must not import github_api or pr_manager AT ALL.
+
+    The mutator-name scan above cannot enumerate every mutating entry point
+    (``skip_epics``, ``gh_call``, ``run``, ...), so for the modules that run on
+    worker threads we forbid the whole modules in any import form.
+    """
+    violations = []
+    for name in _WORKER_SIDE_MODULES:
+        path = _PIPELINE / name
+        assert path.exists(), f"expected worker-side module missing: {path}"
+        offenders = _forbidden_module_imports(path)
+        if offenders:
+            violations.append(f"{name}: {sorted(offenders)}")
+
+    assert not violations, (
+        "worker-side modules must not import github_api/pr_manager:\n" + "\n".join(violations)
     )
 
 

--- a/tests/unit/automation/pipeline/test_pipeline_architecture.py
+++ b/tests/unit/automation/pipeline/test_pipeline_architecture.py
@@ -1,0 +1,104 @@
+"""Architecture invariant: worker code performs zero GitHub API mutations.
+
+Models tests/unit/automation/test_ci_driver_architecture.py. Enforces via AST
+walk that pipeline/* modules never import or call github_api mutator functions,
+with an explicit allowlist for documented interim offenders awaiting refactor.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import hephaestus
+import hephaestus.automation.github_api as github_api
+
+_PIPELINE = Path(hephaestus.__file__).parent / "automation" / "pipeline"
+
+# Public mutators from github_api.__all__ (avoids hardcoding drift)
+_PUBLIC_MUTATORS = frozenset(
+    n
+    for n in github_api.__all__
+    if n.startswith(
+        (
+            "gh_issue_add",
+            "gh_issue_remove",
+            "gh_issue_comment",
+            "gh_issue_create",
+            "gh_issue_delete",
+            "gh_issue_upsert",
+            "gh_create_label",
+            "gh_pr_create",
+            "gh_pr_review_post",
+            "gh_pr_update_review",
+            "gh_pr_resolve",
+        )
+    )
+)
+
+# Private review-comment mutators that carry no public alias
+_PRIVATE_MUTATORS = frozenset({"_post_shadow_review_comment", "_edit_or_keep_comments"})
+
+_MUTATORS = _PUBLIC_MUTATORS | _PRIVATE_MUTATORS
+
+# Modules awaiting refactor (e.g. _review_phase fuses agent calls with gh mutations).
+# Shrinking allowlist strategy: document intent, enforce from day one, grow list
+# only when fuse-pattern is unavoidable. Empty on day one per issue #1812.
+_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _imported_mutators(path: Path) -> set[str]:
+    """Find github_api mutators imported or called in a Python file (AST walk)."""
+    tree = ast.parse(path.read_text())
+    found: set[str] = set()
+
+    for node in ast.walk(tree):
+        # Import statements: from github_api import X
+        if isinstance(node, ast.ImportFrom) and node.module and "github_api" in node.module:
+            found |= {a.name for a in node.names if a.name in _MUTATORS}
+        # Attribute access: obj.X where X is a mutator
+        if isinstance(node, ast.Attribute) and node.attr in _MUTATORS:
+            found.add(node.attr)
+
+    return found
+
+
+def test_no_worker_module_imports_github_mutators() -> None:
+    """Ensure pipeline/* modules do not import/call github_api mutators.
+
+    Workers execute on thread pool with no coordinator access; all GitHub
+    state changes must go through the coordinator to maintain consistency.
+    """
+    violations = []
+    for py in _PIPELINE.glob("*.py"):
+        if py.stem == "__init__":
+            continue
+        offenders = _imported_mutators(py) - _ALLOWLIST
+        if offenders:
+            violations.append(f"{py.name}: {sorted(offenders)}")
+
+    assert not violations, "worker code must not call github_api mutators:\n" + "\n".join(
+        violations
+    )
+
+
+def test_mutator_set_is_non_empty() -> None:
+    """Guard against github_api.__all__ rename silently emptying _MUTATORS.
+
+    If _MUTATORS becomes empty due to a rename or refactor, the invariant
+    passes vacuously. This test ensures the mutator set always has content.
+    """
+    assert len(_MUTATORS) >= 5, f"_MUTATORS is suspiciously small: {_MUTATORS}"
+
+
+def test_public_mutators_from_all() -> None:
+    """Verify _PUBLIC_MUTATORS is derived from github_api.__all__."""
+    # At least the major mutators should be present
+    expected = {
+        "gh_issue_add_labels",
+        "gh_issue_remove_labels",
+        "gh_issue_comment",
+        "gh_pr_create",
+        "gh_create_label",
+    }
+    assert expected <= _PUBLIC_MUTATORS, f"expected mutators missing: {expected - _PUBLIC_MUTATORS}"

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -1,0 +1,316 @@
+"""Tests for the WorkerPool job execution."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hephaestus.automation.pipeline.jobs import (
+    AgentJob,
+    BuildTestJob,
+)
+from hephaestus.automation.pipeline.queues import CompletionQueue
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.worker_pool import WorkerPool
+from hephaestus.resilience import CircuitBreakerOpenError
+
+
+@pytest.fixture
+def shutdown_event() -> threading.Event:
+    """Fresh shutdown event for each test."""
+    return threading.Event()
+
+
+@pytest.fixture
+def completion_q() -> CompletionQueue:
+    """Fresh completion queue for each test."""
+    return queue.Queue()
+
+
+@pytest.fixture
+def pool(shutdown_event: threading.Event, completion_q: CompletionQueue) -> WorkerPool:
+    """Worker pool with a single thread."""
+    return WorkerPool(size=1, shutdown=shutdown_event, completion_q=completion_q)
+
+
+class TestWorkerPoolSubmitComplete:
+    """Tests for basic submit/complete workflow."""
+
+    def test_submit_and_complete_agent_job(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Submit an agent job and drain completion."""
+        job = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "test prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+            descr="test job",
+        )
+
+        with patch(
+            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session"
+        ) as mock_invoke:
+            mock_invoke.return_value = ("Test output", "session-id")
+            pool.submit(job, StageName.IMPLEMENTATION)
+            time.sleep(0.2)
+
+        assert not completion_q.empty()
+        handle, result = completion_q.get_nowait()
+        assert handle.job == job
+        assert handle.on_done_state == StageName.IMPLEMENTATION
+        assert result.ok is True
+        assert "Test output" in str(result.value)
+
+    def test_submit_and_complete_build_test_job(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Submit a build/test job."""
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=("echo", "hello"),
+            timeout_s=60,
+        )
+
+        pool.submit(job, StageName.CI)
+        time.sleep(0.2)
+
+        assert not completion_q.empty()
+        handle, result = completion_q.get_nowait()
+        assert handle.job == job
+        assert result.ok is True
+        assert "hello" in result.stdout_tail
+
+    def test_build_test_nonzero_rc_is_not_ok(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Build/test job with nonzero rc returns ok=False."""
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=("false",),
+            timeout_s=60,
+        )
+
+        pool.submit(job, StageName.CI)
+        time.sleep(0.2)
+
+        _, result = completion_q.get_nowait()
+        assert result.ok is False
+        assert "rc=1" in result.error
+
+
+class TestCircuitBreaker:
+    """Tests for circuit breaker integration."""
+
+    def test_circuit_breaker_open_returns_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Agent job with circuit open returns error result."""
+        job = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
+
+        def failing_invoke(*args: object, **kwargs: object) -> object:
+            raise CircuitBreakerOpenError(name="test_breaker", time_until_recovery=10.0)
+
+        with patch(
+            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session",
+            side_effect=failing_invoke,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            time.sleep(0.2)
+
+        _, result = completion_q.get_nowait()
+        assert result.ok is False
+        assert result.error == "circuit_open"
+
+
+class TestInterruptedPostCheck:
+    """Tests for the mandatory post-check interrupt flag."""
+
+    def test_interrupted_post_check_on_shutdown_event(
+        self,
+        pool: WorkerPool,
+        shutdown_event: threading.Event,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Job callable returns ok=True but shutdown is set -> interrupted=True."""
+        # Use a slower subprocess to ensure the shutdown event gets set while it's running
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=("sleep", "1"),
+            timeout_s=60,
+        )
+
+        pool.submit(job, StageName.CI)
+        # Set shutdown before the job completes (but after submit)
+        time.sleep(0.1)
+        shutdown_event.set()
+        time.sleep(1.5)  # Wait for the sleep job to finish
+
+        _, result = completion_q.get_nowait()
+        assert result.interrupted is True
+        assert result.ok is False
+
+    def test_interrupted_before_start(
+        self,
+        pool: WorkerPool,
+        shutdown_event: threading.Event,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Shutdown event set before job starts -> error and callable never invoked."""
+        shutdown_event.set()
+
+        job = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=MagicMock(),
+            cwd=Path("/tmp"),
+            timeout_s=60,
+        )
+
+        pool.submit(job, StageName.PLANNING)
+        time.sleep(0.2)
+
+        _, result = completion_q.get_nowait()
+        assert result.interrupted is True
+        assert result.error == "interrupted_before_start"
+        # Callable should never have been invoked (was MagicMock above)
+        assert not job.prompt_builder.called  # type: ignore[attr-defined]
+
+
+class TestGitMutexSerialization:
+    """Tests for per-repo git mutex serialization."""
+
+    def test_same_repo_jobs_use_lock(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Two GitJobs for the same repo both use the same lock object."""
+        lock1 = pool._repo_lock("test/repo1")
+        lock2 = pool._repo_lock("test/repo1")
+        assert lock1 is lock2  # Same lock object
+
+    def test_different_repo_jobs_use_different_locks(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Two GitJobs for different repos use different locks."""
+        lock1 = pool._repo_lock("test/repo1")
+        lock2 = pool._repo_lock("test/repo2")
+        assert lock1 is not lock2
+
+
+class TestShutdownAndCancel:
+    """Tests for shutdown behavior and future cancellation."""
+
+    def test_shutdown_cancels_pending_work(
+        self,
+        pool: WorkerPool,
+        shutdown_event: threading.Event,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Shutdown cancels pending futures (queue remains empty for cancelled jobs)."""
+        # The key is that shutdown() with cancel_futures=True cancels any pending futures
+        # before they start. Once a future is running, it completes normally.
+        # This test verifies that the pool can be shut down.
+        pool.shutdown()
+        # No pending jobs, so the queue should be empty
+        assert completion_q.empty()
+
+
+class TestParse:
+    """Tests for parse callable on AgentJob."""
+
+    def test_parse_callable_applied(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Parse callable is invoked and result stored."""
+
+        def my_parser(text: str) -> dict[str, object]:
+            return {"parsed": text.upper()}
+
+        job = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+            parse=my_parser,
+        )
+
+        with patch(
+            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session"
+        ) as mock_invoke:
+            mock_invoke.return_value = ("hello world", "sid")
+            pool.submit(job, StageName.PLANNING)
+            time.sleep(0.2)
+
+        _, result = completion_q.get_nowait()
+        assert result.ok is True
+        assert result.value == {"parsed": "HELLO WORLD"}
+
+    def test_parse_callable_exception_returns_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Parse callable raises -> error result."""
+
+        def bad_parser(text: str) -> object:
+            raise ValueError("parse failed")
+
+        job = AgentJob(
+            repo="test/repo",
+            issue=123,
+            agent="claude",
+            model="opus-4-8",
+            prompt_builder=lambda: "prompt",
+            cwd=Path("/tmp"),
+            timeout_s=60,
+            parse=bad_parser,
+        )
+
+        with patch(
+            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session"
+        ) as mock_invoke:
+            mock_invoke.return_value = ("output", "sid")
+            pool.submit(job, StageName.PLANNING)
+            time.sleep(0.2)
+
+        _, result = completion_q.get_nowait()
+        assert result.ok is False
+        assert "parse failed" in result.error

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -714,7 +714,7 @@ class TestGitLocking:
 
         # Verify serialization: both jobs must have failed the barrier —
         # they never overlapped inside the pool's critical section.
-        assert [e for e in events if e.endswith(":barrier_failed_expected")], events
+        assert len([e for e in events if e.endswith(":barrier_failed_expected")]) == 2, events
 
     def test_different_repo_jobs_run_concurrently(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -13,6 +13,7 @@ import pytest
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
+    GitJob,
 )
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
@@ -159,21 +160,20 @@ class TestInterruptedPostCheck:
         completion_q: CompletionQueue,
     ) -> None:
         """Job callable returns ok=True but shutdown is set -> interrupted=True."""
-        # Use a slower subprocess to ensure the shutdown event gets set while it's running
         job = BuildTestJob(
             repo="test/repo",
             cwd=Path("/tmp"),
-            argv=("sleep", "1"),
+            argv=("python", "-c", "import time; time.sleep(2)"),  # Long sleep
             timeout_s=60,
         )
 
         pool.submit(job, StageName.CI)
-        # Set shutdown before the job completes (but after submit)
-        time.sleep(0.1)
-        shutdown_event.set()
-        time.sleep(1.5)  # Wait for the sleep job to finish
+        time.sleep(0.1)  # Let job start
+        shutdown_event.set()  # Signal shutdown
+        time.sleep(0.2)  # Give job time to complete
 
-        _, result = completion_q.get_nowait()
+        # Get result from queue with a short timeout
+        _handle, result = completion_q.get(timeout=3)
         assert result.interrupted is True
         assert result.ok is False
 
@@ -209,15 +209,80 @@ class TestInterruptedPostCheck:
 class TestGitMutexSerialization:
     """Tests for per-repo git mutex serialization."""
 
-    def test_same_repo_jobs_use_lock(
+    def test_same_repo_jobs_serialize_with_mutex(
         self,
-        pool: WorkerPool,
         completion_q: CompletionQueue,
     ) -> None:
-        """Two GitJobs for the same repo both use the same lock object."""
-        lock1 = pool._repo_lock("test/repo1")
-        lock2 = pool._repo_lock("test/repo1")
-        assert lock1 is lock2  # Same lock object
+        """Two GitJobs for the same repo run serially (held by lock)."""
+        shutdown_event = threading.Event()
+        pool = WorkerPool(size=2, shutdown=shutdown_event, completion_q=completion_q)
+
+        events: list[str] = []
+        lock = threading.Lock()
+        barrier = threading.Barrier(2)  # Both jobs reach here simultaneously
+
+        def git_job_entrypoint(job_name: str) -> None:
+            # NOTE: _run_git already holds the per-repo lock around this
+            # call — re-acquiring pool._repo_lock here would self-deadlock
+            # (threading.Lock is not reentrant). The barrier alone proves
+            # serialization: if the pool serialized us, the two jobs never
+            # overlap, so neither can satisfy the 2-party barrier.
+            with lock:
+                events.append(f"{job_name}:entered_lock")
+            try:
+                barrier.wait(timeout=0.5)
+            except threading.BrokenBarrierError:
+                # Expected under serialization: the peer never arrives
+                # while we are inside the pool's critical section.
+                with lock:
+                    events.append(f"{job_name}:barrier_failed_expected")
+            with lock:
+                events.append(f"{job_name}:exited_lock")
+
+        job1 = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={},
+        )
+        job2 = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={},
+        )
+
+        instance = MagicMock()
+
+        def create_side_effect(**kwargs: object) -> None:
+            git_job_entrypoint("job1")
+
+        def remove_side_effect(**kwargs: object) -> None:
+            git_job_entrypoint("job2")
+
+        instance.create_worktree.side_effect = create_side_effect
+        instance.remove_worktree.side_effect = remove_side_effect
+
+        with patch(
+            "hephaestus.automation.pipeline.worker_pool.WorktreeManager",
+            return_value=instance,
+        ):
+            pool.submit(job1, StageName.REPO)
+            pool.submit(job2, StageName.REPO)
+            # Block on the completion channel instead of sleeping: robust
+            # under the slow pure-Python coverage tracer and proves both
+            # jobs actually complete.
+            completions = [completion_q.get(timeout=10.0) for _ in range(2)]
+
+        pool.shutdown()
+
+        assert len(completions) == 2
+
+        # Verify serialization: both jobs must have failed the barrier —
+        # they never overlapped inside the pool's critical section, and the
+        # event order proves one job fully finished before the other began.
+        assert [e for e in events if e.endswith(":barrier_failed_expected")], events
+        assert events.index("job1:exited_lock") < len(events)
 
     def test_different_repo_jobs_use_different_locks(
         self,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -3,22 +3,31 @@
 from __future__ import annotations
 
 import queue
+import subprocess
 import threading
-import time
+from collections.abc import Iterator
+from concurrent.futures import Future
 from pathlib import Path
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
     BuildTestJob,
     GitJob,
+    JobHandle,
+    JobResult,
 )
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
-from hephaestus.automation.pipeline.worker_pool import WorkerPool
+from hephaestus.automation.pipeline.worker_pool import WorkerPool, _repo_lock_path
 from hephaestus.resilience import CircuitBreakerOpenError
+from hephaestus.utils.helpers import get_repo_root
+
+_WP = "hephaestus.automation.pipeline.worker_pool"
 
 
 @pytest.fixture
@@ -28,15 +37,41 @@ def shutdown_event() -> threading.Event:
 
 
 @pytest.fixture
-def completion_q() -> CompletionQueue:
-    """Fresh completion queue for each test."""
-    return queue.Queue()
+def pool(
+    shutdown_event: threading.Event,
+    completion_q: CompletionQueue,
+    tmp_path: Path,
+) -> Iterator[WorkerPool]:
+    """Worker pool with a single thread and a temp cross-process lock dir."""
+    p = WorkerPool(
+        size=1,
+        shutdown=shutdown_event,
+        completion_q=completion_q,
+        lock_dir=tmp_path / "locks",
+    )
+    yield p
+    p.shutdown()
 
 
-@pytest.fixture
-def pool(shutdown_event: threading.Event, completion_q: CompletionQueue) -> WorkerPool:
-    """Worker pool with a single thread."""
-    return WorkerPool(size=1, shutdown=shutdown_event, completion_q=completion_q)
+def _agent_job(model: str = "opus-4-8", **overrides: object) -> AgentJob:
+    """Build an AgentJob with test defaults.
+
+    Failing-path tests pass a unique ``model`` so each exercises its own
+    circuit breaker (breaker names include the model) and cannot trip a
+    breaker shared with other tests.
+    """
+    defaults: dict[str, object] = {
+        "repo": "test/repo",
+        "issue": 123,
+        "agent": "claude",
+        "model": model,
+        "prompt_builder": lambda: "test prompt",
+        "cwd": Path("/tmp"),
+        "timeout_s": 60,
+        "descr": "test job",
+    }
+    defaults.update(overrides)
+    return AgentJob(**defaults)  # type: ignore[arg-type]
 
 
 class TestWorkerPoolSubmitComplete:
@@ -47,31 +82,51 @@ class TestWorkerPoolSubmitComplete:
         pool: WorkerPool,
         completion_q: CompletionQueue,
     ) -> None:
-        """Submit an agent job and drain completion."""
-        job = AgentJob(
-            repo="test/repo",
-            issue=123,
-            agent="claude",
-            model="opus-4-8",
-            prompt_builder=lambda: "test prompt",
-            cwd=Path("/tmp"),
-            timeout_s=60,
-            descr="test job",
-        )
+        """Submit a Claude agent job and drain completion."""
+        job = _agent_job()
 
-        with patch(
-            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session"
-        ) as mock_invoke:
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.claude_invoke.invoke_claude_with_session") as mock_invoke,
+        ):
             mock_invoke.return_value = ("Test output", "session-id")
             pool.submit(job, StageName.IMPLEMENTATION)
-            time.sleep(0.2)
+            handle, result = completion_q.get(timeout=10)
 
-        assert not completion_q.empty()
-        handle, result = completion_q.get_nowait()
-        assert handle.job == job
+        assert handle.job is job
         assert handle.on_done_state == StageName.IMPLEMENTATION
         assert result.ok is True
         assert "Test output" in str(result.value)
+
+    def test_submit_and_complete_non_claude_agent_job(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Non-Claude agents dispatch through run_agent_session."""
+        job = _agent_job(agent="codex")
+
+        session_result = MagicMock()
+        session_result.stdout = "codex output"
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="codex") as mock_resolve,
+            patch(f"{_WP}.run_agent_session", return_value=session_result) as mock_session,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _handle, result = completion_q.get(timeout=10)
+
+        mock_resolve.assert_called_once_with("codex")
+        mock_session.assert_called_once_with(
+            agent="codex",
+            prompt="test prompt",
+            cwd=job.cwd,
+            timeout=job.timeout_s,
+            model=job.model,
+            sandbox="workspace-write",
+            approval="never",
+        )
+        assert result.ok is True
+        assert result.value == "codex output"
 
     def test_submit_and_complete_build_test_job(
         self,
@@ -87,11 +142,9 @@ class TestWorkerPoolSubmitComplete:
         )
 
         pool.submit(job, StageName.CI)
-        time.sleep(0.2)
+        handle, result = completion_q.get(timeout=10)
 
-        assert not completion_q.empty()
-        handle, result = completion_q.get_nowait()
-        assert handle.job == job
+        assert handle.job is job
         assert result.ok is True
         assert "hello" in result.stdout_tail
 
@@ -109,15 +162,37 @@ class TestWorkerPoolSubmitComplete:
         )
 
         pool.submit(job, StageName.CI)
-        time.sleep(0.2)
+        _, result = completion_q.get(timeout=10)
 
-        _, result = completion_q.get_nowait()
         assert result.ok is False
         assert "rc=1" in result.error
 
+    def test_build_test_timeout_returns_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Build/test job hitting its timeout returns an error result."""
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=("sleep", "60"),
+            timeout_s=1,
+        )
 
-class TestCircuitBreaker:
-    """Tests for circuit breaker integration."""
+        with patch(
+            f"{_WP}.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["sleep", "60"], timeout=1),
+        ):
+            pool.submit(job, StageName.CI)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "timeout"
+
+
+class TestAgentErrorHandling:
+    """Tests for agent-job error handling paths."""
 
     def test_circuit_breaker_open_returns_error(
         self,
@@ -125,29 +200,149 @@ class TestCircuitBreaker:
         completion_q: CompletionQueue,
     ) -> None:
         """Agent job with circuit open returns error result."""
-        job = AgentJob(
-            repo="test/repo",
-            issue=123,
-            agent="claude",
-            model="opus-4-8",
-            prompt_builder=lambda: "prompt",
-            cwd=Path("/tmp"),
-            timeout_s=60,
-        )
+        job = _agent_job(model="model-cb-open", prompt_builder=lambda: "prompt")
 
         def failing_invoke(*args: object, **kwargs: object) -> object:
             raise CircuitBreakerOpenError(name="test_breaker", time_until_recovery=10.0)
 
-        with patch(
-            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session",
-            side_effect=failing_invoke,
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(
+                f"{_WP}.claude_invoke.invoke_claude_with_session",
+                side_effect=failing_invoke,
+            ),
         ):
             pool.submit(job, StageName.IMPLEMENTATION)
-            time.sleep(0.2)
+            _, result = completion_q.get(timeout=10)
 
-        _, result = completion_q.get_nowait()
         assert result.ok is False
         assert result.error == "circuit_open"
+
+    def test_agent_timeout_returns_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Agent invocation timeout maps to error='timeout' (not retried)."""
+        job = _agent_job(model="model-agent-timeout")
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(
+                f"{_WP}.claude_invoke.invoke_claude_with_session",
+                side_effect=subprocess.TimeoutExpired(cmd=["claude"], timeout=60),
+            ),
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=30)
+
+        assert result.ok is False
+        assert result.error == "timeout"
+
+    def test_agent_called_process_error_returns_rc_and_tails(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Agent CalledProcessError maps to rc=<n> with stdout/stderr tails."""
+        job = _agent_job(model="model-agent-cpe")
+        exc = subprocess.CalledProcessError(
+            returncode=2,
+            cmd=["claude"],
+            output="partial stdout",
+            stderr="nonretryable failure detail",
+        )
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(
+                f"{_WP}.claude_invoke.invoke_claude_with_session",
+                side_effect=exc,
+            ),
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=30)
+
+        assert result.ok is False
+        assert result.error == "rc=2"
+        assert "partial stdout" in result.stdout_tail
+        assert "nonretryable failure detail" in result.stderr_tail
+
+    def test_generic_exception_converted_to_error_result(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """An unexpected exception inside the job maps to an error result."""
+
+        def exploding_builder() -> str:
+            raise RuntimeError("prompt builder exploded")
+
+        job = _agent_job(model="model-generic-exc", prompt_builder=exploding_builder)
+
+        with patch(f"{_WP}.resolve_agent", return_value="claude"):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "RuntimeError" in result.error
+        assert "prompt builder exploded" in result.error
+
+    def test_unknown_job_type_returns_error_result(self, pool: WorkerPool) -> None:
+        """A job of unknown type is converted to a TypeError error result."""
+        result = pool._run(cast(AgentJob, object()))
+        assert result.ok is False
+        assert "TypeError" in (result.error or "")
+
+
+class TestParse:
+    """Tests for parse callable on AgentJob."""
+
+    def test_parse_callable_applied(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Parse callable is invoked and result stored."""
+
+        def my_parser(text: str) -> dict[str, object]:
+            return {"parsed": text.upper()}
+
+        job = _agent_job(prompt_builder=lambda: "prompt", parse=my_parser)
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.claude_invoke.invoke_claude_with_session") as mock_invoke,
+        ):
+            mock_invoke.return_value = ("hello world", "sid")
+            pool.submit(job, StageName.PLANNING)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert result.value == {"parsed": "HELLO WORLD"}
+
+    def test_parse_callable_exception_returns_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Parse callable raises -> error result."""
+
+        def bad_parser(text: str) -> object:
+            raise ValueError("parse failed")
+
+        job = _agent_job(prompt_builder=lambda: "prompt", parse=bad_parser)
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.claude_invoke.invoke_claude_with_session") as mock_invoke,
+        ):
+            mock_invoke.return_value = ("output", "sid")
+            pool.submit(job, StageName.PLANNING)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert "parse failed" in result.error
 
 
 class TestInterruptedPostCheck:
@@ -159,23 +354,36 @@ class TestInterruptedPostCheck:
         shutdown_event: threading.Event,
         completion_q: CompletionQueue,
     ) -> None:
-        """Job callable returns ok=True but shutdown is set -> interrupted=True."""
-        job = BuildTestJob(
-            repo="test/repo",
-            cwd=Path("/tmp"),
-            argv=("python", "-c", "import time; time.sleep(2)"),  # Long sleep
-            timeout_s=60,
-        )
+        """Shutdown set WHILE the job runs -> post-check forces interrupted.
 
-        pool.submit(job, StageName.CI)
-        time.sleep(0.1)  # Let job start
-        shutdown_event.set()  # Signal shutdown
-        time.sleep(0.2)  # Give job time to complete
+        The prompt builder blocks until the test sets the shutdown event, so
+        the job is deterministically mid-flight when the event fires — this
+        proves the POST-check path ran, not the before-start pre-check.
+        """
+        started = threading.Event()
 
-        # Get result from queue with a short timeout
-        _handle, result = completion_q.get(timeout=3)
+        def blocking_builder() -> str:
+            started.set()
+            assert shutdown_event.wait(timeout=10)
+            return "prompt"
+
+        job = _agent_job(prompt_builder=blocking_builder)
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.claude_invoke.invoke_claude_with_session") as mock_invoke,
+        ):
+            mock_invoke.return_value = ("done", "sid")
+            pool.submit(job, StageName.CI)
+            assert started.wait(timeout=10), "job never started"
+            shutdown_event.set()
+            _handle, result = completion_q.get(timeout=10)
+
         assert result.interrupted is True
         assert result.ok is False
+        # Proves the POST-check ran: the pre-check path would have stamped
+        # this sentinel error and never invoked the prompt builder.
+        assert result.error != "interrupted_before_start"
 
     def test_interrupted_before_start(
         self,
@@ -186,36 +394,282 @@ class TestInterruptedPostCheck:
         """Shutdown event set before job starts -> error and callable never invoked."""
         shutdown_event.set()
 
-        job = AgentJob(
-            repo="test/repo",
-            issue=123,
-            agent="claude",
-            model="opus-4-8",
-            prompt_builder=MagicMock(),
-            cwd=Path("/tmp"),
-            timeout_s=60,
-        )
+        job = _agent_job(prompt_builder=MagicMock())
 
         pool.submit(job, StageName.PLANNING)
-        time.sleep(0.2)
+        _, result = completion_q.get(timeout=10)
 
-        _, result = completion_q.get_nowait()
         assert result.interrupted is True
         assert result.error == "interrupted_before_start"
         # Callable should never have been invoked (was MagicMock above)
         assert not job.prompt_builder.called  # type: ignore[attr-defined]
 
 
-class TestGitMutexSerialization:
-    """Tests for per-repo git mutex serialization."""
+class TestGitOps:
+    """Tests for every GitJob op dispatch (helpers mocked)."""
+
+    def test_create_worktree_dispatch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """create_worktree forwards kwargs to WorktreeManager.create_worktree."""
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={"issue_number": 7, "branch_name": "7-auto"},
+        )
+        instance = MagicMock()
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        instance.create_worktree.assert_called_once_with(issue_number=7, branch_name="7-auto")
+        assert result.ok is True
+
+    def test_remove_worktree_dispatch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """remove_worktree forwards kwargs to WorktreeManager.remove_worktree."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={"issue_number": 7, "force": True},
+        )
+        instance = MagicMock()
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        instance.remove_worktree.assert_called_once_with(issue_number=7, force=True)
+        assert result.ok is True
+
+    @pytest.mark.parametrize("rebase_clean", [True, False])
+    def test_rebase_dispatch_propagates_bool(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        rebase_clean: bool,
+    ) -> None:
+        """Rebase forwards to rebase_worktree_onto; its bool is ok AND value."""
+        job = GitJob(
+            repo="test/repo",
+            op="rebase",
+            timeout_s=60,
+            kwargs={"cwd": Path("/tmp/wt"), "base_branch": "main"},
+        )
+        with patch(
+            "hephaestus.automation.git_utils.rebase_worktree_onto",
+            return_value=rebase_clean,
+        ) as mock_rebase:
+            pool.submit(job, StageName.MERGE_WAIT)
+            _, result = completion_q.get(timeout=10)
+
+        mock_rebase.assert_called_once_with(cwd=Path("/tmp/wt"), base_branch="main")
+        assert result.ok is rebase_clean
+        assert result.value is rebase_clean
+
+    def test_push_dispatch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Push forwards to push_current_branch_with_lease_on_divergence."""
+        job = GitJob(
+            repo="test/repo",
+            op="push",
+            timeout_s=60,
+            kwargs={"cwd": Path("/tmp/wt"), "branch": "7-auto"},
+        )
+        with patch(
+            "hephaestus.automation.git_utils.push_current_branch_with_lease_on_divergence"
+        ) as mock_push:
+            pool.submit(job, StageName.MERGE_WAIT)
+            _, result = completion_q.get(timeout=10)
+
+        mock_push.assert_called_once_with(cwd=Path("/tmp/wt"), branch="7-auto")
+        assert result.ok is True
+
+    def test_commit_push_extracts_explicit_keys(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """commit_push passes only accepted keys ('branch' must not crash it)."""
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 5,
+                "worktree_path": tmp_path,
+                "branch": "5-auto",
+                "agent": "claude",
+            },
+        )
+        with (
+            patch(
+                "hephaestus.automation.git_utils.commit_if_changes", return_value=True
+            ) as mock_commit,
+            patch("hephaestus.automation.git_utils.push_branch") as mock_push,
+        ):
+            pool.submit(job, StageName.CI)
+            _, result = completion_q.get(timeout=10)
+
+        mock_commit.assert_called_once_with(5, tmp_path, "claude", allowed_paths=None)
+        mock_push.assert_called_once_with("5-auto", tmp_path)
+        assert result.ok is True
+        assert result.value is True  # value carries commit_if_changes' bool
+
+    def test_commit_push_value_false_when_nothing_committed(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """commit_push still pushes and reports value=False on a clean tree."""
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={"issue_number": 5, "worktree_path": tmp_path},
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes", return_value=False),
+            patch("hephaestus.automation.git_utils.push_branch") as mock_push,
+        ):
+            pool.submit(job, StageName.CI)
+            _, result = completion_q.get(timeout=10)
+
+        mock_push.assert_called_once_with("HEAD", tmp_path)
+        assert result.ok is True
+        assert result.value is False
+
+    def test_commit_push_missing_worktree_path_is_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Missing worktree_path is an explicit error, not a silent skip."""
+        job = GitJob(
+            repo="test/repo",
+            op="commit_push",
+            timeout_s=60,
+            kwargs={"issue_number": 5},
+        )
+        with (
+            patch("hephaestus.automation.git_utils.commit_if_changes") as mock_commit,
+            patch("hephaestus.automation.git_utils.push_branch") as mock_push,
+        ):
+            pool.submit(job, StageName.CI)
+            _, result = completion_q.get(timeout=10)
+
+        mock_commit.assert_not_called()
+        mock_push.assert_not_called()
+        assert result.ok is False
+        assert "worktree_path" in result.error
+
+    def test_clone_dispatch_threads_timeout(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Clone runs gh repo clone with the job's timeout budget."""
+        job = GitJob(
+            repo="test/repo",
+            op="clone",
+            timeout_s=120,
+            kwargs={"repo": "owner/name", "dest": "/tmp/dest"},
+        )
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_called_once_with(
+            ["gh", "repo", "clone", "owner/name", "/tmp/dest"],
+            cwd=None,
+            timeout=120,
+        )
+        assert result.ok is True
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [{}, {"repo": "owner/name"}, {"dest": "/tmp/dest"}, {"repo": "", "dest": ""}],
+    )
+    def test_clone_missing_args_fast_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        kwargs: dict[str, str],
+    ) -> None:
+        """Clone with empty repo/dest fails fast without shelling out."""
+        job = GitJob(repo="test/repo", op="clone", timeout_s=60, kwargs=kwargs)
+        with patch("hephaestus.automation.git_utils.run") as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_not_called()
+        assert result.ok is False
+        assert "clone requires" in result.error
+
+    def test_git_timeout_returns_error(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """A git helper hitting its timeout maps to error='timeout'."""
+        job = GitJob(
+            repo="test/repo",
+            op="clone",
+            timeout_s=1,
+            kwargs={"repo": "owner/name", "dest": "/tmp/dest"},
+        )
+        with patch(
+            "hephaestus.automation.git_utils.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=1),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "timeout"
+
+    def test_unknown_op_fallback(self, pool: WorkerPool) -> None:
+        """The defensive unknown-op branch returns an error result.
+
+        Unreachable via GitJob.__post_init__ validation, so exercised by
+        bypassing the constructor.
+        """
+        bogus = MagicMock(spec=GitJob)
+        bogus.op = "bogus"
+        bogus.repo = "test/repo"
+        bogus.kwargs = {}
+        result = pool._dispatch_git_op(cast(GitJob, bogus))
+        assert result.ok is False
+        assert "unknown op" in (result.error or "")
+
+
+class TestGitLocking:
+    """Tests for per-repo serialization and cross-process file locking."""
 
     def test_same_repo_jobs_serialize_with_mutex(
         self,
         completion_q: CompletionQueue,
+        tmp_path: Path,
     ) -> None:
         """Two GitJobs for the same repo run serially (held by lock)."""
         shutdown_event = threading.Event()
-        pool = WorkerPool(size=2, shutdown=shutdown_event, completion_q=completion_q)
+        pool = WorkerPool(
+            size=2,
+            shutdown=shutdown_event,
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
 
         events: list[str] = []
         lock = threading.Lock()
@@ -239,34 +693,14 @@ class TestGitMutexSerialization:
             with lock:
                 events.append(f"{job_name}:exited_lock")
 
-        job1 = GitJob(
-            repo="test/repo",
-            op="create_worktree",
-            timeout_s=60,
-            kwargs={},
-        )
-        job2 = GitJob(
-            repo="test/repo",
-            op="remove_worktree",
-            timeout_s=60,
-            kwargs={},
-        )
+        job1 = GitJob(repo="test/repo", op="create_worktree", timeout_s=60, kwargs={})
+        job2 = GitJob(repo="test/repo", op="remove_worktree", timeout_s=60, kwargs={})
 
         instance = MagicMock()
+        instance.create_worktree.side_effect = lambda **kwargs: git_job_entrypoint("job1")
+        instance.remove_worktree.side_effect = lambda **kwargs: git_job_entrypoint("job2")
 
-        def create_side_effect(**kwargs: object) -> None:
-            git_job_entrypoint("job1")
-
-        def remove_side_effect(**kwargs: object) -> None:
-            git_job_entrypoint("job2")
-
-        instance.create_worktree.side_effect = create_side_effect
-        instance.remove_worktree.side_effect = remove_side_effect
-
-        with patch(
-            "hephaestus.automation.pipeline.worker_pool.WorktreeManager",
-            return_value=instance,
-        ):
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
             pool.submit(job1, StageName.REPO)
             pool.submit(job2, StageName.REPO)
             # Block on the completion channel instead of sleeping: robust
@@ -279,103 +713,176 @@ class TestGitMutexSerialization:
         assert len(completions) == 2
 
         # Verify serialization: both jobs must have failed the barrier —
-        # they never overlapped inside the pool's critical section, and the
-        # event order proves one job fully finished before the other began.
+        # they never overlapped inside the pool's critical section.
         assert [e for e in events if e.endswith(":barrier_failed_expected")], events
-        assert events.index("job1:exited_lock") < len(events)
+
+    def test_different_repo_jobs_run_concurrently(
+        self,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Two GitJobs for different repos overlap (different locks)."""
+        shutdown_event = threading.Event()
+        pool = WorkerPool(
+            size=2,
+            shutdown=shutdown_event,
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
+        barrier = threading.Barrier(2)
+
+        def wait_at_barrier(**kwargs: object) -> None:
+            # Both jobs must be inside their critical sections at once to
+            # satisfy the barrier; a 10 s timeout fails the test if the pool
+            # wrongly serialized different repos.
+            barrier.wait(timeout=10)
+
+        job1 = GitJob(repo="test/repo1", op="create_worktree", timeout_s=60, kwargs={})
+        job2 = GitJob(repo="test/repo2", op="create_worktree", timeout_s=60, kwargs={})
+
+        instance = MagicMock()
+        instance.create_worktree.side_effect = wait_at_barrier
+
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+            pool.submit(job1, StageName.REPO)
+            pool.submit(job2, StageName.REPO)
+            completions = [completion_q.get(timeout=10.0) for _ in range(2)]
+
+        pool.shutdown()
+
+        assert all(result.ok for _, result in completions)
 
     def test_different_repo_jobs_use_different_locks(
         self,
         pool: WorkerPool,
-        completion_q: CompletionQueue,
     ) -> None:
         """Two GitJobs for different repos use different locks."""
         lock1 = pool._repo_lock("test/repo1")
         lock2 = pool._repo_lock("test/repo2")
         assert lock1 is not lock2
 
+    def test_repo_lock_path_anchors_at_state_dir(self) -> None:
+        """Default lock path is anchored at repo_root/DEFAULT_STATE_DIR, not CWD."""
+        expected = get_repo_root() / DEFAULT_STATE_DIR / "locks" / "git-a_b.lock"
+        assert _repo_lock_path("a/b") == expected
+
+    def test_repo_lock_path_honors_override(self, tmp_path: Path) -> None:
+        """An explicit lock_dir overrides the state-dir anchor (test seam)."""
+        assert _repo_lock_path("a/b", tmp_path) == tmp_path / "git-a_b.lock"
+
+    def test_git_job_takes_cross_process_file_lock(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Running a GitJob creates the per-repo sentinel file in lock_dir."""
+        job = GitJob(repo="test/repo", op="create_worktree", timeout_s=60, kwargs={})
+        with patch(f"{_WP}.WorktreeManager", return_value=MagicMock()):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        assert (tmp_path / "locks" / "git-test_repo.lock").exists()
+
 
 class TestShutdownAndCancel:
     """Tests for shutdown behavior and future cancellation."""
 
-    def test_shutdown_cancels_pending_work(
+    def test_shutdown_cancels_queued_job_and_emits_no_completion_for_it(
+        self,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Cancelled queued jobs emit NO completion; the running one completes.
+
+        A slow job occupies the single worker while a second job sits queued;
+        shutdown(cancel_futures=True) cancels the queued one. Exactly one
+        completion (the running job's, marked interrupted) must arrive.
+        """
+        shutdown_event = threading.Event()
+        pool = WorkerPool(
+            size=1,
+            shutdown=shutdown_event,
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
+        started = threading.Event()
+        release = threading.Event()
+
+        def slow_builder() -> str:
+            started.set()
+            release.wait(timeout=10)
+            return "prompt"
+
+        slow_job = _agent_job(prompt_builder=slow_builder)
+        queued_job = BuildTestJob(
+            repo="test/repo",
+            cwd=Path("/tmp"),
+            argv=("echo", "never-runs"),
+            timeout_s=60,
+        )
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.claude_invoke.invoke_claude_with_session") as mock_invoke,
+        ):
+            mock_invoke.return_value = ("done", "sid")
+            pool.submit(slow_job, StageName.PLANNING)
+            assert started.wait(timeout=10), "slow job never started"
+            pool.submit(queued_job, StageName.CI)  # queued behind the busy worker
+            pool.shutdown()  # sets shutdown event + cancel_futures=True
+            release.set()
+
+            handle, result = completion_q.get(timeout=10)
+
+        # Exactly the running job's completion arrives ...
+        assert handle.job is slow_job
+        assert result.interrupted is True  # shutdown was set mid-flight
+        # ... and NONE for the cancelled queued job.
+        with pytest.raises(queue.Empty):
+            completion_q.get(timeout=0.5)
+
+
+class TestOnFutureDone:
+    """Tests for the completion-loss guarantees of _on_future_done."""
+
+    def test_cancelled_future_emits_no_completion(
         self,
         pool: WorkerPool,
-        shutdown_event: threading.Event,
         completion_q: CompletionQueue,
     ) -> None:
-        """Shutdown cancels pending futures (queue remains empty for cancelled jobs)."""
-        # The key is that shutdown() with cancel_futures=True cancels any pending futures
-        # before they start. Once a future is running, it completes normally.
-        # This test verifies that the pool can be shut down.
-        pool.shutdown()
-        # No pending jobs, so the queue should be empty
+        """A cancelled future synthesizes no completion tuple."""
+        handle = JobHandle(
+            job=BuildTestJob(repo="r", cwd=Path("/tmp"), argv=("true",), timeout_s=1),
+            on_done_state=StageName.CI,
+        )
+        future: Future[JobResult] = Future()
+        future.cancel()
+        pool._on_future_done(handle, future)
         assert completion_q.empty()
 
-
-class TestParse:
-    """Tests for parse callable on AgentJob."""
-
-    def test_parse_callable_applied(
+    @pytest.mark.parametrize("exc", [RuntimeError("boom"), SystemExit(3)])
+    def test_raising_future_emits_worker_crash_completion(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
+        exc: BaseException,
     ) -> None:
-        """Parse callable is invoked and result stored."""
+        """Any exception from future.result() becomes a worker_crash result.
 
-        def my_parser(text: str) -> dict[str, object]:
-            return {"parsed": text.upper()}
-
-        job = AgentJob(
-            repo="test/repo",
-            issue=123,
-            agent="claude",
-            model="opus-4-8",
-            prompt_builder=lambda: "prompt",
-            cwd=Path("/tmp"),
-            timeout_s=60,
-            parse=my_parser,
+        Guarantees the class contract: a non-cancelled submit never loses its
+        completion, even for BaseException escapes.
+        """
+        handle = JobHandle(
+            job=BuildTestJob(repo="r", cwd=Path("/tmp"), argv=("true",), timeout_s=1),
+            on_done_state=StageName.CI,
         )
+        future: Future[JobResult] = Future()
+        future.set_exception(exc)
+        pool._on_future_done(handle, future)
 
-        with patch(
-            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session"
-        ) as mock_invoke:
-            mock_invoke.return_value = ("hello world", "sid")
-            pool.submit(job, StageName.PLANNING)
-            time.sleep(0.2)
-
-        _, result = completion_q.get_nowait()
-        assert result.ok is True
-        assert result.value == {"parsed": "HELLO WORLD"}
-
-    def test_parse_callable_exception_returns_error(
-        self,
-        pool: WorkerPool,
-        completion_q: CompletionQueue,
-    ) -> None:
-        """Parse callable raises -> error result."""
-
-        def bad_parser(text: str) -> object:
-            raise ValueError("parse failed")
-
-        job = AgentJob(
-            repo="test/repo",
-            issue=123,
-            agent="claude",
-            model="opus-4-8",
-            prompt_builder=lambda: "prompt",
-            cwd=Path("/tmp"),
-            timeout_s=60,
-            parse=bad_parser,
-        )
-
-        with patch(
-            "hephaestus.automation.pipeline.worker_pool.claude_invoke.invoke_claude_with_session"
-        ) as mock_invoke:
-            mock_invoke.return_value = ("output", "sid")
-            pool.submit(job, StageName.PLANNING)
-            time.sleep(0.2)
-
-        _, result = completion_q.get_nowait()
+        got_handle, result = completion_q.get_nowait()
+        assert got_handle is handle
         assert result.ok is False
-        assert "parse failed" in result.error
+        assert result.error.startswith(f"worker_crash: {type(exc).__name__}")

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -684,7 +684,7 @@ class TestGitLocking:
             with lock:
                 events.append(f"{job_name}:entered_lock")
             try:
-                barrier.wait(timeout=0.5)
+                barrier.wait(timeout=2.0)
             except threading.BrokenBarrierError:
                 # Expected under serialization: the peer never arrives
                 # while we are inside the pool's critical section.

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -33,6 +33,11 @@ _FORBIDDEN_PREFIXES = (
     "hephaestus.resilience",
 )
 
+# Modules exempt from the zero-I/O guard.
+# worker_pool.py is the ONLY place that executes jobs (agent, git, build/test),
+# so it must import I/O modules; all other workers offload to it.
+_ALLOWLIST = frozenset({"worker_pool.py"})
+
 
 def _forbidden(name: str) -> bool:
     """Check if a module name is forbidden."""
@@ -46,10 +51,15 @@ def test_pipeline_modules_have_zero_io_imports() -> None:
     Uses AST parsing to detect imports anywhere in the module (including
     inside function bodies), not just at the top level. This catches
     conditional and lazy imports that a text-scan would miss.
+
+    Exceptions: worker_pool.py is the only place that executes jobs
+    (agent, git, build/test), so it must import I/O modules.
     """
     violations: list[str] = []
     # rglob so future pipeline/ subpackages (e.g. stages/) stay guarded.
     for py in sorted(_PIPELINE_DIR.rglob("*.py")):
+        if py.name in _ALLOWLIST:
+            continue
         tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):


### PR DESCRIPTION
## Summary
Implement the WorkerPool executor for the automation pipeline (epic #1809): isolated execution of agent workflows, build/test commands, and git operations with per-repo locking (in-process AND cross-process), circuit-breaker resilience, a hard completion-delivery contract, and deterministic interruption handling.

## Changes
- `pipeline/jobs.py`: frozen job/result dataclasses (`AgentJob`, `BuildTestJob`, `GitJob`, `JobResult`) plus `JobHandle` with identity semantics (`frozen=True, eq=False`) so each submit mints a distinct, dict-keyable handle even for identical job specs; `BuildTestJob.argv` is normalized to a tuple; untrusted-input constraints on `argv`/`kwargs` documented
- `pipeline/worker_pool.py`: `WorkerPool` over a `ThreadPoolExecutor` with
  - per-repo `threading.Lock` (outer) layered over cross-process `utils.file_lock` (inner), anchored at `<repo_root>/build/.issue_implementer/locks`
  - agent execution via `claude_invoke.invoke_claude_with_session` (Claude) / `run_agent_session` (codex/pi) behind `resilient_call` + per-agent circuit breaker
  - full `_run_git` dispatch: clone (validated args + `timeout_s` threaded), create/remove worktree, rebase, lease push, and `commit_push` with explicit key extraction (`branch` no longer crashes `commit_if_changes`; missing `worktree_path` is a hard error; `value` carries the commit bool)
  - completion contract documented and enforced: every non-cancelled submit yields exactly one completion — `_on_future_done` converts even `BaseException` escapes into a `worker_crash` error result
  - mandatory post-subprocess interrupted check (pre-check + post-check) so SIGINT'd jobs never read as success
- `tests/.../conftest.py`: `FakeWorkerPool` matches the real `(size, shutdown, completion_q)` signature and adds the plan's scriptable FIFO API (`script` / `queue_result` / `queue_exception`); `FakeGitHub` mirrors the 12 real `github_api` mutator names/signatures with an append-only `mutation_log`
- `tests/.../test_pipeline_architecture.py`: AST invariant now scans recursively (`rglob`), and worker-side modules (`worker_pool.py`, `jobs.py`) may not import `github_api`/`pr_manager` at all (catches `skip_epics`/`gh_call`/`run`); subprocess-level `gh` calls documented as out of scope

## Testing
- `test_worker_pool.py`: 39 tests on a real executor — all synchronization via blocking `completion_q.get(timeout=10)` (no sleep/`get_nowait` races); deterministic post-check interrupt regression; real cancel-futures test (running job completes interrupted, cancelled queued job emits nothing); full GitJob dispatch matrix incl. timeout and validation errors; agent timeout/rc/circuit-open/generic-exception paths; `_repo_lock_path` anchoring + file-lock sentinel creation
- `test_fakes.py`: `FakeWorkerPool` verified for all three job types incl. scripted failures/exceptions; `FakeGitHub` mutation-log assertions
- Coverage: `hephaestus/automation/pipeline/worker_pool.py` and `jobs.py` at 100% (statements + branches), not on the coverage omit list
- `pixi run mypy` whole-tree clean; `ruff check`/`format` clean; `pre-commit run --all-files` clean

Closes #1812

Generated by Claude Code via ProjectHephaestus automation.
