### PR TITLE
[mino] _run_git only catches TimeoutExpired; git CalledProcessError loses the rc/stderr framing other job kinds provide

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -443,6 +443,13 @@ class WorkerPool:
                 stdout_tail=str(exc.stdout or "")[-_TAIL:],
                 stderr_tail=str(exc.stderr or "")[-_TAIL:],
             )
+        except subprocess.CalledProcessError as exc:
+            return JobResult(
+                ok=False,
+                error=f"rc={exc.returncode}",
+                stdout_tail=(exc.stdout or "")[-_TAIL:],
+                stderr_tail=(exc.stderr or "")[-_TAIL:],
+            )
 
     def _dispatch_git_op(self, job: GitJob) -> JobResult:
         """Dispatch a git operation to its handler.

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -755,6 +755,34 @@ class TestGitOps:
         assert result.ok is False
         assert result.error == "timeout"
 
+    def test_git_called_process_error_returns_rc_and_tails(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """Git CalledProcessError maps to rc=<n> with stdout/stderr tails."""
+        job = GitJob(
+            repo="test/repo",
+            op="clone",
+            timeout_s=60,
+            kwargs={"repo": "owner/name", "dest": "/tmp/dest"},
+        )
+        exc = subprocess.CalledProcessError(
+            returncode=128,
+            cmd=["gh", "repo", "clone", "owner/name", "/tmp/dest"],
+            output="clone stdout tail",
+            stderr="fatal: repository access denied",
+        )
+
+        with patch("hephaestus.automation.git_utils.run", side_effect=exc):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error == "rc=128"
+        assert result.stdout_tail == "clone stdout tail"
+        assert result.stderr_tail == "fatal: repository access denied"
+
     def test_unknown_op_fallback(self, pool: WorkerPool) -> None:
         """The defensive unknown-op branch returns an error result.
 


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: `_run_git` now returns `rc=<returncode>` plus stdout/stderr tails for git `CalledProcessError`; regression added in `test_worker_pool.py`; verified with full `pixi run python -m pytest tests/ -v` (`6067 passed, 25 skipped`, coverage `83.89%`), mypy, ruff, format check, pre-commit, and `git diff --check`.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1884

Generated by ProjectHephaestus automation
