### PR TITLE
[mino] defer_auto_merge / arm_auto_merge are non-idempotent under concurrency and don't swallow already-(dis)armed errors

### DIFF
--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -925,7 +925,7 @@ class PipelineGitHub:
             )
             data = json.loads(result.stdout or "{}")
             if data.get("autoMergeRequest") is not None:
-                self._gh(["pr", "merge", str(pr_number), "--disable-auto"])
+                self._gh(["pr", "merge", str(pr_number), "--disable-auto"], check=False)
             return
         pr_manager.ensure_pr_auto_merge_deferred(pr_number)
 
@@ -934,7 +934,7 @@ class PipelineGitHub:
         if self._skip(f"arm auto-merge on PR #{pr_number}"):
             return
         if self._repo_slug is not None:
-            self._gh(["pr", "merge", str(pr_number), "--auto", "--squash"])
+            self._gh(["pr", "merge", str(pr_number), "--auto", "--squash"], check=False)
             return
         pr_manager.enable_auto_merge_after_implementation_go(pr_number)
 

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -420,6 +420,58 @@ class TestRepoScoping:
         assert any("repos/org/repo-a/pulls/7/reviews" in call for call in calls)
 
 
+class TestRepoScopedAutoMerge:
+    """Repo-scoped auto-merge mutations are idempotent under racing workers."""
+
+    def test_defer_auto_merge_disables_with_check_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append((argv, kwargs))
+            if argv[:2] == ["pr", "view"]:
+                return SimpleNamespace(
+                    stdout=json.dumps({"autoMergeRequest": {"enabledAt": "now"}})
+                )
+            return SimpleNamespace(stdout="", returncode=1, stderr="already disabled")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).defer_auto_merge(7)
+
+        assert calls == [
+            (
+                ["pr", "view", "7", "--json", "autoMergeRequest", "--repo", "org/repo-a"],
+                {"check": False},
+            ),
+            (
+                ["pr", "merge", "7", "--disable-auto", "--repo", "org/repo-a"],
+                {"check": False},
+            ),
+        ]
+
+    def test_arm_auto_merge_arms_with_check_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append((argv, kwargs))
+            return SimpleNamespace(stdout="", returncode=1, stderr="already enabled")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).arm_auto_merge(7)
+
+        assert calls == [
+            (
+                ["pr", "merge", "7", "--auto", "--squash", "--repo", "org/repo-a"],
+                {"check": False},
+            )
+        ]
+
+
 class TestCreatePr:
     """create_pr: idempotent reuse, given-body create, dry-run neutral."""
 


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: repo-scoped `defer_auto_merge`/`arm_auto_merge` now call `gh pr merge` with `check=False`, regression tests cover both paths, and final verification passed: pytest `6078 passed, 25 skipped`, mypy, ruff, format check, pre-commit, and `git diff --check`; issue comments/plan fetch was blocked by local GitHub auth/network.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1886

Generated by ProjectHephaestus automation
