### PR TITLE
[Feat] Pipeline planning and plan-review stages

### DIFF
--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -10,6 +10,7 @@ from .base import (
     JobRequest,
     Stage,
     StageContext,
+    StageGitHub,
     StageOutcome,
     StepResult,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "PlanningStage",
     "Stage",
     "StageContext",
+    "StageGitHub",
     "StageOutcome",
     "StepResult",
 ]

--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -1,0 +1,28 @@
+"""Pipeline stage implementations.
+
+Stages are pure-ish step functions that process work items through a
+stage-local state machine. The base protocol and step-result types live in
+:mod:`.base`; concrete stages (planning, plan_review, ...) follow.
+"""
+
+from .base import (
+    Continue,
+    JobRequest,
+    Stage,
+    StageContext,
+    StageOutcome,
+    StepResult,
+)
+from .plan_review import PlanReviewStage
+from .planning import PlanningStage
+
+__all__ = [
+    "Continue",
+    "JobRequest",
+    "PlanReviewStage",
+    "PlanningStage",
+    "Stage",
+    "StageContext",
+    "StageOutcome",
+    "StepResult",
+]

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -195,10 +195,6 @@ class StageContext:
             return self.budget_fn(name)
         return 1  # conservative default
 
-    def option(self, name: str, default: Any = None) -> Any:
-        """Read an optional config attribute with a default (POLA accessor)."""
-        return getattr(self.config, name, default)
-
 
 @runtime_checkable
 class Stage(Protocol):
@@ -231,6 +227,15 @@ class Stage(Protocol):
 
         Returns:
             None to proceed with step(), or a StageOutcome to skip/finish.
+
+        Note:
+            Implementations MAY mutate ``item.state`` as a side effect during
+            ``on_enter`` to fast-forward past already-completed work (e.g. an
+            existing plan comment jumps ``item.state`` to VERIFY so a restart
+            never redoes finished sub-steps). This side effect is *in addition*
+            to the return value; a ``None`` return does not imply ``item.state``
+            is unchanged. Callers MUST re-read ``item.state`` after ``on_enter``
+            to observe any fast-forward.
 
         """
         ...

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -30,6 +30,13 @@ Coordinator convention (binding for #1817, the coordinator slice):
 - All durable GitHub mutations go through ``ctx.github`` and happen
   immediately BEFORE the outcome that causes a queue push ("durable write
   precedes the queue push").
+- ``ctx.github`` implements the :class:`StageGitHub` protocol. Its mutator
+  surface (``add_labels`` / ``remove_labels`` / ``close_issue_as_covered`` /
+  ``upsert_plan_comment``) uses coordinator-neutral names the coordinator
+  (#1817) maps onto the ``github_api`` mutators; ``upsert_plan_comment`` is
+  the durable plan-comment channel (doc section 2: "plan comment = durable
+  artifact") — the planning stage calls it in VERIFY so the plan the agent
+  produced is journaled BEFORE the verify/ADVANCE decision.
 """
 
 from __future__ import annotations
@@ -53,11 +60,77 @@ __all__ = [
     "JobResult",
     "Stage",
     "StageContext",
+    "StageGitHub",
     "StageName",
     "StageOutcome",
     "StepResult",
     "WorkItem",
 ]
+
+
+@runtime_checkable
+class StageGitHub(Protocol):
+    """Coordinator-owned GitHub accessor injected as ``StageContext.github``.
+
+    The single seam through which stages read GitHub facts and request
+    durable mutations. Dry-run is honored INSIDE the accessor implementation
+    (#1817): when the coordinator runs with ``--dry-run``, the mutator
+    methods below log-and-skip the underlying ``gh`` calls, so stages never
+    branch on ``ctx.dry_run`` around a write.
+
+    Read surface mirrors the existing helper names; the mutator surface uses
+    coordinator-neutral names the coordinator maps onto ``github_api``
+    mutators (the pipeline architecture guard forbids ``github_api`` mutator
+    names inside pipeline modules).
+    """
+
+    def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+        """Fetch issue JSON (mirrors ``github_api.issues.gh_issue_json``)."""
+        ...
+
+    def find_merged_closing_pr(self, issue_number: int) -> int | None:
+        """Return the merged PR closing this issue, if any (``_review_utils``)."""
+        ...
+
+    def find_pr_for_issue(self, issue_number: int) -> int | None:
+        """Return an open PR covering this issue, if any (``_review_utils``)."""
+        ...
+
+    def has_existing_plan(self, issue_number: int) -> bool:
+        """Return True when the issue already counts as planned.
+
+        Contract for the real implementation (#1817): this must reuse the
+        labels-first ``is_plan_review_go`` semantics INCLUDING its one-time
+        comment-scan backfill for issues that converged before the labels
+        rollout (reference: ``planner.py`` ``Planner._has_existing_plan``,
+        which delegates to ``state.review.is_plan_review_go``). A pure
+        label-equality check is NOT sufficient.
+        """
+        ...
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Durably add labels (coordinator maps to ``gh_issue_add_labels``)."""
+        ...
+
+    def remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Durably remove labels (coordinator maps to ``gh_issue_remove_labels``)."""
+        ...
+
+    def close_issue_as_covered(self, issue_number: int, pr_number: int) -> None:
+        """Close the issue as covered by a merged PR (``_review_utils``)."""
+        ...
+
+    def upsert_plan_comment(self, issue_number: int, body: str) -> None:
+        """Upsert the single plan comment, keyed on ``PLAN_COMMENT_MARKER``.
+
+        Durable plan-comment channel (doc section 2: "plan comment = durable
+        artifact"). The coordinator maps this onto
+        ``gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)``
+        so the issue holds exactly one plan comment, updated in place
+        (re-housed from ``planner_review_loop._upsert_plan_comment``).
+        Callers pass a body already normalized to start with the marker.
+        """
+        ...
 
 
 @dataclass(frozen=True)
@@ -91,11 +164,12 @@ class StageContext:
 
     All coordinator-owned accessors (github, paths, clock, budgets) are
     injected here so stages never construct their own I/O helpers. The
-    ``github`` accessor is the coordinator's single mutation channel: its
-    mutator surface uses coordinator-neutral names (``add_labels``,
-    ``remove_labels``, ``close_issue_as_covered``) that the coordinator
-    (#1817) maps onto the ``github_api`` mutators, while its read surface
-    mirrors the existing helper names (``gh_issue_json``,
+    ``github`` accessor is the coordinator's single mutation channel and
+    implements the :class:`StageGitHub` protocol: its mutator surface uses
+    coordinator-neutral names (``add_labels``, ``remove_labels``,
+    ``close_issue_as_covered``, ``upsert_plan_comment``) that the
+    coordinator (#1817) maps onto the ``github_api`` mutators, while its
+    read surface mirrors the existing helper names (``gh_issue_json``,
     ``find_merged_closing_pr``, ``find_pr_for_issue``,
     ``has_existing_plan``). Stages never import ``github_api`` directly —
     enforced by ``tests/unit/automation/pipeline/test_pipeline_architecture``.
@@ -104,7 +178,7 @@ class StageContext:
     config: Any  # PlannerOptions-like (enable_advise, enable_learn, force, agent, dry_run)
     org: str
     dry_run: bool
-    github: Any  # coordinator-owned GitHub accessor (label/comment/PR writes+reads)
+    github: StageGitHub  # coordinator-owned GitHub accessor (label/comment/PR writes+reads)
     paths: Any  # coordinator-owned path accessor (repo_root, worktree)
     now_fn: Callable[[], float] | None = None  # injectable clock (tests pass a fake)
     budget_fn: Callable[[str], int] | None = None  # routing accessor: ROUTES budget lookup

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -1,0 +1,192 @@
+"""Base protocol and step-result types for pipeline stages.
+
+This module defines the :class:`Stage` protocol that all pipeline stages
+implement, the step-result types (:class:`Continue` / :class:`JobRequest` /
+re-exported :class:`StageOutcome`), and :class:`StageContext`, the bundle of
+coordinator-owned accessors injected into every stage call.
+
+Core types come from their source modules (epic #1809):
+``StageOutcome``/``Disposition``/``StageName`` from :mod:`..routing`,
+``WorkItem``/``ItemKind`` from :mod:`..work_item`, and
+``AgentJob``/``JobResult``/``JobHandle`` from :mod:`..jobs`. They are
+re-exported here so stage modules and their tests have a single import
+surface for the stage contract.
+
+Coordinator convention (binding for #1817, the coordinator slice):
+
+- ``on_enter`` runs once when an item enters the stage. It must be
+  idempotent, and its label checks are ordered at-or-past checks (never
+  equality), so re-entry after a restart fast-forwards instead of redoing
+  work. It returns ``None`` to proceed or a ``StageOutcome`` to route away.
+- ``step`` is invoked for the item's *current* ``state``. Returning
+  ``Continue`` advances ``item.state`` and steps again; returning
+  ``JobRequest`` submits the job while ``item.state`` stays at the
+  submitting WAIT state; returning ``StageOutcome`` routes via ROUTES.
+- When a requested job completes and was NOT interrupted, the coordinator
+  calls ``on_job_done`` (``item.state`` still the WAIT state that submitted
+  the job), then sets ``item.state = on_done_state`` and steps again.
+  ``on_job_done`` is never called for interrupted results — interrupts
+  leave items resumable, never failed.
+- All durable GitHub mutations go through ``ctx.github`` and happen
+  immediately BEFORE the outcome that causes a queue push ("durable write
+  precedes the queue push").
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, TypeAlias, runtime_checkable
+
+from ..jobs import AgentJob, JobHandle, JobResult
+from ..routing import Disposition, StageName, StageOutcome
+from ..work_item import ItemKind, WorkItem
+
+__all__ = [
+    "AgentJob",
+    "Continue",
+    "Disposition",
+    "ItemKind",
+    "JobHandle",
+    "JobRequest",
+    "JobResult",
+    "Stage",
+    "StageContext",
+    "StageName",
+    "StageOutcome",
+    "StepResult",
+    "WorkItem",
+]
+
+
+@dataclass(frozen=True)
+class Continue:
+    """Advance to the next state without requesting a job."""
+
+    next_state: str
+
+
+@dataclass(frozen=True)
+class JobRequest:
+    """Request a job be submitted to the worker pool.
+
+    Attributes:
+        job: The frozen job spec to submit.
+        on_done_state: The state the coordinator moves the item to after the
+            job completes and ``on_job_done`` has run.
+
+    """
+
+    job: AgentJob
+    on_done_state: str
+
+
+StepResult: TypeAlias = "Continue | JobRequest | StageOutcome"
+
+
+@dataclass(frozen=True)
+class StageContext:
+    """Context passed to every stage call.
+
+    All coordinator-owned accessors (github, paths, clock, budgets) are
+    injected here so stages never construct their own I/O helpers. The
+    ``github`` accessor is the coordinator's single mutation channel: its
+    mutator surface uses coordinator-neutral names (``add_labels``,
+    ``remove_labels``, ``close_issue_as_covered``) that the coordinator
+    (#1817) maps onto the ``github_api`` mutators, while its read surface
+    mirrors the existing helper names (``gh_issue_json``,
+    ``find_merged_closing_pr``, ``find_pr_for_issue``,
+    ``has_existing_plan``). Stages never import ``github_api`` directly —
+    enforced by ``tests/unit/automation/pipeline/test_pipeline_architecture``.
+    """
+
+    config: Any  # PlannerOptions-like (enable_advise, enable_learn, force, agent, dry_run)
+    org: str
+    dry_run: bool
+    github: Any  # coordinator-owned GitHub accessor (label/comment/PR writes+reads)
+    paths: Any  # coordinator-owned path accessor (repo_root, worktree)
+    now_fn: Callable[[], float] | None = None  # injectable clock (tests pass a fake)
+    budget_fn: Callable[[str], int] | None = None  # routing accessor: ROUTES budget lookup
+
+    def now(self) -> float:
+        """Return the current time in seconds since epoch (injectable for tests)."""
+        if self.now_fn is not None:
+            return self.now_fn()
+        return time.time()
+
+    def budget(self, name: str) -> int:
+        """Look up the budget for a given counter name from the routing tables."""
+        if self.budget_fn is not None:
+            return self.budget_fn(name)
+        return 1  # conservative default
+
+    def option(self, name: str, default: Any = None) -> Any:
+        """Read an optional config attribute with a default (POLA accessor)."""
+        return getattr(self.config, name, default)
+
+
+@runtime_checkable
+class Stage(Protocol):
+    """Protocol for pipeline stage implementations.
+
+    A stage processes work items through a small in-memory state machine
+    (states are stage-local strings, never GitHub labels):
+
+    1. ``on_enter``: refresh item state, perform idempotent fast-forward
+       checks (ordered at-or-past label checks, never equality), and ensure
+       required entry labels durably. Return ``None`` to proceed or a
+       ``StageOutcome`` to skip/finish.
+    2. ``step``: take the next action for the current state (``Continue`` to
+       advance state, ``JobRequest`` to submit work, or ``StageOutcome`` to
+       route). Every durable mutation happens immediately before the return.
+    3. ``on_job_done``: handle the result of a completed job (never called
+       for interrupted results), storing parsed values on ``item.payload``.
+    """
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """Refresh labels and perform idempotent fast-forward checks on entry.
+
+        Must be safe to call repeatedly (restart = re-run): label checks are
+        ordered at-or-past checks, and any entry-label write is guarded by a
+        presence check so re-entry produces no duplicate mutations.
+
+        Args:
+            item: The work item being processed.
+            ctx: The stage context.
+
+        Returns:
+            None to proceed with step(), or a StageOutcome to skip/finish.
+
+        """
+        ...
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Execute the next action for the item's current state.
+
+        Args:
+            item: The work item being processed.
+            ctx: The stage context.
+
+        Returns:
+            A Continue (advance state), JobRequest (submit work while this
+            state waits), or StageOutcome (route via ROUTES). All durable
+            mutations happen immediately before the return.
+
+        """
+        ...
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Handle completion of a job (never called for interrupted results).
+
+        Called with ``item.state`` still at the WAIT state that submitted the
+        job. Store parsed results on ``item.payload``; the coordinator then
+        advances ``item.state`` to the JobRequest's ``on_done_state``.
+
+        Args:
+            item: The work item being processed.
+            result: The job result from the worker pool.
+            ctx: The stage context.
+
+        """
+        ...

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -1,0 +1,283 @@
+"""Plan-review stage: review, amend, and approve issue plans (issue #1814).
+
+Re-houses the plan-review control flow from
+``planner_review_loop.py::PlanReviewLoop.run`` as a pipeline stage
+(docs/AUTOMATION_LOOP_ARCHITECTURE.md section "3. plan_review" is the
+binding contract):
+
+- States: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT -> (loop) -> LEARN_WAIT.
+- Budgets: ``plan_review_iter`` = 3 (max review iterations),
+  ``plan_cycles`` = 2 (max plan->review->amend cycles before giving up).
+- Owned labels: ``state:plan-go`` (GO) [durable], ``state:plan-no-go``
+  (exhausted) [durable] — both computed by the shared pure
+  ``state_labels.apply_plan_verdict`` so this stage and the legacy loop
+  apply identical transitions.
+- Verdict parsed IN-WORKER by ``claude_invoke.parse_review_verdict``
+  (carried as the review job's ``parse`` callable).
+- ERROR verdicts leave labels untouched and RETRY (reviewer-infrastructure
+  failure must not stamp a go/no-go label, #911).
+- Prompt functions (imported, never re-authored):
+  ``prompts/planning.py get_plan_loop_review_prompt``,
+  ``prompts/planning.py get_plan_prompt`` (amend), and
+  ``learn.py build_learn_prompt`` (GO only).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hephaestus.automation.agent_config import (
+    learn_claude_timeout,
+    plan_reviewer_claude_timeout,
+    planner_claude_timeout,
+    planner_model,
+    reviewer_model,
+)
+from hephaestus.automation.claude_invoke import parse_review_verdict
+from hephaestus.automation.learn import build_learn_prompt
+from hephaestus.automation.prompts.planning import (
+    get_plan_loop_review_prompt,
+    get_plan_prompt,
+)
+from hephaestus.automation.session_naming import AGENT_PLAN_REVIEWER, AGENT_PLANNER
+from hephaestus.automation.state_labels import apply_plan_verdict
+
+from .base import (
+    AgentJob,
+    Continue,
+    Disposition,
+    JobRequest,
+    JobResult,
+    Stage,
+    StageContext,
+    StageOutcome,
+    StepResult,
+    WorkItem,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PlanReviewStage(Stage):
+    """Stage for reviewing and iterating on a plan.
+
+    State machine (doc section "3. plan_review"):
+
+    - ENTER: route to REVIEW_WAIT (no [M] entry step in the doc contract).
+    - REVIEW_WAIT: submit the reviewer job; the verdict is parsed in-worker
+      by ``parse_review_verdict`` and lands in
+      ``item.payload["review_verdict"]``.
+    - EVAL [M]: GO -> durably apply ``state:plan-go`` (write BEFORE the
+      advancing outcome) then learn step or ADVANCE; NOGO within the
+      iteration budget -> AMEND_WAIT; NOGO/AMBIGUOUS at the cap -> durably
+      apply ``state:plan-no-go``, then FAIL_BACK("nogo") while plan_cycles
+      remain or FAIL_BACK("plan_cycles_exhausted") once exhausted; ERROR ->
+      labels untouched, RETRY.
+    - AMEND_WAIT: submit the planner amend job (planner session resumed with
+      the reviewer feedback block by the worker, #1817), loop to REVIEW_WAIT.
+    - LEARN_WAIT (GO only, gated by ``enable_learn``): submit the learn job,
+      then ADVANCE.
+
+    Fail routes (ROUTES): "nogo" -> planning, "plan_cycles_exhausted" ->
+    finished(fail).
+    """
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """No durable entry work: the doc defines no [M] entry step here.
+
+        Idempotent by construction (nothing is written). Label fast-forward
+        for items already at-or-past ``state:plan-go`` happens in the
+        planning stage's on_enter before the item is ever routed here.
+
+        Args:
+            item: The work item being processed.
+            ctx: The stage context.
+
+        Returns:
+            None (always proceed to step()).
+
+        """
+        return None
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Execute the next plan-review action for the item's current state.
+
+        Args:
+            item: The work item with current state.
+            ctx: Stage context.
+
+        Returns:
+            Continue, JobRequest, or StageOutcome.
+
+        """
+        if not item.issue:
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        if item.state == "ENTER":
+            return Continue(next_state="REVIEW_WAIT")
+
+        if item.state == "REVIEW_WAIT":
+            iteration = item.attempts.get("plan_review_iter", 0) + 1
+            item.attempts["plan_review_iter"] = iteration
+            logger.info(
+                "plan_review:%d: requesting review job (iteration %d)", item.issue, iteration
+            )
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_PLAN_REVIEWER,
+                model=reviewer_model(),
+                prompt_builder=get_plan_loop_review_prompt,
+                cwd=ctx.paths.worktree,
+                timeout_s=plan_reviewer_claude_timeout(),
+                # get_plan_loop_review_prompt takes a 0-based iteration index
+                # (full-sweep suffix on the final iteration). Issue title/body
+                # are seeded into item.payload by the coordinator (#1817).
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "issue_title": item.payload.get("issue_title", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
+                    "plan_text": item.payload.get("plan_text", ""),
+                    "learnings": item.payload.get("learnings", ""),
+                    "iteration": iteration - 1,
+                    "prior_review": item.payload.get("prior_review") or None,
+                    "advise_findings": item.payload.get("advise_findings", ""),
+                },
+                parse=parse_review_verdict,  # verdict parsed in-worker
+                descr="review",
+            )
+            return JobRequest(job, on_done_state="EVAL")
+
+        if item.state == "EVAL":
+            return self._eval(item, ctx)
+
+        if item.state == "AMEND_WAIT":
+            logger.info("plan_review:%d: requesting amend job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_PLANNER,
+                model=planner_model(),
+                prompt_builder=get_plan_prompt,
+                cwd=ctx.paths.worktree,
+                timeout_s=planner_claude_timeout(),
+                # The worker resumes the planner session and prepends the
+                # reviewer feedback block from item.payload["prior_review"]
+                # (doc: "resume planner session with feedback block"; mirrors
+                # planner_review_loop.generate_plan(prior_review=...); #1817
+                # wires that session setup).
+                prompt_kwargs={"issue_number": item.issue},
+                descr="amend",
+            )
+            return JobRequest(job, on_done_state="REVIEW_WAIT")
+
+        if item.state == "LEARN_WAIT":
+            logger.info("plan_review:%d: requesting learn job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_PLANNER,  # resume the planner's own session (legacy parity)
+                model=planner_model(),
+                prompt_builder=build_learn_prompt,
+                cwd=ctx.paths.worktree,
+                timeout_s=learn_claude_timeout(),
+                prompt_kwargs={"context": item.payload.get("plan_text", "")},
+                descr="learn",
+            )
+            return JobRequest(job, on_done_state="FINISH")
+
+        if item.state == "FINISH":
+            logger.info("plan_review:%d: learn completed; advancing", item.issue)
+            return StageOutcome(Disposition.ADVANCE, "plan approved and learned")
+
+        logger.warning("plan_review:%d: unknown state %r", item.issue, item.state)
+        return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+    def _eval(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """EVAL [M]: decide the next action from the parsed reviewer verdict.
+
+        Every durable label write below happens BEFORE the outcome that
+        causes a queue push (the load-bearing pipeline invariant).
+        """
+        if item.issue is None:  # guarded by step(); kept for type narrowing
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+        verdict = item.payload.get("review_verdict")
+        if verdict is None:
+            logger.warning("plan_review:%d: no verdict found; retry", item.issue)
+            return StageOutcome(Disposition.RETRY, "no verdict found")
+
+        # ERROR = reviewer-infrastructure failure: labels untouched, RETRY
+        # (must not stamp a go/no-go label, #911).
+        if verdict.is_error:
+            logger.warning("plan_review:%d: reviewer error; retry", item.issue)
+            return StageOutcome(Disposition.RETRY, "reviewer error")
+
+        if verdict.is_go:
+            logger.info("plan_review:%d: GO verdict; applying label and advancing", item.issue)
+            label_to_add, labels_to_remove = apply_plan_verdict(is_go=True)
+            ctx.github.add_labels(item.issue, [label_to_add])
+            ctx.github.remove_labels(item.issue, labels_to_remove)
+            if ctx.config.enable_learn:
+                return Continue(next_state="LEARN_WAIT")
+            return StageOutcome(Disposition.ADVANCE, "plan approved (learn disabled)")
+
+        # NOGO (or AMBIGUOUS, treated as not-GO): amend within budget
+        iteration = item.attempts.get("plan_review_iter", 0)
+        budget_iter = ctx.budget("plan_review_iter")
+        if iteration < budget_iter:
+            logger.info(
+                "plan_review:%d: %s verdict (iteration %d/%d); amending plan",
+                item.issue,
+                verdict.verdict,
+                iteration,
+                budget_iter,
+            )
+            return Continue(next_state="AMEND_WAIT")
+
+        # Iteration cap: durably apply state:plan-no-go, then fail back —
+        # "nogo" while plan_cycles remain, "plan_cycles_exhausted" once the
+        # cycle budget is consumed (routes to finished(fail) via ROUTES).
+        logger.warning(
+            "plan_review:%d: %s exhausted (iteration %d/%d); applying no-go label",
+            item.issue,
+            verdict.verdict,
+            iteration,
+            budget_iter,
+        )
+        label_to_add, labels_to_remove = apply_plan_verdict(is_go=False)
+        ctx.github.add_labels(item.issue, [label_to_add])
+        ctx.github.remove_labels(item.issue, labels_to_remove)
+
+        cycles = item.attempts.get("plan_cycles", 0) + 1
+        item.attempts["plan_cycles"] = cycles
+        if cycles >= ctx.budget("plan_cycles"):
+            logger.error(
+                "plan_review:%d: plan_cycles exhausted (%d/%d)",
+                item.issue,
+                cycles,
+                ctx.budget("plan_cycles"),
+            )
+            return StageOutcome(Disposition.FAIL_BACK, "plan_cycles_exhausted")
+        return StageOutcome(Disposition.FAIL_BACK, "nogo")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Store job results on the item payload (state is still the WAIT state).
+
+        Args:
+            item: The work item to update.
+            result: The job result from the worker pool.
+            ctx: Stage context.
+
+        """
+        if not result.ok:
+            logger.warning("plan_review:%s: job failed: %s", item.issue, result.error)
+            return
+
+        if result.value:
+            if item.state == "REVIEW_WAIT":
+                item.payload["review_verdict"] = result.value
+                # Feed the raw review text to the next amend/review round,
+                # mirroring the legacy loop's prior_review threading.
+                item.payload["prior_review"] = getattr(result.value, "raw", str(result.value))
+            elif item.state == "AMEND_WAIT":
+                item.payload["plan_text"] = result.value

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -434,3 +434,6 @@ class PlanReviewStage(Stage):
                 item.payload["prior_review"] = getattr(result.value, "raw", str(result.value))
             elif item.state == "AMEND_WAIT":
                 item.payload["plan_text"] = result.value
+            # LEARN_WAIT intentionally has no branch: the learn job's output
+            # is a side effect for the Mnemosyne skill store, not a payload
+            # value any later state consumes.

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -6,19 +6,41 @@ Re-houses the plan-review control flow from
 binding contract):
 
 - States: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT -> (loop) -> LEARN_WAIT.
-- Budgets: ``plan_review_iter`` = 3 (max review iterations),
+- Budgets: ``plan_review_iter`` = 3 (max review iterations per cycle),
   ``plan_cycles`` = 2 (max plan->review->amend cycles before giving up).
+- Iteration accounting: ``item.attempts["plan_review_iter"]`` is the
+  PER-LIFETIME audit trail (routing.py contract: attempts are never reset),
+  so EVAL gates on the CYCLE-RELATIVE counter
+  ``item.payload["review_round"]``, reset by ``on_enter`` whenever the item
+  enters a new plan cycle (keyed on ``attempts["plan_cycles"]``). Cycle 2
+  therefore gets its full ``plan_review_iter`` reviews/amends and
+  ``get_plan_loop_review_prompt`` always sees a 0-based iteration in
+  ``0..plan_review_iter-1``; ``plan_cycles`` bounds the number of cycles.
+- Both counters advance in EVAL and ONLY for real verdicts
+  (GO/NOGO/AMBIGUOUS). ERROR and missing verdicts never burn an iteration
+  (claude_invoke ``ReviewVerdict`` doctrine: "the reviewer never ran" must
+  not be mistaken for a judgement, #911/#1554/#1794); they RETRY with
+  labels untouched, bounded in-stage by
+  ``item.payload["review_error_retries"]`` (cap
+  ``REVIEW_ERROR_RETRY_CAP`` consecutive failures, reset on any real
+  verdict). At the cap the item FINISH_FAILs — a reviewer-infrastructure
+  failure is not fixed by replanning, so failing back to planning would
+  only spend ``plan_cycles`` on more doomed reviews; labels stay untouched
+  on the whole ERROR path.
 - Owned labels: ``state:plan-go`` (GO) [durable], ``state:plan-no-go``
   (exhausted) [durable] — both computed by the shared pure
   ``state_labels.apply_plan_verdict`` so this stage and the legacy loop
-  apply identical transitions.
+  apply identical transitions; the paired add/remove writes are non-fatal
+  (legacy try/except-warn pattern from
+  ``planner_review_loop._apply_state_label``).
 - Verdict parsed IN-WORKER by ``claude_invoke.parse_review_verdict``
-  (carried as the review job's ``parse`` callable).
-- ERROR verdicts leave labels untouched and RETRY (reviewer-infrastructure
-  failure must not stamp a go/no-go label, #911).
+  (carried as the review job's ``parse`` callable). REVIEW_WAIT clears any
+  stale ``payload["review_verdict"]`` at submission so a failed later round
+  can never replay an earlier round's verdict.
 - Prompt functions (imported, never re-authored):
   ``prompts/planning.py get_plan_loop_review_prompt``,
-  ``prompts/planning.py get_plan_prompt`` (amend), and
+  ``prompts/planning.py get_plan_prompt`` (composed with the reviewer
+  feedback block by :func:`build_amend_prompt` for amends), and
   ``learn.py build_learn_prompt`` (GO only).
 """
 
@@ -57,24 +79,69 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+#: Max CONSECUTIVE reviewer-infrastructure failures (ERROR verdicts or
+#: failed/valueless review jobs) tolerated before the item FINISH_FAILs.
+#: Bounds the in-stage ERROR retry loop without burning ``plan_review_iter``
+#: or stamping labels (#911). Reset whenever a real verdict arrives.
+REVIEW_ERROR_RETRY_CAP = 2
+
+
+def build_amend_prompt(issue_number: int, prior_review: str) -> str:
+    """Compose the amend prompt: plan prompt + reviewer feedback block.
+
+    Module-level composed builder (NOT a closure): :class:`AgentJob` is
+    frozen and prompt builders run in-worker, so the builder must be a
+    top-level function receiving everything via ``prompt_kwargs``. The
+    feedback block mirrors the legacy
+    ``planner_review_loop.generate_plan(prior_review=...)`` formatting (doc
+    section 3 step 3: "resume planner session with feedback block"); the
+    prompt template itself is reused verbatim via :func:`get_plan_prompt`.
+
+    Args:
+        issue_number: GitHub issue number being re-planned.
+        prior_review: The previous review round's NOGO critique text.
+
+    Returns:
+        The full amend prompt with the feedback block appended.
+
+    """
+    prompt = get_plan_prompt(issue_number)
+    feedback = "\n".join(
+        [
+            "",
+            "---",
+            "",
+            "## Prior reviewer critique — your previous plan got NOGO",
+            "",
+            "Address every concrete finding below in your revised plan:",
+            "",
+            prior_review,
+        ]
+    )
+    return prompt + feedback
+
 
 class PlanReviewStage(Stage):
     """Stage for reviewing and iterating on a plan.
 
     State machine (doc section "3. plan_review"):
 
-    - ENTER: route to REVIEW_WAIT (no [M] entry step in the doc contract).
-    - REVIEW_WAIT: submit the reviewer job; the verdict is parsed in-worker
-      by ``parse_review_verdict`` and lands in
-      ``item.payload["review_verdict"]``.
-    - EVAL [M]: GO -> durably apply ``state:plan-go`` (write BEFORE the
-      advancing outcome) then learn step or ADVANCE; NOGO within the
-      iteration budget -> AMEND_WAIT; NOGO/AMBIGUOUS at the cap -> durably
-      apply ``state:plan-no-go``, then FAIL_BACK("nogo") while plan_cycles
-      remain or FAIL_BACK("plan_cycles_exhausted") once exhausted; ERROR ->
-      labels untouched, RETRY.
-    - AMEND_WAIT: submit the planner amend job (planner session resumed with
-      the reviewer feedback block by the worker, #1817), loop to REVIEW_WAIT.
+    - ENTER: reset the cycle-relative review counter when a new plan cycle
+      begins, then route to REVIEW_WAIT.
+    - REVIEW_WAIT: clear any stale verdict, then submit the reviewer job;
+      the verdict is parsed in-worker by ``parse_review_verdict`` and lands
+      in ``item.payload["review_verdict"]``.
+    - EVAL [M]: real verdicts (GO/NOGO/AMBIGUOUS) advance both iteration
+      counters; ERROR/missing verdicts never do. GO -> durably apply
+      ``state:plan-go`` (write BEFORE the advancing outcome) then learn
+      step or ADVANCE; NOGO within the cycle-relative iteration budget ->
+      AMEND_WAIT; NOGO/AMBIGUOUS at the cap -> durably apply
+      ``state:plan-no-go``, then FAIL_BACK("nogo") while plan_cycles remain
+      or FAIL_BACK("plan_cycles_exhausted") once exhausted; ERROR/missing
+      verdict -> labels untouched, RETRY (bounded by
+      ``REVIEW_ERROR_RETRY_CAP`` consecutive failures, then FINISH_FAIL).
+    - AMEND_WAIT: submit the planner amend job (:func:`build_amend_prompt`
+      carries the reviewer feedback block), loop to REVIEW_WAIT.
     - LEARN_WAIT (GO only, gated by ``enable_learn``): submit the learn job,
       then ADVANCE.
 
@@ -83,11 +150,20 @@ class PlanReviewStage(Stage):
     """
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
-        """No durable entry work: the doc defines no [M] entry step here.
+        """Reset the cycle-relative review counter on a new plan cycle.
 
-        Idempotent by construction (nothing is written). Label fast-forward
-        for items already at-or-past ``state:plan-go`` happens in the
-        planning stage's on_enter before the item is ever routed here.
+        ``attempts["plan_review_iter"]`` is per-lifetime (routing.py:
+        attempts are never reset), so the per-cycle review budget is
+        tracked in ``payload["review_round"]``. The reset keys on
+        ``attempts["plan_cycles"]`` (recorded in ``payload["review_cycle"]``)
+        so it fires exactly once per fail-back cycle: a same-cycle re-entry
+        (e.g. the ERROR-path RETRY) matches the recorded cycle and keeps its
+        round count. Idempotent — a literal double on_enter is a no-op.
+
+        No durable entry work: the doc defines no [M] entry step here, and
+        nothing is written. Label fast-forward for items already at-or-past
+        ``state:plan-go`` happens in the planning stage's on_enter before
+        the item is ever routed here.
 
         Args:
             item: The work item being processed.
@@ -97,6 +173,10 @@ class PlanReviewStage(Stage):
             None (always proceed to step()).
 
         """
+        cycle = item.attempts.get("plan_cycles", 0)
+        if item.payload.get("review_cycle") != cycle:
+            item.payload["review_cycle"] = cycle
+            item.payload["review_round"] = 0
         return None
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
@@ -117,11 +197,14 @@ class PlanReviewStage(Stage):
             return Continue(next_state="REVIEW_WAIT")
 
         if item.state == "REVIEW_WAIT":
-            iteration = item.attempts.get("plan_review_iter", 0) + 1
-            item.attempts["plan_review_iter"] = iteration
-            logger.info(
-                "plan_review:%d: requesting review job (iteration %d)", item.issue, iteration
-            )
+            # Counters advance in EVAL, and only for real verdicts — a
+            # submission is not an iteration (#1554/#1794). The 0-based
+            # prompt iteration is the cycle-relative round count.
+            round_index = item.payload.get("review_round", 0)
+            # Clear any stale verdict at submission so a failed later round
+            # can never replay an earlier round's verdict in EVAL.
+            item.payload.pop("review_verdict", None)
+            logger.info("plan_review:%d: requesting review job (round %d)", item.issue, round_index)
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
@@ -138,8 +221,11 @@ class PlanReviewStage(Stage):
                     "issue_title": item.payload.get("issue_title", ""),
                     "issue_body": item.payload.get("issue_body", ""),
                     "plan_text": item.payload.get("plan_text", ""),
+                    # Populated from the payload when present; wiring the
+                    # legacy capture_planner_learnings step into the pipeline
+                    # is deferred to the coordinator slice (#1817).
                     "learnings": item.payload.get("learnings", ""),
-                    "iteration": iteration - 1,
+                    "iteration": round_index,
                     "prior_review": item.payload.get("prior_review") or None,
                     "advise_findings": item.payload.get("advise_findings", ""),
                 },
@@ -158,15 +244,19 @@ class PlanReviewStage(Stage):
                 issue=item.issue,
                 agent=AGENT_PLANNER,
                 model=planner_model(),
-                prompt_builder=get_plan_prompt,
+                prompt_builder=build_amend_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
-                # The worker resumes the planner session and prepends the
-                # reviewer feedback block from item.payload["prior_review"]
-                # (doc: "resume planner session with feedback block"; mirrors
-                # planner_review_loop.generate_plan(prior_review=...); #1817
-                # wires that session setup).
-                prompt_kwargs={"issue_number": item.issue},
+                # build_amend_prompt composes get_plan_prompt with the
+                # reviewer feedback block in-worker (doc: "resume planner
+                # session with feedback block"; mirrors
+                # planner_review_loop.generate_plan(prior_review=...)). The
+                # worker resumes the planner session (#1817 wires that
+                # session setup).
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "prior_review": item.payload.get("prior_review", ""),
+                },
                 descr="amend",
             )
             return JobRequest(job, on_done_state="REVIEW_WAIT")
@@ -197,39 +287,69 @@ class PlanReviewStage(Stage):
         """EVAL [M]: decide the next action from the parsed reviewer verdict.
 
         Every durable label write below happens BEFORE the outcome that
-        causes a queue push (the load-bearing pipeline invariant).
+        causes a queue push (the load-bearing pipeline invariant). Both
+        iteration counters (lifetime ``attempts["plan_review_iter"]`` audit
+        trail and cycle-relative ``payload["review_round"]`` gate) advance
+        here, and only for real verdicts — never for ERROR or missing
+        verdicts (#911/#1554/#1794).
         """
         if item.issue is None:  # guarded by step(); kept for type narrowing
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         verdict = item.payload.get("review_verdict")
-        if verdict is None:
-            logger.warning("plan_review:%d: no verdict found; retry", item.issue)
-            return StageOutcome(Disposition.RETRY, "no verdict found")
 
-        # ERROR = reviewer-infrastructure failure: labels untouched, RETRY
-        # (must not stamp a go/no-go label, #911).
-        if verdict.is_error:
-            logger.warning("plan_review:%d: reviewer error; retry", item.issue)
-            return StageOutcome(Disposition.RETRY, "reviewer error")
+        # ERROR verdict or missing verdict (the review job failed, so
+        # on_job_done stored nothing) = reviewer-infrastructure failure:
+        # labels untouched, no iteration burned, RETRY — bounded by the
+        # consecutive-failure cap so the retry loop cannot spin forever.
+        if verdict is None or verdict.is_error:
+            reason = "no verdict found" if verdict is None else "reviewer error"
+            retries = item.payload.get("review_error_retries", 0) + 1
+            item.payload["review_error_retries"] = retries
+            if retries > REVIEW_ERROR_RETRY_CAP:
+                logger.error(
+                    "plan_review:%d: %s; %d consecutive reviewer failures "
+                    "(cap %d) — failing without labels",
+                    item.issue,
+                    reason,
+                    retries,
+                    REVIEW_ERROR_RETRY_CAP,
+                )
+                return StageOutcome(
+                    Disposition.FINISH_FAIL,
+                    f"reviewer error retries exhausted ({reason})",
+                )
+            logger.warning(
+                "plan_review:%d: %s; retry %d/%d (no iteration burned)",
+                item.issue,
+                reason,
+                retries,
+                REVIEW_ERROR_RETRY_CAP,
+            )
+            return StageOutcome(Disposition.RETRY, reason)
+
+        # Real verdict: this review round counts. Advance the cycle-relative
+        # gate and the lifetime audit trail; reset the consecutive-failure cap.
+        item.payload["review_error_retries"] = 0
+        round_done = item.payload.get("review_round", 0) + 1
+        item.payload["review_round"] = round_done
+        item.attempts["plan_review_iter"] = item.attempts.get("plan_review_iter", 0) + 1
 
         if verdict.is_go:
             logger.info("plan_review:%d: GO verdict; applying label and advancing", item.issue)
-            label_to_add, labels_to_remove = apply_plan_verdict(is_go=True)
-            ctx.github.add_labels(item.issue, [label_to_add])
-            ctx.github.remove_labels(item.issue, labels_to_remove)
+            self._write_verdict_labels(item.issue, ctx, is_go=True)
             if ctx.config.enable_learn:
                 return Continue(next_state="LEARN_WAIT")
             return StageOutcome(Disposition.ADVANCE, "plan approved (learn disabled)")
 
-        # NOGO (or AMBIGUOUS, treated as not-GO): amend within budget
-        iteration = item.attempts.get("plan_review_iter", 0)
+        # NOGO (or AMBIGUOUS, treated as not-GO): amend within the
+        # cycle-relative budget.
         budget_iter = ctx.budget("plan_review_iter")
-        if iteration < budget_iter:
+        if round_done < budget_iter:
             logger.info(
-                "plan_review:%d: %s verdict (iteration %d/%d); amending plan",
+                "plan_review:%d: %s verdict (round %d/%d); amending plan",
                 item.issue,
                 verdict.verdict,
-                iteration,
+                round_done,
                 budget_iter,
             )
             return Continue(next_state="AMEND_WAIT")
@@ -238,15 +358,13 @@ class PlanReviewStage(Stage):
         # "nogo" while plan_cycles remain, "plan_cycles_exhausted" once the
         # cycle budget is consumed (routes to finished(fail) via ROUTES).
         logger.warning(
-            "plan_review:%d: %s exhausted (iteration %d/%d); applying no-go label",
+            "plan_review:%d: %s exhausted (round %d/%d); applying no-go label",
             item.issue,
             verdict.verdict,
-            iteration,
+            round_done,
             budget_iter,
         )
-        label_to_add, labels_to_remove = apply_plan_verdict(is_go=False)
-        ctx.github.add_labels(item.issue, [label_to_add])
-        ctx.github.remove_labels(item.issue, labels_to_remove)
+        self._write_verdict_labels(item.issue, ctx, is_go=False)
 
         cycles = item.attempts.get("plan_cycles", 0) + 1
         item.attempts["plan_cycles"] = cycles
@@ -259,6 +377,41 @@ class PlanReviewStage(Stage):
             )
             return StageOutcome(Disposition.FAIL_BACK, "plan_cycles_exhausted")
         return StageOutcome(Disposition.FAIL_BACK, "nogo")
+
+    @staticmethod
+    def _write_verdict_labels(issue_number: int, ctx: StageContext, *, is_go: bool) -> None:
+        """Apply the verdict's label pair, each write non-fatal (legacy parity).
+
+        Mirrors ``planner_review_loop._apply_state_label``: the add and the
+        remove are wrapped independently so an exception between the pair
+        never propagates half-applied — the reviewer's verdict comment
+        remains the ultimate fallback for the backfill path.
+
+        Args:
+            issue_number: GitHub issue number.
+            ctx: Stage context carrying the GitHub accessor.
+            is_go: True for a GO verdict, False for NOGO-exhausted.
+
+        """
+        label_to_add, labels_to_remove = apply_plan_verdict(is_go=is_go)
+        try:
+            ctx.github.add_labels(issue_number, [label_to_add])
+        except Exception as e:
+            logger.warning(
+                "plan_review:%d: failed to add label %r (non-fatal): %s",
+                issue_number,
+                label_to_add,
+                e,
+            )
+        try:
+            ctx.github.remove_labels(issue_number, labels_to_remove)
+        except Exception as e:
+            logger.warning(
+                "plan_review:%d: failed to remove labels %s (non-fatal): %s",
+                issue_number,
+                labels_to_remove,
+                e,
+            )
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Store job results on the item payload (state is still the WAIT state).

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -1,0 +1,248 @@
+"""Planning stage: generate and verify issue plans (issue #1814).
+
+Re-houses the planning control flow from ``planner.py::Planner._plan_issue``
+as a pipeline stage (docs/AUTOMATION_LOOP_ARCHITECTURE.md section
+"2. planning" is the binding contract):
+
+- States: ENTER -> ADVISE_WAIT -> PLAN_WAIT -> VERIFY.
+- Budget: ``plan`` = 2 (max plan attempts per issue); exhaustion ->
+  finished(fail).
+- Owned label: ``state:needs-plan`` (idempotent, on entry) [durable].
+- Prompt functions (imported, never re-authored):
+  ``prompts/advise.py get_advise_prompt_builder`` and
+  ``prompts/planning.py get_plan_prompt``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hephaestus.automation.agent_config import (
+    advise_claude_timeout,
+    advise_model,
+    planner_claude_timeout,
+    planner_model,
+)
+from hephaestus.automation.prompts.advise import get_advise_prompt_builder
+from hephaestus.automation.prompts.planning import get_plan_prompt
+from hephaestus.automation.session_naming import AGENT_ADVISE, AGENT_PLANNER
+from hephaestus.automation.state_labels import (
+    STATE_NEEDS_PLAN,
+    is_plan_go,
+    is_skipped,
+)
+
+from .base import (
+    AgentJob,
+    Continue,
+    Disposition,
+    JobRequest,
+    JobResult,
+    Stage,
+    StageContext,
+    StageOutcome,
+    StepResult,
+    WorkItem,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _issue_labels(item: WorkItem, ctx: StageContext) -> list[str]:
+    """Refresh the item's labels from GitHub and update ``labels_cache``.
+
+    Reads through ``ctx.github.gh_issue_json`` (mirrors
+    ``github_api.issues.gh_issue_json``); on any read failure the cached
+    labels are used so a transient API blip cannot mis-route the item.
+    """
+    if item.issue is None:
+        return []
+    try:
+        data = ctx.github.gh_issue_json(item.issue)
+    except Exception as e:  # transient gh failure: fall back to cache
+        logger.warning("planning:%d: label refresh failed (using cache): %s", item.issue, e)
+        return list(item.labels_cache)
+    raw = data.get("labels", []) if isinstance(data, dict) else []
+    labels = [entry["name"] if isinstance(entry, dict) else str(entry) for entry in raw]
+    item.labels_cache = dict.fromkeys(labels, True)
+    return labels
+
+
+class PlanningStage(Stage):
+    """Stage for planning an issue: advise -> plan -> verify.
+
+    State machine (doc section "2. planning"):
+
+    - ENTER: route to ADVISE_WAIT (or PLAN_WAIT when advise is disabled).
+    - ADVISE_WAIT: submit the advise agent job; findings land in
+      ``item.payload["advise_findings"]``.
+    - PLAN_WAIT: submit the plan agent job (planner session); plan text
+      lands in ``item.payload["plan_text"]``; the plan comment posted by the
+      pipeline is the durable artifact.
+    - VERIFY: check the plan comment exists -> ADVANCE, else RETRY within
+      the ``plan`` budget, then FINISH_FAIL.
+
+    on_enter idempotency guards (re-housed from ``Planner._pr_coverage_skip``
+    and ``Planner._has_existing_plan``, all ordered at-or-past checks):
+
+    - already at-or-past ``state:plan-go`` -> ADVANCE (zero jobs)
+    - ``state:skip`` -> SKIP
+    - merged closing PR -> close issue as covered, SKIP
+    - open PR -> SKIP (PR already covers implementation)
+    - unlabeled entry -> durably add ``state:needs-plan`` before proceeding
+    """
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """Refresh labels and perform idempotent fast-forward checks.
+
+        Args:
+            item: The work item (must have an issue number).
+            ctx: Stage context with the GitHub accessor.
+
+        Returns:
+            None to proceed with step(), or a StageOutcome to skip/finish.
+
+        """
+        if not item.issue:
+            logger.warning("planning: work item has no issue number")
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        labels = _issue_labels(item, ctx)
+
+        # Fast-forward (at-or-past, never equality): already plan-go -> ADVANCE
+        if is_plan_go(labels):
+            logger.info("planning:%d: already plan-go; advancing", item.issue)
+            return StageOutcome(Disposition.ADVANCE, "plan already approved")
+
+        # Operator override: state:skip -> SKIP
+        if is_skipped(labels):
+            logger.info("planning:%d: state:skip; skipping", item.issue)
+            return StageOutcome(Disposition.SKIP, "state:skip")
+
+        # Re-housed _pr_coverage_skip gate A: merged closing PR covers the issue
+        merged_pr = ctx.github.find_merged_closing_pr(item.issue)
+        if merged_pr:
+            logger.info("planning:%d: merged PR #%d covers issue; closing", item.issue, merged_pr)
+            ctx.github.close_issue_as_covered(item.issue, merged_pr)
+            return StageOutcome(Disposition.SKIP, f"covered by merged PR #{merged_pr}")
+
+        # Re-housed _pr_coverage_skip gate B: open PR already in flight
+        open_pr = ctx.github.find_pr_for_issue(item.issue)
+        if open_pr:
+            logger.info("planning:%d: open PR #%d exists; skipping", item.issue, open_pr)
+            return StageOutcome(Disposition.SKIP, f"open PR #{open_pr} exists")
+
+        # Owned label: state:needs-plan, idempotent durable write before proceeding
+        if STATE_NEEDS_PLAN not in labels:
+            logger.info("planning:%d: adding %s label", item.issue, STATE_NEEDS_PLAN)
+            ctx.github.add_labels(item.issue, [STATE_NEEDS_PLAN])
+
+        return None  # proceed to step()
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Execute the next planning action for the item's current state.
+
+        Args:
+            item: The work item with current state.
+            ctx: Stage context.
+
+        Returns:
+            Continue, JobRequest, or StageOutcome.
+
+        """
+        if not item.issue:
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        if item.state == "ENTER":
+            if ctx.config.enable_advise:
+                return Continue(next_state="ADVISE_WAIT")
+            logger.info("planning:%d: advise disabled; skipping to plan", item.issue)
+            return Continue(next_state="PLAN_WAIT")
+
+        if item.state == "ADVISE_WAIT":
+            logger.info("planning:%d: requesting advise job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_ADVISE,
+                model=advise_model(),
+                prompt_builder=get_advise_prompt_builder(ctx.config.agent),
+                cwd=ctx.paths.worktree,
+                timeout_s=advise_claude_timeout(),
+                # Issue title/body and the Mnemosyne marketplace path are
+                # seeded into item.payload by the coordinator (#1817), which
+                # owns issue fetching and advise_runner setup.
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "issue_title": item.payload.get("issue_title", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
+                    "marketplace_path": item.payload.get("marketplace_path", ""),
+                },
+                descr="advise",
+            )
+            return JobRequest(job, on_done_state="PLAN_WAIT")
+
+        if item.state == "PLAN_WAIT":
+            logger.info("planning:%d: requesting plan job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_PLANNER,
+                model=planner_model(),
+                prompt_builder=get_plan_prompt,
+                cwd=ctx.paths.worktree,
+                timeout_s=planner_claude_timeout(),
+                # The worker prepends the issue context + advise findings when
+                # opening the planner session, exactly as the legacy
+                # planner_review_loop.generate_plan composes it (#1817 wires
+                # that session setup; the prompt template itself is reused
+                # verbatim via get_plan_prompt).
+                prompt_kwargs={"issue_number": item.issue},
+                descr="plan",
+            )
+            return JobRequest(job, on_done_state="VERIFY")
+
+        if item.state == "VERIFY":
+            # Doc step 4 [M]: verify the plan comment exists (the
+            # PlannerStateManager.has_existing_plan read, via ctx.github).
+            if ctx.github.has_existing_plan(item.issue):
+                logger.info("planning:%d: plan verified; advancing", item.issue)
+                return StageOutcome(Disposition.ADVANCE, "plan generated and verified")
+
+            attempt = item.attempts.get("plan", 0) + 1
+            item.attempts["plan"] = attempt
+            budget = ctx.budget("plan")
+            if attempt < budget:
+                logger.warning(
+                    "planning:%d: plan comment not found; retry %d/%d",
+                    item.issue,
+                    attempt,
+                    budget,
+                )
+                return StageOutcome(Disposition.RETRY, f"plan not found, retry {attempt}/{budget}")
+            logger.error(
+                "planning:%d: plan not found after %d attempts; exhausted", item.issue, budget
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, f"plan not found after {budget} attempts")
+
+        logger.warning("planning:%d: unknown state %r", item.issue, item.state)
+        return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Store job results on the item payload (state is still the WAIT state).
+
+        Args:
+            item: The work item to update.
+            result: The job result from the worker pool.
+            ctx: Stage context.
+
+        """
+        if not result.ok:
+            logger.warning("planning:%s: job failed: %s", item.issue, result.error)
+            return
+
+        if result.value:
+            if item.state == "ADVISE_WAIT":
+                item.payload["advise_findings"] = result.value
+            elif item.state == "PLAN_WAIT":
+                item.payload["plan_text"] = result.value

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -8,9 +8,19 @@ as a pipeline stage (docs/AUTOMATION_LOOP_ARCHITECTURE.md section
 - Budget: ``plan`` = 2 (max plan attempts per issue); exhaustion ->
   finished(fail).
 - Owned label: ``state:needs-plan`` (idempotent, on entry) [durable].
+- Plan comment: the PIPELINE posts it (doc section 2: "plan comment =
+  durable artifact"). VERIFY upserts ``item.payload["plan_text"]`` via
+  ``ctx.github.upsert_plan_comment`` BEFORE the verify/ADVANCE decision
+  (journal order: durable write precedes the queue push). Marker
+  normalization is re-housed from
+  ``planner_review_loop._upsert_plan_comment``; the content-missing banner
+  and "Changes from review" enrichment stay with the legacy loop until the
+  cutover issue.
 - Prompt functions (imported, never re-authored):
   ``prompts/advise.py get_advise_prompt_builder`` and
-  ``prompts/planning.py get_plan_prompt``.
+  ``prompts/planning.py get_plan_prompt`` (composed with the advise
+  findings block by :func:`build_plan_prompt`, mirroring the legacy
+  ``planner_review_loop.generate_plan`` context assembly).
 """
 
 from __future__ import annotations
@@ -25,6 +35,7 @@ from hephaestus.automation.agent_config import (
 )
 from hephaestus.automation.prompts.advise import get_advise_prompt_builder
 from hephaestus.automation.prompts.planning import get_plan_prompt
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from hephaestus.automation.session_naming import AGENT_ADVISE, AGENT_PLANNER
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
@@ -46,6 +57,63 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def build_plan_prompt(issue_number: int, advise_findings: str = "") -> str:
+    """Compose the plan prompt with the advise-findings block.
+
+    Module-level composed builder (NOT a closure): :class:`AgentJob` is
+    frozen and prompt builders run in-worker, so the builder must be a
+    top-level function receiving everything via ``prompt_kwargs``. Mirrors
+    the "Prior Learnings from Team Knowledge Base" block that the legacy
+    ``planner_review_loop.generate_plan`` appends when advise findings are
+    available; the prompt template itself is reused verbatim via
+    :func:`get_plan_prompt`.
+
+    Args:
+        issue_number: GitHub issue number to plan.
+        advise_findings: Advise-step findings; empty string means no block.
+
+    Returns:
+        The full planner prompt, with the findings block appended when
+        ``advise_findings`` is non-empty.
+
+    """
+    prompt = get_plan_prompt(issue_number)
+    if not advise_findings:
+        return prompt
+    block = "\n".join(
+        [
+            "",
+            "---",
+            "",
+            "## Prior Learnings from Team Knowledge Base",
+            "",
+            advise_findings,
+        ]
+    )
+    return prompt + block
+
+
+def _normalize_plan_comment(plan: str) -> str:
+    """Normalize plan text so the body begins exactly at the plan marker.
+
+    Re-housed from ``planner_review_loop._upsert_plan_comment``: the upsert
+    helper keys off ``body.startswith(PLAN_COMMENT_MARKER)``, and
+    ``plan.lstrip()`` is load-bearing — a plan arriving with leading
+    whitespace would otherwise keep it and break the marker match (#700).
+
+    Args:
+        plan: Raw plan text from the planner agent.
+
+    Returns:
+        The plan body, guaranteed to start with ``PLAN_COMMENT_MARKER``.
+
+    """
+    stripped = plan.lstrip()
+    if stripped.startswith(PLAN_COMMENT_MARKER):
+        return stripped
+    return f"{PLAN_COMMENT_MARKER}\n\n{stripped}"
 
 
 def _issue_labels(item: WorkItem, ctx: StageContext) -> list[str]:
@@ -90,6 +158,10 @@ class PlanningStage(Stage):
     - merged closing PR -> close issue as covered, SKIP
     - open PR -> SKIP (PR already covers implementation)
     - unlabeled entry -> durably add ``state:needs-plan`` before proceeding
+    - plan comment already exists (``ctx.github.has_existing_plan``) ->
+      fast-forward ``item.state`` to VERIFY so a restart mid-stage never
+      redoes advise + plan (the base-protocol idempotency promise); the
+      ``is_plan_review_go`` label check above stays the primary gate.
     """
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
@@ -136,6 +208,15 @@ class PlanningStage(Stage):
         if STATE_NEEDS_PLAN not in labels:
             logger.info("planning:%d: adding %s label", item.issue, STATE_NEEDS_PLAN)
             ctx.github.add_labels(item.issue, [STATE_NEEDS_PLAN])
+
+        # Restart fast-forward: a plan comment already exists (real has-plan
+        # semantics via ctx.github), so re-entry must not redo advise + plan.
+        # Jump straight to VERIFY; idempotent on repeated on_enter calls.
+        if ctx.github.has_existing_plan(item.issue):
+            logger.info(
+                "planning:%d: plan comment already exists; fast-forward to VERIFY", item.issue
+            )
+            item.state = "VERIFY"
 
         return None  # proceed to step()
 
@@ -189,21 +270,34 @@ class PlanningStage(Stage):
                 issue=item.issue,
                 agent=AGENT_PLANNER,
                 model=planner_model(),
-                prompt_builder=get_plan_prompt,
+                prompt_builder=build_plan_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
-                # The worker prepends the issue context + advise findings when
-                # opening the planner session, exactly as the legacy
-                # planner_review_loop.generate_plan composes it (#1817 wires
-                # that session setup; the prompt template itself is reused
-                # verbatim via get_plan_prompt).
-                prompt_kwargs={"issue_number": item.issue},
+                # build_plan_prompt composes get_plan_prompt with the advise
+                # findings block in-worker, mirroring the legacy
+                # planner_review_loop.generate_plan(cached_advise=...)
+                # context assembly. The issue title/body header is prepended
+                # by the worker session setup (#1817).
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "advise_findings": item.payload.get("advise_findings", ""),
+                },
                 descr="plan",
             )
             return JobRequest(job, on_done_state="VERIFY")
 
         if item.state == "VERIFY":
-            # Doc step 4 [M]: verify the plan comment exists (the
+            # Doc step 4 [M], part 1: the pipeline POSTS the plan comment
+            # (doc section 2: "plan comment = durable artifact"). The upsert
+            # is the durable write and happens BEFORE the verify/ADVANCE
+            # decision (journal order). Guarded by has_existing_plan so
+            # re-entry never double-posts.
+            plan_text = item.payload.get("plan_text")
+            if plan_text and not ctx.github.has_existing_plan(item.issue):
+                logger.info("planning:%d: upserting plan comment", item.issue)
+                ctx.github.upsert_plan_comment(item.issue, _normalize_plan_comment(plan_text))
+
+            # Doc step 4 [M], part 2: verify the plan comment exists (the
             # PlannerStateManager.has_existing_plan read, via ctx.github).
             if ctx.github.has_existing_plan(item.issue):
                 logger.info("planning:%d: plan verified; advancing", item.issue)

--- a/hephaestus/automation/planner_review_loop.py
+++ b/hephaestus/automation/planner_review_loop.py
@@ -44,7 +44,7 @@ from .models import PLAN_COMMENT_MARKER
 from .prompts import get_plan_loop_review_prompt, get_plan_prompt
 from .review_state import PLAN_REVIEW_PREFIX
 from .session_naming import AGENT_PLAN_REVIEWER, AGENT_PLANNER, reviewer_agent
-from .state_labels import STATE_NEEDS_PLAN, STATE_PLAN_GO, STATE_PLAN_NO_GO
+from .state_labels import apply_plan_verdict
 
 logger = logging.getLogger(__name__)
 
@@ -441,6 +441,9 @@ class PlanReviewLoop:
     def _apply_state_label(self, issue_number: int, *, is_go: bool) -> None:
         """Apply the verdict's ``state:*`` label and remove the others (#704).
 
+        Delegates the label-set computation to state_labels.apply_plan_verdict
+        (#1814); the gh writes + non-fatal warnings stay here unchanged.
+
         The state-label family is mutually exclusive. On GO, set
         ``state:plan-go`` and remove both ``state:plan-no-go`` and
         ``state:needs-plan``. On NOGO (each iteration), set
@@ -457,12 +460,7 @@ class PlanReviewLoop:
                 NOGO (either per-iteration or NOGO-exhausted).
 
         """
-        if is_go:
-            label_to_add = STATE_PLAN_GO
-            labels_to_remove = [STATE_PLAN_NO_GO, STATE_NEEDS_PLAN]
-        else:
-            label_to_add = STATE_PLAN_NO_GO
-            labels_to_remove = [STATE_PLAN_GO, STATE_NEEDS_PLAN]
+        label_to_add, labels_to_remove = apply_plan_verdict(is_go=is_go)
         try:
             gh_issue_add_labels(issue_number, [label_to_add])
         except Exception as e:

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -221,3 +221,28 @@ def needs_plan(labels: Iterable[str]) -> bool:
     """
     label_set = set(labels)
     return STATE_PLAN_GO not in label_set and STATE_PLAN_NO_GO not in label_set
+
+
+def apply_plan_verdict(*, is_go: bool) -> tuple[str, list[str]]:
+    """Compute the atomic plan-state transition for a reviewer verdict.
+
+    Pure: returns (label_to_add, labels_to_remove). The caller performs the
+    GitHub writes and any logging. Promoted from
+    planner_review_loop._apply_state_label (#1814) so the legacy loop, the
+    plan_review stage, and seeding compute the transition identically.
+
+    On GO   → add state:plan-go,    remove [state:plan-no-go, state:needs-plan].
+    On NOGO → add state:plan-no-go, remove [state:plan-go,     state:needs-plan].
+
+    Args:
+        is_go: ``True`` when the reviewer's verdict is GO; ``False`` for NOGO.
+
+    Returns:
+        A tuple (label_to_add, labels_to_remove) where label_to_add is the
+        single label to apply and labels_to_remove is the list of labels to
+        remove.
+
+    """
+    if is_go:
+        return STATE_PLAN_GO, [STATE_PLAN_NO_GO, STATE_NEEDS_PLAN]
+    return STATE_PLAN_NO_GO, [STATE_PLAN_GO, STATE_NEEDS_PLAN]

--- a/tests/unit/automation/pipeline/stages/__init__.py
+++ b/tests/unit/automation/pipeline/stages/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pipeline stages."""

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -10,19 +10,21 @@ format stay identical to what coordinator tests (#1817) will assert.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from hephaestus.automation.pipeline.routing import ROUTES, StageName
-from hephaestus.automation.pipeline.stages import StageContext
+from hephaestus.automation.pipeline.stages import StageContext, StageGitHub
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from tests.unit.automation.pipeline.conftest import FakeGitHub
 
 
 class FakeStageGitHub(FakeGitHub):
     """Canonical FakeGitHub plus the stage read queries.
 
+    Implements the :class:`StageGitHub` protocol (mypy-checked below).
     Reads mirror the real helper names the stages call through
     ``ctx.github``: ``gh_issue_json`` (github_api.issues),
     ``find_merged_closing_pr`` / ``find_pr_for_issue`` /
@@ -93,6 +95,23 @@ class FakeStageGitHub(FakeGitHub):
         """Coordinator-neutral label remove (delegates to gh_issue_remove_labels)."""
         self._issue_labels(issue_number)
         self.gh_issue_remove_labels(issue_number, labels)
+
+    def upsert_plan_comment(self, issue_number: int, body: str) -> None:
+        """Mirror the coordinator plan-comment upsert (PLAN_COMMENT_MARKER-keyed).
+
+        Delegates to the canonical ``gh_issue_upsert_comment`` recorder so
+        the mutation_log keeps the canonical format, and flips the
+        ``has_existing_plan`` answer to True — the posted comment IS the
+        durable plan artifact the verify step reads back.
+        """
+        self._has_plan = True
+        self.gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)
+
+
+if TYPE_CHECKING:
+    # mypy-enforced declaration that FakeStageGitHub satisfies the
+    # StageGitHub protocol (m5): a drifted signature fails type checking.
+    _stage_github_protocol_check: StageGitHub = FakeStageGitHub()
 
 
 def _budget_fn(name: str) -> int:

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -1,0 +1,177 @@
+"""Fixtures and fakes for pipeline stage tests.
+
+``FakeStageGitHub`` extends the canonical pipeline ``FakeGitHub`` (see
+``tests/unit/automation/pipeline/conftest.py``) with the read surface the
+planning/plan_review stages use (``gh_issue_json``, PR-coverage lookups,
+plan-comment presence), so mutator call sites and the ``mutation_log``
+format stay identical to what coordinator tests (#1817) will assert.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline.routing import ROUTES, StageName
+from hephaestus.automation.pipeline.stages import StageContext
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeGitHub
+
+
+class FakeStageGitHub(FakeGitHub):
+    """Canonical FakeGitHub plus the stage read queries.
+
+    Reads mirror the real helper names the stages call through
+    ``ctx.github``: ``gh_issue_json`` (github_api.issues),
+    ``find_merged_closing_pr`` / ``find_pr_for_issue`` /
+    ``close_issue_as_covered`` (_review_utils), and ``has_existing_plan``
+    (PlannerStateManager).
+    """
+
+    def __init__(
+        self,
+        *,
+        labels: list[str] | None = None,
+        merged_pr: int | None = None,
+        open_pr: int | None = None,
+        has_plan: bool = False,
+    ) -> None:
+        """Initialize the fake with canned read answers.
+
+        Args:
+            labels: Seed labels applied to any issue on first read/mutation.
+            merged_pr: Canned answer for find_merged_closing_pr.
+            open_pr: Canned answer for find_pr_for_issue.
+            has_plan: Canned answer for has_existing_plan.
+
+        """
+        super().__init__()
+        self._seed_labels = list(labels or [])
+        self._merged_pr = merged_pr
+        self._open_pr = open_pr
+        self._has_plan = has_plan
+
+    def _issue_labels(self, issue_number: int) -> set[str]:
+        """Return the issue's label set, seeding it on first access."""
+        if issue_number not in self.labels:
+            self.labels[issue_number] = set(self._seed_labels)
+        return self.labels[issue_number]
+
+    # -- read surface used by the stages -----------------------------------
+    def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+        """Mirror github_api.issues.gh_issue_json (labels subset only)."""
+        return {"labels": [{"name": name} for name in sorted(self._issue_labels(issue_number))]}
+
+    def find_merged_closing_pr(self, issue_number: int) -> int | None:
+        """Mirror _review_utils.find_merged_closing_pr."""
+        return self._merged_pr
+
+    def find_pr_for_issue(self, issue_number: int) -> int | None:
+        """Mirror _review_utils.find_pr_for_issue (open PR lookup)."""
+        return self._open_pr
+
+    def has_existing_plan(self, issue_number: int) -> bool:
+        """Mirror PlannerStateManager.has_existing_plan (plan comment check)."""
+        return self._has_plan
+
+    # -- mutator surface used by the stages ----------------------------------
+    # Coordinator-neutral names (the pipeline architecture guard forbids
+    # github_api mutator names inside pipeline modules); each delegates to
+    # the canonical gh_* recorder so mutation_log keeps the canonical format.
+    def close_issue_as_covered(self, issue_number: int, pr_number: int) -> None:
+        """Mirror _review_utils.close_issue_as_covered (records mutation)."""
+        self._log("close_issue_as_covered", issue_number, pr_number)
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Coordinator-neutral label add (delegates to gh_issue_add_labels)."""
+        self._issue_labels(issue_number)
+        self.gh_issue_add_labels(issue_number, labels)
+
+    def remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Coordinator-neutral label remove (delegates to gh_issue_remove_labels)."""
+        self._issue_labels(issue_number)
+        self.gh_issue_remove_labels(issue_number, labels)
+
+
+def _budget_fn(name: str) -> int:
+    """Look up a budget across all ROUTES rows (conservative default 1)."""
+    for route in ROUTES.values():
+        if name in route.budgets:
+            return route.budgets[name]
+    return 1
+
+
+class _Config:
+    """PlannerOptions-like config stub for stage tests."""
+
+    def __init__(self, *, dry_run: bool = False) -> None:
+        self.enable_advise = True
+        self.enable_learn = True
+        self.force = False
+        self.agent = "claude"
+        self.dry_run = dry_run
+
+
+class _Paths:
+    """Path accessor stub for stage tests."""
+
+    repo_root = "/tmp/repo"
+    worktree = "/tmp/repo/worktree"
+
+
+@pytest.fixture
+def make_ctx() -> Callable[..., StageContext]:
+    """Build StageContext instances with a fake clock and ROUTES budgets."""
+
+    def _make_ctx(
+        *,
+        config: Any = None,
+        org: str = "test-org",
+        dry_run: bool = False,
+        github: FakeStageGitHub | None = None,
+        paths: Any = None,
+    ) -> StageContext:
+        ticks = [0]
+
+        def now_fn() -> float:
+            ticks[0] += 1
+            return 1000.0 + ticks[0]
+
+        return StageContext(
+            config=config if config is not None else _Config(dry_run=dry_run),
+            org=org,
+            dry_run=dry_run,
+            github=github if github is not None else FakeStageGitHub(),
+            paths=paths if paths is not None else _Paths(),
+            now_fn=now_fn,
+            budget_fn=_budget_fn,
+        )
+
+    return _make_ctx
+
+
+@pytest.fixture
+def make_work_item() -> Callable[..., WorkItem]:
+    """Build WorkItem instances parked in a plan-side stage."""
+
+    def _make_item(
+        *,
+        repo: str = "test-repo",
+        kind: ItemKind = ItemKind.ISSUE,
+        issue: int | None = 1,
+        pr: int | None = None,
+        stage: StageName = StageName.PLANNING,
+        state: str = "ENTER",
+        labels: list[str] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> WorkItem:
+        item = WorkItem(repo=repo, kind=kind, issue=issue, pr=pr, stage=stage, state=state)
+        if labels:
+            item.labels_cache = dict.fromkeys(labels, True)
+        if payload:
+            item.payload = payload
+        return item
+
+    return _make_item

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -1,0 +1,91 @@
+"""Tests for the stage base contract (protocol, context, step-result types)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.pipeline.routing import Disposition, StageOutcome
+from hephaestus.automation.pipeline.stages import PlanningStage, PlanReviewStage, Stage
+from hephaestus.automation.pipeline.stages.base import Continue, JobRequest, StageContext
+
+
+class TestStageContext:
+    """StageContext accessor behavior with and without injected callables."""
+
+    def _bare_ctx(self, **overrides: Any) -> StageContext:
+        defaults: dict[str, Any] = {
+            "config": object(),
+            "org": "test-org",
+            "dry_run": False,
+            "github": object(),
+            "paths": object(),
+        }
+        defaults.update(overrides)
+        return StageContext(**defaults)
+
+    def test_now_uses_injected_clock(self) -> None:
+        """now() returns the injected fake clock's value."""
+        ctx = self._bare_ctx(now_fn=lambda: 1234.5)
+        assert ctx.now() == 1234.5
+
+    def test_now_defaults_to_wall_clock(self) -> None:
+        """now() without an injected clock returns epoch seconds."""
+        ctx = self._bare_ctx()
+        assert ctx.now() > 1_000_000_000.0
+
+    def test_budget_uses_injected_lookup(self) -> None:
+        """budget() returns the injected routing lookup's value."""
+        ctx = self._bare_ctx(budget_fn=lambda name: {"plan": 2}.get(name, 0))
+        assert ctx.budget("plan") == 2
+
+    def test_budget_defaults_conservatively(self) -> None:
+        """budget() without a lookup defaults to 1 (never unbounded)."""
+        ctx = self._bare_ctx()
+        assert ctx.budget("anything") == 1
+
+    def test_option_reads_config_with_default(self) -> None:
+        """option() reads config attributes and falls back to the default."""
+
+        class Config:
+            enable_learn = False
+
+        ctx = self._bare_ctx(config=Config())
+        assert ctx.option("enable_learn") is False
+        assert ctx.option("missing", "fallback") == "fallback"
+
+
+class TestStageProtocol:
+    """Both concrete stages satisfy the runtime-checkable Stage protocol."""
+
+    def test_planning_stage_is_a_stage(self) -> None:
+        """PlanningStage structurally satisfies Stage."""
+        assert isinstance(PlanningStage(), Stage)
+
+    def test_plan_review_stage_is_a_stage(self) -> None:
+        """PlanReviewStage structurally satisfies Stage."""
+        assert isinstance(PlanReviewStage(), Stage)
+
+    def test_non_stage_rejected(self) -> None:
+        """An unrelated object does not satisfy the protocol."""
+        assert not isinstance(object(), Stage)
+
+
+class TestStepResultTypes:
+    """Step-result value objects are frozen and carry their routing data."""
+
+    def test_continue_carries_next_state(self) -> None:
+        """Continue names the next in-memory state."""
+        assert Continue(next_state="VERIFY").next_state == "VERIFY"
+
+    def test_stage_outcome_is_the_routing_type(self) -> None:
+        """The re-exported StageOutcome is routing.StageOutcome itself."""
+        from hephaestus.automation.pipeline.stages import StageOutcome as ReExported
+
+        assert ReExported is StageOutcome
+        outcome = ReExported(Disposition.ADVANCE, "done")
+        assert outcome.disposition == Disposition.ADVANCE
+
+    def test_job_request_carries_on_done_state(self) -> None:
+        """JobRequest names the state entered after on_job_done."""
+        request = JobRequest(job=None, on_done_state="EVAL")  # type: ignore[arg-type]
+        assert request.on_done_state == "EVAL"

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -43,16 +43,6 @@ class TestStageContext:
         ctx = self._bare_ctx()
         assert ctx.budget("anything") == 1
 
-    def test_option_reads_config_with_default(self) -> None:
-        """option() reads config attributes and falls back to the default."""
-
-        class Config:
-            enable_learn = False
-
-        ctx = self._bare_ctx(config=Config())
-        assert ctx.option("enable_learn") is False
-        assert ctx.option("missing", "fallback") == "fallback"
-
 
 class TestStageProtocol:
     """Both concrete stages satisfy the runtime-checkable Stage protocol."""

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -8,7 +8,12 @@ from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verd
 from hephaestus.automation.pipeline.jobs import JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
-from hephaestus.automation.pipeline.stages.plan_review import PlanReviewStage
+from hephaestus.automation.pipeline.stages.plan_review import (
+    REVIEW_ERROR_RETRY_CAP,
+    PlanReviewStage,
+    build_amend_prompt,
+)
+from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
     STATE_PLAN_GO,
@@ -22,11 +27,24 @@ def _verdict(kind: str) -> ReviewVerdict:
     return ReviewVerdict(grade=None, verdict=kind, raw=f"review text ({kind})")
 
 
-class TestPlanReviewStageStep:
-    """step state machine: ENTER -> REVIEW_WAIT -> EVAL -> AMEND/LEARN."""
+class TestBuildAmendPrompt:
+    """build_amend_prompt composes the plan prompt with the feedback block."""
 
-    def test_on_enter_is_noop(self, make_ctx: Any, make_work_item: Any) -> None:
-        """on_enter writes nothing and always proceeds (idempotent)."""
+    def test_contains_plan_prompt_and_feedback_block(self) -> None:
+        """The output is the verbatim plan prompt plus the critique block."""
+        prompt = build_amend_prompt(42, "The plan misses the tests section.")
+
+        assert prompt.startswith(get_plan_prompt(42))  # template reused verbatim
+        assert "## Prior reviewer critique — your previous plan got NOGO" in prompt
+        assert "Address every concrete finding below in your revised plan:" in prompt
+        assert prompt.endswith("The plan misses the tests section.")
+
+
+class TestPlanReviewStageOnEnter:
+    """on_enter cycle-relative counter reset (attempts are per-lifetime)."""
+
+    def test_on_enter_writes_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
+        """on_enter performs no durable writes and always proceeds."""
         stage = PlanReviewStage()
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
@@ -34,6 +52,50 @@ class TestPlanReviewStageStep:
 
         assert stage.on_enter(item, ctx) is None
         assert github.mutation_log == []
+
+    def test_on_enter_resets_round_for_new_cycle(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Entering with a fresh plan_cycles value resets the cycle counter."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="ENTER")
+        item.attempts["plan_cycles"] = 1  # fail-back happened; new cycle
+        item.payload["review_cycle"] = 0
+        item.payload["review_round"] = 3  # cycle 1 exhausted its rounds
+
+        stage.on_enter(item, ctx)
+
+        assert item.payload["review_cycle"] == 1
+        assert item.payload["review_round"] == 0  # cycle 2 gets a full budget
+
+    def test_on_enter_same_cycle_keeps_round(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Same-cycle re-entry (e.g. the ERROR-path RETRY) keeps the round count."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2, state="ENTER")
+        item.payload["review_cycle"] = 0
+        item.payload["review_round"] = 1  # one NOGO round already done
+
+        stage.on_enter(item, ctx)
+
+        assert item.payload["review_round"] == 1  # progress preserved
+
+    def test_on_enter_double_call_is_idempotent(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A literal double on_enter changes nothing the second time."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=3, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        snapshot = dict(item.payload)
+        assert stage.on_enter(item, ctx) is None
+
+        assert item.payload == snapshot
+        assert github.mutation_log == []
+
+
+class TestPlanReviewStageStep:
+    """step state machine: ENTER -> REVIEW_WAIT -> EVAL -> AMEND/LEARN."""
 
     def test_enter_routes_to_review(self, make_ctx: Any, make_work_item: Any) -> None:
         """ENTER advances to REVIEW_WAIT."""
@@ -47,7 +109,11 @@ class TestPlanReviewStageStep:
         assert result.next_state == "REVIEW_WAIT"
 
     def test_review_wait_requests_review(self, make_ctx: Any, make_work_item: Any) -> None:
-        """REVIEW_WAIT submits the review job with in-worker verdict parsing."""
+        """REVIEW_WAIT submits the review job with in-worker verdict parsing.
+
+        A submission is NOT an iteration: counters advance only in EVAL and
+        only for real verdicts (#1554/#1794).
+        """
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=2, state="REVIEW_WAIT")
@@ -59,7 +125,7 @@ class TestPlanReviewStageStep:
         assert result.on_done_state == "EVAL"
         assert result.job.descr == "review"
         assert result.job.parse is parse_review_verdict  # verdict parsed in-worker
-        assert item.attempts["plan_review_iter"] == 1
+        assert item.attempts["plan_review_iter"] == 0  # submission burns nothing
         assert result.job.prompt_kwargs["iteration"] == 0  # 0-based for the prompt
         assert result.job.prompt_kwargs["prior_review"] is None  # first round
         assert result.job.prompt_kwargs["plan_text"] == "# Plan"
@@ -69,15 +135,31 @@ class TestPlanReviewStageStep:
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=3, state="REVIEW_WAIT")
-        item.attempts["plan_review_iter"] = 1
+        item.payload["review_round"] = 1  # one review round completed
         item.payload["prior_review"] = "fix the tests section"
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
-        assert item.attempts["plan_review_iter"] == 2
         assert result.job.prompt_kwargs["iteration"] == 1
         assert result.job.prompt_kwargs["prior_review"] == "fix the tests section"
+        assert item.attempts["plan_review_iter"] == 0  # still EVAL's job to count
+
+    def test_review_wait_clears_stale_verdict(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Submission clears any stale verdict (M3).
+
+        Clearing payload["review_verdict"] at submission means a failed
+        later round can never replay an earlier round's verdict in EVAL.
+        """
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=4, state="REVIEW_WAIT")
+        item.payload["review_verdict"] = _verdict("NOGO")  # stale round-1 verdict
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert "review_verdict" not in item.payload
 
     def test_eval_go_applies_label_advances(self, make_ctx: Any, make_work_item: Any) -> None:
         """GO durably applies state:plan-go then advances (learn disabled)."""
@@ -96,6 +178,8 @@ class TestPlanReviewStageStep:
             ("gh_issue_add_labels", (2, (STATE_PLAN_GO,))),
             ("gh_issue_remove_labels", (2, (STATE_PLAN_NO_GO, STATE_NEEDS_PLAN))),
         ]
+        assert item.attempts["plan_review_iter"] == 1  # real verdict counted
+        assert item.payload["review_round"] == 1
 
     def test_eval_go_with_learn_continues_to_learn(
         self, make_ctx: Any, make_work_item: Any
@@ -115,12 +199,12 @@ class TestPlanReviewStageStep:
         assert STATE_PLAN_GO in github.labels[3]
 
     def test_eval_nogo_within_budget_amends(self, make_ctx: Any, make_work_item: Any) -> None:
-        """NOGO within the iteration budget continues to AMEND_WAIT, no writes."""
+        """NOGO within the cycle budget continues to AMEND_WAIT, no writes."""
         stage = PlanReviewStage()
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
         item = make_work_item(issue=4, state="EVAL")
-        item.attempts["plan_review_iter"] = 1  # 1 < budget 3
+        item.payload["review_round"] = 0  # first review round of the cycle
         item.payload["review_verdict"] = _verdict("NOGO")
 
         result = stage.step(item, ctx)
@@ -128,6 +212,8 @@ class TestPlanReviewStageStep:
         assert isinstance(result, Continue)
         assert result.next_state == "AMEND_WAIT"
         assert github.mutation_log == []
+        assert item.payload["review_round"] == 1  # round counted in EVAL
+        assert item.attempts["plan_review_iter"] == 1  # lifetime audit trail
 
     def test_eval_nogo_exhausted_fails_back_nogo(self, make_ctx: Any, make_work_item: Any) -> None:
         """NOGO at the iteration cap applies no-go and fails back ("nogo")."""
@@ -135,7 +221,7 @@ class TestPlanReviewStageStep:
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
         item = make_work_item(issue=5, state="EVAL")
-        item.attempts["plan_review_iter"] = 3  # 3 >= budget 3
+        item.payload["review_round"] = 2  # this verdict is round 3/3
         item.payload["review_verdict"] = _verdict("NOGO")
 
         result = stage.step(item, ctx)
@@ -155,7 +241,7 @@ class TestPlanReviewStageStep:
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
         item = make_work_item(issue=6, state="EVAL")
-        item.attempts["plan_review_iter"] = 3
+        item.payload["review_round"] = 2
         item.attempts["plan_cycles"] = 1  # this fail-back becomes 2/2
         item.payload["review_verdict"] = _verdict("NOGO")
 
@@ -175,7 +261,7 @@ class TestPlanReviewStageStep:
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
         item = make_work_item(issue=7, state="EVAL")
-        item.attempts["plan_review_iter"] = 3
+        item.payload["review_round"] = 2
         item.payload["review_verdict"] = _verdict("AMBIGUOUS")
 
         result = stage.step(item, ctx)
@@ -185,7 +271,11 @@ class TestPlanReviewStageStep:
         assert STATE_PLAN_NO_GO in github.labels[7]
 
     def test_eval_error_leaves_labels_untouched(self, make_ctx: Any, make_work_item: Any) -> None:
-        """ERROR (reviewer infrastructure) retries with zero label writes."""
+        """ERROR retries with zero label writes and burns no iteration.
+
+        Reviewer-infrastructure failure must not stamp a go/no-go label or
+        consume review budget (#911/#1554/#1794).
+        """
         stage = PlanReviewStage()
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
@@ -197,6 +287,9 @@ class TestPlanReviewStageStep:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.RETRY
         assert github.mutation_log == []  # labels untouched on ERROR
+        assert item.attempts["plan_review_iter"] == 0  # no iteration burned
+        assert item.payload.get("review_round", 0) == 0
+        assert item.payload["review_error_retries"] == 1  # bounded retry loop
 
     def test_eval_missing_verdict_retries(self, make_ctx: Any, make_work_item: Any) -> None:
         """EVAL without a stored verdict retries instead of guessing."""
@@ -208,9 +301,11 @@ class TestPlanReviewStageStep:
 
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.RETRY
+        assert item.attempts["plan_review_iter"] == 0  # no iteration burned
+        assert item.payload["review_error_retries"] == 1
 
     def test_amend_wait_requests_plan(self, make_ctx: Any, make_work_item: Any) -> None:
-        """AMEND_WAIT submits the planner amend job and loops to REVIEW_WAIT."""
+        """AMEND_WAIT submits the amend job carrying the reviewer feedback."""
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=10, state="AMEND_WAIT")
@@ -221,7 +316,13 @@ class TestPlanReviewStageStep:
         assert isinstance(result, JobRequest)
         assert result.on_done_state == "REVIEW_WAIT"  # loop back to review
         assert result.job.descr == "amend"
-        assert result.job.prompt_kwargs == {"issue_number": 10}
+        assert result.job.prompt_builder is build_amend_prompt
+        # The feedback block travels via prompt_kwargs (builders run
+        # in-worker; AgentJob is frozen, so no closures over payload).
+        assert result.job.prompt_kwargs == {
+            "issue_number": 10,
+            "prior_review": "Feedback: improve clarity",
+        }
 
     def test_learn_wait_requests_learn(self, make_ctx: Any, make_work_item: Any) -> None:
         """LEARN_WAIT submits the learn job carrying the approved plan."""
@@ -337,7 +438,7 @@ class TestDurableWriteOrdering:
         github = FakeStageGitHub()
         ctx = make_ctx(github=github)
         item = make_work_item(issue=12, state="EVAL")
-        item.attempts["plan_review_iter"] = 3
+        item.payload["review_round"] = 2  # this verdict is round 3/3
         item.payload["review_verdict"] = _verdict("NOGO")
 
         result = stage.step(item, ctx)
@@ -345,6 +446,214 @@ class TestDurableWriteOrdering:
         assert github.mutation_log[0][0] == "gh_issue_add_labels"
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.FAIL_BACK
+
+
+class TestStaleVerdictAndErrorAccounting:
+    """M3 (no stale-verdict replay) + M4 (ERROR burns nothing, bounded)."""
+
+    def test_failed_round2_job_retries_instead_of_replaying_round1_nogo(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed round-2 job hits EVAL's no-verdict RETRY, not round 1's NOGO.
+
+        Scenario: round 1 produced a NOGO verdict; the amend ran; the round-2
+        review job FAILS (on_job_done stores nothing). Because REVIEW_WAIT
+        cleared the stale verdict at submission, EVAL must RETRY — without
+        amending again and without burning iteration budget.
+        """
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=30, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")  # round 1
+        item.payload["review_round"] = 0
+
+        assert isinstance(stage.step(item, ctx), Continue)  # round 1 -> AMEND_WAIT
+        item.state = "AMEND_WAIT"
+        stage.on_job_done(item, JobResult(ok=True, value="# Amended"), ctx)
+        item.state = "REVIEW_WAIT"
+
+        request = stage.step(item, ctx)  # round-2 submission clears the verdict
+        assert isinstance(request, JobRequest)
+
+        failed = JobResult(ok=False, error="reviewer crashed")
+        stage.on_job_done(item, failed, ctx)  # stores nothing
+        item.state = "EVAL"
+        iter_before = item.attempts["plan_review_iter"]
+        round_before = item.payload["review_round"]
+
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY  # NOT a replayed NOGO
+        assert item.attempts["plan_review_iter"] == iter_before  # budget intact
+        assert item.payload["review_round"] == round_before
+        assert github.mutation_log == []  # no labels on the error path
+
+    def test_error_round_burns_nothing_and_nogo_still_amendable(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An ERROR round burns nothing; the next NOGO can still amend.
+
+        R1 NOGO -> R2 ERROR -> RETRY (iter unchanged, no labels) -> R2 NOGO
+        -> amend still available (no premature no-go).
+        """
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=31, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        # Round 1: NOGO -> amend (round 1/3 consumed).
+        item.payload["review_verdict"] = _verdict("NOGO")
+        assert isinstance(stage.step(item, ctx), Continue)
+        assert item.attempts["plan_review_iter"] == 1
+
+        # Round 2 attempt: reviewer infrastructure ERROR.
+        item.payload["review_verdict"] = _verdict("ERROR")
+        outcome = stage.step(item, ctx)
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert item.attempts["plan_review_iter"] == 1  # iter unchanged
+        assert item.payload["review_round"] == 1
+        assert github.mutation_log == []  # no labels
+
+        # Round 2 rerun: a real NOGO — the cycle still has amends left.
+        item.payload["review_verdict"] = _verdict("NOGO")
+        result = stage.step(item, ctx)
+        assert isinstance(result, Continue)
+        assert result.next_state == "AMEND_WAIT"  # no premature no-go
+        assert item.payload["review_error_retries"] == 0  # reset on real verdict
+        assert github.mutation_log == []
+
+    def test_error_retry_cap_trips(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Consecutive reviewer failures beyond the cap FINISH_FAIL, no labels."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=32, state="EVAL")
+
+        for expected_retry in range(1, REVIEW_ERROR_RETRY_CAP + 1):
+            item.payload["review_verdict"] = _verdict("ERROR")
+            outcome = stage.step(item, ctx)
+            assert isinstance(outcome, StageOutcome)
+            assert outcome.disposition == Disposition.RETRY
+            assert item.payload["review_error_retries"] == expected_retry
+
+        item.payload["review_verdict"] = _verdict("ERROR")
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FINISH_FAIL
+        assert "reviewer error retries exhausted" in outcome.note
+        assert github.mutation_log == []  # labels stay untouched on ERROR path
+        assert item.attempts["plan_review_iter"] == 0  # nothing ever burned
+
+
+class TestCycleRelativeBudget:
+    """m1: cycle 2 gets a full review budget; attempts stay per-lifetime."""
+
+    def test_full_cycle_two_path(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Cycle 2 gets a full, fresh review budget.
+
+        Cycle 1 exhausts 3 NOGOs -> FAIL_BACK(nogo); cycle 2 gets 3 fresh
+        rounds (prompt iterations 0..2 again) -> plan_cycles_exhausted.
+        """
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=33, state="ENTER")
+
+        def run_cycle() -> StageOutcome:
+            assert stage.on_enter(item, ctx) is None
+            assert isinstance(stage.step(item, ctx), Continue)  # ENTER
+            item.state = "REVIEW_WAIT"
+            prompt_iterations = []
+            while True:
+                request = stage.step(item, ctx)
+                assert isinstance(request, JobRequest)
+                prompt_iterations.append(request.job.prompt_kwargs["iteration"])
+                stage.on_job_done(item, JobResult(ok=True, value=_verdict("NOGO")), ctx)
+                item.state = "EVAL"
+                result = stage.step(item, ctx)
+                if isinstance(result, StageOutcome):
+                    assert prompt_iterations == [0, 1, 2]  # 0-based, per cycle
+                    return result
+                assert isinstance(result, Continue)  # AMEND_WAIT
+                item.state = "AMEND_WAIT"
+                amend = stage.step(item, ctx)
+                assert isinstance(amend, JobRequest)
+                stage.on_job_done(item, JobResult(ok=True, value="# Amended"), ctx)
+                item.state = "REVIEW_WAIT"
+
+        first = run_cycle()
+        assert first.disposition == Disposition.FAIL_BACK
+        assert first.note == "nogo"
+        assert item.attempts["plan_review_iter"] == 3
+        assert item.attempts["plan_cycles"] == 1
+
+        # Fail-back routes through planning; the item re-enters this stage.
+        item.state = "ENTER"
+        second = run_cycle()  # full fresh budget: 3 more reviews
+        assert second.disposition == Disposition.FAIL_BACK
+        assert second.note == "plan_cycles_exhausted"
+        assert item.attempts["plan_review_iter"] == 6  # lifetime audit trail
+        assert item.attempts["plan_cycles"] == 2
+
+
+class TestNonFatalLabelWrites:
+    """m3: EVAL label-pair writes follow the legacy try/except-warn pattern."""
+
+    def test_add_label_failure_does_not_propagate_and_remove_still_runs(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An add_labels exception is swallowed; remove_labels still runs.
+
+        Mirrors the legacy planner_review_loop._apply_state_label pattern.
+        """
+
+        class AddFailsGitHub(FakeStageGitHub):
+            def add_labels(self, issue_number: int, labels: list[str]) -> None:
+                raise RuntimeError("gh add failed")
+
+        stage = PlanReviewStage()
+        github = AddFailsGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.enable_learn = False
+        item = make_work_item(issue=34, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert github.mutation_log == [
+            ("gh_issue_remove_labels", (34, (STATE_PLAN_NO_GO, STATE_NEEDS_PLAN))),
+        ]
+
+    def test_remove_label_failure_does_not_propagate(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A remove_labels exception after the add is swallowed too."""
+
+        class RemoveFailsGitHub(FakeStageGitHub):
+            def remove_labels(self, issue_number: int, labels: list[str]) -> None:
+                raise RuntimeError("gh remove failed")
+
+        stage = PlanReviewStage()
+        github = RemoveFailsGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=35, state="EVAL")
+        item.payload["review_round"] = 2
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert github.mutation_log == [
+            ("gh_issue_add_labels", (35, (STATE_PLAN_NO_GO,))),
+        ]
 
 
 class TestReviewFlowWithFakePool:
@@ -379,3 +688,57 @@ class TestReviewFlowWithFakePool:
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition == Disposition.ADVANCE
         assert STATE_PLAN_GO in github.labels[20]
+
+    def test_full_walk_enter_to_advance(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Full pool-driven walk of the whole stage.
+
+        ENTER -> REVIEW -> EVAL(NOGO) -> AMEND -> REVIEW -> EVAL(GO) ->
+        LEARN -> FINISH -> ADVANCE.
+        """
+        from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.enable_learn = True
+        item = make_work_item(issue=21, state="ENTER")
+        item.payload["plan_text"] = "# Plan v1"
+
+        pool = FakeWorkerPool()
+        pool.script(
+            JobResult(ok=True, value=_verdict("NOGO")),  # review round 1
+            JobResult(ok=True, value="# Plan v2"),  # amend
+            JobResult(ok=True, value=_verdict("GO")),  # review round 2
+            JobResult(ok=True, value="learn bullets"),  # learn
+        )
+
+        assert stage.on_enter(item, ctx) is None
+
+        outcome = None
+        for _ in range(20):  # bounded driver loop
+            result = stage.step(item, ctx)
+            if isinstance(result, Continue):
+                item.state = result.next_state
+                continue
+            if isinstance(result, JobRequest):
+                pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+                _handle, job_result = pool.completion_q.get_nowait()
+                assert not job_result.interrupted
+                stage.on_job_done(item, job_result, ctx)
+                item.state = result.on_done_state
+                continue
+            outcome = result
+            break
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        # The amended plan and both counters reflect the two real rounds.
+        assert item.payload["plan_text"] == "# Plan v2"
+        assert item.attempts["plan_review_iter"] == 2
+        # All four jobs ran, in order.
+        assert [h.job.descr for h in pool.submitted] == ["review", "amend", "review", "learn"]
+        # Durable GO write happened (before the ADVANCE outcome).
+        assert github.mutation_log == [
+            ("gh_issue_add_labels", (21, (STATE_PLAN_GO,))),
+            ("gh_issue_remove_labels", (21, (STATE_PLAN_NO_GO, STATE_NEEDS_PLAN))),
+        ]

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -1,0 +1,381 @@
+"""Tests for the plan-review stage (doc section "3. plan_review")."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
+from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.routing import Disposition
+from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.plan_review import PlanReviewStage
+from hephaestus.automation.state_labels import (
+    STATE_NEEDS_PLAN,
+    STATE_PLAN_GO,
+    STATE_PLAN_NO_GO,
+)
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _verdict(kind: str) -> ReviewVerdict:
+    """Build a ReviewVerdict of the given kind for EVAL tests."""
+    return ReviewVerdict(grade=None, verdict=kind, raw=f"review text ({kind})")
+
+
+class TestPlanReviewStageStep:
+    """step state machine: ENTER -> REVIEW_WAIT -> EVAL -> AMEND/LEARN."""
+
+    def test_on_enter_is_noop(self, make_ctx: Any, make_work_item: Any) -> None:
+        """on_enter writes nothing and always proceeds (idempotent)."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        assert github.mutation_log == []
+
+    def test_enter_routes_to_review(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ENTER advances to REVIEW_WAIT."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"
+
+    def test_review_wait_requests_review(self, make_ctx: Any, make_work_item: Any) -> None:
+        """REVIEW_WAIT submits the review job with in-worker verdict parsing."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2, state="REVIEW_WAIT")
+        item.payload["plan_text"] = "# Plan"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.on_done_state == "EVAL"
+        assert result.job.descr == "review"
+        assert result.job.parse is parse_review_verdict  # verdict parsed in-worker
+        assert item.attempts["plan_review_iter"] == 1
+        assert result.job.prompt_kwargs["iteration"] == 0  # 0-based for the prompt
+        assert result.job.prompt_kwargs["prior_review"] is None  # first round
+        assert result.job.prompt_kwargs["plan_text"] == "# Plan"
+
+    def test_review_wait_threads_prior_review(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A later review round passes the prior review text to the prompt."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="REVIEW_WAIT")
+        item.attempts["plan_review_iter"] = 1
+        item.payload["prior_review"] = "fix the tests section"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert item.attempts["plan_review_iter"] == 2
+        assert result.job.prompt_kwargs["iteration"] == 1
+        assert result.job.prompt_kwargs["prior_review"] == "fix the tests section"
+
+    def test_eval_go_applies_label_advances(self, make_ctx: Any, make_work_item: Any) -> None:
+        """GO durably applies state:plan-go then advances (learn disabled)."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.enable_learn = False
+        item = make_work_item(issue=2, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert github.mutation_log == [
+            ("gh_issue_add_labels", (2, (STATE_PLAN_GO,))),
+            ("gh_issue_remove_labels", (2, (STATE_PLAN_NO_GO, STATE_NEEDS_PLAN))),
+        ]
+
+    def test_eval_go_with_learn_continues_to_learn(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """GO with learn enabled writes the label then continues to LEARN_WAIT."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.enable_learn = True
+        item = make_work_item(issue=3, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "LEARN_WAIT"
+        assert STATE_PLAN_GO in github.labels[3]
+
+    def test_eval_nogo_within_budget_amends(self, make_ctx: Any, make_work_item: Any) -> None:
+        """NOGO within the iteration budget continues to AMEND_WAIT, no writes."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=4, state="EVAL")
+        item.attempts["plan_review_iter"] = 1  # 1 < budget 3
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "AMEND_WAIT"
+        assert github.mutation_log == []
+
+    def test_eval_nogo_exhausted_fails_back_nogo(self, make_ctx: Any, make_work_item: Any) -> None:
+        """NOGO at the iteration cap applies no-go and fails back ("nogo")."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=5, state="EVAL")
+        item.attempts["plan_review_iter"] = 3  # 3 >= budget 3
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "nogo"  # plan_cycles remain (1 < 2)
+        assert item.attempts["plan_cycles"] == 1
+        assert github.mutation_log == [
+            ("gh_issue_add_labels", (5, (STATE_PLAN_NO_GO,))),
+            ("gh_issue_remove_labels", (5, (STATE_PLAN_GO, STATE_NEEDS_PLAN))),
+        ]
+
+    def test_eval_nogo_plan_cycles_exhausted(self, make_ctx: Any, make_work_item: Any) -> None:
+        """NOGO at the cap with plan_cycles consumed fails back terminally."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=6, state="EVAL")
+        item.attempts["plan_review_iter"] = 3
+        item.attempts["plan_cycles"] = 1  # this fail-back becomes 2/2
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "plan_cycles_exhausted"
+        assert item.attempts["plan_cycles"] == 2
+        assert STATE_PLAN_NO_GO in github.labels[6]  # label still written first
+
+    def test_eval_ambiguous_at_cap_treated_as_nogo(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """AMBIGUOUS at the iteration cap takes the no-go exhaustion path."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=7, state="EVAL")
+        item.attempts["plan_review_iter"] = 3
+        item.payload["review_verdict"] = _verdict("AMBIGUOUS")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert STATE_PLAN_NO_GO in github.labels[7]
+
+    def test_eval_error_leaves_labels_untouched(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ERROR (reviewer infrastructure) retries with zero label writes."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=8, state="EVAL")
+        item.payload["review_verdict"] = _verdict("ERROR")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert github.mutation_log == []  # labels untouched on ERROR
+
+    def test_eval_missing_verdict_retries(self, make_ctx: Any, make_work_item: Any) -> None:
+        """EVAL without a stored verdict retries instead of guessing."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=9, state="EVAL")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+
+    def test_amend_wait_requests_plan(self, make_ctx: Any, make_work_item: Any) -> None:
+        """AMEND_WAIT submits the planner amend job and loops to REVIEW_WAIT."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=10, state="AMEND_WAIT")
+        item.payload["prior_review"] = "Feedback: improve clarity"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.on_done_state == "REVIEW_WAIT"  # loop back to review
+        assert result.job.descr == "amend"
+        assert result.job.prompt_kwargs == {"issue_number": 10}
+
+    def test_learn_wait_requests_learn(self, make_ctx: Any, make_work_item: Any) -> None:
+        """LEARN_WAIT submits the learn job carrying the approved plan."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=11, state="LEARN_WAIT")
+        item.payload["plan_text"] = "# My Plan\n..."
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.on_done_state == "FINISH"
+        assert result.job.descr == "learn"
+        assert result.job.prompt_kwargs == {"context": "# My Plan\n..."}
+
+    def test_finish_advances(self, make_ctx: Any, make_work_item: Any) -> None:
+        """FINISH advances to the next stage."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=12, state="FINISH")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+
+    def test_unknown_state_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An unknown state finishes failed instead of looping silently."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=13, state="BOGUS")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+    def test_no_issue_number_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Step without an issue number finishes failed."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=None, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+
+class TestPlanReviewStageOnJobDone:
+    """on_job_done payload handling (state still at the WAIT state)."""
+
+    def test_review_verdict_stored_in_payload(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The parsed verdict and its raw text are stored on the payload."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="REVIEW_WAIT")
+        verdict = _verdict("GO")
+        result = JobResult(ok=True, value=verdict)
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.payload["review_verdict"] == verdict
+        assert item.payload["prior_review"] == verdict.raw
+
+    def test_amend_result_stored_in_payload(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The amended plan text is stored on the payload."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2, state="AMEND_WAIT")
+        result = JobResult(ok=True, value="# Amended plan here")
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.payload["plan_text"] == "# Amended plan here"
+
+    def test_failed_result_is_not_stored(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failed job result is logged and never stored."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="REVIEW_WAIT")
+        result = JobResult(ok=False, error="reviewer crashed")
+
+        stage.on_job_done(item, result, ctx)
+
+        assert "review_verdict" not in item.payload
+
+
+class TestDurableWriteOrdering:
+    """The load-bearing invariant: durable writes precede advancing outcomes."""
+
+    def test_go_verdict_mutation_before_advance(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The state:plan-go write is recorded before ADVANCE is returned."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.enable_learn = False
+        item = make_work_item(issue=11, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        # Mutations are recorded at the moment the advancing outcome exists.
+        assert github.mutation_log[0][0] == "gh_issue_add_labels"
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+
+    def test_nogo_exhausted_mutation_before_fail_back(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The state:plan-no-go write is recorded before FAIL_BACK is returned."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=12, state="EVAL")
+        item.attempts["plan_review_iter"] = 3
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert github.mutation_log[0][0] == "gh_issue_add_labels"
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+
+
+class TestReviewFlowWithFakePool:
+    """Drive the review round through the canonical FakeWorkerPool."""
+
+    def test_review_round_to_go(self, make_ctx: Any, make_work_item: Any) -> None:
+        """REVIEW_WAIT job -> pool -> on_job_done -> EVAL -> ADVANCE."""
+        from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.enable_learn = False
+        item = make_work_item(issue=20, state="REVIEW_WAIT")
+        item.payload["plan_text"] = "# Plan"
+
+        request = stage.step(item, ctx)
+        assert isinstance(request, JobRequest)
+
+        pool = FakeWorkerPool()
+        pool.script(JobResult(ok=True, value=_verdict("GO")))
+        handle = pool.submit(request.job, request.on_done_state)  # type: ignore[arg-type]
+        done_handle, done_result = pool.completion_q.get_nowait()
+        assert done_handle is handle
+        assert not done_result.interrupted  # on_job_done contract precondition
+
+        stage.on_job_done(item, done_result, ctx)  # state still REVIEW_WAIT
+        item.state = request.on_done_state  # coordinator advances to EVAL
+
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        assert STATE_PLAN_GO in github.labels[20]

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -4,16 +4,38 @@ from __future__ import annotations
 
 from typing import Any
 
-from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
-from hephaestus.automation.pipeline.stages.planning import PlanningStage
+from hephaestus.automation.pipeline.stages.planning import (
+    PlanningStage,
+    build_plan_prompt,
+)
+from hephaestus.automation.prompts.planning import get_plan_prompt
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
     STATE_PLAN_GO,
     STATE_SKIP,
 )
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class TestBuildPlanPrompt:
+    """build_plan_prompt composes the plan prompt with the advise block."""
+
+    def test_without_findings_is_plan_prompt_verbatim(self) -> None:
+        """No advise findings means the untouched template output."""
+        assert build_plan_prompt(7) == get_plan_prompt(7)
+        assert build_plan_prompt(7, "") == get_plan_prompt(7)
+
+    def test_with_findings_appends_learnings_block(self) -> None:
+        """Advise findings ride in the legacy learnings block."""
+        prompt = build_plan_prompt(7, "Use the retry helper from utils.")
+
+        assert prompt.startswith(get_plan_prompt(7))  # template reused verbatim
+        assert "## Prior Learnings from Team Knowledge Base" in prompt
+        assert prompt.endswith("Use the retry helper from utils.")
 
 
 class TestPlanningStageEnter:
@@ -140,6 +162,41 @@ class TestPlanningStageEnter:
         assert outcome is not None
         assert outcome.disposition == Disposition.FINISH_FAIL
 
+    def test_existing_plan_fast_forwards_to_verify(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A restart with a posted plan comment jumps straight to VERIFY.
+
+        Real has-plan semantics: advise + plan are never redone mid-stage.
+        """
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN], has_plan=True)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=9, state="ENTER")
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is None  # proceed, but...
+        assert item.state == "VERIFY"  # ...straight to verification
+        assert github.mutation_log == []  # no rewrites on re-entry
+
+    def test_double_on_enter_is_idempotent(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A literal double on_enter produces no extra mutations or moves."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=True)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=10, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        assert item.state == "VERIFY"
+        log_after_first = list(github.mutation_log)
+        assert log_after_first == [("gh_issue_add_labels", (10, (STATE_NEEDS_PLAN,)))]
+
+        assert stage.on_enter(item, ctx) is None  # second literal call
+
+        assert item.state == "VERIFY"
+        assert github.mutation_log == log_after_first  # nothing new written
+
 
 class TestPlanningStageStep:
     """step state machine: ENTER -> ADVISE_WAIT -> PLAN_WAIT -> VERIFY."""
@@ -186,25 +243,98 @@ class TestPlanningStageStep:
         stage = PlanningStage()
         ctx = make_ctx()
         item = make_work_item(issue=4, state="PLAN_WAIT")
+        item.payload["advise_findings"] = "prior learnings"
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
         assert result.on_done_state == "VERIFY"
         assert result.job.descr == "plan"
-        assert result.job.prompt_kwargs == {"issue_number": 4}
+        assert result.job.prompt_builder is build_plan_prompt
+        # Advise findings travel via prompt_kwargs (builders run in-worker;
+        # AgentJob is frozen, so no closures over payload).
+        assert result.job.prompt_kwargs == {
+            "issue_number": 4,
+            "advise_findings": "prior learnings",
+        }
 
     def test_verify_with_plan_advances(self, make_ctx: Any, make_work_item: Any) -> None:
-        """VERIFY with an existing plan comment advances."""
+        """VERIFY with an existing plan comment advances without re-posting."""
         stage = PlanningStage()
         github = FakeStageGitHub(has_plan=True)
         ctx = make_ctx(github=github)
         item = make_work_item(issue=5, state="VERIFY")
+        item.payload["plan_text"] = "# Implementation Plan\n\nAlready posted."
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
+        assert github.mutation_log == []  # existing plan: no duplicate upsert
+
+    def test_verify_posts_plan_comment_then_advances(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The PIPELINE posts the plan comment (M1).
+
+        VERIFY upserts the durable artifact BEFORE the verify/ADVANCE
+        decision (journal order).
+        """
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=False)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=11, state="VERIFY")
+        item.payload["plan_text"] = "# Implementation Plan\n\nDo the thing."
+
+        result = stage.step(item, ctx)
+
+        # Durable write happened, in journal order, before ADVANCE existed.
+        assert github.mutation_log == [
+            ("gh_issue_upsert_comment", (11, PLAN_COMMENT_MARKER)),
+        ]
+        assert github.comments[11] == ["# Implementation Plan\n\nDo the thing."]
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+
+    def test_verify_posts_exactly_once_on_reentry(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Re-entering VERIFY never double-posts.
+
+        The upsert is guarded by has_existing_plan (idempotent on re-entry).
+        """
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=False)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=12, state="VERIFY")
+        item.payload["plan_text"] = "# Implementation Plan\n\nOnce only."
+
+        first = stage.step(item, ctx)
+        second = stage.step(item, ctx)  # re-entry (e.g. after a restart)
+
+        upserts = [m for m in github.mutation_log if m[0] == "gh_issue_upsert_comment"]
+        assert len(upserts) == 1  # exactly one durable post
+        assert isinstance(first, StageOutcome)
+        assert first.disposition == Disposition.ADVANCE
+        assert isinstance(second, StageOutcome)
+        assert second.disposition == Disposition.ADVANCE
+
+    def test_verify_normalizes_plan_body_to_marker(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Marker normalization is re-housed from _upsert_plan_comment.
+
+        A markerless (or whitespace-prefixed) plan gets the marker prepended.
+        """
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=False)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=13, state="VERIFY")
+        item.payload["plan_text"] = "\n\nSome plan without the heading."
+
+        stage.step(item, ctx)
+
+        (body,) = github.comments[13]
+        assert body.startswith(PLAN_COMMENT_MARKER)  # upsert helper keys on this
+        assert body == f"{PLAN_COMMENT_MARKER}\n\nSome plan without the heading."
 
     def test_verify_without_plan_retries(self, make_ctx: Any, make_work_item: Any) -> None:
         """VERIFY without a plan retries while within the plan budget."""
@@ -290,3 +420,59 @@ class TestPlanningStageOnJobDone:
         stage.on_job_done(item, result, ctx)
 
         assert "plan_text" not in item.payload
+
+
+class TestPlanningFlowWithFakePool:
+    """Drive the whole stage through the canonical FakeWorkerPool (m6)."""
+
+    def test_full_walk_enter_to_advance(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Full pool-driven walk of the whole stage.
+
+        ENTER -> ADVISE_WAIT -> PLAN_WAIT -> VERIFY -> ADVANCE, with the
+        durable writes in journal order.
+        """
+        from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+
+        stage = PlanningStage()
+        github = FakeStageGitHub()  # unlabeled, no PRs, no plan yet
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=40, state="ENTER")
+
+        pool = FakeWorkerPool()
+        pool.script(
+            JobResult(ok=True, value="advise findings"),  # advise
+            JobResult(ok=True, value="# Implementation Plan\n\nSteps."),  # plan
+        )
+
+        assert stage.on_enter(item, ctx) is None
+
+        outcome = None
+        for _ in range(10):  # bounded driver loop
+            result = stage.step(item, ctx)
+            if isinstance(result, Continue):
+                item.state = result.next_state
+                continue
+            if isinstance(result, JobRequest):
+                pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+                _handle, job_result = pool.completion_q.get_nowait()
+                assert not job_result.interrupted
+                stage.on_job_done(item, job_result, ctx)
+                item.state = result.on_done_state
+                continue
+            outcome = result
+            break
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        # Both agent jobs ran, in order, with the payload threaded through.
+        assert [h.job.descr for h in pool.submitted] == ["advise", "plan"]
+        plan_job = pool.submitted[1].job
+        assert isinstance(plan_job, AgentJob)  # narrows the job union for mypy
+        assert plan_job.prompt_kwargs["advise_findings"] == "advise findings"
+        # Durable writes, pinned in journal order: entry label first, then
+        # the plan-comment artifact — both before the ADVANCE outcome.
+        assert github.mutation_log == [
+            ("gh_issue_add_labels", (40, (STATE_NEEDS_PLAN,))),
+            ("gh_issue_upsert_comment", (40, PLAN_COMMENT_MARKER)),
+        ]
+        assert github.comments[40] == ["# Implementation Plan\n\nSteps."]

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -1,0 +1,292 @@
+"""Tests for the planning stage (doc section "2. planning")."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.routing import Disposition
+from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.planning import PlanningStage
+from hephaestus.automation.state_labels import (
+    STATE_NEEDS_PLAN,
+    STATE_PLAN_GO,
+    STATE_SKIP,
+)
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class TestPlanningStageEnter:
+    """on_enter idempotency guards and fast-forward checks."""
+
+    def test_plan_go_fast_forward_advance(self, make_ctx: Any, make_work_item: Any) -> None:
+        """At-or-past state:plan-go advances immediately with zero jobs/writes."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_PLAN_GO])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.ADVANCE
+        assert github.mutation_log == []  # no mutations on fast-forward
+
+    def test_skip_label_skips(self, make_ctx: Any, make_work_item: Any) -> None:
+        """state:skip routes the item away without any writes."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_SKIP])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.SKIP
+        assert github.mutation_log == []
+
+    def test_merged_pr_closes_issue(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A merged closing PR closes the issue as covered (gate A)."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(merged_pr=123)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=3)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.SKIP
+        assert github.mutation_log == [("close_issue_as_covered", (3, 123))]
+
+    def test_open_pr_skips(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An open PR for the issue skips planning with zero writes (gate B)."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(open_pr=456)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=4)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.SKIP
+        assert github.mutation_log == []
+
+    def test_unlabeled_entry_adds_needs_plan(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Unlabeled entry durably writes state:needs-plan before proceeding."""
+        stage = PlanningStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=5)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is None  # proceed to step()
+        assert github.mutation_log == [("gh_issue_add_labels", (5, (STATE_NEEDS_PLAN,)))]
+        assert STATE_NEEDS_PLAN in github.labels[5]
+
+    def test_reentry_with_needs_plan_is_idempotent(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Re-entry with state:needs-plan already present writes nothing."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=6)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is None
+        assert github.mutation_log == []
+
+    def test_label_refresh_updates_cache(self, make_ctx: Any, make_work_item: Any) -> None:
+        """on_enter refreshes item.labels_cache from GitHub."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_NEEDS_PLAN])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=7, labels=["stale:label"])
+
+        stage.on_enter(item, ctx)
+
+        assert STATE_NEEDS_PLAN in item.labels_cache
+        assert "stale:label" not in item.labels_cache
+
+    def test_label_refresh_failure_falls_back_to_cache(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failing label read falls back to the cached labels."""
+
+        class BrokenGitHub(FakeStageGitHub):
+            def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+                raise RuntimeError("gh unavailable")
+
+        stage = PlanningStage()
+        github = BrokenGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=8, labels=[STATE_PLAN_GO])
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.ADVANCE  # cached plan-go honored
+
+    def test_no_issue_number_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A work item without an issue number finishes failed."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=None)
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.FINISH_FAIL
+
+
+class TestPlanningStageStep:
+    """step state machine: ENTER -> ADVISE_WAIT -> PLAN_WAIT -> VERIFY."""
+
+    def test_enter_routes_to_advise_when_enabled(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ENTER advances to ADVISE_WAIT when advise is enabled."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        ctx.config.enable_advise = True
+        item = make_work_item(issue=1, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "ADVISE_WAIT"
+
+    def test_enter_skips_advise_when_disabled(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ENTER advances straight to PLAN_WAIT when advise is disabled."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=2, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "PLAN_WAIT"
+
+    def test_advise_wait_requests_advise_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ADVISE_WAIT submits the advise job and lands in PLAN_WAIT."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="ADVISE_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.on_done_state == "PLAN_WAIT"
+        assert result.job.descr == "advise"
+        assert result.job.prompt_kwargs["issue_number"] == 3
+
+    def test_plan_wait_requests_plan_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """PLAN_WAIT submits the plan job (planner session) and lands in VERIFY."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=4, state="PLAN_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.on_done_state == "VERIFY"
+        assert result.job.descr == "plan"
+        assert result.job.prompt_kwargs == {"issue_number": 4}
+
+    def test_verify_with_plan_advances(self, make_ctx: Any, make_work_item: Any) -> None:
+        """VERIFY with an existing plan comment advances."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=True)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=5, state="VERIFY")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+
+    def test_verify_without_plan_retries(self, make_ctx: Any, make_work_item: Any) -> None:
+        """VERIFY without a plan retries while within the plan budget."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=False)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=6, state="VERIFY")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert item.attempts["plan"] == 1
+
+    def test_verify_exhausts_budget(self, make_ctx: Any, make_work_item: Any) -> None:
+        """VERIFY fails after exhausting the plan budget (2)."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(has_plan=False)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=7, state="VERIFY")
+        item.attempts["plan"] = 1  # this attempt becomes 2/2
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+    def test_unknown_state_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An unknown state finishes failed instead of looping silently."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=8, state="BOGUS")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+    def test_no_issue_number_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Step without an issue number finishes failed."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=None, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+
+class TestPlanningStageOnJobDone:
+    """on_job_done payload handling (state still at the WAIT state)."""
+
+    def test_advise_result_stored_in_payload(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The advise job's findings are stored on the payload."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="ADVISE_WAIT")
+        result = JobResult(ok=True, value="advise findings here")
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.payload["advise_findings"] == "advise findings here"
+
+    def test_plan_result_stored_in_payload(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The plan job's text is stored on the payload."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2, state="PLAN_WAIT")
+        result = JobResult(ok=True, value="# Issue plan here")
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.payload["plan_text"] == "# Issue plan here"
+
+    def test_failed_result_is_not_stored(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failed job result is logged and never stored."""
+        stage = PlanningStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=3, state="PLAN_WAIT")
+        result = JobResult(ok=False, error="agent timeout")
+
+        stage.on_job_done(item, result, ctx)
+
+        assert "plan_text" not in item.payload

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -54,6 +54,13 @@ _THIN_FETCH_PREFIXES = (
 _CAPABILITY_EXEMPT: dict[str, tuple[str, ...]] = {
     "seeding.py": _THIN_FETCH_PREFIXES,
     "admission.py": _THIN_FETCH_PREFIXES,
+    # stages/plan_review.py imports ONLY the pure verdict parser
+    # (claude_invoke.parse_review_verdict / ReviewVerdict) to attach as
+    # AgentJob.parse — the architecture doc's plan_review contract says the
+    # "verdict [is] parsed in-worker by claude_invoke.parse_review_verdict"
+    # (#1814). The exemption is prefix-scoped: any other I/O-flavored import
+    # in the module still trips the guard via the remaining prefixes.
+    "plan_review.py": ("hephaestus.automation.claude_invoke",),
 }
 
 

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -65,9 +65,7 @@ _CAPABILITY_EXEMPT: dict[str, dict[str, frozenset[str] | None]] = {
     # (#1814). The exemption is SYMBOL-scoped: importing any other
     # claude_invoke symbol (e.g. invoke_claude_with_session) or the module
     # itself still trips the guard, as does any other I/O-flavored import.
-    "plan_review.py": {
-        "hephaestus.automation.claude_invoke": frozenset({"parse_review_verdict", "ReviewVerdict"})
-    },
+    "plan_review.py": {"hephaestus.automation.claude_invoke": frozenset({"parse_review_verdict"})},
 }
 
 
@@ -197,12 +195,11 @@ def test_capability_scope_still_blocks_io_in_seeding() -> None:
 
 
 def test_plan_review_exemption_is_symbol_scoped() -> None:
-    """The plan_review.py claude_invoke exemption permits ONLY the parser symbols.
+    """The plan_review.py claude_invoke exemption permits ONLY parse_review_verdict.
 
-    A synthetic plan_review.py importing an execution symbol
-    (invoke_claude_with_session) or the whole claude_invoke module must
-    still be flagged; the sanctioned parse_review_verdict / ReviewVerdict
-    from-imports must pass.
+    A synthetic plan_review.py importing ReviewVerdict, an execution symbol
+    (invoke_claude_with_session), or the whole claude_invoke module must
+    all be flagged. Only the sanctioned parse_review_verdict from-import passes.
     """
     synthetic_source = (
         "from hephaestus.automation.claude_invoke import parse_review_verdict\n"
@@ -213,9 +210,10 @@ def test_plan_review_exemption_is_symbol_scoped() -> None:
     tree = ast.parse(synthetic_source, filename="<synthetic-plan-review>")
     violations = _collect_violations(tree, "plan_review.py", _CAPABILITY_EXEMPT["plan_review.py"])
 
-    # Exactly the two offending lines (3 and 4); the sanctioned symbol
-    # imports on lines 1-2 produce no violations.
-    assert len(violations) == 2, violations
+    # Lines 2, 3, and 4 violate the tightened exemption (only parse_review_verdict
+    # is allowed). Line 1 (parse_review_verdict) produces no violation.
+    assert len(violations) == 3, violations
+    assert any("import ReviewVerdict" in v for v in violations)
     assert any("import invoke_claude_with_session" in v for v in violations)
     # A bare module import exposes the whole surface: always a violation
     # under a symbol-scoped exemption.
@@ -223,7 +221,7 @@ def test_plan_review_exemption_is_symbol_scoped() -> None:
         v.startswith("plan_review.py:4: import hephaestus.automation.claude_invoke")
         for v in violations
     )
-    assert not any(":1:" in v or ":2:" in v for v in violations)
+    assert not any(":1:" in v for v in violations)
 
 
 def test_forbidden_detects_synthetic_forbidden_import() -> None:

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -51,16 +51,23 @@ _THIN_FETCH_PREFIXES = (
     "hephaestus.automation.state_labels",
     "hephaestus.automation.dependency_resolver",
 )
-_CAPABILITY_EXEMPT: dict[str, tuple[str, ...]] = {
-    "seeding.py": _THIN_FETCH_PREFIXES,
-    "admission.py": _THIN_FETCH_PREFIXES,
-    # stages/plan_review.py imports ONLY the pure verdict parser
+# Each exemption maps a permitted prefix to an allowed-symbols set, or None
+# for an unscoped (whole-prefix) exemption. A symbol-scoped prefix only
+# permits `from <prefix...> import <allowed symbol>` — a bare
+# `import <prefix>` or a from-import of any other symbol still trips.
+_CAPABILITY_EXEMPT: dict[str, dict[str, frozenset[str] | None]] = {
+    "seeding.py": dict.fromkeys(_THIN_FETCH_PREFIXES),
+    "admission.py": dict.fromkeys(_THIN_FETCH_PREFIXES),
+    # stages/plan_review.py may import ONLY the pure verdict parser pieces
     # (claude_invoke.parse_review_verdict / ReviewVerdict) to attach as
     # AgentJob.parse — the architecture doc's plan_review contract says the
     # "verdict [is] parsed in-worker by claude_invoke.parse_review_verdict"
-    # (#1814). The exemption is prefix-scoped: any other I/O-flavored import
-    # in the module still trips the guard via the remaining prefixes.
-    "plan_review.py": ("hephaestus.automation.claude_invoke",),
+    # (#1814). The exemption is SYMBOL-scoped: importing any other
+    # claude_invoke symbol (e.g. invoke_claude_with_session) or the module
+    # itself still trips the guard, as does any other I/O-flavored import.
+    "plan_review.py": {
+        "hephaestus.automation.claude_invoke": frozenset({"parse_review_verdict", "ReviewVerdict"})
+    },
 }
 
 
@@ -70,22 +77,71 @@ def _forbidden(name: str) -> bool:
     return root in _FORBIDDEN_MODULES or name.startswith(_FORBIDDEN_PREFIXES)
 
 
-def _collect_violations(tree: ast.AST, filename: str, exempt: tuple[str, ...]) -> list[str]:
-    """Walk *tree* and return forbidden-import violations, honoring *exempt* prefixes."""
+def _matching_prefix(module: str, exempt: dict[str, frozenset[str] | None]) -> str | None:
+    """Return the exempt prefix that covers *module*, or None."""
+    for prefix in exempt:
+        if module.startswith(prefix):
+            return prefix
+    return None
 
-    def _is_violation(module: str) -> bool:
-        return _forbidden(module) and not module.startswith(exempt)
 
+def _import_violations(
+    node: ast.Import, filename: str, exempt: dict[str, frozenset[str] | None]
+) -> list[str]:
+    """Violations for a plain ``import X`` statement.
+
+    Only an UNscoped exemption can permit a whole-module import: a bare
+    import of a symbol-scoped prefix exposes the whole module surface.
+    """
+    violations = []
+    for alias in node.names:
+        if not _forbidden(alias.name):
+            continue
+        prefix = _matching_prefix(alias.name, exempt)
+        if prefix is not None and exempt[prefix] is None:
+            continue
+        violations.append(f"{filename}:{node.lineno}: import {alias.name}")
+    return violations
+
+
+def _import_from_violations(
+    node: ast.ImportFrom, filename: str, exempt: dict[str, frozenset[str] | None]
+) -> list[str]:
+    """Violations for a ``from X import Y`` statement (symbol scoping applies)."""
+    mod = node.module or ""
+    if not _forbidden(mod):
+        return []
+    prefix = _matching_prefix(mod, exempt)
+    if prefix is None:
+        return [f"{filename}:{node.lineno}: from {mod} import ..."]
+    allowed = exempt[prefix]
+    if allowed is None:
+        return []  # unscoped exemption: whole prefix permitted
+    return [
+        f"{filename}:{node.lineno}: from {mod} import {alias.name} "
+        f"(symbol not in allowed set {sorted(allowed)})"
+        for alias in node.names
+        if alias.name not in allowed
+    ]
+
+
+def _collect_violations(
+    tree: ast.AST, filename: str, exempt: dict[str, frozenset[str] | None]
+) -> list[str]:
+    """Walk *tree* and return forbidden-import violations, honoring *exempt*.
+
+    ``exempt`` maps permitted module prefixes to an allowed-symbols set
+    (``None`` = whole prefix permitted). Symbol scoping applies to
+    ``from X import Y`` only: each imported name must be in the allowed set.
+    A plain ``import X`` of a symbol-scoped prefix exposes the whole module
+    surface, so it is always a violation.
+    """
     violations: list[str] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            for alias in node.names:
-                if _is_violation(alias.name):
-                    violations.append(f"{filename}:{node.lineno}: import {alias.name}")
+            violations.extend(_import_violations(node, filename, exempt))
         elif isinstance(node, ast.ImportFrom):
-            mod = node.module or ""
-            if _is_violation(mod):
-                violations.append(f"{filename}:{node.lineno}: from {mod} import ...")
+            violations.extend(_import_from_violations(node, filename, exempt))
     return violations
 
 
@@ -106,7 +162,7 @@ def test_pipeline_modules_have_zero_io_imports() -> None:
     for py in sorted(_PIPELINE_DIR.rglob("*.py")):
         if py.name in _ALLOWLIST:
             continue
-        exempt = _CAPABILITY_EXEMPT.get(py.name, ())
+        exempt = _CAPABILITY_EXEMPT.get(py.name, {})
         tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
         violations.extend(_collect_violations(tree, py.name, exempt))
     assert not violations, "pipeline modules must do zero I/O imports:\n" + "\n".join(violations)
@@ -140,6 +196,36 @@ def test_capability_scope_still_blocks_io_in_seeding() -> None:
     assert not any("dependency_resolver" in v for v in violations)
 
 
+def test_plan_review_exemption_is_symbol_scoped() -> None:
+    """The plan_review.py claude_invoke exemption permits ONLY the parser symbols.
+
+    A synthetic plan_review.py importing an execution symbol
+    (invoke_claude_with_session) or the whole claude_invoke module must
+    still be flagged; the sanctioned parse_review_verdict / ReviewVerdict
+    from-imports must pass.
+    """
+    synthetic_source = (
+        "from hephaestus.automation.claude_invoke import parse_review_verdict\n"
+        "from hephaestus.automation.claude_invoke import ReviewVerdict\n"
+        "from hephaestus.automation.claude_invoke import invoke_claude_with_session\n"
+        "import hephaestus.automation.claude_invoke\n"
+    )
+    tree = ast.parse(synthetic_source, filename="<synthetic-plan-review>")
+    violations = _collect_violations(tree, "plan_review.py", _CAPABILITY_EXEMPT["plan_review.py"])
+
+    # Exactly the two offending lines (3 and 4); the sanctioned symbol
+    # imports on lines 1-2 produce no violations.
+    assert len(violations) == 2, violations
+    assert any("import invoke_claude_with_session" in v for v in violations)
+    # A bare module import exposes the whole surface: always a violation
+    # under a symbol-scoped exemption.
+    assert any(
+        v.startswith("plan_review.py:4: import hephaestus.automation.claude_invoke")
+        for v in violations
+    )
+    assert not any(":1:" in v or ":2:" in v for v in violations)
+
+
 def test_forbidden_detects_synthetic_forbidden_import() -> None:
     """Negative test: the guard must actually flag forbidden imports.
 
@@ -157,7 +243,7 @@ def test_forbidden_detects_synthetic_forbidden_import() -> None:
         "import json\n"  # allowed stdlib module; must NOT be flagged
     )
     tree = ast.parse(synthetic_source, filename="<synthetic>")
-    violations = _collect_violations(tree, "<synthetic>", ())
+    violations = _collect_violations(tree, "<synthetic>", {})
 
     assert any("import subprocess" in v for v in violations)
     assert any("import hephaestus.automation.git_utils" in v for v in violations)

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -59,7 +59,7 @@ _CAPABILITY_EXEMPT: dict[str, dict[str, frozenset[str] | None]] = {
     "seeding.py": dict.fromkeys(_THIN_FETCH_PREFIXES),
     "admission.py": dict.fromkeys(_THIN_FETCH_PREFIXES),
     # stages/plan_review.py may import ONLY the pure verdict parser pieces
-    # (claude_invoke.parse_review_verdict / ReviewVerdict) to attach as
+    # (claude_invoke.parse_review_verdict — the ONLY allowed symbol) to attach as
     # AgentJob.parse — the architecture doc's plan_review contract says the
     # "verdict [is] parsed in-worker by claude_invoke.parse_review_verdict"
     # (#1814). The exemption is SYMBOL-scoped: importing any other

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -20,6 +20,7 @@ from hephaestus.automation.state_labels import (
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
     STATE_SKIP,
+    apply_plan_verdict,
     has_label,
     is_epic,
     is_implementation_go,
@@ -208,6 +209,25 @@ class TestIsEpic:
 
     def test_epic_labels_constant_contents(self) -> None:
         assert set(EPIC_LABELS) == {"epic", "roadmap"}
+
+
+class TestApplyPlanVerdict:
+    """``apply_plan_verdict`` returns the (add, remove) labels for a reviewer verdict.
+
+    Pure function: no I/O, no logging, no GitHub calls. Both the legacy
+    planner_review_loop and the new plan_review stage call it to ensure
+    identical transitions (#1814).
+    """
+
+    def test_go_verdict_adds_go_removes_others(self) -> None:
+        add, remove = apply_plan_verdict(is_go=True)
+        assert add == STATE_PLAN_GO
+        assert set(remove) == {STATE_PLAN_NO_GO, STATE_NEEDS_PLAN}
+
+    def test_nogo_verdict_adds_nogo_removes_others(self) -> None:
+        add, remove = apply_plan_verdict(is_go=False)
+        assert add == STATE_PLAN_NO_GO
+        assert set(remove) == {STATE_PLAN_GO, STATE_NEEDS_PLAN}
 
 
 class TestPartitionEpics:


### PR DESCRIPTION
## Summary

Epic #1809 slice: adds the `Stage` protocol and the first two concrete pipeline stages, re-housing the planning and plan-review control flow out of the legacy orchestrators per the binding contract in `docs/AUTOMATION_LOOP_ARCHITECTURE.md` sections "2. planning" and "3. plan_review". Includes the full remediation of the strict 6-dimension audit (all four MAJORs + minors).

### What's in the slice

- **`pipeline/stages/base.py`** — `Stage` protocol (`on_enter` idempotent with at-or-past checks, `step -> Continue | JobRequest | StageOutcome`, `on_job_done` never called for interrupted results), `StageContext` (coordinator-owned github/paths/clock/budget accessors), and a `StageGitHub` `typing.Protocol` typing `ctx.github`'s now-8-method surface (dry-run honored inside the accessor implementation; `has_existing_plan` documents the `is_plan_review_go` comment-scan backfill contract for #1817). Core types re-exported from their source modules (`routing`, `work_item`, `jobs`); the coordinator convention for #1817 — including the durable `upsert_plan_comment` channel — is documented in the module docstring.
- **`pipeline/stages/planning.py`** — `PlanningStage`: ENTER -> ADVISE_WAIT -> PLAN_WAIT -> VERIFY; budget `plan`=2; owns `state:needs-plan` (idempotent durable write on entry). **The pipeline posts the plan comment**: VERIFY upserts `payload["plan_text"]` via `ctx.github.upsert_plan_comment` BEFORE the verify/ADVANCE decision (journal order), with marker normalization re-housed from `planner_review_loop._upsert_plan_comment`; the upsert is guarded by `has_existing_plan` so re-entry posts exactly once. `on_enter` re-houses the `_pr_coverage_skip` / `_has_existing_plan` idempotency guards and additionally fast-forwards `item.state` to VERIFY when the plan comment already exists, so a restart mid-stage never redoes advise+plan. PLAN_WAIT uses the top-level composed builder `build_plan_prompt(issue_number, advise_findings)` so advise findings actually reach the planner (mirrors legacy `generate_plan` context assembly; builders run in-worker, so no closures).
- **`pipeline/stages/plan_review.py`** — `PlanReviewStage`: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT (loop) -> LEARN_WAIT; budgets `plan_review_iter`=3 / `plan_cycles`=2. Verdict parsed in-worker via `claude_invoke.parse_review_verdict` carried as `AgentJob.parse`.
  - **Iteration accounting**: `attempts["plan_review_iter"]` is the per-lifetime audit trail (routing.py contract — attempts never reset); EVAL gates on the cycle-relative `payload["review_round"]`, reset by `on_enter` per new plan cycle, so cycle 2 gets its full 3 reviews/amends and the prompt always sees 0-based iterations 0..2.
  - **ERROR doctrine**: counters advance in EVAL and only for real verdicts (GO/NOGO/AMBIGUOUS). ERROR/missing verdicts burn nothing, leave labels untouched, and RETRY, bounded in-stage by `REVIEW_ERROR_RETRY_CAP`=2 consecutive failures -> `FINISH_FAIL` (documented choice: reviewer-infrastructure failure is not fixed by replanning, so no plan-cycle is spent and no label stamped).
  - **Stale-verdict replay fixed**: REVIEW_WAIT clears `payload["review_verdict"]` at submission, so a failed round-2 job hits EVAL's no-verdict RETRY instead of replaying round 1's NOGO.
  - **Amend feedback channel**: AMEND_WAIT uses the top-level composed builder `build_amend_prompt(issue_number, prior_review)` (feedback block mirrors legacy `generate_plan(prior_review=...)`), threaded via `prompt_kwargs`.
  - EVAL durably applies `state:plan-go` on GO (write before the advancing outcome) then runs the learn step; at the cap it durably applies `state:plan-no-go` then `FAIL_BACK("nogo")` / `FAIL_BACK("plan_cycles_exhausted")`. Label-pair writes use the legacy non-fatal try/except-warn pattern from `planner_review_loop._apply_state_label`.
- **`state_labels.apply_plan_verdict`** — the plan-state label transition promoted to a pure function; legacy `planner_review_loop._apply_state_label` now consumes it (its gh writes + non-fatal warnings unchanged; `test_planner_loop.py` stays green).
- **Tests** — stage state-machine tables; durable-write-before-outcome ordering asserts; plan-comment posted-exactly-once + marker-normalization + mutation-log journal-order pins; stale-verdict-replay and ERROR-accounting scenarios (R1 NOGO -> R2 ERROR -> RETRY -> R2 NOGO -> amend still available; error-retry cap trips); full cycle-2 path; non-fatal label-write failure tests; literal double-`on_enter` idempotence tests; full pool-driven walks of BOTH stages through the canonical `FakeWorkerPool`. `FakeStageGitHub` extends the canonical pipeline `FakeGitHub` (mutation_log format unchanged) and is mypy-checked against the `StageGitHub` protocol.
- **Zero-I/O guard** — the `plan_review.py` claude_invoke exemption is now SYMBOL-scoped (`{parse_review_verdict, ReviewVerdict}` only), with a negative test proving `invoke_claude_with_session` (and a bare module import) still trips; all mutations flow through the coordinator-neutral `ctx.github` accessor surface, so the pipeline mutator guard holds with an empty allowlist.

### Verification

- `pixi run mypy` — clean (523 files)
- `pixi run pytest tests/unit/automation/pipeline/ tests/unit/automation/test_planner_loop.py tests/unit/automation/test_state_labels.py` — 408 passed
- Stage-module coverage: base.py 100%, planning.py 97.33%, plan_review.py 97.89% (all >= 95%)
- `pre-commit run --all-files` — all hooks pass (exit 0)
- Mutation probes re-run: fail-back reason swap -> 3 tests fail; GO-label-write removal -> 6 tests fail; NEW probe: removing the REVIEW_WAIT verdict-clear -> 2 tests fail. All reverted; tree matches the committed state.

### Review provenance

- Implementation review: pending (auto-merge stays disabled until `state:implementation-go`).

Closes #1814

🤖 Generated with [Claude Code](https://claude.com/claude-code)
