### PR TITLE
[nit] implementation.step and pr_review.step carry # noqa: C901; extract per-state handlers like ci/merge_wait

### DIFF
--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -61,6 +61,8 @@ binding contract):
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
+from typing import cast
 
 from hephaestus.automation.agent_config import (
     advise_claude_timeout,
@@ -117,6 +119,28 @@ TEST_WAIT = "TEST_WAIT"
 TESTFIX_WAIT = "TESTFIX_WAIT"
 COMMIT_PUSH_WAIT = "COMMIT_PUSH_WAIT"
 PR_CREATE = "PR_CREATE"
+
+_STEP_HANDLER_NAMES: dict[str, str] = {
+    ENTER: "_enter",
+    GATE: "_gate",
+    WORKTREE_WAIT: "_worktree_wait",
+    DIRTY_DECISION_WAIT: "_dirty_decision_wait",
+    ADOPTED: "_adopted",
+    ADVISE_WAIT: "_advise_wait",
+    IMPLEMENT_WAIT: "_implement_wait",
+    TEST_WAIT: "_test_wait",
+    TESTFIX_WAIT: "_testfix_wait",
+    COMMIT_PUSH_WAIT: "_commit_push_wait",
+    PR_CREATE: "_create_pr",
+}
+
+
+def _issue_number(item: WorkItem) -> int:
+    """Return the issue number after the stage-level guard has run."""
+    if item.issue is None:
+        raise RuntimeError("implementation stage reached without an issue number")
+    return item.issue
+
 
 #: Max CONSECUTIVE transient git failures (worktree creation / commit+push)
 #: tolerated before the stage finishes failed (``git_error``) instead of
@@ -238,7 +262,7 @@ class ImplementationStage(Stage):
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         return None
 
-    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Execute the next implementation action for the item's current state.
 
         Args:
@@ -251,212 +275,230 @@ class ImplementationStage(Stage):
         """
         if not item.issue:
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
-
-        if item.state == ENTER:
-            return Continue(next_state=GATE)
-
-        if item.state == GATE:
-            return self._gate(item, ctx)
-
-        if item.state == WORKTREE_WAIT:
-            logger.info("implementation:%d: requesting worktree job", item.issue)
-            adopted = bool(item.payload.get("existing_pr"))
-            kwargs: dict[str, object] = {
-                "issue_number": item.issue,
-                "branch_name": item.branch,
-                # Fresh branch: cut from a freshly refreshed trunk (doc step
-                # 2: worktree_manager.create_worktree(refresh_base=True)).
-                # ADOPTED branch: never reset to trunk — sync to the PR's
-                # remote head instead (the anti-clobber reset of
-                # _prepare_worktree_for_existing_pr :649/:693, so re-running
-                # never discards pushed commits). Values coordinator-vetted.
-                "refresh_base": not adopted,
-            }
-            if adopted:
-                kwargs["sync_to_remote"] = True
-            worktree_job = GitJob(
-                repo=item.repo,
-                op="create_worktree",
-                timeout_s=GIT_JOB_TIMEOUT_S,
-                kwargs=kwargs,
-                descr="create_worktree",
+        handler_name = _STEP_HANDLER_NAMES.get(item.state)
+        if handler_name is not None:
+            handler = cast(
+                Callable[[WorkItem, StageContext], StepResult],
+                getattr(self, handler_name),
             )
-            return JobRequest(worktree_job, on_done_state=DIRTY_DECISION_WAIT)
-
-        if item.state == DIRTY_DECISION_WAIT:
-            if item.payload.pop("git_error", None):
-                # Worktree creation failed: transient infrastructure, not an
-                # implement outcome — RETRY without burning the implement
-                # budget, bounded by GIT_ERROR_RETRY_CAP (M5).
-                return self._git_retry(item, "worktree creation failed")
-            # Adopted-PR path: after the (clean or salvaged) worktree is
-            # ready, skip the implement leg — the PR's code already exists;
-            # pr_review's address leg drives it from here.
-            adopted_next = ADOPTED if item.payload.get("existing_pr") else ADVISE_WAIT
-            if not item.payload.get("worktree_dirty"):
-                return Continue(next_state=adopted_next)
-            logger.info("implementation:%d: requesting dirty-worktree decision", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "implementer", implementer_model),
-                prompt_builder=get_dirty_reused_worktree_decision_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=implementer_claude_timeout(),
-                session_agent=AGENT_IMPLEMENTER,
-                prompt_kwargs={
-                    "branch_name": item.branch,
-                    "status_text": item.payload.get("worktree_status", ""),
-                    "diff_text": item.payload.get("worktree_diff", ""),
-                },
-                descr="dirty_decision",
-            )
-            return JobRequest(job, on_done_state=adopted_next)
-
-        if item.state == ADOPTED:
-            # Existing-PR fast path complete: worktree ready on the PR's real
-            # head branch — hand the PR to pr_review (doc step 1 "skip to
-            # step 8": nothing to implement, commit, or create).
-            logger.info(
-                "implementation:%d: adopted PR #%s (branch %r); advancing to pr_review",
-                item.issue,
-                item.pr,
-                item.branch,
-            )
-            return StageOutcome(Disposition.ADVANCE, f"existing PR #{item.pr}")
-
-        if item.state == ADVISE_WAIT:
-            if not ctx.config.enable_advise:
-                logger.info("implementation:%d: advise disabled; skipping", item.issue)
-                return Continue(next_state=IMPLEMENT_WAIT)
-            logger.info("implementation:%d: requesting advise job", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "advise", advise_model),
-                prompt_builder=get_advise_prompt_builder(ctx.config.agent),
-                cwd=_worktree_path(item, ctx),
-                timeout_s=advise_claude_timeout(),
-                session_agent=AGENT_ADVISE,
-                prompt_kwargs={
-                    "issue_number": item.issue,
-                    "issue_title": item.payload.get("issue_title", ""),
-                    "issue_body": item.payload.get("issue_body", ""),
-                    "marketplace_path": item.payload.get("marketplace_path", ""),
-                },
-                descr="advise",
-            )
-            return JobRequest(job, on_done_state=IMPLEMENT_WAIT)
-
-        if item.state == IMPLEMENT_WAIT:
-            budget = ctx.budget("implement")
-            if item.attempts.get("implement", 0) >= budget:
-                logger.error(
-                    "implementation:%d: implement budget exhausted (%d/%d)",
-                    item.issue,
-                    item.attempts.get("implement", 0),
-                    budget,
-                )
-                return StageOutcome(Disposition.FINISH_FAIL, "implement_exhausted")
-            # Clear stale results at submission so a failed later attempt can
-            # never replay an earlier attempt's output downstream.
-            item.payload.pop("implement_error", None)
-            item.payload.pop("implement_summary", None)
-            logger.info("implementation:%d: requesting implement job", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "implementer", implementer_model),
-                prompt_builder=build_implementation_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=implementer_claude_timeout(),
-                session_agent=AGENT_IMPLEMENTER,
-                prompt_kwargs={
-                    "issue_number": item.issue,
-                    "issue_title": item.payload.get("issue_title", ""),
-                    "issue_body": item.payload.get("issue_body", ""),
-                    "branch_name": item.branch,
-                    "worktree_path": item.worktree,
-                    "advise_findings": item.payload.get("advise_findings", ""),
-                },
-                descr="implement",
-            )
-            return JobRequest(job, on_done_state=TEST_WAIT)
-
-        if item.state == TEST_WAIT:
-            if item.payload.pop("implement_error", None):
-                # The implement job hard-failed. The attempt was counted in
-                # on_job_done (doc: agent_error consumes the implement
-                # budget); RETRY re-enters the stage for the next attempt.
-                return StageOutcome(Disposition.RETRY, "agent_error")
-            if not getattr(ctx.config, "run_pre_pr_tests", False):
-                return Continue(next_state=COMMIT_PUSH_WAIT)
-            item.payload.pop("tests_failed", None)
-            item.payload.pop("test_output", None)
-            logger.info("implementation:%d: requesting pre-PR test job", item.issue)
-            test_job = BuildTestJob(
-                repo=item.repo,
-                cwd=_worktree_path(item, ctx),
-                argv=PRE_PR_TEST_ARGV,
-                timeout_s=PRE_PR_TEST_TIMEOUT_S,
-                descr="pre_pr_tests",
-            )
-            return JobRequest(test_job, on_done_state=COMMIT_PUSH_WAIT)
-
-        if item.state == TESTFIX_WAIT:
-            budget = ctx.budget("test_fix")
-            if item.attempts.get("test_fix", 0) >= budget:
-                logger.error(
-                    "implementation:%d: tests still red after %d fix attempt(s)",
-                    item.issue,
-                    budget,
-                )
-                return StageOutcome(Disposition.FINISH_FAIL, "tests_red")
-            logger.info("implementation:%d: requesting test-fix job", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "implementer", implementer_model),
-                prompt_builder=build_test_fix_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=implementer_claude_timeout(),
-                session_agent=AGENT_IMPLEMENTER,
-                prompt_kwargs={
-                    "issue_number": item.issue,
-                    "prev_iteration": item.attempts.get("test_fix", 0),
-                    "test_output": item.payload.get("test_output", ""),
-                },
-                descr="test_fix",
-            )
-            return JobRequest(job, on_done_state=TEST_WAIT)
-
-        if item.state == COMMIT_PUSH_WAIT:
-            if item.payload.get("tests_failed"):
-                return Continue(next_state=TESTFIX_WAIT)
-            logger.info("implementation:%d: requesting commit+push job", item.issue)
-            push_job = GitJob(
-                repo=item.repo,
-                op="commit_push",
-                timeout_s=GIT_JOB_TIMEOUT_S,
-                kwargs={
-                    "issue_number": item.issue,
-                    "worktree_path": item.worktree,
-                    "branch": item.branch,
-                    "agent": agent_provider(ctx),
-                },
-                descr="commit_push",
-            )
-            return JobRequest(push_job, on_done_state=PR_CREATE)
-
-        if item.state == PR_CREATE:
-            return self._create_pr(item, ctx)
+            return handler(item, ctx)
 
         logger.warning("implementation:%d: unknown state %r", item.issue, item.state)
         return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+    def _enter(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """ENTER advances to GATE."""
+        return Continue(next_state=GATE)
+
+    def _worktree_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """WORKTREE_WAIT submits the create-worktree git job."""
+        issue = _issue_number(item)
+        logger.info("implementation:%d: requesting worktree job", issue)
+        adopted = bool(item.payload.get("existing_pr"))
+        kwargs: dict[str, object] = {
+            "issue_number": issue,
+            "branch_name": item.branch,
+            # Fresh branch: cut from a freshly refreshed trunk (doc step
+            # 2: worktree_manager.create_worktree(refresh_base=True)).
+            # ADOPTED branch: never reset to trunk — sync to the PR's
+            # remote head instead (the anti-clobber reset of
+            # _prepare_worktree_for_existing_pr :649/:693, so re-running
+            # never discards pushed commits). Values coordinator-vetted.
+            "refresh_base": not adopted,
+        }
+        if adopted:
+            kwargs["sync_to_remote"] = True
+        worktree_job = GitJob(
+            repo=item.repo,
+            op="create_worktree",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            kwargs=kwargs,
+            descr="create_worktree",
+        )
+        return JobRequest(worktree_job, on_done_state=DIRTY_DECISION_WAIT)
+
+    def _dirty_decision_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """DIRTY_DECISION_WAIT routes either to retry or to the dirty-decision job."""
+        issue = _issue_number(item)
+        if item.payload.pop("git_error", None):
+            # Worktree creation failed: transient infrastructure, not an
+            # implement outcome — RETRY without burning the implement
+            # budget, bounded by GIT_ERROR_RETRY_CAP (M5).
+            return self._git_retry(item, "worktree creation failed")
+        # Adopted-PR path: after the (clean or salvaged) worktree is
+        # ready, skip the implement leg — the PR's code already exists;
+        # pr_review's address leg drives it from here.
+        adopted_next = ADOPTED if item.payload.get("existing_pr") else ADVISE_WAIT
+        if not item.payload.get("worktree_dirty"):
+            return Continue(next_state=adopted_next)
+        logger.info("implementation:%d: requesting dirty-worktree decision", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
+            prompt_builder=get_dirty_reused_worktree_decision_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=implementer_claude_timeout(),
+            session_agent=AGENT_IMPLEMENTER,
+            prompt_kwargs={
+                "branch_name": item.branch,
+                "status_text": item.payload.get("worktree_status", ""),
+                "diff_text": item.payload.get("worktree_diff", ""),
+            },
+            descr="dirty_decision",
+        )
+        return JobRequest(job, on_done_state=adopted_next)
+
+    def _adopted(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """ADOPTED advances to pr_review after the adopted worktree is ready."""
+        issue = _issue_number(item)
+        # Existing-PR fast path complete: worktree ready on the PR's real
+        # head branch — hand the PR to pr_review (doc step 1 "skip to
+        # step 8": nothing to implement, commit, or create).
+        logger.info(
+            "implementation:%d: adopted PR #%s (branch %r); advancing to pr_review",
+            issue,
+            item.pr,
+            item.branch,
+        )
+        return StageOutcome(Disposition.ADVANCE, f"existing PR #{item.pr}")
+
+    def _advise_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """ADVISE_WAIT either skips advice or submits the advise job."""
+        issue = _issue_number(item)
+        if not ctx.config.enable_advise:
+            logger.info("implementation:%d: advise disabled; skipping", issue)
+            return Continue(next_state=IMPLEMENT_WAIT)
+        logger.info("implementation:%d: requesting advise job", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "advise", advise_model),
+            prompt_builder=get_advise_prompt_builder(ctx.config.agent),
+            cwd=_worktree_path(item, ctx),
+            timeout_s=advise_claude_timeout(),
+            session_agent=AGENT_ADVISE,
+            prompt_kwargs={
+                "issue_number": item.issue,
+                "issue_title": item.payload.get("issue_title", ""),
+                "issue_body": item.payload.get("issue_body", ""),
+                "marketplace_path": item.payload.get("marketplace_path", ""),
+            },
+            descr="advise",
+        )
+        return JobRequest(job, on_done_state=IMPLEMENT_WAIT)
+
+    def _implement_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """IMPLEMENT_WAIT submits the implementation job when budget remains."""
+        issue = _issue_number(item)
+        budget = ctx.budget("implement")
+        if item.attempts.get("implement", 0) >= budget:
+            logger.error(
+                "implementation:%d: implement budget exhausted (%d/%d)",
+                issue,
+                item.attempts.get("implement", 0),
+                budget,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "implement_exhausted")
+        # Clear stale results at submission so a failed later attempt can
+        # never replay an earlier attempt's output downstream.
+        item.payload.pop("implement_error", None)
+        item.payload.pop("implement_summary", None)
+        logger.info("implementation:%d: requesting implement job", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
+            prompt_builder=build_implementation_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=implementer_claude_timeout(),
+            session_agent=AGENT_IMPLEMENTER,
+            prompt_kwargs={
+                "issue_number": item.issue,
+                "issue_title": item.payload.get("issue_title", ""),
+                "issue_body": item.payload.get("issue_body", ""),
+                "branch_name": item.branch,
+                "worktree_path": item.worktree,
+                "advise_findings": item.payload.get("advise_findings", ""),
+            },
+            descr="implement",
+        )
+        return JobRequest(job, on_done_state=TEST_WAIT)
+
+    def _test_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """TEST_WAIT either retries the implementer or runs the pre-PR tests."""
+        issue = _issue_number(item)
+        if item.payload.pop("implement_error", None):
+            # The implement job hard-failed. The attempt was counted in
+            # on_job_done (doc: agent_error consumes the implement
+            # budget); RETRY re-enters the stage for the next attempt.
+            return StageOutcome(Disposition.RETRY, "agent_error")
+        if not getattr(ctx.config, "run_pre_pr_tests", False):
+            return Continue(next_state=COMMIT_PUSH_WAIT)
+        item.payload.pop("tests_failed", None)
+        item.payload.pop("test_output", None)
+        logger.info("implementation:%d: requesting pre-PR test job", issue)
+        test_job = BuildTestJob(
+            repo=item.repo,
+            cwd=_worktree_path(item, ctx),
+            argv=PRE_PR_TEST_ARGV,
+            timeout_s=PRE_PR_TEST_TIMEOUT_S,
+            descr="pre_pr_tests",
+        )
+        return JobRequest(test_job, on_done_state=COMMIT_PUSH_WAIT)
+
+    def _testfix_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """TESTFIX_WAIT submits the test-fix job while budget remains."""
+        issue = _issue_number(item)
+        budget = ctx.budget("test_fix")
+        if item.attempts.get("test_fix", 0) >= budget:
+            logger.error(
+                "implementation:%d: tests still red after %d fix attempt(s)",
+                issue,
+                budget,
+            )
+            return StageOutcome(Disposition.FINISH_FAIL, "tests_red")
+        logger.info("implementation:%d: requesting test-fix job", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
+            prompt_builder=build_test_fix_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=implementer_claude_timeout(),
+            session_agent=AGENT_IMPLEMENTER,
+            prompt_kwargs={
+                "issue_number": item.issue,
+                "prev_iteration": item.attempts.get("test_fix", 0),
+                "test_output": item.payload.get("test_output", ""),
+            },
+            descr="test_fix",
+        )
+        return JobRequest(job, on_done_state=TEST_WAIT)
+
+    def _commit_push_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """COMMIT_PUSH_WAIT either re-enters test-fix or submits commit+push."""
+        issue = _issue_number(item)
+        if item.payload.get("tests_failed"):
+            return Continue(next_state=TESTFIX_WAIT)
+        logger.info("implementation:%d: requesting commit+push job", issue)
+        push_job = GitJob(
+            repo=item.repo,
+            op="commit_push",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            kwargs={
+                "issue_number": issue,
+                "worktree_path": item.worktree,
+                "branch": item.branch,
+                "agent": agent_provider(ctx),
+            },
+            descr="commit_push",
+        )
+        return JobRequest(push_job, on_done_state=PR_CREATE)
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Store job results on the item payload (state is still the WAIT state).

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -104,7 +104,8 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 
 from hephaestus.automation.agent_config import (
     address_review_claude_timeout,
@@ -163,6 +164,27 @@ PUSH_WAIT = "PUSH_WAIT"
 EVAL = "EVAL"
 FOLLOWUP_WAIT = "FOLLOWUP_WAIT"
 FINISH = "FINISH"
+
+_STEP_HANDLER_NAMES: dict[str, str] = {
+    ENTER: "_enter",
+    REVIEW_WAIT: "_review_wait",
+    VALIDATE_WAIT: "_validate_wait",
+    POST: "_post",
+    DIFFICULTY_WAIT: "_difficulty_wait",
+    ADDRESS_WAIT: "_address",
+    PUSH_WAIT: "_push_wait",
+    EVAL: "_eval",
+    FOLLOWUP_WAIT: "_followup_wait",
+    FINISH: "_finish",
+}
+
+
+def _issue_number(item: WorkItem) -> int:
+    """Return the issue number after the stage-level guard has run."""
+    if item.issue is None:
+        raise RuntimeError("pr_review stage reached without an issue number")
+    return item.issue
+
 
 #: Max CONSECUTIVE reviewer-infrastructure failures (ERROR verdicts or
 #: failed/valueless review jobs) tolerated before failing back
@@ -351,7 +373,7 @@ class PrReviewStage(Stage):
             item.payload.pop("review_error_retries", None)
         return None
 
-    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:  # noqa: C901
+    def step(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """Execute the next PR-review action for the item's current state.
 
         Args:
@@ -370,146 +392,158 @@ class PrReviewStage(Stage):
             logger.warning("pr_review:%d: no PR on item; failing back", item.issue)
             return self._fail_back_agent_error(item)
 
-        if item.state == ENTER:
-            return Continue(next_state=REVIEW_WAIT)
-
-        if item.state == REVIEW_WAIT:
-            # Clear ALL round-scoped payload at submission (stale-result
-            # guard, M3 pattern): a failed later round must never replay an
-            # earlier round's verdict, threads, or address output.
-            for key in _ROUND_PAYLOAD_KEYS:
-                item.payload.pop(key, None)
-            round_index = item.payload.get("pr_review_round", 0)
-            logger.info(
-                "pr_review:%d: requesting review job (round %d, PR #%d)",
-                item.issue,
-                round_index,
-                item.pr,
+        handler_name = _STEP_HANDLER_NAMES.get(item.state)
+        if handler_name is not None:
+            handler = cast(
+                Callable[[WorkItem, StageContext], StepResult],
+                getattr(self, handler_name),
             )
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "reviewer", reviewer_model),
-                prompt_builder=get_pr_review_analysis_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=pr_reviewer_claude_timeout(),
-                session_agent=AGENT_PR_REVIEWER,
-                # Diff / body / CI context are seeded into item.payload by
-                # the coordinator (#1817), which owns the gh reads.
-                prompt_kwargs={
-                    "pr_number": item.pr,
-                    "issue_number": item.issue,
-                    "pr_diff": item.payload.get("pr_diff", ""),
-                    "issue_body": item.payload.get("issue_body", ""),
-                    "ci_status": item.payload.get("ci_status", ""),
-                    "pr_description": item.payload.get("pr_description", ""),
-                    "advise_findings": item.payload.get("advise_findings", ""),
-                    "include_nitpicks": bool(
-                        getattr(
-                            ctx.config,
-                            "nitpick",
-                            getattr(ctx.config, "include_nitpicks", False),
-                        )
-                    ),
-                },
-                parse=parse_review_verdict,  # verdict parsed in-worker
-                descr="review",
-            )
-            return JobRequest(job, on_done_state=VALIDATE_WAIT)
-
-        if item.state == VALIDATE_WAIT:
-            if item.payload.pop("review_failed", None):
-                # The review job itself failed: skip the validate/post/
-                # address leg — EVAL's missing-verdict ERROR path handles it
-                # without burning a round.
-                return Continue(next_state=EVAL)
-            logger.info("pr_review:%d: requesting validation job", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "reviewer", reviewer_model),
-                prompt_builder=get_review_validation_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=pr_reviewer_claude_timeout(),
-                session_agent=AGENT_PR_REVIEWER,
-                prompt_kwargs={
-                    "pr_number": item.pr,
-                    "issue_number": item.issue,
-                    "prior_comments_json": item.payload.get("prior_comments_json", "[]"),
-                    "diff_text": item.payload.get("pr_diff", ""),
-                },
-                descr="validate",
-            )
-            return JobRequest(job, on_done_state=POST)
-
-        if item.state == POST:
-            return self._post(item, ctx)
-
-        if item.state == DIFFICULTY_WAIT:
-            logger.info("pr_review:%d: requesting difficulty job", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "reviewer", reviewer_model),
-                prompt_builder=get_comment_difficulty_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=pr_reviewer_claude_timeout(),
-                session_agent=AGENT_COMMENT_CLASSIFIER,
-                prompt_kwargs={
-                    "issue_number": item.issue,
-                    "comments_json": json.dumps(item.payload.get("review_threads", [])),
-                },
-                descr="difficulty",
-            )
-            return JobRequest(job, on_done_state=ADDRESS_WAIT)
-
-        if item.state == ADDRESS_WAIT:
-            return self._address(item, ctx)
-
-        if item.state == PUSH_WAIT:
-            logger.info("pr_review:%d: requesting push job", item.issue)
-            git_job = GitJob(
-                repo=item.repo,
-                op="commit_push",
-                timeout_s=GIT_JOB_TIMEOUT_S,
-                kwargs={
-                    "issue_number": item.issue,
-                    "worktree_path": item.worktree,
-                    "branch": item.branch,
-                    "agent": agent_provider(ctx),
-                },
-                descr="push_fixes",
-            )
-            return JobRequest(git_job, on_done_state=EVAL)
-
-        if item.state == EVAL:
-            return self._eval(item, ctx)
-
-        if item.state == FOLLOWUP_WAIT:
-            logger.info("pr_review:%d: requesting follow-up job", item.issue)
-            job = AgentJob(
-                repo=item.repo,
-                issue=item.issue,
-                agent=agent_provider(ctx),
-                model=stage_model(ctx, "implementer", implementer_model),
-                prompt_builder=get_follow_up_prompt,
-                cwd=_worktree_path(item, ctx),
-                timeout_s=follow_up_claude_timeout(),
-                session_agent=AGENT_IMPLEMENTER,  # resume implementer session (legacy parity)
-                prompt_kwargs={"issue_number": item.issue},
-                descr="follow_up",
-            )
-            return JobRequest(job, on_done_state=FINISH)
-
-        if item.state == FINISH:
-            logger.info("pr_review:%d: follow-up completed; advancing", item.issue)
-            return StageOutcome(Disposition.ADVANCE, "implementation review approved")
+            return handler(item, ctx)
 
         logger.warning("pr_review:%d: unknown state %r", item.issue, item.state)
         return StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {item.state}")
+
+    def _enter(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """ENTER advances to REVIEW_WAIT."""
+        return Continue(next_state=REVIEW_WAIT)
+
+    def _review_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """REVIEW_WAIT submits the inline review job with parsed verdicts."""
+        issue = _issue_number(item)
+        # Clear ALL round-scoped payload at submission (stale-result
+        # guard, M3 pattern): a failed later round must never replay an
+        # earlier round's verdict, threads, or address output.
+        for key in _ROUND_PAYLOAD_KEYS:
+            item.payload.pop(key, None)
+        round_index = item.payload.get("pr_review_round", 0)
+        logger.info(
+            "pr_review:%d: requesting review job (round %d, PR #%d)",
+            issue,
+            round_index,
+            item.pr,
+        )
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "reviewer", reviewer_model),
+            prompt_builder=get_pr_review_analysis_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=pr_reviewer_claude_timeout(),
+            session_agent=AGENT_PR_REVIEWER,
+            # Diff / body / CI context are seeded into item.payload by
+            # the coordinator (#1817), which owns the gh reads.
+            prompt_kwargs={
+                "pr_number": item.pr,
+                "issue_number": item.issue,
+                "pr_diff": item.payload.get("pr_diff", ""),
+                "issue_body": item.payload.get("issue_body", ""),
+                "ci_status": item.payload.get("ci_status", ""),
+                "pr_description": item.payload.get("pr_description", ""),
+                "advise_findings": item.payload.get("advise_findings", ""),
+                "include_nitpicks": bool(
+                    getattr(
+                        ctx.config,
+                        "nitpick",
+                        getattr(ctx.config, "include_nitpicks", False),
+                    )
+                ),
+            },
+            parse=parse_review_verdict,  # verdict parsed in-worker
+            descr="review",
+        )
+        return JobRequest(job, on_done_state=VALIDATE_WAIT)
+
+    def _validate_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """VALIDATE_WAIT either skips the dead round or submits validation."""
+        issue = _issue_number(item)
+        if item.payload.pop("review_failed", None):
+            # The review job itself failed: skip the validate/post/
+            # address leg — EVAL's missing-verdict ERROR path handles it
+            # without burning a round.
+            return Continue(next_state=EVAL)
+        logger.info("pr_review:%d: requesting validation job", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "reviewer", reviewer_model),
+            prompt_builder=get_review_validation_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=pr_reviewer_claude_timeout(),
+            session_agent=AGENT_PR_REVIEWER,
+            prompt_kwargs={
+                "pr_number": item.pr,
+                "issue_number": item.issue,
+                "prior_comments_json": item.payload.get("prior_comments_json", "[]"),
+                "diff_text": item.payload.get("pr_diff", ""),
+            },
+            descr="validate",
+        )
+        return JobRequest(job, on_done_state=POST)
+
+    def _difficulty_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """DIFFICULTY_WAIT submits the comment-difficulty job."""
+        issue = _issue_number(item)
+        logger.info("pr_review:%d: requesting difficulty job", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "reviewer", reviewer_model),
+            prompt_builder=get_comment_difficulty_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=pr_reviewer_claude_timeout(),
+            session_agent=AGENT_COMMENT_CLASSIFIER,
+            prompt_kwargs={
+                "issue_number": item.issue,
+                "comments_json": json.dumps(item.payload.get("review_threads", [])),
+            },
+            descr="difficulty",
+        )
+        return JobRequest(job, on_done_state=ADDRESS_WAIT)
+
+    def _push_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """PUSH_WAIT submits the commit+push job for the addressing changes."""
+        issue = _issue_number(item)
+        logger.info("pr_review:%d: requesting push job", issue)
+        git_job = GitJob(
+            repo=item.repo,
+            op="commit_push",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            kwargs={
+                "issue_number": issue,
+                "worktree_path": item.worktree,
+                "branch": item.branch,
+                "agent": agent_provider(ctx),
+            },
+            descr="push_fixes",
+        )
+        return JobRequest(git_job, on_done_state=EVAL)
+
+    def _followup_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """FOLLOWUP_WAIT submits the follow-up job before FINISH advances."""
+        issue = _issue_number(item)
+        logger.info("pr_review:%d: requesting follow-up job", issue)
+        job = AgentJob(
+            repo=item.repo,
+            issue=issue,
+            agent=agent_provider(ctx),
+            model=stage_model(ctx, "implementer", implementer_model),
+            prompt_builder=get_follow_up_prompt,
+            cwd=_worktree_path(item, ctx),
+            timeout_s=follow_up_claude_timeout(),
+            session_agent=AGENT_IMPLEMENTER,  # resume implementer session (legacy parity)
+            prompt_kwargs={"issue_number": item.issue},
+            descr="follow_up",
+        )
+        return JobRequest(job, on_done_state=FINISH)
+
+    def _finish(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """FINISH advances after the follow-up job completes."""
+        issue = _issue_number(item)
+        logger.info("pr_review:%d: follow-up completed; advancing", issue)
+        return StageOutcome(Disposition.ADVANCE, "implementation review approved")
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Store job results on the item payload (state is still the WAIT state).

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 from hephaestus.automation.pipeline.jobs import AgentJob, BuildTestJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
@@ -396,6 +397,19 @@ class TestGitErrorRetryCap:
 
 class TestWorktreeAndAdvise:
     """WORKTREE_WAIT / DIRTY_DECISION_WAIT / ADVISE_WAIT."""
+
+    def test_worktree_wait_dispatches_to_handler(self, make_ctx: Any, make_work_item: Any) -> None:
+        """WORKTREE_WAIT routes through the dedicated state handler."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, state="WORKTREE_WAIT")
+        expected = StageOutcome(Disposition.ADVANCE, "dispatched")
+
+        with patch.object(stage, "_worktree_wait", create=True, return_value=expected) as mock:
+            result = stage.step(item, ctx)
+
+        assert result == expected
+        mock.assert_called_once_with(item, ctx)
 
     def test_worktree_wait_requests_refreshed_worktree(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
 from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
@@ -107,6 +108,19 @@ class TestPrReviewStageOnEnter:
 
 class TestPrReviewStageStep:
     """step state machine: ENTER -> REVIEW -> VALIDATE -> POST -> ... -> EVAL."""
+
+    def test_review_wait_dispatches_to_handler(self, make_ctx: Any, make_work_item: Any) -> None:
+        """REVIEW_WAIT routes through the dedicated state handler."""
+        stage = PrReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="REVIEW_WAIT")
+        expected = StageOutcome(Disposition.ADVANCE, "dispatched")
+
+        with patch.object(stage, "_review_wait", create=True, return_value=expected) as mock:
+            result = stage.step(item, ctx)
+
+        assert result == expected
+        mock.assert_called_once_with(item, ctx)
 
     def test_no_issue_number_fails(self, make_ctx: Any, make_work_item: Any) -> None:
         """Step without an issue number finishes failed."""


### PR DESCRIPTION
## Summary
Verdict: fixed | Reason: extracted flat state-handler dispatch in [implementation.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1919/hephaestus/automation/pipeline/stages/implementation.py#L123) and [pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1919/hephaestus/automation/pipeline/stages/pr_review.py#L168), moved the inlined state logic into private handlers behind those dispatch tables at [implementation.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1919/hephaestus/automation/pipeline/stages/implementation.py#L265) and [pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1919/hephaestus/automation/pipeline/stages/pr_review.py#L376), added dispatch tests in [test_stage_implementation.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1919/tests/unit/automation/pipeline/stages/test_stage_implementation.py#L401) and [test_stage_pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1919/tests/unit/automation/pipeline/stages/test_stage_pr_review.py#L112), and verified with `python -m pytest tests/ -v` (6142 passed, 21 skipped), `python -m mypy hephaestus/`, `python -m ruff check hephaestus/ tests/`, and `python -m ruff format --check hephaestus/ tests/`; `pre-commit run --files ...` is blocked here by offline hook-environment package fetches.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1919

Generated by ProjectHephaestus automation
