### PR TITLE
[mino] plan_review prior_review raw-extraction is coupled to the verdict class (fragile feedback threading)

### DIFF
--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -445,10 +445,14 @@ class PlanReviewStage(Stage):
 
         if result.value:
             if item.state == "REVIEW_WAIT":
-                item.payload["review_verdict"] = result.value
-                # Feed the raw review text to the next amend/review round,
-                # mirroring the legacy loop's prior_review threading.
-                item.payload["prior_review"] = getattr(result.value, "raw", str(result.value))
+                verdict = result.value
+                item.payload["review_verdict"] = verdict
+                if getattr(verdict, "verdict", None) == "NOGO":
+                    raw_review = getattr(verdict, "raw", None)
+                    assert isinstance(raw_review, str), (  # noqa: S101 - explicit worker contract
+                        "plan_review REVIEW_WAIT NOGO verdict must expose raw review text"
+                    )
+                    item.payload["prior_review"] = raw_review
             elif item.state == "AMEND_WAIT":
                 item.payload["plan_text"] = result.value
             # LEARN_WAIT intentionally has no branch: the learn job's output

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+import pytest
+
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
@@ -425,18 +427,56 @@ class TestPlanReviewStageStep:
 class TestPlanReviewStageOnJobDone:
     """on_job_done payload handling (state still at the WAIT state)."""
 
-    def test_review_verdict_stored_in_payload(self, make_ctx: Any, make_work_item: Any) -> None:
-        """The parsed verdict and its raw text are stored on the payload."""
+    def test_nogo_review_verdict_threads_raw_prior_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A real NOGO stores raw review text for the amend prompt."""
         stage = PlanReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, state="REVIEW_WAIT")
-        verdict = _verdict("GO")
+        verdict = _verdict("NOGO")
         result = JobResult(ok=True, value=verdict)
 
         stage.on_job_done(item, result, ctx)
 
         assert item.payload["review_verdict"] == verdict
         assert item.payload["prior_review"] == verdict.raw
+
+    @pytest.mark.parametrize("kind", ["GO", "ERROR", "AMBIGUOUS"])
+    def test_non_nogo_review_verdict_does_not_thread_prior_review(
+        self, make_ctx: Any, make_work_item: Any, kind: str
+    ) -> None:
+        """GO, ERROR, and AMBIGUOUS verdicts do not create amend feedback."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="REVIEW_WAIT")
+        verdict = _verdict(kind)
+        result = JobResult(ok=True, value=verdict)
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.payload["review_verdict"] == verdict
+        assert "prior_review" not in item.payload
+
+    def test_nogo_review_verdict_requires_raw_text(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A NOGO-shaped verdict without raw text fails instead of str() fallback."""
+
+        class NogoWithoutRaw:
+            verdict = "NOGO"
+
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="REVIEW_WAIT")
+        verdict = NogoWithoutRaw()
+        result = JobResult(ok=True, value=verdict)
+
+        with pytest.raises(AssertionError, match="NOGO verdict must expose raw"):
+            stage.on_job_done(item, result, ctx)
+
+        assert item.payload["review_verdict"] is verdict
+        assert "prior_review" not in item.payload
 
     def test_amend_result_stored_in_payload(self, make_ctx: Any, make_work_item: Any) -> None:
         """The amended plan text is stored on the payload."""


### PR DESCRIPTION
## Summary
Verdict: PASS | Reason: #1895 implemented and local verification passed.

Changed [plan_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1895/hephaestus/automation/pipeline/stages/plan_review.py:448): `REVIEW_WAIT` still stores `review_verdict`, but only `verdict == "NOGO"` writes `prior_review`, with an explicit raw-text assertion.

Added regressions in [test_stage_plan_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1895/tests/unit/automation/pipeline/stages/test_stage_plan_review.py:430): NOGO threads raw feedback, GO/ERROR/AMBIGUOUS do not, and NOGO without `raw` fails loudly.

Verification run:
- `pixi run python -m pytest tests/ -v`: 6080 passed, 25 skipped, coverage 83.90%
- `pixi run python -m mypy hephaestus/`: passed
- `pixi run ruff check hephaestus/ tests/`: passed
- `pixi run ruff format --check hephaestus/ tests/`: passed
- `pixi run pre-commit run --files $(git diff --name-only HEAD)`: passed

Working tree contains only the two intended modified files; no git or GitHub writes were performed.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1895

Generated by ProjectHephaestus automation
