### PR TITLE
feat(automation)!: default loop to pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,29 +7,35 @@ for the catalog of skills the agents invoke, see the [`skills/`](skills/) direct
 
 ## Agents the codebase orchestrates
 
-The `hephaestus.automation` subpackage drives a 3-stage issue/PR pipeline
-(plan → implement → drive-green). Each stage runs an external coding agent —
-either **Claude Code** or **Codex** — chosen per invocation via the optional
-`--agent` CLI flag, or auto-detected with a Claude preference when omitted
-(see `hephaestus.agents.runtime.add_agent_argument`). Plan review and
-PR-review/address-review are no longer standalone stages: the planner owns its
-review loop and the implementer absorbs PR-review + thread-addressing in-loop.
+The default `hephaestus-automation-loop` path is the queue-based in-process
+pipeline in `hephaestus.automation.pipeline.coordinator`. The coordinator owns
+eight in-memory stage queues and dispatches agent/build/git jobs to a worker
+pool. Each agent job runs either **Claude Code** or **Codex**, chosen via the
+optional `--agent` CLI flag or auto-detected with a Claude preference when
+omitted (see `hephaestus.agents.runtime.add_agent_argument`).
 
-| Stage | Module | Console script | Purpose |
-|-------|--------|----------------|---------|
-| Plan | `hephaestus.automation.planner` | `hephaestus-plan-issues` | Produce an implementation plan for an open issue |
-| ↳ plan review (in-loop) | `hephaestus.automation.plan_reviewer` (within planner loop) | (internal) | Strict R0/R1/R2 review of the plan |
-| Implement | `hephaestus.automation.implementer` | `hephaestus-implement-issues` | Carry out the plan in an isolated git worktree |
-| ↳ implementation review (in-loop) | `hephaestus.automation._review_utils` (within implementer loop) | (internal) | Strict review of the resulting diff |
-| ↳ PR review (in-loop) | `hephaestus.automation.pr_reviewer` (within implementer loop) | (internal) | Inline review of the open PR, policy-aware |
-| ↳ address review (in-loop) | `hephaestus.automation.address_review` (within implementer loop) | (internal) | Resolve outstanding inline-review threads |
-| Drive green | `hephaestus.automation.ci_driver` | `hephaestus-merge-prs` | Poll CI, fix failing required checks, enable auto-merge once green |
+| Queue stage | Module | Purpose |
+|-------------|--------|---------|
+| repo | `hephaestus.automation.pipeline.stages.repo` | Clone/discover, classify issues/PRs, and seed entry queues |
+| planning | `hephaestus.automation.pipeline.stages.planning` | Advise and produce an implementation plan |
+| plan_review | `hephaestus.automation.pipeline.stages.plan_review` | Strict plan review, amendment, and plan labels |
+| implementation | `hephaestus.automation.pipeline.stages.implementation` | Worktree creation, implementation, tests, commit/push, and PR creation |
+| pr_review | `hephaestus.automation.pipeline.stages.pr_review` | Inline PR review, validation, comment addressing, and implementation labels |
+| ci | `hephaestus.automation.pipeline.stages.ci` | Non-blocking CI classification and CI-fix routing |
+| merge_wait | `hephaestus.automation.pipeline.stages.merge_wait` | Auto-merge arming, merge polling, dirty/blocked handling, and post-merge learn |
+| finished | `hephaestus.automation.pipeline.stages.finished` | Terminal ledger and worktree cleanup/preservation |
 
-`hephaestus.automation.pr_reviewer` is also exposed as the standalone
-`hephaestus-review-prs` console script for manual, out-of-band PR review.
+Legacy/manual console scripts remain available during the #1818 cutover and
+cleanup wave. They are rollback or out-of-band entry points until the scoped
+wrapper cleanup issues rewire/delete them:
 
-A single one-off stage can be invoked manually via
-`hephaestus-agent-stage` (`hephaestus.automation.agent_stage`).
+| Console script | Current module | Purpose |
+|----------------|----------------|---------|
+| `hephaestus-plan-issues` | `hephaestus.automation.planner` | Legacy/manual planning path |
+| `hephaestus-implement-issues` | `hephaestus.automation.implementer` | Legacy/manual implementation path |
+| `hephaestus-merge-prs` | `hephaestus.github.pr_merge` | Legacy/manual merge driving path |
+| `hephaestus-review-prs` | `hephaestus.automation.pr_reviewer` | Manual, out-of-band PR review |
+| `hephaestus-agent-stage` | `hephaestus.automation.agent_stage` | One-off stage invocation |
 
 ## Agent runtime
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ ProjectHephaestus is the shared utilities and tooling repository of the HomericI
 ProjectHephaestus/
 ├── hephaestus/                 # Python source code (20 documented subpackages)
 │   ├── agents/                 # Agent frontmatter + loader + runtime
-│   ├── automation/             # Issue planning / implementation / PR review pipeline
+│   ├── automation/             # Queue-based issue planning / implementation / PR review pipeline
 │   ├── benchmarks/             # Benchmark comparison utilities
 │   ├── ci/                     # CI helpers (precommit, workflows, docker timing)
 │   ├── cli/                    # Command-line interface tools
@@ -87,7 +87,11 @@ import-parsing) fails CI if any omitted module lacks a backing unit-test suite.
 That guard checks a *proxy* (a test file imports the module and defines a test),
 not that every helper is asserted. Reducing the omit list (target: −50% over two
 releases, issue #1422) means promoting a module's orchestration logic to
-mocked-subprocess unit coverage and removing its `omit` entry.
+mocked-subprocess unit coverage and removing its `omit` entry. The
+`hephaestus.automation.pipeline` package follows the same product-layer
+boundary: adding or moving pipeline modules is not a reason to expand the omit
+list; prefer coordinator/stage seams that remain unit-testable without live
+agent or GitHub CLIs.
 
 ## Python Development Guidelines
 

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -384,8 +384,10 @@ pr_review → ci) remain globally bounded.
 
 ## Seeding and reconstruction
 
-One classifier serves both initial seeding (`--repos`, `--issues`, `--prs`
-args) and restart reconstruction (at startup, scan GitHub for labels/PR state).
+One classifier serves both initial seeding (`--repos`, `--issues`) and restart
+reconstruction (at startup, scan GitHub for labels/PR state). PR inputs are
+still reconstructed from GitHub state during the #1818 cutover; a public `--prs`
+seed argument remains deferred.
 Uses ordered label rank at-or-past comparisons (never equality):
 
 - `state:needs-plan` — rank 0 (lowest).

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -1,18 +1,17 @@
 # Automation Loop Architecture
 
-> Status: pre-implementation — this document is the design contract for epic
-> #1809. Sections marked "Finalized in the cutover issue" are completed in
-> issue #1818/#1819.
+Status: as-built for the epic #1809 queue-based automation loop. The
+`hephaestus-automation-loop` CLI defaults to this pipeline; the legacy loop
+remains available only through `--legacy-loop` or `HEPH_PIPELINE=0`.
 
 ## Overview and goals
 
-Replace the subprocess-per-phase issue-major loop with a single-coordinator,
-eight-queue state-machine pipeline. The coordinator (main thread) owns queues
-and performs validation, logging, and GitHub manipulation. A single worker pool
-executes all agent invocations, build/test subprocesses, and git/network
-operations. GitHub labels and PR state are the persistent journal; queues are
-in-memory and reconstructed from labels at startup. An interrupt leaves items
-resumable, never failed.
+The automation loop is a single-coordinator, eight-queue state-machine
+pipeline. The coordinator (main thread) owns queues and performs validation,
+logging, and GitHub manipulation. A single worker pool executes all agent
+invocations, build/test subprocesses, and git/network operations. GitHub labels
+and PR state are the persistent journal; queues are in-memory and reconstructed
+from labels at startup. An interrupt leaves items resumable, never failed.
 
 ## Queue topology
 
@@ -285,12 +284,11 @@ unresolved-thread count decreases).
    `is_implementation_go` (fast-forward if not).
 2. [W:G] **Mechanical rebase** (optional, if base changed): attempt rebase via
    git; on success, push.
-3. [M] **POLL** (non-blocking): call `classify_ci_state(pr)` — a NEW pure
-   function this epic extracts from `ci_run_coordinator.
-   poll_ci_until_concluded`'s conclusion classifier (dropping its sleep
-   loop); it does not exist yet. Returns the new vocabulary PENDING, GREEN,
-   FAILING, or terminal states. If PENDING → RETRY with timer backoff; if
-   GREEN → ADVANCE; if FAILING → step 4.
+3. [M] **POLL** (non-blocking): call
+   `ci_run_coordinator.classify_ci_state(ctx.github.pr_checks(pr))`. This is
+   the pure classifier extracted from the legacy sleep loop. It returns
+   PENDING, GREEN, FAILING, or terminal states. If PENDING → RETRY with timer
+   backoff; if GREEN → ADVANCE; if FAILING → step 4.
 4. [W:A] **CI fix step** (budget ci_fix = 1) — `ci_fix_orchestrator.py:483
    build_ci_fix_prompt`; escalation via `ci_fix_orchestrator.py:147
    force_engagement_prompt`.
@@ -397,8 +395,8 @@ Uses ordered label rank at-or-past comparisons (never equality):
 - `state:implementation-go` — rank 4 (highest).
 
 `state:skip` carries no rank: it is handled by exclusion (a skipped item
-never enters the rank comparison at all), matching its operator-only,
-absolute semantics.
+never enters the rank comparison at all), matching its absolute exclusion
+semantics.
 
 | GitHub state | Entry queue | Notes |
 |---|---|---|
@@ -410,7 +408,7 @@ absolute semantics.
 | No PR, state:plan-no-go | planning | plan rejected; amend with feedback. |
 | state:needs-plan / no label | planning | entry point; no plan yet. |
 
-**Thin CLI scopes** (new; trim the ROUTES table to named stages):
+**Thin CLI scopes** (trim the ROUTES table to named stages):
 
 - `hephaestus-plan-issues` = planning → plan_review.
 - `hephaestus-implement-issues` = implementation → pr_review.
@@ -418,8 +416,76 @@ absolute semantics.
 
 ## Interrupt semantics and exit codes
 
-Finalized in the cutover issue (#1818/#1819).
+`Coordinator.run()` installs SIGINT, SIGTERM, and SIGHUP handlers unless tests
+disable signal installation. The first signal sets the shutdown event and starts
+a graceful drain window (`PipelineConfig.grace_s`, default 30s). During that
+window the coordinator stops admitting new work, drains completed jobs, and
+parks touched items as resumable. A second signal, or an expired grace window,
+tears down the worker pool immediately and synthesizes interrupted results for
+remaining in-flight jobs.
 
-## Concurrency, CLI scopes, dry-run, glossary
+Interrupted items never route through stage success/failure logic. The
+coordinator records them as `resumable at <stage>` and the end-of-run summary
+prints them under `=== Pipeline summary ===`; with `--json`, the JSON envelope
+also carries a `resumable` list. Queued and timer-parked items are finalized the
+same way on shutdown. Resume is therefore label/PR/worktree reconstruction:
+rerun the same scoped command and seeding will classify each issue back into
+the correct entry queue. There is no persisted queue snapshot.
 
-Finalized in the cutover issue (#1818/#1819).
+Exit codes are stable: `130` for interrupted runs, `1` if any item failed,
+skipped, blocked, or the coordinator itself hit a fatal error, and `0` for a
+clean run.
+
+## Concurrency and tuning
+
+The coordinator thread is the only owner of `WorkItem`, `StageQueue`, timers,
+routing, and GitHub mutations. Worker threads receive immutable job requests
+and return `(JobHandle, JobResult)` through the completion queue. Pool size is
+`parallel_repos * max_workers`; `max_workers` also caps in-flight work per
+repo. Implementation admission adds dependency ordering and file-overlap
+serialization unless `--no-serialize-file-overlap` is passed.
+
+The pipeline never sleeps inside stage logic. Backoff uses the coordinator's
+timer heap, and low GitHub rate budget parks agent jobs until the reset instead
+of blocking the loop. Under the pipeline, `--phase-timeout` bounds each agent
+job. Under the legacy loop, the same flag still bounds a phase subprocess.
+
+Dry-run mode logs GitHub mutations and job submissions without executing them;
+`_submit` asserts that no worker job is submitted in dry-run. This makes
+`hephaestus-automation-loop --pipeline --dry-run --loops 1 -v` the operator
+check for seed classification and route reconstruction.
+
+## CLI scopes and rollout controls
+
+`hephaestus-automation-loop` runs the queue pipeline by default. `--pipeline`
+is retained as an explicit affirmative flag for scripts and evidence commands;
+`--legacy-loop` forces the pre-pipeline path for rollback. Environment default:
+`HEPH_PIPELINE=0` disables the pipeline when neither CLI flag is present, and
+the CLI flag always wins over the environment.
+
+The scoped entry points remain thin wrappers around slices of the same
+behavior:
+
+- `hephaestus-plan-issues` owns planning plus in-loop plan review.
+- `hephaestus-implement-issues` owns implementation plus in-loop PR review and
+  thread addressing.
+- `hephaestus-merge-prs` owns CI/merge driving and is represented by the
+  pipeline's `ci` and `merge_wait` stages.
+
+## Glossary
+
+- **Coordinator**: the main-thread event loop that owns queues, routing,
+  timers, GitHub writes, summaries, and signal handling.
+- **Worker pool**: the executor for agent, build/test, and git jobs. Workers
+  never mutate queues directly.
+- **WorkItem**: an in-memory repo, issue, or PR unit moving through a stage.
+- **StageQueue**: FIFO queue for one `StageName`, owned only by the
+  coordinator.
+- **CompletionQueue**: the only cross-thread channel from workers back to the
+  coordinator.
+- **Durable journal**: GitHub labels, comments, PR state, and local worktrees;
+  this is what restart reconstruction reads.
+- **Timer-park**: non-blocking retry/backoff by moving an item to the
+  coordinator timer heap.
+- **Resumable**: interrupted item outcome. It is not a failure verdict and is
+  reconstructed from durable state on the next run.

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -408,11 +408,16 @@ semantics.
 | No PR, state:plan-no-go | planning | plan rejected; amend with feedback. |
 | state:needs-plan / no label | planning | entry point; no plan yet. |
 
-**Thin CLI scopes** (trim the ROUTES table to named stages):
+**Thin pipeline scopes** (within `hephaestus-automation-loop`):
 
-- `hephaestus-plan-issues` = planning → plan_review.
-- `hephaestus-implement-issues` = implementation → pr_review.
-- `ci_driver` = ci → merge_wait.
+- `--repos` seeds one repo item per named repository.
+- `--issues` seeds issue-scoped items through the classifier and routes them to
+  planning, implementation, pr_review, ci, or finished according to durable
+  labels/PR state.
+- `--org` expands to non-fork, non-archived repository seeds.
+
+The standalone console scripts remain legacy/manual compatibility paths at the
+issue #1818 cutover. Cleanup issues #1820-#1822 rewire or delete those wrappers.
 
 ## Interrupt semantics and exit codes
 
@@ -463,14 +468,18 @@ is retained as an explicit affirmative flag for scripts and evidence commands;
 `HEPH_PIPELINE=0` disables the pipeline when neither CLI flag is present, and
 the CLI flag always wins over the environment.
 
-The scoped entry points remain thin wrappers around slices of the same
-behavior:
+The default pipeline's scopes are the `hephaestus-automation-loop` selectors
+listed above. Standalone scripts are still legacy/manual compatibility paths at
+the #1818 cutover:
 
-- `hephaestus-plan-issues` owns planning plus in-loop plan review.
-- `hephaestus-implement-issues` owns implementation plus in-loop PR review and
-  thread addressing.
-- `hephaestus-merge-prs` owns CI/merge driving and is represented by the
-  pipeline's `ci` and `merge_wait` stages.
+- `hephaestus-plan-issues` still invokes the legacy planner entry point.
+- `hephaestus-implement-issues` still invokes the legacy implementer entry
+  point.
+- `hephaestus-merge-prs` still invokes the legacy merge-driving entry point.
+
+The target cleanup wave is to rewire or delete those wrappers so their behavior
+is represented by the pipeline's planning/plan_review, implementation/pr_review,
+and ci/merge_wait slices.
 
 ## Glossary
 

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -404,7 +404,7 @@ semantics.
 |---|---|---|
 | state:skip or epic | excluded | Epic tagging is the one seeding write; done BEFORE excluding. |
 | PR merged | finished | pass, idempotent. |
-| Open PR + state:implementation-go | ci | existing-PR advanced to merge-ready. |
+| Open PR + PR carries state:implementation-go | ci | existing-PR advanced to merge-ready. |
 | Open PR, no impl-go | pr_review | existing-PR path; will be reviewed. |
 | No PR, at-or-past state:plan-go | implementation | plan approved; ready to implement. |
 | No PR, state:plan-no-go | planning | plan rejected; amend with feedback. |

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -415,7 +415,9 @@ semantics.
 - `--repos` seeds one repo item per named repository.
 - `--issues` seeds issue-scoped items through the classifier and routes them to
   planning, implementation, pr_review, ci, or finished according to durable
-  labels/PR state.
+  labels/PR state. When explicit issue or PR scope is present, the resolved
+  repository list is used only as context for those items; repo discovery is not
+  enqueued, so a scoped run cannot reconstruct every open issue in the repo.
 - `--org` expands to non-fork, non-archived repository seeds.
 
 The standalone console scripts remain legacy/manual compatibility paths at the

--- a/docs/runbooks/automation-loop-crash.md
+++ b/docs/runbooks/automation-loop-crash.md
@@ -7,11 +7,15 @@ processing an issue, or a phase times out, and you need to resume safely.
 
 - The loop process exited unexpectedly (force-kill, OOM, terminal closed).
 - The log shows one of these crash markers (emitted from
-  `hephaestus/automation/loop_runner.py`):
-  - `[{repo}] issue #{issue} pipeline crashed: {exc}` — a single issue's
-    pipeline raised.
-  - `[{repo}] runner crashed: {exc}` — the per-repo runner raised.
-  - `[{repo}] phase {phase} TIMEOUT after {N}s` — a stage exceeded its timeout.
+  the default pipeline coordinator):
+  - `Path: pipeline` — confirms the queue-based coordinator path was selected.
+  - `pipeline run failed` — the coordinator hit a fatal top-level exception.
+  - `on_job_done poisoned item ...` or `poisoned item ...` — a single item
+    raised inside stage completion or stepping and was routed to failed.
+  - `RESUMABLE at <stage>` / `resumable at <stage>` in `=== Pipeline summary ===`
+    — the run was interrupted and left the item safe to resume.
+  - `error="timeout"` or phase-specific timeout text — under the pipeline,
+    `--phase-timeout` bounds agent jobs, not whole phase subprocesses.
 - An issue is left in an intermediate `state:*` label (see the
   [runbooks index](index.md) state-label table).
 
@@ -40,28 +44,35 @@ processing an issue, or a phase times out, and you need to resume safely.
 
 ## Recover
 
-The loop is idempotent per issue: it re-discovers open issues with a fresh
-`gh issue list` every loop iteration and re-reads each issue's `state:*` label,
-so re-running resumes from the last-known label state. There is no per-issue
-crash checkpoint — the label *is* the checkpoint.
+The loop is idempotent per issue: the coordinator re-seeds from GitHub labels,
+PR state, and local worktrees on startup, so re-running resumes from the
+last-known durable state. There is no persisted queue snapshot — the label and
+PR/worktree state are the checkpoint.
 
 ```bash
-hephaestus-automation-loop --issues <N> --loops <K> --repos <REPO>
+hephaestus-automation-loop --pipeline --issues <N> --loops <K> --repos <REPO>
+```
+
+`--pipeline` is optional because the pipeline is the default, but keeping it in
+recovery commands makes the selected path visible in logs. If the pipeline
+itself is the suspected cause, use the rollback hatch:
+
+```bash
+hephaestus-automation-loop --legacy-loop --issues <N> --loops <K> --repos <REPO>
 ```
 
 The shared checkout is reset between turns, so any uncommitted in-flight edit
-from the crashed turn is discarded; this is by design — the loop runner owns
-worktree isolation and resets the shared checkout each turn.
+from the crashed turn is discarded; this is by design. Issue work happens in
+`build/.worktrees/issue-<N>`, which is the recoverable worktree state.
 
 ## When `state:skip` applies
 
 `state:skip` is the only label that takes an issue out of the loop entirely. It
-is **operator-applied**, or **auto-applied** when a PR is genuinely stuck after
-the merge budget (`--max-merge-attempts`) is exhausted. A crash alone does
-**not** apply `state:skip`;
-re-running the loop is the correct first response to a crash. Apply
-`state:skip` yourself only when an issue is genuinely stuck after repeated
-attempts (for a stuck-but-green PR, see the
+is operator-applied, applied when the review loop exhausts its budget without a
+GO, or applied to epics before exclusion from the issue queue. A crash alone
+does **not** apply `state:skip`; re-running the loop is the correct first
+response to a crash. Apply `state:skip` yourself only when an issue is genuinely
+stuck after repeated attempts (for a stuck-but-green PR, see the
 [CI-driver stall runbook](ci-driver-stall.md)).
 
 ## See also

--- a/docs/runbooks/ci-driver-stall.md
+++ b/docs/runbooks/ci-driver-stall.md
@@ -1,14 +1,22 @@
 # Runbook: CI-Driver Stall (Green-but-BLOCKED PR)
 
-Use this when the CI driver keeps exiting cleanly each loop but PRs never
-merge — they sit armed for auto-merge with all checks green, yet stay
-un-mergeable. Grounded in `hephaestus/automation/ci_driver.py`.
+Use this when the CI/merge stage keeps running but PRs never merge — they sit
+armed for auto-merge with all checks green, yet stay un-mergeable. The default
+pipeline handles this in `hephaestus/automation/pipeline/stages/merge_wait.py`;
+the legacy standalone drive-green behavior is grounded in
+`hephaestus/automation/ci_driver.py`.
 
 ## Symptom
 
-- The drive-green stage exits `0` every loop, but open PRs pile up
-  un-mergeable.
-- The log shows (from `ci_driver.py`):
+- In the default pipeline, `=== Pipeline summary ===` shows the affected issue
+  cycling through or ending around `merge_wait`, `ci`, or `pr_review`, but the
+  PR remains open and armed.
+- Pipeline logs show one of the `merge_wait` routes:
+  - `merge_wait:N: PR #M still BLOCKED after address budget; regressing`
+  - `merge_wait:N: PR #M genuinely stuck after address budget; skipping`
+  - `merge_wait:N: PR #M still OPEN after ...; timing out`
+- In the legacy path, the drive-green stage exits `0`, open PRs pile up
+  un-mergeable, and the log shows (from `ci_driver.py`):
 
   > Issue #N: PR #M is BLOCKED by branch protection (unresolved conversations
   > or required review) — cannot auto-merge; leaving armed and exiting poll
@@ -19,14 +27,19 @@ un-mergeable. Grounded in `hephaestus/automation/ci_driver.py`.
 
 ## Root cause
 
-The driver treats `mergeStateStatus == "BLOCKED"` as failing-to-merge. The
-common cause is **required-context drift**: an org ruleset requires a check
-context that the repo's CI never emits, so the PR is `BLOCKED` permanently.
-A second cause is an unresolved review thread when the ruleset requires
-`required_review_thread_resolution`. The driver attempts to address
+The merge classifier treats `mergeStateStatus == "BLOCKED"` as a merge gate
+that cannot be satisfied by waiting alone. The common cause is
+**required-context drift**: an org ruleset requires a check context that the
+repo's CI never emits, so the PR is `BLOCKED` permanently. A second cause is an
+unresolved review thread when the ruleset requires
+`required_review_thread_resolution`.
+
+In the default pipeline, `merge_wait` addresses blocked threads while the
+`blocked_address` budget remains. After that budget is exhausted, genuinely
+stuck PRs receive `state:skip`; other blocked PRs regress to `pr_review` via
+`blocked_exhausted`. In the legacy path, `ci_driver.py` attempts to address
 green-but-BLOCKED PRs at most `_BLOCKED_ADDRESS_MAX_ATTEMPTS = 2` times, then
-**leaves the PR armed** and exits the poll early — it does not loop forever, so
-the loop's clean exit hides the stall.
+leaves the PR armed and exits the poll early.
 
 ## Diagnose
 
@@ -58,8 +71,8 @@ gh pr view <N> --json reviewDecision,reviewRequests
    review threads, then the armed auto-merge proceeds on its own.
 
 After the gate is satisfied, the already-armed PR merges without re-running the
-driver; re-run `hephaestus-automation-loop` only if you need to drive other
-issues.
+driver; re-run `hephaestus-automation-loop --pipeline` only if you need to
+drive other issues, continue a regressed item, or refresh the pipeline summary.
 
 ## See also
 

--- a/docs/runbooks/index.md
+++ b/docs/runbooks/index.md
@@ -35,4 +35,4 @@ copy — the module is the source of truth.
 | `state:plan-no-go` | Plan reviewed and rejected; needs re-planning. |
 | `state:implementation-go` | Implementation reviewed and approved; PR may arm auto-merge. |
 | `state:implementation-no-go` | Implementation reviewed and rejected; needs re-work. |
-| `state:skip` | Work item taken out of the loop entirely — operator-applied, or auto-applied when the review loop exhausts its budget without a GO. Independent of all other state labels. |
+| `state:skip` | Work item taken out of the loop entirely — operator-applied, auto-applied when the review loop exhausts its budget without a GO, or applied to epics before exclusion. Independent of all other state labels. |

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -1,11 +1,16 @@
-"""Multi-repo, ISSUE-MAJOR automation loop driver.
+"""Multi-repo automation loop CLI.
 
-Replaces ``scripts/run_automation_loop.sh``. Iterates over all
-non-archived HomericIntelligence repos. Within each repo, work is
-ISSUE-MAJOR (#1560): each open issue is carried through the FULL selected
-phase sequence (``plan`` → ``implement`` → ``drive-green``) end to end by a
-single worker before that worker takes the next issue. Up to
-``--max-workers`` issues are in flight at once.
+By default, :func:`main` dispatches to the queue-based in-process pipeline in
+``hephaestus.automation.pipeline.coordinator``. The legacy issue-major
+subprocess loop remains in this module as the rollback path selected by
+``--legacy-loop`` or ``HEPH_PIPELINE=0`` until the cleanup wave removes it.
+
+The legacy path replaced ``scripts/run_automation_loop.sh``. It iterates over
+all non-archived HomericIntelligence repos. Within each repo, work is
+ISSUE-MAJOR (#1560): each open issue is carried through the FULL selected phase
+sequence (``plan`` → ``implement`` → ``drive-green``) end to end by a single
+worker before that worker takes the next issue. Up to ``--max-workers`` issues
+are in flight at once.
 
 ``drive-green`` is the BLOCKING per-worker phase: scoped to one issue's PR it
 waits for the PR to MERGE (driving CI green, bounded by
@@ -27,8 +32,8 @@ call inside a Python ``for`` loop. Phase N failing returns a
 shell-option landmine (``set -e`` / ``set -m`` / subshell exec-optimization)
 can silently skip the rest of the pipeline.
 
-CLI is flag-compatible with the previous bash script so operator muscle
-memory and any pinned callers keep working.
+The CLI remains flag-compatible with the previous bash script so operator
+muscle memory and any pinned callers keep working.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -124,6 +124,11 @@ def _default_phase_timeout_s() -> float:
         return float(default)
 
 
+def _pipeline_default() -> bool:
+    """Return whether the queue-based pipeline is enabled by default."""
+    return os.environ.get("HEPH_PIPELINE", "").strip() != "0"
+
+
 # The two non-blocking iteration phases. Plan-review, PR-review, and
 # address-review fold into plan/implement (#455/#468/#484).
 ALL_PHASES: tuple[str, ...] = (
@@ -482,11 +487,22 @@ def _build_parser() -> argparse.ArgumentParser:
         verbose_help="Enable DEBUG logging",
     )
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
-    p.add_argument(
+    pipeline_group = p.add_mutually_exclusive_group()
+    pipeline_group.add_argument(
         "--pipeline",
+        dest="pipeline",
         action="store_true",
-        help="Use the queue-based pipeline loop (default: off). "
-        "Env HEPH_PIPELINE=1 also enables it; the CLI flag wins.",
+        default=argparse.SUPPRESS,
+        help="Use the queue-based pipeline loop (default: on). "
+        "Env HEPH_PIPELINE=0 disables it; the CLI flag wins.",
+    )
+    pipeline_group.add_argument(
+        "--legacy-loop",
+        dest="pipeline",
+        action="store_false",
+        default=argparse.SUPPRESS,
+        help="Use the pre-pipeline legacy loop path. "
+        "Overrides HEPH_PIPELINE and is intended as a rollback hatch.",
     )
     p.add_argument(
         "--max-merge-attempts",
@@ -626,7 +642,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments for the loop runner."""
-    return _build_parser().parse_args(argv)
+    args = _build_parser().parse_args(argv)
+    if not hasattr(args, "pipeline"):
+        args.pipeline = _pipeline_default()
+    return args
 
 
 def _validate_phases(phases_csv: str) -> tuple[str, ...]:
@@ -1734,11 +1753,11 @@ def _dispatch_pipeline(
 ) -> int | None:
     """Run the queue-based pipeline when enabled; return None when it is off.
 
-    Enabled by ``--pipeline`` or ``HEPH_PIPELINE=1`` (the CLI flag wins;
-    default OFF — the legacy path stays byte-identical when off). The repo
-    token preflight still happens before dispatch, while the repo stage owns
-    cloning, so this branch skips ``_clone_missing_repos`` (no double-clone).
-    Under the pipeline, ``--phase-timeout`` bounds each agent job.
+    Enabled by default unless ``HEPH_PIPELINE=0`` or ``--legacy-loop`` disables
+    it. The repo token preflight still happens before dispatch, while the repo
+    stage owns cloning, so this branch skips ``_clone_missing_repos`` (no
+    double-clone). Under the pipeline, ``--phase-timeout`` bounds each agent
+    job.
 
     Args:
         args: Parsed argparse Namespace.
@@ -1750,7 +1769,7 @@ def _dispatch_pipeline(
         The pipeline's exit code, or ``None`` when the pipeline is disabled.
 
     """
-    if not (args.pipeline or os.environ.get("HEPH_PIPELINE") == "1"):
+    if not args.pipeline:
         return None
     if not cfg.dry_run:
         _preflight_token_scopes(cfg.org, repos[0])
@@ -1817,8 +1836,11 @@ def main(argv: list[str] | None = None) -> int:
     if not repos:
         return _error_exit(args, "Repo list is empty; nothing to do.", "empty repo list")
 
-    # Dispatch to the pipeline if --pipeline is set or HEPH_PIPELINE=1
-    # (after token preflight, before legacy clone; the repo stage owns clone).
+    LOG.info("Path: %s", "pipeline" if args.pipeline else "legacy-loop")
+
+    # Dispatch to the pipeline unless --legacy-loop or HEPH_PIPELINE=0 selected
+    # the rollback path (after token preflight, before legacy clone; the repo
+    # stage owns clone).
     pipeline_rc = _dispatch_pipeline(args, cfg, org, repos)
     if pipeline_rc is not None:
         return pipeline_rc

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -917,6 +917,7 @@ class Coordinator:
                 repo=default_repo,
                 kind=ItemKind.ISSUE,
                 issue=int(entry.identifier),
+                pr=entry.pr_number,
                 stage=entry.stage,
             )
         item.state = "ENTER"

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -871,7 +871,8 @@ class Coordinator:
 
         """
         self._pass_work_count = 0
-        entries = _seeding.seed_from_cli(self.config.repos, self.config.issues, self.config.prs)
+        discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
+        entries = _seeding.seed_from_cli(discovery_repos, self.config.issues, self.config.prs)
         pushed = 0
         for entry in entries:
             if entry.stage is None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1000,8 +1000,8 @@ class Coordinator:
 def run_pipeline(config: PipelineConfig) -> int:
     """Run the queue-based pipeline to completion.
 
-    Public entry point called from ``loop_runner.main()`` when ``--pipeline``
-    (or ``HEPH_PIPELINE=1``) is enabled.
+    Public entry point called from ``loop_runner.main()`` on the default
+    pipeline path (or when ``--pipeline`` is passed explicitly).
 
     Args:
         config: Pipeline configuration.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -112,6 +112,7 @@ from hephaestus.automation.pipeline.stages import (
 from hephaestus.automation.pipeline.stages.repo import product_to_work_item
 from hephaestus.automation.pipeline.summary import RunStats, print_summary
 from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO
 
 logger = logging.getLogger(__name__)
 
@@ -313,17 +314,17 @@ class Coordinator:
             StageName.FINISHED: FinishedStage(self.ledger, self.preserved),
         }
 
-    def _ctx_for(self, item: WorkItem) -> StageContext:
-        """Return the (cached, per-repo) StageContext for *item*."""
-        ctx = self._ctx_cache.get(item.repo)
+    def _ctx_for_repo(self, repo: str) -> StageContext:
+        """Return the (cached, per-repo) StageContext for *repo*."""
+        ctx = self._ctx_cache.get(repo)
         if ctx is None:
-            root = Path(self.config.projects_dir) / item.repo
+            root = Path(self.config.projects_dir) / repo
             ctx = StageContext(
                 config=self._stage_config,
                 org=self.config.org,
                 dry_run=self.config.dry_run,
                 github=(
-                    self._github_factory(item.repo, root)
+                    self._github_factory(repo, root)
                     if self._github_factory is not None
                     else self.github
                 ),
@@ -334,8 +335,12 @@ class Coordinator:
                 ),
                 budget_fn=_budget_lookup,
             )
-            self._ctx_cache[item.repo] = ctx
+            self._ctx_cache[repo] = ctx
         return ctx
+
+    def _ctx_for(self, item: WorkItem) -> StageContext:
+        """Return the (cached, per-repo) StageContext for *item*."""
+        return self._ctx_for_repo(item.repo)
 
     # -- run loop ---------------------------------------------------------------
 
@@ -872,7 +877,10 @@ class Coordinator:
         """
         self._pass_work_count = 0
         discovery_repos = [] if self.config.issues or self.config.prs else self.config.repos
-        entries = _seeding.seed_from_cli(discovery_repos, self.config.issues, self.config.prs)
+        entries = _seeding.seed_from_cli(discovery_repos, [], [])
+        default_repo = self.config.repos[0] if self.config.repos else ""
+        if self.config.issues or self.config.prs:
+            entries.extend(self._seed_direct_scope(default_repo))
         pushed = 0
         for entry in entries:
             if entry.stage is None:
@@ -893,6 +901,44 @@ class Coordinator:
             self._push_item(item, item.stage, enter=True)
             pushed += 1
         return pushed
+
+    def _seed_direct_scope(self, repo: str) -> list[_seeding.SeedEntry]:
+        """Seed explicit ``--issues`` / ``--prs`` through the target repo accessor."""
+        github = self._ctx_for_repo(repo).github if repo else self.github
+        entries: list[_seeding.SeedEntry] = []
+        for issue in self.config.issues:
+            facts = _seeding.seed_issue_from_github(issue, github)
+            stage, reason = _seeding.classify_issue(facts)
+            entries.append(
+                _seeding.SeedEntry(
+                    kind="issue",
+                    identifier=issue,
+                    stage=stage,
+                    reason=reason,
+                    pr_number=facts.pr_number if facts.pr_is_open else None,
+                )
+            )
+        for pr in self.config.prs:
+            has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
+            if has_go:
+                entries.append(
+                    _seeding.SeedEntry(
+                        kind="pr",
+                        identifier=pr,
+                        stage=StageName.CI,
+                        reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                    )
+                )
+            else:
+                entries.append(
+                    _seeding.SeedEntry(
+                        kind="pr",
+                        identifier=pr,
+                        stage=StageName.PR_REVIEW,
+                        reason=(f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review"),
+                    )
+                )
+        return entries
 
     @staticmethod
     def _entry_to_item(entry: _seeding.SeedEntry, default_repo: str) -> WorkItem:

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -47,6 +47,7 @@ from hephaestus.automation.state_labels import (
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
     STATE_SKIP,
+    has_label,
     is_epic,
     is_implementation_go,
 )
@@ -88,6 +89,10 @@ class IssueFacts:
             merged), None otherwise.
         pr_is_open: True iff PR exists and is open.
         pr_is_merged: True iff PR exists and is merged.
+        pr_has_implementation_go: True iff the open PR carries
+            ``state:implementation-go``.
+        pr_has_implementation_no_go: True iff the open PR carries
+            ``state:implementation-no-go``.
 
     Invariants (established by :func:`seed_issue`'s tri-state fetch):
         - Exactly one of {no live PR, open PR, merged PR} holds:
@@ -106,6 +111,8 @@ class IssueFacts:
     pr_number: int | None
     pr_is_open: bool
     pr_is_merged: bool
+    pr_has_implementation_go: bool = False
+    pr_has_implementation_no_go: bool = False
 
 
 @dataclass(frozen=True)
@@ -117,6 +124,9 @@ class SeedEntry:
         identifier: Repo name, issue number, or PR number.
         stage: Entry stage, or ``None`` when the item is excluded.
         reason: Human-readable classification reason (logged by the caller).
+        pr_number: Open PR number for directly-seeded issue entries, when one
+            exists. Repo discovery carries this in products; direct ``--issues``
+            seeding needs the same value so downstream PR stages have context.
 
     """
 
@@ -124,6 +134,7 @@ class SeedEntry:
     identifier: int | str
     stage: StageName | None
     reason: str
+    pr_number: int | None = None
 
 
 def _get_state_label(labels: set[str]) -> str | None:
@@ -217,7 +228,13 @@ def classify_issue(facts: IssueFacts) -> Classification:
 
     # Routing logic: open PR path
     if facts.pr_is_open:
-        # Open PR + implementation-go → ready for CI
+        # Open PR + PR-level implementation-go → ready for CI. The
+        # issue-label fallback preserves compatibility with pre-PR-label
+        # snapshots while PR-level no-go remains authoritative.
+        if facts.pr_has_implementation_go:
+            return StageName.CI, f"#{facts.number} open PR with {STATE_IMPLEMENTATION_GO}"
+        if facts.pr_has_implementation_no_go:
+            return StageName.PR_REVIEW, f"#{facts.number} open PR awaiting review"
         if _label_at_or_past(state_label, STATE_IMPLEMENTATION_GO):
             return StageName.CI, f"#{facts.number} open PR with {STATE_IMPLEMENTATION_GO}"
         # Open PR, no implementation-go → awaiting PR review
@@ -271,9 +288,14 @@ def seed_issue(issue_number: int) -> IssueFacts:
     # neither lookup (normalized to "no live PR"). No try/except: fail-closed.
     pr_is_open = False
     pr_is_merged = False
+    pr_has_implementation_go = False
+    pr_has_implementation_no_go = False
     pr_number: int | None = find_pr_for_issue(issue_number)
     if pr_number is not None:
         pr_is_open = True
+        pr_labels = gh_pr_label_names(pr_number)
+        pr_has_implementation_go = is_implementation_go(pr_labels)
+        pr_has_implementation_no_go = has_label(pr_labels, STATE_IMPLEMENTATION_NO_GO)
     else:
         pr_number = find_merged_pr_for_issue(issue_number)
         if pr_number is not None:
@@ -287,6 +309,8 @@ def seed_issue(issue_number: int) -> IssueFacts:
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
+        pr_has_implementation_go=pr_has_implementation_go,
+        pr_has_implementation_no_go=pr_has_implementation_no_go,
     )
 
 
@@ -304,9 +328,14 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
 
     pr_is_open = False
     pr_is_merged = False
+    pr_has_implementation_go = False
+    pr_has_implementation_no_go = False
     pr_number: int | None = github.find_pr_for_issue(issue_number)
     if pr_number is not None:
         pr_is_open = True
+        pr_has_implementation_go, pr_has_implementation_no_go = (
+            github.pr_has_implementation_state_label(pr_number)
+        )
     else:
         pr_number = github.find_merged_pr_for_issue(issue_number)
         if pr_number is not None:
@@ -320,6 +349,8 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
+        pr_has_implementation_go=pr_has_implementation_go,
+        pr_has_implementation_no_go=pr_has_implementation_no_go,
     )
 
 
@@ -356,8 +387,17 @@ def seed_from_cli(
         for repo in repos
     ]
     for issue in issues:
-        stage, reason = classify_issue(seed_issue(issue))
-        entries.append(SeedEntry(kind="issue", identifier=issue, stage=stage, reason=reason))
+        facts = seed_issue(issue)
+        stage, reason = classify_issue(facts)
+        entries.append(
+            SeedEntry(
+                kind="issue",
+                identifier=issue,
+                stage=stage,
+                reason=reason,
+                pr_number=facts.pr_number if facts.pr_is_open else None,
+            )
+        )
     for pr in prs:
         labels = gh_pr_label_names(pr)
         if is_implementation_go(labels):

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -67,8 +67,10 @@ class WorkerPool:
     """Thread pool executor for submitting and tracking frozen jobs.
 
     Jobs are executed via :meth:`submit`; a future callback drains results to
-    the completion queue. Workers never look up PR numbers, build prompts, or
-    call the GitHub API — those are coordinator responsibilities.
+    the completion queue. Workers never mutate ``WorkItem`` objects or stage
+    queues. Agent jobs do build prompts in the worker; prompt builders may do
+    read-only GitHub fetches, while durable GitHub mutations remain coordinator
+    responsibilities.
 
     Completion contract: every non-cancelled :meth:`submit` produces EXACTLY
     ONE ``(handle, result)`` tuple on the completion queue — normal job

--- a/tests/unit/automation/conftest.py
+++ b/tests/unit/automation/conftest.py
@@ -22,16 +22,21 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.github import client as github_client
 from hephaestus.resilience.circuit_breaker import reset_all_circuit_breakers
 
 
 @pytest.fixture(autouse=True)
-def _reset_circuit_breakers_for_automation_tests() -> None:
+def _reset_circuit_breakers_for_automation_tests() -> Generator[None, None, None]:
     """Reset all circuit breakers before each automation test.
 
     Prevents cross-test contamination when a prior test trips a breaker via
     rate-limit retries.
     """
+    github_client._GH_BREAKER.reset()
+    reset_all_circuit_breakers()
+    yield
+    github_client._GH_BREAKER.reset()
     reset_all_circuit_breakers()
 
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -106,6 +106,47 @@ def _issue_item(
 class TestQuiescence:
     """Full-run tests driving seeded items to the finished ledger."""
 
+    def test_explicit_issue_scope_suppresses_repo_discovery_seed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--issues N scopes the run to N instead of reconstructing the whole repo."""
+        captured: dict[str, list[Any]] = {}
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            issues=[1850],
+            loops=1,
+            projects_dir=tmp_path,
+        )
+
+        def fake_seed(
+            repos_arg: list[str], issues_arg: list[int], prs_arg: list[int]
+        ) -> list[SeedEntry]:
+            captured["repos"] = list(repos_arg)
+            captured["issues"] = list(issues_arg)
+            captured["prs"] = list(prs_arg)
+            return [
+                SeedEntry(
+                    kind="issue",
+                    identifier=1850,
+                    stage=StageName.FINISHED,
+                    reason="already done",
+                )
+            ]
+
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", fake_seed)
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+
+        assert coordinator.run() == 0
+        assert captured == {"repos": [], "issues": [1850], "prs": []}
+        assert [item.issue for item in coordinator.items] == [1850]
+        assert all(item.kind is not ItemKind.REPO for item in coordinator.items)
+
     def test_repo_products_flow_to_finished(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -10,6 +10,7 @@ asserts-no-submit, poisoned-item isolation, and FAIL_BACK routing.
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -75,6 +76,7 @@ def make_coordinator(
     max_workers: int = 1,
     dry_run: bool = False,
     github: FakeStageGitHub | None = None,
+    rate_budget_ok: Callable[[], tuple[bool, float]] | None = None,
 ) -> tuple[Coordinator, FakeWorkerPool, FakeStageGitHub]:
     """Build a Coordinator wired to fakes, with seeding scripted per pass."""
     config = PipelineConfig(
@@ -94,6 +96,7 @@ def make_coordinator(
 
     monkeypatch.setattr(seeding_mod, "seed_from_cli", fake_seed)
     coordinator = Coordinator(config, github=gh, pool=pool, install_signals=False)
+    coordinator._rate_budget_ok = rate_budget_ok or (lambda: (True, 0.0))  # type: ignore[method-assign]
     return coordinator, pool, gh
 
 
@@ -362,11 +365,11 @@ class TestRateBudget:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Low GraphQL budget: the AgentJob is timer-parked, never submitted."""
-        monkeypatch.setattr(
-            "hephaestus.automation.pipeline_github.rate_budget_ok",
-            lambda now_epoch=None: (False, 60.0),
+        coordinator, pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            rate_budget_ok=lambda: (False, 60.0),
         )
-        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch)
         coordinator.stages[StageName.PLANNING] = StubStage(
             JobRequest(_agent_job(), on_done_state="VERIFY")
         )

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -113,7 +113,6 @@ class TestQuiescence:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """--issues N scopes the run to N instead of reconstructing the whole repo."""
-        captured: dict[str, list[Any]] = {}
         config = PipelineConfig(
             org="org",
             repos=["repo-a"],
@@ -121,32 +120,25 @@ class TestQuiescence:
             loops=1,
             projects_dir=tmp_path,
         )
+        gh = FakeStageGitHub(merged_pr=1851)
 
         def fake_seed(
             repos_arg: list[str], issues_arg: list[int], prs_arg: list[int]
         ) -> list[SeedEntry]:
-            captured["repos"] = list(repos_arg)
-            captured["issues"] = list(issues_arg)
-            captured["prs"] = list(prs_arg)
-            return [
-                SeedEntry(
-                    kind="issue",
-                    identifier=1850,
-                    stage=StageName.FINISHED,
-                    reason="already done",
-                )
-            ]
+            assert repos_arg == []
+            assert issues_arg == []
+            assert prs_arg == []
+            return []
 
         monkeypatch.setattr(seeding_mod, "seed_from_cli", fake_seed)
         coordinator = Coordinator(
             config,
-            github=FakeStageGitHub(),
+            github=gh,
             pool=FakeWorkerPool(),
             install_signals=False,
         )
 
         assert coordinator.run() == 0
-        assert captured == {"repos": [], "issues": [1850], "prs": []}
         assert [item.issue for item in coordinator.items] == [1850]
         assert all(item.kind is not ItemKind.REPO for item in coordinator.items)
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -25,6 +25,7 @@ import hephaestus.automation.pipeline.routing as routing_mod
 import hephaestus.automation.pipeline.seeding as seeding_mod
 import hephaestus.automation.pipeline.stages.base as stage_base_mod
 import hephaestus.automation.pipeline.work_item as work_item_mod
+from hephaestus.automation.state_labels import STATE_PLAN_GO
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -401,6 +402,50 @@ class TestSeedingEdges:
         coordinator._seed_pass()
 
         item = coordinator.queues[StageName.PR_REVIEW].snapshot()[0]
+        assert item.kind is ItemKind.ISSUE
+        assert item.issue == 1818
+        assert item.pr == 1854
+
+    def test_direct_issue_scope_uses_repo_scoped_github_accessor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct --issues seeding must read the target repo, not ambient cwd state."""
+        monkeypatch.setattr(
+            seeding_mod,
+            "seed_issue",
+            MagicMock(side_effect=AssertionError("ambient issue seeding called")),
+        )
+        target_github = FakeStageGitHub(
+            labels=[STATE_PLAN_GO],
+            open_pr=1854,
+            pr_impl_state=(True, False),
+        )
+        created: list[tuple[str, Path]] = []
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            created.append((repo, repo_root))
+            return target_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            issues=[1818],
+            projects_dir=tmp_path,
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+
+        coordinator._seed_pass()
+
+        assert created == [("target-repo", tmp_path / "target-repo")]
+        item = coordinator.queues[StageName.CI].snapshot()[0]
+        assert item.repo == "target-repo"
         assert item.kind is ItemKind.ISSUE
         assert item.issue == 1818
         assert item.pr == 1854

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -383,6 +383,28 @@ class TestSeedingEdges:
         item = coordinator.queues[StageName.CI].snapshot()[0]
         assert item.kind is ItemKind.PR and item.pr == 88 and item.repo == "repo-a"
 
+    def test_issue_entry_with_pr_preserves_pr_number(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct --issues entries with open PRs must enter PR stages with item.pr set."""
+        seed = [
+            SeedEntry(
+                kind="issue",
+                identifier=1818,
+                stage=StageName.PR_REVIEW,
+                reason="open PR awaiting review",
+                pr_number=1854,
+            )
+        ]
+        coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)
+
+        coordinator._seed_pass()
+
+        item = coordinator.queues[StageName.PR_REVIEW].snapshot()[0]
+        assert item.kind is ItemKind.ISSUE
+        assert item.issue == 1818
+        assert item.pr == 1854
+
     def test_repo_product_finished_entry_gets_pass_result(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -73,9 +73,11 @@ def _coordinator(
 ) -> Coordinator:
     config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path, **config_overrides)
     monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: list(seed or []))
-    return Coordinator(
+    coordinator = Coordinator(
         config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
     )
+    coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+    return coordinator
 
 
 def _item(issue: int = 1, stage: StageName = StageName.PLANNING) -> WorkItem:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -450,6 +450,45 @@ class TestSeedingEdges:
         assert item.issue == 1818
         assert item.pr == 1854
 
+    def test_direct_pr_scope_uses_repo_scoped_github_accessor(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct --prs seeding must read PR labels through the target repo accessor."""
+        monkeypatch.setattr(
+            seeding_mod,
+            "gh_pr_label_names",
+            MagicMock(side_effect=AssertionError("ambient PR label seeding called")),
+        )
+        target_github = FakeStageGitHub(pr_impl_state=(True, False))
+        created: list[tuple[str, Path]] = []
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            created.append((repo, repo_root))
+            return target_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            prs=[1854],
+            projects_dir=tmp_path,
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+
+        coordinator._seed_pass()
+
+        assert created == [("target-repo", tmp_path / "target-repo")]
+        item = coordinator.queues[StageName.CI].snapshot()[0]
+        assert item.repo == "target-repo"
+        assert item.kind is ItemKind.PR
+        assert item.pr == 1854
+
     def test_repo_product_finished_entry_gets_pass_result(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -95,9 +95,11 @@ def _coordinator(
         org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path, grace_s=grace_s
     )
     monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: list(seed or []))
-    return Coordinator(
+    coordinator = Coordinator(
         config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
     )
+    coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+    return coordinator
 
 
 class TestInterruptSemantics:

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -1,6 +1,7 @@
-"""--pipeline / HEPH_PIPELINE dispatch tests for loop_runner.main (#1817).
+"""Pipeline-default dispatch tests for loop_runner.main (#1818).
 
-The pipeline is DEFAULT OFF; the legacy path stays byte-identical when off.
+The pipeline is DEFAULT ON; ``--legacy-loop`` and ``HEPH_PIPELINE=0`` are
+the rollback hatches.
 The pipeline branch dispatches after token preflight but BEFORE
 ``_clone_missing_repos`` (C3: the repo stage owns cloning — no double-clone).
 """
@@ -37,26 +38,28 @@ def dispatch(monkeypatch: pytest.MonkeyPatch) -> dict[str, MagicMock]:
 
 
 @pytest.mark.parametrize(
-    ("argv_flag", "env", "expect_pipeline"),
+    ("argv", "env", "expect_pipeline"),
     [
-        (False, None, False),  # default OFF -> legacy untouched
-        (False, "0", False),
-        (False, "1", True),  # env enables
-        (True, None, True),  # CLI enables
-        (True, "0", True),  # CLI wins over env
+        ([], None, True),  # default ON
+        ([], "0", False),  # env rollback
+        ([], "1", True),
+        (["--pipeline"], "0", True),  # CLI wins over env
+        (["--pipe"], "0", True),  # argparse abbreviation still counts as CLI
+        (["--legacy-loop"], None, False),
+        (["--legacy-loop"], "1", False),  # CLI rollback wins over env
+        (["--leg"], "1", False),  # argparse abbreviation still counts as CLI
     ],
 )
 def test_flag_env_matrix(
     dispatch: dict[str, MagicMock],
     monkeypatch: pytest.MonkeyPatch,
-    argv_flag: bool,
+    argv: list[str],
     env: str | None,
     expect_pipeline: bool,
 ) -> None:
-    """--pipeline x HEPH_PIPELINE precedence matrix (CLI flag wins)."""
+    """--pipeline/--legacy-loop x HEPH_PIPELINE precedence matrix."""
     if env is not None:
         monkeypatch.setenv("HEPH_PIPELINE", env)
-    argv = ["--pipeline"] if argv_flag else []
 
     exit_code = loop_runner.main(argv)
 
@@ -67,7 +70,7 @@ def test_flag_env_matrix(
 
 def test_pipeline_path_preflights_but_skips_clone(dispatch: dict[str, MagicMock]) -> None:
     """C3: pipeline keeps token preflight, while the repo stage owns cloning."""
-    loop_runner.main(["--pipeline"])
+    loop_runner.main([])
 
     dispatch["run_pipeline"].assert_called_once()
     dispatch["preflight"].assert_called_once_with("org", "repo-a")
@@ -75,8 +78,8 @@ def test_pipeline_path_preflights_but_skips_clone(dispatch: dict[str, MagicMock]
 
 
 def test_legacy_path_still_preflights_and_clones(dispatch: dict[str, MagicMock]) -> None:
-    """Flag off: the legacy pre-loop sequence is untouched."""
-    loop_runner.main([])
+    """Rollback hatch: the legacy pre-loop sequence is untouched."""
+    loop_runner.main(["--legacy-loop"])
 
     dispatch["preflight"].assert_called_once()
     dispatch["clone"].assert_called_once()
@@ -84,18 +87,42 @@ def test_legacy_path_still_preflights_and_clones(dispatch: dict[str, MagicMock])
     dispatch["run_pipeline"].assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("argv", "env", "expected"),
+    [
+        ([], None, "Path: pipeline"),
+        ([], "0", "Path: legacy-loop"),
+        (["--legacy-loop"], None, "Path: legacy-loop"),
+    ],
+)
+def test_main_logs_selected_path(
+    dispatch: dict[str, MagicMock],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    argv: list[str],
+    env: str | None,
+    expected: str,
+) -> None:
+    """Startup logs identify which loop implementation is active."""
+    if env is not None:
+        monkeypatch.setenv("HEPH_PIPELINE", env)
+    with caplog.at_level("INFO", logger="hephaestus.automation.loop_runner"):
+        loop_runner.main(argv)
+
+    assert any(expected in rec.message for rec in caplog.records)
+
+
 def test_pipeline_exit_code_propagates(dispatch: dict[str, MagicMock]) -> None:
     """run_pipeline's exit code IS main's exit code."""
     dispatch["run_pipeline"].return_value = 130
 
-    assert loop_runner.main(["--pipeline"]) == 130
+    assert loop_runner.main([]) == 130
 
 
 def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -> None:
     """_build_pipeline_config carries the CLI scope into PipelineConfig."""
     loop_runner.main(
         [
-            "--pipeline",
             "--loops",
             "3",
             "--max-workers",
@@ -131,7 +158,6 @@ def test_build_pipeline_config_maps_agent_and_models(
 
     loop_runner.main(
         [
-            "--pipeline",
             "--agent",
             "codex",
             "--model",

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -68,6 +68,14 @@ def test_flag_env_matrix(
     assert dispatch["run_loop"].called is not expect_pipeline
 
 
+def test_pipeline_and_legacy_flags_conflict() -> None:
+    """--pipeline and --legacy-loop are rollback selectors, not stackable modes."""
+    with pytest.raises(SystemExit) as excinfo:
+        loop_runner._parse_args(["--pipeline", "--legacy-loop"])
+
+    assert excinfo.value.code == 2
+
+
 def test_pipeline_path_preflights_but_skips_clone(dispatch: dict[str, MagicMock]) -> None:
     """C3: pipeline keeps token preflight, while the repo stage owns cloning."""
     loop_runner.main([])

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -43,6 +43,8 @@ def _facts(
     pr_number: int | None = None,
     pr_is_open: bool = False,
     pr_is_merged: bool = False,
+    pr_has_implementation_go: bool = False,
+    pr_has_implementation_no_go: bool = False,
 ) -> IssueFacts:
     """Build IssueFacts with defaults for classifier-matrix tests."""
     return IssueFacts(
@@ -53,6 +55,8 @@ def _facts(
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
+        pr_has_implementation_go=pr_has_implementation_go,
+        pr_has_implementation_no_go=pr_has_implementation_no_go,
     )
 
 
@@ -104,6 +108,19 @@ class TestClassifyIssue:
         """Open PR + state:implementation-go → ready for CI."""
         stage, reason = classify_issue(
             _facts(labels={STATE_IMPLEMENTATION_GO}, pr_number=42, pr_is_open=True)
+        )
+        assert stage is StageName.CI
+        assert "implementation-go" in reason
+
+    def test_open_pr_with_pr_impl_go_routes_to_ci(self) -> None:
+        """Open PR + PR-level state:implementation-go → ready for CI."""
+        stage, reason = classify_issue(
+            _facts(
+                labels={STATE_PLAN_GO},
+                pr_number=42,
+                pr_is_open=True,
+                pr_has_implementation_go=True,
+            )
         )
         assert stage is StageName.CI
         assert "implementation-go" in reason
@@ -241,7 +258,14 @@ def _issue_info(number: int, labels: list[str], title: str = "A task") -> MagicM
 class TestSeedIssueFetchLayer:
     """Tri-state fetch: {open, merged, closed, none} against mocked gh responses."""
 
-    def _seed(self, issue: int, labels: list[str], prs: list[dict[str, Any]]) -> IssueFacts:
+    def _seed(
+        self,
+        issue: int,
+        labels: list[str],
+        prs: list[dict[str, Any]],
+        *,
+        pr_labels: list[str] | None = None,
+    ) -> IssueFacts:
         with (
             patch(
                 "hephaestus.automation.pipeline.seeding.fetch_issue_info",
@@ -250,6 +274,10 @@ class TestSeedIssueFetchLayer:
             patch(
                 "hephaestus.automation._review_utils._gh_call",
                 side_effect=_fake_gh_backend(prs),
+            ),
+            patch(
+                "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+                return_value=pr_labels or [],
             ),
         ):
             return seed_issue(issue)
@@ -264,6 +292,19 @@ class TestSeedIssueFetchLayer:
         assert facts.pr_number == 42
         assert facts.pr_is_open is True
         assert facts.pr_is_merged is False
+
+    def test_open_pr_reads_implementation_state_labels(self) -> None:
+        """An OPEN PR carrying implementation-go records the PR-level GO fact."""
+        facts = self._seed(
+            7,
+            [STATE_PLAN_GO],
+            [{"number": 42, "state": "OPEN", "headRefName": "7-auto-impl", "body": "Closes #7"}],
+            pr_labels=[STATE_IMPLEMENTATION_GO],
+        )
+        assert facts.pr_has_implementation_go is True
+        assert facts.pr_has_implementation_no_go is False
+        stage, _ = classify_issue(facts)
+        assert stage is StageName.CI
 
     def test_merged_pr_found_when_open_lookup_misses(self) -> None:
         """A MERGED PR is surfaced by the merged lookup → pr_is_merged (finished row)."""
@@ -433,6 +474,28 @@ class TestSeedFromCli:
                 identifier=9,
                 stage=StageName.IMPLEMENTATION,
                 reason=f"#9 at-or-past {STATE_PLAN_GO}, no PR yet",
+            )
+        ]
+
+    def test_issues_arm_open_pr_preserves_pr_number(self) -> None:
+        """Direct --issues seeding must keep the open PR number for PR stages."""
+        facts = _facts(
+            number=9,
+            labels={STATE_PLAN_GO},
+            pr_number=77,
+            pr_is_open=True,
+            pr_has_implementation_go=True,
+        )
+        with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
+            entries = seed_from_cli([], [9], [])
+
+        assert entries == [
+            SeedEntry(
+                kind="issue",
+                identifier=9,
+                stage=StageName.CI,
+                reason=f"#9 open PR with {STATE_IMPLEMENTATION_GO}",
+                pr_number=77,
             )
         ]
 

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -727,11 +727,22 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             ("--pipeline",),
             "pipeline",
             "_StoreTrueAction",
-            False,
+            SUPPRESS_DEFAULT,
             nargs=0,
             help_text=(
-                "Use the queue-based pipeline loop (default: off). "
-                "Env HEPH_PIPELINE=1 also enables it; the CLI flag wins."
+                "Use the queue-based pipeline loop (default: on). "
+                "Env HEPH_PIPELINE=0 disables it; the CLI flag wins."
+            ),
+        ),
+        _action_spec(
+            ("--legacy-loop",),
+            "pipeline",
+            "_StoreFalseAction",
+            SUPPRESS_DEFAULT,
+            nargs=0,
+            help_text=(
+                "Use the pre-pipeline legacy loop path. "
+                "Overrides HEPH_PIPELINE and is intended as a rollback hatch."
             ),
         ),
         _action_spec(

--- a/tests/unit/automation/test_implementer_loop.py
+++ b/tests/unit/automation/test_implementer_loop.py
@@ -111,6 +111,7 @@ class TestRunImplReviewLoop:
                 "hephaestus.automation._review_phase.gh_pr_list_unresolved_threads",
                 return_value=[],
             ),
+            patch("hephaestus.automation._review_phase.gh_current_login", return_value=None),
             patch(
                 "hephaestus.automation._review_phase.validate_prior_comments_addressed",
                 return_value=([], True, set()),

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -64,7 +64,10 @@ def test_main_health_check_returns_zero(
 
     monkeypatch.setattr(sys, "argv", ["impl", "--health-check", "--no-ui", "--agent", "claude"])
 
-    with patch.object(implementer, "get_repo_root", return_value=tmp_path):
+    with (
+        patch.object(implementer, "get_repo_root", return_value=tmp_path),
+        patch("hephaestus.github.client.gh_call", side_effect=OSError("missing gh")),
+    ):
         rc = implementer.main()
 
     assert rc == 0

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -1151,14 +1151,14 @@ def test_gh_list_repos_filters_forks_and_archived() -> None:
         '{"name":"drop-archived","isFork":false,"isArchived":true},'
         '{"name":"Odysseus","isFork":false,"isArchived":false}]'
     )
-    with patch("hephaestus.automation.loop_repo_manager.subprocess.run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(
+    with patch("hephaestus.automation.loop_repo_manager.gh_call") as mock_gh_call:
+        mock_gh_call.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=payload, stderr=""
         )
         names = loop_runner._gh_list_repos("MyOrg")
     # Odysseus is included — no name-based filtering (issue #814).
     assert sorted(names) == ["Odysseus", "keep"]
-    invoked_argv = mock_run.call_args[0][0]
+    invoked_argv = mock_gh_call.call_args[0][0]
     assert "--no-archived" in invoked_argv
     assert "name,isArchived,isFork" in invoked_argv
 
@@ -1170,8 +1170,8 @@ def test_gh_list_repos_does_not_filter_by_name() -> None:
         '{"name":"Hephaestus","isFork":false,"isArchived":false},'
         '{"name":"AnyName","isFork":false,"isArchived":false}]'
     )
-    with patch("hephaestus.automation.loop_repo_manager.subprocess.run") as mock_run:
-        mock_run.return_value = subprocess.CompletedProcess(
+    with patch("hephaestus.automation.loop_repo_manager.gh_call") as mock_gh_call:
+        mock_gh_call.return_value = subprocess.CompletedProcess(
             args=[], returncode=0, stdout=payload, stderr=""
         )
         names = loop_runner._gh_list_repos("MyOrg")
@@ -1191,10 +1191,10 @@ def test_list_open_issue_numbers_returns_all_open_sorted() -> None:
         {"number": 10, "labels": [], "title": "b"},
     )
 
-    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_gh_call(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout=payload, stderr="")
 
-    with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+    with patch("hephaestus.automation.loop_repo_manager.gh_call", side_effect=fake_gh_call):
         nums = loop_runner._list_open_issue_numbers("MyOrg", "MyRepo")
     assert nums == [7, 10, 12]
 
@@ -1207,11 +1207,11 @@ def test_list_open_issue_numbers_excludes_epics_and_tags_skip() -> None:
         {"number": 7, "labels": [{"name": "feature"}], "title": "Q3 Roadmap rollup"},
     )
 
-    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_gh_call(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout=payload, stderr="")
 
     with (
-        patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        patch("hephaestus.automation.loop_repo_manager.gh_call", side_effect=fake_gh_call),
         patch("hephaestus.automation.loop_repo_manager.skip_epics") as mock_skip,
     ):
         nums = loop_runner._list_open_issue_numbers("Org", "Repo")
@@ -1230,11 +1230,11 @@ def test_list_open_issue_numbers_no_epics_skips_nothing() -> None:
         {"number": 2, "labels": [], "title": "b"},
     )
 
-    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_gh_call(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout=payload, stderr="")
 
     with (
-        patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        patch("hephaestus.automation.loop_repo_manager.gh_call", side_effect=fake_gh_call),
         patch("hephaestus.automation.loop_repo_manager.skip_epics") as mock_skip,
     ):
         nums = loop_runner._list_open_issue_numbers("Org", "Repo")
@@ -1245,11 +1245,11 @@ def test_list_open_issue_numbers_no_epics_skips_nothing() -> None:
 def test_list_open_issue_numbers_raises_on_bad_json() -> None:
     """Malformed JSON surfaces instead of pretending the repo has no work."""
 
-    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_gh_call(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="not json", stderr="")
 
     with (
-        patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run),
+        patch("hephaestus.automation.loop_repo_manager.gh_call", side_effect=fake_gh_call),
         pytest.raises(RuntimeError, match="failed to list open issues"),
     ):
         loop_runner._list_open_issue_numbers("Org", "Repo")
@@ -1263,11 +1263,11 @@ def test_list_open_issue_numbers_queries_all_open_no_me_filter() -> None:
     """
     seen_argv: list[str] = []
 
-    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+    def fake_gh_call(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
         seen_argv.extend(argv)
         return subprocess.CompletedProcess(args=argv, returncode=0, stdout="[]", stderr="")
 
-    with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=fake_run):
+    with patch("hephaestus.automation.loop_repo_manager.gh_call", side_effect=fake_gh_call):
         loop_runner._list_open_issue_numbers("Org", "Repo")
     assert "--author" not in seen_argv
     assert "--assignee" not in seen_argv
@@ -1776,7 +1776,7 @@ class TestResilientCallAdoption:
         def _hang(*_a: object, **_k: object) -> subprocess.CompletedProcess[str]:
             raise subprocess.TimeoutExpired(cmd="gh repo clone", timeout=120)
 
-        with patch("hephaestus.automation.loop_repo_manager.subprocess.run", side_effect=_hang):
+        with patch("hephaestus.automation.loop_repo_manager.gh_call", side_effect=_hang):
             with pytest.raises(subprocess.TimeoutExpired):
                 _ensure_clone("Org", "Repo", dest)
 

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -1976,7 +1976,18 @@ class TestDefaultPhaseTimeout:
             patch.object(loop_runner, "_clone_missing_repos"),
             patch.object(loop_runner, "run_loop", side_effect=_capture),
         ):
-            main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
+            main(
+                [
+                    "--legacy-loop",
+                    "--repos",
+                    "Repo",
+                    "--dry-run",
+                    "--loops",
+                    "1",
+                    "--agent",
+                    "claude",
+                ]
+            )
         assert captured["cfg"].phase_timeout_s == _default_phase_timeout_s()
 
     def test_main_prefers_current_checkout_parent_for_projects_dir_default(
@@ -2005,7 +2016,18 @@ class TestDefaultPhaseTimeout:
             ) as resolve_projects_dir,
             patch.object(loop_runner, "run_loop", side_effect=_capture),
         ):
-            main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
+            main(
+                [
+                    "--legacy-loop",
+                    "--repos",
+                    "Repo",
+                    "--dry-run",
+                    "--loops",
+                    "1",
+                    "--agent",
+                    "claude",
+                ]
+            )
 
         resolve_projects_dir.assert_called_once_with(None, prefer_cwd_parent=True)
         assert captured["cfg"].projects_dir == projects_dir
@@ -2029,7 +2051,7 @@ class TestDefaultPhaseTimeout:
             patch.object(loop_runner, "resolve_agent", return_value="codex") as mock_resolve,
             patch.object(loop_runner, "run_loop", side_effect=_capture),
         ):
-            main(["--repos", "Repo", "--dry-run", "--loops", "1"])
+            main(["--legacy-loop", "--repos", "Repo", "--dry-run", "--loops", "1"])
 
         mock_resolve.assert_called_once_with(None)
         assert captured["cfg"].agent == "codex"
@@ -2052,7 +2074,19 @@ class TestDefaultPhaseTimeout:
             patch.object(loop_runner, "_clone_missing_repos"),
             patch.object(loop_runner, "run_loop", side_effect=_capture),
         ):
-            main(["--repos", "Repo", "--phase-timeout", "0", "--loops", "1", "--agent", "claude"])
+            main(
+                [
+                    "--legacy-loop",
+                    "--repos",
+                    "Repo",
+                    "--phase-timeout",
+                    "0",
+                    "--loops",
+                    "1",
+                    "--agent",
+                    "claude",
+                ]
+            )
         assert captured["cfg"].phase_timeout_s is None
 
 

--- a/tests/unit/automation/test_loop_runner_early_exit.py
+++ b/tests/unit/automation/test_loop_runner_early_exit.py
@@ -750,6 +750,7 @@ class TestMainLoopsRunReporting:
 
         argv = [
             "--json",
+            "--legacy-loop",
             "--repos",
             "r1",
             "--loops",

--- a/tests/unit/automation/test_loop_runner_early_exit.py
+++ b/tests/unit/automation/test_loop_runner_early_exit.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
@@ -505,6 +506,11 @@ def _unknown_work_result(repo: str, loop_idx: int) -> RepoResult:
 
 class TestRunLoopEarlyExit:
     """Tests for early-exit logic in run_loop (#614)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_rate_budget_probe(self) -> Iterator[None]:
+        with patch.object(loop_runner, "_rate_limit_remaining", return_value=None):
+            yield
 
     def test_early_exit_fires_on_zero_work_pass(self, tmp_path: Path) -> None:
         """When a non-final pass produces 0 new plans and 0 reviews, break early.

--- a/tests/unit/automation/test_planner.py
+++ b/tests/unit/automation/test_planner.py
@@ -533,14 +533,17 @@ class TestGeneratePlan:
 class TestEnsureMnemosyne:
     """Tests for _ensure_mnemosyne method."""
 
-    def test_clone_success(self, planner: Any, tmp_path: Any) -> None:
-        """Test successful clone returns True and clones the resolved slug."""
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
-        target = MnemosyneTarget(
+    def _target(self) -> MnemosyneTarget:
+        return MnemosyneTarget(
             owner="HomericIntelligence",
             slug="HomericIntelligence/ProjectMnemosyne",
             is_fork_of_upstream=False,
         )
+
+    def test_clone_success(self, planner: Any, tmp_path: Any) -> None:
+        """Test successful clone returns True and clones the resolved slug."""
+        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        target = self._target()
 
         with (
             patch("hephaestus.automation.advise_runner.gh_call") as mock_gh,
@@ -565,7 +568,13 @@ class TestEnsureMnemosyne:
         """Test clone failure returns False and logs warning."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
-        with patch("hephaestus.automation.advise_runner.gh_call") as mock_gh:
+        with (
+            patch("hephaestus.automation.advise_runner.gh_call") as mock_gh,
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=self._target(),
+            ),
+        ):
             mock_gh.side_effect = subprocess.CalledProcessError(
                 1, "gh", stderr="authentication failed"
             )
@@ -606,7 +615,13 @@ class TestEnsureMnemosyne:
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
         lock_path = tmp_path / ".mnemosyne.lock"
 
-        with patch("hephaestus.automation.advise_runner.gh_call") as mock_gh:
+        with (
+            patch("hephaestus.automation.advise_runner.gh_call") as mock_gh,
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=self._target(),
+            ),
+        ):
             mock_gh.return_value = MagicMock(returncode=0)
 
             result = planner._ensure_mnemosyne(mnemosyne_root)
@@ -696,6 +711,10 @@ class TestEnsureMnemosyne:
         with (
             patch("subprocess.run", side_effect=fake_subprocess),
             patch("hephaestus.automation.advise_runner.gh_call", side_effect=fake_gh_call),
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=self._target(),
+            ),
         ):
             t1.start()
             t2.start()
@@ -710,7 +729,13 @@ class TestEnsureMnemosyne:
         """TimeoutExpired on gh repo clone must return False without raising (#368)."""
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
-        with patch("hephaestus.automation.advise_runner.gh_call") as mock_gh:
+        with (
+            patch("hephaestus.automation.advise_runner.gh_call") as mock_gh,
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=self._target(),
+            ),
+        ):
             mock_gh.side_effect = subprocess.TimeoutExpired("gh", 120)
 
             result = planner._ensure_mnemosyne(mnemosyne_root)
@@ -725,7 +750,13 @@ class TestEnsureMnemosyne:
         """
         mnemosyne_root = tmp_path / "ProjectMnemosyne"
 
-        with patch("hephaestus.automation.advise_runner.gh_call") as mock_gh:
+        with (
+            patch("hephaestus.automation.advise_runner.gh_call") as mock_gh,
+            patch(
+                "hephaestus.automation.advise_runner.resolve_mnemosyne_target",
+                return_value=self._target(),
+            ),
+        ):
             mock_gh.return_value = MagicMock(returncode=0)
 
             planner._ensure_mnemosyne(mnemosyne_root)


### PR DESCRIPTION
## Summary
Flip pipeline as the default automation-loop path. Cutover is gated by entry criteria: two-layer editable-install verification, dry-run classification, shadow diff against legacy, scoped live drive end-to-end, and interrupt-resume correctness. Legacy path remains available via --legacy-loop / HEPH_PIPELINE=0 escape hatch.

## Changes
- Default HEPH_PIPELINE=1; --legacy-loop / HEPH_PIPELINE=0 restores old path
- Remove legacy pipeline-seeding code and redundant caching abstractions (745 lines deleted)
- Tighten pipeline GitHub API scope to repo boundaries; mock seams in unit tests
- Update docs/AUTOMATION_LOOP_ARCHITECTURE.md per-stage routes and interrupt semantics
- Update CLAUDE.md automation tree mention and coverage omit-list invariant notes
- Update runbooks: automation-loop-crash.md recovery story; ci-driver-stall.md cross-check

## Testing
- Two-layer editable-install: pixi run dev-install && python -c 'import hephaestus.automation.pipeline.coordinator; print("live")'
- Dry-run classification: pixi run hephaestus-automation-loop --pipeline --dry-run --loops 1 -v
- Shadow diff: legacy vs --pipeline on 3 issues in distinct states (needs-plan / plan-go / impl-go+PR)
- Scoped live drive: end-to-end merge on one low-stakes issue with max-workers=1
- Interrupt drill: Ctrl-C mid-implementation, re-run verifies resume at correct stage

## Closes
Closes #1818

Generated by Claude Code via ProjectHephaestus automation.
