### PR TITLE
[nit] PRE_PR_TEST_ARGV hardcodes tests/unit and pixi with no config override

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -116,6 +116,7 @@ from hephaestus.automation.pipeline.stages import (
     StageContext,
     StageGitHub,
 )
+from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.stages.repo import product_to_work_item
 from hephaestus.automation.pipeline.summary import RunStats, print_summary
 from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
@@ -217,6 +218,10 @@ class PipelineConfig:
     # coordinator's budget accessor. ``--max-fix-iterations N`` maps to
     # ``{"ci_fix": N}`` so the CI-fix attempt budget is caller-tunable.
     budget_overrides: dict[str, int] = field(default_factory=dict)
+    # Configurable argv for the optional pre-PR unit-test gate. The
+    # implementation stage reads this vector instead of hardcoding the test
+    # command so non-pixi repos and non-standard unit-test layouts can opt in.
+    pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV
     serialize_file_overlap: bool = True
     event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
@@ -252,6 +257,7 @@ class _StageRunConfig:
     drive_green_all: bool = False
     enable_mechanical_rebase: bool = True
     poll_max_wait: int = DEFAULT_CI_POLL_MAX_WAIT
+    pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV
 
 
 @dataclass
@@ -363,6 +369,7 @@ class Coordinator:
             drive_green_all=config.drive_green_all,
             enable_mechanical_rebase=config.enable_mechanical_rebase,
             poll_max_wait=config.poll_max_wait,
+            pre_pr_test_argv=config.pre_pr_test_argv,
         )
         self._ctx_cache: dict[str, StageContext] = {}
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -441,10 +441,11 @@ class ImplementationStage(Stage):
         item.payload.pop("tests_failed", None)
         item.payload.pop("test_output", None)
         logger.info("implementation:%d: requesting pre-PR test job", issue)
+        test_argv = tuple(getattr(ctx.config, "pre_pr_test_argv", PRE_PR_TEST_ARGV))
         test_job = BuildTestJob(
             repo=item.repo,
             cwd=_worktree_path(item, ctx),
-            argv=PRE_PR_TEST_ARGV,
+            argv=test_argv,
             timeout_s=PRE_PR_TEST_TIMEOUT_S,
             descr="pre_pr_tests",
         )

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -25,7 +25,7 @@ def _utcnow() -> datetime:
 
 def _default_attempts() -> dict[str, int]:
     """Return zeroed per-item-lifetime counters, one per budget key."""
-    return {key: 0 for key in budget_keys()}
+    return dict.fromkeys(budget_keys(), 0)
 
 
 class ItemKind(str, Enum):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -78,9 +78,7 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(
-        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
-    )
+    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
     return automation, len(threads) - automation
 
 

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -16,6 +16,7 @@ import pytest
 
 from hephaestus.automation.pipeline.routing import ROUTES, StageName
 from hephaestus.automation.pipeline.stages import StageContext, StageGitHub
+from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from tests.unit.automation.pipeline.conftest import FakeGitHub
@@ -330,6 +331,7 @@ class _Config:
         self.force = False
         self.agent = "claude"
         self.dry_run = dry_run
+        self.pre_pr_test_argv = PRE_PR_TEST_ARGV
 
 
 class _Paths:

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -12,10 +12,10 @@ from hephaestus.automation.pipeline.stages import (
     PlanningStage,
     PlanReviewStage,
     Stage,
+    base as stage_base,
     ci,
     merge_wait,
 )
-from hephaestus.automation.pipeline.stages import base as stage_base
 from hephaestus.automation.pipeline.stages.base import (
     BACKOFF_CAP_S,
     Continue,

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -679,6 +679,20 @@ class TestTestsAndFix:
         assert result.on_done_state == "COMMIT_PUSH_WAIT"
         assert "tests_failed" not in item.payload  # stale result cleared at submit
 
+    def test_tests_enabled_use_configured_argv(self, make_ctx: Any, make_work_item: Any) -> None:
+        """The pre-PR test command comes from config when overridden."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        ctx.config.run_pre_pr_tests = True
+        ctx.config.pre_pr_test_argv = ("pytest", "tests/custom", "-q")
+        item = make_work_item(issue=1, state="TEST_WAIT")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, BuildTestJob)
+        assert result.job.argv == ("pytest", "tests/custom", "-q")
+
     def test_failed_tests_route_to_testfix(self, make_ctx: Any, make_work_item: Any) -> None:
         """A red test run stores the output and routes to TESTFIX_WAIT."""
         stage = ImplementationStage()

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -85,9 +85,8 @@ class TestCoordinatorCapOwnership:
 
     def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
         """The deferred cap is intentionally owned by Coordinator._admit."""
-        assert (
-            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
-            in (admission.__doc__ or "")
+        assert ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`" in (
+            admission.__doc__ or ""
         )
 
 

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -10,8 +10,8 @@ from hephaestus.automation.pipeline import (
     ItemResult,
     StageName,
     WorkItem,
+    work_item as work_item_module,
 )
-from hephaestus.automation.pipeline import work_item as work_item_module
 from hephaestus.automation.pipeline.routing import budget_keys
 
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,8 +1,8 @@
 """Tests for GitHub API utilities."""
 
 import json
-import threading
 import subprocess
+import threading
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -11,7 +11,6 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
-from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -38,6 +37,7 @@ from hephaestus.automation.github_api import (
     skip_epics,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.io import utils as io_utils
 
 # Circuit-breaker reset is now an autouse package-scope fixture in


### PR DESCRIPTION
## Summary
Verdict: complete | Reason: `PRE_PR_TEST_ARGV` now flows from pipeline config into the implementation stage, with a regression test covering overrides; verified with `python -m pytest tests/ -v` (6148 passed), `mypy hephaestus/`, and `ruff` on the touched files.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1921

Generated by ProjectHephaestus automation
