### PR TITLE
fix(pipeline): bound git file lock waits

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -13,7 +13,7 @@ import threading
 import time
 from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -34,12 +34,13 @@ from hephaestus.resilience import (
     CircuitBreakerOpenError,
     resilient_call,
 )
-from hephaestus.utils.file_lock import file_lock
+from hephaestus.utils.file_lock import LockUnavailableError, file_lock
 from hephaestus.utils.helpers import get_repo_root
 
 logger = logging.getLogger(__name__)
 
 _TAIL = 4000  # chars of stdout/stderr retained in a JobResult
+_GIT_LOCK_WAIT_POLL_S = 0.1
 
 
 def _repo_lock_path(repo: str, lock_dir: Path | None = None) -> Path:
@@ -71,6 +72,47 @@ class _RepoLockEntry:
 
     lock: threading.Lock
     users: int = 0
+
+
+class _GitLockTimeoutError(TimeoutError):
+    """Raised when a Git job cannot acquire its cross-process repo lock in time."""
+
+
+class _GitLockInterruptedError(RuntimeError):
+    """Raised when shutdown interrupts a Git job while it waits for the repo lock."""
+
+
+@contextmanager
+def _interruptible_file_lock(
+    path: Path,
+    *,
+    shutdown: threading.Event,
+    timeout_s: float,
+) -> Iterator[None]:
+    """Acquire ``path`` without an unbounded blocking flock wait."""
+    deadline = time.monotonic() + max(timeout_s, 0.0)
+
+    while True:
+        if shutdown.is_set():
+            raise _GitLockInterruptedError
+
+        with ExitStack() as stack:
+            try:
+                stack.enter_context(file_lock(path, blocking=False))
+            except LockUnavailableError as exc:
+                now = time.monotonic()
+                if now >= deadline:
+                    raise _GitLockTimeoutError from exc
+
+                wait_s = min(_GIT_LOCK_WAIT_POLL_S, deadline - now)
+                if shutdown.wait(timeout=wait_s):
+                    raise _GitLockInterruptedError from exc
+                continue
+
+            if shutdown.is_set():
+                raise _GitLockInterruptedError
+            yield
+            return
 
 
 class WorkerPool:
@@ -375,9 +417,25 @@ class WorkerPool:
         blocking flock wait to one thread. Both locks are held for the entire
         operation because worktrees share ``.git``.
         """
+        lock_path = _repo_lock_path(job.repo, self._lock_dir)
         try:
-            with self._repo_lock(job.repo), file_lock(_repo_lock_path(job.repo, self._lock_dir)):
+            with (
+                self._repo_lock(job.repo),
+                _interruptible_file_lock(
+                    lock_path,
+                    shutdown=self._shutdown,
+                    timeout_s=job.timeout_s,
+                ),
+            ):
                 return self._dispatch_git_op(job)
+        except _GitLockTimeoutError:
+            return JobResult(ok=False, error="lock_timeout")
+        except _GitLockInterruptedError:
+            return JobResult(
+                ok=False,
+                interrupted=True,
+                error="interrupted_waiting_for_git_lock",
+            )
         except subprocess.TimeoutExpired as exc:
             return JobResult(
                 ok=False,

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import queue
 import subprocess
 import threading
@@ -26,6 +27,7 @@ from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.worker_pool import WorkerPool, _repo_lock_path
 from hephaestus.resilience import CircuitBreakerOpenError
+from hephaestus.utils.file_lock import LockUnavailableError
 from hephaestus.utils.helpers import get_repo_root
 
 _WP = "hephaestus.automation.pipeline.worker_pool"
@@ -959,6 +961,71 @@ class TestGitLocking:
 
         assert result.ok is True
         assert (tmp_path / "locks" / "git-test_repo.lock").exists()
+
+    def test_git_file_lock_timeout_returns_lock_timeout_and_releases_repo_lock(
+        self,
+        pool: WorkerPool,
+        tmp_path: Path,
+    ) -> None:
+        """A held cross-process lock fails fast with lock_timeout."""
+        fcntl = pytest.importorskip("fcntl")
+        lock_path = _repo_lock_path("test/repo", tmp_path / "locks")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        held_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+        job = GitJob(repo="test/repo", op="create_worktree", timeout_s=0, kwargs={})
+
+        try:
+            fcntl.flock(held_fd, fcntl.LOCK_EX)
+            with patch(f"{_WP}.WorktreeManager") as manager:
+                result = pool._run_git(job)
+        finally:
+            fcntl.flock(held_fd, fcntl.LOCK_UN)
+            os.close(held_fd)
+
+        manager.assert_not_called()
+        assert result.ok is False
+        assert result.error == "lock_timeout"
+        with pool._repo_locks_guard:
+            assert pool._repo_locks == {}
+
+    def test_git_file_lock_wait_is_interrupted_by_shutdown(
+        self,
+        pool: WorkerPool,
+        shutdown_event: threading.Event,
+    ) -> None:
+        """Shutdown while waiting for the file lock returns an interrupted result."""
+        job = GitJob(repo="test/repo", op="create_worktree", timeout_s=60, kwargs={})
+
+        def interrupting_wait(timeout: float | None = None) -> bool:
+            shutdown_event.set()
+            return True
+
+        with (
+            patch(f"{_WP}.file_lock", side_effect=LockUnavailableError("held")),
+            patch.object(shutdown_event, "wait", side_effect=interrupting_wait),
+            patch(f"{_WP}.WorktreeManager") as manager,
+        ):
+            result = pool._run_git(job)
+
+        manager.assert_not_called()
+        assert result.ok is False
+        assert result.interrupted is True
+        assert result.error == "interrupted_waiting_for_git_lock"
+        with pool._repo_locks_guard:
+            assert pool._repo_locks == {}
+
+    def test_git_file_lock_wait_does_not_swallow_dispatch_lock_errors(
+        self,
+        pool: WorkerPool,
+    ) -> None:
+        """Only outer lock acquisition failures are mapped to lock_timeout."""
+        job = GitJob(repo="test/repo", op="create_worktree", timeout_s=0, kwargs={})
+        instance = MagicMock()
+        instance.create_worktree.side_effect = LockUnavailableError("inner lock")
+
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+            with pytest.raises(LockUnavailableError, match="inner lock"):
+                pool._run_git(job)
 
 
 class TestShutdownAndCancel:


### PR DESCRIPTION
## Summary
- add bounded, shutdown-interruptible acquisition for WorkerPool git file locks
- map stale file-lock waits to lock_timeout and shutdown waits to interrupted results
- cover timeout, shutdown, and dispatch LockUnavailableError regression behavior

Closes #1883

## Verification
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking::test_git_file_lock_timeout_returns_lock_timeout_and_releases_repo_lock tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking::test_git_file_lock_wait_is_interrupted_by_shutdown tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking::test_git_file_lock_wait_does_not_swallow_dispatch_lock_errors -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py::TestGitLocking -v --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py -v --no-cov
- pixi run ruff check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run ruff format --check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run python -m mypy hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py
- pixi run pre-commit run --files hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py

## Audit
- read-only audit agent returned GO/no blocking findings