### PR TITLE
[nit] RepoStage SEEDED branch recomputes the seeded count on every step

### DIFF
--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -128,8 +128,12 @@ class RepoStage(Stage):
             return self._discover(item, ctx)
 
         if item.state == "SEEDED":
-            products = item.payload.get("products", [])
-            seeded = sum(1 for p in products if p.get("stage") is not None)
+            seeded_count = item.payload.get("seeded_count")
+            if seeded_count is None:
+                seeded_count = sum(
+                    1 for p in item.payload.get("products", []) if p.get("stage") is not None
+                )
+            seeded = int(seeded_count)
             return StageOutcome(Disposition.FINISH_PASS, note=f"seeded:{seeded}")
 
         return StageOutcome(Disposition.FINISH_FAIL, note=f"unknown state: {item.state}")
@@ -249,6 +253,7 @@ class RepoStage(Stage):
                 )
 
         item.payload["products"] = products
+        item.payload["seeded_count"] = sum(1 for p in products if p.get("stage") is not None)
         return Continue(next_state="SEEDED")
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -287,6 +287,7 @@ class TestDiscover:
         products = repo_item.payload["products"]
         stages = {p["number"]: p["stage"] for p in products}
         assert stages == {1: StageName.PLANNING, 2: StageName.IMPLEMENTATION}
+        assert repo_item.payload["seeded_count"] == 2
 
     def test_epics_tagged_durably_before_exclusion(
         self,
@@ -407,20 +408,23 @@ class TestDiscover:
         assert result.disposition is Disposition.FINISH_FAIL
         assert "discovery failed" in result.note
 
-    def test_seeded_finishes_pass_with_count(self, repo_item: WorkItem, repo_ctx: Any) -> None:
-        """Terminal: FINISH_PASS(seeded:N) counting only queued products."""
+    def test_seeded_finishes_pass_with_cached_count(
+        self, repo_item: WorkItem, repo_ctx: Any
+    ) -> None:
+        """Terminal: FINISH_PASS(seeded:N) uses the cached discovery count."""
         repo_item.state = "SEEDED"
         repo_item.payload["products"] = [
             {"number": 1, "stage": StageName.PLANNING, "reason": "r"},
             {"number": 2, "stage": None, "reason": "excluded"},
             {"number": 3, "stage": StageName.CI, "reason": "r"},
         ]
+        repo_item.payload["seeded_count"] = 1
 
         result = RepoStage().step(repo_item, repo_ctx)
 
         assert isinstance(result, StageOutcome)
         assert result.disposition is Disposition.FINISH_PASS
-        assert result.note == "seeded:2"
+        assert result.note == "seeded:1"
 
     def test_unknown_state_finishes_failed(self, repo_item: WorkItem, repo_ctx: Any) -> None:
         repo_item.state = "BOGUS"


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: `RepoStage` now caches `seeded_count` during DISCOVER and reads it in SEEDED with a legacy fallback in [repo.py:130](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1923/hephaestus/automation/pipeline/stages/repo.py:130) and [repo.py:250](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1923/hephaestus/automation/pipeline/stages/repo.py:250); tests pin the cache write/read path in [test_stage_repo.py:287](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1923/tests/unit/automation/pipeline/stages/test_stage_repo.py:287) and [test_stage_repo.py:410](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1923/tests/unit/automation/pipeline/stages/test_stage_repo.py:410); verified with the existing `.pixi/envs/default` Python because `pixi run` hit cache/network errors, running `python -m pytest tests/ -v -o addopts='--strict-markers'` (6140 passed, 21 skipped), `python -m pytest tests/unit/automation/pipeline/stages/test_stage_repo.py -v -o addopts='--strict-markers'` (22 passed), `python -m mypy hephaestus/automation/pipeline/stages/repo.py`, `python -m ruff check hephaestus/automation/pipeline/stages/repo.py tests/unit/automation/pipeline/stages/test_stage_repo.py`, and `python -m ruff format --check hephaestus/automation/pipeline/stages/repo.py tests/unit/automation/pipeline/stages/test_stage_repo.py`; `pre-commit run --files ...` was blocked by offline hook bootstrap fetching `markdownlint-cli2` from GitHub.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1923

Generated by ProjectHephaestus automation
