### PR TITLE
feat(automation): runnable-evidence gate for metric claims (ADR-014)

### DIFF
--- a/hephaestus/automation/prompts/_strict_rubric.py
+++ b/hephaestus/automation/prompts/_strict_rubric.py
@@ -163,6 +163,29 @@ D4 — CI failure analysis (only when CI Status block is non-empty).
     the failing job(s), quote the relevant error signal, and tie each
     failure to a diff hunk (or note "unrelated to diff" with evidence).
     Silently ignoring red CI is a major finding against the review.
+
+D5 — Runnable evidence for metric / training-run claims (NOGO gate).
+    Per ADR-014 (Odysseus docs/adr/014-runnable-evidence-for-metric-claims.md):
+    any claim of a measured metric, accuracy, loss, convergence, benchmark
+    number, or "successful run" is treated as UNPROVEN unless it is backed by
+    output produced by a gate the author does not control — a CI-produced
+    artifact or independently re-executed output pasted verbatim. A log file
+    committed into the diff (e.g. ``validation/epoch1.log``, a results table, a
+    metrics JSON) is NOT evidence, no matter how plausible: the author can write
+    any numbers into it. Grade this dimension:
+      - If the PR/issue asserts a metric/convergence/run result AND the only
+        support is a committed artifact or the author's own prose ("I ran it and
+        got X"), that is a MAJOR finding and forces NOGO. Absence of runnable
+        evidence is evidence of absence.
+      - Watch for forensic tells of fabrication and call them out explicitly:
+        uniform fixed-decimal losses where the code prints full
+        ``String(Float32)`` precision, monotone evenly-spaced loss curves, or a
+        "completed" artifact whose timestamp predates any run finishing.
+      - A PR that delivers code + a runnable command and HONESTLY defers the
+        measured result to a separate gated evidence step (per ADR-014) is
+        CORRECT and must NOT be penalized for the deferral. A truthful "did not
+        complete in the window" is acceptable; an invented number is not.
+    N/A only when the PR makes no metric/run claim at all.
 """
 
 

--- a/hephaestus/automation/prompts/implementation.py
+++ b/hephaestus/automation/prompts/implementation.py
@@ -58,6 +58,19 @@ Implement GitHub issue #{issue_number}.
 5. Ensure all tests pass before finishing
 6. Follow the code quality guidelines in CLAUDE.md
 
+**Evidence Integrity (MANDATORY — ADR-014):**
+- NEVER hand-write, edit, or commit a log, metric, accuracy, loss, benchmark,
+  or training-run output to represent a run that did not actually execute.
+  Plausible invented numbers are the failure, not a shortcut.
+- A file you commit (e.g. `validation/epoch1.log`, a results table, a metrics
+  JSON) is NOT evidence — the reviewer treats it as unproven.
+- If honest verification of a criterion requires a run longer than your
+  session/timeout budget (e.g. a full training epoch), DO NOT report its result
+  as done. Deliver the code and the runnable command, and state plainly in your
+  summary that the measured result is deferred to a separate evidence step.
+- When blocked from obtaining a measurement, say so — what you tried and why it
+  did not finish. A truthful failure is acceptable; an invented success is not.
+
 **Testing:**
 - Write unit tests for new functionality
 - Ensure existing tests still pass

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -63,7 +63,14 @@ you know the line.</files_to_modify>
 <implementation_order>A numbered sequence of concrete steps.</implementation_order>
 <verification>One runnable command per acceptance criterion in the issue, each
 labelled with the criterion it proves. Use the repo's real runner
-(e.g. `pixi run pytest <path>`).</verification>
+(e.g. `pixi run pytest <path>`). RUNNABLE-EVIDENCE RULE (ADR-014): if a
+criterion's honest verification requires a run longer than the session/timeout
+budget (e.g. a full training epoch), the plan authors the *command* but MUST
+NOT make the run's measured *result* (an accuracy/loss/metric number) a
+deliverable of this task. Split the measured result into a separate, gated
+evidence-collection step whose only acceptable input is verbatim output from a
+run the agent does not author. Never plan to hand-write or commit a log/metric
+file as evidence.</verification>
 <skills_used>Skills you invoked during planning AND any team knowledge-base
 skills from the Prior Learnings section above.</skills_used>
 <changes_from_review>ONLY when a prior `## 🔍 Plan Review` is in your context

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -141,6 +141,9 @@ class TestPRReviewAnalysisPrompt:
         assert "D2 — Diff review of CHANGED lines only" in out
         assert "D3 — Inline-comment quality" in out
         assert "D4 — CI failure analysis" in out
+        # D5 — runnable-evidence gate for metric/training-run claims (ADR-014).
+        assert "D5 — Runnable evidence for metric / training-run claims" in out
+        assert "committed into the diff" in out
         # Seven principles markers.
         for marker in (
             "P1 — KISS",


### PR DESCRIPTION
## Summary

Implement the strict-review enforcement side of Odysseus ADR-014. Closes the gap where an agent hand-writes a training log with fabricated metrics and it passes every automated gate (observed 8x across the ProjectOdyssey #3181/#3184/#3187 lanes).

## Changes

- **`_strict_rubric.py`** — new **D5 "Runnable evidence for metric / training-run claims"** NOGO gate. Any accuracy/loss/convergence/benchmark claim backed only by a committed artifact or the author's prose is a MAJOR finding forcing NOGO. The reviewer is given the forensic tells of fabrication (uniform fixed-decimal losses where the code prints full `String(Float32)` precision, monotone evenly-spaced curves, completion timestamps predating any run). An **honest deferral** of the measured result to a separate gated evidence step is explicitly NOT penalized.
- **`planning.py`** — `<verification>` carries the runnable-evidence rule: a criterion needing a run longer than the session budget authors the command but must not make the measured result a deliverable.
- **`implementation.py`** — Evidence Integrity block forbidding hand-written logs/metrics; requires truthful "did not complete" over invented success.
- **`test_prompts.py`** — asserts D5 is embedded in the PR-review prompt.

## Testing

- `pixi run python -m pytest tests/unit/automation/test_prompts.py` — 81 passed.

Refs Odysseus ADR-014 (HomericIntelligence/Odysseus#380).

Closes #1853

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>