### PR TITLE
fix(github): centralize git subprocess helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ ProjectHephaestus/
 │   ├── resilience/             # Circuit breaker + retry + subprocess resilience
 │   ├── scripts_lib/            # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/                 # System information collection
-│   ├── utils/                  # General utility functions (slugify, retry, subprocess)
+│   ├── utils/                  # General utility functions (slugify, retry, subprocess, git helpers)
 │   ├── validation/             # README, schema, and structural validation
 │   └── version/                # Version management
 ├── scripts/                    # Automation and maintenance scripts

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -247,6 +247,7 @@ Lazy-loaded symbols (accessible via `hephaestus.<name>`): `add_logging_args`,
 | `retry_on_network_error` | 0.2.0 | Retry decorator scoped to network errors |
 | `retry_with_backoff` | 0.1.0 | Exponential backoff retry decorator |
 | `run_subprocess` | 0.1.0 | Execute shell commands with error handling |
+| `run_git` | TBD | Execute Git commands through the shared subprocess adapter |
 | `slugify` | 0.1.0 | Convert text to URL-friendly slug |
 | `terminal_guard` | 0.3.0 | Context manager that saves/restores terminal state |
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -247,9 +247,25 @@ Lazy-loaded symbols (accessible via `hephaestus.<name>`): `add_logging_args`,
 | `retry_on_network_error` | 0.2.0 | Retry decorator scoped to network errors |
 | `retry_with_backoff` | 0.1.0 | Exponential backoff retry decorator |
 | `run_subprocess` | 0.1.0 | Execute shell commands with error handling |
-| `run_git` | TBD | Execute Git commands through the shared subprocess adapter |
+| `run_git` | TBD | Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection |
 | `slugify` | 0.1.0 | Convert text to URL-friendly slug |
 | `terminal_guard` | 0.3.0 | Context manager that saves/restores terminal state |
+
+### `hephaestus.utils.git`
+
+| Symbol | Added | Notes |
+|--------|-------|-------|
+| `git_branch_exists` | TBD | Check whether a local branch exists through the shared Git adapter |
+| `git_config_get` | TBD | Read Git config values through the shared Git adapter |
+| `git_ls_remote_contains` | TBD | Check exact advertised remote refs with retry-protected `ls-remote` |
+| `git_push` | TBD | Push a refspec through the retry-protected shared Git adapter |
+| `git_remote_url` | TBD | Read a remote URL through the shared Git adapter |
+| `git_rev_list_count` | TBD | Count revisions for a revspec through the shared Git adapter |
+| `git_unmerged_files` | TBD | List unresolved merge-conflict paths through the shared Git adapter |
+| `in_git_repo` | TBD | Check whether cwd is inside a Git repository through the shared Git adapter |
+| `repo_root` | TBD | Resolve the current Git repository root through the shared Git adapter |
+| `run_git` | TBD | Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection |
+| `working_tree_clean` | TBD | Check porcelain status through the shared Git adapter |
 
 ### `hephaestus.cli`
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -247,7 +247,7 @@ Lazy-loaded symbols (accessible via `hephaestus.<name>`): `add_logging_args`,
 | `retry_on_network_error` | 0.2.0 | Retry decorator scoped to network errors |
 | `retry_with_backoff` | 0.1.0 | Exponential backoff retry decorator |
 | `run_subprocess` | 0.1.0 | Execute shell commands with error handling |
-| `run_git` | TBD | Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection |
+| `run_git` | TBD | Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection; captures text output only |
 | `slugify` | 0.1.0 | Convert text to URL-friendly slug |
 | `terminal_guard` | 0.3.0 | Context manager that saves/restores terminal state |
 
@@ -264,7 +264,7 @@ Lazy-loaded symbols (accessible via `hephaestus.<name>`): `add_logging_args`,
 | `git_unmerged_files` | TBD | List unresolved merge-conflict paths through the shared Git adapter |
 | `in_git_repo` | TBD | Check whether cwd is inside a Git repository through the shared Git adapter |
 | `repo_root` | TBD | Resolve the current Git repository root through the shared Git adapter |
-| `run_git` | TBD | Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection |
+| `run_git` | TBD | Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection; captures text output only |
 | `working_tree_clean` | TBD | Check porcelain status through the shared Git adapter |
 
 ### `hephaestus.cli`

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ProjectHephaestus/
 │   ├── resilience/    # Circuit breaker + retry + subprocess resilience primitives
 │   ├── scripts_lib/   # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/        # System information collection
-│   ├── utils/         # General utility functions (slugify, retry, subprocess)
+│   ├── utils/         # General utility functions (slugify, retry, subprocess, git helpers)
 │   ├── validation/    # README, schema, and structural validation
 │   └── version/       # Version management (hatch-vcs + consistency checks)
 ├── tests/             # Unit tests
@@ -284,6 +284,7 @@ homericintelligence-hephaestus = { path = "../ProjectHephaestus", editable = tru
 - `human_readable_size(bytes)`: Convert bytes to human readable format
 - `flatten_dict(dict)`: Flatten nested dictionaries
 - `run_subprocess(cmd)`: Execute shell commands with error handling
+- `run_git(args)`: Execute Git commands through the shared subprocess adapter
 - `get_setting(config, key_path)`: Get nested dict values with dot notation
 
 ### Configuration (`hephaestus.config`)

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ homericintelligence-hephaestus = { path = "../ProjectHephaestus", editable = tru
 - `human_readable_size(bytes)`: Convert bytes to human readable format
 - `flatten_dict(dict)`: Flatten nested dictionaries
 - `run_subprocess(cmd)`: Execute shell commands with error handling
-- `run_git(args)`: Execute Git commands through the shared subprocess adapter
+- `run_git(args, retries=None)`: Execute Git commands through the shared subprocess adapter with bounded timeout and network retry protection
 - `get_setting(config, key_path)`: Get nested dict values with dot notation
 
 ### Configuration (`hephaestus.config`)

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ ProjectHephaestus is the shared utilities and tooling library for the HomericInt
 - **hephaestus.nats** — NATS JetStream subscriber for event-driven workflows
 - **hephaestus.resilience** — Circuit breaker + retry + subprocess resilience primitives
 - **hephaestus.system** — System information collection
-- **hephaestus.utils** — General utility functions (slugify, retry, subprocess helpers)
+- **hephaestus.utils** — General utility functions (slugify, retry, subprocess and git helpers)
 - **hephaestus.validation** — README, schema, and structural validation
 - **hephaestus.version** — Version management (hatch-vcs + consistency checks)
 

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -77,6 +77,7 @@ def run(
             check=check,
             log_on_error=log_errors,
             env=env,
+            retries=0,
         )
     return run_subprocess(
         cmd,

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -22,6 +22,7 @@ from hephaestus.constants import agent_git_timeout
 # marks it an explicit re-export so mypy does not flag ``attr-defined`` at the
 # 13 import sites under --no-implicit-reexport.
 from hephaestus.utils.cache import ThreadSafeCache
+from hephaestus.utils.git import run_git as _shared_run_git
 from hephaestus.utils.helpers import get_repo_root as get_repo_root, run_subprocess
 from hephaestus.utils.retry import retry_with_backoff
 
@@ -68,6 +69,15 @@ def run(
 
     """
     logger.debug("Running command: %s", " ".join(cmd))
+    if cmd and cmd[0] == "git":
+        return _shared_run_git(
+            cmd,
+            cwd=cwd,
+            timeout=timeout,
+            check=check,
+            log_on_error=log_errors,
+            env=env,
+        )
     return run_subprocess(
         cmd,
         cwd=str(cwd) if cwd else None,

--- a/hephaestus/github/fleet_sync/conflict_resolver.py
+++ b/hephaestus/github/fleet_sync/conflict_resolver.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import contextlib
-import subprocess
 from pathlib import Path
 
 from hephaestus.agents.runtime import (
@@ -20,8 +19,14 @@ from hephaestus.github.fleet_sync.git_ops import (
 )
 from hephaestus.github.fleet_sync.gpg import get_resign_email, get_resign_exec
 from hephaestus.github.fleet_sync.models import UNICODE_SYMBOLS, PRInfo, Symbols
+from hephaestus.github.git_ops import (
+    git_ls_remote_contains,
+    git_rev_list_count,
+    git_unmerged_files,
+    run_git,
+)
 from hephaestus.logging.utils import get_logger
-from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 logger = get_logger(__name__)
 
@@ -83,8 +88,8 @@ def resolve_conflict_with_agent(
         repo_clone = ensure_repo_clone(pr.repo, org, repo_clone.parent, dry_run=False)
         add_pr_worktree(repo_clone, work, branch, base, dry_run=False)
 
-        subprocess.run(
-            ["git", "rebase", f"origin/{base}"],
+        run_git(
+            ["rebase", f"origin/{base}"],
             cwd=work,
             capture_output=True,
             text=True,
@@ -92,15 +97,7 @@ def resolve_conflict_with_agent(
             timeout=NETWORK_TIMEOUT,
         )
 
-        status_result = subprocess.run(
-            ["git", "diff", "--name-only", "--diff-filter=U"],
-            cwd=work,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=METADATA_TIMEOUT,
-        )
-        conflict_files = [f.strip() for f in status_result.stdout.splitlines() if f.strip()]
+        conflict_files = git_unmerged_files(work)
 
         if not conflict_files:
             _git(["rebase", "--continue"], cwd=work, dry_run=False, check=False)
@@ -117,15 +114,7 @@ def resolve_conflict_with_agent(
                 return False
 
             conflict_list = "\n".join(f"- {f}" for f in conflict_files)
-            commit_count_result = subprocess.run(
-                ["git", "rev-list", "--count", f"origin/{base}..HEAD"],
-                cwd=work,
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=METADATA_TIMEOUT,
-            )
-            commit_count = commit_count_result.stdout.strip()
+            commit_count = str(git_rev_list_count(work, f"origin/{base}..HEAD"))
             resign_email = get_resign_email()
             resign_exec = get_resign_exec()
 
@@ -166,15 +155,7 @@ Rules:
             if not _run_conflict_agent(agent, prompt, work, pr.number):
                 return False
 
-        verify = subprocess.run(
-            ["git", "ls-remote", "origin", branch],
-            cwd=work,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=NETWORK_TIMEOUT,
-        )
-        if branch in verify.stdout:
+        if git_ls_remote_contains(work, "origin", branch):
             logger.info("  %s Conflict resolved and pushed for PR #%d", symbols.check, pr.number)
             return True
 

--- a/hephaestus/github/fleet_sync/conflict_resolver.py
+++ b/hephaestus/github/fleet_sync/conflict_resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import subprocess
 from pathlib import Path
 
 from hephaestus.agents.runtime import (
@@ -155,7 +156,13 @@ Rules:
             if not _run_conflict_agent(agent, prompt, work, pr.number):
                 return False
 
-        if git_ls_remote_contains(work, "origin", branch):
+        try:
+            remote_has_branch = git_ls_remote_contains(work, "origin", branch, raise_on_error=True)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            logger.warning("  Could not verify pushed branch for PR #%d: %s", pr.number, e)
+            return False
+
+        if remote_has_branch:
             logger.info("  %s Conflict resolved and pushed for PR #%d", symbols.check, pr.number)
             return True
 

--- a/hephaestus/github/fleet_sync/git_ops.py
+++ b/hephaestus/github/fleet_sync/git_ops.py
@@ -13,8 +13,6 @@ from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 logger = get_logger(__name__)
 
-_NETWORK_RETRY_COMMANDS = frozenset({"clone", "fetch", "ls-remote", "pull", "push"})
-
 
 def _git(
     args: list[str],
@@ -26,8 +24,7 @@ def _git(
     if dry_run:
         logger.info("[dry-run] git %s (in %s)", " ".join(args), cwd)
         return subprocess.CompletedProcess(["git", *args], 0, stdout="", stderr="")
-    retries = 2 if args and args[0] in _NETWORK_RETRY_COMMANDS else 0
-    return run_git(args, cwd=cwd, check=check, timeout=NETWORK_TIMEOUT, retries=retries)
+    return run_git(args, cwd=cwd, check=check, timeout=NETWORK_TIMEOUT)
 
 
 def ensure_repo_clone(repo: str, org: str, clone_dir: Path, dry_run: bool = False) -> Path:

--- a/hephaestus/github/fleet_sync/git_ops.py
+++ b/hephaestus/github/fleet_sync/git_ops.py
@@ -13,6 +13,8 @@ from hephaestus.utils.helpers import NETWORK_TIMEOUT
 
 logger = get_logger(__name__)
 
+_NETWORK_RETRY_COMMANDS = frozenset({"clone", "fetch", "ls-remote", "pull", "push"})
+
 
 def _git(
     args: list[str],
@@ -24,7 +26,8 @@ def _git(
     if dry_run:
         logger.info("[dry-run] git %s (in %s)", " ".join(args), cwd)
         return subprocess.CompletedProcess(["git", *args], 0, stdout="", stderr="")
-    return run_git(args, cwd=cwd, check=check, timeout=NETWORK_TIMEOUT)
+    retries = 2 if args and args[0] in _NETWORK_RETRY_COMMANDS else 0
+    return run_git(args, cwd=cwd, check=check, timeout=NETWORK_TIMEOUT, retries=retries)
 
 
 def ensure_repo_clone(repo: str, org: str, clone_dir: Path, dry_run: bool = False) -> Path:

--- a/hephaestus/github/fleet_sync/gpg.py
+++ b/hephaestus/github/fleet_sync/gpg.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 
 from hephaestus.github.git_ops import git_config_get
@@ -87,4 +88,5 @@ def get_resign_email() -> str:
 
 def get_resign_exec() -> str:
     """Return the ``git commit --amend`` shell command used as ``rebase --exec``."""
-    return f"git -c user.email={get_resign_email()} commit --amend --no-edit -S -s --reset-author"
+    email = shlex.quote(get_resign_email())
+    return f"git -c user.email={email} commit --amend --no-edit -S -s --reset-author"

--- a/hephaestus/github/fleet_sync/gpg.py
+++ b/hephaestus/github/fleet_sync/gpg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 
+from hephaestus.github.git_ops import git_config_get
 from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 
@@ -15,18 +16,8 @@ def _signing_key_uid_emails() -> list[str] | None:
     via ``gpg --list-keys --with-colons``. Returns ``None`` when the key cannot
     be determined, and an empty list when the key exposes no UID emails.
     """
-    try:
-        key_result = subprocess.run(
-            ["git", "config", "--get", "user.signingkey"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=METADATA_TIMEOUT,
-        )
-    except subprocess.TimeoutExpired:
-        return None
-    signing_key = key_result.stdout.strip()
-    if key_result.returncode != 0 or not signing_key:
+    signing_key = git_config_get("user.signingkey")
+    if not signing_key:
         return None
 
     try:
@@ -84,20 +75,10 @@ def get_resign_email() -> str:
     env = os.environ.get("FLEET_GIT_EMAIL", "").strip()
     if env:
         return _validate_resign_email(env)
-    for args in (["--global"], []):
-        try:
-            result = subprocess.run(
-                ["git", "config", *args, "--get", "user.email"],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=METADATA_TIMEOUT,
-            )
-            email = result.stdout.strip()
-            if result.returncode == 0 and email:
-                return _validate_resign_email(email)
-        except subprocess.TimeoutExpired:
-            continue
+    for global_ in (True, False):
+        email = git_config_get("user.email", global_=global_)
+        if email:
+            return _validate_resign_email(email)
     raise RuntimeError(
         "fleet_sync: no resign email configured. Set FLEET_GIT_EMAIL=<address> "
         "or `git config --global user.email <address>` before running."

--- a/hephaestus/github/git_ops.py
+++ b/hephaestus/github/git_ops.py
@@ -5,27 +5,146 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
+
+
+def _cwd_arg(cwd: Path | str | None) -> str | None:
+    """Return a subprocess-compatible cwd value."""
+    return str(cwd) if isinstance(cwd, Path) else cwd
+
+
+def _git_command(args: list[str]) -> list[str]:
+    """Normalize a git argument vector to exactly one leading ``git``."""
+    normalized = list(args)
+    if normalized and normalized[0] == "git":
+        normalized = normalized[1:]
+    return ["git", *normalized]
 
 
 def run_git(
     args: list[str],
     *,
-    cwd: Path | None = None,
-    timeout: float = NETWORK_TIMEOUT,
+    cwd: Path | str | None = None,
+    timeout: int | None = NETWORK_TIMEOUT,
     capture_output: bool = True,
     text: bool = True,
     check: bool = True,
+    dry_run: bool = False,
+    log_on_error: bool = True,
 ) -> subprocess.CompletedProcess[str]:
-    """Run git with the repository's standard subprocess defaults."""
-    return subprocess.run(
-        ["git", *args],
-        cwd=cwd,
-        capture_output=capture_output,
-        text=text,
+    """Run git through the repository's standard subprocess helper."""
+    if not capture_output or not text:
+        raise ValueError("run_git always captures text output through run_subprocess")
+    return run_subprocess(
+        _git_command(args),
+        cwd=_cwd_arg(cwd),
         check=check,
         timeout=timeout,
+        dry_run=dry_run,
+        log_on_error=log_on_error,
     )
+
+
+def git_config_get(key: str, *, global_: bool = False, cwd: Path | str | None = None) -> str | None:
+    """Return a git config value, or None when the key is unset."""
+    args = ["config"]
+    if global_:
+        args.append("--global")
+    args.extend(["--get", key])
+    try:
+        result = run_git(
+            args,
+            cwd=cwd,
+            timeout=METADATA_TIMEOUT,
+            check=False,
+            log_on_error=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        return None
+    return value
+
+
+def git_remote_url(remote: str = "origin", *, cwd: Path | str | None = None) -> str | None:
+    """Return a git remote URL, or None when it cannot be read."""
+    try:
+        result = run_git(
+            ["remote", "get-url", remote],
+            cwd=cwd,
+            timeout=METADATA_TIMEOUT,
+            check=False,
+            log_on_error=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        return None
+    return value
+
+
+def git_branch_exists(branch_name: str, *, cwd: Path | str | None = None) -> bool:
+    """Return whether a local branch exists."""
+    try:
+        result = run_git(
+            ["branch", "--list", branch_name],
+            cwd=cwd,
+            timeout=METADATA_TIMEOUT,
+            check=False,
+            log_on_error=False,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return False
+    return bool(result.stdout.strip())
+
+
+def git_push(
+    cwd: Path | str | None,
+    remote: str,
+    refspec: str,
+    *,
+    dry_run: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Push ``refspec`` to ``remote`` from ``cwd``."""
+    return run_git(
+        ["push", remote, refspec],
+        cwd=cwd,
+        dry_run=dry_run,
+        timeout=NETWORK_TIMEOUT,
+    )
+
+
+def git_unmerged_files(cwd: Path | str) -> list[str]:
+    """Return files with unresolved merge conflicts in ``cwd``."""
+    result = run_git(
+        ["diff", "--name-only", "--diff-filter=U"],
+        cwd=cwd,
+        timeout=METADATA_TIMEOUT,
+    )
+    return [path.strip() for path in result.stdout.splitlines() if path.strip()]
+
+
+def git_rev_list_count(cwd: Path | str, revspec: str) -> int:
+    """Return ``git rev-list --count`` for ``revspec`` in ``cwd``."""
+    result = run_git(
+        ["rev-list", "--count", revspec],
+        cwd=cwd,
+        timeout=METADATA_TIMEOUT,
+    )
+    return int(result.stdout.strip())
+
+
+def git_ls_remote_contains(cwd: Path | str, remote: str, ref: str) -> bool:
+    """Return whether ``remote`` advertises ``ref``."""
+    result = run_git(
+        ["ls-remote", remote, ref],
+        cwd=cwd,
+        timeout=NETWORK_TIMEOUT,
+        check=False,
+    )
+    return result.returncode == 0 and ref in result.stdout
 
 
 def working_tree_clean() -> bool:

--- a/hephaestus/github/git_ops.py
+++ b/hephaestus/github/git_ops.py
@@ -1,176 +1,36 @@
-"""Shared git subprocess helpers for GitHub-facing CLIs."""
+"""Compatibility exports for shared git subprocess helpers.
+
+The implementation lives in :mod:`hephaestus.utils.git` so library packages and
+``hephaestus.automation`` can share one git subprocess path without making
+``hephaestus.github`` depend on the automation product layer.
+"""
 
 from __future__ import annotations
 
-import subprocess
-from pathlib import Path
+from hephaestus.utils.git import (
+    git_branch_exists,
+    git_config_get,
+    git_ls_remote_contains,
+    git_push,
+    git_remote_url,
+    git_rev_list_count,
+    git_unmerged_files,
+    in_git_repo,
+    repo_root,
+    run_git,
+    working_tree_clean,
+)
 
-from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
-
-
-def _cwd_arg(cwd: Path | str | None) -> str | None:
-    """Return a subprocess-compatible cwd value."""
-    return str(cwd) if isinstance(cwd, Path) else cwd
-
-
-def _git_command(args: list[str]) -> list[str]:
-    """Normalize a git argument vector to exactly one leading ``git``."""
-    normalized = list(args)
-    if normalized and normalized[0] == "git":
-        normalized = normalized[1:]
-    return ["git", *normalized]
-
-
-def run_git(
-    args: list[str],
-    *,
-    cwd: Path | str | None = None,
-    timeout: int | None = NETWORK_TIMEOUT,
-    capture_output: bool = True,
-    text: bool = True,
-    check: bool = True,
-    dry_run: bool = False,
-    log_on_error: bool = True,
-) -> subprocess.CompletedProcess[str]:
-    """Run git through the repository's standard subprocess helper."""
-    if not capture_output or not text:
-        raise ValueError("run_git always captures text output through run_subprocess")
-    return run_subprocess(
-        _git_command(args),
-        cwd=_cwd_arg(cwd),
-        check=check,
-        timeout=timeout,
-        dry_run=dry_run,
-        log_on_error=log_on_error,
-    )
-
-
-def git_config_get(key: str, *, global_: bool = False, cwd: Path | str | None = None) -> str | None:
-    """Return a git config value, or None when the key is unset."""
-    args = ["config"]
-    if global_:
-        args.append("--global")
-    args.extend(["--get", key])
-    try:
-        result = run_git(
-            args,
-            cwd=cwd,
-            timeout=METADATA_TIMEOUT,
-            check=False,
-            log_on_error=False,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    value = result.stdout.strip()
-    if result.returncode != 0 or not value:
-        return None
-    return value
-
-
-def git_remote_url(remote: str = "origin", *, cwd: Path | str | None = None) -> str | None:
-    """Return a git remote URL, or None when it cannot be read."""
-    try:
-        result = run_git(
-            ["remote", "get-url", remote],
-            cwd=cwd,
-            timeout=METADATA_TIMEOUT,
-            check=False,
-            log_on_error=False,
-        )
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return None
-    value = result.stdout.strip()
-    if result.returncode != 0 or not value:
-        return None
-    return value
-
-
-def git_branch_exists(branch_name: str, *, cwd: Path | str | None = None) -> bool:
-    """Return whether a local branch exists."""
-    try:
-        result = run_git(
-            ["branch", "--list", branch_name],
-            cwd=cwd,
-            timeout=METADATA_TIMEOUT,
-            check=False,
-            log_on_error=False,
-        )
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-        return False
-    return bool(result.stdout.strip())
-
-
-def git_push(
-    cwd: Path | str | None,
-    remote: str,
-    refspec: str,
-    *,
-    dry_run: bool = False,
-) -> subprocess.CompletedProcess[str]:
-    """Push ``refspec`` to ``remote`` from ``cwd``."""
-    return run_git(
-        ["push", remote, refspec],
-        cwd=cwd,
-        dry_run=dry_run,
-        timeout=NETWORK_TIMEOUT,
-    )
-
-
-def git_unmerged_files(cwd: Path | str) -> list[str]:
-    """Return files with unresolved merge conflicts in ``cwd``."""
-    result = run_git(
-        ["diff", "--name-only", "--diff-filter=U"],
-        cwd=cwd,
-        timeout=METADATA_TIMEOUT,
-    )
-    return [path.strip() for path in result.stdout.splitlines() if path.strip()]
-
-
-def git_rev_list_count(cwd: Path | str, revspec: str) -> int:
-    """Return ``git rev-list --count`` for ``revspec`` in ``cwd``."""
-    result = run_git(
-        ["rev-list", "--count", revspec],
-        cwd=cwd,
-        timeout=METADATA_TIMEOUT,
-    )
-    return int(result.stdout.strip())
-
-
-def git_ls_remote_contains(cwd: Path | str, remote: str, ref: str) -> bool:
-    """Return whether ``remote`` advertises ``ref``."""
-    result = run_git(
-        ["ls-remote", remote, ref],
-        cwd=cwd,
-        timeout=NETWORK_TIMEOUT,
-        check=False,
-    )
-    return result.returncode == 0 and ref in result.stdout
-
-
-def working_tree_clean() -> bool:
-    """Return True if the current git working tree has no uncommitted changes."""
-    result = run_git(
-        ["status", "--porcelain"],
-        timeout=METADATA_TIMEOUT,
-        check=False,
-    )
-    return result.returncode == 0 and result.stdout.strip() == ""
-
-
-def in_git_repo() -> bool:
-    """Return True if the current directory is inside a git repository."""
-    result = run_git(
-        ["rev-parse", "--git-dir"],
-        timeout=METADATA_TIMEOUT,
-        check=False,
-    )
-    return result.returncode == 0
-
-
-def repo_root() -> Path:
-    """Return the root directory of the current git repository."""
-    result = run_git(
-        ["rev-parse", "--show-toplevel"],
-        timeout=METADATA_TIMEOUT,
-    )
-    return Path(result.stdout.strip())
+__all__ = [
+    "git_branch_exists",
+    "git_config_get",
+    "git_ls_remote_contains",
+    "git_push",
+    "git_remote_url",
+    "git_rev_list_count",
+    "git_unmerged_files",
+    "in_git_repo",
+    "repo_root",
+    "run_git",
+    "working_tree_clean",
+]

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -31,8 +31,8 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 from hephaestus.github.client import gh_call
+from hephaestus.github.git_ops import git_branch_exists, git_push, git_remote_url, run_git
 from hephaestus.logging.utils import get_logger
-from hephaestus.utils.helpers import METADATA_TIMEOUT, run_subprocess
 
 logger = get_logger(__name__)
 
@@ -45,8 +45,10 @@ def detect_repo_from_remote() -> str | None:
 
     """
     try:
-        result = run_subprocess(["git", "remote", "get-url", "origin"])
-        remote_url = result.stdout.strip()
+        remote_url = git_remote_url()
+        if not remote_url:
+            logger.warning("Could not read GitHub repo from origin remote")
+            return None
 
         # Parse github.com:owner/repo.git or https://github.com/owner/repo.git
         patterns = [
@@ -81,7 +83,7 @@ def run_git_cmd(cmd: list[str], dry_run: bool = False, cwd: str | None = None) -
         logger.info("$ %s (cwd=%s)", " ".join(cmd), cwd)
     else:
         logger.info("$ %s", " ".join(cmd))
-    run_subprocess(cmd, cwd=cwd, dry_run=dry_run)
+    run_git(cmd, cwd=cwd, dry_run=dry_run)
 
 
 def checks_success_and_log(commit: Any) -> tuple[bool | None, list[Any]]:
@@ -150,12 +152,7 @@ def local_branch_exists(branch_name: str) -> bool:
 
     """
     try:
-        result = run_subprocess(
-            ["git", "branch", "--list", branch_name],
-            timeout=METADATA_TIMEOUT,
-            log_on_error=False,
-        )
-        return bool(result.stdout.strip())
+        return git_branch_exists(branch_name)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return False
 
@@ -175,7 +172,7 @@ def try_push_head_branch(head_branch: str, dry_run: bool) -> None:
         return
 
     if local_branch_exists(head_branch):
-        run_git_cmd(["git", "push", "origin", f"{head_branch}:{head_branch}"], dry_run=False)
+        git_push(None, "origin", f"{head_branch}:{head_branch}", dry_run=False)
     else:
         logger.info(
             "  Local branch '%s' not found; assuming remote branch already present.", head_branch

--- a/hephaestus/utils/__init__.py
+++ b/hephaestus/utils/__init__.py
@@ -3,6 +3,9 @@
 # Import from cache
 from .cache import ThreadSafeCache
 
+# Import from git
+from .git import run_git
+
 # Import from helpers
 from .helpers import (
     flatten_dict,
@@ -40,6 +43,7 @@ __all__ = [
     "restore_terminal",
     "retry_on_network_error",
     "retry_with_backoff",
+    "run_git",
     "run_subprocess",
     "slugify",
     "terminal_guard",

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -44,6 +45,18 @@ _GIT_GLOBAL_FLAGS = frozenset(
     }
 )
 _LOG_STREAM_TAIL_MAX = 2000
+
+
+_REDACTED_GIT_URL = "<redacted-git-url>"
+_REDACTED_VALUE = "<redacted-value>"
+_GIT_URL_RE = re.compile(r"\b(?:https?|ssh|git)://\S+", re.IGNORECASE)
+_GIT_SCP_REMOTE_RE = re.compile(r"(?<![\w./-])(?:[\w.-]+@)?[\w.-]+:\S+(?:\.git)?")
+_GIT_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(access_token|auth_token|oauth_token|token|password|passwd|secret|credential)="
+    r"([^&\s]+)"
+)
+_GIT_AUTH_HEADER_RE = re.compile(r"(?i)\b(authorization:\s*(?:basic|bearer)\s+)\S+")
+_GITHUB_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b")
 
 
 def _cwd_arg(cwd: Path | str | None) -> str | None:
@@ -109,6 +122,28 @@ def _tail_for_log(value: str, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
     return f"...({omitted} earlier chars){value[-limit:]}"
 
 
+def _redact_git_diagnostics(value: str) -> str:
+    """Return Git diagnostics with credential-bearing values redacted."""
+    redacted = _GIT_AUTH_HEADER_RE.sub(r"\1" + _REDACTED_VALUE, value)
+    redacted = _GIT_SECRET_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}={_REDACTED_VALUE}", redacted
+    )
+    redacted = _GITHUB_TOKEN_RE.sub(_REDACTED_VALUE, redacted)
+    redacted = _GIT_URL_RE.sub(_REDACTED_GIT_URL, redacted)
+    redacted = _GIT_SCP_REMOTE_RE.sub(_REDACTED_GIT_URL, redacted)
+    return redacted
+
+
+def _format_git_cmd_for_log(cmd: list[str]) -> str:
+    """Return a redacted Git command string for logs."""
+    return " ".join(_redact_git_diagnostics(part) for part in cmd)
+
+
+def _tail_for_git_log(value: str) -> str:
+    """Return a bounded redacted tail for Git subprocess streams."""
+    return _tail_for_log(_redact_git_diagnostics(value))
+
+
 def _is_retryable_git_error(error: BaseException) -> bool:
     """Return True for transient Git subprocess failures."""
     if isinstance(error, subprocess.TimeoutExpired):
@@ -123,7 +158,7 @@ def _is_retryable_git_error(error: BaseException) -> bool:
 
 def _log_retry_managed_git_failure(cmd: list[str], error: BaseException) -> None:
     """Log the final failure from a retry-managed Git command."""
-    logger.error("Git command failed after retry handling: %s", " ".join(cmd))
+    logger.error("Git command failed after retry handling: %s", _format_git_cmd_for_log(cmd))
     if isinstance(error, subprocess.TimeoutExpired):
         if error.timeout is not None:
             logger.error("timeout: %s", error.timeout)
@@ -133,12 +168,12 @@ def _log_retry_managed_git_failure(cmd: list[str], error: BaseException) -> None
         stdout = _as_text(error.stdout)
         stderr = _as_text(error.stderr)
     else:
-        logger.error("error: %s", error)
+        logger.error("error: %s", _redact_git_diagnostics(str(error)))
         return
     if stdout:
-        logger.error("stdout: %s", _tail_for_log(stdout))
+        logger.error("stdout: %s", _tail_for_git_log(stdout))
     if stderr:
-        logger.error("stderr: %s", _tail_for_log(stderr))
+        logger.error("stderr: %s", _tail_for_git_log(stderr))
 
 
 def run_git(

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -13,6 +13,37 @@ from hephaestus.utils.retry import is_network_error, retry_with_backoff
 logger = logging.getLogger(__name__)
 
 _NETWORK_GIT_COMMANDS = frozenset({"clone", "fetch", "ls-remote", "pull", "push"})
+_GIT_GLOBAL_OPTIONS_WITH_VALUE = frozenset(
+    {
+        "-C",
+        "-c",
+        "--config-env",
+        "--exec-path",
+        "--git-dir",
+        "--namespace",
+        "--super-prefix",
+        "--work-tree",
+    }
+)
+_GIT_GLOBAL_FLAGS = frozenset(
+    {
+        "--bare",
+        "--glob-pathspecs",
+        "--help",
+        "--html-path",
+        "--icase-pathspecs",
+        "--info-path",
+        "--literal-pathspecs",
+        "--man-path",
+        "--no-optional-locks",
+        "--no-pager",
+        "--no-replace-objects",
+        "--noglob-pathspecs",
+        "--paginate",
+        "--version",
+    }
+)
+_LOG_STREAM_TAIL_MAX = 2000
 
 
 def _cwd_arg(cwd: Path | str | None) -> str | None:
@@ -33,14 +64,81 @@ def _git_args(args: list[str]) -> list[str]:
     return _git_command(args)[1:]
 
 
+def _git_option_name(arg: str) -> str:
+    """Return the option name without an inline ``=value`` suffix."""
+    return arg.split("=", 1)[0]
+
+
+def _git_subcommand(args: list[str]) -> str | None:
+    """Return the git subcommand after leading global options."""
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        option_name = _git_option_name(arg)
+        if arg == "--":
+            return args[index + 1] if index + 1 < len(args) else None
+        if arg in _GIT_GLOBAL_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if "=" in arg and option_name in _GIT_GLOBAL_OPTIONS_WITH_VALUE:
+            index += 1
+            continue
+        if arg in _GIT_GLOBAL_FLAGS:
+            index += 1
+            continue
+        if arg.startswith("-"):
+            return None
+        return arg
+    return None
+
+
+def _as_text(value: object) -> str:
+    """Return subprocess stream data as text for classification/logging."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _tail_for_log(value: str, limit: int = _LOG_STREAM_TAIL_MAX) -> str:
+    """Return a bounded tail for Git subprocess streams."""
+    if len(value) <= limit:
+        return value
+    omitted = len(value) - limit
+    return f"...({omitted} earlier chars){value[-limit:]}"
+
+
 def _is_retryable_git_error(error: BaseException) -> bool:
     """Return True for transient Git subprocess failures."""
     if isinstance(error, subprocess.TimeoutExpired):
         return True
     if not isinstance(error, subprocess.CalledProcessError):
         return False
-    blob = "\n".join(part for part in (error.stdout, error.stderr, str(error)) if part)
+    blob = "\n".join(
+        part for part in (_as_text(error.stdout), _as_text(error.stderr), str(error)) if part
+    )
     return is_network_error(Exception(blob))
+
+
+def _log_retry_managed_git_failure(cmd: list[str], error: BaseException) -> None:
+    """Log the final failure from a retry-managed Git command."""
+    logger.error("Git command failed after retry handling: %s", " ".join(cmd))
+    if isinstance(error, subprocess.TimeoutExpired):
+        if error.timeout is not None:
+            logger.error("timeout: %s", error.timeout)
+        stdout = _as_text(error.output)
+        stderr = _as_text(error.stderr)
+    elif isinstance(error, subprocess.CalledProcessError):
+        stdout = _as_text(error.stdout)
+        stderr = _as_text(error.stderr)
+    else:
+        logger.error("error: %s", error)
+        return
+    if stdout:
+        logger.error("stdout: %s", _tail_for_log(stdout))
+    if stderr:
+        logger.error("stderr: %s", _tail_for_log(stderr))
 
 
 def run_git(
@@ -62,7 +160,7 @@ def run_git(
 
     normalized_args = _git_args(args)
     if retries is None:
-        retries = 2 if normalized_args and normalized_args[0] in _NETWORK_GIT_COMMANDS else 0
+        retries = 2 if _git_subcommand(normalized_args) in _NETWORK_GIT_COMMANDS else 0
 
     def _call(*, log_errors: bool = log_on_error) -> subprocess.CompletedProcess[str]:
         kwargs: dict[str, Any] = {
@@ -79,8 +177,6 @@ def run_git(
     if retries <= 0:
         return _call()
 
-    retry_log_on_error = False if log_on_error else log_on_error
-
     @retry_with_backoff(
         max_retries=retries,
         initial_delay=1.0,
@@ -91,9 +187,14 @@ def run_git(
         retry_predicate=_is_retryable_git_error,
     )
     def _retrying_call() -> subprocess.CompletedProcess[str]:
-        return _call(log_errors=retry_log_on_error)
+        return _call(log_errors=False)
 
-    return _retrying_call()
+    try:
+        return _retrying_call()
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        if log_on_error:
+            _log_retry_managed_git_failure(["git", *normalized_args], e)
+        raise
 
 
 def git_config_get(key: str, *, global_: bool = False, cwd: Path | str | None = None) -> str | None:

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 from pathlib import Path
 
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
+from hephaestus.utils.retry import retry_with_backoff
+
+logger = logging.getLogger(__name__)
+
+_NETWORK_GIT_COMMANDS = frozenset({"clone", "fetch", "ls-remote", "pull", "push"})
 
 
 def _cwd_arg(cwd: Path | str | None) -> str | None:
@@ -21,6 +27,11 @@ def _git_command(args: list[str]) -> list[str]:
     return ["git", *normalized]
 
 
+def _git_args(args: list[str]) -> list[str]:
+    """Return git arguments without the leading executable."""
+    return _git_command(args)[1:]
+
+
 def run_git(
     args: list[str],
     *,
@@ -32,28 +43,52 @@ def run_git(
     dry_run: bool = False,
     log_on_error: bool = True,
     env: dict[str, str] | None = None,
+    retries: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run git through the repository's standard subprocess helper."""
     if not capture_output or not text:
         raise ValueError("run_git always captures text output through run_subprocess")
-    if env is None:
+
+    normalized_args = _git_args(args)
+    if retries is None:
+        retries = 2 if normalized_args and normalized_args[0] in _NETWORK_GIT_COMMANDS else 0
+
+    def _call() -> subprocess.CompletedProcess[str]:
+        cmd = ["git", *normalized_args]
+        if env is None:
+            return run_subprocess(
+                cmd,
+                cwd=_cwd_arg(cwd),
+                check=check,
+                timeout=timeout,
+                dry_run=dry_run,
+                log_on_error=log_on_error,
+            )
         return run_subprocess(
-            _git_command(args),
+            cmd,
             cwd=_cwd_arg(cwd),
             check=check,
             timeout=timeout,
             dry_run=dry_run,
             log_on_error=log_on_error,
+            env=env,
         )
-    return run_subprocess(
-        _git_command(args),
-        cwd=_cwd_arg(cwd),
-        check=check,
-        timeout=timeout,
-        dry_run=dry_run,
-        log_on_error=log_on_error,
-        env=env,
+
+    if retries <= 0:
+        return _call()
+
+    @retry_with_backoff(
+        max_retries=retries,
+        initial_delay=1.0,
+        backoff_factor=2,
+        retry_on=(subprocess.CalledProcessError, subprocess.TimeoutExpired),
+        logger=logger.warning,
+        jitter=True,
     )
+    def _retrying_call() -> subprocess.CompletedProcess[str]:
+        return _call()
+
+    return _retrying_call()
 
 
 def git_config_get(key: str, *, global_: bool = False, cwd: Path | str | None = None) -> str | None:
@@ -117,6 +152,7 @@ def git_push(
     refspec: str,
     *,
     dry_run: bool = False,
+    retries: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Push ``refspec`` to ``remote`` from ``cwd``."""
     return run_git(
@@ -124,6 +160,7 @@ def git_push(
         cwd=cwd,
         dry_run=dry_run,
         timeout=NETWORK_TIMEOUT,
+        retries=retries,
     )
 
 
@@ -157,13 +194,15 @@ def _remote_ref_candidates(ref: str) -> set[str]:
 
 def git_ls_remote_contains(cwd: Path | str, remote: str, ref: str) -> bool:
     """Return whether ``remote`` advertises ``ref`` as an exact ref."""
-    result = run_git(
-        ["ls-remote", remote, ref],
-        cwd=cwd,
-        timeout=NETWORK_TIMEOUT,
-        check=False,
-    )
-    if result.returncode != 0:
+    try:
+        result = run_git(
+            ["ls-remote", remote, ref],
+            cwd=cwd,
+            timeout=NETWORK_TIMEOUT,
+            check=True,
+            log_on_error=False,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
         return False
 
     candidates = _remote_ref_candidates(ref)

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -1,0 +1,218 @@
+"""Shared git subprocess helpers for library and product layers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
+
+
+def _cwd_arg(cwd: Path | str | None) -> str | None:
+    """Return a subprocess-compatible cwd value."""
+    return str(cwd) if isinstance(cwd, Path) else cwd
+
+
+def _git_command(args: list[str]) -> list[str]:
+    """Normalize a git argument vector to exactly one leading ``git``."""
+    normalized = list(args)
+    if normalized and normalized[0] == "git":
+        normalized = normalized[1:]
+    return ["git", *normalized]
+
+
+def run_git(
+    args: list[str],
+    *,
+    cwd: Path | str | None = None,
+    timeout: int | None = NETWORK_TIMEOUT,
+    capture_output: bool = True,
+    text: bool = True,
+    check: bool = True,
+    dry_run: bool = False,
+    log_on_error: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run git through the repository's standard subprocess helper."""
+    if not capture_output or not text:
+        raise ValueError("run_git always captures text output through run_subprocess")
+    if env is None:
+        return run_subprocess(
+            _git_command(args),
+            cwd=_cwd_arg(cwd),
+            check=check,
+            timeout=timeout,
+            dry_run=dry_run,
+            log_on_error=log_on_error,
+        )
+    return run_subprocess(
+        _git_command(args),
+        cwd=_cwd_arg(cwd),
+        check=check,
+        timeout=timeout,
+        dry_run=dry_run,
+        log_on_error=log_on_error,
+        env=env,
+    )
+
+
+def git_config_get(key: str, *, global_: bool = False, cwd: Path | str | None = None) -> str | None:
+    """Return a git config value, or None when the key is unset."""
+    args = ["config"]
+    if global_:
+        args.append("--global")
+    args.extend(["--get", key])
+    try:
+        result = run_git(
+            args,
+            cwd=cwd,
+            timeout=METADATA_TIMEOUT,
+            check=False,
+            log_on_error=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        return None
+    return value
+
+
+def git_remote_url(remote: str = "origin", *, cwd: Path | str | None = None) -> str | None:
+    """Return a git remote URL, or None when it cannot be read."""
+    try:
+        result = run_git(
+            ["remote", "get-url", remote],
+            cwd=cwd,
+            timeout=METADATA_TIMEOUT,
+            check=False,
+            log_on_error=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    value = result.stdout.strip()
+    if result.returncode != 0 or not value:
+        return None
+    return value
+
+
+def git_branch_exists(branch_name: str, *, cwd: Path | str | None = None) -> bool:
+    """Return whether a local branch exists."""
+    try:
+        result = run_git(
+            ["branch", "--list", branch_name],
+            cwd=cwd,
+            timeout=METADATA_TIMEOUT,
+            check=False,
+            log_on_error=False,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    return bool(result.stdout.strip())
+
+
+def git_push(
+    cwd: Path | str | None,
+    remote: str,
+    refspec: str,
+    *,
+    dry_run: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Push ``refspec`` to ``remote`` from ``cwd``."""
+    return run_git(
+        ["push", remote, refspec],
+        cwd=cwd,
+        dry_run=dry_run,
+        timeout=NETWORK_TIMEOUT,
+    )
+
+
+def git_unmerged_files(cwd: Path | str) -> list[str]:
+    """Return files with unresolved merge conflicts in ``cwd``."""
+    result = run_git(
+        ["diff", "--name-only", "--diff-filter=U"],
+        cwd=cwd,
+        timeout=METADATA_TIMEOUT,
+    )
+    return [path.strip() for path in result.stdout.splitlines() if path.strip()]
+
+
+def git_rev_list_count(cwd: Path | str, revspec: str) -> int:
+    """Return ``git rev-list --count`` for ``revspec`` in ``cwd``."""
+    result = run_git(
+        ["rev-list", "--count", revspec],
+        cwd=cwd,
+        timeout=METADATA_TIMEOUT,
+    )
+    return int(result.stdout.strip())
+
+
+def _remote_ref_candidates(ref: str) -> set[str]:
+    """Return exact advertised refs that satisfy ``ref``."""
+    candidates = {ref}
+    if ref != "HEAD" and not ref.startswith("refs/"):
+        candidates.add(f"refs/heads/{ref}")
+    return candidates
+
+
+def git_ls_remote_contains(cwd: Path | str, remote: str, ref: str) -> bool:
+    """Return whether ``remote`` advertises ``ref`` as an exact ref."""
+    result = run_git(
+        ["ls-remote", remote, ref],
+        cwd=cwd,
+        timeout=NETWORK_TIMEOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+
+    candidates = _remote_ref_candidates(ref)
+    for line in result.stdout.splitlines():
+        fields = line.split()
+        if len(fields) >= 2 and fields[1] in candidates:
+            return True
+    return False
+
+
+def working_tree_clean() -> bool:
+    """Return True if the current git working tree has no uncommitted changes."""
+    result = run_git(
+        ["status", "--porcelain"],
+        timeout=METADATA_TIMEOUT,
+        check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip() == ""
+
+
+def in_git_repo() -> bool:
+    """Return True if the current directory is inside a git repository."""
+    result = run_git(
+        ["rev-parse", "--git-dir"],
+        timeout=METADATA_TIMEOUT,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def repo_root() -> Path:
+    """Return the root directory of the current git repository."""
+    result = run_git(
+        ["rev-parse", "--show-toplevel"],
+        timeout=METADATA_TIMEOUT,
+    )
+    return Path(result.stdout.strip())
+
+
+__all__ = [
+    "git_branch_exists",
+    "git_config_get",
+    "git_ls_remote_contains",
+    "git_push",
+    "git_remote_url",
+    "git_rev_list_count",
+    "git_unmerged_files",
+    "in_git_repo",
+    "repo_root",
+    "run_git",
+    "working_tree_clean",
+]

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -64,13 +64,13 @@ def run_git(
     if retries is None:
         retries = 2 if normalized_args and normalized_args[0] in _NETWORK_GIT_COMMANDS else 0
 
-    def _call() -> subprocess.CompletedProcess[str]:
+    def _call(*, log_errors: bool = log_on_error) -> subprocess.CompletedProcess[str]:
         kwargs: dict[str, Any] = {
             "cwd": _cwd_arg(cwd),
             "check": check,
             "timeout": timeout,
             "dry_run": dry_run,
-            "log_on_error": log_on_error,
+            "log_on_error": log_errors,
         }
         if env is not None:
             kwargs["env"] = env
@@ -78,6 +78,8 @@ def run_git(
 
     if retries <= 0:
         return _call()
+
+    retry_log_on_error = False if log_on_error else log_on_error
 
     @retry_with_backoff(
         max_retries=retries,
@@ -89,7 +91,7 @@ def run_git(
         retry_predicate=_is_retryable_git_error,
     )
     def _retrying_call() -> subprocess.CompletedProcess[str]:
-        return _call()
+        return _call(log_errors=retry_log_on_error)
 
     return _retrying_call()
 
@@ -195,7 +197,13 @@ def _remote_ref_candidates(ref: str) -> set[str]:
     return candidates
 
 
-def git_ls_remote_contains(cwd: Path | str, remote: str, ref: str) -> bool:
+def git_ls_remote_contains(
+    cwd: Path | str,
+    remote: str,
+    ref: str,
+    *,
+    raise_on_error: bool = False,
+) -> bool:
     """Return whether ``remote`` advertises ``ref`` as an exact ref."""
     try:
         result = run_git(
@@ -206,6 +214,8 @@ def git_ls_remote_contains(cwd: Path | str, remote: str, ref: str) -> bool:
             log_on_error=False,
         )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+        if raise_on_error:
+            raise
         return False
 
     candidates = _remote_ref_candidates(ref)

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -56,7 +56,10 @@ _GIT_SECRET_ASSIGNMENT_RE = re.compile(
     r"([^&\s]+)"
 )
 _GIT_AUTH_HEADER_RE = re.compile(r"(?i)\b(authorization:\s*(?:basic|bearer)\s+)\S+")
-_GITHUB_TOKEN_RE = re.compile(r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b")
+_GITHUB_TOKEN_RE = re.compile(
+    r"\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github"
+    r"_pat_[A-Za-z0-9_]{20,})\b"
+)
 
 
 def _cwd_arg(cwd: Path | str | None) -> str | None:
@@ -144,6 +147,11 @@ def _tail_for_git_log(value: str) -> str:
     return _tail_for_log(_redact_git_diagnostics(value))
 
 
+def _log_git_retry_warning(message: str) -> None:
+    """Log retry utility warnings without credential-bearing Git diagnostics."""
+    logger.warning(_redact_git_diagnostics(message))
+
+
 def _is_retryable_git_error(error: BaseException) -> bool:
     """Return True for transient Git subprocess failures."""
     if isinstance(error, subprocess.TimeoutExpired):
@@ -217,7 +225,7 @@ def run_git(
         initial_delay=1.0,
         backoff_factor=2,
         retry_on=(subprocess.CalledProcessError, subprocess.TimeoutExpired),
-        logger=logger.warning,
+        logger=_log_git_retry_warning,
         jitter=True,
         retry_predicate=_is_retryable_git_error,
     )

--- a/hephaestus/utils/git.py
+++ b/hephaestus/utils/git.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 import subprocess
 from pathlib import Path
+from typing import Any
 
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT, run_subprocess
-from hephaestus.utils.retry import retry_with_backoff
+from hephaestus.utils.retry import is_network_error, retry_with_backoff
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,16 @@ def _git_args(args: list[str]) -> list[str]:
     return _git_command(args)[1:]
 
 
+def _is_retryable_git_error(error: BaseException) -> bool:
+    """Return True for transient Git subprocess failures."""
+    if isinstance(error, subprocess.TimeoutExpired):
+        return True
+    if not isinstance(error, subprocess.CalledProcessError):
+        return False
+    blob = "\n".join(part for part in (error.stdout, error.stderr, str(error)) if part)
+    return is_network_error(Exception(blob))
+
+
 def run_git(
     args: list[str],
     *,
@@ -54,25 +65,16 @@ def run_git(
         retries = 2 if normalized_args and normalized_args[0] in _NETWORK_GIT_COMMANDS else 0
 
     def _call() -> subprocess.CompletedProcess[str]:
-        cmd = ["git", *normalized_args]
-        if env is None:
-            return run_subprocess(
-                cmd,
-                cwd=_cwd_arg(cwd),
-                check=check,
-                timeout=timeout,
-                dry_run=dry_run,
-                log_on_error=log_on_error,
-            )
-        return run_subprocess(
-            cmd,
-            cwd=_cwd_arg(cwd),
-            check=check,
-            timeout=timeout,
-            dry_run=dry_run,
-            log_on_error=log_on_error,
-            env=env,
-        )
+        kwargs: dict[str, Any] = {
+            "cwd": _cwd_arg(cwd),
+            "check": check,
+            "timeout": timeout,
+            "dry_run": dry_run,
+            "log_on_error": log_on_error,
+        }
+        if env is not None:
+            kwargs["env"] = env
+        return run_subprocess(["git", *normalized_args], **kwargs)
 
     if retries <= 0:
         return _call()
@@ -84,6 +86,7 @@ def run_git(
         retry_on=(subprocess.CalledProcessError, subprocess.TimeoutExpired),
         logger=logger.warning,
         jitter=True,
+        retry_predicate=_is_retryable_git_error,
     )
     def _retrying_call() -> subprocess.CompletedProcess[str]:
         return _call()

--- a/hephaestus/utils/helpers.py
+++ b/hephaestus/utils/helpers.py
@@ -233,11 +233,12 @@ def run_subprocess(
         )
         return result
     except subprocess.TimeoutExpired:
-        logger.error(
-            "Command timed out after %ds: %s",
-            timeout,
-            _format_cmd_for_log(cmd),
-        )
+        if log_on_error:
+            logger.error(
+                "Command timed out after %ds: %s",
+                timeout,
+                _format_cmd_for_log(cmd),
+            )
         raise
     except subprocess.CalledProcessError as e:
         if log_on_error:

--- a/hephaestus/validation/api_table_docs.py
+++ b/hephaestus/validation/api_table_docs.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 from hephaestus.cli.utils import create_validation_parser, resolve_repo_root
 
-# Subpackages whose API tables are completeness-guarded. Add a name here only
+# Modules whose API tables are completeness-guarded. Add a name here only
 # after authoring its table in COMPATIBILITY.md.
 GUARDED_PACKAGES: tuple[str, ...] = (
     "hephaestus.cli",
@@ -65,8 +65,8 @@ def load_documented_symbols(compatibility_path: Path) -> dict[str, set[str]]:
         compatibility_path: Path to ``COMPATIBILITY.md``.
 
     Returns:
-        Mapping from fully-qualified package name to the set of symbol names
-        parsed from that package's table.
+        Mapping from fully-qualified module name to the set of symbol names
+        parsed from that module's table.
 
     """
     tables: dict[str, set[str]] = {}
@@ -95,10 +95,10 @@ def live_all(package: str) -> set[str]:
     """Return the live ``__all__`` of *package* as a set.
 
     Args:
-        package: Fully-qualified package name (e.g. ``hephaestus.utils``).
+        package: Fully-qualified module name (e.g. ``hephaestus.utils``).
 
     Returns:
-        Set of public symbol names exported by the package.
+        Set of public symbol names exported by the module.
 
     """
     mod = importlib.import_module(package)
@@ -111,9 +111,9 @@ def find_violations(
 ) -> list[ApiTableFinding]:
     """Cross-check *packages* live ``__all__`` against *documented* table rows.
 
-    For each package in *packages*:
+    For each module name in *packages*:
 
-    - ``table-not-found`` if the package has no ``### `hephaestus.<pkg>``` heading.
+    - ``table-not-found`` if the module has no ``### `hephaestus.<pkg>``` heading.
     - ``parser-found-no-rows`` if the heading exists but zero rows were parsed.
     - ``missing-from-docs`` for each ``__all__`` symbol with no table row.
     - ``missing-from-all`` for each table row whose symbol is not in ``__all__``.
@@ -124,7 +124,7 @@ def find_violations(
 
     Args:
         documented: Output of :func:`load_documented_symbols`.
-        packages: Tuple of package names to check; defaults to
+        packages: Tuple of module names to check; defaults to
             :data:`GUARDED_PACKAGES`.
 
     Returns:
@@ -175,7 +175,7 @@ def find_violations(
 def format_report(findings: list[ApiTableFinding]) -> str:
     """Render *findings* as a human-readable text report."""
     if not findings:
-        return "OK: every guarded subpackage's __all__ is fully documented in COMPATIBILITY.md."
+        return "OK: every guarded module's __all__ is fully documented in COMPATIBILITY.md."
     lines = [f"FAIL: {len(findings)} API-table violation(s):"]
     lines.extend(f"  [{f.kind}] {f.detail}" for f in findings)
     return "\n".join(lines)

--- a/hephaestus/validation/api_table_docs.py
+++ b/hephaestus/validation/api_table_docs.py
@@ -1,7 +1,7 @@
 """Enforce per-symbol API stability-table documentation.
 
-Every member of a documented subpackage's __all__ MUST have a matching row in
-that subpackage's "### `hephaestus.<pkg>`" table in COMPATIBILITY.md, and every
+Every member of a documented module's __all__ MUST have a matching row in
+that module's "### `hephaestus.<pkg>[.<module>]`" table in COMPATIBILITY.md, and every
 documented row MUST correspond to a live __all__ member. Only TABLE MEMBERSHIP
 is validated — the "Added" version column is a best-effort historical anchor
 and is intentionally NOT asserted.
@@ -34,10 +34,11 @@ GUARDED_PACKAGES: tuple[str, ...] = (
     "hephaestus.config",
     "hephaestus.system",
     "hephaestus.utils",
+    "hephaestus.utils.git",
     "hephaestus.version",
 )
 
-_HEADER_RE = re.compile(r"^###\s+`(hephaestus\.[a-z_]+)`\s*$")
+_HEADER_RE = re.compile(r"^###\s+`(hephaestus(?:\.[a-z_]+)+)`\s*$")
 _SEPARATOR_RE = re.compile(r"^\|[\s\-:|]+\|?\s*$")
 _ROW_RE = re.compile(r"^\|\s*`([A-Za-z_][A-Za-z0-9_]*)`\s*\|")
 
@@ -54,9 +55,9 @@ class ApiTableFinding:
 
 
 def load_documented_symbols(compatibility_path: Path) -> dict[str, set[str]]:
-    """Return ``{package: {symbol, ...}}`` parsed from each ``### `hephaestus.<pkg>``` table.
+    """Return symbols parsed from each guarded ``hephaestus.*`` API table.
 
-    Scans all ``### `hephaestus.<pkg>``` headings, reading table rows until
+    Scans all ``### `hephaestus.<pkg>[.<module>]``` headings, reading table rows until
     the next heading (``###`` or ``##``) or the end of the file. Separator
     rows and the column header row are skipped.
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -94,6 +94,7 @@ class TestRun:
             check=False,
             log_on_error=False,
             env=None,
+            retries=0,
         )
 
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -72,6 +72,30 @@ class TestRun:
         assert result.returncode == 0
         assert "test.txt" in result.stdout
 
+    def test_git_command_delegates_to_shared_git_helper(self) -> None:
+        """Automation keeps its run seam while sharing git subprocess execution."""
+        completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+        with patch(
+            "hephaestus.automation.git_utils._shared_run_git", return_value=completed
+        ) as mock_run:
+            result = run(
+                ["git", "status"],
+                cwd=Path("/repo"),
+                check=False,
+                timeout=42,
+                log_errors=False,
+            )
+
+        assert result is completed
+        mock_run.assert_called_once_with(
+            ["git", "status"],
+            cwd=Path("/repo"),
+            timeout=42,
+            check=False,
+            log_on_error=False,
+            env=None,
+        )
+
 
 class TestGetRepoRoot:
     """Tests for get_repo_root function."""

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -515,6 +515,145 @@ def _pr(number: int, status: PRStatus, head: str = "feat") -> PRInfo:
     )
 
 
+class TestResolveConflictWithAgent:
+    """Direct coverage for conflict resolver git-helper orchestration."""
+
+    def test_no_conflicts_continues_rebase_and_verifies_push(self, tmp_path: Path) -> None:
+        """A clean rebase continues and requires an advertised remote branch."""
+        pr = _pr(7, PRStatus.CONFLICTED, head="feature")
+        repo_clone = tmp_path / "RepoA"
+        work = tmp_path / "RepoA-7-conflict"
+
+        with (
+            patch.object(fleet_conflicts, "ensure_repo_clone", return_value=repo_clone) as ensure,
+            patch.object(fleet_conflicts, "add_pr_worktree") as add_worktree,
+            patch.object(fleet_conflicts, "run_git") as run_git,
+            patch.object(fleet_conflicts, "git_unmerged_files", return_value=[]) as unmerged,
+            patch.object(fleet_conflicts, "_git") as raw_git,
+            patch.object(
+                fleet_conflicts, "git_ls_remote_contains", return_value=True
+            ) as remote_has,
+            patch.object(fleet_conflicts, "remove_worktree") as remove,
+        ):
+            assert fleet_conflicts.resolve_conflict_with_agent(pr, "Org", repo_clone) is True
+
+        ensure.assert_called_once_with("RepoA", "Org", tmp_path, dry_run=False)
+        add_worktree.assert_called_once_with(repo_clone, work, "feature", "main", dry_run=False)
+        run_git.assert_called_once_with(
+            ["rebase", "origin/main"],
+            cwd=work,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=NETWORK_TIMEOUT,
+        )
+        unmerged.assert_called_once_with(work)
+        raw_git.assert_called_once_with(
+            ["rebase", "--continue"], cwd=work, dry_run=False, check=False
+        )
+        remote_has.assert_called_once_with(work, "origin", "feature")
+        remove.assert_called_once_with(repo_clone, work, dry_run=False)
+
+    def test_dry_run_conflicts_abort_without_agent(self, tmp_path: Path) -> None:
+        """Dry-run conflict handling aborts the rebase and never invokes an agent."""
+        pr = _pr(8, PRStatus.CONFLICTED, head="feature")
+        repo_clone = tmp_path / "RepoA"
+
+        with (
+            patch.object(fleet_conflicts, "ensure_repo_clone", return_value=repo_clone),
+            patch.object(fleet_conflicts, "add_pr_worktree"),
+            patch.object(fleet_conflicts, "run_git"),
+            patch.object(fleet_conflicts, "git_unmerged_files", return_value=["a.py"]),
+            patch.object(fleet_conflicts, "_git") as raw_git,
+            patch.object(fleet_conflicts, "_run_conflict_agent") as agent,
+            patch.object(fleet_conflicts, "git_ls_remote_contains") as remote_has,
+            patch.object(fleet_conflicts, "remove_worktree"),
+        ):
+            assert (
+                fleet_conflicts.resolve_conflict_with_agent(pr, "Org", repo_clone, dry_run=True)
+                is False
+            )
+
+        raw_git.assert_called_once_with(
+            ["rebase", "--abort"],
+            cwd=tmp_path / "RepoA-8-conflict",
+            dry_run=False,
+            check=False,
+        )
+        agent.assert_not_called()
+        remote_has.assert_not_called()
+
+    def test_conflicts_run_agent_and_verify_remote_branch(self, tmp_path: Path) -> None:
+        """Agent resolution must count commits, build a prompt, and verify the push."""
+        pr = _pr(9, PRStatus.CONFLICTED, head="feature")
+        repo_clone = tmp_path / "RepoA"
+
+        with (
+            patch.object(fleet_conflicts, "ensure_repo_clone", return_value=repo_clone),
+            patch.object(fleet_conflicts, "add_pr_worktree"),
+            patch.object(fleet_conflicts, "run_git"),
+            patch.object(fleet_conflicts, "git_unmerged_files", return_value=["a.py", "b.py"]),
+            patch.object(fleet_conflicts, "git_rev_list_count", return_value=2) as rev_count,
+            patch.object(fleet_conflicts, "get_resign_email", return_value="dev@example.com"),
+            patch.object(fleet_conflicts, "get_resign_exec", return_value="git resign"),
+            patch.object(fleet_conflicts, "_run_conflict_agent", return_value=True) as agent,
+            patch.object(
+                fleet_conflicts, "git_ls_remote_contains", return_value=True
+            ) as remote_has,
+            patch.object(fleet_conflicts, "remove_worktree"),
+        ):
+            assert fleet_conflicts.resolve_conflict_with_agent(pr, "Org", repo_clone) is True
+
+        work = tmp_path / "RepoA-9-conflict"
+        assert pr.conflict_files == ["a.py", "b.py"]
+        rev_count.assert_called_once_with(work, "origin/main..HEAD")
+        prompt = agent.call_args.args[1]
+        assert "- a.py" in prompt
+        assert "git -c user.email=dev@example.com rebase --continue" in prompt
+        assert "git rebase HEAD~2 --exec 'git resign'" in prompt
+        remote_has.assert_called_once_with(work, "origin", "feature")
+
+    def test_agent_failure_returns_false_and_skips_remote_probe(self, tmp_path: Path) -> None:
+        """If the resolver agent fails, the branch is not reported as pushed."""
+        pr = _pr(10, PRStatus.CONFLICTED, head="feature")
+        repo_clone = tmp_path / "RepoA"
+
+        with (
+            patch.object(fleet_conflicts, "ensure_repo_clone", return_value=repo_clone),
+            patch.object(fleet_conflicts, "add_pr_worktree"),
+            patch.object(fleet_conflicts, "run_git"),
+            patch.object(fleet_conflicts, "git_unmerged_files", return_value=["a.py"]),
+            patch.object(fleet_conflicts, "git_rev_list_count", return_value=1),
+            patch.object(fleet_conflicts, "get_resign_email", return_value="dev@example.com"),
+            patch.object(fleet_conflicts, "get_resign_exec", return_value="git resign"),
+            patch.object(fleet_conflicts, "_run_conflict_agent", return_value=False),
+            patch.object(fleet_conflicts, "git_ls_remote_contains") as remote_has,
+            patch.object(fleet_conflicts, "remove_worktree") as remove,
+        ):
+            assert fleet_conflicts.resolve_conflict_with_agent(pr, "Org", repo_clone) is False
+
+        remote_has.assert_not_called()
+        remove.assert_called_once_with(repo_clone, tmp_path / "RepoA-10-conflict", dry_run=False)
+
+    def test_exceptions_abort_rebase_and_clean_worktree(self, tmp_path: Path) -> None:
+        """Unexpected git failures abort the rebase before cleanup."""
+        pr = _pr(11, PRStatus.CONFLICTED, head="feature")
+        repo_clone = tmp_path / "RepoA"
+        work = tmp_path / "RepoA-11-conflict"
+
+        with (
+            patch.object(fleet_conflicts, "ensure_repo_clone", return_value=repo_clone),
+            patch.object(fleet_conflicts, "add_pr_worktree"),
+            patch.object(fleet_conflicts, "run_git", side_effect=RuntimeError("boom")),
+            patch.object(fleet_conflicts, "_git") as raw_git,
+            patch.object(fleet_conflicts, "remove_worktree") as remove,
+        ):
+            assert fleet_conflicts.resolve_conflict_with_agent(pr, "Org", repo_clone) is False
+
+        raw_git.assert_called_once_with(["rebase", "--abort"], cwd=work, dry_run=False, check=False)
+        remove.assert_called_once_with(repo_clone, work, dry_run=False)
+
+
 @pytest.fixture
 def capture_fleet_sync_logs():
     r"""Fixture to capture fleet_sync logger messages.

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -475,16 +475,37 @@ class TestTimeoutHandling:
             timeout=NETWORK_TIMEOUT,
         )
 
-    def test_git_uses_network_timeout(self) -> None:
-        """_git function uses NETWORK_TIMEOUT."""
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(stdout="")
+    def test_git_uses_network_timeout_and_retries(self) -> None:
+        """_git routes network commands through the shared helper with retries."""
+        completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+        with patch.object(fleet_git_ops, "run_git", return_value=completed) as mock_run:
             work_dir = Path("/tmp/test")
-            fleet_git_ops._git(["clone", "url", "."], cwd=work_dir)
-            assert mock_run.called
-            call_kwargs = mock_run.call_args[1]
-            assert "timeout" in call_kwargs
-            assert call_kwargs["timeout"] == NETWORK_TIMEOUT
+            assert fleet_git_ops._git(["clone", "url", "."], cwd=work_dir) is completed
+
+        mock_run.assert_called_once_with(
+            ["clone", "url", "."],
+            cwd=work_dir,
+            check=True,
+            timeout=NETWORK_TIMEOUT,
+            retries=2,
+        )
+
+    def test_git_does_not_retry_local_commands(self) -> None:
+        """_git keeps local commands single-shot while still using the shared helper."""
+        completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+        with patch.object(fleet_git_ops, "run_git", return_value=completed) as mock_run:
+            work_dir = Path("/tmp/test")
+            assert (
+                fleet_git_ops._git(["rebase", "--continue"], cwd=work_dir, check=False) is completed
+            )
+
+        mock_run.assert_called_once_with(
+            ["rebase", "--continue"],
+            cwd=work_dir,
+            check=False,
+            timeout=NETWORK_TIMEOUT,
+            retries=0,
+        )
 
     def test_conflict_agent_uses_env_configured_rebase_timeout(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 from pathlib import Path
 from typing import Any, cast
@@ -246,6 +247,20 @@ class TestGetResignEmail:
         cmd = get_resign_exec()
         assert "user.email=carol@example.com" in cmd
         assert "commit --amend --no-edit -S -s --reset-author" in cmd
+
+    def test_get_resign_exec_shell_quotes_resolved_email(self, monkeypatch) -> None:
+        """Rebase --exec command construction keeps email metacharacters in one argv."""
+        from hephaestus.github.fleet_sync import get_resign_exec
+
+        monkeypatch.setenv("FLEET_SKIP_EMAIL_KEY_CHECK", "1")
+        monkeypatch.setenv("FLEET_GIT_EMAIL", "dev@example.com; injected-word")
+        argv = shlex.split(get_resign_exec())
+        assert argv[:3] == [
+            "git",
+            "-c",
+            "user.email=dev@example.com; injected-word",
+        ]
+        assert "injected-word" not in argv[3:]
 
 
 class TestResignEmailKeyGuard:

--- a/tests/unit/github/test_fleet_sync.py
+++ b/tests/unit/github/test_fleet_sync.py
@@ -475,8 +475,8 @@ class TestTimeoutHandling:
             timeout=NETWORK_TIMEOUT,
         )
 
-    def test_git_uses_network_timeout_and_retries(self) -> None:
-        """_git routes network commands through the shared helper with retries."""
+    def test_git_uses_network_timeout_and_shared_retry_defaults(self) -> None:
+        """_git routes through the shared helper and its central retry policy."""
         completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
         with patch.object(fleet_git_ops, "run_git", return_value=completed) as mock_run:
             work_dir = Path("/tmp/test")
@@ -487,11 +487,10 @@ class TestTimeoutHandling:
             cwd=work_dir,
             check=True,
             timeout=NETWORK_TIMEOUT,
-            retries=2,
         )
 
-    def test_git_does_not_retry_local_commands(self) -> None:
-        """_git keeps local commands single-shot while still using the shared helper."""
+    def test_git_delegates_local_commands_to_shared_helper(self) -> None:
+        """_git keeps local command policy centralized in the shared helper."""
         completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
         with patch.object(fleet_git_ops, "run_git", return_value=completed) as mock_run:
             work_dir = Path("/tmp/test")
@@ -504,7 +503,6 @@ class TestTimeoutHandling:
             cwd=work_dir,
             check=False,
             timeout=NETWORK_TIMEOUT,
-            retries=0,
         )
 
     def test_conflict_agent_uses_env_configured_rebase_timeout(
@@ -572,7 +570,7 @@ class TestResolveConflictWithAgent:
         raw_git.assert_called_once_with(
             ["rebase", "--continue"], cwd=work, dry_run=False, check=False
         )
-        remote_has.assert_called_once_with(work, "origin", "feature")
+        remote_has.assert_called_once_with(work, "origin", "feature", raise_on_error=True)
         remove.assert_called_once_with(repo_clone, work, dry_run=False)
 
     def test_dry_run_conflicts_abort_without_agent(self, tmp_path: Path) -> None:
@@ -632,7 +630,36 @@ class TestResolveConflictWithAgent:
         assert "- a.py" in prompt
         assert "git -c user.email=dev@example.com rebase --continue" in prompt
         assert "git rebase HEAD~2 --exec 'git resign'" in prompt
-        remote_has.assert_called_once_with(work, "origin", "feature")
+        remote_has.assert_called_once_with(work, "origin", "feature", raise_on_error=True)
+
+    def test_remote_probe_failure_returns_false_with_specific_warning(self, tmp_path: Path) -> None:
+        """A failed remote probe is reported separately from a missing agent push."""
+        pr = _pr(10, PRStatus.CONFLICTED, head="feature")
+        repo_clone = tmp_path / "RepoA"
+        probe_error = subprocess.TimeoutExpired(["git", "ls-remote"], timeout=1)
+
+        with (
+            patch.object(fleet_conflicts, "ensure_repo_clone", return_value=repo_clone),
+            patch.object(fleet_conflicts, "add_pr_worktree"),
+            patch.object(fleet_conflicts, "run_git"),
+            patch.object(fleet_conflicts, "git_unmerged_files", return_value=["a.py"]),
+            patch.object(fleet_conflicts, "git_rev_list_count", return_value=1),
+            patch.object(fleet_conflicts, "get_resign_email", return_value="dev@example.com"),
+            patch.object(fleet_conflicts, "get_resign_exec", return_value="git resign"),
+            patch.object(fleet_conflicts, "_run_conflict_agent", return_value=True),
+            patch.object(
+                fleet_conflicts, "git_ls_remote_contains", side_effect=probe_error
+            ) as remote_has,
+            patch.object(fleet_conflicts, "logger") as logger,
+            patch.object(fleet_conflicts, "remove_worktree"),
+        ):
+            assert fleet_conflicts.resolve_conflict_with_agent(pr, "Org", repo_clone) is False
+
+        remote_has.assert_called_once_with(
+            tmp_path / "RepoA-10-conflict", "origin", "feature", raise_on_error=True
+        )
+        logger.warning.assert_called_once()
+        assert "Could not verify pushed branch" in logger.warning.call_args.args[0]
 
     def test_agent_failure_returns_false_and_skips_remote_probe(self, tmp_path: Path) -> None:
         """If the resolver agent fails, the branch is not reported as pushed."""

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -57,6 +57,43 @@ def test_run_git_accepts_git_prefixed_commands_and_dry_run() -> None:
     )
 
 
+def test_run_git_retries_network_commands_by_default() -> None:
+    """Network git commands get bounded retry protection by default."""
+    failure = subprocess.CalledProcessError(128, ["git", "fetch"], stderr="network timeout")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+    ):
+        assert run_git(["fetch", "origin"]) is completed
+
+    assert mock_run.call_count == 2
+
+
+def test_run_git_does_not_retry_local_commands_by_default() -> None:
+    """Local metadata commands stay single-shot unless the caller asks for retries."""
+    failure = subprocess.CalledProcessError(128, ["git", "status"], stderr="fatal")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run:
+        with pytest.raises(subprocess.CalledProcessError):
+            run_git(["status"])
+
+    assert mock_run.call_count == 1
+
+
+def test_run_git_honors_explicit_retry_budget_for_local_commands() -> None:
+    """Callers can request retries even for local git commands."""
+    failure = subprocess.TimeoutExpired(["git", "status"], timeout=1)
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+    ):
+        assert run_git(["status"], retries=1) is completed
+
+    assert mock_run.call_count == 2
+
+
 def test_working_tree_clean_uses_git_status_porcelain() -> None:
     """A clean porcelain status means the working tree is clean."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
@@ -169,6 +206,7 @@ def test_git_push_builds_remote_refspec_command() -> None:
         cwd=Path("/repo"),
         dry_run=True,
         timeout=NETWORK_TIMEOUT,
+        retries=None,
     )
 
 

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from hephaestus.github.git_ops import (
     git_branch_exists,
@@ -25,7 +28,7 @@ from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 def test_run_git_uses_shared_subprocess_helper() -> None:
     """run_git centralizes git execution through the standard subprocess helper."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_subprocess", return_value=completed) as mock_run:
         assert run_git(["status"]) is completed
 
     mock_run.assert_called_once_with(
@@ -41,7 +44,7 @@ def test_run_git_uses_shared_subprocess_helper() -> None:
 def test_run_git_accepts_git_prefixed_commands_and_dry_run() -> None:
     """Compatibility wrappers may pass a full git command without duplicating git."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_subprocess", return_value=completed) as mock_run:
         assert run_git(["git", "push"], cwd=Path("/repo"), dry_run=True) is completed
 
     mock_run.assert_called_once_with(
@@ -57,7 +60,7 @@ def test_run_git_accepts_git_prefixed_commands_and_dry_run() -> None:
 def test_working_tree_clean_uses_git_status_porcelain() -> None:
     """A clean porcelain status means the working tree is clean."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_subprocess", return_value=completed) as mock_run:
         assert working_tree_clean() is True
 
     mock_run.assert_called_once()
@@ -71,16 +74,16 @@ def test_working_tree_clean_rejects_dirty_or_failed_status() -> None:
     dirty = subprocess.CompletedProcess(["git"], 0, stdout=" M file.py\n", stderr="")
     failed = subprocess.CompletedProcess(["git"], 128, stdout="", stderr="fatal")
 
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=dirty):
+    with patch("hephaestus.utils.git.run_subprocess", return_value=dirty):
         assert working_tree_clean() is False
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=failed):
+    with patch("hephaestus.utils.git.run_subprocess", return_value=failed):
         assert working_tree_clean() is False
 
 
 def test_in_git_repo_uses_rev_parse_git_dir() -> None:
     """in_git_repo delegates to git rev-parse --git-dir."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout=".git\n", stderr="")
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_subprocess", return_value=completed) as mock_run:
         assert in_git_repo() is True
 
     mock_run.assert_called_once()
@@ -92,7 +95,7 @@ def test_in_git_repo_uses_rev_parse_git_dir() -> None:
 def test_repo_root_parses_rev_parse_stdout() -> None:
     """repo_root returns the stripped git toplevel path."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="/repo\n", stderr="")
-    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_subprocess", return_value=completed) as mock_run:
         assert repo_root() == Path("/repo")
 
     mock_run.assert_called_once()
@@ -106,7 +109,7 @@ def test_git_config_get_reads_local_and_global_values() -> None:
     global_result = subprocess.CompletedProcess(
         ["git"], 0, stdout="global@example.com\n", stderr=""
     )
-    with patch("hephaestus.github.git_ops.run_git", side_effect=[local, global_result]) as mock_run:
+    with patch("hephaestus.utils.git.run_git", side_effect=[local, global_result]) as mock_run:
         assert git_config_get("user.email") == "local@example.com"
         assert git_config_get("user.email", global_=True) == "global@example.com"
 
@@ -120,7 +123,7 @@ def test_git_config_get_reads_local_and_global_values() -> None:
 def test_git_config_get_returns_none_for_missing_values() -> None:
     """Missing git config keys produce None instead of raising."""
     missing = subprocess.CompletedProcess(["git"], 1, stdout="", stderr="missing")
-    with patch("hephaestus.github.git_ops.run_git", return_value=missing):
+    with patch("hephaestus.utils.git.run_git", return_value=missing):
         assert git_config_get("user.signingkey") is None
 
 
@@ -129,7 +132,7 @@ def test_git_remote_url_returns_origin_url() -> None:
     completed = subprocess.CompletedProcess(
         ["git"], 0, stdout="git@github.com:o/r.git\n", stderr=""
     )
-    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_git", return_value=completed) as mock_run:
         assert git_remote_url() == "git@github.com:o/r.git"
 
     mock_run.assert_called_once_with(
@@ -145,7 +148,7 @@ def test_git_branch_exists_checks_local_branch_list() -> None:
     """git_branch_exists returns whether a local branch is listed."""
     present = subprocess.CompletedProcess(["git"], 0, stdout="  feature\n", stderr="")
     absent = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.github.git_ops.run_git", side_effect=[present, absent]) as mock_run:
+    with patch("hephaestus.utils.git.run_git", side_effect=[present, absent]) as mock_run:
         assert git_branch_exists("feature") is True
         assert git_branch_exists("missing") is False
 
@@ -158,7 +161,7 @@ def test_git_branch_exists_checks_local_branch_list() -> None:
 def test_git_push_builds_remote_refspec_command() -> None:
     """git_push wraps the standard push form used by PR merge helpers."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_git", return_value=completed) as mock_run:
         assert git_push(Path("/repo"), "origin", "feature:feature", dry_run=True) is completed
 
     mock_run.assert_called_once_with(
@@ -177,7 +180,7 @@ def test_git_unmerged_files_splits_conflict_output() -> None:
         stdout=" a.py\n\nsubdir/b.py \n",
         stderr="",
     )
-    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_git", return_value=completed) as mock_run:
         assert git_unmerged_files(Path("/repo")) == ["a.py", "subdir/b.py"]
 
     mock_run.assert_called_once_with(
@@ -190,7 +193,7 @@ def test_git_unmerged_files_splits_conflict_output() -> None:
 def test_git_rev_list_count_parses_integer_count() -> None:
     """git_rev_list_count parses git rev-list --count output."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="3\n", stderr="")
-    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+    with patch("hephaestus.utils.git.run_git", return_value=completed) as mock_run:
         assert git_rev_list_count(Path("/repo"), "origin/main..HEAD") == 3
 
     mock_run.assert_called_once_with(
@@ -204,6 +207,89 @@ def test_git_ls_remote_contains_checks_ref_stdout() -> None:
     """git_ls_remote_contains returns True when the requested ref appears remotely."""
     found = subprocess.CompletedProcess(["git"], 0, stdout="abc\trefs/heads/feature\n", stderr="")
     missing = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.github.git_ops.run_git", side_effect=[found, missing]):
+    with patch("hephaestus.utils.git.run_git", side_effect=[found, missing]):
         assert git_ls_remote_contains(Path("/repo"), "origin", "feature") is True
         assert git_ls_remote_contains(Path("/repo"), "origin", "missing") is False
+
+
+def test_git_ls_remote_contains_rejects_partial_ref_matches() -> None:
+    """A similarly named remote branch must not satisfy the requested branch."""
+    partial = subprocess.CompletedProcess(
+        ["git"],
+        0,
+        stdout="abc\trefs/heads/feature-old\n",
+        stderr="",
+    )
+    with patch("hephaestus.utils.git.run_git", return_value=partial):
+        assert git_ls_remote_contains(Path("/repo"), "origin", "feature") is False
+
+
+def test_shared_git_helpers_live_in_utils_package() -> None:
+    """The shared git helper implementation belongs below hephaestus.utils."""
+    assert importlib.util.find_spec("hephaestus.utils.git") is not None
+
+
+def test_run_git_requires_captured_text_output() -> None:
+    """run_git keeps one captured text-output contract for all callers."""
+    with pytest.raises(ValueError, match="captures text output"):
+        run_git(["status"], capture_output=False)
+    with pytest.raises(ValueError, match="captures text output"):
+        run_git(["status"], text=False)
+
+
+def test_git_config_get_returns_none_for_process_errors() -> None:
+    """git_config_get treats unavailable git metadata as missing config."""
+    with patch(
+        "hephaestus.utils.git.run_git",
+        side_effect=[subprocess.TimeoutExpired(["git"], 1), FileNotFoundError("git")],
+    ):
+        assert git_config_get("user.email") is None
+        assert git_config_get("user.name") is None
+
+
+def test_git_remote_url_returns_none_for_missing_values_and_process_errors() -> None:
+    """git_remote_url handles missing remotes and unavailable git."""
+    missing = subprocess.CompletedProcess(["git"], 1, stdout="", stderr="missing")
+    with patch(
+        "hephaestus.utils.git.run_git",
+        side_effect=[
+            missing,
+            subprocess.TimeoutExpired(["git"], 1),
+            FileNotFoundError("git"),
+        ],
+    ):
+        assert git_remote_url() is None
+        assert git_remote_url("upstream") is None
+        assert git_remote_url("fork") is None
+
+
+def test_git_branch_exists_returns_false_for_process_errors() -> None:
+    """git_branch_exists degrades to False when git cannot list branches."""
+    called_process_error = subprocess.CalledProcessError(128, ["git"], stderr="fatal")
+    with patch(
+        "hephaestus.utils.git.run_git",
+        side_effect=[
+            called_process_error,
+            subprocess.TimeoutExpired(["git"], 1),
+            FileNotFoundError("git"),
+        ],
+    ):
+        assert git_branch_exists("feature") is False
+        assert git_branch_exists("feature") is False
+        assert git_branch_exists("feature") is False
+
+
+def test_git_ls_remote_contains_accepts_full_exact_refs() -> None:
+    """Full ref names are matched exactly without forcing a branch shorthand."""
+    found = subprocess.CompletedProcess(["git"], 0, stdout="abc\trefs/tags/v1.0.0\n", stderr="")
+    with patch("hephaestus.utils.git.run_git", return_value=found):
+        assert git_ls_remote_contains(Path("/repo"), "origin", "refs/tags/v1.0.0") is True
+
+
+def test_github_git_ops_reexports_shared_helpers() -> None:
+    """GitHub callers keep their old import path while using the utils implementation."""
+    import hephaestus.github.git_ops as github_git_ops
+    import hephaestus.utils.git as shared_git
+
+    assert github_git_ops.run_git is shared_git.run_git
+    assert github_git_ops.git_ls_remote_contains is shared_git.git_ls_remote_contains

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -9,20 +9,21 @@ from unittest.mock import patch
 
 import pytest
 
-from hephaestus.github.git_ops import (
-    git_branch_exists,
-    git_config_get,
-    git_ls_remote_contains,
-    git_push,
-    git_remote_url,
-    git_rev_list_count,
-    git_unmerged_files,
-    in_git_repo,
-    repo_root,
-    run_git,
-    working_tree_clean,
-)
+import hephaestus.github.git_ops as github_git_ops
+import hephaestus.utils.git as shared_git
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
+
+git_branch_exists = github_git_ops.git_branch_exists
+git_config_get = github_git_ops.git_config_get
+git_ls_remote_contains = github_git_ops.git_ls_remote_contains
+git_push = github_git_ops.git_push
+git_remote_url = github_git_ops.git_remote_url
+git_rev_list_count = github_git_ops.git_rev_list_count
+git_unmerged_files = github_git_ops.git_unmerged_files
+in_git_repo = github_git_ops.in_git_repo
+repo_root = github_git_ops.repo_root
+run_git = github_git_ops.run_git
+working_tree_clean = github_git_ops.working_tree_clean
 
 
 def test_run_git_uses_shared_subprocess_helper() -> None:
@@ -155,15 +156,22 @@ def test_run_git_logs_final_failure_after_retries() -> None:
 def test_run_git_redacts_sensitive_command_and_stream_diagnostics() -> None:
     """Final retry diagnostics redact credential-bearing remotes and tokens."""
     token_value = "gh" + "p_" + "1" * 36
+    fine_grained_token = "github" + "_pat_" + "A" * 28
     query_key = "access" + "_token"
     query_value = "super" + "sensitive"
+    auth_value = "bearer" + "value" * 6
     remote_path = "example.invalid/o/r.git"
     remote_url = f"https://user:{token_value}@{remote_path}"
+    scp_remote = "git@example.invalid:o/r.git"
     failure = subprocess.CalledProcessError(
         128,
         ["git", "fetch"],
         output=f"clone from {remote_url}?{query_key}={query_value} failed",
-        stderr=f"fatal: Authentication failed for {remote_url}",
+        stderr=(
+            f"fatal: Authentication failed for {remote_url}\n"
+            f"Authorization: Bearer {auth_value}\n"
+            f"try {fine_grained_token} with {scp_remote}"
+        ),
     )
     with (
         patch("hephaestus.utils.git.run_subprocess", side_effect=failure),
@@ -173,6 +181,37 @@ def test_run_git_redacts_sensitive_command_and_stream_diagnostics() -> None:
             run_git(["fetch", remote_url])
 
     rendered = "\n".join(str(call.args) for call in logger.error.call_args_list)
+    assert token_value not in rendered
+    assert fine_grained_token not in rendered
+    assert query_value not in rendered
+    assert auth_value not in rendered
+    assert remote_path not in rendered
+    assert scp_remote not in rendered
+    assert "Authorization: Bearer <redacted-value>" in rendered
+    assert "<redacted-git-url>" in rendered
+
+
+def test_run_git_redacts_retry_warning_diagnostics() -> None:
+    """Retry warnings redact credential-bearing remotes before a later success."""
+    token_value = "gh" + "p_" + "2" * 36
+    query_key = "access" + "_token"
+    query_value = "retry" + "sensitive"
+    remote_path = "example.invalid/o/retry.git"
+    remote_url = f"https://user:{token_value}@{remote_path}?{query_key}={query_value}"
+    failure = subprocess.CalledProcessError(
+        128,
+        ["git", "fetch", remote_url],
+        stderr="network timeout",
+    )
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]),
+        patch("hephaestus.utils.retry.time.sleep"),
+        patch("hephaestus.utils.git.logger") as logger,
+    ):
+        assert run_git(["fetch", remote_url], retries=1) is completed
+
+    rendered = "\n".join(str(call.args) for call in logger.warning.call_args_list)
     assert token_value not in rendered
     assert query_value not in rendered
     assert remote_path not in rendered
@@ -526,8 +565,5 @@ def test_git_ls_remote_contains_accepts_full_exact_refs() -> None:
 
 def test_github_git_ops_reexports_shared_helpers() -> None:
     """GitHub callers keep their old import path while using the utils implementation."""
-    import hephaestus.github.git_ops as github_git_ops
-    import hephaestus.utils.git as shared_git
-
     assert github_git_ops.run_git is shared_git.run_git
     assert github_git_ops.git_ls_remote_contains is shared_git.git_ls_remote_contains

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -70,6 +70,38 @@ def test_run_git_retries_network_commands_by_default() -> None:
     assert mock_run.call_count == 2
 
 
+def test_run_git_retries_network_commands_after_global_options() -> None:
+    """Leading git global options do not hide a retryable network command."""
+    failure = subprocess.CalledProcessError(128, ["git", "fetch"], stderr="network timeout")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+    ):
+        assert run_git(["-C", "/repo", "-c", "http.lowSpeedLimit=0", "fetch"]) is completed
+
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == [
+        "git",
+        "-C",
+        "/repo",
+        "-c",
+        "http.lowSpeedLimit=0",
+        "fetch",
+    ]
+
+
+def test_run_git_keeps_local_commands_after_global_options_single_shot() -> None:
+    """Leading git global options do not make local commands retry by accident."""
+    failure = subprocess.CalledProcessError(128, ["git", "status"], stderr="fatal")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run:
+        with pytest.raises(subprocess.CalledProcessError):
+            run_git(["-C", "/repo", "status"])
+
+    assert mock_run.call_count == 1
+
+
 def test_run_git_suppresses_error_log_noise_during_retries() -> None:
     """Retry attempts use retry warnings instead of per-attempt ERROR logs."""
     failure = subprocess.CalledProcessError(128, ["git", "fetch"], stderr="network timeout")
@@ -81,6 +113,23 @@ def test_run_git_suppresses_error_log_noise_during_retries() -> None:
         assert run_git(["fetch", "origin"]) is completed
 
     assert [call.kwargs["log_on_error"] for call in mock_run.call_args_list] == [False, False]
+
+
+def test_run_git_logs_final_failure_after_retries() -> None:
+    """Retry-managed commands log diagnostics once when retries are exhausted."""
+    failure = subprocess.CalledProcessError(128, ["git", "fetch"], stderr="network timeout")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=failure) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+        patch("hephaestus.utils.git.logger") as logger,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            run_git(["fetch", "origin"])
+
+    assert mock_run.call_count == 3
+    assert [call.kwargs["log_on_error"] for call in mock_run.call_args_list] == [False] * 3
+    logger.error.assert_any_call("Git command failed after retry handling: %s", "git fetch origin")
+    logger.error.assert_any_call("stderr: %s", "network timeout")
 
 
 def test_run_git_does_not_retry_local_commands_by_default() -> None:
@@ -100,11 +149,16 @@ def test_run_git_does_not_retry_deterministic_network_command_errors() -> None:
         128, ["git", "fetch"], stderr="fatal: Authentication failed"
     )
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run:
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.git.logger") as logger,
+    ):
         with pytest.raises(subprocess.CalledProcessError):
             run_git(["fetch", "origin"])
 
     assert mock_run.call_count == 1
+    logger.error.assert_any_call("Git command failed after retry handling: %s", "git fetch origin")
+    logger.error.assert_any_call("stderr: %s", "fatal: Authentication failed")
 
 
 def test_run_git_honors_explicit_retry_budget_for_local_commands() -> None:

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -6,30 +6,58 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from hephaestus.github.git_ops import in_git_repo, repo_root, run_git, working_tree_clean
+from hephaestus.github.git_ops import (
+    git_branch_exists,
+    git_config_get,
+    git_ls_remote_contains,
+    git_push,
+    git_remote_url,
+    git_rev_list_count,
+    git_unmerged_files,
+    in_git_repo,
+    repo_root,
+    run_git,
+    working_tree_clean,
+)
 from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 
-def test_run_git_uses_standard_defaults() -> None:
-    """run_git prepends git and applies the repository timeout defaults."""
+def test_run_git_uses_shared_subprocess_helper() -> None:
+    """run_git centralizes git execution through the standard subprocess helper."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("subprocess.run", return_value=completed) as mock_run:
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
         assert run_git(["status"]) is completed
 
     mock_run.assert_called_once_with(
         ["git", "status"],
         cwd=None,
-        capture_output=True,
-        text=True,
         check=True,
         timeout=NETWORK_TIMEOUT,
+        dry_run=False,
+        log_on_error=True,
+    )
+
+
+def test_run_git_accepts_git_prefixed_commands_and_dry_run() -> None:
+    """Compatibility wrappers may pass a full git command without duplicating git."""
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
+        assert run_git(["git", "push"], cwd=Path("/repo"), dry_run=True) is completed
+
+    mock_run.assert_called_once_with(
+        ["git", "push"],
+        cwd="/repo",
+        check=True,
+        timeout=NETWORK_TIMEOUT,
+        dry_run=True,
+        log_on_error=True,
     )
 
 
 def test_working_tree_clean_uses_git_status_porcelain() -> None:
     """A clean porcelain status means the working tree is clean."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
-    with patch("subprocess.run", return_value=completed) as mock_run:
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
         assert working_tree_clean() is True
 
     mock_run.assert_called_once()
@@ -43,16 +71,16 @@ def test_working_tree_clean_rejects_dirty_or_failed_status() -> None:
     dirty = subprocess.CompletedProcess(["git"], 0, stdout=" M file.py\n", stderr="")
     failed = subprocess.CompletedProcess(["git"], 128, stdout="", stderr="fatal")
 
-    with patch("subprocess.run", return_value=dirty):
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=dirty):
         assert working_tree_clean() is False
-    with patch("subprocess.run", return_value=failed):
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=failed):
         assert working_tree_clean() is False
 
 
 def test_in_git_repo_uses_rev_parse_git_dir() -> None:
     """in_git_repo delegates to git rev-parse --git-dir."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout=".git\n", stderr="")
-    with patch("subprocess.run", return_value=completed) as mock_run:
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
         assert in_git_repo() is True
 
     mock_run.assert_called_once()
@@ -64,9 +92,118 @@ def test_in_git_repo_uses_rev_parse_git_dir() -> None:
 def test_repo_root_parses_rev_parse_stdout() -> None:
     """repo_root returns the stripped git toplevel path."""
     completed = subprocess.CompletedProcess(["git"], 0, stdout="/repo\n", stderr="")
-    with patch("subprocess.run", return_value=completed) as mock_run:
+    with patch("hephaestus.github.git_ops.run_subprocess", return_value=completed) as mock_run:
         assert repo_root() == Path("/repo")
 
     mock_run.assert_called_once()
     assert mock_run.call_args.args[0] == ["git", "rev-parse", "--show-toplevel"]
     assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
+
+
+def test_git_config_get_reads_local_and_global_values() -> None:
+    """git_config_get returns stripped config values from local or global config."""
+    local = subprocess.CompletedProcess(["git"], 0, stdout="local@example.com\n", stderr="")
+    global_result = subprocess.CompletedProcess(
+        ["git"], 0, stdout="global@example.com\n", stderr=""
+    )
+    with patch("hephaestus.github.git_ops.run_git", side_effect=[local, global_result]) as mock_run:
+        assert git_config_get("user.email") == "local@example.com"
+        assert git_config_get("user.email", global_=True) == "global@example.com"
+
+    assert mock_run.call_args_list[0].args[0] == ["config", "--get", "user.email"]
+    assert mock_run.call_args_list[1].args[0] == ["config", "--global", "--get", "user.email"]
+    assert mock_run.call_args_list[0].kwargs["timeout"] == METADATA_TIMEOUT
+    assert mock_run.call_args_list[0].kwargs["check"] is False
+    assert mock_run.call_args_list[0].kwargs["log_on_error"] is False
+
+
+def test_git_config_get_returns_none_for_missing_values() -> None:
+    """Missing git config keys produce None instead of raising."""
+    missing = subprocess.CompletedProcess(["git"], 1, stdout="", stderr="missing")
+    with patch("hephaestus.github.git_ops.run_git", return_value=missing):
+        assert git_config_get("user.signingkey") is None
+
+
+def test_git_remote_url_returns_origin_url() -> None:
+    """git_remote_url wraps git remote get-url."""
+    completed = subprocess.CompletedProcess(
+        ["git"], 0, stdout="git@github.com:o/r.git\n", stderr=""
+    )
+    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+        assert git_remote_url() == "git@github.com:o/r.git"
+
+    mock_run.assert_called_once_with(
+        ["remote", "get-url", "origin"],
+        cwd=None,
+        timeout=METADATA_TIMEOUT,
+        check=False,
+        log_on_error=False,
+    )
+
+
+def test_git_branch_exists_checks_local_branch_list() -> None:
+    """git_branch_exists returns whether a local branch is listed."""
+    present = subprocess.CompletedProcess(["git"], 0, stdout="  feature\n", stderr="")
+    absent = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.github.git_ops.run_git", side_effect=[present, absent]) as mock_run:
+        assert git_branch_exists("feature") is True
+        assert git_branch_exists("missing") is False
+
+    assert mock_run.call_args_list[0].args[0] == ["branch", "--list", "feature"]
+    assert mock_run.call_args_list[0].kwargs["timeout"] == METADATA_TIMEOUT
+    assert mock_run.call_args_list[0].kwargs["check"] is False
+    assert mock_run.call_args_list[0].kwargs["log_on_error"] is False
+
+
+def test_git_push_builds_remote_refspec_command() -> None:
+    """git_push wraps the standard push form used by PR merge helpers."""
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+        assert git_push(Path("/repo"), "origin", "feature:feature", dry_run=True) is completed
+
+    mock_run.assert_called_once_with(
+        ["push", "origin", "feature:feature"],
+        cwd=Path("/repo"),
+        dry_run=True,
+        timeout=NETWORK_TIMEOUT,
+    )
+
+
+def test_git_unmerged_files_splits_conflict_output() -> None:
+    """git_unmerged_files returns stripped non-empty conflicted file paths."""
+    completed = subprocess.CompletedProcess(
+        ["git"],
+        0,
+        stdout=" a.py\n\nsubdir/b.py \n",
+        stderr="",
+    )
+    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+        assert git_unmerged_files(Path("/repo")) == ["a.py", "subdir/b.py"]
+
+    mock_run.assert_called_once_with(
+        ["diff", "--name-only", "--diff-filter=U"],
+        cwd=Path("/repo"),
+        timeout=METADATA_TIMEOUT,
+    )
+
+
+def test_git_rev_list_count_parses_integer_count() -> None:
+    """git_rev_list_count parses git rev-list --count output."""
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="3\n", stderr="")
+    with patch("hephaestus.github.git_ops.run_git", return_value=completed) as mock_run:
+        assert git_rev_list_count(Path("/repo"), "origin/main..HEAD") == 3
+
+    mock_run.assert_called_once_with(
+        ["rev-list", "--count", "origin/main..HEAD"],
+        cwd=Path("/repo"),
+        timeout=METADATA_TIMEOUT,
+    )
+
+
+def test_git_ls_remote_contains_checks_ref_stdout() -> None:
+    """git_ls_remote_contains returns True when the requested ref appears remotely."""
+    found = subprocess.CompletedProcess(["git"], 0, stdout="abc\trefs/heads/feature\n", stderr="")
+    missing = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.github.git_ops.run_git", side_effect=[found, missing]):
+        assert git_ls_remote_contains(Path("/repo"), "origin", "feature") is True
+        assert git_ls_remote_contains(Path("/repo"), "origin", "missing") is False

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -53,7 +53,7 @@ def test_run_git_accepts_git_prefixed_commands_and_dry_run() -> None:
         check=True,
         timeout=NETWORK_TIMEOUT,
         dry_run=True,
-        log_on_error=True,
+        log_on_error=False,
     )
 
 
@@ -68,6 +68,19 @@ def test_run_git_retries_network_commands_by_default() -> None:
         assert run_git(["fetch", "origin"]) is completed
 
     assert mock_run.call_count == 2
+
+
+def test_run_git_suppresses_error_log_noise_during_retries() -> None:
+    """Retry attempts use retry warnings instead of per-attempt ERROR logs."""
+    failure = subprocess.CalledProcessError(128, ["git", "fetch"], stderr="network timeout")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+    ):
+        assert run_git(["fetch", "origin"]) is completed
+
+    assert [call.kwargs["log_on_error"] for call in mock_run.call_args_list] == [False, False]
 
 
 def test_run_git_does_not_retry_local_commands_by_default() -> None:
@@ -273,6 +286,15 @@ def test_git_ls_remote_contains_rejects_partial_ref_matches() -> None:
     )
     with patch("hephaestus.utils.git.run_git", return_value=partial):
         assert git_ls_remote_contains(Path("/repo"), "origin", "feature") is False
+
+
+def test_git_ls_remote_contains_can_raise_probe_errors() -> None:
+    """Callers can distinguish remote probe failures from absent refs."""
+    probe_error = subprocess.TimeoutExpired(["git", "ls-remote"], timeout=1)
+    with patch("hephaestus.utils.git.run_git", side_effect=probe_error):
+        assert git_ls_remote_contains(Path("/repo"), "origin", "feature") is False
+        with pytest.raises(subprocess.TimeoutExpired):
+            git_ls_remote_contains(Path("/repo"), "origin", "feature", raise_on_error=True)
 
 
 def test_shared_git_helpers_live_in_utils_package() -> None:

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -91,6 +91,26 @@ def test_run_git_retries_network_commands_after_global_options() -> None:
     ]
 
 
+def test_run_git_retries_network_commands_after_inline_global_options_and_flags() -> None:
+    """Inline git global options and flags still expose the network subcommand."""
+    failure = subprocess.CalledProcessError(128, ["git", "fetch"], stderr="network timeout")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+    ):
+        assert run_git(["--no-pager", "--git-dir=/repo/.git", "fetch", "origin"]) is completed
+
+    assert mock_run.call_count == 2
+    assert mock_run.call_args_list[0].args[0] == [
+        "git",
+        "--no-pager",
+        "--git-dir=/repo/.git",
+        "fetch",
+        "origin",
+    ]
+
+
 def test_run_git_keeps_local_commands_after_global_options_single_shot() -> None:
     """Leading git global options do not make local commands retry by accident."""
     failure = subprocess.CalledProcessError(128, ["git", "status"], stderr="fatal")
@@ -130,6 +150,97 @@ def test_run_git_logs_final_failure_after_retries() -> None:
     assert [call.kwargs["log_on_error"] for call in mock_run.call_args_list] == [False] * 3
     logger.error.assert_any_call("Git command failed after retry handling: %s", "git fetch origin")
     logger.error.assert_any_call("stderr: %s", "network timeout")
+
+
+def test_run_git_redacts_sensitive_command_and_stream_diagnostics() -> None:
+    """Final retry diagnostics redact credential-bearing remotes and tokens."""
+    token_value = "gh" + "p_" + "1" * 36
+    query_key = "access" + "_token"
+    query_value = "super" + "sensitive"
+    remote_path = "example.invalid/o/r.git"
+    remote_url = f"https://user:{token_value}@{remote_path}"
+    failure = subprocess.CalledProcessError(
+        128,
+        ["git", "fetch"],
+        output=f"clone from {remote_url}?{query_key}={query_value} failed",
+        stderr=f"fatal: Authentication failed for {remote_url}",
+    )
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=failure),
+        patch("hephaestus.utils.git.logger") as logger,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            run_git(["fetch", remote_url])
+
+    rendered = "\n".join(str(call.args) for call in logger.error.call_args_list)
+    assert token_value not in rendered
+    assert query_value not in rendered
+    assert remote_path not in rendered
+    assert "<redacted-git-url>" in rendered
+
+
+def test_run_git_logs_timeout_diagnostics_after_retries() -> None:
+    """Timeout failures log timeout/stdout/stderr details after retry handling."""
+    failure = subprocess.TimeoutExpired(
+        ["git", "fetch"],
+        timeout=5,
+        output="partial stdout",
+        stderr="timeout stderr",
+    )
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=failure) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+        patch("hephaestus.utils.git.logger") as logger,
+    ):
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_git(["fetch", "origin"])
+
+    assert mock_run.call_count == 3
+    logger.error.assert_any_call("Git command failed after retry handling: %s", "git fetch origin")
+    logger.error.assert_any_call("timeout: %s", 5)
+    logger.error.assert_any_call("stdout: %s", "partial stdout")
+    logger.error.assert_any_call("stderr: %s", "timeout stderr")
+
+
+def test_run_git_suppresses_subprocess_timeout_error_logs_during_retries() -> None:
+    """Retry-managed timeout attempts do not emit lower-level ERROR logs."""
+    failure = subprocess.TimeoutExpired(["git", "fetch"], timeout=5)
+    with (
+        patch("subprocess.run", side_effect=failure),
+        patch("hephaestus.utils.retry.time.sleep"),
+        patch("hephaestus.utils.helpers.logger") as helpers_logger,
+        patch("hephaestus.utils.git.logger") as git_logger,
+    ):
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_git(["fetch", "origin"], retries=1)
+
+    helpers_logger.error.assert_not_called()
+    git_logger.error.assert_any_call(
+        "Git command failed after retry handling: %s", "git fetch origin"
+    )
+
+
+def test_run_git_bounds_long_final_failure_stream_logs() -> None:
+    """Final retry-managed diagnostics log bounded stream tails."""
+    long_stdout = "x" * 2105
+    failure = subprocess.CalledProcessError(
+        128,
+        ["git", "fetch"],
+        output=long_stdout,
+        stderr="network timeout",
+    )
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=failure),
+        patch("hephaestus.utils.retry.time.sleep"),
+        patch("hephaestus.utils.git.logger") as logger,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            run_git(["fetch", "origin"])
+
+    stdout_logs = [
+        call.args[1] for call in logger.error.call_args_list if call.args[:1] == ("stdout: %s",)
+    ]
+    assert stdout_logs == ["...(105 earlier chars)" + "x" * 2000]
 
 
 def test_run_git_does_not_retry_local_commands_by_default() -> None:

--- a/tests/unit/github/test_git_ops.py
+++ b/tests/unit/github/test_git_ops.py
@@ -81,6 +81,19 @@ def test_run_git_does_not_retry_local_commands_by_default() -> None:
     assert mock_run.call_count == 1
 
 
+def test_run_git_does_not_retry_deterministic_network_command_errors() -> None:
+    """Network commands fail fast when Git reports a deterministic error."""
+    failure = subprocess.CalledProcessError(
+        128, ["git", "fetch"], stderr="fatal: Authentication failed"
+    )
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run:
+        with pytest.raises(subprocess.CalledProcessError):
+            run_git(["fetch", "origin"])
+
+    assert mock_run.call_count == 1
+
+
 def test_run_git_honors_explicit_retry_budget_for_local_commands() -> None:
     """Callers can request retries even for local git commands."""
     failure = subprocess.TimeoutExpired(["git", "status"], timeout=1)

--- a/tests/unit/github/test_github_utils.py
+++ b/tests/unit/github/test_github_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Tests for GitHub utilities."""
 
-from subprocess import CalledProcessError, CompletedProcess
+from subprocess import CalledProcessError
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,46 +20,38 @@ from hephaestus.github.pr_merge import (
 class TestDetectRepoFromRemote:
     """Tests for detect_repo_from_remote."""
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detect_repo_ssh_url(self, mock_run):
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detect_repo_ssh_url(self, mock_remote_url):
         """Detects repo from SSH remote URL."""
-        mock_result = MagicMock()
-        mock_result.stdout = "git@github.com:owner/repo.git\n"
-        mock_run.return_value = mock_result
+        mock_remote_url.return_value = "git@github.com:owner/repo.git"
         result = detect_repo_from_remote()
         assert result == "owner/repo"
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detect_repo_https_url(self, mock_run):
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detect_repo_https_url(self, mock_remote_url):
         """Detects repo from HTTPS remote URL."""
-        mock_result = MagicMock()
-        mock_result.stdout = "https://github.com/owner/repo.git\n"
-        mock_run.return_value = mock_result
+        mock_remote_url.return_value = "https://github.com/owner/repo.git"
         result = detect_repo_from_remote()
         assert result == "owner/repo"
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detect_repo_without_git_suffix(self, mock_run):
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detect_repo_without_git_suffix(self, mock_remote_url):
         """Detects repo from URL without .git suffix."""
-        mock_result = MagicMock()
-        mock_result.stdout = "https://github.com/owner/repo\n"
-        mock_run.return_value = mock_result
+        mock_remote_url.return_value = "https://github.com/owner/repo"
         result = detect_repo_from_remote()
         assert result == "owner/repo"
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detect_repo_failure_returns_none(self, mock_run):
-        """Returns None when git command fails."""
-        mock_run.side_effect = Exception("Git command failed")
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detect_repo_failure_returns_none(self, mock_remote_url):
+        """Returns None when git remote lookup fails."""
+        mock_remote_url.side_effect = Exception("Git command failed")
         result = detect_repo_from_remote()
         assert result is None
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detect_repo_non_github_url_returns_none(self, mock_run):
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detect_repo_non_github_url_returns_none(self, mock_remote_url):
         """Returns None for non-GitHub remote URLs."""
-        mock_result = MagicMock()
-        mock_result.stdout = "https://gitlab.com/owner/repo.git\n"
-        mock_run.return_value = mock_result
+        mock_remote_url.return_value = "https://gitlab.com/owner/repo.git"
         result = detect_repo_from_remote()
         assert result is None
 
@@ -67,56 +59,41 @@ class TestDetectRepoFromRemote:
 class TestLocalBranchExists:
     """Tests for local_branch_exists."""
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_branch_exists(self, mock_run):
+    @patch("hephaestus.github.pr_merge.git_branch_exists", return_value=True)
+    def test_branch_exists(self, mock_exists):
         """Returns True when branch exists."""
-        mock_run.return_value = CompletedProcess(
-            ["git", "branch", "--list", "feature-branch"],
-            0,
-            stdout="  feature-branch\n",
-            stderr="",
-        )
         result = local_branch_exists("feature-branch")
         assert result is True
+        mock_exists.assert_called_once_with("feature-branch")
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_branch_not_exists(self, mock_run):
-        """Returns False when branch doesn't exist (empty output)."""
-        mock_run.return_value = CompletedProcess(
-            ["git", "branch", "--list", "non-existent-branch"],
-            0,
-            stdout="",
-            stderr="",
-        )
+    @patch("hephaestus.github.pr_merge.git_branch_exists", return_value=False)
+    def test_branch_not_exists(self, mock_exists):
+        """Returns False when branch doesn't exist."""
         result = local_branch_exists("non-existent-branch")
         assert result is False
+        mock_exists.assert_called_once_with("non-existent-branch")
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_branch_check_error_returns_false(self, mock_run):
+    @patch("hephaestus.github.pr_merge.git_branch_exists")
+    def test_branch_check_error_returns_false(self, mock_exists):
         """Returns False on CalledProcessError."""
-        mock_run.side_effect = CalledProcessError(1, ["git", "branch"])
+        mock_exists.side_effect = CalledProcessError(1, ["git", "branch"])
         result = local_branch_exists("any-branch")
         assert result is False
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_branch_with_whitespace_output(self, mock_run):
-        """Branch name with whitespace in output still returns True."""
-        mock_run.return_value = CompletedProcess(
-            ["git", "branch", "--list", "main"],
-            0,
-            stdout="  main  \n",
-            stderr="",
-        )
+    @patch("hephaestus.github.pr_merge.git_branch_exists", return_value=True)
+    def test_branch_with_whitespace_output(self, mock_exists):
+        """Branch lookup remains truthy when the helper finds a branch."""
         result = local_branch_exists("main")
         assert result is True
+        mock_exists.assert_called_once_with("main")
 
 
 class TestRunGitCmd:
     """Tests for run_git_cmd."""
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
+    @patch("hephaestus.github.pr_merge.run_git")
     def test_dry_run_delegates_to_shared_helper(self, mock_run):
-        """Dry-run handling is delegated to the shared subprocess helper."""
+        """Dry-run handling is delegated to the shared git helper."""
         run_git_cmd(["git", "push", "origin", "main"], dry_run=True)
         mock_run.assert_called_once_with(
             ["git", "push", "origin", "main"],
@@ -124,9 +101,9 @@ class TestRunGitCmd:
             dry_run=True,
         )
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
+    @patch("hephaestus.github.pr_merge.run_git")
     def test_non_dry_run_delegates_to_shared_helper(self, mock_run):
-        """Non-dry-run execution is delegated to the shared subprocess helper."""
+        """Non-dry-run execution is delegated to the shared git helper."""
         run_git_cmd(["git", "status"], dry_run=False)
         mock_run.assert_called_once_with(["git", "status"], cwd=None, dry_run=False)
 
@@ -241,23 +218,23 @@ class TestTryPushHeadBranch:
 
     def test_dry_run_does_not_push(self):
         """In dry-run mode, no push happens."""
-        with patch("hephaestus.github.pr_merge.run_git_cmd") as mock_cmd:
+        with patch("hephaestus.github.pr_merge.git_push") as mock_push:
             try_push_head_branch("feature", dry_run=True)
-            mock_cmd.assert_not_called()
+            mock_push.assert_not_called()
 
     @patch("hephaestus.github.pr_merge.local_branch_exists", return_value=True)
     def test_pushes_when_branch_exists(self, mock_exists):
         """Pushes branch when it exists locally."""
-        with patch("hephaestus.github.pr_merge.run_git_cmd") as mock_cmd:
+        with patch("hephaestus.github.pr_merge.git_push") as mock_push:
             try_push_head_branch("feature", dry_run=False)
-            mock_cmd.assert_called_once()
+            mock_push.assert_called_once_with(None, "origin", "feature:feature", dry_run=False)
 
     @patch("hephaestus.github.pr_merge.local_branch_exists", return_value=False)
     def test_skips_push_when_branch_missing(self, mock_exists):
         """Does not push when local branch doesn't exist."""
-        with patch("hephaestus.github.pr_merge.run_git_cmd") as mock_cmd:
+        with patch("hephaestus.github.pr_merge.git_push") as mock_push:
             try_push_head_branch("feature", dry_run=False)
-            mock_cmd.assert_not_called()
+            mock_push.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/github/test_no_raw_git_subprocess.py
+++ b/tests/unit/github/test_no_raw_git_subprocess.py
@@ -1,0 +1,154 @@
+"""Structural guard against bypassing the shared git adapter."""
+
+from __future__ import annotations
+
+import ast
+import shlex
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_TARGETS = (
+    *_REPO_ROOT.joinpath("hephaestus", "github", "fleet_sync").glob("*.py"),
+    _REPO_ROOT / "hephaestus" / "github" / "pr_merge.py",
+)
+_RUNNERS = {"run", "Popen", "check_output", "check_call"}
+
+
+def _subprocess_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "subprocess":
+                    aliases[alias.asname or alias.name] = "subprocess"
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            for alias in node.names:
+                if alias.name in _RUNNERS:
+                    aliases[alias.asname or alias.name] = f"subprocess.{alias.name}"
+    return aliases
+
+
+def _assignments(tree: ast.AST) -> dict[str, ast.expr]:
+    assignments: dict[str, ast.expr] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = node.value
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.value is not None
+        ):
+            assignments[node.target.id] = node.value
+    return assignments
+
+
+def _call_name(func: ast.expr, aliases: dict[str, str]) -> str | None:
+    if (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and aliases.get(func.value.id) == "subprocess"
+        and func.attr in _RUNNERS
+    ):
+        return f"subprocess.{func.attr}"
+    if isinstance(func, ast.Name):
+        alias = aliases.get(func.id)
+        if alias in {f"subprocess.{runner}" for runner in _RUNNERS}:
+            return alias
+    return None
+
+
+def _literal_strings(node: ast.expr, assignments: dict[str, ast.expr]) -> list[str] | None:
+    if isinstance(node, ast.Name):
+        value = assignments.get(node.id)
+        return _literal_strings(value, assignments) if value is not None else None
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.List, ast.Tuple)):
+        values: list[str] = []
+        for element in node.elts:
+            strings = _literal_strings(element, assignments)
+            if strings is None:
+                return None
+            values.extend(strings)
+        return values
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _literal_strings(node.left, assignments)
+        right = _literal_strings(node.right, assignments)
+        if left is None or right is None:
+            return None
+        return [*left, *right]
+    return None
+
+
+def _first_executables(node: ast.expr, assignments: dict[str, ast.expr]) -> set[str]:
+    strings = _literal_strings(node, assignments)
+    if not strings:
+        return set()
+
+    first = strings[0]
+    try:
+        shell_words = shlex.split(first)
+    except ValueError:
+        shell_words = []
+    return {shell_words[0] if shell_words else first}
+
+
+def _raw_git_subprocess_violations(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    aliases = _subprocess_aliases(tree)
+    assignments = _assignments(tree)
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        call = _call_name(node.func, aliases)
+        if call is None or not node.args:
+            continue
+
+        executables = _first_executables(node.args[0], assignments)
+        if "git" in executables:
+            violations.append(f"{path}:{node.lineno}: raw git subprocess via {call}")
+
+    return violations
+
+
+def test_github_modules_do_not_run_git_via_raw_subprocess() -> None:
+    """GitHub modules must use hephaestus.github.git_ops for git commands."""
+    violations: list[str] = []
+    for path in _TARGETS:
+        violations.extend(_raw_git_subprocess_violations(path))
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "import subprocess\nsubprocess.run(['git', 'status'])\n",
+        "import subprocess as sp\nsp.Popen(('git', 'status'))\n",
+        "from subprocess import run\nrun(['git'] + ['status'])\n",
+        "from subprocess import check_output as co\ncmd = ['git', 'status']\nco(cmd)\n",
+        "import subprocess\nsubprocess.run('git status', shell=True)\n",
+    ],
+)
+def test_detector_finds_raw_git_subprocess_forms(tmp_path: Path, source: str) -> None:
+    """The structural guard covers aliases, command variables, and shell strings."""
+    path = tmp_path / "sample.py"
+    path.write_text(source, encoding="utf-8")
+
+    assert _raw_git_subprocess_violations(path)
+
+
+def test_detector_allows_non_git_subprocess(tmp_path: Path) -> None:
+    """Non-git subprocess calls, such as gpg, remain valid."""
+    path = tmp_path / "sample.py"
+    path.write_text(
+        "import subprocess\nsubprocess.run(['gpg', '--list-keys'], check=False)\n",
+        encoding="utf-8",
+    )
+
+    assert _raw_git_subprocess_violations(path) == []

--- a/tests/unit/github/test_no_raw_git_subprocess.py
+++ b/tests/unit/github/test_no_raw_git_subprocess.py
@@ -12,6 +12,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]
 _TARGETS = (
     *_REPO_ROOT.joinpath("hephaestus", "github", "fleet_sync").glob("*.py"),
     _REPO_ROOT / "hephaestus" / "github" / "pr_merge.py",
+    _REPO_ROOT / "hephaestus" / "github" / "tidy.py",
 )
 _RUNNERS = {"run", "Popen", "check_output", "check_call"}
 
@@ -118,7 +119,7 @@ def _raw_git_subprocess_violations(path: Path) -> list[str]:
 
 
 def test_github_modules_do_not_run_git_via_raw_subprocess() -> None:
-    """GitHub modules must use hephaestus.github.git_ops for git commands."""
+    """GitHub modules must use the shared git adapter for git commands."""
     violations: list[str] = []
     for path in _TARGETS:
         violations.extend(_raw_git_subprocess_violations(path))

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -15,7 +15,6 @@ from hephaestus.github.pr_merge import (
     run_git_cmd,
     try_push_head_branch,
 )
-from hephaestus.utils.helpers import METADATA_TIMEOUT
 
 
 def _gh_result(payload: object) -> MagicMock:
@@ -30,42 +29,38 @@ def _gh_result(payload: object) -> MagicMock:
 class TestDetectRepoFromRemote:
     """Tests for detect_repo_from_remote."""
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detects_ssh_url(self, mock_run) -> None:
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detects_ssh_url(self, mock_remote_url) -> None:
         """Parses SSH-style github.com:owner/repo.git."""
-        mock_run.return_value = MagicMock(
-            stdout="git@github.com:HomericIntelligence/ProjectHephaestus.git"
-        )
+        mock_remote_url.return_value = "git@github.com:HomericIntelligence/ProjectHephaestus.git"
         result = detect_repo_from_remote()
         assert result == "HomericIntelligence/ProjectHephaestus"
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detects_https_url(self, mock_run) -> None:
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detects_https_url(self, mock_remote_url) -> None:
         """Parses HTTPS github.com/owner/repo.git."""
-        mock_run.return_value = MagicMock(
-            stdout="https://github.com/HomericIntelligence/ProjectScylla.git"
-        )
+        mock_remote_url.return_value = "https://github.com/HomericIntelligence/ProjectScylla.git"
         result = detect_repo_from_remote()
         assert result == "HomericIntelligence/ProjectScylla"
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_detects_url_without_git_suffix(self, mock_run) -> None:
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_detects_url_without_git_suffix(self, mock_remote_url) -> None:
         """Parses URL without .git suffix."""
-        mock_run.return_value = MagicMock(stdout="https://github.com/owner/repo")
+        mock_remote_url.return_value = "https://github.com/owner/repo"
         result = detect_repo_from_remote()
         assert result == "owner/repo"
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_returns_none_for_non_github_url(self, mock_run) -> None:
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_returns_none_for_non_github_url(self, mock_remote_url) -> None:
         """Returns None when URL is not a GitHub URL."""
-        mock_run.return_value = MagicMock(stdout="https://gitlab.com/owner/repo.git")
+        mock_remote_url.return_value = "https://gitlab.com/owner/repo.git"
         result = detect_repo_from_remote()
         assert result is None
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_returns_none_on_exception(self, mock_run) -> None:
-        """Returns None when run_subprocess raises."""
-        mock_run.side_effect = RuntimeError("git not found")
+    @patch("hephaestus.github.pr_merge.git_remote_url")
+    def test_returns_none_on_exception(self, mock_remote_url) -> None:
+        """Returns None when git remote lookup raises."""
+        mock_remote_url.side_effect = RuntimeError("git not found")
         result = detect_repo_from_remote()
         assert result is None
 
@@ -73,33 +68,33 @@ class TestDetectRepoFromRemote:
 class TestRunGitCmd:
     """Tests for run_git_cmd."""
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_calls_run_subprocess(self, mock_run) -> None:
-        """Passes command to run_subprocess."""
+    @patch("hephaestus.github.pr_merge.run_git")
+    def test_calls_run_git(self, mock_run) -> None:
+        """Passes command to the shared git helper."""
         run_git_cmd(["git", "status"])
         mock_run.assert_called_once_with(["git", "status"], cwd=None, dry_run=False)
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
+    @patch("hephaestus.github.pr_merge.run_git")
     def test_dry_run_passed_through(self, mock_run) -> None:
-        """dry_run flag is forwarded to run_subprocess."""
+        """dry_run flag is forwarded to the shared git helper."""
         run_git_cmd(["git", "push"], dry_run=True)
         mock_run.assert_called_once_with(["git", "push"], cwd=None, dry_run=True)
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
+    @patch("hephaestus.github.pr_merge.run_git")
     def test_cwd_passed_through(self, mock_run) -> None:
-        """Cwd is forwarded to run_subprocess."""
+        """Cwd is forwarded to the shared git helper."""
         run_git_cmd(["git", "log"], cwd="/some/path")
         mock_run.assert_called_once_with(["git", "log"], cwd="/some/path", dry_run=False)
 
     @patch("hephaestus.github.pr_merge.logger")
-    @patch("hephaestus.github.pr_merge.run_subprocess")
+    @patch("hephaestus.github.pr_merge.run_git")
     def test_log_includes_cwd_when_provided(self, _mock_run, mock_logger) -> None:
         """Log line includes (cwd=...) when cwd is passed."""
         run_git_cmd(["git", "log"], cwd="/some/path")
         mock_logger.info.assert_called_once_with("$ %s (cwd=%s)", "git log", "/some/path")
 
     @patch("hephaestus.github.pr_merge.logger")
-    @patch("hephaestus.github.pr_merge.run_subprocess")
+    @patch("hephaestus.github.pr_merge.run_git")
     def test_log_omits_cwd_when_not_provided(self, _mock_run, mock_logger) -> None:
         """Log line omits cwd suffix when cwd is None (no noise added to existing traces)."""
         run_git_cmd(["git", "status"])
@@ -241,65 +236,60 @@ class TestLegacyStatusAndPrint:
 class TestLocalBranchExists:
     """Tests for local_branch_exists."""
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_returns_true_when_branch_exists(self, mock_run) -> None:
-        """Returns True when git branch --list output is non-empty."""
-        mock_run.return_value = MagicMock(stdout="  my-feature\n")
+    @patch("hephaestus.github.pr_merge.git_branch_exists", return_value=True)
+    def test_returns_true_when_branch_exists(self, mock_exists) -> None:
+        """Returns True when the shared git helper finds the branch."""
         assert local_branch_exists("my-feature") is True
+        mock_exists.assert_called_once_with("my-feature")
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_returns_false_when_branch_absent(self, mock_run) -> None:
-        """Returns False when git branch --list output is empty."""
-        mock_run.return_value = MagicMock(stdout="")
+    @patch("hephaestus.github.pr_merge.git_branch_exists", return_value=False)
+    def test_returns_false_when_branch_absent(self, mock_exists) -> None:
+        """Returns False when the shared git helper does not find the branch."""
         assert local_branch_exists("nonexistent") is False
+        mock_exists.assert_called_once_with("nonexistent")
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_returns_false_on_subprocess_error(self, mock_run) -> None:
-        """Returns False when subprocess raises CalledProcessError."""
-        mock_run.side_effect = subprocess.CalledProcessError(1, "git")
+    @patch("hephaestus.github.pr_merge.git_branch_exists")
+    def test_returns_false_on_subprocess_error(self, mock_exists) -> None:
+        """Returns False when git helper raises CalledProcessError."""
+        mock_exists.side_effect = subprocess.CalledProcessError(1, "git")
         assert local_branch_exists("branch") is False
 
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_passes_timeout_and_suppresses_expected_error_logs(self, mock_run) -> None:
-        """The git branch lookup is bounded and avoids noisy expected-error logs."""
-        mock_run.return_value = MagicMock(stdout="  my-feature\n")
-        local_branch_exists("my-feature")
-        assert mock_run.call_args.kwargs["timeout"] == METADATA_TIMEOUT
-        assert mock_run.call_args.kwargs["log_on_error"] is False
-
-    @patch("hephaestus.github.pr_merge.run_subprocess")
-    def test_returns_false_on_timeout(self, mock_run) -> None:
-        """A hung ``git branch --list`` degrades to False instead of hanging (#684)."""
-        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
+    @patch("hephaestus.github.pr_merge.git_branch_exists")
+    def test_returns_false_on_timeout(self, mock_exists) -> None:
+        """A hung branch lookup degrades to False instead of hanging (#684)."""
+        mock_exists.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=10)
         assert local_branch_exists("branch") is False
 
 
 class TestTryPushHeadBranch:
     """Tests for try_push_head_branch."""
 
-    @patch("hephaestus.github.pr_merge.run_git_cmd")
+    @patch("hephaestus.github.pr_merge.git_push")
     @patch("hephaestus.github.pr_merge.local_branch_exists", return_value=True)
-    def test_pushes_when_branch_exists(self, mock_exists, mock_run) -> None:
+    def test_pushes_when_branch_exists(self, mock_exists, mock_push) -> None:
         """Pushes the branch when it exists locally."""
         try_push_head_branch("feature-branch", dry_run=False)
-        mock_run.assert_called_once()
-        cmd = mock_run.call_args[0][0]
-        assert "feature-branch:feature-branch" in cmd
+        mock_push.assert_called_once_with(
+            None,
+            "origin",
+            "feature-branch:feature-branch",
+            dry_run=False,
+        )
 
-    @patch("hephaestus.github.pr_merge.run_git_cmd")
+    @patch("hephaestus.github.pr_merge.git_push")
     @patch("hephaestus.github.pr_merge.local_branch_exists", return_value=False)
-    def test_skips_push_when_branch_absent(self, mock_exists, mock_run) -> None:
+    def test_skips_push_when_branch_absent(self, mock_exists, mock_push) -> None:
         """Does not push when branch is not found locally."""
         try_push_head_branch("feature-branch", dry_run=False)
-        mock_run.assert_not_called()
+        mock_push.assert_not_called()
 
-    @patch("hephaestus.github.pr_merge.run_git_cmd")
+    @patch("hephaestus.github.pr_merge.git_push")
     @patch("hephaestus.github.pr_merge.local_branch_exists")
-    def test_dry_run_skips_local_check_and_push(self, mock_exists, mock_run) -> None:
+    def test_dry_run_skips_local_check_and_push(self, mock_exists, mock_push) -> None:
         """In dry-run mode, skips local branch check and push entirely."""
         try_push_head_branch("feature-branch", dry_run=True)
         mock_exists.assert_not_called()
-        mock_run.assert_not_called()
+        mock_push.assert_not_called()
 
 
 class TestHandleMergeResult:
@@ -661,16 +651,18 @@ class TestSquashOnlyInvariant:
         assert "merge_method=squash" in source
 
 
-class TestCanonicalRunSubprocess:
-    """Source-level regressions for subprocess helper consolidation."""
+class TestCanonicalGitOps:
+    """Source-level regressions for git helper consolidation."""
 
-    def test_pr_merge_uses_canonical_run_subprocess(self) -> None:
+    def test_pr_merge_uses_canonical_git_helpers(self) -> None:
         import inspect
 
-        from hephaestus.github import pr_merge
-        from hephaestus.utils import helpers
+        from hephaestus.github import git_ops, pr_merge
 
         source = inspect.getsource(pr_merge)
-        assert vars(pr_merge)["run_subprocess"] is helpers.run_subprocess
+        assert vars(pr_merge)["run_git"] is git_ops.run_git
+        assert vars(pr_merge)["git_remote_url"] is git_ops.git_remote_url
+        assert vars(pr_merge)["git_branch_exists"] is git_ops.git_branch_exists
+        assert vars(pr_merge)["git_push"] is git_ops.git_push
         assert "def run_subprocess(" not in source
         assert "subprocess.check_output" not in source

--- a/tests/unit/utils/test_general_utils.py
+++ b/tests/unit/utils/test_general_utils.py
@@ -521,3 +521,15 @@ class TestRunSubprocessTimeoutLogging:
         with patch("subprocess.run", side_effect=exc):
             with pytest.raises(subprocess.TimeoutExpired):
                 run_subprocess(["ls"], timeout=5)
+
+    def test_timeout_log_on_error_false_suppresses_error_log(self) -> None:
+        """Expected timeout failures can suppress lower-level ERROR logs."""
+        exc = subprocess.TimeoutExpired(cmd=["sleep", "99"], timeout=1)
+        with (
+            patch("subprocess.run", side_effect=exc),
+            patch("hephaestus.utils.helpers.logger.error") as mock_error,
+        ):
+            with pytest.raises(subprocess.TimeoutExpired):
+                run_subprocess(["sleep", "99"], timeout=1, log_on_error=False)
+
+        mock_error.assert_not_called()

--- a/tests/unit/utils/test_git.py
+++ b/tests/unit/utils/test_git.py
@@ -1,0 +1,43 @@
+"""Tests for shared git utilities."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import hephaestus.utils as utils_pkg
+import hephaestus.utils.git as shared_git
+from hephaestus.utils.helpers import NETWORK_TIMEOUT
+
+
+def test_run_git_routes_through_standard_subprocess_helper() -> None:
+    """run_git normalizes git commands and uses the shared subprocess adapter."""
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.utils.git.run_subprocess", return_value=completed) as mock_run:
+        assert shared_git.run_git(["git", "status"], cwd=Path("/repo")) is completed
+
+    mock_run.assert_called_once_with(
+        ["git", "status"],
+        cwd="/repo",
+        check=True,
+        timeout=NETWORK_TIMEOUT,
+        dry_run=False,
+        log_on_error=True,
+    )
+
+
+def test_git_ls_remote_contains_matches_exact_branch_refs_only() -> None:
+    """Branch shorthand must not match similarly named remote refs."""
+    found = subprocess.CompletedProcess(["git"], 0, stdout="abc\trefs/heads/feature\n", stderr="")
+    partial = subprocess.CompletedProcess(
+        ["git"], 0, stdout="abc\trefs/heads/feature-old\n", stderr=""
+    )
+    with patch("hephaestus.utils.git.run_git", side_effect=[found, partial]):
+        assert shared_git.git_ls_remote_contains(Path("/repo"), "origin", "feature") is True
+        assert shared_git.git_ls_remote_contains(Path("/repo"), "origin", "feature") is False
+
+
+def test_run_git_is_available_from_utils_package() -> None:
+    """The package-level utils surface exposes the shared git runner."""
+    assert utils_pkg.run_git is shared_git.run_git

--- a/tests/unit/utils/test_git.py
+++ b/tests/unit/utils/test_git.py
@@ -40,6 +40,23 @@ def test_run_git_retries_network_commands() -> None:
     assert mock_run.call_count == 2
 
 
+def test_run_git_does_not_retry_deterministic_network_command_errors() -> None:
+    """Deterministic network-command failures are not retried."""
+    failure = subprocess.CalledProcessError(
+        128, ["git", "push"], stderr="fatal: Authentication failed"
+    )
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run:
+        try:
+            shared_git.run_git(["push", "origin", "feature"])
+        except subprocess.CalledProcessError:
+            pass
+        else:  # pragma: no cover - assertion below is clearer when this fails
+            raise AssertionError("deterministic Git failure should be raised")
+
+    assert mock_run.call_count == 1
+
+
 def test_git_ls_remote_contains_matches_exact_branch_refs_only() -> None:
     """Branch shorthand must not match similarly named remote refs."""
     found = subprocess.CompletedProcess(["git"], 0, stdout="abc\trefs/heads/feature\n", stderr="")

--- a/tests/unit/utils/test_git.py
+++ b/tests/unit/utils/test_git.py
@@ -27,6 +27,19 @@ def test_run_git_routes_through_standard_subprocess_helper() -> None:
     )
 
 
+def test_run_git_retries_network_commands() -> None:
+    """Network git operations retry transient subprocess failures."""
+    failure = subprocess.CalledProcessError(128, ["git", "push"], stderr="network timeout")
+    completed = subprocess.CompletedProcess(["git"], 0, stdout="", stderr="")
+    with (
+        patch("hephaestus.utils.git.run_subprocess", side_effect=[failure, completed]) as mock_run,
+        patch("hephaestus.utils.retry.time.sleep"),
+    ):
+        assert shared_git.run_git(["push", "origin", "feature"]) is completed
+
+    assert mock_run.call_count == 2
+
+
 def test_git_ls_remote_contains_matches_exact_branch_refs_only() -> None:
     """Branch shorthand must not match similarly named remote refs."""
     found = subprocess.CompletedProcess(["git"], 0, stdout="abc\trefs/heads/feature\n", stderr="")

--- a/tests/unit/utils/test_git.py
+++ b/tests/unit/utils/test_git.py
@@ -68,6 +68,21 @@ def test_git_ls_remote_contains_matches_exact_branch_refs_only() -> None:
         assert shared_git.git_ls_remote_contains(Path("/repo"), "origin", "feature") is False
 
 
+def test_git_ls_remote_contains_can_raise_probe_errors() -> None:
+    """Callers can request an exception when a remote probe fails."""
+    probe_error = subprocess.TimeoutExpired(["git", "ls-remote"], timeout=1)
+    with patch("hephaestus.utils.git.run_git", side_effect=probe_error):
+        assert shared_git.git_ls_remote_contains(Path("/repo"), "origin", "feature") is False
+        try:
+            shared_git.git_ls_remote_contains(
+                Path("/repo"), "origin", "feature", raise_on_error=True
+            )
+        except subprocess.TimeoutExpired:
+            pass
+        else:  # pragma: no cover - assertion below is clearer when this fails
+            raise AssertionError("remote probe failure should be raised")
+
+
 def test_run_git_is_available_from_utils_package() -> None:
     """The package-level utils surface exposes the shared git runner."""
     assert utils_pkg.run_git is shared_git.run_git

--- a/tests/unit/validation/test_api_table_docs.py
+++ b/tests/unit/validation/test_api_table_docs.py
@@ -47,6 +47,18 @@ class TestLoadDocumentedSymbols:
         assert tables["hephaestus.config"] == {"load_config"}
         assert tables["hephaestus.utils"] == {"slugify"}
 
+    def test_parses_nested_module_table(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(
+            "### `hephaestus.utils.git`\n\n"
+            "| Symbol | Added | Notes |\n"
+            "|--------|-------|-------|\n"
+            "| `run_git` | TBD | Execute Git commands |\n",
+            encoding="utf-8",
+        )
+        tables = load_documented_symbols(p)
+        assert tables["hephaestus.utils.git"] == {"run_git"}
+
     def test_skips_separator_rows(self, tmp_path: Path) -> None:
         p = tmp_path / "COMPATIBILITY.md"
         p.write_text(
@@ -147,6 +159,20 @@ class TestFindViolations:
         p.write_text("# empty\n", encoding="utf-8")
         documented = load_documented_symbols(p)
         assert find_violations(documented, packages=()) == []
+
+    def test_nested_module_missing_from_docs_detected(self, tmp_path: Path) -> None:
+        p = tmp_path / "COMPATIBILITY.md"
+        p.write_text(
+            "### `hephaestus.utils.git`\n\n"
+            "| Symbol | Added | Notes |\n"
+            "|--------|-------|-------|\n"
+            "| `run_git` | TBD | Execute Git commands |\n",
+            encoding="utf-8",
+        )
+        documented = load_documented_symbols(p)
+        findings = find_violations(documented, packages=("hephaestus.utils.git",))
+        assert any(f.kind == "missing-from-docs" for f in findings)
+        assert any("git_ls_remote_contains" in f.detail for f in findings)
 
     def test_finding_is_dataclass(self, tmp_path: Path) -> None:
         p = tmp_path / "COMPATIBILITY.md"


### PR DESCRIPTION
## Summary
- Move the shared Git subprocess adapter and GitHub-facing helper surface into `hephaestus.utils.git` so GitHub and automation callers use the same library-layer Git execution path.
- Add bounded retry protection for network Git commands (`clone`, `fetch`, `ls-remote`, `pull`, `push`) while keeping local metadata commands single-shot unless a caller opts in.
- Filter Git retries to transient failures/timeouts so deterministic auth/ref/rejection errors fail fast, log final diagnostics once, and avoid noisy per-attempt subprocess ERROR logs.
- Redact credential-bearing Git URLs, token-like values, credential query parameters, and authorization headers before final retry diagnostics are logged.
- Detect retry-eligible Git subcommands after leading git global options such as `-C`, `-c`, `--git-dir=...`, and git global flags.
- Keep `hephaestus.github.git_ops` as a compatibility export surface for existing GitHub callers, and route fleet-sync Git execution through the shared helper without duplicating retry classification.
- Route `hephaestus.automation.git_utils.run(["git", ...])` through the shared helper while preserving the existing automation patch seam, non-git command behavior, and automation-level retry loops.
- Fix `git_ls_remote_contains()` to require exact advertised refs, and let callers distinguish remote probe failures from absent refs; the conflict resolver now logs probe failures separately from missing agent pushes.
- Guard nested `hephaestus.utils.git` API-table documentation, and add direct regression tests for retry filtering, retry log noise, redacted diagnostics, exact remote refs, remote-probe failures, fleet-sync delegation, and the mirrored utility surface.
- `hephaestus.github.tidy` was already on shared Git wrappers; the raw-Git structural guard covers it to keep that requirement from regressing.

## Architecture note
- `hephaestus.utils.git` stays in the ADR-0001 library layer and does not import `hephaestus.automation`.
- Product-specific automation workflow helpers remain in `hephaestus.automation.git_utils`; moving those into `utils` would promote automation commit-policy and worktree lifecycle behavior into the base library API.
- The public compatibility docs now state that `run_git` captures text output only.

## Verification
- RED: `pixi run pytest tests/unit/github/test_git_ops.py -k "partial_ref_matches or shared_git_helpers_live_in_utils_package" -q --no-cov --tb=short` failed as expected before implementation (partial remote ref matched; `hephaestus.utils.git` missing).
- RED: D5 regression tests failed before the security fix (`test_run_git_redacts_sensitive_command_and_stream_diagnostics`, `test_run_git_suppresses_subprocess_timeout_error_logs_during_retries`).
- CI scanner follow-up: replaced static secret-shaped redaction fixtures with runtime-built synthetic values after `security/secrets-scan` and HOL scanner failed on the PR diff.
- History rewrite follow-up: squashed the scanner-fixture cleanup into the redaction commit so the fake classic PAT-shaped fixture is no longer present in `origin/main..HEAD`; CI `security/secrets-scan` passes at rewritten head `7823b39`.
- D3/D5 hardening follow-up: retry warnings now pass through the Git diagnostic redactor, modern fine-grained PAT-shaped values are redacted, auth-header and SCP-style remote redaction are covered, and fleet-sync `rebase --exec` email config values are shell-quoted.
- Review-fix verification: `pixi run pytest tests/unit/github/test_git_ops.py tests/unit/github/test_fleet_sync.py -q --no-cov --tb=short` (103 passed); `pixi run pytest tests/unit/github/test_git_ops.py tests/unit/utils/test_git.py tests/unit/utils/test_general_utils.py tests/unit/automation/test_git_utils.py tests/unit/github/test_fleet_sync.py tests/unit/github/test_no_raw_git_subprocess.py tests/unit/github/test_pr_merge.py tests/unit/github/test_github_utils.py tests/unit/validation/test_api_table_docs.py -q --no-cov --tb=short` (346 passed); `pixi run python -m mypy hephaestus/utils/git.py hephaestus/github/fleet_sync/gpg.py tests/unit/github/test_git_ops.py tests/unit/github/test_fleet_sync.py` (passed); `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` (passed).
- `pixi run pytest tests/unit/github/test_git_ops.py -q --no-cov --tb=short` (36 passed)
- `pixi run pytest tests/unit/github/test_git_ops.py tests/unit/utils/test_git.py tests/unit/utils/test_general_utils.py tests/unit/automation/test_git_utils.py tests/unit/github/test_fleet_sync.py tests/unit/github/test_no_raw_git_subprocess.py tests/unit/github/test_pr_merge.py tests/unit/github/test_github_utils.py tests/unit/validation/test_api_table_docs.py -q --no-cov --tb=short` (344 passed)
- `pixi run pytest tests/unit -v` (5913 passed, 21 skipped, coverage 84.32%)
- `pixi run python -m mypy hephaestus/` (Success: no issues found in 214 source files)
- `pixi run ruff check hephaestus/ tests/` (passed)
- `pixi run ruff format --check hephaestus/ tests/` (523 files already formatted)
- `git diff --check origin/main...HEAD` (no output)
- `pixi run pre-commit run --from-ref origin/main --to-ref HEAD` (passed)

Closes #1408



