### PR TITLE
[nit] Duplicated thread-counting logic between the repo-scoped and legacy branches of count_unresolved_threads

### DIFF
--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -73,6 +73,17 @@ logger = logging.getLogger(__name__)
 _CLOSES_ISSUE_LINE_RE = re.compile(r"^Closes #(\d+)\s*$", re.MULTILINE)
 
 
+def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
+    """Return ``(automation_unresolved, human_unresolved)`` for unresolved threads."""
+    if not threads:
+        return (0, 0)
+    current_login = github_api.gh_current_login()
+    automation = sum(
+        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
+    )
+    return automation, len(threads) - automation
+
+
 def rate_limit_remaining() -> tuple[int, int] | None:
     """Return ``(remaining, reset_epoch)`` for the GraphQL budget, or ``None``.
 
@@ -606,12 +617,7 @@ class PipelineGitHub:
         open on fetch errors; repo-scoped pipeline runs query the configured
         repo directly so unresolved human threads are not hidden.
         """
-        threads = self._unresolved_threads(pr_number)
-        if not threads:
-            return (0, 0)
-        current_login = github_api.gh_current_login()
-        automation = sum(1 for t in threads if _is_automation_owned_thread(t, current_login))
-        return (automation, len(threads) - automation)
+        return _split_threads(self._unresolved_threads(pr_number))
 
     def count_unresolved_threads_by_severity(self, pr_number: int) -> tuple[int, int, int]:
         """Return ``(blocking_automation, minor_automation, human)`` (#1856).

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -682,6 +682,18 @@ class TestReadSurface:
 class TestUnresolvedThreads:
     """count_unresolved_threads mirrors #1152: counts only, resolves nothing."""
 
+    def test_count_unresolved_threads_uses_split_helper(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """count_unresolved_threads delegates ownership splitting to _split_threads."""
+        threads = [{"id": "a"}, {"id": "b"}]
+        monkeypatch.setattr(adapter, "_unresolved_threads", lambda n: threads)
+        split = MagicMock(return_value=(3, 4))
+        monkeypatch.setattr(pg, "_split_threads", split)
+
+        assert adapter.count_unresolved_threads(7) == (3, 4)
+        split.assert_called_once_with(threads)
+
     def test_counts_by_ownership(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: added a shared `_split_threads` helper in [hephaestus/automation/pipeline_github.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1913/hephaestus/automation/pipeline_github.py#L76) and routed `count_unresolved_threads` through it in the same file ([line 612](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1913/hephaestus/automation/pipeline_github.py#L612)); added a regression test in [tests/unit/automation/test_pipeline_github.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1913/tests/unit/automation/test_pipeline_github.py#L685); verified with `/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/.pixi/envs/default/bin/python -m pytest tests/ -v` (6141 passed, 21 skipped, coverage 84.05%) and `ruff check`; `pixi run python -m pytest tests/ -v` was attempted but blocked by offline package fetches in this sandbox.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1913

Generated by ProjectHephaestus automation
