### PR TITLE
fix(pipeline): stabilize automation-loop issue planning

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -34,13 +34,14 @@ CODEX_GPT_56_MODEL = "gpt-5.6"
 CODEX_GPT_55_MODEL = "gpt-5.5"
 CODEX_FABLE_MODEL = CODEX_GPT_55_MODEL
 CODEX_FABLE_REASONING_EFFORT = "xhigh"
-CODEX_OPUS_MODEL = CODEX_GPT_56_MODEL
+CODEX_OPUS_MODEL = CODEX_GPT_55_MODEL
 CODEX_OPUS_REASONING_EFFORT = "xhigh"
 CODEX_SONNET_MODEL = CODEX_GPT_55_MODEL
 CODEX_SONNET_REASONING_EFFORT = "medium"
 CODEX_HAIKU_MODEL = "gpt-5.4-mini"
 CODEX_DEFAULT_MODEL = CODEX_OPUS_MODEL
 CODEX_DEFAULT_REASONING_EFFORT = CODEX_OPUS_REASONING_EFFORT
+CODEX_PARENT_CONTEXT_ENV_VARS = ("CODEX_THREAD_ID",)
 PI_PROVIDER_ENV = "HEPH_PI_PROVIDER"
 PI_MODEL_ENV = "HEPH_PI_MODEL"
 PI_MODEL_CONFIG_RELATIVE_PATH = Path(".pi") / "agent" / "models.json"
@@ -634,6 +635,8 @@ def _run_codex_command(
         cmd.extend(["--output-last-message", output_file.name, "-"])
         env = os.environ.copy()
         env.setdefault("CODEX_HOME", str(Path.home() / ".codex"))
+        for key in CODEX_PARENT_CONTEXT_ENV_VARS:
+            env.pop(key, None)
         try:
             stdout_text, stderr_text = _communicate_codex_process(
                 cmd,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1027,6 +1027,8 @@ class Coordinator:
                     stage=stage,
                     reason=reason,
                     pr_number=facts.pr_number if facts.pr_is_open else None,
+                    issue_title=facts.title,
+                    issue_body=facts.body,
                 )
             )
         for pr in self.config.prs:
@@ -1077,6 +1079,8 @@ class Coordinator:
                 pr=entry.pr_number,
                 stage=entry.stage,
             )
+            item.payload["issue_title"] = entry.issue_title
+            item.payload["issue_body"] = entry.issue_body
         item.state = "ENTER"
         item.payload["entry_reason"] = entry.reason
         return item

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -85,6 +85,7 @@ class IssueFacts:
         title: Issue title (feeds the epic title-marker signal, #1669).
         is_epic: Whether this issue is an epic/roadmap (excluded from queuing).
         labels: Set of labels currently on this issue.
+        body: Issue body used to hydrate downstream task prompts.
         pr_number: GitHub PR number if one exists and is live (open or
             merged), None otherwise.
         pr_is_open: True iff PR exists and is open.
@@ -113,6 +114,7 @@ class IssueFacts:
     pr_is_merged: bool
     pr_has_implementation_go: bool = False
     pr_has_implementation_no_go: bool = False
+    body: str = ""
 
 
 @dataclass(frozen=True)
@@ -127,6 +129,10 @@ class SeedEntry:
         pr_number: Open PR number for directly-seeded issue entries, when one
             exists. Repo discovery carries this in products; direct ``--issues``
             seeding needs the same value so downstream PR stages have context.
+        issue_title: Issue title copied into the issue WorkItem payload for
+            planner/reviewer/implementer prompts.
+        issue_body: Issue body copied into the issue WorkItem payload for
+            planner/reviewer/implementer prompts.
 
     """
 
@@ -135,6 +141,8 @@ class SeedEntry:
     stage: StageName | None
     reason: str
     pr_number: int | None = None
+    issue_title: str = ""
+    issue_body: str = ""
 
 
 def _get_state_label(labels: set[str]) -> str | None:
@@ -306,6 +314,7 @@ def seed_issue(issue_number: int) -> IssueFacts:
         title=issue_info.title,
         is_epic=epic,
         labels=labels,
+        body=issue_info.body,
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
@@ -324,6 +333,7 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
         if isinstance(label, dict) and label.get("name")
     }
     title = str(issue_data.get("title") or "") if isinstance(issue_data, dict) else ""
+    body = str(issue_data.get("body") or "") if isinstance(issue_data, dict) else ""
     epic = is_epic(sorted(labels), title)
 
     pr_is_open = False
@@ -346,6 +356,7 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
         title=title,
         is_epic=epic,
         labels=labels,
+        body=body,
         pr_number=pr_number,
         pr_is_open=pr_is_open,
         pr_is_merged=pr_is_merged,
@@ -395,6 +406,8 @@ def seed_from_cli(
                 stage=stage,
                 reason=reason,
                 pr_number=facts.pr_number if facts.pr_is_open else None,
+                issue_title=facts.title,
+                issue_body=facts.body,
             )
         )
     for pr in prs:

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -57,9 +57,9 @@ from hephaestus.automation.agent_config import (
 )
 from hephaestus.automation.claude_invoke import parse_review_verdict
 from hephaestus.automation.learn import build_learn_prompt
+from hephaestus.automation.prompts._shared import fence_content
 from hephaestus.automation.prompts.planning import (
     get_plan_loop_review_prompt,
-    get_plan_prompt,
 )
 from hephaestus.automation.session_naming import AGENT_PLAN_REVIEWER, AGENT_PLANNER
 from hephaestus.automation.state_labels import apply_plan_verdict
@@ -78,6 +78,7 @@ from .base import (
     agent_provider,
     stage_model,
 )
+from .planning import build_plan_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -88,35 +89,47 @@ logger = logging.getLogger(__name__)
 REVIEW_ERROR_RETRY_CAP = 2
 
 
-def build_amend_prompt(issue_number: int, prior_review: str) -> str:
-    """Compose the amend prompt: plan prompt + reviewer feedback block.
+def build_amend_prompt(
+    issue_number: int,
+    prior_review: str,
+    issue_title: str = "",
+    issue_body: str = "",
+    advise_findings: str = "",
+) -> str:
+    """Compose the amend prompt: task-aware plan prompt + reviewer feedback block.
 
     Module-level composed builder (NOT a closure): :class:`AgentJob` is
     frozen and prompt builders run in-worker, so the builder must be a
     top-level function receiving everything via ``prompt_kwargs``. The
-    feedback block appends the prior reviewer critique to the plan prompt (doc
-    section 3 step 3: "resume planner session with feedback block"); the
-    prompt template itself is reused verbatim via :func:`get_plan_prompt`.
+    feedback block appends the prior reviewer critique to the same
+    task-aware plan prompt used by initial planning (doc section 3 step 3:
+    "resume planner session with feedback block").
 
     Args:
         issue_number: GitHub issue number being re-planned.
         prior_review: The previous review round's NOGO critique text.
+        issue_title: Source issue title.
+        issue_body: Source issue body.
+        advise_findings: Advise-step findings; empty string means no block.
 
     Returns:
         The full amend prompt with the feedback block appended.
 
     """
-    prompt = get_plan_prompt(issue_number)
+    prompt = build_plan_prompt(issue_number, issue_title, issue_body, advise_findings)
+    fenced = fence_content()
     feedback = "\n".join(
         [
             "",
             "---",
             "",
+            fenced.untrusted_notice,
+            "",
             "## Prior reviewer critique — your previous plan got NOGO",
             "",
             "Address every concrete finding below in your revised plan:",
             "",
-            prior_review,
+            fenced.fence("PRIOR_REVIEW", prior_review),
         ]
     )
     return prompt + feedback
@@ -256,6 +269,9 @@ class PlanReviewStage(Stage):
                 # session (#1817 wires that session setup).
                 prompt_kwargs={
                     "issue_number": item.issue,
+                    "issue_title": item.payload.get("issue_title", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
+                    "advise_findings": item.payload.get("advise_findings", ""),
                     "prior_review": item.payload.get("prior_review", ""),
                 },
                 descr="amend",

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -219,7 +219,8 @@ class PlanningStage(Stage):
         # has_existing_plan gate stuck-False so VERIFY can never ADVANCE
         # (#1857). Swap atomically: add needs-plan, remove both siblings, in
         # ONE gh issue edit. Restores state:plan-no-go ──re-plan──▶ needs-plan.
-        if STATE_PLAN_NO_GO in labels or STATE_PLAN_GO in labels:
+        is_replan_entry = STATE_PLAN_NO_GO in labels
+        if is_replan_entry or STATE_PLAN_GO in labels:
             add, remove = enter_planning_transition()
             logger.info("planning:%d: entry swap; add %s, remove %s", item.issue, add, remove)
             ctx.github.edit_labels(item.issue, add=add, remove=remove)
@@ -231,7 +232,7 @@ class PlanningStage(Stage):
         # Restart fast-forward: a plan comment already exists (real has-plan
         # semantics via ctx.github), so re-entry must not redo advise + plan.
         # Jump straight to VERIFY; idempotent on repeated on_enter calls.
-        if ctx.github.has_existing_plan(item.issue):
+        if not is_replan_entry and ctx.github.has_existing_plan(item.issue):
             logger.info(
                 "planning:%d: plan comment already exists; fast-forward to VERIFY", item.issue
             )

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -34,6 +34,7 @@ from hephaestus.automation.agent_config import (
     planner_claude_timeout,
     planner_model,
 )
+from hephaestus.automation.prompts._shared import fence_content
 from hephaestus.automation.prompts.advise import get_advise_prompt_builder
 from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
@@ -92,10 +93,15 @@ def build_plan_prompt(
         ``advise_findings`` is non-empty.
 
     """
+    fenced = fence_content()
     context_parts = [
-        f"# Issue #{issue_number}: {issue_title or f'Issue #{issue_number}'}",
+        fenced.untrusted_notice,
         "",
-        issue_body,
+        f"**Issue Title (untrusted, GitHub issue #{issue_number}):**",
+        fenced.fence("ISSUE_TITLE", issue_title or f"Issue #{issue_number}"),
+        "",
+        "**Issue Description (untrusted):**",
+        fenced.fence("ISSUE_BODY", issue_body),
     ]
     if advise_findings:
         context_parts.extend(
@@ -103,9 +109,9 @@ def build_plan_prompt(
                 "",
                 "---",
                 "",
-                "## Prior Learnings from Team Knowledge Base",
+                "## Prior Learnings from Team Knowledge Base (untrusted)",
                 "",
-                advise_findings,
+                fenced.fence("ADVISE_FINDINGS", advise_findings),
             ]
         )
     context_parts.extend(["", "---", "", get_plan_prompt(issue_number)])

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -66,8 +66,13 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
-def build_plan_prompt(issue_number: int, advise_findings: str = "") -> str:
-    """Compose the plan prompt with the advise-findings block.
+def build_plan_prompt(
+    issue_number: int,
+    issue_title: str = "",
+    issue_body: str = "",
+    advise_findings: str = "",
+) -> str:
+    """Compose the plan prompt with the issue TASK and advise-findings block.
 
     Module-level composed builder (NOT a closure): :class:`AgentJob` is
     frozen and prompt builders run in-worker, so the builder must be a
@@ -78,6 +83,8 @@ def build_plan_prompt(issue_number: int, advise_findings: str = "") -> str:
 
     Args:
         issue_number: GitHub issue number to plan.
+        issue_title: Source issue title.
+        issue_body: Source issue body.
         advise_findings: Advise-step findings; empty string means no block.
 
     Returns:
@@ -85,20 +92,24 @@ def build_plan_prompt(issue_number: int, advise_findings: str = "") -> str:
         ``advise_findings`` is non-empty.
 
     """
-    prompt = get_plan_prompt(issue_number)
-    if not advise_findings:
-        return prompt
-    block = "\n".join(
-        [
-            "",
-            "---",
-            "",
-            "## Prior Learnings from Team Knowledge Base",
-            "",
-            advise_findings,
-        ]
-    )
-    return prompt + block
+    context_parts = [
+        f"# Issue #{issue_number}: {issue_title or f'Issue #{issue_number}'}",
+        "",
+        issue_body,
+    ]
+    if advise_findings:
+        context_parts.extend(
+            [
+                "",
+                "---",
+                "",
+                "## Prior Learnings from Team Knowledge Base",
+                "",
+                advise_findings,
+            ]
+        )
+    context_parts.extend(["", "---", "", get_plan_prompt(issue_number)])
+    return "\n".join(context_parts)
 
 
 def _normalize_plan_comment(plan: str) -> str:
@@ -277,11 +288,14 @@ class PlanningStage(Stage):
                 cwd=ctx.paths.worktree,
                 timeout_s=planner_claude_timeout(),
                 session_agent=AGENT_PLANNER,
-                # build_plan_prompt composes get_plan_prompt with the advise
-                # findings block in-worker. The issue title/body header is
-                # prepended by the worker session setup (#1817).
+                # build_plan_prompt composes get_plan_prompt with the issue
+                # title/body and advise findings in-worker, mirroring the
+                # legacy planner_review_loop.generate_plan(cached_advise=...)
+                # context assembly.
                 prompt_kwargs={
                     "issue_number": item.issue,
+                    "issue_title": item.payload.get("issue_title", ""),
+                    "issue_body": item.payload.get("issue_body", ""),
                     "advise_findings": item.payload.get("advise_findings", ""),
                 },
                 descr="plan",

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -316,13 +316,15 @@ class PlanningStage(Stage):
             # decision (journal order). Guarded by has_existing_plan so
             # re-entry never double-posts.
             plan_text = item.payload.get("plan_text")
+            posted_plan = False
             if plan_text and not ctx.github.has_existing_plan(item.issue):
                 logger.info("planning:%d: upserting plan comment", item.issue)
                 ctx.github.upsert_plan_comment(item.issue, _normalize_plan_comment(plan_text))
+                posted_plan = True
 
             # Doc step 4 [M], part 2: verify the plan comment exists (the
             # PlannerStateManager.has_existing_plan read, via ctx.github).
-            if ctx.github.has_existing_plan(item.issue):
+            if posted_plan or ctx.github.has_existing_plan(item.issue):
                 logger.info("planning:%d: plan verified; advancing", item.issue)
                 return StageOutcome(Disposition.ADVANCE, "plan generated and verified")
 

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -205,6 +205,8 @@ class RepoStage(Stage):
                     "reason": reason,
                     "pr": facts.pr_number if facts.pr_is_open else None,
                     "labels": sorted(facts.labels),
+                    "title": facts.title,
+                    "body": facts.body,
                 }
             )
 
@@ -281,6 +283,9 @@ def product_to_work_item(repo: str, product: dict[str, Any]) -> WorkItem | None:
     labels = product.get("labels") or []
     if labels:
         item.labels_cache = dict.fromkeys(labels, True)
+    if kind is ItemKind.ISSUE:
+        item.payload["issue_title"] = str(product.get("title") or "")
+        item.payload["issue_body"] = str(product.get("body") or "")
     item.payload["entry_stage"] = stage.value
     item.payload["entry_reason"] = product.get("reason", "")
     return item

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -534,15 +534,14 @@ class PipelineGitHub:
                 return False
 
             comments = data.get("comments")
-            if self._comments_have_plan(comments):
+            latest_review_body = self._latest_plan_review_body(comments)
+            if latest_review_body is not None:
+                if latest_verdict(latest_review_body) != "GO":
+                    return False
+                self._backfill_plan_go(issue_number)
                 return True
 
-            latest_review_body = self._latest_plan_review_body(comments)
-            if latest_review_body is None or latest_verdict(latest_review_body) != "GO":
-                return False
-
-            self._backfill_plan_go(issue_number)
-            return True
+            return bool(self._comments_have_plan(comments))
         return bool(is_plan_review_go(issue_number))
 
     def get_pr_head_branch(self, pr_number: int) -> str | None:

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -285,6 +285,23 @@ class PipelineGitHub:
                 latest_review_body = body
         return latest_review_body
 
+    @staticmethod
+    def _comments_have_plan(comments: Any) -> bool:
+        if not isinstance(comments, list):
+            return False
+        for comment in comments:
+            if not isinstance(comment, dict):
+                continue
+            body = comment.get("body")
+            if not isinstance(body, str):
+                continue
+            stripped = body.lstrip()
+            if stripped.startswith(PLAN_REVIEW_PREFIX):
+                continue
+            if stripped.startswith(PLAN_COMMENT_MARKER):
+                return True
+        return False
+
     def _backfill_plan_go(self, issue_number: int) -> None:
         if self.dry_run:
             logger.info("[dry-run] would backfill %s on #%d", STATE_PLAN_GO, issue_number)
@@ -516,7 +533,11 @@ class PipelineGitHub:
             if has_label(labels, STATE_PLAN_NO_GO):
                 return False
 
-            latest_review_body = self._latest_plan_review_body(data.get("comments"))
+            comments = data.get("comments")
+            if self._comments_have_plan(comments):
+                return True
+
+            latest_review_body = self._latest_plan_review_body(comments)
             if latest_review_body is None or latest_verdict(latest_review_body) != "GO":
                 return False
 

--- a/hephaestus/automation/prompts/_shared.py
+++ b/hephaestus/automation/prompts/_shared.py
@@ -117,13 +117,19 @@ def _iteration_guidance(iteration: int) -> str:
     )
 
 
-def _prior_review_block(prior_review: str | None) -> str:
+def _prior_review_block(
+    prior_review: str | None,
+    fenced: FencedContent | None = None,
+    *,
+    label: str = "PRIOR_REVIEW",
+) -> str:
     """Format the prior review (if any) as a context block."""
     if not prior_review:
         return ""
+    body = fenced.fence(label, prior_review) if fenced is not None else prior_review
     return (
         "\n---\n\n**Prior review (from previous iteration) — verify these findings "
-        f"have been addressed:**\n\n{prior_review}\n"
+        f"have been addressed:**\n\n{body}\n"
     )
 
 

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -147,7 +147,8 @@ any earlier review, verdict line, or `## 🔍 Plan Review` text as the plan
 
 {untrusted_notice}
 
-**Issue Title (untrusted):** {issue_title}
+**Issue Title (untrusted):**
+{issue_title_block}
 
 **Issue Description (untrusted):**
 {issue_body_block}
@@ -196,7 +197,8 @@ actually addressed in the current plan.
 
 {untrusted_notice}
 
-**Issue Title (untrusted):** {issue_title}
+**Issue Title (untrusted):**
+{issue_title_block}
 
 **Issue Description (untrusted):**
 {issue_body_block}
@@ -245,7 +247,7 @@ def get_plan_review_prompt(
 
     Args:
         issue_number: GitHub issue number
-        issue_title: Issue title (interpolated as untrusted text)
+        issue_title: Issue title (fenced as untrusted)
         issue_body: Issue body/description (fenced as untrusted)
         plan_text: The full plan text to review (fenced as untrusted)
 
@@ -256,7 +258,7 @@ def get_plan_review_prompt(
     fenced = fence_content()
     return PLAN_REVIEW_PROMPT.format(
         issue_number=issue_number,
-        issue_title=issue_title,
+        issue_title_block=fenced.fence("ISSUE_TITLE", issue_title),
         issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
         plan_text_block=fenced.fence("PLAN_TEXT", plan_text),
         untrusted_notice=fenced.untrusted_notice,
@@ -301,7 +303,7 @@ def get_plan_loop_review_prompt(
         iteration_label=_iteration_label(iteration),
         iteration_guidance=_iteration_guidance(iteration),
         issue_number=issue_number,
-        issue_title=issue_title,
+        issue_title_block=fenced.fence("ISSUE_TITLE", issue_title),
         issue_body_block=fenced.fence("ISSUE_BODY", issue_body),
         advise_findings_block=fenced.fence(
             "ADVISE_FINDINGS",
@@ -309,7 +311,7 @@ def get_plan_loop_review_prompt(
         ),
         plan_text_block=fenced.fence("PLAN_TEXT", plan_text),
         learnings=learnings or "_(no learnings captured this iteration)_",
-        prior_review_block=_prior_review_block(prior_review),
+        prior_review_block=_prior_review_block(prior_review, fenced),
         full_sweep_suffix=full_sweep_suffix,
         output_format=_STRICT_REVIEW_OUTPUT_FORMAT.strip(),
         untrusted_notice=fenced.untrusted_notice,

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -329,7 +329,7 @@ def test_codex_approval_args_preserves_legacy_flag() -> None:
 @pytest.mark.parametrize(
     ("claude_model", "expected_model", "expected_reasoning"),
     [
-        ("claude-opus-4-7", "gpt-5.6", "xhigh"),
+        ("claude-opus-4-7", "gpt-5.5", "xhigh"),
         ("claude-sonnet-4-6", "gpt-5.5", "medium"),
     ],
 )
@@ -371,13 +371,42 @@ def test_codex_base_cmd_keeps_native_codex_model_ids(
     assert "model_reasoning_effort" not in cmd
 
 
-def test_codex_base_cmd_defaults_new_sessions_to_gpt_56_xhigh(tmp_path: Path) -> None:
+def test_codex_base_cmd_defaults_new_sessions_to_gpt_55_xhigh(tmp_path: Path) -> None:
     """A fresh Codex session should not depend on the operator's CLI default."""
     with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
         cmd = agent_runtime._codex_base_cmd(cwd=tmp_path)
 
-    assert cmd[cmd.index("--model") + 1] == "gpt-5.6"
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.5"
     assert cmd[cmd.index("-c") + 1] == 'model_reasoning_effort="xhigh"'
+
+
+def test_run_codex_session_does_not_inherit_parent_thread_id(tmp_path: Path) -> None:
+    """Automation child sessions must not inherit the interactive Codex thread."""
+    captured_env: dict[str, str] = {}
+
+    def fake_popen(cmd: list[str], **kwargs: Any) -> _FakeCodexPopen:
+        captured_env.update(kwargs["env"])
+        stdout = (
+            '{"type":"session_meta","payload":{"id":"019e1e57-7652-7892-b1ca-c31c93d4b160"}}\n'
+            '{"type":"agent_message","message":"fallback"}\n'
+        )
+        return _FakeCodexPopen(cmd, proc_stdout=stdout, final_message="final answer", **kwargs)
+
+    with (
+        patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]),
+        patch("hephaestus.agents.runtime._codex_extra_writable_dirs", return_value=[]),
+        patch.dict("os.environ", {"CODEX_THREAD_ID": "parent-thread"}, clear=False),
+        patch("subprocess.Popen", side_effect=fake_popen),
+    ):
+        agent_runtime.run_codex_session(
+            "prompt",
+            cwd=tmp_path,
+            timeout=30,
+            sandbox="workspace-write",
+        )
+
+    assert "CODEX_THREAD_ID" not in captured_env
+    assert captured_env["CODEX_HOME"]
 
 
 def test_codex_base_cmd_adds_git_common_dir_for_worktree_metadata(tmp_path: Path) -> None:

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -36,6 +36,8 @@ class FakeStageGitHub(FakeGitHub):
         self,
         *,
         labels: list[str] | None = None,
+        issue_title: str = "A task",
+        issue_body: str = "",
         merged_pr: int | None = None,
         open_pr: int | None = None,
         has_plan: bool = False,
@@ -55,6 +57,8 @@ class FakeStageGitHub(FakeGitHub):
 
         Args:
             labels: Seed labels applied to any issue on first read/mutation.
+            issue_title: Canned issue title returned by gh_issue_json.
+            issue_body: Canned issue body returned by gh_issue_json.
             merged_pr: Canned answer for find_merged_closing_pr.
             open_pr: Canned answer for find_pr_for_issue.
             has_plan: Canned answer for has_existing_plan.
@@ -82,6 +86,8 @@ class FakeStageGitHub(FakeGitHub):
         """
         super().__init__()
         self._seed_labels = list(labels or [])
+        self._issue_title = issue_title
+        self._issue_body = issue_body
         self._merged_pr = merged_pr
         self._open_pr = open_pr
         self._has_plan = has_plan
@@ -111,8 +117,13 @@ class FakeStageGitHub(FakeGitHub):
 
     # -- read surface used by the stages -----------------------------------
     def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
-        """Mirror github_api.issues.gh_issue_json (labels subset only)."""
-        return {"labels": [{"name": name} for name in sorted(self._issue_labels(issue_number))]}
+        """Mirror github_api.issues.gh_issue_json (issue context plus labels)."""
+        return {
+            "number": issue_number,
+            "title": self._issue_title,
+            "body": self._issue_body,
+            "labels": [{"name": name} for name in sorted(self._issue_labels(issue_number))],
+        }
 
     def find_merged_closing_pr(self, issue_number: int) -> int | None:
         """Mirror _review_utils.find_merged_closing_pr."""

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
@@ -13,6 +14,7 @@ from hephaestus.automation.pipeline.stages.plan_review import (
     PlanReviewStage,
     build_amend_prompt,
 )
+from hephaestus.automation.prompts._shared import _UNTRUSTED_NOTICE
 from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
@@ -27,17 +29,36 @@ def _verdict(kind: str) -> ReviewVerdict:
     return ReviewVerdict(grade=None, verdict=kind, raw=f"review text ({kind})")
 
 
+def _fence_present(prompt: str, label: str) -> bool:
+    """Return True when a prompt has nonce-delimited markers for label."""
+    return bool(
+        re.search(rf"BEGIN_[0-9A-F]+_{label}\b", prompt)
+        and re.search(rf"END_[0-9A-F]+_{label}\b", prompt)
+    )
+
+
 class TestBuildAmendPrompt:
     """build_amend_prompt composes the plan prompt with the feedback block."""
 
     def test_contains_plan_prompt_and_feedback_block(self) -> None:
-        """The output is the verbatim plan prompt plus the critique block."""
-        prompt = build_amend_prompt(42, "The plan misses the tests section.")
+        """The output keeps issue context and fences reviewer critique."""
+        prompt = build_amend_prompt(
+            42,
+            "The plan misses the tests section.",
+            issue_title="Retry failure",
+            issue_body="The loop retries forever.",
+            advise_findings="Use the retry helper.",
+        )
 
-        assert prompt.startswith(get_plan_prompt(42))  # template reused verbatim
+        assert get_plan_prompt(42) in prompt  # template reused inside the composed prompt
+        assert _UNTRUSTED_NOTICE in prompt
+        assert _fence_present(prompt, "ISSUE_TITLE")
+        assert _fence_present(prompt, "ISSUE_BODY")
+        assert _fence_present(prompt, "ADVISE_FINDINGS")
+        assert _fence_present(prompt, "PRIOR_REVIEW")
         assert "## Prior reviewer critique — your previous plan got NOGO" in prompt
         assert "Address every concrete finding below in your revised plan:" in prompt
-        assert prompt.endswith("The plan misses the tests section.")
+        assert "The plan misses the tests section." in prompt
 
 
 class TestPlanReviewStageOnEnter:
@@ -330,6 +351,9 @@ class TestPlanReviewStageStep:
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=10, state="AMEND_WAIT")
+        item.payload["issue_title"] = "Retry failure"
+        item.payload["issue_body"] = "The loop retries forever."
+        item.payload["advise_findings"] = "Use the retry helper."
         item.payload["prior_review"] = "Feedback: improve clarity"
 
         result = stage.step(item, ctx)
@@ -343,6 +367,9 @@ class TestPlanReviewStageStep:
         # in-worker; AgentJob is frozen, so no closures over payload).
         assert result.job.prompt_kwargs == {
             "issue_number": 10,
+            "issue_title": "Retry failure",
+            "issue_body": "The loop retries forever.",
+            "advise_findings": "Use the retry helper.",
             "prior_review": "Feedback: improve clarity",
         }
 

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
@@ -11,6 +12,7 @@ from hephaestus.automation.pipeline.stages.planning import (
     PlanningStage,
     build_plan_prompt,
 )
+from hephaestus.automation.prompts._shared import _UNTRUSTED_NOTICE
 from hephaestus.automation.prompts.planning import get_plan_prompt
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from hephaestus.automation.state_labels import (
@@ -22,18 +24,30 @@ from hephaestus.automation.state_labels import (
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
 
+def _fence_present(prompt: str, label: str) -> bool:
+    """Return True when a prompt has nonce-delimited markers for label."""
+    return bool(
+        re.search(rf"BEGIN_[0-9A-F]+_{label}\b", prompt)
+        and re.search(rf"END_[0-9A-F]+_{label}\b", prompt)
+    )
+
+
 class TestBuildPlanPrompt:
     """build_plan_prompt composes the plan prompt with the advise block."""
 
     def test_without_findings_includes_issue_context(self) -> None:
-        """The planner prompt carries the TASK title/body before the template."""
+        """The planner prompt carries fenced TASK title/body before the template."""
         prompt = build_plan_prompt(7, "Retry failure", "The loop retries forever.")
 
-        assert prompt.startswith("# Issue #7: Retry failure\n\nThe loop retries forever.")
+        assert _UNTRUSTED_NOTICE in prompt
+        assert _fence_present(prompt, "ISSUE_TITLE")
+        assert _fence_present(prompt, "ISSUE_BODY")
+        assert "Retry failure" in prompt
+        assert "The loop retries forever." in prompt
         assert prompt.endswith(get_plan_prompt(7))
 
     def test_with_findings_appends_learnings_block(self) -> None:
-        """Advise findings ride in the legacy learnings block."""
+        """Advise findings ride in a fenced learnings block."""
         prompt = build_plan_prompt(
             7,
             "Retry failure",
@@ -41,8 +55,8 @@ class TestBuildPlanPrompt:
             "Use the retry helper from utils.",
         )
 
-        assert prompt.startswith("# Issue #7: Retry failure")
-        assert "## Prior Learnings from Team Knowledge Base" in prompt
+        assert "## Prior Learnings from Team Knowledge Base (untrusted)" in prompt
+        assert _fence_present(prompt, "ADVISE_FINDINGS")
         assert "Use the retry helper from utils." in prompt
         assert prompt.endswith(get_plan_prompt(7))
 

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -426,6 +426,29 @@ class TestPlanningStageStep:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
 
+    def test_verify_advances_after_upsert_even_when_old_review_gate_is_false(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A just-written revised plan is valid even before a new review exists."""
+
+        class StaleNoGoGitHub(FakeStageGitHub):
+            def has_existing_plan(self, issue_number: int) -> bool:
+                return False
+
+        stage = PlanningStage()
+        github = StaleNoGoGitHub(has_plan=False)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=24, state="VERIFY")
+        item.payload["plan_text"] = "# Implementation Plan\n\nRevised plan."
+
+        result = stage.step(item, ctx)
+
+        assert github.mutation_log == [
+            ("gh_issue_upsert_comment", (24, PLAN_COMMENT_MARKER)),
+        ]
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+
     def test_verify_posts_exactly_once_on_reentry(self, make_ctx: Any, make_work_item: Any) -> None:
         """Re-entering VERIFY never double-posts.
 

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -25,18 +25,26 @@ from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 class TestBuildPlanPrompt:
     """build_plan_prompt composes the plan prompt with the advise block."""
 
-    def test_without_findings_is_plan_prompt_verbatim(self) -> None:
-        """No advise findings means the untouched template output."""
-        assert build_plan_prompt(7) == get_plan_prompt(7)
-        assert build_plan_prompt(7, "") == get_plan_prompt(7)
+    def test_without_findings_includes_issue_context(self) -> None:
+        """The planner prompt carries the TASK title/body before the template."""
+        prompt = build_plan_prompt(7, "Retry failure", "The loop retries forever.")
+
+        assert prompt.startswith("# Issue #7: Retry failure\n\nThe loop retries forever.")
+        assert prompt.endswith(get_plan_prompt(7))
 
     def test_with_findings_appends_learnings_block(self) -> None:
         """Advise findings ride in the legacy learnings block."""
-        prompt = build_plan_prompt(7, "Use the retry helper from utils.")
+        prompt = build_plan_prompt(
+            7,
+            "Retry failure",
+            "The loop retries forever.",
+            "Use the retry helper from utils.",
+        )
 
-        assert prompt.startswith(get_plan_prompt(7))  # template reused verbatim
+        assert prompt.startswith("# Issue #7: Retry failure")
         assert "## Prior Learnings from Team Knowledge Base" in prompt
-        assert prompt.endswith("Use the retry helper from utils.")
+        assert "Use the retry helper from utils." in prompt
+        assert prompt.endswith(get_plan_prompt(7))
 
 
 class TestPlanningStageEnter:
@@ -298,6 +306,8 @@ class TestPlanningStageStep:
         stage = PlanningStage()
         ctx = make_ctx()
         item = make_work_item(issue=4, state="PLAN_WAIT")
+        item.payload["issue_title"] = "Retry failure"
+        item.payload["issue_body"] = "The loop retries forever."
         item.payload["advise_findings"] = "prior learnings"
 
         result = stage.step(item, ctx)
@@ -311,6 +321,8 @@ class TestPlanningStageStep:
         # AgentJob is frozen, so no closures over payload).
         assert result.job.prompt_kwargs == {
             "issue_number": 4,
+            "issue_title": "Retry failure",
+            "issue_body": "The loop retries forever.",
             "advise_findings": "prior learnings",
         }
 

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -241,6 +241,23 @@ class TestPlanningStageEnter:
         assert STATE_PLAN_GO not in github.labels[20]
         assert STATE_NEEDS_PLAN in github.labels[20]
 
+    def test_replan_entry_ignores_existing_rejected_plan_comment(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A NOGO fail-back must not VERIFY against the stale rejected plan."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_PLAN_NO_GO], has_plan=True)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=23, state="ENTER")
+
+        outcome = stage.on_enter(item, ctx)
+
+        assert outcome is None
+        assert item.state == "ENTER"
+        assert github.mutation_log == [
+            ("edit_labels", (23, (STATE_NEEDS_PLAN,), (STATE_PLAN_NO_GO, STATE_PLAN_GO))),
+        ]
+
     def test_plan_go_on_entry_fast_forwards_without_swap(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -50,6 +50,8 @@ def repo_ctx(tmp_path: Path, make_ctx: Callable[..., Any]) -> Any:
 def _facts(
     number: int,
     *,
+    title: str | None = None,
+    body: str = "",
     labels: set[str] | None = None,
     pr: int | None = None,
     pr_open: bool = False,
@@ -57,12 +59,13 @@ def _facts(
 ) -> IssueFacts:
     return IssueFacts(
         number=number,
-        title=f"task {number}",
+        title=title or f"task {number}",
         is_epic=False,
         labels=labels or set(),
         pr_number=pr,
         pr_is_open=pr_open,
         pr_is_merged=pr_merged,
+        body=body,
     )
 
 
@@ -413,6 +416,24 @@ class TestProductToWorkItem:
         assert item.stage is StageName.PLANNING and item.state == "ENTER"
         assert item.labels_cache == {"state:needs-plan": True}
         assert item.payload["entry_stage"] == "planning"
+
+    def test_issue_product_hydrates_issue_context_payload(self) -> None:
+        item = product_to_work_item(
+            "repo-a",
+            {
+                "kind": "issue",
+                "number": 9,
+                "stage": StageName.PLANNING,
+                "reason": "r",
+                "labels": ["state:needs-plan"],
+                "title": "Repo-discovered task",
+                "body": "Repo-discovered body.",
+            },
+        )
+
+        assert item is not None
+        assert item.payload["issue_title"] == "Repo-discovered task"
+        assert item.payload["issue_body"] == "Repo-discovered body."
 
     def test_issue_product_with_open_pr(self) -> None:
         item = product_to_work_item(

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -551,6 +551,24 @@ class TestPipelineScopeWiring:
 
         assert coordinator._routes is ROUTES
 
+    def test_direct_issue_scope_hydrates_issue_context_payload(self, tmp_path: Path) -> None:
+        """Explicit --issues seeding preserves the real issue title/body for prompts."""
+        gh = FakeStageGitHub(
+            labels=["state:needs-plan"],
+            issue_title="Hydrate planner context",
+            issue_body="Use the real issue body.",
+        )
+        config = self._scoped_config(tmp_path, issues=[1881])
+        coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
+
+        entries = coordinator._seed_direct_scope("repo-a")
+        item = coordinator._entry_to_item(entries[0], "repo-a")
+
+        assert entries[0].issue_title == "Hydrate planner context"
+        assert entries[0].issue_body == "Use the real issue body."
+        assert item.payload["issue_title"] == "Hydrate planner context"
+        assert item.payload["issue_body"] == "Use the real issue body."
+
     def test_at_or_past_plan_go_issue_clamps_to_finished(self, tmp_path: Path) -> None:
         """A plan-go issue classifies to IMPLEMENTATION; the scope clamps it to FINISHED-pass."""
         gh = FakeStageGitHub(labels=["state:plan-go"])

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -575,9 +575,7 @@ class TestLivenessAndFatal:
         with caplog.at_level("ERROR"):
             coordinator._force_run_one()
 
-        assert any(
-            "inflight_per_repo={'repo-a': 1}" in record.message for record in caplog.records
-        )
+        assert any("inflight_per_repo={'repo-a': 1}" in record.message for record in caplog.records)
 
     def test_idle_wait_resets_stall_counter_on_progress(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -38,6 +38,7 @@ def _facts(
     *,
     number: int = 1,
     title: str = "A task",
+    body: str = "",
     is_epic: bool = False,
     labels: set[str] | None = None,
     pr_number: int | None = None,
@@ -57,6 +58,7 @@ def _facts(
         pr_is_merged=pr_is_merged,
         pr_has_implementation_go=pr_has_implementation_go,
         pr_has_implementation_no_go=pr_has_implementation_no_go,
+        body=body,
     )
 
 
@@ -462,7 +464,12 @@ class TestSeedFromCli:
 
     def test_issues_arm_classified_via_seed_issue(self) -> None:
         """Issues run through seed_issue + classify_issue."""
-        facts = _facts(number=9, labels={STATE_PLAN_GO})
+        facts = _facts(
+            number=9,
+            title="Hydrate planner context",
+            body="Use the real issue body.",
+            labels={STATE_PLAN_GO},
+        )
         with patch(
             "hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts
         ) as mock_seed:
@@ -474,6 +481,8 @@ class TestSeedFromCli:
                 identifier=9,
                 stage=StageName.IMPLEMENTATION,
                 reason=f"#9 at-or-past {STATE_PLAN_GO}, no PR yet",
+                issue_title="Hydrate planner context",
+                issue_body="Use the real issue body.",
             )
         ]
 
@@ -496,6 +505,7 @@ class TestSeedFromCli:
                 stage=StageName.CI,
                 reason=f"#9 open PR with {STATE_IMPLEMENTATION_GO}",
                 pr_number=77,
+                issue_title="A task",
             )
         ]
 

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -243,6 +243,30 @@ class TestRepoScoping:
 
         assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
 
+    def test_repo_scoped_has_existing_plan_rejects_plan_comment_after_latest_nogo(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale plan comment is not valid after the latest plan review is NOGO."""
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            if argv[:2] == ["issue", "view"]:
+                payload = {
+                    "labels": [],
+                    "comments": [
+                        {"body": f"{PLAN_COMMENT_MARKER}\n\nOld rejected plan."},
+                        {"body": f"{PLAN_REVIEW_PREFIX}\n\nVerdict: NOGO"},
+                    ],
+                }
+                return SimpleNamespace(stdout=json.dumps(payload))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        assert (
+            pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
+            is False
+        )
+
     def test_repo_scoped_pr_lookup_raises_on_gh_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -227,6 +227,22 @@ class TestRepoScoping:
             ],
         ]
 
+    def test_repo_scoped_has_existing_plan_detects_plan_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            if argv[:2] == ["issue", "view"]:
+                payload = {
+                    "labels": [],
+                    "comments": [{"body": f"{PLAN_COMMENT_MARKER}\n\nDo the thing."}],
+                }
+                return SimpleNamespace(stdout=json.dumps(payload))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        assert pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).has_existing_plan(5)
+
     def test_repo_scoped_pr_lookup_raises_on_gh_failure(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -415,19 +415,34 @@ class TestUntrustedFencing:
         assert prompts._UNTRUSTED_NOTICE in out
 
     def test_plan_loop_review_prompt_fences_untrusted_fields(self) -> None:
-        """get_plan_loop_review_prompt fences issue_body, advise, and plan_text."""
+        """get_plan_loop_review_prompt fences all untrusted planning-loop fields."""
         out = prompts.get_plan_loop_review_prompt(
             issue_number=1,
-            issue_title="t",
+            issue_title=self.INJECTION,
             issue_body=self.INJECTION,
             plan_text=self.INJECTION,
             learnings="",
-            iteration=0,
-            prior_review=None,
+            iteration=1,
+            prior_review=self.INJECTION,
             advise_findings=self.INJECTION,
         )
+        assert self._fence_present(out, "ISSUE_TITLE")
         assert self._fence_present(out, "ISSUE_BODY")
         assert self._fence_present(out, "ADVISE_FINDINGS")
+        assert self._fence_present(out, "PLAN_TEXT")
+        assert self._fence_present(out, "PRIOR_REVIEW")
+        assert prompts._UNTRUSTED_NOTICE in out
+
+    def test_plan_review_prompt_fences_untrusted_fields(self) -> None:
+        """get_plan_review_prompt fences title, body, and plan text."""
+        out = prompts.get_plan_review_prompt(
+            issue_number=1,
+            issue_title=self.INJECTION,
+            issue_body=self.INJECTION,
+            plan_text=self.INJECTION,
+        )
+        assert self._fence_present(out, "ISSUE_TITLE")
+        assert self._fence_present(out, "ISSUE_BODY")
         assert self._fence_present(out, "PLAN_TEXT")
         assert prompts._UNTRUSTED_NOTICE in out
 


### PR DESCRIPTION
Closes #1950

## Summary
- hydrate direct issue title/body context through seeding into pipeline work items
- include and fence issue/advice/review context for planner and amendment prompts
- prevent Codex child processes from inheriting unrelated parent thread IDs
- make repo-scoped existing-plan detection ignore plan-review comments
- apply one mechanical Ruff formatting cleanup needed for the full format gate

## Verification
- pixi run pytest tests/unit -v
- pixi run python -m mypy hephaestus/
- pixi run ruff check hephaestus/ tests/
- pixi run ruff format --check hephaestus/ tests/
- pixi run pytest tests/unit/automation/pipeline/test_coordinator_edges.py -q --no-cov
- pixi run pre-commit run --files <changed files>