### PR TITLE
fix(pipeline): normalize interrupted worker results

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -183,32 +183,36 @@ class WorkerPool:
 
         # Pre-check: do not start a queued job if shutdown is set.
         if self._shutdown.is_set():
-            return JobResult(ok=False, interrupted=True, error="interrupted_before_start")
-
-        try:
-            if isinstance(job, AgentJob):
-                result = self._run_agent(job)
-            elif isinstance(job, BuildTestJob):
-                result = self._run_build_test(job)
-            elif isinstance(job, GitJob):
-                result = self._run_git(job)
-            else:
-                raise TypeError(f"unknown job type {type(job)}")
-        except Exception as exc:
-            # Convert job execution failures into a JobResult so the callback
-            # never re-raises into its thread. This catches normal runtime errors
-            # but allows process-control exceptions to propagate normally.
-            logger.exception("Job %s raised, returning error result", job)
             result = JobResult(
                 ok=False,
-                error=f"{type(exc).__name__}: {exc!s}"[:500],
+                interrupted=True,
+                error="interrupted_before_start",
             )
+        else:
+            try:
+                if isinstance(job, AgentJob):
+                    result = self._run_agent(job)
+                elif isinstance(job, BuildTestJob):
+                    result = self._run_build_test(job)
+                elif isinstance(job, GitJob):
+                    result = self._run_git(job)
+                else:
+                    raise TypeError(f"unknown job type {type(job)}")
+            except Exception as exc:
+                # Convert job execution failures into a JobResult so the callback
+                # never re-raises into its thread. This catches normal runtime errors
+                # but allows process-control exceptions to propagate normally.
+                logger.exception("Job %s raised, returning error result", job)
+                result = JobResult(
+                    ok=False,
+                    error=f"{type(exc).__name__}: {exc!s}"[:500],
+                )
 
-        # Mandatory post-check: SIGINT to the process group makes subprocess
-        # children return "normally" (rc=0 or some other code), so an
-        # interrupted job must never read as success.
-        if self._shutdown.is_set():
-            result = replace(result, interrupted=True, ok=False)
+            # Mandatory post-check: SIGINT to the process group makes subprocess
+            # children return "normally" (rc=0 or some other code), so an
+            # interrupted job must never read as success.
+            if self._shutdown.is_set():
+                result = replace(result, interrupted=True, ok=False)
 
         return replace(
             result,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -437,11 +437,16 @@ class TestInterruptedPostCheck:
 
         job = _agent_job(prompt_builder=MagicMock())
 
-        pool.submit(job, StageName.PLANNING)
-        _, result = completion_q.get(timeout=10)
+        with patch(f"{_WP}.time.monotonic", side_effect=[10.0, 10.25]):
+            pool.submit(job, StageName.PLANNING)
+            _, result = completion_q.get(timeout=10)
 
         assert result.interrupted is True
+        assert result.ok is False
         assert result.error == "interrupted_before_start"
+        assert result.duration_s == pytest.approx(0.25)
+        assert result.stdout_tail == ""
+        assert result.stderr_tail == ""
         # Callable should never have been invoked (was MagicMock above)
         assert not job.prompt_builder.called  # type: ignore[attr-defined]
 


### PR DESCRIPTION
## Summary
- Route shutdown-before-start worker results through the shared JobResult normalization path.
- Extend the interrupted-before-start regression test to assert measured duration and normalized tails while still skipping the prompt builder.

Closes #1881

## Verification
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -k interrupted_before_start -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_coordinator_edges.py -k agent_job_time_accounting -v --no-cov
- pixi run ruff check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run ruff format --check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run python -m mypy hephaestus/automation/pipeline/worker_pool.py
- pixi run pre-commit run --files hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py