### PR TITLE
[mino] Interrupt exit code 130 masks genuine pre-interrupt failures; document the deliberate priority

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -445,7 +445,9 @@ the correct entry queue. There is no persisted queue snapshot.
 
 Exit codes are stable: `130` for interrupted runs, `1` if any item failed,
 skipped, blocked, or the coordinator itself hit a fatal error, and `0` for a
-clean run.
+clean run. If an interrupt overlaps a non-passing ledger entry or fatal
+coordinator error, `130` deliberately takes priority because the run did not
+complete.
 
 ## Concurrency and tuning
 

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -67,6 +67,9 @@ immediately and synthesizes interrupted results. Items touched by an
 interrupt report ``RESUMABLE at <stage>``, never FAILED. Exit codes: 130
 interrupt, 1 any fail/skip/blocked, 0 clean. The summary prints in this
 module's ``finally`` — on completion AND interrupt.
+
+When an interrupt overlaps a non-passing ledger entry or fatal coordinator
+error, 130 deliberately takes priority because the run did not complete.
 """
 
 from __future__ import annotations
@@ -511,6 +514,10 @@ class Coordinator:
     def _exit_code(self) -> int:
         """130 on interrupt; 1 on any fail/skip/blocked (or fatal error); 0 clean."""
         if self.shutdown.is_set():
+            # Interrupt deliberately takes priority over non-passing ledger
+            # entries and fatal coordinator errors: a signal means the run did
+            # not complete, so wrappers must classify it as cancellation even
+            # if earlier work had already failed.
             return 130
         if self._fatal or any(not result.passed for result in self.ledger):
             return 1

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -148,6 +148,44 @@ class TestWiring:
         assert _budget_lookup("nonexistent") == 1
 
 
+class TestExitCode:
+    """Exit-code precedence contract."""
+
+    def test_exit_code_documents_interrupt_priority(self) -> None:
+        """The interrupt branch should explain why it wins over prior failures."""
+        source = inspect.getsource(Coordinator._exit_code)
+
+        assert "Interrupt deliberately takes priority" in source
+        assert "earlier work had already failed" in source
+
+    @pytest.mark.parametrize(
+        ("reason"),
+        [
+            "fail: stage crash",
+            "skip: state:skip",
+            "blocked: unresolved review",
+        ],
+    )
+    def test_shutdown_takes_priority_over_recorded_nonpassing_result(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        reason: str,
+    ) -> None:
+        """Interrupts should still exit 130 when the ledger already has failures."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        coordinator.ledger.append(
+            work_item_mod.ItemResult(
+                passed=False,
+                reason=reason,
+                final_stage=StageName.FINISHED,
+            )
+        )
+        coordinator.shutdown.set()
+
+        assert coordinator._exit_code() == 130
+
+
 class TestCompletionEdges:
     """_handle_completion bookkeeping branches."""
 

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -81,12 +81,17 @@ def test_automation_loop_architecture_status_is_implemented() -> None:
 def test_automation_loop_architecture_has_interrupt_semantics_and_exit_codes() -> None:
     """The architecture contract must keep interrupt and exit-code details."""
     text = _arch_text()
+    normalized = " ".join(text.split())
 
     assert "Finalized in the cutover issue." not in text
     assert "## Interrupt semantics and exit codes" in text
     assert "SIGINT, SIGTERM, and SIGHUP" in text
     assert "resumable at <stage>" in text
     assert "Exit codes are stable: `130` for interrupted runs" in text
+    assert (
+        "If an interrupt overlaps a non-passing ledger entry or fatal coordinator error, "
+        "`130` deliberately takes priority because the run did not complete." in normalized
+    )
 
 
 def test_automation_loop_architecture_has_concurrency_cli_dry_run_and_glossary() -> None:


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: added the explicit interrupt-priority comment in `hephaestus/automation/pipeline/coordinator.py:62-72,514-523`, mirrored it in `docs/AUTOMATION_LOOP_ARCHITECTURE.md:446-450`, and added regression tests in `tests/unit/automation/pipeline/test_coordinator_edges.py:151-186` and `tests/unit/docs/test_automation_loop_architecture.py:81-94`; `python -m pytest tests/ -v -o addopts=''` passed, the new contract tests pass under `pixi run --as-is ... -o addopts=''`, and the exact `pixi run python -m pytest tests/ -v` wrapper is blocked here by the sandbox cache/network restriction.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1878

Generated by ProjectHephaestus automation
