### PR TITLE
[nit] routing.py:78 cites a stale ci_driver.py:104 line for blocked_address (actual :105)

### DIFF
--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -75,7 +75,7 @@ class Route:
 # is the doc's default target. Budget provenance:
 #   plan_review_iter=3, pr_review_iter=3  <- _review_phase.py:87 MAX_REVIEW_ITERATIONS
 #   pr_review_hard=6                       <- _review_phase.py:95 (=3*2, progress-aware)
-#   blocked_address=2                      <- ci_driver.py:104 _BLOCKED_ADDRESS_MAX_ATTEMPTS
+#   blocked_address=2                     <- review_thread_resolver.py _BLOCKED_ADDRESS_MAX_ATTEMPTS
 #   clone=2, plan=2, plan_cycles=2,
 #   implement=2, test_fix=1, ci_fix=1,
 #   rebase=2                               <- architecture doc stage sections


### PR DESCRIPTION
## Summary
Verdict: pass | Reason: Updated `hephaestus/automation/pipeline/routing.py:78`; verified with acceptance check, focused routing tests, full `pixi run python -m pytest tests/ -v` (6067 passed, 25 skipped, 83.89% coverage), mypy, ruff, format, pre-commit, and `git diff --check`; changes left uncommitted.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1901

Generated by ProjectHephaestus automation
