### PR TITLE
[Bug]: error when running just drive-green

### DIFF
--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -534,8 +534,8 @@ def sync_worktree_to_remote_branch(
     logger.info("Syncing worktree at %s to %s/%s before agent run", cwd, remote, branch)
     try:
         run(["git", "fetch", remote, branch], cwd=cwd, **_timeout_kw(timeout))
-    except subprocess.CalledProcessError:
-        if pr_number is None:
+    except subprocess.CalledProcessError as error:
+        if pr_number is None or not _is_missing_remote_ref_error(error):
             raise
         pull_ref = f"refs/pull/{pr_number}/head"
         logger.info(
@@ -549,6 +549,21 @@ def sync_worktree_to_remote_branch(
         run(["git", "reset", "--hard", "FETCH_HEAD"], cwd=cwd, **_timeout_kw(timeout))
         return
     run(["git", "reset", "--hard", f"{remote}/{branch}"], cwd=cwd, **_timeout_kw(timeout))
+
+
+def _is_missing_remote_ref_error(error: subprocess.CalledProcessError) -> bool:
+    """Return whether a fetch failed because the requested branch ref is absent."""
+    diagnostics = "\n".join(
+        str(value) for value in (error.stdout, error.stderr) if value is not None
+    ).lower()
+    return any(
+        marker in diagnostics
+        for marker in (
+            "couldn't find remote ref",
+            "could not find remote ref",
+            "remote ref does not exist",
+        )
+    )
 
 
 def _remove_untracked_files_tracked_by_ref(

--- a/hephaestus/automation/git_utils.py
+++ b/hephaestus/automation/git_utils.py
@@ -494,6 +494,7 @@ def sync_worktree_to_remote_branch(
     branch: str,
     *,
     remote: str = "origin",
+    pr_number: int | None = None,
     timeout: int | None = None,
 ) -> None:
     """Reset ``cwd`` to ``<remote>/<branch>`` so the agent starts from the PR head.
@@ -508,9 +509,10 @@ def sync_worktree_to_remote_branch(
     This runs in two steps in ``cwd``:
 
     1. ``git fetch <remote> <branch>`` — updates the remote-tracking ref so the
-       reset has a current target.
-    2. ``git reset --hard <remote>/<branch>`` — moves HEAD to the PR's actual
-       head, discarding any divergent local commits or working-tree edits.
+       reset has a current target. If that branch ref is unavailable and
+       ``pr_number`` is supplied, fetch GitHub's ``refs/pull/N/head`` instead.
+    2. ``git reset --hard <remote>/<branch>`` (or ``FETCH_HEAD`` for the pull
+       ref fallback) moves HEAD to the PR's actual head.
 
     The worktree is throwaway (the driver removes it after each issue), so
     ``reset --hard`` is safe here: there is no human work to preserve.
@@ -519,6 +521,8 @@ def sync_worktree_to_remote_branch(
         cwd: Worktree path.
         branch: Remote branch name (the PR's head).
         remote: Remote name (default ``origin``).
+        pr_number: Optional PR number used to fall back to GitHub's pull ref
+            when the head branch is not available on ``remote``.
         timeout: Optional timeout in seconds for each git command.
 
     Raises:
@@ -528,7 +532,22 @@ def sync_worktree_to_remote_branch(
 
     """
     logger.info("Syncing worktree at %s to %s/%s before agent run", cwd, remote, branch)
-    run(["git", "fetch", remote, branch], cwd=cwd, **_timeout_kw(timeout))
+    try:
+        run(["git", "fetch", remote, branch], cwd=cwd, **_timeout_kw(timeout))
+    except subprocess.CalledProcessError:
+        if pr_number is None:
+            raise
+        pull_ref = f"refs/pull/{pr_number}/head"
+        logger.info(
+            "Branch %s is unavailable on %s; syncing worktree at %s from %s",
+            branch,
+            remote,
+            cwd,
+            pull_ref,
+        )
+        run(["git", "fetch", remote, pull_ref], cwd=cwd, **_timeout_kw(timeout))
+        run(["git", "reset", "--hard", "FETCH_HEAD"], cwd=cwd, **_timeout_kw(timeout))
+        return
     run(["git", "reset", "--hard", f"{remote}/{branch}"], cwd=cwd, **_timeout_kw(timeout))
 
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -316,6 +316,7 @@ class ImplementationStage(Stage):
         }
         if adopted:
             kwargs["sync_to_remote"] = True
+            kwargs["pr_number"] = item.pr
         worktree_job = GitJob(
             repo=item.repo,
             op="create_worktree",

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -558,6 +558,7 @@ class WorkerPool:
         manager = WorktreeManager()
         kwargs = dict(job.kwargs)
         sync_to_remote = bool(kwargs.pop("sync_to_remote", False))
+        pr_number = kwargs.pop("pr_number", None)
         created = manager.create_worktree(**kwargs, timeout=job.timeout_s)
         if created is None:
             return JobResult(ok=True)
@@ -590,6 +591,7 @@ class WorkerPool:
             git_utils.sync_worktree_to_remote_branch(
                 worktree_path,
                 branch_name,
+                pr_number=int(pr_number) if pr_number is not None else None,
                 timeout=job.timeout_s,
             )
         return JobResult(

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -291,6 +291,7 @@ class TestGate:
             "branch_name": "1-some-real-branch",
             "refresh_base": False,
             "sync_to_remote": True,
+            "pr_number": 1001,
         }
 
     def test_adopted_clean_worktree_advances_to_pr_review(

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -656,6 +656,7 @@ class TestGitOps:
                 "branch_name": "7-existing",
                 "refresh_base": False,
                 "sync_to_remote": True,
+                "pr_number": 70,
             },
         )
         instance = MagicMock()
@@ -675,7 +676,7 @@ class TestGitOps:
             timeout=60,
         )
         mock_clean.assert_called_once_with(Path("/tmp/wt"), timeout=60)
-        mock_sync.assert_called_once_with(Path("/tmp/wt"), "7-existing", timeout=60)
+        mock_sync.assert_called_once_with(Path("/tmp/wt"), "7-existing", pr_number=70, timeout=60)
         assert result.ok is True
         assert result.value == {"path": "/tmp/wt", "dirty": False, "status": "", "diff": ""}
 

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -675,6 +675,23 @@ class TestSyncWorktreeToRemoteBranch:
             "FETCH_HEAD",
         ]
 
+    def test_non_missing_fetch_failure_propagates_with_pr_number(
+        self, git_utils_mocks: Any
+    ) -> None:
+        """Authentication and transport failures must not use the PR-ref fallback."""
+        fetch_error = subprocess.CalledProcessError(
+            128,
+            ["git", "fetch"],
+            output="",
+            stderr="fatal: authentication failed for remote\n",
+        )
+        git_utils_mocks.run.side_effect = [fetch_error]
+
+        with pytest.raises(subprocess.CalledProcessError):
+            sync_worktree_to_remote_branch(Path("/tmp/worktree-xyz"), "feature", pr_number=42)
+
+        assert git_utils_mocks.run.call_count == 1
+
     def test_timeout_threads_through_fetch_and_reset(self, git_utils_mocks: Any) -> None:
         """sync_worktree_to_remote_branch bounds fetch and reset."""
         git_utils_mocks.run.return_value = Mock(returncode=0)

--- a/tests/unit/automation/test_git_utils.py
+++ b/tests/unit/automation/test_git_utils.py
@@ -646,6 +646,35 @@ class TestSyncWorktreeToRemoteBranch:
         # Reset must NOT have run after a fetch failure.
         assert git_utils_mocks.run.call_count == 1
 
+    def test_uses_pull_request_ref_when_branch_ref_is_missing(self, git_utils_mocks: Any) -> None:
+        """Adopted PRs can be reachable through GitHub's pull ref only."""
+        fetch_error = subprocess.CalledProcessError(
+            128,
+            ["git", "fetch"],
+            output="",
+            stderr="fatal: couldn't find remote ref feature\n",
+        )
+        git_utils_mocks.run.side_effect = [
+            fetch_error,
+            Mock(returncode=0),
+            Mock(returncode=0),
+        ]
+
+        sync_worktree_to_remote_branch(Path("/tmp/worktree-xyz"), "feature", pr_number=42)
+
+        assert git_utils_mocks.run.call_args_list[1].args[0] == [
+            "git",
+            "fetch",
+            "origin",
+            "refs/pull/42/head",
+        ]
+        assert git_utils_mocks.run.call_args_list[2].args[0] == [
+            "git",
+            "reset",
+            "--hard",
+            "FETCH_HEAD",
+        ]
+
     def test_timeout_threads_through_fetch_and_reset(self, git_utils_mocks: Any) -> None:
         """sync_worktree_to_remote_branch bounds fetch and reset."""
         git_utils_mocks.run.return_value = Mock(returncode=0)


### PR DESCRIPTION
## Summary
Implemented issue #2034.

- Added fallback to `refs/pull/<N>/head` when the PR branch is missing remotely.
- Propagated PR number through adopted worktree creation.
- Added regression coverage.

Verification:
- 176 targeted tests passed.
- Mypy, Ruff, formatting, compile, and diff checks passed.
- Full suite was interrupted after 5% due duration.
- Pixi/pre-commit tasks were blocked by sandbox cache/network restrictions.

Verdict: Implemented | Reason: Adopted PR worktrees now sync from GitHub pull refs when branch refs are unavailable.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2034

Generated by ProjectHephaestus automation
