### PR TITLE
[automation-loop] Preserve repo identity when filtering preserved worktrees

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -117,7 +117,12 @@ from hephaestus.automation.pipeline.stages import (
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
 from hephaestus.automation.pipeline.stages.repo import product_to_work_item
 from hephaestus.automation.pipeline.summary import RunStats, latest_logical_items, print_summary
-from hephaestus.automation.pipeline.work_item import ItemKind, ItemResult, WorkItem
+from hephaestus.automation.pipeline.work_item import (
+    ItemKind,
+    ItemResult,
+    PreservedWorktree,
+    WorkItem,
+)
 from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO
 
 logger = logging.getLogger(__name__)
@@ -332,7 +337,7 @@ class Coordinator:
         self.in_flight: dict[JobHandle, WorkItem] = {}
         self.inflight_per_repo: Counter[str] = Counter()
         self.ledger: list[ItemResult] = []
-        self.preserved: list[tuple[int, str]] = []
+        self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
         self.event_log: list[tuple[Any, ...]] = []
         self._event_log_disabled = False
@@ -530,18 +535,18 @@ class Coordinator:
         """Return latest logical items, collapsing superseded re-seed attempts."""
         return latest_logical_items(self.items)
 
-    def _active_preserved_worktrees(self) -> list[tuple[int, str]]:
+    def _active_preserved_worktrees(self) -> list[PreservedWorktree]:
         """Return preserved worktrees for latest failed items that still exist."""
-        failed_numbers = {
-            item.issue or item.pr or 0
+        failed_items = {
+            (item.repo, item.issue or item.pr or 0)
             for item in self._effective_items()
             if item.result is not None and not item.result.passed
         }
-        active: list[tuple[int, str]] = []
-        seen: set[tuple[int, str]] = set()
-        for issue_or_pr, path in self.preserved:
-            entry = (issue_or_pr, path)
-            if entry in seen or issue_or_pr not in failed_numbers or not Path(path).exists():
+        active: list[PreservedWorktree] = []
+        seen: set[PreservedWorktree] = set()
+        for repo, issue_or_pr, path in self.preserved:
+            entry = (repo, issue_or_pr, path)
+            if entry in seen or (repo, issue_or_pr) not in failed_items or not Path(path).exists():
                 continue
             seen.add(entry)
             active.append(entry)

--- a/hephaestus/automation/pipeline/stages/finished.py
+++ b/hephaestus/automation/pipeline/stages/finished.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 
-from hephaestus.automation.pipeline.work_item import ItemResult
+from hephaestus.automation.pipeline.work_item import ItemResult, PreservedWorktree
 
 from .base import (
     GIT_JOB_TIMEOUT_S,
@@ -47,7 +47,7 @@ class FinishedStage(Stage):
     Args:
         ledger: The coordinator's run ledger; RECORD appends here.
         preserved: The coordinator's preserved-worktree list
-            (``(item_number, worktree_path)`` tuples) the summary prints.
+            (``(repo, item_number, worktree_path)`` tuples) the summary prints.
             Failed issue items use the issue number; PR-only items use the PR
             number; unknown items fall back to 0.
 
@@ -58,7 +58,7 @@ class FinishedStage(Stage):
     def __init__(
         self,
         ledger: list[ItemResult],
-        preserved: list[tuple[int, str]],
+        preserved: list[PreservedWorktree],
     ) -> None:
         """Bind the coordinator-owned ledger and preserved-worktree list."""
         self._ledger = ledger
@@ -118,7 +118,7 @@ class FinishedStage(Stage):
 
         passed = bool(item.result and item.result.passed)
         if not passed:
-            entry = (item.issue or item.pr or 0, item.worktree)
+            entry = (item.repo, item.issue or item.pr or 0, item.worktree)
             if entry not in self._preserved:
                 self._preserved.append(entry)
             logger.info(

--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -16,9 +16,8 @@ import logging
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
-from pathlib import Path
 
-from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.automation.pipeline.work_item import ItemKind, PreservedWorktree, WorkItem
 from hephaestus.cli.utils import emit_json_status
 
 logger = logging.getLogger(__name__)
@@ -40,9 +39,7 @@ class RunStats:
         return self.exit_code == 130
 
 
-def format_preserved_worktrees(
-    preserved: Sequence[tuple[int, str | Path]], script: str
-) -> list[str]:
+def format_preserved_worktrees(preserved: Sequence[PreservedWorktree], script: str) -> list[str]:
     """Format the preserved-worktree footer (legacy line sequence, verbatim).
 
     Re-housed from the legacy implementer preserved-worktree footer so the
@@ -50,7 +47,7 @@ def format_preserved_worktrees(
     with the pipeline conversion (#1821).
 
     Args:
-        preserved: ``(issue_number, worktree_path)`` tuples for failed items.
+        preserved: ``(repo, issue_number, worktree_path)`` tuples for failed items.
         script: The script name (``sys.argv[0]``) for the rerun hint.
 
     Returns:
@@ -59,14 +56,14 @@ def format_preserved_worktrees(
     """
     if not preserved:
         return []
-    issue_nums = [n for n, _ in preserved]
+    issue_nums = [number for _, number, _ in preserved]
     issues_arg = " ".join(str(n) for n in issue_nums)
     lines: list[str] = ["\nPreserved worktrees (contain uncommitted changes):"]
-    lines.extend(f"  #{issue_num}: {path}" for issue_num, path in preserved)
+    lines.extend(f"  #{number}: {path}" for _, number, path in preserved)
     lines.append("\nRerun these issues after inspecting/cleaning the worktrees:")
     lines.append(f"  {script} --issues {issues_arg} --resume")
     lines.append("To discard them instead:")
-    lines.extend(f"  git worktree remove --force {path}" for _, path in preserved)
+    lines.extend(f"  git worktree remove --force {path}" for _, _, path in preserved)
     return lines
 
 
@@ -138,7 +135,7 @@ def _item_row(item: WorkItem) -> str:
 def print_summary(
     items: list[WorkItem],
     stats: RunStats,
-    preserved: list[tuple[int, str]],
+    preserved: list[PreservedWorktree],
     *,
     json_out: bool,
 ) -> None:
@@ -147,7 +144,7 @@ def print_summary(
     Args:
         items: Every work item the run ever queued (results attached).
         stats: Aggregate run statistics (exit code, loops, agent time, wall).
-        preserved: ``(issue_number, worktree_path)`` tuples for failed items.
+        preserved: ``(repo, issue_number, worktree_path)`` tuples for failed items.
         json_out: Emit the machine-readable ``emit_json_status`` envelope.
 
     """
@@ -201,5 +198,5 @@ def print_summary(
             agent_job_time_s=round(stats.agent_job_time_s, 1),
             wall_s=round(stats.wall_s, 1),
             resumable=resumable,
-            preserved_worktrees=[list(entry) for entry in preserved],
+            preserved_worktrees=[[number, path] for _, number, path in preserved],
         )

--- a/hephaestus/automation/pipeline/work_item.py
+++ b/hephaestus/automation/pipeline/work_item.py
@@ -10,12 +10,15 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import Any, TypeAlias
 
 from .routing import StageName, budget_keys
 
 #: Maximum retained history events per item (oldest dropped first).
 HISTORY_CAP = 200
+
+PreservedWorktree: TypeAlias = tuple[str, int, str]
+"""Repository, issue/PR number, and path for a preserved worktree."""
 
 
 def _utcnow() -> datetime:

--- a/tests/unit/automation/pipeline/stages/test_stage_finished.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finished.py
@@ -32,13 +32,13 @@ def ledger() -> list[ItemResult]:
 
 
 @pytest.fixture
-def preserved() -> list[tuple[int, str]]:
+def preserved() -> list[tuple[str, int, str]]:
     """Fresh preserved-worktree list."""
     return []
 
 
 @pytest.fixture
-def stage(ledger: list[ItemResult], preserved: list[tuple[int, str]]) -> FinishedStage:
+def stage(ledger: list[ItemResult], preserved: list[tuple[str, int, str]]) -> FinishedStage:
     """FinishedStage bound to the fixture ledger/preserved lists."""
     return FinishedStage(ledger, preserved)
 
@@ -144,7 +144,7 @@ class TestCleanup:
     def test_fail_with_worktree_preserves_for_debugging(
         self,
         stage: FinishedStage,
-        preserved: list[tuple[int, str]],
+        preserved: list[tuple[str, int, str]],
         make_ctx: Any,
     ) -> None:
         """Preserve-on-fail: recorded for the summary, no removal job."""
@@ -153,12 +153,12 @@ class TestCleanup:
         result = stage.step(item, make_ctx())
 
         assert isinstance(result, Continue) and result.next_state == "DONE"
-        assert preserved == [(42, "/wt/issue-42")]
+        assert preserved == [("repo-a", 42, "/wt/issue-42")]
 
     def test_fail_preserve_is_idempotent(
         self,
         stage: FinishedStage,
-        preserved: list[tuple[int, str]],
+        preserved: list[tuple[str, int, str]],
         make_ctx: Any,
     ) -> None:
         ctx = make_ctx()
@@ -168,12 +168,12 @@ class TestCleanup:
         item.state = "CLEANUP"
         stage.step(item, ctx)
 
-        assert preserved == [(42, "/wt/issue-42")]
+        assert preserved == [("repo-a", 42, "/wt/issue-42")]
 
     def test_pr_only_failure_preserves_pr_number(
         self,
         stage: FinishedStage,
-        preserved: list[tuple[int, str]],
+        preserved: list[tuple[str, int, str]],
         make_ctx: Any,
     ) -> None:
         """PR-only failures are attributable in the preserved summary."""
@@ -190,12 +190,12 @@ class TestCleanup:
         result = stage.step(item, make_ctx())
 
         assert isinstance(result, Continue) and result.next_state == "DONE"
-        assert preserved == [(777, "/wt/pr-777")]
+        assert preserved == [("repo-a", 777, "/wt/pr-777")]
 
     def test_distinct_pr_only_failures_do_not_dedupe_on_zero_key(
         self,
         stage: FinishedStage,
-        preserved: list[tuple[int, str]],
+        preserved: list[tuple[str, int, str]],
         make_ctx: Any,
     ) -> None:
         ctx = make_ctx()
@@ -219,7 +219,10 @@ class TestCleanup:
         stage.step(first, ctx)
         stage.step(second, ctx)
 
-        assert preserved == [(777, "/wt/shared-pr"), (888, "/wt/shared-pr")]
+        assert preserved == [
+            ("repo-a", 777, "/wt/shared-pr"),
+            ("repo-a", 888, "/wt/shared-pr"),
+        ]
 
     def test_no_worktree_skips_cleanup(self, stage: FinishedStage, make_ctx: Any) -> None:
         result = stage.step(_item(state="CLEANUP"), make_ctx())

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -229,7 +229,7 @@ class TestExitCode:
             passed=True, reason="merged", final_stage=StageName.FINISHED
         )
         coordinator.items = [failed, passed]
-        coordinator.preserved.append((2009, str(preserved_path)))
+        coordinator.preserved.append(("repo-a", 2009, str(preserved_path)))
 
         assert coordinator._active_preserved_worktrees() == []
 
@@ -245,7 +245,28 @@ class TestExitCode:
             passed=False, reason="git_error", final_stage=StageName.FINISHED
         )
         coordinator.items = [failed]
-        coordinator.preserved.append((2009, str(missing_path)))
+        coordinator.preserved.append(("repo-a", 2009, str(missing_path)))
+
+        assert coordinator._active_preserved_worktrees() == []
+
+    def test_preserved_worktrees_keep_repository_identity_for_colliding_numbers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed item in one repo must not preserve a passed repo's worktree."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        preserved_path = tmp_path / "repo-b-issue-2009"
+        preserved_path.mkdir()
+        failed = _item(2009, StageName.FINISHED)
+        failed.result = work_item_mod.ItemResult(
+            passed=False, reason="git_error", final_stage=StageName.FINISHED
+        )
+        passed = _item(2009, StageName.FINISHED)
+        passed.repo = "repo-b"
+        passed.result = work_item_mod.ItemResult(
+            passed=True, reason="merged", final_stage=StageName.FINISHED
+        )
+        coordinator.items = [failed, passed]
+        coordinator.preserved.append(("repo-b", 2009, str(preserved_path)))
 
         assert coordinator._active_preserved_worktrees() == []
 

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -64,7 +64,7 @@ class TestFormatPreservedWorktrees:
         assert format_preserved_worktrees([], "script.py") == []
 
     def test_line_sequence_matches_legacy(self) -> None:
-        preserved = [(101, "/wt/issue-101"), (202, "/wt/issue-202")]
+        preserved = [("repo-a", 101, "/wt/issue-101"), ("repo-b", 202, "/wt/issue-202")]
 
         lines = format_preserved_worktrees(preserved, "impl.py")
 
@@ -161,7 +161,7 @@ class TestPrintSummaryRows:
     def test_preserved_footer_present(self, caplog: pytest.LogCaptureFixture) -> None:
         """The preserved-worktree footer prints via the shared helper."""
         with caplog.at_level(logging.INFO):
-            print_summary([], _stats(exit_code=1), [(9, "/wt/9")], json_out=False)
+            print_summary([], _stats(exit_code=1), [("repo-a", 9, "/wt/9")], json_out=False)
 
         assert "Preserved worktrees (contain uncommitted changes):" in caplog.text
         assert "git worktree remove --force /wt/9" in caplog.text
@@ -180,7 +180,7 @@ class TestJsonEnvelope:
         print_summary(
             items,
             _stats(exit_code=130, loops_run=3),
-            [(2, "/wt/2")],
+            [("repo-a", 2, "/wt/2")],
             json_out=True,
         )
 


### PR DESCRIPTION
## Summary
Verdict: PASS | Reason: Repository identity is preserved through worktree filtering, with regression coverage for colliding issue numbers.

- Updated preserved-worktree bookkeeping to `(repo, number, path)`.
- Preserved legacy summary/JSON output formats.
- Tests: 6,329 passed, 21 skipped; focused tests 70 passed.
- Mypy, Ruff, formatting, and diff checks pass.
- Pixi/pre-commit blocked by read-only cache/network environment.
- GitHub plan/comments unavailable due API connectivity.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2028

Generated by ProjectHephaestus automation
