### PR TITLE
[Bug]: automation loop child phases can fail when inherited PYTHONPATH shadows stdlib modules

### DIFF
--- a/hephaestus/automation/_plan_phase.py
+++ b/hephaestus/automation/_plan_phase.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from hephaestus.github.client import gh_call
@@ -23,6 +25,18 @@ from .planner_state import _comments_contain_plan
 
 if TYPE_CHECKING:
     from ._stage_context import StageContext
+
+
+def _phase_env(repo_root: Path) -> dict[str, str]:
+    """Return a sanitized environment for a phase subprocess.
+
+    Child phase invocations must not inherit a ``PYTHONPATH`` that can place
+    third-party ``site-packages`` ahead of the stdlib. Keep only the repo root
+    so source-checkout fallback still works without the ambient search path.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+    return env
 
 
 class PlanPhase(StageMixin):
@@ -74,11 +88,13 @@ class PlanPhase(StageMixin):
             run(
                 [entry_point, "--issues", str(issue_number), "--agent", self.options.agent],
                 timeout=plan_timeout,
+                env=_phase_env(self.repo_root),
             )
             return
 
-        # Fall back to python -m invocation (works when PYTHONPATH is set).
-        # On failure, fall through to the legacy scripts/plan_issues.py path.
+        # Fall back to python -m invocation using the sanitized repo-root-only
+        # PYTHONPATH (source-checkout fallback). On failure, fall through to the
+        # legacy scripts/plan_issues.py path.
         with contextlib.suppress(subprocess.SubprocessError, OSError):
             run(
                 [
@@ -91,6 +107,7 @@ class PlanPhase(StageMixin):
                     self.options.agent,
                 ],
                 timeout=plan_timeout,
+                env=_phase_env(self.repo_root),
             )
             return
 
@@ -100,6 +117,7 @@ class PlanPhase(StageMixin):
             run(
                 [sys.executable, str(plan_script), "--issues", str(issue_number)],
                 timeout=plan_timeout,
+                env=_phase_env(self.repo_root),
             )
             return
 

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -25,7 +25,7 @@ def _utcnow() -> datetime:
 
 def _default_attempts() -> dict[str, int]:
     """Return zeroed per-item-lifetime counters, one per budget key."""
-    return {key: 0 for key in budget_keys()}
+    return dict.fromkeys(budget_keys(), 0)
 
 
 class ItemKind(str, Enum):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -78,9 +78,7 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(
-        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
-    )
+    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
     return automation, len(threads) - automation
 
 

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -12,10 +12,10 @@ from hephaestus.automation.pipeline.stages import (
     PlanningStage,
     PlanReviewStage,
     Stage,
+    base as stage_base,
     ci,
     merge_wait,
 )
-from hephaestus.automation.pipeline.stages import base as stage_base
 from hephaestus.automation.pipeline.stages.base import (
     BACKOFF_CAP_S,
     Continue,

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -85,9 +85,8 @@ class TestCoordinatorCapOwnership:
 
     def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
         """The deferred cap is intentionally owned by Coordinator._admit."""
-        assert (
-            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
-            in (admission.__doc__ or "")
+        assert ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`" in (
+            admission.__doc__ or ""
         )
 
 

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -10,8 +10,8 @@ from hephaestus.automation.pipeline import (
     ItemResult,
     StageName,
     WorkItem,
+    work_item as work_item_module,
 )
-from hephaestus.automation.pipeline import work_item as work_item_module
 from hephaestus.automation.pipeline.routing import budget_keys
 
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,8 +1,8 @@
 """Tests for GitHub API utilities."""
 
 import json
-import threading
 import subprocess
+import threading
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -11,7 +11,6 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
-from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -38,6 +37,7 @@ from hephaestus.automation.github_api import (
     skip_epics,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.io import utils as io_utils
 
 # Circuit-breaker reset is now an autouse package-scope fixture in

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -9,6 +9,7 @@ cross-phase dispatch contract that the pipeline stages rely on.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -18,7 +19,7 @@ import pytest
 
 from hephaestus.automation._followup_phase import FollowUpPhase
 from hephaestus.automation._implement_phase import ImplementPhase, _prepend_advise
-from hephaestus.automation._plan_phase import PlanPhase
+from hephaestus.automation._plan_phase import PlanPhase, _phase_env
 from hephaestus.automation._pr_create_phase import PRCreatePhase
 from hephaestus.automation._review_phase import ReviewPhase, _is_automation_owned_thread
 from hephaestus.automation._stage_context import StageContext, StageMixin
@@ -104,6 +105,17 @@ def test_plan_phase_has_plan_false_on_subprocess_error(tmp_path: Path) -> None:
         assert phase._has_plan(7) is False
 
 
+def test_phase_env_keeps_only_repo_root_pythonpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The child phase env drops inherited site-packages contamination."""
+    monkeypatch.setenv("PYTHONPATH", f"/opt/site-packages{os.pathsep}/tmp/elsewhere")
+
+    env = _phase_env(tmp_path)
+
+    assert env["PYTHONPATH"] == str(tmp_path)
+
+
 def test_plan_phase_generate_uses_entry_point(tmp_path: Path) -> None:
     """_generate prefers the installed hephaestus-plan-issues entry point."""
     phase = PlanPhase(_make_ctx(tmp_path))
@@ -115,6 +127,20 @@ def test_plan_phase_generate_uses_entry_point(tmp_path: Path) -> None:
     args = mock_run.call_args[0][0]
     assert args[0] == "/usr/bin/hpi"
     assert "--issues" in args and "7" in args
+
+
+def test_plan_phase_generate_sanitizes_pythonpath(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """_generate passes a repo-root-only PYTHONPATH to child subprocesses."""
+    monkeypatch.setenv("PYTHONPATH", f"/opt/site-packages{os.pathsep}/tmp/elsewhere")
+    phase = PlanPhase(_make_ctx(tmp_path))
+    with (
+        mock.patch("shutil.which", return_value="/usr/bin/hpi"),
+        mock.patch("hephaestus.automation._plan_phase.run") as mock_run,
+    ):
+        phase._generate(7)
+    assert mock_run.call_args.kwargs["env"]["PYTHONPATH"] == str(tmp_path)
 
 
 def test_plan_phase_generate_uses_long_stage_timeout(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_scripts_smoke.py
+++ b/tests/unit/scripts/test_scripts_smoke.py
@@ -59,9 +59,7 @@ def test_script_help_exits_zero(script_path: Path) -> None:
     """``python scripts/<name>.py --help`` must succeed within the timeout."""
     env = {
         **os.environ,
-        "PYTHONPATH": os.pathsep.join(
-            [str(REPO_ROOT), *([os.environ["PYTHONPATH"]] if os.environ.get("PYTHONPATH") else [])]
-        ),
+        "PYTHONPATH": str(REPO_ROOT),
     }
     proc = subprocess.run(
         [sys.executable, str(script_path), "--help"],


### PR DESCRIPTION
## Summary
Verdict: fixed | Reason: Plan-phase subprocesses now use a sanitized repo-root-only `PYTHONPATH`, with regression tests covering env stripping and propagation; verified by `pixi run --as-is python -m pytest tests/ -v` (6142 passed), a focused rerun of `tests/unit/automation/test_stage_phases.py` + `tests/unit/scripts/test_scripts_smoke.py`, and `ruff check`.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1942

Generated by ProjectHephaestus automation
