### PR TITLE
[nit] pr_review item.pr-None narrowing guard fails back to agent_error while ci/merge_wait return FINISH_FAIL(no_pr)

### DIFF
--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -562,8 +562,8 @@ class PrReviewStage(Stage):
         Zero open automation threads skip the address leg straight to EVAL
         (the legacy zero-thread guard — nothing to classify or address).
         """
-        if item.pr is None:  # guarded by step(); kept for type narrowing
-            return self._fail_back_agent_error(item)
+        if item.pr is None:  # guarded by step(); kept for restart safety
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
         raw_threads = [dict(t) for t in item.payload.get("review_threads") or []]
         threads = _surviving_threads(raw_threads, item.payload.get("validation_result"))
         item.payload["raw_review_threads"] = raw_threads
@@ -599,8 +599,8 @@ class PrReviewStage(Stage):
         leg is the designated recovery (bounded by the M1 agent_error
         budget consumption).
         """
-        if item.pr is None:  # guarded by step(); kept for type narrowing
-            return self._fail_back_agent_error(item)
+        if item.pr is None:  # guarded by step(); kept for restart safety
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
         if not item.worktree:
             logger.warning(
                 "pr_review:%s: no worktree for the address step; failing back "
@@ -661,8 +661,10 @@ class PrReviewStage(Stage):
         and cycle-relative ``payload`` gate) advance here, and only for real
         verdicts — never for ERROR or missing verdicts (#911/#1554/#1794).
         """
-        if item.pr is None or item.issue is None:  # guarded by step(); narrowing
-            return self._fail_back_agent_error(item)
+        if item.pr is None:  # guarded by step(); kept for restart safety
+            return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        if item.issue is None:  # guarded by step(); kept for type narrowing
+            return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
         payload = item.payload
 
         address_error = self._handle_address_error(item)

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
 from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
@@ -390,6 +392,33 @@ class TestPrReviewStageStep:
 
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.FINISH_FAIL
+
+
+class TestPrReviewRestartSafetyGuards:
+    """Unreachable PR-narrowing guards use the restart-safety no_pr contract."""
+
+    @pytest.mark.parametrize(
+        ("method_name", "state"),
+        [
+            pytest.param("_post", "POST", id="post"),
+            pytest.param("_address", "ADDRESS_WAIT", id="address"),
+            pytest.param("_eval", "EVAL", id="eval"),
+        ],
+    )
+    def test_unreachable_pr_none_guards_finish_no_pr(
+        self, make_ctx: Any, make_work_item: Any, method_name: str, state: str
+    ) -> None:
+        """Direct calls to the unreachable guards finish failed with no_pr."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, pr=None, state=state)
+
+        result = getattr(stage, method_name)(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "no_pr")
+        assert "agent_error_failback" not in item.payload
+        assert github.mutation_log == []
 
 
 class TestEvalVerdicts:


### PR DESCRIPTION
## Summary
Verdict: pass | Reason: standardized the unreachable pr_review pr-None guards in [pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1920/hephaestus/automation/pipeline/stages/pr_review.py#L565), [pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1920/hephaestus/automation/pipeline/stages/pr_review.py#L602), and [pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1920/hephaestus/automation/pipeline/stages/pr_review.py#L664) to `FINISH_FAIL("no_pr")`, added a regression in [test_stage_pr_review.py](/mnt/weka/home/micah.villmow/Projects/ProjectHephaestus/build/.worktrees/issue-1920/tests/unit/automation/pipeline/stages/test_stage_pr_review.py#L397), and verified with `pixi run --as-is -e default python -m pytest tests/ -v` (6149 passed, 21 skipped).

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1920

Generated by ProjectHephaestus automation
