### PR TITLE
docs: remove stale pipeline selector comments

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -31,12 +31,10 @@ implementation queue is additionally gated by dependency topological order
 (:func:`~.admission._select_non_overlapping`). Pool size =
 ``parallel_repos x max_workers``.
 
-### ``--phase-timeout`` semantic shift
+### ``--phase-timeout`` queue semantics
 
-Under ``--pipeline`` this flag bounds each AGENT JOB, not a whole phase
-subprocess: the coordinator maps ``phase_timeout_s`` onto
-``AgentJob.timeout_s`` at submit time. The legacy path binds it to the phase
-subprocess lifetime.
+This flag bounds each AGENT JOB, not a whole phase subprocess: the coordinator
+maps ``phase_timeout_s`` onto ``AgentJob.timeout_s`` at submit time.
 
 ### Journal-order invariant
 
@@ -930,8 +928,7 @@ class Coordinator:
                 self._timer_park(item, delay)
                 return
             if self.config.phase_timeout_s and self.config.phase_timeout_s > 0:
-                # --phase-timeout semantic shift (M4): under --pipeline it
-                # bounds each AGENT JOB, not a phase subprocess.
+                # --phase-timeout bounds each AGENT JOB, not a phase subprocess.
                 job = replace(job, timeout_s=int(self.config.phase_timeout_s))
         handle = self.pool.submit(
             job,
@@ -1430,7 +1427,7 @@ def run_pipeline(config: PipelineConfig) -> int:
     """Run the queue-based pipeline to completion.
 
     Public entry point called from ``loop_runner.main()`` on the default
-    pipeline path (or when ``--pipeline`` is passed explicitly).
+    queue-pipeline path.
 
     Args:
         config: Pipeline configuration.

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -407,7 +407,7 @@ class TestSubmitEdges:
     def test_phase_timeout_maps_onto_agent_job(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """M4: --phase-timeout bounds each AGENT JOB under --pipeline."""
+        """M4: --phase-timeout bounds each queue-pipeline AGENT JOB."""
         monkeypatch.setattr(
             "hephaestus.automation.pipeline_github.rate_budget_ok",
             lambda now_epoch=None: (True, 0.0),

--- a/tests/unit/docs/test_automation_loop_architecture.py
+++ b/tests/unit/docs/test_automation_loop_architecture.py
@@ -20,6 +20,13 @@ from hephaestus.automation.prompts.planning import (
 
 DOC_PATH = Path(__file__).resolve().parents[3] / "docs" / "AUTOMATION_LOOP_ARCHITECTURE.md"
 AGENTS_PATH = Path(__file__).resolve().parents[3] / "AGENTS.md"
+COORDINATOR_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "hephaestus"
+    / "automation"
+    / "pipeline"
+    / "coordinator.py"
+)
 
 PROMPT_REFS: tuple[tuple[str, str, Callable[..., object]], ...] = (
     ("prompts/planning.py", "get_plan_prompt", get_plan_prompt),
@@ -92,6 +99,15 @@ def test_automation_loop_architecture_describes_post_cutover_loop() -> None:
     assert "legacy loop remains available" not in normalized
     assert "HEPH_PIPELINE=0" not in text
     assert "forces the pre-pipeline path" not in text
+
+
+def test_coordinator_comments_describe_queue_only_loop() -> None:
+    """Coordinator comments must not describe removed pipeline selector flags."""
+    text = COORDINATOR_PATH.read_text(encoding="utf-8")
+
+    assert "when ``--pipeline`` is passed explicitly" not in text
+    assert "Under ``--pipeline``" not in text
+    assert "legacy path binds it to the phase subprocess" not in text
 
 
 def test_automation_loop_architecture_describes_thin_queue_wrappers() -> None:


### PR DESCRIPTION
## Summary
- remove stale coordinator comments/docstrings that implied `--pipeline` is still an explicit selector
- align `--phase-timeout` comments with the queue-only coordinator architecture
- add a docs regression asserting the stale selector wording does not return to coordinator comments

## Verification
- `pixi run pytest tests/unit/automation/pipeline/test_worker_pool.py::TestWorkerPoolSubmitComplete::test_worker_claim_logs_and_result_carries_worker_id tests/unit/automation/pipeline/test_worker_pool.py::TestWorkerPoolSubmitComplete::test_distinct_workers_claim_concurrent_queue_entries tests/unit/automation/pipeline/test_coordinator.py::TestDurableEventLog::test_event_log_completion_records_worker_id tests/unit/docs/test_automation_loop_architecture.py::test_coordinator_comments_describe_queue_only_loop -q --no-cov --tb=short`
- `pixi run python -m ruff check hephaestus/automation/pipeline/coordinator.py tests/unit/automation/pipeline/test_coordinator_edges.py tests/unit/docs/test_automation_loop_architecture.py`
- `pixi run python -m ruff format --check hephaestus/automation/pipeline/coordinator.py tests/unit/automation/pipeline/test_coordinator_edges.py tests/unit/docs/test_automation_loop_architecture.py`

Closes #2030
