### PR TITLE
[mino] _label_at_or_past treats an unknown target label as rank -1, making every label silently "at or past" it

### DIFF
--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -190,11 +190,16 @@ def _label_at_or_past(label: str | None, target: str) -> bool:
         True iff the label's rank >= target's rank (absence == needs-plan,
         rank 0).
 
+    Raises:
+        ValueError: If ``target`` is not a known ordered state label.
+
     """
     if label is None:
         label = STATE_NEEDS_PLAN  # absence == needs-plan
+    if target not in _LABEL_RANK:
+        raise ValueError(f"Unknown target state label: {target}")
     label_rank = _LABEL_RANK.get(label, -1)
-    target_rank = _LABEL_RANK.get(target, -1)
+    target_rank = _LABEL_RANK[target]
     return label_rank >= target_rank
 
 

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -20,6 +20,7 @@ from hephaestus.automation.pipeline.seeding import (
     EPIC_NEEDS_SKIP_TAG,
     IssueFacts,
     SeedEntry,
+    _label_at_or_past,
     classify_issue,
     seed_from_cli,
     seed_issue,
@@ -563,6 +564,11 @@ class TestSeedFromCli:
 
 class TestLabelRank:
     """At-or-past label rank comparisons prevent re-queueing."""
+
+    def test_unknown_target_label_raises(self) -> None:
+        """A typo in a compile-time target label must fail closed."""
+        with pytest.raises(ValueError, match="Unknown target state label: state:typo"):
+            _label_at_or_past(STATE_PLAN_GO, "state:typo")
 
     def test_issue_already_past_plan_go_not_requeued_to_planning(self) -> None:
         """AC: issue with state:implementation-go is NOT re-routed to planning."""


### PR DESCRIPTION
## Summary
Verdict: pass | Reason: Updated `seeding.py` to raise on unknown `_label_at_or_past` targets and added the regression test; verified `pytest tests/ -v` = 6082 passed/21 skipped, ruff check/format passed, mypy passed, and changed-file pre-commit passed with a temporary Pixi manifest wrapper; `gh issue view` comments were unavailable due auth/network.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1889

Generated by ProjectHephaestus automation
