### PR TITLE
[nit] Architecture doc is still marked "Status: pre-implementation" with two stubbed sections despite the design being fully implemented

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Automation Loop Architecture
 
-Status: as-built for the epic #1809 queue-based automation loop. The
+Status: implemented for the epic #1809 queue-based automation loop. The
 `hephaestus-automation-loop` CLI defaults to this pipeline; the legacy loop
 remains available only through `--legacy-loop` or `HEPH_PIPELINE=0`.
 
@@ -458,8 +458,8 @@ serialization unless `--no-serialize-file-overlap` is passed.
 
 The pipeline never sleeps inside stage logic. Backoff uses the coordinator's
 timer heap, and low GitHub rate budget parks agent jobs until the reset instead
-of blocking the loop. Under the pipeline, `--phase-timeout` bounds each agent
-job. Under the legacy loop, the same flag still bounds a phase subprocess.
+of blocking the loop. Under the pipeline, `--phase-timeout` bounds each agent job.
+Under the legacy loop, the same flag still bounds a phase subprocess.
 
 Dry-run mode logs GitHub mutations and job submissions without executing them;
 `_submit` asserts that no worker job is submitted in dry-run. This makes

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -43,6 +43,10 @@ PROMPT_REFS: tuple[tuple[str, str, Callable[..., object]], ...] = (
 )
 
 
+def _arch_text() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
 def test_ci_stage_documents_shipped_classifier() -> None:
     """The CI-stage doc must describe classify_ci_state as shipped code."""
     text = DOC_PATH.read_text(encoding="utf-8")
@@ -63,3 +67,36 @@ def test_issue_1929_prompt_line_refs_match_source_definitions() -> None:
         refs = re.findall(rf"`{re.escape(path)}:(\d+)\s+{function_name}`", doc)
         assert refs, f"missing documented reference for {path} {function_name}"
         assert set(refs) == {expected_line}
+
+
+def test_automation_loop_architecture_status_is_implemented() -> None:
+    """The architecture contract must describe the implemented pipeline."""
+    text = _arch_text()
+    header = "\n".join(text.splitlines()[:5])
+
+    assert "Status: implemented for the epic #1809 queue-based automation loop." in header
+    assert "pre-implementation" not in header
+
+
+def test_automation_loop_architecture_has_interrupt_semantics_and_exit_codes() -> None:
+    """The architecture contract must keep interrupt and exit-code details."""
+    text = _arch_text()
+
+    assert "Finalized in the cutover issue." not in text
+    assert "## Interrupt semantics and exit codes" in text
+    assert "SIGINT, SIGTERM, and SIGHUP" in text
+    assert "resumable at <stage>" in text
+    assert "Exit codes are stable: `130` for interrupted runs" in text
+
+
+def test_automation_loop_architecture_has_concurrency_cli_dry_run_and_glossary() -> None:
+    """The architecture contract keeps concurrency, CLI, dry-run, and glossary details."""
+    text = _arch_text()
+
+    assert "## Concurrency and tuning" in text
+    assert "`parallel_repos * max_workers`" in text
+    assert "`--phase-timeout` bounds each agent job" in text
+    assert "Dry-run mode logs GitHub mutations and job submissions without executing them" in text
+    assert "## CLI scopes and rollout controls" in text
+    assert "## Glossary" in text
+    assert "- **Coordinator**:" in text


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: updated the architecture doc status and added regression coverage for issue #1927.

Changed:
- `docs/AUTOMATION_LOOP_ARCHITECTURE.md`: status now says implemented; kept the implemented interrupt/concurrency/CLI/dry-run/glossary content pinned.
- `tests/unit/docs/test_automation_loop_architecture.py`: new docs regression tests for stale status and stub text.

Verification:
- Full suite passed: `6074 passed, 21 skipped`, coverage `83.89%` via `pixi run --manifest-path ... python -m pytest tests/ -v`.
- `ruff check hephaestus/ tests/`, `ruff format --check hephaestus/ tests/`, and `python -m mypy hephaestus/` passed.
- Link check passed for the architecture doc.
- `pre-commit run --files ...` was blocked because hooks invoke the incomplete local worktree Pixi env and network fetches are denied; equivalent direct hook commands passed where runnable.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1927

Generated by ProjectHephaestus automation
