### PR TITLE
[nit] _TAIL and the repeated [:500] error truncation are unnamed magic numbers

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -40,6 +40,7 @@ from hephaestus.utils.helpers import get_repo_root
 logger = logging.getLogger(__name__)
 
 _TAIL = 4000  # chars of stdout/stderr retained in a JobResult
+_ERR_MAX = 500  # chars of error detail retained in a JobResult
 _GIT_LOCK_WAIT_POLL_S = 0.1
 
 
@@ -231,7 +232,7 @@ class WorkerPool:
             logger.exception("Worker future raised; converting to worker_crash result")
             result = JobResult(
                 ok=False,
-                error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:500],
+                error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
             )
         self._completion_q.put((handle, result))
 
@@ -271,7 +272,7 @@ class WorkerPool:
                 logger.exception("Job %s raised, returning error result", job)
                 result = JobResult(
                     ok=False,
-                    error=f"{type(exc).__name__}: {exc!s}"[:500],
+                    error=f"{type(exc).__name__}: {exc!s}"[:_ERR_MAX],
                 )
 
             # Mandatory post-check: SIGINT to the process group makes subprocess
@@ -351,7 +352,7 @@ class WorkerPool:
                     logger.exception("Parse callable raised for agent job")
                     return JobResult(
                         ok=False,
-                        error=f"parse failed: {type(exc).__name__}: {exc!s}"[:500],
+                        error=f"parse failed: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
                         stdout_tail=stdout[-_TAIL:],
                     )
 
@@ -376,7 +377,7 @@ class WorkerPool:
             logger.exception("Agent job raised, returning error result")
             return JobResult(
                 ok=False,
-                error=f"{type(exc).__name__}: {exc!s}"[:500],
+                error=f"{type(exc).__name__}: {exc!s}"[:_ERR_MAX],
             )
 
     def _run_build_test(self, job: BuildTestJob) -> JobResult:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -275,11 +275,14 @@ class TestAgentErrorHandling:
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """An unexpected exception inside the job maps to an error result."""
+        """An unexpected exception inside the job is bounded by the shared cap."""
+        small_err_max = 40
+        monkeypatch.setattr(f"{_WP}._ERR_MAX", small_err_max)
 
         def exploding_builder() -> str:
-            raise RuntimeError("prompt builder exploded")
+            raise RuntimeError("prompt builder exploded " + ("x" * 200))
 
         job = _agent_job(model="model-generic-exc", prompt_builder=exploding_builder)
 
@@ -288,8 +291,9 @@ class TestAgentErrorHandling:
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert "RuntimeError" in result.error
-        assert "prompt builder exploded" in result.error
+        assert result.error is not None
+        assert result.error.startswith("RuntimeError: ")
+        assert len(result.error) == small_err_max
 
     def test_run_agent_classifies_resolve_agent_exception(
         self,
@@ -318,6 +322,24 @@ class TestAgentErrorHandling:
         assert result.ok is False
         assert "KeyError" in (result.error or "")
         assert "prompt-template" in (result.error or "")
+
+    def test_run_converts_escaping_exception_to_bounded_error(
+        self,
+        pool: WorkerPool,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Exceptions escaping _run_agent are still capped in _run."""
+        small_err_max = 40
+        monkeypatch.setattr(f"{_WP}._ERR_MAX", small_err_max)
+        job = _agent_job(model="model-run-generic", prompt_builder=lambda: "prompt")
+
+        with patch.object(pool, "_run_agent", side_effect=RuntimeError("z" * 200)):
+            result = pool._run(job)
+
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.startswith("RuntimeError: ")
+        assert len(result.error) == small_err_max
 
     def test_run_agent_classifies_resilient_call_exception(self, pool: WorkerPool) -> None:
         """Unexpected resilience-wrapper failures are classified inside _run_agent."""
@@ -391,11 +413,14 @@ class TestParse:
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Parse callable raises -> error result."""
+        """Parse callable failures are bounded by the shared cap."""
+        small_err_max = 40
+        monkeypatch.setattr(f"{_WP}._ERR_MAX", small_err_max)
 
         def bad_parser(text: str) -> object:
-            raise ValueError("parse failed")
+            raise ValueError("parse failed " + ("y" * 200))
 
         job = _agent_job(prompt_builder=lambda: "prompt", parse=bad_parser)
 
@@ -408,7 +433,9 @@ class TestParse:
             _, result = completion_q.get(timeout=10)
 
         assert result.ok is False
-        assert "parse failed" in result.error
+        assert result.error is not None
+        assert result.error.startswith("parse failed: ValueError: ")
+        assert len(result.error) == small_err_max
 
 
 class TestInterruptedPostCheck:
@@ -1199,3 +1226,28 @@ class TestOnFutureDone:
         assert got_handle is handle
         assert result.ok is False
         assert result.error.startswith(f"worker_crash: {type(exc).__name__}")
+
+    def test_raising_future_emits_truncated_worker_crash_completion(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A worker crash message longer than the cap is truncated once."""
+        small_err_max = 40
+        monkeypatch.setattr(f"{_WP}._ERR_MAX", small_err_max)
+        handle = JobHandle(
+            job=BuildTestJob(repo="r", cwd=Path("/tmp"), argv=("true",), timeout_s=1),
+            on_done_state=StageName.CI,
+        )
+        future: Future[JobResult] = Future()
+        future.set_exception(RuntimeError("w" * 200))
+
+        pool._on_future_done(handle, future)
+
+        got_handle, result = completion_q.get_nowait()
+        assert got_handle is handle
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.startswith("worker_crash: RuntimeError: ")
+        assert len(result.error) == small_err_max

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,7 +1,9 @@
 """Tests for GitHub API utilities."""
 
 import json
+import threading
 import subprocess
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -9,6 +11,7 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -1771,11 +1774,14 @@ class TestGhCallThrottle:
     """Tests for the per-thread `gh` call throttle inside _gh_call."""
 
     @pytest.fixture(autouse=True)
-    def _reset_throttle(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _reset_throttle(self, monkeypatch: pytest.MonkeyPatch) -> Generator[None, None, None]:
         # Reset the per-thread throttle state and force a known rate so tests
         # don't inherit clock state from earlier suite calls.
-        client_module._GH_THROTTLE = __import__("threading").local()
+        client_module._GH_THROTTLE = threading.local()
         monkeypatch.setenv("GH_RATE_LIMIT_PER_SEC", "5")
+        configure_gh_global_throttle(rate=0, burst=10)
+        yield
+        configure_gh_global_throttle(rate=10.0, burst=30.0)
 
     @patch("hephaestus.github.client.run_subprocess")
     def test_consecutive_calls_are_paced_to_min_interval(self, mock_run: Any) -> None:


### PR DESCRIPTION
## Summary
Verdict: done | Reason: Extracted the 500-char error cap into `_ERR_MAX` in [worker_pool.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1911/hephaestus/automation/pipeline/worker_pool.py#L43), updated the worker-pool regression coverage in [test_worker_pool.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1911/tests/unit/automation/pipeline/test_worker_pool.py#L274), and isolated the shared throttle state in [test_github_api.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1911/tests/unit/automation/test_github_api.py#L1773); verified with `pixi run --frozen --no-install python -m pytest tests/ -v` (6142 passed, 21 skipped).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1911

Generated by ProjectHephaestus automation
