### PR TITLE
[Fix] Dedup implementation queue instead of fatal assert

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -809,16 +809,26 @@ class Coordinator:
         q = self.queues[StageName.IMPLEMENTATION]
         if not len(q):
             return
-        queued = q.snapshot()
-        issue_numbers = [it.issue for it in queued if it.issue is not None]
-        duplicate_issues = sorted(
-            issue for issue, count in Counter(issue_numbers).items() if count > 1
-        )
-        assert not duplicate_issues, (  # noqa: S101
-            f"implementation queue must not contain duplicate issue numbers: {duplicate_issues}"
-        )
-
         items = [q.pop() for _ in range(len(q))]
+        # A transient retry/fail-back can re-enqueue an issue while a prior copy
+        # is still queued, so the implementation queue may briefly hold two work
+        # items for the same issue. Building ``issue_items`` (and the downstream
+        # dispatch) requires unique issue numbers, so collapse duplicates here —
+        # keep the first-queued item and terminalize the rest as superseded —
+        # instead of crashing the whole org-wide run (was a hard assert, #1952).
+        seen_issues: set[int] = set()
+        deduped: list[WorkItem] = []
+        for it in items:
+            if it.issue is not None and it.issue in seen_issues:
+                logger.warning(
+                    "implementation #%s already queued; dropping duplicate work item", it.issue
+                )
+                self._finish(it, passed=True, reason=f"#{it.issue} superseded by queued duplicate")
+                continue
+            if it.issue is not None:
+                seen_issues.add(it.issue)
+            deduped.append(it)
+        items = deduped
         issue_items = {it.issue: it for it in items if it.issue is not None}
         infos = [
             IssueInfo(

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -481,10 +481,16 @@ class TestFailBackRouting:
 class TestImplementationAdmission:
     """Topological order + file-overlap reuse for the implementation queue."""
 
-    def test_duplicate_issue_numbers_assert_before_dispatch(
+    def test_duplicate_issue_numbers_collapse_to_first_queued(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Duplicate issue-number work items assert before dict indexing."""
+        """A duplicate issue work item is dropped, not fatal (#1952 regression).
+
+        A transient retry/fail-back can re-enqueue an issue while a prior copy
+        is still queued. The drain must keep the first-queued item, terminalize
+        the later duplicate as superseded, and dispatch normally — never crash
+        the whole org-wide run.
+        """
         coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
         ran: list[int] = []
 
@@ -498,14 +504,18 @@ class TestImplementationAdmission:
         duplicate = _issue_item(21, StageName.IMPLEMENTATION)
         coordinator._push_item(first, StageName.IMPLEMENTATION, enter=True)
         coordinator._push_item(duplicate, StageName.IMPLEMENTATION, enter=True)
-        coordinator.event_log.clear()
 
-        with pytest.raises(AssertionError, match=r"duplicate issue numbers: \[21\]"):
-            coordinator._drain_implementation()
+        coordinator._drain_implementation()
 
-        assert ran == []
-        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [first, duplicate]
-        assert coordinator.event_log == []
+        # First-queued item dispatched exactly once; duplicate never ran.
+        assert ran == [21]
+        # The duplicate was terminalized as superseded (kept out of dispatch).
+        assert duplicate.stage is StageName.FINISHED
+        assert duplicate.result is not None
+        assert duplicate.result.passed
+        assert "superseded" in duplicate.result.reason
+        # Implementation queue is drained — no duplicate left behind.
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
 
     def test_topo_order_and_overlap_reuse(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

`_drain_implementation` hard-asserted that the IMPLEMENTATION queue held no duplicate issue numbers (added in #1952, closing #1879). A transient retry/fail-back re-enqueues an issue while a prior copy is still queued, so the queue can briefly hold two work items for the same issue. In a live `hephaestus-automation-loop --org` run this assertion fired on `Odysseus #71/#206`, propagated through `run()`, and **crashed the entire org-wide pipeline loop** — dropping 321 pending items across 15 repos.

## Change

Collapse duplicates defensively at the top of `_drain_implementation`: keep the first-queued item, terminalize later duplicates as `superseded` (pass), log a warning, and dispatch normally. The queue's `issue_items` dict-build (the invariant #1879 cared about) is preserved without a fatal crash.

## Testing

- `test_duplicate_issue_numbers_collapse_to_first_queued` rewritten to assert the dedup behavior (was asserting the crash).
- `pixi run pytest tests/unit/automation/pipeline/` — 832 passed.
- `pixi run mypy` — clean (543 files).
- `pixi run ruff check` + pre-commit on changed files — clean.

Closes #2057