### PR TITLE
fix(pipeline): make epic skips nonblocking

### DIFF
--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -62,6 +62,27 @@ def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
     return Path(str(ctx.paths.projects_dir)) / item.repo
 
 
+def _tag_epics_best_effort(
+    repo: str,
+    ctx: StageContext,
+    epics: list[int],
+    epics_labels: dict[int, list[str]],
+) -> None:
+    """Tag excluded epics without blocking repo discovery on label failures."""
+    skip_tagged = True
+    try:
+        ctx.github.skip_epics(epics_labels)
+    except Exception as exc:
+        skip_tagged = False
+        logger.warning("repo:%s: could not tag excluded epics state:skip: %s", repo, exc)
+
+    for num in epics:
+        if skip_tagged:
+            logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", repo, num)
+        else:
+            logger.info("repo:%s: #%d is an epic; state:skip tag failed, excluded", repo, num)
+
+
 class RepoStage(Stage):
     """Repo discovery and classification stage (the pipeline's sole producer).
 
@@ -178,9 +199,7 @@ class RepoStage(Stage):
                 for m in deduped
                 if int(m["number"]) in epic_set
             }
-            ctx.github.skip_epics(epics_labels)
-            for num in epics:
-                logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", item.repo, num)
+            _tag_epics_best_effort(item.repo, ctx, epics, epics_labels)
 
         products: list[dict[str, Any]] = [
             {

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -31,6 +31,7 @@ each apply-state helper removes the other two as it sets its own.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable, Sequence
 from typing import Any
 
@@ -156,7 +157,7 @@ def is_epic(labels: Iterable[str], title: str = "") -> bool:
 
     * it carries a label whose name is in :data:`EPIC_LABELS`
       (``epic`` / ``roadmap``), **or**
-    * its ``title`` contains one of those markers as a substring.
+    * its ``title`` contains one of those markers as a standalone token.
 
     The title fallback catches the convention even when the label was not
     applied. Pure function (no I/O) so both discovery paths and unit tests can
@@ -173,7 +174,10 @@ def is_epic(labels: Iterable[str], title: str = "") -> bool:
     if {label.lower() for label in labels} & set(EPIC_LABELS):
         return True
     lowered_title = title.lower()
-    return any(marker in lowered_title for marker in EPIC_LABELS)
+    return any(
+        re.search(rf"(?<![a-z0-9_]){re.escape(marker)}(?![a-z0-9_])", lowered_title)
+        for marker in EPIC_LABELS
+    )
 
 
 def partition_epics(

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -319,6 +319,41 @@ class TestDiscover:
         epic_products = [p for p in repo_item.payload["products"] if p["number"] == 5]
         assert epic_products[0]["stage"] is None
 
+    def test_skip_epics_failure_is_non_fatal_to_discovery(
+        self,
+        repo_item: WorkItem,
+        repo_ctx: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed epic label write does not block emitting discovered products."""
+        meta = [
+            {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
+            {"number": 6, "labels": [], "title": "real work"},
+        ]
+        classified = self._patch_discovery(
+            monkeypatch,
+            meta=meta,
+            facts={6: _facts(6)},
+            classifications={6: (StageName.PLANNING, "needs plan")},
+        )
+        gh: FakeStageGitHub = repo_ctx.github
+        monkeypatch.setattr(
+            gh,
+            "skip_epics",
+            lambda _epics_labels: (_ for _ in ()).throw(RuntimeError("label write failed")),
+        )
+        repo_item.state = "DISCOVER"
+
+        result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue) and result.next_state == "SEEDED"
+        assert classified == [6]
+        products = repo_item.payload["products"]
+        assert {p["number"]: p["stage"] for p in products} == {
+            5: None,
+            6: StageName.PLANNING,
+        }
+
     def test_drive_green_all_routes_orphan_prs_to_ci(
         self,
         repo_item: WorkItem,

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -194,6 +194,10 @@ class TestIsEpic:
         assert is_epic([], title="Epic: ship the new pipeline") is True
         assert is_epic([], title="Q3 Roadmap tracking") is True
 
+    def test_title_marker_does_not_match_inside_identifier(self) -> None:
+        """Function names like skip_epics are code tasks, not epic trackers."""
+        assert is_epic([], title="repo _discover calls skip_epics unguarded") is False
+
     def test_title_match_is_case_insensitive(self) -> None:
         assert is_epic([], title="EPIC umbrella issue") is True
 


### PR DESCRIPTION
## Summary
- make title-based epic detection require standalone epic/roadmap tokens so identifiers like skip_epics do not exclude normal issues
- keep repo discovery moving when the state:skip epic-label write fails, logging the label failure while still emitting discovered products

Closes #1896

## Verification
- pixi run pytest tests/unit/automation/test_state_labels.py::TestIsEpic tests/unit/automation/pipeline/stages/test_stage_repo.py -q --no-cov
- pixi run ruff check hephaestus/automation/state_labels.py hephaestus/automation/pipeline/stages/repo.py tests/unit/automation/test_state_labels.py tests/unit/automation/pipeline/stages/test_stage_repo.py
- pixi run ruff format --check hephaestus/automation/state_labels.py hephaestus/automation/pipeline/stages/repo.py tests/unit/automation/test_state_labels.py tests/unit/automation/pipeline/stages/test_stage_repo.py
- pixi run python -m mypy hephaestus/automation/state_labels.py hephaestus/automation/pipeline/stages/repo.py
- pixi run pre-commit run --files hephaestus/automation/pipeline/stages/repo.py hephaestus/automation/state_labels.py tests/unit/automation/pipeline/stages/test_stage_repo.py tests/unit/automation/test_state_labels.py