### PR TITLE
[nit] _normalize_plan_comment docstring's marker-vs-ADVANCE-gate reference is stale

### DIFF
--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -121,9 +121,17 @@ def build_plan_prompt(
 def _normalize_plan_comment(plan: str) -> str:
     """Normalize plan text so the body begins exactly at the plan marker.
 
-    The upsert helper keys off ``body.startswith(PLAN_COMMENT_MARKER)``, and
-    ``plan.lstrip()`` is load-bearing — a plan arriving with leading
-    whitespace would otherwise keep it and break the marker match (#700).
+    The marker prefix is the upsert dedupe key for
+    ``ctx.github.upsert_plan_comment``: the GitHub adapter updates the latest
+    existing plan comment whose body starts with ``PLAN_COMMENT_MARKER``.
+    ``plan.lstrip()`` is load-bearing because a plan arriving with leading
+    whitespace would otherwise keep it and break that dedupe match (#700).
+
+    This normalization is separate from the PlanningStage VERIFY ADVANCE gate.
+    VERIFY advances only after this step posts a plan comment or
+    ``ctx.github.has_existing_plan(item.issue)`` reports an existing plan or
+    approved plan-review gate. Do not read this function as the ADVANCE
+    decision.
 
     Args:
         plan: Raw plan text from the planner agent.

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -10,6 +10,7 @@ from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.planning import (
     PlanningStage,
+    _normalize_plan_comment,
     build_plan_prompt,
 )
 from hephaestus.automation.prompts._shared import _UNTRUSTED_NOTICE
@@ -488,6 +489,16 @@ class TestPlanningStageStep:
         (body,) = github.comments[13]
         assert body.startswith(PLAN_COMMENT_MARKER)  # upsert helper keys on this
         assert body == f"{PLAN_COMMENT_MARKER}\n\nSome plan without the heading."
+
+    def test_normalize_plan_comment_docstring_distinguishes_marker_from_advance_gate(
+        self,
+    ) -> None:
+        """Docstring says marker normalization is not the VERIFY ADVANCE gate."""
+        doc = _normalize_plan_comment.__doc__ or ""
+
+        assert "upsert dedupe key" in doc
+        assert "VERIFY ADVANCE gate" in doc
+        assert "ctx.github.has_existing_plan(item.issue)" in doc
 
     def test_verify_without_plan_retries(self, make_ctx: Any, make_work_item: Any) -> None:
         """VERIFY without a plan retries while within the plan budget."""


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: Plan read via `gh --json` (no separate Plan Review comment returned); updated `planning.py:121` docstring and added regression test at `test_stage_planning.py:493`; `PIXI_CACHE_DIR=/tmp/pixi-cache-issue-1925 pixi run --as-is python -m pytest tests/ -v` passed `6072 passed, 21 skipped, 83.89%`; ruff/mypy passed; pre-commit was attempted but blocked by offline hook/package fetches, not code failures.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1925

Generated by ProjectHephaestus automation
