### PR TITLE
[nit] PIPELINE_ORDER = tuple(StageName) depends on undocumented enum declaration order; add a do-not-reorder note

### DIFF
--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -23,7 +23,10 @@ DEFAULT_MERGE_ATTEMPTS = 1
 
 
 class StageName(str, Enum):
-    """Pipeline stage identifiers."""
+    """Pipeline stage identifiers.
+
+    Members are declared in pipeline order and MUST NOT be reordered.
+    """
 
     REPO = "repo"
     PLANNING = "planning"

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -37,6 +37,12 @@ class TestStageName:
         assert isinstance(StageName.REPO, str)
         assert StageName.REPO == "repo"
 
+    def test_stage_name_docstring_warns_about_order(self) -> None:
+        """StageName docstring must warn that declaration order is semantic."""
+        assert StageName.__doc__ is not None
+        assert "pipeline order" in StageName.__doc__
+        assert "MUST NOT be reordered" in StageName.__doc__
+
 
 class TestDisposition:
     """Tests for Disposition enum."""


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: Added a do-not-reorder warning to `StageName` in [hephaestus/automation/pipeline/routing.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1903/hephaestus/automation/pipeline/routing.py#L25) and pinned it with a regression test in [tests/unit/automation/pipeline/test_routing.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1903/tests/unit/automation/pipeline/test_routing.py#L40); verified with `python -m pytest tests/ -v` (6141 passed, 21 skipped, coverage 84.05%).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1903

Generated by ProjectHephaestus automation
