### PR TITLE
fix(pipeline): wire queue controls and event logging

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -348,6 +348,7 @@ def build_automation_parser(
     formatter_class: type[argparse.HelpFormatter] | None = None,
     add_agent: bool = True,
     add_max_workers: bool = True,
+    max_workers_default: int = DEFAULT_WORKER_COUNT,
     max_workers_help: str = "Maximum number of parallel workers, 1-32 (default: 3)",
     add_parallel: bool = False,
     parallel_help: str = "Number of parallel workers, 1-32 (default: 3)",
@@ -370,6 +371,7 @@ def build_automation_parser(
         formatter_class: Optional argparse formatter class.
         add_agent: Add the common ``--agent`` provider selector.
         add_max_workers: Add the common validated ``--max-workers`` flag.
+        max_workers_default: Default worker count when ``--max-workers`` is omitted.
         max_workers_help: Help text for ``--max-workers``.
         add_parallel: Add the planner-style ``--parallel`` worker flag.
         parallel_help: Help text for ``--parallel``.
@@ -394,7 +396,7 @@ def build_automation_parser(
     if add_agent:
         add_agent_argument(parser)
     if add_max_workers:
-        add_max_workers_arg(parser, help_text=max_workers_help)
+        add_max_workers_arg(parser, default=max_workers_default, help_text=max_workers_help)
     if add_parallel:
         parser.add_argument(
             "--parallel",

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -77,6 +77,8 @@ ALL_POST_LOOP_STAGES: tuple[str, ...] = ("drive-green",)
 # any subset via --phases; unselected phases are skipped.
 ALL_SELECTABLE: tuple[str, ...] = ALL_PHASES + ALL_POST_LOOP_STAGES
 
+LOOP_DEFAULT_MAX_WORKERS = 6
+
 # DEFAULT_PROJECTS_DIR is re-exported from hephaestus.config.paths so existing
 # tests that patch this module-level name continue to work. See #704: the
 # projects root is now resolved at runtime via resolve_projects_dir().
@@ -163,7 +165,7 @@ class LoopConfig:
     """
 
     loops: int = 5
-    max_workers: int = 3
+    max_workers: int = LOOP_DEFAULT_MAX_WORKERS
     parallel_repos: int = 1
     # Dataclass default covers ONLY the iteration phases (``ALL_PHASES`` =
     # plan, implement), deliberately excluding drive-green — a bare
@@ -214,8 +216,9 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="hephaestus-automation-loop",
         description=("Run the queue-based automation pipeline across HomericIntelligence repos."),
         max_workers_help=(
-            "Parallel workers per repo per phase (1-32, default: 3). Passes to child phases."
+            "Parallel workers per repo per phase (1-32, default: 6). Passes to child phases."
         ),
+        max_workers_default=LOOP_DEFAULT_MAX_WORKERS,
         add_github_throttle=True,
         dry_run_prefix=(
             "Forward --dry-run to every phase (suppresses GitHub mutations and git pushes)."
@@ -429,13 +432,17 @@ def _pipeline_scope_for_phases(phases: tuple[str, ...]) -> PipelineScope | None:
 
 
 def _pipeline_event_log_path(projects_dir: Path, repos: list[str]) -> Path | None:
-    """Return the default durable event-log path for a loop invocation."""
+    """Return the default durable event-log path for a loop invocation.
+
+    The coordinator writes ``run_start`` before repo discovery. Keeping the
+    default log under the local automation state dir avoids creating
+    ``projects_dir / repo`` early, which would look like a cloned checkout to
+    the repo stage.
+    """
     if not repos:
         return None
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    return (
-        projects_dir / repos[0] / DEFAULT_STATE_DIR / f"pipeline-events-{stamp}-{os.getpid()}.jsonl"
-    )
+    return Path(DEFAULT_STATE_DIR) / f"pipeline-events-{stamp}-{os.getpid()}.jsonl"
 
 
 # ---------------------------------------------------------------------------

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -38,6 +38,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from hephaestus.automation.pipeline.coordinator import PipelineConfig
+    from hephaestus.automation.pipeline.routing import PipelineScope
 
 from hephaestus.agents.runtime import resolve_agent
 from hephaestus.automation._review_utils import build_automation_parser
@@ -396,6 +397,34 @@ def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
     return warnings
 
 
+def _pipeline_scope_for_phases(phases: tuple[str, ...]) -> PipelineScope | None:
+    """Translate top-level phase names into a contiguous pipeline scope.
+
+    ``None`` preserves the default full pipeline, including repo discovery.
+    Partial selections use the same stage ownership as the focused wrapper
+    CLIs: plan = planning+plan_review, implement = implementation+pr_review,
+    drive-green = ci+merge_wait.
+    """
+    selected = set(phases)
+    if selected == set(ALL_SELECTABLE):
+        return None
+
+    from hephaestus.automation.pipeline.routing import PipelineScope, StageName
+
+    stage_sets = {
+        "plan": (StageName.PLANNING, StageName.PLAN_REVIEW),
+        "implement": (StageName.IMPLEMENTATION, StageName.PR_REVIEW),
+        "drive-green": (StageName.CI, StageName.MERGE_WAIT),
+    }
+    stages = frozenset(
+        stage for phase in ALL_SELECTABLE if phase in selected for stage in stage_sets[phase]
+    )
+    try:
+        return PipelineScope(stages)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+
 # ---------------------------------------------------------------------------
 # Repo discovery — re-exported from loop_repo_manager (refs #1360 / #1179).
 # The helpers above are imported at module level with explicit ``as`` aliases,
@@ -546,8 +575,10 @@ def _build_pipeline_config(
         no_advise=cfg.no_advise,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
+        budget_overrides={"merge": cfg.max_merge_attempts},
         projects_dir=cfg.projects_dir,
         json_out=args.json,
+        scope=_pipeline_scope_for_phases(cfg.phases),
     )
 
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -30,9 +30,11 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -49,6 +51,7 @@ from hephaestus.automation.loop_repo_manager import (
     _resolve_repo_dir as _resolve_repo_dir,
     _sort_repos_by_open_count as _sort_repos_by_open_count,
 )
+from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.cli.utils import (
     configure_github_throttle_from_args,
     emit_json_status,
@@ -425,6 +428,16 @@ def _pipeline_scope_for_phases(phases: tuple[str, ...]) -> PipelineScope | None:
         raise SystemExit(str(exc)) from exc
 
 
+def _pipeline_event_log_path(projects_dir: Path, repos: list[str]) -> Path | None:
+    """Return the default durable event-log path for a loop invocation."""
+    if not repos:
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return (
+        projects_dir / repos[0] / DEFAULT_STATE_DIR / f"pipeline-events-{stamp}-{os.getpid()}.jsonl"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Repo discovery — re-exported from loop_repo_manager (refs #1360 / #1179).
 # The helpers above are imported at module level with explicit ``as`` aliases,
@@ -576,6 +589,8 @@ def _build_pipeline_config(
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
         budget_overrides={"merge": cfg.max_merge_attempts},
+        serialize_file_overlap=cfg.serialize_file_overlap,
+        event_log_path=_pipeline_event_log_path(cfg.projects_dir, repos),
         projects_dir=cfg.projects_dir,
         json_out=args.json,
         scope=_pipeline_scope_for_phases(cfg.phases),

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -623,8 +623,25 @@ class Coordinator:
         self._progress = True
         item = self.in_flight.pop(handle, None)
         if item is None:
+            self._record_event(
+                "complete_unknown",
+                type(handle.job).__name__,
+                handle.on_done_state,
+                self._job_result_event_fields(result),
+            )
             logger.warning("completion for unknown handle (already torn down?): %s", handle)
             return
+        self._record_event(
+            "complete",
+            type(handle.job).__name__,
+            self._item_key(item),
+            item.stage.value,
+            handle.on_done_state,
+            {
+                "descr": getattr(handle.job, "descr", ""),
+                **self._job_result_event_fields(result),
+            },
+        )
         self.inflight_per_repo[item.repo] -= 1
         if self.inflight_per_repo[item.repo] <= 0:
             del self.inflight_per_repo[item.repo]
@@ -673,11 +690,22 @@ class Coordinator:
         )
         item.add_history_event(item.stage, item.state, note="interrupted; resumable")
         self._resumable.append(item)
+        self._record_event("resumable", self._item_key(item), item.stage.value, item.state)
         logger.info(
             "interrupt: item %s RESUMABLE at %s (never failed)",
             self._item_key(item),
             item.stage.value,
         )
+
+    @staticmethod
+    def _job_result_event_fields(result: JobResult) -> dict[str, Any]:
+        """Return bounded, output-free job result fields for durable event logs."""
+        return {
+            "ok": result.ok,
+            "interrupted": result.interrupted,
+            "error": result.error,
+            "duration_s": round(result.duration_s, 3),
+        }
 
     # -- queue draining and admission ---------------------------------------
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -72,6 +72,7 @@ module's ``finally`` — on completion AND interrupt.
 from __future__ import annotations
 
 import heapq
+import json
 import logging
 import queue as queue_mod
 import signal
@@ -136,6 +137,8 @@ _MAX_STEPS_PER_TICK = 100
 #: cycles terminate even if a stage's own bookkeeping has a bug.
 _FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
 
+_WAKE_HANDLE = object()
+
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
 #: finished sink drains first of all so results are recorded promptly).
@@ -157,6 +160,23 @@ def _budget_lookup(name: str) -> int:
         if name in route.budgets:
             return route.budgets[name]
     return 1
+
+
+def _json_safe(value: Any) -> Any:
+    """Return a JSON-serializable representation for event-log fields."""
+    if isinstance(value, StageName):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, tuple):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
 
 
 @dataclass(frozen=True)
@@ -192,6 +212,8 @@ class PipelineConfig:
     # coordinator's budget accessor. ``--max-fix-iterations N`` maps to
     # ``{"ci_fix": N}`` so the CI-fix attempt budget is caller-tunable.
     budget_overrides: dict[str, int] = field(default_factory=dict)
+    serialize_file_overlap: bool = True
+    event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
     json_out: bool = False
     # Optional contiguous stage subset. When set, the coordinator routes items
@@ -297,6 +319,7 @@ class Coordinator:
         self.preserved: list[tuple[int, str]] = []
         self.items: list[WorkItem] = []
         self.event_log: list[tuple[Any, ...]] = []
+        self._event_log_disabled = False
         self.stages: dict[StageName, Stage] = stages or self._default_stages()
         # Route table for this run: the full ROUTES, or a scope-trimmed copy
         # (out-of-scope next/fail targets rewritten to FINISHED) when the
@@ -394,6 +417,31 @@ class Coordinator:
             return override
         return _budget_lookup(name)
 
+    def _record_event(self, event: str, *fields: Any) -> None:
+        """Append an event to memory and, when configured, to JSONL on disk."""
+        self.event_log.append((event, *fields))
+        if self._event_log_disabled:
+            return
+        path = self.config.event_log_path
+        if path is None:
+            return
+        record = {
+            "ts": time.time(),
+            "event": event,
+            "fields": [_json_safe(field) for field in fields],
+        }
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, sort_keys=True) + "\n")
+        except OSError as exc:
+            logger.warning("failed to write pipeline event log %s: %s", path, exc)
+            self._event_log_disabled = True
+
+    def _wake_completion_wait(self) -> None:
+        """Wake the coordinator if it is blocked in completion_q.get()."""
+        self.completion_q.put((_WAKE_HANDLE, JobResult(ok=False, interrupted=True, error="wake")))
+
     # -- run loop ---------------------------------------------------------------
 
     def run(self) -> int:
@@ -402,6 +450,17 @@ class Coordinator:
         if self._install_signals:
             self._install_signal_handlers()
         try:
+            self._record_event(
+                "run_start",
+                {
+                    "org": self.config.org,
+                    "repos": self.config.repos,
+                    "issues": self.config.issues,
+                    "prs": self.config.prs,
+                    "loops": self.config.loops,
+                    "max_workers": self.config.max_workers,
+                },
+            )
             self._loops_run = 1
             self._seed_pass()
             while True:
@@ -435,6 +494,16 @@ class Coordinator:
                 agent_job_count=self._agent_job_count,
                 agent_job_time_s=self._agent_job_time_s,
                 wall_s=time.monotonic() - started,
+            )
+            self._record_event(
+                "run_end",
+                {
+                    "exit_code": exit_code,
+                    "interrupted": self.shutdown.is_set(),
+                    "items": len(self.items),
+                    "agent_jobs": self._agent_job_count,
+                    "wall_s": stats.wall_s,
+                },
             )
             print_summary(self.items, stats, self.preserved, json_out=self.config.json_out)
         return exit_code
@@ -510,7 +579,7 @@ class Coordinator:
         heapq.heappush(self.timers, (wake, self._seq, item))
         self._seq += 1
         item.add_history_event(item.stage, item.state, note=f"timer-parked {delay_s:.1f}s")
-        self.event_log.append(("timer_park", item.stage.value, self._item_key(item), delay_s))
+        self._record_event("timer_park", item.stage.value, self._item_key(item), delay_s)
 
     def _wake_timers(self) -> None:
         """Move every expired timer entry back into its stage queue."""
@@ -529,6 +598,9 @@ class Coordinator:
                 handle, result = self.completion_q.get_nowait()
             except queue_mod.Empty:
                 return
+            if handle is _WAKE_HANDLE:
+                self._record_event("wake", "completion_q")
+                continue
             self._handle_completion(handle, result)
 
     def _wait_for_completion(self, timeout: float) -> None:
@@ -536,6 +608,9 @@ class Coordinator:
         try:
             handle, result = self.completion_q.get(timeout=timeout)
         except queue_mod.Empty:
+            return
+        if handle is _WAKE_HANDLE:
+            self._record_event("wake", "completion_q")
             return
         self._handle_completion(handle, result)
 
@@ -622,7 +697,7 @@ class Coordinator:
                 if not self._admit(item):
                     q.push(item)
                     continue
-                self.event_log.append(("drain", stage_name.value, self._item_key(item)))
+                self._record_event("drain", stage_name.value, self._item_key(item))
                 self._run_item(item)
 
     def _drain_implementation(self) -> None:
@@ -659,7 +734,7 @@ class Coordinator:
         ]
         ordered = _admission.order_for_implementation(infos)
         dispatch = ordered
-        if self.config.max_workers > 1 and len(ordered) > 1:
+        if self.config.serialize_file_overlap and self.config.max_workers > 1 and len(ordered) > 1:
             dispatch, deferred = _admission._select_non_overlapping(ordered)
             for number in deferred:
                 logger.info("implementation #%s deferred (file overlap)", number)
@@ -669,7 +744,7 @@ class Coordinator:
             if self.shutdown.is_set() or not self._admit(item):
                 continue  # stays queued (re-pushed below)
             ran.add(id(item))
-            self.event_log.append(("drain", StageName.IMPLEMENTATION.value, self._item_key(item)))
+            self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
             self._run_item(item)
         # Preserve original queue order for deferred / non-admitted / non-issue items.
         for it in items:
@@ -771,8 +846,11 @@ class Coordinator:
         handle = self.pool.submit(job, request.on_done_state)
         self.in_flight[handle] = item
         self.inflight_per_repo[item.repo] += 1
-        self.event_log.append(
-            ("submit", type(job).__name__, self._item_key(item), request.on_done_state)
+        self._record_event(
+            "submit",
+            type(job).__name__,
+            self._item_key(item),
+            request.on_done_state,
         )
 
     def _rate_budget_ok(self) -> tuple[bool, float]:
@@ -792,7 +870,7 @@ class Coordinator:
 
         if item.stage is StageName.FINISHED:
             # Sink outcomes are terminal: the result is already recorded.
-            self.event_log.append(("done", self._item_key(item), outcome.note))
+            self._record_event("done", self._item_key(item), outcome.note)
             return
 
         if disposition is Disposition.ADVANCE:
@@ -919,7 +997,7 @@ class Coordinator:
             self.items.append(item)
             item.payload.setdefault("entry_stage", stage.value)
         self.queues[stage].push(item)
-        self.event_log.append(("push", stage.value, self._item_key(item)))
+        self._record_event("push", stage.value, self._item_key(item))
 
     @staticmethod
     def _item_key(item: WorkItem) -> str:
@@ -1133,6 +1211,7 @@ class Coordinator:
             if self.shutdown.is_set():
                 logger.warning("second signal %d: immediate shutdown", signum)
                 self._immediate = True
+                self._wake_completion_wait()
             else:
                 logger.warning(
                     "signal %d: graceful shutdown (grace %.0fs; press again to force)",
@@ -1141,6 +1220,7 @@ class Coordinator:
                 )
                 self.shutdown.set()
                 self._grace_deadline = time.monotonic() + self.config.grace_s
+                self._wake_completion_wait()
 
         sigs = [signal.SIGINT, signal.SIGTERM]
         if hasattr(signal, "SIGHUP"):  # pragma: no branch - always true on POSIX

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1129,6 +1129,7 @@ class Coordinator:
             )
         for pr in self.config.prs:
             has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
+            issue_number = github.find_issue_for_pr(pr)
             if has_go:
                 entries.append(
                     _seeding.SeedEntry(
@@ -1136,6 +1137,8 @@ class Coordinator:
                         identifier=pr,
                         stage=StageName.CI,
                         reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                        pr_number=pr,
+                        issue_number=issue_number,
                     )
                 )
             else:
@@ -1145,6 +1148,8 @@ class Coordinator:
                         identifier=pr,
                         stage=StageName.PR_REVIEW,
                         reason=(f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review"),
+                        pr_number=pr,
+                        issue_number=issue_number,
                     )
                 )
         return entries
@@ -1165,7 +1170,11 @@ class Coordinator:
             item = WorkItem(repo=str(entry.identifier), kind=ItemKind.REPO, stage=entry.stage)
         elif entry.kind == "pr":
             item = WorkItem(
-                repo=default_repo, kind=ItemKind.PR, pr=int(entry.identifier), stage=entry.stage
+                repo=default_repo,
+                kind=ItemKind.PR,
+                issue=entry.issue_number,
+                pr=entry.pr_number or int(entry.identifier),
+                stage=entry.stage,
             )
         else:
             item = WorkItem(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -703,9 +703,20 @@ class Coordinator:
         return {
             "ok": result.ok,
             "interrupted": result.interrupted,
-            "error": result.error,
+            "error": Coordinator._job_result_error_class(result),
             "duration_s": round(result.duration_s, 3),
         }
+
+    @staticmethod
+    def _job_result_error_class(result: JobResult) -> str | None:
+        """Classify job failures without persisting raw error text."""
+        if result.error is None:
+            return None
+        if result.interrupted:
+            return "interrupted"
+        if result.error.startswith("worker_crash:"):
+            return "worker_crash"
+        return "error"
 
     # -- queue draining and admission ---------------------------------------
 
@@ -1066,7 +1077,7 @@ class Coordinator:
                 self._pass_work_count += 1
             if item.stage is StageName.FINISHED and item.result is None:
                 item.result = ItemResult(
-                    passed=True, reason=entry.reason, final_stage=StageName.FINISHED
+                    passed=entry.passed, reason=entry.reason, final_stage=StageName.FINISHED
                 )
             self._push_item(item, item.stage, enter=True)
             pushed += 1
@@ -1079,6 +1090,17 @@ class Coordinator:
         reason: str,
         scope_stages: frozenset[StageName] | None,
     ) -> tuple[StageName | None, str]:
+        """Compatibility wrapper returning only stage/reason for callers."""
+        stage, reason, _passed = self._scope_seed_decision(issue, stage, reason, scope_stages)
+        return stage, reason
+
+    def _scope_seed_decision(
+        self,
+        issue: int,
+        stage: StageName | None,
+        reason: str,
+        scope_stages: frozenset[StageName] | None,
+    ) -> tuple[StageName | None, str, bool]:
         """Reconcile a classified entry stage with the run's pipeline scope.
 
         Full-pipeline runs (``scope_stages is None``) pass the classification
@@ -1105,11 +1127,12 @@ class Coordinator:
             scope_stages: The scope's stage set, or None for a full run.
 
         Returns:
-            The reconciled ``(stage, reason)``.
+            The reconciled ``(stage, reason, passed)``. ``passed`` is used when
+            the stage is clamped directly to ``FINISHED``.
 
         """
         if stage is None or scope_stages is None:
-            return stage, reason
+            return stage, reason, True
 
         first_in_scope = next((s for s in PIPELINE_ORDER if s in scope_stages), None)
         if self.config.force:
@@ -1124,13 +1147,21 @@ class Coordinator:
             if first_in_scope is not None and stage != first_in_scope:
                 first_idx = PIPELINE_ORDER.index(first_in_scope)
                 if PIPELINE_ORDER.index(stage) >= first_idx:
-                    return first_in_scope, f"#{issue} force re-plan ({reason})"
-            return stage, reason
+                    return first_in_scope, f"#{issue} force re-plan ({reason})", True
+            return stage, reason, True
 
         if stage not in scope_stages:
+            if first_in_scope is not None and PIPELINE_ORDER.index(stage) < PIPELINE_ORDER.index(
+                first_in_scope
+            ):
+                return (
+                    StageName.FINISHED,
+                    f"#{issue} not ready for selected scope ({reason})",
+                    False,
+                )
             # Classified past the scope: the scoped work is already done.
-            return StageName.FINISHED, f"#{issue} already past planning scope ({reason})"
-        return stage, reason
+            return StageName.FINISHED, f"#{issue} already past selected scope ({reason})", True
+        return stage, reason, True
 
     def _seed_direct_scope(self, repo: str) -> list[_seeding.SeedEntry]:
         """Seed explicit ``--issues`` / ``--prs`` through the target repo accessor."""
@@ -1143,7 +1174,7 @@ class Coordinator:
         for issue in issue_numbers:
             facts = _seeding.seed_issue_from_github(issue, github)
             stage, reason = _seeding.classify_issue(facts)
-            stage, reason = self._clamp_seed_stage_to_scope(issue, stage, reason, scope_stages)
+            stage, reason, passed = self._scope_seed_decision(issue, stage, reason, scope_stages)
             entries.append(
                 _seeding.SeedEntry(
                     kind="issue",
@@ -1153,31 +1184,47 @@ class Coordinator:
                     pr_number=facts.pr_number if facts.pr_is_open else None,
                     issue_title=facts.title,
                     issue_body=facts.body,
+                    passed=passed,
                 )
             )
         for pr in self.config.prs:
             has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
             issue_number = github.find_issue_for_pr(pr)
+            scope_identifier = issue_number if issue_number is not None else pr
             if has_go:
+                stage, reason, passed = self._scope_seed_decision(
+                    scope_identifier,
+                    StageName.CI,
+                    f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                    scope_stages,
+                )
                 entries.append(
                     _seeding.SeedEntry(
                         kind="pr",
                         identifier=pr,
-                        stage=StageName.CI,
-                        reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                        stage=stage,
+                        reason=reason,
                         pr_number=pr,
                         issue_number=issue_number,
+                        passed=passed,
                     )
                 )
             else:
+                stage, reason, passed = self._scope_seed_decision(
+                    scope_identifier,
+                    StageName.PR_REVIEW,
+                    f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
+                    scope_stages,
+                )
                 entries.append(
                     _seeding.SeedEntry(
                         kind="pr",
                         identifier=pr,
-                        stage=StageName.PR_REVIEW,
-                        reason=(f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review"),
+                        stage=stage,
+                        reason=reason,
                         pr_number=pr,
                         issue_number=issue_number,
+                        passed=passed,
                     )
                 )
         return entries

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -135,6 +135,7 @@ class SeedEntry:
             planner/reviewer/implementer prompts.
         issue_body: Issue body copied into the issue WorkItem payload for
             planner/reviewer/implementer prompts.
+        passed: Terminal result for entries clamped directly to ``finished``.
 
     """
 
@@ -146,6 +147,7 @@ class SeedEntry:
     issue_number: int | None = None
     issue_title: str = ""
     issue_body: str = ""
+    passed: bool = True
 
 
 def _get_state_label(labels: set[str]) -> str | None:

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -129,6 +129,8 @@ class SeedEntry:
         pr_number: Open PR number for directly-seeded issue entries, when one
             exists. Repo discovery carries this in products; direct ``--issues``
             seeding needs the same value so downstream PR stages have context.
+        issue_number: Linked issue number for directly-seeded PR entries, when
+            the PR body carries the repo-policy ``Closes #N`` line.
         issue_title: Issue title copied into the issue WorkItem payload for
             planner/reviewer/implementer prompts.
         issue_body: Issue body copied into the issue WorkItem payload for
@@ -141,6 +143,7 @@ class SeedEntry:
     stage: StageName | None
     reason: str
     pr_number: int | None = None
+    issue_number: int | None = None
     issue_title: str = ""
     issue_body: str = ""
 
@@ -460,6 +463,7 @@ def seed_from_cli(
                     identifier=pr,
                     stage=StageName.CI,
                     reason=f"PR #{pr} carries {STATE_IMPLEMENTATION_GO}",
+                    pr_number=pr,
                 )
             )
         else:
@@ -469,6 +473,7 @@ def seed_from_cli(
                     identifier=pr,
                     stage=StageName.PR_REVIEW,
                     reason=f"PR #{pr} without {STATE_IMPLEMENTATION_GO} — awaiting review",
+                    pr_number=pr,
                 )
             )
     return entries

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -125,6 +125,10 @@ class StageGitHub(Protocol):
         """Return an open PR covering this issue, if any (``_review_utils``)."""
         ...
 
+    def find_issue_for_pr(self, pr_number: int) -> int | None:
+        """Return the linked issue for this PR, if its body has ``Closes #N``."""
+        ...
+
     def has_existing_plan(self, issue_number: int) -> bool:
         """Return True when the issue already counts as planned.
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -127,7 +127,7 @@ class StageGitHub(Protocol):
 
     def find_issue_for_pr(self, pr_number: int) -> int | None:
         """Return the linked issue for this PR, if its body has ``Closes #N``."""
-        ...
+        pass
 
     def has_existing_plan(self, issue_number: int) -> bool:
         """Return True when the issue already counts as planned.
@@ -226,6 +226,15 @@ class StageGitHub(Protocol):
         The coordinator maps this onto ``gh_issue_comment`` (PRs share the
         issue comment channel). Used by pr_review's HUMAN_BLOCKED terminal
         path to record WHY automation stood down before finishing failed.
+        """
+        pass
+
+    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+        """Durably create-or-update a marker-keyed PR conversation comment.
+
+        PRs share the issue comment channel, so the coordinator maps this onto
+        an issue-comment upsert scoped to the PR number. Used by lightweight
+        durable artifacts that should remain one-per-role across retries.
         """
         pass
 

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -44,8 +44,10 @@ binding contract):
     wall-clock bound is preserved via ``ctx.now()`` against
     ``payload["merge_wait_started_at"]`` (stamped at ARM; missing in POLL
     is an invariant failure, not a new stamp) and ``HEPH_PR_MERGE_MAX_WAIT``
-    (default 1800s, exactly the legacy ``_wait_for_pr_terminal`` budget)
-    -> FINISH_FAIL(``timeout``).
+    (default 1800s, exactly the legacy ``_wait_for_pr_terminal`` budget).
+    The queue CLI's ``--max-merge-attempts`` feeds the ``merge`` budget:
+    once pending polls reach that count, the issue is durably tagged
+    ``state:skip`` and the item SKIPs.
 - LEARN_WAIT [W:A]: the drive-green learnings session (re-housed
   ``post_merge_processor.run_drive_green_learnings``), prompt composed
   in-worker by :func:`build_drive_green_learn_prompt` reusing
@@ -296,19 +298,33 @@ class MergeWaitStage(Stage):
             return self._route_dirty(item, ctx, gh_state)
         if state is PrMergeState.BLOCKED:
             return self._route_blocked(item, ctx)
-        # PENDING: timer-park with exponential backoff, wall-clock bounded.
+        return self._route_pending(item, ctx, float(started))
+
+    def _route_pending(self, item: WorkItem, ctx: StageContext, started: float) -> StageOutcome:
+        """PENDING: timer-park with exponential backoff, bounded by time and budget."""
         now = ctx.now()
         max_wait = read_timeout_env(MERGE_MAX_WAIT_ENV, MERGE_MAX_WAIT_DEFAULT_S)
-        if now - float(started) > max_wait:
+        if now - started > max_wait:
             logger.warning(
                 "merge_wait:%s: PR #%d still OPEN after %ds (limit %ds); timing out",
                 item.issue,
                 item.pr,
-                int(now - float(started)),
+                int(now - started),
                 max_wait,
             )
             return StageOutcome(Disposition.FINISH_FAIL, "timeout")
         polls = item.payload.get("merge_poll_count", 0)
+        if polls >= ctx.budget("merge"):
+            if item.issue is not None:
+                logger.warning(
+                    "merge_wait:%s: PR #%d exhausted merge pending budget (%d); skipping",
+                    item.issue,
+                    item.pr,
+                    ctx.budget("merge"),
+                )
+                write_skip_label(item.issue, ctx)
+                return StageOutcome(Disposition.SKIP, "merge_attempts_exhausted")
+            return StageOutcome(Disposition.FINISH_FAIL, "merge_attempts_exhausted")
         delay = min(2**polls, BACKOFF_CAP_S)
         item.payload["merge_poll_count"] = polls + 1
         # Timer-park contract (base.py): the coordinator (#1817) reads the

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -999,6 +999,7 @@ class PrReviewStage(Stage):
             PrReviewStage._post_human_blocked_comment(pr_number, human_unresolved, ctx)
             return False
 
+        PrReviewStage._post_clean_go_comment(pr_number, ctx)
         try:
             ctx.github.mark_pr_implementation_go(pr_number)
         except Exception as e:
@@ -1016,3 +1017,21 @@ class PrReviewStage(Stage):
                 "pr_review: failed to arm auto-merge on PR #%d (non-fatal): %s", pr_number, e
             )
         return True
+
+    @staticmethod
+    def _post_clean_go_comment(pr_number: int, ctx: StageContext) -> None:
+        """Leave a durable public artifact for clean automated GO reviews."""
+        body = (
+            "<!-- hephaestus-pr-review-go -->\n"
+            "Automated PR review result: GO.\n\n"
+            "No unresolved blocking review threads were found by the automation reviewer. "
+            "The pipeline is marking this PR `state:implementation-go` and arming auto-merge."
+        )
+        try:
+            ctx.github.post_pr_comment(pr_number, body)
+        except Exception as e:
+            logger.warning(
+                "pr_review: failed to post clean-GO review comment on PR #%d (non-fatal): %s",
+                pr_number,
+                e,
+            )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -999,7 +999,6 @@ class PrReviewStage(Stage):
             PrReviewStage._post_human_blocked_comment(pr_number, human_unresolved, ctx)
             return False
 
-        PrReviewStage._post_clean_go_comment(pr_number, ctx)
         try:
             ctx.github.mark_pr_implementation_go(pr_number)
         except Exception as e:
@@ -1010,28 +1009,41 @@ class PrReviewStage(Stage):
                 e,
             )
             return True
+        auto_merge_armed = False
         try:
             ctx.github.arm_auto_merge(pr_number)
+            auto_merge_armed = True
         except Exception as e:
             logger.warning(
                 "pr_review: failed to arm auto-merge on PR #%d (non-fatal): %s", pr_number, e
             )
+        PrReviewStage._upsert_clean_go_comment(pr_number, ctx, auto_merge_armed=auto_merge_armed)
         return True
 
     @staticmethod
-    def _post_clean_go_comment(pr_number: int, ctx: StageContext) -> None:
+    def _upsert_clean_go_comment(
+        pr_number: int, ctx: StageContext, *, auto_merge_armed: bool
+    ) -> None:
         """Leave a durable public artifact for clean automated GO reviews."""
+        arm_sentence = (
+            "The pipeline marked this PR `state:implementation-go` and armed auto-merge."
+            if auto_merge_armed
+            else (
+                "The pipeline marked this PR `state:implementation-go`. Auto-merge arming "
+                "failed; a later run will retry."
+            )
+        )
         body = (
             "<!-- hephaestus-pr-review-go -->\n"
             "Automated PR review result: GO.\n\n"
             "No unresolved blocking review threads were found by the automation reviewer. "
-            "The pipeline is marking this PR `state:implementation-go` and arming auto-merge."
+            f"{arm_sentence}"
         )
         try:
-            ctx.github.post_pr_comment(pr_number, body)
+            ctx.github.upsert_pr_comment(pr_number, "<!-- hephaestus-pr-review-go -->", body)
         except Exception as e:
             logger.warning(
-                "pr_review: failed to post clean-GO review comment on PR #%d (non-fatal): %s",
+                "pr_review: failed to upsert clean-GO review comment on PR #%d (non-fatal): %s",
                 pr_number,
                 e,
             )

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -405,7 +405,13 @@ class PrReviewStage(Stage):
                     "ci_status": item.payload.get("ci_status", ""),
                     "pr_description": item.payload.get("pr_description", ""),
                     "advise_findings": item.payload.get("advise_findings", ""),
-                    "include_nitpicks": False,
+                    "include_nitpicks": bool(
+                        getattr(
+                            ctx.config,
+                            "nitpick",
+                            getattr(ctx.config, "include_nitpicks", False),
+                        )
+                    ),
                 },
                 parse=parse_review_verdict,  # verdict parsed in-worker
                 descr="review",

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -340,6 +340,7 @@ class WorkerPool:
             stdout = resilient_call(
                 _invoke,
                 circuit_breaker_name=f"agent:{agent}:{job.model}",
+                retry_predicate=lambda _exc: not self._shutdown.is_set(),
             )
 
             value = None

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -911,6 +911,56 @@ class PipelineGitHub:
             return
         github_api.gh_issue_comment(pr_number, body)
 
+    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+        """Create-or-update a marker-keyed PR comment (issue comment channel)."""
+        if self._skip(f"upsert comment on PR #{pr_number}"):
+            return
+        if self._repo_slug is None:
+            github_api.gh_issue_upsert_comment(pr_number, marker_prefix, body)
+            return
+        self._upsert_repo_issue_comment(pr_number, marker_prefix, body)
+
+    def _upsert_repo_issue_comment(
+        self, issue_number: int, marker_prefix: str, body: str
+    ) -> int | None:
+        """Repo-scoped version of ``gh_issue_upsert_comment``."""
+        comments = self._repo_issue_comments(issue_number)
+        matching = [
+            comment
+            for comment in comments
+            if str(comment.get("body", "")).startswith(marker_prefix)
+            and comment.get("databaseId") is not None
+        ]
+        if not matching:
+            self.post_pr_comment(issue_number, body)
+            return None
+
+        owner, name = self._owner_name()
+        target_id = int(matching[-1]["databaseId"])
+        for duplicate in matching[:-1]:
+            duplicate_id = duplicate.get("databaseId")
+            if duplicate_id is not None:
+                gh_call(
+                    [
+                        "api",
+                        "--method",
+                        "DELETE",
+                        f"/repos/{owner}/{name}/issues/comments/{int(duplicate_id)}",
+                    ]
+                )
+        with github_api._body_file(body) as path:
+            gh_call(
+                [
+                    "api",
+                    "--method",
+                    "PATCH",
+                    f"/repos/{owner}/{name}/issues/comments/{target_id}",
+                    "-F",
+                    f"body=@{path}",
+                ]
+            )
+        return target_id
+
     def mark_pr_implementation_no_go(self, pr_number: int) -> None:
         """Apply ``state:implementation-no-go`` (``pr_manager``)."""
         if self._skip(f"mark PR #{pr_number} implementation-no-go"):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -70,6 +70,8 @@ from hephaestus.github.client import gh_call
 
 logger = logging.getLogger(__name__)
 
+_CLOSES_ISSUE_LINE_RE = re.compile(r"^Closes #(\d+)\s*$", re.MULTILINE)
+
 
 def rate_limit_remaining() -> tuple[int, int] | None:
     """Return ``(remaining, reset_epoch)`` for the GraphQL budget, or ``None``.
@@ -512,6 +514,21 @@ class PipelineGitHub:
         if self._repo_slug is not None:
             return self._find_pr_for_issue(issue_number, state="open")
         return find_pr_for_issue(issue_number)
+
+    def find_issue_for_pr(self, pr_number: int) -> int | None:
+        """Return the PR's linked issue from its exact ``Closes #N`` body line."""
+        try:
+            result = self._gh(["pr", "view", str(pr_number), "--json", "body"], check=False)
+            data = json.loads(result.stdout or "{}")
+        except Exception as exc:
+            logger.warning("PR #%s: linked issue read failed: %s", pr_number, exc)
+            return None
+        body = str(data.get("body") or "")
+        match = _CLOSES_ISSUE_LINE_RE.search(body)
+        if match is None:
+            logger.warning("PR #%s: no exact Closes #N line found for PR-scope seeding", pr_number)
+            return None
+        return int(match.group(1))
 
     def has_existing_plan(self, issue_number: int) -> bool:
         """Labels-first plan gate incl. comment-scan backfill (``is_plan_review_go``)."""

--- a/hephaestus/resilience/subprocess_resilience.py
+++ b/hephaestus/resilience/subprocess_resilience.py
@@ -99,6 +99,7 @@ def resilient_call(
     max_retries: int = 3,
     initial_delay: float = 1.0,
     max_delay: float = 30.0,
+    retry_predicate: Callable[[BaseException], bool] | None = None,
     **kwargs: Any,
 ) -> R:
     """Execute a function with retry and optional circuit breaker.
@@ -120,6 +121,8 @@ def resilient_call(
         max_retries: Maximum retry attempts
         initial_delay: Initial backoff delay in seconds
         max_delay: Maximum backoff delay cap in seconds
+        retry_predicate: Optional extra predicate applied after the standard
+            transient-error classifier. Returning False suppresses retry.
         **kwargs: Keyword arguments for func
 
     Returns:
@@ -134,13 +137,18 @@ def resilient_call(
     if circuit_breaker_name:
         cb = get_circuit_breaker(circuit_breaker_name)
 
+    def _retry_predicate(error: BaseException) -> bool:
+        if not is_transient_subprocess_error(error):
+            return False
+        return retry_predicate is None or retry_predicate(error)
+
     @retry_with_backoff(
         max_retries=max_retries,
         initial_delay=initial_delay,
         backoff_factor=2,
         max_delay=max_delay,
         retry_on=TRANSIENT_SUBPROCESS_ERRORS,
-        retry_predicate=is_transient_subprocess_error,
+        retry_predicate=_retry_predicate,
         logger=logger.warning,
         jitter=True,
     )

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -181,7 +181,15 @@ class FakeGitHub:
 
     def gh_issue_upsert_comment(self, issue_number: int, marker_prefix: str, body: str) -> int:
         """Mirror github_api.gh_issue_upsert_comment (returns a comment id)."""
-        self.comments.setdefault(issue_number, []).append(body)
+        comments = self.comments.setdefault(issue_number, [])
+        matches = [i for i, value in enumerate(comments) if value.startswith(marker_prefix)]
+        if matches:
+            keep = matches[-1]
+            comments[keep] = body
+            for index in reversed(matches[:-1]):
+                del comments[index]
+        else:
+            comments.append(body)
         self._log("gh_issue_upsert_comment", issue_number, marker_prefix)
         return len(self.comments[issue_number])
 

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -243,6 +243,10 @@ class FakeStageGitHub(FakeGitHub):
         """
         self.gh_issue_comment(pr_number, body)
 
+    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+        """Mirror the coordinator PR-comment upsert (delegates to issue comments)."""
+        self.gh_issue_upsert_comment(pr_number, marker_prefix, body)
+
     def arm_auto_merge(self, pr_number: int) -> None:
         """Mirror pr_manager.enable_auto_merge_after_implementation_go."""
         self._log("arm_auto_merge", pr_number)
@@ -346,6 +350,7 @@ def make_ctx() -> Callable[..., StageContext]:
         dry_run: bool = False,
         github: FakeStageGitHub | None = None,
         paths: Any = None,
+        budget_fn: Callable[[str], int] | None = None,
     ) -> StageContext:
         ticks = [0]
 
@@ -360,7 +365,7 @@ def make_ctx() -> Callable[..., StageContext]:
             github=github if github is not None else FakeStageGitHub(),
             paths=paths if paths is not None else _Paths(),
             now_fn=now_fn,
-            budget_fn=_budget_fn,
+            budget_fn=budget_fn if budget_fn is not None else _budget_fn,
         )
 
     return _make_ctx

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -40,6 +40,7 @@ class FakeStageGitHub(FakeGitHub):
         issue_body: str = "",
         merged_pr: int | None = None,
         open_pr: int | None = None,
+        pr_issue: int | None = None,
         has_plan: bool = False,
         pr_head_branch: str | None = None,
         pr_impl_state: tuple[bool, bool] = (False, False),
@@ -61,6 +62,7 @@ class FakeStageGitHub(FakeGitHub):
             issue_body: Canned issue body returned by gh_issue_json.
             merged_pr: Canned answer for find_merged_closing_pr.
             open_pr: Canned answer for find_pr_for_issue.
+            pr_issue: Canned answer for find_issue_for_pr.
             has_plan: Canned answer for has_existing_plan.
             pr_head_branch: Canned answer for get_pr_head_branch.
             pr_impl_state: Canned (has_go, has_no_go) answer for
@@ -90,6 +92,7 @@ class FakeStageGitHub(FakeGitHub):
         self._issue_body = issue_body
         self._merged_pr = merged_pr
         self._open_pr = open_pr
+        self._pr_issue = pr_issue
         self._has_plan = has_plan
         self._pr_head_branch = pr_head_branch
         self._pr_impl_state = pr_impl_state
@@ -136,6 +139,10 @@ class FakeStageGitHub(FakeGitHub):
     def find_pr_for_issue(self, issue_number: int) -> int | None:
         """Mirror _review_utils.find_pr_for_issue (open PR lookup)."""
         return self._open_pr
+
+    def find_issue_for_pr(self, pr_number: int) -> int | None:
+        """Mirror PipelineGitHub.find_issue_for_pr (PR body Closes lookup)."""
+        return self._pr_issue
 
     def has_existing_plan(self, issue_number: int) -> bool:
         """Mirror PlannerStateManager.has_existing_plan (plan comment check)."""

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -32,6 +32,7 @@ assert ROUTES[StageName.MERGE_WAIT].fail_routes["ci_red"] == StageName.CI
 assert ROUTES[StageName.MERGE_WAIT].fail_routes["blocked_exhausted"] == StageName.PR_REVIEW
 assert ROUTES[StageName.MERGE_WAIT].budgets["blocked_address"] == 2
 assert ROUTES[StageName.MERGE_WAIT].budgets["rebase"] == 2
+assert ROUTES[StageName.MERGE_WAIT].budgets["merge"] == 1
 
 MERGED_STATE = {"state": "MERGED", "headRefOid": "abc123"}
 CLOSED_STATE = {"state": "CLOSED"}
@@ -313,7 +314,10 @@ class TestMergeWaitPoll:
     ) -> None:
         """PENDING parks with the legacy min(2**n, 60) delay in the payload."""
         stage = MergeWaitStage()
-        ctx = make_ctx(github=FakeStageGitHub(pr_state=OPEN_STATE))
+        ctx = make_ctx(
+            github=FakeStageGitHub(pr_state=OPEN_STATE),
+            budget_fn=lambda name: 10 if name == "merge" else 1,
+        )
         item = _armed_item(make_work_item)
         item.payload["merge_wait_started_at"] = 1000.0
 
@@ -325,6 +329,24 @@ class TestMergeWaitPoll:
         # The wall clock lives in the payload, NEVER in the attempts dict.
         assert "merge_elapsed" not in item.attempts
         assert "merge_poll" not in item.attempts
+
+    def test_pending_exhausts_merge_attempt_budget_before_wall_clock_timeout(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The CLI merge budget bounds pending polls and durably skips the issue."""
+        stage = MergeWaitStage()
+        github = FakeStageGitHub(pr_state=OPEN_STATE)
+        ctx = make_ctx(github=github, budget_fn=lambda _name: 1)
+        item = _armed_item(make_work_item)
+
+        first = stage.step(item, ctx)
+        assert first == StageOutcome(Disposition.RETRY, "merge_pending")
+        item.payload.pop("retry_delay_s")
+
+        second = stage.step(item, ctx)
+
+        assert second == StageOutcome(Disposition.SKIP, "merge_attempts_exhausted")
+        assert STATE_SKIP in github.labels[item.issue]
 
     def test_wall_clock_timeout_uses_ctx_now(
         self, make_ctx: Any, make_work_item: Any, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
@@ -162,6 +163,20 @@ class TestPrReviewStageStep:
         assert result.job.parse is parse_review_verdict  # verdict parsed in-worker
         assert result.job.prompt_kwargs["pr_number"] == 1001
         assert item.attempts["pr_review_iter"] == 0  # submission burns nothing
+
+    def test_review_wait_forwards_nitpick_config(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """--nitpick must reach the strict PR-review prompt."""
+        stage = PrReviewStage()
+        ctx = make_ctx(config=SimpleNamespace(agent="claude", nitpick=True))
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.prompt_kwargs["include_nitpicks"] is True
 
     def test_review_wait_clears_stale_round_payload(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -164,9 +164,7 @@ class TestPrReviewStageStep:
         assert result.job.prompt_kwargs["pr_number"] == 1001
         assert item.attempts["pr_review_iter"] == 0  # submission burns nothing
 
-    def test_review_wait_forwards_nitpick_config(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
+    def test_review_wait_forwards_nitpick_config(self, make_ctx: Any, make_work_item: Any) -> None:
         """--nitpick must reach the strict PR-review prompt."""
         stage = PrReviewStage()
         ctx = make_ctx(config=SimpleNamespace(agent="claude", nitpick=True))
@@ -417,9 +415,12 @@ class TestEvalVerdicts:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
         assert github.mutation_log == [
+            ("gh_issue_comment", (1001,)),
             ("mark_pr_implementation_go", (1001,)),
             ("arm_auto_merge", (1001,)),
         ]
+        assert "<!-- hephaestus-pr-review-go -->" in github.comments[1001][0]
+        assert "Automated PR review result: GO" in github.comments[1001][0]
         assert item.attempts["pr_review_iter"] == 1  # real verdict counted
 
     def test_go_rechecks_human_threads_inside_arm_helper(
@@ -456,7 +457,8 @@ class TestEvalVerdicts:
 
         assert isinstance(result, Continue)
         assert result.next_state == "FOLLOWUP_WAIT"
-        assert github.mutation_log[0] == ("mark_pr_implementation_go", (1001,))
+        assert github.mutation_log[0] == ("gh_issue_comment", (1001,))
+        assert github.mutation_log[1] == ("mark_pr_implementation_go", (1001,))
 
     def test_failed_mark_write_skips_arming(self, make_ctx: Any, make_work_item: Any) -> None:
         """If the implementation-go mark fails, auto-merge is NOT armed.
@@ -497,7 +499,10 @@ class TestEvalVerdicts:
         result = stage.step(item, ctx)  # must not raise
 
         assert isinstance(result, Continue)
-        assert github.mutation_log == [("mark_pr_implementation_go", (1001,))]
+        assert github.mutation_log == [
+            ("gh_issue_comment", (1001,)),
+            ("mark_pr_implementation_go", (1001,)),
+        ]
 
     def test_go_with_human_thread_is_human_blocked_and_unlabeled(
         self, make_ctx: Any, make_work_item: Any
@@ -1000,6 +1005,7 @@ class TestFullWalks:
         assert item.attempts["pr_review_iter"] == 2  # two real rounds
         assert github.mutation_log == [
             ("mark_pr_implementation_no_go", (1001,)),  # round 1 NOGO recorded (M2)
+            ("gh_issue_comment", (1001,)),
             ("mark_pr_implementation_go", (1001,)),
             ("arm_auto_merge", (1001,)),
         ]

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -415,13 +415,34 @@ class TestEvalVerdicts:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.ADVANCE
         assert github.mutation_log == [
-            ("gh_issue_comment", (1001,)),
             ("mark_pr_implementation_go", (1001,)),
             ("arm_auto_merge", (1001,)),
+            ("gh_issue_upsert_comment", (1001, "<!-- hephaestus-pr-review-go -->")),
         ]
         assert "<!-- hephaestus-pr-review-go -->" in github.comments[1001][0]
         assert "Automated PR review result: GO" in github.comments[1001][0]
+        assert "marked this PR `state:implementation-go`" in github.comments[1001][0]
+        assert "armed auto-merge" in github.comments[1001][0]
         assert item.attempts["pr_review_iter"] == 1  # real verdict counted
+
+    def test_go_clean_artifact_is_upserted_not_duplicated(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Clean GO leaves one marker-keyed durable comment across retries."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 0)])
+        github.comments[1001] = ["<!-- hephaestus-pr-review-go -->\nstale"]
+        ctx = make_ctx(github=github)
+        ctx.config.enable_follow_up = False
+        item = make_work_item(issue=1, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("GO")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.ADVANCE
+        assert len(github.comments[1001]) == 1
+        assert "stale" not in github.comments[1001][0]
 
     def test_go_rechecks_human_threads_inside_arm_helper(
         self, make_ctx: Any, make_work_item: Any
@@ -457,8 +478,8 @@ class TestEvalVerdicts:
 
         assert isinstance(result, Continue)
         assert result.next_state == "FOLLOWUP_WAIT"
-        assert github.mutation_log[0] == ("gh_issue_comment", (1001,))
-        assert github.mutation_log[1] == ("mark_pr_implementation_go", (1001,))
+        assert github.mutation_log[0] == ("mark_pr_implementation_go", (1001,))
+        assert github.mutation_log[1] == ("arm_auto_merge", (1001,))
 
     def test_failed_mark_write_skips_arming(self, make_ctx: Any, make_work_item: Any) -> None:
         """If the implementation-go mark fails, auto-merge is NOT armed.
@@ -482,6 +503,9 @@ class TestEvalVerdicts:
 
         assert isinstance(result, Continue)  # still proceeds (non-fatal)
         assert ("arm_auto_merge", (1001,)) not in github.mutation_log
+        assert ("gh_issue_upsert_comment", (1001, "<!-- hephaestus-pr-review-go -->")) not in (
+            github.mutation_log
+        )
 
     def test_failed_arm_write_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failing arm_auto_merge write is swallowed; the GO still proceeds."""
@@ -500,9 +524,11 @@ class TestEvalVerdicts:
 
         assert isinstance(result, Continue)
         assert github.mutation_log == [
-            ("gh_issue_comment", (1001,)),
             ("mark_pr_implementation_go", (1001,)),
+            ("gh_issue_upsert_comment", (1001, "<!-- hephaestus-pr-review-go -->")),
         ]
+        assert "Auto-merge arming failed" in github.comments[1001][0]
+        assert "armed auto-merge" not in github.comments[1001][0]
 
     def test_go_with_human_thread_is_human_blocked_and_unlabeled(
         self, make_ctx: Any, make_work_item: Any
@@ -1005,9 +1031,9 @@ class TestFullWalks:
         assert item.attempts["pr_review_iter"] == 2  # two real rounds
         assert github.mutation_log == [
             ("mark_pr_implementation_no_go", (1001,)),  # round 1 NOGO recorded (M2)
-            ("gh_issue_comment", (1001,)),
             ("mark_pr_implementation_go", (1001,)),
             ("arm_auto_merge", (1001,)),
+            ("gh_issue_upsert_comment", (1001, "<!-- hephaestus-pr-review-go -->")),
         ]
 
     def test_exhaustion_walk_applies_skip(self, make_ctx: Any, make_work_item: Any) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -134,6 +134,10 @@ class TestQuiescence:
             return []
 
         monkeypatch.setattr(seeding_mod, "seed_from_cli", fake_seed)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
         coordinator = Coordinator(
             config,
             github=gh,
@@ -611,6 +615,7 @@ class TestDurableEventLog:
             stages={StageName.PLANNING: stage},
             install_signals=False,
         )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
         item = _issue_item(44, StageName.PLANNING)
 
         coordinator._submit(item, JobRequest(_agent_job(issue=44), "REVIEWED"))
@@ -633,6 +638,42 @@ class TestDurableEventLog:
         ]
         assert "stdout_tail" not in complete["fields"][-1]
         assert "stderr_tail" not in complete["fields"][-1]
+
+    def test_event_log_path_sanitizes_job_error_text(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Job completions persist safe error classes, not raw error text."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        stage = StubStage()
+        pool = FakeWorkerPool()
+        pool.queue_result(JobResult(ok=False, error="token=secret private-endpoint"))
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=pool,
+            stages={StageName.PLANNING: stage},
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+        item = _issue_item(44, StageName.PLANNING)
+
+        coordinator._submit(item, JobRequest(_agent_job(issue=44), "REVIEWED"))
+        coordinator._drain_completions()
+
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        text = event_log_path.read_text()
+        complete = next(record for record in records if record["event"] == "complete")
+        assert "token=secret" not in text
+        assert "private-endpoint" not in text
+        assert complete["fields"][-1]["error"] == "error"
 
     def test_event_log_path_persists_resumable_records(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -665,6 +706,14 @@ class TestDurableEventLog:
 
 class TestPipelineScopeWiring:
     """Scope-trimmed routing + the planner CLI's --force re-plan override (#1820)."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_open_issue_filter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep scope-wiring tests unit-local; filter behavior has its own test."""
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
 
     def _scoped_config(
         self, tmp_path: Path, *, issues: list[int], force: bool = False

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -9,6 +9,7 @@ asserts-no-submit, poisoned-item isolation, and FAIL_BACK routing.
 
 from __future__ import annotations
 
+import json
 from collections import deque
 from collections.abc import Callable
 from pathlib import Path
@@ -75,6 +76,7 @@ def make_coordinator(
     loops: int = 1,
     max_workers: int = 1,
     dry_run: bool = False,
+    serialize_file_overlap: bool = True,
     github: FakeStageGitHub | None = None,
     rate_budget_ok: Callable[[], tuple[bool, float]] | None = None,
 ) -> tuple[Coordinator, FakeWorkerPool, FakeStageGitHub]:
@@ -85,6 +87,7 @@ def make_coordinator(
         loops=loops,
         max_workers=max_workers,
         dry_run=dry_run,
+        serialize_file_overlap=serialize_file_overlap,
         projects_dir=tmp_path,
     )
     gh = github or FakeStageGitHub()
@@ -528,6 +531,64 @@ class TestImplementationAdmission:
 
         assert run_order == [22]  # dependency first; 21 deferred by overlap
         assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
+
+    def test_file_overlap_serialization_can_be_disabled(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--no-serialize-file-overlap lets all ready implementation items dispatch."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path, monkeypatch, max_workers=2, serialize_file_overlap=False
+        )
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        item_a = _issue_item(21, StageName.IMPLEMENTATION)
+        item_b = _issue_item(22, StageName.IMPLEMENTATION)
+        coordinator._push_item(item_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(item_b, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._select_non_overlapping",
+            lambda issues: (_ for _ in ()).throw(AssertionError("should not serialize overlap")),
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_order == [21, 22]
+        assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 0
+
+
+class TestDurableEventLog:
+    """Optional JSONL event log mirrors the coordinator's in-memory event log."""
+
+    def test_event_log_path_persists_queue_events(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Configured event_log_path receives JSONL queue/event records."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        item = _issue_item(44, StageName.PLANNING)
+
+        coordinator._push_item(item, StageName.PLANNING, enter=True)
+
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        assert records[-1]["event"] == "push"
+        assert records[-1]["fields"] == ["planning", "repo-a#44"]
+        assert coordinator.event_log[-1] == ("push", "planning", "repo-a#44")
 
 
 class TestPipelineScopeWiring:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -590,6 +590,78 @@ class TestDurableEventLog:
         assert records[-1]["fields"] == ["planning", "repo-a#44"]
         assert coordinator.event_log[-1] == ("push", "planning", "repo-a#44")
 
+    def test_event_log_path_persists_job_completion_records(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Job completions are durable without logging raw agent output."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        stage = StubStage()
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            stages={StageName.PLANNING: stage},
+            install_signals=False,
+        )
+        item = _issue_item(44, StageName.PLANNING)
+
+        coordinator._submit(item, JobRequest(_agent_job(issue=44), "REVIEWED"))
+        coordinator._drain_completions()
+
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        complete = next(record for record in records if record["event"] == "complete")
+        assert complete["fields"] == [
+            "AgentJob",
+            "repo-a#44",
+            "planning",
+            "REVIEWED",
+            {
+                "descr": "stub agent job",
+                "duration_s": 0.0,
+                "error": None,
+                "interrupted": False,
+                "ok": True,
+            },
+        ]
+        assert "stdout_tail" not in complete["fields"][-1]
+        assert "stderr_tail" not in complete["fields"][-1]
+
+    def test_event_log_path_persists_resumable_records(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Interrupted items leave durable resumable breadcrumbs."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        item = _issue_item(44, StageName.PR_REVIEW)
+        item.state = "REVIEW_WAIT"
+
+        coordinator._park_resumable(item)
+
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        assert records[-1]["event"] == "resumable"
+        assert records[-1]["fields"] == ["repo-a#44", "pr_review", "REVIEW_WAIT"]
+
 
 class TestPipelineScopeWiring:
     """Scope-trimmed routing + the planner CLI's --force re-plan override (#1820)."""

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -459,7 +459,7 @@ class TestSeedingEdges:
             "gh_pr_label_names",
             MagicMock(side_effect=AssertionError("ambient PR label seeding called")),
         )
-        target_github = FakeStageGitHub(pr_impl_state=(True, False))
+        target_github = FakeStageGitHub(pr_impl_state=(True, False), pr_issue=1818)
         created: list[tuple[str, Path]] = []
 
         def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
@@ -487,6 +487,7 @@ class TestSeedingEdges:
         item = coordinator.queues[StageName.CI].snapshot()[0]
         assert item.repo == "target-repo"
         assert item.kind is ItemKind.PR
+        assert item.issue == 1818
         assert item.pr == 1854
 
     def test_repo_product_finished_entry_gets_pass_result(

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -415,6 +415,10 @@ class TestSeedingEdges:
             "seed_issue",
             MagicMock(side_effect=AssertionError("ambient issue seeding called")),
         )
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            lambda _repo, issues: list(issues),
+        )
         target_github = FakeStageGitHub(
             labels=[STATE_PLAN_GO],
             open_pr=1854,
@@ -489,6 +493,80 @@ class TestSeedingEdges:
         assert item.kind is ItemKind.PR
         assert item.issue == 1818
         assert item.pr == 1854
+
+    def test_direct_pr_scope_hydrates_issue_for_pr_review_route(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct --prs seeding preserves linked issue context for PR review."""
+        monkeypatch.setattr(
+            seeding_mod,
+            "gh_pr_label_names",
+            MagicMock(side_effect=AssertionError("ambient PR label seeding called")),
+        )
+        target_github = FakeStageGitHub(pr_impl_state=(False, False), pr_issue=1818)
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            return target_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            prs=[1854],
+            projects_dir=tmp_path,
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+
+        coordinator._seed_pass()
+
+        item = coordinator.queues[StageName.PR_REVIEW].snapshot()[0]
+        assert item.repo == "target-repo"
+        assert item.kind is ItemKind.PR
+        assert item.issue == 1818
+        assert item.pr == 1854
+
+    def test_direct_pr_scope_respects_drive_green_phase_scope(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-implementation-go direct PR must not enter pr_review in CI scope."""
+        monkeypatch.setattr(
+            seeding_mod,
+            "gh_pr_label_names",
+            MagicMock(side_effect=AssertionError("ambient PR label seeding called")),
+        )
+        target_github = FakeStageGitHub(pr_impl_state=(False, False), pr_issue=1818)
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            return target_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            prs=[1854],
+            projects_dir=tmp_path,
+            scope=routing_mod.PipelineScope(frozenset({StageName.CI, StageName.MERGE_WAIT})),
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+
+        assert coordinator.run() == 1
+
+        assert not coordinator.queues[StageName.PR_REVIEW].snapshot()
+        assert len(coordinator.ledger) == 1
+        assert not coordinator.ledger[0].passed
+        assert "not ready for selected scope" in coordinator.ledger[0].reason
 
     def test_repo_product_finished_entry_gets_pass_result(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -267,9 +267,13 @@ class TestInterruptSemantics:
         assert coordinator.shutdown.is_set()
         assert coordinator._grace_deadline is not None
         assert coordinator._immediate is False
+        assert not coordinator.completion_q.empty()
+        coordinator._drain_completions()
+        assert coordinator.completion_q.empty()
 
         handler(signal_mod.SIGTERM, None)
         assert coordinator._immediate is True
+        assert not coordinator.completion_q.empty()
 
 
 def _classify_from_fake(

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -9,13 +9,16 @@ The queue-based pipeline is the only automation-loop path (epic #1809, cutover
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
 import hephaestus.automation.loop_runner as loop_runner
 import hephaestus.automation.pipeline.coordinator as coordinator_mod
+from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.config.paths import DEFAULT_PROJECTS_DIR
 
 
 @pytest.fixture
@@ -104,6 +107,16 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.scope is None
     assert config.event_log_path is not None
     assert config.event_log_path.name.startswith("pipeline-events-")
+    assert config.event_log_path.parent == Path(DEFAULT_STATE_DIR)
+
+
+def test_default_pipeline_event_log_path_does_not_create_repo_checkout() -> None:
+    """The default event log path must not live under a repo clone directory."""
+    path = loop_runner._pipeline_event_log_path(DEFAULT_PROJECTS_DIR, ["repo-a"])
+
+    assert path is not None
+    assert path.parent == Path(DEFAULT_STATE_DIR)
+    assert DEFAULT_PROJECTS_DIR / "repo-a" not in path.parents
 
 
 def test_build_pipeline_config_maps_plan_phase_to_planning_scope(

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -84,6 +84,7 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
             "--prs",
             "21,22",
             "--no-advise",
+            "--no-serialize-file-overlap",
             "--nitpick",
         ]
     )
@@ -98,8 +99,11 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.parallel_repos == 2
     assert config.dry_run is True
     assert config.no_advise is True
+    assert config.serialize_file_overlap is False
     assert config.nitpick is True
     assert config.scope is None
+    assert config.event_log_path is not None
+    assert config.event_log_path.name.startswith("pipeline-events-")
 
 
 def test_build_pipeline_config_maps_plan_phase_to_planning_scope(

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -15,6 +15,7 @@ import pytest
 
 import hephaestus.automation.loop_runner as loop_runner
 import hephaestus.automation.pipeline.coordinator as coordinator_mod
+from hephaestus.automation.pipeline.routing import StageName
 
 
 @pytest.fixture
@@ -98,6 +99,50 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.dry_run is True
     assert config.no_advise is True
     assert config.nitpick is True
+    assert config.scope is None
+
+
+def test_build_pipeline_config_maps_plan_phase_to_planning_scope(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """A planning-only top-level run must stop after plan_review."""
+    loop_runner.main(["--issues", "11", "--phases", "plan"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.scope is not None
+    assert config.scope.stages == frozenset({StageName.PLANNING, StageName.PLAN_REVIEW})
+
+
+def test_build_pipeline_config_maps_implement_phase_to_review_scope(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """The implement phase owns implementation plus PR review."""
+    loop_runner.main(["--issues", "11", "--phases", "implement"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.scope is not None
+    assert config.scope.stages == frozenset({StageName.IMPLEMENTATION, StageName.PR_REVIEW})
+
+
+def test_build_pipeline_config_maps_drive_green_phase_to_ci_scope(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """The drive-green phase owns CI classification plus merge wait."""
+    loop_runner.main(["--issues", "11", "--phases", "drive-green"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.scope is not None
+    assert config.scope.stages == frozenset({StageName.CI, StageName.MERGE_WAIT})
+
+
+def test_build_pipeline_config_maps_max_merge_attempts_to_budget(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """The loop CLI's merge-attempt flag must tune the merge_wait budget."""
+    loop_runner.main(["--max-merge-attempts", "3"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.budget_overrides["merge"] == 3
 
 
 def test_build_pipeline_config_maps_agent_and_models(

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -556,6 +556,7 @@ class TestSeedFromCli:
                 identifier=77,
                 stage=StageName.CI,
                 reason=f"PR #77 carries {STATE_IMPLEMENTATION_GO}",
+                pr_number=77,
             )
         ]
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -332,6 +332,28 @@ class TestAgentErrorHandling:
         assert result.ok is False
         assert result.error == "OSError: retry wrapper failed"
 
+    def test_run_agent_does_not_retry_transient_error_after_shutdown(
+        self, pool: WorkerPool, shutdown_event: threading.Event
+    ) -> None:
+        """Shutdown suppresses retrying an interrupted agent session."""
+        job = _agent_job(model="model-shutdown-no-retry", prompt_builder=lambda: "prompt")
+        shutdown_event.set()
+
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(
+                f"{_WP}.claude_invoke.invoke_claude_with_session",
+                side_effect=OSError("connection reset"),
+            ) as invoke,
+            patch("hephaestus.utils.retry.time.sleep") as sleep,
+        ):
+            result = pool._run_agent(job)
+
+        assert result.ok is False
+        assert result.error == "OSError: connection reset"
+        assert invoke.call_count == 1
+        sleep.assert_not_called()
+
     def test_unknown_job_type_returns_error_result(self, pool: WorkerPool) -> None:
         """A job of unknown type is converted to a TypeError error result."""
         result = pool._run(cast(AgentJob, object()))

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -96,13 +96,13 @@ def _agent_spec() -> ActionSpec:
     )
 
 
-def _max_workers_spec(help_text: str) -> ActionSpec:
+def _max_workers_spec(help_text: str, default: int = 3) -> ActionSpec:
     """Return the common --max-workers action spec."""
     return _action_spec(
         ("--max-workers",),
         "max_workers",
         "_StoreAction",
-        3,
+        default,
         choices=WORKER_CHOICES,
         help_text=help_text,
     )
@@ -593,7 +593,8 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             help_text="Number of loop iterations (default: 5)",
         ),
         _max_workers_spec(
-            "Parallel workers per repo per phase (1-32, default: 3). Passes to child phases."
+            "Parallel workers per repo per phase (1-32, default: 6). Passes to child phases.",
+            default=6,
         ),
         _action_spec(
             ("--max-merge-attempts",),

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -158,10 +158,10 @@ def test_parse_args_accepts_valid_max_workers() -> None:
     assert args.max_workers == 8
 
 
-def test_parse_args_default_max_workers_is_three() -> None:
-    """Omitted --max-workers defaults to 3."""
+def test_parse_args_default_max_workers_is_six() -> None:
+    """Omitted --max-workers defaults to 6 for the queue-based loop."""
     args = loop_runner._parse_args([])
-    assert args.max_workers == 3
+    assert args.max_workers == 6
 
 
 def test_parse_args_serialize_file_overlap_default_on() -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -50,6 +50,12 @@ _MUTATOR_CASES = [
     ("close_issue_as_covered", (5, 7), "module", "close_issue_as_covered"),
     ("upsert_plan_comment", (5, "body"), "github_api", "gh_issue_upsert_comment"),
     ("post_pr_comment", (7, "why"), "github_api", "gh_issue_comment"),
+    (
+        "upsert_pr_comment",
+        (7, "<!-- marker -->", "<!-- marker -->\nbody"),
+        "github_api",
+        "gh_issue_upsert_comment",
+    ),
     ("mark_pr_implementation_go", (7,), "pr_manager", "mark_pr_implementation_go"),
     ("mark_pr_implementation_no_go", (7,), "pr_manager", "mark_pr_implementation_no_go"),
     ("defer_auto_merge", (7,), "pr_manager", "ensure_pr_auto_merge_deferred"),
@@ -374,6 +380,39 @@ class TestRepoScoping:
 
         assert any(call[:3] == ["api", "--method", "PATCH"] for call in calls)
         assert any("/repos/org/repo-a/issues/comments/9" in call for call in calls)
+        assert not any(call[:2] == ["issue", "comment"] for call in calls)
+
+    def test_repo_scoped_upsert_pr_comment_updates_marker_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+        marker = "<!-- hephaestus-pr-review-go -->"
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv[:2] == ["api", "graphql"]:
+                payload = {
+                    "data": {
+                        "repository": {
+                            "issue": {
+                                "comments": {
+                                    "nodes": [{"databaseId": 12, "body": f"{marker}\nold"}]
+                                }
+                            }
+                        }
+                    }
+                }
+                return SimpleNamespace(stdout=json.dumps(payload))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).upsert_pr_comment(
+            7, marker, f"{marker}\nnew"
+        )
+
+        assert any(call[:3] == ["api", "--method", "PATCH"] for call in calls)
+        assert any("/repos/org/repo-a/issues/comments/12" in call for call in calls)
         assert not any(call[:2] == ["issue", "comment"] for call in calls)
 
     def test_repo_scoped_review_post_uses_repo_endpoint(

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -580,6 +580,36 @@ class TestReadSurface:
         assert adapter.get_pr_head_branch(9) == "head"
         assert adapter.has_existing_plan(9) is True
 
+    def test_find_issue_for_pr_parses_exact_closes_line(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            return SimpleNamespace(stdout=json.dumps({"body": "Summary\n\nCloses #1899\n"}))
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        issue = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_issue_for_pr(1984)
+
+        assert issue == 1899
+        assert calls == [["pr", "view", "1984", "--json", "body", "--repo", "org/repo-a"]]
+
+    @pytest.mark.parametrize("body", ["Fixes #1899\n", "Closes #1899, #1900\n", ""])
+    def test_find_issue_for_pr_rejects_non_policy_body(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, body: str
+    ) -> None:
+        monkeypatch.setattr(
+            pg,
+            "gh_call",
+            lambda argv, **kwargs: SimpleNamespace(stdout=json.dumps({"body": body})),
+        )
+
+        issue = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_issue_for_pr(1984)
+
+        assert issue is None
+
     def test_pr_manager_reads(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- wire automation-loop controls into the queue pipeline: phase scoping, merge budget override, nitpick forwarding, and file-overlap serialization control
- add durable per-run queue/event JSONL logging under the canonical automation state directory
- leave a lightweight clean-GO PR review comment before marking implementation-go
- wake the coordinator immediately on shutdown signals and suppress agent retries after shutdown

Closes #1958
Closes #1875

## Verification
- pixi run pytest tests/unit/automation/pipeline/test_coordinator.py tests/unit/automation/pipeline/test_pipeline_flag.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_coordinator_shutdown.py tests/unit/automation/pipeline/test_worker_pool.py -v --no-cov
- pixi run pytest tests/unit -q --no-cov
- pixi run ruff check hephaestus/ tests/
- pixi run ruff format --check hephaestus/ tests/
- pixi run python -m mypy hephaestus/
- pixi run pre-commit run --files hephaestus/automation/loop_runner.py
- pixi run hephaestus-automation-loop --issues 1889 --loops 1 --max-workers 4 --agent codex --model gpt-5.5 --phases plan --dry-run --allow-unsafe-phase-order -v --json

Dry-run also produced a 9-record pipeline-events JSONL file with run_start, push/drain, done, and run_end records.