### PR TITLE
fix(pr_review): filter GO gate by thread severity

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -185,6 +185,14 @@ class StageGitHub(Protocol):
         """
         ...
 
+    def count_unresolved_threads_by_severity(self, pr_number: int) -> tuple[int, int, int]:
+        """Return (blocking_automation, minor_automation, human) unresolved counts (#1856)."""
+        ...
+
+    def resolve_automation_threads(self, pr_number: int) -> int:
+        """Resolve unresolved automation-owned review threads; return the count (#1856)."""
+        ...
+
     def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
         """Durably ensure the PR exists and return its number (idempotent).
 

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -682,16 +682,16 @@ class PrReviewStage(Stage):
             # Audit trail of progress-earned extension rounds (4..hard_cap).
             item.attempts["pr_review_hard"] = item.attempts.get("pr_review_hard", 0) + 1
 
-        # Fresh unresolved counts AFTER the address/push leg (the GO gate
-        # must see what is open NOW, not the pre-address snapshot).
-        automation_unresolved, human_unresolved = ctx.github.count_unresolved_threads(item.pr)
+        # Fresh counts AFTER the address/push leg, split by severity so a GO is
+        # downgraded only by BLOCKING automation threads (#1856 / re-introduced #1554).
+        blocking_auto, minor_auto, human_unresolved = (
+            ctx.github.count_unresolved_threads_by_severity(item.pr)
+        )
+        automation_unresolved = blocking_auto + minor_auto  # progress-trail parity (#1554)
         unresolved = automation_unresolved + human_unresolved
 
         if verdict.is_go and human_unresolved:
-            # A GO cannot stand while a HUMAN review thread is open —
-            # automation must not resolve it and cannot fix it. Post the
-            # explanatory stand-down comment [durable, before the outcome],
-            # then finish with the PR left UNLABELED (no go/no-go/skip).
+            # Unchanged human-blocked guard (pr_review.py:690-701).
             logger.info(
                 "pr_review:%d: GO blocked by %d human thread(s); finishing (unlabeled)",
                 item.issue,
@@ -700,12 +700,21 @@ class PrReviewStage(Stage):
             self._post_human_blocked_comment(item.pr, human_unresolved, ctx)
             return StageOutcome(Disposition.FINISH_FAIL, "human_blocked")
 
-        if verdict.is_go and unresolved == 0:
+        if verdict.is_go and blocking_auto == 0:
+            if minor_auto:
+                # Automation owns these waved minor/nitpick threads; resolve them so
+                # required_review_thread_resolution does not re-block at merge_wait.
+                logger.info(
+                    "pr_review:%d: GO with %d advisory minor thread(s); resolving before arm",
+                    item.issue,
+                    minor_auto,
+                )
+                ctx.github.resolve_automation_threads(item.pr)
             logger.info("pr_review:%d: clean GO; marking PR #%d and arming", item.issue, item.pr)
             self._write_go_and_arm(item.pr, ctx)
             if getattr(ctx.config, "enable_follow_up", True):
                 return Continue(next_state=FOLLOWUP_WAIT)
-            return StageOutcome(Disposition.ADVANCE, "GO with zero unresolved threads")
+            return StageOutcome(Disposition.ADVANCE, "GO with zero blocking threads")
 
         # NOGO/AMBIGUOUS — or a GO downgraded by open automation threads
         # (re-housed downgrade: address + re-review before GO can stand;

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -129,7 +129,7 @@ def _with_severity_marker(comment: dict[str, Any]) -> str:
     if sev not in VALID_SEVERITIES:
         sev = "major"
     body = str(comment.get("body") or "")
-    if body.lstrip().startswith(SEVERITY_MARKER_PREFIX):
+    if body.startswith(SEVERITY_MARKER_PREFIX):
         return body  # already marked (idempotent re-post)
     return f"{SEVERITY_MARKER_PREFIX} {sev} -->\n{body}"
 

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -41,6 +41,11 @@ from hephaestus.automation._review_utils import (
 )
 from hephaestus.automation.arming_state import ArmingStateStore
 from hephaestus.automation.ci_check_inspector import CICheckInspector
+from hephaestus.automation.prompts.pr_review import (
+    BLOCKING_SEVERITIES,
+    SEVERITY_MARKER_PREFIX,
+    VALID_SEVERITIES,
+)
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from hephaestus.automation.review_state import (
     PLAN_REVIEW_PREFIX,
@@ -111,6 +116,33 @@ def rate_budget_ok(now_epoch: float | None = None) -> tuple[bool, float]:
         return True, 0.0
     now = time.time() if now_epoch is None else now_epoch
     return False, max(0.0, reset_epoch - now + 5.0)
+
+
+def _with_severity_marker(comment: dict[str, Any]) -> str:
+    """Prepend the ``<!-- hephaestus-severity: X -->`` marker line (#1856).
+
+    An absent/unknown severity is written as ``major`` (blocking) so an
+    unclassifiable thread never silently unblocks a GO, and so the pre-#1856
+    all-blocking behavior is reproduced until the reviewer's severity is seeded.
+    """
+    sev = str(comment.get("severity") or "").strip().lower()
+    if sev not in VALID_SEVERITIES:
+        sev = "major"
+    body = str(comment.get("body") or "")
+    if body.lstrip().startswith(SEVERITY_MARKER_PREFIX):
+        return body  # already marked (idempotent re-post)
+    return f"{SEVERITY_MARKER_PREFIX} {sev} -->\n{body}"
+
+
+def _thread_severity_is_blocking(thread: dict[str, Any]) -> bool:
+    """Return True if the thread's recovered severity is blocking; missing means blocking."""
+    body = str(thread.get("body") or "")
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(SEVERITY_MARKER_PREFIX) and stripped.endswith("-->"):
+            sev = stripped[len(SEVERITY_MARKER_PREFIX) : -3].strip().lower()
+            return sev in BLOCKING_SEVERITIES
+    return True
 
 
 class PipelineGitHub:
@@ -518,6 +550,16 @@ class PipelineGitHub:
             return is_implementation_go(labels), has_label(labels, STATE_IMPLEMENTATION_NO_GO)
         return pr_manager.pr_has_implementation_state_label(pr_number)
 
+    def _unresolved_threads(self, pr_number: int) -> list[dict[str, Any]]:
+        """Fetch unresolved threads (repo-scoped or legacy). Fails open to []."""
+        if self._repo_slug is not None:
+            return self._repo_unresolved_threads(pr_number)
+        try:
+            return github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
+        except Exception as exc:  # legacy path fails open (parity with existing code)
+            logger.warning("PR #%s: could not list unresolved threads: %s", pr_number, exc)
+            return []
+
     def count_unresolved_threads(self, pr_number: int) -> tuple[int, int]:
         """Return ``(automation_unresolved, human_unresolved)`` thread counts.
 
@@ -526,23 +568,52 @@ class PipelineGitHub:
         open on fetch errors; repo-scoped pipeline runs query the configured
         repo directly so unresolved human threads are not hidden.
         """
-        if self._repo_slug is not None:
-            threads = self._repo_unresolved_threads(pr_number)
-            if not threads:
-                return (0, 0)
-            current_login = github_api.gh_current_login()
-            automation = sum(1 for t in threads if _is_automation_owned_thread(t, current_login))
-            return (automation, len(threads) - automation)
-        try:
-            threads = github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
-        except Exception as exc:
-            logger.warning("PR #%s: could not list unresolved threads: %s", pr_number, exc)
-            return (0, 0)
+        threads = self._unresolved_threads(pr_number)
         if not threads:
             return (0, 0)
         current_login = github_api.gh_current_login()
         automation = sum(1 for t in threads if _is_automation_owned_thread(t, current_login))
         return (automation, len(threads) - automation)
+
+    def count_unresolved_threads_by_severity(self, pr_number: int) -> tuple[int, int, int]:
+        """Return ``(blocking_automation, minor_automation, human)`` (#1856).
+
+        Severity is read from the ``<!-- hephaestus-severity: X -->`` marker
+        prepended at post time; an automation thread with a missing/garbled marker
+        counts as BLOCKING (fail-safe). Resolves nothing.
+        """
+        threads = self._unresolved_threads(pr_number)
+        if not threads:
+            return (0, 0, 0)
+        current_login = github_api.gh_current_login()
+        blocking = minor = human = 0
+        for t in threads:
+            if _is_automation_owned_thread(t, current_login):
+                if _thread_severity_is_blocking(t):
+                    blocking += 1
+                else:
+                    minor += 1
+            else:
+                human += 1
+        return (blocking, minor, human)
+
+    def resolve_automation_threads(self, pr_number: int) -> int:
+        """Resolve unresolved AUTOMATION-owned threads; return the count (#1856).
+
+        Never resolves human threads. Used by the GO gate to clear advisory
+        minor/nitpick threads the reviewer waved so ``required_review_thread_
+        resolution`` does not re-block the armed PR at merge (merge_wait.py:427).
+        """
+        if self._skip(f"resolve automation threads on PR #{pr_number}"):
+            return 0
+        threads = self._unresolved_threads(pr_number)
+        current_login = github_api.gh_current_login()
+        resolved = 0
+        for t in threads:
+            if _is_automation_owned_thread(t, current_login) and t.get("id"):
+                github_api.gh_pr_resolve_thread(str(t["id"]), dry_run=self.dry_run)
+                resolved += 1
+        return resolved
 
     def gh_pr_state(self, pr_number: int) -> dict[str, Any] | None:
         """Return the merge_wait PR-state read, or ``None`` on failure.
@@ -833,7 +904,7 @@ class PipelineGitHub:
                     "path": c["path"],
                     "line": c["line"],
                     "side": c.get("side", "RIGHT"),
-                    "body": c["body"],
+                    "body": _with_severity_marker(c),
                 }
                 for c in threads
             ]

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -100,6 +100,19 @@ _NITPICK_INCLUDE = (
     "downstream."
 )
 
+#: Severities that BLOCK a GO when their automation thread is unresolved (#1856).
+#: ``minor``/``nitpick`` are advisory — a GO the reviewer returned must not
+#: deadlock to state:skip over a nit it declined to block on. An unmarked or
+#: unknown severity is treated as BLOCKING (fail-safe), which reproduces the
+#: pre-#1856 all-blocking behavior when severity is not yet seeded.
+BLOCKING_SEVERITIES: frozenset[str] = frozenset({"critical", "major"})
+VALID_SEVERITIES: frozenset[str] = frozenset({"critical", "major", "minor", "nitpick"})
+
+#: HTML-comment marker prepended to each posted review-thread body so the GO
+#: gate can recover the reviewer's severity after the GitHub round-trip.
+#: Anchored as a full marker line — never matched by a free substring scan.
+SEVERITY_MARKER_PREFIX = "<!-- hephaestus-severity:"
+
 
 def get_pr_review_analysis_prompt(
     pr_number: int,

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -42,12 +42,14 @@ class FakeStageGitHub(FakeGitHub):
         pr_head_branch: str | None = None,
         pr_impl_state: tuple[bool, bool] = (False, False),
         unresolved: list[tuple[int, int]] | None = None,
+        by_severity: list[tuple[int, int, int]] | None = None,
         pr_state: dict[str, Any] | None = None,
         failing_checks: list[str] | None = None,
         pending_checks: list[str] | None = None,
         checks: list[dict[str, Any]] | None = None,
         pr_stuck: bool = False,
         learn_terminal: bool = False,
+        resolve_count: int = 0,
     ) -> None:
         """Initialize the fake with canned read answers.
 
@@ -63,6 +65,9 @@ class FakeStageGitHub(FakeGitHub):
                 count_unresolved_threads — consumed one per call, last
                 entry repeating (lets tests script a decreasing /
                 plateauing thread count for the #1554 progress rule).
+            by_severity: FIFO of (blocking, minor, human) answers for
+                count_unresolved_threads_by_severity (#1856); defaults to
+                deriving from unresolved (legacy: all automation = blocking).
             pr_state: Canned answer for gh_pr_state (merge_wait's single
                 PR-state read); ``None`` mirrors a transient read failure.
             failing_checks: Canned answer for failing_required_check_names.
@@ -72,6 +77,7 @@ class FakeStageGitHub(FakeGitHub):
             learn_terminal: Seed answer for drive_green_learn_terminal —
                 True mirrors an issue whose post-merge /learn already ran
                 terminally (the #848 dedupe record).
+            resolve_count: Canned return count for resolve_automation_threads.
 
         """
         super().__init__()
@@ -82,12 +88,18 @@ class FakeStageGitHub(FakeGitHub):
         self._pr_head_branch = pr_head_branch
         self._pr_impl_state = pr_impl_state
         self._unresolved: list[tuple[int, int]] = list(unresolved or [(0, 0)])
+        self._by_severity = (
+            list(by_severity)
+            if by_severity is not None
+            else [(a, 0, h) for (a, h) in self._unresolved]  # legacy: all automation = blocking
+        )
         self._pr_state = pr_state
         self._failing_checks = list(failing_checks or [])
         self._pending_checks = list(pending_checks or [])
         self._checks = list(checks or [])
         self._pr_stuck = pr_stuck
         self._learn_terminal = learn_terminal
+        self._resolve_count = resolve_count
         self.arming_records: dict[int, tuple[int, str]] = {}
         self.learn_results: dict[int, bool] = {}
 
@@ -135,6 +147,16 @@ class FakeStageGitHub(FakeGitHub):
         if len(self._unresolved) > 1:
             return self._unresolved.pop(0)
         return self._unresolved[0]
+
+    def count_unresolved_threads_by_severity(self, pr_number: int) -> tuple[int, int, int]:
+        """FIFO of scripted (blocking, minor, human) answers (#1856)."""
+        if len(self._by_severity) > 1:
+            return self._by_severity.pop(0)
+        return self._by_severity[0]
+
+    def resolve_automation_threads(self, pr_number: int) -> int:
+        self._log("resolve_automation_threads", pr_number)
+        return self._resolve_count
 
     # -- mutator surface used by the stages ----------------------------------
     # Coordinator-neutral names (the pipeline architecture guard forbids

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -554,6 +554,93 @@ class TestEvalVerdicts:
         assert item.attempts["pr_review_iter"] == 0  # no round burned
         assert github.mutation_log == []
 
+    # Severity-aware GO gate tests (#1856)
+    def test_go_with_only_minor_automation_thread_arms(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """GO with only minor/nitpick automation threads resolves and arms.
+
+        This is the regression case from #1856: previously a GO with minor
+        automation threads would deadlock to skip because `unresolved == 0`
+        never held. Now severity filtering allows the GO to arm.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(by_severity=[(0, 2, 0)])  # 0 blocking, 2 minor, 0 human
+        ctx = make_ctx(github=github)
+        ctx.config.enable_follow_up = False
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        # Should resolve the minor threads AND arm
+        assert ("resolve_automation_threads", (1001,)) in github.mutation_log
+        assert ("mark_pr_implementation_go", (1001,)) in github.mutation_log
+        assert ("arm_auto_merge", (1001,)) in github.mutation_log
+
+    def test_go_with_blocking_automation_thread_downgrades(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """GO with blocking automation threads downgrades to NOGO.
+
+        Tightening check: blocking threads still block, minor threads don't.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(by_severity=[(1, 0, 0)])  # 1 blocking, 0 minor, 0 human
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+        item.payload["pr_review_round"] = 1
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "REVIEW_WAIT"
+        # Should NOT resolve (no minor threads), should write no-go
+        assert ("mark_pr_implementation_no_go", (1001,)) in github.mutation_log
+        # resolve_automation_threads should NOT be called
+        assert ("resolve_automation_threads", (1001,)) not in github.mutation_log
+
+    def test_go_with_human_thread_still_blocks(self, make_ctx: Any, make_work_item: Any) -> None:
+        """GO with human thread still hard-blocks (unregressed).
+
+        Human threads are never filtered by severity.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(by_severity=[(0, 0, 1)])  # 0 blocking, 0 minor, 1 human
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FINISH_FAIL
+        # The underlying function is gh_issue_comment (not post_pr_comment)
+        assert github.mutation_log[0][0] == "gh_issue_comment"
+
+    def test_go_zero_threads_does_not_resolve(self, make_ctx: Any, make_work_item: Any) -> None:
+        """GO with zero threads does not call resolve_automation_threads.
+
+        Optimization: no minor threads → no resolve needed.
+        """
+        stage = PrReviewStage()
+        github = FakeStageGitHub(by_severity=[(0, 0, 0)])  # 0 blocking, 0 minor, 0 human
+        ctx = make_ctx(github=github)
+        ctx.config.enable_follow_up = False
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        # resolve should NOT be in the log
+        assert ("resolve_automation_threads", (1001,)) not in github.mutation_log
+        assert ("mark_pr_implementation_go", (1001,)) in github.mutation_log
+
 
 class TestEvalErrorNoBurn:
     """The #1554 doctrine: ERROR burns no budget, stamps no labels."""
@@ -834,7 +921,14 @@ class TestFullWalks:
         resolved -> mark + arm [durable] -> follow-up -> ADVANCE.
         """
         stage = PrReviewStage()
-        github = FakeStageGitHub(unresolved=[(2, 0), (1, 0), (0, 0), (0, 0)])
+        # POST calls count_unresolved_threads once per round; EVAL calls the
+        # new by_severity method once per round. Two rounds => one entry each
+        # per round. Round 1 has 2 open blocking threads (NOGO address leg);
+        # round 2 is clean (GO: skips difficulty/address, arms).
+        github = FakeStageGitHub(
+            unresolved=[(2, 0), (0, 0)],
+            by_severity=[(2, 0, 0), (0, 0, 0)],
+        )
         ctx = make_ctx(github=github)
         item = make_work_item(issue=21, pr=1001, state="ENTER")
         item.branch = "21-auto-impl"

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -603,3 +603,145 @@ class TestRateBudget:
 
         monkeypatch.setattr(pg, "gh_call", lambda argv: SimpleNamespace(stdout="{}"))
         assert pg.rate_limit_remaining() is None
+
+
+class TestSeverityMarker:
+    """Severity marker embedding and classification for the GO gate (#1856)."""
+
+    def test_with_severity_marker_embeds(self) -> None:
+        """_with_severity_marker embeds severity marker in body."""
+        comment = {
+            "severity": "minor",
+            "body": "Fix this",
+        }
+        result = pg._with_severity_marker(comment)
+        assert result.startswith("<!-- hephaestus-severity: minor -->")
+        assert "Fix this" in result
+
+    def test_with_severity_marker_defaults_absent_to_major(self) -> None:
+        """_with_severity_marker defaults absent severity to major (fail-safe)."""
+        comment = {
+            "body": "Fix this",
+        }
+        result = pg._with_severity_marker(comment)
+        assert result.startswith("<!-- hephaestus-severity: major -->")
+
+    def test_with_severity_marker_is_idempotent(self) -> None:
+        """_with_severity_marker does not double-stamp already-marked bodies."""
+        comment = {
+            "body": "<!-- hephaestus-severity: critical -->\nAlready marked",
+            "severity": "minor",
+        }
+        result = pg._with_severity_marker(comment)
+        # Should return the body unchanged because it already has the marker
+        assert result == comment["body"]
+
+    def test_thread_severity_is_blocking_critical(self) -> None:
+        """_thread_severity_is_blocking returns True for critical severity."""
+        thread = {"body": "<!-- hephaestus-severity: critical -->\nSome issue"}
+        assert pg._thread_severity_is_blocking(thread) is True
+
+    def test_thread_severity_is_blocking_major(self) -> None:
+        """_thread_severity_is_blocking returns True for major severity."""
+        thread = {"body": "<!-- hephaestus-severity: major -->\nSome issue"}
+        assert pg._thread_severity_is_blocking(thread) is True
+
+    def test_thread_severity_is_blocking_minor_false(self) -> None:
+        """_thread_severity_is_blocking returns False for minor severity."""
+        thread = {"body": "<!-- hephaestus-severity: minor -->\nSome issue"}
+        assert pg._thread_severity_is_blocking(thread) is False
+
+    def test_thread_severity_is_blocking_nitpick_false(self) -> None:
+        """_thread_severity_is_blocking returns False for nitpick severity."""
+        thread = {"body": "<!-- hephaestus-severity: nitpick -->\nSome issue"}
+        assert pg._thread_severity_is_blocking(thread) is False
+
+    def test_thread_severity_is_blocking_missing_defaults_true(self) -> None:
+        """_thread_severity_is_blocking returns True (blocking) for missing marker."""
+        thread = {"body": "No marker here\nJust plain text"}
+        assert pg._thread_severity_is_blocking(thread) is True
+
+    def test_thread_severity_anchors_on_marker_line(self) -> None:
+        """_thread_severity_is_blocking anchors on marker line, not substring."""
+        thread = {
+            "body": "Some text mentioning minor\n<!-- hephaestus-severity: critical -->\nMore text"
+        }
+        # Should find 'critical' in marker, not 'minor' in prose
+        assert pg._thread_severity_is_blocking(thread) is True
+
+    def test_count_unresolved_threads_by_severity_classifies(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """count_unresolved_threads_by_severity classifies threads by severity."""
+        automation_thread_critical = {
+            "body": "<!-- hephaestus-severity: critical -->\nIssue",
+            "author": "automation-bot",
+        }
+        automation_thread_minor = {
+            "body": "<!-- hephaestus-severity: minor -->\nNit",
+            "author": "automation-bot",
+        }
+        human_thread = {
+            "body": "Human comment",
+            "author": "reviewer",
+        }
+
+        threads = [automation_thread_critical, automation_thread_minor, human_thread]
+
+        monkeypatch.setattr(adapter, "_unresolved_threads", lambda pr: threads)
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "automation-bot")
+
+        blocking, minor, human = adapter.count_unresolved_threads_by_severity(42)
+
+        assert blocking == 1
+        assert minor == 1
+        assert human == 1
+
+    def test_count_unresolved_threads_by_severity_unmarked_is_blocking(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """count_unresolved_threads_by_severity treats unmarked automation as blocking."""
+        automation_thread_unmarked = {
+            "body": "No marker",
+            "author": "automation-bot",
+        }
+
+        threads = [automation_thread_unmarked]
+
+        monkeypatch.setattr(adapter, "_unresolved_threads", lambda pr: threads)
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "automation-bot")
+
+        blocking, minor, human = adapter.count_unresolved_threads_by_severity(42)
+
+        assert blocking == 1
+        assert minor == 0
+        assert human == 0
+
+    def test_resolve_automation_threads_skips_human(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """resolve_automation_threads skips human-owned threads."""
+        automation_thread = {
+            "id": "auto_thread_id",
+            "author": "automation-bot",
+        }
+        human_thread = {
+            "id": "human_thread_id",
+            "author": "reviewer",
+        }
+
+        threads = [automation_thread, human_thread]
+        resolved_ids = []
+
+        def capture_resolve(thread_id: str, dry_run: bool = False) -> None:
+            resolved_ids.append(thread_id)
+
+        monkeypatch.setattr(adapter, "_unresolved_threads", lambda pr: threads)
+        monkeypatch.setattr(github_api_mod, "gh_current_login", lambda: "automation-bot")
+        monkeypatch.setattr(github_api_mod, "gh_pr_resolve_thread", capture_resolve)
+
+        count = adapter.resolve_automation_threads(42)
+
+        assert count == 1
+        assert "auto_thread_id" in resolved_ids
+        assert "human_thread_id" not in resolved_ids


### PR DESCRIPTION
Makes the pipeline pr_review GO gate severity-aware so a MINOR automation thread the reviewer itself GO'd no longer deadlocks the PR to state:skip (the #1554 minor-thread deadlock, re-introduced in the new stage).

- Add count_unresolved_threads_by_severity -> (blocking_auto, minor_auto, human_unresolved).
- A standing GO now requires only blocking_auto == 0; waved advisory minor threads are resolved before arming so required_review_thread_resolution does not re-block at merge_wait.
- Human-thread gate unchanged.

Found by the epic #1809 strict review. Part of the #1855 hardening sub-epic.

Closes #1856