### PR TITLE
[mino] merge_wait _poll re-stamps merge_wait_started_at, which would reset the wall-clock timeout if it ever fired

### DIFF
--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -42,9 +42,10 @@ binding contract):
     is recorded in ``payload["retry_delay_s"]`` and the stage returns
     ``StageOutcome(RETRY)`` (base.py coordinator convention). The
     wall-clock bound is preserved via ``ctx.now()`` against
-    ``payload["merge_wait_started_at"]`` (stamped at ARM) and
-    ``HEPH_PR_MERGE_MAX_WAIT`` (default 1800s, exactly the legacy
-    ``_wait_for_pr_terminal`` budget) -> FINISH_FAIL(``timeout``).
+    ``payload["merge_wait_started_at"]`` (stamped at ARM; missing in POLL
+    is an invariant failure, not a new stamp) and ``HEPH_PR_MERGE_MAX_WAIT``
+    (default 1800s, exactly the legacy ``_wait_for_pr_terminal`` budget)
+    -> FINISH_FAIL(``timeout``).
 - LEARN_WAIT [W:A]: the drive-green learnings session (re-housed
   ``post_merge_processor.run_drive_green_learnings``), prompt composed
   in-worker by :func:`build_drive_green_learn_prompt` reusing
@@ -256,6 +257,15 @@ class MergeWaitStage(Stage):
         """
         if item.pr is None:  # guarded by ARM; kept for restart safety
             return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        started = item.payload.get("merge_wait_started_at")
+        if started is None:
+            logger.error(
+                "merge_wait:%s: PR #%d reached POLL without merge_wait_started_at",
+                item.issue,
+                item.pr,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "missing_merge_wait_started_at")
+
         gh_state = ctx.github.gh_pr_state(item.pr)
         pr_state_str = ((gh_state or {}).get("state") or "").upper()
         failing: list[str] = []
@@ -288,10 +298,6 @@ class MergeWaitStage(Stage):
             return self._route_blocked(item, ctx)
         # PENDING: timer-park with exponential backoff, wall-clock bounded.
         now = ctx.now()
-        started = item.payload.get("merge_wait_started_at")
-        if started is None:
-            started = now
-            item.payload["merge_wait_started_at"] = started
         max_wait = read_timeout_env(MERGE_MAX_WAIT_ENV, MERGE_MAX_WAIT_DEFAULT_S)
         if now - float(started) > max_wait:
             logger.warning(

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -110,10 +110,12 @@ def _item(make_work_item: Any, **kwargs: Any) -> Any:
     return item
 
 
-def _armed_item(make_work_item: Any, **kwargs: Any) -> Any:
+def _armed_item(make_work_item: Any, *, with_anchor: bool = True, **kwargs: Any) -> Any:
     kwargs.setdefault("state", POLL)
     item = _item(make_work_item, **kwargs)
     item.armed = True
+    if with_anchor:
+        item.payload["merge_wait_started_at"] = 1000.0
     return item
 
 
@@ -338,18 +340,22 @@ class TestMergeWaitPoll:
 
         assert result == StageOutcome(Disposition.FINISH_FAIL, "timeout")
 
-    def test_poll_stamps_missing_wall_clock_anchor(
-        self, make_ctx: Any, make_work_item: Any
+    @pytest.mark.parametrize("payload", ({}, {"merge_wait_started_at": None}))
+    def test_poll_missing_wall_clock_anchor_finishes_failed(
+        self, make_ctx: Any, make_work_item: Any, payload: dict[str, object]
     ) -> None:
-        """A restart that lost the anchor re-stamps it instead of timing out."""
+        """A restart that reaches POLL without the ARM anchor fails the invariant."""
         stage = MergeWaitStage()
         ctx = make_ctx(github=FakeStageGitHub(pr_state=OPEN_STATE))
-        item = _armed_item(make_work_item)
+        item = _armed_item(make_work_item, with_anchor=False)
+        item.payload.update(payload)
 
         result = stage.step(item, ctx)
 
-        assert result == StageOutcome(Disposition.RETRY, "merge_pending")
-        assert item.payload["merge_wait_started_at"] > 0
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "missing_merge_wait_started_at")
+        assert item.payload == payload
+        assert "retry_delay_s" not in item.payload
+        assert "merge_poll_count" not in item.payload
 
     def test_poll_without_pr_finishes_no_pr(self, make_ctx: Any, make_work_item: Any) -> None:
         """Restart safety: POLL with no PR finishes failed."""


### PR DESCRIPTION
## Summary
Verdict: implemented-with-blockers | Reason: `merge_wait.py` now fails missing `merge_wait_started_at` in POLL without restamping; regression tests updated in `test_stage_merge_wait.py`; focused tests/ruff/format/mypy pass, but full `pixi run python -m pytest tests/ -v` hit unrelated `TestGhCallThrottle::test_throttle_disabled_when_rate_zero` flake (passes alone) and pre-commit is blocked by DNS fetching `markdownlint-cli2`.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1893

Generated by ProjectHephaestus automation
