### PR TITLE
feat(pipeline): GitHub-journal seeding and admission control

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -884,6 +884,56 @@ def find_merged_closing_pr(issue_number: int) -> int | None:
     return None
 
 
+def find_merged_pr_for_issue(issue_number: int) -> int | None:
+    """Find the MERGED PR for a single issue (tri-state fetch layer, epic #1809).
+
+    Mirrors :func:`find_pr_for_issue`'s strategies with ``--state merged``:
+
+    1. Branch name lookup (``{issue}-auto-impl``, merged PRs).
+    2. Exact ``Closes #N`` body search via :func:`find_merged_closing_pr`.
+
+    Used by pipeline seeding so the "PR merged → finished" classification row
+    is reachable: when the open-PR lookup misses, this lookup distinguishes
+    merged work (finished, idempotent) from closed/abandoned PRs (invisible —
+    normalized to "no PR") and from genuinely PR-less issues.
+
+    Args:
+        issue_number: GitHub issue number.
+
+    Returns:
+        The merged PR number if found, ``None`` otherwise.
+
+    """
+    branch_name = f"{issue_number}-auto-impl"
+    try:
+        result = _gh_call(
+            [
+                "pr",
+                "list",
+                "--head",
+                branch_name,
+                "--state",
+                "merged",
+                "--json",
+                "number",
+                "--limit",
+                "1",
+            ],
+            check=False,
+        )
+        pr_data = json.loads(result.stdout or "[]")
+        if pr_data:
+            pr_number = int(pr_data[0]["number"])
+            logger.info(
+                "Found merged PR #%d for issue #%d via branch name", pr_number, issue_number
+            )
+            return pr_number
+    except Exception as e:
+        logger.debug("Merged branch-name lookup failed for issue #%d: %s", issue_number, e)
+
+    return find_merged_closing_pr(issue_number)
+
+
 def close_issue_as_covered(issue_number: int, pr_number: int) -> bool:
     """Close an OPEN issue already covered by a merged closing PR (idempotent).
 

--- a/hephaestus/automation/github_api/__init__.py
+++ b/hephaestus/automation/github_api/__init__.py
@@ -87,6 +87,7 @@ from .prs import (  # noqa: E402
     fetch_open_prs as fetch_open_prs,
     gh_current_login as gh_current_login,
     gh_pr_create as gh_pr_create,
+    gh_pr_label_names as gh_pr_label_names,
 )
 from .reviews import (  # noqa: E402
     ReviewCommentIndexKey as ReviewCommentIndexKey,
@@ -156,6 +157,7 @@ __all__ = [
     "gh_pr_checks",
     "gh_pr_create",
     "gh_pr_inline_comment_index",
+    "gh_pr_label_names",
     "gh_pr_list_unresolved_threads",
     "gh_pr_resolve_thread",
     "gh_pr_review_post",

--- a/hephaestus/automation/github_api/prs.py
+++ b/hephaestus/automation/github_api/prs.py
@@ -282,7 +282,7 @@ def gh_pr_label_names(pr_number: int) -> list[str]:
     try:
         result = _api._gh_call(["pr", "view", str(pr_number), "--json", "labels"], check=False)
         pr = cast(dict[str, Any], json.loads(result.stdout or "{}"))
-    except (json.JSONDecodeError, OSError) as exc:
+    except (json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
         _api.logger.warning("Could not fetch PR #%s labels: %s", pr_number, exc)
         return []
     labels = pr.get("labels")

--- a/hephaestus/automation/github_api/prs.py
+++ b/hephaestus/automation/github_api/prs.py
@@ -261,6 +261,44 @@ def fetch_open_prs() -> list[dict[str, Any]]:
     return cast(list[dict[str, Any]], json.loads(result.stdout or "[]"))
 
 
+def gh_pr_label_names(pr_number: int) -> list[str]:
+    """Return the label names on a PR by number, best-effort (read-only).
+
+    Fetches ``gh pr view <n> --json labels`` and normalizes the ``labels``
+    array (each entry is a ``{"name": ...}`` dict) to a flat list of names.
+    Any subprocess or JSON failure yields an empty list so callers can treat a
+    fetch error as "no labels" without raising — mirroring
+    ``pr_manager._pr_label_names`` (the ``_review_existing_pr`` seam) so
+    pipeline seeding's ``--prs`` mapping shares its semantics without
+    importing the ``pr_manager`` product module.
+
+    Args:
+        pr_number: GitHub PR number.
+
+    Returns:
+        The PR's label names, or an empty list on any fetch failure.
+
+    """
+    try:
+        result = _api._gh_call(["pr", "view", str(pr_number), "--json", "labels"], check=False)
+        pr = cast(dict[str, Any], json.loads(result.stdout or "{}"))
+    except (json.JSONDecodeError, OSError) as exc:
+        _api.logger.warning("Could not fetch PR #%s labels: %s", pr_number, exc)
+        return []
+    labels = pr.get("labels")
+    if not isinstance(labels, list):
+        return []
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+        elif isinstance(label, dict):
+            name = label.get("name")
+            if isinstance(name, str):
+                names.append(name)
+    return names
+
+
 def gh_current_login() -> str | None:
     """Return the authenticated GitHub login for the current ``gh`` token."""
     try:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -38,7 +38,6 @@ import contextlib
 import json
 import logging
 import os
-import re
 import shlex
 import shutil
 import signal
@@ -55,10 +54,7 @@ from pathlib import Path
 from hephaestus.agents.runtime import resolve_agent
 from hephaestus.automation._review_utils import build_automation_parser, find_pr_for_issue
 from hephaestus.automation.github_api import (
-    _fetch_issue_comment_ids,
     gh_issue_add_labels,
-    is_issue_closed,
-    prefetch_issue_states,
 )
 from hephaestus.automation.loop_repo_manager import (
     _clone_missing_repos as _clone_missing_repos,
@@ -75,7 +71,6 @@ from hephaestus.automation.loop_repo_manager import (
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
 from hephaestus.automation.pr_manager import pr_is_genuinely_stuck
-from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from hephaestus.automation.state_labels import STATE_SKIP
 from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
@@ -1040,141 +1035,15 @@ def _process_repo_inner(
     return result
 
 
-def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
-    """Drop CLOSED issues from an explicit ``--issues`` list (#1576).
-
-    An operator-pinned ``cfg.issues`` list bypasses the ``--state open`` filter
-    that auto-discovery applies, so a closed issue would otherwise be driven
-    every loop and wrongly tagged ``state:skip`` by drive-green. States are
-    fetched once via :func:`prefetch_issue_states` and checked with
-    :func:`is_issue_closed`. On any lookup failure an issue is KEPT (fail-open:
-    never silently drop work over a transient API blip).
-
-    Args:
-        repo: Repository name (for logging).
-        issue_numbers: The explicit issue list.
-
-    Returns:
-        The subset that is not closed (order preserved).
-
-    """
-    try:
-        cached_states = prefetch_issue_states(issue_numbers)
-    except Exception as exc:  # transient API failure → keep all, don't drop work
-        LOG.warning("[%s] could not prefetch issue states for closed-filter: %s", repo, exc)
-        return issue_numbers
-    kept: list[int] = []
-    for num in issue_numbers:
-        if is_issue_closed(num, cached_states):
-            LOG.info("[%s] issue #%s is closed — excluding from phase loop", repo, num)
-            continue
-        kept.append(num)
-    return kept
-
-
-# ---------------------------------------------------------------------------
-# File-overlap serialization (#1623)
-# ---------------------------------------------------------------------------
-
-# Backticked repo-relative path inside a plan's Files sections, e.g.
-# `hephaestus/automation/address_review.py`. Requires a slash so bare tokens
-# like `pyproject.toml` or symbol refs like `os.replace` are not treated as
-# in-tree paths (over-match → needless deferral; the slash requirement keeps
-# the key tight to actual source paths).
-# NOTE: Bare top-level file paths without a directory prefix (e.g., `errors.py`)
-# are intentionally NOT captured — overlap goes undetected and both plans dispatch
-# concurrently, falling back to pre-#1623 behavior (acceptable tradeoff for regex tightness).
-_PLAN_FILE_RE = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)`")
-_PLAN_FILE_SECTION_RE = re.compile(r"^#{2,}\s+Files to (Modify|Create)\b", re.IGNORECASE)
-
-
-def _parse_planned_files(plan_body: str) -> set[str]:
-    """Return the repo-relative paths a plan intends to touch.
-
-    Scans the ``## Files to Modify`` and ``## Files to Create`` sections of an
-    ``# Implementation Plan`` comment (either or both may be present) and
-    collects every backticked in-tree path until the next top-level ``## ``
-    heading. Empty set when neither section exists.
-
-    Args:
-        plan_body: The full body of the plan comment.
-
-    Returns:
-        The set of backticked repo-relative paths found in the Files sections.
-
-    """
-    files: set[str] = set()
-    in_section = False
-    for line in plan_body.splitlines():
-        if _PLAN_FILE_SECTION_RE.match(line):
-            in_section = True
-            continue
-        # A new top-level ``## `` heading (not a ``### `` sub-header inside the
-        # section) ends the scan region.
-        if line.startswith("## "):
-            in_section = False
-        if in_section:
-            files.update(_PLAN_FILE_RE.findall(line))
-    return files
-
-
-def _fetch_planned_files(issue: int) -> set[str] | None:
-    """Return the file set an issue's plan claims, or None if unknown.
-
-    None (no plan comment / empty fetch) → caller fails OPEN and dispatches the
-    issue this round. :func:`_fetch_issue_comment_ids` already swallows all
-    errors and returns ``[]`` on failure, so NO try/except is needed here — the
-    "no plan" signal is simply an empty/no-match list.
-
-    Args:
-        issue: GitHub issue number.
-
-    Returns:
-        The parsed plan file set, or None when no plan comment is present.
-
-    """
-    for comment in _fetch_issue_comment_ids(issue):
-        body = str(comment.get("body", ""))
-        if body.startswith(PLAN_COMMENT_MARKER):
-            return _parse_planned_files(body)
-    return None
-
-
-def _select_non_overlapping(issues: list[int]) -> tuple[list[int], list[int]]:
-    """Partition *issues* into (dispatch_now, defer_next_round).
-
-    Greedy first-fit in the given order: an issue whose parsed plan file set
-    intersects the union of already-claimed files is deferred. Unknown file set
-    (no plan / parse failure) claims NO files and is always dispatched
-    (fail-open). The first issue always dispatches, so a whole batch can never
-    be deferred (liveness). Performs one serial GraphQL comment fetch per issue;
-    only invoked in multi-worker rounds (guarded at the call site), so the cost
-    is bounded by the issue count already being processed that round.
-
-    Args:
-        issues: The issue numbers to partition, in dispatch-priority order.
-
-    Returns:
-        A ``(dispatch, defer)`` tuple of issue-number lists (order preserved).
-
-    """
-    claimed: set[str] = set()
-    dispatch: list[int] = []
-    defer: list[int] = []
-    for issue in issues:
-        planned = _fetch_planned_files(issue)
-        if planned and (planned & claimed):
-            LOG.info(
-                "issue #%s deferred: plan files %s overlap in-flight peers",
-                issue,
-                sorted(planned & claimed),
-            )
-            defer.append(issue)
-            continue
-        if planned:
-            claimed |= planned
-        dispatch.append(issue)
-    return dispatch, defer
+# Backward-compatibility shims for admission control functions (moved to pipeline/admission.py).
+# See #1813, epic #1809.
+from hephaestus.automation.pipeline import admission as _admission  # noqa: E402
+from hephaestus.automation.pipeline.admission import (  # noqa: E402
+    _fetch_planned_files as _fetch_planned_files,
+    _filter_open_issues as _filter_open_issues,
+    _parse_planned_files as _parse_planned_files,
+    _select_non_overlapping as _select_non_overlapping,
+)
 
 
 def _issue_owns_genuinely_failing_pr(issue: int) -> bool:
@@ -1502,7 +1371,7 @@ def _open_peer_pr_claims(cfg: LoopConfig, repo: str, deferred: set[int]) -> dict
             continue
         if pr_number is None:
             continue
-        files = _fetch_planned_files(peer)
+        files = _admission._fetch_planned_files(peer)
         if files:
             claims[peer] = files
     return claims
@@ -1566,7 +1435,7 @@ def _run_terminal_deferred_issues(
                 )
                 return catchup_results, blocked
 
-            planned = _fetch_planned_files(issue)
+            planned = _admission._fetch_planned_files(issue)
             blocker = next(
                 (peer for peer, files in claims.items() if planned and planned & files),
                 None,

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -70,6 +70,18 @@ from hephaestus.automation.loop_repo_manager import (
     _resolve_repo_dir as _resolve_repo_dir,
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
+
+# Admission-control seams live in pipeline.admission (#1813, epic #1809);
+# internal call sites go through the `_admission` module attribute so tests
+# patch one canonical seam, and the `as name` imports re-export the moved
+# symbols for external callers (ruff's explicit re-export idiom).
+from hephaestus.automation.pipeline import admission as _admission
+from hephaestus.automation.pipeline.admission import (
+    _fetch_planned_files as _fetch_planned_files,
+    _filter_open_issues as _filter_open_issues,
+    _parse_planned_files as _parse_planned_files,
+    _select_non_overlapping as _select_non_overlapping,
+)
 from hephaestus.automation.pr_manager import pr_is_genuinely_stuck
 from hephaestus.automation.state_labels import STATE_SKIP
 from hephaestus.cli.utils import (
@@ -980,7 +992,7 @@ def _process_repo_inner(
     # otherwise be driven (and wrongly tagged ``state:skip``) every loop.
     open_issues = cfg.issues or _list_open_issue_numbers(cfg.org, repo)
     if cfg.issues:
-        open_issues = _filter_open_issues(repo, open_issues)
+        open_issues = _admission._filter_open_issues(repo, open_issues)
 
     # ISSUE-MAJOR control flow (#1560): iterate issues outermost and run the
     # FULL selected-phase sequence (plan → implement → drive-green) for each
@@ -1001,7 +1013,7 @@ def _process_repo_inner(
     # alive by RepoResult.produced_work), by which point the conflicting peer
     # has merged and the deferred branch rebases cleanly.
     if cfg.serialize_file_overlap and workers > 1 and len(open_issues) > 1:
-        open_issues, deferred = _select_non_overlapping(open_issues)
+        open_issues, deferred = _admission._select_non_overlapping(open_issues)
         if deferred:
             LOG.info(
                 "[%s] deferring %d file-overlapping issue(s) to next round: %s",
@@ -1033,17 +1045,6 @@ def _process_repo_inner(
                 result.phases.append(PhaseResult(name="implement", rc=1, elapsed_s=0.0))
 
     return result
-
-
-# Backward-compatibility shims for admission control functions (moved to pipeline/admission.py).
-# See #1813, epic #1809.
-from hephaestus.automation.pipeline import admission as _admission  # noqa: E402
-from hephaestus.automation.pipeline.admission import (  # noqa: E402
-    _fetch_planned_files as _fetch_planned_files,
-    _filter_open_issues as _filter_open_issues,
-    _parse_planned_files as _parse_planned_files,
-    _select_non_overlapping as _select_non_overlapping,
-)
 
 
 def _issue_owns_genuinely_failing_pr(issue: int) -> bool:
@@ -1298,7 +1299,7 @@ def _run_post_loop_stages(cfg: LoopConfig, repos: list[str]) -> list[RepoResult]
             trunk_sha, _fetch_ok = _rebase_main(repo, repo_dir)
             open_issues = cfg.issues or _list_open_issue_numbers(cfg.org, repo)
             if cfg.issues:
-                open_issues = _filter_open_issues(repo, open_issues)
+                open_issues = _admission._filter_open_issues(repo, open_issues)
             for stage in selected_post:
                 skip_reason = _post_loop_stage_skip_reason(cfg, repo, stage, open_issues)
                 if skip_reason is not None:

--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -1,25 +1,43 @@
-"""Admission control for implementation queue: file-overlap serialization and dependency ordering.
+"""Admission control for the implementation queue.
 
 Part of epic #1809. Provides:
-- File-overlap detection via greedy first-fit partitioning
-- Dependency-based execution ordering via topological sort
-- Per-repo in-flight work-item cap helpers
+
+- File-overlap serialization via greedy first-fit partitioning
+  (:func:`_select_non_overlapping`, re-housed from ``loop_runner.py``, #1623)
+- Dependency-based execution ordering via
+  ``DependencyResolver.topological_sort`` (:func:`order_for_implementation`)
+- Closed-issue filtering for explicit ``--issues`` lists
+  (:func:`_filter_open_issues`, #1576)
 
 The file-overlap guard (#1623) prevents concurrent plan execution on the same
 source files, which would lead to merge conflicts when the first PR lands.
+
+Dropped deliverable (documented): the per-repo in-flight cap helper
+(``within_repo_cap``) is intentionally NOT implemented. The issue #1813
+"# Implementation Plan" comment sanctions the drop: "justify or drop
+``within_repo_cap`` (YAGNI — no named consumer)" — no consumer exists until
+the coordinator slice (#1817), which owns worker-slot accounting and can add
+a cap where it dispatches.
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from typing import TYPE_CHECKING
 
+from hephaestus.automation.dependency_resolver import CyclicDependencyError, DependencyResolver
 from hephaestus.automation.github_api import (
     _fetch_issue_comment_ids,
     is_issue_closed,
     prefetch_issue_states,
 )
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from hephaestus.automation.models import IssueInfo
 
 LOG = logging.getLogger(__name__)
 
@@ -44,10 +62,10 @@ def _parse_planned_files(plan_body: str) -> set[str]:
     heading. Empty set when neither section exists.
 
     Args:
-            plan_body: The full body of the plan comment.
+        plan_body: The full body of the plan comment.
 
     Returns:
-            The set of backticked repo-relative paths found in the Files sections.
+        The set of backticked repo-relative paths found in the Files sections.
 
     """
     files: set[str] = set()
@@ -74,10 +92,10 @@ def _fetch_planned_files(issue: int) -> set[str] | None:
     "no plan" signal is simply an empty/no-match list.
 
     Args:
-            issue: GitHub issue number.
+        issue: GitHub issue number.
 
     Returns:
-            The parsed plan file set, or None when no plan comment is present.
+        The parsed plan file set, or None when no plan comment is present.
 
     """
     for comment in _fetch_issue_comment_ids(issue):
@@ -99,10 +117,10 @@ def _select_non_overlapping(issues: list[int]) -> tuple[list[int], list[int]]:
     is bounded by the issue count already being processed that round.
 
     Args:
-            issues: The issue numbers to partition, in dispatch-priority order.
+        issues: The issue numbers to partition, in dispatch-priority order.
 
     Returns:
-            A ``(dispatch, defer)`` tuple of issue-number lists (order preserved).
+        A ``(dispatch, defer)`` tuple of issue-number lists (order preserved).
 
     """
     claimed: set[str] = set()
@@ -124,6 +142,47 @@ def _select_non_overlapping(issues: list[int]) -> tuple[list[int], list[int]]:
     return dispatch, defer
 
 
+def order_for_implementation(issue_infos: Sequence[IssueInfo]) -> list[int]:
+    """Order implementation-queue issues so dependencies come first.
+
+    Topological-order gating via ``DependencyResolver.topological_sort``:
+    builds a graph over exactly the given issues, keeping only dependency
+    edges whose target is ALSO in the set — an edge to an issue outside the
+    implementation queue cannot be ordered here and is dropped (fail-open;
+    that dependency's own classification decides when it runs). Kahn's
+    algorithm preserves the input order among issues at equal depth, so the
+    result is deterministic.
+
+    On a dependency cycle the original order is returned unchanged with a
+    warning (fail-open: never wedge the queue over bad metadata).
+
+    Args:
+        issue_infos: Issue metadata (``number`` + ``dependencies``) for every
+            issue currently admitted to the implementation queue.
+
+    Returns:
+        The issue numbers reordered so every in-set dependency precedes its
+        dependents.
+
+    """
+    in_set = {info.number for info in issue_infos}
+    resolver = DependencyResolver(skip_closed=False)
+    for info in issue_infos:
+        resolver.graph.add_issue(info)
+    for info in issue_infos:
+        for dep in info.dependencies:
+            if dep in in_set:
+                resolver.graph.add_dependency(info.number, dep)
+    try:
+        return resolver.topological_sort()
+    except CyclicDependencyError:
+        LOG.warning(
+            "dependency cycle among implementation-queue issues %s — keeping input order",
+            sorted(in_set),
+        )
+        return [info.number for info in issue_infos]
+
+
 def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
     """Drop CLOSED issues from an explicit ``--issues`` list (#1576).
 
@@ -135,11 +194,11 @@ def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
     never silently drop work over a transient API blip).
 
     Args:
-            repo: Repository name (for logging).
-            issue_numbers: The explicit issue list.
+        repo: Repository name (for logging).
+        issue_numbers: The explicit issue list.
 
     Returns:
-            The subset that is not closed (order preserved).
+        The subset that is not closed (order preserved).
 
     """
     try:
@@ -157,7 +216,9 @@ def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
 
 
 __all__ = [
+    "_fetch_planned_files",
     "_filter_open_issues",
     "_parse_planned_files",
     "_select_non_overlapping",
+    "order_for_implementation",
 ]

--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -1,0 +1,163 @@
+"""Admission control for implementation queue: file-overlap serialization and dependency ordering.
+
+Part of epic #1809. Provides:
+- File-overlap detection via greedy first-fit partitioning
+- Dependency-based execution ordering via topological sort
+- Per-repo in-flight work-item cap helpers
+
+The file-overlap guard (#1623) prevents concurrent plan execution on the same
+source files, which would lead to merge conflicts when the first PR lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from hephaestus.automation.github_api import (
+    _fetch_issue_comment_ids,
+    is_issue_closed,
+    prefetch_issue_states,
+)
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
+
+LOG = logging.getLogger(__name__)
+
+# Backticked repo-relative path inside a plan's Files sections, e.g.
+# `hephaestus/automation/address_review.py`. Requires a slash so bare tokens
+# like `pyproject.toml` or symbol refs like `os.replace` are not treated as
+# in-tree paths (over-match → needless deferral; the slash requirement keeps
+# the key tight to actual source paths).
+# NOTE: Bare top-level file paths without a directory prefix (e.g., `errors.py`)
+# are intentionally NOT captured — overlap goes undetected and both plans dispatch
+# concurrently, falling back to pre-#1623 behavior (acceptable tradeoff for regex tightness).
+_PLAN_FILE_RE = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_./-]*/[A-Za-z0-9_./-]+\.[A-Za-z0-9_]+)`")
+_PLAN_FILE_SECTION_RE = re.compile(r"^#{2,}\s+Files to (Modify|Create)\b", re.IGNORECASE)
+
+
+def _parse_planned_files(plan_body: str) -> set[str]:
+    """Return the repo-relative paths a plan intends to touch.
+
+    Scans the ``## Files to Modify`` and ``## Files to Create`` sections of an
+    ``# Implementation Plan`` comment (either or both may be present) and
+    collects every backticked in-tree path until the next top-level ``## ``
+    heading. Empty set when neither section exists.
+
+    Args:
+            plan_body: The full body of the plan comment.
+
+    Returns:
+            The set of backticked repo-relative paths found in the Files sections.
+
+    """
+    files: set[str] = set()
+    in_section = False
+    for line in plan_body.splitlines():
+        if _PLAN_FILE_SECTION_RE.match(line):
+            in_section = True
+            continue
+        # A new top-level ``## `` heading (not a ``### `` sub-header inside the
+        # section) ends the scan region.
+        if line.startswith("## "):
+            in_section = False
+        if in_section:
+            files.update(_PLAN_FILE_RE.findall(line))
+    return files
+
+
+def _fetch_planned_files(issue: int) -> set[str] | None:
+    """Return the file set an issue's plan claims, or None if unknown.
+
+    None (no plan comment / empty fetch) → caller fails OPEN and dispatches the
+    issue this round. :func:`_fetch_issue_comment_ids` already swallows all
+    errors and returns ``[]`` on failure, so NO try/except is needed here — the
+    "no plan" signal is simply an empty/no-match list.
+
+    Args:
+            issue: GitHub issue number.
+
+    Returns:
+            The parsed plan file set, or None when no plan comment is present.
+
+    """
+    for comment in _fetch_issue_comment_ids(issue):
+        body = str(comment.get("body", ""))
+        if body.startswith(PLAN_COMMENT_MARKER):
+            return _parse_planned_files(body)
+    return None
+
+
+def _select_non_overlapping(issues: list[int]) -> tuple[list[int], list[int]]:
+    """Partition *issues* into (dispatch_now, defer_next_round).
+
+    Greedy first-fit in the given order: an issue whose parsed plan file set
+    intersects the union of already-claimed files is deferred. Unknown file set
+    (no plan / parse failure) claims NO files and is always dispatched
+    (fail-open). The first issue always dispatches, so a whole batch can never
+    be deferred (liveness). Performs one serial GraphQL comment fetch per issue;
+    only invoked in multi-worker rounds (guarded at the call site), so the cost
+    is bounded by the issue count already being processed that round.
+
+    Args:
+            issues: The issue numbers to partition, in dispatch-priority order.
+
+    Returns:
+            A ``(dispatch, defer)`` tuple of issue-number lists (order preserved).
+
+    """
+    claimed: set[str] = set()
+    dispatch: list[int] = []
+    defer: list[int] = []
+    for issue in issues:
+        planned = _fetch_planned_files(issue)
+        if planned and (planned & claimed):
+            LOG.info(
+                "issue #%s deferred: plan files %s overlap in-flight peers",
+                issue,
+                sorted(planned & claimed),
+            )
+            defer.append(issue)
+            continue
+        if planned:
+            claimed |= planned
+        dispatch.append(issue)
+    return dispatch, defer
+
+
+def _filter_open_issues(repo: str, issue_numbers: list[int]) -> list[int]:
+    """Drop CLOSED issues from an explicit ``--issues`` list (#1576).
+
+    An operator-pinned ``cfg.issues`` list bypasses the ``--state open`` filter
+    that auto-discovery applies, so a closed issue would otherwise be driven
+    every loop and wrongly tagged ``state:skip`` by drive-green. States are
+    fetched once via :func:`prefetch_issue_states` and checked with
+    :func:`is_issue_closed`. On any lookup failure an issue is KEPT (fail-open:
+    never silently drop work over a transient API blip).
+
+    Args:
+            repo: Repository name (for logging).
+            issue_numbers: The explicit issue list.
+
+    Returns:
+            The subset that is not closed (order preserved).
+
+    """
+    try:
+        cached_states = prefetch_issue_states(issue_numbers)
+    except Exception as exc:  # transient API failure → keep all, don't drop work
+        LOG.warning("[%s] could not prefetch issue states for closed-filter: %s", repo, exc)
+        return issue_numbers
+    kept: list[int] = []
+    for num in issue_numbers:
+        if is_issue_closed(num, cached_states):
+            LOG.info("[%s] issue #%s is closed — excluding from phase loop", repo, num)
+            continue
+        kept.append(num)
+    return kept
+
+
+__all__ = [
+    "_filter_open_issues",
+    "_parse_planned_files",
+    "_select_non_overlapping",
+]

--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -168,7 +168,7 @@ def order_for_implementation(issue_infos: Sequence[IssueInfo]) -> list[int]:
     in_set = {info.number for info in issue_infos}
     resolver = DependencyResolver(skip_closed=False)
     for info in issue_infos:
-        resolver.graph.add_issue(info)
+        resolver.add_issue(info)
     for info in issue_infos:
         for dep in info.dependencies:
             if dep in in_set:

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -3,28 +3,43 @@
 Part of epic #1809. Reconstructs in-memory queues from GitHub labels and PR state,
 the single source of truth for "GitHub is the journal" architecture.
 
-Pure classifier: (labels, PR existence/state) → entry queue, using **ordered label rank**:
+Pure classifier: (labels, PR existence/state) → entry stage, using **ordered label rank**:
 - needs-plan(0) < plan-no-go(1) < plan-go(2) < implementation-no-go(3) < implementation-go(4)
 - At-or-past comparisons, NEVER equality (verified lesson: `==` strands items already past target)
 
-Entry queue routing:
-- `state:skip` or epic label → excluded (logged)
+Entry routing (the binding contract is the classification table in
+``docs/AUTOMATION_LOOP_ARCHITECTURE.md`` "Seeding and reconstruction"):
+
+- ``state:skip`` or epic → excluded (stage ``None``, logged)
 - PR merged → finished (pass, idempotent)
-- Open PR + `state:implementation-go` → ci
+- Open PR + at-or-past ``state:implementation-go`` → ci
 - Open PR, no impl-GO → pr_review (existing-PR path)
-- No PR, at-or-past `state:plan-go` → implementation
-- No PR, `state:plan-no-go` → planning (amend path)
-- `state:needs-plan` / no state label → planning
+- No PR, at-or-past ``state:plan-go`` → implementation
+- No PR, ``state:plan-no-go`` → planning (amend path)
+- ``state:needs-plan`` / no state label → planning
+
+Write-path boundary (epic tagging)
+----------------------------------
+Per the doc row "Epic tagging is the one seeding write; done BEFORE excluding",
+an untagged epic must receive ``state:skip``. The pipeline mutator guard
+(``tests/unit/automation/pipeline/test_pipeline_architecture.py``) forbids
+GitHub mutations in this module, so seeding only SURFACES the tag need: an
+epic without ``state:skip`` is excluded with reason prefix
+:data:`EPIC_NEEDS_SKIP_TAG`, and the caller — the coordinator slice (#1817) —
+executes the actual label write via the existing ``github_api.skip_epics``
+chokepoint before honoring the exclusion.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal
 
-from hephaestus.automation._review_utils import find_pr_for_issue
-from hephaestus.automation.github_api import fetch_issue_info
+from hephaestus.automation._review_utils import find_merged_pr_for_issue, find_pr_for_issue
+from hephaestus.automation.github_api import fetch_issue_info, gh_pr_label_names
+from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
     STATE_IMPLEMENTATION_NO_GO,
@@ -32,6 +47,8 @@ from hephaestus.automation.state_labels import (
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
     STATE_SKIP,
+    is_epic,
+    is_implementation_go,
 )
 
 LOG = logging.getLogger(__name__)
@@ -46,7 +63,16 @@ _LABEL_RANK = {
     STATE_IMPLEMENTATION_GO: 4,
 }
 
-QueueName = Literal["planning", "pr_review", "ci", "implementation", "finished"]
+#: Exclusion-reason prefix surfacing the one sanctioned seeding write to the
+#: caller: an epic that still lacks ``state:skip`` must be tagged (via the
+#: existing ``github_api.skip_epics`` chokepoint, executed by the coordinator,
+#: #1817) BEFORE the exclusion is final. See module docstring.
+EPIC_NEEDS_SKIP_TAG = "epic_needs_skip_tag"
+
+#: Classification result: ``(stage, reason)``. ``stage is None`` means the
+#: issue is EXCLUDED from the pipeline (state:skip / epic) — exclusion is NOT
+#: completion, so it is deliberately distinct from ``StageName.FINISHED``.
+Classification = tuple[StageName | None, str]
 
 
 @dataclass(frozen=True)
@@ -54,21 +80,27 @@ class IssueFacts:
     """GitHub state snapshot for a single issue.
 
     Attributes:
-            number: GitHub issue number.
-            is_epic: Whether this issue is an epic (excluded from queuing).
-            labels: Set of state labels currently on this issue.
-            pr_number: GitHub PR number if one exists and is live (open or merged), None otherwise.
-            pr_is_open: True iff PR exists and is open.
-            pr_is_merged: True iff PR exists and is merged.
+        number: GitHub issue number.
+        title: Issue title (feeds the epic title-marker signal, #1669).
+        is_epic: Whether this issue is an epic/roadmap (excluded from queuing).
+        labels: Set of labels currently on this issue.
+        pr_number: GitHub PR number if one exists and is live (open or
+            merged), None otherwise.
+        pr_is_open: True iff PR exists and is open.
+        pr_is_merged: True iff PR exists and is merged.
 
-    Invariants:
-            - At most one `state:*` label is present.
-            - If `pr_number is None`, then `pr_is_open` and `pr_is_merged` are both False.
-            - If PR is neither open nor merged, `pr_number` is None (normalized at fetch layer).
+    Invariants (established by :func:`seed_issue`'s tri-state fetch):
+        - Exactly one of {no live PR, open PR, merged PR} holds:
+          ``pr_number is None`` ⇔ ``not pr_is_open and not pr_is_merged``,
+          and ``pr_is_open``/``pr_is_merged`` are mutually exclusive.
+        - A PR that is neither open nor merged (closed/abandoned) is
+          normalized to ``pr_number = None`` at the fetch layer, so the
+          classifier can never fall through on a dead PR.
 
     """
 
     number: int
+    title: str
     is_epic: bool
     labels: set[str]
     pr_number: int | None
@@ -76,14 +108,37 @@ class IssueFacts:
     pr_is_merged: bool
 
 
+@dataclass(frozen=True)
+class SeedEntry:
+    """One planned queue push produced by :func:`seed_from_cli`.
+
+    Attributes:
+        kind: Source CLI scope of the entry (``repo`` / ``issue`` / ``pr``).
+        identifier: Repo name, issue number, or PR number.
+        stage: Entry stage, or ``None`` when the item is excluded.
+        reason: Human-readable classification reason (logged by the caller).
+
+    """
+
+    kind: Literal["repo", "issue", "pr"]
+    identifier: int | str
+    stage: StageName | None
+    reason: str
+
+
 def _get_state_label(labels: set[str]) -> str | None:
-    """Extract the single active `state:*` label, or None.
+    """Extract the single active ``state:*`` label, or None when absent.
+
+    Contradictory combinations (multiple ``state:*`` labels) resolve
+    deterministically to the HIGHEST-rank (latest-stage) label and emit a
+    warning — they never return None.
 
     Args:
-            labels: Set of label names on an issue.
+        labels: Set of label names on an issue.
 
     Returns:
-            The state label, or None if absent or contradictory (multiple state labels).
+        The state label; the highest-rank one when contradictory; None only
+        when no ``state:*`` label is present.
 
     """
     state_labels = [lbl for lbl in labels if lbl.startswith("state:")]
@@ -102,16 +157,19 @@ def _label_at_or_past(label: str | None, target: str) -> bool:
     """Check whether a label is at or past a target rank.
 
     At-or-past semantics prevent re-queueing issues already past the target:
-    - An issue with `state:plan-go` (rank 2) is at-or-past `state:plan-go` ✓
-    - An issue with `state:implementation-go` (rank 4) is at-or-past `state:plan-go` ✓
-    - An issue with `state:needs-plan` (rank 0) is NOT at-or-past `state:plan-go` ✗
+    - An issue with ``state:plan-go`` (rank 2) is at-or-past ``state:plan-go``
+    - An issue with ``state:implementation-go`` (rank 4) is at-or-past
+      ``state:plan-go``
+    - An issue with ``state:needs-plan`` (rank 0) is NOT at-or-past
+      ``state:plan-go``
 
     Args:
-            label: The label to check (or None for absence).
-            target: The target state label name.
+        label: The label to check (or None for absence).
+        target: The target state label name.
 
     Returns:
-            True iff the label's rank >= target's rank (or is absent, treated as rank 0).
+        True iff the label's rank >= target's rank (absence == needs-plan,
+        rank 0).
 
     """
     if label is None:
@@ -121,28 +179,38 @@ def _label_at_or_past(label: str | None, target: str) -> bool:
     return label_rank >= target_rank
 
 
-def classify_issue(facts: IssueFacts) -> tuple[QueueName, str]:
-    """Classify an issue into a single entry queue based on GitHub state.
+def classify_issue(facts: IssueFacts) -> Classification:
+    """Classify an issue into a single entry stage based on GitHub state.
+
+    Exclusion (``state:skip`` / epic) is distinct from completion: excluded
+    issues return ``stage=None`` (and are logged), while genuinely finished
+    work (merged PR) returns :attr:`StageName.FINISHED`.
 
     Args:
-            facts: GitHub state snapshot for the issue.
+        facts: GitHub state snapshot for the issue.
 
     Returns:
-            A (queue_name, reason) tuple describing where the issue should be queued.
-
-    Raises:
-            No exceptions; contradictory or unknown states default to safe routing.
+        A ``(stage, reason)`` :data:`Classification`; ``stage is None`` means
+        excluded.
 
     """
-    # Exclusions: skip and epics
+    # Exclusions: skip wins over everything (operator-only, absolute — it
+    # carries no rank and never enters the rank comparison).
     if STATE_SKIP in facts.labels:
-        return "finished", f"#{facts.number} tagged {STATE_SKIP}"
+        reason = f"#{facts.number} tagged {STATE_SKIP}"
+        LOG.info("issue excluded: %s", reason)
+        return None, reason
     if facts.is_epic:
-        return "finished", f"#{facts.number} is an epic (excluded from routing)"
+        # Untagged epic: surface the sanctioned write to the caller (see
+        # module docstring — the state:skip write executes at the coordinator
+        # via the existing skip_epics chokepoint, #1817).
+        reason = f"{EPIC_NEEDS_SKIP_TAG}: #{facts.number} is an epic without {STATE_SKIP}"
+        LOG.info("issue excluded: %s", reason)
+        return None, reason
 
     # Terminal state: merged PR
     if facts.pr_is_merged:
-        return "finished", f"#{facts.number} PR merged (idempotent)"
+        return StageName.FINISHED, f"#{facts.number} PR merged (idempotent)"
 
     # Extract the active state label
     state_label = _get_state_label(facts.labels)
@@ -151,68 +219,70 @@ def classify_issue(facts: IssueFacts) -> tuple[QueueName, str]:
     if facts.pr_is_open:
         # Open PR + implementation-go → ready for CI
         if _label_at_or_past(state_label, STATE_IMPLEMENTATION_GO):
-            return "ci", f"#{facts.number} open PR with {STATE_IMPLEMENTATION_GO}"
+            return StageName.CI, f"#{facts.number} open PR with {STATE_IMPLEMENTATION_GO}"
         # Open PR, no implementation-go → awaiting PR review
-        return "pr_review", f"#{facts.number} open PR awaiting review"
+        return StageName.PR_REVIEW, f"#{facts.number} open PR awaiting review"
 
     # No PR path: check implementation readiness
     if _label_at_or_past(state_label, STATE_PLAN_GO):
-        return "implementation", f"#{facts.number} at-or-past {STATE_PLAN_GO}, no PR yet"
+        return StageName.IMPLEMENTATION, f"#{facts.number} at-or-past {STATE_PLAN_GO}, no PR yet"
 
     # No PR, plan rejected or needs plan → planning phase
     if state_label == STATE_PLAN_NO_GO:
-        return "planning", f"#{facts.number} {STATE_PLAN_NO_GO} (amend path)"
+        return StageName.PLANNING, f"#{facts.number} {STATE_PLAN_NO_GO} (amend path)"
 
     # Default: no label or needs-plan → planning
-    return "planning", f"#{facts.number} {state_label or STATE_NEEDS_PLAN}"
+    return StageName.PLANNING, f"#{facts.number} {state_label or STATE_NEEDS_PLAN}"
 
 
 def seed_issue(issue_number: int) -> IssueFacts:
-    """Fetch and normalize GitHub state for a single issue.
+    """Fetch and normalize GitHub state for a single issue (tri-state PR).
 
-    Normalizes PR facts: if a PR exists but is neither open nor merged, sets
-    `pr_number = None` so `classify_issue` only ever sees a clean tri-state.
-    This prevents misclassification of closed/draft PRs.
+    PR facts are a real tri-state fetch: the open-PR lookup
+    (:func:`find_pr_for_issue`) runs first; on a miss, the merged-PR lookup
+    (:func:`find_merged_pr_for_issue`) runs so merged work classifies as
+    finished instead of being re-queued after a restart. A PR that is neither
+    open nor merged (closed/abandoned) is invisible to both lookups and is
+    normalized to ``pr_number = None``, so :func:`classify_issue` only ever
+    sees a clean {no live PR | open PR | merged PR} tri-state.
+
+    Fail-closed: any GitHub error — from the issue fetch or either PR lookup —
+    propagates. Swallowing a PR-probe failure would misclassify toward
+    IMPLEMENTATION and cause duplicate-PR churn.
 
     Args:
-            issue_number: GitHub issue number.
+        issue_number: GitHub issue number.
 
     Returns:
-            Normalized GitHub state snapshot.
+        Normalized GitHub state snapshot.
 
     Raises:
-            Exception: Any GitHub API error is re-raised (caller's responsibility to handle).
+        Exception: Any GitHub API error from the issue fetch or the PR
+            lookups is re-raised (caller's responsibility to handle).
 
     """
     issue_info = fetch_issue_info(issue_number)
     labels = set(issue_info.labels)
 
-    # Determine if this is an epic by checking for "epic" label.
-    is_epic = any(lbl.lower() == "epic" for lbl in labels)
+    # Epic detection: label (epic/roadmap) OR title marker, per #1669.
+    epic = is_epic(issue_info.labels, issue_info.title)
 
-    # Fetch PR if exists; normalize to None if closed/draft.
-    pr_number: int | None = None
+    # Tri-state PR fetch: open first, then merged; closed PRs surface in
+    # neither lookup (normalized to "no live PR"). No try/except: fail-closed.
     pr_is_open = False
     pr_is_merged = False
-
-    try:
-        found_pr = find_pr_for_issue(issue_number)
-        if found_pr is not None:
-            # We have a PR. find_pr_for_issue finds open/merged PRs for the issue.
-            # Per the plan: "resolve it at the FETCH layer — `seed_issue` yields
-            # `pr_number=None` for any PR that is neither open nor merged."
-            # find_pr_for_issue is a best-effort search; it may find closed PRs too.
-            # For now, we trust it returns live PRs (open or merged via merge strategies).
-            pr_number = found_pr
-            # Assume returned PR is open for now; merge state would be determined
-            # by fetching the full PR object, which is outside the scope of this MVP.
-            pr_is_open = True
-    except Exception as exc:
-        LOG.warning("Could not resolve PR for issue #%s: %s", issue_number, exc)
+    pr_number: int | None = find_pr_for_issue(issue_number)
+    if pr_number is not None:
+        pr_is_open = True
+    else:
+        pr_number = find_merged_pr_for_issue(issue_number)
+        if pr_number is not None:
+            pr_is_merged = True
 
     return IssueFacts(
         number=issue_number,
-        is_epic=is_epic,
+        title=issue_info.title,
+        is_epic=epic,
         labels=labels,
         pr_number=pr_number,
         pr_is_open=pr_is_open,
@@ -220,9 +290,70 @@ def seed_issue(issue_number: int) -> IssueFacts:
     )
 
 
+def seed_from_cli(
+    repos: Sequence[str],
+    issues: Sequence[int],
+    prs: Sequence[int],
+) -> list[SeedEntry]:
+    """Map CLI scope args (``--repos`` / ``--issues`` / ``--prs``) to queue pushes.
+
+    Pure planning plus thin fetch — no mutations:
+
+    - ``repos`` → one :attr:`StageName.REPO` entry each (discovery seeds).
+    - ``issues`` → :func:`seed_issue` + :func:`classify_issue` per issue.
+    - ``prs`` → :attr:`StageName.CI` when the PR carries
+      ``state:implementation-go``, else :attr:`StageName.PR_REVIEW` —
+      mirroring ``_review_existing_pr`` semantics
+      (``implementer_phase_runner.py:750``): GO short-circuits review, and a
+      failed label fetch reads as "not yet reviewed" (→ pr_review).
+
+    Args:
+        repos: Repository names to seed for discovery.
+        issues: Issue numbers to classify directly.
+        prs: PR numbers to route by implementation-review label.
+
+    Returns:
+        Planned queue pushes, in the given order (repos, issues, prs).
+
+    """
+    entries: list[SeedEntry] = [
+        SeedEntry(
+            kind="repo", identifier=repo, stage=StageName.REPO, reason=f"{repo} CLI repo seed"
+        )
+        for repo in repos
+    ]
+    for issue in issues:
+        stage, reason = classify_issue(seed_issue(issue))
+        entries.append(SeedEntry(kind="issue", identifier=issue, stage=stage, reason=reason))
+    for pr in prs:
+        labels = gh_pr_label_names(pr)
+        if is_implementation_go(labels):
+            entries.append(
+                SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=StageName.CI,
+                    reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                )
+            )
+        else:
+            entries.append(
+                SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=StageName.PR_REVIEW,
+                    reason=f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
+                )
+            )
+    return entries
+
+
 __all__ = [
+    "EPIC_NEEDS_SKIP_TAG",
+    "Classification",
     "IssueFacts",
-    "QueueName",
+    "SeedEntry",
     "classify_issue",
+    "seed_from_cli",
     "seed_issue",
 ]

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -1,0 +1,228 @@
+"""GitHub-journal seeding: classify issues into stage queues based on GitHub state.
+
+Part of epic #1809. Reconstructs in-memory queues from GitHub labels and PR state,
+the single source of truth for "GitHub is the journal" architecture.
+
+Pure classifier: (labels, PR existence/state) → entry queue, using **ordered label rank**:
+- needs-plan(0) < plan-no-go(1) < plan-go(2) < implementation-no-go(3) < implementation-go(4)
+- At-or-past comparisons, NEVER equality (verified lesson: `==` strands items already past target)
+
+Entry queue routing:
+- `state:skip` or epic label → excluded (logged)
+- PR merged → finished (pass, idempotent)
+- Open PR + `state:implementation-go` → ci
+- Open PR, no impl-GO → pr_review (existing-PR path)
+- No PR, at-or-past `state:plan-go` → implementation
+- No PR, `state:plan-no-go` → planning (amend path)
+- `state:needs-plan` / no state label → planning
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Literal
+
+from hephaestus.automation._review_utils import find_pr_for_issue
+from hephaestus.automation.github_api import fetch_issue_info
+from hephaestus.automation.state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
+    STATE_NEEDS_PLAN,
+    STATE_PLAN_GO,
+    STATE_PLAN_NO_GO,
+    STATE_SKIP,
+)
+
+LOG = logging.getLogger(__name__)
+
+# Ordered label rank for at-or-past comparisons.
+# Lower rank = earlier stage; higher rank = later stage.
+_LABEL_RANK = {
+    STATE_NEEDS_PLAN: 0,
+    STATE_PLAN_NO_GO: 1,
+    STATE_PLAN_GO: 2,
+    STATE_IMPLEMENTATION_NO_GO: 3,
+    STATE_IMPLEMENTATION_GO: 4,
+}
+
+QueueName = Literal["planning", "pr_review", "ci", "implementation", "finished"]
+
+
+@dataclass(frozen=True)
+class IssueFacts:
+    """GitHub state snapshot for a single issue.
+
+    Attributes:
+            number: GitHub issue number.
+            is_epic: Whether this issue is an epic (excluded from queuing).
+            labels: Set of state labels currently on this issue.
+            pr_number: GitHub PR number if one exists and is live (open or merged), None otherwise.
+            pr_is_open: True iff PR exists and is open.
+            pr_is_merged: True iff PR exists and is merged.
+
+    Invariants:
+            - At most one `state:*` label is present.
+            - If `pr_number is None`, then `pr_is_open` and `pr_is_merged` are both False.
+            - If PR is neither open nor merged, `pr_number` is None (normalized at fetch layer).
+
+    """
+
+    number: int
+    is_epic: bool
+    labels: set[str]
+    pr_number: int | None
+    pr_is_open: bool
+    pr_is_merged: bool
+
+
+def _get_state_label(labels: set[str]) -> str | None:
+    """Extract the single active `state:*` label, or None.
+
+    Args:
+            labels: Set of label names on an issue.
+
+    Returns:
+            The state label, or None if absent or contradictory (multiple state labels).
+
+    """
+    state_labels = [lbl for lbl in labels if lbl.startswith("state:")]
+    if not state_labels:
+        return None
+    if len(state_labels) > 1:
+        LOG.warning(
+            "Issue has contradictory state labels: %s (using highest rank)", sorted(state_labels)
+        )
+        # Return the highest-rank (latest-stage) label when contradictory.
+        return max(state_labels, key=lambda lbl: _LABEL_RANK.get(lbl, -1))
+    return state_labels[0]
+
+
+def _label_at_or_past(label: str | None, target: str) -> bool:
+    """Check whether a label is at or past a target rank.
+
+    At-or-past semantics prevent re-queueing issues already past the target:
+    - An issue with `state:plan-go` (rank 2) is at-or-past `state:plan-go` ✓
+    - An issue with `state:implementation-go` (rank 4) is at-or-past `state:plan-go` ✓
+    - An issue with `state:needs-plan` (rank 0) is NOT at-or-past `state:plan-go` ✗
+
+    Args:
+            label: The label to check (or None for absence).
+            target: The target state label name.
+
+    Returns:
+            True iff the label's rank >= target's rank (or is absent, treated as rank 0).
+
+    """
+    if label is None:
+        label = STATE_NEEDS_PLAN  # absence == needs-plan
+    label_rank = _LABEL_RANK.get(label, -1)
+    target_rank = _LABEL_RANK.get(target, -1)
+    return label_rank >= target_rank
+
+
+def classify_issue(facts: IssueFacts) -> tuple[QueueName, str]:
+    """Classify an issue into a single entry queue based on GitHub state.
+
+    Args:
+            facts: GitHub state snapshot for the issue.
+
+    Returns:
+            A (queue_name, reason) tuple describing where the issue should be queued.
+
+    Raises:
+            No exceptions; contradictory or unknown states default to safe routing.
+
+    """
+    # Exclusions: skip and epics
+    if STATE_SKIP in facts.labels:
+        return "finished", f"#{facts.number} tagged {STATE_SKIP}"
+    if facts.is_epic:
+        return "finished", f"#{facts.number} is an epic (excluded from routing)"
+
+    # Terminal state: merged PR
+    if facts.pr_is_merged:
+        return "finished", f"#{facts.number} PR merged (idempotent)"
+
+    # Extract the active state label
+    state_label = _get_state_label(facts.labels)
+
+    # Routing logic: open PR path
+    if facts.pr_is_open:
+        # Open PR + implementation-go → ready for CI
+        if _label_at_or_past(state_label, STATE_IMPLEMENTATION_GO):
+            return "ci", f"#{facts.number} open PR with {STATE_IMPLEMENTATION_GO}"
+        # Open PR, no implementation-go → awaiting PR review
+        return "pr_review", f"#{facts.number} open PR awaiting review"
+
+    # No PR path: check implementation readiness
+    if _label_at_or_past(state_label, STATE_PLAN_GO):
+        return "implementation", f"#{facts.number} at-or-past {STATE_PLAN_GO}, no PR yet"
+
+    # No PR, plan rejected or needs plan → planning phase
+    if state_label == STATE_PLAN_NO_GO:
+        return "planning", f"#{facts.number} {STATE_PLAN_NO_GO} (amend path)"
+
+    # Default: no label or needs-plan → planning
+    return "planning", f"#{facts.number} {state_label or STATE_NEEDS_PLAN}"
+
+
+def seed_issue(issue_number: int) -> IssueFacts:
+    """Fetch and normalize GitHub state for a single issue.
+
+    Normalizes PR facts: if a PR exists but is neither open nor merged, sets
+    `pr_number = None` so `classify_issue` only ever sees a clean tri-state.
+    This prevents misclassification of closed/draft PRs.
+
+    Args:
+            issue_number: GitHub issue number.
+
+    Returns:
+            Normalized GitHub state snapshot.
+
+    Raises:
+            Exception: Any GitHub API error is re-raised (caller's responsibility to handle).
+
+    """
+    issue_info = fetch_issue_info(issue_number)
+    labels = set(issue_info.labels)
+
+    # Determine if this is an epic by checking for "epic" label.
+    is_epic = any(lbl.lower() == "epic" for lbl in labels)
+
+    # Fetch PR if exists; normalize to None if closed/draft.
+    pr_number: int | None = None
+    pr_is_open = False
+    pr_is_merged = False
+
+    try:
+        found_pr = find_pr_for_issue(issue_number)
+        if found_pr is not None:
+            # We have a PR. find_pr_for_issue finds open/merged PRs for the issue.
+            # Per the plan: "resolve it at the FETCH layer — `seed_issue` yields
+            # `pr_number=None` for any PR that is neither open nor merged."
+            # find_pr_for_issue is a best-effort search; it may find closed PRs too.
+            # For now, we trust it returns live PRs (open or merged via merge strategies).
+            pr_number = found_pr
+            # Assume returned PR is open for now; merge state would be determined
+            # by fetching the full PR object, which is outside the scope of this MVP.
+            pr_is_open = True
+    except Exception as exc:
+        LOG.warning("Could not resolve PR for issue #%s: %s", issue_number, exc)
+
+    return IssueFacts(
+        number=issue_number,
+        is_epic=is_epic,
+        labels=labels,
+        pr_number=pr_number,
+        pr_is_open=pr_is_open,
+        pr_is_merged=pr_is_merged,
+    )
+
+
+__all__ = [
+    "IssueFacts",
+    "QueueName",
+    "classify_issue",
+    "seed_issue",
+]

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -1,0 +1,227 @@
+"""File-overlap serialization and admission control for the implementation queue.
+
+Tests the within-round file-overlap guard that defers issues whose planned file
+sets intersect an in-flight peer's, and the filtered-open-issues helper.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hephaestus.automation.pipeline.admission import (
+    _filter_open_issues,
+    _parse_planned_files,
+    _select_non_overlapping,
+)
+
+
+class TestParsePlannedFiles:
+    """Plan-body parser: extract repo-relative paths from Files sections."""
+
+    def test_parse_planned_files_modify_section(self) -> None:
+        """A ``## Files to Modify`` body yields its backticked in-tree paths."""
+        body = (
+            "# Implementation Plan\n\n"
+            "## Files to Modify\n\n"
+            "### `hephaestus/automation/address_review.py`\n"
+            "Do a thing.\n"
+            "- `hephaestus/automation/ci_driver.py`\n"
+        )
+        assert _parse_planned_files(body) == {
+            "hephaestus/automation/address_review.py",
+            "hephaestus/automation/ci_driver.py",
+        }
+
+    def test_parse_planned_files_create_section(self) -> None:
+        """A ``## Files to Create`` body is scanned too (both headings)."""
+        body = (
+            "# Implementation Plan\n\n## Files to Create\n\n"
+            "### `tests/unit/automation/test_new.py`\n"
+        )
+        assert _parse_planned_files(body) == {"tests/unit/automation/test_new.py"}
+
+    def test_parse_planned_files_no_section_returns_empty(self) -> None:
+        """A plan with neither Files heading yields an empty set."""
+        body = "# Implementation Plan\n\n## Objective\n\nJust do `x/y.py` inline."
+        assert _parse_planned_files(body) == set()
+
+    def test_parse_planned_files_stops_at_next_heading(self) -> None:
+        """Backticked paths after the section's closing ``## `` heading are ignored."""
+        body = (
+            "# Implementation Plan\n\n"
+            "## Files to Modify\n\n"
+            "- `hephaestus/automation/ci_driver.py`\n\n"
+            "## Verification\n\n"
+            "- `hephaestus/automation/should_not_count.py`\n"
+        )
+        assert _parse_planned_files(body) == {"hephaestus/automation/ci_driver.py"}
+
+    def test_parse_planned_files_bare_filenames_not_captured(self) -> None:
+        """Bare filenames without directory (e.g., `pyproject.toml`) are NOT captured."""
+        body = "# Implementation Plan\n\n## Files to Modify\n\n- `pyproject.toml`\n"
+        assert _parse_planned_files(body) == set()
+
+    def test_parse_planned_files_case_insensitive_heading(self) -> None:
+        """## Files to Modify/Create headings are case-insensitive."""
+        body = "# Implementation Plan\n\n## FILES TO MODIFY\n\n- `hephaestus/automation/test.py`\n"
+        assert _parse_planned_files(body) == {"hephaestus/automation/test.py"}
+
+
+class TestFetchPlannedFiles:
+    """Fetch plan file set from issue comments: fail-open on missing/unparseable."""
+
+    def test_fetch_planned_files_no_plan_comment_returns_none(self) -> None:
+        """Comments present but none is a plan comment → None (fail-open)."""
+        comments = [{"body": "just a chat comment"}, {"body": "## 🔍 Plan Review"}]
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",
+            return_value=comments,
+        ):
+            from hephaestus.automation.pipeline.admission import _fetch_planned_files
+
+            assert _fetch_planned_files(101) is None
+
+    def test_fetch_planned_files_empty_comment_list_returns_none(self) -> None:
+        """An empty fetch (the swallowed-error signal) → None; no try/except needed."""
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",
+            return_value=[],
+        ):
+            from hephaestus.automation.pipeline.admission import _fetch_planned_files
+
+            assert _fetch_planned_files(102) is None
+
+    def test_fetch_planned_files_returns_plan_file_set(self) -> None:
+        """A real plan comment yields its parsed file set."""
+        comments = [
+            {"body": "chatter"},
+            {
+                "body": (
+                    "# Implementation Plan\n\n## Files to Modify\n\n"
+                    "- `hephaestus/automation/address_review.py`\n"
+                )
+            },
+        ]
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",
+            return_value=comments,
+        ):
+            from hephaestus.automation.pipeline.admission import _fetch_planned_files
+
+            assert _fetch_planned_files(103) == {"hephaestus/automation/address_review.py"}
+
+
+class TestSelectNonOverlapping:
+    """Greedy first-fit partitioning: defer issues with overlapping file sets."""
+
+    def test_select_non_overlapping_defers_second_of_overlapping_pair(self) -> None:
+        """AC1/AC2: two issues both listing address_review.py → first runs, second defers."""
+        plans = {
+            1: {"hephaestus/automation/address_review.py", "hephaestus/automation/a.py"},
+            2: {"hephaestus/automation/address_review.py", "hephaestus/automation/b.py"},
+        }
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ):
+            dispatch, defer = _select_non_overlapping([1, 2])
+        assert dispatch == [1]
+        assert defer == [2]
+
+    def test_select_non_overlapping_disjoint_both_dispatched(self) -> None:
+        """Non-intersecting file sets → both dispatched, none deferred."""
+        plans = {
+            1: {"hephaestus/automation/a.py"},
+            2: {"hephaestus/automation/b.py"},
+        }
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ):
+            dispatch, defer = _select_non_overlapping([1, 2])
+        assert dispatch == [1, 2]
+        assert defer == []
+
+    def test_select_non_overlapping_unknown_plan_fails_open(self) -> None:
+        """An issue whose plan file set is None claims no files → always dispatched."""
+        plans: dict[int, set[str] | None] = {
+            1: {"hephaestus/automation/address_review.py"},
+            2: None,  # no plan yet — fail open
+            3: {"hephaestus/automation/address_review.py"},
+        }
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ):
+            dispatch, defer = _select_non_overlapping([1, 2, 3])
+        # #1 claims address_review.py; #2 unknown → dispatched; #3 overlaps #1 → deferred.
+        assert dispatch == [1, 2]
+        assert defer == [3]
+
+    def test_select_non_overlapping_first_issue_always_dispatched(self) -> None:
+        """Liveness: the first issue always dispatches, so a batch is never wholly deferred."""
+        plans = {
+            1: {"hephaestus/automation/address_review.py"},
+            2: {"hephaestus/automation/address_review.py"},
+        }
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ):
+            dispatch, defer = _select_non_overlapping([1, 2])
+        assert dispatch[0] == 1
+        assert defer == [2]
+
+    def test_select_non_overlapping_three_way_chain(self) -> None:
+        """Three issues: first claimed, second overlaps, third overlaps second but not first."""
+        plans = {
+            1: {"hephaestus/automation/file1.py"},
+            2: {"hephaestus/automation/file1.py"},  # overlaps #1
+            3: {"hephaestus/automation/file2.py"},  # overlaps #2 (both claim distinct files)
+        }
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ):
+            dispatch, defer = _select_non_overlapping([1, 2, 3])
+        # #1 claims file1.py; #2 overlaps file1.py → defer; #3 claims file2.py → dispatch.
+        assert dispatch == [1, 3]
+        assert defer == [2]
+
+
+class TestFilterOpenIssues:
+    """Filter closed issues from explicit --issues list (#1576)."""
+
+    @patch("hephaestus.automation.pipeline.admission.prefetch_issue_states")
+    @patch("hephaestus.automation.pipeline.admission.is_issue_closed")
+    def test_filter_open_issues_keeps_open(self, mock_is_closed, mock_prefetch) -> None:
+        """Open issues are kept."""
+        mock_prefetch.return_value = {}
+        mock_is_closed.return_value = False
+        result = _filter_open_issues("repo", [1, 2, 3])
+        assert result == [1, 2, 3]
+
+    @patch("hephaestus.automation.pipeline.admission.prefetch_issue_states")
+    @patch("hephaestus.automation.pipeline.admission.is_issue_closed")
+    def test_filter_open_issues_excludes_closed(self, mock_is_closed, mock_prefetch) -> None:
+        """Closed issues are excluded."""
+        mock_prefetch.return_value = {}
+        mock_is_closed.side_effect = lambda num, _: num == 2
+        result = _filter_open_issues("repo", [1, 2, 3])
+        assert result == [1, 3]
+
+    @patch("hephaestus.automation.pipeline.admission.prefetch_issue_states")
+    def test_filter_open_issues_fails_open_on_api_error(self, mock_prefetch) -> None:
+        """Transient API failure → keep all, don't drop work (fail-open)."""
+        mock_prefetch.side_effect = RuntimeError("API error")
+        result = _filter_open_issues("repo", [1, 2, 3])
+        assert result == [1, 2, 3]
+
+    @patch("hephaestus.automation.pipeline.admission.prefetch_issue_states")
+    @patch("hephaestus.automation.pipeline.admission.is_issue_closed")
+    def test_filter_open_issues_preserves_order(self, mock_is_closed, mock_prefetch) -> None:
+        """Excluded issues maintain the original order."""
+        mock_prefetch.return_value = {}
+        mock_is_closed.side_effect = lambda num, _: num in {2, 4}
+        result = _filter_open_issues("repo", [1, 2, 3, 4, 5])
+        assert result == [1, 3, 5]

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -1,18 +1,29 @@
 """File-overlap serialization and admission control for the implementation queue.
 
 Tests the within-round file-overlap guard that defers issues whose planned file
-sets intersect an in-flight peer's, and the filtered-open-issues helper.
+sets intersect an in-flight peer's, the topological-order gating for the
+implementation queue, and the filtered-open-issues helper.
 """
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import patch
 
+import pytest
+
+from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline.admission import (
     _filter_open_issues,
     _parse_planned_files,
     _select_non_overlapping,
+    order_for_implementation,
 )
+
+
+def _info(number: int, dependencies: list[int] | None = None) -> IssueInfo:
+    """Build a minimal IssueInfo for dependency-ordering tests."""
+    return IssueInfo(number=number, title=f"Issue {number}", dependencies=dependencies or [])
 
 
 class TestParsePlannedFiles:
@@ -187,6 +198,40 @@ class TestSelectNonOverlapping:
         # #1 claims file1.py; #2 overlaps file1.py → defer; #3 claims file2.py → dispatch.
         assert dispatch == [1, 3]
         assert defer == [2]
+
+
+class TestOrderForImplementation:
+    """Topological-order gating: dependencies dispatch before dependents."""
+
+    def test_dependency_ordered_before_dependent(self) -> None:
+        """#A depends on #B → B precedes A regardless of input order."""
+        order = order_for_implementation([_info(10, dependencies=[20]), _info(20)])
+        assert order.index(20) < order.index(10)
+
+    def test_no_dependencies_preserves_input_order(self) -> None:
+        """Independent issues keep their dispatch-priority (input) order."""
+        assert order_for_implementation([_info(3), _info(1), _info(2)]) == [3, 1, 2]
+
+    def test_out_of_set_dependency_ignored(self) -> None:
+        """A dependency outside the implementation queue is dropped (fail-open)."""
+        # #5 depends on #999 which is not admitted — #5 must still be ordered.
+        order = order_for_implementation([_info(5, dependencies=[999]), _info(6)])
+        assert sorted(order) == [5, 6]
+
+    def test_chain_fully_ordered(self) -> None:
+        """A → B → C chain sorts leaf-dependency first."""
+        order = order_for_implementation(
+            [_info(1, dependencies=[2]), _info(2, dependencies=[3]), _info(3)]
+        )
+        assert order == [3, 2, 1]
+
+    def test_cycle_falls_open_to_input_order(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A dependency cycle keeps input order and warns (never wedges the queue)."""
+        infos = [_info(1, dependencies=[2]), _info(2, dependencies=[1]), _info(3)]
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.pipeline.admission"):
+            order = order_for_implementation(infos)
+        assert order == [1, 2, 3]
+        assert any("dependency cycle" in record.message for record in caplog.records)
 
 
 class TestFilterOpenIssues:

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -1,15 +1,27 @@
 """GitHub-journal seeding: classification of issues into stage queues.
 
-Tests the classifier that maps GitHub state (labels, PR, epic) → entry queue.
+Tests the classifier that maps GitHub state (labels, PR, epic) → entry stage,
+the tri-state fetch layer (open / merged / closed-normalized / no PR), epic
+detection, and the CLI seed mapping.
 """
 
 from __future__ import annotations
 
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.seeding import (
+    EPIC_NEEDS_SKIP_TAG,
     IssueFacts,
+    SeedEntry,
     classify_issue,
+    seed_from_cli,
     seed_issue,
 )
 from hephaestus.automation.state_labels import (
@@ -22,227 +34,458 @@ from hephaestus.automation.state_labels import (
 )
 
 
+def _facts(
+    *,
+    number: int = 1,
+    title: str = "A task",
+    is_epic: bool = False,
+    labels: set[str] | None = None,
+    pr_number: int | None = None,
+    pr_is_open: bool = False,
+    pr_is_merged: bool = False,
+) -> IssueFacts:
+    """Build IssueFacts with defaults for classifier-matrix tests."""
+    return IssueFacts(
+        number=number,
+        title=title,
+        is_epic=is_epic,
+        labels=labels or set(),
+        pr_number=pr_number,
+        pr_is_open=pr_is_open,
+        pr_is_merged=pr_is_merged,
+    )
+
+
 class TestClassifyIssue:
-    """Classifier routing matrix: GitHub state → entry queue."""
+    """Classifier routing matrix: GitHub state → entry stage."""
 
-    def test_skip_label_excluded(self) -> None:
-        """Issue tagged state:skip is excluded (finished)."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_SKIP},
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, reason = classify_issue(facts)
-        assert queue == "finished"
+    def test_skip_label_excluded_and_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Issue tagged state:skip is excluded (stage None) and the exclusion is logged."""
+        with caplog.at_level(logging.INFO, logger="hephaestus.automation.pipeline.seeding"):
+            stage, reason = classify_issue(_facts(labels={STATE_SKIP}))
+        assert stage is None
         assert "state:skip" in reason
+        assert any("excluded" in record.message for record in caplog.records)
 
-    def test_epic_excluded(self) -> None:
-        """Issues marked as epics are excluded (finished)."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=True,
-            labels=set(),
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, reason = classify_issue(facts)
-        assert queue == "finished"
-        assert "epic" in reason
+    def test_epic_excluded_with_skip_tag_flag(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An UNTAGGED epic is excluded with the epic_needs_skip_tag flag for the caller.
+
+        The state:skip write itself executes at the caller (coordinator #1817)
+        via the existing skip_epics chokepoint — seeding only surfaces the need.
+        """
+        with caplog.at_level(logging.INFO, logger="hephaestus.automation.pipeline.seeding"):
+            stage, reason = classify_issue(_facts(is_epic=True))
+        assert stage is None
+        assert reason.startswith(EPIC_NEEDS_SKIP_TAG)
+        assert any("excluded" in record.message for record in caplog.records)
+
+    def test_epic_already_tagged_skip_needs_no_retag(self) -> None:
+        """An epic that already carries state:skip excludes via skip — no tag flag."""
+        stage, reason = classify_issue(_facts(is_epic=True, labels={STATE_SKIP}))
+        assert stage is None
+        assert STATE_SKIP in reason
+        assert EPIC_NEEDS_SKIP_TAG not in reason
+
+    def test_skip_wins_over_plan_go(self) -> None:
+        """state:skip + state:plan-go → excluded; skip is absolute and never ranked."""
+        stage, reason = classify_issue(_facts(labels={STATE_SKIP, STATE_PLAN_GO}))
+        assert stage is None
+        assert STATE_SKIP in reason
 
     def test_pr_merged_finished(self) -> None:
-        """Merged PR is idempotent (finished)."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_IMPLEMENTATION_GO},
-            pr_number=42,
-            pr_is_open=False,
-            pr_is_merged=True,
+        """Merged PR is genuinely finished (pass, idempotent) — NOT an exclusion."""
+        stage, reason = classify_issue(
+            _facts(labels={STATE_IMPLEMENTATION_GO}, pr_number=42, pr_is_merged=True)
         )
-        queue, reason = classify_issue(facts)
-        assert queue == "finished"
+        assert stage is StageName.FINISHED
         assert "merged" in reason
 
     def test_open_pr_with_impl_go_routes_to_ci(self) -> None:
         """Open PR + state:implementation-go → ready for CI."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_IMPLEMENTATION_GO},
-            pr_number=42,
-            pr_is_open=True,
-            pr_is_merged=False,
+        stage, reason = classify_issue(
+            _facts(labels={STATE_IMPLEMENTATION_GO}, pr_number=42, pr_is_open=True)
         )
-        queue, reason = classify_issue(facts)
-        assert queue == "ci"
-        assert "implementation-go" in reason or "impl" in reason
+        assert stage is StageName.CI
+        assert "implementation-go" in reason
 
     def test_open_pr_without_impl_go_routes_to_pr_review(self) -> None:
         """Open PR without implementation-go awaits PR review."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_PLAN_GO},
-            pr_number=42,
-            pr_is_open=True,
-            pr_is_merged=False,
+        stage, reason = classify_issue(
+            _facts(labels={STATE_PLAN_GO}, pr_number=42, pr_is_open=True)
         )
-        queue, reason = classify_issue(facts)
-        assert queue == "pr_review"
+        assert stage is StageName.PR_REVIEW
         assert "review" in reason
+
+    def test_open_pr_with_impl_no_go_routes_to_pr_review(self) -> None:
+        """Open PR + state:implementation-no-go → pr_review, NOT ci.
+
+        The ci gate requires at-or-past implementation-GO (rank 4); a NO-GO
+        (rank 3) PR must re-enter the review cycle (mutation-probe killer:
+        weakening the gate to impl-no-go must fail this test).
+        """
+        stage, _reason = classify_issue(
+            _facts(labels={STATE_IMPLEMENTATION_NO_GO}, pr_number=42, pr_is_open=True)
+        )
+        assert stage is StageName.PR_REVIEW
 
     def test_no_pr_at_plan_go_routes_to_implementation(self) -> None:
         """No PR, at-or-past state:plan-go → ready for implementation."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_PLAN_GO},
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, reason = classify_issue(facts)
-        assert queue == "implementation"
-        assert "at-or-past" in reason or "plan-go" in reason
+        stage, reason = classify_issue(_facts(labels={STATE_PLAN_GO}))
+        assert stage is StageName.IMPLEMENTATION
+        assert "at-or-past" in reason
 
     def test_no_pr_past_plan_go_routes_to_implementation(self) -> None:
         """No PR, past state:plan-go (e.g., impl-no-go) → implementation (at-or-past)."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_IMPLEMENTATION_NO_GO},
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, _reason = classify_issue(facts)
-        assert queue == "implementation"
+        stage, _reason = classify_issue(_facts(labels={STATE_IMPLEMENTATION_NO_GO}))
+        assert stage is StageName.IMPLEMENTATION
 
     def test_no_pr_plan_no_go_routes_to_planning(self) -> None:
         """No PR, state:plan-no-go → planning (amend path)."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_PLAN_NO_GO},
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, reason = classify_issue(facts)
-        assert queue == "planning"
-        assert "no-go" in reason or "amend" in reason
+        stage, reason = classify_issue(_facts(labels={STATE_PLAN_NO_GO}))
+        assert stage is StageName.PLANNING
+        assert "amend" in reason
 
     def test_needs_plan_routes_to_planning(self) -> None:
         """state:needs-plan → planning."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_NEEDS_PLAN},
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, _reason = classify_issue(facts)
-        assert queue == "planning"
+        stage, _reason = classify_issue(_facts(labels={STATE_NEEDS_PLAN}))
+        assert stage is StageName.PLANNING
 
     def test_no_label_defaults_to_planning(self) -> None:
         """No state label → planning (needs-plan by default)."""
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels=set(),
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
+        stage, _reason = classify_issue(_facts())
+        assert stage is StageName.PLANNING
+
+    def test_contradictory_labels_warn_and_use_highest_rank(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Contradictory state labels → warning + deterministic highest-rank routing."""
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.pipeline.seeding"):
+            stage, _reason = classify_issue(_facts(labels={STATE_NEEDS_PLAN, STATE_PLAN_GO}))
+        # Highest rank wins: plan-go (2) beats needs-plan (0) → implementation.
+        assert stage is StageName.IMPLEMENTATION
+        assert any("contradictory state labels" in record.message for record in caplog.records)
+
+
+_STATE_LABEL_SETS: tuple[frozenset[str], ...] = (
+    frozenset(),
+    frozenset({STATE_NEEDS_PLAN}),
+    frozenset({STATE_PLAN_NO_GO}),
+    frozenset({STATE_PLAN_GO}),
+    frozenset({STATE_IMPLEMENTATION_NO_GO}),
+    frozenset({STATE_IMPLEMENTATION_GO}),
+    frozenset({STATE_SKIP}),
+    frozenset({STATE_SKIP, STATE_PLAN_GO}),
+    frozenset({STATE_NEEDS_PLAN, STATE_IMPLEMENTATION_GO}),  # contradictory
+)
+_PR_STATES: tuple[dict[str, Any], ...] = (
+    {"pr_number": None, "pr_is_open": False, "pr_is_merged": False},
+    {"pr_number": 42, "pr_is_open": True, "pr_is_merged": False},
+    {"pr_number": 42, "pr_is_open": False, "pr_is_merged": True},
+)
+
+
+class TestClassificationIsStageNameSSOT:
+    """Every non-excluded classifier output is a routing.StageName member (SSOT guard)."""
+
+    @pytest.mark.parametrize("labels", _STATE_LABEL_SETS)
+    @pytest.mark.parametrize("pr_state", _PR_STATES)
+    @pytest.mark.parametrize("is_epic", [False, True])
+    def test_stage_is_none_or_stagename_member(
+        self, labels: set[str], pr_state: dict[str, Any], is_epic: bool
+    ) -> None:
+        """The classifier never mints a queue name outside routing.StageName."""
+        stage, reason = classify_issue(_facts(labels=set(labels), is_epic=is_epic, **pr_state))
+        assert stage is None or stage in set(StageName), f"non-StageName output: {stage!r}"
+        assert isinstance(reason, str) and reason
+
+    def test_excluded_only_for_skip_or_epic(self) -> None:
+        """stage=None (exclusion) occurs ONLY for state:skip / epic inputs."""
+        for labels in _STATE_LABEL_SETS:
+            for pr_state in _PR_STATES:
+                stage, _ = classify_issue(_facts(labels=set(labels), **pr_state))
+                if STATE_SKIP in labels:
+                    assert stage is None
+                else:
+                    assert stage is not None
+
+
+def _fake_gh_backend(prs: list[dict[str, Any]]) -> Any:
+    """Build a ``_gh_call`` side-effect simulating ``gh pr list`` state filters.
+
+    Each PR dict carries ``number``, ``state`` (OPEN/MERGED/CLOSED),
+    ``headRefName``, and ``body``. The fake honors ``--state`` and ``--head``
+    args the way GitHub does, so a CLOSED PR is invisible to both the open
+    and merged lookups — exactly the normalization seed_issue relies on.
+    """
+
+    def _gh_call(args: list[str], **_kw: Any) -> SimpleNamespace:
+        state = args[args.index("--state") + 1] if "--state" in args else "open"
+        head = args[args.index("--head") + 1] if "--head" in args else None
+        rows = [pr for pr in prs if pr["state"].lower() == state.lower()]
+        if head is not None:
+            rows = [pr for pr in rows if pr["headRefName"] == head]
+        payload = [{"number": pr["number"], "body": pr.get("body", "")} for pr in rows]
+        return SimpleNamespace(stdout=json.dumps(payload), returncode=0)
+
+    return _gh_call
+
+
+def _issue_info(number: int, labels: list[str], title: str = "A task") -> MagicMock:
+    info = MagicMock()
+    info.number = number
+    info.labels = labels
+    info.title = title
+    return info
+
+
+class TestSeedIssueFetchLayer:
+    """Tri-state fetch: {open, merged, closed, none} against mocked gh responses."""
+
+    def _seed(self, issue: int, labels: list[str], prs: list[dict[str, Any]]) -> IssueFacts:
+        with (
+            patch(
+                "hephaestus.automation.pipeline.seeding.fetch_issue_info",
+                return_value=_issue_info(issue, labels),
+            ),
+            patch(
+                "hephaestus.automation._review_utils._gh_call",
+                side_effect=_fake_gh_backend(prs),
+            ),
+        ):
+            return seed_issue(issue)
+
+    def test_open_pr(self) -> None:
+        """An OPEN PR on the issue branch → pr_is_open, not merged."""
+        facts = self._seed(
+            7,
+            [STATE_PLAN_GO],
+            [{"number": 42, "state": "OPEN", "headRefName": "7-auto-impl", "body": "Closes #7"}],
         )
-        queue, _reason = classify_issue(facts)
-        assert queue == "planning"
-
-    def test_closed_pr_normalized_to_none(self) -> None:
-        """Closed PR (neither open nor merged) with plan-no-go → planning (no PR path)."""
-        # This tests the normalization: if PR is closed, seed_issue should have set
-        # pr_number = None. But in the test, we construct IssueFacts directly.
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_PLAN_NO_GO},
-            pr_number=None,  # Normalized by seed_issue
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, _reason = classify_issue(facts)
-        assert queue == "planning"
-
-
-class TestSeedIssue:
-    """Fetch and normalize GitHub state for a single issue."""
-
-    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
-    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
-    def test_seed_issue_basic(self, mock_find_pr, mock_fetch) -> None:
-        """seed_issue fetches and normalizes GitHub state."""
-        mock_fetch.return_value = MagicMock(
-            number=101,
-            labels=[STATE_PLAN_GO, "other-label"],
-        )
-        mock_find_pr.return_value = None
-
-        facts = seed_issue(101)
-
-        assert facts.number == 101
-        assert STATE_PLAN_GO in facts.labels
-        assert facts.pr_number is None
-        assert facts.pr_is_open is False
-        assert facts.pr_is_merged is False
-
-    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
-    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
-    def test_seed_issue_with_open_pr(self, mock_find_pr, mock_fetch) -> None:
-        """seed_issue finds and records open PR."""
-        mock_fetch.return_value = MagicMock(
-            number=102,
-            labels=[STATE_PLAN_GO],
-        )
-        mock_find_pr.return_value = 42
-
-        facts = seed_issue(102)
-
         assert facts.pr_number == 42
         assert facts.pr_is_open is True
         assert facts.pr_is_merged is False
 
-    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
-    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
-    def test_seed_issue_epic_detection(self, mock_find_pr, mock_fetch) -> None:
-        """seed_issue detects epic label."""
-        mock_fetch.return_value = MagicMock(
-            number=103,
-            labels=["epic", STATE_NEEDS_PLAN],
+    def test_merged_pr_found_when_open_lookup_misses(self) -> None:
+        """A MERGED PR is surfaced by the merged lookup → pr_is_merged (finished row)."""
+        facts = self._seed(
+            7,
+            [STATE_IMPLEMENTATION_GO],
+            [{"number": 43, "state": "MERGED", "headRefName": "7-auto-impl", "body": "Closes #7"}],
         )
-        mock_find_pr.return_value = None
+        assert facts.pr_number == 43
+        assert facts.pr_is_open is False
+        assert facts.pr_is_merged is True
+        # And the classifier reaches the doc's "PR merged → finished" row.
+        stage, _ = classify_issue(facts)
+        assert stage is StageName.FINISHED
 
-        facts = seed_issue(103)
+    def test_merged_pr_found_via_body_search(self) -> None:
+        """A merged PR on a NON-canonical branch is still found via Closes-body search."""
+        facts = self._seed(
+            7,
+            [STATE_IMPLEMENTATION_GO],
+            [
+                {
+                    "number": 44,
+                    "state": "MERGED",
+                    "headRefName": "some-manual-branch",
+                    "body": "Fix things.\n\nCloses #7\n",
+                }
+            ],
+        )
+        assert facts.pr_number == 44
+        assert facts.pr_is_merged is True
 
+    def test_closed_pr_normalized_to_none(self) -> None:
+        """A CLOSED (abandoned) PR is invisible to both lookups → normalized to no PR.
+
+        Prevents the dead-PR fall-through: with plan-go the issue re-enters
+        implementation (a fresh PR is legitimate), never a phantom PR path.
+        """
+        facts = self._seed(
+            7,
+            [STATE_PLAN_GO],
+            [{"number": 45, "state": "CLOSED", "headRefName": "7-auto-impl", "body": "Closes #7"}],
+        )
+        assert facts.pr_number is None
+        assert facts.pr_is_open is False
+        assert facts.pr_is_merged is False
+        stage, _ = classify_issue(facts)
+        assert stage is StageName.IMPLEMENTATION
+
+    def test_no_pr_at_all(self) -> None:
+        """No PR anywhere → clean no-PR facts."""
+        facts = self._seed(7, [STATE_NEEDS_PLAN], [])
+        assert facts.pr_number is None
+        assert facts.pr_is_open is False
+        assert facts.pr_is_merged is False
+
+    def test_labels_and_number_threaded(self) -> None:
+        """seed_issue carries number and the full label set into IssueFacts."""
+        facts = self._seed(101, [STATE_PLAN_GO, "other-label"], [])
+        assert facts.number == 101
+        assert {STATE_PLAN_GO, "other-label"} <= facts.labels
+
+
+class TestSeedIssueEpicDetection:
+    """Epic detection uses state_labels.is_epic (labels + title markers, #1669)."""
+
+    def _seed_no_pr(self, info: MagicMock) -> IssueFacts:
+        with (
+            patch("hephaestus.automation.pipeline.seeding.fetch_issue_info", return_value=info),
+            patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue", return_value=None),
+            patch(
+                "hephaestus.automation.pipeline.seeding.find_merged_pr_for_issue",
+                return_value=None,
+            ),
+        ):
+            return seed_issue(info.number)
+
+    def test_epic_label_detected(self) -> None:
+        """An 'epic' label marks the issue as an epic."""
+        facts = self._seed_no_pr(_issue_info(103, ["epic", STATE_NEEDS_PLAN]))
         assert facts.is_epic is True
 
-    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
-    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
-    def test_seed_issue_pr_fetch_failure_handled(self, mock_find_pr, mock_fetch) -> None:
-        """seed_issue handles PR lookup failures gracefully (fail-open)."""
-        mock_fetch.return_value = MagicMock(
-            number=104,
-            labels=[STATE_PLAN_GO],
-        )
-        mock_find_pr.side_effect = RuntimeError("API error")
+    def test_roadmap_label_detected(self) -> None:
+        """A 'roadmap' label ALSO marks the issue as an epic (EPIC_LABELS)."""
+        facts = self._seed_no_pr(_issue_info(104, ["roadmap"]))
+        assert facts.is_epic is True
 
-        facts = seed_issue(104)
+    def test_title_marker_detected(self) -> None:
+        """A title marker ('[Epic] ...') marks an unlabeled issue as an epic."""
+        facts = self._seed_no_pr(_issue_info(105, [], title="[Epic] Queue-based pipeline"))
+        assert facts.is_epic is True
+        assert facts.title == "[Epic] Queue-based pipeline"
 
-        assert facts.pr_number is None  # Fail-open
-        assert facts.pr_is_open is False
+    def test_plain_issue_not_epic(self) -> None:
+        """No epic label and no title marker → not an epic."""
+        facts = self._seed_no_pr(_issue_info(106, [STATE_PLAN_GO], title="Fix the widget"))
+        assert facts.is_epic is False
+
+
+class TestSeedIssueFailClosed:
+    """PR-probe failures re-raise: never misclassify toward implementation."""
+
+    def test_open_pr_lookup_failure_raises(self) -> None:
+        """find_pr_for_issue raising propagates (fail-closed, no PR-less fallback)."""
+        with (
+            patch(
+                "hephaestus.automation.pipeline.seeding.fetch_issue_info",
+                return_value=_issue_info(104, [STATE_PLAN_GO]),
+            ),
+            patch(
+                "hephaestus.automation.pipeline.seeding.find_pr_for_issue",
+                side_effect=RuntimeError("API error"),
+            ),
+            pytest.raises(RuntimeError, match="API error"),
+        ):
+            seed_issue(104)
+
+    def test_merged_pr_lookup_failure_raises(self) -> None:
+        """find_merged_pr_for_issue raising propagates too."""
+        with (
+            patch(
+                "hephaestus.automation.pipeline.seeding.fetch_issue_info",
+                return_value=_issue_info(104, [STATE_PLAN_GO]),
+            ),
+            patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue", return_value=None),
+            patch(
+                "hephaestus.automation.pipeline.seeding.find_merged_pr_for_issue",
+                side_effect=RuntimeError("merged probe down"),
+            ),
+            pytest.raises(RuntimeError, match="merged probe down"),
+        ):
+            seed_issue(104)
+
+    def test_issue_fetch_failure_raises(self) -> None:
+        """fetch_issue_info raising propagates (parity with the PR probes)."""
+        with (
+            patch(
+                "hephaestus.automation.pipeline.seeding.fetch_issue_info",
+                side_effect=RuntimeError("issue fetch down"),
+            ),
+            pytest.raises(RuntimeError, match="issue fetch down"),
+        ):
+            seed_issue(104)
+
+
+class TestSeedFromCli:
+    """CLI mapping: repos → repo queue; issues → classified; prs → ci/pr_review."""
+
+    def test_repos_arm(self) -> None:
+        """Each repo becomes a StageName.REPO discovery seed."""
+        entries = seed_from_cli(["RepoA", "RepoB"], [], [])
+        assert [e.kind for e in entries] == ["repo", "repo"]
+        assert [e.identifier for e in entries] == ["RepoA", "RepoB"]
+        assert all(e.stage is StageName.REPO for e in entries)
+
+    def test_issues_arm_classified_via_seed_issue(self) -> None:
+        """Issues run through seed_issue + classify_issue."""
+        facts = _facts(number=9, labels={STATE_PLAN_GO})
+        with patch(
+            "hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts
+        ) as mock_seed:
+            entries = seed_from_cli([], [9], [])
+        mock_seed.assert_called_once_with(9)
+        assert entries == [
+            SeedEntry(
+                kind="issue",
+                identifier=9,
+                stage=StageName.IMPLEMENTATION,
+                reason=f"#9 at-or-past {STATE_PLAN_GO}, no PR yet",
+            )
+        ]
+
+    def test_issues_arm_excluded_issue_maps_to_none_stage(self) -> None:
+        """An excluded (skip/epic) issue surfaces stage=None to the caller."""
+        facts = _facts(number=10, labels={STATE_SKIP})
+        with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
+            entries = seed_from_cli([], [10], [])
+        assert entries[0].stage is None
+
+    def test_prs_arm_impl_go_routes_to_ci(self) -> None:
+        """A PR carrying state:implementation-go seeds into ci (GO short-circuit)."""
+        with patch(
+            "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+            return_value=[STATE_IMPLEMENTATION_GO],
+        ):
+            entries = seed_from_cli([], [], [77])
+        assert entries == [
+            SeedEntry(
+                kind="pr",
+                identifier=77,
+                stage=StageName.CI,
+                reason=f"PR #77 carries {STATE_IMPLEMENTATION_GO}",
+            )
+        ]
+
+    def test_prs_arm_no_go_routes_to_pr_review(self) -> None:
+        """A PR without impl-GO (e.g. NO-GO) seeds into pr_review."""
+        with patch(
+            "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+            return_value=[STATE_IMPLEMENTATION_NO_GO],
+        ):
+            entries = seed_from_cli([], [], [78])
+        assert entries[0].stage is StageName.PR_REVIEW
+
+    def test_prs_arm_label_fetch_failure_reads_as_not_reviewed(self) -> None:
+        """An empty label fetch (best-effort failure) → pr_review.
+
+        Mirrors _review_existing_pr's (False, False) "not yet reviewed" semantics.
+        """
+        with patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]):
+            entries = seed_from_cli([], [], [79])
+        assert entries[0].stage is StageName.PR_REVIEW
+
+    def test_order_repos_then_issues_then_prs(self) -> None:
+        """Entries preserve CLI order: repos, then issues, then prs."""
+        facts = _facts(number=5)
+        with (
+            patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts),
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]),
+        ):
+            entries = seed_from_cli(["R"], [5], [6])
+        assert [e.kind for e in entries] == ["repo", "issue", "pr"]
 
 
 class TestLabelRank:
@@ -250,16 +493,12 @@ class TestLabelRank:
 
     def test_issue_already_past_plan_go_not_requeued_to_planning(self) -> None:
         """AC: issue with state:implementation-go is NOT re-routed to planning."""
-        # This is the critical AC from the plan: "==` strands items already past the target"
+        # This is the critical AC from the plan: "`==` strands items already past the target".
         # Our fix: use at-or-past (>=) not equality (==).
-        facts = IssueFacts(
-            number=1,
-            is_epic=False,
-            labels={STATE_IMPLEMENTATION_GO},
-            pr_number=None,
-            pr_is_open=False,
-            pr_is_merged=False,
-        )
-        queue, _ = classify_issue(facts)
-        # If we mistakenly routed to planning, this would fail.
-        assert queue == "implementation"
+        stage, _ = classify_issue(_facts(labels={STATE_IMPLEMENTATION_GO}))
+        assert stage is StageName.IMPLEMENTATION
+
+    def test_reconstruction_is_idempotent(self) -> None:
+        """Classifying the same facts twice yields the same result (restart safety)."""
+        facts = _facts(labels={STATE_PLAN_GO}, pr_number=42, pr_is_open=True)
+        assert classify_issue(facts) == classify_issue(facts)

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -1,0 +1,265 @@
+"""GitHub-journal seeding: classification of issues into stage queues.
+
+Tests the classifier that maps GitHub state (labels, PR, epic) → entry queue.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hephaestus.automation.pipeline.seeding import (
+    IssueFacts,
+    classify_issue,
+    seed_issue,
+)
+from hephaestus.automation.state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
+    STATE_NEEDS_PLAN,
+    STATE_PLAN_GO,
+    STATE_PLAN_NO_GO,
+    STATE_SKIP,
+)
+
+
+class TestClassifyIssue:
+    """Classifier routing matrix: GitHub state → entry queue."""
+
+    def test_skip_label_excluded(self) -> None:
+        """Issue tagged state:skip is excluded (finished)."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_SKIP},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "finished"
+        assert "state:skip" in reason
+
+    def test_epic_excluded(self) -> None:
+        """Issues marked as epics are excluded (finished)."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=True,
+            labels=set(),
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "finished"
+        assert "epic" in reason
+
+    def test_pr_merged_finished(self) -> None:
+        """Merged PR is idempotent (finished)."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_IMPLEMENTATION_GO},
+            pr_number=42,
+            pr_is_open=False,
+            pr_is_merged=True,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "finished"
+        assert "merged" in reason
+
+    def test_open_pr_with_impl_go_routes_to_ci(self) -> None:
+        """Open PR + state:implementation-go → ready for CI."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_IMPLEMENTATION_GO},
+            pr_number=42,
+            pr_is_open=True,
+            pr_is_merged=False,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "ci"
+        assert "implementation-go" in reason or "impl" in reason
+
+    def test_open_pr_without_impl_go_routes_to_pr_review(self) -> None:
+        """Open PR without implementation-go awaits PR review."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_PLAN_GO},
+            pr_number=42,
+            pr_is_open=True,
+            pr_is_merged=False,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "pr_review"
+        assert "review" in reason
+
+    def test_no_pr_at_plan_go_routes_to_implementation(self) -> None:
+        """No PR, at-or-past state:plan-go → ready for implementation."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_PLAN_GO},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "implementation"
+        assert "at-or-past" in reason or "plan-go" in reason
+
+    def test_no_pr_past_plan_go_routes_to_implementation(self) -> None:
+        """No PR, past state:plan-go (e.g., impl-no-go) → implementation (at-or-past)."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_IMPLEMENTATION_NO_GO},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, _reason = classify_issue(facts)
+        assert queue == "implementation"
+
+    def test_no_pr_plan_no_go_routes_to_planning(self) -> None:
+        """No PR, state:plan-no-go → planning (amend path)."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_PLAN_NO_GO},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, reason = classify_issue(facts)
+        assert queue == "planning"
+        assert "no-go" in reason or "amend" in reason
+
+    def test_needs_plan_routes_to_planning(self) -> None:
+        """state:needs-plan → planning."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_NEEDS_PLAN},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, _reason = classify_issue(facts)
+        assert queue == "planning"
+
+    def test_no_label_defaults_to_planning(self) -> None:
+        """No state label → planning (needs-plan by default)."""
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels=set(),
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, _reason = classify_issue(facts)
+        assert queue == "planning"
+
+    def test_closed_pr_normalized_to_none(self) -> None:
+        """Closed PR (neither open nor merged) with plan-no-go → planning (no PR path)."""
+        # This tests the normalization: if PR is closed, seed_issue should have set
+        # pr_number = None. But in the test, we construct IssueFacts directly.
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_PLAN_NO_GO},
+            pr_number=None,  # Normalized by seed_issue
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, _reason = classify_issue(facts)
+        assert queue == "planning"
+
+
+class TestSeedIssue:
+    """Fetch and normalize GitHub state for a single issue."""
+
+    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
+    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
+    def test_seed_issue_basic(self, mock_find_pr, mock_fetch) -> None:
+        """seed_issue fetches and normalizes GitHub state."""
+        mock_fetch.return_value = MagicMock(
+            number=101,
+            labels=[STATE_PLAN_GO, "other-label"],
+        )
+        mock_find_pr.return_value = None
+
+        facts = seed_issue(101)
+
+        assert facts.number == 101
+        assert STATE_PLAN_GO in facts.labels
+        assert facts.pr_number is None
+        assert facts.pr_is_open is False
+        assert facts.pr_is_merged is False
+
+    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
+    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
+    def test_seed_issue_with_open_pr(self, mock_find_pr, mock_fetch) -> None:
+        """seed_issue finds and records open PR."""
+        mock_fetch.return_value = MagicMock(
+            number=102,
+            labels=[STATE_PLAN_GO],
+        )
+        mock_find_pr.return_value = 42
+
+        facts = seed_issue(102)
+
+        assert facts.pr_number == 42
+        assert facts.pr_is_open is True
+        assert facts.pr_is_merged is False
+
+    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
+    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
+    def test_seed_issue_epic_detection(self, mock_find_pr, mock_fetch) -> None:
+        """seed_issue detects epic label."""
+        mock_fetch.return_value = MagicMock(
+            number=103,
+            labels=["epic", STATE_NEEDS_PLAN],
+        )
+        mock_find_pr.return_value = None
+
+        facts = seed_issue(103)
+
+        assert facts.is_epic is True
+
+    @patch("hephaestus.automation.pipeline.seeding.fetch_issue_info")
+    @patch("hephaestus.automation.pipeline.seeding.find_pr_for_issue")
+    def test_seed_issue_pr_fetch_failure_handled(self, mock_find_pr, mock_fetch) -> None:
+        """seed_issue handles PR lookup failures gracefully (fail-open)."""
+        mock_fetch.return_value = MagicMock(
+            number=104,
+            labels=[STATE_PLAN_GO],
+        )
+        mock_find_pr.side_effect = RuntimeError("API error")
+
+        facts = seed_issue(104)
+
+        assert facts.pr_number is None  # Fail-open
+        assert facts.pr_is_open is False
+
+
+class TestLabelRank:
+    """At-or-past label rank comparisons prevent re-queueing."""
+
+    def test_issue_already_past_plan_go_not_requeued_to_planning(self) -> None:
+        """AC: issue with state:implementation-go is NOT re-routed to planning."""
+        # This is the critical AC from the plan: "==` strands items already past the target"
+        # Our fix: use at-or-past (>=) not equality (==).
+        facts = IssueFacts(
+            number=1,
+            is_epic=False,
+            labels={STATE_IMPLEMENTATION_GO},
+            pr_number=None,
+            pr_is_open=False,
+            pr_is_merged=False,
+        )
+        queue, _ = classify_issue(facts)
+        # If we mistakenly routed to planning, this would fail.
+        assert queue == "implementation"

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -33,20 +33,53 @@ _FORBIDDEN_PREFIXES = (
     "hephaestus.resilience",
 )
 
-# Modules exempt from the zero-I/O guard.
+# Modules exempt from the zero-I/O guard entirely.
 # worker_pool.py is the ONLY place that executes jobs (agent, git, build/test),
 # so it must import I/O modules; all other workers offload to it.
-# seeding.py and admission.py are the sanctioned "thin fetch over
-# github_api" layer (epic #1809 PR-4): they READ GitHub facts for the
-# classifier/serializer but perform no mutations (the AST mutator guard in
-# test_pipeline_architecture.py still applies to them).
-_ALLOWLIST = frozenset({"worker_pool.py", "seeding.py", "admission.py"})
+_ALLOWLIST = frozenset({"worker_pool.py"})
+
+# Capability-scoped exemptions: seeding.py and admission.py are the sanctioned
+# "thin fetch over github_api" layer (epic #1809 PR-4): they READ GitHub facts
+# for the classifier/serializer but perform no mutations (the AST mutator guard
+# in test_pipeline_architecture.py still applies to them). Their exemption is
+# NOT module-wide — only the read-seam prefixes below are permitted, so a
+# direct `import subprocess` / `import os` in either file still trips the
+# guard.
+_THIN_FETCH_PREFIXES = (
+    "hephaestus.automation.github_api",
+    "hephaestus.automation._review_utils",
+    "hephaestus.automation.state_labels",
+    "hephaestus.automation.dependency_resolver",
+)
+_CAPABILITY_EXEMPT: dict[str, tuple[str, ...]] = {
+    "seeding.py": _THIN_FETCH_PREFIXES,
+    "admission.py": _THIN_FETCH_PREFIXES,
+}
 
 
 def _forbidden(name: str) -> bool:
     """Check if a module name is forbidden."""
     root = name.split(".")[0]
     return root in _FORBIDDEN_MODULES or name.startswith(_FORBIDDEN_PREFIXES)
+
+
+def _collect_violations(tree: ast.AST, filename: str, exempt: tuple[str, ...]) -> list[str]:
+    """Walk *tree* and return forbidden-import violations, honoring *exempt* prefixes."""
+
+    def _is_violation(module: str) -> bool:
+        return _forbidden(module) and not module.startswith(exempt)
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if _is_violation(alias.name):
+                    violations.append(f"{filename}:{node.lineno}: import {alias.name}")
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if _is_violation(mod):
+                violations.append(f"{filename}:{node.lineno}: from {mod} import ...")
+    return violations
 
 
 def test_pipeline_modules_have_zero_io_imports() -> None:
@@ -57,24 +90,47 @@ def test_pipeline_modules_have_zero_io_imports() -> None:
     conditional and lazy imports that a text-scan would miss.
 
     Exceptions: worker_pool.py is the only place that executes jobs
-    (agent, git, build/test), so it must import I/O modules.
+    (agent, git, build/test), so it must import I/O modules; seeding.py and
+    admission.py get a capability-scoped exemption for their sanctioned
+    read seams only (see ``_CAPABILITY_EXEMPT``).
     """
     violations: list[str] = []
     # rglob so future pipeline/ subpackages (e.g. stages/) stay guarded.
     for py in sorted(_PIPELINE_DIR.rglob("*.py")):
         if py.name in _ALLOWLIST:
             continue
+        exempt = _CAPABILITY_EXEMPT.get(py.name, ())
         tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Import):
-                for alias in node.names:
-                    if _forbidden(alias.name):
-                        violations.append(f"{py.name}:{node.lineno}: import {alias.name}")
-            elif isinstance(node, ast.ImportFrom):
-                mod = node.module or ""
-                if _forbidden(mod):
-                    violations.append(f"{py.name}:{node.lineno}: from {mod} import ...")
+        violations.extend(_collect_violations(tree, py.name, exempt))
     assert not violations, "pipeline modules must do zero I/O imports:\n" + "\n".join(violations)
+
+
+def test_capability_scope_still_blocks_io_in_seeding() -> None:
+    """The seeding/admission exemption is capability-scoped, not module-wide.
+
+    A synthetic seeding.py that imports subprocess/os alongside its sanctioned
+    read seams must still be flagged for the I/O modules — only imports under
+    the ``_THIN_FETCH_PREFIXES`` capability prefixes escape the guard.
+    """
+    synthetic_source = (
+        "import subprocess\n"
+        "import os\n"
+        "from hephaestus.automation.github_api import fetch_issue_info\n"
+        "from hephaestus.automation._review_utils import find_pr_for_issue\n"
+        "from hephaestus.automation.state_labels import is_epic\n"
+        "from hephaestus.automation.dependency_resolver import DependencyResolver\n"
+        "import hephaestus.utils.helpers\n"  # NOT a sanctioned seam — must trip
+    )
+    tree = ast.parse(synthetic_source, filename="<synthetic-seeding>")
+    violations = _collect_violations(tree, "seeding.py", _CAPABILITY_EXEMPT["seeding.py"])
+
+    assert any("import subprocess" in v for v in violations)
+    assert any("import os" in v for v in violations)
+    assert any("hephaestus.utils.helpers" in v for v in violations)
+    assert not any("github_api" in v for v in violations)
+    assert not any("_review_utils" in v for v in violations)
+    assert not any("state_labels" in v for v in violations)
+    assert not any("dependency_resolver" in v for v in violations)
 
 
 def test_forbidden_detects_synthetic_forbidden_import() -> None:
@@ -84,8 +140,8 @@ def test_forbidden_detects_synthetic_forbidden_import() -> None:
     would let `test_pipeline_modules_have_zero_io_imports` pass vacuously
     with an empty `violations` list. Here we parse synthetic source
     containing known-forbidden imports (stdlib module, forbidden prefix,
-    and a from-import) through the same AST walk and assert each is
-    caught, plus that an allowed import is not.
+    and a from-import) through the same collector (no exemptions) and
+    assert each is caught, plus that an allowed import is not.
     """
     synthetic_source = (
         "import subprocess\n"
@@ -94,21 +150,11 @@ def test_forbidden_detects_synthetic_forbidden_import() -> None:
         "import json\n"  # allowed stdlib module; must NOT be flagged
     )
     tree = ast.parse(synthetic_source, filename="<synthetic>")
+    violations = _collect_violations(tree, "<synthetic>", ())
 
-    violations: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            for alias in node.names:
-                if _forbidden(alias.name):
-                    violations.append(f"import {alias.name}")
-        elif isinstance(node, ast.ImportFrom):
-            mod = node.module or ""
-            if _forbidden(mod):
-                violations.append(f"from {mod} import ...")
-
-    assert "import subprocess" in violations
-    assert "import hephaestus.automation.git_utils" in violations
-    assert "from os import ..." in violations
+    assert any("import subprocess" in v for v in violations)
+    assert any("import hephaestus.automation.git_utils" in v for v in violations)
+    assert any("from os import ..." in v for v in violations)
     assert not any("json" in v for v in violations)
 
 

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -36,7 +36,11 @@ _FORBIDDEN_PREFIXES = (
 # Modules exempt from the zero-I/O guard.
 # worker_pool.py is the ONLY place that executes jobs (agent, git, build/test),
 # so it must import I/O modules; all other workers offload to it.
-_ALLOWLIST = frozenset({"worker_pool.py"})
+# seeding.py and admission.py are the sanctioned "thin fetch over
+# github_api" layer (epic #1809 PR-4): they READ GitHub facts for the
+# classifier/serializer but perform no mutations (the AST mutator guard in
+# test_pipeline_architecture.py still applies to them).
+_ALLOWLIST = frozenset({"worker_pool.py", "seeding.py", "admission.py"})
 
 
 def _forbidden(name: str) -> bool:

--- a/tests/unit/automation/test_github_api_package.py
+++ b/tests/unit/automation/test_github_api_package.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 from unittest import mock
 
 from hephaestus.automation import github_api as gha
@@ -16,7 +17,7 @@ def test_public_reexports_match_canonical_submodules() -> None:
         "issue_states": ["prefetch_issue_states", "_fetch_batch_states"],
         "issues": ["gh_issue_json", "gh_issue_create", "fetch_issue_info"],
         "labels": ["gh_list_labels", "gh_create_label", "_ensure_labels_exist"],
-        "prs": ["gh_pr_create", "fetch_open_prs", "gh_current_login"],
+        "prs": ["gh_pr_create", "fetch_open_prs", "gh_current_login", "gh_pr_label_names"],
         "reviews": ["gh_pr_review_post", "gh_pr_inline_comment_index"],
         "threads": ["gh_pr_list_unresolved_threads", "gh_pr_resolve_thread"],
     }
@@ -50,3 +51,28 @@ def test_patch_gh_call_reaches_submodule() -> None:
         assert labels.gh_list_labels(refresh=True) == set()
 
     gh_call.assert_called_once()
+
+
+def test_gh_pr_label_names_normalizes_label_dicts() -> None:
+    """gh_pr_label_names flattens gh's ``{"name": ...}`` label dicts to names."""
+    payload = {"labels": [{"name": "state:implementation-go"}, {"name": "bug"}, "plain"]}
+    result = mock.Mock(stdout=json.dumps(payload))
+
+    with mock.patch.object(gha, "_gh_call", return_value=result) as gh_call:
+        names = gha.gh_pr_label_names(77)
+
+    assert names == ["state:implementation-go", "bug", "plain"]
+    gh_call.assert_called_once_with(["pr", "view", "77", "--json", "labels"], check=False)
+
+
+def test_gh_pr_label_names_best_effort_empty_on_failure() -> None:
+    """A fetch/JSON failure yields [] (read as "not yet reviewed" by seeding)."""
+    with mock.patch.object(gha, "_gh_call", side_effect=OSError("gh down")):
+        assert gha.gh_pr_label_names(77) == []
+
+
+def test_gh_pr_label_names_non_list_labels_yields_empty() -> None:
+    """A malformed payload (labels not a list) yields [] rather than raising."""
+    result = mock.Mock(stdout=json.dumps({"labels": "oops"}))
+    with mock.patch.object(gha, "_gh_call", return_value=result):
+        assert gha.gh_pr_label_names(77) == []

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -313,8 +313,10 @@ def test_filter_open_issues_drops_closed() -> None:
         return num == 1552
 
     with (
-        patch.object(loop_runner, "prefetch_issue_states", return_value={}),
-        patch.object(loop_runner, "is_issue_closed", side_effect=fake_is_closed),
+        patch("hephaestus.automation.pipeline.admission.prefetch_issue_states", return_value={}),
+        patch(
+            "hephaestus.automation.pipeline.admission.is_issue_closed", side_effect=fake_is_closed
+        ),
     ):
         kept = loop_runner._filter_open_issues("r", [1554, 1552])
     assert kept == [1554]
@@ -322,7 +324,10 @@ def test_filter_open_issues_drops_closed() -> None:
 
 def test_filter_open_issues_keeps_all_on_prefetch_failure() -> None:
     """Fail-open: a prefetch error keeps every issue (never silently drop work)."""
-    with patch.object(loop_runner, "prefetch_issue_states", side_effect=RuntimeError("boom")):
+    with patch(
+        "hephaestus.automation.pipeline.admission.prefetch_issue_states",
+        side_effect=RuntimeError("boom"),
+    ):
         kept = loop_runner._filter_open_issues("r", [1554, 1552])
     assert kept == [1554, 1552]
 

--- a/tests/unit/automation/test_loop_runner_file_overlap.py
+++ b/tests/unit/automation/test_loop_runner_file_overlap.py
@@ -74,13 +74,18 @@ def test_parse_planned_files_stops_at_next_heading() -> None:
 def test_fetch_planned_files_no_plan_comment_returns_none() -> None:
     """Comments present but none is a plan comment → None (fail-open)."""
     comments = [{"body": "just a chat comment"}, {"body": "## 🔍 Plan Review"}]
-    with patch.object(loop_runner, "_fetch_issue_comment_ids", return_value=comments):
+    # Patch the admission module where _fetch_issue_comment_ids is used
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids", return_value=comments
+    ):
         assert loop_runner._fetch_planned_files(101) is None
 
 
 def test_fetch_planned_files_empty_comment_list_returns_none() -> None:
     """An empty fetch (the swallowed-error signal) → None; no try/except needed."""
-    with patch.object(loop_runner, "_fetch_issue_comment_ids", return_value=[]):
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids", return_value=[]
+    ):
         assert loop_runner._fetch_planned_files(102) is None
 
 
@@ -95,7 +100,9 @@ def test_fetch_planned_files_returns_plan_file_set() -> None:
             )
         },
     ]
-    with patch.object(loop_runner, "_fetch_issue_comment_ids", return_value=comments):
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids", return_value=comments
+    ):
         assert loop_runner._fetch_planned_files(103) == {"hephaestus/automation/address_review.py"}
 
 
@@ -110,7 +117,11 @@ def test_select_non_overlapping_defers_second_of_overlapping_pair() -> None:
         1: {"hephaestus/automation/address_review.py", "hephaestus/automation/a.py"},
         2: {"hephaestus/automation/address_review.py", "hephaestus/automation/b.py"},
     }
-    with patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans[i]):
+    # Patch in the admission module where _select_non_overlapping is defined
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_planned_files",
+        side_effect=lambda i: plans[i],
+    ):
         dispatch, defer = loop_runner._select_non_overlapping([1, 2])
     assert dispatch == [1]
     assert defer == [2]
@@ -122,7 +133,10 @@ def test_select_non_overlapping_disjoint_both_dispatched() -> None:
         1: {"hephaestus/automation/a.py"},
         2: {"hephaestus/automation/b.py"},
     }
-    with patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans[i]):
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_planned_files",
+        side_effect=lambda i: plans[i],
+    ):
         dispatch, defer = loop_runner._select_non_overlapping([1, 2])
     assert dispatch == [1, 2]
     assert defer == []
@@ -135,7 +149,10 @@ def test_select_non_overlapping_unknown_plan_fails_open() -> None:
         2: None,  # no plan yet — fail open
         3: {"hephaestus/automation/address_review.py"},
     }
-    with patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans[i]):
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_planned_files",
+        side_effect=lambda i: plans[i],
+    ):
         dispatch, defer = loop_runner._select_non_overlapping([1, 2, 3])
     # #1 claims address_review.py; #2 unknown → dispatched; #3 overlaps #1 → deferred.
     assert dispatch == [1, 2]
@@ -148,7 +165,10 @@ def test_select_non_overlapping_first_issue_always_dispatched() -> None:
         1: {"hephaestus/automation/address_review.py"},
         2: {"hephaestus/automation/address_review.py"},
     }
-    with patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans[i]):
+    with patch(
+        "hephaestus.automation.pipeline.admission._fetch_planned_files",
+        side_effect=lambda i: plans[i],
+    ):
         dispatch, defer = loop_runner._select_non_overlapping([1, 2])
     assert dispatch[0] == 1
     assert defer == [2]
@@ -200,7 +220,15 @@ def test_process_repo_inner_defers_overlapping_issue(tmp_path: object) -> None:
         patch.object(loop_runner, "_resolve_repo_dir", return_value=repo_dir),
         patch.object(loop_runner, "_rebase_main", return_value=("abc123", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1, 2]),
-        patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans[i]),
+        # Patch both: admission (where _select_non_overlapping uses it) and loop_runner (the shim)
+        patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ),
+        patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans[i],
+        ),
         patch.object(loop_runner, "_process_one_issue", side_effect=fake_process_one_issue),
     ):
         out = loop_runner._process_repo_inner("Repo", 1, cfg, result)
@@ -297,7 +325,10 @@ def test_terminal_catchup_runs_after_post_loop_with_guard_on() -> None:
         patch.object(loop_runner, "_run_post_loop_stages", side_effect=fake_post_loop),
         # Both deferred issues are the only open ones → no claiming peers.
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[2, 3]),
-        patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans.get(i)),
+        patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans.get(i),
+        ),
         patch.object(loop_runner, "find_pr_for_issue", return_value=None),
         patch.object(
             loop_runner,
@@ -347,7 +378,10 @@ def test_terminal_catchup_withholds_issue_while_peer_pr_open(
         patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
         # Peer #2 is still open alongside deferred #3 ...
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[2, 3]),
-        patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans.get(i)),
+        patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans.get(i),
+        ),
         # ... and still owns an OPEN PR → its planned files stay claimed.
         patch.object(loop_runner, "find_pr_for_issue", return_value=77),
         patch.object(loop_runner, "_maybe_sleep_for_rate_budget"),
@@ -379,7 +413,10 @@ def test_terminal_catchup_peer_without_open_pr_does_not_block() -> None:
         patch.object(loop_runner, "process_repo", side_effect=fake_process_repo),
         patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[2, 3]),
-        patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans.get(i)),
+        patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans.get(i),
+        ),
         patch.object(loop_runner, "find_pr_for_issue", return_value=None),
         patch.object(loop_runner, "_maybe_sleep_for_rate_budget"),
     ):
@@ -406,7 +443,7 @@ def test_terminal_catchup_shutdown_stops_cleanly() -> None:
         patch.object(loop_runner, "process_repo", side_effect=fake_process_repo),
         patch.object(loop_runner, "_run_post_loop_stages", return_value=[]),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[2, 3]),
-        patch.object(loop_runner, "_fetch_planned_files", return_value=None),
+        patch("hephaestus.automation.pipeline.admission._fetch_planned_files", return_value=None),
         patch.object(loop_runner, "find_pr_for_issue", return_value=None),
         patch.object(loop_runner, "_maybe_sleep_for_rate_budget"),
         patch.object(loop_runner, "_shutdown_requested", side_effect=[False, False, True]),
@@ -424,7 +461,10 @@ def test_open_peer_pr_claims_only_open_pr_peers_claim() -> None:
 
     with (
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[2, 3, 4, 5]),
-        patch.object(loop_runner, "_fetch_planned_files", side_effect=lambda i: plans.get(i)),
+        patch(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            side_effect=lambda i: plans.get(i),
+        ),
         patch.object(loop_runner, "find_pr_for_issue", side_effect=lambda i: open_prs.get(i)),
     ):
         claims = loop_runner._open_peer_pr_claims(LoopConfig(), "Repo", deferred={3})

--- a/tests/unit/automation/test_loop_runner_file_overlap.py
+++ b/tests/unit/automation/test_loop_runner_file_overlap.py
@@ -220,11 +220,8 @@ def test_process_repo_inner_defers_overlapping_issue(tmp_path: object) -> None:
         patch.object(loop_runner, "_resolve_repo_dir", return_value=repo_dir),
         patch.object(loop_runner, "_rebase_main", return_value=("abc123", True)),
         patch.object(loop_runner, "_list_open_issue_numbers", return_value=[1, 2]),
-        # Patch both: admission (where _select_non_overlapping uses it) and loop_runner (the shim)
-        patch(
-            "hephaestus.automation.pipeline.admission._fetch_planned_files",
-            side_effect=lambda i: plans[i],
-        ),
+        # Patch the one canonical seam: admission, where _select_non_overlapping
+        # resolves _fetch_planned_files (loop_runner routes through _admission).
         patch(
             "hephaestus.automation.pipeline.admission._fetch_planned_files",
             side_effect=lambda i: plans[i],

--- a/tests/unit/automation/test_pipeline_shims.py
+++ b/tests/unit/automation/test_pipeline_shims.py
@@ -1,0 +1,42 @@
+"""Parity test for shimmed symbols moved to pipeline/admission.py.
+
+Ensures that loop_runner's shim imports match the canonical implementations
+in pipeline.admission (pattern from tests/unit/automation/state/test_shim_parity.py).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from hephaestus.automation import loop_runner
+
+# Symbols that were moved from loop_runner to pipeline.admission.
+SHIMMED_SYMBOLS = [
+    "_fetch_planned_files",
+    "_filter_open_issues",
+    "_parse_planned_files",
+    "_select_non_overlapping",
+]
+
+
+@pytest.mark.parametrize("symbol_name", SHIMMED_SYMBOLS)
+def test_shim_reexports_match_canonical(symbol_name: str) -> None:
+    """loop_runner shim re-exports match the canonical pipeline.admission implementation."""
+    # Get the shim from loop_runner
+    shim_obj = getattr(loop_runner, symbol_name)
+
+    # Get the canonical from pipeline.admission
+    admission = importlib.import_module("hephaestus.automation.pipeline.admission")
+    canonical_obj = getattr(admission, symbol_name)
+
+    # They should be the same object (re-export via `as name` binding)
+    assert shim_obj is canonical_obj, f"{symbol_name} drifted: shim is not the canonical object"
+
+
+def test_shimmed_functions_callable() -> None:
+    """All shimmed functions are callable."""
+    for symbol_name in SHIMMED_SYMBOLS:
+        obj = getattr(loop_runner, symbol_name)
+        assert callable(obj), f"{symbol_name} is not callable"

--- a/tests/unit/automation/test_pipeline_shims.py
+++ b/tests/unit/automation/test_pipeline_shims.py
@@ -33,10 +33,3 @@ def test_shim_reexports_match_canonical(symbol_name: str) -> None:
 
     # They should be the same object (re-export via `as name` binding)
     assert shim_obj is canonical_obj, f"{symbol_name} drifted: shim is not the canonical object"
-
-
-def test_shimmed_functions_callable() -> None:
-    """All shimmed functions are callable."""
-    for symbol_name in SHIMMED_SYMBOLS:
-        obj = getattr(loop_runner, symbol_name)
-        assert callable(obj), f"{symbol_name} is not callable"

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -17,6 +17,7 @@ from hephaestus.automation._review_utils import (
     drain_completed_futures,
     ensure_state_dir,
     find_merged_closing_pr,
+    find_merged_pr_for_issue,
     find_pr_for_issue,
     get_pr_head_branch,
     load_impl_session_id,
@@ -799,6 +800,79 @@ class TestFindMergedClosingPr:
             result = find_merged_closing_pr(1357)
 
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# find_merged_pr_for_issue
+# ---------------------------------------------------------------------------
+
+
+class TestFindMergedPrForIssue:
+    """Tests for find_merged_pr_for_issue — the tri-state fetch's merged lookup."""
+
+    def test_finds_via_merged_branch_name(self) -> None:
+        """Strategy 1: ``{issue}-auto-impl`` head lookup with ``--state merged``."""
+        captured: dict[str, list[str]] = {}
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            captured["args"] = args
+            return _make_gh_result([{"number": 43}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_merged_pr_for_issue(7)
+
+        assert result == 43
+        assert "--head" in captured["args"]
+        assert "7-auto-impl" in captured["args"]
+        assert "merged" in captured["args"]
+
+    def test_falls_back_to_merged_body_search(self) -> None:
+        """Branch miss → falls through to find_merged_closing_pr's body search."""
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            if "--head" in args:
+                return _make_gh_result([])
+            return _make_gh_result([{"number": 44, "body": "Fix.\n\nCloses #7\n"}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_merged_pr_for_issue(7)
+
+        assert result == 44
+
+    def test_returns_none_when_no_merged_pr(self) -> None:
+        """Neither strategy finds a merged PR → None (closed PRs stay invisible)."""
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            return_value=_make_gh_result([]),
+        ):
+            result = find_merged_pr_for_issue(7)
+
+        assert result is None
+
+    def test_branch_lookup_failure_still_tries_body_search(self) -> None:
+        """A branch-strategy gh failure is swallowed; body search still runs."""
+        calls: list[list[str]] = []
+
+        def _side_effect(args: list[str], **kw: Any) -> MagicMock:
+            calls.append(args)
+            if "--head" in args:
+                raise RuntimeError("gh boom")
+            return _make_gh_result([{"number": 45, "body": "Closes #7\n"}])
+
+        with patch(
+            "hephaestus.automation._review_utils._gh_call",
+            side_effect=_side_effect,
+        ):
+            result = find_merged_pr_for_issue(7)
+
+        assert result == 45
+        assert len(calls) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

GitHub-journal seeding and admission control for the queue-based pipeline (epic #1809). One classifier serves initial seeding (`--repos` / `--issues` / `--prs`) and restart reconstruction; admission control (file-overlap serialization + dependency ordering) lands alongside since it consumes seeding data. The binding contract is the classification table in `docs/AUTOMATION_LOOP_ARCHITECTURE.md` ("Seeding and reconstruction").

### `pipeline/seeding.py`

- **Pure classifier** `classify_issue(IssueFacts) -> Classification` where `Classification = tuple[StageName | None, str]`: real queues are `routing.StageName` members (SSOT — no parallel queue-name Literal), and `None` is an explicit EXCLUSION (state:skip / epic), logged and distinct from `StageName.FINISHED`. Ordered label rank with **at-or-past** comparisons (never equality); contradictory multi-state-label combos resolve to the highest rank with a warning.
- **Tri-state PR fetch** in `seed_issue`: the open-PR lookup (`find_pr_for_issue`) runs first; on a miss, the new `_review_utils.find_merged_pr_for_issue` (branch-name + exact-`Closes #N` body search, both `--state merged`) sets `pr_is_merged` truthfully, so the doc's "PR merged → finished" row is reachable and a restart never re-queues merged work. Closed/abandoned PRs are invisible to both lookups and normalize to `pr_number=None`. PR probes are **fail-closed**: any GitHub error re-raises (no silent misclassification toward implementation).
- **Epic handling**: detection via `state_labels.is_epic(labels, title)` (roadmap label + title markers, #1669; title threaded through `IssueFacts`). The one sanctioned seeding write (epic → `state:skip`, done BEFORE excluding per the doc) is *surfaced, not performed*: untagged epics return the `epic_needs_skip_tag` exclusion reason and the caller — the coordinator slice (#1817) — executes the label write via the existing `github_api.skip_epics` chokepoint. Seeding itself stays read-only under the pipeline mutator guard.
- **CLI mapping** `seed_from_cli(repos, issues, prs)`: repos → `StageName.REPO` seeds; issues → `seed_issue` + `classify_issue`; prs → `ci` when the PR carries `state:implementation-go` else `pr_review`, mirroring `_review_existing_pr` (`implementer_phase_runner.py:750`) via the new thin `github_api.gh_pr_label_names` reader (best-effort empty = "not yet reviewed" → pr_review). Pure planning of pushes + thin fetch; no mutations.

### `pipeline/admission.py`

- Re-housed `_select_non_overlapping` / `_parse_planned_files` / `_fetch_planned_files` (#1623) and `_filter_open_issues` (#1576) from `loop_runner.py`.
- **Topological-order gating** `order_for_implementation(issue_infos)` via `DependencyResolver.topological_sort`: in-set dependencies dispatch first; out-of-set edges are dropped (fail-open); cycles keep input order with a warning.
- **Dropped deliverable (documented in the module docstring)**: the per-repo in-flight cap helper (`within_repo_cap`) is NOT implemented, per the issue #1813 plan comment's sanction: "justify or drop `within_repo_cap` (YAGNI — no named consumer)". No consumer exists until the coordinator slice (#1817).

### Shim-first relocation

`loop_runner.py` keeps explicit `from ...pipeline.admission import name as name` re-exports (top import section, no `noqa`) for external callers; its internal call sites route through the `_admission` module attribute so tests patch one canonical seam. Parity pinned by `tests/unit/automation/test_pipeline_shims.py`.

### Guards

- Zero-IO guard exemption for seeding/admission is **capability-scoped**, not module-wide: only `github_api` / `_review_utils` / `state_labels` / `dependency_resolver` import prefixes are permitted; `subprocess`/`os` in either file still trip the guard (tested with synthetic sources).
- The AST mutator guard (`test_pipeline_architecture.py`) still applies to both modules.

## Patch-seam sweep (mandatory)

```console
$ grep -rln "_select_non_overlapping\|_parse_planned_files\|_filter_open_issues\|_fetch_planned_files" tests/
tests/unit/automation/test_loop_runner_file_overlap.py
tests/unit/automation/pipeline/test_admission.py
tests/unit/automation/test_pipeline_shims.py
tests/unit/automation/test_loop_runner.py

$ grep -rn "patch(\"hephaestus.automation.loop_runner" tests/ | grep -E "_select_non_overlapping|_parse_planned_files|_filter_open_issues|_fetch_planned_files"
(no hits — no test patches the moved symbols via loop_runner string paths)

$ grep -rn "patch.object(loop_runner" tests/ | grep -E "_select_non_overlapping|_parse_planned_files|_filter_open_issues|_fetch_planned_files"
(no hits — no test patches the moved symbols via patch.object(loop_runner, ...))

$ grep -rn "hephaestus.automation.pipeline.admission" tests/ | wc -l   # all admission-seam patches target the canonical module
37
```

Every hit either targets the canonical `pipeline.admission` seam directly or goes through the loop_runner re-export shims, which resolve to the same objects (pinned by `test_pipeline_shims.py`).

## Verification

- `pixi run pytest tests/unit` — 5834 passed, 20 skipped; total coverage 84.68% (gate 83%).
- `hephaestus/automation/pipeline/seeding.py` and `admission.py`: **100%** line+branch coverage each (including the contradictory-label warning branch).
- Mutation probe: weakening the open-PR ci gate to `implementation-no-go` is killed by `test_open_pr_with_impl_no_go_routes_to_pr_review`.
- `pixi run mypy` clean; `pre-commit run --all-files` clean.

Closes #1813
