### PR TITLE
[majo] _reseed_if_converged counts repo seeds as progress, so a run can burn --loops doing zero real work

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1383,7 +1383,8 @@ class Coordinator:
             return False
         self._loops_run += 1
         logger.info("re-seeding: loop %d/%d", self._loops_run, self.config.loops)
-        return self._seed_pass() > 0
+        self._seed_pass()
+        return self._pass_work_count > 0
 
     # -- shutdown ---------------------------------------------------------------
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -218,6 +218,23 @@ class TestQuiescence:
         assert exit_code == 1  # SKIP counts as non-passing (fail-skip-blocked)
         assert [result.reason for result in coordinator.ledger] == ["skip: skip", "skip: skip"]
 
+    def test_reseed_with_only_repo_seeds_is_zero_work_convergence(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repo pushes do not keep a zero-work reseed alive."""
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch, loops=2)
+        coordinator._loops_run = 1
+        coordinator._pass_work_count = 1
+
+        def reseed_repo_only() -> int:
+            coordinator._pass_work_count = 0
+            return 1
+
+        monkeypatch.setattr(coordinator, "_seed_pass", reseed_repo_only)
+
+        assert coordinator._reseed_if_converged() is False
+        assert coordinator._loops_run == 2
+
     def test_poisoned_item_routes_finished_fail_and_loop_survives(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: Reseeding now stops when only repo seeds are pushed.

- Updated `coordinator.py:1386-1387`.
- Added regression test in `test_coordinator.py:221-236`.
- 82 coordinator tests passed; mypy, Ruff, formatting, and diff checks passed.
- Full suite was interrupted after `pixi` dependency access failed in the restricted environment.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1872

Generated by ProjectHephaestus automation
