### PR TITLE
[Fix] Per-target gh errors must not open the circuit breaker

### DIFF
--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -63,6 +63,10 @@ _GH_BREAKER = get_circuit_breaker(
     failure_threshold=5,
     recovery_timeout=60,
     half_open_max_calls=2,
+    # Resolved at call time: `_breaker_should_ignore` is defined below, after the
+    # error-pattern tables it consults. A 404 means GitHub answered — it is not
+    # evidence of unavailability and must not open this breaker (#2048).
+    ignore=lambda exc: _breaker_should_ignore(exc),
 )
 
 
@@ -182,6 +186,57 @@ _NON_TRANSIENT_PATTERNS = [
     )
 ]
 _NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)
+
+# Of the non-transient errors above, these are facts about the REQUESTED TARGET,
+# not about GitHub's health: the service was reachable and answered correctly
+# ("that issue does not exist", "that branch has no checks yet"). They must not
+# count toward the circuit breaker, which exists to detect an unavailable
+# service. Six wrong-repo "Could not resolve" 404s once opened the github-api
+# breaker (failure_threshold=5) and poisoned 236 items across 9 repos (#1795).
+#
+# Deliberately EXCLUDED from this list — they are per-credential or per-request
+# facts that WILL recur on every subsequent call, so failing fast is correct:
+#   403/forbidden, 401/unauthorized, token-scope, 400/bad request,
+#   422/unprocessable entity, invalid argument, unknown json field.
+_PER_TARGET_PATTERNS = [
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"(?:^|\s)404(?:\s|$)|not found",
+        r"could not resolve to (?:an? )?(?:issue|pull request)\b",
+        # GraphQL schema/syntax errors: deterministic properties of the query
+        # this caller sent, not of the service (#1040, #1350).
+        r"doesn't accept argument",
+        r"is declared by .* but not used",
+        r"Expected VALUE",
+        r"UNKNOWN_CHAR",
+        r"Parse error",
+        # Editing another app's review comment: a property of that comment (#1327).
+        r"not editable",
+        # The expected empty state right after a push, before checks register (#1587).
+        r"no checks reported",
+    )
+]
+
+
+def _is_per_target_error(stderr: str) -> bool:
+    """Report whether *stderr* describes the target, not GitHub's availability."""
+    return any(p.search(stderr) for p in _PER_TARGET_PATTERNS)
+
+
+def _is_service_failure(exc: BaseException) -> bool:
+    """Report whether *exc* is evidence that the GitHub API itself is unhealthy.
+
+    Only a ``CalledProcessError`` carries gh's stderr to classify. Anything else
+    (connection reset, timeout) is treated as a genuine service failure.
+    """
+    if isinstance(exc, subprocess.CalledProcessError):
+        return not _is_per_target_error(exc.stderr or "")
+    return True
+
+
+def _breaker_should_ignore(exc: BaseException) -> bool:
+    """Circuit-breaker predicate: exceptions that prove the service is UP (#2048)."""
+    return not _is_service_failure(exc)
 
 
 def _is_token_scope_error(stderr: str) -> bool:

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -64,9 +64,18 @@ def gh_cli_timeout() -> int:
 # opened the github-api breaker (failure_threshold=5) and poisoned 236 items
 # across 9 repos (#1795).
 #
-# Every entry here MUST also appear in _NON_TRANSIENT_PATTERNS below (asserted by
-# tests/unit/github/test_client.py). Otherwise the error would be retried 6x AND
-# excluded from the breaker — the worst of both.
+# These are DELIBERATELY NARROWER than their _NON_TRANSIENT_PATTERNS counterparts
+# below. The two lists answer different questions and tolerate error in opposite
+# directions:
+#
+#   _NON_TRANSIENT_PATTERNS -> "should we retry?"  Over-matching merely skips a
+#       retry. Safe. So a bare `not found` alternation is fine there.
+#   _PER_TARGET_PATTERNS    -> "is the service healthy?"  Over-matching EXCLUDES a
+#       real outage from the failure count and blinds the breaker. Unsafe.
+#
+# `not found` alone matches `gh: command not found`, `Name or service not found`
+# (DNS failure), and outage pages containing "Page not found" — every one of which
+# means GitHub really is unreachable. Anchor to gh's actual per-target phrasings.
 #
 # Deliberately EXCLUDED — per-credential or per-request facts that WILL recur on
 # every subsequent call, so tripping the breaker is correct: 403/forbidden,
@@ -75,19 +84,26 @@ def gh_cli_timeout() -> int:
 _PER_TARGET_PATTERNS = [
     re.compile(p, re.IGNORECASE)
     for p in (
-        r"(?:^|\s)404(?:\s|$)|not found",
-        r"could not resolve to (?:an? )?(?:issue|pull request)\b",
+        # gh's own 404 renderings, anchored to an HTTP status or gh's own prefix
+        # so bare "not found" prose in an outage body cannot match.
+        r"HTTP 404\b",
+        r"\(HTTP 404\)",
+        r"^gh: Not Found\b",
+        r"^Not Found \(HTTP 404\)",
+        # The GraphQL "target does not exist" rendering (#1795). Requires the
+        # object kind, so `Could not resolve hostname` (DNS) cannot match.
+        # gh emits the GraphQL type name (`PullRequest`) as well as prose.
+        r"could not resolve to (?:an? )?(?:issue|pull ?request)\b",
         # GraphQL schema/syntax errors: deterministic properties of the query
-        # this caller sent, not of the service (#1040, #1350).
+        # this caller sent, not of the service (#1040, #1350). Anchored so a
+        # generic "Parse error" from a truncated 502 body cannot match.
         r"doesn't accept argument",
         r"is declared by .* but not used",
-        r"Expected VALUE",
-        r"UNKNOWN_CHAR",
-        r"Parse error",
+        r"Expected VALUE, actual: UNKNOWN_CHAR",
         # Editing another app's review comment: a property of that comment (#1327).
-        r"not editable",
+        r"Body is not editable",
         # The expected empty state right after a push, before checks register (#1587).
-        r"no checks reported",
+        r"no checks reported on the",
     )
 ]
 
@@ -214,7 +230,9 @@ _NON_TRANSIENT_PATTERNS = [
         r"(?:^|\s)403(?:\s|$)|forbidden|permission denied",
         r"(?:^|\s)404(?:\s|$)|not found",
         # gh sometimes phrases missing issue/PR targets without 404/not found.
-        r"could not resolve to (?:an? )?(?:issue|pull request)\b",
+        # It emits the GraphQL type name (`PullRequest`) as well as prose, so the
+        # space is optional — without it, a missing PR was retried 6x (#1806).
+        r"could not resolve to (?:an? )?(?:issue|pull ?request)\b",
         r"(?:^|\s)400(?:\s|$)|bad request",
         r"(?:^|\s)401(?:\s|$)|unauthorized",
         r"(?:^|\s)422(?:\s|$)|unprocessable entity",

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -57,15 +57,72 @@ def gh_cli_timeout() -> int:
         return 120
 
 
+# Facts about the REQUESTED TARGET, not about GitHub's health: the service was
+# reachable and answered correctly ("that issue does not exist", "that branch has
+# no checks yet"). They must not count toward the circuit breaker, which exists to
+# detect an unavailable service. Six wrong-repo "Could not resolve" 404s once
+# opened the github-api breaker (failure_threshold=5) and poisoned 236 items
+# across 9 repos (#1795).
+#
+# Every entry here MUST also appear in _NON_TRANSIENT_PATTERNS below (asserted by
+# tests/unit/github/test_client.py). Otherwise the error would be retried 6x AND
+# excluded from the breaker — the worst of both.
+#
+# Deliberately EXCLUDED — per-credential or per-request facts that WILL recur on
+# every subsequent call, so tripping the breaker is correct: 403/forbidden,
+# 401/unauthorized, token-scope, 400/bad request, 422/unprocessable entity,
+# invalid argument, unknown json field.
+_PER_TARGET_PATTERNS = [
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"(?:^|\s)404(?:\s|$)|not found",
+        r"could not resolve to (?:an? )?(?:issue|pull request)\b",
+        # GraphQL schema/syntax errors: deterministic properties of the query
+        # this caller sent, not of the service (#1040, #1350).
+        r"doesn't accept argument",
+        r"is declared by .* but not used",
+        r"Expected VALUE",
+        r"UNKNOWN_CHAR",
+        r"Parse error",
+        # Editing another app's review comment: a property of that comment (#1327).
+        r"not editable",
+        # The expected empty state right after a push, before checks register (#1587).
+        r"no checks reported",
+    )
+]
+
+
+def _is_per_target_error(stderr: str) -> bool:
+    """Report whether *stderr* describes the target, not GitHub's availability."""
+    return any(p.search(stderr) for p in _PER_TARGET_PATTERNS)
+
+
+def _is_service_failure(exc: BaseException) -> bool:
+    """Report whether *exc* is evidence that the GitHub API itself is unhealthy.
+
+    Only a ``CalledProcessError`` carries gh's stderr to classify. Anything else
+    (connection reset, timeout) is treated as a genuine service failure.
+    """
+    if isinstance(exc, subprocess.CalledProcessError):
+        return not _is_per_target_error(exc.stderr or "")
+    return True
+
+
+def _breaker_should_ignore(exc: BaseException) -> bool:
+    """Circuit-breaker predicate: exceptions that prove the service is UP (#2048)."""
+    return not _is_service_failure(exc)
+
+
 _GH_THROTTLE = threading.local()
+# NOTE: the predicate and its pattern table are defined ABOVE this call on
+# purpose. `ignore=` is evaluated at module import, so a forward reference here
+# raises NameError and makes this module unimportable.
 _GH_BREAKER = get_circuit_breaker(
     "github-api",
     failure_threshold=5,
     recovery_timeout=60,
     half_open_max_calls=2,
-    # Resolved at call time: `_breaker_should_ignore` is defined below, after the
-    # error-pattern tables it consults. A 404 means GitHub answered — it is not
-    # evidence of unavailability and must not open this breaker (#2048).
+    # A 404 means GitHub answered — not evidence of unavailability (#2048).
     ignore=_breaker_should_ignore,
 )
 
@@ -186,57 +243,6 @@ _NON_TRANSIENT_PATTERNS = [
     )
 ]
 _NON_TRANSIENT_PATTERNS.append(_TOKEN_SCOPE_PATTERN)
-
-# Of the non-transient errors above, these are facts about the REQUESTED TARGET,
-# not about GitHub's health: the service was reachable and answered correctly
-# ("that issue does not exist", "that branch has no checks yet"). They must not
-# count toward the circuit breaker, which exists to detect an unavailable
-# service. Six wrong-repo "Could not resolve" 404s once opened the github-api
-# breaker (failure_threshold=5) and poisoned 236 items across 9 repos (#1795).
-#
-# Deliberately EXCLUDED from this list — they are per-credential or per-request
-# facts that WILL recur on every subsequent call, so failing fast is correct:
-#   403/forbidden, 401/unauthorized, token-scope, 400/bad request,
-#   422/unprocessable entity, invalid argument, unknown json field.
-_PER_TARGET_PATTERNS = [
-    re.compile(p, re.IGNORECASE)
-    for p in (
-        r"(?:^|\s)404(?:\s|$)|not found",
-        r"could not resolve to (?:an? )?(?:issue|pull request)\b",
-        # GraphQL schema/syntax errors: deterministic properties of the query
-        # this caller sent, not of the service (#1040, #1350).
-        r"doesn't accept argument",
-        r"is declared by .* but not used",
-        r"Expected VALUE",
-        r"UNKNOWN_CHAR",
-        r"Parse error",
-        # Editing another app's review comment: a property of that comment (#1327).
-        r"not editable",
-        # The expected empty state right after a push, before checks register (#1587).
-        r"no checks reported",
-    )
-]
-
-
-def _is_per_target_error(stderr: str) -> bool:
-    """Report whether *stderr* describes the target, not GitHub's availability."""
-    return any(p.search(stderr) for p in _PER_TARGET_PATTERNS)
-
-
-def _is_service_failure(exc: BaseException) -> bool:
-    """Report whether *exc* is evidence that the GitHub API itself is unhealthy.
-
-    Only a ``CalledProcessError`` carries gh's stderr to classify. Anything else
-    (connection reset, timeout) is treated as a genuine service failure.
-    """
-    if isinstance(exc, subprocess.CalledProcessError):
-        return not _is_per_target_error(exc.stderr or "")
-    return True
-
-
-def _breaker_should_ignore(exc: BaseException) -> bool:
-    """Circuit-breaker predicate: exceptions that prove the service is UP (#2048)."""
-    return not _is_service_failure(exc)
 
 
 def _is_token_scope_error(stderr: str) -> bool:

--- a/hephaestus/github/client.py
+++ b/hephaestus/github/client.py
@@ -66,7 +66,7 @@ _GH_BREAKER = get_circuit_breaker(
     # Resolved at call time: `_breaker_should_ignore` is defined below, after the
     # error-pattern tables it consults. A 404 means GitHub answered — it is not
     # evidence of unavailability and must not open this breaker (#2048).
-    ignore=lambda exc: _breaker_should_ignore(exc),
+    ignore=_breaker_should_ignore,
 )
 
 

--- a/hephaestus/resilience/circuit_breaker.py
+++ b/hephaestus/resilience/circuit_breaker.py
@@ -215,6 +215,11 @@ class CircuitBreaker:
             result = func(*args, **kwargs)
         except Exception as exc:
             if self._ignore is not None and self._ignore(exc):
+                # Leave a trace: an ignored error is invisible to the breaker, so
+                # without this a masked outage would have no breaker-level record.
+                logger.debug(
+                    "Circuit breaker '%s' ignoring non-service exception: %r", self.name, exc
+                )
                 self._release_half_open_slot()
                 raise
             self._record_failure()
@@ -302,6 +307,12 @@ def get_circuit_breaker(
 ) -> CircuitBreaker:
     """Get or create a named circuit breaker (singleton per name).
 
+    The registry is a singleton keyed by *name*. Every configuration argument is
+    applied ONLY when the breaker is first created; a later call for an existing
+    name returns the cached instance and SILENTLY DISCARDS the arguments — including
+    ``ignore``. Construct each named breaker exactly once (at its owning module's
+    import), or you will get a breaker whose predicate you did not install.
+
     Args:
         name: Unique identifier for the circuit breaker
         failure_threshold: Failures before opening (only used on creation)
@@ -310,7 +321,8 @@ def get_circuit_breaker(
             (only used on creation)
         success_threshold: Successes in HALF_OPEN to close (only used on creation)
         ignore: Predicate for exceptions that are not evidence of service
-            unavailability (only used on creation). See :meth:`CircuitBreaker.call`.
+            unavailability (only used on creation; silently dropped if *name*
+            already exists). See :meth:`CircuitBreaker.call`.
 
     Returns:
         CircuitBreaker instance for the given name

--- a/hephaestus/resilience/circuit_breaker.py
+++ b/hephaestus/resilience/circuit_breaker.py
@@ -96,6 +96,8 @@ class CircuitBreaker:
         half_open_max_calls: Maximum number of calls admitted concurrently in-flight
             while HALF_OPEN; each call releases its slot on completion (success or failure)
         success_threshold: Consecutive successes in HALF_OPEN required to close
+        ignore: Optional predicate deciding whether an exception is evidence of
+            service unavailability. See :meth:`call`.
 
     Example:
         >>> cb = CircuitBreaker("api", failure_threshold=3, recovery_timeout=30)
@@ -110,6 +112,8 @@ class CircuitBreaker:
         recovery_timeout: float = 60.0,
         half_open_max_calls: int = 1,
         success_threshold: int = 1,
+        *,
+        ignore: Callable[[BaseException], bool] | None = None,
     ) -> None:
         """Initialize circuit breaker.
 
@@ -120,6 +124,13 @@ class CircuitBreaker:
             half_open_max_calls: Maximum number of calls admitted concurrently
                 in-flight while HALF_OPEN; each call releases its slot on completion
             success_threshold: Consecutive successes in HALF_OPEN to close
+            ignore: Predicate returning True for exceptions that do NOT indicate
+                the service is unavailable (e.g. an HTTP 404 — the service
+                answered, and answered correctly). Such exceptions still
+                propagate to the caller but are neither counted as a failure nor
+                recorded as a success, so a burst of them can never open the
+                breaker and can never clear an accumulating outage signal.
+                Defaults to ignoring nothing.
 
         """
         self.name = name
@@ -127,6 +138,7 @@ class CircuitBreaker:
         self.recovery_timeout = recovery_timeout
         self.half_open_max_calls = half_open_max_calls
         self.success_threshold = success_threshold
+        self._ignore = ignore
 
         self._state = CircuitBreakerState.CLOSED
         self._failure_count = 0
@@ -164,6 +176,12 @@ class CircuitBreaker:
             *args: Positional arguments for func
             **kwargs: Keyword arguments for func
 
+        An exception matched by the ``ignore`` predicate is re-raised without
+        being recorded as either a failure or a success: the service demonstrably
+        responded, so it is not evidence of unavailability, but the call did not
+        succeed either. Recording it as a success would zero an accumulating
+        failure count and mask a real outage.
+
         Returns:
             Result of func(*args, **kwargs)
 
@@ -195,12 +213,26 @@ class CircuitBreaker:
         # Execute outside the lock to avoid blocking other threads
         try:
             result = func(*args, **kwargs)
-        except Exception:
+        except Exception as exc:
+            if self._ignore is not None and self._ignore(exc):
+                self._release_half_open_slot()
+                raise
             self._record_failure()
             raise
 
         self._record_success()
         return result
+
+    def _release_half_open_slot(self) -> None:
+        """Give back a HALF_OPEN slot without scoring the call either way.
+
+        An ignored exception must not hold its probe slot: leaking it would
+        exhaust ``half_open_max_calls`` and wedge the breaker in HALF_OPEN,
+        rejecting every later probe with ``HALF_OPEN_EXHAUSTED``.
+        """
+        with self._lock:
+            if self._state == CircuitBreakerState.HALF_OPEN and self._half_open_calls > 0:
+                self._half_open_calls -= 1
 
     def _record_success(self) -> None:
         """Record a successful call (releases this call's half-open slot)."""
@@ -265,6 +297,8 @@ def get_circuit_breaker(
     recovery_timeout: float = 60.0,
     half_open_max_calls: int = 1,
     success_threshold: int = 1,
+    *,
+    ignore: Callable[[BaseException], bool] | None = None,
 ) -> CircuitBreaker:
     """Get or create a named circuit breaker (singleton per name).
 
@@ -275,6 +309,8 @@ def get_circuit_breaker(
         half_open_max_calls: Maximum concurrent in-flight calls in HALF_OPEN state
             (only used on creation)
         success_threshold: Successes in HALF_OPEN to close (only used on creation)
+        ignore: Predicate for exceptions that are not evidence of service
+            unavailability (only used on creation). See :meth:`CircuitBreaker.call`.
 
     Returns:
         CircuitBreaker instance for the given name
@@ -288,6 +324,7 @@ def get_circuit_breaker(
                 recovery_timeout=recovery_timeout,
                 half_open_max_calls=half_open_max_calls,
                 success_threshold=success_threshold,
+                ignore=ignore,
             )
         return _registry[name]
 

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -9,9 +9,13 @@ import pytest
 
 from hephaestus.github.client import (
     _GH_BREAKER,
+    _NON_TRANSIENT_PATTERNS,
+    _PER_TARGET_PATTERNS,
     ClaudeUsageCapError,
     GitHubRateLimitError,
     GitHubUnavailableError,
+    _is_per_target_error,
+    _is_service_failure,
     gh_call,
     gh_cli_timeout,
 )
@@ -23,6 +27,146 @@ def _reset_breaker() -> Generator[None, None, None]:
     _GH_BREAKER.reset()
     yield
     _GH_BREAKER.reset()
+
+
+def _gh_error(stderr: str) -> subprocess.CalledProcessError:
+    """Build a CalledProcessError shaped like a failed ``gh`` invocation."""
+    return subprocess.CalledProcessError(1, ["gh"], output="", stderr=stderr)
+
+
+class TestPerTargetPatternInvariants:
+    """``_PER_TARGET_PATTERNS`` must stay a strict subset of the non-transient set."""
+
+    def test_every_per_target_pattern_is_also_non_transient(self) -> None:
+        """A per-target error must already be non-transient, else it gets retried.
+
+        The two lists answer different questions — "should we retry?" and "does
+        this indicate an outage?" — but per-target implies non-transient. If a
+        pattern lands only in the per-target list it would be retried 6x AND
+        excluded from the breaker: the worst of both.
+        """
+        non_transient = {p.pattern for p in _NON_TRANSIENT_PATTERNS}
+        per_target = {p.pattern for p in _PER_TARGET_PATTERNS}
+        assert per_target <= non_transient, per_target - non_transient
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "gh: HTTP 401: Bad credentials",
+            "gh: HTTP 403: Forbidden",
+            "gh: HTTP 422: Unprocessable Entity",
+            "gh: HTTP 400: Bad Request",
+            "Resource not accessible by personal access token",
+        ],
+    )
+    def test_credential_and_request_errors_are_not_per_target(self, stderr: str) -> None:
+        """These recur on every later call, so they must still open the breaker."""
+        assert not _is_per_target_error(stderr)
+        assert _is_service_failure(_gh_error(stderr))
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "gh: Could not resolve to an Issue with the number of 188.",
+            "gh: Not Found (HTTP 404)",
+            "no checks reported on the 'main' branch",
+            "Body is not editable",
+        ],
+    )
+    def test_target_errors_are_not_service_failures(self, stderr: str) -> None:
+        assert _is_per_target_error(stderr)
+        assert not _is_service_failure(_gh_error(stderr))
+
+    def test_non_calledprocess_exceptions_are_service_failures(self) -> None:
+        """A ConnectionError carries no stderr — assume the service is down."""
+        assert _is_service_failure(ConnectionError("reset by peer"))
+        assert _is_service_failure(TimeoutError())
+
+
+class TestBreakerIgnoresPerTargetErrors:
+    """Deterministic per-target errors must not open the breaker (#2048).
+
+    Regression for the #1795 cascade: six wrong-repo ``Could not resolve`` 404s
+    opened the ``github-api`` breaker (``failure_threshold=5``), poisoning 236
+    items across 9 repos and aborting the run with ``agent_jobs=0``.
+
+    A 404 proves the service is UP and answering correctly about a target that
+    does not exist. An auth failure (401/403) proves every later call will fail
+    too, so that must still open the breaker.
+    """
+
+    PER_TARGET: tuple[str, ...] = (
+        "gh: Could not resolve to an Issue with the number of 188.",
+        "gh: Not Found (HTTP 404)",
+        "no checks reported on the 'main' branch",
+        "Body is not editable",
+    )
+
+    @pytest.mark.parametrize("stderr", PER_TARGET)
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_per_target_errors_never_open_breaker(self, mock_impl: Mock, stderr: str) -> None:
+        """Well past failure_threshold=5, the breaker stays closed."""
+        mock_impl.side_effect = _gh_error(stderr)
+
+        for _ in range(10):
+            with pytest.raises(subprocess.CalledProcessError):
+                gh_call(["api", "graphql"], log_on_error=False)
+
+        # The 11th call must still reach gh, not be short-circuited.
+        with pytest.raises(subprocess.CalledProcessError):
+            gh_call(["api", "graphql"], log_on_error=False)
+        assert mock_impl.call_count == 11
+
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_swallowed_404s_do_not_poison_a_later_unrelated_call(self, mock_impl: Mock) -> None:
+        """The exact #1795 shape: caller catches each 404; a later call still succeeds.
+
+        Catching the exception never prevented the breaker from counting it,
+        because the breaker records the failure before the caller's ``except``
+        runs. This is what turned 6 bad lookups into a whole-run abort.
+        """
+        ok = Mock(returncode=0, stdout="{}", stderr="")
+        mock_impl.side_effect = [
+            *[_gh_error("gh: Could not resolve to an Issue with the number of 188.")] * 6,
+            ok,
+        ]
+
+        for _ in range(6):
+            with pytest.raises(subprocess.CalledProcessError):
+                gh_call(["api", "graphql"], log_on_error=False)
+
+        assert gh_call(["api", "graphql"]) is ok  # would raise GitHubUnavailableError before
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "gh: HTTP 401: Bad credentials",
+            "gh: HTTP 403: Forbidden",
+        ],
+    )
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_auth_errors_still_open_breaker(self, mock_impl: Mock, stderr: str) -> None:
+        """401/403 are per-credential, not per-target: every later call fails too."""
+        mock_impl.side_effect = _gh_error(stderr)
+
+        for _ in range(5):
+            with pytest.raises(subprocess.CalledProcessError):
+                gh_call(["api", "graphql"], log_on_error=False)
+
+        with pytest.raises(GitHubUnavailableError):
+            gh_call(["api", "graphql"], log_on_error=False)
+
+    @patch("hephaestus.github.client._gh_call_impl")
+    def test_transient_failures_still_open_breaker(self, mock_impl: Mock) -> None:
+        """A genuinely unavailable service must still trip the breaker."""
+        mock_impl.side_effect = ConnectionError("connection reset by peer")
+
+        for _ in range(5):
+            with pytest.raises(ConnectionError):
+                gh_call(["api", "graphql"], log_on_error=False)
+
+        with pytest.raises(GitHubUnavailableError):
+            gh_call(["api", "graphql"], log_on_error=False)
 
 
 class TestGhCallCircuitBreaker:

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -12,11 +12,10 @@ import pytest
 import hephaestus.github.client as client_module
 from hephaestus.github.client import (
     _GH_BREAKER,
-    _NON_TRANSIENT_PATTERNS,
-    _PER_TARGET_PATTERNS,
     ClaudeUsageCapError,
     GitHubRateLimitError,
     GitHubUnavailableError,
+    _is_non_transient_error,
     _is_per_target_error,
     _is_service_failure,
     gh_call,
@@ -77,17 +76,57 @@ class TestBreakerPredicateWiring:
 class TestPerTargetPatternInvariants:
     """``_PER_TARGET_PATTERNS`` must stay a strict subset of the non-transient set."""
 
-    def test_every_per_target_pattern_is_also_non_transient(self) -> None:
-        """A per-target error must already be non-transient, else it gets retried.
+    # Real gh stderr for each per-target pattern. Keep one sample per pattern.
+    PER_TARGET_SAMPLES: tuple[str, ...] = (
+        "gh: Not Found (HTTP 404)",
+        "failed to run git: HTTP 404: Not Found",
+        "gh: Could not resolve to an Issue with the number of 188.",
+        "gh: Could not resolve to a PullRequest with the number of 12.",
+        "Field 'addComment' doesn't accept argument 'foo'",
+        "Variable $owner is declared by query but not used",
+        'gh: Expected VALUE, actual: UNKNOWN_CHAR ("H") at [1, 24]',
+        "gh: Body is not editable",
+        "no checks reported on the '45-foo' branch",
+    )
 
-        The two lists answer different questions — "should we retry?" and "does
-        this indicate an outage?" — but per-target implies non-transient. If a
-        pattern lands only in the per-target list it would be retried 6x AND
-        excluded from the breaker: the worst of both.
+    @pytest.mark.parametrize("stderr", PER_TARGET_SAMPLES)
+    def test_per_target_samples_are_matched(self, stderr: str) -> None:
+        """Narrowing the patterns must not stop them matching real gh output."""
+        assert _is_per_target_error(stderr)
+
+    @pytest.mark.parametrize("stderr", PER_TARGET_SAMPLES)
+    def test_every_per_target_error_is_also_non_transient(self, stderr: str) -> None:
+        """Per-target implies non-transient — asserted on BEHAVIOUR, not on regex text.
+
+        The two lists answer different questions ("should we retry?" vs "is the
+        service healthy?") and are deliberately worded differently: the
+        per-target patterns are narrower, because over-matching there blinds the
+        breaker. So a set-comparison of regex *source strings* would be both
+        wrong and brittle. What must hold is the semantic implication: anything
+        classified per-target must already be non-transient. Otherwise the error
+        would be retried 6x AND excluded from the breaker — the worst of both.
         """
-        non_transient = {p.pattern for p in _NON_TRANSIENT_PATTERNS}
-        per_target = {p.pattern for p in _PER_TARGET_PATTERNS}
-        assert per_target <= non_transient, per_target - non_transient
+        assert _is_per_target_error(stderr)
+        assert _is_non_transient_error(stderr), (
+            f"{stderr!r} is per-target but would still be retried"
+        )
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            "gh: HTTP 401 Unauthorized",
+            "gh: HTTP 403 Forbidden",
+            "Resource not accessible by personal access token",
+        ],
+    )
+    def test_per_target_is_a_strict_subset_of_non_transient(self, stderr: str) -> None:
+        """There exist non-transient errors that are NOT per-target (auth).
+
+        Proves the two classifiers are genuinely distinct: these must skip the
+        retry loop AND still open the breaker.
+        """
+        assert _is_non_transient_error(stderr)
+        assert not _is_per_target_error(stderr)
 
     @pytest.mark.parametrize(
         "stderr",
@@ -102,6 +141,35 @@ class TestPerTargetPatternInvariants:
     def test_credential_and_request_errors_are_not_per_target(self, stderr: str) -> None:
         """These recur on every later call, so they must still open the breaker."""
         assert not _is_per_target_error(stderr)
+        assert _is_service_failure(_gh_error(stderr))
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            # The gh binary is absent — every call fails.
+            "gh: command not found",
+            # DNS failure — the service is unreachable.
+            "ssh: Could not resolve hostname github.com: Name or service not found",
+            "curl: (6) Could not resolve host: api.github.com",
+            # An actual outage page can contain the words "not found".
+            "GitHub is temporarily unavailable. Page not found.",
+            # A 502 HTML body fed to a JSON parser.
+            "error parsing HTTP 502 response body: invalid character '<'",
+            "Parse error on unexpected token at line 1 of the 502 body",
+        ],
+    )
+    def test_outage_shaped_stderr_is_not_treated_as_per_target(self, stderr: str) -> None:
+        """A breaker blinded by a substring match is worse than no breaker.
+
+        ``_NON_TRANSIENT_PATTERNS`` may match these loosely — there, over-matching
+        merely skips a retry, which is safe. Here over-matching would EXCLUDE a
+        genuine outage from the failure count, defeating the breaker entirely.
+        The per-target patterns must therefore be anchored to gh's actual
+        per-target phrasings, not bare substrings like "not found".
+        """
+        assert not _is_per_target_error(stderr), (
+            "outage-shaped stderr must still count toward the circuit breaker"
+        )
         assert _is_service_failure(_gh_error(stderr))
 
     @pytest.mark.parametrize(

--- a/tests/unit/github/test_client.py
+++ b/tests/unit/github/test_client.py
@@ -2,11 +2,14 @@
 """Tests for hephaestus.github.client.gh_call public contract."""
 
 import subprocess
+import sys
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
+import hephaestus.github.client as client_module
 from hephaestus.github.client import (
     _GH_BREAKER,
     _NON_TRANSIENT_PATTERNS,
@@ -32,6 +35,43 @@ def _reset_breaker() -> Generator[None, None, None]:
 def _gh_error(stderr: str) -> subprocess.CalledProcessError:
     """Build a CalledProcessError shaped like a failed ``gh`` invocation."""
     return subprocess.CalledProcessError(1, ["gh"], output="", stderr=stderr)
+
+
+class TestBreakerPredicateWiring:
+    """The ``ignore`` predicate must be defined before ``_GH_BREAKER`` uses it."""
+
+    def test_module_imports_in_a_fresh_interpreter(self) -> None:
+        """``ignore=`` is evaluated at import: a forward reference is a NameError.
+
+        No in-process test can catch this — importing this test module already
+        imported ``client``. A lint autofix once rewrote
+        ``ignore=lambda exc: _breaker_should_ignore(exc)`` into a direct
+        reference while the predicate was still defined ~130 lines BELOW
+        ``_GH_BREAKER``, making the module unimportable and failing every test
+        job on every Python version.
+        """
+        proc = subprocess.run(
+            [sys.executable, "-c", "import hephaestus.github.client"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert proc.returncode == 0, proc.stderr
+
+    def test_predicate_is_defined_before_the_breaker(self) -> None:
+        """Guard the ordering invariant directly, with a readable failure."""
+        source = Path(client_module.__file__).read_text(encoding="utf-8")
+        predicate_def = source.index("def _breaker_should_ignore")
+        breaker_use = source.index("_GH_BREAKER = get_circuit_breaker")
+        assert predicate_def < breaker_use, (
+            "_breaker_should_ignore must be defined before _GH_BREAKER references it"
+        )
+
+    def test_breaker_actually_uses_the_predicate(self) -> None:
+        """The live breaker carries the ignore predicate, not a stale None."""
+        assert _GH_BREAKER._ignore is not None
+        assert _GH_BREAKER._ignore(_gh_error("gh: Not Found (HTTP 404)")) is True
+        assert _GH_BREAKER._ignore(_gh_error("gh: HTTP 401: Bad credentials")) is False
 
 
 class TestPerTargetPatternInvariants:

--- a/tests/unit/resilience/test_circuit_breaker.py
+++ b/tests/unit/resilience/test_circuit_breaker.py
@@ -24,6 +24,100 @@ def _clean_registry() -> None:
     reset_all_circuit_breakers()
 
 
+class TestCircuitBreakerIgnoredExceptions:
+    """``ignore`` excludes caller-classified exceptions from the failure count (#2048).
+
+    A circuit breaker exists to detect an unavailable SERVICE. Some exceptions
+    prove the opposite — the service answered, and answered correctly, about a
+    specific target (e.g. HTTP 404). Counting those toward the failure threshold
+    lets a handful of deterministic, per-target errors open the breaker and fail
+    every unrelated call behind it.
+    """
+
+    def test_ignored_exception_does_not_count_toward_threshold(self) -> None:
+        """N > threshold ignored failures never open the breaker."""
+        breaker = CircuitBreaker(
+            "ignore-probe", failure_threshold=2, ignore=lambda exc: isinstance(exc, KeyError)
+        )
+
+        def boom() -> None:
+            raise KeyError("404-ish: the service answered, the target is absent")
+
+        for _ in range(5):
+            with pytest.raises(KeyError):
+                breaker.call(boom)
+
+        assert breaker.state is CircuitBreakerState.CLOSED
+
+    def test_ignored_exception_still_propagates(self) -> None:
+        """Ignoring is about bookkeeping only — the caller still sees the error."""
+        breaker = CircuitBreaker("ignore-raise", ignore=lambda exc: isinstance(exc, KeyError))
+
+        with pytest.raises(KeyError, match="still raised"):
+            breaker.call(lambda: (_ for _ in ()).throw(KeyError("still raised")))
+
+    def test_non_ignored_exception_still_opens(self) -> None:
+        """Real failures are unaffected by the exclusion predicate."""
+        breaker = CircuitBreaker(
+            "ignore-mixed", failure_threshold=2, ignore=lambda exc: isinstance(exc, KeyError)
+        )
+
+        def down() -> None:
+            raise ConnectionError("service unreachable")
+
+        for _ in range(2):
+            with pytest.raises(ConnectionError):
+                breaker.call(down)
+
+        assert breaker.state is CircuitBreakerState.OPEN
+
+    def test_ignored_exception_does_not_reset_failure_count(self) -> None:
+        """An ignored error is neither a success nor a failure.
+
+        Recording a *success* instead would zero the accumulated failure count
+        and erase a genuine outage signal that was building.
+        """
+        breaker = CircuitBreaker(
+            "ignore-nosuccess", failure_threshold=2, ignore=lambda exc: isinstance(exc, KeyError)
+        )
+
+        with pytest.raises(ConnectionError):
+            breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+        with pytest.raises(KeyError):  # must NOT clear the failure above
+            breaker.call(lambda: (_ for _ in ()).throw(KeyError("404")))
+        with pytest.raises(ConnectionError):
+            breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+
+        assert breaker.state is CircuitBreakerState.OPEN
+
+    def test_ignored_exception_does_not_reopen_half_open_breaker(self) -> None:
+        """In HALF_OPEN a single failure re-opens; an ignored error must not."""
+        breaker = CircuitBreaker(
+            "ignore-halfopen",
+            failure_threshold=1,
+            recovery_timeout=0.0,  # immediately eligible for HALF_OPEN
+            ignore=lambda exc: isinstance(exc, KeyError),
+        )
+        with pytest.raises(ConnectionError):
+            breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+        assert breaker.state is CircuitBreakerState.HALF_OPEN  # recovery_timeout=0
+
+        with pytest.raises(KeyError):
+            breaker.call(lambda: (_ for _ in ()).throw(KeyError("404")))
+
+        assert breaker.state is CircuitBreakerState.HALF_OPEN  # not re-OPENed
+
+    def test_default_ignores_nothing(self) -> None:
+        """Back-compat: no ``ignore`` predicate → every exception counts."""
+        breaker = CircuitBreaker("ignore-default", failure_threshold=2)
+
+        for _ in range(2):
+            with pytest.raises(KeyError):
+                breaker.call(lambda: (_ for _ in ()).throw(KeyError("x")))
+
+        assert breaker.state is CircuitBreakerState.OPEN
+
+
 class TestCircuitBreakerStates:
     """Tests for circuit breaker state transitions."""
 

--- a/tests/unit/resilience/test_circuit_breaker.py
+++ b/tests/unit/resilience/test_circuit_breaker.py
@@ -107,6 +107,90 @@ class TestCircuitBreakerIgnoredExceptions:
 
         assert breaker.state is CircuitBreakerState.HALF_OPEN  # not re-OPENed
 
+    def test_ignored_exception_releases_its_half_open_slot(self) -> None:
+        """An ignored error must give its probe slot back, or recovery wedges.
+
+        Asserting only ``state is HALF_OPEN`` is NOT enough: the state does not
+        change on an ignored exception whether or not the slot was released, so
+        such a test stays green even if ``_release_half_open_slot`` is a no-op.
+        Prove the release by admitting a LATER probe through the single slot.
+        """
+        breaker = CircuitBreaker(
+            "ignore-slot",
+            failure_threshold=1,
+            recovery_timeout=0.0,
+            half_open_max_calls=1,  # exactly one probe may be in flight
+            ignore=lambda exc: isinstance(exc, KeyError),
+        )
+        with pytest.raises(ConnectionError):
+            breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+        assert breaker.state is CircuitBreakerState.HALF_OPEN
+
+        # Burn several probes on ignored errors. Each must return its slot.
+        for _ in range(3):
+            with pytest.raises(KeyError):
+                breaker.call(lambda: (_ for _ in ()).throw(KeyError("404")))
+
+        assert breaker._half_open_calls == 0, "ignored exception leaked its probe slot"
+
+        # A real probe must still be admitted, not rejected as HALF_OPEN_EXHAUSTED.
+        assert breaker.call(lambda: "recovered") == "recovered"
+        assert breaker.state is CircuitBreakerState.CLOSED
+
+    def test_ignored_exception_slot_release_is_thread_safe(self) -> None:
+        """Concurrent ignored errors must never drive the slot counter negative."""
+        breaker = CircuitBreaker(
+            "ignore-threads",
+            failure_threshold=1,
+            recovery_timeout=0.0,
+            half_open_max_calls=8,
+            ignore=lambda exc: isinstance(exc, KeyError),
+        )
+        with pytest.raises(ConnectionError):
+            breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+        assert breaker.state is CircuitBreakerState.HALF_OPEN
+
+        def hammer() -> None:
+            for _ in range(20):
+                with contextlib.suppress(Exception):
+                    breaker.call(lambda: (_ for _ in ()).throw(KeyError("404")))
+
+        threads = [threading.Thread(target=hammer) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert breaker._half_open_calls >= 0, "slot counter went negative"
+        assert breaker.state is CircuitBreakerState.HALF_OPEN
+
+    def test_factory_honors_ignore_for_a_fresh_name(self) -> None:
+        """``get_circuit_breaker(ignore=...)`` wires the predicate on creation."""
+        breaker = get_circuit_breaker(
+            "factory-ignore-fresh",
+            failure_threshold=1,
+            ignore=lambda exc: isinstance(exc, KeyError),
+        )
+        with pytest.raises(KeyError):
+            breaker.call(lambda: (_ for _ in ()).throw(KeyError("404")))
+        assert breaker.state is CircuitBreakerState.CLOSED
+
+    def test_factory_silently_drops_ignore_for_an_existing_name(self) -> None:
+        """Documented footgun: the registry is a singleton keyed by name.
+
+        A second ``get_circuit_breaker`` for an existing name returns the cached
+        instance and DISCARDS every construction kwarg, ``ignore`` included. Pin
+        the behaviour so the trap is visible rather than surprising (POLA).
+        """
+        first = get_circuit_breaker("factory-ignore-dup", failure_threshold=1)
+        assert first._ignore is None
+
+        second = get_circuit_breaker(
+            "factory-ignore-dup", ignore=lambda exc: isinstance(exc, KeyError)
+        )
+        assert second is first
+        assert second._ignore is None, "a later ignore= must not silently rebind"
+
     def test_default_ignores_nothing(self) -> None:
         """Back-compat: no ``ignore`` predicate → every exception counts."""
         breaker = CircuitBreaker("ignore-default", failure_threshold=2)


### PR DESCRIPTION
## Summary

The `github-api` circuit breaker (`failure_threshold=5`) counted **every** non-transient `gh` error as evidence that GitHub was unavailable. But "non-transient" conflates two unrelated facts:

| Kind | Examples | Does it mean GitHub is down? |
|---|---|---|
| **Per-target** | `404` / `Could not resolve to an Issue` / `no checks reported` / `not editable` / GraphQL syntax errors | **No.** The service was reachable and answered *correctly* about a target that doesn't exist. |
| **Per-credential / per-request** | `401`, `403`, token scope, `400`, `422` | **Yes, effectively.** Every later call fails the same way, so failing fast is right. |

Only the second kind is a service failure. A circuit breaker exists to stop hammering a service that is **down**; a 404 proves it is **up and answering**.

## Why this matters

This is the amplifier behind #1795. Six wrong-repo `Could not resolve` 404s opened the breaker, poisoning **236 items across 9 repos** and aborting the run with `agent_jobs=0`. PR #2047 removes that *trigger*; this removes the *amplifier*. Without it, any future defect — or a handful of legitimately deleted issues — reproduces the same whole-run abort.

Catching the exception never helped: `CircuitBreaker.call` does `except Exception: self._record_failure(); raise`, so the failure is recorded **before** the caller's `except` runs. In `_fetch_issue_comment_ids` the 404 was swallowed and logged as a `WARNING` — while the breaker silently counted it.

## Change

**`hephaestus/resilience/circuit_breaker.py`** — new optional, keyword-only `ignore: Callable[[BaseException], bool]` on `CircuitBreaker` and `get_circuit_breaker`.

A matched exception still propagates, but is recorded as **neither failure nor success**:
- Not a failure — the service responded.
- Not a success either — recording one would zero an accumulating `_failure_count` and mask a genuine outage that was building.

It also releases its `HALF_OPEN` probe slot. Leaking that slot would exhaust `half_open_max_calls` and wedge the breaker in `HALF_OPEN`, rejecting every later probe with `HALF_OPEN_EXHAUSTED`.

**`hephaestus/github/client.py`** — supplies the GitHub-specific predicate. `_PER_TARGET_PATTERNS` is a strict **subset** of `_NON_TRANSIENT_PATTERNS`, so the retry behaviour added in #1806 is completely unchanged; only breaker accounting differs.

## Scope

The other two `CircuitBreaker` consumers — `resilience/subprocess_resilience.py` and `nats/subscriber.py` — pass no predicate and are unaffected (the parameter is optional and keyword-only). Neither has GitHub semantics: NATS wraps connection health, where every error genuinely does indicate unavailability. Deliberately untouched.

## Verification

- `pixi run pytest tests/unit` → **5992 passed**, 21 skipped; coverage **84.54%** (gate 83%, was 84.31%).
- `pixi run mypy` → clean, 543 source files. `ruff check` / `format --check` → clean.
- All pre-commit hooks pass; commit is GPG-signed (`-S`) and DCO signed-off (`-s`).

Every new test was confirmed RED before the fix (10 failed, 4 passed — the 4 being the guard tests below, which already held).

**Regression tests** (`tests/unit/github/test_client.py`):
- `test_per_target_errors_never_open_breaker` — 10 consecutive 404s, breaker stays closed, the 11th call still reaches `gh`.
- `test_swallowed_404s_do_not_poison_a_later_unrelated_call` — the exact #1795 shape: 6 caught 404s, then an unrelated call must succeed.
- `test_auth_errors_still_open_breaker` / `test_transient_failures_still_open_breaker` — **guard tests**: 401/403 and `ConnectionError` must *still* trip it. These already passed pre-fix, so they catch over-exclusion.
- `test_every_per_target_pattern_is_also_non_transient` — pins the subset invariant. A pattern that was per-target but *not* non-transient would be retried 6× **and** excluded from the breaker: the worst of both.

**Breaker tests** (`tests/unit/resilience/test_circuit_breaker.py`): ignored errors don't count, still propagate, don't reset the failure count, don't re-open a `HALF_OPEN` breaker; non-ignored errors still open it; and the default (no predicate) ignores nothing.

Both guards were mutation-tested — injecting a per-target pattern outside the non-transient set trips the subset test, and removing `ignore=` reproduces the original cascade opening on call #6.

Closes #2048