### PR TITLE
[nit] summary JSON message is keyed on stats.interrupted rather than stats.exit_code

### DIFF
--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -88,6 +88,15 @@ def _disposition_bucket(item: WorkItem) -> str:
     return cell.split(":")[0].split(" ")[0].lower()
 
 
+def _json_message(exit_code: int) -> str:
+    """Map a pipeline exit code to its JSON summary message."""
+    if exit_code == 130:
+        return "pipeline interrupted"
+    if exit_code == 0:
+        return "pipeline complete"
+    return "pipeline failed"
+
+
 def _item_row(item: WorkItem) -> str:
     """Format one per-item summary row."""
     issue = f"#{item.issue}" if item.issue else "-"
@@ -158,7 +167,7 @@ def print_summary(
         ]
         emit_json_status(
             stats.exit_code,
-            message="pipeline interrupted" if stats.interrupted else "pipeline complete",
+            message=_json_message(stats.exit_code),
             dispositions=dict(sorted(dispositions.items())),
             loops_run=stats.loops_run,
             agent_jobs=stats.agent_job_count,

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -170,6 +170,31 @@ class TestJsonEnvelope:
         assert envelope["resumable"] == ["repo-a#2@ci"]
         assert envelope["preserved_worktrees"] == [[2, "/wt/2"]]
 
+    @pytest.mark.parametrize(
+        ("exit_code", "expected_message"),
+        [
+            (0, "pipeline complete"),
+            (1, "pipeline failed"),
+        ],
+    )
+    def test_json_envelope_message_tracks_exit_code(
+        self,
+        capsys: pytest.CaptureFixture[str],
+        exit_code: int,
+        expected_message: str,
+    ) -> None:
+        """The envelope message derives from exit_code, not the interrupt flag."""
+        print_summary(
+            [],
+            _stats(exit_code=exit_code, interrupted=True),
+            [],
+            json_out=True,
+        )
+
+        envelope = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+        assert envelope["exit_code"] == exit_code
+        assert envelope["message"] == expected_message
+
     def test_no_envelope_without_json_out(self, capsys: pytest.CaptureFixture[str]) -> None:
         """json_out=False never writes the JSON envelope to stdout."""
         print_summary([], _stats(), [], json_out=False)


### PR DESCRIPTION
## Summary
Verdict: fixed | Reason: `hephaestus/automation/pipeline/summary.py:91-97,168-170` now maps the JSON message from `exit_code` (`130` -> interrupted, `0` -> complete, other non-zero -> failed) and `tests/unit/automation/pipeline/test_summary.py:173-196` covers the exit-code/message contract; verified with `pixi run --as-is python -m pytest tests/unit/automation/pipeline/test_summary.py -k json_envelope_message_tracks_exit_code -v --no-cov` and `HOME=/tmp COVERAGE_FILE=/tmp/coverage-issue1908 pixi run --as-is python -m pytest tests/ -v` (`6142 passed, 21 skipped`).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1908

Generated by ProjectHephaestus automation
