### PR TITLE
fix(pipeline): disambiguate finish state names

### DIFF
--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -8,7 +8,7 @@ binding contract):
 
 - States: ENTER -> ARM -> POLL -> DIRTY_REBASE_WAIT -> DIRTY_PUSH_WAIT |
   BLOCKED_ADDRESS_WAIT -> BLOCKED_PUSH_WAIT -> (POLL) -> LEARN_WAIT ->
-  FINISH. Budgets: ``blocked_address`` = 2, ``rebase`` = 2 (both consumed
+  MW_FINISH. Budgets: ``blocked_address`` = 2, ``rebase`` = 2 (both consumed
   in ``on_job_done``, read from ROUTES via ``ctx.budget``); the ``merge``
   poll-window bound stays wall-clock (below), untouched by the pipeline.
 - ARM [M, durable]: arm squash auto-merge (``ctx.github.arm_auto_merge``)
@@ -53,9 +53,9 @@ binding contract):
   in-worker by :func:`build_drive_green_learn_prompt` reusing
   ``learn.build_learn_prompt`` verbatim. Best-effort: ``on_job_done``
   durably marks the learn result on the arming record
-  (``ctx.github.mark_drive_green_learn_result``) BEFORE FINISH — success
+  (``ctx.github.mark_drive_green_learn_result``) BEFORE MW_FINISH — success
   or failure alike, so a restart never replays ``/learn`` — and a failed
-  learn never flips a merged PR to failure (FINISH is FINISH_PASS
+  learn never flips a merged PR to failure (MW_FINISH is FINISH_PASS
   regardless).
 - Owned labels: none (merge state is PR state); ``state:skip`` only on the
   genuinely-stuck exhaustion path above.
@@ -112,7 +112,8 @@ DIRTY_PUSH_WAIT = "DIRTY_PUSH_WAIT"
 BLOCKED_ADDRESS_WAIT = "BLOCKED_ADDRESS_WAIT"
 BLOCKED_PUSH_WAIT = "BLOCKED_PUSH_WAIT"
 LEARN_WAIT = "LEARN_WAIT"
-FINISH = "FINISH"
+MW_FINISH = "MW_FINISH"
+FINISH = MW_FINISH
 
 #: Env var bounding the merge wait (legacy ``_wait_for_pr_terminal`` budget).
 MERGE_MAX_WAIT_ENV = "HEPH_PR_MERGE_MAX_WAIT"
@@ -196,7 +197,7 @@ class MergeWaitStage(Stage):
             return self._request_blocked_push(item, ctx)
         if item.state == LEARN_WAIT:
             return self._request_learn(item, ctx)
-        if item.state == FINISH:
+        if item.state == MW_FINISH:
             # The PR merged; /learn already ran (best-effort) and its result
             # was durably marked in on_job_done. A failed learn never flips
             # a merged PR to failure.
@@ -509,7 +510,7 @@ class MergeWaitStage(Stage):
         Prompt composed in-worker by :func:`build_drive_green_learn_prompt`.
         The dedupe already held at ``_route_merged`` (a terminal record never
         reaches here); ``on_job_done`` durably marks the outcome on the
-        arming record BEFORE FINISH, closing the exactly-once loop.
+        arming record BEFORE MW_FINISH, closing the exactly-once loop.
         """
         job = AgentJob(
             repo=item.repo,
@@ -526,7 +527,7 @@ class MergeWaitStage(Stage):
             },
             descr="drive_green_learn",
         )
-        return JobRequest(job, on_done_state=FINISH)
+        return JobRequest(job, on_done_state=MW_FINISH)
 
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Consume budgets and record result flags (state is still the WAIT state).

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -6,7 +6,8 @@ binding contract). It fully owns the review/amend/learn loop that the legacy
 planner review loop used to run before ``hephaestus-plan-issues`` was
 re-pointed at the pipeline (#1820):
 
-- States: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT -> (loop) -> LEARN_WAIT.
+- States: ENTER -> REVIEW_WAIT -> EVAL -> AMEND_WAIT -> (loop) -> LEARN_WAIT
+  -> PLAN_FINISH.
 - Budgets: ``plan_review_iter`` = 3 (max review iterations per cycle),
   ``plan_cycles`` = 2 (max plan->review->amend cycles before giving up).
 - Iteration accounting: ``item.attempts["plan_review_iter"]`` is the
@@ -81,6 +82,15 @@ from .base import (
 from .planning import build_plan_prompt
 
 logger = logging.getLogger(__name__)
+
+# In-memory mini-states (stage-local strings, never GitHub labels).
+ENTER = "ENTER"
+REVIEW_WAIT = "REVIEW_WAIT"
+EVAL = "EVAL"
+AMEND_WAIT = "AMEND_WAIT"
+LEARN_WAIT = "LEARN_WAIT"
+PLAN_FINISH = "PLAN_FINISH"
+FINISH = PLAN_FINISH
 
 #: Max CONSECUTIVE reviewer-infrastructure failures (ERROR verdicts or
 #: failed/valueless review jobs) tolerated before the item FINISH_FAILs.
@@ -292,9 +302,9 @@ class PlanReviewStage(Stage):
                 prompt_kwargs={"context": item.payload.get("plan_text", "")},
                 descr="learn",
             )
-            return JobRequest(job, on_done_state="FINISH")
+            return JobRequest(job, on_done_state=PLAN_FINISH)
 
-        if item.state == "FINISH":
+        if item.state == PLAN_FINISH:
             logger.info("plan_review:%d: learn completed; advancing", item.issue)
             return StageOutcome(Disposition.ADVANCE, "plan approved and learned")
 

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -163,7 +163,8 @@ ADDRESS_WAIT = "ADDRESS_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
 EVAL = "EVAL"
 FOLLOWUP_WAIT = "FOLLOWUP_WAIT"
-FINISH = "FINISH"
+PR_FINISH = "PR_FINISH"
+FINISH = PR_FINISH
 
 _STEP_HANDLER_NAMES: dict[str, str] = {
     ENTER: "_enter",
@@ -175,7 +176,7 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     PUSH_WAIT: "_push_wait",
     EVAL: "_eval",
     FOLLOWUP_WAIT: "_followup_wait",
-    FINISH: "_finish",
+    PR_FINISH: "_finish",
 }
 
 
@@ -338,7 +339,7 @@ class PrReviewStage(Stage):
     - PUSH_WAIT: commit+push the addressing changes.
     - EVAL [M]: re-housed ``_evaluate_go_verdict`` + budget gate (see
       module docstring).
-    - FOLLOWUP_WAIT (GO only): submit the follow-up job, then FINISH ->
+    - FOLLOWUP_WAIT (GO only): submit the follow-up job, then PR_FINISH ->
       ADVANCE.
     """
 
@@ -522,7 +523,7 @@ class PrReviewStage(Stage):
         return JobRequest(git_job, on_done_state=EVAL)
 
     def _followup_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """FOLLOWUP_WAIT submits the follow-up job before FINISH advances."""
+        """FOLLOWUP_WAIT submits the follow-up job before PR_FINISH advances."""
         issue = _issue_number(item)
         logger.info("pr_review:%d: requesting follow-up job", issue)
         job = AgentJob(
@@ -537,10 +538,10 @@ class PrReviewStage(Stage):
             prompt_kwargs={"issue_number": item.issue},
             descr="follow_up",
         )
-        return JobRequest(job, on_done_state=FINISH)
+        return JobRequest(job, on_done_state=PR_FINISH)
 
     def _finish(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """FINISH advances after the follow-up job completes."""
+        """PR_FINISH advances after the follow-up job completes."""
         issue = _issue_number(item)
         logger.info("pr_review:%d: follow-up completed; advancing", issue)
         return StageOutcome(Disposition.ADVANCE, "implementation review approved")

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -25,7 +25,7 @@ def _utcnow() -> datetime:
 
 def _default_attempts() -> dict[str, int]:
     """Return zeroed per-item-lifetime counters, one per budget key."""
-    return {key: 0 for key in budget_keys()}
+    return dict.fromkeys(budget_keys(), 0)
 
 
 class ItemKind(str, Enum):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -78,9 +78,7 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(
-        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
-    )
+    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
     return automation, len(threads) - automation
 
 

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -12,10 +12,10 @@ from hephaestus.automation.pipeline.stages import (
     PlanningStage,
     PlanReviewStage,
     Stage,
+    base as stage_base,
     ci,
     merge_wait,
 )
-from hephaestus.automation.pipeline.stages import base as stage_base
 from hephaestus.automation.pipeline.stages.base import (
     BACKOFF_CAP_S,
     Continue,

--- a/tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
@@ -1,0 +1,10 @@
+"""Naming checks for stage-local finish mini-states."""
+
+from __future__ import annotations
+
+from hephaestus.automation.pipeline.stages import merge_wait, plan_review, pr_review
+
+
+def test_plan_review_pr_review_and_merge_wait_finish_states_are_distinct() -> None:
+    """Each stage should use a unique finish token in persisted state."""
+    assert len({pr_review.PR_FINISH, plan_review.PLAN_FINISH, merge_wait.MW_FINISH}) == 3

--- a/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_merge_wait.py
@@ -16,9 +16,9 @@ from hephaestus.automation.pipeline.stages.merge_wait import (
     DIRTY_PUSH_WAIT,
     DIRTY_REBASE_WAIT,
     ENTER,
-    FINISH,
     LEARN_WAIT,
     MERGE_MAX_WAIT_ENV,
+    MW_FINISH,
     POLL,
     MergeWaitStage,
     build_drive_green_learn_prompt,
@@ -634,10 +634,10 @@ class TestMergeWaitLearn:
         assert "issue #9" in prompt
 
     def test_finish_state_is_terminal_pass(self, make_ctx: Any, make_work_item: Any) -> None:
-        """FINISH always passes — /learn outcome can never flip a merged PR."""
+        """MW_FINISH always passes — /learn outcome can never flip a merged PR."""
         stage = MergeWaitStage()
         ctx = make_ctx(github=FakeStageGitHub())
-        item = _armed_item(make_work_item, state=FINISH)
+        item = _armed_item(make_work_item, state=MW_FINISH)
 
         assert stage.step(item, ctx) == StageOutcome(Disposition.FINISH_PASS, "merged")
 
@@ -672,7 +672,7 @@ class TestMergeWaitOnJobDone:
             assert "rebase_clean" not in item.payload
 
     def test_learn_wait_step_dispatches_learn_job(self, make_ctx: Any, make_work_item: Any) -> None:
-        """LEARN_WAIT submits the composed learn job targeting FINISH."""
+        """LEARN_WAIT submits the composed learn job targeting MW_FINISH."""
         stage = MergeWaitStage()
         ctx = make_ctx(github=FakeStageGitHub())
         item = _armed_item(make_work_item, state=LEARN_WAIT)
@@ -682,6 +682,6 @@ class TestMergeWaitOnJobDone:
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)
         assert result.job.prompt_builder is build_drive_green_learn_prompt
-        assert result.on_done_state == FINISH
+        assert result.on_done_state == MW_FINISH
         prompt = result.job.prompt_builder(**result.job.prompt_kwargs)
         assert "PR #601" in prompt

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -12,6 +12,7 @@ from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.plan_review import (
+    PLAN_FINISH,
     REVIEW_ERROR_RETRY_CAP,
     PlanReviewStage,
     build_amend_prompt,
@@ -386,15 +387,15 @@ class TestPlanReviewStageStep:
 
         assert isinstance(result, JobRequest)
         assert isinstance(result.job, AgentJob)  # narrow the job union
-        assert result.on_done_state == "FINISH"
+        assert result.on_done_state == PLAN_FINISH
         assert result.job.descr == "learn"
         assert result.job.prompt_kwargs == {"context": "# My Plan\n..."}
 
     def test_finish_advances(self, make_ctx: Any, make_work_item: Any) -> None:
-        """FINISH advances to the next stage."""
+        """PLAN_FINISH advances to the next stage."""
         stage = PlanReviewStage()
         ctx = make_ctx()
-        item = make_work_item(issue=12, state="FINISH")
+        item = make_work_item(issue=12, state=PLAN_FINISH)
 
         result = stage.step(item, ctx)
 
@@ -785,7 +786,7 @@ class TestReviewFlowWithFakePool:
         """Full pool-driven walk of the whole stage.
 
         ENTER -> REVIEW -> EVAL(NOGO) -> AMEND -> REVIEW -> EVAL(GO) ->
-        LEARN -> FINISH -> ADVANCE.
+        LEARN -> PLAN_FINISH -> ADVANCE.
         """
         from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -13,6 +13,7 @@ from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.pr_review import (
+    PR_FINISH,
     REVIEW_ERROR_RETRY_CAP,
     PrReviewStage,
     _surviving_threads,
@@ -380,7 +381,7 @@ class TestPrReviewStageStep:
         assert result.on_done_state == "EVAL"
 
     def test_followup_wait_requests_follow_up(self, make_ctx: Any, make_work_item: Any) -> None:
-        """FOLLOWUP_WAIT submits the follow-up job, then FINISH advances."""
+        """FOLLOWUP_WAIT submits the follow-up job, then PR_FINISH advances."""
         stage = PrReviewStage()
         ctx = make_ctx()
         item = make_work_item(issue=1, pr=1001, state="FOLLOWUP_WAIT")
@@ -389,9 +390,9 @@ class TestPrReviewStageStep:
 
         assert isinstance(result, JobRequest)
         assert result.job.descr == "follow_up"
-        assert result.on_done_state == "FINISH"
+        assert result.on_done_state == PR_FINISH
 
-        item.state = "FINISH"
+        item.state = PR_FINISH
         outcome = stage.step(item, ctx)
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition == Disposition.ADVANCE

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -85,9 +85,8 @@ class TestCoordinatorCapOwnership:
 
     def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
         """The deferred cap is intentionally owned by Coordinator._admit."""
-        assert (
-            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
-            in (admission.__doc__ or "")
+        assert ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`" in (
+            admission.__doc__ or ""
         )
 
 

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -10,8 +10,8 @@ from hephaestus.automation.pipeline import (
     ItemResult,
     StageName,
     WorkItem,
+    work_item as work_item_module,
 )
-from hephaestus.automation.pipeline import work_item as work_item_module
 from hephaestus.automation.pipeline.routing import budget_keys
 
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,8 +1,8 @@
 """Tests for GitHub API utilities."""
 
 import json
-import threading
 import subprocess
+import threading
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -11,7 +11,6 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
-from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -38,6 +37,7 @@ from hephaestus.automation.github_api import (
     skip_epics,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.io import utils as io_utils
 
 # Circuit-breaker reset is now an autouse package-scope fixture in


### PR DESCRIPTION
## Summary
- give plan_review, pr_review, and merge_wait distinct persisted finish mini-state names
- keep compatibility aliases while routing each stage through its own finish token
- add a regression test that the stage-local finish tokens are distinct

Closes #1922

## Verification
- pixi run pytest tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py tests/unit/automation/pipeline/stages/test_stage_merge_wait.py tests/unit/automation/pipeline/stages/test_stage_plan_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py -q --no-cov
- pixi run ruff check hephaestus/automation/pipeline/stages/merge_wait.py hephaestus/automation/pipeline/stages/plan_review.py hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_merge_wait.py tests/unit/automation/pipeline/stages/test_stage_plan_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
- pixi run ruff format --check hephaestus/automation/pipeline/stages/merge_wait.py hephaestus/automation/pipeline/stages/plan_review.py hephaestus/automation/pipeline/stages/pr_review.py tests/unit/automation/pipeline/stages/test_stage_merge_wait.py tests/unit/automation/pipeline/stages/test_stage_plan_review.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py