### PR TITLE
fix(pipeline): use REST for PR comment upserts

### DIFF
--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -25,7 +25,7 @@ def _utcnow() -> datetime:
 
 def _default_attempts() -> dict[str, int]:
     """Return zeroed per-item-lifetime counters, one per budget key."""
-    return {key: 0 for key in budget_keys()}
+    return dict.fromkeys(budget_keys(), 0)
 
 
 class ItemKind(str, Enum):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -78,9 +78,7 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(
-        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
-    )
+    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
     return automation, len(threads) - automation
 
 
@@ -422,25 +420,29 @@ class PipelineGitHub:
         return threads
 
     def _repo_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
-        """Fetch issue comment ids/bodies for explicit-repo marker upserts."""
-        query = (
-            "query($owner:String!,$name:String!,$number:Int!){"
-            "  repository(owner:$owner,name:$name){"
-            "    issue(number:$number){"
-            "      comments(first:100){ nodes{ databaseId body } }"
-            "    }"
-            "  }"
-            "}"
+        """Fetch issue/PR comment ids and bodies for explicit-repo marker upserts."""
+        owner, name = self._owner_name()
+        result = gh_call(
+            [
+                "api",
+                f"/repos/{owner}/{name}/issues/{int(issue_number)}/comments",
+                "--paginate",
+                "--slurp",
+            ]
         )
-        data = self._graphql(query, number=int(issue_number))
-        nodes = (
-            data.get("data", {})
-            .get("repository", {})
-            .get("issue", {})
-            .get("comments", {})
-            .get("nodes", [])
-        )
-        return [node for node in nodes if isinstance(node, dict)]
+        data = json.loads(result.stdout or "[]")
+        pages = data if isinstance(data, list) else []
+        nodes: list[dict[str, Any]] = []
+        for page in pages:
+            page_nodes = page if isinstance(page, list) else [page]
+            for node in page_nodes:
+                if not isinstance(node, dict):
+                    continue
+                normalized = dict(node)
+                if normalized.get("databaseId") is None and normalized.get("id") is not None:
+                    normalized["databaseId"] = normalized["id"]
+                nodes.append(normalized)
+        return nodes
 
     def _repo_review_threads_for_review(self, pr_number: int, review_id: str) -> list[str]:
         """Return unresolved review-thread ids created by one REST review."""

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -12,10 +12,10 @@ from hephaestus.automation.pipeline.stages import (
     PlanningStage,
     PlanReviewStage,
     Stage,
+    base as stage_base,
     ci,
     merge_wait,
 )
-from hephaestus.automation.pipeline.stages import base as stage_base
 from hephaestus.automation.pipeline.stages.base import (
     BACKOFF_CAP_S,
     Continue,

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -85,9 +85,8 @@ class TestCoordinatorCapOwnership:
 
     def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
         """The deferred cap is intentionally owned by Coordinator._admit."""
-        assert (
-            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
-            in (admission.__doc__ or "")
+        assert ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`" in (
+            admission.__doc__ or ""
         )
 
 

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -10,8 +10,8 @@ from hephaestus.automation.pipeline import (
     ItemResult,
     StageName,
     WorkItem,
+    work_item as work_item_module,
 )
-from hephaestus.automation.pipeline import work_item as work_item_module
 from hephaestus.automation.pipeline.routing import budget_keys
 
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,8 +1,8 @@
 """Tests for GitHub API utilities."""
 
 import json
-import threading
 import subprocess
+import threading
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -11,7 +11,6 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
-from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -38,6 +37,7 @@ from hephaestus.automation.github_api import (
     skip_epics,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.io import utils as io_utils
 
 # Circuit-breaker reset is now an autouse package-scope fixture in

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -233,6 +233,33 @@ class TestRepoScoping:
             ],
         ]
 
+    def test_repo_scoped_pr_comment_upsert_reads_pr_comments_via_rest_issue_channel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PR numbers are valid issue-comment REST targets but not GraphQL issue nodes."""
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv == ["api", "/repos/org/repo-a/issues/1001/comments", "--paginate", "--slurp"]:
+                payload = [[{"id": 42, "body": "<!-- marker -->\nstale"}]]
+                return SimpleNamespace(stdout=json.dumps(payload))
+            return SimpleNamespace(stdout="")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path).upsert_pr_comment(
+            1001, "<!-- marker -->", "<!-- marker -->\nupdated"
+        )
+
+        assert calls[0] == [
+            "api",
+            "/repos/org/repo-a/issues/1001/comments",
+            "--paginate",
+            "--slurp",
+        ]
+        assert all("graphql" not in call for call in calls)
+
     def test_repo_scoped_has_existing_plan_detects_plan_comment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -355,20 +382,8 @@ class TestRepoScoping:
 
         def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
             calls.append(argv)
-            if argv[:2] == ["api", "graphql"]:
-                payload = {
-                    "data": {
-                        "repository": {
-                            "issue": {
-                                "comments": {
-                                    "nodes": [
-                                        {"databaseId": 9, "body": f"{PLAN_COMMENT_MARKER}\nold"}
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                }
+            if argv == ["api", "/repos/org/repo-a/issues/5/comments", "--paginate", "--slurp"]:
+                payload = [[{"id": 9, "body": f"{PLAN_COMMENT_MARKER}\nold"}]]
                 return SimpleNamespace(stdout=json.dumps(payload))
             return SimpleNamespace(stdout="")
 
@@ -390,18 +405,8 @@ class TestRepoScoping:
 
         def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
             calls.append(argv)
-            if argv[:2] == ["api", "graphql"]:
-                payload = {
-                    "data": {
-                        "repository": {
-                            "issue": {
-                                "comments": {
-                                    "nodes": [{"databaseId": 12, "body": f"{marker}\nold"}]
-                                }
-                            }
-                        }
-                    }
-                }
+            if argv == ["api", "/repos/org/repo-a/issues/7/comments", "--paginate", "--slurp"]:
+                payload = [[{"id": 12, "body": f"{marker}\nold"}]]
                 return SimpleNamespace(stdout=json.dumps(payload))
             return SimpleNamespace(stdout="")
 


### PR DESCRIPTION
## Summary
- route repo-scoped marker comment discovery through the REST issue-comments endpoint so issue and PR numbers both work
- normalize REST comment ids to the existing databaseId shape before PATCH/DELETE marker upserts
- add regression coverage proving PR-number upserts do not use GraphQL repository.issue(number:)
- include minimal repo-wide ruff/format fixes required by current main's static gates

Closes #2009

## Verification
- pixi run pytest tests/unit/automation/test_pipeline_github.py tests/unit/automation/pipeline/test_work_item.py tests/unit/automation/test_github_api.py tests/unit/automation/pipeline/test_admission.py -q --no-cov
- pixi run pytest tests/unit -q --no-cov
- pixi run ruff check hephaestus/ tests/
- pixi run ruff format --check hephaestus/ tests/
- pixi run python -m mypy hephaestus/ scripts/ tests/
- pixi run pre-commit run --files hephaestus/automation/pipeline_github.py tests/unit/automation/test_pipeline_github.py hephaestus/automation/pipeline/work_item.py tests/unit/automation/pipeline/test_work_item.py tests/unit/automation/test_github_api.py tests/unit/automation/pipeline/test_admission.py

## Notes
- The full unit run was before the final formatter-only admission-test amend; post-amend targeted tests cover every changed file and all static/pre-commit gates pass.
