### PR TITLE
fix(pipeline): filter closed direct issues before seeding

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1031,7 +1031,10 @@ class Coordinator:
         github = self._ctx_for_repo(repo).github if repo else self.github
         entries: list[_seeding.SeedEntry] = []
         scope_stages = self.config.scope.stages if self.config.scope is not None else None
-        for issue in self.config.issues:
+        issue_numbers = list(self.config.issues)
+        if issue_numbers:
+            issue_numbers = _admission._filter_open_issues(repo, issue_numbers)
+        for issue in issue_numbers:
             facts = _seeding.seed_issue_from_github(issue, github)
             stage, reason = _seeding.classify_issue(facts)
             stage, reason = self._clamp_seed_stage_to_scope(issue, stage, reason, scope_stages)

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -595,6 +595,37 @@ class TestPipelineScopeWiring:
         assert item.payload["issue_title"] == "Hydrate planner context"
         assert item.payload["issue_body"] == "Use the real issue body."
 
+    def test_seed_pass_filters_closed_explicit_issues_before_classification(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Closed explicit --issues are dropped before pipeline classification (#1899)."""
+
+        class RecordingGitHub(FakeStageGitHub):
+            def __init__(self) -> None:
+                super().__init__(labels=["state:needs-plan"])
+                self.issue_json_calls: list[int] = []
+
+            def gh_issue_json(self, issue_number: int) -> dict[str, Any]:
+                self.issue_json_calls.append(issue_number)
+                return super().gh_issue_json(issue_number)
+
+        def fake_filter(repo: str, issue_numbers: list[int]) -> list[int]:
+            assert repo == "repo-a"
+            assert issue_numbers == [1, 2, 3]
+            return [1, 3]
+
+        gh = RecordingGitHub()
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.coordinator._admission._filter_open_issues",
+            fake_filter,
+        )
+        config = self._scoped_config(tmp_path, issues=[1, 2, 3])
+        coordinator = Coordinator(config, github=gh, pool=FakeWorkerPool(), install_signals=False)
+
+        assert coordinator._seed_pass() == 2
+        assert [item.issue for item in coordinator.items] == [1, 3]
+        assert gh.issue_json_calls == [1, 3]
+
     def test_at_or_past_plan_go_issue_clamps_to_finished(self, tmp_path: Path) -> None:
         """A plan-go issue classifies to IMPLEMENTATION; the scope clamps it to FINISHED-pass."""
         gh = FakeStageGitHub(labels=["state:plan-go"])


### PR DESCRIPTION
## Summary
- filter explicit direct-scope issue numbers through the open-issue admission filter before classification
- add coordinator coverage proving closed explicit issues are not hydrated or routed

Closes #1899

## Verification
- pixi run pytest tests/unit/automation/pipeline/test_coordinator.py -q --no-cov
- pixi run pytest tests/unit/automation/pipeline/test_coordinator.py::TestPipelineScopeWiring::test_seed_pass_filters_closed_explicit_issues_before_classification -q --no-cov
- pixi run ruff check hephaestus/automation/pipeline/coordinator.py tests/unit/automation/pipeline/test_coordinator.py
- pixi run ruff format --check hephaestus/automation/pipeline/coordinator.py tests/unit/automation/pipeline/test_coordinator.py