### PR TITLE
[nit] admission module documents a deferred per-repo cap but doesn't cross-reference the coordinator function that owns it

### DIFF
--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -15,9 +15,10 @@ source files, which would lead to merge conflicts when the first PR lands.
 Dropped deliverable (documented): the per-repo in-flight cap helper
 (``within_repo_cap``) is intentionally NOT implemented. The issue #1813
 "# Implementation Plan" comment sanctions the drop: "justify or drop
-``within_repo_cap`` (YAGNI — no named consumer)" — no consumer exists until
-the coordinator slice (#1817), which owns worker-slot accounting and can add
-a cap where it dispatches.
+``within_repo_cap`` (YAGNI — no named consumer)" — the cap is owned by
+:meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`, where
+the coordinator slice tracks per-repo worker slots and applies the cap at
+dispatch time.
 """
 
 from __future__ import annotations

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from hephaestus.automation.models import IssueInfo
+from hephaestus.automation.pipeline import admission
 from hephaestus.automation.pipeline.admission import (
     _filter_open_issues,
     _parse_planned_files,
@@ -76,6 +77,17 @@ class TestParsePlannedFiles:
         """## Files to Modify/Create headings are case-insensitive."""
         body = "# Implementation Plan\n\n## FILES TO MODIFY\n\n- `hephaestus/automation/test.py`\n"
         assert _parse_planned_files(body) == {"hephaestus/automation/test.py"}
+
+
+class TestCoordinatorCapOwnership:
+    """Traceability guard for the deferred per-repo cap."""
+
+    def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
+        """The deferred cap is intentionally owned by Coordinator._admit."""
+        assert (
+            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
+            in (admission.__doc__ or "")
+        )
 
 
 class TestFetchPlannedFiles:


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: updated [hephaestus/automation/pipeline/admission.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1917/hephaestus/automation/pipeline/admission.py) to cross-reference `Coordinator._admit` and added a regression guard in [tests/unit/automation/pipeline/test_admission.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1917/tests/unit/automation/pipeline/test_admission.py); `pixi run --frozen --as-is python -m pytest tests/ -v` passed (6144 passed, 21 skipped).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1917

Generated by ProjectHephaestus automation
