### PR TITLE
[nit] BACKOFF_CAP_S = 60 is duplicated as a module constant across ci and merge_wait

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -63,6 +63,7 @@ from ..routing import Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
 
 __all__ = [
+    "BACKOFF_CAP_S",
     "GIT_JOB_TIMEOUT_S",
     "AgentJob",
     "BuildTestJob",
@@ -91,6 +92,10 @@ logger = logging.getLogger(__name__)
 #: by every stage that submits :class:`GitJob`s (single home — stages must
 #: not import it from each other).
 GIT_JOB_TIMEOUT_S = 600
+
+#: Poll backoff cap in seconds (legacy ``min(2**attempt, 60)`` — shared by
+#: every stage that uses the legacy exponential poll delay.
+BACKOFF_CAP_S = 60
 
 
 @runtime_checkable

--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -75,6 +75,7 @@ from hephaestus.automation.ci_run_coordinator import CiConclusion, classify_ci_s
 from hephaestus.automation.session_naming import AGENT_CI_DRIVER
 
 from .base import (
+    BACKOFF_CAP_S as _BACKOFF_CAP_S,
     GIT_JOB_TIMEOUT_S,
     AgentJob,
     Continue,
@@ -94,6 +95,8 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+BACKOFF_CAP_S = _BACKOFF_CAP_S
+
 # In-memory mini-states (stage-local strings, never GitHub labels).
 ENTER = "ENTER"
 DISCOVER = "DISCOVER"
@@ -101,10 +104,6 @@ REBASE_WAIT = "REBASE_WAIT"
 POLL = "POLL"
 FIX_WAIT = "FIX_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
-
-#: Poll backoff cap in seconds (legacy ``min(2**attempt, 60)`` —
-#: ``ci_run_coordinator.poll_ci_until_concluded`` :288).
-BACKOFF_CAP_S = 60
 
 #: Historical number of capped-backoff parks that approximately consumed the
 #: default 1200s CI poll budget. Kept as a compatibility constant for callers

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -80,6 +80,7 @@ from hephaestus.automation.session_naming import AGENT_ADDRESS_REVIEW, AGENT_CI_
 from hephaestus.constants import read_timeout_env
 
 from .base import (
+    BACKOFF_CAP_S as _BACKOFF_CAP_S,
     GIT_JOB_TIMEOUT_S,
     AgentJob,
     Continue,
@@ -100,6 +101,8 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+BACKOFF_CAP_S = _BACKOFF_CAP_S
+
 # In-memory mini-states (stage-local strings, never GitHub labels).
 ENTER = "ENTER"
 ARM = "ARM"
@@ -110,10 +113,6 @@ BLOCKED_ADDRESS_WAIT = "BLOCKED_ADDRESS_WAIT"
 BLOCKED_PUSH_WAIT = "BLOCKED_PUSH_WAIT"
 LEARN_WAIT = "LEARN_WAIT"
 FINISH = "FINISH"
-
-#: Poll backoff cap in seconds (legacy ``min(2**attempt, 60)`` —
-#: ``ci_driver._wait_for_pr_terminal`` :1583).
-BACKOFF_CAP_S = 60
 
 #: Env var bounding the merge wait (legacy ``_wait_for_pr_terminal`` budget).
 MERGE_MAX_WAIT_ENV = "HEPH_PR_MERGE_MAX_WAIT"

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -5,8 +5,19 @@ from __future__ import annotations
 from typing import Any
 
 from hephaestus.automation.pipeline.routing import Disposition, StageOutcome
-from hephaestus.automation.pipeline.stages import PlanningStage, PlanReviewStage, Stage
-from hephaestus.automation.pipeline.stages.base import Continue, JobRequest, StageContext
+from hephaestus.automation.pipeline.stages import (
+    PlanningStage,
+    PlanReviewStage,
+    Stage,
+    ci,
+    merge_wait,
+)
+from hephaestus.automation.pipeline.stages.base import (
+    BACKOFF_CAP_S,
+    Continue,
+    JobRequest,
+    StageContext,
+)
 
 
 class TestStageContext:
@@ -79,3 +90,13 @@ class TestStepResultTypes:
         """JobRequest names the state entered after on_job_done."""
         request = JobRequest(job=None, on_done_state="EVAL")  # type: ignore[arg-type]
         assert request.on_done_state == "EVAL"
+
+
+class TestSharedBackoffCap:
+    """The legacy poll backoff cap is owned once by the stage base module."""
+
+    def test_backoff_cap_is_shared_by_ci_and_merge_wait(self) -> None:
+        """Ci and merge_wait read the same exported cap from base.py."""
+        assert BACKOFF_CAP_S == 60
+        assert ci.BACKOFF_CAP_S == BACKOFF_CAP_S
+        assert merge_wait.BACKOFF_CAP_S == BACKOFF_CAP_S


### PR DESCRIPTION
## Summary
Verdict: pass | Reason: Hoisted `BACKOFF_CAP_S` into `hephaestus/automation/pipeline/stages/base.py:65-98`, re-exported it from `hephaestus/automation/pipeline/stages/ci.py:77-104` and `hephaestus/automation/pipeline/stages/merge_wait.py:82-104`, added regression coverage in `tests/unit/automation/pipeline/stages/test_stage_base.py:7-102`, and verified the final tree with `python -m pytest tests/unit/automation/pipeline/stages/test_stage_base.py tests/unit/automation/pipeline/stages/test_stage_ci.py tests/unit/automation/pipeline/stages/test_stage_merge_wait.py -v --no-cov`, the full suite (`6141 passed, 21 skipped`), `ruff check`, `ruff format --check`, and file-scoped `mypy`; `pre-commit run --files ...` in the worktree still hit Pixi cache/network resolution, so I relied on the direct checks.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1918

Generated by ProjectHephaestus automation
