### PR TITLE
fix(pipeline): make zero-thread NOGO reviews durable and actionable

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -247,6 +247,11 @@ ADDRESS_WAIT → PUSH_WAIT → EVAL → (loop) → FOLLOWUP_WAIT.
 6. [W:G] Push (commit+force-push addressing changes).
 7. [M] **EVAL**: invoke `_evaluate_go_verdict` (parse reviewerAgent verdict:
    GO, NOGO, AMBIGUOUS, ERROR, HUMAN_BLOCKED) + count unresolved threads;
+   an explicit NOGO with zero posted thread IDs and zero unresolved automation
+   or human threads is not a completed round: upsert the bounded
+   `<!-- hephaestus-pr-review-zero-thread-nogo -->` artifact, emit the typed
+   `pr_review_zero_thread_nogo` event, and re-enter `REVIEW_WAIT` for a fresh
+   reviewer invocation without consuming a round;
    if GO + 0 unresolved threads → apply `state:implementation-go` label and
    arm auto-merge [durable] → ADVANCE; if NOGO/AMBIGUOUS/ERROR and iteration
    < 3 → RETRY; if HUMAN_BLOCKED or iteration cap exhausted → routes depend on
@@ -265,6 +270,13 @@ finished(fail, human_blocked); default → pr_review (RETRY).
 **Budgets**: `pr_review_iter` = 3 (soft; max iterations while threads
 decrease), `pr_review_hard` = 6 (hard cap; iterations 4-6 only if
 unresolved-thread count decreases).
+
+Zero-thread NOGO anomalies use the bounded reviewer-error retry cap and
+consume neither `pr_review_iter` nor `pr_review_hard`; cap exhaustion fails
+back through `agent_error` without writing `state:implementation-no-go` or
+`state:skip`. Stage-originated JSONL events use the closed schema in
+`pipeline/events.py`; raw reviewer text, GitHub bodies, and arbitrary event
+objects are rejected.
 
 **Owned labels**: `state:implementation-go` (GO verdict) [durable],
 `state:implementation-no-go` (NOGO verdict, before retry/regress) [durable],

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -88,6 +88,7 @@ from typing import Any, TypeAlias
 from hephaestus.automation.agent_config import DEFAULT_CI_POLL_MAX_WAIT
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
+from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
 from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
 from hephaestus.automation.pipeline.queues import CompletionQueue, StageQueue
 from hephaestus.automation.pipeline.routing import (
@@ -425,6 +426,7 @@ class Coordinator:
                     projects_dir=Path(self.config.projects_dir),
                 ),
                 budget_fn=self._budget_for,
+                event_fn=self._record_stage_event,
             )
             self._ctx_cache[repo] = ctx
         return ctx
@@ -444,6 +446,11 @@ class Coordinator:
         if override is not None:
             return override
         return _budget_lookup(name)
+
+    def _record_stage_event(self, event: StageEvent) -> None:
+        """Validate and persist a closed-schema event emitted by a stage."""
+        event_name, fields = encode_stage_event(event)
+        self._record_event(event_name, fields)
 
     def _record_event(self, event: str, *fields: Any) -> None:
         """Append an event to memory and, when configured, to JSONL on disk."""

--- a/hephaestus/automation/pipeline/events.py
+++ b/hephaestus/automation/pipeline/events.py
@@ -1,0 +1,79 @@
+"""Bounded stage-originated events for the durable pipeline JSONL log."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+_REPO_NAME_RE = re.compile(r"[A-Za-z0-9_.-]{1,100}\Z")
+EventField: TypeAlias = str | int | bool
+
+
+class ZeroThreadNogoAction(str, Enum):
+    """Action taken after a zero-thread NOGO anomaly."""
+
+    RETRY_FRESH_REVIEW = "retry_fresh_review"
+    FAIL_BACK_AGENT_ERROR = "fail_back_agent_error"
+
+
+@dataclass(frozen=True)
+class PrReviewZeroThreadNogoEvent:
+    """Closed-schema audit record for an artifactless NOGO verdict."""
+
+    repo: str
+    issue: int
+    pr: int
+    completed_rounds: int
+    retry_attempt: int
+    retry_cap: int
+    action: ZeroThreadNogoAction
+    artifact_written: bool
+
+
+StageEvent: TypeAlias = PrReviewZeroThreadNogoEvent
+
+
+def encode_stage_event(event: StageEvent) -> tuple[str, dict[str, EventField]]:
+    """Validate and encode a stage event using only fixed JSON-safe fields."""
+    if type(event) is not PrReviewZeroThreadNogoEvent:
+        raise TypeError(f"unsupported stage event: {type(event).__name__}")
+    if not _REPO_NAME_RE.fullmatch(event.repo):
+        raise ValueError("stage event repo must be a bounded repository name")
+    for name in ("issue", "pr", "retry_attempt", "retry_cap"):
+        value = getattr(event, name)
+        if type(value) is not int or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+    if type(event.completed_rounds) is not int or event.completed_rounds < 0:
+        raise ValueError("completed_rounds must be a non-negative integer")
+    if type(event.artifact_written) is not bool:
+        raise ValueError("artifact_written must be boolean")
+    if not isinstance(event.action, ZeroThreadNogoAction):
+        raise ValueError("action must be a ZeroThreadNogoAction")
+    if (
+        event.action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW
+        and event.retry_attempt > event.retry_cap
+    ):
+        raise ValueError("fresh-review action exceeds retry cap")
+    if (
+        event.action is ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR
+        and event.retry_attempt <= event.retry_cap
+    ):
+        raise ValueError("fail-back action has not exceeded retry cap")
+    return (
+        "pr_review_zero_thread_nogo",
+        {
+            "repo": event.repo,
+            "issue": event.issue,
+            "pr": event.pr,
+            "completed_rounds": event.completed_rounds,
+            "retry_attempt": event.retry_attempt,
+            "retry_cap": event.retry_cap,
+            "action": event.action.value,
+            "artifact_written": event.artifact_written,
+            "posted_threads": 0,
+            "unresolved_threads": 0,
+            "round_consumed": False,
+        },
+    )

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -59,6 +59,7 @@ from typing import Any, Protocol, TypeAlias, runtime_checkable
 from hephaestus.agents.runtime import DEFAULT_AGENT
 from hephaestus.automation.state_labels import STATE_SKIP
 
+from ..events import StageEvent
 from ..jobs import AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
 from ..routing import ROUTES, Disposition, StageName, StageOutcome
 from ..work_item import ItemKind, WorkItem
@@ -77,6 +78,7 @@ __all__ = [
     "JobResult",
     "Stage",
     "StageContext",
+    "StageEvent",
     "StageGitHub",
     "StageName",
     "StageOutcome",
@@ -447,6 +449,7 @@ class StageContext:
     paths: Any  # coordinator-owned path accessor (repo_root, worktree)
     now_fn: Callable[[], float] | None = None  # injectable clock (tests pass a fake)
     budget_fn: Callable[[str], int] | None = None  # injected overrides; falls back to ROUTES
+    event_fn: Callable[[StageEvent], None] | None = None
 
     def now(self) -> float:
         """Return the current time in seconds since epoch (injectable for tests)."""
@@ -462,6 +465,11 @@ class StageContext:
             if name in route.budgets:
                 return route.budgets[name]
         return 1  # conservative default for unknown keys
+
+    def emit_event(self, event: StageEvent) -> None:
+        """Emit a runtime-validated stage event when coordinator wiring exists."""
+        if self.event_fn is not None:
+            self.event_fn(event)
 
 
 def agent_provider(ctx: StageContext) -> str:

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -237,7 +237,7 @@ class StageGitHub(Protocol):
         """
         pass
 
-    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
         """Durably create-or-update a marker-keyed PR conversation comment.
 
         PRs share the issue comment channel, so the coordinator maps this onto

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -908,7 +908,9 @@ class PrReviewStage(Stage):
             f"Artifactless reviewer attempt: {retry_attempt}/{REVIEW_ERROR_RETRY_CAP}."
         )
         try:
-            ctx.github.upsert_pr_comment(pr_number, _ZERO_THREAD_NOGO_MARKER, body)
+            artifact_written = ctx.github.upsert_pr_comment(
+                pr_number, _ZERO_THREAD_NOGO_MARKER, body
+            )
         except Exception as error:
             logger.warning(
                 "pr_review:%s: failed to upsert zero-thread NOGO artifact (%s)",
@@ -916,7 +918,7 @@ class PrReviewStage(Stage):
                 type(error).__name__,
             )
             return False
-        return True
+        return artifact_written
 
     def _handle_address_error(self, item: WorkItem) -> StageOutcome | None:
         """Fail back hard address/push errors with explicit retry cleanup."""

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -910,11 +910,11 @@ class PrReviewStage(Stage):
         )
         try:
             ctx.github.upsert_pr_comment(pr_number, _ZERO_THREAD_NOGO_MARKER, body)
-        except Exception as exc:
+        except Exception as error:
             logger.warning(
-                "pr_review:%s: failed to upsert zero-thread NOGO artifact: %s",
+                "pr_review:%s: failed to upsert zero-thread NOGO artifact (%s)",
                 item.issue,
-                exc,
+                type(error).__name__,
             )
             return False
         return True

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -808,7 +808,6 @@ class PrReviewStage(Stage):
         return StageOutcome(Disposition.SKIP, "exhaustion")
 
     @staticmethod
-    @staticmethod
     def _is_zero_thread_nogo(verdict: Any, payload: dict[str, Any], total_unresolved: int) -> bool:
         """Return whether an explicit NOGO has no durable actionable threads."""
         return (

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -105,6 +105,7 @@ import json
 import logging
 import re
 from collections.abc import Callable
+from html import escape
 from typing import Any, cast
 
 from hephaestus.automation.agent_config import (
@@ -132,6 +133,7 @@ from hephaestus.automation.session_naming import (
 )
 from hephaestus.automation.state_labels import STATE_SKIP
 
+from ..events import PrReviewZeroThreadNogoEvent, ZeroThreadNogoAction
 from .base import (
     GIT_JOB_TIMEOUT_S,
     AgentJob,
@@ -194,6 +196,9 @@ def _issue_number(item: WorkItem) -> int:
 #: plan_review.REVIEW_ERROR_RETRY_CAP). Reset whenever a real verdict
 #: arrives.
 REVIEW_ERROR_RETRY_CAP = 2
+
+_ZERO_THREAD_NOGO_MARKER = "<!-- hephaestus-pr-review-zero-thread-nogo -->"
+_NO_STRUCTURED_SUMMARY = "No structured reviewer summary was provided."
 
 #: Round-scoped payload keys cleared at REVIEW_WAIT submission so a failed
 #: later round can never replay an earlier round's results.
@@ -725,8 +730,8 @@ class PrReviewStage(Stage):
         automation_unresolved = blocking_auto + minor_auto  # progress-trail parity (#1554)
         unresolved = automation_unresolved + human_unresolved
 
-        if self._nogo_without_durable_artifact(verdict, payload, automation_unresolved):
-            return self._handle_lost_review_artifact(item)
+        if self._is_zero_thread_nogo(verdict, payload, unresolved):
+            return self._handle_zero_thread_nogo(item, ctx, verdict)
 
         # Real verdict: this round counts. Reset the consecutive-failure
         # cap; advance the cycle-relative gate and the lifetime audit trail.
@@ -803,41 +808,116 @@ class PrReviewStage(Stage):
         return StageOutcome(Disposition.SKIP, "exhaustion")
 
     @staticmethod
-    def _nogo_without_durable_artifact(
-        verdict: Any, payload: dict[str, Any], automation_unresolved: int
-    ) -> bool:
-        """Return True for a NOGO verdict that left no durable review artifact."""
-        if getattr(verdict, "verdict", "").upper() != "NOGO" or automation_unresolved:
-            return False
-        artifact_keys = (
-            "raw_review_threads",
-            "review_threads",
-            "posted_thread_ids",
-            "unaddressed_findings",
+    @staticmethod
+    def _is_zero_thread_nogo(verdict: Any, payload: dict[str, Any], total_unresolved: int) -> bool:
+        """Return whether an explicit NOGO has no durable actionable threads."""
+        return (
+            getattr(verdict, "verdict", "").upper() == "NOGO"
+            and total_unresolved == 0
+            and not payload.get("posted_thread_ids")
         )
-        return not any(payload.get(key) for key in artifact_keys)
 
-    def _handle_lost_review_artifact(self, item: WorkItem) -> StageOutcome:
-        """Retry an artifactless NOGO without burning a review round."""
-        payload = item.payload
-        retries = payload.get("review_error_retries", 0) + 1
-        payload["review_error_retries"] = retries
-        if retries > REVIEW_ERROR_RETRY_CAP:
-            logger.error(
-                "pr_review:%s: NOGO produced no durable findings; %d consecutive "
-                "artifact failures (cap %d) — failing back to implementation",
+    @staticmethod
+    def _structured_review_summary(raw: object) -> str:
+        """Extract and bound the final JSON summary without exposing raw prose."""
+        if not isinstance(raw, str):
+            return _NO_STRUCTURED_SUMMARY
+        blocks = re.findall(r"```(?:json)?\s*(.*?)```", raw, flags=re.DOTALL | re.IGNORECASE)
+        for candidate in reversed(blocks):
+            try:
+                parsed = json.loads(candidate.strip())
+            except (json.JSONDecodeError, ValueError):
+                continue
+            summary = parsed.get("summary") if isinstance(parsed, dict) else None
+            if isinstance(summary, str) and (compact := " ".join(summary.split())):
+                escaped = escape(compact, quote=False)
+                return escaped if len(escaped) <= 200 else f"{escaped[:197]}..."
+        return _NO_STRUCTURED_SUMMARY
+
+    def _handle_zero_thread_nogo(
+        self, item: WorkItem, ctx: StageContext, verdict: Any
+    ) -> Continue | StageOutcome:
+        """Persist the anomaly and force a new reviewer invocation."""
+        if item.pr is None:
+            return self._fail_back_agent_error(item)
+        pr_number = item.pr
+        retries = int(item.payload.get("review_error_retries", 0)) + 1
+        item.payload["review_error_retries"] = retries
+        action = (
+            ZeroThreadNogoAction.RETRY_FRESH_REVIEW
+            if retries <= REVIEW_ERROR_RETRY_CAP
+            else ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR
+        )
+        artifact_written = self._upsert_zero_thread_nogo_comment(
+            item,
+            ctx,
+            summary=self._structured_review_summary(getattr(verdict, "raw", "")),
+            retry_attempt=retries,
+            action=action,
+        )
+        ctx.emit_event(
+            PrReviewZeroThreadNogoEvent(
+                repo=item.repo,
+                issue=_issue_number(item),
+                pr=pr_number,
+                completed_rounds=int(item.payload.get("pr_review_round", 0)),
+                retry_attempt=retries,
+                retry_cap=REVIEW_ERROR_RETRY_CAP,
+                action=action,
+                artifact_written=artifact_written,
+            )
+        )
+        if action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW:
+            logger.warning(
+                "pr_review:%s: zero-thread NOGO; retry %d/%d without consuming a round",
                 item.issue,
                 retries,
                 REVIEW_ERROR_RETRY_CAP,
             )
-            return self._fail_back_agent_error(item)
-        logger.warning(
-            "pr_review:%s: NOGO produced no durable findings; retry %d/%d (no round burned)",
+            return Continue(next_state=REVIEW_WAIT)
+        logger.error(
+            "pr_review:%s: zero-thread NOGO retry cap exhausted; failing back",
             item.issue,
-            retries,
-            REVIEW_ERROR_RETRY_CAP,
         )
-        return StageOutcome(Disposition.RETRY, "nogo_without_artifact")
+        return self._fail_back_agent_error(item)
+
+    @staticmethod
+    def _upsert_zero_thread_nogo_comment(
+        item: WorkItem,
+        ctx: StageContext,
+        *,
+        summary: str,
+        retry_attempt: int,
+        action: ZeroThreadNogoAction,
+    ) -> bool:
+        """Upsert one bounded PR artifact describing the anomaly."""
+        if item.pr is None:
+            return False
+        pr_number = item.pr
+        action_text = (
+            "A fresh reviewer invocation will be requested without consuming a review round."
+            if action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW
+            else "The reviewer retry cap is exhausted; the item will fail back as an agent error."
+        )
+        body = (
+            f"{_ZERO_THREAD_NOGO_MARKER}\n"
+            "**Automated PR review anomaly: NOGO without actionable threads.**\n\n"
+            f"Reviewer summary:\n> {summary}\n\n"
+            "No postable or unresolved review thread accompanied this verdict, so "
+            "`state:implementation-no-go` is not being applied. "
+            f"{action_text}\n\n"
+            f"Artifactless reviewer attempt: {retry_attempt}/{REVIEW_ERROR_RETRY_CAP}."
+        )
+        try:
+            ctx.github.upsert_pr_comment(pr_number, _ZERO_THREAD_NOGO_MARKER, body)
+        except Exception as exc:
+            logger.warning(
+                "pr_review:%s: failed to upsert zero-thread NOGO artifact: %s",
+                item.issue,
+                exc,
+            )
+            return False
+        return True
 
     def _handle_address_error(self, item: WorkItem) -> StageOutcome | None:
         """Fail back hard address/push errors with explicit retry cleanup."""

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -922,14 +922,15 @@ class PipelineGitHub:
             return
         github_api.gh_issue_comment(pr_number, body)
 
-    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
         """Create-or-update a marker-keyed PR comment (issue comment channel)."""
         if self._skip(f"upsert comment on PR #{pr_number}"):
-            return
+            return False
         if self._repo_slug is None:
             github_api.gh_issue_upsert_comment(pr_number, marker_prefix, body)
-            return
+            return True
         self._upsert_repo_issue_comment(pr_number, marker_prefix, body)
+        return True
 
     def _upsert_repo_issue_comment(
         self, issue_number: int, marker_prefix: str, body: str

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -245,9 +245,10 @@ class FakeStageGitHub(FakeGitHub):
         """
         self.gh_issue_comment(pr_number, body)
 
-    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+    def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
         """Mirror the coordinator PR-comment upsert (delegates to issue comments)."""
         self.gh_issue_upsert_comment(pr_number, marker_prefix, body)
+        return True
 
     def arm_auto_merge(self, pr_number: int) -> None:
         """Mirror pr_manager.enable_auto_merge_after_implementation_go."""

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from hephaestus.automation.pipeline.events import StageEvent
 from hephaestus.automation.pipeline.routing import ROUTES, StageName
 from hephaestus.automation.pipeline.stages import StageContext, StageGitHub
 from hephaestus.automation.pipeline.stages.implementation import PRE_PR_TEST_ARGV
@@ -353,6 +354,7 @@ def make_ctx() -> Callable[..., StageContext]:
         github: FakeStageGitHub | None = None,
         paths: Any = None,
         budget_fn: Callable[[str], int] | None = None,
+        event_fn: Callable[[StageEvent], None] | None = None,
     ) -> StageContext:
         ticks = [0]
 
@@ -368,6 +370,7 @@ def make_ctx() -> Callable[..., StageContext]:
             paths=paths if paths is not None else _Paths(),
             now_fn=now_fn,
             budget_fn=budget_fn if budget_fn is not None else _budget_fn,
+            event_fn=event_fn,
         )
 
     return _make_ctx

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1178,6 +1178,40 @@ class TestFullWalks:
         assert "<private reviewer detail>" not in zero_thread_comments[0]
         assert not any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
 
+    @pytest.mark.parametrize(
+        ("by_severity", "posted_thread_ids"),
+        [
+            pytest.param((0, 0, 1), [], id="human-thread"),
+            pytest.param((0, 0, 0), ["thread-existing"], id="posted-thread"),
+        ],
+    )
+    def test_zero_thread_nogo_predicate_exclusions_count_real_round(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+        by_severity: tuple[int, int, int],
+        posted_thread_ids: list[str],
+    ) -> None:
+        """Human or already-posted threads follow the ordinary NOGO path."""
+        events: list[Any] = []
+        github = FakeStageGitHub(by_severity=[by_severity])
+        ctx = make_ctx(github=github, event_fn=events.append)
+        item = make_work_item(issue=28, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+        item.payload["posted_thread_ids"] = posted_thread_ids
+
+        outcome = PrReviewStage().step(item, ctx)
+
+        assert isinstance(outcome, Continue)
+        assert outcome.next_state == "REVIEW_WAIT"
+        assert item.attempts["pr_review_iter"] == 1
+        assert events == []
+        assert not any(
+            body.startswith("<!-- hephaestus-pr-review-zero-thread-nogo -->")
+            for body in github.comments.get(1001, [])
+        )
+        assert any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
+
     def test_zero_thread_nogo_cap_fails_back_without_rounds_or_skip(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
@@ -1214,7 +1248,7 @@ class TestFullWalks:
         sensitive_details = "private provider diagnostics"
 
         class CommentFailsGitHub(FakeStageGitHub):
-            def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+            def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
                 raise RuntimeError(sensitive_details)
 
         events: list[Any] = []
@@ -1232,6 +1266,29 @@ class TestFullWalks:
         assert events[0].artifact_written is False
         assert sensitive_details not in str(logger.warning.call_args)
 
+    def test_zero_thread_nogo_dry_run_reports_artifact_not_written(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A dry-run no-op must not be recorded as a durable artifact write."""
+
+        class DryRunGitHub(FakeStageGitHub):
+            def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> bool:
+                return False
+
+        events: list[Any] = []
+        ctx = make_ctx(
+            dry_run=True,
+            github=DryRunGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)]),
+            event_fn=events.append,
+        )
+        item = make_work_item(issue=29, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        outcome = PrReviewStage().step(item, ctx)
+
+        assert isinstance(outcome, Continue)
+        assert events[0].artifact_written is False
+
     def test_zero_thread_summary_is_escaped_and_bounded(self) -> None:
         """Only a short escaped structured summary enters the PR artifact."""
         raw = f"```json\n{json.dumps({'summary': '<secret> ' + 'x' * 300})}\n```"
@@ -1240,6 +1297,11 @@ class TestFullWalks:
         assert len(summary) == 200
         assert summary.startswith("&lt;secret&gt;")
         assert summary.endswith("...")
+        malformed = PrReviewStage._structured_review_summary(
+            '```json\n{"summary": raw-review-secret\n```'
+        )
+        assert malformed == "No structured reviewer summary was provided."
+        assert "raw-review-secret" not in malformed
 
     def test_reviewer_error_walk_burns_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed review job walks straight to EVAL's ERROR path: RETRY.

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
@@ -9,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from hephaestus.automation.claude_invoke import ReviewVerdict, parse_review_verdict
+from hephaestus.automation.pipeline.events import ZeroThreadNogoAction
 from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
@@ -1106,26 +1108,88 @@ class TestFullWalks:
         assert item.attempts["pr_review_iter"] == 3
         assert github.mutation_log[-1] == ("gh_issue_add_labels", (22, (STATE_SKIP,)))
 
-    def test_nogo_without_durable_artifact_retries_without_skip(
+    def test_zero_thread_nogo_retries_without_skip(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """NOGO with no posted findings is infrastructure loss, not terminal skip."""
+        """A zero-thread NOGO is durable and requests a fresh review."""
+        events: list[Any] = []
         stage = PrReviewStage()
         github = FakeStageGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)])
-        ctx = make_ctx(github=github)
+        ctx = make_ctx(github=github, event_fn=events.append)
         item = make_work_item(issue=24, pr=1001, state="EVAL")
         item.payload["review_verdict"] = _verdict("NOGO")
-        item.payload["review_text"] = "Verdict: NOGO"
+        item.payload["review_text"] = '```json\n{"summary":"No actionable location."}\n```'
         item.payload["raw_review_threads"] = []
         item.payload["review_threads"] = []
 
         outcome = stage.step(item, ctx)
 
-        assert isinstance(outcome, StageOutcome)
-        assert outcome.disposition == Disposition.RETRY
-        assert outcome.note == "nogo_without_artifact"
+        assert isinstance(outcome, Continue)
+        assert outcome.next_state == "REVIEW_WAIT"
         assert item.attempts["pr_review_iter"] == 0
         assert not any(entry[0] == "gh_issue_add_labels" for entry in github.mutation_log)
+        assert events[0].action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW
+        assert github.comments[1001][0].startswith("<!-- hephaestus-pr-review-zero-thread-nogo -->")
+
+    def test_zero_thread_nogo_cap_fails_back_without_rounds_or_skip(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Repeated zero-thread NOGOs fail back without exhausting review rounds."""
+        events: list[Any] = []
+        stage = PrReviewStage()
+        github = FakeStageGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)])
+        ctx = make_ctx(github=github, event_fn=events.append)
+        item = make_work_item(issue=25, pr=1001, state="ENTER")
+        pool = FakeWorkerPool()
+        anomaly = (
+            JobResult(ok=True, value=_verdict("NOGO")),
+            JobResult(ok=True, value='{"unaddressed": []}'),
+        )
+        pool.script(*(anomaly * (REVIEW_ERROR_RETRY_CAP + 1)))
+
+        outcome = _drive(stage, item, ctx, pool)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.FAIL_BACK
+        assert outcome.note == "agent_error"
+        assert [handle.job.descr for handle in pool.submitted].count("review") == (
+            REVIEW_ERROR_RETRY_CAP + 1
+        )
+        assert item.attempts["pr_review_iter"] == 0
+        assert item.payload["pr_review_round"] == 0
+        assert events[-1].action is ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR
+        assert not any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
+
+    def test_zero_thread_nogo_comment_failure_still_retries(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A failed artifact write is visible in the event but does not block retry."""
+
+        class CommentFailsGitHub(FakeStageGitHub):
+            def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
+                raise RuntimeError("comment write failed")
+
+        events: list[Any] = []
+        ctx = make_ctx(
+            github=CommentFailsGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)]),
+            event_fn=events.append,
+        )
+        item = make_work_item(issue=26, pr=1001, state="EVAL")
+        item.payload["review_verdict"] = _verdict("NOGO")
+
+        outcome = PrReviewStage().step(item, ctx)
+
+        assert isinstance(outcome, Continue)
+        assert events[0].artifact_written is False
+
+    def test_zero_thread_summary_is_escaped_and_bounded(self) -> None:
+        """Only a short escaped structured summary enters the PR artifact."""
+        raw = f"```json\n{json.dumps({'summary': '<secret> ' + 'x' * 300})}\n```"
+        summary = PrReviewStage._structured_review_summary(raw)
+
+        assert len(summary) == 200
+        assert summary.startswith("&lt;secret&gt;")
+        assert summary.endswith("...")
 
     def test_reviewer_error_walk_burns_nothing(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failed review job walks straight to EVAL's ERROR path: RETRY.

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1131,6 +1131,53 @@ class TestFullWalks:
         assert events[0].action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW
         assert github.comments[1001][0].startswith("<!-- hephaestus-pr-review-zero-thread-nogo -->")
 
+    def test_zero_thread_nogo_full_walk_reinvokes_fresh_reviewer(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The anomaly clears stale state and runs a new review before counting GO."""
+        events: list[Any] = []
+        github = FakeStageGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)])
+        ctx = make_ctx(github=github, event_fn=events.append)
+        ctx.config.enable_follow_up = False
+        item = make_work_item(issue=27, pr=1001, state="ENTER")
+        pool = FakeWorkerPool()
+        first = ReviewVerdict(
+            grade="B",
+            verdict="NOGO",
+            raw=(
+                'Verdict: NOGO\n```json\n{"comments":[],"summary":"<private reviewer detail>"}\n```'
+            ),
+        )
+        pool.script(
+            JobResult(ok=True, value=first),
+            JobResult(ok=True, value='{"unaddressed": []}'),
+            JobResult(ok=True, value=_verdict("GO")),
+            JobResult(ok=True, value='{"unaddressed": []}'),
+        )
+
+        outcome = _drive(PrReviewStage(), item, ctx, pool)
+
+        assert outcome == StageOutcome(Disposition.ADVANCE, "GO with zero blocking threads")
+        assert [handle.job.descr for handle in pool.submitted] == [
+            "review",
+            "validate",
+            "review",
+            "validate",
+        ]
+        assert item.attempts["pr_review_iter"] == 1
+        assert item.payload["pr_review_round"] == 1
+        assert item.payload["review_error_retries"] == 0
+        assert events[0].action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW
+        zero_thread_comments = [
+            body
+            for body in github.comments[1001]
+            if body.startswith("<!-- hephaestus-pr-review-zero-thread-nogo -->")
+        ]
+        assert len(zero_thread_comments) == 1
+        assert "&lt;private reviewer detail&gt;" in zero_thread_comments[0]
+        assert "<private reviewer detail>" not in zero_thread_comments[0]
+        assert not any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
+
     def test_zero_thread_nogo_cap_fails_back_without_rounds_or_skip(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1164,10 +1164,11 @@ class TestFullWalks:
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
         """A failed artifact write is visible in the event but does not block retry."""
+        sensitive_details = "private provider diagnostics"
 
         class CommentFailsGitHub(FakeStageGitHub):
             def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
-                raise RuntimeError("comment write failed")
+                raise RuntimeError(sensitive_details)
 
         events: list[Any] = []
         ctx = make_ctx(
@@ -1177,10 +1178,12 @@ class TestFullWalks:
         item = make_work_item(issue=26, pr=1001, state="EVAL")
         item.payload["review_verdict"] = _verdict("NOGO")
 
-        outcome = PrReviewStage().step(item, ctx)
+        with patch("hephaestus.automation.pipeline.stages.pr_review.logger") as logger:
+            outcome = PrReviewStage().step(item, ctx)
 
         assert isinstance(outcome, Continue)
         assert events[0].artifact_written is False
+        assert sensitive_details not in str(logger.warning.call_args)
 
     def test_zero_thread_summary_is_escaped_and_bounded(self) -> None:
         """Only a short escaped structured summary enters the PR artifact."""

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -18,6 +18,7 @@ from typing import Any, cast
 
 import pytest
 
+from hephaestus.automation.claude_invoke import ReviewVerdict
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.coordinator import (
     _FAIL_BACK_CAP,
@@ -31,7 +32,12 @@ from hephaestus.automation.pipeline.events import (
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.seeding import SeedEntry
+from hephaestus.automation.pipeline.stages import Continue
 from hephaestus.automation.pipeline.stages.base import JobRequest
+from hephaestus.automation.pipeline.stages.pr_review import (
+    REVIEW_ERROR_RETRY_CAP,
+    PrReviewStage,
+)
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
@@ -659,6 +665,58 @@ class TestDurableEventLog:
             }
         ]
         assert "summary" not in record["fields"][0]
+
+    def test_pr_review_stage_event_uses_coordinator_encoder(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The real stage callback reaches the coordinator's closed JSONL schema."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(by_severity=[(0, 0, 0)]),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        item = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.PR,
+            issue=1985,
+            pr=1984,
+            stage=StageName.PR_REVIEW,
+            state="EVAL",
+        )
+        item.payload["review_verdict"] = ReviewVerdict(
+            grade="B",
+            verdict="NOGO",
+            raw='```json\n{"summary":"No actionable location."}\n```',
+        )
+        stage = PrReviewStage()
+        ctx = coordinator._ctx_for_repo("repo-a")
+
+        first = stage.step(item, ctx)
+        assert isinstance(first, Continue)
+        assert first.next_state == "REVIEW_WAIT"
+
+        item.payload["review_error_retries"] = REVIEW_ERROR_RETRY_CAP
+        second = stage.step(item, ctx)
+        assert second == StageOutcome(Disposition.FAIL_BACK, "agent_error")
+
+        records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+        assert [record["event"] for record in records] == [
+            "pr_review_zero_thread_nogo",
+            "pr_review_zero_thread_nogo",
+        ]
+        assert records[0]["fields"][0]["action"] == "retry_fresh_review"
+        assert records[1]["fields"][0]["action"] == "fail_back_agent_error"
+        assert all(record["fields"][0]["round_consumed"] is False for record in records)
 
     def test_stage_event_rejects_foreign_raw_content_before_jsonl_write(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -714,9 +714,36 @@ class TestDurableEventLog:
             "pr_review_zero_thread_nogo",
             "pr_review_zero_thread_nogo",
         ]
-        assert records[0]["fields"][0]["action"] == "retry_fresh_review"
-        assert records[1]["fields"][0]["action"] == "fail_back_agent_error"
-        assert all(record["fields"][0]["round_consumed"] is False for record in records)
+        assert records[0]["fields"] == [
+            {
+                "action": "retry_fresh_review",
+                "artifact_written": True,
+                "completed_rounds": 0,
+                "issue": 1985,
+                "posted_threads": 0,
+                "pr": 1984,
+                "repo": "repo-a",
+                "retry_attempt": 1,
+                "retry_cap": 2,
+                "round_consumed": False,
+                "unresolved_threads": 0,
+            }
+        ]
+        assert records[1]["fields"] == [
+            {
+                "action": "fail_back_agent_error",
+                "artifact_written": True,
+                "completed_rounds": 0,
+                "issue": 1985,
+                "posted_threads": 0,
+                "pr": 1984,
+                "repo": "repo-a",
+                "retry_attempt": 3,
+                "retry_cap": 2,
+                "round_consumed": False,
+                "unresolved_threads": 0,
+            }
+        ]
 
     def test_stage_event_rejects_foreign_raw_content_before_jsonl_write(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -14,7 +14,7 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -683,8 +683,8 @@ class TestDurableEventLog:
 
         with pytest.raises(TypeError, match="unsupported stage event"):
             coordinator._ctx_for_repo("repo-a").emit_event(
-                UnsafeEvent("token=secret private-endpoint")
-            )  # type: ignore[arg-type]
+                cast(Any, UnsafeEvent("untrusted reviewer data"))
+            )
         assert not event_log_path.exists()
 
     def test_event_log_path_persists_job_completion_records(

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,10 @@ from hephaestus.automation.pipeline.coordinator import (
     _FAIL_BACK_CAP,
     Coordinator,
     PipelineConfig,
+)
+from hephaestus.automation.pipeline.events import (
+    PrReviewZeroThreadNogoEvent,
+    ZeroThreadNogoAction,
 )
 from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
@@ -605,6 +610,82 @@ class TestDurableEventLog:
         assert records[-1]["event"] == "push"
         assert records[-1]["fields"] == ["planning", "repo-a#44"]
         assert coordinator.event_log[-1] == ("push", "planning", "repo-a#44")
+
+    def test_zero_thread_nogo_event_is_durable_and_bounded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stage events persist the fixed zero-thread audit fields."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+
+        coordinator._ctx_for_repo("repo-a").emit_event(
+            PrReviewZeroThreadNogoEvent(
+                repo="repo-a",
+                issue=1985,
+                pr=1984,
+                completed_rounds=0,
+                retry_attempt=1,
+                retry_cap=2,
+                action=ZeroThreadNogoAction.RETRY_FRESH_REVIEW,
+                artifact_written=True,
+            )
+        )
+
+        record = json.loads(event_log_path.read_text().splitlines()[-1])
+        assert record["event"] == "pr_review_zero_thread_nogo"
+        assert record["fields"] == [
+            {
+                "action": "retry_fresh_review",
+                "artifact_written": True,
+                "completed_rounds": 0,
+                "issue": 1985,
+                "posted_threads": 0,
+                "pr": 1984,
+                "repo": "repo-a",
+                "retry_attempt": 1,
+                "retry_cap": 2,
+                "round_consumed": False,
+                "unresolved_threads": 0,
+            }
+        ]
+        assert "summary" not in record["fields"][0]
+
+    def test_stage_event_rejects_foreign_raw_content_before_jsonl_write(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Foreign event objects cannot inject reviewer text into the log."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+
+        @dataclass(frozen=True)
+        class UnsafeEvent:
+            reviewer_summary: str
+
+        with pytest.raises(TypeError, match="unsupported stage event"):
+            coordinator._ctx_for_repo("repo-a").emit_event(
+                UnsafeEvent("token=secret private-endpoint")
+            )  # type: ignore[arg-type]
+        assert not event_log_path.exists()
 
     def test_event_log_path_persists_job_completion_records(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_events.py
+++ b/tests/unit/automation/pipeline/test_events.py
@@ -1,0 +1,56 @@
+"""Tests for closed stage-event schemas."""
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import pytest
+
+from hephaestus.automation.pipeline.events import (
+    PrReviewZeroThreadNogoEvent,
+    ZeroThreadNogoAction,
+    encode_stage_event,
+)
+
+
+def test_zero_thread_nogo_event_has_closed_json_safe_shape() -> None:
+    """Encode only the fixed fields needed to audit the anomaly."""
+    name, fields = encode_stage_event(
+        PrReviewZeroThreadNogoEvent(
+            repo="repo-a",
+            issue=1985,
+            pr=1984,
+            completed_rounds=0,
+            retry_attempt=1,
+            retry_cap=2,
+            action=ZeroThreadNogoAction.RETRY_FRESH_REVIEW,
+            artifact_written=True,
+        )
+    )
+
+    assert name == "pr_review_zero_thread_nogo"
+    assert fields["round_consumed"] is False
+    assert fields["posted_threads"] == fields["unresolved_threads"] == 0
+    assert set(fields) == {
+        "repo",
+        "issue",
+        "pr",
+        "completed_rounds",
+        "retry_attempt",
+        "retry_cap",
+        "action",
+        "artifact_written",
+        "posted_threads",
+        "unresolved_threads",
+        "round_consumed",
+    }
+
+
+def test_encoder_rejects_foreign_event_with_raw_content() -> None:
+    """Reject event objects that could carry unbounded reviewer content."""
+
+    @dataclass(frozen=True)
+    class UnsafeEvent:
+        reviewer_summary: str
+
+    with pytest.raises(TypeError, match="unsupported stage event"):
+        encode_stage_event(cast(Any, UnsafeEvent("token=secret private-endpoint")))

--- a/tests/unit/automation/pipeline/test_events.py
+++ b/tests/unit/automation/pipeline/test_events.py
@@ -1,6 +1,6 @@
 """Tests for closed stage-event schemas."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast
 
 import pytest
@@ -53,4 +53,51 @@ def test_encoder_rejects_foreign_event_with_raw_content() -> None:
         reviewer_summary: str
 
     with pytest.raises(TypeError, match="unsupported stage event"):
-        encode_stage_event(cast(Any, UnsafeEvent("token=secret private-endpoint")))
+        encode_stage_event(cast(Any, UnsafeEvent("untrusted reviewer data")))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("repo", "", "repo"),
+        ("issue", 0, "issue"),
+        ("completed_rounds", -1, "completed_rounds"),
+        ("artifact_written", 1, "artifact_written"),
+    ],
+)
+def test_encoder_rejects_invalid_fixed_fields(field: str, value: Any, match: str) -> None:
+    """Reject malformed values before they reach the durable JSONL log."""
+    event = PrReviewZeroThreadNogoEvent(
+        repo="repo-a",
+        issue=1985,
+        pr=1984,
+        completed_rounds=0,
+        retry_attempt=1,
+        retry_cap=2,
+        action=ZeroThreadNogoAction.RETRY_FRESH_REVIEW,
+        artifact_written=True,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        encode_stage_event(replace(event, **{field: value}))
+
+
+def test_encoder_rejects_action_retry_invariant_violations() -> None:
+    """Retry and fail-back actions must agree with the bounded retry counter."""
+    event = PrReviewZeroThreadNogoEvent(
+        repo="repo-a",
+        issue=1985,
+        pr=1984,
+        completed_rounds=0,
+        retry_attempt=1,
+        retry_cap=2,
+        action=ZeroThreadNogoAction.RETRY_FRESH_REVIEW,
+        artifact_written=True,
+    )
+
+    with pytest.raises(ValueError, match="exceeds retry cap"):
+        encode_stage_event(replace(event, retry_attempt=3))
+    with pytest.raises(ValueError, match="has not exceeded retry cap"):
+        encode_stage_event(
+            replace(event, action=ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR, retry_attempt=2)
+        )

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -117,6 +117,19 @@ class TestMutatorMapping:
         mock.assert_not_called()
         assert any("[dry-run] would" in record.message for record in caplog.records)
 
+    def test_dry_run_pr_comment_upsert_reports_not_written(
+        self,
+        dry_adapter: pg.PipelineGitHub,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dry-run artifacts must be reported as absent in durable stage events."""
+        mock = _patch_target(monkeypatch, "github_api", "gh_issue_upsert_comment")
+
+        written = dry_adapter.upsert_pr_comment(7, "<!-- marker -->", "body")
+
+        assert written is False
+        mock.assert_not_called()
+
     def test_upsert_plan_comment_keys_on_marker(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- Implemented durable zero-thread NOGO artifacts, typed JSONL events, bounded summaries, fresh-review retries, and agent-error failback.
- Added regression and event-schema tests; updated architecture docs.
- Hardened the follow-up with a full state-machine regression proving a fresh reviewer invocation, zero round consumption for the anomaly, escaped artifact content, and clean GO recovery.
- Added end-to-end stage-to-coordinator JSONL coverage with complete field assertions, predicate exclusion coverage, malformed-summary fallback coverage, and explicit dry-run artifact status.
- Removed duplicate decorator noise and added fixed-field/action-invariant schema tests.

## Verification
- `pixi run pytest --no-cov tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_events.py tests/unit/automation/pipeline/test_coordinator.py tests/unit/automation/test_pipeline_github.py -q`: 223 passed
- Full unit suite before the final assertion-only follow-up: 5956 passed, 24 skipped, coverage 84.55% (threshold 83%)
- Coordinator regression after final follow-up: 42 passed
- `pixi run python -m mypy --explicit-package-bases hephaestus/automation/pipeline hephaestus/automation/pipeline_github.py tests/unit/automation/pipeline/stages/test_stage_pr_review.py tests/unit/automation/pipeline/test_coordinator.py tests/unit/automation/test_pipeline_github.py`: passed
- Ruff check and format check: passed
- `git diff --check`: passed
- Signed DCO commits: `703750d`, `e5ada59`, `0f07f38`, `ddafff6`, `e32165d`
- GitHub required checks and full test matrix: green on the earlier head; rerun started for `e32165d`.
- Local pre-commit: formatting, lint, mypy, markdown, YAML, shell, and hygiene hooks passed; Bandit was blocked by the read-only global Pixi cache lock and several local Hephaestus hooks were unavailable in this uninstalled worktree.

## Closes
Closes #1985

Generated by ProjectHephaestus automation
