### PR TITLE
[nit] order_for_implementation mutates resolver.graph via a private attribute rather than a public API

### DIFF
--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -62,7 +62,17 @@ class DependencyResolver:
         """
         self.graph.add_issue(issue)
         for dep in issue.dependencies:
-            self.graph.add_dependency(issue.number, dep)
+            self.add_dependency(issue.number, dep)
+
+    def add_dependency(self, issue_number: int, depends_on: int) -> None:
+        """Add a dependency edge to the resolver's graph.
+
+        Args:
+            issue_number: Issue that depends on another issue.
+            depends_on: Issue that must complete first.
+
+        """
+        self.graph.add_dependency(issue_number, depends_on)
 
     def load_epic(self, epic_number: int) -> None:
         """Load an epic issue and all its sub-issues.

--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -172,7 +172,7 @@ def order_for_implementation(issue_infos: Sequence[IssueInfo]) -> list[int]:
     for info in issue_infos:
         for dep in info.dependencies:
             if dep in in_set:
-                resolver.graph.add_dependency(info.number, dep)
+                resolver.add_dependency(info.number, dep)
     try:
         return resolver.topological_sort()
     except CyclicDependencyError:

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -8,6 +8,7 @@ implementation queue, and the filtered-open-issues helper.
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 from unittest.mock import patch
 
 import pytest
@@ -207,6 +208,48 @@ class TestOrderForImplementation:
         """#A depends on #B → B precedes A regardless of input order."""
         order = order_for_implementation([_info(10, dependencies=[20]), _info(20)])
         assert order.index(20) < order.index(10)
+
+    def test_uses_public_dependency_api(self) -> None:
+        """The admission layer routes dependency edges through the resolver API."""
+
+        class FakeDependencyResolver:
+            """Resolver double that fails if callers reach into ``graph`` directly."""
+
+            instances: ClassVar[list[FakeDependencyResolver]] = []
+
+            class Graph:
+                def add_dependency(self, issue_number: int, depends_on: int) -> None:
+                    pytest.fail(
+                        "order_for_implementation must call DependencyResolver.add_dependency()"
+                    )
+
+            def __init__(self, skip_closed: bool = True) -> None:
+                self.skip_closed = skip_closed
+                self.graph = self.Graph()
+                self.add_issue_calls: list[int] = []
+                self.add_dependency_calls: list[tuple[int, int]] = []
+                self.topological_sort_result = [20, 10]
+                type(self).instances.append(self)
+
+            def add_issue(self, issue: IssueInfo) -> None:
+                self.add_issue_calls.append(issue.number)
+
+            def add_dependency(self, issue_number: int, depends_on: int) -> None:
+                self.add_dependency_calls.append((issue_number, depends_on))
+
+            def topological_sort(self) -> list[int]:
+                return self.topological_sort_result
+
+        FakeDependencyResolver.instances = []
+
+        with patch(
+            "hephaestus.automation.pipeline.admission.DependencyResolver",
+            FakeDependencyResolver,
+        ):
+            order = order_for_implementation([_info(10, dependencies=[20]), _info(20)])
+
+        assert order == [20, 10]
+        assert FakeDependencyResolver.instances[0].add_dependency_calls == [(10, 20)]
 
     def test_no_dependencies_preserves_input_order(self) -> None:
         """Independent issues keep their dispatch-priority (input) order."""

--- a/tests/unit/automation/test_dependency_resolver.py
+++ b/tests/unit/automation/test_dependency_resolver.py
@@ -35,6 +35,15 @@ class TestDependencyResolver:
 
         assert resolver.graph.get_dependencies(123) == [100, 101]
 
+    def test_add_dependency(self) -> None:
+        """Test adding a dependency through the resolver public API."""
+        resolver = DependencyResolver()
+
+        resolver.add_issue(IssueInfo(number=123, title="Test"))
+        resolver.add_dependency(123, 100)
+
+        assert resolver.graph.get_dependencies(123) == [100]
+
     def test_detect_cycles_no_cycle(self) -> None:
         """Test cycle detection with no cycles."""
         resolver = DependencyResolver()


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: `order_for_implementation()` now uses the public `DependencyResolver.add_dependency()` API, with regression coverage on both the resolver method and the admission call path.

- Changed [hephaestus/automation/dependency_resolver.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1915/hephaestus/automation/dependency_resolver.py) to add a public `add_dependency()` wrapper and route `add_issue()` through it.
- Changed [hephaestus/automation/pipeline/admission.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1915/hephaestus/automation/pipeline/admission.py) to call `resolver.add_dependency(...)` instead of reaching into `resolver.graph`.
- Added regression tests in [tests/unit/automation/test_dependency_resolver.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1915/tests/unit/automation/test_dependency_resolver.py) and [tests/unit/automation/pipeline/test_admission.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1915/tests/unit/automation/pipeline/test_admission.py).
- Verified: `python -m pytest tests/ -v` passed, `6142 passed, 21 skipped`.
- Verified: `ruff check hephaestus/ tests/`, `ruff format --check hephaestus/ tests/`, and `python -m mypy hephaestus/` passed.
- Attempted `pre-commit run --files $(git diff --name-only HEAD)`, but the pixi-backed hooks tried to fetch conda packages and failed because network access is blocked in this sandbox.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1915

Generated by ProjectHephaestus automation
