### PR TITLE
[majo] __init__.py TYPE_CHECKING block omits PipelineConfig and run_pipeline, so type-checkers/IDEs can't resolve the public exports

### DIFF
--- a/hephaestus/automation/pipeline/__init__.py
+++ b/hephaestus/automation/pipeline/__init__.py
@@ -13,6 +13,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from .coordinator import PipelineConfig, run_pipeline
     from .jobs import GIT_OPS, AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
     from .queues import CompletionQueue, StageQueue
     from .routing import (

--- a/tests/unit/automation/pipeline/test_package_exports.py
+++ b/tests/unit/automation/pipeline/test_package_exports.py
@@ -1,0 +1,27 @@
+"""Tests for the pipeline package's static and runtime export surfaces."""
+
+import ast
+from pathlib import Path
+
+_PACKAGE_INIT = Path(__file__).parents[4] / "hephaestus" / "automation" / "pipeline" / "__init__.py"
+
+
+def test_lazy_coordinator_exports_are_available_to_type_checkers() -> None:
+    """Mirror lazy coordinator exports in the package TYPE_CHECKING block."""
+    tree = ast.parse(_PACKAGE_INIT.read_text(encoding="utf-8"))
+    type_checking_body = next(
+        node.body
+        for node in tree.body
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Name)
+        and node.test.id == "TYPE_CHECKING"
+    )
+
+    imports = {
+        alias.name
+        for node in type_checking_body
+        if isinstance(node, ast.ImportFrom) and node.module == "coordinator"
+        for alias in node.names
+    }
+
+    assert imports >= {"PipelineConfig", "run_pipeline"}


### PR DESCRIPTION
## Summary
Implemented #1874.

- Added `PipelineConfig` and `run_pipeline` to the `TYPE_CHECKING` imports.
- Added regression coverage for the static export mirror.
- Full suite: 6,355 passed, 21 skipped; coverage 84.58%.
- Mypy, Ruff checks, and formatting passed.
- Exact Pixi command/pre-commit were blocked by the read-only shared Pixi cache.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1874

Generated by ProjectHephaestus automation
