### PR TITLE
[automation-loop] Add strict-review regressions for direct PR terminal edge cases

### DIFF
--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -224,6 +224,26 @@ class TestGate:
 
         assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
 
+    def test_gate_existing_item_pr_with_merged_at_finishes_before_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A truthy mergedAt terminalizes even when state is not MERGED."""
+
+        class MergedGitHub(FakeStageGitHub):
+            def get_pr_head_branch(self, pr_number: int) -> str | None:
+                raise AssertionError("merged PRs should finish before branch adoption")
+
+            def pr_has_implementation_state_label(self, pr_number: int) -> tuple[bool, bool]:
+                raise AssertionError("merged PRs should finish before label routing")
+
+        stage = ImplementationStage()
+        ctx = make_ctx(github=MergedGitHub(pr_state={"state": "OPEN", "mergedAt": "2026-07-10"}))
+        item = make_work_item(issue=1, pr=1001, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FINISH_PASS, "merged")
+
     def test_gate_existing_item_pr_closed_finishes_before_adoption(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -270,6 +270,23 @@ class TestExitCode:
 
         assert coordinator._active_preserved_worktrees() == []
 
+    def test_preserved_worktrees_deduplicate_duplicate_entries(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A preserved worktree recorded more than once is reported once."""
+        coordinator = _coordinator(tmp_path, monkeypatch)
+        preserved_path = tmp_path / "issue-2009"
+        preserved_path.mkdir()
+        failed = _item(2009, StageName.FINISHED)
+        failed.result = work_item_mod.ItemResult(
+            passed=False, reason="git_error", final_stage=StageName.FINISHED
+        )
+        coordinator.items = [failed]
+        entry = ("repo-a", 2009, str(preserved_path))
+        coordinator.preserved.extend([entry, entry])
+
+        assert coordinator._active_preserved_worktrees() == [entry]
+
 
 class TestCompletionEdges:
     """_handle_completion bookkeeping branches."""

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -140,6 +140,35 @@ class TestPrintSummaryRows:
         assert "'fail'" not in text
         assert "FAIL:git_error" not in text
 
+    def test_summary_supersedes_direct_pr_items_with_issue_context(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A direct PR seed with hydrated issue context uses one logical key."""
+        failed = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.PR,
+            issue=2009,
+            pr=2010,
+            stage=StageName.FINISHED,
+            result=ItemResult(passed=False, reason="git_error", final_stage=StageName.FINISHED),
+        )
+        passed = WorkItem(
+            repo="repo-a",
+            kind=ItemKind.PR,
+            issue=2009,
+            pr=2010,
+            stage=StageName.FINISHED,
+            result=ItemResult(passed=True, reason="merged", final_stage=StageName.FINISHED),
+        )
+
+        with caplog.at_level(logging.INFO):
+            print_summary([failed, passed], _stats(), [], json_out=False)
+
+        text = caplog.text
+        assert "items: 1" in text
+        assert "'pass': 1" in text
+        assert "FAIL:git_error" not in text
+
     def test_nonzero_attempts_render(self, caplog: pytest.LogCaptureFixture) -> None:
         """Only non-zero attempt counters appear in the row."""
         item = _item(6, StageName.FINISHED, passed=True, reason="ok")


### PR DESCRIPTION
## Summary
Verdict: Implemented issue #2026 | Reason: Added all three focused regressions.

- Modified three pipeline test files; 66 lines added.
- Pipeline suite: 828 passed.
- Ruff, mypy, and diff checks passed.
- Pixi/pre-commit provisioning was blocked by unavailable network/cache access.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2026

Generated by ProjectHephaestus automation
