### PR TITLE
[nit] _on_future_done logger.exception fires with a full traceback for benign SystemExit/GeneratorExit at shutdown

### DIFF
--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -216,23 +216,32 @@ class WorkerPool:
         If the future was cancelled, do not emit a completion (the coordinator
         synthesizes one later). For every OTHER outcome a completion MUST be
         queued: ``_run`` already converts normal job failures into error
-        results, and anything that still escapes ``future.result()`` is
-        converted here to a ``worker_crash`` result so a non-cancelled submit
-        never silently loses its completion.
+        results, and anything that still escapes ``future.result()`` -- any
+        ``Exception`` plus the process-control escapes ``KeyboardInterrupt``,
+        ``SystemExit``, and ``GeneratorExit`` -- is converted here to a
+        ``worker_crash`` result so a non-cancelled submit never silently loses
+        its completion. Process-control escapes are logged without traceback at
+        warning/info severity; genuine ``Exception`` crashes keep
+        ``logger.exception``. ``KeyboardInterrupt`` is intentionally NOT
+        re-raised after queuing: this callback runs on an executor worker
+        thread where a re-raise would only print a traceback, not stop the
+        process.
         """
         if future.cancelled():
             return  # cancel_futures synthesizes NO completion
         try:
             result = future.result()
-        except (KeyboardInterrupt, SystemExit, GeneratorExit) as exc:
-            # These can escape worker threads via ``future.result()``. Convert
-            # them into a queued crash result instead of re-raising from the
-            # executor callback, otherwise the coordinator can lose a
-            # non-cancelled submission completion.
-            logger.exception("Worker future raised; converting to worker_crash result")
+        except KeyboardInterrupt as exc:
+            logger.warning("Worker future interrupted; converting to worker_crash result")
             result = JobResult(
                 ok=False,
-                error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:500],
+                error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
+            )
+        except (SystemExit, GeneratorExit) as exc:
+            logger.info("Worker future exited during shutdown; converting to worker_crash result")
+            result = JobResult(
+                ok=False,
+                error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
             )
         except Exception as exc:
             logger.exception("Worker future raised; converting to worker_crash result")

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import queue
 import subprocess
@@ -1202,33 +1203,65 @@ class TestOnFutureDone:
         pool._on_future_done(handle, future)
         assert completion_q.empty()
 
-    @pytest.mark.parametrize(
-        "exc",
-        [RuntimeError("boom"), KeyboardInterrupt(), SystemExit(3), GeneratorExit()],
-    )
-    def test_raising_future_emits_worker_crash_completion(
+    def test_exception_future_emits_worker_crash_completion_and_logs_traceback(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
-        exc: BaseException,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Any exception from future.result() becomes a worker_crash result.
+        """RuntimeError from future.result() becomes worker_crash with traceback."""
+        handle = JobHandle(
+            job=BuildTestJob(repo="r", cwd=Path("/tmp"), argv=("true",), timeout_s=1),
+            on_done_state=StageName.CI,
+        )
+        future: Future[JobResult] = Future()
+        future.set_exception(RuntimeError("boom"))
 
-        Guarantees the class contract: a non-cancelled submit never loses its
-        completion, even for BaseException escapes.
-        """
+        with caplog.at_level(logging.INFO, logger=_WP):
+            pool._on_future_done(handle, future)
+
+        got_handle, result = completion_q.get_nowait()
+        assert got_handle is handle
+        assert result.ok is False
+        assert result.error.startswith("worker_crash: RuntimeError")
+        assert any(
+            record.levelno == logging.ERROR and record.exc_info is not None
+            for record in caplog.records
+        )
+
+    @pytest.mark.parametrize(
+        ("exc", "expected_level"),
+        [
+            (KeyboardInterrupt(), logging.WARNING),
+            (SystemExit(3), logging.INFO),
+            (GeneratorExit(), logging.INFO),
+        ],
+    )
+    def test_process_control_future_emits_worker_crash_completion_without_traceback(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        caplog: pytest.LogCaptureFixture,
+        exc: BaseException,
+        expected_level: int,
+    ) -> None:
+        """Process-control escapes stay at lower severity and do not log tracebacks."""
         handle = JobHandle(
             job=BuildTestJob(repo="r", cwd=Path("/tmp"), argv=("true",), timeout_s=1),
             on_done_state=StageName.CI,
         )
         future: Future[JobResult] = Future()
         future.set_exception(exc)
-        pool._on_future_done(handle, future)
+
+        with caplog.at_level(logging.INFO, logger=_WP):
+            pool._on_future_done(handle, future)
 
         got_handle, result = completion_q.get_nowait()
         assert got_handle is handle
         assert result.ok is False
         assert result.error.startswith(f"worker_crash: {type(exc).__name__}")
+        assert any(record.levelno == expected_level for record in caplog.records)
+        assert not any(record.exc_info is not None for record in caplog.records)
 
     def test_raising_future_emits_truncated_worker_crash_completion(
         self,


### PR DESCRIPTION
## Summary
Verdict: partial | Reason: [worker_pool.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1912/hephaestus/automation/pipeline/worker_pool.py) now logs `KeyboardInterrupt` at warning and `SystemExit`/`GeneratorExit` at info while reserving `logger.exception` for real `Exception` crashes, and [test_worker_pool.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1912/tests/unit/automation/pipeline/test_worker_pool.py) adds regressions for both paths; `python -m pytest tests/ -v` passed (6145 passed, 21 skipped), `python -m mypy hephaestus/` passed, `python -m ruff format --check hephaestus/ tests/` passed, `python -m ruff check hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py` passed, but `pre-commit run --files ...` is still blocked offline because hook bootstrap tries to fetch from GitHub/conda.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1912

Generated by ProjectHephaestus automation
