### PR TITLE
fix(automation): key repo-scoped label cache with a lock guard

### DIFF
--- a/hephaestus/automation/github_api/__init__.py
+++ b/hephaestus/automation/github_api/__init__.py
@@ -23,6 +23,7 @@ from hephaestus.github.rate_limit import (
     gh_rate_limit_reset_epoch as gh_rate_limit_reset_epoch,
 )
 from hephaestus.io.utils import write_secure as write_secure
+from hephaestus.utils.cache import ThreadSafeCache as ThreadSafeCache
 from hephaestus.utils.helpers import strip_null_bytes as strip_null_bytes
 
 from ..git_utils import get_repo_info as get_repo_info, run as run
@@ -40,7 +41,11 @@ io_write_secure = write_secure
 
 # Mutable module state from the former flat module. Submodules read and write
 # through this package object so rebinding remains process-wide.
-_label_cache: set[str] | None = None
+# Repo-slug-keyed, lock-protected label cache (#1858). The former bare
+# `set[str] | None` module global was neither repo-keyed nor locked, so the
+# multithreaded pipeline coordinator let one repo's labels mask another's,
+# dropping durable state:* label writes. Mirrors git_utils._repo_info_cache.
+_label_cache: ThreadSafeCache[str, set[str]] = ThreadSafeCache()
 _issue_state_cache: dict[int, IssueState] = {}
 
 from .checks import (  # noqa: E402

--- a/hephaestus/automation/github_api/labels.py
+++ b/hephaestus/automation/github_api/labels.py
@@ -9,11 +9,28 @@ import hephaestus.automation.github_api as _api
 from ..state_labels import STATE_SKIP, is_skipped
 
 
+def _label_cache_key() -> str:
+    """Repo slug ("owner/name") keying the label cache, or "" if unresolved.
+
+    ``get_repo_info`` is memoized per repo root (git_utils._repo_info_cache),
+    so this is a cached dict lookup after the first call, not a git subprocess.
+    """
+    try:
+        owner, name = _api.get_repo_info()
+    except RuntimeError:
+        return ""
+    return f"{owner}/{name}"
+
+
 def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> set[str]:
     """Return the set of label names that exist in the current repository.
 
+    Cached per repo slug under a lock (ThreadSafeCache) so concurrent per-repo
+    pipeline threads never observe another repo's label set (#1858). Returns a
+    defensive copy; callers must not mutate the cache.
+
     Args:
-        refresh: If True, bypass the in-process cache and re-fetch.
+        refresh: If True, bypass the in-process cache for the current repo and re-fetch.
         raise_on_error: If True, propagate label-list failures instead of
             returning an empty set.
 
@@ -21,14 +38,17 @@ def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> se
         Set of existing label names.
 
     """
-    if _api._label_cache is not None and not refresh:
-        return _api._label_cache
+    key = _label_cache_key()
 
-    try:
+    def _fetch() -> set[str]:
         result = _api._gh_call(["label", "list", "--json", "name", "--limit", "200"])
         data = json.loads(result.stdout)
-        _api._label_cache = {item["name"] for item in data}
-        return _api._label_cache
+        return {item["name"] for item in data}
+
+    if refresh:
+        _api._label_cache.remove(key)
+    try:
+        return set(_api._label_cache.get_or_compute(key, _fetch))
     except Exception as e:
         _api.logger.warning("Could not fetch label list: %s; proceeding without validation", e)
         if raise_on_error:
@@ -49,8 +69,7 @@ def gh_create_label(name: str, color: str = "ededed", description: str = "") -> 
     if description:
         cmd.extend(["--description", description])
     _api._gh_call(cmd)
-    if _api._label_cache is not None:
-        _api._label_cache.add(name)
+    _api._label_cache.add_to_entry(_label_cache_key(), name)
     _api.logger.info("Created missing label '%s'", name)
 
 

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -189,7 +189,9 @@ class PipelineGitHub:
 
     def _label_names(self) -> set[str]:
         if self._repo_slug is None:
-            return github_api.gh_list_labels()
+            # Org-scoped fallback: always re-fetch so a multithreaded
+            # coordinator never trusts another repo's slug-keyed entry (#1858).
+            return github_api.gh_list_labels(refresh=True)
         result = self._gh(["label", "list", "--json", "name", "--limit", "200"])
         data = json.loads(result.stdout or "[]")
         return {str(item["name"]) for item in data if isinstance(item, dict) and item.get("name")}

--- a/hephaestus/utils/cache.py
+++ b/hephaestus/utils/cache.py
@@ -68,9 +68,11 @@ class ThreadSafeCache(Generic[K, V]):
     def add_to_entry(self, key: K, item: Any) -> None:
         """If *key* holds a set entry, add *item* to it under the lock.
 
-        No-op when the key is absent or expired — mirrors the label cache's
-        "only augment an already-populated entry" contract. TTL timestamp is
-        preserved (augmenting does not refresh expiry).
+        No-op when the key is absent — mirrors the label cache's "only
+        augment an already-populated entry" contract. This does not check TTL
+        expiry, so an entry past its TTL is still augmented; the stale
+        augmented entry is replaced on the next ``get_or_compute`` call. TTL
+        timestamp is preserved (augmenting does not refresh expiry).
 
         Intended for use with ``ThreadSafeCache[K, set[V]]`` where adding an
         element to a cached set is atomic (label cache in github_api).

--- a/hephaestus/utils/cache.py
+++ b/hephaestus/utils/cache.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -64,3 +64,24 @@ class ThreadSafeCache(Generic[K, V]):
         """Remove all entries. For test isolation and long-lived processes."""
         with self._lock:
             self._cache.clear()
+
+    def add_to_entry(self, key: K, item: Any) -> None:
+        """If *key* holds a set entry, add *item* to it under the lock.
+
+        No-op when the key is absent or expired — mirrors the label cache's
+        "only augment an already-populated entry" contract. TTL timestamp is
+        preserved (augmenting does not refresh expiry).
+
+        Intended for use with ``ThreadSafeCache[K, set[V]]`` where adding an
+        element to a cached set is atomic (label cache in github_api).
+        """
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry is not None:
+                value, ts = entry
+                self._cache[key] = ({*value, item}, ts)  # type: ignore[assignment,misc]
+
+    def remove(self, key: K) -> None:
+        """Remove *key* from the cache. No-op if the key is absent."""
+        with self._lock:
+            self._cache.pop(key, None)

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1112,7 +1112,7 @@ class TestGhListLabels:
 
     def setup_method(self) -> None:
         """Reset module-level label cache before each test."""
-        _github_api_module._label_cache = None
+        _github_api_module._label_cache.clear()
 
     @patch("hephaestus.automation.github_api._gh_call")
     def test_returns_set_of_label_names(self, mock_gh_call: Any) -> None:
@@ -1161,22 +1161,90 @@ class TestGhListLabels:
         assert "testing" in args
         assert "--force" in args
 
+    @patch("hephaestus.automation.github_api.labels._label_cache_key", return_value="o/r")
     @patch("hephaestus.automation.github_api._gh_call")
-    def test_create_label_updates_cache(self, mock_gh_call: Any) -> None:
-        """gh_create_label adds the new label to the cache if it exists."""
-        _github_api_module._label_cache = {"bug"}
+    def test_create_label_updates_cache(self, mock_gh_call: Any, _key: Any) -> None:
+        """gh_create_label augments the current repo's cache entry."""
+        _github_api_module._label_cache.get_or_compute("o/r", lambda: {"bug"})
         mock_gh_call.return_value = Mock()
 
         gh_create_label("testing")
 
-        assert "testing" in _github_api_module._label_cache
+        assert "testing" in gh_list_labels()
+
+
+class TestGhListLabelsRepoKeyedConcurrency:
+    """#1858: label cache is repo-keyed and lock-guarded."""
+
+    def setup_method(self) -> None:
+        _github_api_module._label_cache.clear()
+
+    @patch("hephaestus.automation.github_api.labels._label_cache_key")
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_distinct_repos_do_not_share_cache(self, mock_gh_call: Any, mock_key: Any) -> None:
+        """Distinct repos must not reuse each other's cached label sets."""
+
+        def _labels_for(_argv: Any, *a: Any, **k: Any) -> Any:
+            payload = {"x/x": [{"name": "state:skip"}], "y/y": [{"name": "bug"}]}[
+                mock_key.return_value
+            ]
+            return Mock(stdout=json.dumps(payload))
+
+        mock_gh_call.side_effect = _labels_for
+        mock_key.return_value = "x/x"
+        assert gh_list_labels() == {"state:skip"}
+        mock_key.return_value = "y/y"
+        assert gh_list_labels() == {"bug"}  # Y must not reuse X's entry
+
+    def test_concurrent_cross_repo_access_is_isolated(self) -> None:
+        """Concurrent threads on different repos never see cross-repo cache interference."""
+        import threading
+
+        results: dict[str, set[str]] = {}
+
+        def mock_key_fn() -> str:
+            """Return the currently-patched repo slug based on thread context."""
+            import threading
+
+            return threading.current_thread().name
+
+        def mock_gh_call(argv: Any) -> Any:
+            """Return label payload based on the calling thread's repo slug."""
+            slug = mock_key_fn()
+            payload = {"t1": [{"name": "state:skip"}], "t2": [{"name": "bug"}]}[slug]
+            return Mock(stdout=json.dumps(payload))
+
+        def _run(slug: str) -> None:
+            t = threading.current_thread()
+            t.name = slug
+            results[slug] = gh_list_labels(refresh=True)
+
+        with patch(
+            "hephaestus.automation.github_api.labels._label_cache_key", side_effect=mock_key_fn
+        ):
+            with patch("hephaestus.automation.github_api._gh_call", side_effect=mock_gh_call):
+                t1 = threading.Thread(target=_run, args=("t1",), name="t1")
+                t2 = threading.Thread(target=_run, args=("t2",), name="t2")
+                t1.start()
+                t2.start()
+                t1.join(timeout=5)
+                t2.join(timeout=5)
+
+        assert "state:skip" in results["t1"] and "bug" in results["t2"]
+
+    @patch("hephaestus.automation.github_api.labels._label_cache_key", return_value="")
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_unresolved_repo_key_is_empty_string(self, mock_gh_call: Any, _key: Any) -> None:
+        """RuntimeError from get_repo_info degrades to the '' key, not a crash."""
+        mock_gh_call.return_value = Mock(stdout=json.dumps([{"name": "bug"}]))
+        assert gh_list_labels() == {"bug"}
 
 
 class TestGhIssueAddLabels:
     """Tests for gh_issue_add_labels (#704)."""
 
     def teardown_method(self) -> None:
-        _github_api_module._label_cache = None
+        _github_api_module._label_cache.clear()
 
     @patch("hephaestus.automation.github_api._gh_call")
     def test_no_labels_is_noop(self, mock_gh_call: Any) -> None:
@@ -1232,7 +1300,7 @@ class TestSkipEpics:
     """Tests for skip_epics — idempotent ``state:skip`` tagging of excluded epics."""
 
     def teardown_method(self) -> None:
-        _github_api_module._label_cache = None
+        _github_api_module._label_cache.clear()
 
     @patch("hephaestus.automation.github_api.gh_issue_add_labels")
     def test_tags_unskipped_epics(self, mock_add: Any) -> None:

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1201,6 +1201,10 @@ class TestGhListLabelsRepoKeyedConcurrency:
         import threading
 
         results: dict[str, set[str]] = {}
+        # Force both threads to be *inside* gh_list_labels simultaneously so the
+        # test actually exercises concurrent cache access (a non-thread-safe
+        # cache could otherwise pass by running the threads sequentially).
+        overlap = threading.Barrier(2, timeout=5)
 
         def mock_key_fn() -> str:
             """Return the currently-patched repo slug based on thread context."""
@@ -1212,6 +1216,7 @@ class TestGhListLabelsRepoKeyedConcurrency:
             """Return label payload based on the calling thread's repo slug."""
             slug = mock_key_fn()
             payload = {"t1": [{"name": "state:skip"}], "t2": [{"name": "bug"}]}[slug]
+            overlap.wait()  # both threads block here until both are mid-fetch
             return Mock(stdout=json.dumps(payload))
 
         def _run(slug: str) -> None:

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -152,3 +152,37 @@ def test_concurrency_distinct_keys_no_lost_writes() -> None:
     # Every key is present afterward with its correct value (no lost writes).
     observed = {i: cache.get_or_compute(i, lambda: -1) for i in range(num_threads)}
     assert observed == {i: i for i in range(num_threads)}
+
+
+def test_add_to_entry_augments_existing_set() -> None:
+    """add_to_entry adds an item to an existing set-typed entry."""
+    c: ThreadSafeCache[str, set[str]] = ThreadSafeCache()
+    c.get_or_compute("k", lambda: {"a"})
+    c.add_to_entry("k", "b")
+    assert c.get_or_compute("k", lambda: set()) == {"a", "b"}
+
+
+def test_add_to_entry_noop_when_key_absent() -> None:
+    """add_to_entry is a no-op when the key is absent or expired."""
+    c: ThreadSafeCache[str, set[str]] = ThreadSafeCache()
+    c.add_to_entry("missing", "b")
+    # No entry created; accessing the key triggers a fresh compute.
+    assert c.get_or_compute("missing", lambda: {"x"}) == {"x"}
+
+
+def test_remove_deletes_entry() -> None:
+    """remove(key) deletes the entry; subsequent access recomputes."""
+    c: ThreadSafeCache[str, int] = ThreadSafeCache()
+    compute = Mock(side_effect=[1, 2])
+
+    assert c.get_or_compute("k", compute) == 1
+    c.remove("k")
+    assert c.get_or_compute("k", compute) == 2
+    assert compute.call_count == 2
+
+
+def test_remove_noop_when_key_absent() -> None:
+    """remove(key) is a no-op when the key is absent."""
+    c: ThreadSafeCache[str, int] = ThreadSafeCache()
+    c.remove("missing")  # should not raise
+    assert c.get_or_compute("missing", lambda: 42) == 42

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -159,7 +159,7 @@ def test_add_to_entry_augments_existing_set() -> None:
     c: ThreadSafeCache[str, set[str]] = ThreadSafeCache()
     c.get_or_compute("k", lambda: {"a"})
     c.add_to_entry("k", "b")
-    assert c.get_or_compute("k", set) == {"a", "b"}
+    assert c.get_or_compute("k", lambda: {"SENTINEL"}) == {"a", "b"}
 
 
 def test_add_to_entry_noop_when_key_absent() -> None:

--- a/tests/unit/utils/test_cache.py
+++ b/tests/unit/utils/test_cache.py
@@ -159,11 +159,11 @@ def test_add_to_entry_augments_existing_set() -> None:
     c: ThreadSafeCache[str, set[str]] = ThreadSafeCache()
     c.get_or_compute("k", lambda: {"a"})
     c.add_to_entry("k", "b")
-    assert c.get_or_compute("k", lambda: set()) == {"a", "b"}
+    assert c.get_or_compute("k", set) == {"a", "b"}
 
 
 def test_add_to_entry_noop_when_key_absent() -> None:
-    """add_to_entry is a no-op when the key is absent or expired."""
+    """add_to_entry is a no-op when the key is absent."""
     c: ThreadSafeCache[str, set[str]] = ThreadSafeCache()
     c.add_to_entry("missing", "b")
     # No entry created; accessing the key triggers a fresh compute.


### PR DESCRIPTION
Fixes the cross-repo label-cache corruption (#1858, a CRITICAL from the epic #1809 strict review).

The module-global `_label_cache` in `github_api.labels` was unkeyed and unguarded, so under the multithreaded pipeline coordinator one repo could mask another repo state:* labels, dropping durable journal writes and breaking the crash-restart invariant.

- Introduce `ThreadSafeCache` (lock-protected, keyed) in `hephaestus/utils/cache.py` (documented in COMPATIBILITY.md).
- Key the label cache by `(org, repo)` and guard all access; org-scoped path fetches fresh per repo.

Part of the #1855 hardening sub-epic.

Closes #1858