### PR TITLE
[nit] Disposition.FINISH_FAIL lacks the explanatory comment its sibling FINISH_PASS has

### DIFF
--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -51,6 +51,7 @@ class Disposition(str, Enum):
     # "PASS" trips ruff's hardcoded-password heuristic (S105); this is a
     # pipeline disposition, not a credential.
     FINISH_PASS = "finish_pass"  # noqa: S105
+    # terminal fail; no S105 needed
     FINISH_FAIL = "finish_fail"
 
 

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -54,6 +54,17 @@ class TestDisposition:
         }
         assert {d.value for d in Disposition} == expected
 
+    def test_finish_fail_has_terminal_comment(self) -> None:
+        """FINISH_FAIL keeps the terse terminal-fail rationale comment."""
+        source_lines = Path(routing.__file__).read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(source_lines):
+            if line.strip() == 'FINISH_FAIL = "finish_fail"':
+                assert index > 0
+                assert source_lines[index - 1].strip() == "# terminal fail; no S105 needed"
+                break
+        else:
+            pytest.fail("FINISH_FAIL enum member not found")
+
 
 class TestStageOutcome:
     """Tests for StageOutcome dataclass."""


### PR DESCRIPTION
## Summary
Verdict: done | Reason: Added the missing `# terminal fail; no S105 needed` comment above `FINISH_FAIL` in [routing.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1905/hephaestus/automation/pipeline/routing.py:53) and pinned it with a regression test in [test_routing.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1905/tests/unit/automation/pipeline/test_routing.py:57); verified with `python -m pytest -o addopts='' tests/ -v` (`6141 passed, 21 skipped`), `python -m mypy hephaestus/`, `XDG_CACHE_HOME=/tmp/codex-xdg-cache pixi run --as-is ruff check hephaestus/ tests/`, and `XDG_CACHE_HOME=/tmp/codex-xdg-cache pixi run --as-is ruff format --check hephaestus/ tests/`; `pre-commit run --files $(git diff --name-only HEAD)` is still blocked by the network while fetching `markdownlint-cli2`.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1905

Generated by ProjectHephaestus automation
