### PR TITLE
feat(agents): add GPT-5.6 tier aliases

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -32,6 +32,11 @@ CODEX_FINAL_MESSAGE_GRACE_ENV = "HEPH_CODEX_FINAL_MESSAGE_GRACE"
 CODEX_FINAL_MESSAGE_GRACE_SECONDS = 5.0
 CODEX_GPT_56_MODEL = "gpt-5.6"
 CODEX_GPT_55_MODEL = "gpt-5.5"
+CODEX_GPT_56_SOL_MODEL = "gpt-5.6-sol"
+CODEX_GPT_56_TERRA_MODEL = "gpt-5.6-terra"
+CODEX_GPT_56_LUNA_MODEL = "gpt-5.6-luna"
+# Preserve the established Claude-tier translation while exposing the GPT-5.6
+# Sol/Terra/Luna family as explicit capability-tier aliases below.
 CODEX_FABLE_MODEL = CODEX_GPT_55_MODEL
 CODEX_FABLE_REASONING_EFFORT = "xhigh"
 CODEX_OPUS_MODEL = CODEX_GPT_55_MODEL
@@ -376,13 +381,19 @@ def codex_approval_args(approval: str) -> list[str]:
 
 
 def _codex_model_config(model: str, *, use_default: bool = False) -> CodexModelConfig:
-    """Translate Claude tier IDs into Codex-native model/reasoning settings."""
+    """Translate legacy and GPT-5.6 tier IDs into Codex model settings."""
     normalized = model.strip()
     if not normalized:
         if use_default:
             return CodexModelConfig(CODEX_DEFAULT_MODEL, CODEX_DEFAULT_REASONING_EFFORT)
         return CodexModelConfig("")
     lower_model = normalized.lower()
+    if lower_model in {"sol", CODEX_GPT_56_SOL_MODEL}:
+        return CodexModelConfig(CODEX_GPT_56_SOL_MODEL, CODEX_FABLE_REASONING_EFFORT)
+    if lower_model in {"terra", CODEX_GPT_56_TERRA_MODEL}:
+        return CodexModelConfig(CODEX_GPT_56_TERRA_MODEL, CODEX_OPUS_REASONING_EFFORT)
+    if lower_model in {"luna", CODEX_GPT_56_LUNA_MODEL}:
+        return CodexModelConfig(CODEX_GPT_56_LUNA_MODEL, CODEX_SONNET_REASONING_EFFORT)
     if lower_model == "fable" or lower_model.startswith("claude-fable-"):
         return CodexModelConfig(CODEX_FABLE_MODEL, CODEX_FABLE_REASONING_EFFORT)
     if lower_model == "opus" or lower_model.startswith("claude-opus-"):

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -327,21 +327,28 @@ def test_codex_approval_args_preserves_legacy_flag() -> None:
 
 
 @pytest.mark.parametrize(
-    ("claude_model", "expected_model", "expected_reasoning"),
+    ("model", "expected_model", "expected_reasoning"),
     [
+        ("claude-fable-5", "gpt-5.5", "xhigh"),
         ("claude-opus-4-7", "gpt-5.5", "xhigh"),
         ("claude-sonnet-4-6", "gpt-5.5", "medium"),
+        ("sol", "gpt-5.6-sol", "xhigh"),
+        ("terra", "gpt-5.6-terra", "xhigh"),
+        ("luna", "gpt-5.6-luna", "medium"),
+        ("gpt-5.6-sol", "gpt-5.6-sol", "xhigh"),
+        ("gpt-5.6-terra", "gpt-5.6-terra", "xhigh"),
+        ("gpt-5.6-luna", "gpt-5.6-luna", "medium"),
     ],
 )
 def test_codex_base_cmd_maps_claude_reasoning_tiers(
     tmp_path: Path,
-    claude_model: str,
+    model: str,
     expected_model: str,
     expected_reasoning: str,
 ) -> None:
-    """Codex must receive Codex model IDs plus tier-specific reasoning config."""
+    """Codex must receive recognized tier IDs plus matching reasoning config."""
     with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
-        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model=claude_model)
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model=model)
 
     assert cmd[cmd.index("--model") + 1] == expected_model
     assert cmd[cmd.index("-c") + 1] == (f"model_reasoning_effort={json.dumps(expected_reasoning)}")
@@ -358,7 +365,10 @@ def test_codex_base_cmd_maps_haiku_to_mini_without_reasoning_override(
     assert "model_reasoning_effort" not in cmd
 
 
-@pytest.mark.parametrize("native_model", ["gpt-5.4-mini", "gpt-5.5", "gpt-5.6"])
+@pytest.mark.parametrize(
+    "native_model",
+    ["gpt-5.4-mini", "gpt-5.5", "gpt-5.6"],
+)
 def test_codex_base_cmd_keeps_native_codex_model_ids(
     tmp_path: Path,
     native_model: str,


### PR DESCRIPTION
## Summary

- Add `sol`, `terra`, and `luna` aliases for the GPT-5.6 Sol/Terra/Luna model tiers.
- Preserve existing GPT-5.5 and GPT-5.6 legacy Claude-tier mappings.

## Test Plan

- [x] `pixi run pytest tests/unit/agents/test_runtime.py -v --no-cov`
- [x] `pixi run mypy`
- [x] `pixi run ruff check hephaestus/ tests/`
- [x] `pixi run ruff format --check hephaestus/ tests/`
- [x] `pixi run pre-commit run --files hephaestus/agents/runtime.py tests/unit/agents/test_runtime.py`
- [ ] Full unit suite (GitHub CI)

Closes #2035