### PR TITLE
[mino] ci POLL_DEADLINE is a cycle count, not wall-clock, so a restart resumes the count and can time out a still-concluding CI

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -52,6 +52,7 @@ from hephaestus.config.paths import resolve_projects_dir
 from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 
 from ._review_utils import build_automation_parser
+from .agent_config import ci_poll_max_wait
 from .ci_check_inspector import (
     FAILING_CHECK_CONCLUSIONS as FAILING_CHECK_CONCLUSIONS,  # re-export
 )
@@ -342,6 +343,9 @@ def main() -> int:
             # --no-mechanical-rebase: the CI stage reads this off ctx.config to
             # skip the pre-fix mechanical rebase (#871).
             enable_mechanical_rebase=args.enable_mechanical_rebase,
+            poll_max_wait=(
+                args.poll_max_wait if args.poll_max_wait is not None else ci_poll_max_wait()
+            ),
             # --max-fix-iterations N overrides the CI-fix attempt budget
             # (ROUTES ci=ci_fix default 1) for every failing PR in this run.
             budget_overrides={"ci_fix": args.max_fix_iterations},

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -83,6 +83,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
+from hephaestus.automation.agent_config import DEFAULT_CI_POLL_MAX_WAIT
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
@@ -184,6 +185,9 @@ class PipelineConfig:
     # behind/conflicting PR falls through to the fix agent (``--no-mechanical-rebase``).
     # Read by ``stages/ci.py`` via ``ctx.config.enable_mechanical_rebase``.
     enable_mechanical_rebase: bool = True
+    # Wall-clock seconds the CI stage may wait for pending checks before timing
+    # out. Mirrors ``CIDriverOptions.poll_max_wait`` / ``--poll-max-wait``.
+    poll_max_wait: int = DEFAULT_CI_POLL_MAX_WAIT
     # Per-budget overrides applied on top of the ROUTES defaults by the
     # coordinator's budget accessor. ``--max-fix-iterations N`` maps to
     # ``{"ci_fix": N}`` so the CI-fix attempt budget is caller-tunable.
@@ -220,6 +224,7 @@ class _StageRunConfig:
     nitpick: bool = False
     drive_green_all: bool = False
     enable_mechanical_rebase: bool = True
+    poll_max_wait: int = DEFAULT_CI_POLL_MAX_WAIT
 
 
 @dataclass
@@ -330,6 +335,7 @@ class Coordinator:
             nitpick=config.nitpick,
             drive_green_all=config.drive_green_all,
             enable_mechanical_rebase=config.enable_mechanical_rebase,
+            poll_max_wait=config.poll_max_wait,
         )
         self._ctx_cache: dict[str, StageContext] = {}
 

--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -27,12 +27,11 @@ contract):
   is recorded in ``payload["retry_delay_s"]`` and the stage returns
   ``StageOutcome(RETRY)`` — the coordinator (#1817) consumes the delay from
   the payload (see the base.py coordinator convention; ``StageOutcome`` has
-  no delay field). POLL cycles are capped by the ``payload["ci_poll_count"]``
-  counter against :data:`POLL_DEADLINE` (the legacy 1200s
-  ``poll_max_wait`` expressed in capped-backoff cycles) ->
-  FINISH_FAIL(``timeout``). GREEN / NO_CHECKS ADVANCE (no CI configured is
-  the legacy success case); FAILING enters the fix leg while the ``ci_fix``
-  budget remains, else fails back ``fix_exhausted`` (routes to
+  no delay field). The PENDING window is capped by elapsed wall-clock via
+  ``ctx.now()`` against ``payload["ci_poll_started_at"]`` and the configured
+  ``poll_max_wait`` budget -> FINISH_FAIL(``timeout``). GREEN / NO_CHECKS
+  ADVANCE (no CI configured is the legacy success case); FAILING enters the
+  fix leg while the ``ci_fix`` budget remains, else fails back ``fix_exhausted`` (routes to
   implementation).
 - FIX_WAIT [W:A]: the CI-fix agent session. The prompt is composed
   in-worker by :func:`build_ci_fix_prompt`, which reuses
@@ -66,7 +65,11 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
-from hephaestus.automation.agent_config import ci_driver_claude_timeout, implementer_model
+from hephaestus.automation.agent_config import (
+    DEFAULT_CI_POLL_MAX_WAIT,
+    ci_driver_claude_timeout,
+    implementer_model,
+)
 from hephaestus.automation.ci_fix_orchestrator import CIFixOrchestrator
 from hephaestus.automation.ci_run_coordinator import CiConclusion, classify_ci_state
 from hephaestus.automation.session_naming import AGENT_CI_DRIVER
@@ -103,13 +106,12 @@ PUSH_WAIT = "PUSH_WAIT"
 #: ``ci_run_coordinator.poll_ci_until_concluded`` :288).
 BACKOFF_CAP_S = 60
 
-#: Max POLL cycles before FINISH_FAIL("timeout"). The legacy loop bounds by
-#: ``poll_max_wait`` wall-clock seconds (default 1200, ``agent_config.
-#: ci_poll_max_wait``); with the capped exponential backoff that budget is
-#: exhausted after ~25 parks (1+2+...+32 + 19*60 >= 1200), so the
-#: non-blocking stage counts cycles in ``payload["ci_poll_count"]`` against
-#: this constant instead of sleeping out a wall clock.
+#: Historical number of capped-backoff parks that approximately consumed the
+#: default 1200s CI poll budget. Kept as a compatibility constant for callers
+#: and tests; timeout enforcement is wall-clock based via ``ctx.now()``.
 POLL_DEADLINE = 25
+
+CI_POLL_STARTED_AT = "ci_poll_started_at"
 
 
 def build_ci_fix_prompt(
@@ -353,9 +355,9 @@ class CiStage(Stage):
           exhaustion.
 
         Then the pure classifier routes: PENDING timer-parks (RETRY with the
-        backoff delay in ``payload["retry_delay_s"]``, cycles capped by
-        :data:`POLL_DEADLINE`); GREEN / NO_CHECKS ADVANCE; FAILING enters the
-        fix leg while the ``ci_fix`` budget remains.
+        backoff delay in ``payload["retry_delay_s"]``, elapsed wall-clock
+        capped by ``poll_max_wait``); GREEN / NO_CHECKS ADVANCE; FAILING
+        enters the fix leg while the ``ci_fix`` budget remains.
         """
         if item.payload.pop("push_failed", None):
             logger.warning("ci:%s: fix push failed; failing back", item.issue)
@@ -380,14 +382,22 @@ class CiStage(Stage):
 
         conclusion = classify_ci_state(ctx.github.pr_checks(item.pr))
         if conclusion is CiConclusion.PENDING:
-            polls = item.payload.get("ci_poll_count", 0)
-            if polls >= POLL_DEADLINE:
+            now = ctx.now()
+            started = item.payload.get(CI_POLL_STARTED_AT)
+            if started is None:
+                started = now
+                item.payload[CI_POLL_STARTED_AT] = started
+            max_wait = _ci_poll_max_wait(ctx)
+            elapsed = now - float(started)
+            if elapsed > max_wait:
                 logger.warning(
-                    "ci:%s: CI still pending after %d poll cycles; timing out",
+                    "ci:%s: CI still pending after %ds (limit %ds); timing out",
                     item.issue,
-                    polls,
+                    int(elapsed),
+                    max_wait,
                 )
                 return StageOutcome(Disposition.FINISH_FAIL, "timeout")
+            polls = item.payload.get("ci_poll_count", 0)
             delay = min(2**polls, BACKOFF_CAP_S)
             item.payload["ci_poll_count"] = polls + 1
             # Timer-park contract (base.py): the coordinator (#1817) reads
@@ -528,6 +538,15 @@ class CiStage(Stage):
                 item.payload["push_no_commit"] = True
             else:
                 # Real commit pushed: CI restarts, so the poll backoff does too.
+                item.payload.pop(CI_POLL_STARTED_AT, None)
                 item.payload.pop("ci_poll_count", None)
                 item.payload.pop("retry_delay_s", None)
             return
+
+
+def _ci_poll_max_wait(ctx: StageContext) -> int:
+    """Return the wall-clock CI poll budget in seconds."""
+    value = getattr(ctx.config, "poll_max_wait", DEFAULT_CI_POLL_MAX_WAIT)
+    if value is None:
+        return DEFAULT_CI_POLL_MAX_WAIT
+    return int(value)

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -8,6 +8,8 @@ from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import ROUTES, Disposition, StageName
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.ci import (
+    BACKOFF_CAP_S,
+    CI_POLL_STARTED_AT,
     DISCOVER,
     ENTER,
     FIX_WAIT,
@@ -293,17 +295,35 @@ class TestCiPoll:
             assert result == StageOutcome(Disposition.RETRY, "ci_pending")
             assert item.payload["retry_delay_s"] == expected_delay
         assert item.payload["ci_poll_count"] == 4
+        assert item.payload[CI_POLL_STARTED_AT] > 0
 
-    def test_poll_deadline_times_out(self, make_ctx: Any, make_work_item: Any) -> None:
-        """The POLL cycle counter capped at POLL_DEADLINE finishes timeout."""
+    def test_wall_clock_deadline_times_out(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Elapsed wall-clock over poll_max_wait finishes timeout."""
         stage = CiStage()
         ctx = make_ctx(github=_go_github(checks=PENDING_CHECKS))
+        ctx.config.poll_max_wait = 10
         item = _item(make_work_item, state=POLL)
-        item.payload["ci_poll_count"] = POLL_DEADLINE
+        item.payload[CI_POLL_STARTED_AT] = 0.0
 
         result = stage.step(item, ctx)
 
         assert result == StageOutcome(Disposition.FINISH_FAIL, "timeout")
+
+    def test_pending_uses_wall_clock_not_durable_poll_count(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A restart with many prior polls keeps waiting until wall-clock expires."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github(checks=PENDING_CHECKS))
+        item = _item(make_work_item, state=POLL)
+        item.payload[CI_POLL_STARTED_AT] = 1000.0
+        item.payload["ci_poll_count"] = POLL_DEADLINE
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.RETRY, "ci_pending")
+        assert item.payload["retry_delay_s"] == BACKOFF_CAP_S
+        assert item.payload["ci_poll_count"] == POLL_DEADLINE + 1
 
     def test_green_advances(self, make_ctx: Any, make_work_item: Any) -> None:
         """GREEN checks ADVANCE to merge_wait."""
@@ -637,9 +657,11 @@ class TestCiOnJobDone:
         ctx = make_ctx(github=_go_github())
         item = _item(make_work_item, state=PUSH_WAIT)
 
+        item.payload[CI_POLL_STARTED_AT] = 111.0
         item.payload["ci_poll_count"] = 9
         item.payload["retry_delay_s"] = 60
         stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
+        assert CI_POLL_STARTED_AT not in item.payload
         assert "ci_poll_count" not in item.payload
         assert "retry_delay_s" not in item.payload
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -703,6 +703,21 @@ class TestConfigWiring:
 
         assert ctx.config.enable_mechanical_rebase is False
 
+    def test_poll_max_wait_flows_to_stage_config(self, tmp_path: Path) -> None:
+        """poll_max_wait reaches ctx.config for wall-clock CI polling."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            projects_dir=tmp_path,
+            poll_max_wait=42,
+        )
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        ctx = coordinator._ctx_for_repo("repo-a")
+
+        assert ctx.config.poll_max_wait == 42
+
     def test_enable_mechanical_rebase_defaults_true(self, tmp_path: Path) -> None:
         """The default keeps the CI stage's mechanical rebase enabled."""
         config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)

--- a/tests/unit/automation/test_ci_driver_main.py
+++ b/tests/unit/automation/test_ci_driver_main.py
@@ -143,6 +143,13 @@ def test_main_no_mechanical_rebase_propagates() -> None:
     assert captured["config"].enable_mechanical_rebase is False
 
 
+def test_main_poll_max_wait_propagates() -> None:
+    """--poll-max-wait flows to PipelineConfig.poll_max_wait."""
+    captured = _run_main_capturing_config(["--issues", "5", "--poll-max-wait", "42", "--dry-run"])
+
+    assert captured["config"].poll_max_wait == 42
+
+
 def test_main_default_ci_fix_budget_is_one() -> None:
     """Without --max-fix-iterations the ci_fix budget override defaults to 1."""
     captured = _run_main_capturing_config(["--issues", "5", "--dry-run"])


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: CI PENDING timeout now uses `ctx.now()` + `poll_max_wait` instead of durable `ci_poll_count`; added regression/config tests; full `pixi` pytest passed (`6083 passed, 21 skipped`, coverage `83.90%`), plus mypy/ruff/format/direct hook equivalents passed. `gh issue view` was blocked by token/network, and `pre-commit` wrapper was environment-blocked by network/worktree-local Pixi bootstrap.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1892

Generated by ProjectHephaestus automation
