### PR TITLE
[mino] git rebase/push/worktree ops silently ignore job.timeout_s, allowing an unbounded network hang

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -11,6 +11,7 @@ import logging
 import subprocess
 from collections.abc import Collection
 from pathlib import Path
+from typing import Any
 
 from hephaestus.constants import agent_git_timeout
 
@@ -27,6 +28,11 @@ from hephaestus.utils.retry import retry_with_backoff
 logger = logging.getLogger(__name__)
 
 COMMIT_POLICY_REWRITE_EXEC = "git commit --amend --no-edit -S -s"
+
+
+def _timeout_kw(timeout: int | None) -> dict[str, Any]:
+    """Return a ``run`` kwargs fragment only when a timeout was provided."""
+    return {} if timeout is None else {"timeout": timeout}
 
 
 def run(
@@ -181,6 +187,7 @@ def commit_if_changes(
     *,
     committed_log_message: str = "Committed changes for issue #%s",
     allowed_paths: Collection[str] | None = None,
+    timeout: int | None = None,
 ) -> bool:
     """Commit pending changes in *worktree_path* if the worktree is dirty.
 
@@ -191,6 +198,7 @@ def commit_if_changes(
         committed_log_message: ``logging`` format string for a successful commit.
         allowed_paths: Optional exact path allowlist forwarded to the commit
             helper. When set, only those porcelain paths may be staged.
+        timeout: Optional timeout in seconds for local git commands.
 
     Returns:
         True if a commit was created, otherwise False.
@@ -200,6 +208,7 @@ def commit_if_changes(
         ["git", "status", "--porcelain"],
         cwd=worktree_path,
         capture_output=True,
+        **_timeout_kw(timeout),
     )
     if not result.stdout.strip():
         logger.info("No changes to commit for issue #%s", issue_number)
@@ -208,7 +217,15 @@ def commit_if_changes(
     try:
         from .pr_manager import commit_changes
 
-        commit_changes(issue_number, worktree_path, agent, allowed_paths=allowed_paths)
+        commit_kwargs: dict[str, Any] = {"allowed_paths": allowed_paths}
+        if timeout is not None:
+            commit_kwargs["git_timeout"] = timeout
+        commit_changes(
+            issue_number,
+            worktree_path,
+            agent,
+            **commit_kwargs,
+        )
         logger.info(committed_log_message, issue_number)
         return True
     except RuntimeError as e:
@@ -216,19 +233,24 @@ def commit_if_changes(
         return False
 
 
-def push_branch(branch_name: str, worktree_path: Path) -> None:
+def push_branch(branch_name: str, worktree_path: Path, *, timeout: int | None = None) -> None:
     """Push *branch_name* to ``origin``.
 
     Args:
         branch_name: Branch name to push.
         worktree_path: Path to the git worktree.
+        timeout: Optional timeout in seconds for the push.
 
     Raises:
         RuntimeError: If the push fails.
 
     """
     try:
-        run(["git", "push", "origin", branch_name], cwd=worktree_path)
+        run(
+            ["git", "push", "origin", branch_name],
+            cwd=worktree_path,
+            **_timeout_kw(timeout),
+        )
         logger.info("Pushed branch %s to origin", branch_name)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to push branch {branch_name}: {e}") from e
@@ -310,11 +332,12 @@ def clean_stale_git_locks(repo_root: Path) -> None:
                     logger.error("Failed to remove lock %s: %s", lock_pattern, e)
 
 
-def get_current_branch(repo_root: Path | None = None) -> str:
+def get_current_branch(repo_root: Path | None = None, *, timeout: int | None = None) -> str:
     """Get the current git branch name.
 
     Args:
         repo_root: Repository root (defaults to auto-detect)
+        timeout: Optional timeout in seconds for the git command.
 
     Returns:
         Branch name
@@ -332,6 +355,7 @@ def get_current_branch(repo_root: Path | None = None) -> str:
             cwd=repo_root,
             capture_output=True,
             check=True,
+            **_timeout_kw(timeout),
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
@@ -360,6 +384,7 @@ def push_current_branch_with_lease_on_divergence(
     branch: str | None = None,
     remote: str = "origin",
     push_ref: str = "HEAD",
+    timeout: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Push ``HEAD`` to ``<remote>``; on divergence, fetch + force-with-lease retry.
 
@@ -388,6 +413,7 @@ def push_current_branch_with_lease_on_divergence(
             should pass an explicit refspec like ``f"HEAD:{branch}"`` to force
             the push to land on the named remote branch regardless of local
             branch state.
+        timeout: Optional timeout in seconds for each git command.
 
     Returns:
         The successful push's ``CompletedProcess``.
@@ -408,6 +434,7 @@ def push_current_branch_with_lease_on_divergence(
                 push_ref,
             ],
             cwd=cwd,
+            **_timeout_kw(timeout),
         )
     except subprocess.CalledProcessError as exc:
         if not _is_push_rejected_diverged(exc):
@@ -415,7 +442,7 @@ def push_current_branch_with_lease_on_divergence(
         # Resolve the branch name lazily — most callers know it, but we don't
         # want to require it on every caller.
         if branch is None:
-            branch = get_current_branch(cwd)
+            branch = get_current_branch(cwd, timeout=timeout)
         logger.warning(
             "git push to %s/%s rejected as diverged; fetching + force-with-lease retry",
             remote,
@@ -424,7 +451,7 @@ def push_current_branch_with_lease_on_divergence(
         # Fetch the canonical tip so the lease check has something current to
         # compare against. If this fetch fails, raise — we cannot safely
         # lease-push without an up-to-date remote-tracking ref.
-        run(["git", "fetch", remote, branch], cwd=cwd)
+        run(["git", "fetch", remote, branch], cwd=cwd, **_timeout_kw(timeout))
         # The lease retry preserves any explicit ``push_ref`` the caller passed
         # so HEAD lands on the right *remote* branch even if the local HEAD has
         # drifted (#832). The default ``"HEAD"`` is rewritten to
@@ -440,6 +467,7 @@ def push_current_branch_with_lease_on_divergence(
                 lease_push_ref,
             ],
             cwd=cwd,
+            **_timeout_kw(timeout),
         )
 
 
@@ -448,6 +476,7 @@ def sync_worktree_to_remote_branch(
     branch: str,
     *,
     remote: str = "origin",
+    timeout: int | None = None,
 ) -> None:
     """Reset ``cwd`` to ``<remote>/<branch>`` so the agent starts from the PR head.
 
@@ -472,6 +501,7 @@ def sync_worktree_to_remote_branch(
         cwd: Worktree path.
         branch: Remote branch name (the PR's head).
         remote: Remote name (default ``origin``).
+        timeout: Optional timeout in seconds for each git command.
 
     Raises:
         subprocess.CalledProcessError: If either git command fails. Callers
@@ -480,11 +510,16 @@ def sync_worktree_to_remote_branch(
 
     """
     logger.info("Syncing worktree at %s to %s/%s before agent run", cwd, remote, branch)
-    run(["git", "fetch", remote, branch], cwd=cwd)
-    run(["git", "reset", "--hard", f"{remote}/{branch}"], cwd=cwd)
+    run(["git", "fetch", remote, branch], cwd=cwd, **_timeout_kw(timeout))
+    run(["git", "reset", "--hard", f"{remote}/{branch}"], cwd=cwd, **_timeout_kw(timeout))
 
 
-def _remove_untracked_files_tracked_by_ref(cwd: Path, ref: str) -> list[Path]:
+def _remove_untracked_files_tracked_by_ref(
+    cwd: Path,
+    ref: str,
+    *,
+    timeout: int | None = None,
+) -> list[Path]:
     """Remove untracked worktree files whose paths are tracked by ``ref``.
 
     ``git reset --hard`` intentionally leaves untracked files behind. In reused
@@ -499,6 +534,7 @@ def _remove_untracked_files_tracked_by_ref(cwd: Path, ref: str) -> list[Path]:
             ["git", "ls-files", "--others", "--exclude-standard", "-z"],
             cwd=cwd,
             log_errors=False,
+            **_timeout_kw(timeout),
         )
     except subprocess.CalledProcessError:
         return []
@@ -512,7 +548,12 @@ def _remove_untracked_files_tracked_by_ref(cwd: Path, ref: str) -> list[Path]:
             logger.warning("Skipping unsafe untracked path before rebase: %s", rel)
             continue
         try:
-            run(["git", "cat-file", "-e", f"{ref}:{rel}"], cwd=cwd, log_errors=False)
+            run(
+                ["git", "cat-file", "-e", f"{ref}:{rel}"],
+                cwd=cwd,
+                log_errors=False,
+                **_timeout_kw(timeout),
+            )
         except subprocess.CalledProcessError:
             continue
 
@@ -554,17 +595,18 @@ def ensure_branch_commit_metadata(
     base_branch: str = "main",
     *,
     remote: str = "origin",
+    timeout: int | None = None,
 ) -> None:
     """Rewrite branch commits so each carries a verified signature and DCO trailer."""
     base_ref = f"{remote}/{base_branch}"
-    run(["git", "fetch", remote, base_branch], cwd=cwd)
-    _remove_untracked_files_tracked_by_ref(cwd, base_ref)
+    run(["git", "fetch", remote, base_branch], cwd=cwd, **_timeout_kw(timeout))
+    _remove_untracked_files_tracked_by_ref(cwd, base_ref, timeout=timeout)
     try:
-        run(_commit_policy_rebase_command(base_ref), cwd=cwd)
+        run(_commit_policy_rebase_command(base_ref), cwd=cwd, **_timeout_kw(timeout))
     except subprocess.CalledProcessError:
         # Leave the worktree ready for the caller's next automation attempt.
         # ``check=False`` preserves the original rebase failure signal.
-        run(["git", "rebase", "--abort"], cwd=cwd, check=False)
+        run(["git", "rebase", "--abort"], cwd=cwd, check=False, **_timeout_kw(timeout))
         raise
 
 
@@ -573,6 +615,7 @@ def rebase_worktree_onto(
     base_branch: str = "main",
     *,
     remote: str = "origin",
+    timeout: int | None = None,
 ) -> bool:
     """Mechanically rebase the worktree at ``cwd`` onto ``<remote>/<base_branch>``.
 
@@ -600,6 +643,7 @@ def rebase_worktree_onto(
         cwd: Worktree path (already synced to the PR head).
         base_branch: Branch to rebase onto (default ``main``).
         remote: Remote name (default ``origin``).
+        timeout: Optional timeout in seconds for each git command.
 
     Returns:
         ``True`` if the rebase applied cleanly. ``False`` if the rebase hit
@@ -613,17 +657,17 @@ def rebase_worktree_onto(
 
     """
     base_ref = f"{remote}/{base_branch}"
-    run(["git", "fetch", remote, base_branch], cwd=cwd)
-    _remove_untracked_files_tracked_by_ref(cwd, base_ref)
+    run(["git", "fetch", remote, base_branch], cwd=cwd, **_timeout_kw(timeout))
+    _remove_untracked_files_tracked_by_ref(cwd, base_ref, timeout=timeout)
     try:
-        run(_commit_policy_rebase_command(base_ref), cwd=cwd)
+        run(_commit_policy_rebase_command(base_ref), cwd=cwd, **_timeout_kw(timeout))
         logger.info("Rebased worktree at %s onto %s/%s cleanly", cwd, remote, base_branch)
         return True
     except subprocess.CalledProcessError:
         # Conflicts — abort so the worktree is restored to the PR head, then let
         # the caller hand the real conflict to the agent. ``check=False`` because
         # an abort that itself errors must not mask the conflict signal.
-        run(["git", "rebase", "--abort"], cwd=cwd, check=False)
+        run(["git", "rebase", "--abort"], cwd=cwd, check=False, **_timeout_kw(timeout))
         logger.info(
             "Rebase of worktree at %s onto %s/%s hit conflicts; aborted",
             cwd,
@@ -633,11 +677,12 @@ def rebase_worktree_onto(
         return False
 
 
-def is_clean_working_tree(repo_root: Path | None = None) -> bool:
+def is_clean_working_tree(repo_root: Path | None = None, *, timeout: int | None = None) -> bool:
     """Check if the working tree is clean (no uncommitted changes).
 
     Args:
         repo_root: Repository root (defaults to auto-detect)
+        timeout: Optional timeout in seconds for the git status probe.
 
     Returns:
         True if working tree is clean
@@ -652,6 +697,7 @@ def is_clean_working_tree(repo_root: Path | None = None) -> bool:
             cwd=repo_root,
             capture_output=True,
             check=True,
+            **_timeout_kw(timeout),
         )
         return len(result.stdout.strip()) == 0
     except subprocess.CalledProcessError:

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -454,13 +454,8 @@ class WorkerPool:
     def _dispatch_git_op(self, job: GitJob) -> JobResult:
         """Dispatch a git operation to its handler.
 
-        ``job.timeout_s`` is threaded into every dispatch whose helper accepts
-        a timeout (currently only ``clone`` via ``git_utils.run``). The
-        remaining helpers (``WorktreeManager.create_worktree`` /
-        ``remove_worktree``, ``rebase_worktree_onto``,
-        ``push_current_branch_with_lease_on_divergence``, ``commit_if_changes``,
-        ``push_branch``) expose no timeout parameter today; each call site
-        below documents that gap rather than silently dropping the budget.
+        ``job.timeout_s`` is threaded into every git helper call so network
+        operations cannot outlive the job budget while holding repo locks.
         """
         if job.op == "create_worktree":
             return self._git_create_worktree(job)
@@ -469,16 +464,14 @@ class WorkerPool:
             return self._git_remove_worktree(job)
 
         elif job.op == "rebase":
-            # rebase_worktree_onto(cwd, base_branch="main", *, remote) has no
-            # timeout parameter; job.timeout_s cannot be enforced here.
-            result = git_utils.rebase_worktree_onto(**job.kwargs)
+            result = git_utils.rebase_worktree_onto(**job.kwargs, timeout=job.timeout_s)
             return JobResult(ok=result, value=result)
 
         elif job.op == "push":
-            # push_current_branch_with_lease_on_divergence(cwd, *, branch,
-            # remote, push_ref) has no timeout parameter; job.timeout_s
-            # cannot be enforced here.
-            git_utils.push_current_branch_with_lease_on_divergence(**job.kwargs)
+            git_utils.push_current_branch_with_lease_on_divergence(
+                **job.kwargs,
+                timeout=job.timeout_s,
+            )
             return JobResult(ok=True)
 
         elif job.op == "commit_push":
@@ -505,9 +498,7 @@ class WorkerPool:
         manager = WorktreeManager()
         kwargs = dict(job.kwargs)
         sync_to_remote = bool(kwargs.pop("sync_to_remote", False))
-        # WorktreeManager.create_worktree has no timeout parameter;
-        # job.timeout_s cannot be enforced here.
-        created = manager.create_worktree(**kwargs)
+        created = manager.create_worktree(**kwargs, timeout=job.timeout_s)
         if created is None:
             return JobResult(ok=True)
         worktree_path = Path(created)
@@ -515,7 +506,7 @@ class WorkerPool:
         if not sync_to_remote:
             return JobResult(ok=True, value=str(worktree_path))
 
-        dirty = not git_utils.is_clean_working_tree(worktree_path)
+        dirty = not git_utils.is_clean_working_tree(worktree_path, timeout=job.timeout_s)
         status = ""
         diff = ""
         if dirty:
@@ -524,17 +515,23 @@ class WorkerPool:
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
+                timeout=job.timeout_s,
             )
             diff_result = git_utils.run(
                 ["git", "diff"],
                 cwd=worktree_path,
                 capture_output=True,
                 check=False,
+                timeout=job.timeout_s,
             )
             status = status_result.stdout or ""
             diff = diff_result.stdout or ""
         elif branch_name:
-            git_utils.sync_worktree_to_remote_branch(worktree_path, branch_name)
+            git_utils.sync_worktree_to_remote_branch(
+                worktree_path,
+                branch_name,
+                timeout=job.timeout_s,
+            )
         return JobResult(
             ok=True,
             value={
@@ -553,13 +550,16 @@ class WorkerPool:
             cmd = ["git", "worktree", "remove", str(worktree_path)]
             if job.kwargs.get("force"):
                 cmd.append("--force")
-            git_utils.run(cmd, cwd=repo_root)
-            git_utils.run(["git", "worktree", "prune"], cwd=repo_root, check=False)
+            git_utils.run(cmd, cwd=repo_root, timeout=job.timeout_s)
+            git_utils.run(
+                ["git", "worktree", "prune"],
+                cwd=repo_root,
+                check=False,
+                timeout=job.timeout_s,
+            )
             return JobResult(ok=True)
         manager = WorktreeManager()
-        # WorktreeManager.remove_worktree has no timeout parameter;
-        # job.timeout_s cannot be enforced here.
-        manager.remove_worktree(**job.kwargs)
+        manager.remove_worktree(**job.kwargs, timeout=job.timeout_s)
         return JobResult(ok=True)
 
     def _git_commit_push(self, job: GitJob) -> JobResult:
@@ -587,10 +587,13 @@ class WorkerPool:
             Path(worktree_path),
             str(job.kwargs.get("agent", "claude")),
             allowed_paths=job.kwargs.get("allowed_paths"),
+            timeout=job.timeout_s,
         )
         if not changed:
             return JobResult(ok=True, value=False)
-        # push_branch has no timeout parameter; job.timeout_s cannot be
-        # enforced here.
-        git_utils.push_branch(str(job.kwargs.get("branch", "HEAD")), Path(worktree_path))
+        git_utils.push_branch(
+            str(job.kwargs.get("branch", "HEAD")),
+            Path(worktree_path),
+            timeout=job.timeout_s,
+        )
         return JobResult(ok=True, value=changed)

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -91,6 +91,11 @@ ALLOWED_CONVENTIONAL_TYPES = frozenset(
 _CONVENTIONAL_PREFIX = re.compile(r"^(?P<type>[a-z]+)(?P<scope>\([^)]*\))?(?P<bang>!)?:\s")
 
 
+def _git_timeout_kw(timeout: int | None) -> dict[str, Any]:
+    """Return a ``run`` kwargs fragment only when a git timeout was provided."""
+    return {} if timeout is None else {"timeout": timeout}
+
+
 def _normalize_conventional_type(subject: str, *, default: str = "chore") -> str:
     """Rewrite a subject's leading type to an allowlisted one if it is not already.
 
@@ -215,21 +220,27 @@ def _parse_agent_json(text: str) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _git_output(worktree_path: Path, args: list[str]) -> str:
+def _git_output(worktree_path: Path, args: list[str], *, timeout: int | None = None) -> str:
     """Return best-effort git output for message-agent context."""
     try:
-        result = run(["git", *args], cwd=worktree_path, capture_output=True, check=False)
+        result = run(
+            ["git", *args],
+            cwd=worktree_path,
+            capture_output=True,
+            check=False,
+            **_git_timeout_kw(timeout),
+        )
     except Exception as exc:
         logger.debug("Could not collect git message context for %s: %s", args, exc)
         return ""
     return (result.stdout or "").strip()
 
 
-def _staged_change_context(worktree_path: Path) -> tuple[str, str]:
+def _staged_change_context(worktree_path: Path, *, timeout: int | None = None) -> tuple[str, str]:
     """Return staged changed files and diff stat for commit-message generation."""
     return (
-        _git_output(worktree_path, ["diff", "--cached", "--name-status"]),
-        _git_output(worktree_path, ["diff", "--cached", "--stat"]),
+        _git_output(worktree_path, ["diff", "--cached", "--name-status"], timeout=timeout),
+        _git_output(worktree_path, ["diff", "--cached", "--stat"], timeout=timeout),
     )
 
 
@@ -399,9 +410,10 @@ def _generate_commit_message(
     worktree_path: Path,
     agent: str,
     git_message_timeout: int = DEFAULT_GIT_MESSAGE_AGENT_TIMEOUT,
+    git_timeout: int | None = None,
 ) -> str:
     """Generate a commit message via a lightweight agent with deterministic fallback."""
-    changed_files, diff_stat = _staged_change_context(worktree_path)
+    changed_files, diff_stat = _staged_change_context(worktree_path, timeout=git_timeout)
     prompt = _commit_message_prompt(
         issue_number=issue_number,
         issue_title=issue_title,
@@ -711,6 +723,7 @@ def commit_changes(
     agent: str = "claude",
     git_message_timeout: int = DEFAULT_GIT_MESSAGE_AGENT_TIMEOUT,
     allowed_paths: Collection[str] | None = None,
+    git_timeout: int | None = None,
 ) -> None:
     """Commit changes in worktree, filtering out secret files.
 
@@ -723,6 +736,7 @@ def commit_changes(
             agent. Defaults to :data:`DEFAULT_GIT_MESSAGE_AGENT_TIMEOUT`.
         allowed_paths: Optional exact set of porcelain paths allowed to be
             staged. Secret filtering still applies.
+        git_timeout: Optional timeout in seconds for each local git command.
 
     Raises:
         RuntimeError: If there are no changes, or all changes are secret files.
@@ -733,6 +747,7 @@ def commit_changes(
         ["git", "status", "--porcelain"],
         cwd=worktree_path,
         capture_output=True,
+        **_git_timeout_kw(git_timeout),
     )
 
     if not result.stdout.strip():
@@ -794,9 +809,17 @@ def commit_changes(
 
     # Stage the files
     if files_to_update:
-        run(["git", "add", "-u", "--", *files_to_update], cwd=worktree_path)
+        run(
+            ["git", "add", "-u", "--", *files_to_update],
+            cwd=worktree_path,
+            **_git_timeout_kw(git_timeout),
+        )
     if files_to_add:
-        run(["git", "add", "--", *files_to_add], cwd=worktree_path)
+        run(
+            ["git", "add", "--", *files_to_add],
+            cwd=worktree_path,
+            **_git_timeout_kw(git_timeout),
+        )
 
     # Generate commit message
     issue = fetch_issue_info(issue_number)
@@ -807,12 +830,14 @@ def commit_changes(
         worktree_path=worktree_path,
         agent=agent,
         git_message_timeout=git_message_timeout,
+        git_timeout=git_timeout,
     )
 
     # Commit with cryptographic signature and DCO sign-off — required by repo policy.
     run(
         ["git", "commit", "-S", "-s", "-m", commit_msg],
         cwd=worktree_path,
+        **_git_timeout_kw(git_timeout),
     )
 
 

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -28,6 +28,7 @@ import os
 import shutil
 import threading
 from pathlib import Path
+from typing import Any
 
 from hephaestus.utils.file_lock import file_lock
 
@@ -41,6 +42,11 @@ _AUTOMATION_PROMPT_PREFIXES = (
     ".claude-prompt-",
     ".claude-followup-",
 )
+
+
+def _timeout_kw(timeout: int | None) -> dict[str, Any]:
+    """Return a ``run`` kwargs fragment only when a timeout was provided."""
+    return {} if timeout is None else {"timeout": timeout}
 
 
 def _loop_trunk_githash() -> str | None:
@@ -72,7 +78,7 @@ class WorktreeManager:
     Allows parallel issue implementation in isolated worktrees.
     """
 
-    def __init__(self, base_dir: Path | None = None, base_branch: str | None = None):
+    def __init__(self, base_dir: Path | None = None, base_branch: str | None = None) -> None:
         """Initialize worktree manager.
 
         Args:
@@ -112,15 +118,19 @@ class WorktreeManager:
     @property
     def base_branch(self) -> str:
         """The base branch, auto-detected on first access."""
+        return self._resolve_base_branch()
+
+    def _resolve_base_branch(self, *, timeout: int | None = None) -> str:
+        """Return the base branch, using ``timeout`` for lazy git detection."""
         if self._base_branch_resolved is not None:
             return self._base_branch_resolved
         if self._base_branch_override is not None:
             self._base_branch_resolved = self._base_branch_override
             return self._base_branch_resolved
-        self._base_branch_resolved = self._detect_base_branch()
+        self._base_branch_resolved = self._detect_base_branch(timeout=timeout)
         return self._base_branch_resolved
 
-    def refresh_base_branch(self) -> str:
+    def refresh_base_branch(self, *, timeout: int | None = None) -> str:
         """Re-fetch ``origin`` and re-resolve the auto-detected base branch.
 
         Issue-major loop (#1560): each issue's worktree should branch off the
@@ -141,17 +151,23 @@ class WorktreeManager:
             self._base_branch_override_source = None
         with file_lock(self._git_metadata_lock_path()):
             with contextlib.suppress(Exception):
-                run(["git", "fetch", "origin"], cwd=self.repo_root, capture_output=True)
+                run(
+                    ["git", "fetch", "origin"],
+                    cwd=self.repo_root,
+                    capture_output=True,
+                    **_timeout_kw(timeout),
+                )
             self._base_branch_resolved = None  # force re-detect on next access
-            return self.base_branch
+            return self._resolve_base_branch(timeout=timeout)
 
-    def _detect_base_branch(self) -> str:
+    def _detect_base_branch(self, *, timeout: int | None = None) -> str:
         try:
             result = run(
                 ["git", "symbolic-ref", "refs/remotes/origin/HEAD", "--short"],
                 cwd=self.repo_root,
                 capture_output=True,
                 log_errors=False,
+                **_timeout_kw(timeout),
             )
             detected = result.stdout.strip()
             logger.debug("Auto-detected base branch: %s", detected)
@@ -163,6 +179,7 @@ class WorktreeManager:
                         ["git", "rev-parse", "--verify", candidate],
                         cwd=self.repo_root,
                         capture_output=True,
+                        **_timeout_kw(timeout),
                     )
                     logger.warning("Could not auto-detect base branch, found %s", candidate)
                     return candidate
@@ -181,6 +198,7 @@ class WorktreeManager:
         branch_name: str | None = None,
         *,
         refresh_base: bool = False,
+        timeout: int | None = None,
     ) -> Path:
         """Create a new worktree for an issue.
 
@@ -193,6 +211,7 @@ class WorktreeManager:
                 so each issue branches off the latest trunk; no-op when the base
                 is explicitly pinned. Default False preserves prior behavior for
                 all other callers (review, address-review, ci-driver).
+            timeout: Optional timeout in seconds for each git command.
 
         Returns:
             Path to worktree directory
@@ -207,7 +226,7 @@ class WorktreeManager:
                 return self.worktrees[issue_number]
 
             if refresh_base:
-                self.refresh_base_branch()
+                self.refresh_base_branch(timeout=timeout)
 
             if branch_name is None:
                 branch_name = f"{issue_number}-auto"
@@ -221,7 +240,7 @@ class WorktreeManager:
             # with "already used by worktree at ..." (exit 128). Return that
             # existing worktree and register it under this issue; the caller then
             # syncs it to the PR head (fetch + reset --hard origin/<branch>).
-            existing = self._worktree_holding_branch(branch_name)
+            existing = self._worktree_holding_branch(branch_name, timeout=timeout)
             if existing is not None and existing != worktree_path:
                 logger.info(
                     "Branch %s already checked out at %s — reusing that worktree for issue #%s",
@@ -232,7 +251,7 @@ class WorktreeManager:
                 self.worktrees[issue_number] = existing
                 return existing
 
-            if self._reuse_existing_dirty_worktree(issue_number, worktree_path):
+            if self._reuse_existing_dirty_worktree(issue_number, worktree_path, timeout=timeout):
                 return worktree_path
 
             # Remove existing clean worktree directory if present. Dirty
@@ -240,7 +259,7 @@ class WorktreeManager:
             # unknown contents fail closed there instead of being removed.
             if worktree_path.exists():
                 logger.warning("Removing existing worktree directory: %s", worktree_path)
-                self._remove_worktree_path_forcefully(worktree_path)
+                self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
 
             try:
                 with file_lock(self._git_metadata_lock_path()):
@@ -249,10 +268,11 @@ class WorktreeManager:
                             worktree_path,
                             branch_name,
                             refresh_base=refresh_base,
+                            timeout=timeout,
                         )
                     except Exception:
                         self.worktrees.pop(issue_number, None)
-                        self._remove_worktree_path_forcefully(worktree_path)
+                        self._remove_worktree_path_forcefully(worktree_path, timeout=timeout)
                         raise
                 self.worktrees[issue_number] = worktree_path
                 logger.info("Created worktree for issue #%s at %s", issue_number, worktree_path)
@@ -261,7 +281,12 @@ class WorktreeManager:
             except Exception as e:
                 raise RuntimeError(f"Failed to create worktree: {e}") from e
 
-    def _remove_worktree_path_forcefully(self, worktree_path: Path) -> None:
+    def _remove_worktree_path_forcefully(
+        self,
+        worktree_path: Path,
+        *,
+        timeout: int | None = None,
+    ) -> None:
         """Remove a worktree path and prune stale git metadata."""
         # Try git worktree remove first to clean up git metadata.
         try:
@@ -269,6 +294,7 @@ class WorktreeManager:
                 ["git", "worktree", "remove", "--force", str(worktree_path)],
                 cwd=self.repo_root,
                 check=False,
+                **_timeout_kw(timeout),
             )
         except Exception as e:
             logger.debug("git worktree remove failed (expected if not a worktree): %s", e)
@@ -286,7 +312,12 @@ class WorktreeManager:
                     )
         finally:
             try:
-                run(["git", "worktree", "prune"], cwd=self.repo_root, check=False)
+                run(
+                    ["git", "worktree", "prune"],
+                    cwd=self.repo_root,
+                    check=False,
+                    **_timeout_kw(timeout),
+                )
             except Exception as e:
                 logger.debug("git worktree prune failed: %s", e)
 
@@ -296,6 +327,7 @@ class WorktreeManager:
         branch_name: str,
         *,
         refresh_base: bool = False,
+        timeout: int | None = None,
     ) -> None:
         """Add a git worktree, choosing the right source for ``branch_name``.
 
@@ -314,27 +346,30 @@ class WorktreeManager:
             branch_name: Branch the worktree should track.
             refresh_base: When True, reused issue automation branches are rebased
                 onto the refreshed base before the implementer starts.
+            timeout: Optional timeout in seconds for each git command.
 
         """
-        if self._local_branch_exists(branch_name):
-            self._refresh_stale_local_branch_if_safe(branch_name)
+        if self._local_branch_exists(branch_name, timeout=timeout):
+            self._refresh_stale_local_branch_if_safe(branch_name, timeout=timeout)
             logger.info("Branch %s already exists, reusing it", branch_name)
             run(
                 ["git", "worktree", "add", str(worktree_path), branch_name],
                 cwd=self.repo_root,
+                **_timeout_kw(timeout),
             )
             self._rebase_existing_issue_branch_if_requested(
                 worktree_path,
                 branch_name,
                 refresh_base=refresh_base,
+                timeout=timeout,
             )
-        elif self._remote_branch_exists(branch_name):
+        elif self._remote_branch_exists(branch_name, timeout=timeout):
             logger.info(
                 "Branch %s exists on origin, extending it from origin/%s",
                 branch_name,
                 branch_name,
             )
-            run(["git", "fetch", "origin", branch_name], cwd=self.repo_root)
+            run(["git", "fetch", "origin", branch_name], cwd=self.repo_root, **_timeout_kw(timeout))
             run(
                 [
                     "git",
@@ -346,11 +381,13 @@ class WorktreeManager:
                     f"origin/{branch_name}",
                 ],
                 cwd=self.repo_root,
+                **_timeout_kw(timeout),
             )
             self._rebase_existing_issue_branch_if_requested(
                 worktree_path,
                 branch_name,
                 refresh_base=refresh_base,
+                timeout=timeout,
             )
         else:
             run(
@@ -361,9 +398,10 @@ class WorktreeManager:
                     "-b",
                     branch_name,
                     str(worktree_path),
-                    self.base_branch,
+                    self._resolve_base_branch(timeout=timeout),
                 ],
                 cwd=self.repo_root,
+                **_timeout_kw(timeout),
             )
 
     def _rebase_existing_issue_branch_if_requested(
@@ -372,11 +410,12 @@ class WorktreeManager:
         branch_name: str,
         *,
         refresh_base: bool,
+        timeout: int | None = None,
     ) -> None:
         """Rebase reused issue automation branches before implementation starts."""
         if not refresh_base or not self._is_issue_automation_branch(branch_name):
             return
-        base_branch_name = self._origin_base_branch_name()
+        base_branch_name = self._origin_base_branch_name(timeout=timeout)
         if base_branch_name is None:
             logger.info(
                 "Skipping pre-implementation rebase for %s: base %s is not an origin branch",
@@ -389,7 +428,7 @@ class WorktreeManager:
             branch_name,
             self.base_branch,
         )
-        if not rebase_worktree_onto(worktree_path, base_branch_name):
+        if not rebase_worktree_onto(worktree_path, base_branch_name, **_timeout_kw(timeout)):
             logger.warning(
                 "Could not rebase reused issue branch %s onto %s before implementation; "
                 "proceeding with current branch head",
@@ -397,9 +436,9 @@ class WorktreeManager:
                 self.base_branch,
             )
 
-    def _origin_base_branch_name(self) -> str | None:
+    def _origin_base_branch_name(self, *, timeout: int | None = None) -> str | None:
         """Return the branch name portion for an ``origin/<branch>`` base."""
-        base_ref = self.base_branch
+        base_ref = self._resolve_base_branch(timeout=timeout)
         if base_ref.startswith("refs/remotes/origin/"):
             return base_ref.removeprefix("refs/remotes/origin/")
         if base_ref.startswith("origin/"):
@@ -408,7 +447,12 @@ class WorktreeManager:
             return base_ref
         return None
 
-    def _refresh_stale_local_branch_if_safe(self, branch_name: str) -> None:
+    def _refresh_stale_local_branch_if_safe(
+        self,
+        branch_name: str,
+        *,
+        timeout: int | None = None,
+    ) -> None:
         """Fast-forward a stale local branch that has no work beyond base.
 
         A killed or superseded automation run can leave ``<issue>-auto-impl``
@@ -421,17 +465,19 @@ class WorktreeManager:
         if not self._is_issue_automation_branch(branch_name):
             return
         try:
+            base_branch = self._resolve_base_branch(timeout=timeout)
             result = run(
                 [
                     "git",
                     "rev-list",
                     "--left-right",
                     "--count",
-                    f"{self.base_branch}...{branch_name}",
+                    f"{base_branch}...{branch_name}",
                 ],
                 cwd=self.repo_root,
                 capture_output=True,
                 check=False,
+                **_timeout_kw(timeout),
             )
             if result.returncode != 0:
                 return
@@ -449,17 +495,21 @@ class WorktreeManager:
         logger.info(
             "Branch %s has no commits beyond %s and is %s commit(s) behind; fast-forwarding",
             branch_name,
-            self.base_branch,
+            base_branch,
             behind_base,
         )
-        run(["git", "branch", "-f", branch_name, self.base_branch], cwd=self.repo_root)
+        run(
+            ["git", "branch", "-f", branch_name, base_branch],
+            cwd=self.repo_root,
+            **_timeout_kw(timeout),
+        )
 
     def _is_issue_automation_branch(self, branch_name: str) -> bool:
         """Return True for branch names owned by the issue automation loop."""
         issue_prefix, sep, suffix = branch_name.partition("-")
         return bool(sep and issue_prefix.isdigit() and suffix in {"auto", "auto-impl"})
 
-    def _local_branch_exists(self, branch_name: str) -> bool:
+    def _local_branch_exists(self, branch_name: str, *, timeout: int | None = None) -> bool:
         """Return True if ``branch_name`` exists in the local repository.
 
         Args:
@@ -475,12 +525,13 @@ class WorktreeManager:
                 cwd=self.repo_root,
                 capture_output=True,
                 check=False,
+                **_timeout_kw(timeout),
             )
             return result.returncode == 0
         except Exception:
             return False
 
-    def _remote_branch_exists(self, branch_name: str) -> bool:
+    def _remote_branch_exists(self, branch_name: str, *, timeout: int | None = None) -> bool:
         """Return True if ``branch_name`` exists on origin.
 
         Uses ``git ls-remote --heads origin <branch>`` and checks for the
@@ -502,6 +553,7 @@ class WorktreeManager:
                 capture_output=True,
                 check=False,
                 log_errors=False,
+                **_timeout_kw(timeout),
             )
             return f"refs/heads/{branch_name}" in (result.stdout or "")
         except Exception as e:
@@ -532,10 +584,15 @@ class WorktreeManager:
             if self._is_automation_prompt_artifact(child):
                 child.unlink()
 
-    def _path_is_registered_worktree(self, worktree_path: Path) -> bool:
+    def _path_is_registered_worktree(
+        self,
+        worktree_path: Path,
+        *,
+        timeout: int | None = None,
+    ) -> bool:
         """Return True when ``worktree_path`` appears in git's worktree list."""
         target = worktree_path.resolve()
-        for wt in self.list_worktrees(raise_on_error=True):
+        for wt in self.list_worktrees(raise_on_error=True, timeout=timeout):
             path = wt.get("path")
             if path and Path(path).resolve() == target:
                 return True
@@ -545,7 +602,13 @@ class WorktreeManager:
         """Return True if a path exists and contains any directory entries."""
         return path.exists() and path.is_dir() and any(path.iterdir())
 
-    def _reuse_existing_dirty_worktree(self, issue_number: int, worktree_path: Path) -> bool:
+    def _reuse_existing_dirty_worktree(
+        self,
+        issue_number: int,
+        worktree_path: Path,
+        *,
+        timeout: int | None = None,
+    ) -> bool:
         """Register and reuse an existing dirty worktree instead of deleting it.
 
         A previous automation process may have preserved dirty work for an
@@ -557,8 +620,8 @@ class WorktreeManager:
 
         self._cleanup_automation_prompt_artifacts(worktree_path)
 
-        if self._path_is_registered_worktree(worktree_path):
-            if not is_clean_working_tree(worktree_path):
+        if self._path_is_registered_worktree(worktree_path, timeout=timeout):
+            if not is_clean_working_tree(worktree_path, timeout=timeout):
                 logger.info(
                     "Reusing dirty existing worktree for issue #%s at %s",
                     issue_number,
@@ -576,12 +639,19 @@ class WorktreeManager:
 
         return False
 
-    def remove_worktree(self, issue_number: int, force: bool = False) -> None:
+    def remove_worktree(
+        self,
+        issue_number: int,
+        force: bool = False,
+        *,
+        timeout: int | None = None,
+    ) -> None:
         """Remove a worktree.
 
         Args:
             issue_number: Issue number
             force: Force removal even with uncommitted changes
+            timeout: Optional timeout in seconds for each git command.
 
         Raises:
             WorktreeDirtyError: If the worktree has uncommitted changes and force=False
@@ -608,12 +678,17 @@ class WorktreeManager:
                 )
                 del self.worktrees[issue_number]
                 with contextlib.suppress(Exception):
-                    run(["git", "worktree", "prune"], cwd=self.repo_root, check=False)
+                    run(
+                        ["git", "worktree", "prune"],
+                        cwd=self.repo_root,
+                        check=False,
+                        **_timeout_kw(timeout),
+                    )
                 return
 
             self._cleanup_automation_prompt_artifacts(worktree_path)
 
-            if not force and not is_clean_working_tree(worktree_path):
+            if not force and not is_clean_working_tree(worktree_path, timeout=timeout):
                 raise WorktreeDirtyError(issue_number, worktree_path)
 
             try:
@@ -622,7 +697,7 @@ class WorktreeManager:
                     cmd.append("--force")
 
                 with file_lock(self._git_metadata_lock_path()):
-                    run(cmd, cwd=self.repo_root)
+                    run(cmd, cwd=self.repo_root, **_timeout_kw(timeout))
 
                 del self.worktrees[issue_number]
                 logger.info("Removed worktree for issue #%s", issue_number)
@@ -643,7 +718,7 @@ class WorktreeManager:
         with self.lock:
             return self.worktrees.get(issue_number)
 
-    def cleanup_all(self, force: bool = False) -> None:
+    def cleanup_all(self, force: bool = False, *, timeout: int | None = None) -> None:
         """Remove all managed worktrees.
 
         Dirty worktrees (uncommitted changes) are skipped rather than force-removed.
@@ -651,6 +726,7 @@ class WorktreeManager:
 
         Args:
             force: Force removal even with uncommitted changes
+            timeout: Optional timeout in seconds for each git command.
 
         Note:
             Known limitation: Releases lock between iterations to avoid
@@ -681,7 +757,7 @@ class WorktreeManager:
                 )
                 continue
             try:
-                self.remove_worktree(issue_num, force=force)
+                self.remove_worktree(issue_num, force=force, timeout=timeout)
                 if path is not None:
                     removed_paths.add(path)
             except WorktreeDirtyError as e:
@@ -690,18 +766,23 @@ class WorktreeManager:
             except Exception as e:
                 logger.error("Failed to remove worktree for issue #%s: %s", issue_num, e)
 
-    def prune_worktrees(self) -> None:
+    def prune_worktrees(self, *, timeout: int | None = None) -> None:
         """Prune stale worktree administrative files.
 
         Useful for cleaning up after manual worktree deletion.
         """
         try:
-            run(["git", "worktree", "prune"], cwd=self.repo_root)
+            run(["git", "worktree", "prune"], cwd=self.repo_root, **_timeout_kw(timeout))
             logger.info("Pruned stale worktrees")
         except Exception as e:
             logger.error("Failed to prune worktrees: %s", e)
 
-    def _worktree_holding_branch(self, branch_name: str) -> Path | None:
+    def _worktree_holding_branch(
+        self,
+        branch_name: str,
+        *,
+        timeout: int | None = None,
+    ) -> Path | None:
         """Return the path of the worktree that has ``branch_name`` checked out.
 
         git refuses to check out the same branch in two worktrees, so before
@@ -712,7 +793,7 @@ class WorktreeManager:
         """
         target_ref = f"refs/heads/{branch_name}"
         try:
-            worktrees = self.list_worktrees(raise_on_error=True)
+            worktrees = self.list_worktrees(raise_on_error=True, timeout=timeout)
         except Exception as e:
             raise RuntimeError(
                 f"Cannot safely determine whether branch {branch_name!r} is already "
@@ -724,12 +805,18 @@ class WorktreeManager:
                 return Path(wt["path"])
         return None
 
-    def list_worktrees(self, *, raise_on_error: bool = False) -> list[dict[str, str]]:
+    def list_worktrees(
+        self,
+        *,
+        raise_on_error: bool = False,
+        timeout: int | None = None,
+    ) -> list[dict[str, str]]:
         """List all git worktrees in the repository.
 
         Args:
             raise_on_error: When True, propagate git/listing failures so callers
                 that would otherwise force-remove or collide fail closed.
+            timeout: Optional timeout in seconds for the git command.
 
         Returns:
             List of worktree info dictionaries
@@ -740,6 +827,7 @@ class WorktreeManager:
                 ["git", "worktree", "list", "--porcelain"],
                 cwd=self.repo_root,
                 capture_output=True,
+                **_timeout_kw(timeout),
             )
 
             worktrees = []
@@ -771,11 +859,12 @@ class WorktreeManager:
                 raise RuntimeError("Failed to list git worktrees") from e
             return []
 
-    def ensure_branch_deleted(self, branch_name: str) -> None:
+    def ensure_branch_deleted(self, branch_name: str, *, timeout: int | None = None) -> None:
         """Ensure a branch is deleted from local and remote.
 
         Args:
             branch_name: Branch name to delete
+            timeout: Optional timeout in seconds for each git command.
 
         """
         # Delete local branch
@@ -784,6 +873,7 @@ class WorktreeManager:
                 ["git", "branch", "-D", branch_name],
                 cwd=self.repo_root,
                 check=False,
+                **_timeout_kw(timeout),
             )
             logger.debug("Deleted local branch %s", branch_name)
         except Exception as e:
@@ -795,6 +885,7 @@ class WorktreeManager:
                 ["git", "push", "origin", "--delete", branch_name],
                 cwd=self.repo_root,
                 check=False,
+                **_timeout_kw(timeout),
             )
             logger.debug("Deleted remote branch %s", branch_name)
         except Exception as e:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -475,7 +475,11 @@ class TestGitOps:
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
-        instance.create_worktree.assert_called_once_with(issue_number=7, branch_name="7-auto")
+        instance.create_worktree.assert_called_once_with(
+            issue_number=7,
+            branch_name="7-auto",
+            timeout=60,
+        )
         assert result.ok is True
         assert result.value == "/tmp/wt"
 
@@ -510,9 +514,10 @@ class TestGitOps:
             issue_number=7,
             branch_name="7-existing",
             refresh_base=False,
+            timeout=60,
         )
-        mock_clean.assert_called_once_with(Path("/tmp/wt"))
-        mock_sync.assert_called_once_with(Path("/tmp/wt"), "7-existing")
+        mock_clean.assert_called_once_with(Path("/tmp/wt"), timeout=60)
+        mock_sync.assert_called_once_with(Path("/tmp/wt"), "7-existing", timeout=60)
         assert result.ok is True
         assert result.value == {"path": "/tmp/wt", "dirty": False, "status": "", "diff": ""}
 
@@ -533,7 +538,7 @@ class TestGitOps:
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
-        instance.remove_worktree.assert_called_once_with(issue_number=7, force=True)
+        instance.remove_worktree.assert_called_once_with(issue_number=7, force=True, timeout=60)
         assert result.ok is True
 
     def test_remove_worktree_path_dispatch(
@@ -560,8 +565,14 @@ class TestGitOps:
         mock_run.assert_any_call(
             ["git", "worktree", "remove", str(tmp_path / "issue-7"), "--force"],
             cwd=tmp_path,
+            timeout=60,
         )
-        mock_run.assert_any_call(["git", "worktree", "prune"], cwd=tmp_path, check=False)
+        mock_run.assert_any_call(
+            ["git", "worktree", "prune"],
+            cwd=tmp_path,
+            check=False,
+            timeout=60,
+        )
         assert result.ok is True
 
     @pytest.mark.parametrize("rebase_clean", [True, False])
@@ -585,7 +596,11 @@ class TestGitOps:
             pool.submit(job, StageName.MERGE_WAIT)
             _, result = completion_q.get(timeout=10)
 
-        mock_rebase.assert_called_once_with(cwd=Path("/tmp/wt"), base_branch="main")
+        mock_rebase.assert_called_once_with(
+            cwd=Path("/tmp/wt"),
+            base_branch="main",
+            timeout=60,
+        )
         assert result.ok is rebase_clean
         assert result.value is rebase_clean
 
@@ -607,7 +622,7 @@ class TestGitOps:
             pool.submit(job, StageName.MERGE_WAIT)
             _, result = completion_q.get(timeout=10)
 
-        mock_push.assert_called_once_with(cwd=Path("/tmp/wt"), branch="7-auto")
+        mock_push.assert_called_once_with(cwd=Path("/tmp/wt"), branch="7-auto", timeout=60)
         assert result.ok is True
 
     def test_commit_push_extracts_explicit_keys(
@@ -637,8 +652,14 @@ class TestGitOps:
             pool.submit(job, StageName.CI)
             _, result = completion_q.get(timeout=10)
 
-        mock_commit.assert_called_once_with(5, tmp_path, "claude", allowed_paths=None)
-        mock_push.assert_called_once_with("5-auto", tmp_path)
+        mock_commit.assert_called_once_with(
+            5,
+            tmp_path,
+            "claude",
+            allowed_paths=None,
+            timeout=60,
+        )
+        mock_push.assert_called_once_with("5-auto", tmp_path, timeout=60)
         assert result.ok is True
         assert result.value is True  # value carries commit_if_changes' bool
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -190,6 +190,28 @@ class TestCommitIfChanges:
         mock_commit.assert_called_once_with(123, tmp_path, "codex", allowed_paths=None)
 
     @patch("hephaestus.automation.pr_manager.commit_changes")
+    def test_dirty_tree_threads_timeout_to_commit_helper(
+        self, mock_commit: Any, git_utils_mocks: Any, tmp_path: Path
+    ) -> None:
+        git_utils_mocks.run.return_value = Mock(stdout=" M fixed.py\n")
+
+        assert commit_if_changes(123, tmp_path, "codex", timeout=42) is True
+
+        git_utils_mocks.run.assert_called_once_with(
+            ["git", "status", "--porcelain"],
+            cwd=tmp_path,
+            capture_output=True,
+            timeout=42,
+        )
+        mock_commit.assert_called_once_with(
+            123,
+            tmp_path,
+            "codex",
+            allowed_paths=None,
+            git_timeout=42,
+        )
+
+    @patch("hephaestus.automation.pr_manager.commit_changes")
     def test_dirty_tree_forwards_allowed_paths(
         self, mock_commit: Any, git_utils_mocks: Any, tmp_path: Path
     ) -> None:
@@ -248,6 +270,16 @@ class TestPushBranch:
 
         with pytest.raises(RuntimeError, match="Failed to push branch 123-auto-impl"):
             push_branch("123-auto-impl", tmp_path)
+
+    def test_push_branch_threads_timeout(self, git_utils_mocks: Any, tmp_path: Path) -> None:
+        """push_branch bounds its git push with the caller's timeout."""
+        push_branch("123-auto-impl", tmp_path, timeout=42)
+
+        git_utils_mocks.run.assert_called_once_with(
+            ["git", "push", "origin", "123-auto-impl"],
+            cwd=tmp_path,
+            timeout=42,
+        )
 
 
 class TestGetCurrentBranch:
@@ -519,6 +551,31 @@ class TestPushCurrentBranchWithLeaseOnDivergence:
             "HEAD:5391-auto-impl",
         ]
 
+    def test_timeout_threads_through_push_and_divergence_retry(self, git_utils_mocks: Any) -> None:
+        """Initial push, branch lookup, fetch, and lease retry share one timeout."""
+        worktree = Path("/tmp/worktree-xyz")
+        push_err = subprocess.CalledProcessError(
+            1,
+            ["git", "push", "origin", "HEAD"],
+            output="",
+            stderr="non-fast-forward\n",
+        )
+        git_utils_mocks.run.side_effect = [
+            push_err,
+            Mock(returncode=0, stdout="511-impl\n"),
+            Mock(returncode=0),
+            Mock(returncode=0),
+        ]
+
+        push_current_branch_with_lease_on_divergence(worktree, timeout=42)
+
+        assert [call.kwargs["timeout"] for call in git_utils_mocks.run.call_args_list] == [
+            42,
+            42,
+            42,
+            42,
+        ]
+
 
 class TestSyncWorktreeToRemoteBranch:
     """Tests for sync_worktree_to_remote_branch (#832 — reset before agent)."""
@@ -552,6 +609,18 @@ class TestSyncWorktreeToRemoteBranch:
             sync_worktree_to_remote_branch(Path("/tmp/worktree-xyz"), "any-branch")
         # Reset must NOT have run after a fetch failure.
         assert git_utils_mocks.run.call_count == 1
+
+    def test_timeout_threads_through_fetch_and_reset(self, git_utils_mocks: Any) -> None:
+        """sync_worktree_to_remote_branch bounds fetch and reset."""
+        git_utils_mocks.run.return_value = Mock(returncode=0)
+        worktree = Path("/tmp/worktree-xyz")
+
+        sync_worktree_to_remote_branch(worktree, "5450-auto-impl", timeout=42)
+
+        assert [call.kwargs["timeout"] for call in git_utils_mocks.run.call_args_list] == [
+            42,
+            42,
+        ]
 
 
 class TestRebaseWorktreeOnto:
@@ -690,6 +759,19 @@ class TestRebaseWorktreeOnto:
             "upstream/develop",
             "--exec",
             "git commit --amend --no-edit -S -s",
+        ]
+
+    def test_timeout_threads_through_fetch_cleanup_and_rebase(self, git_utils_mocks: Any) -> None:
+        """rebase_worktree_onto bounds fetch, cleanup probes, and rebase."""
+        git_utils_mocks.run.return_value = Mock(returncode=0, stdout="")
+        worktree = Path("/tmp/worktree-xyz")
+
+        assert rebase_worktree_onto(worktree, "main", timeout=42) is True
+
+        assert [call.kwargs["timeout"] for call in git_utils_mocks.run.call_args_list] == [
+            42,
+            42,
+            42,
         ]
 
 

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -116,6 +116,33 @@ class TestCommitChanges:
         assert commit_cmd[:4] == ["git", "commit", "-S", "-s"]
         assert "-m" in commit_cmd
 
+    def test_commit_changes_threads_git_timeout(self) -> None:
+        porcelain = " M src/foo.py\n"
+        run_mock = MagicMock(
+            side_effect=[
+                _status(porcelain),  # git status
+                _status(""),  # git add
+                _status("M\tsrc/foo.py\n"),  # changed files context
+                _status(" src/foo.py | 1 +\n"),  # stat context
+                _status(""),  # git commit
+            ]
+        )
+        issue = MagicMock(title="Add foo", body="Implement it.")
+        with (
+            patch.object(pr_manager, "run", run_mock),
+            patch.object(pr_manager, "fetch_issue_info", return_value=issue),
+            patch.object(pr_manager, "_invoke_git_message_agent", return_value="not json"),
+        ):
+            pr_manager.commit_changes(3, Path("/tmp/wt"), git_timeout=42)
+
+        assert [call.kwargs["timeout"] for call in run_mock.call_args_list] == [
+            42,
+            42,
+            42,
+            42,
+            42,
+        ]
+
     def test_handles_renamed_files(self) -> None:
         porcelain = "R  old.py -> new.py\n"
         run_mock = MagicMock(

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -247,6 +247,28 @@ class TestWorktreeManager:
         assert "999-auto-impl" in add_argv
         assert "origin/main" in add_argv
 
+    def test_create_worktree_threads_timeout_to_git_commands(
+        self, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """create_worktree bounds local git probes and worktree creation."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        rev_parse = MagicMock(returncode=1)
+        ls_remote = MagicMock(returncode=0, stdout="")
+        detect = MagicMock(stdout="origin/main")
+        add = MagicMock(returncode=0)
+        worktree_mocks.run.side_effect = [rev_parse, ls_remote, detect, add]
+        manager = WorktreeManager()
+
+        with patch.object(manager, "_worktree_holding_branch", return_value=None):
+            manager.create_worktree(999, "999-auto-impl", timeout=42)
+
+        assert [call.kwargs["timeout"] for call in worktree_mocks.run.call_args_list] == [
+            42,
+            42,
+            42,
+            42,
+        ]
+
     def test_create_worktree_prefers_local_branch_over_remote(
         self, worktree_mocks: Any, tmp_path: Any
     ) -> None:
@@ -323,6 +345,23 @@ class TestWorktreeManager:
 
         call_args = worktree_mocks.run.call_args[0][0]
         assert "--force" in call_args
+
+    @patch("hephaestus.automation.worktree_manager.is_clean_working_tree", return_value=True)
+    def test_remove_worktree_threads_timeout(
+        self, mock_clean: Any, worktree_mocks: Any, tmp_path: Any
+    ) -> None:
+        """remove_worktree bounds the clean check and git worktree remove."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+
+        worktree_path = manager.base_dir / "issue-123"
+        worktree_path.mkdir(parents=True)
+        manager.worktrees[123] = worktree_path
+
+        manager.remove_worktree(123, timeout=42)
+
+        mock_clean.assert_called_once_with(worktree_path, timeout=42)
+        assert worktree_mocks.run.call_args.kwargs["timeout"] == 42
 
     def test_remove_worktree_not_found(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test removing non-existent worktree."""


### PR DESCRIPTION
## Summary
Verdict: pass | Reason: Added `job.timeout_s` propagation for Git rebase/push/worktree/sync/commit-push paths across `git_utils`, `WorktreeManager`, `pr_manager`, and `worker_pool`; tests passed via Ruff, `mypy hephaestus/`, affected pytest `196 passed`, and full parent-Pixi pytest `6088 passed, 21 skipped`; exact local `pixi run python -m pytest tests/ -v` and pre-commit were blocked by sandbox network/cache setup before running hooks/tests, and `gh issue view 1885 --comments` was unavailable due auth/network.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1885

Generated by ProjectHephaestus automation
