### PR TITLE
[nit] _default_attempts duplicates the budget_keys() union it mirrors; derive it instead

### DIFF
--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -12,7 +12,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
-from .routing import StageName
+from .routing import StageName, budget_keys
 
 #: Maximum retained history events per item (oldest dropped first).
 HISTORY_CAP = 200
@@ -24,26 +24,8 @@ def _utcnow() -> datetime:
 
 
 def _default_attempts() -> dict[str, int]:
-    """Return zeroed per-item-lifetime counters, one per ROUTES budget key.
-
-    Keys mirror the union of budget keys in ``routing.ROUTES``;
-    ``tests/unit/automation/pipeline/test_work_item.py`` pins the two in
-    lockstep so they cannot drift.
-    """
-    return {
-        "clone": 0,
-        "plan": 0,
-        "plan_review_iter": 0,
-        "plan_cycles": 0,
-        "implement": 0,
-        "test_fix": 0,
-        "pr_review_iter": 0,
-        "pr_review_hard": 0,
-        "ci_fix": 0,
-        "rebase": 0,
-        "blocked_address": 0,
-        "merge": 0,
-    }
+    """Return zeroed per-item-lifetime counters, one per budget key."""
+    return {key: 0 for key in budget_keys()}
 
 
 class ItemKind(str, Enum):

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -207,9 +207,3 @@ def test_scope_closure_over_generated_subsets(stages: frozenset[StageName]) -> N
         assert route.next in allowed
         for target in route.fail_routes.values():
             assert target in allowed
-
-
-def test_attempts_keys_match_routes_budget_keys() -> None:
-    """WorkItem.attempts default keys are exactly the union of ROUTES budgets."""
-    item = WorkItem(repo="r", kind=ItemKind.ISSUE, issue=1)
-    assert frozenset(item.attempts) == budget_keys()

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -11,6 +11,8 @@ from hephaestus.automation.pipeline import (
     StageName,
     WorkItem,
 )
+from hephaestus.automation.pipeline import work_item as work_item_module
+from hephaestus.automation.pipeline.routing import budget_keys
 
 
 class TestItemKind:
@@ -97,22 +99,23 @@ class TestWorkItem:
     def test_work_item_default_attempts(self) -> None:
         """WorkItem initializes all attempt counters to 0."""
         item = WorkItem(repo="repo", kind=ItemKind.REPO)
-        expected_keys = {
-            "clone",
-            "plan",
-            "plan_review_iter",
-            "plan_cycles",
-            "implement",
-            "pr_review_iter",
-            "pr_review_hard",
-            "test_fix",
-            "ci_fix",
-            "blocked_address",
-            "rebase",
-            "merge",
-        }
-        assert set(item.attempts.keys()) == expected_keys
+        assert set(item.attempts.keys()) == budget_keys()
         assert all(v == 0 for v in item.attempts.values())
+
+    def test_work_item_default_attempts_follow_budget_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WorkItem default attempts derive their keys from budget_keys()."""
+        monkeypatch.setattr(
+            work_item_module,
+            "budget_keys",
+            lambda: frozenset({"alpha", "beta"}),
+            raising=False,
+        )
+
+        item = work_item_module.WorkItem(repo="repo", kind=ItemKind.REPO)
+
+        assert item.attempts == {"alpha": 0, "beta": 0}
 
     def test_work_item_mutable_defaults_do_not_alias(self) -> None:
         """Two WorkItems never share attempts/history/session_ids/payload."""


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: [work_item.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1904/hephaestus/automation/pipeline/work_item.py#L15) and [work_item.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1904/hephaestus/automation/pipeline/work_item.py#L26) now derive attempt counters from `routing.budget_keys()`; [test_work_item.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1904/tests/unit/automation/pipeline/test_work_item.py#L99) uses the canonical key set and [test_work_item.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1904/tests/unit/automation/pipeline/test_work_item.py#L105) adds a monkeypatched regression; the redundant equality check was removed from [test_routing_properties.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1904/tests/unit/automation/pipeline/test_routing_properties.py); verified with `PIXI_CACHE_DIR=/tmp/pixi-cache-micah.villmow RATTLER_CACHE_DIR=/tmp/pixi-cache-micah.villmow pixi run python -m pytest tests/ -v` (6136 passed, 25 skipped).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1904

Generated by ProjectHephaestus automation
