### PR TITLE
fix(pipeline): classify generic agent failures

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -230,6 +230,11 @@ class WorkerPool:
         every blip into a failed pipeline stage. Non-transient errors (rc!=0
         with non-transient stderr, timeouts) are NOT retried; they surface
         immediately as error results.
+
+        Unexpected Exception subclasses from agent resolution, prompt
+        construction, and the resilience wrapper are classified in this method
+        for symmetry with the specific agent failures below. Process-control
+        escapes still propagate to _on_future_done's crash handler.
         """
         try:
             agent = resolve_agent(job.agent)
@@ -295,6 +300,12 @@ class WorkerPool:
                 error=f"rc={exc.returncode}",
                 stdout_tail=(exc.stdout or "")[-_TAIL:],
                 stderr_tail=(exc.stderr or "")[-_TAIL:],
+            )
+        except Exception as exc:
+            logger.exception("Agent job raised, returning error result")
+            return JobResult(
+                ok=False,
+                error=f"{type(exc).__name__}: {exc!s}"[:500],
             )
 
     def _run_build_test(self, job: BuildTestJob) -> JobResult:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -288,6 +288,47 @@ class TestAgentErrorHandling:
         assert "RuntimeError" in result.error
         assert "prompt builder exploded" in result.error
 
+    def test_run_agent_classifies_resolve_agent_exception(
+        self,
+        pool: WorkerPool,
+    ) -> None:
+        """resolve_agent failures are classified inside _run_agent."""
+        job = _agent_job(model="model-resolve-generic", agent="bad-agent")
+
+        with patch(f"{_WP}.resolve_agent", side_effect=ValueError("bad agent")):
+            result = pool._run_agent(job)
+
+        assert result.ok is False
+        assert result.error == "ValueError: bad agent"
+
+    def test_run_agent_classifies_prompt_builder_exception(self, pool: WorkerPool) -> None:
+        """Prompt builder failures are classified inside _run_agent."""
+
+        def missing_prompt() -> str:
+            raise KeyError("prompt-template")
+
+        job = _agent_job(model="model-prompt-generic", prompt_builder=missing_prompt)
+
+        with patch(f"{_WP}.resolve_agent", return_value="claude"):
+            result = pool._run_agent(job)
+
+        assert result.ok is False
+        assert "KeyError" in (result.error or "")
+        assert "prompt-template" in (result.error or "")
+
+    def test_run_agent_classifies_resilient_call_exception(self, pool: WorkerPool) -> None:
+        """Unexpected resilience-wrapper failures are classified inside _run_agent."""
+        job = _agent_job(model="model-resilient-generic", prompt_builder=lambda: "prompt")
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.resilient_call", side_effect=OSError("retry wrapper failed")),
+        ):
+            result = pool._run_agent(job)
+
+        assert result.ok is False
+        assert result.error == "OSError: retry wrapper failed"
+
     def test_unknown_job_type_returns_error_result(self, pool: WorkerPool) -> None:
         """A job of unknown type is converted to a TypeError error result."""
         result = pool._run(cast(AgentJob, object()))


### PR DESCRIPTION
## Summary
- classify unexpected _run_agent Exception subclasses inside WorkerPool._run_agent
- preserve existing circuit-open, timeout, and CalledProcessError result shapes
- add direct regression coverage for resolve_agent, prompt-builder, and resilience-wrapper generic failures

Closes #1880

## Verification
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -k "run_agent_classifies" -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -k "circuit_breaker_open_returns_error or agent_timeout_returns_error or agent_called_process_error_returns_rc_and_tails" -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -v --no-cov
- pixi run ruff check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run ruff format --check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run python -m mypy hephaestus/automation/pipeline/worker_pool.py
- pixi run pre-commit run --files hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py