### PR TITLE
Fix queue prerequisite and adopted-worktree routing

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -380,8 +380,8 @@ pr_review → ci) remain globally bounded.
 | plan_review | implementation | planning (nogo, default), finished(fail) on plan_cycles_exhausted | plan_review_iter=3, plan_cycles=2 |
 | implementation | pr_review | plan_review (plan_not_go), ci (already_implementation_go_pr), finished(fail) on exhaustion | implement=2, test_fix=1 |
 | pr_review | ci | implementation (agent_error), finished(fail) on human_blocked, finished(skip) on exhaustion | pr_review_iter=3, pr_review_hard=6 |
-| ci | merge_wait | implementation (fix_exhausted), pr_review (not_implementation_go), finished(fail) on no_pr | ci_fix=1, rebase=2 |
-| merge_wait | finished(pass) | ci (ci_red), pr_review (blocked_exhausted), finished(fail) on closed/timeout | blocked_address=2, rebase=2, merge=--max-merge-attempts |
+| ci | merge_wait | implementation (fix_exhausted, missing_worktree), pr_review (not_implementation_go), finished(fail) on no_pr | ci_fix=1, rebase=2 |
+| merge_wait | finished(pass) | ci (ci_red), implementation (missing_worktree), pr_review (blocked_exhausted), finished(fail) on closed/timeout | blocked_address=2, rebase=2, merge=--max-merge-attempts |
 | finished | — | — | — |
 
 ## Seeding and reconstruction

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -29,7 +29,7 @@ from .session_naming import issue_auto_impl_branch_name as _session_issue_auto_i
 
 logger = logging.getLogger(__name__)
 
-COMMIT_POLICY_REWRITE_EXEC = "git commit --amend --no-edit -S -s"
+COMMIT_POLICY_REWRITE_EXEC = "git commit --amend --no-edit -S -s --allow-empty"
 
 
 def _timeout_kw(timeout: int | None) -> dict[str, Any]:
@@ -591,6 +591,7 @@ def _commit_policy_rebase_command(base_ref: str) -> list[str]:
         "git",
         "rebase",
         "--force-rebase",
+        "--empty=drop",
         base_ref,
         "--exec",
         COMMIT_POLICY_REWRITE_EXEC,

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -433,7 +433,7 @@ def _rebase_main(repo: str, repo_dir: Path) -> tuple[str, bool]:
             fetch_ok = False
     base_ref = _detect_remote_base_ref(repo, repo_dir)
     local_ahead = _local_ahead_count(repo, repo_dir, base_ref)
-    rebase_cmd = ["git", "-C", str(repo_dir), "rebase", base_ref]
+    rebase_cmd = ["git", "-C", str(repo_dir), "rebase", "--empty=drop", base_ref]
     if local_ahead > 0:
         rebase_cmd.extend(["--exec", COMMIT_POLICY_REWRITE_EXEC])
     rebase_cmd.append("--quiet")

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -186,7 +186,6 @@ class LoopConfig:
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
-    allow_unsafe_phase_order: bool = False
     # ``model`` is the catch-all applied to every phase when set; per-phase
     # fields below take precedence over it.
     model: str = ""
@@ -301,11 +300,6 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
-        "--allow-unsafe-phase-order",
-        action="store_true",
-        help="Silence dependency-ordering warnings when --phases skips a recommended predecessor",
-    )
-    p.add_argument(
         "--model",
         default="",
         help=(
@@ -385,22 +379,14 @@ def _validate_phases(phases_csv: str) -> tuple[str, ...]:
 
 
 def _phase_order_warnings(cfg: LoopConfig) -> list[str]:
-    """Dependency-ordering safety warnings for the 2-phase loop body.
+    """Return phase-order warnings.
 
-    Plan-review and PR-review/address-review fold into plan/implement; the
-    only remaining ordering hazard is selecting plan without implement
-    (planning-only, produces no PRs). drive-green intentionally supports being
-    run without implement so operators can drive existing PRs without opening
-    new work.
+    Queue stages own their prerequisites: a selected late stage either acts on
+    a satisfied item or routes it to the prerequisite queue. Therefore a phase
+    subset is an entry hint, not an unsafe ordering contract.
     """
-    warnings: list[str] = []
-    selected = set(cfg.phases)
-    if "plan" in selected and "implement" not in selected:
-        warnings.append(
-            "--phases includes 'plan' but not 'implement'; this is planning-only "
-            "and will not create implementation PRs"
-        )
-    return warnings
+    del cfg
+    return []
 
 
 def _pipeline_scope_for_phases(phases: tuple[str, ...]) -> PipelineScope | None:
@@ -679,7 +665,6 @@ def main(argv: list[str] | None = None) -> int:
         no_advise=args.no_advise,
         nitpick=args.nitpick,
         drive_green_all=args.drive_green_all,
-        allow_unsafe_phase_order=args.allow_unsafe_phase_order,
         model=args.model,
         planner_model=args.planner_model,
         reviewer_model=args.reviewer_model,
@@ -694,10 +679,6 @@ def main(argv: list[str] | None = None) -> int:
             args.phase_timeout if args.phase_timeout and args.phase_timeout > 0 else None
         ),
     )
-
-    if not cfg.allow_unsafe_phase_order:
-        for w in _phase_order_warnings(cfg):
-            LOG.warning("%s (pass --allow-unsafe-phase-order to silence)", w)
 
     if not repos:
         return _error_exit(args, "Repo list is empty; nothing to do.", "empty repo list")

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1209,9 +1209,37 @@ class Coordinator:
                 )
             )
         for pr in self.config.prs:
-            has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
             issue_number = github.find_issue_for_pr(pr)
             scope_identifier = issue_number if issue_number is not None else pr
+            pr_state = github.gh_pr_state(pr)
+            pr_state_name = ((pr_state or {}).get("state") or "").upper()
+            if pr_state_name == "MERGED":
+                entries.append(
+                    _seeding.SeedEntry(
+                        kind="pr",
+                        identifier=pr,
+                        stage=StageName.FINISHED,
+                        reason=f"PR #{pr} already merged",
+                        pr_number=pr,
+                        issue_number=issue_number,
+                        passed=True,
+                    )
+                )
+                continue
+            if pr_state_name == "CLOSED":
+                entries.append(
+                    _seeding.SeedEntry(
+                        kind="pr",
+                        identifier=pr,
+                        stage=StageName.FINISHED,
+                        reason=f"PR #{pr} already closed without merging",
+                        pr_number=pr,
+                        issue_number=issue_number,
+                        passed=False,
+                    )
+                )
+                continue
+            has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
             if has_go:
                 stage, reason, passed = self._scope_seed_decision(
                     scope_identifier,

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -132,6 +132,7 @@ ROUTES: dict[StageName, Route] = {
         fail_routes={
             "fix_exhausted": StageName.IMPLEMENTATION,
             "not_implementation_go": StageName.PR_REVIEW,
+            "missing_worktree": StageName.IMPLEMENTATION,
             "no_pr": StageName.FINISHED,
             "*": StageName.CI,
         },
@@ -142,6 +143,7 @@ ROUTES: dict[StageName, Route] = {
         fail_routes={
             "ci_red": StageName.CI,
             "blocked_exhausted": StageName.PR_REVIEW,
+            "missing_worktree": StageName.IMPLEMENTATION,
             "closed": StageName.FINISHED,
             "timeout": StageName.FINISHED,
             "*": StageName.FINISHED,

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -509,6 +509,19 @@ def _worktree_path(item: WorkItem, ctx: StageContext) -> Path:
     return Path(str(ctx.paths.worktree))
 
 
+def _require_item_worktree(item: WorkItem, stage_name: str, action: str) -> StageOutcome | None:
+    """Return a fail-back outcome when a mutating action lacks a worktree."""
+    if item.worktree:
+        return None
+    logger.warning(
+        "%s:%s: %s requires an item worktree; failing back to implementation",
+        stage_name,
+        item.issue if item.issue is not None else item.pr,
+        action,
+    )
+    return StageOutcome(Disposition.FAIL_BACK, "missing_worktree")
+
+
 def write_skip_label(issue_number: int, ctx: StageContext) -> None:
     """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
 

--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -88,6 +88,7 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _require_item_worktree,
     _worktree_path,
     agent_provider,
     stage_model,
@@ -326,6 +327,9 @@ class CiStage(Stage):
         if item.attempts.get("rebase", 0) >= ctx.budget("rebase"):
             logger.info("ci:%s: rebase budget spent; polling as-is", item.issue)
             return Continue(next_state=POLL)
+        missing_worktree = _require_item_worktree(item, "ci", "mechanical rebase")
+        if missing_worktree is not None:
+            return missing_worktree
         rebase_job = GitJob(
             repo=item.repo,
             op="rebase",
@@ -412,7 +416,7 @@ class CiStage(Stage):
         logger.warning("ci:%s: ci_fix budget exhausted; failing back", item.issue)
         return StageOutcome(Disposition.FAIL_BACK, "fix_exhausted")
 
-    def _request_fix(self, item: WorkItem, ctx: StageContext) -> JobRequest:
+    def _request_fix(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """FIX_WAIT [W:A]: dispatch the CI-fix (or force-engagement) session.
 
         The prompt is composed in-worker by :func:`build_ci_fix_prompt` — or
@@ -424,6 +428,9 @@ class CiStage(Stage):
         attempt can never replay an earlier attempt's outcome.
         """
         item.payload.pop("ci_fix_failed", None)
+        missing_worktree = _require_item_worktree(item, "ci", "CI fix")
+        if missing_worktree is not None:
+            return missing_worktree
         escalate = bool(item.payload.pop("force_engagement", None))
         prompt_builder: Callable[..., str]
         common_kwargs = {
@@ -471,6 +478,9 @@ class CiStage(Stage):
         """
         if item.payload.pop("ci_fix_failed", None):
             return Continue(next_state=POLL)
+        missing_worktree = _require_item_worktree(item, "ci", "CI fix push")
+        if missing_worktree is not None:
+            return missing_worktree
         push_job = GitJob(
             repo=item.repo,
             op="commit_push",

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -329,9 +329,13 @@ class ImplementationStage(Stage):
         issue = _issue_number(item)
         if item.payload.pop("git_error", None):
             # Worktree creation failed: transient infrastructure, not an
-            # implement outcome — RETRY without burning the implement
-            # budget, bounded by GIT_ERROR_RETRY_CAP (M5).
-            return self._git_retry(item, "worktree creation failed")
+            # implement outcome. If the retry budget remains, retry the
+            # worktree job itself; do not let adopted-PR state fall through
+            # to ADOPTED/ADOPTED_CI without a valid synced worktree.
+            outcome = self._git_retry(item, "worktree creation failed")
+            if outcome.disposition is Disposition.RETRY:
+                item.state = WORKTREE_WAIT
+            return outcome
         # Adopted-PR path: after the (clean or salvaged) worktree is
         # ready, skip the implement leg — the PR's code already exists;
         # pr_review's address leg drives it from here.
@@ -620,6 +624,10 @@ class ImplementationStage(Stage):
         """
         if not result.ok:
             logger.warning("implementation:%s: worktree job failed: %s", item.issue, result.error)
+            item.worktree = ""
+            item.payload.pop("worktree_dirty", None)
+            item.payload.pop("worktree_status", None)
+            item.payload.pop("worktree_diff", None)
             item.payload["git_error"] = True
             return
         # A successful worktree job ends the consecutive-git-failure streak.

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -10,7 +10,8 @@ binding contract):
 - States: ENTER -> GATE -> WORKTREE_WAIT -> DIRTY_DECISION_WAIT ->
   ADVISE_WAIT -> IMPLEMENT_WAIT -> TEST_WAIT -> TESTFIX_WAIT ->
   COMMIT_PUSH_WAIT -> PR_CREATE. The existing-PR fast path short-circuits
-  WORKTREE_WAIT -> DIRTY_DECISION_WAIT -> ADOPTED (ADVANCE to pr_review).
+  WORKTREE_WAIT -> DIRTY_DECISION_WAIT -> ADOPTED (ADVANCE to pr_review)
+  or ADOPTED_CI (fail-back to ci for implementation-go PRs).
 - Budgets: ``implement`` = 2 (bounds implement attempts INCLUDING
   agent_error retries — the doc's "agent_error -> RETRY (consumes the
   implement budget)"), ``test_fix`` = 1 (one fix attempt on red pre-PR
@@ -117,6 +118,7 @@ GATE = "GATE"
 WORKTREE_WAIT = "WORKTREE_WAIT"
 DIRTY_DECISION_WAIT = "DIRTY_DECISION_WAIT"
 ADOPTED = "ADOPTED"
+ADOPTED_CI = "ADOPTED_CI"
 ADVISE_WAIT = "ADVISE_WAIT"
 IMPLEMENT_WAIT = "IMPLEMENT_WAIT"
 TEST_WAIT = "TEST_WAIT"
@@ -130,6 +132,7 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     WORKTREE_WAIT: "_worktree_wait",
     DIRTY_DECISION_WAIT: "_dirty_decision_wait",
     ADOPTED: "_adopted",
+    ADOPTED_CI: "_adopted_ci",
     ADVISE_WAIT: "_advise_wait",
     IMPLEMENT_WAIT: "_implement_wait",
     TEST_WAIT: "_test_wait",
@@ -332,7 +335,10 @@ class ImplementationStage(Stage):
         # Adopted-PR path: after the (clean or salvaged) worktree is
         # ready, skip the implement leg — the PR's code already exists;
         # pr_review's address leg drives it from here.
-        adopted_next = ADOPTED if item.payload.get("existing_pr") else ADVISE_WAIT
+        if item.payload.get("existing_pr_impl_go"):
+            adopted_next = ADOPTED_CI
+        else:
+            adopted_next = ADOPTED if item.payload.get("existing_pr") else ADVISE_WAIT
         if not item.payload.get("worktree_dirty"):
             return Continue(next_state=adopted_next)
         logger.info("implementation:%d: requesting dirty-worktree decision", issue)
@@ -367,6 +373,17 @@ class ImplementationStage(Stage):
             item.branch,
         )
         return StageOutcome(Disposition.ADVANCE, f"existing PR #{item.pr}")
+
+    def _adopted_ci(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """ADOPTED_CI routes an implementation-go PR to CI after worktree setup."""
+        issue = _issue_number(item)
+        logger.info(
+            "implementation:%d: adopted implementation-go PR #%s (branch %r); routing to ci",
+            issue,
+            item.pr,
+            item.branch,
+        )
+        return StageOutcome(Disposition.FAIL_BACK, "already_implementation_go_pr")
 
     def _advise_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """ADVISE_WAIT either skips advice or submits the advise job."""
@@ -666,13 +683,25 @@ class ImplementationStage(Stage):
             has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(existing_pr)
             if has_go:
                 # item.pr/item.branch are set above so the ci stage receives
-                # a fully-identified PR (m7).
+                # a fully-identified PR (m7). CI also needs a per-item
+                # worktree for any mutating git job; prepare one first when
+                # this is a late-stage entry that only knew the PR.
+                if item.worktree:
+                    logger.info(
+                        "implementation:%d: PR #%d already implementation-go; routing to ci",
+                        item.issue,
+                        existing_pr,
+                    )
+                    return StageOutcome(Disposition.FAIL_BACK, "already_implementation_go_pr")
+                item.payload["existing_pr"] = True
+                item.payload["existing_pr_impl_go"] = True
                 logger.info(
-                    "implementation:%d: PR #%d already implementation-go; routing to ci",
+                    "implementation:%d: PR #%d already implementation-go; "
+                    "preparing worktree before ci",
                     item.issue,
                     existing_pr,
                 )
-                return StageOutcome(Disposition.FAIL_BACK, "already_implementation_go_pr")
+                return Continue(next_state=WORKTREE_WAIT)
             if agent_error_reentry:
                 # M1: consume the implement budget at GATE-adoption so the
                 # pr_review agent_error -> re-adopt cycle is bounded.

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -93,6 +93,7 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _require_item_worktree,
     _worktree_path,
     agent_provider,
     stage_model,
@@ -399,7 +400,7 @@ class MergeWaitStage(Stage):
             return StageOutcome(Disposition.FAIL_BACK, "blocked_exhausted")
         return Continue(next_state=BLOCKED_ADDRESS_WAIT)
 
-    def _request_dirty_rebase(self, item: WorkItem, ctx: StageContext) -> JobRequest:
+    def _request_dirty_rebase(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """DIRTY_REBASE_WAIT [W:G]: mechanical rebase onto the PR's base.
 
         The cheap deterministic path of the legacy ``_resolve_dirty_pr``:
@@ -410,6 +411,9 @@ class MergeWaitStage(Stage):
         DIRTY_PUSH_WAIT pushes only a clean result.
         """
         item.payload.pop("rebase_clean", None)
+        missing_worktree = _require_item_worktree(item, "merge_wait", "dirty rebase")
+        if missing_worktree is not None:
+            return missing_worktree
         rebase_job = GitJob(
             repo=item.repo,
             op="rebase",
@@ -433,6 +437,9 @@ class MergeWaitStage(Stage):
         """
         if not item.payload.pop("rebase_clean", None):
             return Continue(next_state=POLL)
+        missing_worktree = _require_item_worktree(item, "merge_wait", "dirty rebase push")
+        if missing_worktree is not None:
+            return missing_worktree
         push_job = GitJob(
             repo=item.repo,
             op="push",
@@ -445,7 +452,7 @@ class MergeWaitStage(Stage):
         )
         return JobRequest(push_job, on_done_state=POLL)
 
-    def _request_blocked_address(self, item: WorkItem, ctx: StageContext) -> JobRequest:
+    def _request_blocked_address(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """BLOCKED_ADDRESS_WAIT [W:A]: address the unresolved review threads.
 
         An armed PR sitting BLOCKED behind branch protection (unresolved
@@ -459,6 +466,9 @@ class MergeWaitStage(Stage):
         ``blocked_address`` budget; the push leg then re-POLLs.
         """
         item.payload.pop("address_failed", None)
+        missing_worktree = _require_item_worktree(item, "merge_wait", "blocked address")
+        if missing_worktree is not None:
+            return missing_worktree
         job = AgentJob(
             repo=item.repo,
             issue=item.issue if item.issue is not None else 0,
@@ -490,6 +500,9 @@ class MergeWaitStage(Stage):
         """
         if item.payload.pop("address_failed", None):
             return Continue(next_state=POLL)
+        missing_worktree = _require_item_worktree(item, "merge_wait", "blocked address push")
+        if missing_worktree is not None:
+            return missing_worktree
         push_job = GitJob(
             repo=item.repo,
             op="commit_push",

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -717,6 +717,17 @@ class PrReviewStage(Stage):
         if verdict is None or verdict.is_error:
             return self._handle_error_verdict(item, verdict)
 
+        # Fresh counts AFTER the address/push leg, split by severity so a GO is
+        # downgraded only by BLOCKING automation threads (#1856 / re-introduced #1554).
+        blocking_auto, minor_auto, human_unresolved = (
+            ctx.github.count_unresolved_threads_by_severity(item.pr)
+        )
+        automation_unresolved = blocking_auto + minor_auto  # progress-trail parity (#1554)
+        unresolved = automation_unresolved + human_unresolved
+
+        if self._nogo_without_durable_artifact(verdict, payload, automation_unresolved):
+            return self._handle_lost_review_artifact(item)
+
         # Real verdict: this round counts. Reset the consecutive-failure
         # cap; advance the cycle-relative gate and the lifetime audit trail.
         payload["review_error_retries"] = 0
@@ -728,14 +739,6 @@ class PrReviewStage(Stage):
         if round_done > soft_cap:
             # Audit trail of progress-earned extension rounds (4..hard_cap).
             item.attempts["pr_review_hard"] = item.attempts.get("pr_review_hard", 0) + 1
-
-        # Fresh counts AFTER the address/push leg, split by severity so a GO is
-        # downgraded only by BLOCKING automation threads (#1856 / re-introduced #1554).
-        blocking_auto, minor_auto, human_unresolved = (
-            ctx.github.count_unresolved_threads_by_severity(item.pr)
-        )
-        automation_unresolved = blocking_auto + minor_auto  # progress-trail parity (#1554)
-        unresolved = automation_unresolved + human_unresolved
 
         if verdict.is_go and human_unresolved:
             # Unchanged human-blocked guard (pr_review.py:690-701).
@@ -798,6 +801,43 @@ class PrReviewStage(Stage):
         )
         write_skip_label(item.issue, ctx)
         return StageOutcome(Disposition.SKIP, "exhaustion")
+
+    @staticmethod
+    def _nogo_without_durable_artifact(
+        verdict: Any, payload: dict[str, Any], automation_unresolved: int
+    ) -> bool:
+        """Return True for a NOGO verdict that left no durable review artifact."""
+        if getattr(verdict, "verdict", "").upper() != "NOGO" or automation_unresolved:
+            return False
+        artifact_keys = (
+            "raw_review_threads",
+            "review_threads",
+            "posted_thread_ids",
+            "unaddressed_findings",
+        )
+        return not any(payload.get(key) for key in artifact_keys)
+
+    def _handle_lost_review_artifact(self, item: WorkItem) -> StageOutcome:
+        """Retry an artifactless NOGO without burning a review round."""
+        payload = item.payload
+        retries = payload.get("review_error_retries", 0) + 1
+        payload["review_error_retries"] = retries
+        if retries > REVIEW_ERROR_RETRY_CAP:
+            logger.error(
+                "pr_review:%s: NOGO produced no durable findings; %d consecutive "
+                "artifact failures (cap %d) — failing back to implementation",
+                item.issue,
+                retries,
+                REVIEW_ERROR_RETRY_CAP,
+            )
+            return self._fail_back_agent_error(item)
+        logger.warning(
+            "pr_review:%s: NOGO produced no durable findings; retry %d/%d (no round burned)",
+            item.issue,
+            retries,
+            REVIEW_ERROR_RETRY_CAP,
+        )
+        return StageOutcome(Disposition.RETRY, "nogo_without_artifact")
 
     def _handle_address_error(self, item: WorkItem) -> StageOutcome | None:
         """Fail back hard address/push errors with explicit retry cleanup."""

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -250,6 +250,7 @@ class TestCiRebase:
         stage = CiStage()
         ctx = make_ctx(github=_go_github())
         item = _item(make_work_item, state=REBASE_WAIT)
+        item.worktree = "/tmp/wt/issue-1"
         item.payload["base_branch"] = "develop"
 
         result = stage.step(item, ctx)
@@ -263,6 +264,19 @@ class TestCiRebase:
 
         stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
         assert item.attempts["rebase"] == 1  # consumed on completion
+
+    def test_rebase_without_item_worktree_fails_back_before_git_job(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """CI must not mechanically rebase the loop driver's shared checkout."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github())
+        item = _item(make_work_item, state=REBASE_WAIT)
+        item.worktree = ""
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FAIL_BACK, "missing_worktree")
 
     def test_failed_rebase_is_best_effort(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed rebase counts the budget but records no routing flag."""

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -167,11 +167,27 @@ class TestGate:
     def test_gate_existing_pr_with_impl_go_routes_to_ci(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """An existing implementation-go PR fails back already_implementation_go_pr.
+        """An implementation-go PR with a worktree routes straight to CI."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(
+            open_pr=1001, pr_impl_state=(True, False), pr_head_branch="1-real-branch"
+        )
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+        item.worktree = "/tmp/wt/issue-1"
 
-        The ci stage must receive a fully-identified PR: item.pr and the
-        PR's REAL head branch are set BEFORE the fail-back (m7).
-        """
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.FAIL_BACK
+        assert result.note == "already_implementation_go_pr"
+        assert item.pr == 1001  # set before the fail-back (m7)
+        assert item.branch == "1-real-branch"
+
+    def test_gate_existing_pr_with_impl_go_without_worktree_adopts_first(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """An implementation-go PR still needs an isolated worktree before CI."""
         stage = ImplementationStage()
         github = FakeStageGitHub(
             open_pr=1001, pr_impl_state=(True, False), pr_head_branch="1-real-branch"
@@ -181,11 +197,12 @@ class TestGate:
 
         result = stage.step(item, ctx)
 
-        assert isinstance(result, StageOutcome)
-        assert result.disposition == Disposition.FAIL_BACK
-        assert result.note == "already_implementation_go_pr"
-        assert item.pr == 1001  # set before the fail-back (m7)
+        assert isinstance(result, Continue)
+        assert result.next_state == "WORKTREE_WAIT"
+        assert item.pr == 1001
         assert item.branch == "1-real-branch"
+        assert item.payload["existing_pr"] is True
+        assert item.payload["existing_pr_impl_go"] is True
 
     def test_gate_existing_pr_without_impl_go_adopts_via_worktree(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -374,6 +374,37 @@ class TestGitErrorRetryCap:
         assert outcome.note == "git_error"
         assert item.attempts["implement"] == 0  # git failures never burn implement
 
+    def test_adopted_impl_go_worktree_failure_retries_worktree_not_ci(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed adopted worktree sync must not flow through ADOPTED_CI."""
+        stage = ImplementationStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=1, pr=1001, state="WORKTREE_WAIT")
+        item.branch = "1-real-branch"
+        item.worktree = "/tmp/stale-worktree"
+        item.payload["existing_pr"] = True
+        item.payload["existing_pr_impl_go"] = True
+        item.payload["worktree_dirty"] = False
+
+        stage.on_job_done(item, JobResult(ok=False, error="missing remote ref"), ctx)
+        item.state = "DIRTY_DECISION_WAIT"
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert outcome.note == "worktree creation failed"
+        assert item.state == "WORKTREE_WAIT"
+        assert item.worktree == ""
+        assert "worktree_dirty" not in item.payload
+
+        retry = stage.step(item, ctx)
+
+        assert isinstance(retry, JobRequest)
+        assert isinstance(retry.job, GitJob)
+        assert retry.job.op == "create_worktree"
+        assert retry.on_done_state == "DIRTY_DECISION_WAIT"
+
     def test_push_failures_share_the_same_cap(self, make_ctx: Any, make_work_item: Any) -> None:
         """Consecutive push failures hit the same bounded-RETRY path."""
         stage = ImplementationStage()

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1106,6 +1106,27 @@ class TestFullWalks:
         assert item.attempts["pr_review_iter"] == 3
         assert github.mutation_log[-1] == ("gh_issue_add_labels", (22, (STATE_SKIP,)))
 
+    def test_nogo_without_durable_artifact_retries_without_skip(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """NOGO with no posted findings is infrastructure loss, not terminal skip."""
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=24, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["review_text"] = "Verdict: NOGO"
+        item.payload["raw_review_threads"] = []
+        item.payload["review_threads"] = []
+
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY
+        assert outcome.note == "nogo_without_artifact"
+        assert item.attempts["pr_review_iter"] == 0
+        assert not any(entry[0] == "gh_issue_add_labels" for entry in github.mutation_log)
+
     def test_reviewer_error_walk_burns_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed review job walks straight to EVAL's ERROR path: RETRY.
 

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -575,6 +575,52 @@ class TestSeedingEdges:
         assert item.issue == 1818
         assert item.pr == 1854
 
+    def test_direct_pr_scope_finishes_already_merged_pr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct --prs seeding must not adopt a deleted branch for a merged PR."""
+        monkeypatch.setattr(
+            seeding_mod,
+            "gh_pr_label_names",
+            MagicMock(side_effect=AssertionError("ambient PR label seeding called")),
+        )
+
+        class MergedPrGitHub(FakeStageGitHub):
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("merged PRs should finish before label routing")
+
+        target_github = MergedPrGitHub(
+            pr_issue=1912,
+            pr_state={"state": "MERGED", "headRefOid": "abc123"},
+        )
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            return target_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            prs=[2004],
+            projects_dir=tmp_path,
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+
+        assert coordinator.run() == 0
+
+        assert not coordinator.queues[StageName.CI].snapshot()
+        assert not coordinator.queues[StageName.PR_REVIEW].snapshot()
+        assert len(coordinator.ledger) == 1
+        assert coordinator.ledger[0].passed
+        assert coordinator.ledger[0].final_stage is StageName.FINISHED
+        assert "already merged" in coordinator.ledger[0].reason
+
     def test_direct_pr_scope_respects_drive_green_phase_scope(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -204,6 +204,7 @@ class TestROUTES:
                 fail_routes={
                     "fix_exhausted": StageName.IMPLEMENTATION,
                     "not_implementation_go": StageName.PR_REVIEW,
+                    "missing_worktree": StageName.IMPLEMENTATION,
                     "no_pr": StageName.FINISHED,
                     "*": StageName.CI,
                 },
@@ -214,6 +215,7 @@ class TestROUTES:
                 fail_routes={
                     "ci_red": StageName.CI,
                     "blocked_exhausted": StageName.PR_REVIEW,
+                    "missing_worktree": StageName.IMPLEMENTATION,
                     "closed": StageName.FINISHED,
                     "timeout": StageName.FINISHED,
                     "*": StageName.FINISHED,

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -38,8 +38,8 @@ _REASONS = [*_DECLARED_REASONS, "unknown_reason"]
 # none and resolve purely via the "*" default. Fail-back EXITS that leave
 # their stage rather than retry it consume no retry budget: plan_not_go
 # (implementation -> plan_review), already_implementation_go_pr (-> ci),
-# not_implementation_go (ci -> pr_review), and no_pr (-> finished) all map
-# to None.
+# not_implementation_go (ci -> pr_review), missing_worktree (-> implementation),
+# and no_pr (-> finished) all map to None.
 _REASON_BUDGET: dict[str, str | None] = {
     "nogo": "plan_review_iter",
     "plan_cycles_exhausted": "plan_cycles",
@@ -50,6 +50,7 @@ _REASON_BUDGET: dict[str, str | None] = {
     "exhaustion": None,
     "fix_exhausted": None,
     "not_implementation_go": None,
+    "missing_worktree": None,
     "no_pr": None,
     # ci_red cycles merge_wait -> ci for another merge attempt later, so it
     # consumes a merge slot; closed/timeout EXIT the pipeline entirely and

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -675,11 +675,6 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "opened by teammates and bots. By default drive-green operates only on PRs "
             "authored by the authenticated viewer (#821).",
         ),
-        _store_true(
-            "--allow-unsafe-phase-order",
-            "allow_unsafe_phase_order",
-            "Silence dependency-ordering warnings when --phases skips a recommended predecessor",
-        ),
         _action_spec(
             ("--model",),
             "model",

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -656,9 +656,10 @@ class TestRebaseWorktreeOnto:
             "git",
             "rebase",
             "--force-rebase",
+            "--empty=drop",
             "origin/main",
             "--exec",
-            "git commit --amend --no-edit -S -s",
+            "git commit --amend --no-edit -S -s --allow-empty",
         ]
         assert rebase_kwargs["cwd"] == worktree
 
@@ -676,9 +677,10 @@ class TestRebaseWorktreeOnto:
             "git",
             "rebase",
             "--force-rebase",
+            "--empty=drop",
             "origin/main",
             "--exec",
-            "git commit --amend --no-edit -S -s",
+            "git commit --amend --no-edit -S -s --allow-empty",
         ]
 
     def test_policy_rebase_forces_replay_when_branch_already_based_on_target(
@@ -689,6 +691,14 @@ class TestRebaseWorktreeOnto:
 
         assert "--force-rebase" in command
         assert command.index("--force-rebase") < command.index("--exec")
+
+    def test_policy_rebase_drops_empty_replays_and_allows_empty_amend(self) -> None:
+        """Skipped cherry-picks must not strand automation in an empty amend."""
+        command = _commit_policy_rebase_command("origin/main")
+
+        assert "--empty=drop" in command
+        assert command.index("--empty=drop") < command.index("origin/main")
+        assert "--allow-empty" in command[-1]
 
     def test_conflict_aborts_and_returns_false(self, git_utils_mocks: Any) -> None:
         """A rebase conflict triggers ``git rebase --abort`` and returns False."""
@@ -767,9 +777,10 @@ class TestRebaseWorktreeOnto:
             "git",
             "rebase",
             "--force-rebase",
+            "--empty=drop",
             "upstream/develop",
             "--exec",
-            "git commit --amend --no-edit -S -s",
+            "git commit --amend --no-edit -S -s --allow-empty",
         ]
 
     def test_timeout_threads_through_fetch_cleanup_and_rebase(self, git_utils_mocks: Any) -> None:
@@ -826,9 +837,10 @@ class TestEnsureBranchCommitMetadata:
             "git",
             "rebase",
             "--force-rebase",
+            "--empty=drop",
             "origin/main",
             "--exec",
-            "git commit --amend --no-edit -S -s",
+            "git commit --amend --no-edit -S -s --allow-empty",
         ]
         assert rebase_kwargs["cwd"] == tmp_path
 
@@ -861,9 +873,10 @@ class TestEnsureBranchCommitMetadata:
             "git",
             "rebase",
             "--force-rebase",
+            "--empty=drop",
             "origin/main",
             "--exec",
-            "git commit --amend --no-edit -S -s",
+            "git commit --amend --no-edit -S -s --allow-empty",
         ]
         assert rebase_kwargs["cwd"] == worktree
         abort_args, abort_kwargs = git_utils_mocks.run.call_args_list[3]

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -286,9 +286,10 @@ class TestRebaseMain:
             "-C",
             str(tmp_path),
             "rebase",
+            "--empty=drop",
             "origin/main",
             "--exec",
-            "git commit --amend --no-edit -S -s",
+            "git commit --amend --no-edit -S -s --allow-empty",
             "--quiet",
         ] in commands
 

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -82,11 +82,10 @@ def test_phase_order_warnings_drive_green_no_longer_warns() -> None:
     assert all("drive-green" not in w for w in _phase_order_warnings(cfg_with))
 
 
-def test_phase_order_warnings_plan_without_implement_warns() -> None:
-    """Plan selected without implement makes the invocation planning-only."""
+def test_phase_order_warnings_plan_without_implement_is_queue_safe() -> None:
+    """Partial phase selection is a queue entry hint, not an unsafe order."""
     cfg = LoopConfig(phases=("plan",))
-    warnings = _phase_order_warnings(cfg)
-    assert any("planning-only" in w and "implementation PRs" in w for w in warnings)
+    assert _phase_order_warnings(cfg) == []
 
 
 def test_phase_order_warnings_silent_on_full_pipeline() -> None:


### PR DESCRIPTION
Closes #2016
Closes #2018
Closes #2019
Closes #2020
Closes #2021

## Summary
- Remove `--allow-unsafe-phase-order`; phase selections are queue entry hints, not unsafe order contracts.
- Make CI and merge_wait mutating steps fail back with `missing_worktree` to implementation when item worktrees are absent.
- Make implementation-go PR adoption prepare and sync the PR worktree before routing to CI, with adopted worktree failures retried in place.
- Terminalize already merged or closed direct PR seeds before worktree adoption.
- Treat NOGO reviews with no durable findings as artifact loss and retry without burning review rounds or applying `state:skip`.
- Harden mechanical rebase against empty replay and amend cases by dropping replay-empty commits and allowing the policy amend to stay empty.

## Live Loop Check
- `pixi run hephaestus-automation-loop --prs 1999,2004 --phases implement,drive-green --loops 1 --max-workers 12 --agent codex`
- Observed PR #1999 reroute from artifact-loss review back through implementation, then advance after review GO.
- Observed PR #2004 direct seed finish as already merged or closed instead of trying deleted-branch worktree adoption.
- The remaining clean-GO comment upsert issue is tracked separately by #2009 / PR #2010.

## Verification
- `pixi run pytest tests/unit -v` -> 5816 passed, 21 skipped, coverage 84.05%.
- `pixi run ruff check hephaestus/ tests/`
- `pixi run ruff format --check hephaestus/ tests/`
- `pixi run python -m mypy hephaestus/`
- `pixi run pre-commit run --files ...` -> passed on all changed files.
