### PR TITLE
[nit] Doc claims classify_ci_state "does not exist yet" but it exists, is imported, and is tested

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -285,8 +285,10 @@ unresolved-thread count decreases).
 2. [W:G] **Mechanical rebase** (optional, if base changed): attempt rebase via
    git; on success, push.
 3. [M] **POLL** (non-blocking): call
-   `ci_run_coordinator.classify_ci_state(ctx.github.pr_checks(pr))`. This is
-   the pure classifier extracted from the legacy sleep loop. It returns
+   `ci_run_coordinator.classify_ci_state(ctx.github.pr_checks(pr))`, the
+   shipped pure classifier imported by `hephaestus.automation.pipeline.stages.ci`
+   and covered by
+   `tests/unit/automation/pipeline/stages/test_classify_ci_state.py`. It returns
    PENDING, GREEN, FAILING, or terminal states. If PENDING → RETRY with timer
    backoff; if GREEN → ADVANCE; if FAILING → step 4.
 4. [W:A] **CI fix step** (budget ci_fix = 1) — `ci_fix_orchestrator.py:483

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -1,0 +1,17 @@
+"""Tests for the automation loop architecture document."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ARCHITECTURE_DOC = REPO_ROOT / "docs" / "AUTOMATION_LOOP_ARCHITECTURE.md"
+
+
+def test_ci_stage_documents_shipped_classifier() -> None:
+    """The CI-stage doc must describe classify_ci_state as shipped code."""
+    text = ARCHITECTURE_DOC.read_text(encoding="utf-8")
+
+    assert "classify_ci_state" in text
+    assert "NEW pure function" not in text
+    assert "does not exist yet" not in text
+    assert "shipped pure classifier" in text
+    assert "tests/unit/automation/pipeline/stages/test_classify_ci_state.py" in text


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: updated CI-stage docs to present `classify_ci_state` as shipped/imported/tested, added a regression test, and full pytest passed.

Changed:
- [docs/AUTOMATION_LOOP_ARCHITECTURE.md](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1930/docs/AUTOMATION_LOOP_ARCHITECTURE.md:287)
- [tests/unit/docs/test_automation_loop_architecture.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1930/tests/unit/docs/test_automation_loop_architecture.py:1)

Verification:
- `PIXI_CACHE_DIR=/tmp/pixi-cache-micah.villmow pixi run python -m pytest tests/ -v`: 6068 passed, 25 skipped, coverage 83.89%.
- `pixi run ruff check hephaestus/ tests/`: passed.
- `pixi run ruff format --check hephaestus/ tests/`: passed.
- `pixi run python -m mypy hephaestus/`: passed.
- `git diff --check`: passed.
- `pre-commit run --files ...`: blocked by sandbox DNS while initializing `markdownlint-cli2` from GitHub.

Unable to read the GitHub plan comments: `gh issue view 1930 --comments` failed for missing `read:project`, and `gh api` failed to connect to `api.github.com`.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1930

Generated by ProjectHephaestus automation
