### PR TITLE
[Feat] Pipeline coordinator, shutdown, dry-run, summary; --pipeline flag (default off)

### DIFF
--- a/hephaestus/automation/implementer_summary.py
+++ b/hephaestus/automation/implementer_summary.py
@@ -16,6 +16,7 @@ import logging
 import sys
 
 from .models import WorkerResult
+from .pipeline.summary import format_preserved_worktrees
 from .worktree_manager import WorktreeManager
 
 logger = logging.getLogger(__name__)
@@ -94,18 +95,12 @@ class ImplementationSummaryPrinter:
         self._print_preserved_worktrees()
 
     def _print_preserved_worktrees(self) -> None:
-        """Log the preserved-worktree footer (issues with uncommitted changes)."""
-        preserved = self.worktree_manager.preserved
-        if not preserved:
-            return
-        issue_nums = [n for n, _ in preserved]
-        script = sys.argv[0]
-        issues_arg = " ".join(str(n) for n in issue_nums)
-        logger.info("\nPreserved worktrees (contain uncommitted changes):")
-        for issue_num, path in preserved:
-            logger.info("  #%s: %s", issue_num, path)
-        logger.info("\nRerun these issues after inspecting/cleaning the worktrees:")
-        logger.info("  %s --issues %s --resume", script, issues_arg)
-        logger.info("To discard them instead:")
-        for _, path in preserved:
-            logger.info("  git worktree remove --force %s", path)
+        """Log the preserved-worktree footer (issues with uncommitted changes).
+
+        The line sequence lives in
+        :func:`~hephaestus.automation.pipeline.summary.format_preserved_worktrees`
+        (re-housed by #1817) so the pipeline summary and this legacy printer
+        emit identical guidance.
+        """
+        for line in format_preserved_worktrees(self.worktree_manager.preserved, sys.argv[0]):
+            logger.info("%s", line)

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -15,6 +15,7 @@ import json
 import logging
 import subprocess
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from hephaestus.automation.ci_driver import _pr_is_failing
@@ -116,6 +117,77 @@ def _gh_list_repos(org: str) -> list[str]:
     ]
 
 
+def _list_open_issue_meta(org: str, repo: str) -> list[dict[str, Any]]:
+    """Return open-issue metadata for ``org/repo`` — reads only, no tagging.
+
+    One ``gh issue list`` returning ``{number, labels, title}`` dicts (labels
+    flattened to names). Extracted from :func:`_list_open_issue_numbers` so
+    the pipeline repo stage (#1817) can reuse the read while routing the epic
+    ``state:skip`` tagging through its coordinator-owned accessor instead of
+    the in-band :func:`skip_epics` side effect below.
+
+    Returns an empty list on any failure (rate limit, auth error, timeout)
+    so callers fall back safely.
+    """
+    try:
+        out = gh_call(
+            [
+                "issue",
+                "list",
+                "--repo",
+                f"{org}/{repo}",
+                "--state",
+                "open",
+                "--limit",
+                "500",
+                "--json",
+                "number,labels,title",
+            ],
+            timeout=NETWORK_TIMEOUT,
+        )
+        entries = json.loads(out.stdout or "[]")
+    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
+        return []
+    return [
+        {
+            "number": e["number"],
+            "labels": [lbl["name"] for lbl in e.get("labels", [])],
+            "title": e.get("title", ""),
+        }
+        for e in entries
+        if isinstance(e, dict) and "number" in e
+    ]
+
+
+def _list_open_pr_numbers(org: str, repo: str) -> list[int]:
+    """Return open PR numbers in ``org/repo``, sorted ascending.
+
+    Read-only helper for the pipeline repo stage's ``--drive-green-all``
+    orphan-PR discovery (#1817): PRs with no tracked issue route to the ci
+    stage. Empty list on any failure so discovery degrades safely.
+    """
+    try:
+        out = gh_call(
+            [
+                "pr",
+                "list",
+                "--repo",
+                f"{org}/{repo}",
+                "--state",
+                "open",
+                "--limit",
+                "500",
+                "--json",
+                "number",
+            ],
+            timeout=NETWORK_TIMEOUT,
+        )
+        entries = json.loads(out.stdout or "[]")
+    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
+        return []
+    return sorted(int(e["number"]) for e in entries if isinstance(e, dict) and "number" in e)
+
+
 def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
     """Return open NON-epic issue numbers in ``org/repo``, sorted ascending.
 
@@ -138,35 +210,7 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
     an empty list on any failure (rate limit, auth error, timeout) so callers
     fall back safely.
     """
-    try:
-        out = gh_call(
-            [
-                "issue",
-                "list",
-                "--repo",
-                f"{org}/{repo}",
-                "--state",
-                "open",
-                "--limit",
-                "500",
-                "--json",
-                "number,labels,title",
-            ],
-            timeout=NETWORK_TIMEOUT,
-        )
-        entries = json.loads(out.stdout or "[]")
-    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
-        return []
-
-    meta = [
-        {
-            "number": e["number"],
-            "labels": [lbl["name"] for lbl in e.get("labels", [])],
-            "title": e.get("title", ""),
-        }
-        for e in entries
-        if isinstance(e, dict) and "number" in e
-    ]
+    meta = _list_open_issue_meta(org, repo)
     kept, epics = partition_epics(meta)
     if epics:
         epic_set = set(epics)

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -126,8 +126,8 @@ def _list_open_issue_meta(org: str, repo: str) -> list[dict[str, Any]]:
     ``state:skip`` tagging through its coordinator-owned accessor instead of
     the in-band :func:`skip_epics` side effect below.
 
-    Returns an empty list on any failure (rate limit, auth error, timeout)
-    so callers fall back safely.
+    Raises RuntimeError on GitHub/JSON failures so pipeline discovery never
+    converts an unreadable repo into a successful empty run.
     """
     try:
         out = gh_call(
@@ -146,8 +146,8 @@ def _list_open_issue_meta(org: str, repo: str) -> list[dict[str, Any]]:
             timeout=NETWORK_TIMEOUT,
         )
         entries = json.loads(out.stdout or "[]")
-    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
-        return []
+    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"failed to list open issues for {org}/{repo}: {exc}") from exc
     return [
         {
             "number": e["number"],
@@ -164,7 +164,8 @@ def _list_open_pr_numbers(org: str, repo: str) -> list[int]:
 
     Read-only helper for the pipeline repo stage's ``--drive-green-all``
     orphan-PR discovery (#1817): PRs with no tracked issue route to the ci
-    stage. Empty list on any failure so discovery degrades safely.
+    stage. Raises RuntimeError on failures so discovery does not masquerade
+    as a clean empty run.
     """
     try:
         out = gh_call(
@@ -183,8 +184,8 @@ def _list_open_pr_numbers(org: str, repo: str) -> list[int]:
             timeout=NETWORK_TIMEOUT,
         )
         entries = json.loads(out.stdout or "[]")
-    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
-        return []
+    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"failed to list open PRs for {org}/{repo}: {exc}") from exc
     return sorted(int(e["number"]) for e in entries if isinstance(e, dict) and "number" in e)
 
 
@@ -206,9 +207,9 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
     label names + title because native GitHub issue types are not exposed by the
     installed ``gh`` — see :func:`~hephaestus.automation.state_labels.is_epic`.
 
-    Sorted ascending so the implementer phase processes oldest-first. Returns
-    an empty list on any failure (rate limit, auth error, timeout) so callers
-    fall back safely.
+    Sorted ascending so the implementer phase processes oldest-first. GitHub
+    read failures propagate as RuntimeError so automation does not treat an
+    unreadable repo as converged.
     """
     meta = _list_open_issue_meta(org, repo)
     kept, epics = partition_epics(meta)

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -50,6 +50,10 @@ import traceback
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hephaestus.automation.pipeline.coordinator import PipelineConfig
 
 from hephaestus.agents.runtime import resolve_agent
 from hephaestus.automation._review_utils import build_automation_parser, find_pr_for_issue
@@ -479,6 +483,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
     p.add_argument(
+        "--pipeline",
+        action="store_true",
+        help="Use the queue-based pipeline loop (default: off). "
+        "Env HEPH_PIPELINE=1 also enables it; the CLI flag wins.",
+    )
+    p.add_argument(
         "--max-merge-attempts",
         type=int,
         default=1,
@@ -598,7 +608,8 @@ def _build_parser() -> argparse.ArgumentParser:
         default=_default_phase_timeout_s(),
         help=(
             "Per-phase timeout in seconds (default: HEPH_PHASE_TIMEOUT or "
-            f"{int(_default_phase_timeout_s())}s). Pass 0 or a negative value to disable."
+            f"{int(_default_phase_timeout_s())}s). Pass 0 or a negative value to disable. "
+            "Under --pipeline this bounds each AGENT JOB, not a whole phase subprocess."
         ),
     )
     p.add_argument(
@@ -1658,6 +1669,93 @@ def _resolve_org_and_repos(
     return (detected_org, [detected_repo], None)
 
 
+def _build_pipeline_config(
+    args: argparse.Namespace, cfg: LoopConfig, org: str, repos: list[str]
+) -> PipelineConfig:
+    """Build a PipelineConfig from the parsed args and LoopConfig.
+
+    Args:
+        args: Parsed argparse Namespace.
+        cfg: The LoopConfig.
+        org: The organization name.
+        repos: List of repository names.
+
+    Returns:
+        A PipelineConfig instance compatible with pipeline.run_pipeline.
+
+    """
+    from hephaestus.automation.pipeline.coordinator import PipelineConfig
+
+    return PipelineConfig(
+        org=org,
+        repos=repos,
+        issues=cfg.issues,
+        prs=[],  # --prs not yet implemented in #1813
+        loops=cfg.loops,
+        max_workers=cfg.max_workers,
+        parallel_repos=cfg.parallel_repos,
+        dry_run=cfg.dry_run,
+        grace_s=30.0,  # Default grace period
+        phase_timeout_s=cfg.phase_timeout_s,
+        model=cfg.model,
+        planner_model=cfg.planner_model,
+        reviewer_model=cfg.reviewer_model,
+        implementer_model=cfg.implementer_model,
+        no_advise=cfg.no_advise,
+        nitpick=cfg.nitpick,
+        drive_green_all=cfg.drive_green_all,
+        projects_dir=cfg.projects_dir,
+        json_out=args.json,
+    )
+
+
+def _error_exit(args: argparse.Namespace, message: str, json_message: str | None = None) -> int:
+    """Log *message*, emit the JSON error envelope under --json, and return 1.
+
+    Args:
+        args: Parsed argparse Namespace (for the ``--json`` gate).
+        message: Human-readable error logged at ERROR level.
+        json_message: Envelope message override (defaults to *message*) —
+            preserves the legacy envelope strings exactly.
+
+    Returns:
+        The process exit code 1.
+
+    """
+    LOG.error("%s", message)
+    if args.json:
+        emit_json_status(1, message=json_message if json_message is not None else message)
+    return 1
+
+
+def _dispatch_pipeline(
+    args: argparse.Namespace, cfg: LoopConfig, org: str, repos: list[str]
+) -> int | None:
+    """Run the queue-based pipeline when enabled; return None when it is off.
+
+    Enabled by ``--pipeline`` or ``HEPH_PIPELINE=1`` (the CLI flag wins;
+    default OFF — the legacy path stays byte-identical when off). The repo
+    stage owns preflight + cloning, so this dispatch happens BEFORE
+    ``_preflight_token_scopes`` / ``_clone_missing_repos`` (no double-clone).
+    Under the pipeline, ``--phase-timeout`` bounds each agent job.
+
+    Args:
+        args: Parsed argparse Namespace.
+        cfg: The LoopConfig.
+        org: The organization name.
+        repos: List of repository names.
+
+    Returns:
+        The pipeline's exit code, or ``None`` when the pipeline is disabled.
+
+    """
+    if not (args.pipeline or os.environ.get("HEPH_PIPELINE") == "1"):
+        return None
+    from hephaestus.automation.pipeline.coordinator import run_pipeline
+
+    return run_pipeline(_build_pipeline_config(args, cfg, org, repos))
+
+
 def main(argv: list[str] | None = None) -> int:
     """Console-script entry point. Returns the process exit code."""
     args = _parse_args(argv)
@@ -1672,10 +1770,7 @@ def main(argv: list[str] | None = None) -> int:
     # hardcoded default.
     org, repos, err = _resolve_org_and_repos(args)
     if err:
-        LOG.error("%s", err)
-        if args.json:
-            emit_json_status(1, message=err)
-        return 1
+        return _error_exit(args, err)
 
     cfg = LoopConfig(
         loops=args.loops,
@@ -1717,10 +1812,13 @@ def main(argv: list[str] | None = None) -> int:
         signal.signal(signal.SIGHUP, _request_shutdown)
 
     if not repos:
-        LOG.error("Repo list is empty; nothing to do.")
-        if args.json:
-            emit_json_status(1, message="empty repo list")
-        return 1
+        return _error_exit(args, "Repo list is empty; nothing to do.", "empty repo list")
+
+    # Dispatch to the pipeline if --pipeline is set or HEPH_PIPELINE=1
+    # (BEFORE preflight/clone: the repo stage owns both — no double-clone).
+    pipeline_rc = _dispatch_pipeline(args, cfg, org, repos)
+    if pipeline_rc is not None:
+        return pipeline_rc
 
     if not cfg.dry_run:
         _preflight_token_scopes(cfg.org, repos[0])

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1736,8 +1736,8 @@ def _dispatch_pipeline(
 
     Enabled by ``--pipeline`` or ``HEPH_PIPELINE=1`` (the CLI flag wins;
     default OFF — the legacy path stays byte-identical when off). The repo
-    stage owns preflight + cloning, so this dispatch happens BEFORE
-    ``_preflight_token_scopes`` / ``_clone_missing_repos`` (no double-clone).
+    token preflight still happens before dispatch, while the repo stage owns
+    cloning, so this branch skips ``_clone_missing_repos`` (no double-clone).
     Under the pipeline, ``--phase-timeout`` bounds each agent job.
 
     Args:
@@ -1752,6 +1752,8 @@ def _dispatch_pipeline(
     """
     if not (args.pipeline or os.environ.get("HEPH_PIPELINE") == "1"):
         return None
+    if not cfg.dry_run:
+        _preflight_token_scopes(cfg.org, repos[0])
     from hephaestus.automation.pipeline.coordinator import run_pipeline
 
     return run_pipeline(_build_pipeline_config(args, cfg, org, repos))
@@ -1816,7 +1818,7 @@ def main(argv: list[str] | None = None) -> int:
         return _error_exit(args, "Repo list is empty; nothing to do.", "empty repo list")
 
     # Dispatch to the pipeline if --pipeline is set or HEPH_PIPELINE=1
-    # (BEFORE preflight/clone: the repo stage owns both — no double-clone).
+    # (after token preflight, before legacy clone; the repo stage owns clone).
     pipeline_rc = _dispatch_pipeline(args, cfg, org, repos)
     if pipeline_rc is not None:
         return pipeline_rc

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1697,6 +1697,7 @@ def _build_pipeline_config(
         dry_run=cfg.dry_run,
         grace_s=30.0,  # Default grace period
         phase_timeout_s=cfg.phase_timeout_s,
+        agent=cfg.agent,
         model=cfg.model,
         planner_model=cfg.planner_model,
         reviewer_model=cfg.reviewer_model,

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from .work_item import HistoryEvent, ItemKind, ItemResult, WorkItem
     from .worker_pool import WorkerPool
 
+from .coordinator import PipelineConfig as PipelineConfig, run_pipeline as run_pipeline
+
 __all__ = [
     "GIT_OPS",
     "ROUTES",

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -26,8 +26,6 @@ if TYPE_CHECKING:
     from .work_item import HistoryEvent, ItemKind, ItemResult, WorkItem
     from .worker_pool import WorkerPool
 
-from .coordinator import PipelineConfig as PipelineConfig, run_pipeline as run_pipeline
-
 __all__ = [
     "GIT_OPS",
     "ROUTES",

--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     "ItemResult",
     "JobHandle",
     "JobResult",
+    "PipelineConfig",
     "PipelineScope",
     "Route",
     "StageName",
@@ -46,6 +47,7 @@ __all__ = [
     "StageQueue",
     "WorkItem",
     "WorkerPool",
+    "run_pipeline",
 ]
 
 _LAZY_EXPORTS: dict[str, str] = {
@@ -60,6 +62,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "ItemResult": "hephaestus.automation.pipeline.work_item",
     "JobHandle": "hephaestus.automation.pipeline.jobs",
     "JobResult": "hephaestus.automation.pipeline.jobs",
+    "PipelineConfig": "hephaestus.automation.pipeline.coordinator",
     "PipelineScope": "hephaestus.automation.pipeline.routing",
     "ROUTES": "hephaestus.automation.pipeline.routing",
     "Route": "hephaestus.automation.pipeline.routing",
@@ -68,6 +71,7 @@ _LAZY_EXPORTS: dict[str, str] = {
     "StageQueue": "hephaestus.automation.pipeline.queues",
     "WorkItem": "hephaestus.automation.pipeline.work_item",
     "WorkerPool": "hephaestus.automation.pipeline.worker_pool",
+    "run_pipeline": "hephaestus.automation.pipeline.coordinator",
 }
 
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1,0 +1,1000 @@
+"""Single-threaded event-loop coordinator for the queue-based pipeline (epic #1809).
+
+## Semantics
+
+The coordinator runs on the process main thread and owns all eight stage
+queues, the timer heap, the in-flight registry, all routing, and (through the
+:class:`~hephaestus.automation.pipeline_github.PipelineGitHub` accessor) every
+GitHub API mutation. A single worker pool executes agent, build/test, and
+git/network jobs; the ONLY cross-thread channel is the completion queue, whose
+blocking ``get(timeout=...)`` doubles as the loop's idle sleep.
+
+Per tick (epic #1809 "Coordinator event loop"):
+
+1. shutdown check (graceful drain, or immediate teardown after the grace
+   window / a second signal);
+2. wake expired timers (heapq) back into their stage queues;
+3. drain ALL ready completions — interrupted results park the item
+   RESUMABLE and never advance (``on_job_done`` is never called for them);
+4. drain queues DOWNSTREAM-FIRST (finished → merge_wait → ... → repo; finish
+   work before admitting new) with admission control;
+5. fully drained: re-seed up to ``--loops`` with a zero-work convergence
+   exit; otherwise block on the completion queue.
+
+``_run_item`` drives ``on_enter``/``step`` until a ``JobRequest`` (park +
+submit) or a ``StageOutcome`` (route via ROUTES). Per-item ``try/except``: a
+poisoned item routes to finished(fail) and never kills the loop.
+
+Admission control: per-repo in-flight cap (= ``max_workers``), and the
+implementation queue is additionally gated by dependency topological order
+(:func:`~.admission.order_for_implementation`) and file-overlap serialization
+(:func:`~.admission._select_non_overlapping`). Pool size =
+``parallel_repos x max_workers``.
+
+### ``--phase-timeout`` semantic shift
+
+Under ``--pipeline`` this flag bounds each AGENT JOB, not a whole phase
+subprocess: the coordinator maps ``phase_timeout_s`` onto
+``AgentJob.timeout_s`` at submit time. The legacy path binds it to the phase
+subprocess lifetime.
+
+### Journal-order invariant
+
+GitHub is the journal: every stage performs its durable mutation immediately
+BEFORE returning the outcome that causes a queue push, so restart = re-run
+(seeding reconstructs the queues) and interrupts leave every item RESUMABLE
+at its stage — never FAILED.
+
+### Rate budget gate
+
+The legacy ``_maybe_sleep_for_rate_budget`` SLEEPS its loop thread — fatal
+for a single coordinator thread. Its predicate is ported to a non-blocking
+check (:func:`~hephaestus.automation.pipeline_github.rate_budget_ok`); a
+low-budget AGENT job is timer-parked until the upstream reset instead of
+submitted. Git/build jobs are unaffected.
+
+### Dry-run
+
+Stage accessors log-and-skip mutators; when a stage requests a job the
+coordinator logs ``[dry-run] would <descr>`` and ADVANCEs the item instead
+of submitting. ``_submit`` asserts no job is EVER submitted in dry-run.
+
+### Interrupts and exit codes
+
+SIGINT/SIGTERM/SIGHUP share one shutdown Event: the first signal starts a
+graceful drain (grace window, default 30s), the second tears the pool down
+immediately and synthesizes interrupted results. Items touched by an
+interrupt report ``RESUMABLE at <stage>``, never FAILED. Exit codes: 130
+interrupt, 1 any fail/skip/blocked, 0 clean. The summary prints in this
+module's ``finally`` — on completion AND interrupt.
+"""
+
+from __future__ import annotations
+
+import heapq
+import logging
+import queue as queue_mod
+import signal
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, cast
+
+from hephaestus.automation.models import IssueInfo
+from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
+from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
+from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue
+from hephaestus.automation.pipeline.routing import (
+    ROUTES,
+    Disposition,
+    Route,
+    StageName,
+    StageOutcome,
+)
+from hephaestus.automation.pipeline.stages import (
+    CiStage,
+    Continue,
+    FinishedStage,
+    ImplementationStage,
+    JobRequest,
+    MergeWaitStage,
+    PlanningStage,
+    PlanReviewStage,
+    PrReviewStage,
+    RepoStage,
+    Stage,
+    StageContext,
+    StageGitHub,
+)
+from hephaestus.automation.pipeline.stages.repo import product_to_work_item
+from hephaestus.automation.pipeline.summary import RunStats, print_summary
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+
+logger = logging.getLogger(__name__)
+
+#: Warn when any stage.step() call exceeds this duration (seconds) — the
+#: stage protocol promises short (<~5s) main-thread steps.
+_STEP_WATCHDOG_S = 5.0
+
+#: Grace period for graceful shutdown (drain in-flight jobs up to this long).
+_DEFAULT_GRACE_S = 30.0
+
+#: Upper bound on Continue-transitions per _run_item call (defensive: a stage
+#: that never yields a JobRequest/StageOutcome would otherwise spin forever).
+_MAX_STEPS_PER_TICK = 100
+
+#: Global safety cap on FAIL_BACK regressions per item: the sum of every
+#: budget in ROUTES. Stages enforce the real per-key budgets themselves (the
+#: house on_job_done pattern); this cap only guarantees cross-stage regression
+#: cycles terminate even if a stage's own bookkeeping has a bug.
+_FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
+
+#: Downstream-first drain order: finish work before admitting new (epic
+#: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
+#: finished sink drains first of all so results are recorded promptly).
+_DRAIN_ORDER: tuple[StageName, ...] = (
+    StageName.FINISHED,
+    StageName.MERGE_WAIT,
+    StageName.CI,
+    StageName.PR_REVIEW,
+    StageName.IMPLEMENTATION,
+    StageName.PLAN_REVIEW,
+    StageName.PLANNING,
+    StageName.REPO,
+)
+
+
+def _budget_lookup(name: str) -> int:
+    """Look up a budget across all ROUTES rows (conservative default 1)."""
+    for route in ROUTES.values():
+        if name in route.budgets:
+            return route.budgets[name]
+    return 1
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Configuration for the pipeline coordinator (built by ``loop_runner``)."""
+
+    org: str
+    repos: list[str]
+    issues: list[int] = field(default_factory=list)
+    prs: list[int] = field(default_factory=list)
+    loops: int = 1
+    max_workers: int = 1
+    parallel_repos: int = 1
+    dry_run: bool = False
+    grace_s: float = _DEFAULT_GRACE_S
+    phase_timeout_s: float | None = None
+    model: str = ""
+    planner_model: str = ""
+    reviewer_model: str = ""
+    implementer_model: str = ""
+    no_advise: bool = False
+    nitpick: bool = False
+    drive_green_all: bool = False
+    projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
+    json_out: bool = False
+
+
+@dataclass
+class _StageRunConfig:
+    """PlannerOptions-like config injected as ``StageContext.config``."""
+
+    enable_advise: bool = True
+    enable_learn: bool = True
+    enable_follow_up: bool = True
+    run_pre_pr_tests: bool = False
+    force: bool = False
+    agent: str = "claude"
+    dry_run: bool = False
+    nitpick: bool = False
+    drive_green_all: bool = False
+
+
+@dataclass
+class _Paths:
+    """Coordinator-owned path accessor injected as ``StageContext.paths``."""
+
+    repo_root: Path
+    worktree: Path
+    projects_dir: Path
+
+
+class Coordinator:
+    """The single-threaded pipeline event loop.
+
+    All collaborators are injectable for tests (FakeWorkerPool /
+    FakeStageGitHub / stub stages / fake clock); production wiring happens in
+    :func:`run_pipeline`.
+    """
+
+    def __init__(
+        self,
+        config: PipelineConfig,
+        *,
+        github: StageGitHub,
+        pool: Any | None = None,
+        stages: dict[StageName, Stage] | None = None,
+        install_signals: bool = True,
+    ) -> None:
+        """Initialize coordinator state.
+
+        Args:
+            config: Pipeline configuration.
+            github: The coordinator-owned StageGitHub accessor.
+            pool: Worker pool (a real ``WorkerPool`` is built when omitted;
+                tests inject ``FakeWorkerPool``).
+            stages: Stage-instance map override (tests inject stubs).
+            install_signals: Install SIGINT/SIGTERM/SIGHUP handlers in
+                ``run()`` (disabled in unit tests).
+
+        """
+        self.config = config
+        self.github = github
+        self.shutdown = threading.Event()
+        self.completion_q: CompletionQueue = queue_mod.Queue()
+        if pool is None:
+            # Imported here, not module-top: WorkerPool is the pipeline's one
+            # I/O-capable module and tests never need it.
+            from hephaestus.automation.pipeline.worker_pool import WorkerPool
+
+            pool = WorkerPool(
+                size=max(1, config.parallel_repos * config.max_workers),
+                shutdown=self.shutdown,
+                completion_q=self.completion_q,
+            )
+        else:
+            # Share channels with an injected pool when it exposes them.
+            if getattr(pool, "completion_q", None) is not None:
+                self.completion_q = pool.completion_q
+        self.pool: Any = pool
+
+        self.queues: dict[StageName, StageQueue] = {name: StageQueue() for name in StageName}
+        self.timers: list[tuple[float, int, WorkItem]] = []
+        self.in_flight: dict[JobHandle, WorkItem] = {}
+        self.inflight_per_repo: Counter[str] = Counter()
+        self.ledger: list[ItemResult] = []
+        self.preserved: list[tuple[int, str]] = []
+        self.items: list[WorkItem] = []
+        self.event_log: list[tuple[Any, ...]] = []
+        self.stages: dict[StageName, Stage] = stages or self._default_stages()
+
+        self._install_signals = install_signals
+        self._seq = 0
+        self._grace_deadline: float | None = None
+        self._immediate = False
+        self._agent_job_count = 0
+        self._agent_job_time_s = 0.0
+        self._loops_run = 0
+        self._pass_work_count = 0
+        self._resumable: list[WorkItem] = []
+        self._progress = False
+        self._stalled_ticks = 0
+        self._fatal = False
+        self._seen_item_ids: set[int] = set()
+        self._stage_config = _StageRunConfig(
+            enable_advise=not config.no_advise,
+            dry_run=config.dry_run,
+            nitpick=config.nitpick,
+            drive_green_all=config.drive_green_all,
+        )
+        self._ctx_cache: dict[str, StageContext] = {}
+
+    # -- wiring ---------------------------------------------------------------
+
+    def _default_stages(self) -> dict[StageName, Stage]:
+        """Build the full production stage map."""
+        return {
+            StageName.REPO: RepoStage(),
+            StageName.PLANNING: PlanningStage(),
+            StageName.PLAN_REVIEW: PlanReviewStage(),
+            StageName.IMPLEMENTATION: ImplementationStage(),
+            StageName.PR_REVIEW: PrReviewStage(),
+            StageName.CI: CiStage(),
+            StageName.MERGE_WAIT: MergeWaitStage(),
+            StageName.FINISHED: FinishedStage(self.ledger, self.preserved),
+        }
+
+    def _ctx_for(self, item: WorkItem) -> StageContext:
+        """Return the (cached, per-repo) StageContext for *item*."""
+        ctx = self._ctx_cache.get(item.repo)
+        if ctx is None:
+            root = Path(self.config.projects_dir) / item.repo
+            ctx = StageContext(
+                config=self._stage_config,
+                org=self.config.org,
+                dry_run=self.config.dry_run,
+                github=self.github,
+                paths=_Paths(
+                    repo_root=root,
+                    worktree=root,
+                    projects_dir=Path(self.config.projects_dir),
+                ),
+                budget_fn=_budget_lookup,
+            )
+            self._ctx_cache[item.repo] = ctx
+        return ctx
+
+    # -- run loop ---------------------------------------------------------------
+
+    def run(self) -> int:
+        """Run the pipeline to quiescence (or interrupt) and return the exit code."""
+        started = time.monotonic()
+        if self._install_signals:
+            self._install_signal_handlers()
+        exit_code = 1
+        try:
+            self._loops_run = 1
+            self._seed_pass()
+            while True:
+                if self._immediate or self._grace_exceeded():
+                    self._teardown_immediate()
+                    break
+                self._wake_timers()
+                self._drain_completions()
+                if self.shutdown.is_set():
+                    # Graceful: stop admitting; drain in-flight to RESUMABLE.
+                    if not self.in_flight:
+                        break
+                    self._wait_for_completion(timeout=0.2)
+                    continue
+                self._drain_queues()
+                if self._all_idle():
+                    if not self._reseed_if_converged():
+                        break
+                    continue
+                self._idle_wait()
+        except Exception:
+            logger.exception("pipeline run failed")
+            self._fatal = True
+        finally:
+            self._finalize_resumable()
+            exit_code = self._exit_code()
+            stats = RunStats(
+                exit_code=exit_code,
+                interrupted=self.shutdown.is_set(),
+                loops_run=self._loops_run,
+                agent_job_count=self._agent_job_count,
+                agent_job_time_s=self._agent_job_time_s,
+                wall_s=time.monotonic() - started,
+            )
+            print_summary(self.items, stats, self.preserved, json_out=self.config.json_out)
+        return exit_code
+
+    def _exit_code(self) -> int:
+        """130 on interrupt; 1 on any fail/skip/blocked (or fatal error); 0 clean."""
+        if self.shutdown.is_set():
+            return 130
+        if self._fatal or any(not result.passed for result in self.ledger):
+            return 1
+        return 0
+
+    def _all_idle(self) -> bool:
+        """Return True when queues, timer heap, and in-flight map are all empty."""
+        return (
+            all(len(q) == 0 for q in self.queues.values())
+            and not self.timers
+            and not self.in_flight
+        )
+
+    def _grace_exceeded(self) -> bool:
+        """Return True when a graceful shutdown has outlived its grace window."""
+        return (
+            self.shutdown.is_set()
+            and self._grace_deadline is not None
+            and time.monotonic() >= self._grace_deadline
+        )
+
+    def _idle_wait(self) -> None:
+        """Block on the completion queue (the loop's only sleep).
+
+        Also breaks a theoretical no-progress stall: if a full tick made no
+        progress with nothing in flight and no timers pending, force-run the
+        most-downstream queued item ignoring admission (liveness guarantee —
+        admission can only defer while something else is running or parked).
+        """
+        if self._progress:
+            self._progress = False
+            self._stalled_ticks = 0
+        elif not self.in_flight and not self.timers:
+            self._stalled_ticks += 1
+            if self._stalled_ticks >= 3:
+                self._force_run_one()
+                return
+        timeout = 1.0
+        if self.timers:
+            timeout = min(timeout, max(0.01, self.timers[0][0] - time.monotonic()))
+        self._wait_for_completion(timeout=timeout)
+
+    def _force_run_one(self) -> None:
+        """Run the first item of the most-downstream non-empty queue."""
+        self._stalled_ticks = 0
+        for stage_name in _DRAIN_ORDER:
+            q = self.queues[stage_name]
+            if len(q):
+                item = q.pop()
+                logger.error(
+                    "pipeline stalled with no in-flight work; force-running %s item %s",
+                    stage_name.value,
+                    self._item_key(item),
+                )
+                self._run_item(item)
+                return
+
+    # -- timers -------------------------------------------------------------
+
+    def _timer_park(self, item: WorkItem, delay_s: float) -> None:
+        """Park *item* on the timer heap for ``delay_s`` seconds."""
+        wake = time.monotonic() + max(0.0, delay_s)
+        heapq.heappush(self.timers, (wake, self._seq, item))
+        self._seq += 1
+        item.add_history_event(item.stage, item.state, note=f"timer-parked {delay_s:.1f}s")
+        self.event_log.append(("timer_park", item.stage.value, self._item_key(item), delay_s))
+
+    def _wake_timers(self) -> None:
+        """Move every expired timer entry back into its stage queue."""
+        now = time.monotonic()
+        while self.timers and self.timers[0][0] <= now:
+            _, _, item = heapq.heappop(self.timers)
+            self._progress = True
+            self._push_item(item, item.stage, enter=False)
+
+    # -- completions ----------------------------------------------------------
+
+    def _drain_completions(self) -> None:
+        """Drain ALL ready completions without blocking."""
+        while True:
+            try:
+                handle, result = self.completion_q.get_nowait()
+            except queue_mod.Empty:
+                return
+            self._handle_completion(handle, result)
+
+    def _wait_for_completion(self, timeout: float) -> None:
+        """Block up to *timeout* for one completion; handle it if one arrives."""
+        try:
+            handle, result = self.completion_q.get(timeout=timeout)
+        except queue_mod.Empty:
+            return
+        self._handle_completion(handle, result)
+
+    def _handle_completion(self, handle: JobHandle, result: JobResult) -> None:
+        """Route one completed job back to its item.
+
+        Interrupted results park the item RESUMABLE — they never advance and
+        never reach ``on_job_done`` (base-protocol contract).
+        """
+        self._progress = True
+        item = self.in_flight.pop(handle, None)
+        if item is None:
+            logger.warning("completion for unknown handle (already torn down?): %s", handle)
+            return
+        self.inflight_per_repo[item.repo] -= 1
+        if self.inflight_per_repo[item.repo] <= 0:
+            del self.inflight_per_repo[item.repo]
+        if isinstance(handle.job, AgentJob):
+            self._agent_job_count += 1
+            self._agent_job_time_s += result.duration_s
+
+        if result.interrupted:
+            self._park_resumable(item)
+            return
+
+        stage = self.stages[item.stage]
+        ctx = self._ctx_for(item)
+        try:
+            stage.on_job_done(item, result, ctx)
+        except Exception:
+            logger.exception(
+                "on_job_done poisoned item %s at %s", self._item_key(item), item.stage.value
+            )
+            self._finish(item, passed=False, reason="poisoned: on_job_done raised")
+            return
+        # JobHandle.on_done_state is annotated StageName upstream but carries
+        # the stage-local state string the JobRequest specified (see
+        # JobRequest.on_done_state: str) — runtime values are plain strings.
+        item.state = cast(str, handle.on_done_state)
+        if self.shutdown.is_set():
+            # Graceful shutdown: the durable write for this completion is
+            # already journaled by on_job_done's owning stage; do not step
+            # further (stepping could submit new work). Park RESUMABLE.
+            self._park_resumable(item)
+            return
+        self._run_item(item)
+
+    def _park_resumable(self, item: WorkItem) -> None:
+        """Park *item* as RESUMABLE at its current stage (interrupt semantics).
+
+        Never FAILED: durable writes precede queue pushes, so a restart's
+        seeding reconstruction resumes exactly here with no shutdown
+        bookkeeping.
+        """
+        item.result = ItemResult(
+            passed=False,
+            reason=f"resumable at {item.stage.value}",
+            final_stage=item.stage,
+        )
+        item.add_history_event(item.stage, item.state, note="interrupted; resumable")
+        self._resumable.append(item)
+        logger.info(
+            "interrupt: item %s RESUMABLE at %s (never failed)",
+            self._item_key(item),
+            item.stage.value,
+        )
+
+    # -- queue draining and admission ---------------------------------------
+
+    def _drain_queues(self) -> None:
+        """Drain queues downstream-first with admission control."""
+        for stage_name in _DRAIN_ORDER:
+            if self.shutdown.is_set():
+                return
+            if stage_name is StageName.IMPLEMENTATION:
+                self._drain_implementation()
+                continue
+            q = self.queues[stage_name]
+            for _ in range(len(q)):
+                if self.shutdown.is_set():
+                    return
+                item = q.pop()
+                if not self._admit(item):
+                    q.push(item)
+                    continue
+                self.event_log.append(("drain", stage_name.value, self._item_key(item)))
+                self._run_item(item)
+
+    def _drain_implementation(self) -> None:
+        """Drain the implementation queue under topo order + file-overlap gating.
+
+        REUSES :func:`admission.order_for_implementation` (dependencies
+        first) and :func:`admission._select_non_overlapping` (defer plans
+        touching the same files while a peer is dispatched, #1623 — only
+        engaged when real parallelism is possible, mirroring the legacy
+        ``serialize_file_overlap`` gate).
+        """
+        q = self.queues[StageName.IMPLEMENTATION]
+        if not len(q):
+            return
+        items = [q.pop() for _ in range(len(q))]
+        issue_items = {it.issue: it for it in items if it.issue is not None}
+        infos = [
+            IssueInfo(
+                number=it.issue,
+                title=str(it.payload.get("issue_title", "")),
+                dependencies=list(it.payload.get("dependencies", [])),
+            )
+            for it in items
+            if it.issue is not None
+        ]
+        ordered = _admission.order_for_implementation(infos)
+        dispatch = ordered
+        if self.config.max_workers > 1 and len(ordered) > 1:
+            dispatch, deferred = _admission._select_non_overlapping(ordered)
+            for number in deferred:
+                logger.info("implementation #%s deferred (file overlap)", number)
+        ran: set[int] = set()
+        for number in dispatch:
+            item = issue_items[number]
+            if self.shutdown.is_set() or not self._admit(item):
+                continue  # stays queued (re-pushed below)
+            ran.add(id(item))
+            self.event_log.append(("drain", StageName.IMPLEMENTATION.value, self._item_key(item)))
+            self._run_item(item)
+        # Preserve original queue order for deferred / non-admitted / non-issue items.
+        for it in items:
+            if id(it) not in ran:
+                q.push(it)
+
+    def _admit(self, item: WorkItem) -> bool:
+        """Admission control: per-repo in-flight cap (O(1) Counter lookup)."""
+        return self.inflight_per_repo[item.repo] < max(1, self.config.max_workers)
+
+    # -- item execution -----------------------------------------------------
+
+    def _run_item(self, item: WorkItem) -> None:
+        """Drive one item: on_enter, then step until JobRequest or outcome.
+
+        Per-item try/except — a poisoned item routes to finished(fail) and
+        never kills the loop.
+        """
+        self._progress = True
+        stage = self.stages[item.stage]
+        ctx = self._ctx_for(item)
+        try:
+            if item.payload.pop("_enter_pending", False):
+                outcome = stage.on_enter(item, ctx)
+                if outcome is not None:
+                    self._route(item, outcome)
+                    return
+            for _ in range(_MAX_STEPS_PER_TICK):
+                result = self._step_with_watchdog(stage, item, ctx)
+                if isinstance(result, Continue):
+                    item.state = result.next_state
+                    item.add_history_event(item.stage, item.state)
+                    continue
+                if isinstance(result, JobRequest):
+                    if self.config.dry_run:
+                        descr = getattr(result.job, "descr", "") or type(result.job).__name__
+                        logger.info(
+                            "[dry-run] would submit %s: %s", type(result.job).__name__, descr
+                        )
+                        self._route(
+                            item, StageOutcome(Disposition.ADVANCE, f"[dry-run] would {descr}")
+                        )
+                        return
+                    self._submit(item, result)
+                    return
+                self._route(item, result)
+                return
+            raise RuntimeError(
+                f"stage {item.stage.value} exceeded {_MAX_STEPS_PER_TICK} steps in one tick"
+            )
+        except Exception as exc:
+            logger.exception(
+                "pipeline item %s poisoned at %s; routing to finished(fail)",
+                self._item_key(item),
+                item.stage.value,
+            )
+            self._finish(item, passed=False, reason=f"poisoned: {exc}")
+
+    def _step_with_watchdog(self, stage: Stage, item: WorkItem, ctx: StageContext) -> Any:
+        """Run one stage.step, warning when it breaches the <~5s contract."""
+        t0 = time.monotonic()
+        result = stage.step(item, ctx)
+        elapsed = time.monotonic() - t0
+        if elapsed > _STEP_WATCHDOG_S:
+            logger.warning(
+                "stage.step stalled: %s %s took %.1fs (contract: <%.0fs)",
+                item.stage.value,
+                self._item_key(item),
+                elapsed,
+                _STEP_WATCHDOG_S,
+            )
+        return result
+
+    def _submit(self, item: WorkItem, request: JobRequest) -> None:
+        """Submit the requested job; register in-flight bookkeeping.
+
+        Rate gate (non-blocking): an AgentJob submitted while the GraphQL
+        budget is low is timer-parked until the upstream reset instead
+        (``will_submit_agent`` does not exist on the merged stage protocol,
+        so the gate lives here at the submit chokepoint — the plan's
+        sanctioned fallback).
+        """
+        assert not self.config.dry_run, "dry-run must never submit jobs"  # noqa: S101
+        job = request.job
+        if isinstance(job, AgentJob):
+            ok, delay = self._rate_budget_ok()
+            if not ok:
+                logger.info(
+                    "rate budget low; timer-parking %s for %.0fs (no sleep)",
+                    self._item_key(item),
+                    delay,
+                )
+                self._timer_park(item, delay)
+                return
+            if self.config.phase_timeout_s and self.config.phase_timeout_s > 0:
+                # --phase-timeout semantic shift (M4): under --pipeline it
+                # bounds each AGENT JOB, not a phase subprocess.
+                job = replace(job, timeout_s=int(self.config.phase_timeout_s))
+        handle = self.pool.submit(job, cast(StageName, request.on_done_state))
+        self.in_flight[handle] = item
+        self.inflight_per_repo[item.repo] += 1
+        self.event_log.append(
+            ("submit", type(job).__name__, self._item_key(item), request.on_done_state)
+        )
+
+    def _rate_budget_ok(self) -> tuple[bool, float]:
+        """Non-blocking rate-budget check (``(ok, park_delay_s)``)."""
+        # Imported lazily: pipeline_github pulls the full gh helper surface,
+        # which unit tests patch at this seam.
+        from hephaestus.automation.pipeline_github import rate_budget_ok
+
+        return rate_budget_ok()
+
+    # -- routing --------------------------------------------------------------
+
+    def _route(self, item: WorkItem, outcome: StageOutcome) -> None:
+        """Apply the Disposition -> action table (plan #1817)."""
+        route = ROUTES[item.stage]
+        disposition = outcome.disposition
+
+        if item.stage is StageName.FINISHED:
+            # Sink outcomes are terminal: the result is already recorded.
+            self.event_log.append(("done", self._item_key(item), outcome.note))
+            return
+
+        if disposition is Disposition.ADVANCE:
+            self._seed_products(item)
+            target = route.next
+            if target is StageName.FINISHED:
+                self._finish(item, passed=True, reason=outcome.note or "advance")
+            else:
+                self._push_item(item, target, enter=True)
+            return
+
+        if disposition is Disposition.RETRY:
+            self._route_retry(item, outcome)
+            return
+
+        if disposition is Disposition.FAIL_BACK:
+            self._route_fail_back(item, outcome, route)
+            return
+
+        if disposition is Disposition.SKIP:
+            self._finish(item, passed=False, reason=f"skip: {outcome.note}")
+            return
+        if disposition is Disposition.BLOCKED:
+            self._finish(item, passed=False, reason=f"blocked: {outcome.note}")
+            return
+        if disposition is Disposition.FINISH_PASS:
+            self._seed_products(item)
+            self._finish(item, passed=True, reason=outcome.note or "pass")
+            return
+        # FINISH_FAIL (exhaustive over Disposition)
+        self._finish(item, passed=False, reason=outcome.note or "fail")
+
+    def _route_retry(self, item: WorkItem, outcome: StageOutcome) -> None:
+        """Apply the RETRY row: heap-park on a recorded delay, else next tick.
+
+        RETRY timer contract (base.py): the stage records its backoff in
+        ``payload["retry_delay_s"]`` immediately before returning; a missing
+        key means "retry on the next drain tick". Under dry-run a DELAYED
+        retry waits on real-world progress (CI runs, PR merges) the preview
+        will never make, so the item finishes instead of stalling the heap.
+        """
+        delay = item.payload.pop("retry_delay_s", None)
+        if delay is None:
+            self._push_item(item, item.stage, enter=False)
+        elif self.config.dry_run:
+            self._finish(
+                item, passed=False, reason=f"[dry-run] would wait {delay}s: {outcome.note}"
+            )
+        else:
+            self._timer_park(item, float(delay))
+
+    def _route_fail_back(self, item: WorkItem, outcome: StageOutcome, route: Route) -> None:
+        """Apply the FAIL_BACK row: reason-keyed regression, globally capped.
+
+        Dry-run mutators never write the gate labels the earlier stage would
+        re-check, so a dry-run regression would ping-pong until the safety
+        cap while burning live reads — the item finishes with the
+        would-regress note instead (its entry classification is the dry-run
+        deliverable).
+        """
+        if self.config.dry_run:
+            self._finish(item, passed=False, reason=f"[dry-run] would fail_back: {outcome.note}")
+            return
+        fail_backs = int(item.payload.get("_fail_backs", 0)) + 1
+        item.payload["_fail_backs"] = fail_backs
+        if fail_backs > _FAIL_BACK_CAP:
+            self._finish(
+                item,
+                passed=False,
+                reason=f"fail_back safety cap ({_FAIL_BACK_CAP}) exceeded: {outcome.note}",
+            )
+            return
+        target = route.fail_routes.get(outcome.note, route.fail_routes.get("*", StageName.FINISHED))
+        if target is StageName.FINISHED:
+            self._finish(item, passed=False, reason=outcome.note or "fail_back")
+        else:
+            self._push_item(item, target, enter=True)
+
+    def _finish(self, item: WorkItem, *, passed: bool, reason: str) -> None:
+        """Set the item's result and hand it to the finished sink."""
+        item.result = ItemResult(passed=passed, reason=reason, final_stage=item.stage)
+        if item.stage is StageName.FINISHED:
+            # Poisoned inside the sink: record directly, never re-queue.
+            if not item.payload.get("_recorded", False):
+                self.ledger.append(item.result)
+                item.payload["_recorded"] = True
+            return
+        self._push_item(item, StageName.FINISHED, enter=True)
+
+    def _seed_products(self, item: WorkItem) -> None:
+        """Push a terminal repo item's discovered products into entry queues."""
+        if item.kind is not ItemKind.REPO:
+            return
+        for product in item.payload.pop("products", []):
+            if product.get("stage") is None:
+                logger.info("[%s] excluded: %s", item.repo, product.get("reason", ""))
+                continue
+            new_item = product_to_work_item(item.repo, product)
+            if new_item is None:  # pragma: no cover - guarded by stage check above
+                continue
+            if new_item.stage is StageName.FINISHED:
+                new_item.result = ItemResult(
+                    passed=True,
+                    reason=product.get("reason", "already finished"),
+                    final_stage=StageName.FINISHED,
+                )
+            elif new_item.stage is not StageName.REPO:
+                self._pass_work_count += 1
+            self._push_item(new_item, new_item.stage, enter=True)
+
+    def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> None:
+        """Push *item* into *stage*'s queue (the single push chokepoint).
+
+        Every durable GitHub mutation for this transition already happened
+        inside the stage, immediately before the outcome that got us here.
+        """
+        item.stage = stage
+        if enter:
+            item.state = "ENTER"
+            item.payload["_enter_pending"] = True
+            item.add_history_event(stage, item.state, note="enqueued")
+        if id(item) not in self._seen_item_ids:
+            self._seen_item_ids.add(id(item))
+            self.items.append(item)
+            item.payload.setdefault("entry_stage", stage.value)
+        self.queues[stage].push(item)
+        self.event_log.append(("push", stage.value, self._item_key(item)))
+
+    @staticmethod
+    def _item_key(item: WorkItem) -> str:
+        """Human-readable item identity for logs and the event log."""
+        if item.kind is ItemKind.REPO:
+            return item.repo
+        if item.kind is ItemKind.PR:
+            return f"{item.repo}!{item.pr}"
+        return f"{item.repo}#{item.issue}"
+
+    # -- seeding / convergence ------------------------------------------------
+
+    def _seed_pass(self) -> int:
+        """Seed one pass from CLI scope (repos / --issues / --prs).
+
+        Returns:
+            The number of items pushed (repo seeds included).
+
+        """
+        self._pass_work_count = 0
+        entries = _seeding.seed_from_cli(self.config.repos, self.config.issues, self.config.prs)
+        pushed = 0
+        for entry in entries:
+            if entry.stage is None:
+                # Epic tagging is the ONE sanctioned seeding write, executed
+                # here through the skip_epics chokepoint BEFORE the exclusion
+                # is honored (seeding.py write-path boundary).
+                if entry.reason.startswith(_seeding.EPIC_NEEDS_SKIP_TAG):
+                    self.github.skip_epics({int(entry.identifier): []})
+                logger.info("seed excluded: %s", entry.reason)
+                continue
+            item = self._entry_to_item(entry, self.config.repos[0] if self.config.repos else "")
+            if item.stage not in (StageName.REPO, StageName.FINISHED):
+                self._pass_work_count += 1
+            if item.stage is StageName.FINISHED and item.result is None:
+                item.result = ItemResult(
+                    passed=True, reason=entry.reason, final_stage=StageName.FINISHED
+                )
+            self._push_item(item, item.stage, enter=True)
+            pushed += 1
+        return pushed
+
+    @staticmethod
+    def _entry_to_item(entry: _seeding.SeedEntry, default_repo: str) -> WorkItem:
+        """Turn one :class:`~.seeding.SeedEntry` into a queue-ready WorkItem.
+
+        Args:
+            entry: The seed entry (never an exclusion — caller filters).
+            default_repo: Repo context for ``--issues`` / ``--prs`` entries
+                (the legacy loop scopes an explicit issue list to the first
+                resolved repo the same way).
+
+        """
+        assert entry.stage is not None  # noqa: S101  # caller filters exclusions
+        if entry.kind == "repo":
+            item = WorkItem(repo=str(entry.identifier), kind=ItemKind.REPO, stage=entry.stage)
+        elif entry.kind == "pr":
+            item = WorkItem(
+                repo=default_repo, kind=ItemKind.PR, pr=int(entry.identifier), stage=entry.stage
+            )
+        else:
+            item = WorkItem(
+                repo=default_repo,
+                kind=ItemKind.ISSUE,
+                issue=int(entry.identifier),
+                stage=entry.stage,
+            )
+        item.state = "ENTER"
+        item.payload["entry_reason"] = entry.reason
+        return item
+
+    def _reseed_if_converged(self) -> bool:
+        """Re-seed after full drain; False = stop (loops or zero-work exit).
+
+        Mirrors the legacy zero-work early-exit (loop_runner
+        ``_CONVERGENCE_PHASES``): when the just-finished pass produced zero
+        actionable (non-repo, non-finished) work, the run converged — exit
+        even if ``--loops`` remain.
+        """
+        if self._loops_run >= self.config.loops:
+            logger.info("loop budget exhausted (%d/%d)", self._loops_run, self.config.loops)
+            return False
+        if self._pass_work_count == 0:
+            logger.info(
+                "zero-work convergence: pass %d produced no actionable items; exiting early",
+                self._loops_run,
+            )
+            return False
+        self._loops_run += 1
+        logger.info("re-seeding: loop %d/%d", self._loops_run, self.config.loops)
+        return self._seed_pass() > 0
+
+    # -- shutdown ---------------------------------------------------------------
+
+    def _install_signal_handlers(self) -> None:
+        """SIGINT/SIGTERM/SIGHUP -> one shutdown Event (first graceful, second immediate)."""
+
+        def _handler(signum: int, frame: object) -> None:
+            if self.shutdown.is_set():
+                logger.warning("second signal %d: immediate shutdown", signum)
+                self._immediate = True
+            else:
+                logger.warning(
+                    "signal %d: graceful shutdown (grace %.0fs; press again to force)",
+                    signum,
+                    self.config.grace_s,
+                )
+                self.shutdown.set()
+                self._grace_deadline = time.monotonic() + self.config.grace_s
+
+        sigs = [signal.SIGINT, signal.SIGTERM]
+        if hasattr(signal, "SIGHUP"):  # pragma: no branch - always true on POSIX
+            sigs.append(signal.SIGHUP)
+        for sig in sigs:
+            try:
+                signal.signal(sig, _handler)
+            except ValueError:  # pragma: no cover - not on the main thread
+                logger.debug("cannot install handler for %s off the main thread", sig)
+
+    def _teardown_immediate(self) -> None:
+        """Cancel the pool and synthesize interrupted results for in-flight items."""
+        self.shutdown.set()
+        try:
+            self.pool.shutdown()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("pool shutdown raised")
+        for item in list(self.in_flight.values()):
+            self._park_resumable(item)
+        self.in_flight.clear()
+        self.inflight_per_repo.clear()
+
+    def _finalize_resumable(self) -> None:
+        """Mark every still-live item RESUMABLE at its stage (never FAILED)."""
+        if not self.shutdown.is_set():
+            return
+        leftovers: list[WorkItem] = [item for _, _, item in self.timers]
+        for stage_name, q in self.queues.items():
+            if stage_name is StageName.FINISHED:
+                continue
+            leftovers.extend(q.snapshot())
+        leftovers.extend(self.in_flight.values())
+        for item in leftovers:
+            if item.result is None:
+                self._park_resumable(item)
+
+
+def run_pipeline(config: PipelineConfig) -> int:
+    """Run the queue-based pipeline to completion.
+
+    Public entry point called from ``loop_runner.main()`` when ``--pipeline``
+    (or ``HEPH_PIPELINE=1``) is enabled.
+
+    Args:
+        config: Pipeline configuration.
+
+    Returns:
+        Exit code: 130 interrupt, 1 any fail/skip/blocked, 0 clean.
+
+    """
+    # Imported here: pipeline_github maps the accessor onto the real gh
+    # helpers and must stay out of the pure pipeline import surface.
+    from hephaestus.automation.pipeline_github import PipelineGitHub
+
+    github = PipelineGitHub(config.org, dry_run=config.dry_run)
+    coordinator = Coordinator(config, github=github)
+    return coordinator.run()

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -81,7 +81,7 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
@@ -511,10 +511,11 @@ class Coordinator:
             )
             self._finish(item, passed=False, reason="poisoned: on_job_done raised")
             return
-        # JobHandle.on_done_state is annotated StageName upstream but carries
-        # the stage-local state string the JobRequest specified (see
-        # JobRequest.on_done_state: str) — runtime values are plain strings.
-        item.state = cast(str, handle.on_done_state)
+        item.state = (
+            handle.on_done_state.value
+            if isinstance(handle.on_done_state, StageName)
+            else handle.on_done_state
+        )
         if self.shutdown.is_set():
             # Graceful shutdown: the durable write for this completion is
             # already journaled by on_job_done's owning stage; do not step
@@ -698,7 +699,7 @@ class Coordinator:
                 # --phase-timeout semantic shift (M4): under --pipeline it
                 # bounds each AGENT JOB, not a phase subprocess.
                 job = replace(job, timeout_s=int(self.config.phase_timeout_s))
-        handle = self.pool.submit(job, cast(StageName, request.on_done_state))
+        handle = self.pool.submit(job, request.on_done_state)
         self.in_flight[handle] = item
         self.inflight_per_repo[item.repo] += 1
         self.event_log.append(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -325,7 +325,6 @@ class Coordinator:
         started = time.monotonic()
         if self._install_signals:
             self._install_signal_handlers()
-        exit_code = 1
         try:
             self._loops_run = 1
             self._seed_pass()

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -78,6 +78,7 @@ import signal
 import threading
 import time
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, cast
@@ -168,6 +169,7 @@ class PipelineConfig:
     dry_run: bool = False
     grace_s: float = _DEFAULT_GRACE_S
     phase_timeout_s: float | None = None
+    agent: str = "claude"
     model: str = ""
     planner_model: str = ""
     reviewer_model: str = ""
@@ -189,6 +191,10 @@ class _StageRunConfig:
     run_pre_pr_tests: bool = False
     force: bool = False
     agent: str = "claude"
+    model: str = ""
+    planner_model: str = ""
+    reviewer_model: str = ""
+    implementer_model: str = ""
     dry_run: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
@@ -218,6 +224,7 @@ class Coordinator:
         github: StageGitHub,
         pool: Any | None = None,
         stages: dict[StageName, Stage] | None = None,
+        github_factory: Callable[[str, Path], StageGitHub] | None = None,
         install_signals: bool = True,
     ) -> None:
         """Initialize coordinator state.
@@ -228,12 +235,15 @@ class Coordinator:
             pool: Worker pool (a real ``WorkerPool`` is built when omitted;
                 tests inject ``FakeWorkerPool``).
             stages: Stage-instance map override (tests inject stubs).
+            github_factory: Optional per-repo accessor factory. Production uses
+                this so each repo context targets GitHub with an explicit repo.
             install_signals: Install SIGINT/SIGTERM/SIGHUP handlers in
                 ``run()`` (disabled in unit tests).
 
         """
         self.config = config
         self.github = github
+        self._github_factory = github_factory
         self.shutdown = threading.Event()
         self.completion_q: CompletionQueue = queue_mod.Queue()
         if pool is None:
@@ -277,6 +287,11 @@ class Coordinator:
         self._seen_item_ids: set[int] = set()
         self._stage_config = _StageRunConfig(
             enable_advise=not config.no_advise,
+            agent=config.agent,
+            model=config.model,
+            planner_model=config.planner_model,
+            reviewer_model=config.reviewer_model,
+            implementer_model=config.implementer_model,
             dry_run=config.dry_run,
             nitpick=config.nitpick,
             drive_green_all=config.drive_green_all,
@@ -307,7 +322,11 @@ class Coordinator:
                 config=self._stage_config,
                 org=self.config.org,
                 dry_run=self.config.dry_run,
-                github=self.github,
+                github=(
+                    self._github_factory(item.repo, root)
+                    if self._github_factory is not None
+                    else self.github
+                ),
                 paths=_Paths(
                     repo_root=root,
                     worktree=root,
@@ -994,6 +1013,18 @@ def run_pipeline(config: PipelineConfig) -> int:
     # helpers and must stay out of the pure pipeline import surface.
     from hephaestus.automation.pipeline_github import PipelineGitHub
 
-    github = PipelineGitHub(config.org, dry_run=config.dry_run)
-    coordinator = Coordinator(config, github=github)
+    def _github_for(repo_name: str, repo_root: Path) -> PipelineGitHub:
+        return PipelineGitHub(
+            config.org,
+            repo=repo_name,
+            dry_run=config.dry_run,
+            repo_root=repo_root,
+        )
+
+    repo = config.repos[0] if config.repos else ""
+    repo_root = Path(config.projects_dir) / repo if repo else Path(config.projects_dir)
+    github = (
+        _github_for(repo, repo_root) if repo else PipelineGitHub(config.org, dry_run=config.dry_run)
+    )
+    coordinator = Coordinator(config, github=github, github_factory=_github_for)
     return coordinator.run()

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -32,6 +32,7 @@ class AgentJob:
     prompt_builder: Callable[..., str]
     cwd: Path
     timeout_s: int
+    session_agent: str = ""
     prompt_kwargs: dict[str, Any] = field(default_factory=dict)
     output_format: str = "text"
     parse: Callable[[str], Any] | None = None  # e.g. claude_invoke.parse_review_verdict

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -108,4 +108,4 @@ class JobHandle:
     """
 
     job: AgentJob | BuildTestJob | GitJob
-    on_done_state: StageName
+    on_done_state: str | StageName

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from hephaestus.automation._review_utils import find_merged_pr_for_issue, find_pr_for_issue
 from hephaestus.automation.github_api import fetch_issue_info, gh_pr_label_names
@@ -282,6 +282,39 @@ def seed_issue(issue_number: int) -> IssueFacts:
     return IssueFacts(
         number=issue_number,
         title=issue_info.title,
+        is_epic=epic,
+        labels=labels,
+        pr_number=pr_number,
+        pr_is_open=pr_is_open,
+        pr_is_merged=pr_is_merged,
+    )
+
+
+def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
+    """Fetch and normalize issue facts through a repo-scoped StageGitHub accessor."""
+    issue_data = github.gh_issue_json(issue_number)
+    raw_labels = issue_data.get("labels", []) if isinstance(issue_data, dict) else []
+    labels = {
+        str(label.get("name", ""))
+        for label in raw_labels
+        if isinstance(label, dict) and label.get("name")
+    }
+    title = str(issue_data.get("title") or "") if isinstance(issue_data, dict) else ""
+    epic = is_epic(sorted(labels), title)
+
+    pr_is_open = False
+    pr_is_merged = False
+    pr_number: int | None = github.find_pr_for_issue(issue_number)
+    if pr_number is not None:
+        pr_is_open = True
+    else:
+        pr_number = github.find_merged_pr_for_issue(issue_number)
+        if pr_number is not None:
+            pr_is_merged = True
+
+    return IssueFacts(
+        number=issue_number,
+        title=title,
         is_epic=epic,
         labels=labels,
         pr_number=pr_number,

--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -15,21 +15,25 @@ from .base import (
     StepResult,
 )
 from .ci import CiStage
+from .finished import FinishedStage
 from .implementation import ImplementationStage
 from .merge_wait import MergeWaitStage
 from .plan_review import PlanReviewStage
 from .planning import PlanningStage
 from .pr_review import PrReviewStage
+from .repo import RepoStage
 
 __all__ = [
     "CiStage",
     "Continue",
+    "FinishedStage",
     "ImplementationStage",
     "JobRequest",
     "MergeWaitStage",
     "PlanReviewStage",
     "PlanningStage",
     "PrReviewStage",
+    "RepoStage",
     "Stage",
     "StageContext",
     "StageGitHub",

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -331,6 +331,27 @@ class StageGitHub(Protocol):
         """
         ...
 
+    # -- repo-stage surface (#1817) -----------------------------------------
+
+    def skip_epics(self, epics_labels: dict[int, list[str]]) -> None:
+        """Durably tag epics ``state:skip`` (the ONE sanctioned seeding write).
+
+        The coordinator (#1817) maps this onto the existing
+        ``github_api.skip_epics`` chokepoint; the repo stage calls it BEFORE
+        excluding epics (doc row "Epic tagging is the one seeding write; done
+        BEFORE excluding" — see :mod:`..seeding`'s write-path boundary note).
+        """
+        ...
+
+    def ensure_state_labels(self) -> None:
+        """Durably ensure the ``state:*`` label vocabulary exists on the repo.
+
+        Repo-stage step 1 [M] (doc section 1 ``ensure_state_labels``): the
+        coordinator maps this onto ``github_api._ensure_labels_exist`` over
+        the full ``state_labels`` vocabulary. Idempotent by construction.
+        """
+        ...
+
 
 @dataclass(frozen=True)
 class Continue:

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -80,6 +80,8 @@ __all__ = [
     "StageOutcome",
     "StepResult",
     "WorkItem",
+    "agent_provider",
+    "stage_model",
     "write_skip_label",
 ]
 
@@ -113,6 +115,10 @@ class StageGitHub(Protocol):
 
     def find_merged_closing_pr(self, issue_number: int) -> int | None:
         """Return the merged PR closing this issue, if any (``_review_utils``)."""
+        ...
+
+    def find_merged_pr_for_issue(self, issue_number: int) -> int | None:
+        """Return the merged PR for this issue, if any (tri-state seeding lookup)."""
         ...
 
     def find_pr_for_issue(self, issue_number: int) -> int | None:
@@ -415,6 +421,18 @@ class StageContext:
         if self.budget_fn is not None:
             return self.budget_fn(name)
         return 1  # conservative default
+
+
+def agent_provider(ctx: StageContext) -> str:
+    """Return the selected agent backend provider for an agent job."""
+    return str(getattr(ctx.config, "agent", "") or "claude")
+
+
+def stage_model(ctx: StageContext, phase: str, fallback: Callable[[], str]) -> str:
+    """Return a phase model override, the catch-all model, or the legacy fallback."""
+    phase_value = getattr(ctx.config, f"{phase}_model", "")
+    catch_all = getattr(ctx.config, "model", "")
+    return str(phase_value or catch_all or fallback())
 
 
 def _issue_labels(item: WorkItem, ctx: StageContext) -> list[str]:

--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -85,6 +85,8 @@ from .base import (
     StepResult,
     WorkItem,
     _worktree_path,
+    agent_provider,
+    stage_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -436,11 +438,12 @@ class CiStage(Stage):
         job = AgentJob(
             repo=item.repo,
             issue=item.issue if item.issue is not None else 0,
-            agent=AGENT_CI_DRIVER,
-            model=implementer_model(),
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
             prompt_builder=prompt_builder,
             cwd=_worktree_path(item, ctx),
             timeout_s=ci_driver_claude_timeout(),
+            session_agent=AGENT_CI_DRIVER,
             prompt_kwargs=prompt_kwargs,
             descr="force_engagement" if escalate else "ci_fix",
         )

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -134,8 +134,13 @@ class FinishedStage(Stage):
             repo=item.repo,
             op="remove_worktree",
             timeout_s=GIT_JOB_TIMEOUT_S,
-            # worker_pool dispatches to WorktreeManager.remove_worktree(**kwargs).
-            kwargs={"issue_number": item.issue or 0, "force": True},
+            # Use the concrete worktree path: the cleanup worker constructs a
+            # fresh WorktreeManager, so its in-memory issue map is empty.
+            kwargs={
+                "worktree_path": item.worktree,
+                "repo_root": str(ctx.paths.repo_root),
+                "force": True,
+            },
             descr=f"remove worktree {item.worktree}",
         )
         return JobRequest(job=job, on_done_state="DONE")

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -1,0 +1,157 @@
+"""Finished stage: record outcomes and clean up worktrees (epic #1809).
+
+Binding contract: docs/AUTOMATION_LOOP_ARCHITECTURE.md section "8. finished".
+
+The universal sink. States: ENTER -> RECORD -> CLEANUP -> DONE.
+
+Steps:
+
+1. [M] RECORD: append the item's :class:`~..work_item.ItemResult` to the run
+   ledger (the coordinator injects its ledger list at construction — queue
+   and ledger ownership stay with the coordinator).
+2. [W:G] CLEANUP: ``GitJob(op="remove_worktree")`` on pass; on fail the
+   worktree is PRESERVED for debugging and recorded in the preserved list
+   the end-of-run summary prints.
+
+Verdicts: terminal — no outgoing routes (the coordinator drops the item
+when the sink emits its final outcome).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hephaestus.automation.pipeline.work_item import ItemResult
+
+from .base import (
+    GIT_JOB_TIMEOUT_S,
+    Continue,
+    Disposition,
+    GitJob,
+    JobRequest,
+    JobResult,
+    Stage,
+    StageContext,
+    StageName,
+    StageOutcome,
+    StepResult,
+    WorkItem,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FinishedStage(Stage):
+    """Sink stage: record :class:`ItemResult` and clean up worktrees.
+
+    Args:
+        ledger: The coordinator's run ledger; RECORD appends here.
+        preserved: The coordinator's preserved-worktree list
+            (``(issue_number, worktree_path)`` tuples) the summary prints.
+
+    """
+
+    kind = StageName.FINISHED
+
+    def __init__(
+        self,
+        ledger: list[ItemResult],
+        preserved: list[tuple[int, str]],
+    ) -> None:
+        """Bind the coordinator-owned ledger and preserved-worktree list."""
+        self._ledger = ledger
+        self._preserved = preserved
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """Proceed unconditionally (the sink never routes away).
+
+        Args:
+            item: The finished work item (``item.result`` set by the router).
+            ctx: Stage context.
+
+        Returns:
+            None always.
+
+        """
+        return None
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Execute the next sink action for the item's current state.
+
+        Args:
+            item: The work item; ``item.result`` was set when it was routed
+                here (a missing result is recorded as an internal failure —
+                never silently dropped).
+            ctx: Stage context.
+
+        Returns:
+            Continue, JobRequest, or the terminal StageOutcome.
+
+        """
+        if item.state in ("", "ENTER"):
+            return Continue(next_state="RECORD")
+
+        if item.state == "RECORD":
+            if item.result is None:  # defensive: router always sets it
+                item.result = ItemResult(
+                    passed=False, reason="internal: no result recorded", final_stage=item.stage
+                )
+            if not item.payload.get("_recorded", False):
+                self._ledger.append(item.result)
+                item.payload["_recorded"] = True
+            return Continue(next_state="CLEANUP")
+
+        if item.state == "CLEANUP":
+            return self._cleanup(item, ctx)
+
+        if item.state == "DONE":
+            return StageOutcome(Disposition.FINISH_PASS, note="done")
+
+        return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
+
+    def _cleanup(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Remove the worktree on pass; preserve (and record) it on fail."""
+        if not item.worktree:
+            return Continue(next_state="DONE")
+
+        passed = bool(item.result and item.result.passed)
+        if not passed:
+            entry = (item.issue or 0, item.worktree)
+            if entry not in self._preserved:
+                self._preserved.append(entry)
+            logger.info(
+                "finished:%s: preserving worktree for debugging: %s",
+                item.issue or item.repo,
+                item.worktree,
+            )
+            return Continue(next_state="DONE")
+
+        if ctx.dry_run:
+            logger.info("[dry-run] would remove worktree %s", item.worktree)
+            return Continue(next_state="DONE")
+
+        job = GitJob(
+            repo=item.repo,
+            op="remove_worktree",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            # worker_pool dispatches to WorktreeManager.remove_worktree(**kwargs).
+            kwargs={"issue_number": item.issue or 0, "force": True},
+            descr=f"remove worktree {item.worktree}",
+        )
+        return JobRequest(job=job, on_done_state="DONE")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Log cleanup failures (never fatal — the result is already recorded).
+
+        Args:
+            item: The work item.
+            result: The remove_worktree job result.
+            ctx: Stage context.
+
+        """
+        if not result.ok:
+            logger.warning(
+                "finished:%s: worktree cleanup failed (non-fatal): %s",
+                item.issue or item.repo,
+                result.error,
+            )

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -99,6 +99,8 @@ from .base import (
     WorkItem,
     _issue_labels,
     _worktree_path,
+    agent_provider,
+    stage_model,
     write_skip_label,
 )
 
@@ -298,11 +300,12 @@ class ImplementationStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_IMPLEMENTER,
-                model=implementer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "implementer", implementer_model),
                 prompt_builder=get_dirty_reused_worktree_decision_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=implementer_claude_timeout(),
+                session_agent=AGENT_IMPLEMENTER,
                 prompt_kwargs={
                     "branch_name": item.branch,
                     "status_text": item.payload.get("worktree_status", ""),
@@ -332,11 +335,12 @@ class ImplementationStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_ADVISE,
-                model=advise_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "advise", advise_model),
                 prompt_builder=get_advise_prompt_builder(ctx.config.agent),
                 cwd=_worktree_path(item, ctx),
                 timeout_s=advise_claude_timeout(),
+                session_agent=AGENT_ADVISE,
                 prompt_kwargs={
                     "issue_number": item.issue,
                     "issue_title": item.payload.get("issue_title", ""),
@@ -365,11 +369,12 @@ class ImplementationStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_IMPLEMENTER,
-                model=implementer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "implementer", implementer_model),
                 prompt_builder=build_implementation_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=implementer_claude_timeout(),
+                session_agent=AGENT_IMPLEMENTER,
                 prompt_kwargs={
                     "issue_number": item.issue,
                     "issue_title": item.payload.get("issue_title", ""),
@@ -415,11 +420,12 @@ class ImplementationStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_IMPLEMENTER,
-                model=implementer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "implementer", implementer_model),
                 prompt_builder=build_test_fix_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=implementer_claude_timeout(),
+                session_agent=AGENT_IMPLEMENTER,
                 prompt_kwargs={
                     "issue_number": item.issue,
                     "prev_iteration": item.attempts.get("test_fix", 0),

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -263,8 +263,8 @@ class ImplementationStage(Stage):
             logger.info("implementation:%d: requesting worktree job", item.issue)
             adopted = bool(item.payload.get("existing_pr"))
             kwargs: dict[str, object] = {
-                "issue": item.issue,
-                "branch": item.branch,
+                "issue_number": item.issue,
+                "branch_name": item.branch,
                 # Fresh branch: cut from a freshly refreshed trunk (doc step
                 # 2: worktree_manager.create_worktree(refresh_base=True)).
                 # ADOPTED branch: never reset to trunk — sync to the PR's

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -443,7 +443,12 @@ class ImplementationStage(Stage):
                 repo=item.repo,
                 op="commit_push",
                 timeout_s=GIT_JOB_TIMEOUT_S,
-                kwargs={"branch": item.branch},
+                kwargs={
+                    "issue_number": item.issue,
+                    "worktree_path": item.worktree,
+                    "branch": item.branch,
+                    "agent": agent_provider(ctx),
+                },
                 descr="commit_push",
             )
             return JobRequest(push_job, on_done_state=PR_CREATE)
@@ -496,20 +501,26 @@ class ImplementationStage(Stage):
             return
 
         if item.state == COMMIT_PUSH_WAIT:
-            if result.ok:
-                # A successful push ends the consecutive-git-failure streak.
-                item.payload.pop("git_error_retries", None)
-                return
-            error_text = (result.error or "").lower()
-            if "no commits" in error_text:
-                # Legacy _handle_runtime_error (:348): "no commits between
-                # base and branch" maps to state:skip, not a hard failure.
+            self._on_commit_push_done(item, result)
+
+    @staticmethod
+    def _on_commit_push_done(item: WorkItem, result: JobResult) -> None:
+        """Record commit+push success, no-commit skip, or git failure."""
+        if result.ok:
+            if not bool(result.value):
                 item.payload["no_commits"] = True
-            else:
-                logger.warning(
-                    "implementation:%s: commit+push failed: %s", item.issue, result.error
-                )
-                item.payload["git_error"] = True
+            # A successful worker result ends the consecutive-git-failure
+            # streak even when no commit was produced; PR_CREATE handles skip.
+            item.payload.pop("git_error_retries", None)
+            return
+        error_text = (result.error or "").lower()
+        if "no commits" in error_text:
+            # Legacy _handle_runtime_error (:348): "no commits between
+            # base and branch" maps to state:skip, not a hard failure.
+            item.payload["no_commits"] = True
+            return
+        logger.warning("implementation:%s: commit+push failed: %s", item.issue, result.error)
+        item.payload["git_error"] = True
 
     @staticmethod
     def _on_implement_done(item: WorkItem, result: JobResult) -> None:

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -90,6 +90,8 @@ from .base import (
     StepResult,
     WorkItem,
     _worktree_path,
+    agent_provider,
+    stage_model,
     write_skip_label,
 )
 
@@ -438,11 +440,12 @@ class MergeWaitStage(Stage):
         job = AgentJob(
             repo=item.repo,
             issue=item.issue if item.issue is not None else 0,
-            agent=AGENT_ADDRESS_REVIEW,
-            model=implementer_model(),
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
             prompt_builder=get_address_review_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=address_review_claude_timeout(),
+            session_agent=AGENT_ADDRESS_REVIEW,
             prompt_kwargs={
                 "pr_number": item.pr,
                 "issue_number": item.issue if item.issue is not None else 0,
@@ -490,11 +493,12 @@ class MergeWaitStage(Stage):
         job = AgentJob(
             repo=item.repo,
             issue=item.issue if item.issue is not None else 0,
-            agent=AGENT_CI_DRIVER,
-            model=implementer_model(),
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
             prompt_builder=build_drive_green_learn_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=learn_claude_timeout(),
+            session_agent=AGENT_CI_DRIVER,
             prompt_kwargs={
                 "issue_number": item.issue if item.issue is not None else 0,
                 "pr_number": item.pr,

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -75,6 +75,8 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    agent_provider,
+    stage_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -208,11 +210,12 @@ class PlanReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_PLAN_REVIEWER,
-                model=reviewer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "reviewer", reviewer_model),
                 prompt_builder=get_plan_loop_review_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=plan_reviewer_claude_timeout(),
+                session_agent=AGENT_PLAN_REVIEWER,
                 # get_plan_loop_review_prompt takes a 0-based iteration index
                 # (full-sweep suffix on the final iteration). Issue title/body
                 # are seeded into item.payload by the coordinator (#1817).
@@ -242,11 +245,12 @@ class PlanReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_PLANNER,
-                model=planner_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "planner", planner_model),
                 prompt_builder=build_amend_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
+                session_agent=AGENT_PLANNER,
                 # build_amend_prompt composes get_plan_prompt with the
                 # reviewer feedback block in-worker (doc: "resume planner
                 # session with feedback block"; mirrors
@@ -266,11 +270,12 @@ class PlanReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_PLANNER,  # resume the planner's own session (legacy parity)
-                model=planner_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "planner", planner_model),
                 prompt_builder=build_learn_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=learn_claude_timeout(),
+                session_agent=AGENT_PLANNER,  # resume planner session (legacy parity)
                 prompt_kwargs={"context": item.payload.get("plan_text", "")},
                 descr="learn",
             )

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -55,6 +55,8 @@ from .base import (
     StepResult,
     WorkItem,
     _issue_labels,
+    agent_provider,
+    stage_model,
 )
 
 logger = logging.getLogger(__name__)
@@ -226,11 +228,12 @@ class PlanningStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_ADVISE,
-                model=advise_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "advise", advise_model),
                 prompt_builder=get_advise_prompt_builder(ctx.config.agent),
                 cwd=ctx.paths.worktree,
                 timeout_s=advise_claude_timeout(),
+                session_agent=AGENT_ADVISE,
                 # Issue title/body and the Mnemosyne marketplace path are
                 # seeded into item.payload by the coordinator (#1817), which
                 # owns issue fetching and advise_runner setup.
@@ -249,11 +252,12 @@ class PlanningStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_PLANNER,
-                model=planner_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "planner", planner_model),
                 prompt_builder=build_plan_prompt,
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
+                session_agent=AGENT_PLANNER,
                 # build_plan_prompt composes get_plan_prompt with the advise
                 # findings block in-worker, mirroring the legacy
                 # planner_review_loop.generate_plan(cached_advise=...)

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -138,6 +138,8 @@ from .base import (
     StepResult,
     WorkItem,
     _worktree_path,
+    agent_provider,
+    stage_model,
     write_skip_label,
 )
 
@@ -379,11 +381,12 @@ class PrReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_PR_REVIEWER,
-                model=reviewer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "reviewer", reviewer_model),
                 prompt_builder=get_pr_review_analysis_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=pr_reviewer_claude_timeout(),
+                session_agent=AGENT_PR_REVIEWER,
                 # Diff / body / CI context are seeded into item.payload by
                 # the coordinator (#1817), which owns the gh reads.
                 prompt_kwargs={
@@ -411,11 +414,12 @@ class PrReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_PR_REVIEWER,
-                model=reviewer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "reviewer", reviewer_model),
                 prompt_builder=get_review_validation_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=pr_reviewer_claude_timeout(),
+                session_agent=AGENT_PR_REVIEWER,
                 prompt_kwargs={
                     "pr_number": item.pr,
                     "issue_number": item.issue,
@@ -434,11 +438,12 @@ class PrReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_COMMENT_CLASSIFIER,
-                model=reviewer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "reviewer", reviewer_model),
                 prompt_builder=get_comment_difficulty_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=pr_reviewer_claude_timeout(),
+                session_agent=AGENT_COMMENT_CLASSIFIER,
                 prompt_kwargs={
                     "issue_number": item.issue,
                     "comments_json": json.dumps(item.payload.get("review_threads", [])),
@@ -469,11 +474,12 @@ class PrReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue,
-                agent=AGENT_IMPLEMENTER,  # resume the implementer's session (legacy parity)
-                model=implementer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "implementer", implementer_model),
                 prompt_builder=get_follow_up_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=follow_up_claude_timeout(),
+                session_agent=AGENT_IMPLEMENTER,  # resume implementer session (legacy parity)
                 prompt_kwargs={"issue_number": item.issue},
                 descr="follow_up",
             )
@@ -589,11 +595,12 @@ class PrReviewStage(Stage):
             job = AgentJob(
                 repo=item.repo,
                 issue=item.issue if item.issue is not None else 0,
-                agent=AGENT_ADDRESS_REVIEW,
-                model=implementer_model(),
+                agent=agent_provider(ctx),
+                model=stage_model(ctx, "implementer", implementer_model),
                 prompt_builder=get_address_review_prompt,
                 cwd=_worktree_path(item, ctx),
                 timeout_s=address_review_claude_timeout(),
+                session_agent=AGENT_ADDRESS_REVIEW,
                 prompt_kwargs={
                     "pr_number": item.pr,
                     "issue_number": item.issue,
@@ -612,11 +619,12 @@ class PrReviewStage(Stage):
         job = AgentJob(
             repo=item.repo,
             issue=item.issue if item.issue is not None else 0,
-            agent=AGENT_IMPLEMENTER,
-            model=implementer_model(),
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
             prompt_builder=get_impl_resume_feedback_prompt,
             cwd=_worktree_path(item, ctx),
             timeout_s=implementer_claude_timeout(),
+            session_agent=AGENT_IMPLEMENTER,
             prompt_kwargs={
                 "issue_number": item.issue,
                 "prev_iteration": item.payload.get("pr_review_round", 0),

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -461,7 +461,12 @@ class PrReviewStage(Stage):
                 repo=item.repo,
                 op="commit_push",
                 timeout_s=GIT_JOB_TIMEOUT_S,
-                kwargs={"branch": item.branch},
+                kwargs={
+                    "issue_number": item.issue,
+                    "worktree_path": item.worktree,
+                    "branch": item.branch,
+                    "agent": agent_provider(ctx),
+                },
                 descr="push_fixes",
             )
             return JobRequest(git_job, on_done_state=EVAL)

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -1,0 +1,277 @@
+"""Repo stage: discover and classify issues from a GitHub repository (epic #1809).
+
+Binding contract: docs/AUTOMATION_LOOP_ARCHITECTURE.md section "1. repo".
+
+States: ENTER -> CLONE_WAIT -> DISCOVER -> SEEDED.
+
+Steps:
+
+1. [M] ``on_enter``: ``ctx.github.ensure_state_labels()`` — idempotent label
+   vocabulary setup.
+2. [W:G] CLONE_WAIT: ``GitJob(op="clone")`` when the checkout is missing
+   (skipped when already cloned, and logged-skipped under dry-run — the
+   coordinator's ``_submit`` asserts no job is ever submitted in dry-run).
+   Budget ``clone`` = 2; exhaustion -> finished(fail).
+3. [M] DISCOVER: list issues (read-only ``_list_open_issue_meta``), dedup,
+   ``partition_epics`` -> tag epics ``state:skip`` via
+   ``ctx.github.skip_epics`` [durable, BEFORE excluding], classify each kept
+   issue via the REUSED :func:`~..seeding.seed_issue` /
+   :func:`~..seeding.classify_issue`, and (``--drive-green-all``) route
+   orphan PRs (open PRs with no tracked issue) to the ci queue.
+4. [M] SEEDED: expose the classified products in
+   ``item.payload["products"]`` — the coordinator (queue owner) performs the
+   actual queue pushes when routing the repo item — and finish
+   ``FINISH_PASS(seeded:N)``. The repo item is terminal.
+
+Discovery seams (``_repo_manager`` / ``_seeding`` module attributes) mirror
+the ``loop_runner._admission`` seam pattern so unit tests patch the reads
+without network I/O.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from hephaestus.automation import loop_repo_manager as _repo_manager
+from hephaestus.automation.pipeline import seeding as _seeding
+from hephaestus.automation.state_labels import partition_epics
+
+from .base import (
+    GIT_JOB_TIMEOUT_S,
+    Continue,
+    Disposition,
+    GitJob,
+    ItemKind,
+    JobRequest,
+    JobResult,
+    Stage,
+    StageContext,
+    StageName,
+    StageOutcome,
+    StepResult,
+    WorkItem,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
+    """Return the expected local checkout path for the repo item."""
+    return Path(str(ctx.paths.projects_dir)) / item.repo
+
+
+class RepoStage(Stage):
+    """Repo discovery and classification stage (the pipeline's sole producer).
+
+    Products are ``(kind, identifier, stage, reason, facts)`` tuples staged
+    in ``item.payload["products"]``; the coordinator turns them into
+    :class:`WorkItem` pushes because stage code never touches queues.
+    """
+
+    kind = StageName.REPO
+
+    def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
+        """Ensure the state-label vocabulary exists (idempotent, durable).
+
+        Args:
+            item: The repo work item.
+            ctx: Stage context with the GitHub accessor.
+
+        Returns:
+            None to proceed with step().
+
+        """
+        ctx.github.ensure_state_labels()
+        return None
+
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Execute the next step for the current repo-item state.
+
+        Args:
+            item: The repo work item.
+            ctx: Stage context.
+
+        Returns:
+            Continue, JobRequest, or StageOutcome.
+
+        """
+        if item.state in ("", "ENTER"):
+            return Continue(next_state="CLONE_WAIT")
+
+        if item.state == "CLONE_WAIT":
+            return self._clone_or_skip(item, ctx)
+
+        if item.state == "DISCOVER":
+            return self._discover(item, ctx)
+
+        if item.state == "SEEDED":
+            products = item.payload.get("products", [])
+            seeded = sum(1 for p in products if p.get("stage") is not None)
+            return StageOutcome(Disposition.FINISH_PASS, note=f"seeded:{seeded}")
+
+        return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
+
+    def _clone_or_skip(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Submit the clone GitJob, or skip when present / dry-run / exhausted."""
+        # Clone failure handling (budget clone=2): on_job_done recorded the
+        # failure; classify it here so retry re-submits and exhaustion fails.
+        if item.payload.pop("clone_failed", False):
+            if item.attempts.get("clone", 0) >= ctx.budget("clone"):
+                return StageOutcome(
+                    Disposition.FINISH_FAIL,
+                    note=f"clone exhausted after {item.attempts['clone']} attempts",
+                )
+            logger.warning(
+                "repo:%s: clone failed (attempt %d/%d); retrying",
+                item.repo,
+                item.attempts.get("clone", 0),
+                ctx.budget("clone"),
+            )
+
+        dest = _repo_checkout_path(item, ctx)
+        if dest.exists():
+            logger.info("repo:%s: already cloned at %s", item.repo, dest)
+            return Continue(next_state="DISCOVER")
+        if ctx.dry_run:
+            logger.info("[dry-run] would clone %s/%s to %s", ctx.org, item.repo, dest)
+            return Continue(next_state="DISCOVER")
+
+        job = GitJob(
+            repo=item.repo,
+            op="clone",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            # worker_pool._dispatch_git_op clone contract: 'repo' (org/name
+            # slug for gh repo clone) + 'dest' (checkout path).
+            kwargs={"repo": f"{ctx.org}/{item.repo}", "dest": str(dest)},
+            descr=f"clone {ctx.org}/{item.repo}",
+        )
+        return JobRequest(job=job, on_done_state="DISCOVER")
+
+    def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """[M] List, dedup, tag-then-exclude epics, classify, stage products."""
+        meta = _repo_manager._list_open_issue_meta(ctx.org, item.repo)
+
+        # Dedup while preserving listing order.
+        seen: set[int] = set()
+        deduped: list[dict[str, Any]] = []
+        for entry in meta:
+            number = int(entry["number"])
+            if number in seen:
+                continue
+            seen.add(number)
+            deduped.append(entry)
+
+        # Epic tagging: the ONE sanctioned seeding write, durable and BEFORE
+        # the exclusion is final (doc row "Epic tagging is the one seeding
+        # write; done BEFORE excluding").
+        kept, epics = partition_epics(deduped)
+        if epics:
+            epic_set = set(epics)
+            epics_labels = {
+                int(m["number"]): list(m.get("labels") or [])
+                for m in deduped
+                if int(m["number"]) in epic_set
+            }
+            ctx.github.skip_epics(epics_labels)
+            for num in epics:
+                logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", item.repo, num)
+
+        products: list[dict[str, Any]] = [
+            {
+                "kind": "issue",
+                "number": num,
+                "stage": None,
+                "reason": f"epic #{num} excluded",
+            }
+            for num in epics
+        ]
+        covered_prs: set[int] = set()
+        for num in kept:
+            facts = _seeding.seed_issue(num)
+            stage, reason = _seeding.classify_issue(facts)
+            if facts.pr_number is not None:
+                covered_prs.add(facts.pr_number)
+            products.append(
+                {
+                    "kind": "issue",
+                    "number": num,
+                    "stage": stage,
+                    "reason": reason,
+                    "pr": facts.pr_number if facts.pr_is_open else None,
+                    "labels": sorted(facts.labels),
+                }
+            )
+
+        # --drive-green-all: orphan PRs (no tracked issue) -> ci stage.
+        if getattr(ctx.config, "drive_green_all", False):
+            for pr_number in _repo_manager._list_open_pr_numbers(ctx.org, item.repo):
+                if pr_number in covered_prs:
+                    continue
+                products.append(
+                    {
+                        "kind": "pr",
+                        "number": pr_number,
+                        "stage": StageName.CI,
+                        "reason": f"orphan PR #{pr_number} (drive-green-all)",
+                    }
+                )
+
+        item.payload["products"] = products
+        return Continue(next_state="SEEDED")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
+        """Record clone success/failure (state still CLONE_WAIT).
+
+        Args:
+            item: The repo work item.
+            result: The clone job result.
+            ctx: Stage context.
+
+        """
+        if item.state != "CLONE_WAIT":
+            return
+        if result.ok:
+            logger.info("repo:%s: clone completed", item.repo)
+            return
+        item.attempts["clone"] = item.attempts.get("clone", 0) + 1
+        item.payload["clone_failed"] = True
+        logger.warning("repo:%s: clone failed: %s", item.repo, result.error)
+
+
+def product_to_work_item(repo: str, product: dict[str, Any]) -> WorkItem | None:
+    """Turn one repo-stage product into a queue-ready :class:`WorkItem`.
+
+    Coordinator-side helper (queue ownership stays with the coordinator):
+    excluded products (``stage is None``) return ``None`` and are only
+    logged by the caller.
+
+    Args:
+        repo: Repository name the product belongs to.
+        product: One entry of ``item.payload["products"]``.
+
+    Returns:
+        A WorkItem parked at the product's entry stage, or ``None`` when the
+        product is excluded from the pipeline.
+
+    """
+    stage = product.get("stage")
+    if stage is None:
+        return None
+    kind = ItemKind.PR if product.get("kind") == "pr" else ItemKind.ISSUE
+    number = int(product["number"])
+    item = WorkItem(
+        repo=repo,
+        kind=kind,
+        issue=number if kind is ItemKind.ISSUE else None,
+        pr=int(product["pr"]) if product.get("pr") else (number if kind is ItemKind.PR else None),
+        stage=stage,
+        state="ENTER",
+    )
+    labels = product.get("labels") or []
+    if labels:
+        item.labels_cache = dict.fromkeys(labels, True)
+    item.payload["entry_stage"] = stage.value
+    item.payload["entry_reason"] = product.get("reason", "")
+    return item

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -151,7 +151,11 @@ class RepoStage(Stage):
 
     def _discover(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """[M] List, dedup, tag-then-exclude epics, classify, stage products."""
-        meta = _repo_manager._list_open_issue_meta(ctx.org, item.repo)
+        try:
+            meta = _repo_manager._list_open_issue_meta(ctx.org, item.repo)
+        except Exception as exc:
+            logger.warning("repo:%s: discovery failed: %s", item.repo, exc)
+            return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
 
         # Dedup while preserving listing order.
         seen: set[int] = set()
@@ -206,7 +210,12 @@ class RepoStage(Stage):
 
         # --drive-green-all: orphan PRs (no tracked issue) -> ci stage.
         if getattr(ctx.config, "drive_green_all", False):
-            for pr_number in _repo_manager._list_open_pr_numbers(ctx.org, item.repo):
+            try:
+                open_pr_numbers = _repo_manager._list_open_pr_numbers(ctx.org, item.repo)
+            except Exception as exc:
+                logger.warning("repo:%s: PR discovery failed: %s", item.repo, exc)
+                return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
+            for pr_number in open_pr_numbers:
                 if pr_number in covered_prs:
                     continue
                 products.append(

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -189,7 +189,7 @@ class RepoStage(Stage):
         ]
         covered_prs: set[int] = set()
         for num in kept:
-            facts = _seeding.seed_issue(num)
+            facts = _seeding.seed_issue_from_github(num, ctx.github)
             stage, reason = _seeding.classify_issue(facts)
             if facts.pr_number is not None:
                 covered_prs.add(facts.pr_number)

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -1,0 +1,169 @@
+"""Pipeline end-of-run / interrupt summary (epic #1809, coordinator slice #1817).
+
+Printed from the coordinator's ``finally`` — on completion AND interrupt:
+per-item rows (repo, issue, PR, entry queue, final stage,
+PASS/FAIL:reason/SKIP/BLOCKED/RESUMABLE, attempt counters, elapsed),
+aggregates (per-disposition counts, per-stage throughput, agent-job
+count/time, wall clock, loops), preserved worktrees (the exact
+``implementer_summary._print_preserved_worktrees`` line sequence, re-housed
+here as :func:`format_preserved_worktrees`), and the ``emit_json_status``
+envelope extension when ``--json`` is active.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from hephaestus.automation.pipeline.work_item import WorkItem
+from hephaestus.cli.utils import emit_json_status
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RunStats:
+    """Aggregate run statistics the coordinator hands to :func:`print_summary`."""
+
+    exit_code: int
+    interrupted: bool
+    loops_run: int
+    agent_job_count: int
+    agent_job_time_s: float
+    wall_s: float
+
+
+def format_preserved_worktrees(
+    preserved: Sequence[tuple[int, str | Path]], script: str
+) -> list[str]:
+    """Format the preserved-worktree footer (legacy line sequence, verbatim).
+
+    Re-housed from ``implementer_summary._print_preserved_worktrees`` so the
+    pipeline and the legacy implementer print byte-identical guidance;
+    ``implementer_summary`` now delegates here.
+
+    Args:
+        preserved: ``(issue_number, worktree_path)`` tuples for failed items.
+        script: The script name (``sys.argv[0]``) for the rerun hint.
+
+    Returns:
+        The formatted lines (empty when nothing is preserved).
+
+    """
+    if not preserved:
+        return []
+    issue_nums = [n for n, _ in preserved]
+    issues_arg = " ".join(str(n) for n in issue_nums)
+    lines: list[str] = ["\nPreserved worktrees (contain uncommitted changes):"]
+    lines.extend(f"  #{issue_num}: {path}" for issue_num, path in preserved)
+    lines.append("\nRerun these issues after inspecting/cleaning the worktrees:")
+    lines.append(f"  {script} --issues {issues_arg} --resume")
+    lines.append("To discard them instead:")
+    lines.extend(f"  git worktree remove --force {path}" for _, path in preserved)
+    return lines
+
+
+def _disposition(item: WorkItem) -> str:
+    """Classify one item's summary disposition cell."""
+    result = item.result
+    if result is None:
+        return "PENDING"
+    if result.reason.startswith("resumable"):
+        return f"RESUMABLE at {result.final_stage.value}"
+    if result.passed:
+        return "PASS"
+    if result.reason.startswith("skip"):
+        return "SKIP"
+    if result.reason.startswith("blocked"):
+        return "BLOCKED"
+    return f"FAIL:{result.reason}"
+
+
+def _disposition_bucket(item: WorkItem) -> str:
+    """Aggregate-count bucket for one item (pass/fail/skip/blocked/resumable)."""
+    cell = _disposition(item)
+    return cell.split(":")[0].split(" ")[0].lower()
+
+
+def _item_row(item: WorkItem) -> str:
+    """Format one per-item summary row."""
+    issue = f"#{item.issue}" if item.issue else "-"
+    pr = f"!{item.pr}" if item.pr else "-"
+    entry = str(item.payload.get("entry_stage", item.stage.value))
+    attempts = ",".join(f"{k}={v}" for k, v in sorted(item.attempts.items()) if v) or "-"
+    elapsed_s = (item.updated_at - item.created_at).total_seconds()
+    return (
+        f"  {item.repo:<28} {issue:>7} {pr:>7} {entry:<15} "
+        f"{item.stage.value:<15} {_disposition(item):<28} {attempts:<24} {elapsed_s:7.1f}s"
+    )
+
+
+def print_summary(
+    items: list[WorkItem],
+    stats: RunStats,
+    preserved: list[tuple[int, str]],
+    *,
+    json_out: bool,
+) -> None:
+    """Log the end-of-run summary; emit the JSON envelope when requested.
+
+    Args:
+        items: Every work item the run ever queued (results attached).
+        stats: Aggregate run statistics (exit code, loops, agent time, wall).
+        preserved: ``(issue_number, worktree_path)`` tuples for failed items.
+        json_out: Emit the machine-readable ``emit_json_status`` envelope.
+
+    """
+    logger.info("")
+    logger.info("=== Pipeline summary ===")
+    header = (
+        f"  {'repo':<28} {'issue':>7} {'pr':>7} {'entry':<15} "
+        f"{'final':<15} {'disposition':<28} {'attempts':<24} {'elapsed':>8}"
+    )
+    logger.info("%s", header)
+    logger.info("  %s", "-" * (len(header) - 2))
+    for item in items:
+        logger.info("%s", _item_row(item))
+
+    dispositions: dict[str, int] = {}
+    per_stage: dict[str, int] = {}
+    for item in items:
+        dispositions[_disposition_bucket(item)] = dispositions.get(_disposition_bucket(item), 0) + 1
+        per_stage[item.stage.value] = per_stage.get(item.stage.value, 0) + 1
+
+    logger.info("")
+    logger.info("=== Aggregates ===")
+    logger.info("  items: %d  dispositions: %s", len(items), dict(sorted(dispositions.items())))
+    logger.info("  per-stage: %s", dict(sorted(per_stage.items())))
+    logger.info(
+        "  agent jobs: %d (%.1fs total)  loops: %d  wall: %.1fs  interrupted: %s",
+        stats.agent_job_count,
+        stats.agent_job_time_s,
+        stats.loops_run,
+        stats.wall_s,
+        stats.interrupted,
+    )
+
+    for line in format_preserved_worktrees(preserved, sys.argv[0]):
+        logger.info("%s", line)
+
+    if json_out:
+        resumable = [
+            f"{item.repo}#{item.issue or item.pr or ''}@{item.stage.value}"
+            for item in items
+            if item.result is not None and item.result.reason.startswith("resumable")
+        ]
+        emit_json_status(
+            stats.exit_code,
+            message="pipeline interrupted" if stats.interrupted else "pipeline complete",
+            dispositions=dict(sorted(dispositions.items())),
+            loops_run=stats.loops_run,
+            agent_jobs=stats.agent_job_count,
+            agent_job_time_s=round(stats.agent_job_time_s, 1),
+            wall_s=round(stats.wall_s, 1),
+            resumable=resumable,
+            preserved_worktrees=[list(entry) for entry in preserved],
+        )

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -475,16 +475,16 @@ class WorkerPool:
             )
         # NOTE: commit_if_changes returns False BOTH for "worktree clean,
         # nothing to commit" AND for "commit attempted but failed" (it logs
-        # and swallows the RuntimeError). value=False is therefore ambiguous;
-        # a failed commit still reaches the push below, which pushes whatever
-        # HEAD already holds. commit_if_changes has no timeout parameter;
-        # job.timeout_s cannot be enforced here.
+        # and swallows the RuntimeError). Do not push in either case; stages
+        # consume value=False as the no-real-commit path.
         changed = git_utils.commit_if_changes(
             int(issue_number),
             Path(worktree_path),
             str(job.kwargs.get("agent", "claude")),
             allowed_paths=job.kwargs.get("allowed_paths"),
         )
+        if not changed:
+            return JobResult(ok=True, value=False)
         # push_branch has no timeout parameter; job.timeout_s cannot be
         # enforced here.
         git_utils.push_branch(str(job.kwargs.get("branch", "HEAD")), Path(worktree_path))

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -111,7 +111,9 @@ class WorkerPool:
         with self._repo_locks_guard:
             return self._repo_locks.setdefault(repo, threading.Lock())
 
-    def submit(self, job: AgentJob | BuildTestJob | GitJob, on_done_state: StageName) -> JobHandle:
+    def submit(
+        self, job: AgentJob | BuildTestJob | GitJob, on_done_state: str | StageName
+    ) -> JobHandle:
         """Submit a job for execution.
 
         Args:
@@ -356,18 +358,10 @@ class WorkerPool:
         below documents that gap rather than silently dropping the budget.
         """
         if job.op == "create_worktree":
-            manager = WorktreeManager()
-            # WorktreeManager.create_worktree has no timeout parameter;
-            # job.timeout_s cannot be enforced here.
-            manager.create_worktree(**job.kwargs)
-            return JobResult(ok=True)
+            return self._git_create_worktree(job)
 
         elif job.op == "remove_worktree":
-            manager = WorktreeManager()
-            # WorktreeManager.remove_worktree has no timeout parameter;
-            # job.timeout_s cannot be enforced here.
-            manager.remove_worktree(**job.kwargs)
-            return JobResult(ok=True)
+            return self._git_remove_worktree(job)
 
         elif job.op == "rebase":
             # rebase_worktree_onto(cwd, base_branch="main", *, remote) has no
@@ -400,6 +394,68 @@ class WorkerPool:
         else:
             # Should be impossible due to GitJob.__post_init__ validation
             return JobResult(ok=False, error=f"unknown op {job.op!r}")
+
+    def _git_create_worktree(self, job: GitJob) -> JobResult:
+        """Create a worktree and optionally sync an adopted PR branch."""
+        manager = WorktreeManager()
+        kwargs = dict(job.kwargs)
+        sync_to_remote = bool(kwargs.pop("sync_to_remote", False))
+        # WorktreeManager.create_worktree has no timeout parameter;
+        # job.timeout_s cannot be enforced here.
+        created = manager.create_worktree(**kwargs)
+        if created is None:
+            return JobResult(ok=True)
+        worktree_path = Path(created)
+        branch_name = str(kwargs.get("branch_name") or "")
+        if not sync_to_remote:
+            return JobResult(ok=True, value=str(worktree_path))
+
+        dirty = not git_utils.is_clean_working_tree(worktree_path)
+        status = ""
+        diff = ""
+        if dirty:
+            status_result = git_utils.run(
+                ["git", "status", "--short"],
+                cwd=worktree_path,
+                capture_output=True,
+                check=False,
+            )
+            diff_result = git_utils.run(
+                ["git", "diff"],
+                cwd=worktree_path,
+                capture_output=True,
+                check=False,
+            )
+            status = status_result.stdout or ""
+            diff = diff_result.stdout or ""
+        elif branch_name:
+            git_utils.sync_worktree_to_remote_branch(worktree_path, branch_name)
+        return JobResult(
+            ok=True,
+            value={
+                "path": str(worktree_path),
+                "dirty": dirty,
+                "status": status,
+                "diff": diff,
+            },
+        )
+
+    def _git_remove_worktree(self, job: GitJob) -> JobResult:
+        """Remove a worktree by known path, or fall back to manager state."""
+        if job.kwargs.get("worktree_path"):
+            worktree_path = Path(str(job.kwargs["worktree_path"]))
+            repo_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
+            cmd = ["git", "worktree", "remove", str(worktree_path)]
+            if job.kwargs.get("force"):
+                cmd.append("--force")
+            git_utils.run(cmd, cwd=repo_root)
+            git_utils.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+            return JobResult(ok=True)
+        manager = WorktreeManager()
+        # WorktreeManager.remove_worktree has no timeout parameter;
+        # job.timeout_s cannot be enforced here.
+        manager.remove_worktree(**job.kwargs)
+        return JobResult(ok=True)
 
     def _git_commit_push(self, job: GitJob) -> JobResult:
         """Commit pending changes in a worktree, then push its branch.

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -230,6 +230,7 @@ class WorkerPool:
         try:
             agent = resolve_agent(job.agent)
             is_claude = agent == "claude"
+            session_agent = job.session_agent or job.agent
             prompt = job.prompt_builder(**job.prompt_kwargs)
 
             def _invoke() -> str:
@@ -237,7 +238,7 @@ class WorkerPool:
                     stdout, _ = claude_invoke.invoke_claude_with_session(
                         repo=job.repo,
                         issue=job.issue,
-                        agent=job.agent,
+                        agent=session_agent,
                         prompt=prompt,
                         model=job.model,
                         cwd=job.cwd,

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -1,0 +1,385 @@
+"""Real :class:`~hephaestus.automation.pipeline.stages.base.StageGitHub` adapter.
+
+Coordinator-owned GitHub accessor (epic #1809, coordinator slice #1817). This
+module is the ONE place where the pipeline's coordinator-neutral mutator names
+(``add_labels``, ``upsert_plan_comment``, ``create_pr``, ...) are mapped onto
+the real ``github_api`` / ``pr_manager`` / ``_review_utils`` helpers.
+
+It deliberately lives OUTSIDE ``hephaestus/automation/pipeline/``: the
+architecture guard (``tests/unit/automation/pipeline/test_pipeline_architecture``)
+forbids ``github_api`` mutator imports in any ``pipeline/*`` module, so the
+adapter is coordinator-side by construction — stages only ever see it through
+``StageContext.github``.
+
+Dry-run contract (``stages/base.py`` :class:`StageGitHub` docstring): dry-run
+is honored INSIDE this accessor. Every mutator logs ``[dry-run] would ...``
+and skips the underlying ``gh`` call when the adapter was built with
+``dry_run=True``; reads always hit GitHub so classification stays truthful.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from hephaestus.automation import github_api, pr_manager
+from hephaestus.automation._review_phase import _is_automation_owned_thread
+from hephaestus.automation._review_utils import (
+    close_issue_as_covered,
+    ensure_state_dir,
+    find_merged_closing_pr,
+    find_pr_for_issue,
+    get_pr_head_branch,
+)
+from hephaestus.automation.arming_state import ArmingStateStore
+from hephaestus.automation.ci_check_inspector import CICheckInspector
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
+from hephaestus.automation.review_state import is_plan_review_go
+from hephaestus.automation.state_labels import (
+    ALL_IMPLEMENTATION_STATE_LABELS,
+    ALL_STATE_LABELS,
+    STATE_SKIP,
+)
+from hephaestus.constants import read_timeout_env
+from hephaestus.github.client import gh_call
+
+logger = logging.getLogger(__name__)
+
+
+def rate_limit_remaining() -> tuple[int, int] | None:
+    """Return ``(remaining, reset_epoch)`` for the GraphQL budget, or ``None``.
+
+    Ported from ``loop_runner._rate_limit_remaining`` for the coordinator's
+    non-blocking rate gate (the legacy helper feeds a *sleeping* guard, which
+    is fatal for a single coordinator thread — the pipeline timer-parks
+    instead, see ``coordinator._rate_budget_ok``).
+    """
+    try:
+        out = gh_call(["api", "rate_limit"])
+    except (subprocess.SubprocessError, RuntimeError, OSError):
+        return None
+    try:
+        data = json.loads(out.stdout)
+        gql = data["resources"]["graphql"]
+        return int(gql["remaining"]), int(gql["reset"])
+    except (json.JSONDecodeError, KeyError, ValueError, TypeError):
+        return None
+
+
+def rate_budget_ok(now_epoch: float | None = None) -> tuple[bool, float]:
+    """Non-blocking port of ``loop_runner._maybe_sleep_for_rate_budget``.
+
+    Args:
+        now_epoch: Current epoch seconds (injectable for tests).
+
+    Returns:
+        ``(ok, park_delay_s)``. ``ok`` is False when the GraphQL budget is
+        below ``HEPHAESTUS_RATE_GUARD_THRESHOLD`` (default 200) and the
+        ``HEPHAESTUS_RATE_GUARD`` env gate is enabled; ``park_delay_s`` is the
+        seconds until the upstream reset (+5s slack, mirroring the legacy
+        guard), 0.0 when ``ok``.
+
+    """
+    if os.environ.get("HEPHAESTUS_RATE_GUARD", "1") == "0":
+        return True, 0.0
+    threshold = read_timeout_env("HEPHAESTUS_RATE_GUARD_THRESHOLD", 200)
+    rl = rate_limit_remaining()
+    if rl is None:
+        return True, 0.0
+    remaining, reset_epoch = rl
+    if remaining >= threshold:
+        return True, 0.0
+    now = time.time() if now_epoch is None else now_epoch
+    return False, max(0.0, reset_epoch - now + 5.0)
+
+
+class PipelineGitHub:
+    """Coordinator-owned GitHub accessor implementing ``StageGitHub``.
+
+    Read surface delegates to the existing helpers verbatim; the mutator
+    surface maps the coordinator-neutral names onto ``github_api`` /
+    ``pr_manager`` / ``_review_utils`` mutators, honoring dry-run inside each
+    mutator (log-and-skip) per the ``StageGitHub`` protocol docstring.
+    """
+
+    def __init__(self, org: str, *, dry_run: bool = False, repo_root: Path | None = None) -> None:
+        """Initialize the accessor.
+
+        Args:
+            org: GitHub organization (used for logging context only; the
+                underlying helpers resolve the repo from their cwd exactly as
+                the legacy phases do).
+            dry_run: When True, every mutator logs-and-skips.
+            repo_root: Repo checkout root anchoring the drive-green arming
+                state dir (defaults to the current working directory).
+
+        """
+        self.org = org
+        self.dry_run = dry_run
+        self._repo_root = repo_root or Path.cwd()
+        self._arming = ArmingStateStore(lambda: ensure_state_dir(self._repo_root))
+        self._inspector = CICheckInspector(
+            get_pr_branch=lambda pr: get_pr_head_branch(pr) or "",
+            # Reads stay live even under pipeline dry-run so CI classification
+            # is truthful; only mutators log-and-skip.
+            options_provider=lambda: SimpleNamespace(dry_run=False),
+        )
+
+    def _skip(self, what: str) -> bool:
+        """Return True (and log) when dry-run should skip a mutation."""
+        if self.dry_run:
+            logger.info("[dry-run] would %s", what)
+            return True
+        return False
+
+    # -- read surface --------------------------------------------------------
+
+    def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+        """Fetch issue JSON (``github_api.issues.gh_issue_json``)."""
+        return github_api.gh_issue_json(issue_number)
+
+    def find_merged_closing_pr(self, issue_number: int) -> int | None:
+        """Return the merged PR closing this issue (``_review_utils``)."""
+        return find_merged_closing_pr(issue_number)
+
+    def find_pr_for_issue(self, issue_number: int) -> int | None:
+        """Return an open PR covering this issue (``_review_utils``)."""
+        return find_pr_for_issue(issue_number)
+
+    def has_existing_plan(self, issue_number: int) -> bool:
+        """Labels-first plan gate incl. comment-scan backfill (``is_plan_review_go``)."""
+        return bool(is_plan_review_go(issue_number))
+
+    def get_pr_head_branch(self, pr_number: int) -> str | None:
+        """Return the PR's head branch (``_review_utils.get_pr_head_branch``)."""
+        return get_pr_head_branch(pr_number)
+
+    def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+        """Return ``(has_go, has_no_go)`` (``pr_manager``)."""
+        return pr_manager.pr_has_implementation_state_label(pr_number)
+
+    def count_unresolved_threads(self, pr_number: int) -> tuple[int, int]:
+        """Return ``(automation_unresolved, human_unresolved)`` thread counts.
+
+        Mirrors ``_review_phase._count_unresolved_threads_blocking_go``
+        (#1152): resolves nothing; fails open to ``(0, 0)`` on a fetch error
+        so a transient API blip cannot strand a GO.
+        """
+        try:
+            threads = github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
+        except Exception as exc:
+            logger.warning("PR #%s: could not list unresolved threads: %s", pr_number, exc)
+            return (0, 0)
+        if not threads:
+            return (0, 0)
+        current_login = github_api.gh_current_login()
+        automation = sum(1 for t in threads if _is_automation_owned_thread(t, current_login))
+        return (automation, len(threads) - automation)
+
+    def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
+        """Return the merge_wait PR-state read, or ``None`` on failure.
+
+        Re-housed from ``ci_driver.CIDriver._gh_pr_state``: one ``gh pr view``
+        returning ``{state, headRefOid, mergedAt, mergeStateStatus,
+        baseRefName}``.
+        """
+        try:
+            result = gh_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--json",
+                    "state,headRefOid,mergedAt,mergeStateStatus,baseRefName",
+                ]
+            )
+            data = json.loads(result.stdout or "{}")
+            return data if isinstance(data, dict) else None
+        except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+            logger.warning("PR #%s: gh_pr_state read failed: %s", pr_number, exc)
+            return None
+
+    def failing_required_check_names(self, pr_number: int) -> list[str]:
+        """Names of required checks currently failing (``CICheckInspector``)."""
+        return self._inspector.failing_required_check_names(pr_number)
+
+    def pending_required_check_names(self, pr_number: int) -> list[str]:
+        """Names of required checks still in flight (``CICheckInspector``)."""
+        return self._inspector.pending_required_check_names(pr_number)
+
+    def pr_checks(self, pr_number: int) -> list[dict[str, Any]]:
+        """All checks for the PR (``gh_pr_checks``)."""
+        return github_api.gh_pr_checks(pr_number, dry_run=False)
+
+    def pr_is_genuinely_stuck(self, pr_number: int) -> bool:
+        """Return True iff the PR cannot merge without manual action (``pr_manager``)."""
+        return pr_manager.pr_is_genuinely_stuck(pr_number)
+
+    def drive_green_learn_terminal(self, issue_number: int) -> bool:
+        """Return True when the post-merge ``/learn`` is already terminal.
+
+        Mirrors ``ci_driver.CIDriver._learn_record_terminal`` over the issue's
+        arming record: captured/succeeded timestamps or a terminal
+        ``learn_status`` mean ``/learn`` must never fire again (#848).
+        """
+        record = self._arming.load(issue_number) or {}
+        if record.get("learn_captured_at") or record.get("learn_succeeded_at"):
+            return True
+        return str(record.get("learn_status") or "").lower() in {"succeeded", "failed"}
+
+    # -- mutator surface (dry-run honored here) -------------------------------
+
+    def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Durably add labels (``gh_issue_add_labels``)."""
+        if self._skip(f"add labels {labels} to #{issue_number}"):
+            return
+        github_api.gh_issue_add_labels(issue_number, labels)
+
+    def remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Durably remove labels (``gh_issue_remove_labels``)."""
+        if self._skip(f"remove labels {labels} from #{issue_number}"):
+            return
+        github_api.gh_issue_remove_labels(issue_number, labels)
+
+    def close_issue_as_covered(self, issue_number: int, pr_number: int) -> None:
+        """Close the issue as covered by a merged PR (``_review_utils``)."""
+        if self._skip(f"close #{issue_number} as covered by PR #{pr_number}"):
+            return
+        close_issue_as_covered(issue_number, pr_number)
+
+    def upsert_plan_comment(self, issue_number: int, body: str) -> None:
+        """Upsert the single plan comment keyed on ``PLAN_COMMENT_MARKER``."""
+        if self._skip(f"upsert plan comment on #{issue_number}"):
+            return
+        github_api.gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)
+
+    def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
+        """Durably ensure the PR exists and return its number (idempotent).
+
+        ``find_pr_for_issue`` first (reuse an existing open PR), then
+        ``gh_pr_create`` with the *given* title/body — NOT
+        ``pr_manager.ensure_pr_created``, which would discard the stage's
+        composed body (protocol docstring). Dry-run returns 0 (no PR).
+        """
+        existing = find_pr_for_issue(issue_number)
+        if existing:
+            return existing
+        if self._skip(f"create PR for #{issue_number} from {branch!r}"):
+            return 0
+        return github_api.gh_pr_create(branch, title, body)
+
+    def post_pr_comment(self, pr_number: int, body: str) -> None:
+        """Post an explanatory PR comment (``gh_issue_comment`` channel)."""
+        if self._skip(f"post comment on PR #{pr_number}"):
+            return
+        github_api.gh_issue_comment(pr_number, body)
+
+    def mark_pr_implementation_no_go(self, pr_number: int) -> None:
+        """Apply ``state:implementation-no-go`` (``pr_manager``)."""
+        if self._skip(f"mark PR #{pr_number} implementation-no-go"):
+            return
+        pr_manager.mark_pr_implementation_no_go(pr_number)
+
+    def mark_pr_implementation_go(self, pr_number: int) -> None:
+        """Apply ``state:implementation-go`` (``pr_manager``)."""
+        if self._skip(f"mark PR #{pr_number} implementation-go"):
+            return
+        pr_manager.mark_pr_implementation_go(pr_number)
+
+    def defer_auto_merge(self, pr_number: int) -> None:
+        """Keep auto-merge disabled until implementation GO (``pr_manager``)."""
+        if self._skip(f"defer auto-merge on PR #{pr_number}"):
+            return
+        pr_manager.ensure_pr_auto_merge_deferred(pr_number)
+
+    def arm_auto_merge(self, pr_number: int) -> None:
+        """Arm squash auto-merge after implementation GO (``pr_manager``)."""
+        if self._skip(f"arm auto-merge on PR #{pr_number}"):
+            return
+        pr_manager.enable_auto_merge_after_implementation_go(pr_number)
+
+    def post_review_threads(
+        self, pr_number: int, threads: list[dict[str, Any]], summary: str
+    ) -> list[str]:
+        """Post surviving review threads (``gh_pr_review_post``)."""
+        if self._skip(f"post {len(threads)} review thread(s) on PR #{pr_number}"):
+            return []
+        return github_api.gh_pr_review_post(pr_number, threads, summary)
+
+    def arm_drive_green(self, issue_number: int, pr_number: int, head_sha: str) -> None:
+        """Persist the drive-green arming record (``ArmingStateStore.save``).
+
+        Record shape mirrors ``ci_driver.CIDriver._arm_drive_green``; an
+        already-terminal record is never overwritten (its learn evidence is
+        the /learn dedupe key).
+        """
+        if self._skip(f"arm drive-green record for #{issue_number} (PR #{pr_number})"):
+            return
+        if self.drive_green_learn_terminal(issue_number):
+            return
+        self._arming.save(
+            issue_number,
+            {
+                "pr_number": pr_number,
+                "pr_head_branch": get_pr_head_branch(pr_number) or "",
+                "head_sha_at_arming": head_sha,
+                "armed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "learn_attempted_at": None,
+                "learn_captured_at": None,
+                "learn_status": None,
+                "learn_succeeded_at": None,
+            },
+        )
+
+    def mark_drive_green_learn_result(self, issue_number: int, *, succeeded: bool) -> None:
+        """Record the post-merge ``/learn`` outcome on the arming record.
+
+        Mirrors ``post_merge_processor.mark_drive_green_learn_result`` (minus
+        the session-evidence enrichment, which stays with the legacy driver
+        until the cutover issue): written before FINISH_PASS so a restart can
+        never replay ``/learn`` for the same merged PR.
+        """
+        if self._skip(f"record drive-green learn result for #{issue_number}"):
+            return
+        record = self._arming.load(issue_number) or {}
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        record["learn_attempted_at"] = timestamp
+        if succeeded:
+            record["learn_status"] = "succeeded"
+            record["learn_succeeded_at"] = timestamp
+            record["learn_captured_at"] = timestamp
+        else:
+            record["learn_status"] = "failed"
+            record["learn_succeeded_at"] = None
+            record["learn_captured_at"] = None
+        self._arming.save(issue_number, record)
+
+    # -- repo-stage surface (#1817) -------------------------------------------
+
+    def skip_epics(self, epics_labels: dict[int, list[str]]) -> None:
+        """Tag epics ``state:skip`` via the sanctioned chokepoint.
+
+        The ONE seeding write (doc row "Epic tagging is the one seeding
+        write; done BEFORE excluding"), executed by the coordinator through
+        ``github_api.skip_epics``.
+        """
+        if self._skip(f"tag epics {sorted(epics_labels)} {STATE_SKIP}"):
+            return
+        github_api.skip_epics(epics_labels)
+
+    def ensure_state_labels(self) -> None:
+        """Ensure the ``state:*`` label vocabulary exists on the repo.
+
+        Repo-stage step 1 [M] (doc section 1): idempotent
+        ``_ensure_labels_exist`` over the full ``state_labels`` vocabulary.
+        """
+        wanted = [*ALL_STATE_LABELS, *ALL_IMPLEMENTATION_STATE_LABELS, STATE_SKIP]
+        if self._skip(f"ensure state labels exist: {wanted}"):
+            return
+        github_api._ensure_labels_exist(wanted)

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -159,6 +159,25 @@ class PipelineGitHub:
             return None
         return f"{self.org}/{self.repo}"
 
+    def _owner_name(self) -> tuple[str, str]:
+        """Return explicit owner/name for repo-scoped GitHub API calls."""
+        if self.repo is None:
+            raise RuntimeError("repo-scoped GitHub operation requires a repo")
+        return self.org, self.repo
+
+    def _graphql(self, query: str, **fields: int | str) -> dict[str, Any]:
+        """Run a repo-scoped GraphQL query with explicit owner/repo fields."""
+        owner, name = self._owner_name()
+        argv = ["api", "graphql", "-f", f"query={query}"]
+        for key, value in {"owner": owner, "name": name, **fields}.items():
+            argv.extend(["-F", f"{key}={value}"])
+        result = gh_call(argv)
+        data = json.loads(result.stdout or "{}")
+        if not isinstance(data, dict):
+            raise RuntimeError("GraphQL response was not an object")
+        github_api._check_graphql_errors(data, "repo-scoped pipeline GraphQL")
+        return data
+
     def _with_repo(self, argv: list[str]) -> list[str]:
         """Append an explicit repo selector when this accessor is repo-scoped."""
         if self._repo_slug is None:
@@ -250,51 +269,156 @@ class PipelineGitHub:
 
     def _find_pr_for_issue(self, issue_number: int, *, state: str) -> int | None:
         branch_name = f"{issue_number}-auto-impl"
-        try:
-            result = self._gh(
-                [
-                    "pr",
-                    "list",
-                    "--head",
-                    branch_name,
-                    "--state",
-                    state,
-                    "--json",
-                    "number",
-                    "--limit",
-                    "1",
-                ],
-                check=False,
-            )
-            pr_data = json.loads(result.stdout or "[]")
-            if pr_data:
-                return int(pr_data[0]["number"])
-        except Exception as exc:
-            logger.debug("%s PR branch lookup failed for issue #%d: %s", state, issue_number, exc)
+        result = self._gh(
+            [
+                "pr",
+                "list",
+                "--head",
+                branch_name,
+                "--state",
+                state,
+                "--json",
+                "number",
+                "--limit",
+                "1",
+            ]
+        )
+        pr_data = json.loads(result.stdout or "[]")
+        if pr_data:
+            return int(pr_data[0]["number"])
 
-        try:
-            result = self._gh(
-                [
-                    "pr",
-                    "list",
-                    "--state",
-                    state,
-                    "--search",
-                    f"Closes #{issue_number} in:body",
-                    "--json",
-                    "number,body",
-                    "--limit",
-                    "10",
-                ],
-                check=False,
-            )
-            closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
-            for candidate in json.loads(result.stdout or "[]"):
-                if closes_pattern.search(candidate.get("body") or ""):
-                    return int(candidate["number"])
-        except Exception as exc:
-            logger.debug("%s PR body lookup failed for issue #%d: %s", state, issue_number, exc)
+        result = self._gh(
+            [
+                "pr",
+                "list",
+                "--state",
+                state,
+                "--search",
+                f"Closes #{issue_number} in:body",
+                "--json",
+                "number,body",
+                "--limit",
+                "10",
+            ]
+        )
+        closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
+        for candidate in json.loads(result.stdout or "[]"):
+            if closes_pattern.search(candidate.get("body") or ""):
+                return int(candidate["number"])
         return None
+
+    def _repo_unresolved_threads(self, pr_number: int) -> list[dict[str, Any]]:
+        """List unresolved PR review threads for this accessor's explicit repo."""
+        query = (
+            "query($owner:String!,$name:String!,$number:Int!){"
+            "  repository(owner:$owner,name:$name){"
+            "    pullRequest(number:$number){"
+            "      reviewThreads(first:100){"
+            "        nodes{ id isResolved path line side:diffSide "
+            "comments(first:20){ nodes{ body author{ login } } } }"
+            "      }"
+            "    }"
+            "  }"
+            "}"
+        )
+        data = self._graphql(query, number=int(pr_number))
+        nodes = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+            .get("nodes", [])
+        )
+        threads: list[dict[str, Any]] = []
+        for node in nodes:
+            if node.get("isResolved"):
+                continue
+            comment_nodes = node.get("comments", {}).get("nodes", [])
+            first_comment = comment_nodes[0] if comment_nodes else {}
+            comments: list[dict[str, str]] = []
+            authors: list[str] = []
+            for comment in comment_nodes:
+                author_node = comment.get("author")
+                author = author_node.get("login") if isinstance(author_node, dict) else ""
+                author = author or ""
+                if author:
+                    authors.append(author)
+                comments.append({"body": comment.get("body") or "", "author": author})
+            threads.append(
+                {
+                    "id": node["id"],
+                    "path": node.get("path", ""),
+                    "line": node.get("line"),
+                    "side": node.get("side") or "RIGHT",
+                    "body": first_comment.get("body", ""),
+                    "author": authors[0] if authors else "",
+                    "authors": authors,
+                    "comments": comments,
+                }
+            )
+        return threads
+
+    def _repo_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
+        """Fetch issue comment ids/bodies for explicit-repo marker upserts."""
+        query = (
+            "query($owner:String!,$name:String!,$number:Int!){"
+            "  repository(owner:$owner,name:$name){"
+            "    issue(number:$number){"
+            "      comments(first:100){ nodes{ databaseId body } }"
+            "    }"
+            "  }"
+            "}"
+        )
+        data = self._graphql(query, number=int(issue_number))
+        nodes = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("issue", {})
+            .get("comments", {})
+            .get("nodes", [])
+        )
+        return [node for node in nodes if isinstance(node, dict)]
+
+    def _repo_review_threads_for_review(self, pr_number: int, review_id: str) -> list[str]:
+        """Return unresolved review-thread ids created by one REST review."""
+        query = (
+            "query($owner:String!,$name:String!,$number:Int!){"
+            "  repository(owner:$owner,name:$name){"
+            "    pullRequest(number:$number){"
+            "      reviewThreads(first:100){"
+            "        nodes{ id isResolved comments(first:1){ "
+            "nodes{ pullRequestReview{ id } } } }"
+            "      }"
+            "    }"
+            "  }"
+            "}"
+        )
+        try:
+            data = self._graphql(query, number=int(pr_number))
+        except (subprocess.SubprocessError, RuntimeError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch review threads for PR #%s: %s", pr_number, exc)
+            return []
+        nodes = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+            .get("nodes", [])
+        )
+        seen: dict[str, None] = {}
+        for node in nodes:
+            if node.get("isResolved"):
+                continue
+            first_comments = node.get("comments", {}).get("nodes", [])
+            if not first_comments:
+                continue
+            review = first_comments[0].get("pullRequestReview") or {}
+            if review.get("id") != review_id:
+                continue
+            thread_id = node.get("id")
+            if thread_id:
+                seen[thread_id] = None
+        return list(seen)
 
     def _skip(self, what: str) -> bool:
         """Return True (and log) when dry-run should skip a mutation."""
@@ -398,14 +522,17 @@ class PipelineGitHub:
         """Return ``(automation_unresolved, human_unresolved)`` thread counts.
 
         Mirrors ``_review_phase._count_unresolved_threads_blocking_go``
-        (#1152): resolves nothing; fails open to ``(0, 0)`` on a fetch error
-        so a transient API blip cannot strand a GO.
+        (#1152): resolves nothing. Current-repo legacy helpers still fail
+        open on fetch errors; repo-scoped pipeline runs query the configured
+        repo directly so unresolved human threads are not hidden.
         """
         if self._repo_slug is not None:
-            # TODO(#1823): move the full GraphQL thread ownership query behind a
-            # repo-scoped helper. Until then, fail open like the legacy adapter
-            # on fetch errors rather than resolving or mutating anything.
-            return (0, 0)
+            threads = self._repo_unresolved_threads(pr_number)
+            if not threads:
+                return (0, 0)
+            current_login = github_api.gh_current_login()
+            automation = sum(1 for t in threads if _is_automation_owned_thread(t, current_login))
+            return (automation, len(threads) - automation)
         try:
             threads = github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
         except Exception as exc:
@@ -559,12 +686,43 @@ class PipelineGitHub:
         """Upsert the single plan comment keyed on ``PLAN_COMMENT_MARKER``."""
         if self._skip(f"upsert plan comment on #{issue_number}"):
             return
-        # TODO(#1823): exact repo-scoped upsert needs the GraphQL comment-id
-        # helper to accept owner/repo. Until then, repo-scoped runs post a new
-        # durable comment rather than silently targeting the current repo.
         if self._repo_slug is not None:
+            comments = self._repo_issue_comments(issue_number)
+            matching = [
+                c
+                for c in comments
+                if str(c.get("body", "")).startswith(PLAN_COMMENT_MARKER)
+                and c.get("databaseId") is not None
+            ]
+            if not matching:
+                with github_api._body_file(body) as path:
+                    self._gh(["issue", "comment", str(issue_number), "--body-file", path])
+                return
+
+            owner, name = self._owner_name()
+            target_id = int(matching[-1]["databaseId"])
+            for dup in matching[:-1]:
+                dup_id = dup.get("databaseId")
+                if dup_id is not None:
+                    gh_call(
+                        [
+                            "api",
+                            "--method",
+                            "DELETE",
+                            f"/repos/{owner}/{name}/issues/comments/{int(dup_id)}",
+                        ]
+                    )
             with github_api._body_file(body) as path:
-                self._gh(["issue", "comment", str(issue_number), "--body-file", path])
+                gh_call(
+                    [
+                        "api",
+                        "--method",
+                        "PATCH",
+                        f"/repos/{owner}/{name}/issues/comments/{target_id}",
+                        "-F",
+                        f"body=@{path}",
+                    ]
+                )
             return
         github_api.gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)
 
@@ -666,9 +824,40 @@ class PipelineGitHub:
         """Post surviving review threads (``gh_pr_review_post``)."""
         if self._skip(f"post {len(threads)} review thread(s) on PR #{pr_number}"):
             return []
-        # TODO(#1823): repo-scope the GraphQL review-post helper. This remains
-        # delegated for now because it needs diff-position validation and GraphQL
-        # review creation, not a simple gh CLI command.
+        if self._repo_slug is not None:
+            if threads:
+                diff_result = self._gh(["pr", "diff", str(pr_number)], check=False)
+                threads = github_api._filter_comments_to_diff(threads, diff_result.stdout or "")
+            review_comments = [
+                {
+                    "path": c["path"],
+                    "line": c["line"],
+                    "side": c.get("side", "RIGHT"),
+                    "body": c["body"],
+                }
+                for c in threads
+            ]
+            owner, name = self._owner_name()
+            request_body = json.dumps(
+                {"body": summary, "event": "COMMENT", "comments": review_comments}
+            )
+            with github_api._body_file(request_body) as input_path:
+                result = gh_call(
+                    [
+                        "api",
+                        "-X",
+                        "POST",
+                        f"repos/{owner}/{name}/pulls/{pr_number}/reviews",
+                        "--input",
+                        input_path,
+                    ]
+                )
+            review = json.loads(result.stdout or "{}")
+            review_node_id = review.get("node_id")
+            if not review_node_id:
+                logger.warning("Posted PR review on #%s but no review node id returned", pr_number)
+                return []
+            return self._repo_review_threads_for_review(pr_number, str(review_node_id))
         return github_api.gh_pr_review_post(pr_number, threads, summary)
 
     def arm_drive_green(self, issue_number: int, pr_number: int, head_sha: str) -> None:

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -34,17 +35,30 @@ from hephaestus.automation._review_utils import (
     close_issue_as_covered,
     ensure_state_dir,
     find_merged_closing_pr,
+    find_merged_pr_for_issue,
     find_pr_for_issue,
     get_pr_head_branch,
 )
 from hephaestus.automation.arming_state import ArmingStateStore
 from hephaestus.automation.ci_check_inspector import CICheckInspector
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
-from hephaestus.automation.review_state import is_plan_review_go
+from hephaestus.automation.review_state import (
+    PLAN_REVIEW_PREFIX,
+    is_plan_review_go,
+    latest_verdict,
+)
 from hephaestus.automation.state_labels import (
     ALL_IMPLEMENTATION_STATE_LABELS,
     ALL_STATE_LABELS,
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
+    STATE_LABEL_SPECS,
+    STATE_PLAN_GO,
+    STATE_PLAN_NO_GO,
     STATE_SKIP,
+    has_label,
+    is_implementation_go,
+    is_plan_go,
 )
 from hephaestus.constants import read_timeout_env
 from hephaestus.github.client import gh_call
@@ -108,19 +122,27 @@ class PipelineGitHub:
     mutator (log-and-skip) per the ``StageGitHub`` protocol docstring.
     """
 
-    def __init__(self, org: str, *, dry_run: bool = False, repo_root: Path | None = None) -> None:
+    def __init__(
+        self,
+        org: str,
+        *,
+        repo: str | None = None,
+        dry_run: bool = False,
+        repo_root: Path | None = None,
+    ) -> None:
         """Initialize the accessor.
 
         Args:
-            org: GitHub organization (used for logging context only; the
-                underlying helpers resolve the repo from their cwd exactly as
-                the legacy phases do).
+            org: GitHub organization.
+            repo: Optional repository name. When set, every supported gh CLI
+                read/write is explicitly scoped with ``--repo org/repo``.
             dry_run: When True, every mutator logs-and-skips.
             repo_root: Repo checkout root anchoring the drive-green arming
                 state dir (defaults to the current working directory).
 
         """
         self.org = org
+        self.repo = repo
         self.dry_run = dry_run
         self._repo_root = repo_root or Path.cwd()
         self._arming = ArmingStateStore(lambda: ensure_state_dir(self._repo_root))
@@ -130,6 +152,149 @@ class PipelineGitHub:
             # is truthful; only mutators log-and-skip.
             options_provider=lambda: SimpleNamespace(dry_run=False),
         )
+
+    @property
+    def _repo_slug(self) -> str | None:
+        if not self.repo:
+            return None
+        return f"{self.org}/{self.repo}"
+
+    def _with_repo(self, argv: list[str]) -> list[str]:
+        """Append an explicit repo selector when this accessor is repo-scoped."""
+        if self._repo_slug is None:
+            return argv
+        return [*argv, "--repo", self._repo_slug]
+
+    def _gh(self, argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return gh_call(self._with_repo(argv), **kwargs)
+
+    def _label_names(self) -> set[str]:
+        if self._repo_slug is None:
+            return github_api.gh_list_labels()
+        result = self._gh(["label", "list", "--json", "name", "--limit", "200"])
+        data = json.loads(result.stdout or "[]")
+        return {str(item["name"]) for item in data if isinstance(item, dict) and item.get("name")}
+
+    def _create_label(self, name: str) -> None:
+        spec = STATE_LABEL_SPECS.get(name, {})
+        cmd = ["label", "create", name, "--color", spec.get("color", "ededed"), "--force"]
+        if desc := spec.get("description", ""):
+            cmd.extend(["--description", desc])
+        self._gh(cmd)
+
+    def _add_labels(self, issue_number: int, labels: list[str]) -> None:
+        if not labels:
+            return
+        existing = self._label_names()
+        for label in labels:
+            if label not in existing:
+                self._create_label(label)
+                existing.add(label)
+        cmd = ["issue", "edit", str(issue_number)]
+        for label in labels:
+            cmd.extend(["--add-label", label])
+        self._gh(cmd)
+
+    def _remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        if not labels:
+            return
+        existing = self._label_names()
+        labels_to_remove = [label for label in labels if label in existing]
+        if not labels_to_remove:
+            return
+        cmd = ["issue", "edit", str(issue_number)]
+        for label in labels_to_remove:
+            cmd.extend(["--remove-label", label])
+        self._gh(cmd)
+
+    @staticmethod
+    def _label_names_from_payload(payload: dict[str, Any]) -> list[str]:
+        labels = payload.get("labels")
+        if not isinstance(labels, list):
+            return []
+        names: list[str] = []
+        for label in labels:
+            if isinstance(label, str):
+                names.append(label)
+            elif isinstance(label, dict) and isinstance(label.get("name"), str):
+                names.append(str(label["name"]))
+        return names
+
+    @staticmethod
+    def _latest_plan_review_body(comments: Any) -> str | None:
+        if not isinstance(comments, list):
+            return None
+        latest_review_body: str | None = None
+        for comment in comments:
+            if not isinstance(comment, dict):
+                continue
+            body = comment.get("body")
+            if isinstance(body, str) and body.startswith(PLAN_REVIEW_PREFIX):
+                latest_review_body = body
+        return latest_review_body
+
+    def _backfill_plan_go(self, issue_number: int) -> None:
+        if self.dry_run:
+            logger.info("[dry-run] would backfill %s on #%d", STATE_PLAN_GO, issue_number)
+            return
+        try:
+            self._add_labels(issue_number, [STATE_PLAN_GO])
+        except Exception as exc:
+            logger.warning(
+                "Issue #%d: failed to backfill %s in %s: %s",
+                issue_number,
+                STATE_PLAN_GO,
+                self._repo_slug,
+                exc,
+            )
+
+    def _find_pr_for_issue(self, issue_number: int, *, state: str) -> int | None:
+        branch_name = f"{issue_number}-auto-impl"
+        try:
+            result = self._gh(
+                [
+                    "pr",
+                    "list",
+                    "--head",
+                    branch_name,
+                    "--state",
+                    state,
+                    "--json",
+                    "number",
+                    "--limit",
+                    "1",
+                ],
+                check=False,
+            )
+            pr_data = json.loads(result.stdout or "[]")
+            if pr_data:
+                return int(pr_data[0]["number"])
+        except Exception as exc:
+            logger.debug("%s PR branch lookup failed for issue #%d: %s", state, issue_number, exc)
+
+        try:
+            result = self._gh(
+                [
+                    "pr",
+                    "list",
+                    "--state",
+                    state,
+                    "--search",
+                    f"Closes #{issue_number} in:body",
+                    "--json",
+                    "number,body",
+                    "--limit",
+                    "10",
+                ],
+                check=False,
+            )
+            closes_pattern = re.compile(rf"^Closes #{issue_number}\b", re.MULTILINE)
+            for candidate in json.loads(result.stdout or "[]"):
+                if closes_pattern.search(candidate.get("body") or ""):
+                    return int(candidate["number"])
+        except Exception as exc:
+            logger.debug("%s PR body lookup failed for issue #%d: %s", state, issue_number, exc)
+        return None
 
     def _skip(self, what: str) -> bool:
         """Return True (and log) when dry-run should skip a mutation."""
@@ -142,26 +307,91 @@ class PipelineGitHub:
 
     def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
         """Fetch issue JSON (``github_api.issues.gh_issue_json``)."""
+        if self._repo_slug is not None:
+            result = self._gh(
+                ["issue", "view", str(issue_number), "--json", "number,title,state,labels,body"]
+            )
+            data = json.loads(result.stdout or "{}")
+            if not isinstance(data, dict):
+                raise RuntimeError(f"Failed to fetch issue #{issue_number}: non-object response")
+            for field in ("title", "body"):
+                value = data.get(field)
+                if isinstance(value, str):
+                    data[field] = github_api.strip_null_bytes(value)
+            return data
         return github_api.gh_issue_json(issue_number)
 
     def find_merged_closing_pr(self, issue_number: int) -> int | None:
         """Return the merged PR closing this issue (``_review_utils``)."""
+        if self._repo_slug is not None:
+            return self._find_pr_for_issue(issue_number, state="merged")
         return find_merged_closing_pr(issue_number)
+
+    def find_merged_pr_for_issue(self, issue_number: int) -> int | None:
+        """Return the merged PR for this issue (tri-state seeding lookup)."""
+        if self._repo_slug is not None:
+            return self._find_pr_for_issue(issue_number, state="merged")
+        return find_merged_pr_for_issue(issue_number)
 
     def find_pr_for_issue(self, issue_number: int) -> int | None:
         """Return an open PR covering this issue (``_review_utils``)."""
+        if self._repo_slug is not None:
+            return self._find_pr_for_issue(issue_number, state="open")
         return find_pr_for_issue(issue_number)
 
     def has_existing_plan(self, issue_number: int) -> bool:
         """Labels-first plan gate incl. comment-scan backfill (``is_plan_review_go``)."""
+        if self._repo_slug is not None:
+            try:
+                result = self._gh(
+                    ["issue", "view", str(issue_number), "--json", "labels,comments"],
+                    check=False,
+                )
+                data = json.loads(result.stdout or "{}")
+            except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
+                return False
+            if not isinstance(data, dict):
+                return False
+
+            labels = self._label_names_from_payload(data)
+            if is_plan_go(labels):
+                return True
+            if has_label(labels, STATE_PLAN_NO_GO):
+                return False
+
+            latest_review_body = self._latest_plan_review_body(data.get("comments"))
+            if latest_review_body is None or latest_verdict(latest_review_body) != "GO":
+                return False
+
+            self._backfill_plan_go(issue_number)
+            return True
         return bool(is_plan_review_go(issue_number))
 
     def get_pr_head_branch(self, pr_number: int) -> str | None:
         """Return the PR's head branch (``_review_utils.get_pr_head_branch``)."""
+        if self._repo_slug is not None:
+            try:
+                result = self._gh(
+                    ["pr", "view", str(pr_number), "--json", "headRefName"],
+                    check=False,
+                )
+                data = json.loads(result.stdout or "{}")
+                value = data.get("headRefName") if isinstance(data, dict) else None
+                return str(value) if value else None
+            except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
+                return None
         return get_pr_head_branch(pr_number)
 
     def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
         """Return ``(has_go, has_no_go)`` (``pr_manager``)."""
+        if self._repo_slug is not None:
+            try:
+                result = self._gh(["pr", "view", str(pr_number), "--json", "labels"], check=False)
+                data = json.loads(result.stdout or "{}")
+                labels = self._label_names_from_payload(data if isinstance(data, dict) else {})
+            except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
+                return (False, False)
+            return is_implementation_go(labels), has_label(labels, STATE_IMPLEMENTATION_NO_GO)
         return pr_manager.pr_has_implementation_state_label(pr_number)
 
     def count_unresolved_threads(self, pr_number: int) -> tuple[int, int]:
@@ -171,6 +401,11 @@ class PipelineGitHub:
         (#1152): resolves nothing; fails open to ``(0, 0)`` on a fetch error
         so a transient API blip cannot strand a GO.
         """
+        if self._repo_slug is not None:
+            # TODO(#1823): move the full GraphQL thread ownership query behind a
+            # repo-scoped helper. Until then, fail open like the legacy adapter
+            # on fetch errors rather than resolving or mutating anything.
+            return (0, 0)
         try:
             threads = github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
         except Exception as exc:
@@ -190,7 +425,7 @@ class PipelineGitHub:
         baseRefName}``.
         """
         try:
-            result = gh_call(
+            result = self._gh(
                 [
                     "pr",
                     "view",
@@ -207,18 +442,67 @@ class PipelineGitHub:
 
     def failing_required_check_names(self, pr_number: int) -> list[str]:
         """Names of required checks currently failing (``CICheckInspector``)."""
+        if self._repo_slug is not None:
+            checks = self.pr_checks(pr_number)
+            required = [c for c in checks if c.get("required")] or checks
+            return [
+                c.get("name", "")
+                for c in required
+                if c.get("status") == "completed" and c.get("conclusion") == "failure"
+            ]
         return self._inspector.failing_required_check_names(pr_number)
 
     def pending_required_check_names(self, pr_number: int) -> list[str]:
         """Names of required checks still in flight (``CICheckInspector``)."""
+        if self._repo_slug is not None:
+            checks = self.pr_checks(pr_number)
+            required = [c for c in checks if c.get("required")] or checks
+            return [c.get("name", "") for c in required if c.get("status") != "completed"]
         return self._inspector.pending_required_check_names(pr_number)
 
     def pr_checks(self, pr_number: int) -> list[dict[str, Any]]:
         """All checks for the PR (``gh_pr_checks``)."""
+        if self._repo_slug is not None:
+            try:
+                result = self._gh(
+                    ["pr", "checks", str(pr_number), "--json", "name,state,bucket,workflow"],
+                    log_on_error=False,
+                )
+            except subprocess.CalledProcessError as exc:
+                if github_api._is_gh_pr_checks_no_checks_error(exc):
+                    return []
+                raise
+            raw = json.loads(result.stdout or "[]")
+            return [github_api._map_pr_check(item) for item in raw]
         return github_api.gh_pr_checks(pr_number, dry_run=False)
 
     def pr_is_genuinely_stuck(self, pr_number: int) -> bool:
         """Return True iff the PR cannot merge without manual action (``pr_manager``)."""
+        if self._repo_slug is not None:
+            try:
+                result = self._gh(
+                    [
+                        "pr",
+                        "view",
+                        str(pr_number),
+                        "--json",
+                        "mergeStateStatus,mergeable,statusCheckRollup",
+                    ],
+                    check=False,
+                )
+                pr = json.loads(result.stdout or "{}")
+            except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError):
+                return False
+            merge_state = str(pr.get("mergeStateStatus") or "").upper()
+            mergeable = str(pr.get("mergeable") or "").upper()
+            if merge_state in {"DIRTY", "CONFLICTING"} or mergeable == "CONFLICTING":
+                return True
+            rollup = pr.get("statusCheckRollup")
+            return isinstance(rollup, list) and any(
+                isinstance(check, dict)
+                and check.get("conclusion") in {"FAILURE", "CANCELLED", "TIMED_OUT"}
+                for check in rollup
+            )
         return pr_manager.pr_is_genuinely_stuck(pr_number)
 
     def drive_green_learn_terminal(self, issue_number: int) -> bool:
@@ -239,11 +523,17 @@ class PipelineGitHub:
         """Durably add labels (``gh_issue_add_labels``)."""
         if self._skip(f"add labels {labels} to #{issue_number}"):
             return
+        if self._repo_slug is not None:
+            self._add_labels(issue_number, labels)
+            return
         github_api.gh_issue_add_labels(issue_number, labels)
 
     def remove_labels(self, issue_number: int, labels: list[str]) -> None:
         """Durably remove labels (``gh_issue_remove_labels``)."""
         if self._skip(f"remove labels {labels} from #{issue_number}"):
+            return
+        if self._repo_slug is not None:
+            self._remove_labels(issue_number, labels)
             return
         github_api.gh_issue_remove_labels(issue_number, labels)
 
@@ -251,11 +541,30 @@ class PipelineGitHub:
         """Close the issue as covered by a merged PR (``_review_utils``)."""
         if self._skip(f"close #{issue_number} as covered by PR #{pr_number}"):
             return
+        if self._repo_slug is not None:
+            self._gh(
+                [
+                    "issue",
+                    "close",
+                    str(issue_number),
+                    "--comment",
+                    f"Closed by merged PR #{pr_number} (Closes #{issue_number}).",
+                ],
+                check=False,
+            )
+            return
         close_issue_as_covered(issue_number, pr_number)
 
     def upsert_plan_comment(self, issue_number: int, body: str) -> None:
         """Upsert the single plan comment keyed on ``PLAN_COMMENT_MARKER``."""
         if self._skip(f"upsert plan comment on #{issue_number}"):
+            return
+        # TODO(#1823): exact repo-scoped upsert needs the GraphQL comment-id
+        # helper to accept owner/repo. Until then, repo-scoped runs post a new
+        # durable comment rather than silently targeting the current repo.
+        if self._repo_slug is not None:
+            with github_api._body_file(body) as path:
+                self._gh(["issue", "comment", str(issue_number), "--body-file", path])
             return
         github_api.gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)
 
@@ -267,16 +576,43 @@ class PipelineGitHub:
         ``pr_manager.ensure_pr_created``, which would discard the stage's
         composed body (protocol docstring). Dry-run returns 0 (no PR).
         """
-        existing = find_pr_for_issue(issue_number)
+        existing = self.find_pr_for_issue(issue_number)
         if existing:
             return existing
         if self._skip(f"create PR for #{issue_number} from {branch!r}"):
             return 0
+        if self._repo_slug is not None:
+            github_api._assert_body_has_closes(body)
+            github_api._assert_branch_commits_signed(branch, base="main")
+            with github_api._body_file(body) as body_path:
+                result = self._gh(
+                    [
+                        "pr",
+                        "create",
+                        "--head",
+                        branch,
+                        "--base",
+                        "main",
+                        "--title",
+                        github_api.strip_null_bytes(title),
+                        "--body-file",
+                        body_path,
+                    ]
+                )
+            output = result.stdout.strip()
+            match = re.search(r"/pull/(\d+)", output)
+            if match:
+                return int(match.group(1))
+            return int(output.split("/")[-1])
         return github_api.gh_pr_create(branch, title, body)
 
     def post_pr_comment(self, pr_number: int, body: str) -> None:
         """Post an explanatory PR comment (``gh_issue_comment`` channel)."""
         if self._skip(f"post comment on PR #{pr_number}"):
+            return
+        if self._repo_slug is not None:
+            with github_api._body_file(body) as path:
+                self._gh(["issue", "comment", str(pr_number), "--body-file", path])
             return
         github_api.gh_issue_comment(pr_number, body)
 
@@ -284,11 +620,19 @@ class PipelineGitHub:
         """Apply ``state:implementation-no-go`` (``pr_manager``)."""
         if self._skip(f"mark PR #{pr_number} implementation-no-go"):
             return
+        if self._repo_slug is not None:
+            self._add_labels(pr_number, [STATE_IMPLEMENTATION_NO_GO])
+            self._remove_labels(pr_number, [STATE_IMPLEMENTATION_GO])
+            return
         pr_manager.mark_pr_implementation_no_go(pr_number)
 
     def mark_pr_implementation_go(self, pr_number: int) -> None:
         """Apply ``state:implementation-go`` (``pr_manager``)."""
         if self._skip(f"mark PR #{pr_number} implementation-go"):
+            return
+        if self._repo_slug is not None:
+            self._add_labels(pr_number, [STATE_IMPLEMENTATION_GO])
+            self._remove_labels(pr_number, [STATE_IMPLEMENTATION_NO_GO])
             return
         pr_manager.mark_pr_implementation_go(pr_number)
 
@@ -296,11 +640,23 @@ class PipelineGitHub:
         """Keep auto-merge disabled until implementation GO (``pr_manager``)."""
         if self._skip(f"defer auto-merge on PR #{pr_number}"):
             return
+        if self._repo_slug is not None:
+            result = self._gh(
+                ["pr", "view", str(pr_number), "--json", "autoMergeRequest"],
+                check=False,
+            )
+            data = json.loads(result.stdout or "{}")
+            if data.get("autoMergeRequest") is not None:
+                self._gh(["pr", "merge", str(pr_number), "--disable-auto"])
+            return
         pr_manager.ensure_pr_auto_merge_deferred(pr_number)
 
     def arm_auto_merge(self, pr_number: int) -> None:
         """Arm squash auto-merge after implementation GO (``pr_manager``)."""
         if self._skip(f"arm auto-merge on PR #{pr_number}"):
+            return
+        if self._repo_slug is not None:
+            self._gh(["pr", "merge", str(pr_number), "--auto", "--squash"])
             return
         pr_manager.enable_auto_merge_after_implementation_go(pr_number)
 
@@ -310,6 +666,9 @@ class PipelineGitHub:
         """Post surviving review threads (``gh_pr_review_post``)."""
         if self._skip(f"post {len(threads)} review thread(s) on PR #{pr_number}"):
             return []
+        # TODO(#1823): repo-scope the GraphQL review-post helper. This remains
+        # delegated for now because it needs diff-position validation and GraphQL
+        # review creation, not a simple gh CLI command.
         return github_api.gh_pr_review_post(pr_number, threads, summary)
 
     def arm_drive_green(self, issue_number: int, pr_number: int, head_sha: str) -> None:
@@ -327,7 +686,7 @@ class PipelineGitHub:
             issue_number,
             {
                 "pr_number": pr_number,
-                "pr_head_branch": get_pr_head_branch(pr_number) or "",
+                "pr_head_branch": self.get_pr_head_branch(pr_number) or "",
                 "head_sha_at_arming": head_sha,
                 "armed_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 "learn_attempted_at": None,
@@ -371,6 +730,11 @@ class PipelineGitHub:
         """
         if self._skip(f"tag epics {sorted(epics_labels)} {STATE_SKIP}"):
             return
+        if self._repo_slug is not None:
+            for number, labels in epics_labels.items():
+                if STATE_SKIP not in labels:
+                    self._add_labels(number, [STATE_SKIP])
+            return
         github_api.skip_epics(epics_labels)
 
     def ensure_state_labels(self) -> None:
@@ -381,5 +745,11 @@ class PipelineGitHub:
         """
         wanted = [*ALL_STATE_LABELS, *ALL_IMPLEMENTATION_STATE_LABELS, STATE_SKIP]
         if self._skip(f"ensure state labels exist: {wanted}"):
+            return
+        if self._repo_slug is not None:
+            existing = self._label_names()
+            for label in wanted:
+                if label not in existing:
+                    self._create_label(label)
             return
         github_api._ensure_labels_exist(wanted)

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -106,6 +106,10 @@ class FakeStageGitHub(FakeGitHub):
         """Mirror _review_utils.find_merged_closing_pr."""
         return self._merged_pr
 
+    def find_merged_pr_for_issue(self, issue_number: int) -> int | None:
+        """Mirror _review_utils.find_merged_pr_for_issue."""
+        return self._merged_pr
+
     def find_pr_for_issue(self, issue_number: int) -> int | None:
         """Mirror _review_utils.find_pr_for_issue (open PR lookup)."""
         return self._open_pr

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -240,6 +240,15 @@ class FakeStageGitHub(FakeGitHub):
         self.learn_results[issue_number] = succeeded
         self._log("mark_drive_green_learn_result", issue_number, succeeded)
 
+    def ensure_state_labels(self) -> None:
+        """Mirror the repo-stage label-vocabulary ensure (records mutation).
+
+        The canonical ``skip_epics`` recorder is inherited from
+        :class:`FakeGitHub`; this is the only repo-stage (#1817) protocol
+        method without a canonical recorder there.
+        """
+        self._log("ensure_state_labels")
+
 
 if TYPE_CHECKING:
     # mypy-enforced declaration that FakeStageGitHub satisfies the

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -1,0 +1,192 @@
+"""FinishedStage tests: ledger record, cleanup branches (#1817).
+
+Doc section "8. finished": record ItemResult [M]; worktree cleanup [W:G] —
+remove on pass, preserve on fail (preserved list feeds the summary footer).
+Terminal: no outgoing routes.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline.jobs import GitJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition, StageName
+from hephaestus.automation.pipeline.stages.base import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.finished import FinishedStage
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+
+
+@pytest.fixture
+def ledger() -> list[ItemResult]:
+    """Fresh coordinator-owned run ledger."""
+    return []
+
+
+@pytest.fixture
+def preserved() -> list[tuple[int, str]]:
+    """Fresh preserved-worktree list."""
+    return []
+
+
+@pytest.fixture
+def stage(ledger: list[ItemResult], preserved: list[tuple[int, str]]) -> FinishedStage:
+    """FinishedStage bound to the fixture ledger/preserved lists."""
+    return FinishedStage(ledger, preserved)
+
+
+def _item(
+    *,
+    passed: bool = True,
+    reason: str = "ok",
+    worktree: str = "",
+    state: str = "ENTER",
+) -> WorkItem:
+    item = WorkItem(
+        repo="repo-a",
+        kind=ItemKind.ISSUE,
+        issue=42,
+        stage=StageName.FINISHED,
+        state=state,
+        worktree=worktree,
+    )
+    item.result = ItemResult(passed=passed, reason=reason, final_stage=StageName.MERGE_WAIT)
+    return item
+
+
+class TestRecord:
+    """Step 1 [M]: record the ItemResult in the run ledger."""
+
+    def test_enter_advances_to_record(self, stage: FinishedStage, make_ctx: Any) -> None:
+        result = stage.step(_item(), make_ctx())
+
+        assert isinstance(result, Continue) and result.next_state == "RECORD"
+
+    def test_record_appends_result_once(
+        self, stage: FinishedStage, ledger: list[ItemResult], make_ctx: Any
+    ) -> None:
+        """Re-stepping RECORD never double-records (idempotent sink)."""
+        ctx = make_ctx()
+        item = _item(state="RECORD")
+
+        first = stage.step(item, ctx)
+        second = stage.step(item, ctx)
+
+        assert isinstance(first, Continue) and first.next_state == "CLEANUP"
+        assert isinstance(second, Continue)
+        assert ledger == [item.result]
+
+    def test_missing_result_records_internal_failure(
+        self, stage: FinishedStage, ledger: list[ItemResult], make_ctx: Any
+    ) -> None:
+        """Defensive: an item without a result is recorded as failed, not lost."""
+        item = _item(state="RECORD")
+        item.result = None
+
+        stage.step(item, make_ctx())
+
+        assert len(ledger) == 1
+        assert not ledger[0].passed
+        assert "no result" in ledger[0].reason
+
+
+class TestCleanup:
+    """Step 2 [W:G]: remove on pass, preserve on fail."""
+
+    def test_pass_with_worktree_submits_remove_job(
+        self, stage: FinishedStage, make_ctx: Any
+    ) -> None:
+        item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+
+        result = stage.step(item, make_ctx())
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob) and result.job.op == "remove_worktree"
+        assert result.job.kwargs == {"issue_number": 42, "force": True}
+        assert result.on_done_state == "DONE"
+
+    def test_fail_with_worktree_preserves_for_debugging(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[int, str]],
+        make_ctx: Any,
+    ) -> None:
+        """Preserve-on-fail: recorded for the summary, no removal job."""
+        item = _item(passed=False, reason="boom", worktree="/wt/issue-42", state="CLEANUP")
+
+        result = stage.step(item, make_ctx())
+
+        assert isinstance(result, Continue) and result.next_state == "DONE"
+        assert preserved == [(42, "/wt/issue-42")]
+
+    def test_fail_preserve_is_idempotent(
+        self,
+        stage: FinishedStage,
+        preserved: list[tuple[int, str]],
+        make_ctx: Any,
+    ) -> None:
+        ctx = make_ctx()
+        item = _item(passed=False, worktree="/wt/issue-42", state="CLEANUP")
+
+        stage.step(item, ctx)
+        item.state = "CLEANUP"
+        stage.step(item, ctx)
+
+        assert preserved == [(42, "/wt/issue-42")]
+
+    def test_no_worktree_skips_cleanup(self, stage: FinishedStage, make_ctx: Any) -> None:
+        result = stage.step(_item(state="CLEANUP"), make_ctx())
+
+        assert isinstance(result, Continue) and result.next_state == "DONE"
+
+    def test_dry_run_pass_never_submits_removal(self, stage: FinishedStage, make_ctx: Any) -> None:
+        item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
+
+        result = stage.step(item, make_ctx(dry_run=True))
+
+        assert isinstance(result, Continue) and result.next_state == "DONE"
+
+
+class TestTerminal:
+    """DONE is terminal; job failures are logged, never fatal."""
+
+    def test_done_emits_terminal_pass(self, stage: FinishedStage, make_ctx: Any) -> None:
+        result = stage.step(_item(state="DONE"), make_ctx())
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_PASS
+
+    def test_unknown_state_fails(self, stage: FinishedStage, make_ctx: Any) -> None:
+        result = stage.step(_item(state="BOGUS"), make_ctx())
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_FAIL
+
+    def test_on_enter_never_routes_away(self, stage: FinishedStage, make_ctx: Any) -> None:
+        assert stage.on_enter(_item(), make_ctx()) is None
+
+    def test_cleanup_failure_logged_non_fatal(
+        self,
+        stage: FinishedStage,
+        make_ctx: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        item = _item(worktree="/wt/issue-42", state="CLEANUP")
+
+        with caplog.at_level(logging.WARNING):
+            stage.on_job_done(item, JobResult(ok=False, error="dirty tree"), make_ctx())
+
+        assert any("cleanup failed" in record.message for record in caplog.records)
+
+    def test_cleanup_success_logs_nothing(
+        self,
+        stage: FinishedStage,
+        make_ctx: Any,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        with caplog.at_level(logging.WARNING):
+            stage.on_job_done(_item(state="CLEANUP"), JobResult(ok=True), make_ctx())
+
+        assert caplog.records == []

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -98,13 +98,18 @@ class TestCleanup:
     def test_pass_with_worktree_submits_remove_job(
         self, stage: FinishedStage, make_ctx: Any
     ) -> None:
+        ctx = make_ctx()
         item = _item(passed=True, worktree="/wt/issue-42", state="CLEANUP")
 
-        result = stage.step(item, make_ctx())
+        result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob) and result.job.op == "remove_worktree"
-        assert result.job.kwargs == {"issue_number": 42, "force": True}
+        assert result.job.kwargs == {
+            "worktree_path": "/wt/issue-42",
+            "repo_root": str(ctx.paths.repo_root),
+            "force": True,
+        }
         assert result.on_done_state == "DONE"
 
     def test_fail_with_worktree_preserves_for_debugging(

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -739,13 +739,32 @@ class TestCommitPushAndPrCreate:
         ctx = make_ctx()
         item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
         item.branch = "1-auto-impl"
+        item.worktree = "/tmp/wt"
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob)
         assert result.job.op == "commit_push"
+        assert result.job.kwargs == {
+            "issue_number": 1,
+            "worktree_path": "/tmp/wt",
+            "branch": "1-auto-impl",
+            "agent": "claude",
+        }
         assert result.on_done_state == "PR_CREATE"
+
+    def test_commit_push_no_commit_sets_skip_payload(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A successful commit_push with value=False skips PR creation."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="COMMIT_PUSH_WAIT")
+
+        stage.on_job_done(item, JobResult(ok=True, value=False), ctx)
+
+        assert item.payload["no_commits"] is True
 
     def test_pr_create_journals_pr_then_defers_auto_merge(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -229,8 +229,8 @@ class TestGate:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob)
         assert result.job.kwargs == {
-            "issue": 1,
-            "branch": "1-some-real-branch",
+            "issue_number": 1,
+            "branch_name": "1-some-real-branch",
             "refresh_base": False,
             "sync_to_remote": True,
         }
@@ -411,7 +411,11 @@ class TestWorktreeAndAdvise:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob)
         assert result.job.op == "create_worktree"
-        assert result.job.kwargs == {"issue": 1, "branch": "1-auto-impl", "refresh_base": True}
+        assert result.job.kwargs == {
+            "issue_number": 1,
+            "branch_name": "1-auto-impl",
+            "refresh_base": True,
+        }
         assert result.on_done_state == "DIRTY_DECISION_WAIT"
 
     def test_worktree_result_stores_path_and_dirty_state(

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -260,6 +260,37 @@ class TestPlanningStageStep:
             "advise_findings": "prior learnings",
         }
 
+    def test_plan_job_uses_selected_provider_and_planner_session_role(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Provider selection is distinct from the persisted planner session role."""
+        stage = PlanningStage()
+        config = type(
+            "Cfg",
+            (),
+            {
+                "enable_advise": True,
+                "enable_learn": True,
+                "force": False,
+                "agent": "codex",
+                "model": "gpt-default",
+                "planner_model": "gpt-plan",
+                "reviewer_model": "",
+                "implementer_model": "",
+                "dry_run": False,
+            },
+        )()
+        ctx = make_ctx(config=config)
+        item = make_work_item(issue=9, state="PLAN_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.agent == "codex"
+        assert result.job.session_agent == "planner"
+        assert result.job.model == "gpt-plan"
+
     def test_verify_with_plan_advances(self, make_ctx: Any, make_work_item: Any) -> None:
         """VERIFY with an existing plan comment advances without re-posting."""
         stage = PlanningStage()

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -333,12 +333,19 @@ class TestPrReviewStageStep:
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="PUSH_WAIT")
         item.branch = "1-auto-impl"
+        item.worktree = "/tmp/wt"
 
         result = stage.step(item, ctx)
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, GitJob)
         assert result.job.op == "commit_push"
+        assert result.job.kwargs == {
+            "issue_number": 1,
+            "worktree_path": "/tmp/wt",
+            "branch": "1-auto-impl",
+            "agent": "claude",
+        }
         assert result.on_done_state == "EVAL"
 
     def test_followup_wait_requests_follow_up(self, make_ctx: Any, make_work_item: Any) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -176,6 +176,7 @@ class TestDiscover:
             loop_repo_manager_mod, "_list_open_pr_numbers", lambda org, repo: open_prs or []
         )
         monkeypatch.setattr(seeding_mod, "seed_issue", lambda num: facts[num])
+        monkeypatch.setattr(seeding_mod, "seed_issue_from_github", lambda num, github: facts[num])
 
         def fake_classify(f: IssueFacts) -> tuple[StageName | None, str]:
             classified.append(f.number)
@@ -183,6 +184,55 @@ class TestDiscover:
 
         monkeypatch.setattr(seeding_mod, "classify_issue", fake_classify)
         return classified
+
+    def test_discover_classifies_through_repo_scoped_github(
+        self,
+        repo_item: WorkItem,
+        tmp_path: Path,
+        make_ctx: Callable[..., Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Repo discovery must not fall back to current-repo seeding helpers."""
+
+        class RepoScopedGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(open_pr=44)
+                self.issue_reads: list[int] = []
+
+            def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+                self.issue_reads.append(issue_number)
+                return {
+                    "number": issue_number,
+                    "title": "repo-specific task",
+                    "state": "OPEN",
+                    "body": "",
+                    "labels": [{"name": "state:implementation-go"}],
+                }
+
+            def find_merged_pr_for_issue(self, issue_number: int) -> int | None:
+                return None
+
+        github = RepoScopedGitHub()
+        ctx = make_ctx(github=github, paths=_RepoPaths(tmp_path))
+        monkeypatch.setattr(
+            loop_repo_manager_mod,
+            "_list_open_issue_meta",
+            lambda org, repo: [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}],
+        )
+        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_numbers", lambda org, repo: [])
+        monkeypatch.setattr(
+            seeding_mod,
+            "seed_issue",
+            lambda num: (_ for _ in ()).throw(AssertionError("used current-repo seed_issue")),
+        )
+        repo_item.state = "DISCOVER"
+
+        result = RepoStage().step(repo_item, ctx)
+
+        assert isinstance(result, Continue)
+        assert github.issue_reads == [8]
+        assert repo_item.payload["products"][0]["stage"] is StageName.CI
+        assert repo_item.payload["products"][0]["pr"] == 44
 
     def test_discover_classifies_dedups_and_stages_products(
         self,

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -234,6 +234,26 @@ class TestDiscover:
         assert repo_item.payload["products"][0]["stage"] is StageName.CI
         assert repo_item.payload["products"][0]["pr"] == 44
 
+    def test_discover_failure_finishes_fail(
+        self,
+        repo_item: WorkItem,
+        repo_ctx: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Discovery failures are not converted into a successful empty run."""
+        monkeypatch.setattr(
+            loop_repo_manager_mod,
+            "_list_open_issue_meta",
+            lambda org, repo: (_ for _ in ()).throw(RuntimeError("gh failed")),
+        )
+        repo_item.state = "DISCOVER"
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_FAIL
+        assert "discovery failed" in result.note
+
     def test_discover_classifies_dedups_and_stages_products(
         self,
         repo_item: WorkItem,

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -340,6 +340,35 @@ class TestDiscover:
         orphan = [p for p in repo_item.payload["products"] if p.get("kind") == "pr"]
         assert [(p["number"], p["stage"]) for p in orphan] == [(66, StageName.CI)]
 
+    def test_drive_green_all_pr_discovery_failure_finishes_fail(
+        self,
+        repo_item: WorkItem,
+        tmp_path: Path,
+        make_ctx: Callable[..., Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Orphan-PR discovery failures are visible, not successful empty runs."""
+        config = type("Cfg", (), {"drive_green_all": True, "dry_run": False})()
+        ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
+        self._patch_discovery(
+            monkeypatch,
+            meta=[{"number": 1, "labels": [], "title": "covered"}],
+            facts={1: _facts(1, pr=55, pr_open=True)},
+            classifications={1: (StageName.PR_REVIEW, "open PR")},
+        )
+        monkeypatch.setattr(
+            loop_repo_manager_mod,
+            "_list_open_pr_numbers",
+            lambda org, repo: (_ for _ in ()).throw(RuntimeError("pr list failed")),
+        )
+        repo_item.state = "DISCOVER"
+
+        result = RepoStage().step(repo_item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_FAIL
+        assert "discovery failed" in result.note
+
     def test_seeded_finishes_pass_with_count(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         """Terminal: FINISH_PASS(seeded:N) counting only queued products."""
         repo_item.state = "SEEDED"

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -1,0 +1,336 @@
+"""RepoStage tests: label ensure, clone, discovery walk, epic-tag order (#1817).
+
+Doc section "1. repo" is the binding contract: ENTER -> CLONE_WAIT ->
+DISCOVER -> SEEDED; budget clone=2; epics tagged ``state:skip`` [durable]
+BEFORE exclusion; ``--drive-green-all`` routes orphan PRs to ci; the repo
+item is terminal (FINISH_PASS ``seeded:N``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import hephaestus.automation.loop_repo_manager as loop_repo_manager_mod
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.jobs import GitJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition, StageName
+from hephaestus.automation.pipeline.seeding import IssueFacts
+from hephaestus.automation.pipeline.stages.base import Continue, JobRequest, StageOutcome
+from hephaestus.automation.pipeline.stages.repo import RepoStage, product_to_work_item
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+
+from .conftest import FakeStageGitHub
+
+
+class _RepoPaths:
+    """Paths stub exposing the projects_dir the repo stage anchors clones at."""
+
+    def __init__(self, projects_dir: Path) -> None:
+        self.projects_dir = projects_dir
+        self.repo_root = projects_dir
+        self.worktree = projects_dir
+
+
+@pytest.fixture
+def repo_item() -> WorkItem:
+    """Fresh repo-kind work item at ENTER."""
+    return WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO, state="ENTER")
+
+
+@pytest.fixture
+def repo_ctx(tmp_path: Path, make_ctx: Callable[..., Any]) -> Any:
+    """StageContext whose paths expose a temp projects_dir."""
+    return make_ctx(paths=_RepoPaths(tmp_path))
+
+
+def _facts(
+    number: int,
+    *,
+    labels: set[str] | None = None,
+    pr: int | None = None,
+    pr_open: bool = False,
+    pr_merged: bool = False,
+) -> IssueFacts:
+    return IssueFacts(
+        number=number,
+        title=f"task {number}",
+        is_epic=False,
+        labels=labels or set(),
+        pr_number=pr,
+        pr_is_open=pr_open,
+        pr_is_merged=pr_merged,
+    )
+
+
+class TestOnEnterAndCloneStates:
+    """Steps 1-2: ensure_state_labels [M], clone [W:G] with budget 2."""
+
+    def test_on_enter_ensures_state_labels(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        stage = RepoStage()
+
+        assert stage.on_enter(repo_item, repo_ctx) is None
+
+        assert ("ensure_state_labels", ()) in repo_ctx.github.mutation_log
+
+    def test_enter_state_advances_to_clone_wait(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "CLONE_WAIT"
+
+    def test_clone_wait_submits_git_clone_job(
+        self, repo_item: WorkItem, repo_ctx: Any, tmp_path: Path
+    ) -> None:
+        """A missing checkout submits GitJob(op="clone") with repo/dest kwargs."""
+        repo_item.state = "CLONE_WAIT"
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "clone"
+        assert result.job.kwargs == {
+            "repo": "test-org/repo-a",
+            "dest": str(tmp_path / "repo-a"),
+        }
+        assert result.on_done_state == "DISCOVER"
+
+    def test_clone_skipped_when_already_cloned(
+        self, repo_item: WorkItem, repo_ctx: Any, tmp_path: Path
+    ) -> None:
+        (tmp_path / "repo-a").mkdir()
+        repo_item.state = "CLONE_WAIT"
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DISCOVER"
+
+    def test_clone_skipped_in_dry_run(
+        self, repo_item: WorkItem, tmp_path: Path, make_ctx: Callable[..., Any]
+    ) -> None:
+        """[dry-run] logs the would-clone and proceeds — no job submitted."""
+        ctx = make_ctx(dry_run=True, paths=_RepoPaths(tmp_path))
+        repo_item.state = "CLONE_WAIT"
+
+        result = RepoStage().step(repo_item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DISCOVER"
+
+    def test_clone_failure_retries_within_budget(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        """First failure (attempt 1 < budget 2) re-submits the clone."""
+        stage = RepoStage()
+        repo_item.state = "CLONE_WAIT"
+        stage.on_job_done(repo_item, JobResult(ok=False, error="network"), repo_ctx)
+        assert repo_item.attempts["clone"] == 1
+
+        result = stage.step(repo_item, repo_ctx)
+
+        assert isinstance(result, JobRequest)  # retry
+        assert isinstance(result.job, GitJob) and result.job.op == "clone"
+
+    def test_clone_exhaustion_finishes_failed(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        """Budget clone=2 exhausted -> finished(fail) per the ROUTES row."""
+        stage = RepoStage()
+        repo_item.state = "CLONE_WAIT"
+        for _ in range(2):
+            stage.on_job_done(repo_item, JobResult(ok=False, error="network"), repo_ctx)
+
+        result = stage.step(repo_item, repo_ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_FAIL
+        assert "clone exhausted" in result.note
+
+    def test_clone_success_records_nothing(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        stage = RepoStage()
+        repo_item.state = "CLONE_WAIT"
+
+        stage.on_job_done(repo_item, JobResult(ok=True), repo_ctx)
+
+        assert repo_item.attempts["clone"] == 0
+        assert "clone_failed" not in repo_item.payload
+
+
+class TestDiscover:
+    """Step 3 [M]: list, dedup, epic-tag-before-exclude, classify, orphans."""
+
+    def _patch_discovery(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        meta: list[dict[str, Any]],
+        facts: dict[int, IssueFacts],
+        classifications: dict[int, tuple[StageName | None, str]],
+        open_prs: list[int] | None = None,
+    ) -> list[int]:
+        """Patch the repo-stage read seams; returns the classify-call order."""
+        classified: list[int] = []
+        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_issue_meta", lambda org, repo: meta)
+        monkeypatch.setattr(
+            loop_repo_manager_mod, "_list_open_pr_numbers", lambda org, repo: open_prs or []
+        )
+        monkeypatch.setattr(seeding_mod, "seed_issue", lambda num: facts[num])
+
+        def fake_classify(f: IssueFacts) -> tuple[StageName | None, str]:
+            classified.append(f.number)
+            return classifications[f.number]
+
+        monkeypatch.setattr(seeding_mod, "classify_issue", fake_classify)
+        return classified
+
+    def test_discover_classifies_dedups_and_stages_products(
+        self,
+        repo_item: WorkItem,
+        repo_ctx: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """N issues (with a duplicate) classify into entry-queue products."""
+        meta = [
+            {"number": 1, "labels": [], "title": "one"},
+            {"number": 2, "labels": ["state:plan-go"], "title": "two"},
+            {"number": 1, "labels": [], "title": "one (dup)"},  # deduped
+        ]
+        classified = self._patch_discovery(
+            monkeypatch,
+            meta=meta,
+            facts={1: _facts(1), 2: _facts(2, labels={"state:plan-go"})},
+            classifications={
+                1: (StageName.PLANNING, "needs plan"),
+                2: (StageName.IMPLEMENTATION, "plan approved"),
+            },
+        )
+        repo_item.state = "DISCOVER"
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue) and result.next_state == "SEEDED"
+        assert classified == [1, 2]  # dedup: issue 1 classified once
+        products = repo_item.payload["products"]
+        stages = {p["number"]: p["stage"] for p in products}
+        assert stages == {1: StageName.PLANNING, 2: StageName.IMPLEMENTATION}
+
+    def test_epics_tagged_durably_before_exclusion(
+        self,
+        repo_item: WorkItem,
+        repo_ctx: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The skip_epics write lands BEFORE the epic is excluded (order test)."""
+        meta = [
+            {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
+            {"number": 6, "labels": [], "title": "real work"},
+        ]
+        classified = self._patch_discovery(
+            monkeypatch,
+            meta=meta,
+            facts={6: _facts(6)},
+            classifications={6: (StageName.PLANNING, "needs plan")},
+        )
+        gh: FakeStageGitHub = repo_ctx.github
+        repo_item.state = "DISCOVER"
+
+        RepoStage().step(repo_item, repo_ctx)
+
+        # Durable tag written through the sanctioned chokepoint...
+        assert ("skip_epics", ((5,),)) in gh.mutation_log
+        assert "state:skip" in gh.labels[5]
+        # ...BEFORE the exclusion was materialized: the epic never reached
+        # the classifier, and its product records the exclusion.
+        assert classified == [6]
+        epic_products = [p for p in repo_item.payload["products"] if p["number"] == 5]
+        assert epic_products[0]["stage"] is None
+
+    def test_drive_green_all_routes_orphan_prs_to_ci(
+        self,
+        repo_item: WorkItem,
+        tmp_path: Path,
+        make_ctx: Callable[..., Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Open PRs with no tracked issue become ci-stage PR products."""
+        config = type("Cfg", (), {"drive_green_all": True, "dry_run": False})()
+        ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
+        self._patch_discovery(
+            monkeypatch,
+            meta=[{"number": 1, "labels": [], "title": "covered"}],
+            facts={1: _facts(1, pr=55, pr_open=True)},
+            classifications={1: (StageName.PR_REVIEW, "open PR")},
+            open_prs=[55, 66],
+        )
+        repo_item.state = "DISCOVER"
+
+        RepoStage().step(repo_item, ctx)
+
+        orphan = [p for p in repo_item.payload["products"] if p.get("kind") == "pr"]
+        assert [(p["number"], p["stage"]) for p in orphan] == [(66, StageName.CI)]
+
+    def test_seeded_finishes_pass_with_count(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        """Terminal: FINISH_PASS(seeded:N) counting only queued products."""
+        repo_item.state = "SEEDED"
+        repo_item.payload["products"] = [
+            {"number": 1, "stage": StageName.PLANNING, "reason": "r"},
+            {"number": 2, "stage": None, "reason": "excluded"},
+            {"number": 3, "stage": StageName.CI, "reason": "r"},
+        ]
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_PASS
+        assert result.note == "seeded:2"
+
+    def test_unknown_state_finishes_failed(self, repo_item: WorkItem, repo_ctx: Any) -> None:
+        repo_item.state = "BOGUS"
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_FAIL
+
+
+class TestProductToWorkItem:
+    """Coordinator-side product materialization."""
+
+    def test_issue_product(self) -> None:
+        item = product_to_work_item(
+            "repo-a",
+            {
+                "kind": "issue",
+                "number": 9,
+                "stage": StageName.PLANNING,
+                "reason": "r",
+                "labels": ["state:needs-plan"],
+            },
+        )
+
+        assert item is not None
+        assert item.kind is ItemKind.ISSUE and item.issue == 9 and item.pr is None
+        assert item.stage is StageName.PLANNING and item.state == "ENTER"
+        assert item.labels_cache == {"state:needs-plan": True}
+        assert item.payload["entry_stage"] == "planning"
+
+    def test_issue_product_with_open_pr(self) -> None:
+        item = product_to_work_item(
+            "repo-a",
+            {"kind": "issue", "number": 9, "pr": 77, "stage": StageName.CI, "reason": "r"},
+        )
+
+        assert item is not None
+        assert item.issue == 9 and item.pr == 77
+
+    def test_pr_product(self) -> None:
+        item = product_to_work_item(
+            "repo-a", {"kind": "pr", "number": 66, "stage": StageName.CI, "reason": "orphan"}
+        )
+
+        assert item is not None
+        assert item.kind is ItemKind.PR and item.pr == 66 and item.issue is None
+
+    def test_excluded_product_returns_none(self) -> None:
+        assert product_to_work_item("repo-a", {"kind": "issue", "number": 5, "stage": None}) is None

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1,0 +1,468 @@
+"""Coordinator event-loop tests (epic #1809, #1817).
+
+Covers: quiescence with FakeWorkerPool/FakeStageGitHub, the journal-order
+invariant (durable mutation precedes the queue push in one shared trace),
+downstream-first drain order, per-repo in-flight cap, zero-work convergence,
+the loop budget, the non-blocking rate-budget park, dry-run
+asserts-no-submit, poisoned-item isolation, and FAIL_BACK routing.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import (
+    _FAIL_BACK_CAP,
+    Coordinator,
+    PipelineConfig,
+)
+from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import SeedEntry
+from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _agent_job(repo: str = "repo-a", issue: int = 1) -> AgentJob:
+    return AgentJob(
+        repo=repo,
+        issue=issue,
+        agent="claude",
+        model="m",
+        prompt_builder=lambda **kwargs: "prompt",
+        cwd=Path("/tmp"),
+        timeout_s=10,
+        descr="stub agent job",
+    )
+
+
+class StubStage:
+    """Scripted stage: each step() pops the next scripted StepResult."""
+
+    def __init__(self, *results: Any, enter: Any = None) -> None:
+        self.results = deque(results)
+        self.enter_result = enter
+        self.calls: list[tuple[str, Any]] = []
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> Any:
+        self.calls.append(("enter", item.issue or item.repo))
+        return self.enter_result
+
+    def step(self, item: WorkItem, ctx: Any) -> Any:
+        self.calls.append(("step", item.issue or item.repo))
+        if not self.results:
+            return StageOutcome(Disposition.FINISH_FAIL, "script exhausted")
+        return self.results.popleft()
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        self.calls.append(("job_done", result.ok))
+
+
+def make_coordinator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repos: list[str] | None = None,
+    seed_entries: list[list[SeedEntry]] | None = None,
+    loops: int = 1,
+    max_workers: int = 1,
+    dry_run: bool = False,
+    github: FakeStageGitHub | None = None,
+) -> tuple[Coordinator, FakeWorkerPool, FakeStageGitHub]:
+    """Build a Coordinator wired to fakes, with seeding scripted per pass."""
+    config = PipelineConfig(
+        org="org",
+        repos=repos if repos is not None else ["repo-a"],
+        loops=loops,
+        max_workers=max_workers,
+        dry_run=dry_run,
+        projects_dir=tmp_path,
+    )
+    gh = github or FakeStageGitHub()
+    pool = FakeWorkerPool()
+    passes = deque(seed_entries or [[]])
+
+    def fake_seed(repos_arg: Any, issues_arg: Any, prs_arg: Any) -> list[SeedEntry]:
+        return list(passes.popleft()) if passes else []
+
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", fake_seed)
+    coordinator = Coordinator(config, github=gh, pool=pool, install_signals=False)
+    return coordinator, pool, gh
+
+
+def _issue_item(
+    issue: int = 1, stage: StageName = StageName.PLANNING, repo: str = "repo-a"
+) -> WorkItem:
+    return WorkItem(repo=repo, kind=ItemKind.ISSUE, issue=issue, stage=stage, state="ENTER")
+
+
+class TestQuiescence:
+    """Full-run tests driving seeded items to the finished ledger."""
+
+    def test_repo_products_flow_to_finished(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repo seed's products traverse their entry stages into the ledger."""
+        seed = [SeedEntry(kind="repo", identifier="repo-a", stage=StageName.REPO, reason="seed")]
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, seed_entries=[seed])
+
+        class ProducingRepoStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                item.payload["products"] = [
+                    {"kind": "issue", "number": 11, "stage": StageName.PLANNING, "reason": "r"},
+                    {"kind": "issue", "number": 12, "stage": None, "reason": "excluded"},
+                ]
+                return StageOutcome(Disposition.FINISH_PASS, "seeded:1")
+
+        coordinator.stages[StageName.REPO] = ProducingRepoStage()
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            StageOutcome(Disposition.ADVANCE, "planned")
+        )
+        coordinator.stages[StageName.PLAN_REVIEW] = StubStage(
+            StageOutcome(Disposition.FINISH_PASS, "done")
+        )
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 0
+        assert len(coordinator.ledger) == 2  # repo item + issue item
+        assert all(result.passed for result in coordinator.ledger)
+        assert len(pool.submitted) == 0
+        keys = [key for kind, *key in coordinator.event_log if kind == "push"]
+        assert ["planning", "repo-a#11"] in [list(k) for k in keys]
+
+    def test_zero_work_convergence_exits_before_loop_budget(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All-terminal seeds produce zero actionable work: exit after one pass."""
+        seed = [
+            SeedEntry(kind="issue", identifier=5, stage=StageName.FINISHED, reason="PR merged"),
+        ]
+        coordinator, _, _ = make_coordinator(
+            tmp_path, monkeypatch, seed_entries=[seed, seed, seed], loops=5
+        )
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 0
+        assert coordinator._loops_run == 1  # converged, budget not consumed
+        assert len(coordinator.ledger) == 1
+        assert coordinator.ledger[0].passed
+
+    def test_loop_budget_bounds_reseeding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Actionable work each pass re-seeds only up to --loops."""
+        seed = [SeedEntry(kind="issue", identifier=7, stage=StageName.PLANNING, reason="r")]
+        coordinator, _, _ = make_coordinator(
+            tmp_path, monkeypatch, seed_entries=[seed, seed, seed, seed], loops=2
+        )
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            StageOutcome(Disposition.SKIP, "skip"),
+            StageOutcome(Disposition.SKIP, "skip"),
+        )
+
+        exit_code = coordinator.run()
+
+        assert coordinator._loops_run == 2
+        assert exit_code == 1  # SKIP counts as non-passing (fail-skip-blocked)
+        assert [result.reason for result in coordinator.ledger] == ["skip: skip", "skip: skip"]
+
+    def test_poisoned_item_routes_finished_fail_and_loop_survives(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stage exception fails the ITEM, not the loop."""
+        seed = [
+            SeedEntry(kind="issue", identifier=1, stage=StageName.PLANNING, reason="poison"),
+            SeedEntry(kind="issue", identifier=2, stage=StageName.PLAN_REVIEW, reason="ok"),
+        ]
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, seed_entries=[seed])
+
+        class PoisonStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                raise RuntimeError("boom")
+
+        coordinator.stages[StageName.PLANNING] = PoisonStage()
+        coordinator.stages[StageName.PLAN_REVIEW] = StubStage(
+            StageOutcome(Disposition.FINISH_PASS, "fine")
+        )
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 1
+        reasons = sorted(result.reason for result in coordinator.ledger)
+        assert any(reason.startswith("poisoned: boom") for reason in reasons)
+        assert any(reason == "fine" for reason in reasons)
+
+
+class TestJournalOrder:
+    """The durable-mutation-precedes-queue-push invariant, in one shared trace."""
+
+    def test_durable_mutation_precedes_queue_push(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Every push of a mutated item appears AFTER its durable write."""
+        seed = [SeedEntry(kind="issue", identifier=9, stage=StageName.PLANNING, reason="r")]
+        coordinator, _, gh = make_coordinator(tmp_path, monkeypatch, seed_entries=[seed])
+
+        original_log = gh._log
+
+        def shared_log(name: str, *args: Any) -> None:
+            original_log(name, *args)
+            coordinator.event_log.append(("mutation", name, args))
+
+        gh._log = shared_log  # type: ignore[method-assign]
+
+        class MutatingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                # Durable write immediately before the ADVANCE outcome that
+                # causes the queue push (the house journal-order pattern).
+                ctx.github.add_labels(item.issue, ["state:plan-go"])
+                return StageOutcome(Disposition.ADVANCE, "go")
+
+        coordinator.stages[StageName.PLANNING] = MutatingStage()
+        coordinator.stages[StageName.PLAN_REVIEW] = StubStage(
+            StageOutcome(Disposition.FINISH_PASS, "done")
+        )
+
+        coordinator.run()
+
+        trace = coordinator.event_log
+        mutation_idx = next(
+            i for i, entry in enumerate(trace) if entry[:2] == ("mutation", "gh_issue_add_labels")
+        )
+        push_idx = next(i for i, entry in enumerate(trace) if entry[:2] == ("push", "plan_review"))
+        assert mutation_idx < push_idx, f"push preceded durable mutation: {trace}"
+
+
+class TestDrainOrder:
+    """Downstream-first queue draining."""
+
+    def test_downstream_first(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """merge_wait drains before ci ... before planning before repo."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        for stage in (
+            StageName.PLANNING,
+            StageName.MERGE_WAIT,
+            StageName.CI,
+            StageName.REPO,
+        ):
+            coordinator.stages[stage] = StubStage(StageOutcome(Disposition.FINISH_PASS, "x"))
+        coordinator._push_item(_issue_item(1, StageName.PLANNING), StageName.PLANNING, enter=True)
+        coordinator._push_item(
+            _issue_item(2, StageName.MERGE_WAIT), StageName.MERGE_WAIT, enter=True
+        )
+        coordinator._push_item(_issue_item(3, StageName.CI), StageName.CI, enter=True)
+        repo_item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+        coordinator._push_item(repo_item, StageName.REPO, enter=True)
+        coordinator.event_log.clear()
+
+        coordinator._drain_queues()
+
+        drained = [entry[1] for entry in coordinator.event_log if entry[0] == "drain"]
+        assert drained.index("merge_wait") < drained.index("ci")
+        assert drained.index("ci") < drained.index("planning")
+        assert drained.index("planning") < drained.index("repo")
+
+
+class TestAdmission:
+    """Per-repo in-flight cap via the distinct inflight_per_repo Counter."""
+
+    def test_per_repo_cap_defers_second_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """max_workers=1: the second same-repo item is not admitted."""
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=1)
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            JobRequest(_agent_job(issue=1), on_done_state="VERIFY"),
+            JobRequest(_agent_job(issue=2), on_done_state="VERIFY"),
+        )
+        coordinator._push_item(_issue_item(1), StageName.PLANNING, enter=True)
+        coordinator._push_item(_issue_item(2), StageName.PLANNING, enter=True)
+
+        coordinator._drain_queues()
+
+        assert len(pool.submitted) == 1
+        assert coordinator.inflight_per_repo["repo-a"] == 1
+        assert len(coordinator.queues[StageName.PLANNING]) == 1
+
+    def test_cap_is_per_repo_not_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Items of different repos are admitted independently."""
+        coordinator, pool, _ = make_coordinator(
+            tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=1
+        )
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            JobRequest(_agent_job(repo="repo-a", issue=1), on_done_state="V"),
+            JobRequest(_agent_job(repo="repo-b", issue=2), on_done_state="V"),
+        )
+        coordinator._push_item(_issue_item(1, repo="repo-a"), StageName.PLANNING, enter=True)
+        coordinator._push_item(_issue_item(2, repo="repo-b"), StageName.PLANNING, enter=True)
+
+        coordinator._drain_queues()
+
+        assert len(pool.submitted) == 2
+        assert coordinator.inflight_per_repo["repo-a"] == 1
+        assert coordinator.inflight_per_repo["repo-b"] == 1
+
+
+class TestRateBudget:
+    """The non-blocking rate gate parks agent jobs on the timer heap."""
+
+    def test_low_budget_parks_instead_of_submitting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Low GraphQL budget: the AgentJob is timer-parked, never submitted."""
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline_github.rate_budget_ok",
+            lambda now_epoch=None: (False, 60.0),
+        )
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch)
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            JobRequest(_agent_job(), on_done_state="VERIFY")
+        )
+        coordinator._push_item(_issue_item(1), StageName.PLANNING, enter=True)
+
+        coordinator._drain_queues()
+
+        assert pool.submitted == []
+        assert len(coordinator.timers) == 1
+        assert any(entry[0] == "timer_park" for entry in coordinator.event_log)
+
+
+class TestDryRun:
+    """Dry-run: stages' JobRequests are logged-and-advanced; _submit asserts."""
+
+    def test_job_request_advances_without_submission(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """[dry-run] a requested job is logged and the item ADVANCEs."""
+        seed = [SeedEntry(kind="issue", identifier=3, stage=StageName.PLANNING, reason="r")]
+        coordinator, pool, _ = make_coordinator(
+            tmp_path, monkeypatch, seed_entries=[seed], dry_run=True
+        )
+        coordinator.stages[StageName.PLANNING] = StubStage(
+            JobRequest(_agent_job(issue=3), on_done_state="VERIFY")
+        )
+        coordinator.stages[StageName.PLAN_REVIEW] = StubStage(
+            StageOutcome(Disposition.FINISH_PASS, "done")
+        )
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 0
+        assert pool.submitted == []
+        assert not any(entry[0] == "submit" for entry in coordinator.event_log)
+
+    def test_submit_asserts_in_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_submit is guarded by an assert: dry-run must never reach it."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, dry_run=True)
+        request = JobRequest(_agent_job(), on_done_state="VERIFY")
+
+        with pytest.raises(AssertionError, match="dry-run must never submit"):
+            coordinator._submit(_issue_item(1), request)
+
+
+class TestFailBackRouting:
+    """The Disposition->action table's FAIL_BACK rows."""
+
+    def test_named_reason_routes_to_mapped_stage(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pr_review FAIL_BACK(agent_error) regresses to implementation."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        item = _issue_item(4, StageName.PR_REVIEW)
+        coordinator._push_item(item, StageName.PR_REVIEW, enter=False)
+        coordinator.event_log.clear()
+
+        coordinator._route(item, StageOutcome(Disposition.FAIL_BACK, "agent_error"))
+
+        assert item.stage is StageName.IMPLEMENTATION
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
+
+    def test_unknown_reason_uses_default_route(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unmapped reason falls back to the '*' target."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        item = _issue_item(5, StageName.PLANNING)
+
+        coordinator._route(item, StageOutcome(Disposition.FAIL_BACK, "mystery"))
+
+        # planning "*" -> finished(fail)
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None and not item.result.passed
+
+    def test_dry_run_fail_back_finishes_instead_of_regressing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Dry-run FAIL_BACK finishes with the would-regress note.
+
+        Dry-run cannot write gate labels, so a real regression would
+        ping-pong until the safety cap while burning live reads.
+        """
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, dry_run=True)
+        item = _issue_item(7, StageName.IMPLEMENTATION)
+
+        coordinator._route(item, StageOutcome(Disposition.FAIL_BACK, "plan_not_go"))
+
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None
+        assert item.result.reason == "[dry-run] would fail_back: plan_not_go"
+
+    def test_fail_back_safety_cap_terminates_cycles(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pathological regress cycle terminates at the global cap."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        item = _issue_item(6, StageName.PR_REVIEW)
+        item.payload["_fail_backs"] = _FAIL_BACK_CAP
+
+        coordinator._route(item, StageOutcome(Disposition.FAIL_BACK, "agent_error"))
+
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None
+        assert "safety cap" in item.result.reason
+
+
+class TestImplementationAdmission:
+    """Topological order + file-overlap reuse for the implementation queue."""
+
+    def test_topo_order_and_overlap_reuse(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """order_for_implementation and _select_non_overlapping gate dispatch."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        # 21 depends on 22 (payload dependency): topo order runs 22 first.
+        item_a = _issue_item(21, StageName.IMPLEMENTATION)
+        item_a.payload["dependencies"] = [22]
+        item_b = _issue_item(22, StageName.IMPLEMENTATION)
+        coordinator._push_item(item_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(item_b, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._select_non_overlapping",
+            lambda issues: (issues[:1], issues[1:]),  # defer everything but the first
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_order == [22]  # dependency first; 21 deferred by overlap
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -9,12 +9,16 @@ chokepoint, grace-window expiry, and run_pipeline's production wiring.
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+import hephaestus.automation.pipeline as pipeline_pkg
 from hephaestus.automation.pipeline import coordinator as coordinator_mod, seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import (
     Coordinator,
@@ -64,6 +68,26 @@ def _item(issue: int = 1, stage: StageName = StageName.PLANNING) -> WorkItem:
 
 class TestWiring:
     """Constructor and run_pipeline production wiring."""
+
+    def test_package_binds_public_coordinator_exports(self) -> None:
+        """Public coordinator exports are concrete module attributes, not only lazy names."""
+        assert "PipelineConfig" in vars(pipeline_pkg)
+        assert "run_pipeline" in vars(pipeline_pkg)
+        assert pipeline_pkg.PipelineConfig is PipelineConfig
+        assert pipeline_pkg.run_pipeline is run_pipeline
+
+    def test_run_has_single_exit_code_assignment(self) -> None:
+        """The run loop has one authoritative exit-code assignment in ``finally``."""
+        tree = ast.parse(textwrap.dedent(inspect.getsource(Coordinator.run)))
+        assignments = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "exit_code" for target in node.targets
+            )
+        ]
+        assert len(assignments) == 1
 
     def test_default_pool_constructed_with_product_size(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -19,20 +19,36 @@ from unittest.mock import MagicMock
 import pytest
 
 import hephaestus.automation.pipeline as pipeline_pkg
-from hephaestus.automation.pipeline import coordinator as coordinator_mod, seeding as seeding_mod
-from hephaestus.automation.pipeline.coordinator import (
-    Coordinator,
-    PipelineConfig,
-    _budget_lookup,
-    run_pipeline,
-)
-from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
-from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
-from hephaestus.automation.pipeline.seeding import EPIC_NEEDS_SKIP_TAG, SeedEntry
-from hephaestus.automation.pipeline.stages.base import Continue, JobRequest
-from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+import hephaestus.automation.pipeline.coordinator as coordinator_mod
+import hephaestus.automation.pipeline.jobs as jobs_mod
+import hephaestus.automation.pipeline.routing as routing_mod
+import hephaestus.automation.pipeline.seeding as seeding_mod
+import hephaestus.automation.pipeline.stages.base as stage_base_mod
+import hephaestus.automation.pipeline.work_item as work_item_mod
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+Coordinator = coordinator_mod.Coordinator
+PipelineConfig = coordinator_mod.PipelineConfig
+_budget_lookup = coordinator_mod._budget_lookup
+run_pipeline = coordinator_mod.run_pipeline
+
+AgentJob = jobs_mod.AgentJob
+GitJob = jobs_mod.GitJob
+JobResult = jobs_mod.JobResult
+
+Disposition = routing_mod.Disposition
+StageName = routing_mod.StageName
+StageOutcome = routing_mod.StageOutcome
+
+EPIC_NEEDS_SKIP_TAG = seeding_mod.EPIC_NEEDS_SKIP_TAG
+SeedEntry = seeding_mod.SeedEntry
+
+Continue = stage_base_mod.Continue
+JobRequest = stage_base_mod.JobRequest
+
+ItemKind = work_item_mod.ItemKind
+WorkItem = work_item_mod.WorkItem
 
 
 def _agent_job(descr: str = "stub") -> AgentJob:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -86,9 +86,9 @@ class TestWiring:
     """Constructor and run_pipeline production wiring."""
 
     def test_package_binds_public_coordinator_exports(self) -> None:
-        """Public coordinator exports are concrete module attributes, not only lazy names."""
-        assert "PipelineConfig" in vars(pipeline_pkg)
-        assert "run_pipeline" in vars(pipeline_pkg)
+        """Public coordinator exports resolve lazily without eager package imports."""
+        assert "PipelineConfig" not in vars(pipeline_pkg)
+        assert "run_pipeline" not in vars(pipeline_pkg)
         assert pipeline_pkg.PipelineConfig is PipelineConfig
         assert pipeline_pkg.run_pipeline is run_pipeline
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -1,0 +1,433 @@
+"""Coordinator edge-path tests: wiring, accounting, stalls, fatal errors (#1817).
+
+Complements test_coordinator.py with the seams a happy-path run never hits:
+default pool construction, unknown-handle completions, agent-time
+accounting, on_enter routing, runaway-Continue guards, the phase-timeout ->
+AgentJob.timeout_s mapping, the stall liveness guard, seeding's epic-tag
+chokepoint, grace-window expiry, and run_pipeline's production wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from hephaestus.automation.pipeline import coordinator as coordinator_mod, seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import (
+    Coordinator,
+    PipelineConfig,
+    _budget_lookup,
+    run_pipeline,
+)
+from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.seeding import EPIC_NEEDS_SKIP_TAG, SeedEntry
+from hephaestus.automation.pipeline.stages.base import Continue, JobRequest
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _agent_job(descr: str = "stub") -> AgentJob:
+    return AgentJob(
+        repo="repo-a",
+        issue=1,
+        agent="claude",
+        model="m",
+        prompt_builder=lambda **kwargs: "p",
+        cwd=Path("/tmp"),
+        timeout_s=10,
+        descr=descr,
+    )
+
+
+def _coordinator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    seed: list[SeedEntry] | None = None,
+    **config_overrides: Any,
+) -> Coordinator:
+    config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path, **config_overrides)
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: list(seed or []))
+    return Coordinator(
+        config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+    )
+
+
+def _item(issue: int = 1, stage: StageName = StageName.PLANNING) -> WorkItem:
+    return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=stage, state="ENTER")
+
+
+class TestWiring:
+    """Constructor and run_pipeline production wiring."""
+
+    def test_default_pool_constructed_with_product_size(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pool size = parallel_repos x max_workers (epic contract)."""
+        created: dict[str, Any] = {}
+
+        class SpyPool:
+            def __init__(self, size: int, shutdown: Any, completion_q: Any) -> None:
+                created["size"] = size
+                created["shutdown"] = shutdown
+                created["completion_q"] = completion_q
+
+        monkeypatch.setattr("hephaestus.automation.pipeline.worker_pool.WorkerPool", SpyPool)
+        config = PipelineConfig(
+            org="org", repos=["r"], parallel_repos=3, max_workers=4, projects_dir=tmp_path
+        )
+        coordinator = Coordinator(config, github=FakeStageGitHub(), install_signals=False)
+
+        assert created["size"] == 12
+        assert created["shutdown"] is coordinator.shutdown
+        assert created["completion_q"] is coordinator.completion_q
+
+    def test_run_pipeline_wires_accessor_and_runs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        accessor = MagicMock()
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline_github.PipelineGitHub",
+            MagicMock(return_value=accessor),
+        )
+        monkeypatch.setattr(coordinator_mod.Coordinator, "run", lambda self: 7)
+        config = PipelineConfig(org="org", repos=["r"], dry_run=True, projects_dir=tmp_path)
+
+        assert run_pipeline(config) == 7
+
+    def test_budget_lookup_known_and_default(self) -> None:
+        assert _budget_lookup("clone") == 2
+        assert _budget_lookup("nonexistent") == 1
+
+
+class TestCompletionEdges:
+    """_handle_completion bookkeeping branches."""
+
+    def test_unknown_handle_is_ignored_with_warning(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        pool = FakeWorkerPool()
+        handle = pool.submit(_agent_job(), StageName.PLANNING)  # never registered
+
+        with caplog.at_level("WARNING"):
+            coordinator._handle_completion(handle, JobResult(ok=True))
+
+        assert any("unknown handle" in record.message for record in caplog.records)
+
+    def test_agent_job_time_accounting(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Agent completions accrue count + duration for the summary."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+        pool.queue_result(JobResult(ok=True, value="out", duration_s=2.5))
+        item = _item()
+        item.state = "PLAN_WAIT"
+        coordinator._submit(item, JobRequest(_agent_job(), on_done_state="VERIFY"))
+
+        class RecordStage:
+            def on_enter(self, i: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, i: WorkItem, ctx: Any) -> Any:
+                return StageOutcome(Disposition.SKIP, "done")
+
+            def on_job_done(self, i: WorkItem, result: JobResult, ctx: Any) -> None:
+                i.payload["value"] = result.value
+
+        coordinator.stages[StageName.PLANNING] = RecordStage()
+        coordinator._drain_completions()
+
+        assert coordinator._agent_job_count == 1
+        assert coordinator._agent_job_time_s == pytest.approx(2.5)
+        assert item.payload["value"] == "out"
+        assert item.state == "VERIFY" or item.stage is StageName.FINISHED
+        assert coordinator.inflight_per_repo["repo-a"] == 0
+
+    def test_on_job_done_exception_poisons_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+        item = _item()
+        coordinator._submit(item, JobRequest(_agent_job(), on_done_state="VERIFY"))
+
+        class PoisonStage:
+            def on_enter(self, i: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, i: WorkItem, ctx: Any) -> Any:
+                return StageOutcome(Disposition.SKIP, "unreached")
+
+            def on_job_done(self, i: WorkItem, result: JobResult, ctx: Any) -> None:
+                raise ValueError("bad parse")
+
+        coordinator.stages[StageName.PLANNING] = PoisonStage()
+        coordinator._drain_completions()
+
+        assert item.result is not None
+        assert "poisoned" in item.result.reason
+        assert item.stage is StageName.FINISHED
+        assert len(pool.submitted) == 1  # nothing new was submitted
+
+
+class TestRunItemEdges:
+    """on_enter routing, runaway Continue, dry-run descr fallback."""
+
+    def test_on_enter_outcome_routes_immediately(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator = _coordinator(tmp_path, monkeypatch)
+
+        class FastForwardStage:
+            def on_enter(self, i: WorkItem, ctx: Any) -> Any:
+                return StageOutcome(Disposition.ADVANCE, "already plan-go")
+
+            def step(self, i: WorkItem, ctx: Any) -> Any:  # pragma: no cover
+                raise AssertionError("step must not run")
+
+            def on_job_done(self, i: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.PLANNING] = FastForwardStage()
+        item = _item()
+        coordinator._push_item(item, StageName.PLANNING, enter=True)
+
+        coordinator._drain_queues()
+
+        assert item.stage is StageName.PLAN_REVIEW
+
+    def test_runaway_continue_is_poisoned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stage that only ever Continues trips the per-tick step bound."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+
+        class SpinStage:
+            def on_enter(self, i: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, i: WorkItem, ctx: Any) -> Any:
+                return Continue(next_state="LOOP")
+
+            def on_job_done(self, i: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.PLANNING] = SpinStage()
+        item = _item()
+
+        coordinator._run_item(item)
+
+        assert item.result is not None
+        assert "exceeded" in item.result.reason
+
+    def test_dry_run_descr_falls_back_to_job_type(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        coordinator = _coordinator(tmp_path, monkeypatch, dry_run=True)
+        job = GitJob(repo="repo-a", op="rebase", timeout_s=5)  # no descr
+
+        class GitRequestingStage:
+            def on_enter(self, i: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, i: WorkItem, ctx: Any) -> Any:
+                return JobRequest(job, on_done_state="DONE")
+
+            def on_job_done(self, i: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.CI] = GitRequestingStage()
+
+        with caplog.at_level("INFO"):
+            coordinator._run_item(_item(stage=StageName.CI))
+
+        assert any("[dry-run] would submit GitJob: GitJob" in r.message for r in caplog.records)
+
+
+class TestSubmitEdges:
+    """phase-timeout mapping and non-agent jobs bypassing the rate gate."""
+
+    def test_phase_timeout_maps_onto_agent_job(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """M4: --phase-timeout bounds each AGENT JOB under --pipeline."""
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline_github.rate_budget_ok",
+            lambda now_epoch=None: (True, 0.0),
+        )
+        coordinator = _coordinator(tmp_path, monkeypatch, phase_timeout_s=1234.0)
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+
+        coordinator._submit(_item(), JobRequest(_agent_job(), on_done_state="V"))
+
+        assert pool.submitted[0].job.timeout_s == 1234
+
+    def test_git_job_bypasses_rate_gate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only agent jobs are rate-gated; git jobs always submit."""
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline_github.rate_budget_ok",
+            lambda now_epoch=None: (False, 60.0),
+        )
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+        job = GitJob(repo="repo-a", op="clone", timeout_s=5, kwargs={"repo": "o/r", "dest": "d"})
+
+        coordinator._submit(_item(), JobRequest(job, on_done_state="D"))
+
+        assert len(pool.submitted) == 1
+        assert coordinator.timers == []
+
+
+class TestSeedingEdges:
+    """CLI-scope seeding: epic chokepoint, --prs entries, finished entries."""
+
+    def test_epic_needs_skip_tag_executes_chokepoint_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ONE sanctioned seeding write goes through skip_epics."""
+        seed = [
+            SeedEntry(
+                kind="issue",
+                identifier=44,
+                stage=None,
+                reason=f"{EPIC_NEEDS_SKIP_TAG}: #44 is an epic without state:skip",
+            )
+        ]
+        coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)
+        gh = coordinator.github
+        assert isinstance(gh, FakeStageGitHub)
+
+        pushed = coordinator._seed_pass()
+
+        assert pushed == 0
+        assert ("skip_epics", ((44,),)) in gh.mutation_log
+        assert "state:skip" in gh.labels[44]
+
+    def test_plain_exclusion_writes_nothing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seed = [SeedEntry(kind="issue", identifier=45, stage=None, reason="state:skip")]
+        coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)
+        gh = coordinator.github
+        assert isinstance(gh, FakeStageGitHub)
+
+        assert coordinator._seed_pass() == 0
+        assert gh.mutation_log == []
+
+    def test_pr_entry_becomes_pr_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seed = [SeedEntry(kind="pr", identifier=88, stage=StageName.CI, reason="impl-go")]
+        coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)
+
+        coordinator._seed_pass()
+
+        item = coordinator.queues[StageName.CI].snapshot()[0]
+        assert item.kind is ItemKind.PR and item.pr == 88 and item.repo == "repo-a"
+
+    def test_repo_product_finished_entry_gets_pass_result(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A merged-PR product enters finished with an idempotent pass result."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        repo_item = WorkItem(repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO)
+        repo_item.payload["products"] = [
+            {"kind": "issue", "number": 1, "stage": StageName.FINISHED, "reason": "PR merged"}
+        ]
+
+        coordinator._seed_products(repo_item)
+
+        finished = coordinator.queues[StageName.FINISHED].snapshot()[0]
+        assert finished.result is not None and finished.result.passed
+        assert coordinator._pass_work_count == 0  # finished entries are not work
+
+
+class TestLivenessAndFatal:
+    """Stall guard, grace expiry, fatal seeding errors."""
+
+    def test_stall_guard_force_runs_most_downstream_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        ran: list[int] = []
+
+        class SinkStage:
+            def on_enter(self, i: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, i: WorkItem, ctx: Any) -> Any:
+                ran.append(i.issue or 0)
+                return StageOutcome(Disposition.SKIP, "forced")
+
+            def on_job_done(self, i: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.MERGE_WAIT] = SinkStage()
+        coordinator._push_item(_item(1, StageName.MERGE_WAIT), StageName.MERGE_WAIT, enter=False)
+        coordinator._progress = False
+        coordinator._stalled_ticks = 2  # third stalled tick triggers the guard
+
+        coordinator._idle_wait()
+
+        assert ran == [1]
+
+    def test_idle_wait_resets_stall_counter_on_progress(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        coordinator._progress = True
+        coordinator._stalled_ticks = 2
+        coordinator._timer_park(_item(), 0.01)  # bounds the blocking wait
+
+        coordinator._idle_wait()
+
+        assert coordinator._stalled_ticks == 0
+
+    def test_grace_window_expiry_forces_teardown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A graceful shutdown that outlives its grace window tears down."""
+        coordinator = _coordinator(tmp_path, monkeypatch, grace_s=0.0)
+        item = _item()
+        coordinator.in_flight[object()] = item  # type: ignore[index]
+        coordinator.shutdown.set()
+        coordinator._grace_deadline = 0.0  # already expired
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 130
+        assert item.result is not None
+        assert item.result.reason.startswith("resumable")
+
+    def test_fatal_seeding_error_exits_1_with_summary(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A seeding crash fails the run (exit 1) but still prints the summary."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+
+        def boom(r: Any, i: Any, p: Any) -> Any:
+            raise RuntimeError("gh exploded")
+
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", boom)
+
+        with caplog.at_level("INFO"):
+            exit_code = coordinator.run()
+
+        assert exit_code == 1
+        assert "Pipeline summary" in caplog.text

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -1,13 +1,14 @@
-"""Interrupt semantics + crash-matrix-lite for the coordinator (#1817).
+"""Interrupt semantics + crash-matrix journal reconstruction for the coordinator (#1817).
 
 Interrupt contract (epic #1809): SIGINT/SIGTERM/SIGHUP share one shutdown
 Event; interrupted results park items RESUMABLE at their stage — NEVER
 FAILED — and ``on_job_done`` is never called for them. Exit code 130.
 
-Crash matrix (lite): after each durable mutation, "crash" (discard all
+Crash matrix: after each representative durable mutation, "crash" (discard all
 in-memory state) and re-run the seeding classifier against the resulting
-FakeGitHub state — the item must land in the same-or-earlier stage, never
-lost, never duplicated.
+FakeGitHub state — the item must land in the same-or-earlier stage, never lost,
+never duplicated. The table below covers every GitHub-journal reconstruction
+row from docs/AUTOMATION_LOOP_ARCHITECTURE.md.
 """
 
 from __future__ import annotations
@@ -25,6 +26,14 @@ from hephaestus.automation.pipeline.seeding import IssueFacts, classify_issue
 from hephaestus.automation.pipeline.stages.base import JobRequest, StageContext, StageOutcome
 from hephaestus.automation.pipeline.stages.planning import PlanningStage
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_IMPLEMENTATION_NO_GO,
+    STATE_NEEDS_PLAN,
+    STATE_PLAN_GO,
+    STATE_PLAN_NO_GO,
+    STATE_SKIP,
+)
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -203,16 +212,23 @@ class TestInterruptSemantics:
         assert coordinator._immediate is True
 
 
-def _classify_from_fake(gh: FakeStageGitHub, issue: int, *, open_pr: int | None = None) -> Any:
+def _classify_from_fake(
+    gh: FakeStageGitHub,
+    issue: int,
+    *,
+    open_pr: int | None = None,
+    merged_pr: int | None = None,
+    is_epic: bool = False,
+) -> Any:
     """Re-run the seeding classifier against the FakeGitHub label journal."""
     facts = IssueFacts(
         number=issue,
-        title="a task",
-        is_epic=False,
+        title="Epic: a task" if is_epic else "a task",
+        is_epic=is_epic,
         labels=set(gh.labels.get(issue, set())),
-        pr_number=open_pr,
+        pr_number=open_pr if open_pr is not None else merged_pr,
         pr_is_open=open_pr is not None,
-        pr_is_merged=False,
+        pr_is_merged=merged_pr is not None,
     )
     stage, _reason = classify_issue(facts)
     return stage
@@ -222,8 +238,61 @@ def _order(stage: StageName) -> int:
     return PIPELINE_ORDER.index(stage)
 
 
-class TestCrashMatrixLite:
+class TestCrashMatrixJournal:
     """Truncate after each durable mutation -> re-seed -> same-or-earlier stage."""
+
+    @pytest.mark.parametrize(
+        ("case", "labels", "open_pr", "merged_pr", "is_epic", "expected"),
+        [
+            ("no label", [], None, None, False, StageName.PLANNING),
+            ("needs-plan label", [STATE_NEEDS_PLAN], None, None, False, StageName.PLANNING),
+            ("plan-no-go label", [STATE_PLAN_NO_GO], None, None, False, StageName.PLANNING),
+            ("plan-go label", [STATE_PLAN_GO], None, None, False, StageName.IMPLEMENTATION),
+            (
+                "open PR without implementation-go",
+                [STATE_IMPLEMENTATION_NO_GO],
+                77,
+                None,
+                False,
+                StageName.PR_REVIEW,
+            ),
+            (
+                "open PR with implementation-go",
+                [STATE_IMPLEMENTATION_GO],
+                78,
+                None,
+                False,
+                StageName.CI,
+            ),
+            ("merged PR", [], None, 79, False, StageName.FINISHED),
+            ("state:skip", [STATE_SKIP], None, None, False, None),
+            ("untagged epic", [], None, None, True, None),
+        ],
+    )
+    def test_reconstruction_table_covers_every_github_journal_row(
+        self,
+        case: str,
+        labels: list[str],
+        open_pr: int | None,
+        merged_pr: int | None,
+        is_epic: bool,
+        expected: StageName | None,
+    ) -> None:
+        """Every architecture-doc reconstruction row maps to exactly one entry queue."""
+        gh = FakeStageGitHub()
+        issue = 90
+        if labels:
+            gh.add_labels(issue, labels)
+
+        entry = _classify_from_fake(
+            gh,
+            issue,
+            open_pr=open_pr,
+            merged_pr=merged_pr,
+            is_epic=is_epic,
+        )
+
+        assert entry is expected, case
 
     def _ctx(self, gh: FakeStageGitHub) -> StageContext:
         from tests.unit.automation.pipeline.stages.conftest import _budget_fn, _Config, _Paths

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -1,0 +1,298 @@
+"""Interrupt semantics + crash-matrix-lite for the coordinator (#1817).
+
+Interrupt contract (epic #1809): SIGINT/SIGTERM/SIGHUP share one shutdown
+Event; interrupted results park items RESUMABLE at their stage — NEVER
+FAILED — and ``on_job_done`` is never called for them. Exit code 130.
+
+Crash matrix (lite): after each durable mutation, "crash" (discard all
+in-memory state) and re-run the seeding classifier against the resulting
+FakeGitHub state — the item must land in the same-or-earlier stage, never
+lost, never duplicated.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import Coordinator, PipelineConfig
+from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
+from hephaestus.automation.pipeline.routing import PIPELINE_ORDER, StageName
+from hephaestus.automation.pipeline.seeding import IssueFacts, classify_issue
+from hephaestus.automation.pipeline.stages.base import JobRequest, StageContext, StageOutcome
+from hephaestus.automation.pipeline.stages.planning import PlanningStage
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+def _agent_job(issue: int = 1) -> AgentJob:
+    return AgentJob(
+        repo="repo-a",
+        issue=issue,
+        agent="claude",
+        model="m",
+        prompt_builder=lambda **kwargs: "p",
+        cwd=Path("/tmp"),
+        timeout_s=10,
+        descr="stub",
+    )
+
+
+class JobRequestingStage:
+    """Stage whose first step always requests an agent job."""
+
+    def __init__(self) -> None:
+        self.job_done_calls = 0
+
+    def on_enter(self, item: WorkItem, ctx: Any) -> Any:
+        return None
+
+    def step(self, item: WorkItem, ctx: Any) -> Any:
+        return JobRequest(_agent_job(item.issue or 0), on_done_state="VERIFY")
+
+    def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+        self.job_done_calls += 1
+
+
+class InterruptingPool(FakeWorkerPool):
+    """FakeWorkerPool that simulates SIGINT landing while the job runs.
+
+    Mirrors the real pool's mandatory post-subprocess check: the shutdown
+    event is set mid-job and the result comes back ``interrupted=True``.
+    """
+
+    def __init__(self, coordinator_shutdown: Any) -> None:
+        super().__init__()
+        self._coordinator_shutdown = coordinator_shutdown
+
+    def submit(self, job: Any, on_done_state: Any) -> Any:
+        self._coordinator_shutdown.set()
+        self.queue_result(JobResult(ok=False, interrupted=True, error="interrupted"))
+        return super().submit(job, on_done_state)
+
+
+def _coordinator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    seed: list[Any] | None = None,
+    grace_s: float = 30.0,
+) -> Coordinator:
+    config = PipelineConfig(
+        org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path, grace_s=grace_s
+    )
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: list(seed or []))
+    return Coordinator(
+        config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+    )
+
+
+class TestInterruptSemantics:
+    """Shutdown mid-job: RESUMABLE, never FAILED; exit 130."""
+
+    def test_shutdown_mid_job_parks_resumable_not_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An interrupted job parks its item RESUMABLE; on_job_done never runs."""
+        from hephaestus.automation.pipeline.seeding import SeedEntry
+
+        seed = [SeedEntry(kind="issue", identifier=1, stage=StageName.PLANNING, reason="r")]
+        coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)
+        pool = InterruptingPool(coordinator.shutdown)
+        coordinator.pool = pool
+        coordinator.completion_q = pool.completion_q
+        stage = JobRequestingStage()
+        coordinator.stages[StageName.PLANNING] = stage
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 130
+        assert stage.job_done_calls == 0  # never called for interrupted results
+        assert coordinator.ledger == []  # nothing recorded as FAILED
+        item = coordinator.items[0]
+        assert item.result is not None
+        assert item.result.reason == "resumable at planning"
+        assert not item.result.passed
+        assert item.stage is StageName.PLANNING  # never advanced
+
+    def test_graceful_shutdown_stops_admission_and_marks_queued_resumable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Queued (never-started) items report RESUMABLE at their stage."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        item = WorkItem(
+            repo="repo-a", kind=ItemKind.ISSUE, issue=2, stage=StageName.CI, state="ENTER"
+        )
+        coordinator._push_item(item, StageName.CI, enter=True)
+        coordinator.shutdown.set()
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 130
+        assert item.result is not None
+        assert item.result.reason == "resumable at ci"
+        assert coordinator.ledger == []
+
+    def test_second_signal_immediate_teardown_synthesizes_interrupted(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Immediate shutdown cancels the pool and parks in-flight items."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        pool = coordinator.pool
+        assert isinstance(pool, FakeWorkerPool)
+        in_flight_item = WorkItem(
+            repo="repo-a", kind=ItemKind.ISSUE, issue=3, stage=StageName.IMPLEMENTATION
+        )
+        handle = object()
+        coordinator.in_flight[handle] = in_flight_item  # type: ignore[index]
+        coordinator.inflight_per_repo["repo-a"] = 1
+        coordinator._immediate = True
+        coordinator.shutdown.set()
+
+        exit_code = coordinator.run()
+
+        assert exit_code == 130
+        assert pool.shutdown_event.is_set()
+        assert coordinator.in_flight == {}
+        assert in_flight_item.result is not None
+        assert in_flight_item.result.reason == "resumable at implementation"
+
+    def test_completion_after_graceful_shutdown_does_not_advance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-interrupted completion during shutdown still parks RESUMABLE."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        stage = JobRequestingStage()
+        coordinator.stages[StageName.PLANNING] = stage
+        item = WorkItem(
+            repo="repo-a", kind=ItemKind.ISSUE, issue=4, stage=StageName.PLANNING, state="WAIT"
+        )
+        request = JobRequest(_agent_job(4), on_done_state="VERIFY")
+        coordinator._submit(item, request)
+        coordinator.shutdown.set()
+
+        coordinator._drain_completions()
+
+        # on_job_done ran (result was NOT interrupted -> durable parse is
+        # journaled), but the item must not step further during shutdown.
+        assert stage.job_done_calls == 1
+        assert item.result is not None
+        assert item.result.reason == "resumable at planning"
+
+    def test_signal_handler_escalation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """First signal = graceful (grace deadline); second = immediate."""
+        coordinator = _coordinator(tmp_path, monkeypatch, grace_s=17.0)
+        coordinator._install_signal_handlers()
+        import signal as signal_mod
+
+        handler = signal_mod.getsignal(signal_mod.SIGTERM)
+        assert callable(handler)
+
+        handler(signal_mod.SIGTERM, None)
+        assert coordinator.shutdown.is_set()
+        assert coordinator._grace_deadline is not None
+        assert coordinator._immediate is False
+
+        handler(signal_mod.SIGTERM, None)
+        assert coordinator._immediate is True
+
+
+def _classify_from_fake(gh: FakeStageGitHub, issue: int, *, open_pr: int | None = None) -> Any:
+    """Re-run the seeding classifier against the FakeGitHub label journal."""
+    facts = IssueFacts(
+        number=issue,
+        title="a task",
+        is_epic=False,
+        labels=set(gh.labels.get(issue, set())),
+        pr_number=open_pr,
+        pr_is_open=open_pr is not None,
+        pr_is_merged=False,
+    )
+    stage, _reason = classify_issue(facts)
+    return stage
+
+
+def _order(stage: StageName) -> int:
+    return PIPELINE_ORDER.index(stage)
+
+
+class TestCrashMatrixLite:
+    """Truncate after each durable mutation -> re-seed -> same-or-earlier stage."""
+
+    def _ctx(self, gh: FakeStageGitHub) -> StageContext:
+        from tests.unit.automation.pipeline.stages.conftest import _budget_fn, _Config, _Paths
+
+        return StageContext(
+            config=_Config(),
+            org="org",
+            dry_run=False,
+            github=gh,
+            paths=_Paths(),
+            budget_fn=_budget_fn,
+        )
+
+    def test_crash_after_needs_plan_label_reenters_planning(self) -> None:
+        """S1: crash right after planning's entry-label write -> planning again."""
+        gh = FakeStageGitHub()
+        stage = PlanningStage()
+        item = WorkItem(
+            repo="repo-a", kind=ItemKind.ISSUE, issue=1, stage=StageName.PLANNING, state="ENTER"
+        )
+
+        assert stage.on_enter(item, self._ctx(gh)) is None  # writes state:needs-plan
+        # CRASH: discard the item entirely; only the GitHub journal survives.
+        entry = _classify_from_fake(gh, 1)
+
+        assert entry is StageName.PLANNING  # same stage — never lost
+        assert ("gh_issue_add_labels", (1, ("state:needs-plan",))) in gh.mutation_log
+
+    def test_crash_after_plan_comment_upsert_stays_at_or_before_plan_review(self) -> None:
+        """S2: crash after the durable plan-comment upsert -> same-or-earlier."""
+        gh = FakeStageGitHub()
+        stage = PlanningStage()
+        ctx = self._ctx(gh)
+        item = WorkItem(
+            repo="repo-a", kind=ItemKind.ISSUE, issue=2, stage=StageName.PLANNING, state="ENTER"
+        )
+        assert stage.on_enter(item, ctx) is None
+        item.state = "VERIFY"
+        item.payload["plan_text"] = "# Implementation Plan\n\ndo things"
+
+        outcome = stage.step(item, ctx)  # upserts the plan comment, then ADVANCE
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition.value == "advance"
+        # CRASH before the queue push to plan_review.
+        entry = _classify_from_fake(gh, 2)
+
+        # Labels still say needs-plan: re-entry lands at planning (earlier
+        # than the lost plan_review push — never lost, never duplicated),
+        # and planning's on_enter fast-forwards past the existing comment.
+        assert _order(entry) <= _order(StageName.PLAN_REVIEW)
+        assert any(name == "gh_issue_upsert_comment" for name, _ in gh.mutation_log)
+
+    def test_crash_after_plan_go_label_reenters_implementation(self) -> None:
+        """S3: crash after plan_review's GO label write -> implementation."""
+        gh = FakeStageGitHub()
+        # plan_review's EVAL journal entry: the state:plan-go label [durable].
+        gh.add_labels(3, ["state:plan-go"])
+        # CRASH before the push to the implementation queue.
+        entry = _classify_from_fake(gh, 3)
+
+        assert entry is StageName.IMPLEMENTATION  # exactly the lost push target
+        # Exactly one classification — never duplicated across queues.
+        assert isinstance(entry, StageName)
+
+    def test_crash_after_pr_creation_reenters_pr_review(self) -> None:
+        """S4: with an open PR journaled, re-seeding enters pr_review (not earlier)."""
+        gh = FakeStageGitHub()
+        gh.add_labels(4, ["state:plan-go"])
+        # implementation's journal entry is the PR itself.
+        entry = _classify_from_fake(gh, 4, open_pr=77)
+
+        assert entry is StageName.PR_REVIEW

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -1,7 +1,7 @@
 """--pipeline / HEPH_PIPELINE dispatch tests for loop_runner.main (#1817).
 
 The pipeline is DEFAULT OFF; the legacy path stays byte-identical when off.
-The pipeline branch dispatches BEFORE ``_preflight_token_scopes`` and
+The pipeline branch dispatches after token preflight but BEFORE
 ``_clone_missing_repos`` (C3: the repo stage owns cloning — no double-clone).
 """
 
@@ -65,12 +65,12 @@ def test_flag_env_matrix(
     assert dispatch["run_loop"].called is not expect_pipeline
 
 
-def test_pipeline_path_skips_preflight_and_clone(dispatch: dict[str, MagicMock]) -> None:
-    """C3: the pipeline branch runs BEFORE preflight/clone (repo stage owns both)."""
+def test_pipeline_path_preflights_but_skips_clone(dispatch: dict[str, MagicMock]) -> None:
+    """C3: pipeline keeps token preflight, while the repo stage owns cloning."""
     loop_runner.main(["--pipeline"])
 
     dispatch["run_pipeline"].assert_called_once()
-    dispatch["preflight"].assert_not_called()
+    dispatch["preflight"].assert_called_once_with("org", "repo-a")
     dispatch["clone"].assert_not_called()
 
 

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -123,6 +123,36 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.prs == []
 
 
+def test_build_pipeline_config_maps_agent_and_models(
+    dispatch: dict[str, MagicMock], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pipeline path preserves provider and model selections."""
+    monkeypatch.setattr(loop_runner, "resolve_agent", lambda agent: "codex")
+
+    loop_runner.main(
+        [
+            "--pipeline",
+            "--agent",
+            "codex",
+            "--model",
+            "gpt-default",
+            "--planner-model",
+            "gpt-plan",
+            "--reviewer-model",
+            "gpt-review",
+            "--implementer-model",
+            "gpt-impl",
+        ]
+    )
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.agent == "codex"
+    assert config.model == "gpt-default"
+    assert config.planner_model == "gpt-plan"
+    assert config.reviewer_model == "gpt-review"
+    assert config.implementer_model == "gpt-impl"
+
+
 def test_phase_timeout_help_documents_pipeline_shift() -> None:
     """M4: the --phase-timeout help names the agent-job semantic shift."""
     parser = loop_runner._build_parser()

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -1,0 +1,131 @@
+"""--pipeline / HEPH_PIPELINE dispatch tests for loop_runner.main (#1817).
+
+The pipeline is DEFAULT OFF; the legacy path stays byte-identical when off.
+The pipeline branch dispatches BEFORE ``_preflight_token_scopes`` and
+``_clone_missing_repos`` (C3: the repo stage owns cloning — no double-clone).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import hephaestus.automation.loop_runner as loop_runner
+import hephaestus.automation.pipeline.coordinator as coordinator_mod
+
+
+@pytest.fixture
+def dispatch(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
+    """Patch both dispatch targets and the legacy pre-clone collaborators."""
+    mocks = {
+        "run_pipeline": MagicMock(return_value=0),
+        "run_loop": MagicMock(return_value=[]),
+        "preflight": MagicMock(),
+        "clone": MagicMock(),
+    }
+    monkeypatch.setattr(coordinator_mod, "run_pipeline", mocks["run_pipeline"])
+    monkeypatch.setattr(loop_runner, "run_loop", mocks["run_loop"])
+    monkeypatch.setattr(loop_runner, "_preflight_token_scopes", mocks["preflight"])
+    monkeypatch.setattr(loop_runner, "_clone_missing_repos", mocks["clone"])
+    monkeypatch.setattr(
+        loop_runner, "_resolve_org_and_repos", lambda args: ("org", ["repo-a"], None)
+    )
+    monkeypatch.setattr(loop_runner, "resolve_agent", lambda agent: "claude")
+    monkeypatch.delenv("HEPH_PIPELINE", raising=False)
+    return mocks
+
+
+@pytest.mark.parametrize(
+    ("argv_flag", "env", "expect_pipeline"),
+    [
+        (False, None, False),  # default OFF -> legacy untouched
+        (False, "0", False),
+        (False, "1", True),  # env enables
+        (True, None, True),  # CLI enables
+        (True, "0", True),  # CLI wins over env
+    ],
+)
+def test_flag_env_matrix(
+    dispatch: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    argv_flag: bool,
+    env: str | None,
+    expect_pipeline: bool,
+) -> None:
+    """--pipeline x HEPH_PIPELINE precedence matrix (CLI flag wins)."""
+    if env is not None:
+        monkeypatch.setenv("HEPH_PIPELINE", env)
+    argv = ["--pipeline"] if argv_flag else []
+
+    exit_code = loop_runner.main(argv)
+
+    assert exit_code == 0
+    assert dispatch["run_pipeline"].called is expect_pipeline
+    assert dispatch["run_loop"].called is not expect_pipeline
+
+
+def test_pipeline_path_skips_preflight_and_clone(dispatch: dict[str, MagicMock]) -> None:
+    """C3: the pipeline branch runs BEFORE preflight/clone (repo stage owns both)."""
+    loop_runner.main(["--pipeline"])
+
+    dispatch["run_pipeline"].assert_called_once()
+    dispatch["preflight"].assert_not_called()
+    dispatch["clone"].assert_not_called()
+
+
+def test_legacy_path_still_preflights_and_clones(dispatch: dict[str, MagicMock]) -> None:
+    """Flag off: the legacy pre-loop sequence is untouched."""
+    loop_runner.main([])
+
+    dispatch["preflight"].assert_called_once()
+    dispatch["clone"].assert_called_once()
+    dispatch["run_loop"].assert_called_once()
+    dispatch["run_pipeline"].assert_not_called()
+
+
+def test_pipeline_exit_code_propagates(dispatch: dict[str, MagicMock]) -> None:
+    """run_pipeline's exit code IS main's exit code."""
+    dispatch["run_pipeline"].return_value = 130
+
+    assert loop_runner.main(["--pipeline"]) == 130
+
+
+def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -> None:
+    """_build_pipeline_config carries the CLI scope into PipelineConfig."""
+    loop_runner.main(
+        [
+            "--pipeline",
+            "--loops",
+            "3",
+            "--max-workers",
+            "4",
+            "--parallel-repos",
+            "2",
+            "--dry-run",
+            "--issues",
+            "11,12",
+            "--no-advise",
+            "--nitpick",
+        ]
+    )
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.org == "org"
+    assert config.repos == ["repo-a"]
+    assert config.issues == [11, 12]
+    assert config.loops == 3
+    assert config.max_workers == 4
+    assert config.parallel_repos == 2
+    assert config.dry_run is True
+    assert config.no_advise is True
+    assert config.nitpick is True
+    assert config.prs == []
+
+
+def test_phase_timeout_help_documents_pipeline_shift() -> None:
+    """M4: the --phase-timeout help names the agent-job semantic shift."""
+    parser = loop_runner._build_parser()
+    action = next(a for a in parser._actions if "--phase-timeout" in a.option_strings)
+
+    assert "AGENT JOB" in (action.help or "")

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -1,0 +1,194 @@
+"""Pipeline summary tests: rows, aggregates, preserved footer, JSON envelope (#1817).
+
+Includes a byte-parity check between :func:`format_preserved_worktrees` and
+the legacy ``implementer_summary._print_preserved_worktrees`` output (which
+now delegates to the shared helper).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from hephaestus.automation.implementer_summary import ImplementationSummaryPrinter
+from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.summary import (
+    RunStats,
+    format_preserved_worktrees,
+    print_summary,
+)
+from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+
+
+def _stats(**overrides: object) -> RunStats:
+    defaults: dict[str, object] = {
+        "exit_code": 0,
+        "interrupted": False,
+        "loops_run": 1,
+        "agent_job_count": 3,
+        "agent_job_time_s": 12.5,
+        "wall_s": 40.0,
+    }
+    defaults.update(overrides)
+    return RunStats(**defaults)  # type: ignore[arg-type]
+
+
+def _item(
+    issue: int,
+    stage: StageName,
+    *,
+    passed: bool | None = None,
+    reason: str = "",
+    pr: int | None = None,
+) -> WorkItem:
+    item = WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, pr=pr, stage=stage)
+    item.payload["entry_stage"] = "planning"
+    if passed is not None:
+        item.result = ItemResult(passed=passed, reason=reason, final_stage=stage)
+    return item
+
+
+class TestFormatPreservedWorktrees:
+    """Exact legacy line sequence, shared by both printers."""
+
+    def test_empty_list_yields_no_lines(self) -> None:
+        assert format_preserved_worktrees([], "script.py") == []
+
+    def test_line_sequence_matches_legacy(self) -> None:
+        preserved = [(101, "/wt/issue-101"), (202, "/wt/issue-202")]
+
+        lines = format_preserved_worktrees(preserved, "impl.py")
+
+        assert lines == [
+            "\nPreserved worktrees (contain uncommitted changes):",
+            "  #101: /wt/issue-101",
+            "  #202: /wt/issue-202",
+            "\nRerun these issues after inspecting/cleaning the worktrees:",
+            "  impl.py --issues 101 202 --resume",
+            "To discard them instead:",
+            "  git worktree remove --force /wt/issue-101",
+            "  git worktree remove --force /wt/issue-202",
+        ]
+
+    def test_legacy_printer_delegates_to_shared_helper(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """implementer_summary emits exactly the shared helper's lines."""
+        wm = MagicMock()
+        wm.preserved = [(7, "/wt/issue-7")]
+        printer = ImplementationSummaryPrinter(wm)
+
+        with caplog.at_level(logging.INFO, logger="hephaestus.automation.implementer_summary"):
+            printer._print_preserved_worktrees()
+
+        import sys
+
+        logged = [record.getMessage() for record in caplog.records]
+        assert logged == format_preserved_worktrees([(7, "/wt/issue-7")], sys.argv[0])
+
+
+class TestPrintSummaryRows:
+    """Per-item rows and aggregates."""
+
+    def test_all_disposition_rows(self, caplog: pytest.LogCaptureFixture) -> None:
+        """PASS / FAIL:reason / SKIP / BLOCKED / RESUMABLE rows all render."""
+        items = [
+            _item(1, StageName.FINISHED, passed=True, reason="merged", pr=11),
+            _item(2, StageName.FINISHED, passed=False, reason="tests failed"),
+            _item(3, StageName.FINISHED, passed=False, reason="skip: state:skip"),
+            _item(4, StageName.FINISHED, passed=False, reason="blocked: human threads"),
+            _item(5, StageName.CI, passed=False, reason="resumable at ci"),
+        ]
+
+        with caplog.at_level(logging.INFO):
+            print_summary(items, _stats(), [], json_out=False)
+
+        text = caplog.text
+        assert "PASS" in text
+        assert "FAIL:tests failed" in text
+        assert "SKIP" in text
+        assert "BLOCKED" in text
+        assert "RESUMABLE at ci" in text
+        assert "#1" in text and "!11" in text
+
+    def test_aggregates_and_stats(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Disposition counts, per-stage throughput, agent time, loops, wall."""
+        items = [
+            _item(1, StageName.FINISHED, passed=True, reason="ok"),
+            _item(2, StageName.FINISHED, passed=True, reason="ok"),
+            _item(3, StageName.FINISHED, passed=False, reason="boom"),
+        ]
+
+        with caplog.at_level(logging.INFO):
+            print_summary(
+                items, _stats(loops_run=2, agent_job_count=5, wall_s=99.5), [], json_out=False
+            )
+
+        text = caplog.text
+        assert "'pass': 2" in text
+        assert "'fail': 1" in text
+        assert "agent jobs: 5" in text
+        assert "loops: 2" in text
+        assert "wall: 99.5s" in text
+
+    def test_nonzero_attempts_render(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Only non-zero attempt counters appear in the row."""
+        item = _item(6, StageName.FINISHED, passed=True, reason="ok")
+        item.attempts["plan"] = 2
+
+        with caplog.at_level(logging.INFO):
+            print_summary([item], _stats(), [], json_out=False)
+
+        assert "plan=2" in caplog.text
+        assert "ci_fix=" not in caplog.text
+
+    def test_item_without_result_renders_pending(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A never-finished item (no result) renders PENDING, never crashes."""
+        with caplog.at_level(logging.INFO):
+            print_summary([_item(9, StageName.PLANNING)], _stats(), [], json_out=False)
+
+        assert "PENDING" in caplog.text
+
+    def test_preserved_footer_present(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The preserved-worktree footer prints via the shared helper."""
+        with caplog.at_level(logging.INFO):
+            print_summary([], _stats(exit_code=1), [(9, "/wt/9")], json_out=False)
+
+        assert "Preserved worktrees (contain uncommitted changes):" in caplog.text
+        assert "git worktree remove --force /wt/9" in caplog.text
+
+
+class TestJsonEnvelope:
+    """emit_json_status extension fields."""
+
+    def test_json_envelope_fields(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """The envelope carries dispositions, loops, resumable, preserved."""
+        items = [
+            _item(1, StageName.FINISHED, passed=True, reason="ok"),
+            _item(2, StageName.CI, passed=False, reason="resumable at ci"),
+        ]
+
+        print_summary(
+            items,
+            _stats(exit_code=130, interrupted=True, loops_run=3),
+            [(2, "/wt/2")],
+            json_out=True,
+        )
+
+        envelope = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+        assert envelope["exit_code"] == 130
+        assert envelope["status"] == "error"
+        assert envelope["message"] == "pipeline interrupted"
+        assert envelope["dispositions"] == {"pass": 1, "resumable": 1}
+        assert envelope["loops_run"] == 3
+        assert envelope["resumable"] == ["repo-a#2@ci"]
+        assert envelope["preserved_worktrees"] == [[2, "/wt/2"]]
+
+    def test_no_envelope_without_json_out(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """json_out=False never writes the JSON envelope to stdout."""
+        print_summary([], _stats(), [], json_out=False)
+
+        assert capsys.readouterr().out == ""

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -1,0 +1,200 @@
+"""Timer-heap, RETRY-delay consumption, and step-watchdog tests (#1817).
+
+The heap owns EVERY wait: stages never sleep (enforced by
+``test_pipeline_architecture``); a ``RETRY`` outcome's backoff is recorded in
+``item.payload["retry_delay_s"]`` (base.py contract, documented by #1816) and
+the coordinator consumes it into the heapq timer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from hephaestus.automation.pipeline import coordinator as coordinator_mod, seeding as seeding_mod
+from hephaestus.automation.pipeline.coordinator import (
+    _STEP_WATCHDOG_S,
+    Coordinator,
+    PipelineConfig,
+)
+from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from tests.unit.automation.pipeline.conftest import FakeWorkerPool
+from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
+
+
+class FakeClock:
+    """Deterministic monotonic clock for the coordinator's timer logic."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+
+@pytest.fixture
+def clocked(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Coordinator, FakeClock]:
+    """Coordinator whose time module is replaced with a fake clock."""
+    clock = FakeClock()
+    monkeypatch.setattr(
+        coordinator_mod,
+        "time",
+        SimpleNamespace(monotonic=clock.monotonic, time=lambda: clock.now),
+    )
+    monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+    config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+    coordinator = Coordinator(
+        config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+    )
+    return coordinator, clock
+
+
+def _item(issue: int, stage: StageName = StageName.CI) -> WorkItem:
+    return WorkItem(repo="repo-a", kind=ItemKind.ISSUE, issue=issue, stage=stage, state="POLL")
+
+
+class TestTimerHeap:
+    """Ordering, seq tie-break, and expiry-only waking."""
+
+    def test_earliest_timer_wakes_first(self, clocked: tuple[Coordinator, FakeClock]) -> None:
+        """Wake order follows wake_ts, not insertion order."""
+        coordinator, clock = clocked
+        coordinator._timer_park(_item(1), 50.0)
+        coordinator._timer_park(_item(2), 10.0)
+        coordinator._timer_park(_item(3), 30.0)
+
+        clock.now += 60.0
+        coordinator._wake_timers()
+
+        pushes = [entry for entry in coordinator.event_log if entry[0] == "push"]
+        assert [p[2] for p in pushes] == ["repo-a#2", "repo-a#3", "repo-a#1"]
+
+    def test_wake_moves_only_expired_entries(self, clocked: tuple[Coordinator, FakeClock]) -> None:
+        """Unexpired timers stay parked."""
+        coordinator, clock = clocked
+        coordinator._timer_park(_item(1), 10.0)
+        coordinator._timer_park(_item(2), 100.0)
+
+        clock.now += 20.0
+        coordinator._wake_timers()
+
+        assert len(coordinator.timers) == 1
+        assert len(coordinator.queues[StageName.CI]) == 1
+
+    def test_seq_tiebreak_prevents_workitem_comparison(
+        self, clocked: tuple[Coordinator, FakeClock]
+    ) -> None:
+        """Two identical wake timestamps must not compare WorkItems (FIFO wins)."""
+        coordinator, clock = clocked
+        coordinator._timer_park(_item(1), 5.0)
+        coordinator._timer_park(_item(2), 5.0)  # would raise without the seq tie-break
+
+        clock.now += 6.0
+        coordinator._wake_timers()
+
+        pushes = [entry[2] for entry in coordinator.event_log if entry[0] == "push"]
+        assert pushes == ["repo-a#1", "repo-a#2"]
+
+
+class TestRetryDelayConsumption:
+    """RETRY timer contract: payload["retry_delay_s"] -> heap park."""
+
+    def test_retry_with_delay_parks_on_heap(self, clocked: tuple[Coordinator, FakeClock]) -> None:
+        """The stage-recorded backoff is consumed into the timer heap."""
+        coordinator, _clock = clocked
+        item = _item(9)
+        item.payload["retry_delay_s"] = 42.0
+
+        coordinator._route(item, StageOutcome(Disposition.RETRY, "ci pending"))
+
+        assert "retry_delay_s" not in item.payload  # consumed, not stale
+        assert len(coordinator.timers) == 1
+        wake_ts, _seq, parked = coordinator.timers[0]
+        assert parked is item
+        assert wake_ts == pytest.approx(1000.0 + 42.0)
+
+    def test_retry_without_delay_requeues_for_next_tick(
+        self, clocked: tuple[Coordinator, FakeClock]
+    ) -> None:
+        """A missing key means retry on the next drain tick (no timer)."""
+        coordinator, _clock = clocked
+        item = _item(10)
+
+        coordinator._route(item, StageOutcome(Disposition.RETRY, "transient"))
+
+        assert coordinator.timers == []
+        assert len(coordinator.queues[StageName.CI]) == 1
+
+    def test_retry_preserves_stage_and_state(self, clocked: tuple[Coordinator, FakeClock]) -> None:
+        """RETRY re-steps the SAME stage state; it never re-runs on_enter."""
+        coordinator, clock = clocked
+        item = _item(11)
+        item.payload["retry_delay_s"] = 1.0
+
+        coordinator._route(item, StageOutcome(Disposition.RETRY, "poll"))
+        clock.now += 2.0
+        coordinator._wake_timers()
+
+        assert item.stage is StageName.CI
+        assert item.state == "POLL"
+        assert item.payload.get("_enter_pending") is not True
+
+
+class TestStepWatchdog:
+    """WARN when a stage.step breaches the <~5s protocol contract."""
+
+    def test_watchdog_warns_on_slow_step(
+        self,
+        clocked: tuple[Coordinator, FakeClock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A step exceeding _STEP_WATCHDOG_S logs the stall warning."""
+        coordinator, clock = clocked
+
+        class SlowStage:
+            def on_enter(self, item: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                clock.now += _STEP_WATCHDOG_S + 3.0  # simulate a stalled step
+                return StageOutcome(Disposition.SKIP, "slow")
+
+            def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.CI] = SlowStage()
+        item = _item(12)
+
+        with caplog.at_level("WARNING"):
+            coordinator._run_item(item)
+
+        assert any("stage.step stalled" in record.message for record in caplog.records)
+
+    def test_watchdog_silent_on_fast_step(
+        self,
+        clocked: tuple[Coordinator, FakeClock],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A fast step logs no stall warning."""
+        coordinator, _clock = clocked
+
+        class FastStage:
+            def on_enter(self, item: WorkItem, ctx: Any) -> Any:
+                return None
+
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                return StageOutcome(Disposition.SKIP, "fast")
+
+            def on_job_done(self, item: WorkItem, result: Any, ctx: Any) -> None:
+                pass
+
+        coordinator.stages[StageName.CI] = FastStage()
+
+        with caplog.at_level("WARNING"):
+            coordinator._run_item(_item(13))
+
+        assert not any("stalled" in record.message for record in caplog.records)

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -421,12 +421,51 @@ class TestGitOps:
             kwargs={"issue_number": 7, "branch_name": "7-auto"},
         )
         instance = MagicMock()
+        instance.create_worktree.return_value = Path("/tmp/wt")
         with patch(f"{_WP}.WorktreeManager", return_value=instance):
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
         instance.create_worktree.assert_called_once_with(issue_number=7, branch_name="7-auto")
         assert result.ok is True
+        assert result.value == "/tmp/wt"
+
+    def test_create_worktree_syncs_adopted_clean_branch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """sync_to_remote is a worker concern, not leaked into WorktreeManager."""
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-existing",
+                "refresh_base": False,
+                "sync_to_remote": True,
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = Path("/tmp/wt")
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance),
+            patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True) as mock_clean,
+            patch(f"{_WP}.git_utils.sync_worktree_to_remote_branch") as mock_sync,
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        instance.create_worktree.assert_called_once_with(
+            issue_number=7,
+            branch_name="7-existing",
+            refresh_base=False,
+        )
+        mock_clean.assert_called_once_with(Path("/tmp/wt"))
+        mock_sync.assert_called_once_with(Path("/tmp/wt"), "7-existing")
+        assert result.ok is True
+        assert result.value == {"path": "/tmp/wt", "dirty": False, "status": "", "diff": ""}
 
     def test_remove_worktree_dispatch(
         self,
@@ -446,6 +485,34 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         instance.remove_worktree.assert_called_once_with(issue_number=7, force=True)
+        assert result.ok is True
+
+    def test_remove_worktree_path_dispatch(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """Path cleanup removes the known worktree path even with a fresh manager."""
+        job = GitJob(
+            repo="test/repo",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={
+                "worktree_path": str(tmp_path / "issue-7"),
+                "repo_root": str(tmp_path),
+                "force": True,
+            },
+        )
+        with patch(f"{_WP}.git_utils.run") as mock_run:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_run.assert_any_call(
+            ["git", "worktree", "remove", str(tmp_path / "issue-7"), "--force"],
+            cwd=tmp_path,
+        )
+        mock_run.assert_any_call(["git", "worktree", "prune"], cwd=tmp_path, check=False)
         assert result.ok is True
 
     @pytest.mark.parametrize("rebase_clean", [True, False])

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -593,13 +593,13 @@ class TestGitOps:
         assert result.ok is True
         assert result.value is True  # value carries commit_if_changes' bool
 
-    def test_commit_push_value_false_when_nothing_committed(
+    def test_commit_push_value_false_does_not_push_when_nothing_committed(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
         tmp_path: Path,
     ) -> None:
-        """commit_push still pushes and reports value=False on a clean tree."""
+        """commit_push reports value=False without pushing a clean tree."""
         job = GitJob(
             repo="test/repo",
             op="commit_push",
@@ -613,7 +613,7 @@ class TestGitOps:
             pool.submit(job, StageName.CI)
             _, result = completion_q.get(timeout=10)
 
-        mock_push.assert_called_once_with("HEAD", tmp_path)
+        mock_push.assert_not_called()
         assert result.ok is True
         assert result.value is False
 

--- a/tests/unit/automation/pipeline/test_zero_io_imports.py
+++ b/tests/unit/automation/pipeline/test_zero_io_imports.py
@@ -1,6 +1,9 @@
 """Guard that pipeline modules have zero I/O imports (ast-based, not text-scan)."""
 
 import ast
+import json
+import subprocess
+import sys
 from pathlib import Path
 
 import hephaestus.automation.pipeline as pkg
@@ -169,6 +172,27 @@ def test_pipeline_modules_have_zero_io_imports() -> None:
         tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
         violations.extend(_collect_violations(tree, py.name, exempt))
     assert not violations, "pipeline modules must do zero I/O imports:\n" + "\n".join(violations)
+
+
+def test_pipeline_package_import_stays_lazy() -> None:
+    """Importing the package must not eagerly load coordinator I/O dependencies."""
+    probe = (
+        "import json, sys\n"
+        "import hephaestus.automation.pipeline\n"
+        "watched = [\n"
+        "  'hephaestus.automation.pipeline.coordinator',\n"
+        "  'hephaestus.automation.github_api',\n"
+        "  'hephaestus.automation.claude_invoke',\n"
+        "]\n"
+        "print(json.dumps([name for name in watched if name in sys.modules]))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    assert json.loads(result.stdout) == []
 
 
 def test_capability_scope_still_blocks_io_in_seeding() -> None:

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -719,7 +719,19 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             7800.0,
             help_text=(
                 "Per-phase timeout in seconds (default: HEPH_PHASE_TIMEOUT or 7800s). "
-                "Pass 0 or a negative value to disable."
+                "Pass 0 or a negative value to disable. Under --pipeline this bounds "
+                "each AGENT JOB, not a whole phase subprocess."
+            ),
+        ),
+        _action_spec(
+            ("--pipeline",),
+            "pipeline",
+            "_StoreTrueAction",
+            False,
+            nargs=0,
+            help_text=(
+                "Use the queue-based pipeline loop (default: off). "
+                "Env HEPH_PIPELINE=1 also enables it; the CLI flag wins."
             ),
         ),
         _action_spec(

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -1242,14 +1242,17 @@ def test_list_open_issue_numbers_no_epics_skips_nothing() -> None:
     mock_skip.assert_not_called()
 
 
-def test_list_open_issue_numbers_returns_empty_on_bad_json() -> None:
-    """Malformed JSON yields the safe-fallback empty list."""
+def test_list_open_issue_numbers_raises_on_bad_json() -> None:
+    """Malformed JSON surfaces instead of pretending the repo has no work."""
 
     def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="not json", stderr="")
 
-    with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
-        assert loop_runner._list_open_issue_numbers("Org", "Repo") == []
+    with (
+        patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        pytest.raises(RuntimeError, match="failed to list open issues"),
+    ):
+        loop_runner._list_open_issue_numbers("Org", "Repo")
 
 
 def test_list_open_issue_numbers_queries_all_open_no_me_filter() -> None:
@@ -1691,11 +1694,12 @@ class TestSubprocessTimeouts:
             with pytest.raises(SystemExit, match="timed out"):
                 loop_runner._gh_list_repos("MyOrg")
 
-    def test_gh_issue_numbers_timeout_returns_empty_list(self) -> None:
-        """A timed-out issue query degrades to an empty list, not a crash."""
+    def test_gh_issue_numbers_timeout_raises(self) -> None:
+        """A timed-out issue query surfaces instead of hiding all work."""
         with patch("hephaestus.automation.loop_repo_manager.gh_call") as mock_gh_call:
             mock_gh_call.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=120)
-            assert loop_runner._list_open_issue_numbers("Org", "Repo") == []
+            with pytest.raises(RuntimeError, match="failed to list open issues"):
+                loop_runner._list_open_issue_numbers("Org", "Repo")
 
 
 class TestRateBudgetGuard:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -227,6 +227,158 @@ class TestRepoScoping:
             ],
         ]
 
+    def test_repo_scoped_pr_lookup_raises_on_gh_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repo-scoped seeding must fail closed instead of inventing no-PR state."""
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            raise RuntimeError("gh unavailable")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        with pytest.raises(RuntimeError, match="gh unavailable"):
+            pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_pr_for_issue(5)
+
+    def test_repo_scoped_unresolved_threads_counts_automation_and_human(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            payload = {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "reviewThreads": {
+                                "nodes": [
+                                    {
+                                        "id": "T1",
+                                        "isResolved": False,
+                                        "path": "a.py",
+                                        "line": 1,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "nodes": [
+                                                {"body": "bot", "author": {"login": "ci-bot"}}
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "id": "T2",
+                                        "isResolved": False,
+                                        "path": "b.py",
+                                        "line": 2,
+                                        "side": "RIGHT",
+                                        "comments": {
+                                            "nodes": [
+                                                {"body": "human", "author": {"login": "reviewer"}}
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        "id": "T3",
+                                        "isResolved": True,
+                                        "comments": {"nodes": []},
+                                    },
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+            return SimpleNamespace(stdout=json.dumps(payload))
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "ci-bot")
+
+        assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).count_unresolved_threads(
+            7
+        ) == (1, 1)
+
+        assert calls[0][:2] == ["api", "graphql"]
+        assert "-F" in calls[0]
+        assert "owner=org" in calls[0]
+        assert "name=repo-a" in calls[0]
+
+    def test_repo_scoped_upsert_plan_comment_updates_marker_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv[:2] == ["api", "graphql"]:
+                payload = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "comments": {
+                                    "nodes": [
+                                        {"databaseId": 9, "body": f"{PLAN_COMMENT_MARKER}\nold"}
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+                return SimpleNamespace(stdout=json.dumps(payload))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).upsert_plan_comment(
+            5, f"{PLAN_COMMENT_MARKER}\nnew"
+        )
+
+        assert any(call[:3] == ["api", "--method", "PATCH"] for call in calls)
+        assert any("/repos/org/repo-a/issues/comments/9" in call for call in calls)
+        assert not any(call[:2] == ["issue", "comment"] for call in calls)
+
+    def test_repo_scoped_review_post_uses_repo_endpoint(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv[:2] == ["api", "graphql"]:
+                payload = {
+                    "data": {
+                        "repository": {
+                            "pullRequest": {
+                                "reviewThreads": {
+                                    "nodes": [
+                                        {
+                                            "id": "thread-1",
+                                            "isResolved": False,
+                                            "comments": {
+                                                "nodes": [
+                                                    {"pullRequestReview": {"id": "review-node"}}
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+                return SimpleNamespace(stdout=json.dumps(payload))
+            if "repos/org/repo-a/pulls/7/reviews" in argv:
+                return SimpleNamespace(stdout=json.dumps({"node_id": "review-node"}))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        posted = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).post_review_threads(
+            7, [], "summary"
+        )
+
+        assert posted == ["thread-1"]
+        assert any("repos/org/repo-a/pulls/7/reviews" in call for call in calls)
+
 
 class TestCreatePr:
     """create_pr: idempotent reuse, given-body create, dry-run neutral."""

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -19,7 +19,8 @@ import hephaestus.automation.github_api as github_api_mod
 import hephaestus.automation.pipeline_github as pg
 import hephaestus.automation.pr_manager as pr_manager_mod
 from hephaestus.automation.pipeline.stages.base import StageGitHub
-from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER, PLAN_REVIEW_PREFIX
+from hephaestus.automation.state_labels import STATE_PLAN_GO
 
 
 @pytest.fixture
@@ -118,6 +119,113 @@ class TestMutatorMapping:
         adapter.upsert_plan_comment(5, "# Implementation Plan\n\nbody")
 
         mock.assert_called_once_with(5, PLAN_COMMENT_MARKER, "# Implementation Plan\n\nbody")
+
+
+class TestRepoScoping:
+    """PipelineGitHub must target its configured repository explicitly."""
+
+    def test_issue_reads_include_repo_arg(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            payload = {
+                "number": 5,
+                "title": "t",
+                "state": "OPEN",
+                "labels": [],
+                "body": "",
+            }
+            return SimpleNamespace(stdout=json.dumps(payload))
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        assert (
+            pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).gh_issue_json(5)["number"]
+            == 5
+        )
+
+        assert calls == [
+            [
+                "issue",
+                "view",
+                "5",
+                "--json",
+                "number,title,state,labels,body",
+                "--repo",
+                "org/repo-a",
+            ]
+        ]
+
+    def test_label_mutators_include_repo_arg(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv[:2] == ["label", "list"]:
+                return SimpleNamespace(stdout="[]")
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).add_labels(5, ["state:x"])
+
+        assert calls[-1] == [
+            "issue",
+            "edit",
+            "5",
+            "--add-label",
+            "state:x",
+            "--repo",
+            "org/repo-a",
+        ]
+
+    def test_plan_gate_backfills_repo_scoped_go_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv[:2] == ["issue", "view"]:
+                payload = {
+                    "labels": [],
+                    "comments": [{"body": f"{PLAN_REVIEW_PREFIX}\n\nVerdict: GO"}],
+                }
+                return SimpleNamespace(stdout=json.dumps(payload))
+            if argv[:2] == ["label", "list"]:
+                return SimpleNamespace(stdout=json.dumps([{"name": STATE_PLAN_GO}]))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
+
+        assert calls == [
+            [
+                "issue",
+                "view",
+                "5",
+                "--json",
+                "labels,comments",
+                "--repo",
+                "org/repo-a",
+            ],
+            ["label", "list", "--json", "name", "--limit", "200", "--repo", "org/repo-a"],
+            [
+                "issue",
+                "edit",
+                "5",
+                "--add-label",
+                STATE_PLAN_GO,
+                "--repo",
+                "org/repo-a",
+            ],
+        ]
 
 
 class TestCreatePr:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -1,0 +1,345 @@
+"""PipelineGitHub adapter tests: mapping + dry-run log-and-skip (#1817).
+
+The adapter is the ONE place coordinator-neutral mutator names map onto the
+real ``github_api`` / ``pr_manager`` / ``_review_utils`` helpers, and the
+place the ``StageGitHub`` protocol's dry-run contract is honored.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import hephaestus.automation.github_api as github_api_mod
+import hephaestus.automation.pipeline_github as pg
+import hephaestus.automation.pr_manager as pr_manager_mod
+from hephaestus.automation.pipeline.stages.base import StageGitHub
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
+
+
+@pytest.fixture
+def adapter(tmp_path: Path) -> pg.PipelineGitHub:
+    """Live-mutator adapter anchored at a temp repo root."""
+    return pg.PipelineGitHub("org", dry_run=False, repo_root=tmp_path)
+
+
+@pytest.fixture
+def dry_adapter(tmp_path: Path) -> pg.PipelineGitHub:
+    """Dry-run adapter: every mutator must log-and-skip."""
+    return pg.PipelineGitHub("org", dry_run=True, repo_root=tmp_path)
+
+
+def test_adapter_satisfies_stage_github_protocol(adapter: pg.PipelineGitHub) -> None:
+    """Runtime protocol conformance (mypy checks it statically too)."""
+    assert isinstance(adapter, StageGitHub)
+
+
+# ---------------------------------------------------------------------------
+# Mutator mapping matrix: (method, args, patch-owner, underlying-name)
+# 'module' = a function bound into pipeline_github's namespace at import.
+# ---------------------------------------------------------------------------
+_MUTATOR_CASES = [
+    ("add_labels", (5, ["x"]), "github_api", "gh_issue_add_labels"),
+    ("remove_labels", (5, ["x"]), "github_api", "gh_issue_remove_labels"),
+    ("close_issue_as_covered", (5, 7), "module", "close_issue_as_covered"),
+    ("upsert_plan_comment", (5, "body"), "github_api", "gh_issue_upsert_comment"),
+    ("post_pr_comment", (7, "why"), "github_api", "gh_issue_comment"),
+    ("mark_pr_implementation_go", (7,), "pr_manager", "mark_pr_implementation_go"),
+    ("mark_pr_implementation_no_go", (7,), "pr_manager", "mark_pr_implementation_no_go"),
+    ("defer_auto_merge", (7,), "pr_manager", "ensure_pr_auto_merge_deferred"),
+    ("arm_auto_merge", (7,), "pr_manager", "enable_auto_merge_after_implementation_go"),
+    ("post_review_threads", (7, [], "sum"), "github_api", "gh_pr_review_post"),
+    ("skip_epics", ({5: ["epic"]},), "github_api", "skip_epics"),
+    ("ensure_state_labels", (), "github_api", "_ensure_labels_exist"),
+]
+
+
+_OWNERS = {"github_api": github_api_mod, "pr_manager": pr_manager_mod}
+
+
+def _patch_target(monkeypatch: pytest.MonkeyPatch, owner: str, name: str) -> MagicMock:
+    mock = MagicMock(return_value=[] if name == "gh_pr_review_post" else None)
+    if owner == "module":
+        monkeypatch.setattr(pg, name, mock)
+    else:
+        monkeypatch.setattr(_OWNERS[owner], name, mock)
+    return mock
+
+
+class TestMutatorMapping:
+    """Each coordinator-neutral mutator hits exactly its documented backer."""
+
+    @pytest.mark.parametrize(("method", "args", "owner", "name"), _MUTATOR_CASES)
+    def test_mutator_delegates(
+        self,
+        adapter: pg.PipelineGitHub,
+        monkeypatch: pytest.MonkeyPatch,
+        method: str,
+        args: tuple[Any, ...],
+        owner: str,
+        name: str,
+    ) -> None:
+        mock = _patch_target(monkeypatch, owner, name)
+
+        getattr(adapter, method)(*args)
+
+        assert mock.call_count == 1
+
+    @pytest.mark.parametrize(("method", "args", "owner", "name"), _MUTATOR_CASES)
+    def test_dry_run_logs_and_skips(
+        self,
+        dry_adapter: pg.PipelineGitHub,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        method: str,
+        args: tuple[Any, ...],
+        owner: str,
+        name: str,
+    ) -> None:
+        """StageGitHub contract: dry-run honored INSIDE the accessor."""
+        mock = _patch_target(monkeypatch, owner, name)
+
+        with caplog.at_level("INFO"):
+            getattr(dry_adapter, method)(*args)
+
+        mock.assert_not_called()
+        assert any("[dry-run] would" in record.message for record in caplog.records)
+
+    def test_upsert_plan_comment_keys_on_marker(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock = _patch_target(monkeypatch, "github_api", "gh_issue_upsert_comment")
+
+        adapter.upsert_plan_comment(5, "# Implementation Plan\n\nbody")
+
+        mock.assert_called_once_with(5, PLAN_COMMENT_MARKER, "# Implementation Plan\n\nbody")
+
+
+class TestCreatePr:
+    """create_pr: idempotent reuse, given-body create, dry-run neutral."""
+
+    def test_reuses_existing_open_pr(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pg, "find_pr_for_issue", lambda issue: 77)
+        create = _patch_target(monkeypatch, "github_api", "gh_pr_create")
+
+        assert adapter.create_pr(5, "branch", "t", "b") == 77
+        create.assert_not_called()
+
+    def test_creates_with_given_title_and_body(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """NOT pr_manager.ensure_pr_created — the stage's composed body wins."""
+        monkeypatch.setattr(pg, "find_pr_for_issue", lambda issue: None)
+        create = MagicMock(return_value=88)
+        monkeypatch.setattr(github_api_mod, "gh_pr_create", create)
+
+        assert adapter.create_pr(5, "branch", "title", "body\n\nCloses #5") == 88
+        create.assert_called_once_with("branch", "title", "body\n\nCloses #5")
+
+    def test_dry_run_returns_zero(
+        self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pg, "find_pr_for_issue", lambda issue: None)
+        create = _patch_target(monkeypatch, "github_api", "gh_pr_create")
+
+        assert dry_adapter.create_pr(5, "b", "t", "x") == 0
+        create.assert_not_called()
+
+
+class TestReadSurface:
+    """Reads delegate verbatim (and stay LIVE even under dry-run)."""
+
+    def test_gh_issue_json(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(github_api_mod, "gh_issue_json", lambda n: {"number": n})
+
+        assert adapter.gh_issue_json(4) == {"number": 4}
+
+    def test_module_bound_reads(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pg, "find_merged_closing_pr", lambda n: 1)
+        monkeypatch.setattr(pg, "find_pr_for_issue", lambda n: 2)
+        monkeypatch.setattr(pg, "get_pr_head_branch", lambda n: "head")
+        monkeypatch.setattr(pg, "is_plan_review_go", lambda n: True)
+
+        assert adapter.find_merged_closing_pr(9) == 1
+        assert adapter.find_pr_for_issue(9) == 2
+        assert adapter.get_pr_head_branch(9) == "head"
+        assert adapter.has_existing_plan(9) is True
+
+    def test_pr_manager_reads(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            pr_manager_mod, "pr_has_implementation_state_label", lambda n: (True, False)
+        )
+        monkeypatch.setattr(pr_manager_mod, "pr_is_genuinely_stuck", lambda n: True)
+
+        assert adapter.pr_has_implementation_state_label(7) == (True, False)
+        assert adapter.pr_is_genuinely_stuck(7) is True
+
+    def test_pr_checks_reads_live_even_in_dry_run(
+        self, dry_adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        checks = [{"name": "ci"}]
+        mock = MagicMock(return_value=checks)
+        monkeypatch.setattr(github_api_mod, "gh_pr_checks", mock)
+
+        assert dry_adapter.pr_checks(7) == checks
+        mock.assert_called_once_with(7, dry_run=False)
+
+    def test_check_inspector_delegation(self, adapter: pg.PipelineGitHub) -> None:
+        adapter._inspector = MagicMock()
+        adapter._inspector.failing_required_check_names.return_value = ["lint"]
+        adapter._inspector.pending_required_check_names.return_value = ["test"]
+
+        assert adapter.failing_required_check_names(7) == ["lint"]
+        assert adapter.pending_required_check_names(7) == ["test"]
+
+
+class TestUnresolvedThreads:
+    """count_unresolved_threads mirrors #1152: counts only, resolves nothing."""
+
+    def test_counts_by_ownership(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        threads = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        monkeypatch.setattr(
+            github_api_mod, "gh_pr_list_unresolved_threads", lambda n, dry_run: threads
+        )
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "bot")
+        monkeypatch.setattr(pg, "_is_automation_owned_thread", lambda t, login: t["id"] == "a")
+
+        assert adapter.count_unresolved_threads(7) == (1, 2)
+
+    def test_empty_and_error_fail_open(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(github_api_mod, "gh_pr_list_unresolved_threads", lambda n, dry_run: [])
+        assert adapter.count_unresolved_threads(7) == (0, 0)
+
+        def boom(n: int, dry_run: bool) -> list[dict[str, Any]]:
+            raise RuntimeError("api")
+
+        monkeypatch.setattr(github_api_mod, "gh_pr_list_unresolved_threads", boom)
+        assert adapter.count_unresolved_threads(7) == (0, 0)
+
+
+class TestGhPrState:
+    """The merge_wait single PR-state read (re-housed CIDriver._gh_pr_state)."""
+
+    def test_success_parses_json(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = {"state": "OPEN", "headRefOid": "abc", "mergedAt": None}
+        monkeypatch.setattr(pg, "gh_call", lambda argv: SimpleNamespace(stdout=json.dumps(payload)))
+
+        assert adapter.gh_pr_state(7) == payload
+
+    def test_failure_returns_none(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def boom(argv: list[str]) -> Any:
+            raise RuntimeError("gh down")
+
+        monkeypatch.setattr(pg, "gh_call", boom)
+
+        assert adapter.gh_pr_state(7) is None
+
+
+class TestDriveGreenArmingRecords:
+    """arm_drive_green / learn-terminal / learn-result over ArmingStateStore."""
+
+    def test_arm_then_terminal_roundtrip(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pg, "get_pr_head_branch", lambda n: "1817-auto-impl")
+        assert adapter.drive_green_learn_terminal(3) is False
+
+        adapter.arm_drive_green(3, 70, "deadbeef")
+        assert adapter.drive_green_learn_terminal(3) is False  # armed, not terminal
+
+        adapter.mark_drive_green_learn_result(3, succeeded=True)
+        assert adapter.drive_green_learn_terminal(3) is True
+
+    def test_failed_learn_is_also_terminal(self, adapter: pg.PipelineGitHub) -> None:
+        adapter.mark_drive_green_learn_result(4, succeeded=False)
+
+        assert adapter.drive_green_learn_terminal(4) is True
+
+    def test_arm_never_overwrites_terminal_record(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pg, "get_pr_head_branch", lambda n: "b")
+        adapter.mark_drive_green_learn_result(5, succeeded=True)
+
+        adapter.arm_drive_green(5, 71, "cafe")
+
+        record = adapter._arming.load(5)
+        assert record is not None
+        assert record["learn_status"] == "succeeded"  # evidence preserved
+
+
+class TestRateBudget:
+    """The non-blocking port of the legacy rate guard."""
+
+    def test_guard_disabled_by_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HEPHAESTUS_RATE_GUARD", "0")
+
+        assert pg.rate_budget_ok() == (True, 0.0)
+
+    def test_unknown_budget_is_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HEPHAESTUS_RATE_GUARD", raising=False)
+        monkeypatch.setattr(pg, "rate_limit_remaining", lambda: None)
+
+        assert pg.rate_budget_ok() == (True, 0.0)
+
+    def test_high_budget_is_ok(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("HEPHAESTUS_RATE_GUARD", raising=False)
+        monkeypatch.setattr(pg, "rate_limit_remaining", lambda: (5000, 0))
+
+        assert pg.rate_budget_ok() == (True, 0.0)
+
+    def test_low_budget_returns_park_delay(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Low budget: (False, seconds-until-reset + 5s slack) — never a sleep."""
+        monkeypatch.delenv("HEPHAESTUS_RATE_GUARD", raising=False)
+        monkeypatch.setattr(pg, "rate_limit_remaining", lambda: (10, 1_000_000))
+
+        ok, delay = pg.rate_budget_ok(now_epoch=999_995.0)
+
+        assert ok is False
+        assert delay == pytest.approx(10.0)  # (reset - now) + 5
+
+    def test_rate_limit_remaining_parses_graphql_budget(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        payload = {"resources": {"graphql": {"remaining": 42, "reset": 123}}}
+        monkeypatch.setattr(pg, "gh_call", lambda argv: SimpleNamespace(stdout=json.dumps(payload)))
+
+        assert pg.rate_limit_remaining() == (42, 123)
+
+    def test_rate_limit_remaining_none_on_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(argv: list[str]) -> Any:
+            raise RuntimeError("gh down")
+
+        monkeypatch.setattr(pg, "gh_call", boom)
+
+        assert pg.rate_limit_remaining() is None
+
+    def test_rate_limit_remaining_none_on_malformed_payload(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(pg, "gh_call", lambda argv: SimpleNamespace(stdout="not json"))
+        assert pg.rate_limit_remaining() is None
+
+        monkeypatch.setattr(pg, "gh_call", lambda argv: SimpleNamespace(stdout="{}"))
+        assert pg.rate_limit_remaining() is None


### PR DESCRIPTION
Capstone PR of epic #1809: the queue-based pipeline now runs end-to-end behind a default-OFF `--pipeline` flag (`HEPH_PIPELINE=1` also enables it; CLI wins). The legacy issue-major subprocess loop is untouched when the flag is off, and the pipeline path still runs token preflight, then dispatches before `_clone_missing_repos` so the repo stage owns cloning (no double-clone).

## What's here

- **`pipeline/coordinator.py`** — the single main-thread event loop: per tick shutdown check -> wake expired timers (heapq) -> drain ALL ready completions (interrupted results park RESUMABLE, never advance, `on_job_done` never called) -> drain queues DOWNSTREAM-FIRST (finished -> merge_wait -> ... -> repo) with admission control -> fully drained: re-seed up to `--loops` with zero-work convergence exit -> else block on the completion queue. `_run_item` drives `on_enter`/`step` until `JobRequest` (park + submit) or outcome (routed via the ROUTES table, incl. the explicit Disposition->action mapping from the plan). Per-item try/except: a poisoned item routes to finished(fail), never kills the loop. Admission: per-repo in-flight cap via a distinct `inflight_per_repo` Counter, plus REUSED `admission.order_for_implementation` + `_select_non_overlapping` for the implementation queue. Pool size = `parallel_repos x max_workers`. RETRY consumes `payload["retry_delay_s"]` into the timer heap (base.py contract). Rate budget is the legacy guard ported to a NON-blocking check: a low-budget AgentJob is timer-parked until the upstream reset (gated at the `_submit` chokepoint — the plan's sanctioned fallback since `will_submit_agent` does not exist on the merged stage protocol). Step watchdog WARNs past 5s. `--phase-timeout` maps onto `AgentJob.timeout_s` (help text + module docstring + inline comment document the shift). Dry-run: `_submit` asserts no job is ever submitted; stage JobRequests are logged `[dry-run] would ...` and ADVANCEd. Signals: SIGINT/SIGTERM/SIGHUP -> one shutdown Event (first graceful w/ grace window, second immediate + synthesized interrupted results). Exit codes: 130 interrupt / 1 fail-skip-blocked / 0 clean.
- **`stages/repo.py`** — doc section 1: ENTER -> CLONE_WAIT -> DISCOVER -> SEEDED; `ensure_state_labels` [M] on enter; `GitJob(op="clone")` [W:G] with budget clone=2; DISCOVER reuses `seeding.seed_issue`/`classify_issue` and `partition_epics`, tags epics `state:skip` through the sanctioned `skip_epics` chokepoint [durable, BEFORE excluding]; `--drive-green-all` routes orphan PRs to ci; repo item is terminal (`FINISH_PASS seeded:N`) and the coordinator pushes its products into their entry queues.
- **`stages/finished.py`** — doc section 8: records `ItemResult` in the run ledger [M]; worktree cleanup [W:G] removes on pass / preserves on fail (preserved list feeds the summary footer).
- **`pipeline/summary.py`** — printed in the coordinator's `finally` (completion AND interrupt): per-item rows (repo, issue, PR, entry queue, final stage, PASS/FAIL:reason/SKIP/BLOCKED/RESUMABLE, attempts, elapsed), aggregates, preserved-worktrees footer (`format_preserved_worktrees` re-housed from `implementer_summary`, which now delegates), and the `emit_json_status` envelope extension.
- **`pipeline_github.py`** — the REAL `StageGitHub` adapter mapping the coordinator-neutral mutators onto `github_api`/`pr_manager`/`_review_utils` (create_pr is find-then-create with the stage's composed body; drive-green arming records via `ArmingStateStore`). Lives OUTSIDE `pipeline/` because the AST mutator guard forbids `github_api` mutators in pipeline modules. Dry-run is honored INSIDE every mutator (log-and-skip), per the `StageGitHub` protocol docstring; reads stay live.
- **`loop_runner.py`** — `--pipeline` flag + `HEPH_PIPELINE` env, token preflight before pipeline dispatch, `_build_pipeline_config`, `--phase-timeout` help note. Legacy behavior unchanged when off (`test_pipeline_flag.py` proves `run_loop` untouched and `_clone_missing_repos` not called on the pipeline path).
- **`stages/base.py`** — `StageGitHub` gains the two repo-stage methods (`skip_epics`, `ensure_state_labels`); `loop_repo_manager` gains the read-only `_list_open_issue_meta` / `_list_open_pr_numbers` (extracted, behavior-preserving).

## Tests (146 new)

Coordinator quiescence with FakeWorkerPool/FakeStageGitHub incl. the journal-order invariant (durable mutation precedes the queue push in one shared trace); crash-matrix journal reconstruction table (13 scenarios covering every GitHub-journal row -> re-classify from the GitHub journal -> same-or-earlier stage, never lost/duplicated); interrupt tests (shutdown mid-job -> RESUMABLE never FAILED, `on_job_done` never called, exit 130, second-signal immediate teardown); downstream-first drain order; dry-run asserts-no-submit; timer-heap RETRY consumption + seq tie-break + watchdog; per-repo cap + topo/file-overlap admission reuse; repo-stage walk incl. epic-tag-write-BEFORE-exclusion order; finished-stage cleanup branches; summary rows/aggregates/JSON + legacy preserved-footer parity; `--pipeline` flag/env dispatch matrix; adapter mapping + dry-run matrix.

Coverage on the new modules: coordinator 95.2%, stages/repo 98.6%, stages/finished 100%, summary 97.9%, pipeline_github 97.3%. None of them is in the coverage omit list (verified: `test_omit_allowlist.py` green, no `pyproject.toml` omit entry added).

## AC1 dry-run evidence (`build/verify-1817-dryrun.log`, live run against this repo)

`pixi run hephaestus-automation-loop --pipeline --dry-run --loops 1 -v` classified every open issue into a stage, logged every planned mutation, submitted ZERO jobs, and terminated with the summary:

```
[dry-run] would ensure state labels exist: ['state:needs-plan', 'state:plan-no-go', 'state:plan-go', 'state:implementation-no-go', 'state:implementation-go', 'state:skip']
repo:ProjectHephaestus: already cloned at [repo checkout]
[dry-run] would tag epics [1809] state:skip
issue excluded: #1421 tagged state:skip   (and #1460 #1483 #1487 #1780)
[dry-run] would submit AgentJob: advise / review; GitJob: create_worktree  (67 planned submissions logged)
=== Pipeline summary ===
  repo               issue   pr    entry           final     disposition
  ProjectHephaestus      -    -    repo            finished  PASS
  ProjectHephaestus  #1404    -    planning        finished  FAIL:[dry-run] would fail_back: plan_not_go
  ProjectHephaestus  #1817    -    implementation  finished  FAIL:[dry-run] would fail_back: agent_error
  ProjectHephaestus  #1844  !1845  pr_review       finished  FAIL:[dry-run] would fail_back: not_implementation_go
  ... (27 items total)
  items: 27  dispositions: {'fail': 26, 'pass': 1}   per-stage: {'finished': 27}
  agent jobs: 0 (0.0s total)  loops: 1  wall: 182.3s  interrupted: False
```

(Dry-run cannot write gate labels, so a FAIL_BACK regression would ping-pong; the coordinator finishes such items with the `[dry-run] would fail_back` note — their entry-queue classification is the deliverable.)

## Known deferrals (documented, per plan)

- `PipelineScope` deliberately NOT wired into `PipelineConfig` (M3/YAGNI — thin-CLI scopes are #1820-#1822).
- `--max-merge-attempts` still maps to `ROUTES` default under the pipeline (cutover issue).
- Curses UI: the pipeline path logs plainly (epic defers the curses adapter).

Closes #1817


