### PR TITLE
[Fix] Scope issue-comment lookups to the owning repo

### DIFF
--- a/hephaestus/automation/github_api/issues.py
+++ b/hephaestus/automation/github_api/issues.py
@@ -126,7 +126,9 @@ def gh_issue_comment(issue_number: int, body: str) -> None:
         raise RuntimeError(f"Failed to post comment to issue #{issue_number}: {e}") from e
 
 
-def _fetch_issue_comment_ids(issue_number: int) -> list[dict[str, Any]]:
+def _fetch_issue_comment_ids(
+    issue_number: int, repo: tuple[str, str] | None = None
+) -> list[dict[str, Any]]:
     """Return up to 100 most-recent issue comments as ``{databaseId, body}`` dicts.
 
     Unlike :func:`_fetch_issue_comments_graphql` in ``review_state`` (which
@@ -136,9 +138,20 @@ def _fetch_issue_comment_ids(issue_number: int) -> list[dict[str, Any]]:
     GraphQL is reversed to chronological order so "last match wins" matches
     the rest of the pipeline.
 
+    Args:
+        issue_number: GitHub issue number, meaningful only within *repo*.
+        repo: ``(owner, name)`` of the repository owning *issue_number*. When
+            omitted the repo is resolved from the ambient working directory,
+            which is correct only for single-repo callers. The multi-repo loop
+            MUST pass this explicitly: an issue number carries no repo, so
+            ambient resolution sent cross-repo lookups to the CWD repo,
+            404-ing (or, on number collision, silently reading an unrelated
+            issue) and tripping the ``github-api`` circuit breaker (#1795).
+
     Returns an empty list on any failure (callers then fall back to create).
+
     """
-    owner, name = _api.get_repo_info()
+    owner, name = repo if repo is not None else _api.get_repo_info()
     query = (
         "query($owner:String!,$name:String!,$number:Int!){"
         "  repository(owner:$owner,name:$name){"

--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -36,7 +36,7 @@ from hephaestus.automation.github_api import (
 from hephaestus.automation.protocol import PLAN_COMMENT_MARKER
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     from hephaestus.automation.models import IssueInfo
 
@@ -84,7 +84,7 @@ def _parse_planned_files(plan_body: str) -> set[str]:
     return files
 
 
-def _fetch_planned_files(issue: int) -> set[str] | None:
+def _fetch_planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str] | None:
     """Return the file set an issue's plan claims, or None if unknown.
 
     None (no plan comment / empty fetch) → caller fails OPEN and dispatches the
@@ -94,19 +94,24 @@ def _fetch_planned_files(issue: int) -> set[str] | None:
 
     Args:
         issue: GitHub issue number.
+        repo: ``(owner, name)`` of the repo owning *issue*. Required in the
+            multi-repo loop; omitting it resolves the repo from the ambient
+            working directory (#1795).
 
     Returns:
         The parsed plan file set, or None when no plan comment is present.
 
     """
-    for comment in _fetch_issue_comment_ids(issue):
+    for comment in _fetch_issue_comment_ids(issue, repo=repo):
         body = str(comment.get("body", ""))
         if body.startswith(PLAN_COMMENT_MARKER):
             return _parse_planned_files(body)
     return None
 
 
-def _select_non_overlapping(issues: list[int]) -> tuple[list[int], list[int]]:
+def _select_non_overlapping(
+    issues: list[int], repo_of: Mapping[int, tuple[str, str]] | None = None
+) -> tuple[list[int], list[int]]:
     """Partition *issues* into (dispatch_now, defer_next_round).
 
     Greedy first-fit in the given order: an issue whose parsed plan file set
@@ -119,16 +124,22 @@ def _select_non_overlapping(issues: list[int]) -> tuple[list[int], list[int]]:
 
     Args:
         issues: The issue numbers to partition, in dispatch-priority order.
+        repo_of: Maps each issue number to the ``(owner, name)`` that owns it.
+            Resolved PER ISSUE, not per batch: the implementation queue is keyed
+            by stage rather than by repo, so one round can legitimately hold
+            issues from several repositories. An issue missing from the mapping
+            falls back to ambient-CWD resolution (#1795).
 
     Returns:
         A ``(dispatch, defer)`` tuple of issue-number lists (order preserved).
 
     """
+    repo_of = repo_of or {}
     claimed: set[str] = set()
     dispatch: list[int] = []
     defer: list[int] = []
     for issue in issues:
-        planned = _fetch_planned_files(issue)
+        planned = _fetch_planned_files(issue, repo=repo_of.get(issue))
         if planned and (planned & claimed):
             LOG.info(
                 "issue #%s deferred: plan files %s overlap in-flight peers",

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -821,7 +821,14 @@ class Coordinator:
         ordered = _admission.order_for_implementation(infos)
         dispatch = ordered
         if self.config.serialize_file_overlap and self.config.max_workers > 1 and len(ordered) > 1:
-            dispatch, deferred = _admission._select_non_overlapping(ordered)
+            # Resolve each issue's owning repo from its own WorkItem: the queue is
+            # keyed by stage, so one round can hold issues from several repos (#1795).
+            repo_of = {
+                number: (self.config.org, item.repo)
+                for number, item in issue_items.items()
+                if item.repo
+            }
+            dispatch, deferred = _admission._select_non_overlapping(ordered, repo_of=repo_of)
             for number in deferred:
                 logger.info("implementation #%s deferred (file overlap)", number)
         ran: set[int] = set()

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -134,6 +134,54 @@ class TestFetchPlannedFiles:
             assert _fetch_planned_files(103) == {"hephaestus/automation/address_review.py"}
 
 
+class TestAdmissionRepoScoping:
+    """Admission must look up plans in the OWNING repo, not the ambient CWD (#1795)."""
+
+    def test_fetch_planned_files_forwards_repo(self) -> None:
+        """``_fetch_planned_files`` threads ``repo`` down to the comment fetch."""
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",
+            return_value=[],
+        ) as mock_fetch:
+            from hephaestus.automation.pipeline.admission import _fetch_planned_files
+
+            _fetch_planned_files(188, repo=("HomericIntelligence", "Myrmidons"))
+
+        mock_fetch.assert_called_once_with(188, repo=("HomericIntelligence", "Myrmidons"))
+
+    def test_select_non_overlapping_resolves_repo_per_issue(self) -> None:
+        """Each issue is looked up in ITS OWN repo.
+
+        The implementation queue is global (keyed by stage, not repo), so a
+        single round can hold issues from different repositories. A batch-wide
+        repo would send some lookups to the wrong repo — the very bug in #1795.
+        """
+        repo_of = {
+            188: ("HomericIntelligence", "Myrmidons"),
+            121: ("HomericIntelligence", "ProjectNestor"),
+        }
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",
+            return_value=[],
+        ) as mock_fetch:
+            dispatch, defer = _select_non_overlapping([188, 121], repo_of=repo_of)
+
+        assert dispatch == [188, 121]
+        assert defer == []
+        seen = {call.args[0]: call.kwargs["repo"] for call in mock_fetch.call_args_list}
+        assert seen == repo_of
+
+    def test_select_non_overlapping_missing_repo_entry_is_ambient(self) -> None:
+        """Back-compat: an issue absent from ``repo_of`` forwards None (ambient)."""
+        with patch(
+            "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",
+            return_value=[],
+        ) as mock_fetch:
+            _select_non_overlapping([7])
+
+        assert mock_fetch.call_args.kwargs["repo"] is None
+
+
 class TestSelectNonOverlapping:
     """Greedy first-fit partitioning: defer issues with overlapping file sets."""
 
@@ -145,7 +193,7 @@ class TestSelectNonOverlapping:
         }
         with patch(
             "hephaestus.automation.pipeline.admission._fetch_planned_files",
-            side_effect=lambda i: plans[i],
+            side_effect=lambda i, repo=None: plans[i],
         ):
             dispatch, defer = _select_non_overlapping([1, 2])
         assert dispatch == [1]
@@ -159,7 +207,7 @@ class TestSelectNonOverlapping:
         }
         with patch(
             "hephaestus.automation.pipeline.admission._fetch_planned_files",
-            side_effect=lambda i: plans[i],
+            side_effect=lambda i, repo=None: plans[i],
         ):
             dispatch, defer = _select_non_overlapping([1, 2])
         assert dispatch == [1, 2]
@@ -174,7 +222,7 @@ class TestSelectNonOverlapping:
         }
         with patch(
             "hephaestus.automation.pipeline.admission._fetch_planned_files",
-            side_effect=lambda i: plans[i],
+            side_effect=lambda i, repo=None: plans[i],
         ):
             dispatch, defer = _select_non_overlapping([1, 2, 3])
         # #1 claims address_review.py; #2 unknown → dispatched; #3 overlaps #1 → deferred.
@@ -189,7 +237,7 @@ class TestSelectNonOverlapping:
         }
         with patch(
             "hephaestus.automation.pipeline.admission._fetch_planned_files",
-            side_effect=lambda i: plans[i],
+            side_effect=lambda i, repo=None: plans[i],
         ):
             dispatch, defer = _select_non_overlapping([1, 2])
         assert dispatch[0] == 1
@@ -204,7 +252,7 @@ class TestSelectNonOverlapping:
         }
         with patch(
             "hephaestus.automation.pipeline.admission._fetch_planned_files",
-            side_effect=lambda i: plans[i],
+            side_effect=lambda i, repo=None: plans[i],
         ):
             dispatch, defer = _select_non_overlapping([1, 2, 3])
         # #1 claims file1.py; #2 overlaps file1.py → defer; #3 claims file2.py → dispatch.

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -521,20 +521,32 @@ class TestImplementationAdmission:
 
         coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
         # 21 depends on 22 (payload dependency): topo order runs 22 first.
-        item_a = _issue_item(21, StageName.IMPLEMENTATION)
+        # Distinct repos: the implementation queue is keyed by stage, not repo,
+        # so the coordinator must resolve each issue's repo from its own item (#1795).
+        item_a = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
         item_a.payload["dependencies"] = [22]
-        item_b = _issue_item(22, StageName.IMPLEMENTATION)
+        item_b = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-b")
         coordinator._push_item(item_a, StageName.IMPLEMENTATION, enter=True)
         coordinator._push_item(item_b, StageName.IMPLEMENTATION, enter=True)
+        seen_repo_of: dict[int, tuple[str, str]] = {}
+
+        def _fake_select(
+            issues: list[int], repo_of: dict[int, tuple[str, str]] | None = None
+        ) -> tuple[list[int], list[int]]:
+            seen_repo_of.update(repo_of or {})
+            return issues[:1], issues[1:]  # defer everything but the first
+
         monkeypatch.setattr(
             "hephaestus.automation.pipeline.admission._select_non_overlapping",
-            lambda issues: (issues[:1], issues[1:]),  # defer everything but the first
+            _fake_select,
         )
 
         coordinator._drain_implementation()
 
         assert run_order == [22]  # dependency first; 21 deferred by overlap
         assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
+        # Each issue is scoped to the repo of ITS OWN WorkItem, not the ambient CWD.
+        assert seen_repo_of == {21: ("org", "repo-a"), 22: ("org", "repo-b")}
 
     def test_file_overlap_serialization_can_be_disabled(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2082,6 +2082,60 @@ class TestGhPrChecks:
         assert exc_info.value.returncode == 128
 
 
+class TestFetchIssueCommentIdsRepoScoping:
+    """``_fetch_issue_comment_ids`` must query the OWNING repo, not the ambient CWD (#1795).
+
+    The multi-repo loop calls this helper with issue numbers belonging to other
+    repositories. Resolving the repo from the process CWD sent every query to
+    ProjectHephaestus, producing 404s (or, where issue numbers collide, silently
+    reading an unrelated issue/PR in the wrong repo).
+    """
+
+    @staticmethod
+    def _graphql_vars(argv: list[str]) -> dict[str, str]:
+        """Extract the ``-F key=value`` GraphQL variables from a gh argv."""
+        return dict(argv[i + 1].split("=", 1) for i, tok in enumerate(argv) if tok == "-F")
+
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_explicit_repo_is_queried_not_ambient_cwd(
+        self, mock_gh_call: Any, mock_repo_info: Any
+    ) -> None:
+        """An explicit ``repo=`` scopes the query and bypasses ambient resolution."""
+        mock_repo_info.return_value = ("HomericIntelligence", "ProjectHephaestus")
+        mock_gh_call.return_value = Mock(
+            stdout=json.dumps({"data": {"repository": {"issue": {"comments": {"nodes": []}}}}})
+        )
+
+        _github_api_module._fetch_issue_comment_ids(188, repo=("HomericIntelligence", "Myrmidons"))
+
+        argv = mock_gh_call.call_args[0][0]
+        variables = self._graphql_vars(argv)
+        assert variables["owner"] == "HomericIntelligence"
+        assert variables["name"] == "Myrmidons", (
+            "query must target the owning repo, not the ambient CWD repo"
+        )
+        assert variables["number"] == "188"
+        mock_repo_info.assert_not_called()
+
+    @patch("hephaestus.automation.github_api.get_repo_info")
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_omitted_repo_falls_back_to_ambient_cwd(
+        self, mock_gh_call: Any, mock_repo_info: Any
+    ) -> None:
+        """Back-compat: no ``repo=`` keeps the historical ambient behaviour."""
+        mock_repo_info.return_value = ("HomericIntelligence", "ProjectHephaestus")
+        mock_gh_call.return_value = Mock(
+            stdout=json.dumps({"data": {"repository": {"issue": {"comments": {"nodes": []}}}}})
+        )
+
+        _github_api_module._fetch_issue_comment_ids(42)
+
+        variables = self._graphql_vars(mock_gh_call.call_args[0][0])
+        assert variables["name"] == "ProjectHephaestus"
+        mock_repo_info.assert_called_once()
+
+
 class TestUpsertAndDeleteComment:
     """Idempotent plan/review comment lifecycle (one comment per role)."""
 


### PR DESCRIPTION
## Summary

The multi-repo automation loop resolved the GitHub repository from the **ambient working directory** when fetching issue comments. Issue numbers carry no repo, so cross-repo lookups were sent to `ProjectHephaestus` regardless of which repo actually owned the issue.

Observed in a real 12-repo run (`build/loop-watch/loop-20260710T055220Z.log`), where `gh` was invoked with `owner=HomericIntelligence name=ProjectHephaestus number=188` while the loop was working `Myrmidons#751` and `ProjectNestor#121`.

## Failure chain

1. `_fetch_issue_comment_ids(issue_number)` called `get_repo_info()` with no `repo_root`.
2. `get_repo_info(repo_root=None)` falls back to the process CWD → `ProjectHephaestus`.
3. Six cross-repo lookups 404'd (issues 188, 206, 211, 212, 213, 230).
4. `hephaestus.github.client` classified each 404 as `Non-transient error` and re-raised **through** `_GH_BREAKER.call(...)`.
5. The breaker's `failure_threshold=5` tripped on the sixth 404.
6. Every subsequent call raised `CircuitBreakerOpenError` → **236 items poisoned across 9 repos**; the run ended `exit_code=130, items=250, agent_jobs=0` — zero useful work.

### The quieter, worse half

Where issue numbers **collide** across repos there is no 404 at all. `ProjectAgamemnon#188` is a real issue; `ProjectHephaestus#188` also exists — as a merged PR. In that case the loop reads and acts on an unrelated object in the wrong repo, silently. The 404s were only the visible symptom.

## Fix

Thread the owning `(owner, name)` down from the `WorkItem` — which already carries `.repo` — through `_select_non_overlapping` → `_fetch_planned_files` → `_fetch_issue_comment_ids`.

The repo is resolved **per issue, not per batch**. The implementation queue is keyed by `StageName`, not by repo, so one round can legitimately hold issues from several repositories. The failing run demonstrates this directly: `Myrmidons#751` and `ProjectNestor#121` were claimed by workers concurrently *even under `--parallel-repos 1`*. A batch-wide repo parameter would have reintroduced the same class of bug.

Omitting the new argument preserves the previous ambient behaviour, so single-repo callers are unaffected.

### Scope

`pipeline_github.PipelineGitHub` was already correct — every mutator is guarded by `if self._repo_slug is not None` and appends an explicit `--repo org/repo`. `admission.py` was the sole unguarded path, which is exactly what the log shows: the only wrong-repo GraphQL query in the entire run was `_fetch_issue_comment_ids`. The other nine ambient `get_repo_info()` call sites are not reachable with cross-repo issue numbers and are deliberately left alone.

## Verification

- `pixi run pytest tests/unit` → **5951 passed**, 21 skipped; coverage **84.31%** (gate 83%).
- `pixi run mypy` → clean, 542 source files.
- `pixi run ruff check` / `ruff format --check` → clean.
- All pre-commit hooks pass; commit is GPG-signed (`-S`) and DCO signed-off (`-s`).

Tests added:
- `TestFetchIssueCommentIdsRepoScoping` — asserts the GraphQL `-F owner/name` variables target the passed repo and that `get_repo_info` is **not** called; plus a back-compat test for the ambient fallback.
- `TestAdmissionRepoScoping` — asserts `repo` is forwarded per issue, with two different repos in one batch.
- `test_topo_order_and_overlap_reuse` — strengthened to assert the coordinator builds `repo_of == {21: ("org","repo-a"), 22: ("org","repo-b")}` from distinct items. Reverting to a batch-wide repo now fails this test.

Each was confirmed RED before the fix (the first failed with `TypeError: got an unexpected keyword argument 'repo'`) and GREEN after.

Exercised against the real code path with the ambient repo pinned to `ProjectHephaestus`, using the two issue numbers from the failing run:

```
number= 751  ->  HomericIntelligence/Myrmidons
number= 121  ->  HomericIntelligence/ProjectNestor
OK: zero queries hit the ambient CWD repo -> breaker never reaches failure_threshold=5.
```

Closes #1795