### PR TITLE
docs(adr): refresh automation guard test paths

### DIFF
--- a/docs/adr/0001-automation-library-boundary.md
+++ b/docs/adr/0001-automation-library-boundary.md
@@ -27,7 +27,7 @@ Adopt a **dual-layer package** with four guarantees:
    imports (`hephaestus/__init__.py`). `import hephaestus` MUST NOT
    transitively import `curses`, `fcntl`, `pydantic`, or any
    `hephaestus.automation.*` module. Verified empirically and locked in
-   by `tests/unit/test_import_surface.py`.
+   by `tests/unit/validation/test_import_surface.py`.
 
 2. **Product layer** — `hephaestus.automation`. Opt-in via the
    `HomericIntelligence-Hephaestus[automation]` extra. The extra declares
@@ -46,7 +46,7 @@ Adopt a **dual-layer package** with four guarantees:
 4. **Boundary contract** — `hephaestus.automation` may import from any
    library subpackage; library subpackages MUST NOT import from
    `hephaestus.automation`. Enforced by
-   `tests/unit/test_automation_boundary.py`.
+   `tests/unit/validation/test_automation_boundary.py`.
 
 ## Alternatives considered
 
@@ -67,10 +67,10 @@ Adopt a **dual-layer package** with four guarantees:
   `[project.optional-dependencies] automation = [...]`.
 - README and CLAUDE.md gain a "Library vs product layer" section pointing
   here.
-- `tests/unit/test_import_surface.py` fails CI if `import hephaestus` ever
+- `tests/unit/validation/test_import_surface.py` fails CI if `import hephaestus` ever
   pulls `curses`, `pydantic`, or any `hephaestus.automation.*` module into
   `sys.modules`.
-- `tests/unit/test_automation_boundary.py` fails CI if any library
+- `tests/unit/validation/test_automation_boundary.py` fails CI if any library
   subpackage gains a `from hephaestus.automation` import.
 - `hephaestus.nats` was migrated off pydantic to stdlib dataclasses
   (issue #1458; `load_nats_config` filters unknown keys to preserve the

--- a/docs/adr/0002-pep562-lazy-imports.md
+++ b/docs/adr/0002-pep562-lazy-imports.md
@@ -40,7 +40,7 @@ Resolve the public symbol surface **lazily** via PEP 562 module-level hooks in
 
 - **Eager top-level imports.** Rejected: importing every subpackage at load
   time pulls `curses`/`fcntl`/`pydantic` into the base surface and breaks the
-  ADR-0001 boundary that `tests/unit/test_import_surface.py` enforces.
+  ADR-0001 boundary that `tests/unit/validation/test_import_surface.py` enforces.
 - **Submodule-only access (`from hephaestus.utils import slugify`).** Rejected
   on POLA grounds: it removes the flat convenience surface that existing
   consumers rely on, with no boundary benefit over the lazy approach.
@@ -48,7 +48,7 @@ Resolve the public symbol surface **lazily** via PEP 562 module-level hooks in
 ## Consequences
 
 - `import hephaestus` stays fast and never imports the product layer; this is
-  locked in by `tests/unit/test_import_surface.py`.
+  locked in by `tests/unit/validation/test_import_surface.py`.
 - Adding a new public symbol means adding one row to `_LAZY_IMPORTS`, not a new
   top-level import.
 - Deprecations flow through `_DEPRECATED_LAZY` so removal is a documented,


### PR DESCRIPTION
## Summary

- Refresh ADR 0001 and ADR 0002 to point at the current validation guard test paths.
- Keep the ADR references aligned with the existing `CLAUDE.md` and `README.md` paths.

## Test Plan

- [x] Confirmed no stale references with `rg -n "tests/unit/test_(import_surface|automation_boundary)\\.py" docs/adr CLAUDE.md README.md` (no matches).
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-heph-1429 pixi run pytest --no-cov tests/unit/docs/test_adr_records.py tests/unit/validation/test_markdown.py tests/unit/validation/test_doc_policy.py -q`
- [x] `env PIXI_CACHE_DIR=/tmp/pixi-cache-heph-1429 PRE_COMMIT_HOME=/tmp/pre-commit-heph-1429 pixi run pre-commit run --files docs/adr/0001-automation-library-boundary.md docs/adr/0002-pep562-lazy-imports.md`

Closes #1844

Implemented-By: Codex
Co-Authored-By: Codex <noreply@openai.com>
