### PR TITLE
fix(pipeline): evict idle repo locks

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -11,8 +11,10 @@ import logging
 import subprocess
 import threading
 import time
+from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import replace
+from contextlib import contextmanager
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from hephaestus.agents.runtime import resolve_agent, run_agent_session
@@ -63,6 +65,14 @@ def _repo_lock_path(repo: str, lock_dir: Path | None = None) -> Path:
     return lock_dir / f"git-{repo.replace('/', '_')}.lock"
 
 
+@dataclass
+class _RepoLockEntry:
+    """In-process git lock plus active/waiting user count."""
+
+    lock: threading.Lock
+    users: int = 0
+
+
 class WorkerPool:
     """Thread pool executor for submitting and tracking frozen jobs.
 
@@ -104,14 +114,28 @@ class WorkerPool:
         self._executor = ThreadPoolExecutor(max_workers=size)
         self._shutdown = shutdown
         self._completion_q = completion_q
-        self._repo_locks: dict[str, threading.Lock] = {}
+        self._repo_locks: dict[str, _RepoLockEntry] = {}
         self._repo_locks_guard = threading.Lock()
         self._lock_dir = lock_dir
 
-    def _repo_lock(self, repo: str) -> threading.Lock:
-        """Get or create a per-repo lock (held during git operations)."""
+    @contextmanager
+    def _repo_lock(self, repo: str) -> Iterator[None]:
+        """Acquire a per-repo git lock and evict its cache entry when idle."""
         with self._repo_locks_guard:
-            return self._repo_locks.setdefault(repo, threading.Lock())
+            entry = self._repo_locks.get(repo)
+            if entry is None:
+                entry = _RepoLockEntry(threading.Lock())
+                self._repo_locks[repo] = entry
+            entry.users += 1
+
+        try:
+            with entry.lock:
+                yield
+        finally:
+            with self._repo_locks_guard:
+                entry.users -= 1
+                if entry.users == 0 and self._repo_locks.get(repo) is entry:
+                    self._repo_locks.pop(repo, None)
 
     def submit(
         self, job: AgentJob | BuildTestJob | GitJob, on_done_state: str | StageName
@@ -351,9 +375,8 @@ class WorkerPool:
         blocking flock wait to one thread. Both locks are held for the entire
         operation because worktrees share ``.git``.
         """
-        lock = self._repo_lock(job.repo)
         try:
-            with lock, file_lock(_repo_lock_path(job.repo, self._lock_dir)):
+            with self._repo_lock(job.repo), file_lock(_repo_lock_path(job.repo, self._lock_dir)):
                 return self._dispatch_git_op(job)
         except subprocess.TimeoutExpired as exc:
             return JobResult(

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import queue
 import subprocess
 import threading
+import time
 from collections.abc import Iterator
 from concurrent.futures import Future
 from pathlib import Path
@@ -869,10 +870,71 @@ class TestGitLocking:
         self,
         pool: WorkerPool,
     ) -> None:
-        """Two GitJobs for different repos use different locks."""
-        lock1 = pool._repo_lock("test/repo1")
-        lock2 = pool._repo_lock("test/repo2")
+        """Two active GitJob repo contexts use different in-process locks."""
+        with pool._repo_lock("test/repo1"), pool._repo_lock("test/repo2"):
+            with pool._repo_locks_guard:
+                lock1 = pool._repo_locks["test/repo1"].lock
+                lock2 = pool._repo_locks["test/repo2"].lock
+
         assert lock1 is not lock2
+        with pool._repo_locks_guard:
+            assert pool._repo_locks == {}
+
+    def test_repo_lock_evicted_after_git_job_completes(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """A completed GitJob does not leave an idle repo lock cached forever."""
+        job = GitJob(repo="test/repo", op="create_worktree", timeout_s=60, kwargs={})
+
+        with patch(f"{_WP}.WorktreeManager", return_value=MagicMock()):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is True
+        with pool._repo_locks_guard:
+            assert pool._repo_locks == {}
+
+    def test_repo_lock_not_evicted_while_waiter_holds_it(
+        self,
+        pool: WorkerPool,
+    ) -> None:
+        """A waiting same-repo user keeps the shared lock entry until it exits."""
+        waiter_acquired = threading.Event()
+        release_waiter = threading.Event()
+
+        def wait_for_users(expected: int) -> None:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                with pool._repo_locks_guard:
+                    entry = pool._repo_locks.get("test/repo")
+                    if entry is not None and entry.users == expected:
+                        return
+                time.sleep(0.01)
+            pytest.fail(f"repo lock users never reached {expected}")
+
+        def waiter() -> None:
+            with pool._repo_lock("test/repo"):
+                waiter_acquired.set()
+                release_waiter.wait(timeout=5.0)
+
+        with pool._repo_lock("test/repo"):
+            with pool._repo_locks_guard:
+                entry = pool._repo_locks["test/repo"]
+            thread = threading.Thread(target=waiter)
+            thread.start()
+            wait_for_users(2)
+
+        assert waiter_acquired.wait(timeout=5.0)
+        with pool._repo_locks_guard:
+            assert pool._repo_locks.get("test/repo") is entry
+
+        release_waiter.set()
+        thread.join(timeout=5.0)
+        assert not thread.is_alive()
+        with pool._repo_locks_guard:
+            assert "test/repo" not in pool._repo_locks
 
     def test_repo_lock_path_anchors_at_state_dir(self) -> None:
         """Default lock path is anchored at repo_root/DEFAULT_STATE_DIR, not CWD."""


### PR DESCRIPTION
## Summary
- Replace WorkerPool's raw per-repo lock cache with reference-counted lock entries.
- Evict idle in-process repo lock entries after GitJob completion while preserving same-repo serialization for waiters.
- Add regression tests for lock eviction and waiter safety.

Closes #1882

## Verification
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking::test_repo_lock_evicted_after_git_job_completes -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking::test_repo_lock_not_evicted_while_waiter_holds_it -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -v --no-cov
- pixi run ruff check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run ruff format --check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run python -m mypy hephaestus/automation/pipeline/worker_pool.py
- pixi run pre-commit run --files hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py