### PR TITLE
[nit] automation-loop-crash.md runbook only covers the legacy loop; no --pipeline recovery guidance

### DIFF
--- a/docs/runbooks/automation-loop-crash.md
+++ b/docs/runbooks/automation-loop-crash.md
@@ -42,6 +42,28 @@ processing an issue, or a phase times out, and you need to resume safely.
    suspect, recover it with the
    [corrupted-worktree runbook](corrupted-worktree.md) before re-running.
 
+## Pipeline recovery semantics
+
+For `--pipeline` recovery, distinguish interrupts from fatal coordinator
+failures:
+
+- A first `SIGINT`, `SIGTERM`, or `SIGHUP` starts graceful shutdown. The
+  coordinator stops admitting new work and drains in-flight jobs for the
+  configured grace window (`30s` by default). An interrupted run exits with
+  exit code 130.
+- A second signal, or expiry of the grace window, forces immediate worker-pool
+  teardown and synthesizes interrupted results for any remaining in-flight
+  jobs.
+- Interrupted, queued, and timer-parked items are reported as `RESUMABLE at
+  <stage>` in `=== Pipeline summary ===`; they are never FAILED by the
+  interrupt path and do not run through normal stage success/failure routing.
+- Restart reconstructs the in-memory queues from the durable journal: GitHub
+  labels, PR state, and local worktrees. There is no persisted queue snapshot.
+  Re-run the same scoped command to let seeding classify the issue back into
+  the correct entry queue.
+- To inspect journal reconstruction without launching work, run the scoped
+  pipeline command with `--dry-run --loops 1 -v`.
+
 ## Recover
 
 The loop is idempotent per issue: the coordinator re-seeds from GitHub labels,

--- a/tests/unit/docs/test_automation_loop_crash_runbook.py
+++ b/tests/unit/docs/test_automation_loop_crash_runbook.py
@@ -1,0 +1,41 @@
+"""Regression tests for the automation-loop crash runbook."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "automation-loop-crash.md"
+
+_PIPELINE_SECTION_RE = re.compile(
+    r"^##\s+Pipeline recovery semantics\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _pipeline_section() -> str:
+    """Return the pipeline recovery section from the crash runbook."""
+    text = RUNBOOK.read_text(encoding="utf-8")
+    match = _PIPELINE_SECTION_RE.search(text)
+    assert match is not None, (
+        "automation-loop-crash.md must document pipeline recovery semantics "
+        "for interrupted or crashed --pipeline runs."
+    )
+    return re.sub(r"\s+", " ", match.group(1).lower())
+
+
+def test_pipeline_recovery_semantics_are_documented() -> None:
+    """The crash runbook must cover pipeline interrupt and restart behavior."""
+    section = _pipeline_section()
+
+    assert "--pipeline" in section
+    assert "exit code 130" in section
+    assert "resumable" in section
+    assert "never failed" in section
+    assert "30s" in section
+    assert "second signal" in section
+    assert "github labels" in section
+    assert "pr state" in section
+    assert "local worktrees" in section
+    assert "no persisted queue snapshot" in section


### PR DESCRIPTION
## Summary
Verdict: done | Reason: Updated `docs/runbooks/automation-loop-crash.md` with `--pipeline` recovery guidance and added `tests/unit/docs/test_automation_loop_crash_runbook.py`; verified full tests `6068 passed, 25 skipped`, mypy, Ruff lint/format, `git diff --check`, and pre-commit on changed files.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1928

Generated by ProjectHephaestus automation
