### PR TITLE
[mino] --prs is dropped by _build_pipeline_config (prs=[] hardcoded) despite full seeding support and doc advertisement

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -386,10 +386,10 @@ pr_review → ci) remain globally bounded.
 
 ## Seeding and reconstruction
 
-One classifier serves both initial seeding (`--repos`, `--issues`) and restart
-reconstruction (at startup, scan GitHub for labels/PR state). PR inputs are
-still reconstructed from GitHub state during the #1818 cutover; a public `--prs`
-seed argument remains deferred.
+One classifier serves both initial seeding (`--repos`, `--issues`, `--prs`) and
+restart reconstruction (at startup, scan GitHub for labels/PR state). Direct PR
+inputs enter the target repo's `pr_review` queue unless the PR already carries
+`state:implementation-go`, in which case they enter `ci`.
 Uses ordered label rank at-or-past comparisons (never equality):
 
 - `state:needs-plan` — rank 0 (lowest).

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -93,25 +93,35 @@ def _parse_repo_list(value: str) -> list[str]:
     return [s.strip() for s in value.split(",") if s.strip()]
 
 
-def _parse_issue_list(value: str) -> list[int]:
-    """Split a comma-separated issue list into positive integers."""
-    issues: list[int] = []
+def _parse_positive_int_list(value: str, label: str) -> list[int]:
+    """Split a comma-separated list into positive integers."""
+    numbers: list[int] = []
     for part in value.split(","):
         item = part.strip()
         if not item:
             continue
         try:
-            issue = int(item)
+            number = int(item)
         except ValueError as exc:
             raise argparse.ArgumentTypeError(
-                f"expected comma-separated issue numbers, got {item!r}"
+                f"expected comma-separated {label} numbers, got {item!r}"
             ) from exc
-        if issue <= 0:
+        if number <= 0:
             raise argparse.ArgumentTypeError(
-                f"issue numbers must be positive integers, got {issue}"
+                f"{label} numbers must be positive integers, got {number}"
             )
-        issues.append(issue)
-    return issues
+        numbers.append(number)
+    return numbers
+
+
+def _parse_issue_list(value: str) -> list[int]:
+    """Split a comma-separated issue list into positive integers."""
+    return _parse_positive_int_list(value, "issue")
+
+
+def _parse_pr_list(value: str) -> list[int]:
+    """Split a comma-separated PR list into positive integers."""
+    return _parse_positive_int_list(value, "PR")
 
 
 def _default_phase_timeout_s() -> float:
@@ -165,6 +175,7 @@ class LoopConfig:
     serialize_file_overlap: bool = True
     agent: str = "claude"
     issues: list[int] = field(default_factory=list)
+    prs: list[int] = field(default_factory=list)
     dry_run: bool = False
     no_advise: bool = False
     nitpick: bool = False
@@ -241,6 +252,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Comma-separated issue numbers to pass to issue-scoped phases "
             "(plan, implement, drive-green). Default: phase auto-discovery."
+        ),
+    )
+    p.add_argument(
+        "--prs",
+        type=_parse_pr_list,
+        default=None,
+        help=(
+            "Comma-separated PR numbers to seed directly into pipeline PR stages. "
+            "Default: no direct PR scope."
         ),
     )
     p.add_argument(
@@ -511,7 +531,7 @@ def _build_pipeline_config(
         org=org,
         repos=repos,
         issues=cfg.issues,
-        prs=[],  # --prs not yet implemented in #1813
+        prs=cfg.prs,
         loops=cfg.loops,
         max_workers=cfg.max_workers,
         parallel_repos=cfg.parallel_repos,
@@ -601,6 +621,7 @@ def main(argv: list[str] | None = None) -> int:
         phases=phases,
         agent=agent,
         issues=args.issues or [],
+        prs=args.prs or [],
         dry_run=args.dry_run,
         no_advise=args.no_advise,
         nitpick=args.nitpick,
@@ -640,6 +661,8 @@ def main(argv: list[str] | None = None) -> int:
     LOG.info("Phases: %s", ",".join(cfg.phases))
     if cfg.issues:
         LOG.info("Issues: %s", ",".join(str(n) for n in cfg.issues))
+    if cfg.prs:
+        LOG.info("PRs: %s", ",".join(str(n) for n in cfg.prs))
 
     return _dispatch_pipeline(args, cfg, org, repos)
 

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -80,6 +80,8 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
             "--dry-run",
             "--issues",
             "11,12",
+            "--prs",
+            "21,22",
             "--no-advise",
             "--nitpick",
         ]
@@ -89,13 +91,13 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.org == "org"
     assert config.repos == ["repo-a"]
     assert config.issues == [11, 12]
+    assert config.prs == [21, 22]
     assert config.loops == 3
     assert config.max_workers == 4
     assert config.parallel_repos == 2
     assert config.dry_run is True
     assert config.no_advise is True
     assert config.nitpick is True
-    assert config.prs == []
 
 
 def test_build_pipeline_config_maps_agent_and_models(

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -636,6 +636,16 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
                 "(plan, implement, drive-green). Default: phase auto-discovery."
             ),
         ),
+        _action_spec(
+            ("--prs",),
+            "prs",
+            "_StoreAction",
+            None,
+            help_text=(
+                "Comma-separated PR numbers to seed directly into pipeline PR stages. "
+                "Default: no direct PR scope."
+            ),
+        ),
         _store_true(
             "--no-advise",
             "no_advise",

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -138,6 +138,12 @@ def test_parse_args_accepts_issue_scope() -> None:
     assert args.issues == [8, 13]
 
 
+def test_parse_args_accepts_pr_scope() -> None:
+    """The loop runner can scope pipeline seeding to a comma-separated PR list."""
+    args = loop_runner._parse_args(["--prs", "77, 78"])
+    assert args.prs == [77, 78]
+
+
 @pytest.mark.parametrize("bad", ["0", "-1", "33", "100"])
 def test_parse_args_rejects_out_of_range_max_workers(bad: str) -> None:
     """Regression for #723: loop_runner must reject --max-workers outside 1-32."""


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: wired `--prs` through loop parsing/config/docs with tests; verified `tests/ -v` passed (`6092 passed, 21 skipped`), plus mypy, Ruff, pre-commit, and `git diff --check`.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1898

Generated by ProjectHephaestus automation
