### PR TITLE
[ci] Branch protection strict mode drifted from required-checks contract

### DIFF
--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -82,8 +82,8 @@ set -euo pipefail
 
 repo=HomericIntelligence/ProjectHephaestus
 branch=main
-state_dir=/tmp/projecthephaestus-issue-2025
-install -d -m 700 "$state_dir"
+umask 077
+state_dir=$(mktemp -d "${TMPDIR:-/tmp}/projecthephaestus-issue-2025.XXXXXX")
 
 gh api \
   -H "Accept: application/vnd.github+json" \
@@ -104,9 +104,11 @@ gh ruleset check --default --repo "$repo"
 ```
 
 The branch snapshot must expose every classic check's `app_id`. The applicable
-rules snapshot retains every ruleset check's optional `integration_id`. Abort
-rather than rebuilding either array when the response shape or effective
-contract is unexpected:
+rules snapshot retains every ruleset check's optional `integration_id`. The
+classic surface intentionally names the three aggregator contexts, while a
+ruleset may name the individual jobs that feed that gate. Abort rather than
+rebuilding either array when the response shape or effective contract is
+unexpected:
 
 ```bash
 expected='[
@@ -123,17 +125,15 @@ jq -e --argjson expected "$expected" '
 
 jq -e --argjson expected "$expected" '
   [.[] | select(.type == "required_status_checks")] as $status_rules
-  | all(
+  | ($status_rules | length) > 0
+    and all(
       $status_rules[];
       .parameters.strict_required_status_checks_policy == true
-    )
-    and (
-      (
-        $expected
-        + [$status_rules[].parameters.required_status_checks[].context]
-        | unique
-        | sort
-      ) == ($expected | sort)
+      and (.parameters.required_status_checks | type) == "array"
+      and all(
+        .parameters.required_status_checks[];
+        has("context") and has("integration_id")
+      )
     )
 ' "$state_dir/rules.before.json"
 ```

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -16,9 +16,11 @@ checks** are green:
 | `test (ubuntu-latest, 3.12, unit)` | `.github/workflows/test.yml` matrix |
 | `test (ubuntu-latest, 3.12, integration)` | `.github/workflows/test.yml` matrix |
 
-Branch protection also has **`strict: true`** (a branch must be up to date with
-`main` before it can merge), which prevents a stale PR from merging around a
-gate that newer `main` would fail.
+Classic branch protection uses **`strict: true`**, and every active
+`required_status_checks` ruleset that applies to `main` must use
+`strict_required_status_checks_policy: true`. Requiring the PR head to be
+tested with current `main` prevents a stale PR from merging around a gate that
+newer `main` would fail.
 
 ## Why a single aggregator gate
 
@@ -72,29 +74,132 @@ forgotten.
 
 ## (Re-)applying branch protection
 
-Branch protection is stored on GitHub, not in git. To apply or restore the
-required-checks contract above, an admin runs:
+GitHub can combine classic branch protection with repository and inherited
+organization rulesets. Inspect both before changing either policy surface.
 
 ```bash
-gh api -X PUT \
-  repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks \
-  -f strict=true \
-  -f 'checks[][context]=required-checks-gate' \
-  -f 'checks[][context]=test (ubuntu-latest, 3.12, unit)' \
-  -f 'checks[][context]=test (ubuntu-latest, 3.12, integration)'
+set -euo pipefail
+
+repo=HomericIntelligence/ProjectHephaestus
+branch=main
+state_dir=/tmp/projecthephaestus-issue-2025
+install -d -m 700 "$state_dir"
+
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/branches/$branch/protection/required_status_checks" \
+  > "$state_dir/branch.before.json"
+
+gh api --paginate --slurp \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/rulesets?includes_parents=true&targets=branch&per_page=100" \
+  | jq 'add' > "$state_dir/rulesets.before.json"
+
+gh api --paginate --slurp \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/rules/branches/$branch?per_page=100" \
+  | jq 'add' > "$state_dir/rules.before.json"
+
+gh ruleset check --default --repo "$repo"
 ```
 
-Verify with:
+The branch snapshot must expose every classic check's `app_id`. The applicable
+rules snapshot retains every ruleset check's optional `integration_id`. Abort
+rather than rebuilding either array when the response shape or effective
+contract is unexpected:
 
 ```bash
-gh api repos/HomericIntelligence/ProjectHephaestus/branches/main/protection/required_status_checks
+expected='[
+  "required-checks-gate",
+  "test (ubuntu-latest, 3.12, unit)",
+  "test (ubuntu-latest, 3.12, integration)"
+]'
+
+jq -e --argjson expected "$expected" '
+  ((.checks | type) == "array")
+  and all(.checks[]; has("context") and has("app_id"))
+  and (([.checks[].context] | sort) == ($expected | sort))
+' "$state_dir/branch.before.json"
+
+jq -e --argjson expected "$expected" '
+  [.[] | select(.type == "required_status_checks")] as $status_rules
+  | all(
+      $status_rules[];
+      .parameters.strict_required_status_checks_policy == true
+    )
+    and (
+      (
+        $expected
+        + [$status_rules[].parameters.required_status_checks[].context]
+        | unique
+        | sort
+      ) == ($expected | sort)
+    )
+' "$state_dir/rules.before.json"
 ```
 
-Expect `strict: true` and exactly the three contexts above.
+Once both assertions pass, patch only the strict-mode field. Do not send
+`contexts` or `checks`; omitting them preserves the existing context and
+GitHub App bindings:
+
+```bash
+gh api -X PATCH \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/branches/$branch/protection/required_status_checks" \
+  -F strict=true \
+  > "$state_dir/branch.patch-response.json"
+```
+
+Read back every policy surface and prove that the repair changed no checks or
+rulesets:
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/branches/$branch/protection/required_status_checks" \
+  > "$state_dir/branch.after.json"
+
+gh api --paginate --slurp \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/rulesets?includes_parents=true&targets=branch&per_page=100" \
+  | jq 'add' > "$state_dir/rulesets.after.json"
+
+gh api --paginate --slurp \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$repo/rules/branches/$branch?per_page=100" \
+  | jq 'add' > "$state_dir/rules.after.json"
+
+jq -e '.strict == true' "$state_dir/branch.after.json"
+
+jq -S '.checks | sort_by(.context)' \
+  "$state_dir/branch.before.json" > "$state_dir/checks.before.json"
+jq -S '.checks | sort_by(.context)' \
+  "$state_dir/branch.after.json" > "$state_dir/checks.after.json"
+cmp -s "$state_dir/checks.before.json" "$state_dir/checks.after.json"
+
+jq -S 'sort_by(.ruleset_id, .type, .ruleset_source_type, .ruleset_source)' \
+  "$state_dir/rules.before.json" > "$state_dir/applicable-rules.before.json"
+jq -S 'sort_by(.ruleset_id, .type, .ruleset_source_type, .ruleset_source)' \
+  "$state_dir/rules.after.json" > "$state_dir/applicable-rules.after.json"
+cmp -s \
+  "$state_dir/applicable-rules.before.json" \
+  "$state_dir/applicable-rules.after.json"
+
+jq -S 'sort_by(.id)' \
+  "$state_dir/rulesets.before.json" > "$state_dir/rulesets-normalized.before.json"
+jq -S 'sort_by(.id)' \
+  "$state_dir/rulesets.after.json" > "$state_dir/rulesets-normalized.after.json"
+cmp -s \
+  "$state_dir/rulesets-normalized.before.json" \
+  "$state_dir/rulesets-normalized.after.json"
+```
+
+Any failed assertion or comparison stops the operation. Do not weaken, replace,
+or hand-reconstruct a check or inherited ruleset to make the command pass.
 
 > **Order matters:** the `required-checks-gate` context only becomes selectable
 > after the workflow containing it has run at least once on a commit. Land the
-> workflow change first, let it report, then apply the protection PUT.
+> workflow change first, let it report, then apply the protection patch.
 
 ## Related
 

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -130,6 +130,7 @@ jq -e --argjson expected "$expected" '
       $status_rules[];
       .parameters.strict_required_status_checks_policy == true
       and (.parameters.required_status_checks | type) == "array"
+      and (.parameters.required_status_checks | length) > 0
       and all(
         .parameters.required_status_checks[];
         has("context") and has("integration_id")

--- a/tests/unit/docs/test_required_checks_policy.py
+++ b/tests/unit/docs/test_required_checks_policy.py
@@ -54,8 +54,8 @@ def test_runbook_audits_rulesets_and_preserves_bindings() -> None:
         "gh ruleset check --default",
         "app_id",
         "integration_id",
-        '($status_rules | length) > 0',
-        'has(\"context\") and has(\"integration_id\")',
+        "($status_rules | length) > 0",
+        'has("context") and has("integration_id")',
         "cmp -s",
     )
     for marker in required_markers:

--- a/tests/unit/docs/test_required_checks_policy.py
+++ b/tests/unit/docs/test_required_checks_policy.py
@@ -1,0 +1,59 @@
+"""Regression tests for the required-checks protection runbook."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POLICY_DOC = REPO_ROOT / "docs" / "ci" / "required-checks.md"
+
+_REAPPLY_SECTION_RE = re.compile(
+    r"^## \(Re-\)applying branch protection\s*$(.*?)(?=^##\s|\Z)",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _policy_text() -> str:
+    return POLICY_DOC.read_text(encoding="utf-8")
+
+
+def _reapply_section() -> str:
+    match = _REAPPLY_SECTION_RE.search(_policy_text())
+    assert match is not None, "required-checks.md must contain the reapply runbook"
+    return match.group(1)
+
+
+def test_strict_policy_has_operational_reason() -> None:
+    """Require the documented strict policy to explain its purpose."""
+    text = _policy_text().lower()
+
+    assert "strict: true" in text
+    assert "stale pr" in text
+    assert "newer `main`" in text
+
+
+def test_repair_patches_only_strict_mode() -> None:
+    """Require the runbook to patch only the classic strict flag."""
+    section = _reapply_section().lower()
+
+    assert "-x patch" in section
+    assert "-f strict=true" in section
+    assert "-x put" not in section
+    assert "checks[][context]" not in section
+
+
+def test_runbook_audits_rulesets_and_preserves_bindings() -> None:
+    """Require ruleset inventory and check-binding preservation safeguards."""
+    section = _reapply_section()
+
+    required_markers = (
+        "rulesets?includes_parents=true&targets=branch",
+        "rules/branches/$branch",
+        "gh ruleset check --default",
+        "app_id",
+        "integration_id",
+        "cmp -s",
+    )
+    for marker in required_markers:
+        assert marker in section, f"required-checks runbook is missing {marker!r}"

--- a/tests/unit/docs/test_required_checks_policy.py
+++ b/tests/unit/docs/test_required_checks_policy.py
@@ -48,11 +48,14 @@ def test_runbook_audits_rulesets_and_preserves_bindings() -> None:
     section = _reapply_section()
 
     required_markers = (
+        'state_dir=$(mktemp -d "${TMPDIR:-/tmp}/projecthephaestus-issue-2025.XXXXXX")',
         "rulesets?includes_parents=true&targets=branch",
         "rules/branches/$branch",
         "gh ruleset check --default",
         "app_id",
         "integration_id",
+        '($status_rules | length) > 0',
+        'has(\"context\") and has(\"integration_id\")',
         "cmp -s",
     )
     for marker in required_markers:

--- a/tests/unit/docs/test_required_checks_policy.py
+++ b/tests/unit/docs/test_required_checks_policy.py
@@ -55,6 +55,7 @@ def test_runbook_audits_rulesets_and_preserves_bindings() -> None:
         "app_id",
         "integration_id",
         "($status_rules | length) > 0",
+        ".parameters.required_status_checks | length) > 0",
         'has("context") and has("integration_id")',
         "cmp -s",
     )


### PR DESCRIPTION
## Summary

Restores the documented strict status-check policy for `main` and hardens the administrative runbook against context or binding loss.

- Updated `docs/ci/required-checks.md` to inventory classic protection, inherited rulesets, and rules applicable to `main`.
- Uses a fail-closed partial `PATCH` of only classic `strict=true`; it preserves existing classic `app_id` and ruleset `integration_id` bindings.
- Distinguishes the classic three aggregator contexts from the ruleset's individual gating-job contexts.
- Uses a private `mktemp` state directory and rejects malformed or empty policy snapshots.
- Added regression coverage in `tests/unit/docs/test_required_checks_policy.py`.

## Live Verification

- Classic required-status checks: `strict=true`; the original three contexts and App ID `15368` are unchanged.
- Repository ruleset `15556494`: `strict_required_status_checks_policy=true`; all existing required contexts and integration ID `15368` are unchanged.

## Testing

- Focused regression: `3 passed`.
- Full unit matrix and required checks are running on this rebased head.

## Closes

Closes #2025

Generated by ProjectHephaestus automation