### PR TITLE
fix: unify automation logging and queue attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,16 +25,16 @@ omitted (see `hephaestus.agents.runtime.add_agent_argument`).
 | merge_wait | `hephaestus.automation.pipeline.stages.merge_wait` | Auto-merge arming, merge polling, dirty/blocked handling, and post-merge learn |
 | finished | `hephaestus.automation.pipeline.stages.finished` | Terminal ledger and worktree cleanup/preservation |
 
-Legacy/manual console scripts remain available during the #1818 cutover and
-cleanup wave. They are rollback or out-of-band entry points until the scoped
-wrapper cleanup issues rewire/delete them:
+Console scripts preserve their historical names. Stage-scoped wrappers are
+thin queue-pipeline scoped entry points over the coordinator; manual commands
+that do not map to a pipeline stage remain out-of-band tools:
 
 | Console script | Current module | Purpose |
 |----------------|----------------|---------|
-| `hephaestus-plan-issues` | `hephaestus.automation.planner` | Legacy/manual planning path |
-| `hephaestus-implement-issues` | `hephaestus.automation.implementer` | Legacy/manual implementation path |
-| `hephaestus-merge-prs` | `hephaestus.github.pr_merge` | Legacy/manual merge driving path |
-| `hephaestus-review-prs` | `hephaestus.automation.pr_reviewer` | Manual, out-of-band PR review |
+| `hephaestus-plan-issues` | `hephaestus.automation.planner` | Thin queue-pipeline planning/plan_review wrapper |
+| `hephaestus-implement-issues` | `hephaestus.automation.implementer` | Thin queue-pipeline implementation/pr_review wrapper |
+| `hephaestus-merge-prs` | `hephaestus.github.pr_merge` | Manual merge-driving command outside the queue coordinator |
+| `hephaestus-review-prs` | `hephaestus.automation.pr_reviewer` | Thin queue-pipeline pr_review wrapper |
 | `hephaestus-agent-stage` | `hephaestus.automation.agent_stage` | One-off stage invocation |
 
 ## Agent runtime

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ ProjectHephaestus/
 ├── hephaestus/        # Main package
 │   ├── __init__.py
 │   ├── agents/        # Agent frontmatter + loader + runtime
-│   ├── automation/    # Issue planning / implementation / PR review pipeline
+│   ├── automation/    # Queue-based automation pipeline and scoped wrappers
 │   ├── benchmarks/    # Benchmark comparison utilities
 │   ├── ci/            # CI helpers (precommit, workflows, docker timing)
 │   ├── cli/           # CLI helpers (argument parsing, output formatting)

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ with `--help` to see full usage.
 
 | Command | Description |
 |---|---|
-| `hephaestus-automation-loop` | Multi-repo 3-stage automation pipeline using Claude Code or Codex (plan → implement → drive-green; plan-review and PR-review/address-review run in-loop within plan/implement) |
+| `hephaestus-automation-loop` | Multi-repo queue-based automation pipeline using Claude Code or Codex (repo → planning → plan_review → implementation → pr_review → ci → merge_wait → finished) |
 | `hephaestus-plan-issues` | Bulk issue planning using Claude Code or Codex |
 | `hephaestus-implement-issues` | Bulk issue implementation using Claude Code or Codex in parallel worktrees |
 | `hephaestus-review-prs` | Read-only PR review automation using Claude Code or Codex in parallel worktrees |

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Automation Loop Architecture
 
 Status: implemented for the epic #1809 queue-based automation loop. The
-`hephaestus-automation-loop` CLI defaults to this pipeline; the legacy loop
-remains available only through `--legacy-loop` or `HEPH_PIPELINE=0`.
+`hephaestus-automation-loop` CLI runs this pipeline directly; the legacy
+subprocess-per-phase loop was removed after the #1818/#1819 cutover.
 
 ## Overview and goals
 
@@ -65,7 +65,11 @@ A single worker pool executes:
 
 The only cross-thread channel is `CompletionQueue = queue.Queue[(JobHandle,
 JobResult)]`, whose blocking `get(timeout=…)` also serves as the loop's idle
-sleep.
+sleep. When a worker starts executing a submitted job it logs a `worker_claim`
+line with the stable worker thread ID plus the coordinator item/stage claim
+context. The returned `JobResult` carries that same `worker_id`, and the
+coordinator persists it in the durable `complete` event record so operators can
+correlate queue drain/submission with actual worker execution.
 
 ## WorkItem lifecycle
 
@@ -154,8 +158,10 @@ causes a queue push.
    FAIL_BACK(nogo) while plan_cycles remain or
    FAIL_BACK(plan_cycles_exhausted) once plan_cycles is exhausted; if ERROR →
    leave labels untouched, RETRY next tick.
-3. [W:A] **Amend step** — resume planner session with feedback block;
-   iteration counter increments.
+3. [W:A] **Amend step** — resume planner session with feedback block.
+   [M] Upsert the amended plan comment [durable] before looping back to
+   review. The iteration counter increments in EVAL when each real review
+   verdict is processed.
 4. [W:A] **Learn step** (on GO only) — `learn.py:111 build_learn_prompt`.
 
 **Verdicts**: ADVANCE, RETRY, FAIL_BACK(nogo, plan_cycles_exhausted).
@@ -460,8 +466,8 @@ serialization unless `--no-serialize-file-overlap` is passed.
 
 The pipeline never sleeps inside stage logic. Backoff uses the coordinator's
 timer heap, and low GitHub rate budget parks agent jobs until the reset instead
-of blocking the loop. Under the pipeline, `--phase-timeout` bounds each agent job.
-Under the legacy loop, the same flag still bounds a phase subprocess.
+of blocking the loop. `--phase-timeout` bounds each agent job inside the
+queue pipeline.
 
 Dry-run mode logs GitHub mutations and job submissions without executing them;
 `_submit` asserts that no worker job is submitted in dry-run. This makes
@@ -470,11 +476,10 @@ check for seed classification and route reconstruction.
 
 ## CLI scopes and rollout controls
 
-`hephaestus-automation-loop` runs the queue pipeline by default. `--pipeline`
-is retained as an explicit affirmative flag for scripts and evidence commands;
-`--legacy-loop` forces the pre-pipeline path for rollback. Environment default:
-`HEPH_PIPELINE=0` disables the pipeline when neither CLI flag is present, and
-the CLI flag always wins over the environment.
+`hephaestus-automation-loop` runs the queue pipeline directly. `--pipeline`
+remains accepted as an affirmative compatibility flag for pinned scripts and
+evidence commands; there is no `--legacy-loop` rollback path, and
+`HEPH_PIPELINE` no longer selects a subprocess-per-phase implementation.
 
 The default pipeline's scopes are the `hephaestus-automation-loop` selectors
 listed above. Standalone scripts are still legacy/manual compatibility paths at

--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -428,8 +428,9 @@ semantics.
   enqueued, so a scoped run cannot reconstruct every open issue in the repo.
 - `--org` expands to non-fork, non-archived repository seeds.
 
-The standalone console scripts remain legacy/manual compatibility paths at the
-issue #1818 cutover. Cleanup issues #1820-#1822 rewire or delete those wrappers.
+The standalone console scripts are thin queue-pipeline scoped entry points.
+They preserve the historical CLI surfaces while building a `PipelineConfig`
+limited to the matching stage slice.
 
 ## Interrupt semantics and exit codes
 
@@ -471,28 +472,33 @@ queue pipeline.
 
 Dry-run mode logs GitHub mutations and job submissions without executing them;
 `_submit` asserts that no worker job is submitted in dry-run. This makes
-`hephaestus-automation-loop --pipeline --dry-run --loops 1 -v` the operator
-check for seed classification and route reconstruction.
+`hephaestus-automation-loop --dry-run --loops 1 -v` the operator check
+for seed classification and route reconstruction.
 
 ## CLI scopes and rollout controls
 
-`hephaestus-automation-loop` runs the queue pipeline directly. `--pipeline`
-remains accepted as an affirmative compatibility flag for pinned scripts and
-evidence commands; there is no `--legacy-loop` rollback path, and
+`hephaestus-automation-loop` runs the queue pipeline directly; there is no
+`--pipeline` compatibility flag, there is no `--legacy-loop` rollback path, and
 `HEPH_PIPELINE` no longer selects a subprocess-per-phase implementation.
 
 The default pipeline's scopes are the `hephaestus-automation-loop` selectors
-listed above. Standalone scripts are still legacy/manual compatibility paths at
-the #1818 cutover:
+listed above. Standalone scripts are thin queue-pipeline scoped entry points:
 
-- `hephaestus-plan-issues` still invokes the legacy planner entry point.
-- `hephaestus-implement-issues` still invokes the legacy implementer entry
-  point.
-- `hephaestus-merge-prs` still invokes the legacy merge-driving entry point.
+- `hephaestus-plan-issues` preserves the historical planner CLI and dispatches
+  the planning/plan_review stage slice.
+- `hephaestus-implement-issues` preserves the historical implementer CLI and
+  dispatches the implementation/pr_review stage slice after the plan-go gate.
+- `hephaestus-review-prs` preserves the historical reviewer CLI and dispatches
+  the pr_review stage slice.
+- `hephaestus-drive-prs-green` preserves the historical drive-green CLI and
+  dispatches the ci/merge_wait stage slice.
+- `hephaestus-merge-prs` remains a manual merge-driving command outside the
+  queue coordinator.
 
-The target cleanup wave is to rewire or delete those wrappers so their behavior
-is represented by the pipeline's planning/plan_review, implementation/pr_review,
-and ci/merge_wait slices.
+`--run-pre-pr-tests` is an opt-in queue-runner flag that enables the
+implementation-stage pre-PR unit-test gate before commit and PR creation. The
+stage executes `PipelineConfig.pre_pr_test_argv` as an argv vector; CLI users get
+the repository default test command through the boolean flag.
 
 ## Glossary
 

--- a/docs/runbooks/automation-loop-crash.md
+++ b/docs/runbooks/automation-loop-crash.md
@@ -44,7 +44,7 @@ processing an issue, or a phase times out, and you need to resume safely.
 
 ## Pipeline recovery semantics
 
-For `--pipeline` recovery, distinguish interrupts from fatal coordinator
+For queue-pipeline recovery, distinguish interrupts from fatal coordinator
 failures:
 
 - A first `SIGINT`, `SIGTERM`, or `SIGHUP` starts graceful shutdown. The
@@ -72,16 +72,12 @@ last-known durable state. There is no persisted queue snapshot — the label and
 PR/worktree state are the checkpoint.
 
 ```bash
-hephaestus-automation-loop --pipeline --issues <N> --loops <K> --repos <REPO>
+hephaestus-automation-loop --issues <N> --loops <K> --repos <REPO>
 ```
 
-`--pipeline` is optional because the pipeline is the default, but keeping it in
-recovery commands makes the selected path visible in logs. If the pipeline
-itself is the suspected cause, use the rollback hatch:
-
-```bash
-hephaestus-automation-loop --legacy-loop --issues <N> --loops <K> --repos <REPO>
-```
+The queue pipeline is the only automation-loop implementation. There is no
+separate rollback selector; use the scoped command above to reconstruct queue
+state from GitHub labels, PR state, and local worktrees.
 
 The shared checkout is reset between turns, so any uncommitted in-flight edit
 from the crashed turn is discarded; this is by design. Issue work happens in

--- a/docs/runbooks/ci-driver-stall.md
+++ b/docs/runbooks/ci-driver-stall.md
@@ -1,10 +1,10 @@
 # Runbook: CI-Driver Stall (Green-but-BLOCKED PR)
 
 Use this when the CI/merge stage keeps running but PRs never merge — they sit
-armed for auto-merge with all checks green, yet stay un-mergeable. The default
-pipeline handles this in `hephaestus/automation/pipeline/stages/merge_wait.py`;
-the legacy standalone drive-green behavior is grounded in
-`hephaestus/automation/ci_driver.py`.
+armed for auto-merge with all checks green, yet stay un-mergeable. The queue
+pipeline handles this in `hephaestus/automation/pipeline/stages/merge_wait.py`; the
+`hephaestus-drive-prs-green` console script is a thin queue-pipeline wrapper for
+the ci/merge_wait slice.
 
 ## Symptom
 
@@ -15,13 +15,6 @@ the legacy standalone drive-green behavior is grounded in
   - `merge_wait:N: PR #M still BLOCKED after address budget; regressing`
   - `merge_wait:N: PR #M genuinely stuck after address budget; skipping`
   - `merge_wait:N: PR #M still OPEN after ...; timing out`
-- In the legacy path, the drive-green stage exits `0`, open PRs pile up
-  un-mergeable, and the log shows (from `ci_driver.py`):
-
-  > Issue #N: PR #M is BLOCKED by branch protection (unresolved conversations
-  > or required review) — cannot auto-merge; leaving armed and exiting poll
-  > early
-
 - `mergeStateStatus` for the PR is `BLOCKED` even though every check is green
   and auto-merge is armed.
 
@@ -34,12 +27,10 @@ repo's CI never emits, so the PR is `BLOCKED` permanently. A second cause is an
 unresolved review thread when the ruleset requires
 `required_review_thread_resolution`.
 
-In the default pipeline, `merge_wait` addresses blocked threads while the
+In the queue pipeline, `merge_wait` addresses blocked threads while the
 `blocked_address` budget remains. After that budget is exhausted, genuinely
 stuck PRs receive `state:skip`; other blocked PRs regress to `pr_review` via
-`blocked_exhausted`. In the legacy path, `ci_driver.py` attempts to address
-green-but-BLOCKED PRs at most `_BLOCKED_ADDRESS_MAX_ATTEMPTS = 2` times, then
-leaves the PR armed and exits the poll early.
+`blocked_exhausted`.
 
 ## Diagnose
 
@@ -71,7 +62,7 @@ gh pr view <N> --json reviewDecision,reviewRequests
    review threads, then the armed auto-merge proceeds on its own.
 
 After the gate is satisfied, the already-armed PR merges without re-running the
-driver; re-run `hephaestus-automation-loop --pipeline` only if you need to
+driver; re-run `hephaestus-automation-loop` only if you need to
 drive other issues, continue a regressed item, or refresh the pipeline summary.
 
 ## See also

--- a/hephaestus/automation/_review_utils.py
+++ b/hephaestus/automation/_review_utils.py
@@ -58,8 +58,8 @@ from hephaestus.cli.utils import (
     add_github_throttle_args,
     add_json_arg,
     add_version_arg,
+    configure_cli_logging,
 )
-from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 from hephaestus.io.utils import write_secure
 
 from .git_utils import issue_auto_impl_branch_name
@@ -199,12 +199,7 @@ def setup_review_logging(verbose: bool = False) -> None:
         verbose: Enable DEBUG-level logging (otherwise INFO).
 
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format=AUTOMATION_LOG_FORMAT,
-        datefmt=LOG_DATEFMT,
-    )
+    configure_cli_logging(verbose=verbose)
 
 
 def ensure_state_dir(repo_root: Path, subdir: str = DEFAULT_STATE_DIR) -> Path:

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -27,10 +27,10 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.cli.utils import (
+    configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
 )
-from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 from hephaestus.io.utils import write_secure
 
 from ._review_utils import build_automation_parser, ensure_state_dir
@@ -271,11 +271,7 @@ def main(argv: list[str] | None = None) -> int:
     """Parse CLI arguments and run the audit reviewer."""
     args = _build_parser().parse_args(argv)
     configure_github_throttle_from_args(args)
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        format=AUTOMATION_LOG_FORMAT,
-        datefmt=LOG_DATEFMT,
-    )
+    configure_cli_logging(verbose=args.verbose)
     selected_agent = "codex" if args.codex else args.agent
     agent = (selected_agent or "claude") if args.dry_run else resolve_agent(selected_agent)
     reviewer = AuditReviewer(

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -45,11 +45,11 @@ from hephaestus.cli.utils import (
     add_agent_timeout_arg,
     add_learn_timeout_arg,
     add_poll_max_wait_arg,
+    configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
 )
 from hephaestus.config.paths import resolve_projects_dir
-from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 
 from ._review_utils import build_automation_parser
 from .agent_config import ci_poll_max_wait
@@ -115,12 +115,7 @@ def _setup_logging(verbose: bool = False) -> None:
         verbose: Enable verbose (DEBUG) logging.
 
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format=AUTOMATION_LOG_FORMAT,
-        datefmt=LOG_DATEFMT,
-    )
+    configure_cli_logging(verbose=verbose)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -52,6 +52,7 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.config.paths import resolve_projects_dir
 from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
+from hephaestus.logging.utils import setup_logging
 
 from ._review_utils import build_automation_parser, ensure_state_dir
 from .agent_config import AGENT_IMPL_TIMEOUT
@@ -107,15 +108,15 @@ def _setup_logging(verbose: bool = False, log_dir: Path | None = None) -> None:
         log_dir: Optional directory to write a ``run.log`` file into.
 
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(level=level, format=AUTOMATION_LOG_FORMAT, datefmt=LOG_DATEFMT)
-
     if log_dir:
         log_dir.mkdir(parents=True, exist_ok=True)
-        fh = logging.FileHandler(log_dir / "run.log", mode="a")
-        fh.setLevel(logging.DEBUG)
-        fh.setFormatter(logging.Formatter(AUTOMATION_LOG_FORMAT, datefmt=LOG_DATEFMT))
-        logging.getLogger().addHandler(fh)
+    setup_logging(
+        level=logging.DEBUG if verbose else logging.INFO,
+        log_file=str(log_dir / "run.log") if log_dir else None,
+        format_string=AUTOMATION_LOG_FORMAT,
+        datefmt=LOG_DATEFMT,
+        primary_stream="stderr",
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -53,6 +53,7 @@ from hephaestus.automation.loop_repo_manager import (
 )
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.cli.utils import (
+    configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
 )
@@ -186,6 +187,7 @@ class LoopConfig:
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
+    run_pre_pr_tests: bool = False
     # ``model`` is the catch-all applied to every phase when set; per-phase
     # fields below take precedence over it.
     model: str = ""
@@ -297,6 +299,13 @@ def _build_parser() -> argparse.ArgumentParser:
             "including those opened by teammates and bots. By default "
             "drive-green operates only on PRs authored by the authenticated "
             "viewer (#821)."
+        ),
+    )
+    p.add_argument(
+        "--run-pre-pr-tests",
+        action="store_true",
+        help=(
+            "Run the implementation-stage pre-PR unit-test gate before committing and creating PRs."
         ),
     )
     p.add_argument(
@@ -481,9 +490,7 @@ def _preflight_token_scopes(org: str, probe_repo: str) -> None:
 
 
 def _setup_logging(verbose: bool) -> None:
-    from hephaestus.logging import setup_logging
-
-    setup_logging(level=logging.DEBUG if verbose else logging.INFO)
+    configure_cli_logging(verbose=verbose)
 
 
 def _resolve_org_and_repos(
@@ -581,6 +588,7 @@ def _build_pipeline_config(
         no_advise=cfg.no_advise,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
+        run_pre_pr_tests=cfg.run_pre_pr_tests,
         budget_overrides={"merge": cfg.max_merge_attempts},
         serialize_file_overlap=cfg.serialize_file_overlap,
         event_log_path=_pipeline_event_log_path(cfg.projects_dir, repos),
@@ -665,6 +673,7 @@ def main(argv: list[str] | None = None) -> int:
         no_advise=args.no_advise,
         nitpick=args.nitpick,
         drive_green_all=args.drive_green_all,
+        run_pre_pr_tests=args.run_pre_pr_tests,
         model=args.model,
         planner_model=args.planner_model,
         reviewer_model=args.reviewer_model,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -228,6 +228,7 @@ class PipelineConfig:
     # implementation stage reads this vector instead of hardcoding the test
     # command so non-pixi repos and non-standard unit-test layouts can opt in.
     pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV
+    run_pre_pr_tests: bool = False
     serialize_file_overlap: bool = True
     event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
@@ -376,6 +377,7 @@ class Coordinator:
             enable_mechanical_rebase=config.enable_mechanical_rebase,
             poll_max_wait=config.poll_max_wait,
             pre_pr_test_argv=config.pre_pr_test_argv,
+            run_pre_pr_tests=config.run_pre_pr_tests,
         )
         self._ctx_cache: dict[str, StageContext] = {}
 
@@ -744,12 +746,15 @@ class Coordinator:
     @staticmethod
     def _job_result_event_fields(result: JobResult) -> dict[str, Any]:
         """Return bounded, output-free job result fields for durable event logs."""
-        return {
+        fields = {
             "ok": result.ok,
             "interrupted": result.interrupted,
             "error": Coordinator._job_result_error_class(result),
             "duration_s": round(result.duration_s, 3),
         }
+        if result.worker_id:
+            fields["worker_id"] = result.worker_id
+        return fields
 
     @staticmethod
     def _job_result_error_class(result: JobResult) -> str | None:
@@ -928,7 +933,12 @@ class Coordinator:
                 # --phase-timeout semantic shift (M4): under --pipeline it
                 # bounds each AGENT JOB, not a phase subprocess.
                 job = replace(job, timeout_s=int(self.config.phase_timeout_s))
-        handle = self.pool.submit(job, request.on_done_state)
+        handle = self.pool.submit(
+            job,
+            request.on_done_state,
+            claim_key=self._item_key(item),
+            claim_stage=item.stage.value,
+        )
         self.in_flight[handle] = item
         self.inflight_per_repo[item.repo] += 1
         self._record_event(

--- a/hephaestus/automation/pipeline/jobs.py
+++ b/hephaestus/automation/pipeline/jobs.py
@@ -93,6 +93,7 @@ class JobResult:
     error: str | None = None
     interrupted: bool = False
     duration_s: float = 0.0
+    worker_id: str = ""
 
 
 @dataclass(frozen=True, eq=False)

--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -41,7 +41,8 @@ re-pointed at the pipeline (#1820):
 - Prompt functions (imported, never re-authored):
   ``prompts/planning.py get_plan_loop_review_prompt``,
   ``prompts/planning.py get_plan_prompt`` (composed with the reviewer
-  feedback block by :func:`build_amend_prompt` for amends), and
+  feedback block by :func:`build_amend_prompt` for amends, then
+  upserted as the durable plan comment before the next review), and
   ``learn.py build_learn_prompt`` (GO only).
 """
 
@@ -79,7 +80,7 @@ from .base import (
     agent_provider,
     stage_model,
 )
-from .planning import build_plan_prompt
+from .planning import _normalize_plan_comment, build_plan_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -464,7 +465,13 @@ class PlanReviewStage(Stage):
                     )
                     item.payload["prior_review"] = raw_review
             elif item.state == "AMEND_WAIT":
-                item.payload["plan_text"] = result.value
+                plan_text = result.value
+                item.payload["plan_text"] = plan_text
+                if item.issue is not None and isinstance(plan_text, str):
+                    ctx.github.upsert_plan_comment(
+                        item.issue,
+                        _normalize_plan_comment(plan_text),
+                    )
             # LEARN_WAIT intentionally has no branch: the learn job's output
             # is a side effect for the Mnemosyne skill store, not a payload
             # value any later state consumes.

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -154,7 +154,10 @@ class WorkerPool:
                 automation state dir — see :func:`_repo_lock_path`).
 
         """
-        self._executor = ThreadPoolExecutor(max_workers=size)
+        self._executor = ThreadPoolExecutor(
+            max_workers=size,
+            thread_name_prefix="hephaestus-pipeline-worker",
+        )
         self._shutdown = shutdown
         self._completion_q = completion_q
         self._repo_locks: dict[str, _RepoLockEntry] = {}
@@ -181,7 +184,12 @@ class WorkerPool:
                     self._repo_locks.pop(repo, None)
 
     def submit(
-        self, job: AgentJob | BuildTestJob | GitJob, on_done_state: str | StageName
+        self,
+        job: AgentJob | BuildTestJob | GitJob,
+        on_done_state: str | StageName,
+        *,
+        claim_key: str = "",
+        claim_stage: str = "",
     ) -> JobHandle:
         """Submit a job for execution.
 
@@ -189,6 +197,8 @@ class WorkerPool:
             job: Immutable frozen job spec.
             on_done_state: Pipeline stage the item should transition to when
                 this job completes.
+            claim_key: Optional coordinator item key for worker-claim logging.
+            claim_stage: Optional stage queue name for worker-claim logging.
 
         Returns:
             JobHandle carrying the submitted job and target state; the
@@ -197,7 +207,7 @@ class WorkerPool:
 
         """
         handle = JobHandle(job=job, on_done_state=on_done_state)
-        future = self._executor.submit(self._run, job)
+        future = self._executor.submit(self._run, job, claim_key, claim_stage)
         future.add_done_callback(lambda f: self._on_future_done(handle, f))
         return handle
 
@@ -229,6 +239,7 @@ class WorkerPool:
         """
         if future.cancelled():
             return  # cancel_futures synthesizes NO completion
+        worker_id = threading.current_thread().name
         try:
             result = future.result()
         except KeyboardInterrupt as exc:
@@ -236,32 +247,50 @@ class WorkerPool:
             result = JobResult(
                 ok=False,
                 error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
+                worker_id=worker_id,
             )
         except (SystemExit, GeneratorExit) as exc:
             logger.info("Worker future exited during shutdown; converting to worker_crash result")
             result = JobResult(
                 ok=False,
                 error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
+                worker_id=worker_id,
             )
         except Exception as exc:
             logger.exception("Worker future raised; converting to worker_crash result")
             result = JobResult(
                 ok=False,
                 error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
+                worker_id=worker_id,
             )
         self._completion_q.put((handle, result))
 
-    def _run(self, job: AgentJob | BuildTestJob | GitJob) -> JobResult:
+    def _run(
+        self,
+        job: AgentJob | BuildTestJob | GitJob,
+        claim_key: str = "",
+        claim_stage: str = "",
+    ) -> JobResult:
         """Execute a job and return its result.
 
-        Catches Exception subclasses so a single job failure does not crash the
-        worker thread; process-control escapes are converted in
-        _on_future_done's crash handler. After every job, post-checks the
-        shutdown event and marks interrupted=True if it was set (SIGINT to the
-        process group makes children return normally; the interrupt flag
-        prevents misreading a killed job as success).
+        Converts normal job exceptions and process-control escapes into
+        ``JobResult`` values so a single job failure does not crash the worker
+        thread. After every job, post-checks the shutdown event and marks
+        interrupted=True if it was set (SIGINT to the process group makes
+        children return normally; the interrupt flag prevents misreading a
+        killed job as success).
         """
         start = time.monotonic()
+        worker_id = threading.current_thread().name
+        logger.info(
+            "worker_claim: worker_id=%s item=%s stage=%s job=%s repo=%s descr=%s",
+            worker_id,
+            claim_key or "-",
+            claim_stage or "-",
+            type(job).__name__,
+            getattr(job, "repo", ""),
+            getattr(job, "descr", ""),
+        )
 
         # Pre-check: do not start a queued job if shutdown is set.
         if self._shutdown.is_set():
@@ -280,10 +309,22 @@ class WorkerPool:
                     result = self._run_git(job)
                 else:
                     raise TypeError(f"unknown job type {type(job)}")
+            except (KeyboardInterrupt, SystemExit, GeneratorExit) as exc:
+                # Preserve the executing worker identity for process-control
+                # escapes. The future callback may run outside the worker
+                # thread if the future completed before callback registration.
+                logger.info(
+                    "Job %s exited via %s, returning worker_crash result",
+                    job,
+                    type(exc).__name__,
+                )
+                result = JobResult(
+                    ok=False,
+                    error=f"worker_crash: {type(exc).__name__}: {exc!s}"[:_ERR_MAX],
+                )
             except Exception as exc:
                 # Convert job execution failures into a JobResult so the callback
-                # never re-raises into its thread. This catches normal runtime errors
-                # but allows process-control exceptions to propagate normally.
+                # never re-raises into its thread.
                 logger.exception("Job %s raised, returning error result", job)
                 result = JobResult(
                     ok=False,
@@ -301,6 +342,7 @@ class WorkerPool:
             duration_s=time.monotonic() - start,
             stdout_tail=result.stdout_tail[-_TAIL:] if result.stdout_tail else "",
             stderr_tail=result.stderr_tail[-_TAIL:] if result.stderr_tail else "",
+            worker_id=worker_id,
         )
 
     def _run_agent(self, job: AgentJob) -> JobResult:
@@ -320,7 +362,8 @@ class WorkerPool:
         Unexpected Exception subclasses from agent resolution, prompt
         construction, and the resilience wrapper are classified in this method
         for symmetry with the specific agent failures below. Process-control
-        escapes still propagate to _on_future_done's crash handler.
+        escapes are converted by :meth:`_run` so the returned result preserves
+        the executing worker identity.
         """
         try:
             agent = resolve_agent(job.agent)

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -31,8 +31,7 @@ from hephaestus.automation._review_utils import (
     print_worker_summary,
     work_report_context,
 )
-from hephaestus.cli.utils import add_agent_timeout_arg, emit_json_status
-from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
+from hephaestus.cli.utils import add_agent_timeout_arg, configure_cli_logging, emit_json_status
 from hephaestus.github.rate_limit import wait_until
 
 from .agent_config import DEFAULT_AGENT_TIMEOUT
@@ -606,12 +605,7 @@ def _setup_logging(verbose: bool = False) -> None:
         verbose: Enable verbose (DEBUG) logging.
 
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format=AUTOMATION_LOG_FORMAT,
-        datefmt=LOG_DATEFMT,
-    )
+    configure_cli_logging(verbose=verbose)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -29,11 +29,11 @@ from hephaestus.cli.utils import (
     add_advise_timeout_arg,
     add_agent_timeout_arg,
     add_git_message_timeout_arg,
+    configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
 )
 from hephaestus.config.paths import resolve_projects_dir
-from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 
 from ._review_utils import build_automation_parser
 from .git_utils import get_repo_slug
@@ -59,12 +59,7 @@ def _setup_logging(verbose: bool = False) -> None:
         verbose: Enable verbose (DEBUG) logging.
 
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format=AUTOMATION_LOG_FORMAT,
-        datefmt=LOG_DATEFMT,
-    )
+    configure_cli_logging(verbose=verbose)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -35,11 +35,11 @@ from hephaestus.agents.runtime import resolve_agent
 from hephaestus.cli.utils import (
     add_agent_timeout_arg,
     add_version_arg,
+    configure_cli_logging,
     configure_github_throttle_from_args,
     emit_json_status,
 )
 from hephaestus.config.paths import resolve_projects_dir
-from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
 
 from ._review_utils import build_review_parser
 from .git_utils import get_repo_slug
@@ -86,12 +86,7 @@ def _setup_logging(verbose: bool = False) -> None:
         verbose: Enable verbose (DEBUG) logging.
 
     """
-    level = logging.DEBUG if verbose else logging.INFO
-    logging.basicConfig(
-        level=level,
-        format=AUTOMATION_LOG_FORMAT,
-        datefmt=LOG_DATEFMT,
-    )
+    configure_cli_logging(verbose=verbose)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/hephaestus/cli/utils.py
+++ b/hephaestus/cli/utils.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from hephaestus._version_lookup import get_version
 from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
+from hephaestus.logging.utils import setup_logging
 from hephaestus.utils.helpers import get_repo_root
 
 __version__ = get_version()
@@ -228,18 +229,19 @@ def resolve_repo_root(args: argparse.Namespace) -> Path:
 def configure_cli_logging(*, verbose: bool = False) -> None:
     """Configure standard stderr-safe logging for a ``hephaestus-*`` CLI.
 
-    Centralizes the ``logging.basicConfig(...)`` boilerplate repeated across
+    Centralizes the logging setup boilerplate repeated across
     CLI entry points so the log level and format stay consistent. Use this
-    in a CLI ``main()`` instead of calling ``logging.basicConfig`` directly.
+    in a CLI ``main()`` instead of configuring root logging directly.
 
     Args:
         verbose: When True, set the root level to ``DEBUG``; otherwise ``INFO``.
 
     """
-    logging.basicConfig(
+    setup_logging(
         level=logging.DEBUG if verbose else logging.INFO,
-        format=AUTOMATION_LOG_FORMAT,
+        format_string=AUTOMATION_LOG_FORMAT,
         datefmt=LOG_DATEFMT,
+        primary_stream="stderr",
     )
 
 

--- a/hephaestus/github/fleet_sync/cli.py
+++ b/hephaestus/github/fleet_sync/cli.py
@@ -18,9 +18,9 @@ from hephaestus.cli.utils import (
 from hephaestus.github.fleet_sync.config import resolve_fleet_config
 from hephaestus.github.fleet_sync.models import ASCII_SYMBOLS, UNICODE_SYMBOLS
 from hephaestus.github.fleet_sync.sync_coordinator import process_repo
-from hephaestus.logging.utils import get_logger
+from hephaestus.logging.utils import setup_logging
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -79,10 +79,11 @@ def main(argv: list[str] | None = None) -> int:
     configure_github_throttle_from_args(args)
     args.agent = resolve_agent(args.agent)
 
-    logging.basicConfig(
+    setup_logging(
         level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)-7s %(message)s",
+        format_string="%(asctime)s %(levelname)-7s %(message)s",
         datefmt="%H:%M:%S",
+        primary_stream="stderr",
     )
 
     try:

--- a/hephaestus/github/tidy.py
+++ b/hephaestus/github/tidy.py
@@ -45,9 +45,9 @@ from hephaestus.github.git_ops import (
     working_tree_clean as _shared_working_tree_clean,
 )
 from hephaestus.github.pr_merge import detect_repo_from_remote
-from hephaestus.logging.utils import get_logger
+from hephaestus.logging.utils import setup_logging
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Model the tidy conflict-resolution swarm runs on. Defined locally rather than
 # imported from hephaestus.automation.claude_models because hephaestus.github
@@ -490,10 +490,11 @@ def _print_summary(results: dict[str, str]) -> int:
 
 def _configure_logging(verbose: bool) -> None:
     """Configure CLI logging for tidy output."""
-    logging.basicConfig(
+    setup_logging(
         level=logging.DEBUG if verbose else logging.INFO,
-        format="%(asctime)s %(levelname)-7s %(message)s",
+        format_string="%(asctime)s %(levelname)-7s %(message)s",
         datefmt="%H:%M:%S",
+        primary_stream="stderr",
     )
 
 

--- a/hephaestus/logging/utils.py
+++ b/hephaestus/logging/utils.py
@@ -21,7 +21,7 @@ import uuid
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from hephaestus.constants import LOG_FORMAT
 from hephaestus.logging.formatters import JsonFormatter
@@ -199,8 +199,7 @@ def get_logger(
                 file_handler.setFormatter(formatter)
                 logger.addHandler(file_handler)
 
-    # Prevent duplicate output when root logger also has handlers
-    # (e.g., from setup_logging() or logging.basicConfig()).
+    # Prevent duplicate output when root logger also has handlers.
     # Safe to set outside the lock — simple attribute assignment on the logger object.
     logger.propagate = propagate
 
@@ -213,6 +212,8 @@ def setup_logging(
     format_string: str | None = None,
     log_to_stderr: bool = False,
     json_format: bool = False,
+    datefmt: str | None = None,
+    primary_stream: Literal["stdout", "stderr"] = "stdout",
 ) -> None:
     """Set up global logging configuration.
 
@@ -222,8 +223,13 @@ def setup_logging(
         format_string: Custom log format (ignored when *json_format* is True)
         log_to_stderr: Whether to also log to stderr
         json_format: If True, use structured JSON output instead of plain text
+        datefmt: Optional date format for text log records
+        primary_stream: Console stream for the primary root handler
 
     """
+    if primary_stream not in {"stdout", "stderr"}:
+        raise ValueError("primary_stream must be 'stdout' or 'stderr'")
+
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
 
@@ -232,34 +238,27 @@ def setup_logging(
         formatter = JsonFormatter()
     else:
         format_string = format_string or LOG_FORMAT
-        formatter = logging.Formatter(format_string)
+        formatter = logging.Formatter(format_string, datefmt=datefmt)
+
+    primary_target = sys.stderr if primary_stream == "stderr" else sys.stdout
+    stream_targets = [primary_target]
+    if log_to_stderr and sys.stderr not in stream_targets:
+        stream_targets.append(sys.stderr)
 
     # Lock protects the check-then-add TOCTOU race on the root logger's handler list
     with _handler_setup_lock:
-        # Deduplicate stdout StreamHandler
-        has_stdout = any(
-            isinstance(h, logging.StreamHandler)
-            and not isinstance(h, logging.FileHandler)
-            and getattr(h, "stream", None) is sys.stdout
-            for h in root_logger.handlers
-        )
-        if not has_stdout:
-            stdout_handler = logging.StreamHandler(sys.stdout)
-            stdout_handler.setFormatter(formatter)
-            root_logger.addHandler(stdout_handler)
-
-        # Deduplicate stderr StreamHandler
-        if log_to_stderr:
-            has_stderr = any(
+        # Deduplicate console StreamHandlers by stream identity.
+        for stream in stream_targets:
+            has_stream = any(
                 isinstance(h, logging.StreamHandler)
                 and not isinstance(h, logging.FileHandler)
-                and getattr(h, "stream", None) is sys.stderr
+                and getattr(h, "stream", None) is stream
                 for h in root_logger.handlers
             )
-            if not has_stderr:
-                stderr_handler = logging.StreamHandler(sys.stderr)
-                stderr_handler.setFormatter(formatter)
-                root_logger.addHandler(stderr_handler)
+            if not has_stream:
+                stream_handler = logging.StreamHandler(stream)
+                stream_handler.setFormatter(formatter)
+                root_logger.addHandler(stream_handler)
 
         # Deduplicate FileHandler by resolved path
         if log_file:

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -65,6 +65,7 @@ class FakeWorkerPool:
             completion_q if completion_q is not None else (queue.Queue())
         )
         self.submitted: list[JobHandle] = []
+        self.submitted_claims: list[tuple[str, str]] = []
         self._scripted: deque[JobResult | Exception] = deque()
 
     def script(self, *outcomes: JobResult | Exception) -> None:
@@ -79,12 +80,21 @@ class FakeWorkerPool:
         """FIFO-enqueue an exception, delivered as an error JobResult."""
         self._scripted.append(exc)
 
-    def submit(self, job: AgentJob | BuildTestJob | GitJob, on_done_state: StageName) -> JobHandle:
+    def submit(
+        self,
+        job: AgentJob | BuildTestJob | GitJob,
+        on_done_state: StageName,
+        *,
+        claim_key: str = "",
+        claim_stage: str = "",
+    ) -> JobHandle:
         """Execute *job* inline and put its completion on the queue.
 
         Args:
             job: Frozen job spec (any of the three job types).
             on_done_state: Target stage on completion.
+            claim_key: Coordinator item key forwarded to the worker pool.
+            claim_stage: Stage queue name forwarded to the worker pool.
 
         Returns:
             The JobHandle also recorded in :attr:`submitted`.
@@ -92,6 +102,7 @@ class FakeWorkerPool:
         """
         handle = JobHandle(job=job, on_done_state=on_done_state)
         self.submitted.append(handle)
+        self.submitted_claims.append((claim_key, claim_stage))
         outcome: JobResult | Exception = (
             self._scripted.popleft() if self._scripted else self._default_result(job)
         )

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -19,6 +19,7 @@ from hephaestus.automation.pipeline.stages.plan_review import (
 )
 from hephaestus.automation.prompts._shared import _UNTRUSTED_NOTICE
 from hephaestus.automation.prompts.planning import get_plan_prompt
+from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 from hephaestus.automation.state_labels import (
     STATE_NEEDS_PLAN,
     STATE_PLAN_GO,
@@ -490,6 +491,24 @@ class TestPlanReviewStageOnJobDone:
 
         assert item.payload["plan_text"] == "# Amended plan here"
 
+    def test_amend_result_upserts_durable_plan_comment(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Amended plans are journaled before the next review can approve them."""
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2, state="AMEND_WAIT")
+        result = JobResult(ok=True, value="\n\n# Amended plan here")
+
+        stage.on_job_done(item, result, ctx)
+
+        assert item.payload["plan_text"] == "\n\n# Amended plan here"
+        assert github.comments[2] == [f"{PLAN_COMMENT_MARKER}\n\n# Amended plan here"]
+        assert github.mutation_log == [
+            ("gh_issue_upsert_comment", (2, PLAN_COMMENT_MARKER)),
+        ]
+
     def test_failed_result_is_not_stored(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed job result is logged and never stored."""
         stage = PlanReviewStage()
@@ -579,7 +598,9 @@ class TestStaleVerdictAndErrorAccounting:
         assert outcome.disposition == Disposition.RETRY  # NOT a replayed NOGO
         assert item.attempts["plan_review_iter"] == iter_before  # budget intact
         assert item.payload["review_round"] == round_before
-        assert github.mutation_log == []  # no labels on the error path
+        assert github.mutation_log == [
+            ("gh_issue_upsert_comment", (30, PLAN_COMMENT_MARKER)),
+        ]  # amended plan persisted, no labels on the error path
 
     def test_error_round_burns_nothing_and_nogo_still_amendable(
         self, make_ctx: Any, make_work_item: Any
@@ -830,8 +851,9 @@ class TestReviewFlowWithFakePool:
         assert item.attempts["plan_review_iter"] == 2
         # All four jobs ran, in order.
         assert [h.job.descr for h in pool.submitted] == ["review", "amend", "review", "learn"]
-        # Durable GO write happened (before the ADVANCE outcome).
+        # Durable amended-plan write happens before the GO label write and ADVANCE outcome.
         assert github.mutation_log == [
+            ("gh_issue_upsert_comment", (21, PLAN_COMMENT_MARKER)),
             ("gh_issue_add_labels", (21, (STATE_PLAN_GO,))),
             ("gh_issue_remove_labels", (21, (STATE_PLAN_NO_GO, STATE_NEEDS_PLAN))),
         ]

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -639,6 +639,66 @@ class TestDurableEventLog:
         assert "stdout_tail" not in complete["fields"][-1]
         assert "stderr_tail" not in complete["fields"][-1]
 
+    def test_event_log_completion_records_worker_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Completion records include the worker that executed the submitted job."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        pool = FakeWorkerPool()
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=pool,
+            stages={StageName.PLANNING: StubStage()},
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+        result = JobResult(ok=True, value="done")
+        object.__setattr__(result, "worker_id", "hephaestus-pipeline-worker_0")
+        pool.queue_result(result)
+        item = _issue_item(45, StageName.PLANNING)
+
+        coordinator._submit(item, JobRequest(_agent_job(issue=45), "REVIEWED"))
+        coordinator._drain_completions()
+
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        complete = next(record for record in records if record["event"] == "complete")
+        assert complete["fields"][-1]["worker_id"] == "hephaestus-pipeline-worker_0"
+
+    def test_submit_forwards_claim_context_to_worker_pool(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Submitted jobs carry item/stage context for worker-claim logging."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        pool = FakeWorkerPool()
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=pool,
+            stages={StageName.PLANNING: StubStage()},
+            install_signals=False,
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+        item = _issue_item(46, StageName.PLANNING)
+
+        coordinator._submit(item, JobRequest(_agent_job(issue=46), "REVIEWED"))
+
+        assert pool.submitted_claims == [("repo-a#46", "planning")]
+
     def test_event_log_path_sanitizes_job_error_text(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -92,10 +92,10 @@ class InterruptingPool(FakeWorkerPool):
         super().__init__()
         self._coordinator_shutdown = coordinator_shutdown
 
-    def submit(self, job: Any, on_done_state: Any) -> Any:
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
         self._coordinator_shutdown.set()
         self.queue_result(JobResult(ok=False, interrupted=True, error="interrupted"))
-        return super().submit(job, on_done_state)
+        return super().submit(job, on_done_state, **kwargs)
 
 
 def _capture_signal_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -122,16 +122,17 @@ def _raise_sigterm() -> None:
 class GracefulSignalCompletionPool(FakeWorkerPool):
     """Send first SIGTERM during submit, then deliver a non-interrupted result."""
 
-    def submit(self, job: Any, on_done_state: Any) -> Any:
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
         _raise_sigterm()
         self.queue_result(JobResult(ok=True, value="completed after shutdown"))
-        return super().submit(job, on_done_state)
+        return super().submit(job, on_done_state, **kwargs)
 
 
 class SecondSignalPool(FakeWorkerPool):
     """Send two SIGTERMs during submit and leave the job in flight."""
 
-    def submit(self, job: Any, on_done_state: Any) -> Any:
+    def submit(self, job: Any, on_done_state: Any, **kwargs: Any) -> Any:
+        del kwargs
         handle = JobHandle(job=job, on_done_state=on_done_state)
         self.submitted.append(handle)
         _raise_sigterm()

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -152,6 +152,114 @@ class TestWorkerPoolSubmitComplete:
         assert result.ok is True
         assert "hello" in result.stdout_tail
 
+    def test_worker_claim_logs_and_result_carries_worker_id(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A worker records its identity when it starts executing a submitted job."""
+        job = BuildTestJob(
+            repo="test/repo",
+            cwd=tmp_path,
+            argv=("pytest", "-q"),
+            timeout_s=60,
+            descr="unit gate",
+        )
+        completed = subprocess.CompletedProcess(job.argv, 0, stdout="", stderr="")
+        caplog.set_level(logging.INFO, logger=_WP)
+
+        with patch(f"{_WP}.subprocess.run", return_value=completed):
+            pool.submit(
+                job,
+                StageName.CI,
+                claim_key="test/repo#123",
+                claim_stage="ci",
+            )
+            _handle, result = completion_q.get(timeout=10)
+
+        worker_id = getattr(result, "worker_id", "")
+        assert worker_id
+        assert any(
+            "worker_claim" in record.message
+            and worker_id in record.message
+            and "item=test/repo#123" in record.message
+            and "stage=ci" in record.message
+            for record in caplog.records
+        )
+
+    def test_distinct_workers_claim_concurrent_queue_entries(
+        self,
+        shutdown_event: threading.Event,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Concurrent entries expose distinct worker IDs in claim logs and results."""
+        pool = WorkerPool(
+            size=2,
+            shutdown=shutdown_event,
+            completion_q=completion_q,
+            lock_dir=tmp_path / "locks",
+        )
+        jobs = [
+            BuildTestJob(
+                repo="test/repo",
+                cwd=tmp_path,
+                argv=("pytest", "-q", f"case-{idx}"),
+                timeout_s=60,
+                descr=f"unit gate {idx}",
+            )
+            for idx in range(2)
+        ]
+        barrier = threading.Barrier(2, timeout=5)
+
+        def complete_after_both_workers_enter(
+            argv: tuple[str, ...],
+            **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            barrier.wait()
+            return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        caplog.set_level(logging.INFO, logger=_WP)
+
+        try:
+            with patch(f"{_WP}.subprocess.run", side_effect=complete_after_both_workers_enter):
+                pool.submit(
+                    jobs[0],
+                    StageName.CI,
+                    claim_key="test/repo#123",
+                    claim_stage="ci",
+                )
+                pool.submit(
+                    jobs[1],
+                    StageName.PR_REVIEW,
+                    claim_key="test/repo!456",
+                    claim_stage="pr_review",
+                )
+                results = [completion_q.get(timeout=10)[1] for _ in jobs]
+        finally:
+            pool.shutdown()
+
+        worker_ids = {result.worker_id for result in results}
+        assert len(worker_ids) == 2
+        claim_messages = [
+            record.message for record in caplog.records if "worker_claim" in record.message
+        ]
+        assert any(
+            worker_id in message and "item=test/repo#123" in message and "stage=ci" in message
+            for worker_id in worker_ids
+            for message in claim_messages
+        )
+        assert any(
+            worker_id in message
+            and "item=test/repo!456" in message
+            and "stage=pr_review" in message
+            for worker_id in worker_ids
+            for message in claim_messages
+        )
+
     def test_build_test_nonzero_rc_is_not_ok(
         self,
         pool: WorkerPool,
@@ -1202,6 +1310,21 @@ class TestOnFutureDone:
         future.cancel()
         pool._on_future_done(handle, future)
         assert completion_q.empty()
+
+    @pytest.mark.parametrize("exc", [KeyboardInterrupt(), SystemExit(3), GeneratorExit()])
+    def test_run_converts_process_control_escape_with_worker_id(
+        self, pool: WorkerPool, exc: BaseException
+    ) -> None:
+        """Escapes inside the worker preserve the executing worker identity."""
+        job = BuildTestJob(repo="r", cwd=Path("/tmp"), argv=("true",), timeout_s=1)
+
+        with patch.object(pool, "_run_build_test", side_effect=exc):
+            result = pool._run(job, claim_key="r#1", claim_stage="ci")
+
+        assert result.ok is False
+        assert result.error is not None
+        assert result.error.startswith(f"worker_crash: {type(exc).__name__}")
+        assert result.worker_id == threading.current_thread().name
 
     def test_exception_future_emits_worker_crash_completion_and_logs_traceback(
         self,

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -487,6 +487,17 @@ class TestParser:
                 mock_resolve.assert_not_called()
                 assert mock_cls.call_args[1]["agent"] == "claude"
 
+    def test_main_configures_cli_logging(self) -> None:
+        with mock.patch("hephaestus.automation.audit_reviewer.configure_cli_logging") as configure:
+            with mock.patch("hephaestus.automation.audit_reviewer.AuditReviewer") as mock_cls:
+                mock_instance = mock.Mock()
+                mock_instance.run.return_value = (0, [])
+                mock_cls.return_value = mock_instance
+
+                main(["--dry-run", "--verbose"])
+
+        configure.assert_called_once_with(verbose=True)
+
     def test_json_flag_emits_envelope_on_exit(self) -> None:
         with mock.patch("hephaestus.automation.audit_reviewer.AuditReviewer") as mock_cls:
             mock_instance = mock.Mock()

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -675,6 +675,12 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "opened by teammates and bots. By default drive-green operates only on PRs "
             "authored by the authenticated viewer (#821).",
         ),
+        _store_true(
+            "--run-pre-pr-tests",
+            "run_pre_pr_tests",
+            "Run the implementation-stage pre-PR unit-test gate before committing and "
+            "creating PRs.",
+        ),
         _action_spec(
             ("--model",),
             "model",

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -112,6 +112,13 @@ def test_parse_args_accepts_no_advise() -> None:
     assert args.no_advise is True
 
 
+def test_parse_args_accepts_run_pre_pr_tests() -> None:
+    """The queue runner can enable the implementation-stage pre-PR test gate."""
+    args = loop_runner._parse_args(["--run-pre-pr-tests"])
+    assert args.run_pre_pr_tests is True
+    assert loop_runner._parse_args([]).run_pre_pr_tests is False
+
+
 def test_parse_args_accepts_nitpick() -> None:
     """The loop runner can enable nitpick comments across review phases."""
     assert loop_runner._parse_args(["--nitpick"]).nitpick is True
@@ -561,3 +568,15 @@ def test_legacy_loop_symbols_removed() -> None:
     assert not hasattr(loop_runner, "run_loop")
     assert not hasattr(loop_runner, "_run_post_loop_stages")
     assert not hasattr(loop_runner, "_PHASE_FLAGS")
+
+
+def test_main_wires_run_pre_pr_tests_to_pipeline_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--run-pre-pr-tests`` reaches the queue implementation stage config."""
+    config = _capture_config(
+        ["--repos", "Repo", "--run-pre-pr-tests", "--loops", "1", "--agent", "claude"],
+        monkeypatch,
+    )
+
+    assert config.run_pre_pr_tests is True  # type: ignore[attr-defined]

--- a/tests/unit/automation/test_review_utils.py
+++ b/tests/unit/automation/test_review_utils.py
@@ -103,37 +103,19 @@ class TestLogFilePath:
 
 
 class TestSetupReviewLogging:
-    """setup_review_logging routes through the canonical constants (#1427)."""
+    """setup_review_logging routes through the shared CLI logging helper."""
 
-    def test_uses_canonical_format(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import hephaestus.constants as constants
+    def test_uses_cli_logging_helper(self) -> None:
+        with patch("hephaestus.automation._review_utils.configure_cli_logging") as configure:
+            review_utils.setup_review_logging(verbose=False)
 
-        captured: dict[str, Any] = {}
+        configure.assert_called_once_with(verbose=False)
 
-        def fake_basic_config(**kwargs: Any) -> None:
-            captured.update(kwargs)
+    def test_verbose_sets_debug_level(self) -> None:
+        with patch("hephaestus.automation._review_utils.configure_cli_logging") as configure:
+            review_utils.setup_review_logging(verbose=True)
 
-        monkeypatch.setattr(
-            "hephaestus.automation._review_utils.logging.basicConfig", fake_basic_config
-        )
-        review_utils.setup_review_logging(verbose=False)
-
-        assert captured["format"] == constants.AUTOMATION_LOG_FORMAT
-        assert captured["datefmt"] == constants.LOG_DATEFMT
-        assert captured["level"] == logging.INFO
-
-    def test_verbose_sets_debug_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        captured: dict[str, Any] = {}
-
-        def fake_basic_config(**kwargs: Any) -> None:
-            captured.update(kwargs)
-
-        monkeypatch.setattr(
-            "hephaestus.automation._review_utils.logging.basicConfig", fake_basic_config
-        )
-        review_utils.setup_review_logging(verbose=True)
-
-        assert captured["level"] == logging.DEBUG
+        configure.assert_called_once_with(verbose=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_utils.py
+++ b/tests/unit/cli/test_utils.py
@@ -174,32 +174,33 @@ class TestConfigureCliLogging:
     """Tests for configure_cli_logging."""
 
     def test_default_uses_info_level(self) -> None:
-        """Without verbose, basicConfig is called at INFO level."""
-        with patch("hephaestus.cli.utils.logging.basicConfig") as basic_config:
+        """Without verbose, setup_logging is called at INFO level."""
+        with patch("hephaestus.cli.utils.setup_logging") as setup:
             configure_cli_logging()
-        assert basic_config.call_args.kwargs["level"] == logging.INFO
+        assert setup.call_args.kwargs["level"] == logging.INFO
 
     def test_verbose_uses_debug_level(self) -> None:
         """verbose=True raises the configured level to DEBUG."""
-        with patch("hephaestus.cli.utils.logging.basicConfig") as basic_config:
+        with patch("hephaestus.cli.utils.setup_logging") as setup:
             configure_cli_logging(verbose=True)
-        assert basic_config.call_args.kwargs["level"] == logging.DEBUG
+        assert setup.call_args.kwargs["level"] == logging.DEBUG
 
     def test_sets_standard_format(self) -> None:
         """A consistent stderr-safe format string is applied."""
-        with patch("hephaestus.cli.utils.logging.basicConfig") as basic_config:
+        with patch("hephaestus.cli.utils.setup_logging") as setup:
             configure_cli_logging()
-        assert "%(levelname)s" in basic_config.call_args.kwargs["format"]
-        assert "%(name)s" in basic_config.call_args.kwargs["format"]
+        assert "%(levelname)s" in setup.call_args.kwargs["format_string"]
+        assert "%(name)s" in setup.call_args.kwargs["format_string"]
+        assert setup.call_args.kwargs["primary_stream"] == "stderr"
 
     def test_routes_through_canonical_constants(self) -> None:
         """configure_cli_logging uses the shared AUTOMATION_LOG_FORMAT (#1427)."""
         import hephaestus.constants as constants
 
-        with patch("hephaestus.cli.utils.logging.basicConfig") as basic_config:
+        with patch("hephaestus.cli.utils.setup_logging") as setup:
             configure_cli_logging()
-        assert basic_config.call_args.kwargs["format"] == constants.AUTOMATION_LOG_FORMAT
-        assert basic_config.call_args.kwargs["datefmt"] == constants.LOG_DATEFMT
+        assert setup.call_args.kwargs["format_string"] == constants.AUTOMATION_LOG_FORMAT
+        assert setup.call_args.kwargs["datefmt"] == constants.LOG_DATEFMT
 
 
 class TestResolveRepoRoot:

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -78,6 +78,18 @@ def test_automation_loop_architecture_status_is_implemented() -> None:
     assert "pre-implementation" not in header
 
 
+def test_automation_loop_architecture_describes_post_cutover_loop() -> None:
+    """The architecture contract must not document removed rollback controls."""
+    text = _arch_text()
+    normalized = " ".join(text.split())
+
+    assert "subprocess-per-phase loop was removed" in text
+    assert "there is no `--legacy-loop` rollback path" in text
+    assert "legacy loop remains available" not in normalized
+    assert "HEPH_PIPELINE=0" not in text
+    assert "forces the pre-pipeline path" not in text
+
+
 def test_automation_loop_architecture_has_interrupt_semantics_and_exit_codes() -> None:
     """The architecture contract must keep interrupt and exit-code details."""
     text = _arch_text()

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -19,6 +19,7 @@ from hephaestus.automation.prompts.planning import (
 )
 
 DOC_PATH = Path(__file__).resolve().parents[3] / "docs" / "AUTOMATION_LOOP_ARCHITECTURE.md"
+AGENTS_PATH = Path(__file__).resolve().parents[3] / "AGENTS.md"
 
 PROMPT_REFS: tuple[tuple[str, str, Callable[..., object]], ...] = (
     ("prompts/planning.py", "get_plan_prompt", get_plan_prompt),
@@ -84,10 +85,32 @@ def test_automation_loop_architecture_describes_post_cutover_loop() -> None:
     normalized = " ".join(text.split())
 
     assert "subprocess-per-phase loop was removed" in text
-    assert "there is no `--legacy-loop` rollback path" in text
+    assert "there is no `--pipeline` compatibility flag" in normalized
+    assert "there is no `--legacy-loop` rollback path" in normalized
+    assert "hephaestus-automation-loop --pipeline" not in text
+    assert "`--pipeline` remains accepted" not in text
     assert "legacy loop remains available" not in normalized
     assert "HEPH_PIPELINE=0" not in text
     assert "forces the pre-pipeline path" not in text
+
+
+def test_automation_loop_architecture_describes_thin_queue_wrappers() -> None:
+    """Wrapper docs must describe queue-pipeline scoped entry points, not legacy paths."""
+    text = _arch_text()
+
+    assert "thin queue-pipeline scoped entry points" in text
+    assert "standalone console scripts remain legacy/manual compatibility paths" not in text
+    assert "still invokes the legacy planner entry point" not in text
+    assert "still invokes the legacy implementer entry" not in text
+
+
+def test_agents_map_describes_thin_queue_wrappers() -> None:
+    """The root agent map must not carry stale cutover-era wrapper language."""
+    text = AGENTS_PATH.read_text(encoding="utf-8")
+
+    assert "thin queue-pipeline scoped entry points" in text
+    assert "rollback or out-of-band entry points" not in text
+    assert "during the #1818 cutover" not in text
 
 
 def test_automation_loop_architecture_has_interrupt_semantics_and_exit_codes() -> None:

--- a/tests/unit/docs/test_automation_loop_crash_runbook.py
+++ b/tests/unit/docs/test_automation_loop_crash_runbook.py
@@ -20,7 +20,7 @@ def _pipeline_section() -> str:
     match = _PIPELINE_SECTION_RE.search(text)
     assert match is not None, (
         "automation-loop-crash.md must document pipeline recovery semantics "
-        "for interrupted or crashed --pipeline runs."
+        "for interrupted or crashed queue-pipeline runs."
     )
     return re.sub(r"\s+", " ", match.group(1).lower())
 
@@ -29,7 +29,7 @@ def test_pipeline_recovery_semantics_are_documented() -> None:
     """The crash runbook must cover pipeline interrupt and restart behavior."""
     section = _pipeline_section()
 
-    assert "--pipeline" in section
+    assert "--pipeline" not in section
     assert "exit code 130" in section
     assert "resumable" in section
     assert "never failed" in section

--- a/tests/unit/logging/test_no_direct_basic_config.py
+++ b/tests/unit/logging/test_no_direct_basic_config.py
@@ -1,0 +1,28 @@
+"""Regression tests for centralized logging setup (#1404)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+def _direct_basic_config_calls() -> list[str]:
+    root = Path("hephaestus")
+    calls: list[str] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "basicConfig"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "logging"
+            ):
+                calls.append(f"{path}:{node.lineno}")
+    return calls
+
+
+def test_no_direct_logging_basic_config_calls_remain() -> None:
+    """CLI modules must route through hephaestus.logging.utils.setup_logging."""
+    assert _direct_basic_config_calls() == []

--- a/tests/unit/logging/test_setup_logging_delegation.py
+++ b/tests/unit/logging/test_setup_logging_delegation.py
@@ -1,0 +1,112 @@
+"""Regression tests for centralized logging setup delegation."""
+
+from __future__ import annotations
+
+import logging
+from importlib import import_module
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from hephaestus.constants import AUTOMATION_LOG_FORMAT, LOG_DATEFMT
+
+
+@pytest.mark.parametrize(
+    ("module_name", "callable_name", "kwargs", "expected_level"),
+    [
+        ("hephaestus.cli.utils", "configure_cli_logging", {"verbose": False}, logging.INFO),
+        ("hephaestus.cli.utils", "configure_cli_logging", {"verbose": True}, logging.DEBUG),
+        (
+            "hephaestus.automation._review_utils",
+            "setup_review_logging",
+            {"verbose": False},
+            logging.INFO,
+        ),
+        (
+            "hephaestus.automation._review_utils",
+            "setup_review_logging",
+            {"verbose": True},
+            logging.DEBUG,
+        ),
+        ("hephaestus.automation.ci_driver", "_setup_logging", {"verbose": True}, logging.DEBUG),
+        ("hephaestus.automation.loop_runner", "_setup_logging", {"verbose": False}, logging.INFO),
+        ("hephaestus.automation.planner", "_setup_logging", {"verbose": False}, logging.INFO),
+        ("hephaestus.automation.pr_reviewer", "_setup_logging", {"verbose": False}, logging.INFO),
+        ("hephaestus.automation.plan_reviewer", "_setup_logging", {"verbose": True}, logging.DEBUG),
+    ],
+)
+def test_cli_logging_helpers_delegate_to_shared_helper(
+    module_name: str,
+    callable_name: str,
+    kwargs: dict[str, object],
+    expected_level: int,
+) -> None:
+    """Standard CLI logging helpers route through ``setup_logging``."""
+    module = import_module(module_name)
+    helper = getattr(module, callable_name)
+
+    with patch("hephaestus.cli.utils.setup_logging") as setup:
+        helper(**kwargs)
+
+    setup.assert_called_once_with(
+        level=expected_level,
+        format_string=AUTOMATION_LOG_FORMAT,
+        datefmt=LOG_DATEFMT,
+        primary_stream="stderr",
+    )
+
+
+def test_implementer_setup_logging_routes_log_dir_to_shared_helper(tmp_path: Path) -> None:
+    """Implementer logging keeps the run.log file handler but delegates setup."""
+    module = import_module("hephaestus.automation.implementer")
+    log_dir = tmp_path / "state"
+
+    with patch.object(module, "setup_logging", Mock()) as setup:
+        module._setup_logging(verbose=True, log_dir=log_dir)
+
+    assert log_dir.is_dir()
+    setup.assert_called_once_with(
+        level=logging.DEBUG,
+        log_file=str(log_dir / "run.log"),
+        format_string=AUTOMATION_LOG_FORMAT,
+        datefmt=LOG_DATEFMT,
+        primary_stream="stderr",
+    )
+
+
+def test_tidy_logging_delegates_to_shared_helper() -> None:
+    """Tidy logging uses the shared helper with its compact human format."""
+    module = import_module("hephaestus.github.tidy")
+
+    with patch.object(module, "setup_logging", Mock()) as setup:
+        module._configure_logging(verbose=False)
+
+    setup.assert_called_once_with(
+        level=logging.INFO,
+        format_string="%(asctime)s %(levelname)-7s %(message)s",
+        datefmt="%H:%M:%S",
+        primary_stream="stderr",
+    )
+
+
+def test_fleet_sync_main_delegates_logging_to_shared_helper() -> None:
+    """Fleet sync CLI uses stderr-safe shared logging setup."""
+    module = import_module("hephaestus.github.fleet_sync.cli")
+
+    with (
+        patch.object(module, "configure_github_throttle_from_args") as throttle,
+        patch.object(module, "resolve_agent", return_value="claude"),
+        patch.object(module, "resolve_fleet_config", return_value=("Org", [])),
+        patch.object(module, "setup_logging", Mock()) as setup,
+    ):
+        rc = module.main(["--verbose"])
+
+    assert rc == 0
+    throttle.assert_called_once()
+    setup.assert_called_once_with(
+        level=logging.DEBUG,
+        format_string="%(asctime)s %(levelname)-7s %(message)s",
+        datefmt="%H:%M:%S",
+        primary_stream="stderr",
+    )

--- a/tests/unit/logging/test_setup_logging_formatter.py
+++ b/tests/unit/logging/test_setup_logging_formatter.py
@@ -1,0 +1,44 @@
+"""Regression tests for setup_logging formatter options."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from hephaestus.logging.utils import setup_logging
+
+
+def test_custom_datefmt_is_forwarded_to_formatter() -> None:
+    """setup_logging forwards an explicit datefmt to logging.Formatter."""
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    root.handlers.clear()
+    captured: dict[str, object] = {}
+
+    class FakeFormatter:
+        def __init__(
+            self,
+            fmt: str | None = None,
+            datefmt: str | None = None,
+        ) -> None:
+            captured["fmt"] = fmt
+            captured["datefmt"] = datefmt
+
+    try:
+        with pytest.MonkeyPatch.context() as mp:
+            mp.delenv("HEPHAESTUS_LOG_FORMAT", raising=False)
+            mp.setattr("hephaestus.logging.utils.logging.Formatter", FakeFormatter)
+            setup_logging(format_string="%(message)s", datefmt="%H:%M:%S")
+    finally:
+        root.handlers.clear()
+        root.handlers.extend(saved)
+
+    assert captured["fmt"] == "%(message)s"
+    assert captured["datefmt"] == "%H:%M:%S"
+
+
+def test_invalid_primary_stream_raises_value_error() -> None:
+    """setup_logging rejects unknown primary stream values."""
+    with pytest.raises(ValueError, match="primary_stream"):
+        setup_logging(primary_stream="file")  # type: ignore[arg-type]

--- a/tests/unit/logging/test_utils.py
+++ b/tests/unit/logging/test_utils.py
@@ -475,6 +475,34 @@ class TestSetupLogging:
             root.handlers.clear()
             root.handlers.extend(saved)
 
+    def test_primary_stream_stderr_does_not_add_stdout(self) -> None:
+        """setup_logging can route CLI logs to stderr without touching stdout."""
+        root = logging.getLogger()
+        saved = list(root.handlers)
+        root.handlers.clear()
+        try:
+            setup_logging(primary_stream="stderr")
+
+            stdout_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler)
+                and not isinstance(h, logging.FileHandler)
+                and h.stream is sys.stdout
+            ]
+            stderr_handlers = [
+                h
+                for h in root.handlers
+                if isinstance(h, logging.StreamHandler)
+                and not isinstance(h, logging.FileHandler)
+                and h.stream is sys.stderr
+            ]
+            assert stdout_handlers == []
+            assert len(stderr_handlers) == 1
+        finally:
+            root.handlers.clear()
+            root.handlers.extend(saved)
+
     def test_no_duplicate_file_handler(self, tmp_path: Path) -> None:
         """Calling setup_logging with same log_file twice adds only one FileHandler."""
         log_file = str(tmp_path / "dup.log")


### PR DESCRIPTION
## Summary
- route CLI logging through shared `setup_logging` and add a regression guard against direct production `logging.basicConfig()` calls
- persist amended plan comments before review resumes
- stamp queue job claims and completions with worker IDs so queue entries can be correlated with worker execution
- update automation-loop docs and README to match the post-cutover queue pipeline

## Verification
- `pixi run python -m ruff check .`
- `pixi run python -m ruff format --check .`
- `pixi run python -m mypy hephaestus/`
- `pixi run pytest tests/unit -q --no-cov --tb=short` — 5853 passed, 21 skipped
- `pixi run pytest tests/integration -q --no-cov --tb=short` — 382 passed
- `pixi run pre-commit run --files hephaestus/automation/pipeline/worker_pool.py tests/unit/automation/pipeline/test_worker_pool.py`

Closes #1404
