### PR TITLE
[Feat] Pipeline implementation and pr-review stages

### DIFF
--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -14,14 +14,18 @@ from .base import (
     StageOutcome,
     StepResult,
 )
+from .implementation import ImplementationStage
 from .plan_review import PlanReviewStage
 from .planning import PlanningStage
+from .pr_review import PrReviewStage
 
 __all__ = [
     "Continue",
+    "ImplementationStage",
     "JobRequest",
     "PlanReviewStage",
     "PlanningStage",
+    "PrReviewStage",
     "Stage",
     "StageContext",
     "StageGitHub",

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -46,14 +46,16 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Protocol, TypeAlias, runtime_checkable
 
-from ..jobs import AgentJob, JobHandle, JobResult
+from ..jobs import AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
 from ..routing import Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
 
 __all__ = [
     "AgentJob",
+    "BuildTestJob",
     "Continue",
     "Disposition",
+    "GitJob",
     "ItemKind",
     "JobHandle",
     "JobRequest",
@@ -132,6 +134,76 @@ class StageGitHub(Protocol):
         """
         ...
 
+    # -- implementation / pr_review surface (#1815) ------------------------
+
+    def get_pr_head_branch(self, pr_number: int) -> str | None:
+        """Return the PR's head branch name (``_review_utils.get_pr_head_branch``)."""
+        ...
+
+    def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+        """Return ``(has_go, has_no_go)`` for the PR's implementation state labels.
+
+        Mirrors ``pr_manager.pr_has_implementation_state_label`` — the
+        existing-PR fast-path read the implementation GATE uses.
+        """
+        ...
+
+    def count_unresolved_threads(self, pr_number: int) -> tuple[int, int]:
+        """Return ``(automation_unresolved, human_unresolved)`` thread counts.
+
+        Mirrors ``_review_phase._count_unresolved_threads_blocking_go``
+        (#1152): the pr_review EVAL gate — a GO only stands with zero of
+        both; open human threads yield HUMAN_BLOCKED, open automation
+        threads downgrade GO to NOGO. This read resolves nothing.
+        """
+        ...
+
+    def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
+        """Durably ensure the PR exists and return its number (idempotent).
+
+        The coordinator maps this onto the ``pr_manager.ensure_pr_created``
+        chain (→ ``gh_pr_create``), which is idempotent for an existing PR.
+        PR creation is the implementation stage's journal entry (doc
+        section 4: "Owned labels: PR creation is the journal entry").
+        """
+        ...
+
+    def defer_auto_merge(self, pr_number: int) -> None:
+        """Durably ensure auto-merge stays DISABLED until implementation GO.
+
+        Mirrors ``pr_manager.ensure_pr_auto_merge_deferred`` — called
+        immediately after PR creation (legacy runner order,
+        ``implementer_phase_runner.py:623``): auto-merge must never be armed
+        before ``state:implementation-go``.
+        """
+        ...
+
+    def post_review_threads(
+        self, pr_number: int, threads: list[dict[str, Any]], summary: str
+    ) -> list[str]:
+        """Durably post surviving review threads to the PR; return thread ids.
+
+        The pr_review POST step's durable write (doc section 5 step 3). The
+        coordinator maps this onto ``gh_pr_review_post``.
+        """
+        ...
+
+    def mark_pr_implementation_go(self, pr_number: int) -> None:
+        """Durably apply ``state:implementation-go`` to the PR.
+
+        Mirrors ``pr_manager.mark_pr_implementation_go``; written BEFORE
+        :meth:`arm_auto_merge` (the label authorizes the arming).
+        """
+        ...
+
+    def arm_auto_merge(self, pr_number: int) -> None:
+        """Durably arm squash auto-merge after implementation GO.
+
+        Mirrors ``pr_manager.enable_auto_merge_after_implementation_go``;
+        only ever called after :meth:`mark_pr_implementation_go` succeeded.
+        """
+        ...
+
 
 @dataclass(frozen=True)
 class Continue:
@@ -145,13 +217,14 @@ class JobRequest:
     """Request a job be submitted to the worker pool.
 
     Attributes:
-        job: The frozen job spec to submit.
+        job: The frozen job spec to submit (agent, build/test, or git — the
+            same union :class:`~..jobs.JobHandle` carries).
         on_done_state: The state the coordinator moves the item to after the
             job completes and ``on_job_done`` has run.
 
     """
 
-    job: AgentJob
+    job: AgentJob | BuildTestJob | GitJob
     on_done_state: str
 
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -41,16 +41,21 @@ Coordinator convention (binding for #1817, the coordinator slice):
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol, TypeAlias, runtime_checkable
+
+from hephaestus.automation.state_labels import STATE_SKIP
 
 from ..jobs import AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
 from ..routing import Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
 
 __all__ = [
+    "GIT_JOB_TIMEOUT_S",
     "AgentJob",
     "BuildTestJob",
     "Continue",
@@ -67,7 +72,15 @@ __all__ = [
     "StageOutcome",
     "StepResult",
     "WorkItem",
+    "write_skip_label",
 ]
+
+logger = logging.getLogger(__name__)
+
+#: Timeout for git worktree/commit/push jobs (mechanical, no agent). Shared
+#: by every stage that submits :class:`GitJob`s (single home — stages must
+#: not import it from each other).
+GIT_JOB_TIMEOUT_S = 600
 
 
 @runtime_checkable
@@ -161,10 +174,32 @@ class StageGitHub(Protocol):
     def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
         """Durably ensure the PR exists and return its number (idempotent).
 
-        The coordinator maps this onto the ``pr_manager.ensure_pr_created``
-        chain (→ ``gh_pr_create``), which is idempotent for an existing PR.
-        PR creation is the implementation stage's journal entry (doc
-        section 4: "Owned labels: PR creation is the journal entry").
+        Backing (#1817): ``_review_utils.find_pr_for_issue`` first (reuse an
+        existing open PR — the idempotence), then ``github_api.gh_pr_create``
+        with the *given* ``title``/``body``. NOT ``pr_manager
+        .ensure_pr_created``, which generates its own PR body and would
+        discard the ``get_pr_description`` body the stage composed. PR
+        creation is the implementation stage's journal entry (doc section 4:
+        "Owned labels: PR creation is the journal entry").
+        """
+        ...
+
+    def post_pr_comment(self, pr_number: int, body: str) -> None:
+        """Durably post an explanatory comment on the PR conversation.
+
+        The coordinator maps this onto ``gh_issue_comment`` (PRs share the
+        issue comment channel). Used by pr_review's HUMAN_BLOCKED terminal
+        path to record WHY automation stood down before finishing failed.
+        """
+        ...
+
+    def mark_pr_implementation_no_go(self, pr_number: int) -> None:
+        """Durably apply ``state:implementation-no-go`` to the PR.
+
+        Mirrors ``pr_manager.mark_pr_implementation_no_go`` (adds the no-go
+        label, removes any stale go label). Doc section 5 owned label:
+        written on every NOGO round, before retry/regress [durable]
+        (legacy ``_review_phase._apply_impl_review_verdict`` :248).
         """
         ...
 
@@ -267,6 +302,63 @@ class StageContext:
         if self.budget_fn is not None:
             return self.budget_fn(name)
         return 1  # conservative default
+
+
+def _issue_labels(item: WorkItem, ctx: StageContext) -> list[str]:
+    """Refresh the item's labels from GitHub and update ``labels_cache``.
+
+    Reads through ``ctx.github.gh_issue_json`` (mirrors
+    ``github_api.issues.gh_issue_json``); on any read failure the cached
+    labels are used so a transient API blip cannot mis-route the item.
+    Shared by every stage that gates on labels (single home — stages must
+    not import it from each other).
+    """
+    if item.issue is None:
+        return []
+    try:
+        data = ctx.github.gh_issue_json(item.issue)
+    except Exception as e:  # transient gh failure: fall back to cache
+        logger.warning("pipeline:%d: label refresh failed (using cache): %s", item.issue, e)
+        return list(item.labels_cache)
+    raw = data.get("labels", []) if isinstance(data, dict) else []
+    labels = [entry["name"] if isinstance(entry, dict) else str(entry) for entry in raw]
+    item.labels_cache = dict.fromkeys(labels, True)
+    return labels
+
+
+def _worktree_path(item: WorkItem, ctx: StageContext) -> Path:
+    """Return the item's worktree as a Path, falling back to the shared one.
+
+    The shared-checkout fallback is only safe for READ-mostly agent jobs
+    (advise, review) that run before a worktree exists; stages that edit or
+    push code MUST guard against dispatching into the shared checkout on the
+    wrong branch (see ``PrReviewStage._address``).
+    """
+    if item.worktree:
+        return Path(item.worktree)
+    return Path(str(ctx.paths.worktree))
+
+
+def write_skip_label(issue_number: int, ctx: StageContext) -> None:
+    """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
+
+    Single home for the exhaustion/no-commits skip write (previously
+    duplicated across the implementation and pr_review stages).
+
+    Args:
+        issue_number: GitHub issue number.
+        ctx: Stage context carrying the GitHub accessor.
+
+    """
+    try:
+        ctx.github.add_labels(issue_number, [STATE_SKIP])
+    except Exception as e:
+        logger.warning(
+            "pipeline:%d: failed to add label %r (non-fatal): %s",
+            issue_number,
+            STATE_SKIP,
+            e,
+        )
 
 
 @runtime_checkable

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -182,7 +182,7 @@ class StageGitHub(Protocol):
         creation is the implementation stage's journal entry (doc section 4:
         "Owned labels: PR creation is the journal entry").
         """
-        ...
+        raise NotImplementedError
 
     def post_pr_comment(self, pr_number: int, body: str) -> None:
         """Durably post an explanatory comment on the PR conversation.
@@ -191,7 +191,7 @@ class StageGitHub(Protocol):
         issue comment channel). Used by pr_review's HUMAN_BLOCKED terminal
         path to record WHY automation stood down before finishing failed.
         """
-        ...
+        pass
 
     def mark_pr_implementation_no_go(self, pr_number: int) -> None:
         """Durably apply ``state:implementation-no-go`` to the PR.

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -1,0 +1,621 @@
+"""Implementation stage: gate plan GO, cut worktree, implement, test, push, PR.
+
+Re-houses the implementation control flow from
+``implementer_phase_runner.py`` (``_dispatch_issue_work`` :208,
+``_ensure_plan_ready`` :429, ``_review_existing_pr`` :750, the
+``ensure_pr_auto_merge_deferred`` call :623) and
+``_pr_create_phase.PRCreatePhase._finalize_pr`` (:36) as a pipeline stage
+(docs/AUTOMATION_LOOP_ARCHITECTURE.md section "4. implementation" is the
+binding contract):
+
+- States: ENTER -> GATE -> WORKTREE_WAIT -> DIRTY_DECISION_WAIT ->
+  ADVISE_WAIT -> IMPLEMENT_WAIT -> TEST_WAIT -> TESTFIX_WAIT ->
+  COMMIT_PUSH_WAIT -> PR_CREATE.
+- Budgets: ``implement`` = 2 (bounds implement attempts INCLUDING
+  agent_error retries — the doc's "agent_error -> RETRY (consumes the
+  implement budget)"), ``test_fix`` = 1 (one fix attempt on red pre-PR
+  tests). Both read from ROUTES via ``ctx.budget``, never hardcoded here.
+- GATE [M]: existing-PR fast path first (``_review_existing_pr``
+  semantics): a PR already carrying ``state:implementation-go`` fails back
+  ``already_implementation_go_pr`` (routes to ci); a PR without it adopts
+  the PR's REAL head branch and ADVANCEs straight to pr_review. Otherwise
+  the plan-review verdict gate: at-or-past ``state:plan-go`` (or already
+  ``state:implementation-go``) proceeds; anything else fails back
+  ``plan_not_go`` (routes to plan_review).
+- Owned labels: none — PR creation is the journal entry (doc section 4).
+  The only label this stage ever writes is ``state:skip`` on the legacy
+  "no commits vs base" runtime error (re-housed
+  ``implementer_phase_runner._handle_runtime_error`` :348), non-fatally.
+- PR_CREATE [M]: ``ctx.github.create_pr`` (idempotent ensure semantics)
+  with a ``prompts/pr_review.py get_pr_description`` body [durable], then
+  ``ctx.github.defer_auto_merge`` — the load-bearing legacy order (runner
+  :623): auto-merge stays disabled until ``state:implementation-go``.
+- Prompt functions (imported, never re-authored):
+  ``prompts/implementation.py get_implementation_prompt`` (composed with
+  the advise-findings block by :func:`build_implementation_prompt`),
+  ``get_dirty_reused_worktree_decision_prompt``,
+  ``get_impl_resume_feedback_prompt`` (composed with the failing test
+  output by :func:`build_test_fix_prompt`), and
+  ``prompts/pr_review.py get_pr_description``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from hephaestus.automation.agent_config import (
+    advise_claude_timeout,
+    advise_model,
+    implementer_claude_timeout,
+    implementer_model,
+)
+from hephaestus.automation.prompts.advise import get_advise_prompt_builder
+from hephaestus.automation.prompts.implementation import (
+    get_dirty_reused_worktree_decision_prompt,
+    get_impl_resume_feedback_prompt,
+    get_implementation_prompt,
+)
+from hephaestus.automation.prompts.pr_review import get_pr_description
+from hephaestus.automation.session_naming import AGENT_ADVISE, AGENT_IMPLEMENTER
+from hephaestus.automation.state_labels import (
+    STATE_SKIP,
+    is_implementation_go,
+    is_plan_go,
+)
+
+from .base import (
+    AgentJob,
+    BuildTestJob,
+    Continue,
+    Disposition,
+    GitJob,
+    JobRequest,
+    JobResult,
+    Stage,
+    StageContext,
+    StageOutcome,
+    StepResult,
+    WorkItem,
+)
+from .planning import _issue_labels
+
+logger = logging.getLogger(__name__)
+
+# In-memory mini-states (stage-local strings, never GitHub labels).
+ENTER = "ENTER"
+GATE = "GATE"
+WORKTREE_WAIT = "WORKTREE_WAIT"
+DIRTY_DECISION_WAIT = "DIRTY_DECISION_WAIT"
+ADVISE_WAIT = "ADVISE_WAIT"
+IMPLEMENT_WAIT = "IMPLEMENT_WAIT"
+TEST_WAIT = "TEST_WAIT"
+TESTFIX_WAIT = "TESTFIX_WAIT"
+COMMIT_PUSH_WAIT = "COMMIT_PUSH_WAIT"
+PR_CREATE = "PR_CREATE"
+
+#: Timeout for git worktree/commit/push jobs (mechanical, no agent).
+GIT_JOB_TIMEOUT_S = 600
+
+#: Timeout for the optional pre-PR unit-test run (mirrors the legacy
+#: ``_pr_create_phase`` bound; the budget that matters — ``test_fix`` —
+#: lives in ROUTES).
+PRE_PR_TEST_TIMEOUT_S = 1800
+
+#: Vetted pre-PR test command (BuildTestJob argv must never carry
+#: issue-derived strings).
+PRE_PR_TEST_ARGV: tuple[str, ...] = ("pixi", "run", "pytest", "tests/unit", "-q", "--tb=short")
+
+
+def build_implementation_prompt(
+    issue_number: int,
+    issue_title: str = "",
+    issue_body: str = "",
+    branch_name: str = "",
+    worktree_path: str = "",
+    advise_findings: str = "",
+) -> str:
+    """Compose the implementation prompt with the advise-findings block.
+
+    Module-level composed builder (NOT a closure): :class:`AgentJob` is
+    frozen and prompt builders run in-worker, so the builder must be a
+    top-level function receiving everything via ``prompt_kwargs``. The base
+    prompt is reused verbatim via :func:`get_implementation_prompt`; the
+    findings block mirrors :func:`..planning.build_plan_prompt`.
+
+    Args:
+        issue_number: GitHub issue number to implement.
+        issue_title: Issue title.
+        issue_body: Issue body (fenced as untrusted by the base builder).
+        branch_name: Feature branch the worktree is on.
+        worktree_path: Worktree the implementer works in.
+        advise_findings: Advise-step findings; empty string means no block.
+
+    Returns:
+        The full implementer prompt, with the findings block appended when
+        ``advise_findings`` is non-empty.
+
+    """
+    prompt = get_implementation_prompt(
+        issue_number,
+        issue_title=issue_title,
+        issue_body=issue_body,
+        branch_name=branch_name,
+        worktree_path=worktree_path,
+    )
+    if not advise_findings:
+        return prompt
+    block = "\n".join(
+        [
+            "",
+            "---",
+            "",
+            "## Prior Learnings from Team Knowledge Base",
+            "",
+            advise_findings,
+        ]
+    )
+    return prompt + block
+
+
+def build_test_fix_prompt(issue_number: int, prev_iteration: int, test_output: str) -> str:
+    """Compose the resume prompt that feeds failing pre-PR test output back.
+
+    Reuses :func:`get_impl_resume_feedback_prompt` verbatim (doc section 4
+    step 7: "resume with test-failure feedback"), with the test failure
+    framed as the NOGO review text the resume template expects.
+
+    Args:
+        issue_number: GitHub issue number being implemented.
+        prev_iteration: 0-based index of the failed test round.
+        test_output: Captured pytest output tail from the failing run.
+
+    Returns:
+        The resume prompt carrying the test-failure feedback block.
+
+    """
+    review_text = (
+        "The pre-PR unit-test run failed. Fix ONLY what the failures below "
+        "require, then the tests will be re-run.\n\n" + test_output
+    )
+    return get_impl_resume_feedback_prompt(
+        issue_number=issue_number,
+        prev_iteration=prev_iteration,
+        verdict="NOGO",
+        review_text=review_text,
+    )
+
+
+def _worktree_path(item: WorkItem, ctx: StageContext) -> Path:
+    """Return the item's worktree as a Path, falling back to the shared one."""
+    if item.worktree:
+        return Path(item.worktree)
+    return Path(str(ctx.paths.worktree))
+
+
+class ImplementationStage(Stage):
+    """Stage: gate plan GO, worktree, advise, implement, test, commit, PR."""
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """Proceed with no durable writes; all entry checks live in GATE.
+
+        The doc's entry step (verify plan GO at-or-past + existing-PR fast
+        path) is the GATE mini-state, an [M] step of this stage — so a
+        restart re-runs it idempotently via step(). Nothing is written here.
+
+        Args:
+            item: The work item being processed.
+            ctx: The stage context.
+
+        Returns:
+            None (always proceed to step()), or FINISH_FAIL when the item
+            has no issue number.
+
+        """
+        if not item.issue:
+            logger.warning("implementation: work item has no issue number")
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+        return None
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
+        """Execute the next implementation action for the item's current state.
+
+        Args:
+            item: The work item with current state.
+            ctx: Stage context.
+
+        Returns:
+            Continue, JobRequest, or StageOutcome.
+
+        """
+        if not item.issue:
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        if item.state == ENTER:
+            return Continue(next_state=GATE)
+
+        if item.state == GATE:
+            return self._gate(item, ctx)
+
+        if item.state == WORKTREE_WAIT:
+            logger.info("implementation:%d: requesting worktree job", item.issue)
+            worktree_job = GitJob(
+                repo=item.repo,
+                op="create_worktree",
+                timeout_s=GIT_JOB_TIMEOUT_S,
+                # refresh_base=True: the worktree is cut from a freshly
+                # refreshed trunk (doc step 2: worktree_manager.create_worktree
+                # (refresh_base=True)); values are coordinator-vetted.
+                kwargs={"issue": item.issue, "branch": item.branch, "refresh_base": True},
+                descr="create_worktree",
+            )
+            return JobRequest(worktree_job, on_done_state=DIRTY_DECISION_WAIT)
+
+        if item.state == DIRTY_DECISION_WAIT:
+            if item.payload.pop("git_error", None):
+                # Worktree creation failed: transient infrastructure, not an
+                # implement outcome — RETRY without burning the budget.
+                return StageOutcome(Disposition.RETRY, "worktree creation failed")
+            if not item.payload.get("worktree_dirty"):
+                return Continue(next_state=ADVISE_WAIT)
+            logger.info("implementation:%d: requesting dirty-worktree decision", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_IMPLEMENTER,
+                model=implementer_model(),
+                prompt_builder=get_dirty_reused_worktree_decision_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=implementer_claude_timeout(),
+                prompt_kwargs={
+                    "branch_name": item.branch,
+                    "status_text": item.payload.get("worktree_status", ""),
+                    "diff_text": item.payload.get("worktree_diff", ""),
+                },
+                descr="dirty_decision",
+            )
+            return JobRequest(job, on_done_state=ADVISE_WAIT)
+
+        if item.state == ADVISE_WAIT:
+            if not ctx.config.enable_advise:
+                logger.info("implementation:%d: advise disabled; skipping", item.issue)
+                return Continue(next_state=IMPLEMENT_WAIT)
+            logger.info("implementation:%d: requesting advise job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_ADVISE,
+                model=advise_model(),
+                prompt_builder=get_advise_prompt_builder(ctx.config.agent),
+                cwd=_worktree_path(item, ctx),
+                timeout_s=advise_claude_timeout(),
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "issue_title": item.payload.get("issue_title", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
+                    "marketplace_path": item.payload.get("marketplace_path", ""),
+                },
+                descr="advise",
+            )
+            return JobRequest(job, on_done_state=IMPLEMENT_WAIT)
+
+        if item.state == IMPLEMENT_WAIT:
+            budget = ctx.budget("implement")
+            if item.attempts.get("implement", 0) >= budget:
+                logger.error(
+                    "implementation:%d: implement budget exhausted (%d/%d)",
+                    item.issue,
+                    item.attempts.get("implement", 0),
+                    budget,
+                )
+                return StageOutcome(Disposition.FINISH_FAIL, "implement_exhausted")
+            # Clear stale results at submission so a failed later attempt can
+            # never replay an earlier attempt's output downstream.
+            item.payload.pop("implement_error", None)
+            item.payload.pop("implement_summary", None)
+            logger.info("implementation:%d: requesting implement job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_IMPLEMENTER,
+                model=implementer_model(),
+                prompt_builder=build_implementation_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=implementer_claude_timeout(),
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "issue_title": item.payload.get("issue_title", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
+                    "branch_name": item.branch,
+                    "worktree_path": item.worktree,
+                    "advise_findings": item.payload.get("advise_findings", ""),
+                },
+                descr="implement",
+            )
+            return JobRequest(job, on_done_state=TEST_WAIT)
+
+        if item.state == TEST_WAIT:
+            if item.payload.pop("implement_error", None):
+                # The implement job hard-failed. The attempt was counted in
+                # on_job_done (doc: agent_error consumes the implement
+                # budget); RETRY re-enters the stage for the next attempt.
+                return StageOutcome(Disposition.RETRY, "agent_error")
+            if not getattr(ctx.config, "run_pre_pr_tests", False):
+                return Continue(next_state=COMMIT_PUSH_WAIT)
+            item.payload.pop("tests_failed", None)
+            item.payload.pop("test_output", None)
+            logger.info("implementation:%d: requesting pre-PR test job", item.issue)
+            test_job = BuildTestJob(
+                repo=item.repo,
+                cwd=_worktree_path(item, ctx),
+                argv=PRE_PR_TEST_ARGV,
+                timeout_s=PRE_PR_TEST_TIMEOUT_S,
+                descr="pre_pr_tests",
+            )
+            return JobRequest(test_job, on_done_state=COMMIT_PUSH_WAIT)
+
+        if item.state == TESTFIX_WAIT:
+            budget = ctx.budget("test_fix")
+            if item.attempts.get("test_fix", 0) >= budget:
+                logger.error(
+                    "implementation:%d: tests still red after %d fix attempt(s)",
+                    item.issue,
+                    budget,
+                )
+                return StageOutcome(Disposition.FINISH_FAIL, "tests_red")
+            logger.info("implementation:%d: requesting test-fix job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_IMPLEMENTER,
+                model=implementer_model(),
+                prompt_builder=build_test_fix_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=implementer_claude_timeout(),
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "prev_iteration": item.attempts.get("test_fix", 0),
+                    "test_output": item.payload.get("test_output", ""),
+                },
+                descr="test_fix",
+            )
+            return JobRequest(job, on_done_state=TEST_WAIT)
+
+        if item.state == COMMIT_PUSH_WAIT:
+            if item.payload.get("tests_failed"):
+                return Continue(next_state=TESTFIX_WAIT)
+            logger.info("implementation:%d: requesting commit+push job", item.issue)
+            push_job = GitJob(
+                repo=item.repo,
+                op="commit_push",
+                timeout_s=GIT_JOB_TIMEOUT_S,
+                kwargs={"branch": item.branch},
+                descr="commit_push",
+            )
+            return JobRequest(push_job, on_done_state=PR_CREATE)
+
+        if item.state == PR_CREATE:
+            return self._create_pr(item, ctx)
+
+        logger.warning("implementation:%d: unknown state %r", item.issue, item.state)
+        return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Store job results on the item payload (state is still the WAIT state).
+
+        The implement attempt is counted HERE, on job completion (success or
+        hard failure alike — doc: "agent_error -> RETRY (consumes the
+        implement budget)"). Interrupted results never reach this method, so
+        an interrupt can never burn budget.
+
+        Args:
+            item: The work item to update.
+            result: The job result from the worker pool.
+            ctx: Stage context.
+
+        """
+        if item.state == WORKTREE_WAIT:
+            self._on_worktree_done(item, result)
+            return
+
+        if item.state == DIRTY_DECISION_WAIT:
+            if result.ok and result.value:
+                # COMMIT/STASH decision; the git worker acts on it (#1817).
+                item.payload["dirty_decision"] = str(result.value)
+            return
+
+        if item.state == ADVISE_WAIT:
+            if result.ok and result.value:
+                item.payload["advise_findings"] = result.value
+            return
+
+        if item.state == IMPLEMENT_WAIT:
+            self._on_implement_done(item, result)
+            return
+
+        if item.state == TEST_WAIT:
+            self._on_tests_done(item, result)
+            return
+
+        if item.state == TESTFIX_WAIT:
+            item.attempts["test_fix"] = item.attempts.get("test_fix", 0) + 1
+            return
+
+        if item.state == COMMIT_PUSH_WAIT and not result.ok:
+            error_text = (result.error or "").lower()
+            if "no commits" in error_text:
+                # Legacy _handle_runtime_error (:348): "no commits between
+                # base and branch" maps to state:skip, not a hard failure.
+                item.payload["no_commits"] = True
+            else:
+                logger.warning(
+                    "implementation:%s: commit+push failed: %s", item.issue, result.error
+                )
+                item.payload["git_error"] = True
+
+    @staticmethod
+    def _on_implement_done(item: WorkItem, result: JobResult) -> None:
+        """Count the implement attempt and record its outcome.
+
+        The attempt is counted on completion, success or hard failure alike
+        (doc: "agent_error -> RETRY (consumes the implement budget)").
+
+        Args:
+            item: The work item to update.
+            result: The implement job result.
+
+        """
+        item.attempts["implement"] = item.attempts.get("implement", 0) + 1
+        if not result.ok:
+            logger.warning("implementation:%s: implement job failed: %s", item.issue, result.error)
+            item.payload["implement_error"] = True
+            return
+        if result.value:
+            item.payload["implement_summary"] = str(result.value)
+
+    @staticmethod
+    def _on_worktree_done(item: WorkItem, result: JobResult) -> None:
+        """Record the created worktree's path and dirty snapshot.
+
+        A failed worktree job flags ``git_error`` (transient — the
+        DIRTY_DECISION_WAIT step RETRYs without burning the implement
+        budget).
+
+        Args:
+            item: The work item to update.
+            result: The create_worktree job result.
+
+        """
+        if not result.ok:
+            logger.warning("implementation:%s: worktree job failed: %s", item.issue, result.error)
+            item.payload["git_error"] = True
+            return
+        value = result.value
+        if isinstance(value, dict):
+            item.worktree = str(value.get("path", item.worktree))
+            item.payload["worktree_dirty"] = bool(value.get("dirty"))
+            item.payload["worktree_status"] = str(value.get("status", ""))
+            item.payload["worktree_diff"] = str(value.get("diff", ""))
+        elif isinstance(value, str) and value:
+            item.worktree = value
+
+    @staticmethod
+    def _on_tests_done(item: WorkItem, result: JobResult) -> None:
+        """Record the pre-PR test outcome (output tail travels to the fixer).
+
+        Args:
+            item: The work item to update.
+            result: The pre-PR test job result.
+
+        """
+        if result.ok and result.value in (0, None, True):
+            item.payload.pop("tests_failed", None)
+            item.payload.pop("test_output", None)
+            return
+        item.payload["tests_failed"] = True
+        item.payload["test_output"] = "\n".join(
+            part for part in (result.stdout_tail, result.stderr_tail, result.error) if part
+        )
+
+    def _gate(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """GATE [M]: existing-PR fast path, then the plan-review verdict gate.
+
+        Re-houses ``_review_existing_pr`` (:750) and ``_ensure_plan_ready``
+        (:429). All checks are at-or-past reads; nothing is written.
+        """
+        if item.issue is None:  # guarded by step(); kept for type narrowing
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        existing_pr = item.pr or ctx.github.find_pr_for_issue(item.issue)
+        if existing_pr:
+            has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(existing_pr)
+            if has_go:
+                logger.info(
+                    "implementation:%d: PR #%d already implementation-go; routing to ci",
+                    item.issue,
+                    existing_pr,
+                )
+                return StageOutcome(Disposition.FAIL_BACK, "already_implementation_go_pr")
+            # Adopt the PR's REAL head branch — never assume {issue}-auto-impl
+            # (the _review_existing_pr branch-assumption bug).
+            item.pr = existing_pr
+            head_branch = ctx.github.get_pr_head_branch(existing_pr)
+            if head_branch:
+                item.branch = head_branch
+            item.payload["existing_pr"] = True
+            logger.info(
+                "implementation:%d: existing PR #%d (branch %r); advancing to pr_review",
+                item.issue,
+                existing_pr,
+                item.branch,
+            )
+            return StageOutcome(Disposition.ADVANCE, f"existing PR #{existing_pr}")
+
+        labels = _issue_labels(item, ctx)
+        # At-or-past (never equality): plan-go OR already implementation-go
+        # both satisfy the gate; anything earlier fails back to plan_review.
+        if not (is_plan_go(labels) or is_implementation_go(labels)):
+            logger.info("implementation:%d: plan not GO; failing back", item.issue)
+            return StageOutcome(Disposition.FAIL_BACK, "plan_not_go")
+
+        if not item.branch:
+            item.branch = f"{item.issue}-auto-impl"
+        return Continue(next_state=WORKTREE_WAIT)
+
+    def _create_pr(self, item: WorkItem, ctx: StageContext) -> StageOutcome:
+        """PR_CREATE [M]: durable PR creation, then auto-merge deferral.
+
+        The ``create_pr`` write is the stage's journal entry and happens
+        BEFORE the advancing outcome (durable write precedes the queue
+        push); ``defer_auto_merge`` immediately after creation preserves the
+        legacy runner order (:623).
+        """
+        if item.issue is None:  # guarded by step(); kept for type narrowing
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        if item.payload.pop("no_commits", None):
+            logger.warning(
+                "implementation:%d: no commits vs base; applying %s", item.issue, STATE_SKIP
+            )
+            self._write_skip_label(item.issue, ctx)
+            return StageOutcome(Disposition.SKIP, "no commits vs base")
+        if item.payload.pop("git_error", None):
+            # Push failed: transient git/network trouble — RETRY the stage
+            # without burning the implement budget.
+            return StageOutcome(Disposition.RETRY, "commit_push failed")
+
+        if item.pr is None:
+            title = item.payload.get("issue_title") or f"[Auto] Implement issue #{item.issue}"
+            body = get_pr_description(
+                item.issue,
+                summary=item.payload.get("implement_summary", "")
+                or f"Automated implementation for issue #{item.issue}.",
+                changes="See the PR diff for the full change set.",
+                testing=item.payload.get("test_output") or "pixi run pytest tests/unit -q",
+            )
+            pr_number = ctx.github.create_pr(item.issue, item.branch, title, body)
+            item.pr = pr_number
+            logger.info("implementation:%d: created PR #%d", item.issue, pr_number)
+        # Load-bearing legacy order (runner :623): defer auto-merge right
+        # after ensuring the PR exists — never armed before implementation GO.
+        ctx.github.defer_auto_merge(item.pr)
+        return StageOutcome(Disposition.ADVANCE, f"PR #{item.pr} ready for review")
+
+    @staticmethod
+    def _write_skip_label(issue_number: int, ctx: StageContext) -> None:
+        """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
+
+        Args:
+            issue_number: GitHub issue number.
+            ctx: Stage context carrying the GitHub accessor.
+
+        """
+        try:
+            ctx.github.add_labels(issue_number, [STATE_SKIP])
+        except Exception as e:
+            logger.warning(
+                "implementation:%d: failed to add label %r (non-fatal): %s",
+                issue_number,
+                STATE_SKIP,
+                e,
+            )

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -10,18 +10,38 @@ binding contract):
 
 - States: ENTER -> GATE -> WORKTREE_WAIT -> DIRTY_DECISION_WAIT ->
   ADVISE_WAIT -> IMPLEMENT_WAIT -> TEST_WAIT -> TESTFIX_WAIT ->
-  COMMIT_PUSH_WAIT -> PR_CREATE.
+  COMMIT_PUSH_WAIT -> PR_CREATE. The existing-PR fast path short-circuits
+  WORKTREE_WAIT -> DIRTY_DECISION_WAIT -> ADOPTED (ADVANCE to pr_review).
 - Budgets: ``implement`` = 2 (bounds implement attempts INCLUDING
   agent_error retries — the doc's "agent_error -> RETRY (consumes the
   implement budget)"), ``test_fix`` = 1 (one fix attempt on red pre-PR
   tests). Both read from ROUTES via ``ctx.budget``, never hardcoded here.
 - GATE [M]: existing-PR fast path first (``_review_existing_pr``
   semantics): a PR already carrying ``state:implementation-go`` fails back
-  ``already_implementation_go_pr`` (routes to ci); a PR without it adopts
-  the PR's REAL head branch and ADVANCEs straight to pr_review. Otherwise
-  the plan-review verdict gate: at-or-past ``state:plan-go`` (or already
-  ``state:implementation-go``) proceeds; anything else fails back
-  ``plan_not_go`` (routes to plan_review).
+  ``already_implementation_go_pr`` (routes to ci) with ``item.pr`` /
+  ``item.branch`` set for the ci stage; a PR without it adopts the PR's
+  REAL head branch, re-ensures the auto-merge deferral [durable], cuts a
+  worktree on the ADOPTED branch (``refresh_base=False`` +
+  ``sync_to_remote`` — the anti-clobber reset of
+  ``_prepare_worktree_for_existing_pr`` :649, so pushed commits are never
+  discarded), runs the dirty-salvage decision if needed, and only then
+  ADVANCEs to pr_review (ADOPTED). Otherwise the plan-review verdict gate:
+  at-or-past ``state:plan-go`` (or already ``state:implementation-go``)
+  proceeds; anything else fails back ``plan_not_go`` (routes to
+  plan_review).
+- agent_error ping-pong bound: when pr_review fails back ``agent_error``
+  (flagged in ``payload["agent_error_failback"]``), the GATE's existing-PR
+  adoption CONSUMES the ``implement`` budget — otherwise the
+  fail-back -> adopt -> ADVANCE cycle would never move a counter and could
+  loop forever. Exhaustion -> FINISH_FAIL(``agent_error_exhausted``): the
+  reviewer/address infrastructure failed repeatedly and re-adopting the
+  same PR again cannot fix it; a human should look at the PR.
+- Transient git failures (worktree creation, commit+push) RETRY without
+  burning the implement budget, but are bounded by
+  :data:`GIT_ERROR_RETRY_CAP` consecutive failures (mirrors
+  pr_review.REVIEW_ERROR_RETRY_CAP); at the cap the item finishes failed
+  (``git_error``) instead of retrying a broken remote forever. The counter
+  resets on any successful git job.
 - Owned labels: none — PR creation is the journal entry (doc section 4).
   The only label this stage ever writes is ``state:skip`` on the legacy
   "no commits vs base" runtime error (re-housed
@@ -42,7 +62,6 @@ binding contract):
 from __future__ import annotations
 
 import logging
-from pathlib import Path
 
 from hephaestus.automation.agent_config import (
     advise_claude_timeout,
@@ -65,6 +84,7 @@ from hephaestus.automation.state_labels import (
 )
 
 from .base import (
+    GIT_JOB_TIMEOUT_S,
     AgentJob,
     BuildTestJob,
     Continue,
@@ -77,8 +97,10 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _issue_labels,
+    _worktree_path,
+    write_skip_label,
 )
-from .planning import _issue_labels
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +109,7 @@ ENTER = "ENTER"
 GATE = "GATE"
 WORKTREE_WAIT = "WORKTREE_WAIT"
 DIRTY_DECISION_WAIT = "DIRTY_DECISION_WAIT"
+ADOPTED = "ADOPTED"
 ADVISE_WAIT = "ADVISE_WAIT"
 IMPLEMENT_WAIT = "IMPLEMENT_WAIT"
 TEST_WAIT = "TEST_WAIT"
@@ -94,8 +117,12 @@ TESTFIX_WAIT = "TESTFIX_WAIT"
 COMMIT_PUSH_WAIT = "COMMIT_PUSH_WAIT"
 PR_CREATE = "PR_CREATE"
 
-#: Timeout for git worktree/commit/push jobs (mechanical, no agent).
-GIT_JOB_TIMEOUT_S = 600
+#: Max CONSECUTIVE transient git failures (worktree creation / commit+push)
+#: tolerated before the stage finishes failed (``git_error``) instead of
+#: RETRYing forever. Mirrors pr_review.REVIEW_ERROR_RETRY_CAP: transient
+#: failures never burn the implement budget, but a persistently broken
+#: remote must still terminate. Reset on any successful git job.
+GIT_ERROR_RETRY_CAP = 2
 
 #: Timeout for the optional pre-PR unit-test run (mirrors the legacy
 #: ``_pr_create_phase`` bound; the budget that matters — ``test_fix`` —
@@ -186,13 +213,6 @@ def build_test_fix_prompt(issue_number: int, prev_iteration: int, test_output: s
     )
 
 
-def _worktree_path(item: WorkItem, ctx: StageContext) -> Path:
-    """Return the item's worktree as a Path, falling back to the shared one."""
-    if item.worktree:
-        return Path(item.worktree)
-    return Path(str(ctx.paths.worktree))
-
-
 class ImplementationStage(Stage):
     """Stage: gate plan GO, worktree, advise, implement, test, commit, PR."""
 
@@ -239,14 +259,25 @@ class ImplementationStage(Stage):
 
         if item.state == WORKTREE_WAIT:
             logger.info("implementation:%d: requesting worktree job", item.issue)
+            adopted = bool(item.payload.get("existing_pr"))
+            kwargs: dict[str, object] = {
+                "issue": item.issue,
+                "branch": item.branch,
+                # Fresh branch: cut from a freshly refreshed trunk (doc step
+                # 2: worktree_manager.create_worktree(refresh_base=True)).
+                # ADOPTED branch: never reset to trunk — sync to the PR's
+                # remote head instead (the anti-clobber reset of
+                # _prepare_worktree_for_existing_pr :649/:693, so re-running
+                # never discards pushed commits). Values coordinator-vetted.
+                "refresh_base": not adopted,
+            }
+            if adopted:
+                kwargs["sync_to_remote"] = True
             worktree_job = GitJob(
                 repo=item.repo,
                 op="create_worktree",
                 timeout_s=GIT_JOB_TIMEOUT_S,
-                # refresh_base=True: the worktree is cut from a freshly
-                # refreshed trunk (doc step 2: worktree_manager.create_worktree
-                # (refresh_base=True)); values are coordinator-vetted.
-                kwargs={"issue": item.issue, "branch": item.branch, "refresh_base": True},
+                kwargs=kwargs,
                 descr="create_worktree",
             )
             return JobRequest(worktree_job, on_done_state=DIRTY_DECISION_WAIT)
@@ -254,10 +285,15 @@ class ImplementationStage(Stage):
         if item.state == DIRTY_DECISION_WAIT:
             if item.payload.pop("git_error", None):
                 # Worktree creation failed: transient infrastructure, not an
-                # implement outcome — RETRY without burning the budget.
-                return StageOutcome(Disposition.RETRY, "worktree creation failed")
+                # implement outcome — RETRY without burning the implement
+                # budget, bounded by GIT_ERROR_RETRY_CAP (M5).
+                return self._git_retry(item, "worktree creation failed")
+            # Adopted-PR path: after the (clean or salvaged) worktree is
+            # ready, skip the implement leg — the PR's code already exists;
+            # pr_review's address leg drives it from here.
+            adopted_next = ADOPTED if item.payload.get("existing_pr") else ADVISE_WAIT
             if not item.payload.get("worktree_dirty"):
-                return Continue(next_state=ADVISE_WAIT)
+                return Continue(next_state=adopted_next)
             logger.info("implementation:%d: requesting dirty-worktree decision", item.issue)
             job = AgentJob(
                 repo=item.repo,
@@ -274,7 +310,19 @@ class ImplementationStage(Stage):
                 },
                 descr="dirty_decision",
             )
-            return JobRequest(job, on_done_state=ADVISE_WAIT)
+            return JobRequest(job, on_done_state=adopted_next)
+
+        if item.state == ADOPTED:
+            # Existing-PR fast path complete: worktree ready on the PR's real
+            # head branch — hand the PR to pr_review (doc step 1 "skip to
+            # step 8": nothing to implement, commit, or create).
+            logger.info(
+                "implementation:%d: adopted PR #%s (branch %r); advancing to pr_review",
+                item.issue,
+                item.pr,
+                item.branch,
+            )
+            return StageOutcome(Disposition.ADVANCE, f"existing PR #{item.pr}")
 
         if item.state == ADVISE_WAIT:
             if not ctx.config.enable_advise:
@@ -441,7 +489,11 @@ class ImplementationStage(Stage):
             item.attempts["test_fix"] = item.attempts.get("test_fix", 0) + 1
             return
 
-        if item.state == COMMIT_PUSH_WAIT and not result.ok:
+        if item.state == COMMIT_PUSH_WAIT:
+            if result.ok:
+                # A successful push ends the consecutive-git-failure streak.
+                item.payload.pop("git_error_retries", None)
+                return
             error_text = (result.error or "").lower()
             if "no commits" in error_text:
                 # Legacy _handle_runtime_error (:348): "no commits between
@@ -490,6 +542,8 @@ class ImplementationStage(Stage):
             logger.warning("implementation:%s: worktree job failed: %s", item.issue, result.error)
             item.payload["git_error"] = True
             return
+        # A successful worktree job ends the consecutive-git-failure streak.
+        item.payload.pop("git_error_retries", None)
         value = result.value
         if isinstance(value, dict):
             item.worktree = str(value.get("path", item.worktree))
@@ -521,35 +575,72 @@ class ImplementationStage(Stage):
         """GATE [M]: existing-PR fast path, then the plan-review verdict gate.
 
         Re-houses ``_review_existing_pr`` (:750) and ``_ensure_plan_ready``
-        (:429). All checks are at-or-past reads; nothing is written.
+        (:429). All checks are at-or-past reads; the only write is the
+        auto-merge deferral re-ensure on PR adoption [durable].
+
+        agent_error bound (M1): a re-entry from a pr_review ``agent_error``
+        fail-back (``payload["agent_error_failback"]``) that adopts an
+        existing PR CONSUMES the ``implement`` budget — the adoption produces
+        no implement job whose completion would otherwise count it, and
+        without a moving counter the fail-back -> adopt -> ADVANCE cycle
+        would ping-pong forever. Exhaustion terminates with
+        ``agent_error_exhausted``.
         """
         if item.issue is None:  # guarded by step(); kept for type narrowing
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
 
+        # Pop the fail-back marker unconditionally: on the fresh-implement
+        # path below the budget is consumed by the implement job itself, so
+        # the marker must never survive into a later GATE pass.
+        agent_error_reentry = bool(item.payload.pop("agent_error_failback", None))
+
         existing_pr = item.pr or ctx.github.find_pr_for_issue(item.issue)
         if existing_pr:
+            item.pr = existing_pr
+            head_branch = ctx.github.get_pr_head_branch(existing_pr)
+            if head_branch:
+                item.branch = head_branch
             has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(existing_pr)
             if has_go:
+                # item.pr/item.branch are set above so the ci stage receives
+                # a fully-identified PR (m7).
                 logger.info(
                     "implementation:%d: PR #%d already implementation-go; routing to ci",
                     item.issue,
                     existing_pr,
                 )
                 return StageOutcome(Disposition.FAIL_BACK, "already_implementation_go_pr")
+            if agent_error_reentry:
+                # M1: consume the implement budget at GATE-adoption so the
+                # pr_review agent_error -> re-adopt cycle is bounded.
+                attempts = item.attempts.get("implement", 0) + 1
+                item.attempts["implement"] = attempts
+                budget = ctx.budget("implement")
+                if attempts >= budget:
+                    logger.error(
+                        "implementation:%d: agent_error fail-backs exhausted the "
+                        "implement budget (%d/%d) re-adopting PR #%d — stopping; "
+                        "the review/address infrastructure failed repeatedly and "
+                        "re-adopting the same PR cannot fix it (manual look needed)",
+                        item.issue,
+                        attempts,
+                        budget,
+                        existing_pr,
+                    )
+                    return StageOutcome(Disposition.FINISH_FAIL, "agent_error_exhausted")
             # Adopt the PR's REAL head branch — never assume {issue}-auto-impl
-            # (the _review_existing_pr branch-assumption bug).
-            item.pr = existing_pr
-            head_branch = ctx.github.get_pr_head_branch(existing_pr)
-            if head_branch:
-                item.branch = head_branch
+            # (the _review_existing_pr branch-assumption bug) — and re-ensure
+            # auto-merge stays deferred on the adopted PR [durable]: it must
+            # never be armed before state:implementation-go.
             item.payload["existing_pr"] = True
+            ctx.github.defer_auto_merge(existing_pr)
             logger.info(
-                "implementation:%d: existing PR #%d (branch %r); advancing to pr_review",
+                "implementation:%d: existing PR #%d (branch %r); preparing adopted worktree",
                 item.issue,
                 existing_pr,
                 item.branch,
             )
-            return StageOutcome(Disposition.ADVANCE, f"existing PR #{existing_pr}")
+            return Continue(next_state=WORKTREE_WAIT)
 
         labels = _issue_labels(item, ctx)
         # At-or-past (never equality): plan-go OR already implementation-go
@@ -577,12 +668,13 @@ class ImplementationStage(Stage):
             logger.warning(
                 "implementation:%d: no commits vs base; applying %s", item.issue, STATE_SKIP
             )
-            self._write_skip_label(item.issue, ctx)
+            write_skip_label(item.issue, ctx)
             return StageOutcome(Disposition.SKIP, "no commits vs base")
         if item.payload.pop("git_error", None):
             # Push failed: transient git/network trouble — RETRY the stage
-            # without burning the implement budget.
-            return StageOutcome(Disposition.RETRY, "commit_push failed")
+            # without burning the implement budget, bounded by
+            # GIT_ERROR_RETRY_CAP (M5).
+            return self._git_retry(item, "commit_push failed")
 
         if item.pr is None:
             title = item.payload.get("issue_title") or f"[Auto] Implement issue #{item.issue}"
@@ -602,20 +694,41 @@ class ImplementationStage(Stage):
         return StageOutcome(Disposition.ADVANCE, f"PR #{item.pr} ready for review")
 
     @staticmethod
-    def _write_skip_label(issue_number: int, ctx: StageContext) -> None:
-        """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
+    def _git_retry(item: WorkItem, note: str) -> StageOutcome:
+        """RETRY a transient git failure, bounded by GIT_ERROR_RETRY_CAP (M5).
+
+        Transient worktree/push failures never burn the implement budget,
+        but a persistently failing remote must still terminate: at the cap
+        the item finishes failed (``git_error``). The consecutive-failure
+        counter lives in ``payload["git_error_retries"]`` and is reset by
+        any successful git job (see ``on_job_done``).
 
         Args:
-            issue_number: GitHub issue number.
-            ctx: Stage context carrying the GitHub accessor.
+            item: The work item whose git job failed.
+            note: Human-readable failure note for the RETRY outcome.
+
+        Returns:
+            RETRY below the cap; FINISH_FAIL(``git_error``) at the cap.
 
         """
-        try:
-            ctx.github.add_labels(issue_number, [STATE_SKIP])
-        except Exception as e:
-            logger.warning(
-                "implementation:%d: failed to add label %r (non-fatal): %s",
-                issue_number,
-                STATE_SKIP,
-                e,
+        retries = item.payload.get("git_error_retries", 0) + 1
+        item.payload["git_error_retries"] = retries
+        if retries > GIT_ERROR_RETRY_CAP:
+            logger.error(
+                "implementation:%s: %s; %d consecutive git failures (cap %d) — "
+                "finishing failed (git_error): the remote/worktree is persistently "
+                "broken and needs a manual look",
+                item.issue,
+                note,
+                retries,
+                GIT_ERROR_RETRY_CAP,
             )
+            return StageOutcome(Disposition.FINISH_FAIL, "git_error")
+        logger.warning(
+            "implementation:%s: %s; git retry %d/%d (implement budget untouched)",
+            item.issue,
+            note,
+            retries,
+            GIT_ERROR_RETRY_CAP,
+        )
+        return StageOutcome(Disposition.RETRY, note)

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -54,6 +54,7 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _issue_labels,
 )
 
 logger = logging.getLogger(__name__)
@@ -114,26 +115,6 @@ def _normalize_plan_comment(plan: str) -> str:
     if stripped.startswith(PLAN_COMMENT_MARKER):
         return stripped
     return f"{PLAN_COMMENT_MARKER}\n\n{stripped}"
-
-
-def _issue_labels(item: WorkItem, ctx: StageContext) -> list[str]:
-    """Refresh the item's labels from GitHub and update ``labels_cache``.
-
-    Reads through ``ctx.github.gh_issue_json`` (mirrors
-    ``github_api.issues.gh_issue_json``); on any read failure the cached
-    labels are used so a transient API blip cannot mis-route the item.
-    """
-    if item.issue is None:
-        return []
-    try:
-        data = ctx.github.gh_issue_json(item.issue)
-    except Exception as e:  # transient gh failure: fall back to cache
-        logger.warning("planning:%d: label refresh failed (using cache): %s", item.issue, e)
-        return list(item.labels_cache)
-    raw = data.get("labels", []) if isinstance(data, dict) else []
-    labels = [entry["name"] if isinstance(entry, dict) else str(entry) for entry in raw]
-    item.labels_cache = dict.fromkeys(labels, True)
-    return labels
 
 
 class PlanningStage(Stage):

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -35,13 +35,47 @@ contract):
   budget, is the doc's designated agent-error recovery).
 - EVAL verdict semantics (re-housed ``_evaluate_go_verdict``): a GO stands
   only with ZERO unresolved threads (#1152). GO + open HUMAN thread ->
-  HUMAN_BLOCKED: finish failed with the PR left UNLABELED (a human must
+  HUMAN_BLOCKED: an explanatory PR comment is posted [durable, before the
+  outcome] naming the blocking human thread count and that automation
+  stands down, then finish failed with the PR left UNLABELED (a human must
   act; automation may not resolve their thread). GO + open automation
   thread -> downgraded to NOGO (address + re-review). Clean GO -> durably
   ``mark_pr_implementation_go`` then ``arm_auto_merge`` [durable, in that
   order — the label authorizes the arming; arming is skipped if the mark
-  write fails] -> follow-up step -> ADVANCE. Exhaustion -> durably apply
-  ``state:skip`` [durable] -> SKIP.
+  write fails] -> follow-up step -> ADVANCE. Every real non-GO round
+  durably writes ``state:implementation-no-go`` (doc section 5 owned
+  label, "NOGO verdict, before retry/regress"; legacy
+  ``_apply_impl_review_verdict`` -> ``mark_pr_implementation_no_go``
+  :248) before looping/regressing, non-fatally. Exhaustion -> durably
+  apply ``state:skip`` [durable] -> SKIP.
+- Downgraded-GO cost (DELIBERATE 2-round divergence from legacy): legacy
+  downgraded a GO with open automation threads and ran the address step in
+  the SAME iteration; this stage records the downgrade in EVAL and lets
+  the NEXT round's POST re-count the live threads before dispatching the
+  address leg, so a downgraded GO costs one extra review round. Chosen
+  because POST live-checks the unresolved counts (a thread resolved
+  out-of-band between rounds skips the address leg entirely) and the
+  budget/extension gate stays a single chokepoint in EVAL.
+- Progress metric (#1554 parity): the extension gate compares AUTOMATION
+  unresolved counts only — a human resolving their own thread is not
+  automation progress and must not earn extension rounds.
+- POST posts only SURVIVING threads: the round's reviewer threads are
+  filtered through the validation job's verdict
+  (:func:`_surviving_threads`, re-housed ``review_validator`` semantics —
+  ``wont_fix`` findings are accepted and dropped, ``unaddressed`` prior
+  findings are re-opened as new postable threads; an unparseable
+  validator output filters nothing, the legacy fail-open).
+- Real-commit gating (#1575): PUSH_WAIT's commit_push result is inspected
+  in EVAL. A push that produced NO commit (the fix agent punted or
+  self-reported a phantom fix) is NOT treated as addressed: the address
+  step is retried ONCE with the ``build_unaddressed_directive`` block
+  (via ``get_address_review_prompt``'s ``unaddressed_findings``), and a
+  second consecutive no-commit turn is evaluated as an unaddressed round.
+- agent_error fail-backs (address failure, reviewer-error cap, missing
+  PR/worktree) set ``payload["agent_error_failback"]`` so the
+  implementation GATE consumes the ``implement`` budget on re-adoption —
+  the cross-stage ping-pong bound (M1). ``review_error_retries`` is reset
+  by ``on_enter`` on each fresh implementation cycle.
 - Prompt functions (imported, never re-authored):
   ``prompts/pr_review.py get_pr_review_analysis_prompt`` /
   ``get_review_validation_prompt`` / ``get_comment_difficulty_prompt``,
@@ -62,6 +96,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from typing import Any
 
 from hephaestus.automation.agent_config import (
     address_review_claude_timeout,
@@ -89,6 +125,7 @@ from hephaestus.automation.session_naming import (
 from hephaestus.automation.state_labels import STATE_SKIP
 
 from .base import (
+    GIT_JOB_TIMEOUT_S,
     AgentJob,
     Continue,
     Disposition,
@@ -100,8 +137,9 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _worktree_path,
+    write_skip_label,
 )
-from .implementation import GIT_JOB_TIMEOUT_S, _worktree_path
 
 logger = logging.getLogger(__name__)
 
@@ -137,7 +175,115 @@ _ROUND_PAYLOAD_KEYS = (
     "difficulty_tiers",
     "address_error",
     "address_output",
+    "push_no_commit",
+    "no_commit_retry_done",
+    "unaddressed_findings",
 )
+
+
+def _parse_validation_result(raw: Any) -> dict[str, Any] | None:
+    """Parse the validator job's output into its verdict dict, tolerantly.
+
+    The validation prompt asks for a single fenced JSON block at the END of
+    the response (``{"unaddressed": [...], "wont_fix": [...]}``); the parser
+    takes the LAST parseable block (legacy last-block-wins convention), then
+    falls back to treating the whole output as JSON. Returns None when
+    nothing parses — callers fail open.
+
+    Args:
+        raw: The validation job's stored output (str, dict, or anything).
+
+    Returns:
+        The parsed verdict dict, or None when unparseable/absent.
+
+    """
+    if isinstance(raw, dict):
+        return raw
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    blocks = re.findall(r"```(?:json)?\s*(.*?)```", raw, flags=re.DOTALL)
+    for candidate in (*reversed(blocks), raw):
+        try:
+            parsed = json.loads(candidate.strip())
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return None
+
+
+def _thread_ids(entries: Any) -> set[str]:
+    """Collect the ``thread_id``/``id`` strings from a validator bucket."""
+    ids: set[str] = set()
+    if not isinstance(entries, list):
+        return ids
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        thread_id = entry.get("thread_id") or entry.get("id")
+        if thread_id:
+            ids.add(str(thread_id))
+    return ids
+
+
+def _surviving_threads(
+    threads: list[dict[str, Any]], validation_result: Any
+) -> list[dict[str, Any]]:
+    """Filter the round's reviewer threads through the validator's verdict.
+
+    Re-housed ``review_validator`` consumption semantics (m1):
+
+    - ``wont_fix`` entries are documented-by-design decisions — accepted,
+      so any reviewer thread re-raising one of those thread ids is DROPPED
+      (never re-posted; the legacy recurrence-acceptance path, #1329).
+    - ``unaddressed`` entries are prior findings the current diff does NOT
+      resolve — RE-OPENED as new postable threads (the legacy
+      ``_classify_unaddressed_findings`` -> post path), unless the reviewer
+      already re-raised the same thread id this round.
+
+    Fail-open: a missing/unparseable validator output filters nothing — a
+    validator blip must never suppress the reviewer's own findings (the
+    legacy fail-open pattern).
+
+    Args:
+        threads: The round's reviewer-produced thread dicts.
+        validation_result: The validation job's stored output.
+
+    Returns:
+        The surviving thread list to durably post.
+
+    """
+    surviving = [dict(t) for t in threads]
+    parsed = _parse_validation_result(validation_result)
+    if parsed is None:
+        return surviving
+    wont_fix_ids = _thread_ids(parsed.get("wont_fix"))
+    if wont_fix_ids:
+        surviving = [
+            t for t in surviving if str(t.get("thread_id") or t.get("id") or "") not in wont_fix_ids
+        ]
+    present_ids = {str(t.get("thread_id") or t.get("id") or "") for t in surviving}
+    unaddressed = parsed.get("unaddressed")
+    if isinstance(unaddressed, list):
+        for entry in unaddressed:
+            if not isinstance(entry, dict):
+                continue
+            thread_id = str(entry.get("thread_id") or entry.get("id") or "")
+            if thread_id and thread_id in present_ids:
+                continue  # reviewer already re-raised it this round
+            detail = (
+                str(entry.get("detail") or "").strip()
+                or str(entry.get("original_body") or "").strip()
+                or "prior review comment not addressed"
+            )
+            surviving.append(
+                {
+                    "path": entry.get("path") or "",
+                    "line": entry.get("line"),
+                    "body": f"Reopened (prior round, still unaddressed): {detail}",
+                }
+            )
+    return surviving
 
 
 class PrReviewStage(Stage):
@@ -188,6 +334,11 @@ class PrReviewStage(Stage):
             item.payload["pr_review_cycle"] = cycle
             item.payload["pr_review_round"] = 0
             item.payload.pop("prev_unresolved", None)
+            # Fresh implementation cycle: the consecutive reviewer-failure
+            # streak restarts too (M1 — a re-entry after an agent_error
+            # fail-back gets a fresh error budget; the implement budget,
+            # consumed at the GATE, bounds the total number of cycles).
+            item.payload.pop("review_error_retries", None)
         return None
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
@@ -207,7 +358,7 @@ class PrReviewStage(Stage):
             # Nothing to review: fail back to implementation, whose
             # PR_CREATE step is the designated (re)creation path.
             logger.warning("pr_review:%d: no PR on item; failing back", item.issue)
-            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+            return self._fail_back_agent_error(item)
 
         if item.state == ENTER:
             return Continue(next_state=REVIEW_WAIT)
@@ -354,6 +505,14 @@ class PrReviewStage(Stage):
                 item.payload["address_error"] = True
             return
 
+        if item.state == PUSH_WAIT:
+            # Real-commit gate (#1575): commit_push reports whether a commit
+            # was actually produced (value/changed True). A no-commit push
+            # means the address turn was a phantom fix — EVAL must NOT treat
+            # the round as addressed.
+            item.payload["push_no_commit"] = not bool(result.value)
+            return
+
         if item.state == REVIEW_WAIT and result.value is not None:
             item.payload["review_verdict"] = result.value
             item.payload["review_text"] = getattr(result.value, "raw", str(result.value))
@@ -368,17 +527,24 @@ class PrReviewStage(Stage):
         # value any later state consumes.
 
     def _post(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """POST [M]: durably post surviving threads, refresh unresolved counts.
+        """POST [M]: durably post SURVIVING threads, refresh unresolved counts.
 
         The thread post is the round's durable write (doc step 3). The
-        surviving-thread list is parsed from the review/validation outputs
-        by the worker/coordinator (#1817) into ``payload["review_threads"]``.
+        reviewer's threads (parsed by the worker/coordinator (#1817) into
+        ``payload["review_threads"]``) are first filtered through the
+        validation job's verdict (:func:`_surviving_threads`, m1): wont_fix
+        findings are dropped, unaddressed prior findings are re-opened.
         Zero open automation threads skip the address leg straight to EVAL
         (the legacy zero-thread guard — nothing to classify or address).
         """
         if item.pr is None:  # guarded by step(); kept for type narrowing
-            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
-        threads = item.payload.get("review_threads") or []
+            return self._fail_back_agent_error(item)
+        threads = _surviving_threads(
+            list(item.payload.get("review_threads") or []),
+            item.payload.get("validation_result"),
+        )
+        # The surviving set is what gets posted, classified, and addressed.
+        item.payload["review_threads"] = threads
         if threads:
             posted = ctx.github.post_review_threads(
                 item.pr, list(threads), item.payload.get("review_text", "")
@@ -398,10 +564,26 @@ class PrReviewStage(Stage):
         session with the review feedback (doc step 5,
         ``get_impl_resume_feedback_prompt``). Existing-PR path (adopted by
         the implementation GATE fast path): run the address-review session
-        against the PR's unresolved threads (``get_address_review_prompt``).
+        against the PR's unresolved threads (``get_address_review_prompt``,
+        with any carried ``unaddressed_findings`` rendering the
+        ``build_unaddressed_directive`` retry block, #1575).
+
+        Fail-closed worktree guard: address jobs EDIT code, so they must
+        never run in the shared checkout (wrong branch — it would commit
+        fixes onto whatever the shared tree has checked out). Without a
+        worktree the item fails back to implementation, whose GATE/worktree
+        leg is the designated recovery (bounded by the M1 agent_error
+        budget consumption).
         """
         if item.pr is None:  # guarded by step(); kept for type narrowing
-            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+            return self._fail_back_agent_error(item)
+        if not item.worktree:
+            logger.warning(
+                "pr_review:%s: no worktree for the address step; failing back "
+                "(never edit in the shared checkout)",
+                item.issue,
+            )
+            return self._fail_back_agent_error(item)
         verdict = item.payload.get("review_verdict")
         if item.payload.get("existing_pr"):
             job = AgentJob(
@@ -418,6 +600,11 @@ class PrReviewStage(Stage):
                     "worktree_path": item.worktree,
                     "threads_json": json.dumps(item.payload.get("review_threads", [])),
                     "todo_block": item.payload.get("difficulty_tiers", ""),
+                    # No-commit retry directive (#1575): non-empty ONLY on
+                    # the one retry after a no-commit address turn;
+                    # get_address_review_prompt renders it via
+                    # build_unaddressed_directive.
+                    "unaddressed_findings": list(item.payload.get("unaddressed_findings") or []),
                 },
                 descr="address",
             )
@@ -449,7 +636,7 @@ class PrReviewStage(Stage):
         verdicts — never for ERROR or missing verdicts (#911/#1554/#1794).
         """
         if item.pr is None or item.issue is None:  # guarded by step(); narrowing
-            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+            return self._fail_back_agent_error(item)
         payload = item.payload
 
         if payload.pop("address_error", None):
@@ -457,34 +644,18 @@ class PrReviewStage(Stage):
             # back to implementation for a fresh implement pass (bounded by
             # the implement budget). No labels, no round burned.
             logger.warning("pr_review:%d: address step failed; failing back", item.issue)
-            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+            return self._fail_back_agent_error(item)
+
+        # Real-commit gate (#1575, M4): a no-commit push retries the address
+        # once with the directive; the second no-commit turn falls through
+        # and is evaluated as an unaddressed round.
+        no_commit_retry = self._gate_no_commit(item)
+        if no_commit_retry is not None:
+            return no_commit_retry
 
         verdict = payload.get("review_verdict")
         if verdict is None or verdict.is_error:
-            # Reviewer-infrastructure failure: labels untouched, no round
-            # burned, RETRY — bounded by the consecutive-failure cap
-            # (plan_review pattern), then fail back agent_error.
-            reason = "no verdict found" if verdict is None else "reviewer error"
-            retries = payload.get("review_error_retries", 0) + 1
-            payload["review_error_retries"] = retries
-            if retries > REVIEW_ERROR_RETRY_CAP:
-                logger.error(
-                    "pr_review:%d: %s; %d consecutive reviewer failures (cap %d)"
-                    " — failing back to implementation",
-                    item.issue,
-                    reason,
-                    retries,
-                    REVIEW_ERROR_RETRY_CAP,
-                )
-                return StageOutcome(Disposition.FAIL_BACK, "agent_error")
-            logger.warning(
-                "pr_review:%d: %s; retry %d/%d (no round burned)",
-                item.issue,
-                reason,
-                retries,
-                REVIEW_ERROR_RETRY_CAP,
-            )
-            return StageOutcome(Disposition.RETRY, reason)
+            return self._handle_error_verdict(item, verdict)
 
         # Real verdict: this round counts. Reset the consecutive-failure
         # cap; advance the cycle-relative gate and the lifetime audit trail.
@@ -505,13 +676,15 @@ class PrReviewStage(Stage):
 
         if verdict.is_go and human_unresolved:
             # A GO cannot stand while a HUMAN review thread is open —
-            # automation must not resolve it and cannot fix it. Terminal,
-            # with the PR left UNLABELED (no go, no no-go, no skip).
+            # automation must not resolve it and cannot fix it. Post the
+            # explanatory stand-down comment [durable, before the outcome],
+            # then finish with the PR left UNLABELED (no go/no-go/skip).
             logger.info(
                 "pr_review:%d: GO blocked by %d human thread(s); finishing (unlabeled)",
                 item.issue,
                 human_unresolved,
             )
+            self._post_human_blocked_comment(item.pr, human_unresolved, ctx)
             return StageOutcome(Disposition.FINISH_FAIL, "human_blocked")
 
         if verdict.is_go and unresolved == 0:
@@ -522,9 +695,18 @@ class PrReviewStage(Stage):
             return StageOutcome(Disposition.ADVANCE, "GO with zero unresolved threads")
 
         # NOGO/AMBIGUOUS — or a GO downgraded by open automation threads
-        # (re-housed downgrade: address + re-review before GO can stand).
+        # (re-housed downgrade: address + re-review before GO can stand;
+        # the address leg runs NEXT round after POST live-checks the
+        # threads — the module docstring's deliberate 2-round divergence).
+        # Doc section 5 owned label: every real non-GO round durably records
+        # state:implementation-no-go BEFORE the retry/regress outcome
+        # (legacy mark_pr_implementation_no_go, _review_phase.py:248).
+        self._write_no_go(item.pr, ctx)
+        # #1554 parity (m2): the progress trail counts AUTOMATION threads
+        # only — a human resolving their own thread is not automation
+        # progress and must not earn extension rounds.
         prev_unresolved = payload.get("prev_unresolved")
-        payload["prev_unresolved"] = unresolved
+        payload["prev_unresolved"] = automation_unresolved
         if round_done < soft_cap:
             logger.info(
                 "pr_review:%d: %s (round %d/%d, %d unresolved); re-reviewing",
@@ -535,30 +717,189 @@ class PrReviewStage(Stage):
                 unresolved,
             )
             return Continue(next_state=REVIEW_WAIT)
-        made_progress = prev_unresolved is not None and unresolved < prev_unresolved
+        made_progress = prev_unresolved is not None and automation_unresolved < prev_unresolved
         if round_done < hard_cap and made_progress:
             # #1554 progress-aware extension: rounds soft_cap+1..hard_cap are
-            # admitted only while the unresolved count strictly decreases.
+            # admitted only while the AUTOMATION unresolved count strictly
+            # decreases.
             logger.info(
-                "pr_review:%d: extension round %d/%d earned (%s -> %d unresolved)",
+                "pr_review:%d: extension round %d/%d earned (%s -> %d automation unresolved)",
                 item.issue,
                 round_done + 1,
                 hard_cap,
                 prev_unresolved,
-                unresolved,
+                automation_unresolved,
             )
             return Continue(next_state=REVIEW_WAIT)
 
         logger.warning(
-            "pr_review:%d: exhausted at round %d (unresolved %s -> %d); applying %s",
+            "pr_review:%d: exhausted at round %d (automation unresolved %s -> %d); applying %s",
             item.issue,
             round_done,
             prev_unresolved,
-            unresolved,
+            automation_unresolved,
             STATE_SKIP,
         )
-        self._write_skip_label(item.issue, ctx)
+        write_skip_label(item.issue, ctx)
         return StageOutcome(Disposition.SKIP, "exhaustion")
+
+    @staticmethod
+    def _gate_no_commit(item: WorkItem) -> Continue | None:
+        """Apply the real-commit gate (#1575): a no-commit push is never "addressed".
+
+        A push that produced NO commit means the address turn self-reported
+        a phantom fix. The FIRST such turn retries the address once, carrying
+        the still-open threads as ``unaddressed_findings`` (rendered by
+        ``build_unaddressed_directive`` inside ``get_address_review_prompt``)
+        to re-ground the resumed session. A SECOND consecutive no-commit turn
+        returns None so EVAL treats it as an unaddressed round. A real commit
+        spends/clears the retry directive (legacy: "a progress round clears
+        the retry directive").
+
+        Args:
+            item: The work item under evaluation.
+
+        Returns:
+            ``Continue(ADDRESS_WAIT)`` for the one retry, else None.
+
+        """
+        payload = item.payload
+        no_commit = payload.pop("push_no_commit", None)
+        if no_commit:
+            if not payload.get("no_commit_retry_done"):
+                payload["no_commit_retry_done"] = True
+                payload["unaddressed_findings"] = list(payload.get("review_threads") or [])
+                logger.warning(
+                    "pr_review:%s: address turn produced NO commit; retrying the "
+                    "address once with the unaddressed-findings directive (#1575)",
+                    item.issue,
+                )
+                return Continue(next_state=ADDRESS_WAIT)
+            logger.warning(
+                "pr_review:%s: address retry still produced no commit; "
+                "treating this as an unaddressed round",
+                item.issue,
+            )
+        elif no_commit is False:
+            payload.pop("no_commit_retry_done", None)
+            payload.pop("unaddressed_findings", None)
+        return None
+
+    def _handle_error_verdict(self, item: WorkItem, verdict: Any) -> StageOutcome:
+        """Handle a missing/ERROR verdict: bounded RETRY, then fail back.
+
+        Reviewer-infrastructure failure: labels untouched, no round burned,
+        RETRY — bounded by the consecutive-failure cap (plan_review
+        pattern), then fail back ``agent_error`` (#911/#1554/#1794).
+
+        Args:
+            item: The work item under evaluation.
+            verdict: The stored verdict (None or an ERROR verdict).
+
+        Returns:
+            RETRY below the cap; the flagged agent_error fail-back at it.
+
+        """
+        payload = item.payload
+        reason = "no verdict found" if verdict is None else "reviewer error"
+        retries = payload.get("review_error_retries", 0) + 1
+        payload["review_error_retries"] = retries
+        if retries > REVIEW_ERROR_RETRY_CAP:
+            logger.error(
+                "pr_review:%s: %s; %d consecutive reviewer failures (cap %d)"
+                " — failing back to implementation",
+                item.issue,
+                reason,
+                retries,
+                REVIEW_ERROR_RETRY_CAP,
+            )
+            return self._fail_back_agent_error(item)
+        logger.warning(
+            "pr_review:%s: %s; retry %d/%d (no round burned)",
+            item.issue,
+            reason,
+            retries,
+            REVIEW_ERROR_RETRY_CAP,
+        )
+        return StageOutcome(Disposition.RETRY, reason)
+
+    @staticmethod
+    def _fail_back_agent_error(item: WorkItem) -> StageOutcome:
+        """FAIL_BACK ``agent_error``, flagging the re-entry for the M1 bound.
+
+        Every agent_error fail-back marks
+        ``payload["agent_error_failback"]`` so the implementation GATE's
+        existing-PR adoption consumes the ``implement`` budget — without a
+        moving counter the fail-back -> adopt -> ADVANCE cycle would
+        ping-pong forever.
+
+        Args:
+            item: The work item failing back.
+
+        Returns:
+            The FAIL_BACK(``agent_error``) outcome.
+
+        """
+        item.payload["agent_error_failback"] = True
+        return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+
+    @staticmethod
+    def _write_no_go(pr_number: int, ctx: StageContext) -> None:
+        """Durably mark implementation NO-GO, non-fatally (legacy warn pattern).
+
+        Doc section 5 owned label ("NOGO verdict, before retry/regress"):
+        written on EVERY real non-GO round so the PR durably reflects the
+        latest converged verdict even across restarts (legacy
+        ``mark_pr_implementation_no_go``, ``_review_phase.py:248``).
+
+        Args:
+            pr_number: GitHub PR number that earned the non-GO round.
+            ctx: Stage context carrying the GitHub accessor.
+
+        """
+        try:
+            ctx.github.mark_pr_implementation_no_go(pr_number)
+        except Exception as e:
+            logger.warning(
+                "pr_review: failed to mark PR #%d implementation-no-go (non-fatal): %s",
+                pr_number,
+                e,
+            )
+
+    @staticmethod
+    def _post_human_blocked_comment(
+        pr_number: int, human_unresolved: int, ctx: StageContext
+    ) -> None:
+        """Post the HUMAN_BLOCKED stand-down comment, non-fatally [durable].
+
+        Written BEFORE the FINISH_FAIL outcome so the reason automation
+        stood down is durably visible on the PR (M3): without it, an
+        unlabeled PR that automation stops touching looks abandoned.
+
+        Args:
+            pr_number: GitHub PR number blocked by human threads.
+            human_unresolved: Count of unresolved human-owned review threads.
+            ctx: Stage context carrying the GitHub accessor.
+
+        """
+        body = (
+            "**Automation stand-down: human review thread(s) block GO.**\n\n"
+            f"The implementation review reached GO, but {human_unresolved} "
+            "unresolved review thread(s) opened by a human remain on this PR. "
+            "Automation will not resolve human threads and cannot act on them, "
+            "so it is standing down: the PR is left unlabeled (no "
+            "`state:implementation-go` / `state:implementation-no-go`) and "
+            "auto-merge stays unarmed. Once the human thread(s) are resolved, "
+            "the next automation pass will re-review this PR."
+        )
+        try:
+            ctx.github.post_pr_comment(pr_number, body)
+        except Exception as e:
+            logger.warning(
+                "pr_review: failed to post HUMAN_BLOCKED comment on PR #%d (non-fatal): %s",
+                pr_number,
+                e,
+            )
 
     @staticmethod
     def _write_go_and_arm(pr_number: int, ctx: StageContext) -> None:
@@ -589,23 +930,4 @@ class PrReviewStage(Stage):
         except Exception as e:
             logger.warning(
                 "pr_review: failed to arm auto-merge on PR #%d (non-fatal): %s", pr_number, e
-            )
-
-    @staticmethod
-    def _write_skip_label(issue_number: int, ctx: StageContext) -> None:
-        """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
-
-        Args:
-            issue_number: GitHub issue number.
-            ctx: Stage context carrying the GitHub accessor.
-
-        """
-        try:
-            ctx.github.add_labels(issue_number, [STATE_SKIP])
-        except Exception as e:
-            logger.warning(
-                "pr_review:%d: failed to add label %r (non-fatal): %s",
-                issue_number,
-                STATE_SKIP,
-                e,
             )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1,0 +1,611 @@
+"""PR-review stage: review, validate, post, address, evaluate, follow up.
+
+Re-houses the fused implementation-review loop from ``_review_phase.py``
+(``_run_impl_review_loop`` :671, ``_evaluate_go_verdict`` :314,
+``_review_thread_count_decreased`` :155) and its collaborators
+(``pr_reviewer.review_pr_inline``, ``review_validator
+.validate_prior_comments_addressed``, ``address_review
+.run_address_fix_session``) as a pipeline stage
+(docs/AUTOMATION_LOOP_ARCHITECTURE.md section "5. pr_review" is the binding
+contract):
+
+- States: ENTER -> REVIEW_WAIT -> VALIDATE_WAIT -> POST -> DIFFICULTY_WAIT
+  -> ADDRESS_WAIT -> PUSH_WAIT -> EVAL -> (loop to REVIEW_WAIT) ->
+  FOLLOWUP_WAIT.
+- Budgets: ``pr_review_iter`` = 3 (soft cap), ``pr_review_hard`` = 6 (hard
+  cap; rounds 4-6 are admitted ONLY while the unresolved-thread count
+  strictly decreases — the #1554 progress-aware extension, legacy
+  ``_review_thread_count_decreased`` + the budget bump at
+  ``_run_impl_review_loop:758-770``). Both read from ROUTES via
+  ``ctx.budget``, never hardcoded here.
+- Iteration accounting: ``item.attempts["pr_review_iter"]`` is the
+  PER-LIFETIME audit trail (routing.py contract: attempts are never
+  reset), so EVAL gates on the CYCLE-RELATIVE counter
+  ``item.payload["pr_review_round"]``, reset by ``on_enter`` whenever a
+  fresh implementation pass starts a new review cycle (keyed on
+  ``attempts["implement"]``). ``attempts["pr_review_hard"]`` audits the
+  extension rounds (rounds past the soft cap).
+- Rounds advance in EVAL and ONLY for real verdicts (GO/NOGO/AMBIGUOUS).
+  ERROR and missing verdicts never burn a round or touch labels
+  (#911/#1554/#1794); they RETRY, bounded in-stage by
+  ``payload["review_error_retries"]`` (cap :data:`REVIEW_ERROR_RETRY_CAP`
+  consecutive failures, reset on any real verdict — the plan_review
+  pattern). At the cap the item fails back ``agent_error`` (routes to
+  implementation: a fresh implement pass, bounded by the ``implement``
+  budget, is the doc's designated agent-error recovery).
+- EVAL verdict semantics (re-housed ``_evaluate_go_verdict``): a GO stands
+  only with ZERO unresolved threads (#1152). GO + open HUMAN thread ->
+  HUMAN_BLOCKED: finish failed with the PR left UNLABELED (a human must
+  act; automation may not resolve their thread). GO + open automation
+  thread -> downgraded to NOGO (address + re-review). Clean GO -> durably
+  ``mark_pr_implementation_go`` then ``arm_auto_merge`` [durable, in that
+  order — the label authorizes the arming; arming is skipped if the mark
+  write fails] -> follow-up step -> ADVANCE. Exhaustion -> durably apply
+  ``state:skip`` [durable] -> SKIP.
+- Prompt functions (imported, never re-authored):
+  ``prompts/pr_review.py get_pr_review_analysis_prompt`` /
+  ``get_review_validation_prompt`` / ``get_comment_difficulty_prompt``,
+  ``prompts/implementation.py get_impl_resume_feedback_prompt`` (fresh-PR
+  address path), ``prompts/address_review.py get_address_review_prompt``
+  (existing-PR address path), ``prompts/follow_up.py get_follow_up_prompt``.
+- Verdict parsed IN-WORKER by ``claude_invoke.parse_review_verdict``
+  (carried as the review job's ``parse`` callable; symbol-scoped zero-I/O
+  exemption mirrors plan_review's). REVIEW_WAIT clears all stale
+  round-scoped payload at submission so a failed later round can never
+  replay an earlier round's verdict or threads.
+- FOLLOWUP_WAIT intentionally stores nothing in ``on_job_done``: the
+  follow-up job's output is a side effect (follow-up issues filed by the
+  agent), not a payload value any later state consumes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from hephaestus.automation.agent_config import (
+    address_review_claude_timeout,
+    follow_up_claude_timeout,
+    implementer_claude_timeout,
+    implementer_model,
+    pr_reviewer_claude_timeout,
+    reviewer_model,
+)
+from hephaestus.automation.claude_invoke import parse_review_verdict
+from hephaestus.automation.prompts.address_review import get_address_review_prompt
+from hephaestus.automation.prompts.follow_up import get_follow_up_prompt
+from hephaestus.automation.prompts.implementation import get_impl_resume_feedback_prompt
+from hephaestus.automation.prompts.pr_review import (
+    get_comment_difficulty_prompt,
+    get_pr_review_analysis_prompt,
+    get_review_validation_prompt,
+)
+from hephaestus.automation.session_naming import (
+    AGENT_ADDRESS_REVIEW,
+    AGENT_COMMENT_CLASSIFIER,
+    AGENT_IMPLEMENTER,
+    AGENT_PR_REVIEWER,
+)
+from hephaestus.automation.state_labels import STATE_SKIP
+
+from .base import (
+    AgentJob,
+    Continue,
+    Disposition,
+    GitJob,
+    JobRequest,
+    JobResult,
+    Stage,
+    StageContext,
+    StageOutcome,
+    StepResult,
+    WorkItem,
+)
+from .implementation import GIT_JOB_TIMEOUT_S, _worktree_path
+
+logger = logging.getLogger(__name__)
+
+# In-memory mini-states (stage-local strings, never GitHub labels).
+ENTER = "ENTER"
+REVIEW_WAIT = "REVIEW_WAIT"
+VALIDATE_WAIT = "VALIDATE_WAIT"
+POST = "POST"
+DIFFICULTY_WAIT = "DIFFICULTY_WAIT"
+ADDRESS_WAIT = "ADDRESS_WAIT"
+PUSH_WAIT = "PUSH_WAIT"
+EVAL = "EVAL"
+FOLLOWUP_WAIT = "FOLLOWUP_WAIT"
+FINISH = "FINISH"
+
+#: Max CONSECUTIVE reviewer-infrastructure failures (ERROR verdicts or
+#: failed/valueless review jobs) tolerated before failing back
+#: ``agent_error``. Bounds the in-stage ERROR retry loop without burning
+#: ``pr_review_iter`` or stamping labels (#911/#1554; mirrors
+#: plan_review.REVIEW_ERROR_RETRY_CAP). Reset whenever a real verdict
+#: arrives.
+REVIEW_ERROR_RETRY_CAP = 2
+
+#: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
+#: later round can never replay an earlier round's results.
+_ROUND_PAYLOAD_KEYS = (
+    "review_verdict",
+    "review_text",
+    "review_failed",
+    "validation_result",
+    "review_threads",
+    "posted_thread_ids",
+    "difficulty_tiers",
+    "address_error",
+    "address_output",
+)
+
+
+class PrReviewStage(Stage):
+    """Stage: review -> validate -> post -> address -> EVAL -> follow-up.
+
+    State machine (doc section "5. pr_review"):
+
+    - ENTER: route to REVIEW_WAIT.
+    - REVIEW_WAIT: clear stale round payload, submit the inline-review job
+      (verdict parsed in-worker; review text is the verdict's ``raw``).
+    - VALIDATE_WAIT: submit the prior-comment validation job (skipped
+      straight to EVAL when the review job failed — the ERROR path burns
+      no downstream work).
+    - POST [M]: durably post surviving review threads, refresh the
+      unresolved-thread counts; zero open automation threads skip the
+      address leg straight to EVAL.
+    - DIFFICULTY_WAIT: submit the comment-difficulty classification job.
+    - ADDRESS_WAIT: fresh-PR path resumes the implementer with the review
+      feedback; existing-PR path runs the address-review session.
+    - PUSH_WAIT: commit+push the addressing changes.
+    - EVAL [M]: re-housed ``_evaluate_go_verdict`` + budget gate (see
+      module docstring).
+    - FOLLOWUP_WAIT (GO only): submit the follow-up job, then FINISH ->
+      ADVANCE.
+    """
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """Reset the cycle-relative round counter on a new implementation pass.
+
+        ``attempts["pr_review_iter"]`` is per-lifetime (routing.py: attempts
+        are never reset), so the per-cycle review budget is tracked in
+        ``payload["pr_review_round"]``. The reset keys on
+        ``attempts["implement"]`` (recorded in ``payload["pr_review_cycle"]``)
+        so it fires exactly once per implementation pass: a same-cycle
+        re-entry (e.g. the ERROR-path RETRY) keeps its round count and its
+        progress trail. Idempotent — a literal double on_enter is a no-op.
+
+        Args:
+            item: The work item being processed.
+            ctx: The stage context.
+
+        Returns:
+            None (always proceed to step()).
+
+        """
+        cycle = item.attempts.get("implement", 0)
+        if item.payload.get("pr_review_cycle") != cycle:
+            item.payload["pr_review_cycle"] = cycle
+            item.payload["pr_review_round"] = 0
+            item.payload.pop("prev_unresolved", None)
+        return None
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
+        """Execute the next PR-review action for the item's current state.
+
+        Args:
+            item: The work item with current state.
+            ctx: Stage context.
+
+        Returns:
+            Continue, JobRequest, or StageOutcome.
+
+        """
+        if not item.issue:
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+        if item.pr is None:
+            # Nothing to review: fail back to implementation, whose
+            # PR_CREATE step is the designated (re)creation path.
+            logger.warning("pr_review:%d: no PR on item; failing back", item.issue)
+            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+
+        if item.state == ENTER:
+            return Continue(next_state=REVIEW_WAIT)
+
+        if item.state == REVIEW_WAIT:
+            # Clear ALL round-scoped payload at submission (stale-result
+            # guard, M3 pattern): a failed later round must never replay an
+            # earlier round's verdict, threads, or address output.
+            for key in _ROUND_PAYLOAD_KEYS:
+                item.payload.pop(key, None)
+            round_index = item.payload.get("pr_review_round", 0)
+            logger.info(
+                "pr_review:%d: requesting review job (round %d, PR #%d)",
+                item.issue,
+                round_index,
+                item.pr,
+            )
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_PR_REVIEWER,
+                model=reviewer_model(),
+                prompt_builder=get_pr_review_analysis_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=pr_reviewer_claude_timeout(),
+                # Diff / body / CI context are seeded into item.payload by
+                # the coordinator (#1817), which owns the gh reads.
+                prompt_kwargs={
+                    "pr_number": item.pr,
+                    "issue_number": item.issue,
+                    "pr_diff": item.payload.get("pr_diff", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
+                    "ci_status": item.payload.get("ci_status", ""),
+                    "pr_description": item.payload.get("pr_description", ""),
+                    "advise_findings": item.payload.get("advise_findings", ""),
+                    "include_nitpicks": False,
+                },
+                parse=parse_review_verdict,  # verdict parsed in-worker
+                descr="review",
+            )
+            return JobRequest(job, on_done_state=VALIDATE_WAIT)
+
+        if item.state == VALIDATE_WAIT:
+            if item.payload.pop("review_failed", None):
+                # The review job itself failed: skip the validate/post/
+                # address leg — EVAL's missing-verdict ERROR path handles it
+                # without burning a round.
+                return Continue(next_state=EVAL)
+            logger.info("pr_review:%d: requesting validation job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_PR_REVIEWER,
+                model=reviewer_model(),
+                prompt_builder=get_review_validation_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=pr_reviewer_claude_timeout(),
+                prompt_kwargs={
+                    "pr_number": item.pr,
+                    "issue_number": item.issue,
+                    "prior_comments_json": item.payload.get("prior_comments_json", "[]"),
+                    "diff_text": item.payload.get("pr_diff", ""),
+                },
+                descr="validate",
+            )
+            return JobRequest(job, on_done_state=POST)
+
+        if item.state == POST:
+            return self._post(item, ctx)
+
+        if item.state == DIFFICULTY_WAIT:
+            logger.info("pr_review:%d: requesting difficulty job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_COMMENT_CLASSIFIER,
+                model=reviewer_model(),
+                prompt_builder=get_comment_difficulty_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=pr_reviewer_claude_timeout(),
+                prompt_kwargs={
+                    "issue_number": item.issue,
+                    "comments_json": json.dumps(item.payload.get("review_threads", [])),
+                },
+                descr="difficulty",
+            )
+            return JobRequest(job, on_done_state=ADDRESS_WAIT)
+
+        if item.state == ADDRESS_WAIT:
+            return self._address(item, ctx)
+
+        if item.state == PUSH_WAIT:
+            logger.info("pr_review:%d: requesting push job", item.issue)
+            git_job = GitJob(
+                repo=item.repo,
+                op="commit_push",
+                timeout_s=GIT_JOB_TIMEOUT_S,
+                kwargs={"branch": item.branch},
+                descr="push_fixes",
+            )
+            return JobRequest(git_job, on_done_state=EVAL)
+
+        if item.state == EVAL:
+            return self._eval(item, ctx)
+
+        if item.state == FOLLOWUP_WAIT:
+            logger.info("pr_review:%d: requesting follow-up job", item.issue)
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue,
+                agent=AGENT_IMPLEMENTER,  # resume the implementer's session (legacy parity)
+                model=implementer_model(),
+                prompt_builder=get_follow_up_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=follow_up_claude_timeout(),
+                prompt_kwargs={"issue_number": item.issue},
+                descr="follow_up",
+            )
+            return JobRequest(job, on_done_state=FINISH)
+
+        if item.state == FINISH:
+            logger.info("pr_review:%d: follow-up completed; advancing", item.issue)
+            return StageOutcome(Disposition.ADVANCE, "implementation review approved")
+
+        logger.warning("pr_review:%d: unknown state %r", item.issue, item.state)
+        return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Store job results on the item payload (state is still the WAIT state).
+
+        Args:
+            item: The work item to update.
+            result: The job result from the worker pool.
+            ctx: Stage context.
+
+        """
+        if not result.ok:
+            logger.warning("pr_review:%s: job failed: %s", item.issue, result.error)
+            if item.state == REVIEW_WAIT:
+                # EVAL treats the missing verdict as a reviewer-infrastructure
+                # ERROR; the flag lets VALIDATE_WAIT skip the dead round.
+                item.payload["review_failed"] = True
+            elif item.state in (ADDRESS_WAIT, PUSH_WAIT):
+                item.payload["address_error"] = True
+            return
+
+        if item.state == REVIEW_WAIT and result.value is not None:
+            item.payload["review_verdict"] = result.value
+            item.payload["review_text"] = getattr(result.value, "raw", str(result.value))
+        elif item.state == VALIDATE_WAIT and result.value is not None:
+            item.payload["validation_result"] = result.value
+        elif item.state == DIFFICULTY_WAIT and result.value is not None:
+            item.payload["difficulty_tiers"] = str(result.value)
+        elif item.state == ADDRESS_WAIT and result.value is not None:
+            item.payload["address_output"] = str(result.value)
+        # FOLLOWUP_WAIT intentionally has no branch: the follow-up job's
+        # output is a side effect (issues filed by the agent), not a payload
+        # value any later state consumes.
+
+    def _post(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """POST [M]: durably post surviving threads, refresh unresolved counts.
+
+        The thread post is the round's durable write (doc step 3). The
+        surviving-thread list is parsed from the review/validation outputs
+        by the worker/coordinator (#1817) into ``payload["review_threads"]``.
+        Zero open automation threads skip the address leg straight to EVAL
+        (the legacy zero-thread guard — nothing to classify or address).
+        """
+        if item.pr is None:  # guarded by step(); kept for type narrowing
+            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+        threads = item.payload.get("review_threads") or []
+        if threads:
+            posted = ctx.github.post_review_threads(
+                item.pr, list(threads), item.payload.get("review_text", "")
+            )
+            item.payload["posted_thread_ids"] = posted
+        automation_unresolved, human_unresolved = ctx.github.count_unresolved_threads(item.pr)
+        item.payload["unresolved_auto"] = automation_unresolved
+        item.payload["unresolved_human"] = human_unresolved
+        if automation_unresolved == 0:
+            return Continue(next_state=EVAL)
+        return Continue(next_state=DIFFICULTY_WAIT)
+
+    def _address(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """ADDRESS_WAIT: dispatch the fresh-PR or existing-PR address job.
+
+        Fresh-PR path (this pipeline created the PR): resume the implementer
+        session with the review feedback (doc step 5,
+        ``get_impl_resume_feedback_prompt``). Existing-PR path (adopted by
+        the implementation GATE fast path): run the address-review session
+        against the PR's unresolved threads (``get_address_review_prompt``).
+        """
+        if item.pr is None:  # guarded by step(); kept for type narrowing
+            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+        verdict = item.payload.get("review_verdict")
+        if item.payload.get("existing_pr"):
+            job = AgentJob(
+                repo=item.repo,
+                issue=item.issue if item.issue is not None else 0,
+                agent=AGENT_ADDRESS_REVIEW,
+                model=implementer_model(),
+                prompt_builder=get_address_review_prompt,
+                cwd=_worktree_path(item, ctx),
+                timeout_s=address_review_claude_timeout(),
+                prompt_kwargs={
+                    "pr_number": item.pr,
+                    "issue_number": item.issue,
+                    "worktree_path": item.worktree,
+                    "threads_json": json.dumps(item.payload.get("review_threads", [])),
+                    "todo_block": item.payload.get("difficulty_tiers", ""),
+                },
+                descr="address",
+            )
+            return JobRequest(job, on_done_state=PUSH_WAIT)
+        job = AgentJob(
+            repo=item.repo,
+            issue=item.issue if item.issue is not None else 0,
+            agent=AGENT_IMPLEMENTER,
+            model=implementer_model(),
+            prompt_builder=get_impl_resume_feedback_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=implementer_claude_timeout(),
+            prompt_kwargs={
+                "issue_number": item.issue,
+                "prev_iteration": item.payload.get("pr_review_round", 0),
+                "verdict": getattr(verdict, "verdict", "NOGO"),
+                "review_text": item.payload.get("review_text", ""),
+            },
+            descr="address",
+        )
+        return JobRequest(job, on_done_state=PUSH_WAIT)
+
+    def _eval(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """EVAL [M]: re-housed ``_evaluate_go_verdict`` + the budget gate.
+
+        Every durable write below happens BEFORE the outcome that causes a
+        queue push. The round counters (lifetime ``attempts`` audit trail
+        and cycle-relative ``payload`` gate) advance here, and only for real
+        verdicts — never for ERROR or missing verdicts (#911/#1554/#1794).
+        """
+        if item.pr is None or item.issue is None:  # guarded by step(); narrowing
+            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+        payload = item.payload
+
+        if payload.pop("address_error", None):
+            # The address/push leg hard-failed: the doc's agent_error route —
+            # back to implementation for a fresh implement pass (bounded by
+            # the implement budget). No labels, no round burned.
+            logger.warning("pr_review:%d: address step failed; failing back", item.issue)
+            return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+
+        verdict = payload.get("review_verdict")
+        if verdict is None or verdict.is_error:
+            # Reviewer-infrastructure failure: labels untouched, no round
+            # burned, RETRY — bounded by the consecutive-failure cap
+            # (plan_review pattern), then fail back agent_error.
+            reason = "no verdict found" if verdict is None else "reviewer error"
+            retries = payload.get("review_error_retries", 0) + 1
+            payload["review_error_retries"] = retries
+            if retries > REVIEW_ERROR_RETRY_CAP:
+                logger.error(
+                    "pr_review:%d: %s; %d consecutive reviewer failures (cap %d)"
+                    " — failing back to implementation",
+                    item.issue,
+                    reason,
+                    retries,
+                    REVIEW_ERROR_RETRY_CAP,
+                )
+                return StageOutcome(Disposition.FAIL_BACK, "agent_error")
+            logger.warning(
+                "pr_review:%d: %s; retry %d/%d (no round burned)",
+                item.issue,
+                reason,
+                retries,
+                REVIEW_ERROR_RETRY_CAP,
+            )
+            return StageOutcome(Disposition.RETRY, reason)
+
+        # Real verdict: this round counts. Reset the consecutive-failure
+        # cap; advance the cycle-relative gate and the lifetime audit trail.
+        payload["review_error_retries"] = 0
+        round_done = payload.get("pr_review_round", 0) + 1
+        payload["pr_review_round"] = round_done
+        item.attempts["pr_review_iter"] = item.attempts.get("pr_review_iter", 0) + 1
+        soft_cap = ctx.budget("pr_review_iter")
+        hard_cap = ctx.budget("pr_review_hard")
+        if round_done > soft_cap:
+            # Audit trail of progress-earned extension rounds (4..hard_cap).
+            item.attempts["pr_review_hard"] = item.attempts.get("pr_review_hard", 0) + 1
+
+        # Fresh unresolved counts AFTER the address/push leg (the GO gate
+        # must see what is open NOW, not the pre-address snapshot).
+        automation_unresolved, human_unresolved = ctx.github.count_unresolved_threads(item.pr)
+        unresolved = automation_unresolved + human_unresolved
+
+        if verdict.is_go and human_unresolved:
+            # A GO cannot stand while a HUMAN review thread is open —
+            # automation must not resolve it and cannot fix it. Terminal,
+            # with the PR left UNLABELED (no go, no no-go, no skip).
+            logger.info(
+                "pr_review:%d: GO blocked by %d human thread(s); finishing (unlabeled)",
+                item.issue,
+                human_unresolved,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "human_blocked")
+
+        if verdict.is_go and unresolved == 0:
+            logger.info("pr_review:%d: clean GO; marking PR #%d and arming", item.issue, item.pr)
+            self._write_go_and_arm(item.pr, ctx)
+            if getattr(ctx.config, "enable_follow_up", True):
+                return Continue(next_state=FOLLOWUP_WAIT)
+            return StageOutcome(Disposition.ADVANCE, "GO with zero unresolved threads")
+
+        # NOGO/AMBIGUOUS — or a GO downgraded by open automation threads
+        # (re-housed downgrade: address + re-review before GO can stand).
+        prev_unresolved = payload.get("prev_unresolved")
+        payload["prev_unresolved"] = unresolved
+        if round_done < soft_cap:
+            logger.info(
+                "pr_review:%d: %s (round %d/%d, %d unresolved); re-reviewing",
+                item.issue,
+                verdict.verdict,
+                round_done,
+                soft_cap,
+                unresolved,
+            )
+            return Continue(next_state=REVIEW_WAIT)
+        made_progress = prev_unresolved is not None and unresolved < prev_unresolved
+        if round_done < hard_cap and made_progress:
+            # #1554 progress-aware extension: rounds soft_cap+1..hard_cap are
+            # admitted only while the unresolved count strictly decreases.
+            logger.info(
+                "pr_review:%d: extension round %d/%d earned (%s -> %d unresolved)",
+                item.issue,
+                round_done + 1,
+                hard_cap,
+                prev_unresolved,
+                unresolved,
+            )
+            return Continue(next_state=REVIEW_WAIT)
+
+        logger.warning(
+            "pr_review:%d: exhausted at round %d (unresolved %s -> %d); applying %s",
+            item.issue,
+            round_done,
+            prev_unresolved,
+            unresolved,
+            STATE_SKIP,
+        )
+        self._write_skip_label(item.issue, ctx)
+        return StageOutcome(Disposition.SKIP, "exhaustion")
+
+    @staticmethod
+    def _write_go_and_arm(pr_number: int, ctx: StageContext) -> None:
+        """Durably mark implementation GO, then arm auto-merge (that order).
+
+        Each write is non-fatal (legacy warn pattern), but arming is SKIPPED
+        when the mark write fails: auto-merge must never be armed on a PR
+        that did not durably receive ``state:implementation-go`` (the
+        pr-policy gate would fail such a PR).
+
+        Args:
+            pr_number: GitHub PR number that earned the clean GO.
+            ctx: Stage context carrying the GitHub accessor.
+
+        """
+        try:
+            ctx.github.mark_pr_implementation_go(pr_number)
+        except Exception as e:
+            logger.warning(
+                "pr_review: failed to mark PR #%d implementation-go (non-fatal, "
+                "auto-merge NOT armed): %s",
+                pr_number,
+                e,
+            )
+            return
+        try:
+            ctx.github.arm_auto_merge(pr_number)
+        except Exception as e:
+            logger.warning(
+                "pr_review: failed to arm auto-merge on PR #%d (non-fatal): %s", pr_number, e
+            )
+
+    @staticmethod
+    def _write_skip_label(issue_number: int, ctx: StageContext) -> None:
+        """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
+
+        Args:
+            issue_number: GitHub issue number.
+            ctx: Stage context carrying the GitHub accessor.
+
+        """
+        try:
+            ctx.github.add_labels(issue_number, [STATE_SKIP])
+        except Exception as e:
+            logger.warning(
+                "pr_review:%d: failed to add label %r (non-fatal): %s",
+                issue_number,
+                STATE_SKIP,
+                e,
+            )

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -156,6 +156,19 @@ class FakeStageGitHub(FakeGitHub):
         """Mirror pr_manager.mark_pr_implementation_go (records mutation)."""
         self._log("mark_pr_implementation_go", pr_number)
 
+    def mark_pr_implementation_no_go(self, pr_number: int) -> None:
+        """Mirror pr_manager.mark_pr_implementation_no_go (records mutation)."""
+        self._log("mark_pr_implementation_no_go", pr_number)
+
+    def post_pr_comment(self, pr_number: int, body: str) -> None:
+        """Mirror the coordinator PR-comment post (delegates to gh_issue_comment).
+
+        PRs share the issue comment channel, so the canonical
+        ``gh_issue_comment`` recorder keeps the mutation_log format and
+        stores the body for content assertions.
+        """
+        self.gh_issue_comment(pr_number, body)
+
     def arm_auto_merge(self, pr_number: int) -> None:
         """Mirror pr_manager.enable_auto_merge_after_implementation_go."""
         self._log("arm_auto_merge", pr_number)

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -39,6 +39,9 @@ class FakeStageGitHub(FakeGitHub):
         merged_pr: int | None = None,
         open_pr: int | None = None,
         has_plan: bool = False,
+        pr_head_branch: str | None = None,
+        pr_impl_state: tuple[bool, bool] = (False, False),
+        unresolved: list[tuple[int, int]] | None = None,
     ) -> None:
         """Initialize the fake with canned read answers.
 
@@ -47,6 +50,13 @@ class FakeStageGitHub(FakeGitHub):
             merged_pr: Canned answer for find_merged_closing_pr.
             open_pr: Canned answer for find_pr_for_issue.
             has_plan: Canned answer for has_existing_plan.
+            pr_head_branch: Canned answer for get_pr_head_branch.
+            pr_impl_state: Canned (has_go, has_no_go) answer for
+                pr_has_implementation_state_label.
+            unresolved: FIFO of (automation, human) answers for
+                count_unresolved_threads — consumed one per call, last
+                entry repeating (lets tests script a decreasing /
+                plateauing thread count for the #1554 progress rule).
 
         """
         super().__init__()
@@ -54,6 +64,9 @@ class FakeStageGitHub(FakeGitHub):
         self._merged_pr = merged_pr
         self._open_pr = open_pr
         self._has_plan = has_plan
+        self._pr_head_branch = pr_head_branch
+        self._pr_impl_state = pr_impl_state
+        self._unresolved: list[tuple[int, int]] = list(unresolved or [(0, 0)])
 
     def _issue_labels(self, issue_number: int) -> set[str]:
         """Return the issue's label set, seeding it on first access."""
@@ -77,6 +90,24 @@ class FakeStageGitHub(FakeGitHub):
     def has_existing_plan(self, issue_number: int) -> bool:
         """Mirror PlannerStateManager.has_existing_plan (plan comment check)."""
         return self._has_plan
+
+    def get_pr_head_branch(self, pr_number: int) -> str | None:
+        """Mirror _review_utils.get_pr_head_branch (canned answer)."""
+        return self._pr_head_branch
+
+    def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+        """Mirror pr_manager.pr_has_implementation_state_label (canned answer)."""
+        return self._pr_impl_state
+
+    def count_unresolved_threads(self, pr_number: int) -> tuple[int, int]:
+        """Mirror _review_phase._count_unresolved_threads_blocking_go (FIFO).
+
+        Consumes one scripted (automation, human) answer per call; the last
+        entry repeats once the FIFO drains.
+        """
+        if len(self._unresolved) > 1:
+            return self._unresolved.pop(0)
+        return self._unresolved[0]
 
     # -- mutator surface used by the stages ----------------------------------
     # Coordinator-neutral names (the pipeline architecture guard forbids
@@ -107,6 +138,28 @@ class FakeStageGitHub(FakeGitHub):
         self._has_plan = True
         self.gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)
 
+    def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
+        """Mirror the coordinator PR-ensure (delegates to gh_pr_create)."""
+        return self.gh_pr_create(branch, title, body)
+
+    def defer_auto_merge(self, pr_number: int) -> None:
+        """Mirror pr_manager.ensure_pr_auto_merge_deferred (records mutation)."""
+        self._log("defer_auto_merge", pr_number)
+
+    def post_review_threads(
+        self, pr_number: int, threads: list[dict[str, Any]], summary: str
+    ) -> list[str]:
+        """Mirror the coordinator thread post (delegates to gh_pr_review_post)."""
+        return self.gh_pr_review_post(pr_number, threads, summary)
+
+    def mark_pr_implementation_go(self, pr_number: int) -> None:
+        """Mirror pr_manager.mark_pr_implementation_go (records mutation)."""
+        self._log("mark_pr_implementation_go", pr_number)
+
+    def arm_auto_merge(self, pr_number: int) -> None:
+        """Mirror pr_manager.enable_auto_merge_after_implementation_go."""
+        self._log("arm_auto_merge", pr_number)
+
 
 if TYPE_CHECKING:
     # mypy-enforced declaration that FakeStageGitHub satisfies the
@@ -128,6 +181,8 @@ class _Config:
     def __init__(self, *, dry_run: bool = False) -> None:
         self.enable_advise = True
         self.enable_learn = True
+        self.enable_follow_up = True
+        self.run_pre_pr_tests = False
         self.force = False
         self.agent = "claude"
         self.dry_run = dry_run

--- a/tests/unit/automation/pipeline/stages/test_reason_routes.py
+++ b/tests/unit/automation/pipeline/stages/test_reason_routes.py
@@ -1,0 +1,104 @@
+"""Lock: every FAIL_BACK reason a stage emits is covered by its ROUTES row (m6).
+
+A FAIL_BACK reason string that ROUTES cannot resolve would fall through to
+the coordinator's default handling (or crash it), silently rewriting the
+architecture doc's routing vocabulary. This test AST-scans each stage module
+for ``StageOutcome(Disposition.FAIL_BACK, "<literal>")`` calls and asserts
+every collected literal is either an explicit ``fail_routes`` key or covered
+by the row's ``"*"`` default. It also pins the expected reason sets so a new
+reason cannot appear without a conscious routing decision.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+from types import ModuleType
+
+import pytest
+
+from hephaestus.automation.pipeline.routing import ROUTES, StageName
+from hephaestus.automation.pipeline.stages import (
+    implementation,
+    plan_review,
+    planning,
+    pr_review,
+)
+
+_STAGE_MODULES: dict[StageName, ModuleType] = {
+    StageName.PLANNING: planning,
+    StageName.PLAN_REVIEW: plan_review,
+    StageName.IMPLEMENTATION: implementation,
+    StageName.PR_REVIEW: pr_review,
+}
+
+#: Reasons each stage is EXPECTED to emit (lock: additions must edit this).
+_EXPECTED_REASONS: dict[StageName, set[str]] = {
+    StageName.PLANNING: set(),
+    StageName.PLAN_REVIEW: {"nogo", "plan_cycles_exhausted"},
+    StageName.IMPLEMENTATION: {"plan_not_go", "already_implementation_go_pr"},
+    # human_blocked is emitted as FINISH_FAIL (terminal), not FAIL_BACK —
+    # its ROUTES row entry (-> FINISHED) documents the same destination.
+    StageName.PR_REVIEW: {"agent_error"},
+}
+
+
+def _fail_back_reason_literals(module: ModuleType) -> set[str]:
+    """Collect the string literals passed to StageOutcome(FAIL_BACK, ...)."""
+    tree = ast.parse(inspect.getsource(module))
+    reasons: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = getattr(func, "id", None) or getattr(func, "attr", None)
+        if name != "StageOutcome":
+            continue
+        args = node.args
+        if not args:
+            continue
+        first = args[0]
+        if not (isinstance(first, ast.Attribute) and first.attr == "FAIL_BACK"):
+            continue
+        note_nodes: list[ast.expr] = list(args[1:2])
+        note_nodes.extend(kw.value for kw in node.keywords if kw.arg == "note")
+        for note in note_nodes:
+            if isinstance(note, ast.Constant) and isinstance(note.value, str):
+                reasons.add(note.value)
+    return reasons
+
+
+@pytest.mark.parametrize("stage_name", list(_STAGE_MODULES), ids=lambda s: s.value)
+def test_every_fail_back_reason_is_routes_covered(stage_name: StageName) -> None:
+    """Each emitted FAIL_BACK reason literal resolves in the stage's row."""
+    module = _STAGE_MODULES[stage_name]
+    reasons = _fail_back_reason_literals(module)
+    fail_routes = ROUTES[stage_name].fail_routes
+    uncovered = {r for r in reasons if r not in fail_routes and "*" not in fail_routes}
+    assert not uncovered, (
+        f"{stage_name.value} emits FAIL_BACK reason(s) {sorted(uncovered)} that "
+        f"ROUTES[{stage_name.value}].fail_routes cannot resolve"
+    )
+
+
+@pytest.mark.parametrize("stage_name", list(_STAGE_MODULES), ids=lambda s: s.value)
+def test_emitted_reason_set_is_pinned(stage_name: StageName) -> None:
+    """The set of emitted reasons matches the lock (no silent vocabulary drift)."""
+    module = _STAGE_MODULES[stage_name]
+    assert _fail_back_reason_literals(module) == _EXPECTED_REASONS[stage_name]
+
+
+def test_scan_is_not_vacuous() -> None:
+    """The AST scan finds real emissions (guards against a silent no-op scan)."""
+    assert "agent_error" in _fail_back_reason_literals(pr_review)
+    assert "plan_not_go" in _fail_back_reason_literals(implementation)
+
+
+def test_named_reasons_route_where_the_doc_says() -> None:
+    """The doc's key cross-stage arrows hold for the emitted vocabulary."""
+    assert ROUTES[StageName.PR_REVIEW].fail_routes["agent_error"] == StageName.IMPLEMENTATION
+    assert ROUTES[StageName.PR_REVIEW].fail_routes["human_blocked"] == StageName.FINISHED
+    assert ROUTES[StageName.IMPLEMENTATION].fail_routes["plan_not_go"] == StageName.PLAN_REVIEW
+    assert (
+        ROUTES[StageName.IMPLEMENTATION].fail_routes["already_implementation_go_pr"] == StageName.CI
+    )

--- a/tests/unit/automation/pipeline/stages/test_stage_cross.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_cross.py
@@ -1,0 +1,157 @@
+"""Cross-stage composition: the agent_error ping-pong terminates (M1).
+
+The failure mode being pinned: pr_review FAIL_BACK(agent_error) routes to
+implementation, whose GATE sees the existing PR and ADVANCEs straight back
+to pr_review. Without the M1 bound no budget ever moves, so the cycle spins
+forever. The bound: pr_review flags its agent_error fail-backs
+(``payload["agent_error_failback"]``), and the implementation GATE consumes
+the ``implement`` budget when it re-adopts the PR on such a re-entry;
+exhaustion terminates with ``agent_error_exhausted``. No labels are ever
+written along the dead cycle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.routing import ROUTES, Disposition, StageName
+from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.implementation import ImplementationStage
+from hephaestus.automation.pipeline.stages.pr_review import PrReviewStage
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+# Sanity anchors: the reasons this composition exercises are ROUTES rows.
+assert ROUTES[StageName.PR_REVIEW].fail_routes["agent_error"] == StageName.IMPLEMENTATION
+assert ROUTES[StageName.IMPLEMENTATION].next == StageName.PR_REVIEW
+
+_LABEL_MUTATIONS = {
+    "gh_issue_add_labels",
+    "gh_issue_remove_labels",
+    "mark_pr_implementation_go",
+    "mark_pr_implementation_no_go",
+    "arm_auto_merge",
+}
+
+
+def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int = 60) -> Any:
+    """Drive one stage pass to its outcome, mirroring the coordinator loop."""
+    entry = stage.on_enter(item, ctx)
+    if entry is not None:
+        return entry
+    for _ in range(max_steps):
+        result = stage.step(item, ctx)
+        if isinstance(result, Continue):
+            item.state = result.next_state
+            continue
+        if isinstance(result, JobRequest):
+            pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+            _handle, job_result = pool.completion_q.get_nowait()
+            stage.on_job_done(item, job_result, ctx)
+            item.state = result.on_done_state
+            continue
+        return result
+    raise AssertionError("stage driver did not terminate")
+
+
+def _drive_pr_review_to_agent_error(
+    pr_stage: PrReviewStage, item: Any, ctx: Any, max_passes: int = 10
+) -> StageOutcome:
+    """Run pr_review passes with a failing reviewer until it fails back.
+
+    Each pass's review job fails (no verdict), so EVAL RETRYs until the
+    consecutive-failure cap, then fails back ``agent_error``. RETRY passes
+    re-enter the stage (coordinator semantics: same stage, fresh pass).
+    """
+    for _ in range(max_passes):
+        item.state = "ENTER"
+        pool = FakeWorkerPool()
+        pool.script(JobResult(ok=False, error="reviewer crashed"))
+        outcome = _drive(pr_stage, item, ctx, pool)
+        assert isinstance(outcome, StageOutcome)
+        if outcome.disposition == Disposition.RETRY:
+            continue
+        return outcome
+    raise AssertionError("pr_review never escalated past RETRY")
+
+
+class TestAgentErrorPingPongTerminates:
+    """pr_review agent_error -> implementation -> pr_review twice: bounded."""
+
+    def test_composition_terminates_at_the_implement_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Two fail-back round trips exhaust implement=2; no label writes.
+
+        Trip 1: pr_review reviewer-error cap -> FAIL_BACK(agent_error) ->
+        implementation GATE re-adopts the PR, consuming implement (1/2) ->
+        ADVANCE back to pr_review (fresh cycle, error streak reset).
+        Trip 2: same fail-back -> GATE consumption hits the budget (2/2) ->
+        FINISH_FAIL(agent_error_exhausted). Nothing ever labels the PR or
+        the issue along the way.
+        """
+        impl_stage = ImplementationStage()
+        pr_stage = PrReviewStage()
+        github = FakeStageGitHub(open_pr=1001, pr_head_branch="1-real-branch")
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="ENTER")
+        item.branch = "1-real-branch"
+
+        # Trip 1: pr_review exhausts its reviewer-error retries.
+        outcome = _drive_pr_review_to_agent_error(pr_stage, item, ctx)
+        assert outcome.disposition == Disposition.FAIL_BACK
+        assert outcome.note == "agent_error"
+        assert item.payload["agent_error_failback"] is True
+
+        # ROUTES: agent_error -> implementation. GATE re-adopts, consuming
+        # the implement budget; the adopted worktree leg runs and ADVANCEs.
+        item.state = "ENTER"
+        outcome = _drive(impl_stage, item, ctx, FakeWorkerPool())
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        assert item.attempts["implement"] == 1  # the bound moved
+
+        # Trip 2: pr_review gets a FRESH error budget (new cycle)...
+        outcome = _drive_pr_review_to_agent_error(pr_stage, item, ctx)
+        assert outcome.disposition == Disposition.FAIL_BACK
+        assert outcome.note == "agent_error"
+
+        # ...and the second GATE re-adoption exhausts the implement budget.
+        item.state = "ENTER"
+        outcome = _drive(impl_stage, item, ctx, FakeWorkerPool())
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FINISH_FAIL
+        assert outcome.note == "agent_error_exhausted"
+        assert item.attempts["implement"] == 2  # terminated AT the budget
+
+        # No label writes anywhere along the dead cycle.
+        label_writes = [name for name, _ in github.mutation_log if name in _LABEL_MUTATIONS]
+        assert label_writes == []
+
+    def test_address_error_path_is_bounded_the_same_way(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The address-failure fail-back consumes the same GATE budget."""
+        impl_stage = ImplementationStage()
+        pr_stage = PrReviewStage()
+        github = FakeStageGitHub(open_pr=1001, pr_head_branch="1-real-branch")
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2, pr=1001, state="EVAL")
+        item.branch = "1-real-branch"
+        item.attempts["implement"] = 1  # one prior trip already consumed
+
+        assert pr_stage.on_enter(item, ctx) is None
+        item.state = "EVAL"
+        item.payload["address_error"] = True
+        outcome = pr_stage.step(item, ctx)
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.note == "agent_error"
+
+        item.state = "ENTER"
+        final = _drive(impl_stage, item, ctx, FakeWorkerPool())
+        assert isinstance(final, StageOutcome)
+        assert final.disposition == Disposition.FINISH_FAIL
+        assert final.note == "agent_error_exhausted"
+        label_writes = [name for name, _ in github.mutation_log if name in _LABEL_MUTATIONS]
+        assert label_writes == []

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -8,6 +8,7 @@ from hephaestus.automation.pipeline.jobs import AgentJob, BuildTestJob, GitJob, 
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.implementation import (
+    GIT_ERROR_RETRY_CAP,
     PRE_PR_TEST_ARGV,
     ImplementationStage,
     build_implementation_prompt,
@@ -165,9 +166,15 @@ class TestGate:
     def test_gate_existing_pr_with_impl_go_routes_to_ci(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """An existing implementation-go PR fails back already_implementation_go_pr."""
+        """An existing implementation-go PR fails back already_implementation_go_pr.
+
+        The ci stage must receive a fully-identified PR: item.pr and the
+        PR's REAL head branch are set BEFORE the fail-back (m7).
+        """
         stage = ImplementationStage()
-        github = FakeStageGitHub(open_pr=1001, pr_impl_state=(True, False))
+        github = FakeStageGitHub(
+            open_pr=1001, pr_impl_state=(True, False), pr_head_branch="1-real-branch"
+        )
         ctx = make_ctx(github=github)
         item = make_work_item(issue=1, state="GATE")
 
@@ -176,11 +183,18 @@ class TestGate:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.FAIL_BACK
         assert result.note == "already_implementation_go_pr"
+        assert item.pr == 1001  # set before the fail-back (m7)
+        assert item.branch == "1-real-branch"
 
-    def test_gate_existing_pr_without_impl_go_advances_to_pr_review(
+    def test_gate_existing_pr_without_impl_go_adopts_via_worktree(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """An existing non-GO PR is adopted (REAL head branch) and ADVANCEs."""
+        """An existing non-GO PR is adopted: real head branch, deferral, worktree.
+
+        Adoption re-ensures the auto-merge deferral [durable] and routes
+        through WORKTREE_WAIT so pr_review's address leg gets an isolated
+        worktree on the ADOPTED branch (never the shared checkout).
+        """
         stage = ImplementationStage()
         github = FakeStageGitHub(open_pr=1001, pr_head_branch="1-some-real-branch")
         ctx = make_ctx(github=github)
@@ -188,11 +202,196 @@ class TestGate:
 
         result = stage.step(item, ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition == Disposition.ADVANCE
+        assert isinstance(result, Continue)
+        assert result.next_state == "WORKTREE_WAIT"
         assert item.pr == 1001
         assert item.branch == "1-some-real-branch"  # never assumed {issue}-auto-impl
         assert item.payload["existing_pr"] is True
+        assert github.mutation_log == [("defer_auto_merge", (1001,))]
+
+    def test_adopted_worktree_job_syncs_without_trunk_reset(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The adopted branch's worktree is synced, never reset to trunk.
+
+        Anti-clobber (_prepare_worktree_for_existing_pr): refresh_base must
+        be False and sync_to_remote True so pushed commits are never
+        discarded.
+        """
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="WORKTREE_WAIT")
+        item.branch = "1-some-real-branch"
+        item.payload["existing_pr"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.kwargs == {
+            "issue": 1,
+            "branch": "1-some-real-branch",
+            "refresh_base": False,
+            "sync_to_remote": True,
+        }
+
+    def test_adopted_clean_worktree_advances_to_pr_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A clean adopted worktree skips the implement leg and ADVANCEs."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="DIRTY_DECISION_WAIT")
+        item.payload["existing_pr"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "ADOPTED"
+
+        item.state = "ADOPTED"
+        outcome = stage.step(item, ctx)
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+
+    def test_adopted_dirty_worktree_salvages_then_advances(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A dirty adopted worktree runs the salvage decision, then ADVANCEs."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="DIRTY_DECISION_WAIT")
+        item.payload["existing_pr"] = True
+        item.payload["worktree_dirty"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.job.descr == "dirty_decision"
+        assert result.on_done_state == "ADOPTED"
+
+
+class TestAgentErrorPingPongBound:
+    """M1: pr_review agent_error fail-backs consume the implement budget."""
+
+    def test_reentry_flag_consumes_budget_at_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A flagged re-entry that adopts a PR consumes attempts["implement"]."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(open_pr=1001, pr_head_branch="1-real")
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+        item.payload["agent_error_failback"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)  # 1 < budget 2: still adopted
+        assert result.next_state == "WORKTREE_WAIT"
+        assert item.attempts["implement"] == 1  # the bound moved
+        assert "agent_error_failback" not in item.payload  # flag consumed
+
+    def test_reentry_exhaustion_finishes_failed_without_labels(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """At the implement budget the re-adoption terminates, labels untouched."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(open_pr=1001, pr_head_branch="1-real")
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+        item.attempts["implement"] = 1  # one fail-back round trip already
+        item.payload["agent_error_failback"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+        assert result.note == "agent_error_exhausted"
+        assert github.mutation_log == []  # no labels, no deferral on the dead path
+
+    def test_flag_never_survives_the_fresh_implement_path(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Without an existing PR the flag is dropped (implement job counts)."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=["state:plan-go"])  # no PR
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=7, state="GATE")
+        item.payload["agent_error_failback"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "WORKTREE_WAIT"
+        assert item.attempts["implement"] == 0  # the implement job itself counts
+        assert "agent_error_failback" not in item.payload
+
+
+class TestGitErrorRetryCap:
+    """M5: transient git RETRYs are bounded by GIT_ERROR_RETRY_CAP."""
+
+    def test_worktree_failures_retry_to_the_cap_then_fail(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Consecutive worktree failures RETRY twice, then finish failed."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+
+        for expected_retry in range(1, GIT_ERROR_RETRY_CAP + 1):
+            stage.on_job_done(item, JobResult(ok=False, error="disk full"), ctx)
+            item.state = "DIRTY_DECISION_WAIT"
+            outcome = stage.step(item, ctx)
+            assert isinstance(outcome, StageOutcome)
+            assert outcome.disposition == Disposition.RETRY
+            assert item.payload["git_error_retries"] == expected_retry
+            item.state = "WORKTREE_WAIT"  # coordinator RETRY re-enters
+
+        stage.on_job_done(item, JobResult(ok=False, error="disk full"), ctx)
+        item.state = "DIRTY_DECISION_WAIT"
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FINISH_FAIL
+        assert outcome.note == "git_error"
+        assert item.attempts["implement"] == 0  # git failures never burn implement
+
+    def test_push_failures_share_the_same_cap(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Consecutive push failures hit the same bounded-RETRY path."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+        item.payload["git_error_retries"] = GIT_ERROR_RETRY_CAP  # at the cap
+
+        stage.on_job_done(item, JobResult(ok=False, error="remote hung up"), ctx)
+        item.state = "PR_CREATE"
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FINISH_FAIL
+        assert outcome.note == "git_error"
+
+    def test_worktree_success_resets_the_counter(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A successful worktree job ends the consecutive-failure streak."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.payload["git_error_retries"] = GIT_ERROR_RETRY_CAP
+
+        stage.on_job_done(item, JobResult(ok=True, value="/tmp/wt"), ctx)
+
+        assert "git_error_retries" not in item.payload
+
+    def test_push_success_resets_the_counter(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A successful commit+push ends the consecutive-failure streak."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+        item.payload["git_error_retries"] = 1
+
+        stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+
+        assert "git_error_retries" not in item.payload
 
 
 class TestWorktreeAndAdvise:

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1,0 +1,771 @@
+"""Tests for the implementation stage (doc section "4. implementation")."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.pipeline.jobs import AgentJob, BuildTestJob, GitJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition
+from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.implementation import (
+    PRE_PR_TEST_ARGV,
+    ImplementationStage,
+    build_implementation_prompt,
+    build_test_fix_prompt,
+)
+from hephaestus.automation.state_labels import STATE_SKIP
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int = 60) -> Any:
+    """Drive a stage through the canonical FakeWorkerPool until an outcome."""
+    entry = stage.on_enter(item, ctx)
+    if entry is not None:
+        return entry
+    for _ in range(max_steps):
+        result = stage.step(item, ctx)
+        if isinstance(result, Continue):
+            item.state = result.next_state
+            continue
+        if isinstance(result, JobRequest):
+            pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+            _handle, job_result = pool.completion_q.get_nowait()
+            assert not job_result.interrupted  # on_job_done contract precondition
+            stage.on_job_done(item, job_result, ctx)
+            item.state = result.on_done_state
+            continue
+        return result
+    raise AssertionError("stage driver did not terminate")
+
+
+class TestComposedPromptBuilders:
+    """Composed top-level builders reuse the base prompts verbatim."""
+
+    def test_implementation_prompt_without_findings_has_no_learnings_block(self) -> None:
+        """No advise findings means no team-KB block is appended.
+
+        The base template is reused verbatim via get_implementation_prompt;
+        its untrusted-content fence nonce is random per call, so structure
+        (not string equality) is asserted.
+        """
+        prompt = build_implementation_prompt(42, branch_name="42-auto-impl")
+
+        assert "42-auto-impl" in prompt  # base template rendered our kwargs
+        assert "#42" in prompt
+        assert "## Prior Learnings from Team Knowledge Base" not in prompt
+
+    def test_implementation_prompt_appends_findings_block(self) -> None:
+        """Advise findings are appended as the team-KB block."""
+        prompt = build_implementation_prompt(42, advise_findings="Use the retry helper.")
+
+        assert "## Prior Learnings from Team Knowledge Base" in prompt
+        assert prompt.endswith("Use the retry helper.")
+
+    def test_test_fix_prompt_carries_failure_output(self) -> None:
+        """The test-fix resume prompt embeds the failing pytest output."""
+        prompt = build_test_fix_prompt(42, 0, "FAILED tests/unit/test_x.py::test_y")
+
+        assert "FAILED tests/unit/test_x.py::test_y" in prompt
+        assert "NOGO" in prompt  # framed as the resume template's NOGO feedback
+
+
+class TestImplementationStageOnEnter:
+    """on_enter is idempotent and performs no durable writes."""
+
+    def test_on_enter_writes_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
+        """on_enter performs no durable writes and always proceeds."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        assert github.mutation_log == []
+
+    def test_on_enter_double_call_is_idempotent(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A literal double on_enter changes nothing the second time."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        snapshot = dict(item.payload)
+        assert stage.on_enter(item, ctx) is None
+
+        assert item.payload == snapshot
+        assert github.mutation_log == []
+
+    def test_on_enter_without_issue_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A work item without an issue number finishes failed on entry."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=None, state="ENTER")
+
+        result = stage.on_enter(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+
+class TestGate:
+    """GATE: existing-PR fast path + the plan-review verdict gate."""
+
+    def test_enter_advances_to_gate(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ENTER advances to GATE."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "GATE"
+
+    def test_gate_plan_not_go_fails_back(self, make_ctx: Any, make_work_item: Any) -> None:
+        """No plan-go label and no PR fails back plan_not_go (-> plan_review)."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()  # no labels, no PR
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "plan_not_go"
+        assert github.mutation_log == []  # gate reads only
+
+    def test_gate_plan_go_proceeds_to_worktree(self, make_ctx: Any, make_work_item: Any) -> None:
+        """state:plan-go admits the item and defaults the branch name."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=["state:plan-go"])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=7, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "WORKTREE_WAIT"
+        assert item.branch == "7-auto-impl"
+
+    def test_gate_is_at_or_past_not_equality(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Already implementation-go (past plan-go) also satisfies the gate."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=["state:implementation-go"])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=7, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "WORKTREE_WAIT"
+
+    def test_gate_existing_pr_with_impl_go_routes_to_ci(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An existing implementation-go PR fails back already_implementation_go_pr."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(open_pr=1001, pr_impl_state=(True, False))
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "already_implementation_go_pr"
+
+    def test_gate_existing_pr_without_impl_go_advances_to_pr_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An existing non-GO PR is adopted (REAL head branch) and ADVANCEs."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(open_pr=1001, pr_head_branch="1-some-real-branch")
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert item.pr == 1001
+        assert item.branch == "1-some-real-branch"  # never assumed {issue}-auto-impl
+        assert item.payload["existing_pr"] is True
+
+
+class TestWorktreeAndAdvise:
+    """WORKTREE_WAIT / DIRTY_DECISION_WAIT / ADVISE_WAIT."""
+
+    def test_worktree_wait_requests_refreshed_worktree(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """WORKTREE_WAIT submits a create_worktree GitJob with refresh_base."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        item.branch = "1-auto-impl"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "create_worktree"
+        assert result.job.kwargs == {"issue": 1, "branch": "1-auto-impl", "refresh_base": True}
+        assert result.on_done_state == "DIRTY_DECISION_WAIT"
+
+    def test_worktree_result_stores_path_and_dirty_state(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A dict worktree result stores path, dirty flag, status, and diff."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        result = JobResult(
+            ok=True, value={"path": "/tmp/wt", "dirty": True, "status": "M x.py", "diff": "+x"}
+        )
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.worktree == "/tmp/wt"
+        assert item.payload["worktree_dirty"] is True
+        assert item.payload["worktree_status"] == "M x.py"
+        assert item.payload["worktree_diff"] == "+x"
+
+    def test_worktree_string_result_stores_path(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A plain string worktree result is the worktree path."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=True, value="/tmp/wt2"), ctx)
+
+        assert item.worktree == "/tmp/wt2"
+
+    def test_worktree_failure_retries_without_burning_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed worktree job RETRYs; the implement budget is untouched."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=False, error="disk full"), ctx)
+        item.state = "DIRTY_DECISION_WAIT"
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert item.attempts["implement"] == 0  # transient: no budget burned
+
+    def test_clean_worktree_skips_dirty_decision(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A clean worktree continues straight to ADVISE_WAIT."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="DIRTY_DECISION_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "ADVISE_WAIT"
+
+    def test_dirty_worktree_requests_decision_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A dirty reused worktree submits the COMMIT/STASH decision job."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="DIRTY_DECISION_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload["worktree_dirty"] = True
+        item.payload["worktree_status"] = "M x.py"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.job.descr == "dirty_decision"
+        assert result.on_done_state == "ADVISE_WAIT"
+        assert result.job.prompt_kwargs["branch_name"] == "1-auto-impl"
+        assert result.job.prompt_kwargs["status_text"] == "M x.py"
+
+    def test_dirty_decision_result_stored(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The COMMIT/STASH decision lands in the payload."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="DIRTY_DECISION_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=True, value="COMMIT"), ctx)
+
+        assert item.payload["dirty_decision"] == "COMMIT"
+
+    def test_advise_disabled_skips_to_implement(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Advise disabled continues straight to IMPLEMENT_WAIT."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=1, state="ADVISE_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "IMPLEMENT_WAIT"
+
+    def test_advise_enabled_requests_advise_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Advise enabled submits the advise job, findings land in payload."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="ADVISE_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.job.descr == "advise"
+        assert result.on_done_state == "IMPLEMENT_WAIT"
+
+        stage.on_job_done(item, JobResult(ok=True, value="prior learnings"), ctx)
+        assert item.payload["advise_findings"] == "prior learnings"
+
+
+class TestImplementBudget:
+    """IMPLEMENT_WAIT budget semantics: agent_error consumes the budget."""
+
+    def test_implement_requests_job_with_advise_findings(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """IMPLEMENT_WAIT submits the composed implement prompt job."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+        item.branch = "1-auto-impl"
+        item.payload["advise_findings"] = "use helpers"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.job.descr == "implement"
+        assert result.job.prompt_builder is build_implementation_prompt
+        assert result.on_done_state == "TEST_WAIT"
+        assert result.job.prompt_kwargs["advise_findings"] == "use helpers"
+        assert result.job.prompt_kwargs["branch_name"] == "1-auto-impl"
+        assert item.attempts["implement"] == 0  # submission burns nothing
+
+    def test_implement_submission_clears_stale_results(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Submission clears any stale error/summary from a prior attempt."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+        item.payload["implement_error"] = True  # stale attempt-1 failure
+        item.payload["implement_summary"] = "old summary"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert "implement_error" not in item.payload
+        assert "implement_summary" not in item.payload
+
+    def test_implement_success_counts_attempt_and_stores_summary(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A completed implement job counts one attempt and stores its output."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=True, value="Implemented the helper"), ctx)
+
+        assert item.attempts["implement"] == 1
+        assert item.payload["implement_summary"] == "Implemented the helper"
+
+    def test_implement_failure_counts_attempt_and_retries(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """agent_error consumes the implement budget then RETRYs (doc rule)."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=False, error="claude crashed"), ctx)
+        item.state = "TEST_WAIT"
+        result = stage.step(item, ctx)
+
+        assert item.attempts["implement"] == 1  # budget consumed
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert result.note == "agent_error"
+
+    def test_implement_budget_exhaustion_finishes_failed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """At the ROUTES implement budget (2) the stage finishes failed."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+        item.attempts["implement"] = 2  # ROUTES budget consumed
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+        assert result.note == "implement_exhausted"
+
+    def test_implement_budget_comes_from_routes(self, make_ctx: Any) -> None:
+        """The implement/test_fix budgets are ROUTES data, not stage constants."""
+        ctx = make_ctx()
+
+        assert ctx.budget("implement") == 2
+        assert ctx.budget("test_fix") == 1
+
+    def test_budget_override_changes_the_cap(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An injected budget_fn (ROUTES stand-in) moves the exhaustion point."""
+        from dataclasses import replace
+
+        stage = ImplementationStage()
+        ctx = replace(make_ctx(), budget_fn=lambda name: 5)
+        item = make_work_item(issue=1, state="IMPLEMENT_WAIT")
+        item.attempts["implement"] = 2  # would exhaust under the default budget
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)  # 2 < 5: still admitted
+
+
+class TestTestsAndFix:
+    """TEST_WAIT / TESTFIX_WAIT: optional pre-PR tests bounded by test_fix."""
+
+    def test_tests_disabled_skip_to_commit_push(self, make_ctx: Any, make_work_item: Any) -> None:
+        """run_pre_pr_tests=False (the default) skips the test leg."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="TEST_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "COMMIT_PUSH_WAIT"
+
+    def test_tests_enabled_request_build_test_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """run_pre_pr_tests=True submits the vetted pytest BuildTestJob."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        ctx.config.run_pre_pr_tests = True
+        item = make_work_item(issue=1, state="TEST_WAIT")
+        item.payload["tests_failed"] = True  # stale prior round result
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, BuildTestJob)
+        assert result.job.argv == PRE_PR_TEST_ARGV
+        assert result.on_done_state == "COMMIT_PUSH_WAIT"
+        assert "tests_failed" not in item.payload  # stale result cleared at submit
+
+    def test_failed_tests_route_to_testfix(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A red test run stores the output and routes to TESTFIX_WAIT."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="TEST_WAIT")
+
+        stage.on_job_done(
+            item, JobResult(ok=False, value=1, stdout_tail="FAILED test_x", error="exit 1"), ctx
+        )
+        item.state = "COMMIT_PUSH_WAIT"
+        result = stage.step(item, ctx)
+
+        assert item.payload["tests_failed"] is True
+        assert "FAILED test_x" in item.payload["test_output"]
+        assert isinstance(result, Continue)
+        assert result.next_state == "TESTFIX_WAIT"
+
+    def test_green_tests_clear_failure_state(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A green run clears any prior failure payload."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="TEST_WAIT")
+        item.payload["tests_failed"] = True
+        item.payload["test_output"] = "old"
+
+        stage.on_job_done(item, JobResult(ok=True, value=0), ctx)
+
+        assert "tests_failed" not in item.payload
+        assert "test_output" not in item.payload
+
+    def test_testfix_requests_resume_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """TESTFIX_WAIT submits the composed test-failure resume job."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="TESTFIX_WAIT")
+        item.payload["test_output"] = "FAILED test_y"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.job.descr == "test_fix"
+        assert result.job.prompt_builder is build_test_fix_prompt
+        assert result.job.prompt_kwargs["test_output"] == "FAILED test_y"
+        assert result.on_done_state == "TEST_WAIT"
+
+        stage.on_job_done(item, JobResult(ok=True, value="fixed"), ctx)
+        assert item.attempts["test_fix"] == 1
+
+    def test_testfix_budget_exhaustion_finishes_failed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """At the test_fix budget (1) still-red tests finish failed."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="TESTFIX_WAIT")
+        item.attempts["test_fix"] = 1
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+        assert result.note == "tests_red"
+
+
+class TestCommitPushAndPrCreate:
+    """COMMIT_PUSH_WAIT / PR_CREATE: durable journal entry + deferral order."""
+
+    def test_commit_push_requests_git_job(self, make_ctx: Any, make_work_item: Any) -> None:
+        """COMMIT_PUSH_WAIT submits the commit_push GitJob."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+        item.branch = "1-auto-impl"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "commit_push"
+        assert result.on_done_state == "PR_CREATE"
+
+    def test_pr_create_journals_pr_then_defers_auto_merge(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """PR creation (the journal entry) precedes the auto-merge deferral.
+
+        Durable-order oracle: the mutation_log must show gh_pr_create BEFORE
+        defer_auto_merge (legacy runner order :623), both before ADVANCE.
+        """
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=9, state="PR_CREATE")
+        item.branch = "9-auto-impl"
+        item.payload["issue_title"] = "Add the widget"
+        item.payload["implement_summary"] = "Added the widget."
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert item.pr == 1001
+        assert [name for name, _ in github.mutation_log] == ["gh_pr_create", "defer_auto_merge"]
+        assert github.mutation_log[1] == ("defer_auto_merge", (1001,))
+        # The PR body is a get_pr_description body carrying the closing line.
+        assert "Closes #9" in github.prs[1001]["body"]
+        assert github.prs[1001]["title"] == "Add the widget"
+
+    def test_pr_create_is_idempotent_for_existing_pr(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An item that already has a PR only re-ensures the deferral."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=9, pr=777, state="PR_CREATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert github.mutation_log == [("defer_auto_merge", (777,))]
+
+    def test_no_commits_applies_skip_durably_before_skip(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The legacy "no commits vs base" error maps to a durable state:skip."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=9, state="COMMIT_PUSH_WAIT")
+
+        stage.on_job_done(
+            item, JobResult(ok=False, error="RuntimeError: no commits between main and head"), ctx
+        )
+        item.state = "PR_CREATE"
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.SKIP
+        assert github.mutation_log == [("gh_issue_add_labels", (9, (STATE_SKIP,)))]
+
+    def test_skip_label_write_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failing state:skip write never turns the SKIP into a crash."""
+
+        class AddFailsGitHub(FakeStageGitHub):
+            def add_labels(self, issue_number: int, labels: list[str]) -> None:
+                raise RuntimeError("gh add failed")
+
+        stage = ImplementationStage()
+        ctx = make_ctx(github=AddFailsGitHub())
+        item = make_work_item(issue=9, state="PR_CREATE")
+        item.payload["no_commits"] = True
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.SKIP
+
+    def test_push_failure_retries_without_pr(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A non-"no commits" push failure RETRYs with no PR created."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=9, state="COMMIT_PUSH_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=False, error="remote hung up"), ctx)
+        item.state = "PR_CREATE"
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert github.mutation_log == []
+
+    def test_unknown_state_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An unknown state finishes failed instead of looping silently."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="BOGUS")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+    def test_no_issue_number_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Step without an issue number finishes failed."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=None, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+
+class TestFullWalks:
+    """Full pool-driven walks of the whole stage (canonical FakeWorkerPool)."""
+
+    def test_happy_path_walk(self, make_ctx: Any, make_work_item: Any) -> None:
+        """GATE -> worktree -> advise -> implement -> tests -> push -> PR.
+
+        Asserts the exact job order and the durable journal order
+        (gh_pr_create before defer_auto_merge, both before ADVANCE).
+        """
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=["state:plan-go"])
+        ctx = make_ctx(github=github)
+        ctx.config.run_pre_pr_tests = True
+        item = make_work_item(issue=5, state="ENTER")
+        item.payload["issue_title"] = "Add the widget"
+
+        pool = FakeWorkerPool()
+        pool.script(
+            JobResult(ok=True, value={"path": "/tmp/wt5", "dirty": False}),  # worktree
+            JobResult(ok=True, value="prior learnings"),  # advise
+            JobResult(ok=True, value="Implemented the widget."),  # implement
+            JobResult(ok=True, value=0),  # pre-PR tests green
+            JobResult(ok=True, value=True),  # commit_push
+        )
+
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        assert [h.job.descr for h in pool.submitted] == [
+            "create_worktree",
+            "advise",
+            "implement",
+            "pre_pr_tests",
+            "commit_push",
+        ]
+        assert item.worktree == "/tmp/wt5"
+        assert item.attempts["implement"] == 1
+        assert item.pr == 1001
+        assert [name for name, _ in github.mutation_log] == ["gh_pr_create", "defer_auto_merge"]
+
+    def test_walk_with_red_tests_and_one_fix(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A red test run earns exactly one test_fix attempt, then converges."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=["state:plan-go"])
+        ctx = make_ctx(github=github)
+        ctx.config.enable_advise = False
+        ctx.config.run_pre_pr_tests = True
+        item = make_work_item(issue=6, state="ENTER")
+
+        pool = FakeWorkerPool()
+        pool.script(
+            JobResult(ok=True, value={"path": "/tmp/wt6", "dirty": False}),  # worktree
+            JobResult(ok=True, value="done"),  # implement
+            JobResult(ok=False, value=1, stdout_tail="FAILED test_z"),  # tests red
+            JobResult(ok=True, value="fixed"),  # test_fix resume
+            JobResult(ok=True, value=0),  # tests green
+            JobResult(ok=True, value=True),  # commit_push
+        )
+
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        assert [h.job.descr for h in pool.submitted] == [
+            "create_worktree",
+            "implement",
+            "pre_pr_tests",
+            "test_fix",
+            "pre_pr_tests",
+            "commit_push",
+        ]
+        assert item.attempts["test_fix"] == 1
+
+    def test_walk_agent_error_retry_then_exhaustion(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Two agent_error implement runs consume the budget; the third entry fails.
+
+        Doc rule: agent_error -> RETRY consumes the implement budget (2);
+        exhaustion -> finished(fail).
+        """
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=["state:plan-go"])
+        ctx = make_ctx(github=github)
+        ctx.config.enable_advise = False
+        item = make_work_item(issue=8, state="ENTER")
+
+        for expected_attempts in (1, 2):
+            pool = FakeWorkerPool()
+            pool.script(
+                JobResult(ok=True, value={"path": "/tmp/wt8"}),  # worktree
+                JobResult(ok=False, error="529 overload"),  # implement crash
+            )
+            outcome = _drive(stage, item, ctx, pool)
+            assert isinstance(outcome, StageOutcome)
+            assert outcome.disposition == Disposition.RETRY
+            assert outcome.note == "agent_error"
+            assert item.attempts["implement"] == expected_attempts
+            item.state = "ENTER"  # coordinator RETRY re-enters the stage
+
+        pool = FakeWorkerPool()
+        pool.script(JobResult(ok=True, value={"path": "/tmp/wt8"}))  # worktree
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FINISH_FAIL
+        assert outcome.note == "implement_exhausted"
+        assert github.mutation_log == []  # exhaustion here owns no labels

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
-from hephaestus.automation.pipeline.jobs import JobResult
+from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.plan_review import (
@@ -122,6 +122,7 @@ class TestPlanReviewStageStep:
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "EVAL"
         assert result.job.descr == "review"
         assert result.job.parse is parse_review_verdict  # verdict parsed in-worker
@@ -141,6 +142,7 @@ class TestPlanReviewStageStep:
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.job.prompt_kwargs["iteration"] == 1
         assert result.job.prompt_kwargs["prior_review"] == "fix the tests section"
         assert item.attempts["plan_review_iter"] == 0  # still EVAL's job to count
@@ -314,6 +316,7 @@ class TestPlanReviewStageStep:
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "REVIEW_WAIT"  # loop back to review
         assert result.job.descr == "amend"
         assert result.job.prompt_builder is build_amend_prompt
@@ -334,6 +337,7 @@ class TestPlanReviewStageStep:
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "FINISH"
         assert result.job.descr == "learn"
         assert result.job.prompt_kwargs == {"context": "# My Plan\n..."}
@@ -572,6 +576,7 @@ class TestCycleRelativeBudget:
             while True:
                 request = stage.step(item, ctx)
                 assert isinstance(request, JobRequest)
+                assert isinstance(request.job, AgentJob)  # narrow the job union
                 prompt_iterations.append(request.job.prompt_kwargs["iteration"])
                 stage.on_job_done(item, JobResult(ok=True, value=_verdict("NOGO")), ctx)
                 item.state = "EVAL"

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -234,6 +234,7 @@ class TestPlanningStageStep:
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "PLAN_WAIT"
         assert result.job.descr == "advise"
         assert result.job.prompt_kwargs["issue_number"] == 3
@@ -248,6 +249,7 @@ class TestPlanningStageStep:
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
         assert result.on_done_state == "VERIFY"
         assert result.job.descr == "plan"
         assert result.job.prompt_builder is build_plan_prompt

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1,0 +1,897 @@
+"""Tests for the PR-review stage (doc section "5. pr_review")."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
+from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition
+from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.pr_review import (
+    REVIEW_ERROR_RETRY_CAP,
+    PrReviewStage,
+)
+from hephaestus.automation.prompts.address_review import get_address_review_prompt
+from hephaestus.automation.prompts.implementation import get_impl_resume_feedback_prompt
+from hephaestus.automation.state_labels import STATE_SKIP
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _verdict(kind: str) -> ReviewVerdict:
+    """Build a ReviewVerdict of the given kind for EVAL tests."""
+    return ReviewVerdict(grade=None, verdict=kind, raw=f"review text ({kind})")
+
+
+def _drive(stage: Any, item: Any, ctx: Any, pool: FakeWorkerPool, max_steps: int = 80) -> Any:
+    """Drive a stage through the canonical FakeWorkerPool until an outcome."""
+    entry = stage.on_enter(item, ctx)
+    if entry is not None:
+        return entry
+    for _ in range(max_steps):
+        result = stage.step(item, ctx)
+        if isinstance(result, Continue):
+            item.state = result.next_state
+            continue
+        if isinstance(result, JobRequest):
+            pool.submit(result.job, result.on_done_state)  # type: ignore[arg-type]
+            _handle, job_result = pool.completion_q.get_nowait()
+            assert not job_result.interrupted  # on_job_done contract precondition
+            stage.on_job_done(item, job_result, ctx)
+            item.state = result.on_done_state
+            continue
+        return result
+    raise AssertionError("stage driver did not terminate")
+
+
+class TestPrReviewStageOnEnter:
+    """on_enter cycle-relative counter reset (attempts are per-lifetime)."""
+
+    def test_on_enter_writes_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
+        """on_enter performs no durable writes and always proceeds."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        assert github.mutation_log == []
+
+    def test_on_enter_resets_round_for_new_implementation_pass(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A fresh implement pass (new cycle key) resets the round counter."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="ENTER")
+        item.attempts["implement"] = 2  # agent_error fail-back re-implemented
+        item.payload["pr_review_cycle"] = 1
+        item.payload["pr_review_round"] = 3  # cycle 1 exhausted its rounds
+        item.payload["prev_unresolved"] = 4
+
+        stage.on_enter(item, ctx)
+
+        assert item.payload["pr_review_cycle"] == 2
+        assert item.payload["pr_review_round"] == 0  # cycle 2 gets a full budget
+        assert "prev_unresolved" not in item.payload  # progress trail reset
+
+    def test_on_enter_same_cycle_keeps_round(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Same-cycle re-entry (e.g. the ERROR-path RETRY) keeps the round count."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=2, pr=1001, state="ENTER")
+        item.payload["pr_review_cycle"] = 0
+        item.payload["pr_review_round"] = 2
+
+        stage.on_enter(item, ctx)
+
+        assert item.payload["pr_review_round"] == 2  # progress preserved
+
+    def test_on_enter_double_call_is_idempotent(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A literal double on_enter changes nothing the second time."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=3, pr=1001, state="ENTER")
+
+        assert stage.on_enter(item, ctx) is None
+        snapshot = dict(item.payload)
+        assert stage.on_enter(item, ctx) is None
+
+        assert item.payload == snapshot
+        assert github.mutation_log == []
+
+
+class TestPrReviewStageStep:
+    """step state machine: ENTER -> REVIEW -> VALIDATE -> POST -> ... -> EVAL."""
+
+    def test_no_issue_number_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Step without an issue number finishes failed."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=None, pr=1001, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+    def test_no_pr_fails_back_to_implementation(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Without a PR there is nothing to review: fail back agent_error."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=None, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "agent_error"
+
+    def test_enter_advances_to_review(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ENTER advances to REVIEW_WAIT."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="ENTER")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"
+
+    def test_review_wait_requests_review_with_in_worker_parse(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """REVIEW_WAIT submits the inline review job; verdict parsed in-worker.
+
+        A submission is NOT an iteration: counters advance only in EVAL and
+        only for real verdicts (#1554/#1794).
+        """
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.on_done_state == "VALIDATE_WAIT"
+        assert result.job.descr == "review"
+        assert result.job.parse is parse_review_verdict  # verdict parsed in-worker
+        assert result.job.prompt_kwargs["pr_number"] == 1001
+        assert item.attempts["pr_review_iter"] == 0  # submission burns nothing
+
+    def test_review_wait_clears_stale_round_payload(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Submission clears ALL stale round results (M3 pattern).
+
+        A failed later round can never replay an earlier round's verdict,
+        threads, or address output in EVAL.
+        """
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=4, pr=1001, state="REVIEW_WAIT")
+        item.payload.update(
+            {
+                "review_verdict": _verdict("NOGO"),
+                "review_text": "stale",
+                "review_threads": [{"id": "t1"}],
+                "posted_thread_ids": ["t1"],
+                "validation_result": "stale",
+                "difficulty_tiers": "stale",
+                "address_error": True,
+                "address_output": "stale",
+            }
+        )
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        for key in (
+            "review_verdict",
+            "review_text",
+            "review_threads",
+            "posted_thread_ids",
+            "validation_result",
+            "difficulty_tiers",
+            "address_error",
+            "address_output",
+        ):
+            assert key not in item.payload
+
+    def test_validate_wait_requests_validation_job(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """VALIDATE_WAIT submits the prior-comment validation job."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.on_done_state == "POST"
+        assert result.job.descr == "validate"
+
+    def test_validate_wait_skips_to_eval_when_review_failed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed review job skips the dead round straight to EVAL."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+        item.payload["review_failed"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "EVAL"
+        assert "review_failed" not in item.payload
+
+    def test_post_posts_threads_durably_and_routes_to_difficulty(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """POST durably posts surviving threads, then classifies difficulty."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(2, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="POST")
+        item.payload["review_threads"] = [{"id": "t1", "body": "fix"}, {"id": "t2", "body": "doc"}]
+        item.payload["review_text"] = "Verdict: NOGO"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DIFFICULTY_WAIT"
+        assert github.mutation_log == [("gh_pr_review_post", (1001, "COMMENT"))]
+        assert item.payload["posted_thread_ids"] == ["thread-1001-0", "thread-1001-1"]
+        assert item.payload["unresolved_auto"] == 2
+
+    def test_post_with_zero_open_automation_threads_skips_to_eval(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """No open automation threads: nothing to address, go straight to EVAL."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="POST")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "EVAL"
+        assert github.mutation_log == []  # no threads -> no post
+
+    def test_difficulty_wait_requests_classification(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """DIFFICULTY_WAIT submits the comment-difficulty job."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="DIFFICULTY_WAIT")
+        item.payload["review_threads"] = [{"id": "t1"}]
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.job.descr == "difficulty"
+        assert result.on_done_state == "ADDRESS_WAIT"
+        assert '"t1"' in result.job.prompt_kwargs["comments_json"]
+
+    def test_address_fresh_pr_resumes_implementer(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Fresh-PR path resumes the implementer with the review feedback."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="ADDRESS_WAIT")
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["review_text"] = "fix the tests"
+        item.payload["pr_review_round"] = 1
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.job.descr == "address"
+        assert result.on_done_state == "PUSH_WAIT"
+        assert result.job.prompt_builder is get_impl_resume_feedback_prompt
+        assert result.job.prompt_kwargs == {
+            "issue_number": 1,
+            "prev_iteration": 1,
+            "verdict": "NOGO",
+            "review_text": "fix the tests",
+        }
+
+    def test_address_existing_pr_runs_address_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Existing-PR path runs the address-review session on the threads."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="ADDRESS_WAIT")
+        item.payload["existing_pr"] = True
+        item.payload["review_threads"] = [{"id": "t1"}]
+        item.payload["difficulty_tiers"] = "@ x.py Line 1 - simple - fix"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)  # narrow the job union
+        assert result.job.descr == "address"
+        assert result.job.prompt_builder is get_address_review_prompt
+        assert result.job.prompt_kwargs["pr_number"] == 1001
+        assert result.job.prompt_kwargs["todo_block"] == "@ x.py Line 1 - simple - fix"
+
+    def test_push_wait_requests_commit_push(self, make_ctx: Any, make_work_item: Any) -> None:
+        """PUSH_WAIT submits the commit+push job for the addressing changes."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
+        item.branch = "1-auto-impl"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "commit_push"
+        assert result.on_done_state == "EVAL"
+
+    def test_followup_wait_requests_follow_up(self, make_ctx: Any, make_work_item: Any) -> None:
+        """FOLLOWUP_WAIT submits the follow-up job, then FINISH advances."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="FOLLOWUP_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert result.job.descr == "follow_up"
+        assert result.on_done_state == "FINISH"
+
+        item.state = "FINISH"
+        outcome = stage.step(item, ctx)
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+
+    def test_unknown_state_fails(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An unknown state finishes failed instead of looping silently."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="BOGUS")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+
+
+class TestEvalVerdicts:
+    """EVAL: re-housed _evaluate_go_verdict semantics + the budget gate."""
+
+    def test_go_with_zero_threads_marks_arms_and_advances(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Clean GO durably marks implementation-go THEN arms auto-merge.
+
+        Durable-order oracle: mark before arm in the mutation_log, both
+        recorded before the advancing outcome exists.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 0)])
+        ctx = make_ctx(github=github)
+        ctx.config.enable_follow_up = False
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert github.mutation_log == [
+            ("mark_pr_implementation_go", (1001,)),
+            ("arm_auto_merge", (1001,)),
+        ]
+        assert item.attempts["pr_review_iter"] == 1  # real verdict counted
+
+    def test_go_with_follow_up_enabled_continues_to_followup(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """GO with follow-up enabled writes labels then runs the follow-up step."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "FOLLOWUP_WAIT"
+        assert github.mutation_log[0] == ("mark_pr_implementation_go", (1001,))
+
+    def test_failed_mark_write_skips_arming(self, make_ctx: Any, make_work_item: Any) -> None:
+        """If the implementation-go mark fails, auto-merge is NOT armed.
+
+        Auto-merge armed on a PR without state:implementation-go would fail
+        the pr-policy gate — the pair is ordered and the arm is gated on
+        the mark's success (non-fatal beyond that).
+        """
+
+        class MarkFailsGitHub(FakeStageGitHub):
+            def mark_pr_implementation_go(self, pr_number: int) -> None:
+                raise RuntimeError("gh label failed")
+
+        stage = PrReviewStage()
+        github = MarkFailsGitHub(unresolved=[(0, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, Continue)  # still proceeds (non-fatal)
+        assert ("arm_auto_merge", (1001,)) not in github.mutation_log
+
+    def test_failed_arm_write_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failing arm_auto_merge write is swallowed; the GO still proceeds."""
+
+        class ArmFailsGitHub(FakeStageGitHub):
+            def arm_auto_merge(self, pr_number: int) -> None:
+                raise RuntimeError("gh merge --auto failed")
+
+        stage = PrReviewStage()
+        github = ArmFailsGitHub(unresolved=[(0, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, Continue)
+        assert github.mutation_log == [("mark_pr_implementation_go", (1001,))]
+
+    def test_go_with_human_thread_is_human_blocked_and_unlabeled(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """GO + open human thread -> HUMAN_BLOCKED: finish failed, NO labels.
+
+        The PR stays unlabeled (neither implementation-go nor no-go nor
+        skip): a human must act, automation may not resolve their thread.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 1)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+        assert result.note == "human_blocked"
+        assert github.mutation_log == []  # PR left unlabeled
+
+    def test_go_with_automation_thread_downgrades_and_loops(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """GO + open automation thread is downgraded to NOGO: re-review."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(2, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"
+        assert github.mutation_log == []  # no GO labels while threads open
+        assert item.payload["prev_unresolved"] == 2
+
+    def test_nogo_within_soft_budget_loops_to_re_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """NOGO within the soft budget loops back for a fresh review round."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"
+        assert item.payload["pr_review_round"] == 1
+        assert item.attempts["pr_review_iter"] == 1  # lifetime audit trail
+
+    def test_ambiguous_counts_as_a_real_not_go_round(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """AMBIGUOUS is a real verdict: it burns a round and loops."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("AMBIGUOUS")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert item.attempts["pr_review_iter"] == 1
+
+    def test_address_error_fails_back_without_burning_a_round(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A hard-failed address/push leg fails back agent_error, no round burned."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["address_error"] = True
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "agent_error"
+        assert item.attempts["pr_review_iter"] == 0  # no round burned
+        assert github.mutation_log == []
+
+
+class TestEvalErrorNoBurn:
+    """The #1554 doctrine: ERROR burns no budget, stamps no labels."""
+
+    def test_error_verdict_retries_without_burning(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """ERROR retries with zero label writes and burns no round."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=8, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("ERROR")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert github.mutation_log == []  # labels untouched on ERROR
+        assert item.attempts["pr_review_iter"] == 0  # no round burned
+        assert item.payload.get("pr_review_round", 0) == 0
+        assert item.payload["review_error_retries"] == 1  # bounded retry loop
+
+    def test_missing_verdict_retries(self, make_ctx: Any, make_work_item: Any) -> None:
+        """EVAL without a stored verdict retries instead of guessing."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=9, pr=1001, state="EVAL")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.RETRY
+        assert item.attempts["pr_review_iter"] == 0
+        assert item.payload["review_error_retries"] == 1
+
+    def test_error_retry_cap_fails_back_to_implementation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Consecutive reviewer failures beyond the cap fail back agent_error."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=10, pr=1001, state="EVAL")
+
+        for expected_retry in range(1, REVIEW_ERROR_RETRY_CAP + 1):
+            item.payload["review_verdict"] = _verdict("ERROR")
+            outcome = stage.step(item, ctx)
+            assert isinstance(outcome, StageOutcome)
+            assert outcome.disposition == Disposition.RETRY
+            assert item.payload["review_error_retries"] == expected_retry
+
+        item.payload["review_verdict"] = _verdict("ERROR")
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FAIL_BACK
+        assert outcome.note == "agent_error"
+        assert github.mutation_log == []  # labels stay untouched
+        assert item.attempts["pr_review_iter"] == 0  # nothing ever burned
+
+    def test_real_verdict_resets_error_retries(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Any real verdict resets the consecutive-failure counter."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(1, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=11, pr=1001, state="EVAL")
+        item.payload["review_error_retries"] = REVIEW_ERROR_RETRY_CAP  # one from the cap
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert item.payload["review_error_retries"] == 0
+
+
+class TestProgressAwareBudget:
+    """Soft cap 3; rounds 4-6 admitted ONLY while threads strictly decrease."""
+
+    def _eval_round(self, stage: Any, item: Any, ctx: Any, verdict: str = "NOGO") -> Any:
+        """Run one EVAL with a fresh verdict (state machine loop shortcut)."""
+        item.payload["review_verdict"] = _verdict(verdict)
+        item.state = "EVAL"
+        return stage.step(item, ctx)
+
+    def test_non_decreasing_at_round_four_exhausts(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Plateaued threads at the soft cap: round 4 is refused -> state:skip.
+
+        Durable-order oracle: the state:skip write is in the mutation_log
+        before the SKIP outcome exists.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 0)])  # plateau at 3 threads
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=12, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # round 1
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # round 2
+        outcome = self._eval_round(stage, item, ctx)  # round 3: no progress
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.SKIP
+        assert outcome.note == "exhaustion"
+        assert github.mutation_log == [("gh_issue_add_labels", (12, (STATE_SKIP,)))]
+        assert item.payload["pr_review_round"] == 3
+
+    def test_decreasing_threads_earn_extension_rounds(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Strictly decreasing threads admit rounds 4+ until the plateau."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(5, 0), (3, 0), (2, 0), (1, 0), (1, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=13, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r1: 5 open
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r2: 3 open
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r3: 2<3 -> r4 earned
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r4: 1<2 -> r5 earned
+        outcome = self._eval_round(stage, item, ctx)  # r5: 1==1 plateau
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.SKIP
+        assert item.payload["pr_review_round"] == 5
+        assert item.attempts["pr_review_iter"] == 5  # lifetime audit trail
+        assert item.attempts["pr_review_hard"] == 2  # extension rounds 4 and 5
+        assert github.mutation_log[-1] == ("gh_issue_add_labels", (13, (STATE_SKIP,)))
+
+    def test_hard_cap_stops_even_with_progress(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Round 6 is the absolute ceiling even while threads keep decreasing."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(9, 0), (8, 0), (7, 0), (6, 0), (5, 0), (4, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=14, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        outcomes = [self._eval_round(stage, item, ctx) for _ in range(6)]
+
+        assert all(isinstance(o, Continue) for o in outcomes[:5])  # rounds 1-5 loop
+        final = outcomes[5]
+        assert isinstance(final, StageOutcome)
+        assert final.disposition == Disposition.SKIP  # 6 == hard cap: stop
+        assert item.payload["pr_review_round"] == 6
+
+    def test_budgets_come_from_routes(self, make_ctx: Any) -> None:
+        """The soft/hard budgets are ROUTES data, not stage constants."""
+        ctx = make_ctx()
+
+        assert ctx.budget("pr_review_iter") == 3
+        assert ctx.budget("pr_review_hard") == 6
+
+    def test_budget_override_changes_the_cap(self, make_ctx: Any, make_work_item: Any) -> None:
+        """An injected budget_fn (ROUTES stand-in) moves the exhaustion point."""
+        from dataclasses import replace
+
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 0)])
+        ctx = replace(make_ctx(github=github), budget_fn=lambda name: 1)
+        item = make_work_item(issue=15, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        outcome = self._eval_round(stage, item, ctx)  # round 1 == soft cap 1
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.SKIP  # cap moved by ROUTES data
+
+    def test_skip_label_write_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failing state:skip write never turns the SKIP into a crash."""
+
+        class AddFailsGitHub(FakeStageGitHub):
+            def add_labels(self, issue_number: int, labels: list[str]) -> None:
+                raise RuntimeError("gh add failed")
+
+        stage = PrReviewStage()
+        ctx = make_ctx(github=AddFailsGitHub(unresolved=[(3, 0)]))
+        item = make_work_item(issue=16, pr=1001, state="EVAL")
+        item.payload["pr_review_round"] = 5  # this round is 6/6
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.SKIP
+
+
+class TestPrReviewOnJobDone:
+    """on_job_done payload handling (state still at the WAIT state)."""
+
+    def test_review_verdict_and_text_stored(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The parsed verdict and its raw review text land on the payload."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+        verdict = _verdict("GO")
+
+        stage.on_job_done(item, JobResult(ok=True, value=verdict), ctx)
+
+        assert item.payload["review_verdict"] == verdict
+        assert item.payload["review_text"] == verdict.raw
+
+    def test_failed_review_job_flags_the_dead_round(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed review job stores no verdict and flags review_failed."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=False, error="reviewer crashed"), ctx)
+
+        assert "review_verdict" not in item.payload
+        assert item.payload["review_failed"] is True
+
+    def test_validation_and_difficulty_results_stored(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Validation and difficulty outputs land on the payload."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="VALIDATE_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=True, value='{"unaddressed": []}'), ctx)
+        assert item.payload["validation_result"] == '{"unaddressed": []}'
+
+        item.state = "DIFFICULTY_WAIT"
+        stage.on_job_done(item, JobResult(ok=True, value="tiers"), ctx)
+        assert item.payload["difficulty_tiers"] == "tiers"
+
+    def test_failed_address_or_push_flags_address_error(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Failed address/push jobs flag address_error for EVAL's fail-back."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="ADDRESS_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=False, error="agent crashed"), ctx)
+        assert item.payload.pop("address_error") is True
+
+        item.state = "PUSH_WAIT"
+        stage.on_job_done(item, JobResult(ok=False, error="push rejected"), ctx)
+        assert item.payload["address_error"] is True
+
+    def test_followup_result_is_intentionally_silent(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """FOLLOWUP output is a side effect: no payload key is written."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="FOLLOWUP_WAIT")
+        snapshot = dict(item.payload)
+
+        stage.on_job_done(item, JobResult(ok=True, value="filed follow-ups"), ctx)
+
+        assert item.payload == snapshot
+
+
+class TestFullWalks:
+    """Full pool-driven walks of the whole stage (canonical FakeWorkerPool)."""
+
+    def test_nogo_round_then_clean_go_walk(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ENTER -> NOGO round (address leg) -> GO round -> mark+arm -> follow-up.
+
+        Round 1: review NOGO, 2 automation threads open -> difficulty ->
+        address -> push -> EVAL loops. Round 2: review GO, all threads
+        resolved -> mark + arm [durable] -> follow-up -> ADVANCE.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(2, 0), (1, 0), (0, 0), (0, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=21, pr=1001, state="ENTER")
+        item.branch = "21-auto-impl"
+
+        pool = FakeWorkerPool()
+        pool.script(
+            JobResult(ok=True, value=_verdict("NOGO")),  # review round 1
+            JobResult(ok=True, value='{"unaddressed": []}'),  # validate round 1
+            JobResult(ok=True, value="tier list"),  # difficulty
+            JobResult(ok=True, value="addressed"),  # address
+            JobResult(ok=True, value=True),  # push
+            JobResult(ok=True, value=_verdict("GO")),  # review round 2
+            JobResult(ok=True, value='{"unaddressed": []}'),  # validate round 2
+            JobResult(ok=True, value="follow-ups filed"),  # follow-up
+        )
+
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.ADVANCE
+        assert [h.job.descr for h in pool.submitted] == [
+            "review",
+            "validate",
+            "difficulty",
+            "address",
+            "push_fixes",
+            "review",
+            "validate",
+            "follow_up",
+        ]
+        assert item.attempts["pr_review_iter"] == 2  # two real rounds
+        assert github.mutation_log == [
+            ("mark_pr_implementation_go", (1001,)),
+            ("arm_auto_merge", (1001,)),
+        ]
+
+    def test_exhaustion_walk_applies_skip(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Three plateaued NOGO rounds exhaust the soft budget -> state:skip."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 0)])  # plateau forever
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=22, pr=1001, state="ENTER")
+
+        pool = FakeWorkerPool()
+        round_jobs = [
+            JobResult(ok=True, value=_verdict("NOGO")),  # review
+            JobResult(ok=True, value='{"unaddressed": []}'),  # validate
+            JobResult(ok=True, value="tier list"),  # difficulty
+            JobResult(ok=True, value="addressed"),  # address
+            JobResult(ok=True, value=True),  # push
+        ]
+        pool.script(*(round_jobs * 3))
+
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.SKIP
+        assert outcome.note == "exhaustion"
+        assert item.attempts["pr_review_iter"] == 3
+        assert github.mutation_log[-1] == ("gh_issue_add_labels", (22, (STATE_SKIP,)))
+
+    def test_reviewer_error_walk_burns_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failed review job walks straight to EVAL's ERROR path: RETRY.
+
+        The dead round submits no validate/difficulty/address jobs and burns
+        no budget (#1554 doctrine).
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=23, pr=1001, state="ENTER")
+
+        pool = FakeWorkerPool()
+        pool.script(JobResult(ok=False, error="reviewer crashed"))  # review job fails
+
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert [h.job.descr for h in pool.submitted] == ["review"]  # dead round short-circuits
+        assert item.attempts["pr_review_iter"] == 0
+        assert github.mutation_log == []

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -11,6 +11,7 @@ from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOut
 from hephaestus.automation.pipeline.stages.pr_review import (
     REVIEW_ERROR_RETRY_CAP,
     PrReviewStage,
+    _surviving_threads,
 )
 from hephaestus.automation.prompts.address_review import get_address_review_prompt
 from hephaestus.automation.prompts.implementation import get_impl_resume_feedback_prompt
@@ -286,6 +287,7 @@ class TestPrReviewStageStep:
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="ADDRESS_WAIT")
+        item.worktree = "/tmp/wt"
         item.payload["review_verdict"] = _verdict("NOGO")
         item.payload["review_text"] = "fix the tests"
         item.payload["pr_review_round"] = 1
@@ -311,6 +313,7 @@ class TestPrReviewStageStep:
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="ADDRESS_WAIT")
+        item.worktree = "/tmp/wt"
         item.payload["existing_pr"] = True
         item.payload["review_threads"] = [{"id": "t1"}]
         item.payload["difficulty_tiers"] = "@ x.py Line 1 - simple - fix"
@@ -471,7 +474,9 @@ class TestEvalVerdicts:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.FINISH_FAIL
         assert result.note == "human_blocked"
-        assert github.mutation_log == []  # PR left unlabeled
+        # PR left unlabeled; the only durable write is the explanatory
+        # stand-down comment (M3), posted BEFORE the failing outcome.
+        assert github.mutation_log == [("gh_issue_comment", (1001,))]
 
     def test_go_with_automation_thread_downgrades_and_loops(
         self, make_ctx: Any, make_work_item: Any
@@ -487,7 +492,9 @@ class TestEvalVerdicts:
 
         assert isinstance(result, Continue)
         assert result.next_state == "REVIEW_WAIT"
-        assert github.mutation_log == []  # no GO labels while threads open
+        # No GO labels while threads open; the downgraded round durably
+        # records NO-GO (doc section 5: "NOGO verdict, before retry/regress").
+        assert github.mutation_log == [("mark_pr_implementation_no_go", (1001,))]
         assert item.payload["prev_unresolved"] == 2
 
     def test_nogo_within_soft_budget_loops_to_re_review(
@@ -646,7 +653,14 @@ class TestProgressAwareBudget:
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition == Disposition.SKIP
         assert outcome.note == "exhaustion"
-        assert github.mutation_log == [("gh_issue_add_labels", (12, (STATE_SKIP,)))]
+        # Every real NOGO round durably records NO-GO before its retry /
+        # regress (M2); the exhaustion's state:skip write comes LAST.
+        assert github.mutation_log == [
+            ("mark_pr_implementation_no_go", (1001,)),
+            ("mark_pr_implementation_no_go", (1001,)),
+            ("mark_pr_implementation_no_go", (1001,)),
+            ("gh_issue_add_labels", (12, (STATE_SKIP,))),
+        ]
         assert item.payload["pr_review_round"] == 3
 
     def test_decreasing_threads_earn_extension_rounds(
@@ -816,6 +830,7 @@ class TestFullWalks:
         ctx = make_ctx(github=github)
         item = make_work_item(issue=21, pr=1001, state="ENTER")
         item.branch = "21-auto-impl"
+        item.worktree = "/tmp/wt21"
 
         pool = FakeWorkerPool()
         pool.script(
@@ -845,6 +860,7 @@ class TestFullWalks:
         ]
         assert item.attempts["pr_review_iter"] == 2  # two real rounds
         assert github.mutation_log == [
+            ("mark_pr_implementation_no_go", (1001,)),  # round 1 NOGO recorded (M2)
             ("mark_pr_implementation_go", (1001,)),
             ("arm_auto_merge", (1001,)),
         ]
@@ -855,6 +871,7 @@ class TestFullWalks:
         github = FakeStageGitHub(unresolved=[(3, 0)])  # plateau forever
         ctx = make_ctx(github=github)
         item = make_work_item(issue=22, pr=1001, state="ENTER")
+        item.worktree = "/tmp/wt22"
 
         pool = FakeWorkerPool()
         round_jobs = [
@@ -895,3 +912,398 @@ class TestFullWalks:
         assert [h.job.descr for h in pool.submitted] == ["review"]  # dead round short-circuits
         assert item.attempts["pr_review_iter"] == 0
         assert github.mutation_log == []
+
+
+class TestNoGoLabel:
+    """M2: state:implementation-no-go is durably written on NOGO rounds."""
+
+    def test_no_go_written_on_every_nogo_round(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Two NOGO rounds record NO-GO twice (per-round, before each loop)."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=30, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        for _ in range(2):
+            item.payload["review_verdict"] = _verdict("NOGO")
+            item.state = "EVAL"
+            assert isinstance(stage.step(item, ctx), Continue)
+
+        assert github.mutation_log == [
+            ("mark_pr_implementation_no_go", (1001,)),
+            ("mark_pr_implementation_no_go", (1001,)),
+        ]
+
+    def test_no_go_write_failure_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failing NO-GO write never turns the round into a crash."""
+
+        class NoGoFailsGitHub(FakeStageGitHub):
+            def mark_pr_implementation_no_go(self, pr_number: int) -> None:
+                raise RuntimeError("gh label failed")
+
+        stage = PrReviewStage()
+        ctx = make_ctx(github=NoGoFailsGitHub(unresolved=[(3, 0)]))
+        item = make_work_item(issue=31, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"
+
+    def test_error_round_never_writes_no_go(self, make_ctx: Any, make_work_item: Any) -> None:
+        """ERROR is not a verdict: no NO-GO label, no label writes at all."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=32, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("ERROR")
+
+        stage.step(item, ctx)
+
+        assert github.mutation_log == []
+
+
+class TestHumanBlockedComment:
+    """M3: HUMAN_BLOCKED posts a durable stand-down comment before finishing."""
+
+    def test_comment_explains_blockage_before_finish_fail(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The comment names the blocking human threads and the stand-down.
+
+        Journal-order oracle: the comment is the ONLY mutation and exists
+        in the mutation_log before the FINISH_FAIL outcome is returned.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 2)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=33, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+        assert result.note == "human_blocked"
+        assert github.mutation_log == [("gh_issue_comment", (1001,))]
+        body = github.comments[1001][0]
+        assert "2 unresolved review thread(s) opened by a human" in body
+        assert "standing down" in body
+        assert "state:implementation-go" in body  # explains the unlabeled state
+
+    def test_comment_failure_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A failing comment write still finishes failed (never crashes)."""
+
+        class CommentFailsGitHub(FakeStageGitHub):
+            def post_pr_comment(self, pr_number: int, body: str) -> None:
+                raise RuntimeError("gh comment failed")
+
+        stage = PrReviewStage()
+        ctx = make_ctx(github=CommentFailsGitHub(unresolved=[(0, 1)]))
+        item = make_work_item(issue=34, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)  # must not raise
+
+        assert isinstance(result, StageOutcome)
+        assert result.note == "human_blocked"
+
+
+class TestRealCommitGate:
+    """M4 (#1575): a no-commit address turn is never treated as addressed."""
+
+    def test_push_result_records_the_no_commit_flag(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """commit_push value False -> push_no_commit True; True -> False."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=40, pr=1001, state="PUSH_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=True, value=False), ctx)
+        assert item.payload["push_no_commit"] is True
+
+        stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+        assert item.payload["push_no_commit"] is False
+
+    def test_first_no_commit_retries_address_with_directive(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The first no-commit turn retries the address once, no round burned."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=41, pr=1001, state="EVAL")
+        threads = [{"id": "t1", "path": "x.py", "line": 3, "body": "fix the bug"}]
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["review_threads"] = threads
+        item.payload["push_no_commit"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "ADDRESS_WAIT"
+        assert item.payload["unaddressed_findings"] == threads
+        assert item.payload["no_commit_retry_done"] is True
+        assert item.attempts["pr_review_iter"] == 0  # no round burned by the retry
+
+    def test_retry_address_job_carries_the_directive_findings(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The existing-PR retry address prompt carries unaddressed_findings.
+
+        get_address_review_prompt renders them via build_unaddressed_directive
+        (reused, not reimplemented) — asserted end-to-end on the built prompt.
+        """
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=42, pr=1001, state="ADDRESS_WAIT")
+        item.worktree = "/tmp/wt"
+        item.payload["existing_pr"] = True
+        threads = [{"id": "t1", "path": "x.py", "line": 3, "body": "fix the bug"}]
+        item.payload["review_threads"] = threads
+        item.payload["unaddressed_findings"] = threads
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.prompt_kwargs["unaddressed_findings"] == threads
+        prompt = result.job.prompt_builder(**result.job.prompt_kwargs)
+        assert "Make sure to handle x.py:3" in prompt  # the #1575 directive block
+        assert "NO commit on the previous turn" in prompt
+
+    def test_second_no_commit_counts_as_an_unaddressed_round(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A second consecutive no-commit turn burns its round normally."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=43, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["push_no_commit"] = True
+        item.payload["no_commit_retry_done"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"  # evaluated, not re-retried
+        assert item.attempts["pr_review_iter"] == 1  # the round was burned
+
+    def test_real_commit_clears_the_retry_directive(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A push with a real commit spends/clears the retry directive."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(1, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=44, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["push_no_commit"] = False  # commit_push produced a commit
+        item.payload["no_commit_retry_done"] = True
+        item.payload["unaddressed_findings"] = [{"id": "t1"}]
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert "no_commit_retry_done" not in item.payload
+        assert "unaddressed_findings" not in item.payload
+
+
+class TestSurvivingThreads:
+    """m1: POST posts only threads that survive the validation verdict."""
+
+    def test_wont_fix_threads_are_dropped(self) -> None:
+        """Threads re-raising a wont_fix (by-design) finding are not posted."""
+        threads = [
+            {"thread_id": "t1", "body": "real bug"},
+            {"thread_id": "t2", "body": "by-design recurrence"},
+        ]
+        validation = '{"unaddressed": [], "wont_fix": [{"thread_id": "t2", "reason": "abstract"}]}'
+
+        surviving = _surviving_threads(threads, validation)
+
+        assert [t["thread_id"] for t in surviving] == ["t1"]
+
+    def test_unaddressed_prior_findings_are_reopened(self) -> None:
+        """Unaddressed prior findings are re-opened as new postable threads."""
+        validation = (
+            '{"unaddressed": [{"thread_id": "t9", "path": "y.py", "line": 7,'
+            ' "original_body": "guard the None", "detail": "still no None guard"}],'
+            ' "wont_fix": []}'
+        )
+
+        surviving = _surviving_threads([{"thread_id": "t1", "body": "new"}], validation)
+
+        assert len(surviving) == 2
+        reopened = surviving[1]
+        assert reopened["path"] == "y.py"
+        assert reopened["line"] == 7
+        assert "still no None guard" in reopened["body"]
+
+    def test_reviewer_reraise_is_not_duplicated(self) -> None:
+        """A finding the reviewer already re-raised is not re-opened twice."""
+        validation = '{"unaddressed": [{"thread_id": "t1", "detail": "x"}], "wont_fix": []}'
+
+        surviving = _surviving_threads([{"thread_id": "t1", "body": "re-raised"}], validation)
+
+        assert len(surviving) == 1
+
+    def test_unparseable_validation_fails_open(self) -> None:
+        """Garbage validator output filters nothing (legacy fail-open)."""
+        threads = [{"thread_id": "t1", "body": "keep me"}]
+
+        assert _surviving_threads(threads, "not json at all") == threads
+        assert _surviving_threads(threads, None) == threads
+        assert _surviving_threads(threads, "") == threads
+
+    def test_fenced_json_block_is_parsed_last_wins(self) -> None:
+        """The validator's LAST fenced JSON block is the verdict (legacy rule)."""
+        validation = (
+            "Reasoning prose...\n```json\n"
+            '{"unaddressed": [], "wont_fix": []}\n```\n'
+            "More prose, corrected verdict:\n```json\n"
+            '{"unaddressed": [], "wont_fix": [{"thread_id": "t1", "reason": "by design"}]}\n```\n'
+        )
+
+        surviving = _surviving_threads([{"thread_id": "t1", "body": "x"}], validation)
+
+        assert surviving == []
+
+    def test_post_filters_through_validation_result(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """POST posts the SURVIVING set and updates the round's thread list."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(1, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=50, pr=1001, state="POST")
+        item.payload["review_threads"] = [
+            {"thread_id": "t1", "body": "real bug"},
+            {"thread_id": "t2", "body": "by-design"},
+        ]
+        item.payload["validation_result"] = (
+            '{"unaddressed": [], "wont_fix": [{"thread_id": "t2", "reason": "documented"}]}'
+        )
+        item.payload["review_text"] = "Verdict: NOGO"
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert github.mutation_log == [("gh_pr_review_post", (1001, "COMMENT"))]
+        posted = github.reviews[1001][0]["comments"]
+        assert [t["thread_id"] for t in posted] == ["t1"]  # t2 filtered out
+        assert [t["thread_id"] for t in item.payload["review_threads"]] == ["t1"]
+
+
+class TestProgressCountsAutomationOnly:
+    """m2: human-resolved threads never earn extension rounds (legacy parity)."""
+
+    def _eval_round(self, stage: Any, item: Any, ctx: Any) -> Any:
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.state = "EVAL"
+        return stage.step(item, ctx)
+
+    def test_human_resolution_earns_no_extension(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Total unresolved decreases only via HUMAN threads: no round 4.
+
+        5->4->3 total would have earned extensions under a total-count
+        metric, but the automation count plateaus at 3 — the extension gate
+        must refuse round 4 and exhaust at the soft cap.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(3, 2), (3, 1), (3, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=51, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r1
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r2
+        outcome = self._eval_round(stage, item, ctx)  # r3: automation plateau
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.SKIP
+        assert outcome.note == "exhaustion"
+
+    def test_automation_decrease_still_earns_extension(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Control: the same walk with a decreasing AUTOMATION count extends."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(5, 2), (4, 2), (3, 2), (3, 2)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=52, pr=1001, state="EVAL")
+        assert stage.on_enter(item, ctx) is None
+
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r1: 5 auto
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r2: 4 auto
+        assert isinstance(self._eval_round(stage, item, ctx), Continue)  # r3: 3<4 -> r4
+        outcome = self._eval_round(stage, item, ctx)  # r4: 3==3 plateau
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.SKIP
+
+
+class TestAgentErrorFailbackFlag:
+    """M1 (pr_review side): every agent_error fail-back flags the re-entry."""
+
+    def test_error_cap_failback_sets_the_flag(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The reviewer-error-cap fail-back marks agent_error_failback."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=60, pr=1001, state="EVAL")
+        item.payload["review_error_retries"] = REVIEW_ERROR_RETRY_CAP
+        item.payload["review_verdict"] = _verdict("ERROR")
+
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.note == "agent_error"
+        assert item.payload["agent_error_failback"] is True
+
+    def test_address_error_failback_sets_the_flag(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The address-failure fail-back marks agent_error_failback."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=61, pr=1001, state="EVAL")
+        item.payload["address_error"] = True
+
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.note == "agent_error"
+        assert item.payload["agent_error_failback"] is True
+
+    def test_missing_worktree_for_address_fails_closed(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """No worktree: the address job must never run in the shared checkout."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=62, pr=1001, state="ADDRESS_WAIT")
+        item.payload["existing_pr"] = True
+        assert item.worktree == ""  # the dangerous configuration
+
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FAIL_BACK
+        assert outcome.note == "agent_error"
+        assert item.payload["agent_error_failback"] is True
+
+    def test_on_enter_new_cycle_resets_error_retries(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A fresh implementation cycle restarts the reviewer-error streak."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=63, pr=1001, state="ENTER")
+        item.attempts["implement"] = 1  # GATE consumed a fail-back re-entry
+        item.payload["pr_review_cycle"] = 0
+        item.payload["review_error_retries"] = REVIEW_ERROR_RETRY_CAP + 1
+
+        stage.on_enter(item, ctx)
+
+        assert "review_error_retries" not in item.payload

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -795,7 +795,8 @@ class TestPrReviewOnJobDone:
         item = make_work_item(issue=1, pr=1001, state="ADDRESS_WAIT")
 
         stage.on_job_done(item, JobResult(ok=False, error="agent crashed"), ctx)
-        assert item.payload.pop("address_error") is True
+        address_error = item.payload.pop("address_error")
+        assert address_error is True
 
         item.state = "PUSH_WAIT"
         stage.on_job_done(item, JobResult(ok=False, error="push rejected"), ctx)

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -66,6 +66,11 @@ _CAPABILITY_EXEMPT: dict[str, dict[str, frozenset[str] | None]] = {
     # claude_invoke symbol (e.g. invoke_claude_with_session) or the module
     # itself still trips the guard, as does any other I/O-flavored import.
     "plan_review.py": {"hephaestus.automation.claude_invoke": frozenset({"parse_review_verdict"})},
+    # stages/pr_review.py gets the SAME symbol-scoped exemption for the same
+    # reason: the architecture doc's pr_review contract parses the reviewer
+    # verdict in-worker (#1815), so the stage attaches parse_review_verdict
+    # as AgentJob.parse. No other claude_invoke symbol is permitted.
+    "pr_review.py": {"hephaestus.automation.claude_invoke": frozenset({"parse_review_verdict"})},
 }
 
 


### PR DESCRIPTION
## Summary

Delivers the two heaviest pipeline stages for epic #1809 — `pipeline/stages/implementation.py` and `pipeline/stages/pr_review.py` — as `Stage`-protocol state machines. `docs/AUTOMATION_LOOP_ARCHITECTURE.md` sections "4. implementation" and "5. pr_review" are the binding contract; the merged planning/plan_review siblings (#1843) are the house pattern.

Second commit remediates the strict 6-dimension audit of this PR: all five MAJORs (ping-pong bound, no-go label, human-blocked comment, #1575 real-commit gating, git-retry cap) plus the minors, each with mandated tests and mutation probes.

## Changes

### `stages/implementation.py` (new)
- States: ENTER → GATE → WORKTREE_WAIT → DIRTY_DECISION_WAIT → ADVISE_WAIT → IMPLEMENT_WAIT → TEST_WAIT → TESTFIX_WAIT → COMMIT_PUSH_WAIT → PR_CREATE, plus the existing-PR short-circuit WORKTREE_WAIT → DIRTY_DECISION_WAIT → ADOPTED (ADVANCE to pr_review).
- GATE re-houses `_ensure_plan_ready` (:429) + `_review_existing_pr` (:750): at-or-past plan-go check (never equality); existing GO PR → `FAIL_BACK(already_implementation_go_pr)` (→ ci) with `item.pr`/`item.branch` set for the ci stage; existing non-GO PR adopts the PR's **real** head branch, **re-ensures `defer_auto_merge`** [durable], and cuts a worktree on the adopted branch (`refresh_base=False` + `sync_to_remote` — the `_prepare_worktree_for_existing_pr` anti-clobber semantics) before ADVANCEing to pr_review; otherwise `FAIL_BACK(plan_not_go)` (→ plan_review).
- **agent_error ping-pong bound (audit M1)**: a GATE re-entry from a pr_review `agent_error` fail-back (`payload["agent_error_failback"]`) consumes the `implement` budget at adoption; exhaustion → `FINISH_FAIL(agent_error_exhausted)`. Without this, fail-back → adopt → ADVANCE moved no counter and could loop forever.
- Budgets `implement=2` / `test_fix=1` read from ROUTES via `ctx.budget` — never hardcoded. `agent_error` consumes the implement budget then RETRYs (doc rule); exhaustion → finished(fail).
- **Bounded git RETRYs (audit M5)**: transient worktree/push failures RETRY without burning the implement budget, but are capped at `GIT_ERROR_RETRY_CAP=2` consecutive failures (mirrors `REVIEW_ERROR_RETRY_CAP`) → `FINISH_FAIL(git_error)`; counter resets on any successful git job.
- PR_CREATE is the durable journal entry (`ctx.github.create_pr` with a `get_pr_description` body carrying `Closes #N`), followed by `defer_auto_merge` — the load-bearing legacy order (`implementer_phase_runner.py:623`). The legacy "no commits vs base" error maps to durable `state:skip` → SKIP.
- Prompt builders reused verbatim: `get_implementation_prompt` (:198), `get_dirty_reused_worktree_decision_prompt` (:280), `get_impl_resume_feedback_prompt` (:323), `get_pr_description` (pr_review.py:339). Composed top-level builders (`build_implementation_prompt`, `build_test_fix_prompt`) add only the advise-findings / test-failure blocks the base prompts lack (AgentJob is frozen; builders run in-worker).

### `stages/pr_review.py` (new)
- States: ENTER → REVIEW_WAIT → VALIDATE_WAIT → POST → DIFFICULTY_WAIT → ADDRESS_WAIT → PUSH_WAIT → EVAL → (loop) → FOLLOWUP_WAIT.
- EVAL re-houses `_evaluate_go_verdict` (:314, #1152): GO stands only with **zero** unresolved threads; GO + human thread → `FINISH_FAIL(human_blocked)` with the PR left **unlabeled** and an **explanatory stand-down comment posted durably first (audit M3)**; GO + automation thread downgrades to NOGO (address + re-review — the 2-round divergence from legacy is documented in the module docstring as deliberate: POST live-checks threads and EVAL stays the single budget chokepoint).
- **`state:implementation-no-go` (audit M2)**: every real non-GO round durably writes the doc §5 owned label via the new `StageGitHub.mark_pr_implementation_no_go`, non-fatally, before retry/regress (legacy `_review_phase.py:248` semantics).
- **Real-commit gating (audit M4, #1575)**: EVAL inspects PUSH_WAIT's `commit_push` result. A no-commit push retries the address ONCE with `build_unaddressed_directive` (reused via `get_address_review_prompt`'s `unaddressed_findings`); a second consecutive no-commit turn is evaluated as an unaddressed round. A real commit clears the directive.
- **POST posts only SURVIVING threads (audit m1)**: the reviewer's threads are filtered through the validation job's verdict (`_surviving_threads`): `wont_fix` findings dropped, `unaddressed` prior findings re-opened, unparseable validator output fails open.
- **Progress metric counts automation threads only (audit m2)**: human-resolved threads never earn #1554 extension rounds (legacy parity).
- Budgets `pr_review_iter=3` soft / `pr_review_hard=6` from ROUTES; rounds 4–6 admitted **only while the automation unresolved count strictly decreases**; exhaustion applies `state:skip` [durable] then SKIPs.
- ERROR/missing verdicts never burn a round or stamp labels (#911/#1554/#1794), bounded by `REVIEW_ERROR_RETRY_CAP` consecutive failures (mirrors plan_review), then a **flagged** `FAIL_BACK(agent_error)` → implementation (the M1 bound); `review_error_retries` resets on each fresh implementation cycle. REVIEW_WAIT clears all round-scoped payload at submission (no stale-verdict replay).
- Address jobs **fail closed without a worktree** (never edit in the shared checkout on the wrong branch); recovery is the implementation worktree leg, bounded by M1.
- Clean GO durably writes `mark_pr_implementation_go` **then** `arm_auto_merge` (arming skipped if the mark write fails — never armed without the label); label writes non-fatal. FOLLOWUP output intentionally unstored (side effect only, documented).
- Cycle-relative round counter keyed on `attempts["implement"]`; `attempts["pr_review_iter"]`/`["pr_review_hard"]` stay the per-lifetime audit trail (routing.py: attempts are never reset).

### Supporting
- `stages/base.py`: StageGitHub protocol extended with the coordinator-neutral surface the stages need — reads `get_pr_head_branch` / `pr_has_implementation_state_label` / `count_unresolved_threads`, mutators `create_pr` / `defer_auto_merge` / `post_review_threads` / `mark_pr_implementation_go` / `arm_auto_merge` / `mark_pr_implementation_no_go` / `post_pr_comment`. The `create_pr` docstring names its real backing (`find_pr_for_issue` + `gh_pr_create` with the given body — NOT `ensure_pr_created`, which generates its own body). Shared stage helpers (`_issue_labels`, `_worktree_path`, `write_skip_label`, `GIT_JOB_TIMEOUT_S`) now live here (audit m4) — no more cross-stage private imports.
- `tests/.../stages/conftest.py`: `FakeStageGitHub` mirrors the full surface (mutation_log-recorded writes; scriptable unresolved-count FIFO for the progress rule).
- `tests/.../stages/test_stage_cross.py` (new): cross-stage composition test proving the agent_error ping-pong terminates at the implement budget with zero label writes.
- `tests/.../stages/test_reason_routes.py` (new): AST lock that every FAIL_BACK reason literal each stage emits is covered by its ROUTES row, with the emitted vocabulary pinned.
- `test_zero_io_imports.py`: `pr_review.py` gets the same **symbol-scoped** exemption as `plan_review.py` (`claude_invoke.parse_review_verdict` only) — the doc's "verdict parsed in-worker" contract.
- All GitHub mutations route through `ctx.github`; the #1812 architecture + zero-I/O guards pass unchanged. Legacy `implementer_phase_runner`/`_review_phase` path untouched (cleanup wave #1821/#1823).

## Testing

- Full pool-driven walks of both stages (canonical `FakeWorkerPool`), exact job-order and mutation_log assertions; cross-stage ping-pong composition walk.
- Budget boundaries: soft cap 3; hard cap 6 with the automation-only progress rule; plateau at round 4 → exhaustion + `state:skip`; git-retry cap boundary; agent_error re-adoption exhaustion; ROUTES-driven budget override test.
- Journal-order oracles: no-go per NOGO round before retry/regress; human-blocked comment before FINISH_FAIL; impl-go before arm; skip last on exhaustion. Non-fatal-write tests for no-go, skip, mark/arm, and the stand-down comment.
- Real-commit gate: both branches (retry-with-directive incl. the rendered `build_unaddressed_directive` block; second no-commit counts as an unaddressed round; real commit clears the directive).
- Mutation probes (each mutant killed by tests, then reverted): (a) strict-decrease inverted to `<=` → 5 failures; (b) mark/arm order swapped → 5 failures; (c) agent_error no longer consumes implement → 2 failures; (d) M1 GATE bound removed → 4 failures incl. the cross-stage test; (e) M4 real-commit gate removed → 2 failures.
- Per-module coverage: `implementation.py` 97.33%, `pr_review.py` 95.70% (uncovered lines are unreachable type-narrowing guards).
- Gates: full unit suite **6069 passed** at **84.60%** coverage (83% gate); `pixi run mypy` clean (529 files); `ruff check` + `ruff format --check` clean; `pre-commit run --all-files` fully clean. Commits GPG-signed (`-S`) with DCO sign-off (`-s`).

Closes #1815

🤖 Generated with [Claude Code](https://claude.com/claude-code)
