### PR TITLE
[nit] routing.py:20,82 cite a stale loop_runner.py:373 for the merge default (actual :389/:494)

### DIFF
--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -15,9 +15,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
-#: Default for the ``merge`` budget. Mirrors the ``--max-merge-attempts`` CLI
-#: default (loop_runner.py:373); the coordinator overrides it from config when
-#: the pipeline is wired up (epic #1809 coordinator slice).
+#: Default for the ``merge`` budget. Mirrors ``LoopConfig.max_merge_attempts``
+#: and the ``--max-merge-attempts`` CLI default in ``loop_runner.py``; the
+#: coordinator overrides it from config when the pipeline is wired up
+#: (epic #1809 coordinator slice).
 DEFAULT_MERGE_ATTEMPTS = 1
 
 
@@ -79,7 +80,8 @@ class Route:
 #   clone=2, plan=2, plan_cycles=2,
 #   implement=2, test_fix=1, ci_fix=1,
 #   rebase=2                               <- architecture doc stage sections
-#   merge=DEFAULT_MERGE_ATTEMPTS           <- loop_runner.py:373 max_merge_attempts
+#   merge=DEFAULT_MERGE_ATTEMPTS           <- loop_runner.py LoopConfig.max_merge_attempts
+#                                             and --max-merge-attempts defaults
 ROUTES: dict[StageName, Route] = {
     # The repo item itself is terminal: it seeds discovered issues/PRs into
     # their classified entry queues and then advances to finished(pass).

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -1,7 +1,10 @@
 """Tests for routing table, stages, and route computation."""
 
+from pathlib import Path
+
 import pytest
 
+import hephaestus.automation.pipeline.routing as routing
 from hephaestus.automation.pipeline import (
     ROUTES,
     Disposition,
@@ -203,6 +206,14 @@ class TestROUTES:
             StageName.FINISHED: Route(next=StageName.FINISHED),
         }
         assert expected == ROUTES
+
+    def test_merge_budget_provenance_uses_stable_source_references(self) -> None:
+        """#1902: merge-budget provenance should not pin volatile line numbers."""
+        assert routing.__file__ is not None
+        source = Path(routing.__file__).read_text(encoding="utf-8")
+        assert "loop_runner.py:" not in source
+        assert "LoopConfig.max_merge_attempts" in source
+        assert "--max-merge-attempts" in source
 
 
 class TestPipelineScope:


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: Updated `routing.py` merge-budget provenance to stable `LoopConfig.max_merge_attempts` / `--max-merge-attempts` references, added regression coverage in `test_routing.py`, and verification passed: full `pixi run python -m pytest tests/ -v`, direct `python -m mypy hephaestus/`, full ruff check/format, and pre-commit on changed files.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1902

Generated by ProjectHephaestus automation
