### PR TITLE
fix(pipeline): default stage budgets from routes

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -60,7 +60,7 @@ from hephaestus.agents.runtime import DEFAULT_AGENT
 from hephaestus.automation.state_labels import STATE_SKIP
 
 from ..jobs import AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
-from ..routing import Disposition, StageName, StageOutcome
+from ..routing import ROUTES, Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
 
 __all__ = [
@@ -444,7 +444,7 @@ class StageContext:
     github: StageGitHub  # coordinator-owned GitHub accessor (label/comment/PR writes+reads)
     paths: Any  # coordinator-owned path accessor (repo_root, worktree)
     now_fn: Callable[[], float] | None = None  # injectable clock (tests pass a fake)
-    budget_fn: Callable[[str], int] | None = None  # routing accessor: ROUTES budget lookup
+    budget_fn: Callable[[str], int] | None = None  # injected overrides; falls back to ROUTES
 
     def now(self) -> float:
         """Return the current time in seconds since epoch (injectable for tests)."""
@@ -456,7 +456,10 @@ class StageContext:
         """Look up the budget for a given counter name from the routing tables."""
         if self.budget_fn is not None:
             return self.budget_fn(name)
-        return 1  # conservative default
+        for route in ROUTES.values():
+            if name in route.budgets:
+                return route.budgets[name]
+        return 1  # conservative default for unknown keys
 
 
 def agent_provider(ctx: StageContext) -> str:

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -25,7 +25,7 @@ def _utcnow() -> datetime:
 
 def _default_attempts() -> dict[str, int]:
     """Return zeroed per-item-lifetime counters, one per budget key."""
-    return {key: 0 for key in budget_keys()}
+    return dict.fromkeys(budget_keys(), 0)
 
 
 class ItemKind(str, Enum):

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -78,9 +78,7 @@ def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
     if not threads:
         return (0, 0)
     current_login = github_api.gh_current_login()
-    automation = sum(
-        1 for thread in threads if _is_automation_owned_thread(thread, current_login)
-    )
+    automation = sum(1 for thread in threads if _is_automation_owned_thread(thread, current_login))
     return automation, len(threads) - automation
 
 

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -7,6 +7,9 @@ from types import SimpleNamespace
 
 import pytest
 
+import pytest
+
+from hephaestus.automation.pipeline import ROUTES
 from hephaestus.automation.pipeline.routing import Disposition, StageOutcome
 from hephaestus.automation.pipeline.stages import (
     PlanningStage,
@@ -22,6 +25,12 @@ from hephaestus.automation.pipeline.stages.base import (
     JobRequest,
     StageContext,
     agent_provider,
+)
+
+KNOWN_ROUTE_BUDGETS: tuple[tuple[str, int], ...] = tuple(
+    (budget_name, budget_value)
+    for route in ROUTES.values()
+    for budget_name, budget_value in route.budgets.items()
 )
 
 
@@ -51,11 +60,19 @@ class TestStageContext:
 
     def test_budget_uses_injected_lookup(self) -> None:
         """budget() returns the injected routing lookup's value."""
-        ctx = self._bare_ctx(budget_fn=lambda name: {"plan": 2}.get(name, 0))
-        assert ctx.budget("plan") == 2
+        ctx = self._bare_ctx(budget_fn=lambda name: {"plan": 7}.get(name, 0))
+        assert ctx.budget("plan") == 7
 
-    def test_budget_defaults_conservatively(self) -> None:
-        """budget() without a lookup defaults to 1 (never unbounded)."""
+    @pytest.mark.parametrize(("budget_name", "expected"), KNOWN_ROUTE_BUDGETS)
+    def test_budget_defaults_to_route_budget_for_known_keys(
+        self, budget_name: str, expected: int
+    ) -> None:
+        """budget() falls back to the declared ROUTES budget for known keys."""
+        ctx = self._bare_ctx()
+        assert ctx.budget(budget_name) == expected
+
+    def test_budget_unknown_key_defaults_conservatively(self) -> None:
+        """budget() without a lookup returns 1 for unknown keys only."""
         ctx = self._bare_ctx()
         assert ctx.budget("anything") == 1
 

--- a/tests/unit/automation/pipeline/stages/test_stage_base.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_base.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
 from types import SimpleNamespace
-
-import pytest
+from typing import Any
 
 import pytest
 
@@ -15,10 +13,10 @@ from hephaestus.automation.pipeline.stages import (
     PlanningStage,
     PlanReviewStage,
     Stage,
+    base as stage_base,
     ci,
     merge_wait,
 )
-from hephaestus.automation.pipeline.stages import base as stage_base
 from hephaestus.automation.pipeline.stages.base import (
     BACKOFF_CAP_S,
     Continue,

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -85,9 +85,8 @@ class TestCoordinatorCapOwnership:
 
     def test_admission_docstring_cross_references_coordinator_admit(self) -> None:
         """The deferred cap is intentionally owned by Coordinator._admit."""
-        assert (
-            ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`"
-            in (admission.__doc__ or "")
+        assert ":meth:`~hephaestus.automation.pipeline.coordinator.Coordinator._admit`" in (
+            admission.__doc__ or ""
         )
 
 

--- a/tests/unit/automation/pipeline/test_work_item.py
+++ b/tests/unit/automation/pipeline/test_work_item.py
@@ -10,8 +10,8 @@ from hephaestus.automation.pipeline import (
     ItemResult,
     StageName,
     WorkItem,
+    work_item as work_item_module,
 )
-from hephaestus.automation.pipeline import work_item as work_item_module
 from hephaestus.automation.pipeline.routing import budget_keys
 
 

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1,8 +1,8 @@
 """Tests for GitHub API utilities."""
 
 import json
-import threading
 import subprocess
+import threading
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -11,7 +11,6 @@ import pytest
 
 import hephaestus.automation.github_api as _github_api_module
 import hephaestus.github.client as client_module
-from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.automation.github_api import (
     GitHubRateLimitError,
     _check_graphql_errors,
@@ -38,6 +37,7 @@ from hephaestus.automation.github_api import (
     skip_epics,
 )
 from hephaestus.automation.models import IssueState
+from hephaestus.github.rate_limit import configure_gh_global_throttle
 from hephaestus.io import utils as io_utils
 
 # Circuit-breaker reset is now an autouse package-scope fixture in


### PR DESCRIPTION
## Summary
- make StageContext.budget fall back to declared ROUTES budgets for known counters
- keep the conservative 1 default only for unknown budget keys
- add regression coverage for injected budgets, route-backed defaults, and unknown-key fallback

Closes #1924

## Verification
- pixi run pytest tests/unit/automation/pipeline/stages/test_stage_base.py -q --no-cov
- pixi run ruff check hephaestus/automation/pipeline/stages/base.py tests/unit/automation/pipeline/stages/test_stage_base.py
- pixi run ruff format --check hephaestus/automation/pipeline/stages/base.py tests/unit/automation/pipeline/stages/test_stage_base.py