### PR TITLE
[mino] _post overwrites payload["review_threads"] with the validator-mutated set, so the no-commit retry re-grounds on synthetic threads

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -173,6 +173,7 @@ _ROUND_PAYLOAD_KEYS = (
     "review_failed",
     "validation_result",
     "review_threads",
+    "raw_review_threads",
     "posted_thread_ids",
     "difficulty_tiers",
     "address_error",
@@ -550,10 +551,9 @@ class PrReviewStage(Stage):
         """
         if item.pr is None:  # guarded by step(); kept for type narrowing
             return self._fail_back_agent_error(item)
-        threads = _surviving_threads(
-            list(item.payload.get("review_threads") or []),
-            item.payload.get("validation_result"),
-        )
+        raw_threads = [dict(t) for t in item.payload.get("review_threads") or []]
+        threads = _surviving_threads(raw_threads, item.payload.get("validation_result"))
+        item.payload["raw_review_threads"] = raw_threads
         # The surviving set is what gets posted, classified, and addressed.
         item.payload["review_threads"] = threads
         if threads:
@@ -790,7 +790,10 @@ class PrReviewStage(Stage):
         if no_commit:
             if not payload.get("no_commit_retry_done"):
                 payload["no_commit_retry_done"] = True
-                payload["unaddressed_findings"] = list(payload.get("review_threads") or [])
+                retry_threads = (
+                    payload.get("raw_review_threads") or payload.get("review_threads") or []
+                )
+                payload["unaddressed_findings"] = [dict(t) for t in retry_threads]
                 logger.warning(
                     "pr_review:%s: address turn produced NO commit; retrying the "
                     "address once with the unaddressed-findings directive (#1575)",

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -179,6 +179,7 @@ class TestPrReviewStageStep:
                 "review_verdict": _verdict("NOGO"),
                 "review_text": "stale",
                 "review_threads": [{"id": "t1"}],
+                "raw_review_threads": [{"id": "raw-t1"}],
                 "posted_thread_ids": ["t1"],
                 "validation_result": "stale",
                 "difficulty_tiers": "stale",
@@ -194,6 +195,7 @@ class TestPrReviewStageStep:
             "review_verdict",
             "review_text",
             "review_threads",
+            "raw_review_threads",
             "posted_thread_ids",
             "validation_result",
             "difficulty_tiers",
@@ -1150,6 +1152,34 @@ class TestRealCommitGate:
         assert item.payload["no_commit_retry_done"] is True
         assert item.attempts["pr_review_iter"] == 0  # no round burned by the retry
 
+    def test_first_no_commit_retry_uses_raw_review_threads_not_survivors(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The retry directive uses reviewer text, not validator-synthesized survivors."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=45, pr=1001, state="EVAL")
+        raw_threads = [{"thread_id": "t1", "path": "x.py", "line": 3, "body": "reviewer text"}]
+        surviving_threads = [
+            {
+                "path": "y.py",
+                "line": 7,
+                "body": "Reopened (prior round, still unaddressed): synthesized text",
+            }
+        ]
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["raw_review_threads"] = raw_threads
+        item.payload["review_threads"] = surviving_threads
+        item.payload["push_no_commit"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "ADDRESS_WAIT"
+        assert item.payload["unaddressed_findings"] == raw_threads
+        assert item.payload["no_commit_retry_done"] is True
+        assert item.attempts["pr_review_iter"] == 0
+
     def test_retry_address_job_carries_the_directive_findings(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -1287,7 +1317,9 @@ class TestSurvivingThreads:
             {"thread_id": "t2", "body": "by-design"},
         ]
         item.payload["validation_result"] = (
-            '{"unaddressed": [], "wont_fix": [{"thread_id": "t2", "reason": "documented"}]}'
+            '{"unaddressed": [{"thread_id": "t9", "path": "y.py", "line": 7,'
+            ' "detail": "still missing"}],'
+            ' "wont_fix": [{"thread_id": "t2", "reason": "documented"}]}'
         )
         item.payload["review_text"] = "Verdict: NOGO"
 
@@ -1296,8 +1328,13 @@ class TestSurvivingThreads:
         assert isinstance(result, Continue)
         assert github.mutation_log == [("gh_pr_review_post", (1001, "COMMENT"))]
         posted = github.reviews[1001][0]["comments"]
-        assert [t["thread_id"] for t in posted] == ["t1"]  # t2 filtered out
-        assert [t["thread_id"] for t in item.payload["review_threads"]] == ["t1"]
+        assert item.payload["raw_review_threads"] == [
+            {"thread_id": "t1", "body": "real bug"},
+            {"thread_id": "t2", "body": "by-design"},
+        ]
+        assert [t.get("thread_id") for t in item.payload["review_threads"]] == ["t1", None]
+        assert [t.get("thread_id") for t in posted] == ["t1", None]
+        assert posted[1]["body"].startswith("Reopened (prior round, still unaddressed):")
 
 
 class TestProgressCountsAutomationOnly:


### PR DESCRIPTION
## Summary
Verdict: implementation-ready | Reason: Preserved `raw_review_threads` for no-commit retry grounding, kept survivors on `review_threads`, added regression coverage; full pytest passed `6081 passed, 25 skipped`, coverage `83.90%`, with ruff, mypy, pre-commit, and `git diff --check` clean.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1894

Generated by ProjectHephaestus automation
