### PR TITLE
[nit] seed_issue_from_github lacks the fail-closed docstring/Raises contract that seed_issue documents

### DIFF
--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -324,7 +324,32 @@ def seed_issue(issue_number: int) -> IssueFacts:
 
 
 def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
-    """Fetch and normalize issue facts through a repo-scoped StageGitHub accessor."""
+    """Fetch and normalize repo-scoped GitHub state for a single issue (tri-state PR).
+
+    PR facts are a real tri-state fetch through the provided StageGitHub
+    accessor: ``github.find_pr_for_issue`` runs first; on a miss,
+    ``github.find_merged_pr_for_issue`` runs so merged work classifies as
+    finished instead of being re-queued after a restart. A PR that is neither
+    open nor merged (closed/abandoned) is invisible to both lookups and is
+    normalized to ``pr_number = None``, so :func:`classify_issue` only ever
+    sees a clean {no live PR | open PR | merged PR} tri-state.
+
+    Fail-closed: any GitHub error -- from the issue fetch or either PR lookup
+    -- propagates. Swallowing a PR-probe failure would misclassify toward
+    IMPLEMENTATION and cause duplicate-PR churn.
+
+    Args:
+        issue_number: GitHub issue number.
+        github: Repo-scoped StageGitHub accessor.
+
+    Returns:
+        Normalized GitHub state snapshot.
+
+    Raises:
+        Exception: Any GitHub API error from the issue fetch or the PR
+            lookups is re-raised (caller's responsibility to handle).
+
+    """
     issue_data = github.gh_issue_json(issue_number)
     raw_labels = issue_data.get("labels", []) if isinstance(issue_data, dict) else []
     labels = {

--- a/tests/unit/automation/pipeline/test_seeding_contracts.py
+++ b/tests/unit/automation/pipeline/test_seeding_contracts.py
@@ -1,0 +1,65 @@
+"""Contract tests for pipeline seeding public helpers."""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from hephaestus.automation.pipeline.seeding import seed_issue_from_github
+from hephaestus.automation.state_labels import STATE_PLAN_GO
+
+
+class TestSeedIssueFromGitHubContract:
+    """Repo-scoped seeding mirrors the seed_issue tri-state/fail-closed contract."""
+
+    def _github(self) -> MagicMock:
+        github = MagicMock()
+        github.gh_issue_json.return_value = {
+            "number": 104,
+            "title": "A task",
+            "body": "",
+            "labels": [{"name": STATE_PLAN_GO}],
+        }
+        github.find_pr_for_issue.return_value = None
+        github.find_merged_pr_for_issue.return_value = None
+        return github
+
+    def test_docstring_documents_tri_state_fail_closed_and_raises(self) -> None:
+        """The repo-scoped helper documents the duplicate-PR prevention contract."""
+        doc = inspect.getdoc(seed_issue_from_github) or ""
+
+        for expected in (
+            "tri-state",
+            "find_pr_for_issue",
+            "find_merged_pr_for_issue",
+            "Fail-closed",
+            "IMPLEMENTATION",
+            "Raises:",
+        ):
+            assert expected in doc
+
+    def test_issue_fetch_failure_raises(self) -> None:
+        """gh_issue_json failures propagate instead of producing fallback facts."""
+        github = self._github()
+        github.gh_issue_json.side_effect = RuntimeError("issue fetch down")
+
+        with pytest.raises(RuntimeError, match="issue fetch down"):
+            seed_issue_from_github(104, github)
+
+    def test_open_pr_lookup_failure_raises(self) -> None:
+        """Open-PR probe failures propagate, never falling back to no-PR facts."""
+        github = self._github()
+        github.find_pr_for_issue.side_effect = RuntimeError("open probe down")
+
+        with pytest.raises(RuntimeError, match="open probe down"):
+            seed_issue_from_github(104, github)
+
+    def test_merged_pr_lookup_failure_raises(self) -> None:
+        """Merged-PR probe failures propagate after an open-PR miss."""
+        github = self._github()
+        github.find_merged_pr_for_issue.side_effect = RuntimeError("merged probe down")
+
+        with pytest.raises(RuntimeError, match="merged probe down"):
+            seed_issue_from_github(104, github)


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: Updated `seed_issue_from_github` docstring contract and added focused tests; full `pixi run python -m pytest tests/ -v` passed: 6071 passed, 25 skipped, coverage 83.89%; ruff, format, direct mypy, and pre-commit passed.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1916

Generated by ProjectHephaestus automation
