### PR TITLE
[nit] _find_pr_for_issue hard-codes the f"{issue}-auto-impl" branch convention as a magic string

### DIFF
--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -62,8 +62,8 @@ from hephaestus.cli.utils import (
 from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 from hephaestus.io.utils import write_secure
 
-from .github_api import _gh_call
 from .git_utils import issue_auto_impl_branch_name
+from .github_api import _gh_call
 from .models import DEFAULT_STATE_DIR as DEFAULT_STATE_DIR, DEFAULT_WORKER_COUNT
 
 if TYPE_CHECKING:

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -63,6 +63,7 @@ from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 from hephaestus.io.utils import write_secure
 
 from .github_api import _gh_call
+from .git_utils import issue_auto_impl_branch_name
 from .models import DEFAULT_STATE_DIR as DEFAULT_STATE_DIR, DEFAULT_WORKER_COUNT
 
 if TYPE_CHECKING:
@@ -735,7 +736,7 @@ def find_pr_for_issue(
 
     """
     # Strategy 1: branch-name lookup
-    branch_name = f"{issue_number}-auto-impl"
+    branch_name = issue_auto_impl_branch_name(issue_number)
     try:
         result = _gh_call(
             [
@@ -906,7 +907,7 @@ def find_merged_pr_for_issue(issue_number: int) -> int | None:
         The merged PR number if found, ``None`` otherwise.
 
     """
-    branch_name = f"{issue_number}-auto-impl"
+    branch_name = issue_auto_impl_branch_name(issue_number)
     try:
         result = _gh_call(
             [

--- a/hephaestus/automation/address_review.py
+++ b/hephaestus/automation/address_review.py
@@ -70,6 +70,7 @@ from .agent_config import DEFAULT_AGENT_TIMEOUT
 from .curses_ui import CursesUI
 from .git_utils import (
     commit_if_changes,
+    issue_auto_impl_branch_name,
     issue_ref,
     pr_ref,
     push_branch,
@@ -291,7 +292,7 @@ class AddressReviewer(BaseReviewer):
         session_id = self._load_impl_session_id(issue_number)
         review_state = self._load_review_state(issue_number)
         if review_state is None:
-            branch_name = f"{issue_number}-auto-impl"
+            branch_name = issue_auto_impl_branch_name(issue_number)
             review_state = ReviewState(
                 issue_number=issue_number,
                 pr_number=pr_number,
@@ -299,7 +300,7 @@ class AddressReviewer(BaseReviewer):
             )
         else:
             review_state.pr_number = pr_number
-        branch_name = review_state.branch_name or f"{issue_number}-auto-impl"
+        branch_name = review_state.branch_name or issue_auto_impl_branch_name(issue_number)
 
         self.status_tracker.update_slot(slot_id, f"{issue_ref(issue_number)}: Setting up worktree")
         worktree_path = self._get_or_create_worktree(issue_number, branch_name, review_state)

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -519,6 +519,14 @@ def current_trunk_githash(repo_path: Path | None = None) -> str:
     return short_githash(repo_path if repo_path is not None else Path.cwd())
 
 
+_AUTO_IMPL_BRANCH_SUFFIX = "-auto-impl"
+
+
+def issue_auto_impl_branch_name(issue_number: int | str) -> str:
+    """Return the canonical branch name for an issue implementation PR."""
+    return f"{issue_number}{_AUTO_IMPL_BRANCH_SUFFIX}"
+
+
 def session_jsonl_path(uuid_str: str, cwd: Path) -> Path:
     """Return the path where Claude Code persists a session's transcript.
 
@@ -586,6 +594,7 @@ __all__ = [
     "git_message_model",
     "implementer_claude_timeout",
     "implementer_model",
+    "issue_auto_impl_branch_name",
     "learn_claude_timeout",
     "learn_model",
     "normalize_claude_model",

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -25,6 +25,8 @@ from hephaestus.utils.cache import ThreadSafeCache
 from hephaestus.utils.helpers import get_repo_root as get_repo_root, run_subprocess
 from hephaestus.utils.retry import retry_with_backoff
 
+from .session_naming import issue_auto_impl_branch_name as _session_issue_auto_impl_branch_name
+
 logger = logging.getLogger(__name__)
 
 COMMIT_POLICY_REWRITE_EXEC = "git commit --amend --no-edit -S -s"
@@ -178,6 +180,11 @@ def issue_ref(issue_number: int | str) -> str:
 def pr_ref(pr_number: int | str) -> str:
     """Return a ``<repo>#<number>`` reference string for PRs (same format as issues)."""
     return f"{get_repo_slug()}#{pr_number}"
+
+
+def issue_auto_impl_branch_name(issue_number: int | str) -> str:
+    """Return the canonical branch name for an issue implementation PR."""
+    return _session_issue_auto_impl_branch_name(issue_number)
 
 
 def commit_if_changes(

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -77,7 +77,11 @@ from hephaestus.automation.prompts.implementation import (
     get_implementation_prompt,
 )
 from hephaestus.automation.prompts.pr_review import get_pr_description
-from hephaestus.automation.session_naming import AGENT_ADVISE, AGENT_IMPLEMENTER
+from hephaestus.automation.session_naming import (
+    AGENT_ADVISE,
+    AGENT_IMPLEMENTER,
+    issue_auto_impl_branch_name,
+)
 from hephaestus.automation.state_labels import (
     STATE_SKIP,
     is_implementation_go,
@@ -708,7 +712,7 @@ class ImplementationStage(Stage):
             return StageOutcome(Disposition.FAIL_BACK, "plan_not_go")
 
         if not item.branch:
-            item.branch = f"{item.issue}-auto-impl"
+            item.branch = issue_auto_impl_branch_name(item.issue)
         return Continue(next_state=WORKTREE_WAIT)
 
     def _create_pr(self, item: WorkItem, ctx: StageContext) -> StageOutcome:

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -25,7 +25,7 @@ def _utcnow() -> datetime:
 
 def _default_attempts() -> dict[str, int]:
     """Return zeroed per-item-lifetime counters, one per budget key."""
-    return {key: 0 for key in budget_keys()}
+    return dict.fromkeys(budget_keys(), 0)
 
 
 class ItemKind(str, Enum):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -39,9 +39,9 @@ from hephaestus.automation._review_utils import (
     find_pr_for_issue,
     get_pr_head_branch,
 )
-from hephaestus.automation.git_utils import issue_auto_impl_branch_name
 from hephaestus.automation.arming_state import ArmingStateStore
 from hephaestus.automation.ci_check_inspector import CICheckInspector
+from hephaestus.automation.git_utils import issue_auto_impl_branch_name
 from hephaestus.automation.prompts.pr_review import (
     BLOCKING_SEVERITIES,
     SEVERITY_MARKER_PREFIX,
@@ -79,9 +79,7 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(
-        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
-    )
+    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
     return automation, len(threads) - automation
 
 

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -39,6 +39,7 @@ from hephaestus.automation._review_utils import (
     find_pr_for_issue,
     get_pr_head_branch,
 )
+from hephaestus.automation.git_utils import issue_auto_impl_branch_name
 from hephaestus.automation.arming_state import ArmingStateStore
 from hephaestus.automation.ci_check_inspector import CICheckInspector
 from hephaestus.automation.prompts.pr_review import (
@@ -331,7 +332,7 @@ class PipelineGitHub:
             )
 
     def _find_pr_for_issue(self, issue_number: int, *, state: str) -> int | None:
-        branch_name = f"{issue_number}-auto-impl"
+        branch_name = issue_auto_impl_branch_name(issue_number)
         result = self._gh(
             [
                 "pr",

--- a/hephaestus/automation/session_naming.py
+++ b/hephaestus/automation/session_naming.py
@@ -13,6 +13,7 @@ from hephaestus.automation.agent_config import (
     AGENT_PR_MESSAGE as AGENT_PR_MESSAGE,
     AGENT_PR_REVIEWER as AGENT_PR_REVIEWER,
     current_trunk_githash as current_trunk_githash,
+    issue_auto_impl_branch_name as issue_auto_impl_branch_name,
     reviewer_agent as reviewer_agent,
     session_jsonl_path as session_jsonl_path,
     session_name as session_name,

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -12,10 +12,10 @@ from hephaestus.automation.pipeline.stages import (
     PlanningStage,
     PlanReviewStage,
     Stage,
+    base as stage_base,
     ci,
     merge_wait,
 )
-from hephaestus.automation.pipeline.stages import base as stage_base
 from hephaestus.automation.pipeline.stages.base import (
     BACKOFF_CAP_S,
     Continue,

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -85,9 +85,8 @@ class TestCoordinatorCapOwnership:
 
     def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
         """The deferred cap is intentionally owned by Coordinator._admit."""
-        assert (
-            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
-            in (admission.__doc__ or "")
+        assert ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`" in (
+            admission.__doc__ or ""
         )
 
 

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -10,8 +10,8 @@ from hephaestus.automation.pipeline import (
     ItemResult,
     StageName,
     WorkItem,
+    work_item as work_item_module,
 )
-from hephaestus.automation.pipeline import work_item as work_item_module
 from hephaestus.automation.pipeline.routing import budget_keys
 
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import hephaestus.automation.git_utils as git_utils
 from hephaestus.automation.git_utils import (
     _commit_policy_rebase_command,
     _remove_untracked_files_tracked_by_ref,
@@ -169,6 +170,18 @@ class TestGetRepoInfo:
         # Next call should invoke run() again
         get_repo_info(repo_root)
         assert git_utils_mocks.run.call_count == 2
+
+
+class TestIssueAutoImplBranchName:
+    """Tests for the canonical issue auto-implementation branch formatter."""
+
+    def test_returns_canonical_branch_name(self) -> None:
+        """Issue branches must use the shared ``<issue>-auto-impl`` formatter."""
+        branch_name = getattr(
+            git_utils, "issue_auto_impl_branch_name", lambda issue_number: "missing"
+        )(123)
+
+        assert branch_name == "123-auto-impl"
 
 
 class TestCommitIfChanges:

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-import hephaestus.automation.git_utils as git_utils
 from hephaestus.automation.git_utils import (
     _commit_policy_rebase_command,
     _remove_untracked_files_tracked_by_ref,
@@ -20,6 +19,7 @@ from hephaestus.automation.git_utils import (
     get_repo_info,
     get_repo_root,
     is_clean_working_tree,
+    issue_auto_impl_branch_name,
     push_branch,
     push_current_branch_with_lease_on_divergence,
     rebase_worktree_onto,
@@ -177,9 +177,7 @@ class TestIssueAutoImplBranchName:
 
     def test_returns_canonical_branch_name(self) -> None:
         """Issue branches must use the shared ``<issue>-auto-impl`` formatter."""
-        branch_name = getattr(
-            git_utils, "issue_auto_impl_branch_name", lambda issue_number: "missing"
-        )(123)
+        branch_name = issue_auto_impl_branch_name(123)
 
         assert branch_name == "123-auto-impl"
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,8 +1,8 @@
 """Tests for GitHub API utilities."""
 
 import json
-import threading
 import subprocess
+import threading
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -11,7 +11,6 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
-from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -38,6 +37,7 @@ from hephaestus.automation.github_api import (
     skip_epics,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.io import utils as io_utils
 
 # Circuit-breaker reset is now an autouse package-scope fixture in

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -305,9 +305,7 @@ class TestRepoScoping:
 
         monkeypatch.setattr(pg, "gh_call", fake_gh_call)
 
-        pr_number = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_pr_for_issue(
-            7
-        )
+        pr_number = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_pr_for_issue(7)
 
         assert pr_number == 5
         assert calls == [

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -286,6 +286,47 @@ class TestRepoScoping:
         with pytest.raises(RuntimeError, match="gh unavailable"):
             pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_pr_for_issue(5)
 
+    def test_repo_scoped_pr_lookup_uses_shared_branch_formatter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The head-branch lookup should consult the shared branch-name formatter."""
+        calls: list[list[str]] = []
+
+        monkeypatch.setattr(
+            pg,
+            "issue_auto_impl_branch_name",
+            lambda issue_number: f"branch-{issue_number}",
+            raising=False,
+        )
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            return SimpleNamespace(stdout=json.dumps([{"number": 5}]))
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pr_number = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).find_pr_for_issue(
+            7
+        )
+
+        assert pr_number == 5
+        assert calls == [
+            [
+                "pr",
+                "list",
+                "--head",
+                "branch-7",
+                "--state",
+                "open",
+                "--json",
+                "number",
+                "--limit",
+                "1",
+                "--repo",
+                "org/repo-a",
+            ]
+        ]
+
     def test_repo_scoped_unresolved_threads_counts_automation_and_human(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
Verdict: pass | Reason: Centralized the canonical `-auto-impl` formatter in `hephaestus/automation/agent_config.py` and re-exported it via `session_naming.py`/`git_utils.py`, then switched the branch-lookup and branch-creation paths in `pipeline_github.py`, `_review_utils.py`, `address_review.py`, and `pipeline/stages/implementation.py` to use it; added regression tests in `tests/unit/automation/test_git_utils.py` and `tests/unit/automation/test_pipeline_github.py`; verified with `python -m pytest tests/ -v` (`6142 passed, 21 skipped`).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1914

Generated by ProjectHephaestus automation
