### PR TITLE
fix(pipeline): terminalize merged direct PR seeds

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -118,7 +118,7 @@ from hephaestus.automation.pipeline.stages import (
 )
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.stages.repo import product_to_work_item
-from hephaestus.automation.pipeline.summary import RunStats, print_summary
+from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
 from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
 from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO
 
@@ -511,28 +511,53 @@ class Coordinator:
                 agent_job_time_s=self._agent_job_time_s,
                 wall_s=time.monotonic() - started,
             )
+            summary_items = self._effective_items()
+            preserved = self._active_preserved_worktrees()
             self._record_event(
                 "run_end",
                 {
                     "exit_code": exit_code,
                     "interrupted": stats.interrupted,
-                    "items": len(self.items),
+                    "items": len(summary_items),
                     "agent_jobs": self._agent_job_count,
                     "wall_s": stats.wall_s,
                 },
             )
-            print_summary(self.items, stats, self.preserved, json_out=self.config.json_out)
+            print_summary(summary_items, stats, preserved, json_out=self.config.json_out)
         return exit_code
 
+    def _effective_items(self) -> list[WorkItem]:
+        """Return latest logical items, collapsing superseded re-seed attempts."""
+        return latest_logical_items(self.items)
+
+    def _active_preserved_worktrees(self) -> list[tuple[int, str]]:
+        """Return preserved worktrees for latest failed items that still exist."""
+        failed_numbers = {
+            item.issue or item.pr or 0
+            for item in self._effective_items()
+            if item.result is not None and not item.result.passed
+        }
+        active: list[tuple[int, str]] = []
+        seen: set[tuple[int, str]] = set()
+        for issue_or_pr, path in self.preserved:
+            entry = (issue_or_pr, path)
+            if entry in seen or issue_or_pr not in failed_numbers or not Path(path).exists():
+                continue
+            seen.add(entry)
+            active.append(entry)
+        return active
+
     def _exit_code(self) -> int:
-        """130 on interrupt; 1 on any fail/skip/blocked (or fatal error); 0 clean."""
+        """130 on interrupt; 1 on any effective fail/skip/blocked; 0 clean."""
         if self.shutdown.is_set():
             # Interrupt deliberately takes priority over non-passing ledger
             # entries and fatal coordinator errors: a signal means the run did
             # not complete, so wrappers must classify it as cancellation even
             # if earlier work had already failed.
             return 130
-        if self._fatal or any(not result.passed for result in self.ledger):
+        effective_results = [item.result for item in self._effective_items() if item.result]
+        results = effective_results or self.ledger
+        if self._fatal or any(not result.passed for result in results):
             return 1
         return 0
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -522,6 +522,20 @@ def _require_item_worktree(item: WorkItem, stage_name: str, action: str) -> Stag
     return StageOutcome(Disposition.FAIL_BACK, "missing_worktree")
 
 
+def _terminal_pr_outcome(pr_state: dict[str, Any] | None, pr_number: int) -> StageOutcome | None:
+    """Return a terminal outcome for PRs already merged/closed, if known."""
+    if not pr_state:
+        return None
+    state = str(pr_state.get("state") or "").upper()
+    if state == "MERGED" or pr_state.get("mergedAt"):
+        logger.info("PR #%d is already merged; terminalizing", pr_number)
+        return StageOutcome(Disposition.FINISH_PASS, "merged")
+    if state == "CLOSED":
+        logger.info("PR #%d is already closed; terminalizing", pr_number)
+        return StageOutcome(Disposition.FINISH_FAIL, "closed")
+    return None
+
+
 def write_skip_label(issue_number: int, ctx: StageContext) -> None:
     """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
 

--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -89,6 +89,7 @@ from .base import (
     StepResult,
     WorkItem,
     _require_item_worktree,
+    _terminal_pr_outcome,
     _worktree_path,
     agent_provider,
     stage_model,
@@ -297,6 +298,9 @@ class CiStage(Stage):
                 logger.info("ci:%d: no open PR found; finishing failed", item.issue)
                 return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
             item.pr = discovered
+        terminal = _terminal_pr_outcome(ctx.github.gh_pr_state(item.pr), item.pr)
+        if terminal is not None:
+            return terminal
         if not item.branch:
             # Adopt the PR's REAL head branch — never assume {issue}-auto-impl
             # (the _review_existing_pr branch-assumption bug).

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -104,6 +104,7 @@ from .base import (
     StepResult,
     WorkItem,
     _issue_labels,
+    _terminal_pr_outcome,
     _worktree_path,
     agent_provider,
     stage_model,
@@ -685,6 +686,9 @@ class ImplementationStage(Stage):
         existing_pr = item.pr or ctx.github.find_pr_for_issue(item.issue)
         if existing_pr:
             item.pr = existing_pr
+            terminal = _terminal_pr_outcome(ctx.github.gh_pr_state(existing_pr), existing_pr)
+            if terminal is not None:
+                return terminal
             head_branch = ctx.github.get_pr_head_branch(existing_pr)
             if head_branch:
                 item.branch = head_branch

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -18,7 +18,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from hephaestus.automation.pipeline.work_item import WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from hephaestus.cli.utils import emit_json_status
 
 logger = logging.getLogger(__name__)
@@ -68,6 +68,27 @@ def format_preserved_worktrees(
     lines.append("To discard them instead:")
     lines.extend(f"  git worktree remove --force {path}" for _, path in preserved)
     return lines
+
+
+def _logical_item_key(item: WorkItem) -> tuple[object, ...]:
+    """Return the stable logical identity for a potentially re-seeded item."""
+    if item.kind is ItemKind.REPO:
+        return (item.repo, "repo")
+    if item.issue is not None:
+        return (item.repo, "issue", item.issue)
+    if item.pr is not None:
+        return (item.repo, "pr", item.pr)
+    return (item.repo, item.kind.value, id(item))
+
+
+def latest_logical_items(items: Sequence[WorkItem]) -> list[WorkItem]:
+    """Return only the latest queued item for each logical issue/PR/repo."""
+    latest: dict[tuple[object, ...], WorkItem] = {}
+    for item in items:
+        key = _logical_item_key(item)
+        latest.pop(key, None)
+        latest[key] = item
+    return list(latest.values())
 
 
 def _disposition(item: WorkItem) -> str:
@@ -130,6 +151,8 @@ def print_summary(
         json_out: Emit the machine-readable ``emit_json_status`` envelope.
 
     """
+    items = latest_logical_items(items)
+
     logger.info("")
     logger.info("=== Pipeline summary ===")
     header = (

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -183,6 +183,27 @@ class TestCiDiscover:
         assert item.pr == 777
         assert item.branch == "real-head"
 
+    def test_already_merged_pr_finishes_before_branch_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A PR merged after review arming must not adopt a deleted head branch."""
+
+        class MergedGitHub(FakeStageGitHub):
+            def get_pr_head_branch(self, pr_number: int) -> str | None:
+                raise AssertionError("merged PRs should finish before branch adoption")
+
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("merged PRs should finish before label routing")
+
+        stage = CiStage()
+        ctx = make_ctx(github=MergedGitHub(pr_state={"state": "MERGED"}))
+        item = _item(make_work_item, state=DISCOVER)
+        item.branch = ""
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+
     def test_missing_implementation_go_fails_back(self, make_ctx: Any, make_work_item: Any) -> None:
         """A PR without state:implementation-go regresses to pr_review."""
         stage = CiStage()

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -204,6 +204,27 @@ class TestCiDiscover:
 
         assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
 
+    def test_already_closed_pr_finishes_before_branch_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A PR closed after review arming must not adopt a deleted head branch."""
+
+        class ClosedGitHub(FakeStageGitHub):
+            def get_pr_head_branch(self, pr_number: int) -> str | None:
+                raise AssertionError("closed PRs should finish before branch adoption")
+
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("closed PRs should finish before label routing")
+
+        stage = CiStage()
+        ctx = make_ctx(github=ClosedGitHub(pr_state={"state": "CLOSED"}))
+        item = _item(make_work_item, state=DISCOVER)
+        item.branch = ""
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "closed")
+
     def test_missing_implementation_go_fails_back(self, make_ctx: Any, make_work_item: Any) -> None:
         """A PR without state:implementation-go regresses to pr_review."""
         stage = CiStage()

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -204,6 +204,26 @@ class TestGate:
         assert item.payload["existing_pr"] is True
         assert item.payload["existing_pr_impl_go"] is True
 
+    def test_gate_existing_item_pr_merged_finishes_before_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A late fail-back must terminalize a PR that merged before adoption."""
+
+        class MergedGitHub(FakeStageGitHub):
+            def get_pr_head_branch(self, pr_number: int) -> str | None:
+                raise AssertionError("merged PRs should finish before branch adoption")
+
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("merged PRs should finish before label routing")
+
+        stage = ImplementationStage()
+        ctx = make_ctx(github=MergedGitHub(pr_state={"state": "MERGED"}))
+        item = make_work_item(issue=1, pr=1001, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+
     def test_gate_existing_pr_without_impl_go_adopts_via_worktree(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -224,6 +224,26 @@ class TestGate:
 
         assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
 
+    def test_gate_existing_item_pr_closed_finishes_before_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A late fail-back must terminalize a PR that closed before adoption."""
+
+        class ClosedGitHub(FakeStageGitHub):
+            def get_pr_head_branch(self, pr_number: int) -> str | None:
+                raise AssertionError("closed PRs should finish before branch adoption")
+
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("closed PRs should finish before label routing")
+
+        stage = ImplementationStage()
+        ctx = make_ctx(github=ClosedGitHub(pr_state={"state": "CLOSED"}))
+        item = make_work_item(issue=1, pr=1001, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_FAIL, "closed")
+
     def test_gate_existing_pr_without_impl_go_adopts_via_worktree(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -191,6 +191,48 @@ class TestExitCode:
 
         assert coordinator._exit_code() == 130
 
+    def test_later_pass_supersedes_earlier_failed_logical_item(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A retry loop that later passes must not exit failed due to stale ledger rows."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        failed = _item(2009, StageName.FINISHED)
+        failed.pr = 2010
+        failed.result = work_item_mod.ItemResult(
+            passed=False, reason="git_error", final_stage=StageName.FINISHED
+        )
+        passed = _item(2009, StageName.FINISHED)
+        passed.pr = 2010
+        passed.result = work_item_mod.ItemResult(
+            passed=True, reason="merged", final_stage=StageName.FINISHED
+        )
+        coordinator.items = [failed, passed]
+        coordinator.ledger.extend([failed.result, passed.result])
+
+        assert coordinator._exit_code() == 0
+
+    def test_preserved_worktrees_ignore_superseded_passed_items(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale preserved path from an earlier failed attempt should not be reported."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        preserved_path = tmp_path / "issue-2009"
+        preserved_path.mkdir()
+        failed = _item(2009, StageName.FINISHED)
+        failed.pr = 2010
+        failed.result = work_item_mod.ItemResult(
+            passed=False, reason="git_error", final_stage=StageName.FINISHED
+        )
+        passed = _item(2009, StageName.FINISHED)
+        passed.pr = 2010
+        passed.result = work_item_mod.ItemResult(
+            passed=True, reason="merged", final_stage=StageName.FINISHED
+        )
+        coordinator.items = [failed, passed]
+        coordinator.preserved.append((2009, str(preserved_path)))
+
+        assert coordinator._active_preserved_worktrees() == []
+
 
 class TestCompletionEdges:
     """_handle_completion bookkeeping branches."""

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -233,6 +233,22 @@ class TestExitCode:
 
         assert coordinator._active_preserved_worktrees() == []
 
+    def test_preserved_worktrees_ignore_missing_paths_for_failed_items(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing preserved path for the latest failed item should not be reported."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        missing_path = tmp_path / "issue-2009"
+        failed = _item(2009, StageName.FINISHED)
+        failed.pr = 2010
+        failed.result = work_item_mod.ItemResult(
+            passed=False, reason="git_error", final_stage=StageName.FINISHED
+        )
+        coordinator.items = [failed]
+        coordinator.preserved.append((2009, str(missing_path)))
+
+        assert coordinator._active_preserved_worktrees() == []
+
 
 class TestCompletionEdges:
     """_handle_completion bookkeeping branches."""
@@ -662,6 +678,52 @@ class TestSeedingEdges:
         assert coordinator.ledger[0].passed
         assert coordinator.ledger[0].final_stage is StageName.FINISHED
         assert "already merged" in coordinator.ledger[0].reason
+
+    def test_direct_pr_scope_finishes_already_closed_pr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct --prs seeding must not adopt a deleted branch for a closed PR."""
+        monkeypatch.setattr(
+            seeding_mod,
+            "gh_pr_label_names",
+            MagicMock(side_effect=AssertionError("ambient PR label seeding called")),
+        )
+
+        class ClosedPrGitHub(FakeStageGitHub):
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("closed PRs should finish before label routing")
+
+        target_github = ClosedPrGitHub(
+            pr_issue=1912,
+            pr_state={"state": "CLOSED", "headRefOid": "abc123"},
+        )
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            return target_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            prs=[2004],
+            projects_dir=tmp_path,
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+
+        assert coordinator.run() == 1
+
+        assert not coordinator.queues[StageName.CI].snapshot()
+        assert not coordinator.queues[StageName.PR_REVIEW].snapshot()
+        assert len(coordinator.ledger) == 1
+        assert not coordinator.ledger[0].passed
+        assert coordinator.ledger[0].final_stage is StageName.FINISHED
+        assert "already closed" in coordinator.ledger[0].reason
 
     def test_direct_pr_scope_respects_drive_green_phase_scope(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -124,6 +124,22 @@ class TestPrintSummaryRows:
         assert "loops: 2" in text
         assert "wall: 99.5s" in text
 
+    def test_summary_uses_latest_logical_item_for_aggregates(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A later PASS for the same issue/PR supersedes an earlier failed attempt."""
+        failed = _item(2009, StageName.FINISHED, passed=False, reason="git_error", pr=2010)
+        passed = _item(2009, StageName.FINISHED, passed=True, reason="merged", pr=2010)
+
+        with caplog.at_level(logging.INFO):
+            print_summary([failed, passed], _stats(), [], json_out=False)
+
+        text = caplog.text
+        assert "items: 1" in text
+        assert "'pass': 1" in text
+        assert "'fail'" not in text
+        assert "FAIL:git_error" not in text
+
     def test_nonzero_attempts_render(self, caplog: pytest.LogCaptureFixture) -> None:
         """Only non-zero attempt counters appear in the row."""
         item = _item(6, StageName.FINISHED, passed=True, reason="ok")


### PR DESCRIPTION
## Summary
- terminalize already-merged or closed PR seeds before branch adoption in CI and implementation gates
- collapse superseded logical items in the final summary, preserved-worktree list, and exit-code calculation
- add regression coverage for merged direct PR retries and stale failed attempts

## Verification
- pixi run pytest tests/unit/automation/pipeline -q --no-cov
- pixi run python -m mypy hephaestus/
- pixi run ruff check hephaestus/ tests/
- pixi run ruff format --check hephaestus/ tests/
- pixi run hephaestus-automation-loop --prs 2010,2017 --phases implement,drive-green --loops 2 --max-workers 12 --agent codex --phase-timeout 900 -v
- pixi run pytest tests/unit -v
- pixi run pre-commit run --files hephaestus/automation/pipeline/coordinator.py hephaestus/automation/pipeline/stages/base.py hephaestus/automation/pipeline/stages/ci.py hephaestus/automation/pipeline/stages/implementation.py hephaestus/automation/pipeline/summary.py tests/unit/automation/pipeline/stages/test_stage_ci.py tests/unit/automation/pipeline/stages/test_stage_implementation.py tests/unit/automation/pipeline/test_coordinator_edges.py tests/unit/automation/pipeline/test_summary.py

Closes #2023