### PR TITLE
[mino] create_pr URL fallback int(output.split("/")[-1]) crashes on a non-numeric trailing segment

### DIFF
--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -873,11 +873,15 @@ class PipelineGitHub:
                         body_path,
                     ]
                 )
-            output = result.stdout.strip()
+            raw_output = result.stdout
+            output = raw_output.strip()
             match = re.search(r"/pull/(\d+)", output)
             if match:
                 return int(match.group(1))
-            return int(output.split("/")[-1])
+            logger.error("Failed to parse PR number from gh pr create output: %r", raw_output)
+            raise RuntimeError(
+                f"Failed to parse PR number from gh pr create output: {raw_output!r}"
+            )
         return github_api.gh_pr_create(branch, title, body)
 
     def post_pr_comment(self, pr_number: int, body: str) -> None:

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -452,6 +452,58 @@ class TestCreatePr:
         assert dry_adapter.create_pr(5, "b", "t", "x") == 0
         create.assert_not_called()
 
+    def test_repo_scoped_create_pr_parses_pull_url(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        monkeypatch.setattr(pg.PipelineGitHub, "find_pr_for_issue", lambda self, issue: None)
+        monkeypatch.setattr(
+            github_api_mod, "_assert_branch_commits_signed", lambda branch, base: None
+        )
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            return SimpleNamespace(stdout="https://github.com/org/repo-a/pull/1888\n")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pr_number = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).create_pr(
+            1887, "1887-auto-impl", "title", "body\n\nCloses #1887"
+        )
+
+        assert pr_number == 1888
+        assert calls[0][-2:] == ["--repo", "org/repo-a"]
+
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            "gh: GraphQL: Head sha can't be blank",
+            "https://github.com/org/repo-a/123?foo=bar",
+        ],
+    )
+    def test_repo_scoped_create_pr_parse_miss_logs_and_raises_runtime_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        stdout: str,
+    ) -> None:
+        monkeypatch.setattr(pg.PipelineGitHub, "find_pr_for_issue", lambda self, issue: None)
+        monkeypatch.setattr(
+            github_api_mod, "_assert_branch_commits_signed", lambda branch, base: None
+        )
+        monkeypatch.setattr(pg, "gh_call", lambda argv, **kwargs: SimpleNamespace(stdout=stdout))
+
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+
+        with caplog.at_level("ERROR", logger=pg.__name__):
+            with pytest.raises(RuntimeError, match="Failed to parse PR number") as excinfo:
+                adapter.create_pr(1887, "1887-auto-impl", "title", "body\n\nCloses #1887")
+
+        assert stdout in str(excinfo.value)
+        assert any(stdout in record.message for record in caplog.records)
+
 
 class TestReadSurface:
     """Reads delegate verbatim (and stay LIVE even under dry-run)."""


### PR DESCRIPTION
## Summary
Verdict: complete | Reason: `create_pr` now logs and raises `RuntimeError` on unparseable `gh pr create` output, with regression coverage added.

Changed:
- [pipeline_github.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1887/hephaestus/automation/pipeline_github.py:876): removed the blind `int(output.split("/")[-1])` fallback.
- [test_pipeline_github.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1887/tests/unit/automation/test_pipeline_github.py:455): added repo-scoped success and parse-miss tests.

Verification:
- `pixi run python -m pytest tests/ -v`: 6080 passed, 25 skipped, coverage 83.94%.
- `pixi run python -m mypy hephaestus/`: passed.
- `pixi run ruff check hephaestus/ tests/`: passed.
- `pixi run ruff format --check hephaestus/ tests/`: passed.
- `pixi run pre-commit run --files $(git diff --name-only HEAD)`: passed.

Working tree left uncommitted as requested; branch is behind `origin/main` by 6 commits.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1887

Generated by ProjectHephaestus automation
