### PR TITLE
fix(automation): ci_driver --no-include-bot-prs / --all not honored under the pipeline drive-green sweep

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -196,14 +196,9 @@ Examples:
         action="store_false",
         default=True,
         help=(
-            "Suppress the union of open bot-authored PRs (Dependabot, "
-            "github-actions, etc.) into the work set. By default the driver "
-            "unions every open is_bot=true PR with the issue-driven list so "
-            "Dependabot PRs are not architecturally invisible (#848). Pass "
-            "this flag only when you explicitly want issue-driven scope. "
-            "(NOT yet honored under the pipeline drive-green-all sweep, which "
-            "currently discovers every open PR regardless of author; tracked "
-            "in a follow-up.)"
+            "Exclude open bot-authored PRs (Dependabot, github-actions, etc.) "
+            "from the no-scope discovery sweep. Bot-authored PRs are included "
+            "by default so they are not architecturally invisible (#848)."
         ),
     )
     parser.add_argument(
@@ -212,14 +207,10 @@ Examples:
         action="store_true",
         default=False,
         help=(
-            "Include PRs opened by other actors (teammates, bots). Without "
-            "this flag, only PRs authored by the authenticated viewer "
-            "(`gh api user`) are driven (#821). NOTE: when scoped to issues "
-            "(--issues N), the resolved PR is processed regardless of "
-            "author — issue-scoped takes precedence. (The author filter is "
-            "NOT yet honored under the pipeline drive-green-all sweep, which "
-            "currently discovers every open PR regardless of author; tracked "
-            "in a follow-up.)"
+            "Include PRs opened by other actors (teammates and bots). Without "
+            "this flag, no-scope discovery drives only PRs authored by the "
+            "authenticated viewer (`gh api user`) (#821). Explicit --issues "
+            "and --prs scopes are processed regardless of author."
         ),
     )
     parser.add_argument(
@@ -335,6 +326,8 @@ def main() -> int:
             agent=agent,
             no_advise=args.no_advise,
             drive_green_all=drive_green_all,
+            include_bot_prs=args.include_bot_prs,
+            include_all_authors=args.include_all_authors,
             # --no-mechanical-rebase: the CI stage reads this off ctx.config to
             # skip the pre-fix mechanical rebase (#871).
             enable_mechanical_rebase=args.enable_mechanical_rebase,

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -159,8 +159,8 @@ def _list_open_issue_meta(org: str, repo: str) -> list[dict[str, Any]]:
     ]
 
 
-def _list_open_pr_numbers(org: str, repo: str) -> list[int]:
-    """Return open PR numbers in ``org/repo``, sorted ascending.
+def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
+    """Return open PR numbers and author metadata, sorted ascending.
 
     Read-only helper for the pipeline repo stage's ``--drive-green-all``
     orphan-PR discovery (#1817): PRs with no tracked issue route to the ci
@@ -170,23 +170,41 @@ def _list_open_pr_numbers(org: str, repo: str) -> list[int]:
     try:
         out = gh_call(
             [
-                "pr",
-                "list",
-                "--repo",
-                f"{org}/{repo}",
-                "--state",
-                "open",
-                "--limit",
-                "500",
-                "--json",
-                "number",
+                "api",
+                f"/repos/{org}/{repo}/pulls?state=open&per_page=100",
+                "--paginate",
+                "--slurp",
             ],
             timeout=NETWORK_TIMEOUT,
         )
-        entries = json.loads(out.stdout or "[]")
-    except (subprocess.SubprocessError, RuntimeError, OSError, json.JSONDecodeError) as exc:
+        pages = json.loads(out.stdout or "[]")
+        if not isinstance(pages, list) or any(not isinstance(page, list) for page in pages):
+            raise ValueError("expected paginated pull response")
+    except (
+        subprocess.SubprocessError,
+        RuntimeError,
+        OSError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
         raise RuntimeError(f"failed to list open PRs for {org}/{repo}: {exc}") from exc
-    return sorted(int(e["number"]) for e in entries if isinstance(e, dict) and "number" in e)
+    pulls: list[dict[str, Any]] = []
+    for page in pages:
+        for entry in page:
+            number = entry.get("number") if isinstance(entry, dict) else None
+            if not isinstance(number, int):
+                continue
+            user = entry.get("user") or {}
+            pulls.append(
+                {
+                    "number": number,
+                    "user": {
+                        "login": user.get("login"),
+                        "type": user.get("type"),
+                    },
+                }
+            )
+    return sorted(pulls, key=lambda pr: pr["number"])
 
 
 def _list_open_issue_numbers(org: str, repo: str) -> list[int]:

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -194,7 +194,8 @@ def _list_open_pr_meta(org: str, repo: str) -> list[dict[str, Any]]:
             number = entry.get("number") if isinstance(entry, dict) else None
             if not isinstance(number, int):
                 continue
-            user = entry.get("user") or {}
+            raw_user = entry.get("user")
+            user = raw_user if isinstance(raw_user, dict) else {}
             pulls.append(
                 {
                     "number": number,

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -588,6 +588,8 @@ def _build_pipeline_config(
         no_advise=cfg.no_advise,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
+        include_bot_prs=True,
+        include_all_authors=cfg.drive_green_all,
         run_pre_pr_tests=cfg.run_pre_pr_tests,
         budget_overrides={"merge": cfg.max_merge_attempts},
         serialize_file_overlap=cfg.serialize_file_overlap,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -216,6 +216,8 @@ class PipelineConfig:
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
+    include_bot_prs: bool = True
+    include_all_authors: bool = False
     # When False, the CI stage's pre-fix mechanical rebase is skipped and every
     # behind/conflicting PR falls through to the fix agent (``--no-mechanical-rebase``).
     # Read by ``stages/ci.py`` via ``ctx.config.enable_mechanical_rebase``.
@@ -265,6 +267,8 @@ class _StageRunConfig:
     dry_run: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
+    include_bot_prs: bool = True
+    include_all_authors: bool = False
     enable_mechanical_rebase: bool = True
     poll_max_wait: int = DEFAULT_CI_POLL_MAX_WAIT
     pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV
@@ -377,6 +381,8 @@ class Coordinator:
             dry_run=config.dry_run,
             nitpick=config.nitpick,
             drive_green_all=config.drive_green_all,
+            include_bot_prs=config.include_bot_prs,
+            include_all_authors=config.include_all_authors,
             enable_mechanical_rebase=config.enable_mechanical_rebase,
             poll_max_wait=config.poll_max_wait,
             pre_pr_test_argv=config.pre_pr_test_argv,

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -34,7 +34,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from hephaestus.automation import loop_repo_manager as _repo_manager
+from hephaestus.automation import loop_repo_manager as _repo_manager, pr_discovery as _pr_discovery
 from hephaestus.automation.pipeline import seeding as _seeding
 from hephaestus.automation.state_labels import partition_epics
 
@@ -55,6 +55,22 @@ from .base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _drive_green_pr_is_in_scope(
+    pr: dict[str, Any], *, include_bot_prs: bool, viewer_login: str
+) -> bool:
+    """Return whether an orphan PR belongs to the configured author scope."""
+    if not include_bot_prs and _pr_discovery._is_bot_pr_author(pr):
+        return False
+    if not _pr_discovery._is_viewer_authored(pr, viewer_login):
+        if (pr.get("user") or {}).get("login") is None:
+            logger.warning(
+                "PR #%s has no user.login; skipping under author filter (#821)",
+                pr.get("number"),
+            )
+        return False
+    return True
 
 
 def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
@@ -235,13 +251,21 @@ class RepoStage(Stage):
 
         # --drive-green-all: orphan PRs (no tracked issue) -> ci stage.
         if getattr(ctx.config, "drive_green_all", False):
+            include_bot_prs = bool(getattr(ctx.config, "include_bot_prs", True))
+            include_all_authors = bool(getattr(ctx.config, "include_all_authors", False))
             try:
-                open_pr_numbers = _repo_manager._list_open_pr_numbers(ctx.org, item.repo)
+                open_prs = _repo_manager._list_open_pr_meta(ctx.org, item.repo)
+                viewer_login = "" if include_all_authors else _pr_discovery._resolve_viewer_login()
             except Exception as exc:
                 logger.warning("repo:%s: PR discovery failed: %s", item.repo, exc)
                 return StageOutcome(Disposition.FINISH_FAIL, note=f"discovery failed: {exc}")
-            for pr_number in open_pr_numbers:
+            for pr in open_prs:
+                pr_number = int(pr["number"])
                 if pr_number in covered_prs:
+                    continue
+                if not _drive_green_pr_is_in_scope(
+                    pr, include_bot_prs=include_bot_prs, viewer_login=viewer_login
+                ):
                     continue
                 products.append(
                     {

--- a/hephaestus/automation/pr_discovery.py
+++ b/hephaestus/automation/pr_discovery.py
@@ -23,6 +23,40 @@ from .github_api import GitHubUnavailableError, _gh_call
 logger = logging.getLogger(__name__)
 
 
+def _resolve_viewer_login() -> str:
+    """Resolve the authenticated GitHub login, failing closed on errors."""
+    try:
+        result = _gh_call(["api", "user", "-q", ".login"], check=True)
+    except (
+        subprocess.CalledProcessError,
+        FileNotFoundError,
+        GitHubUnavailableError,
+    ) as exc:
+        raise RuntimeError(
+            "Could not resolve viewer login via `gh api user`: "
+            f"{exc}. Re-authenticate with `gh auth login`, or pass "
+            "--all to opt out of the @me filter (#821)."
+        ) from exc
+    login = (result.stdout or "").strip()
+    if not login:
+        raise RuntimeError(
+            "Could not resolve viewer login via `gh api user`: "
+            "empty response. Re-authenticate with `gh auth login`, "
+            "or pass --all to opt out of the @me filter (#821)."
+        )
+    return login
+
+
+def _is_bot_pr_author(pr: dict[str, Any]) -> bool:
+    """Return whether a pull-request row was authored by a GitHub bot."""
+    return (pr.get("user") or {}).get("type") == "Bot"
+
+
+def _is_viewer_authored(pr: dict[str, Any], viewer_login: str) -> bool:
+    """Return whether a pull-request row belongs to the selected author scope."""
+    return not viewer_login or (pr.get("user") or {}).get("login") == viewer_login
+
+
 @dataclass(frozen=True)
 class PRWorkset:
     """Resolved PR workset for a drive-green run."""
@@ -219,27 +253,8 @@ class PRDiscovery:
         """
         if self._viewer_login:
             return self._viewer_login
-        try:
-            result = _gh_call(["api", "user", "-q", ".login"], check=True)
-        except (
-            subprocess.CalledProcessError,
-            FileNotFoundError,
-            GitHubUnavailableError,
-        ) as exc:
-            raise RuntimeError(
-                "Could not resolve viewer login via `gh api user`: "
-                f"{exc}. Re-authenticate with `gh auth login`, or pass "
-                "--all to opt out of the @me filter (#821)."
-            ) from exc
-        login = (result.stdout or "").strip()
-        if not login:
-            raise RuntimeError(
-                "Could not resolve viewer login via `gh api user`: "
-                "empty response. Re-authenticate with `gh auth login`, "
-                "or pass --all to opt out of the @me filter (#821)."
-            )
-        self._viewer_login = login
-        return login
+        self._viewer_login = _resolve_viewer_login()
+        return self._viewer_login
 
     def discover_bot_prs(self) -> dict[int, int]:
         """Enumerate every open ``is_bot=true`` PR on the repo (#848).
@@ -277,11 +292,10 @@ class PRDiscovery:
         viewer = "" if self._options().include_all_authors else self.resolve_viewer_login()
         bot_prs: dict[int, int] = {}
         for pr in raw_pulls:
-            user = pr.get("user") or {}
-            if user.get("type") != "Bot":
+            if not _is_bot_pr_author(pr):
                 continue
-            if viewer and user.get("login") != viewer:
-                if user.get("login") is None:
+            if not _is_viewer_authored(pr, viewer):
+                if (pr.get("user") or {}).get("login") is None:
                     logger.warning(
                         "PR #%s has no user.login; skipping under author filter (#821)",
                         pr.get("number"),

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 
 import hephaestus.automation.loop_repo_manager as loop_repo_manager_mod
+import hephaestus.automation.pr_discovery as pr_discovery_mod
 from hephaestus.automation.pipeline import seeding as seeding_mod
 from hephaestus.automation.pipeline.jobs import GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName
@@ -170,13 +172,13 @@ class TestDiscover:
         meta: list[dict[str, Any]],
         facts: dict[int, IssueFacts],
         classifications: dict[int, tuple[StageName | None, str]],
-        open_prs: list[int] | None = None,
+        open_prs: list[dict[str, Any]] | None = None,
     ) -> list[int]:
         """Patch the repo-stage read seams; returns the classify-call order."""
         classified: list[int] = []
         monkeypatch.setattr(loop_repo_manager_mod, "_list_open_issue_meta", lambda org, repo: meta)
         monkeypatch.setattr(
-            loop_repo_manager_mod, "_list_open_pr_numbers", lambda org, repo: open_prs or []
+            loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: open_prs or []
         )
         monkeypatch.setattr(seeding_mod, "seed_issue", lambda num: facts[num])
         monkeypatch.setattr(seeding_mod, "seed_issue_from_github", lambda num, github: facts[num])
@@ -222,7 +224,7 @@ class TestDiscover:
             "_list_open_issue_meta",
             lambda org, repo: [{"number": 8, "labels": ["state:implementation-go"], "title": "x"}],
         )
-        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_numbers", lambda org, repo: [])
+        monkeypatch.setattr(loop_repo_manager_mod, "_list_open_pr_meta", lambda org, repo: [])
         monkeypatch.setattr(
             seeding_mod,
             "seed_issue",
@@ -363,14 +365,26 @@ class TestDiscover:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Open PRs with no tracked issue become ci-stage PR products."""
-        config = type("Cfg", (), {"drive_green_all": True, "dry_run": False})()
+        config = type(
+            "Cfg",
+            (),
+            {
+                "drive_green_all": True,
+                "include_bot_prs": True,
+                "include_all_authors": True,
+                "dry_run": False,
+            },
+        )()
         ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
         self._patch_discovery(
             monkeypatch,
             meta=[{"number": 1, "labels": [], "title": "covered"}],
             facts={1: _facts(1, pr=55, pr_open=True)},
             classifications={1: (StageName.PR_REVIEW, "open PR")},
-            open_prs=[55, 66],
+            open_prs=[
+                {"number": 55, "user": {"login": "alice", "type": "User"}},
+                {"number": 66, "user": {"login": "alice", "type": "User"}},
+            ],
         )
         repo_item.state = "DISCOVER"
 
@@ -378,6 +392,88 @@ class TestDiscover:
 
         orphan = [p for p in repo_item.payload["products"] if p.get("kind") == "pr"]
         assert [(p["number"], p["stage"]) for p in orphan] == [(66, StageName.CI)]
+
+    @pytest.mark.parametrize(
+        ("include_bot_prs", "include_all_authors", "expected"),
+        [
+            pytest.param(True, False, [66, 68], id="viewer-only-including-bots"),
+            pytest.param(False, False, [66], id="viewer-only-without-bots"),
+            pytest.param(True, True, [66, 67, 68, 69], id="all-authors-including-bots"),
+            pytest.param(False, True, [66, 67], id="all-authors-without-bots"),
+        ],
+    )
+    def test_drive_green_all_honors_author_and_bot_filters(
+        self,
+        include_bot_prs: bool,
+        include_all_authors: bool,
+        expected: list[int],
+        repo_item: WorkItem,
+        tmp_path: Path,
+        make_ctx: Callable[..., Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config = type(
+            "Cfg",
+            (),
+            {
+                "drive_green_all": True,
+                "include_bot_prs": include_bot_prs,
+                "include_all_authors": include_all_authors,
+                "dry_run": False,
+            },
+        )()
+        ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
+        self._patch_discovery(
+            monkeypatch,
+            meta=[{"number": 1, "labels": [], "title": "covered"}],
+            facts={1: _facts(1)},
+            classifications={1: (StageName.PLANNING, "needs plan")},
+            open_prs=[
+                {"number": 66, "user": {"login": "alice", "type": "User"}},
+                {"number": 67, "user": {"login": "bob", "type": "User"}},
+                {"number": 68, "user": {"login": "alice", "type": "Bot"}},
+                {"number": 69, "user": {"login": "depbot", "type": "Bot"}},
+            ],
+        )
+        monkeypatch.setattr(
+            pr_discovery_mod,
+            "_resolve_viewer_login",
+            lambda: "alice",
+        )
+        repo_item.state = "DISCOVER"
+
+        RepoStage().step(repo_item, ctx)
+
+        orphan = [p for p in repo_item.payload["products"] if p.get("kind") == "pr"]
+        assert [p["number"] for p in orphan] == expected
+
+    def test_drive_green_all_skips_viewer_resolution_for_all_authors(
+        self,
+        repo_item: WorkItem,
+        tmp_path: Path,
+        make_ctx: Callable[..., Any],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        config = type(
+            "Cfg",
+            (),
+            {"drive_green_all": True, "include_all_authors": True, "dry_run": False},
+        )()
+        ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
+        self._patch_discovery(
+            monkeypatch,
+            meta=[],
+            facts={},
+            classifications={},
+            open_prs=[],
+        )
+        resolver = MagicMock(return_value="x")
+        monkeypatch.setattr(pr_discovery_mod, "_resolve_viewer_login", resolver)
+        repo_item.state = "DISCOVER"
+
+        RepoStage().step(repo_item, ctx)
+
+        resolver.assert_not_called()
 
     def test_drive_green_all_pr_discovery_failure_finishes_fail(
         self,
@@ -387,7 +483,11 @@ class TestDiscover:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Orphan-PR discovery failures are visible, not successful empty runs."""
-        config = type("Cfg", (), {"drive_green_all": True, "dry_run": False})()
+        config = type(
+            "Cfg",
+            (),
+            {"drive_green_all": True, "include_all_authors": True, "dry_run": False},
+        )()
         ctx = make_ctx(config=config, paths=_RepoPaths(tmp_path))
         self._patch_discovery(
             monkeypatch,
@@ -397,7 +497,7 @@ class TestDiscover:
         )
         monkeypatch.setattr(
             loop_repo_manager_mod,
-            "_list_open_pr_numbers",
+            "_list_open_pr_meta",
             lambda org, repo: (_ for _ in ()).throw(RuntimeError("pr list failed")),
         )
         repo_item.state = "DISCOVER"

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -964,6 +964,24 @@ class TestConfigWiring:
         # A non-overridden key still resolves from ROUTES (rebase default 2).
         assert ctx.budget("rebase") == 2
 
+    def test_drive_green_filters_flow_to_stage_config(self, tmp_path: Path) -> None:
+        """Discovery flags survive the coordinator's stage-config copy."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            projects_dir=tmp_path,
+            include_bot_prs=False,
+            include_all_authors=True,
+        )
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+
+        ctx = coordinator._ctx_for_repo("repo-a")
+
+        assert ctx.config.include_bot_prs is False
+        assert ctx.config.include_all_authors is True
+
     def test_no_budget_override_uses_routes_default(self, tmp_path: Path) -> None:
         """Without an override the ci_fix budget is the ROUTES default (1)."""
         config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -110,6 +110,16 @@ def test_build_pipeline_config_maps_cli_fields(dispatch: dict[str, MagicMock]) -
     assert config.event_log_path.parent == Path(DEFAULT_STATE_DIR)
 
 
+def test_drive_green_all_maps_all_authors_and_bots(dispatch: dict[str, MagicMock]) -> None:
+    """The legacy drive-green-all flag keeps its broad discovery scope."""
+    loop_runner.main(["--drive-green-all", "--dry-run"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.drive_green_all is True
+    assert config.include_all_authors is True
+    assert config.include_bot_prs is True
+
+
 def test_default_pipeline_event_log_path_does_not_create_repo_checkout() -> None:
     """The default event log path must not live under a repo clone directory."""
     path = loop_runner._pipeline_event_log_path(DEFAULT_PROJECTS_DIR, ["repo-a"])

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -419,24 +419,18 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             True,
             nargs=0,
             help_text=(
-                "Suppress the union of open bot-authored PRs (Dependabot, github-actions, "
-                "etc.) into the work set. By default the driver unions every open "
-                "is_bot=true PR with the issue-driven list so Dependabot PRs are not "
-                "architecturally invisible (#848). Pass this flag only when you explicitly "
-                "want issue-driven scope. (NOT yet honored under the pipeline "
-                "drive-green-all sweep, which currently discovers every open PR regardless "
-                "of author; tracked in a follow-up.)"
+                "Exclude open bot-authored PRs (Dependabot, github-actions, etc.) from "
+                "the no-scope discovery sweep. Bot-authored PRs are included by default "
+                "so they are not architecturally invisible (#848)."
             ),
         ),
         _store_true(
             "--all",
             "include_all_authors",
-            "Include PRs opened by other actors (teammates, bots). Without this flag, "
-            "only PRs authored by the authenticated viewer (`gh api user`) are driven "
-            "(#821). NOTE: when scoped to issues (--issues N), the resolved PR is processed "
-            "regardless of author — issue-scoped takes precedence. (The author filter is "
-            "NOT yet honored under the pipeline drive-green-all sweep, which currently "
-            "discovers every open PR regardless of author; tracked in a follow-up.)",
+            "Include PRs opened by other actors (teammates and bots). Without this flag, "
+            "no-scope discovery drives only PRs authored by the authenticated viewer "
+            "(`gh api user`) (#821). Explicit --issues and --prs scopes are processed "
+            "regardless of author.",
         ),
         _action_spec(
             ("--no-mechanical-rebase",),

--- a/tests/unit/automation/test_ci_driver_main.py
+++ b/tests/unit/automation/test_ci_driver_main.py
@@ -115,6 +115,30 @@ def test_main_discovery_mode_enables_drive_green_all() -> None:
     assert config.drive_green_all is True
 
 
+@pytest.mark.parametrize(
+    ("argv", "include_bot_prs", "include_all_authors"),
+    [
+        pytest.param(["--dry-run"], True, False, id="defaults"),
+        pytest.param(["--no-include-bot-prs", "--dry-run"], False, False, id="exclude-bots"),
+        pytest.param(["--all", "--dry-run"], True, True, id="all-authors"),
+        pytest.param(
+            ["--all", "--no-include-bot-prs", "--dry-run"],
+            False,
+            True,
+            id="all-non-bots",
+        ),
+    ],
+)
+def test_main_threads_drive_green_filter_flags(
+    argv: list[str], include_bot_prs: bool, include_all_authors: bool
+) -> None:
+    """CLI discovery flags reach the pipeline configuration unchanged."""
+    config = _run_main_capturing_config(argv)["config"]
+
+    assert config.include_bot_prs is include_bot_prs
+    assert config.include_all_authors is include_all_authors
+
+
 def test_main_maps_max_workers_to_worker_pool() -> None:
     """--max-workers maps onto the pipeline worker-pool size."""
     captured = _run_main_capturing_config(["--issues", "5", "--max-workers", "7", "--dry-run"])

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -8,6 +8,7 @@ loop_runner namespace (preserved via explicit re-exports).
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -16,6 +17,7 @@ import pytest
 
 from hephaestus.automation import loop_repo_manager
 from hephaestus.automation.loop_repo_manager import (
+    NETWORK_TIMEOUT,
     _count_open_issues,
     _detect_cwd_repo,
     _detect_remote_base_ref,
@@ -25,6 +27,44 @@ from hephaestus.automation.loop_repo_manager import (
     _sort_repos_by_open_count,
 )
 from hephaestus.utils.helpers import METADATA_TIMEOUT
+
+
+class TestListOpenPrMeta:
+    """Tests for open pull-request metadata discovery."""
+
+    def test_returns_sorted_author_metadata_from_paginated_rows(self) -> None:
+        pages = [
+            [{"number": 9, "user": {"login": "depbot", "type": "Bot"}}],
+            [{"number": 3, "user": {"login": "alice", "type": "User"}}],
+        ]
+        with patch(
+            "hephaestus.automation.loop_repo_manager.gh_call",
+            return_value=MagicMock(stdout=json.dumps(pages)),
+        ) as mock_gh:
+            result = loop_repo_manager._list_open_pr_meta("acme", "widget")
+
+        assert result == [
+            {"number": 3, "user": {"login": "alice", "type": "User"}},
+            {"number": 9, "user": {"login": "depbot", "type": "Bot"}},
+        ]
+        assert mock_gh.call_args.args[0] == [
+            "api",
+            "/repos/acme/widget/pulls?state=open&per_page=100",
+            "--paginate",
+            "--slurp",
+        ]
+        assert mock_gh.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+
+    @pytest.mark.parametrize("stdout", ["not-json", "{}"])
+    def test_rejects_malformed_response(self, stdout: str) -> None:
+        with (
+            patch(
+                "hephaestus.automation.loop_repo_manager.gh_call",
+                return_value=MagicMock(stdout=stdout),
+            ),
+            pytest.raises(RuntimeError, match="failed to list open PRs"),
+        ):
+            loop_repo_manager._list_open_pr_meta("acme", "widget")
 
 
 class TestDetectCwdRepo:

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -17,7 +17,6 @@ import pytest
 
 from hephaestus.automation import loop_repo_manager
 from hephaestus.automation.loop_repo_manager import (
-    NETWORK_TIMEOUT,
     _count_open_issues,
     _detect_cwd_repo,
     _detect_remote_base_ref,
@@ -26,7 +25,7 @@ from hephaestus.automation.loop_repo_manager import (
     _resolve_repo_dir,
     _sort_repos_by_open_count,
 )
-from hephaestus.utils.helpers import METADATA_TIMEOUT
+from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 
 
 class TestListOpenPrMeta:
@@ -54,6 +53,19 @@ class TestListOpenPrMeta:
             "--slurp",
         ]
         assert mock_gh.call_args.kwargs["timeout"] == NETWORK_TIMEOUT
+
+    def test_normalizes_malformed_user_metadata(self) -> None:
+        pages = [[{"number": 7, "user": "unexpected"}, {"number": 8, "user": None}]]
+        with patch(
+            "hephaestus.automation.loop_repo_manager.gh_call",
+            return_value=MagicMock(stdout=json.dumps(pages)),
+        ):
+            result = loop_repo_manager._list_open_pr_meta("acme", "widget")
+
+        assert result == [
+            {"number": 7, "user": {"login": None, "type": None}},
+            {"number": 8, "user": {"login": None, "type": None}},
+        ]
 
     @pytest.mark.parametrize("stdout", ["not-json", "{}"])
     def test_rejects_malformed_response(self, stdout: str) -> None:


### PR DESCRIPTION
## Summary

Thread the CI driver author and bot filters through the queue pipeline's drive-green discovery path.

- Propagates `include_bot_prs` and `include_all_authors` from CLI to `RepoStage`.
- Uses paginated pull-request metadata with fail-closed author filtering.
- Normalizes malformed GitHub `user` payloads instead of raising or widening scope.
- Keeps CLI help and the legacy automation-loop compatibility path aligned.
- Adds focused parser, coordinator, repo-stage, and metadata regression coverage.

## Testing

- Focused suite: `98 passed`.
- Ruff and formatting checks pass.
- Required GitHub checks are running on the rebased head.

## Closes

Closes #1947

Generated by ProjectHephaestus automation