### PR TITLE
[mino] self._resumable list is populated but never consumed (dead accumulator, grows unbounded)

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -342,7 +342,6 @@ class Coordinator:
         self._agent_job_time_s = 0.0
         self._loops_run = 0
         self._pass_work_count = 0
-        self._resumable: list[WorkItem] = []
         self._progress = False
         self._stalled_ticks = 0
         self._fatal = False
@@ -689,7 +688,6 @@ class Coordinator:
             final_stage=item.stage,
         )
         item.add_history_event(item.stage, item.state, note="interrupted; resumable")
-        self._resumable.append(item)
         self._record_event("resumable", self._item_key(item), item.stage.value, item.state)
         logger.info(
             "interrupt: item %s RESUMABLE at %s (never failed)",

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -703,6 +703,19 @@ class TestDurableEventLog:
         assert records[-1]["event"] == "resumable"
         assert records[-1]["fields"] == ["repo-a#44", "pr_review", "REVIEW_WAIT"]
 
+    def test_park_resumable_does_not_keep_private_buffer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """RESUMABLE parking should not accumulate hidden coordinator state."""
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        item = _issue_item(44, StageName.PR_REVIEW)
+        item.state = "REVIEW_WAIT"
+
+        coordinator._park_resumable(item)
+
+        assert "_resumable" not in coordinator.__dict__
+
 
 class TestPipelineScopeWiring:
     """Scope-trimmed routing + the planner CLI's --force re-plan override (#1820)."""


### PR DESCRIPTION
## Summary
Verdict: fixed | Reason: removed the dead `_resumable` accumulator from [coordinator.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1877/hephaestus/automation/pipeline/coordinator.py#L344) and dropped its append in [_park_resumable()](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1877/hephaestus/automation/pipeline/coordinator.py#L684); added a regression test in [test_coordinator.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1877/tests/unit/automation/pipeline/test_coordinator.py#L706) that asserts `_park_resumable` leaves no hidden buffer state; verified with `pixi run --manifest-path /mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/pixi.toml -x python -m pytest tests/ -v` (6141 passed, 21 skipped), `pixi run --manifest-path /mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/pixi.toml -x python -m mypy hephaestus/`, `ruff check`, `ruff format --check`, and manual hook-equivalent runs including `ruff --select C901`, `python -m hephaestus.validation.unlinked_todo`, `--environment lint sast`, `hephaestus-check-test-structure`, and `hephaestus-check-workflow-inventory`; direct `pre-commit run --files` on the worktree still resolves the local Pixi manifest and tries to fetch packages, so I validated those hooks individually against the pinned root manifest.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1877

Generated by ProjectHephaestus automation
