### PR TITLE
[Fix] Reap worker pool on fatal-exception exit

### DIFF
--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -23,15 +23,18 @@ What lives here:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import re
+import signal
 import subprocess
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from hephaestus.automation import subprocess_registry
 from hephaestus.automation.agent_config import (
     agent_default_timeout,
     fallback_model,
@@ -355,18 +358,72 @@ def _invoke_claude_once(
         sid,
         "create" if create else "resume",
     )
-    result = subprocess.run(
+    result = _run_tracked(
         cmd,
-        input=prompt if input_via_stdin else None,
-        capture_output=True,
-        text=True,
-        check=True,
+        stdin_text=prompt if input_via_stdin else None,
         timeout=timeout,
         env=env,
-        stdin=subprocess.DEVNULL if not input_via_stdin else None,
+        use_devnull_stdin=not input_via_stdin,
         cwd=str(cwd),
     )
     return result.stdout, sid
+
+
+def _run_tracked(
+    cmd: list[str],
+    *,
+    stdin_text: str | None,
+    timeout: int,
+    env: dict[str, str],
+    use_devnull_stdin: bool,
+    cwd: str,
+) -> subprocess.CompletedProcess[str]:
+    """Run *cmd* like ``subprocess.run(check=True, timeout=...)`` but killable.
+
+    Spawns the child in its OWN session (``start_new_session=True``) so it leads
+    its own process group, and registers that group with
+    :mod:`~hephaestus.automation.subprocess_registry` for the duration of the
+    call. A pipeline teardown (``WorkerPool.shutdown``) can then ``SIGTERM`` the
+    group and free the blocked worker thread instead of leaking a runaway
+    ``claude`` child (#2059). On timeout the group is killed before re-raising so
+    no orphan survives. The exception contract matches ``subprocess.run``:
+    :class:`subprocess.CalledProcessError` on non-zero exit,
+    :class:`subprocess.TimeoutExpired` on timeout.
+    """
+    proc = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL if use_devnull_stdin else subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+        cwd=cwd,
+        start_new_session=True,
+    )
+    with subprocess_registry.track_process_group(proc.pid):
+        try:
+            stdout, stderr = proc.communicate(input=stdin_text, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_process_tree(proc)
+            proc.communicate()  # reap so no zombie remains
+            raise
+        except BaseException:
+            # Includes the SIGTERM-driven teardown path: never leave the child.
+            _kill_process_tree(proc)
+            raise
+    if proc.returncode != 0:
+        raise subprocess.CalledProcessError(proc.returncode, cmd, output=stdout, stderr=stderr)
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout=stdout, stderr=stderr)
+
+
+def _kill_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Best-effort kill of *proc*'s whole process group, falling back to the proc."""
+    if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+        with contextlib.suppress(ProcessLookupError, OSError):
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            return
+    with contextlib.suppress(ProcessLookupError, OSError):  # pragma: no cover - already gone
+        proc.kill()
 
 
 def _envelope_error_text(stdout: str) -> str | None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -371,6 +371,7 @@ class Coordinator:
         self._progress = False
         self._stalled_ticks = 0
         self._fatal = False
+        self._pool_shut_down = False
         self._seen_item_ids: set[int] = set()
         self._stage_config = _StageRunConfig(
             enable_advise=not config.no_advise,
@@ -520,6 +521,11 @@ class Coordinator:
             logger.exception("pipeline run failed")
             self._fatal = True
         finally:
+            # Reap the pool on EVERY exit path — a fatal exception never sets
+            # self.shutdown, so without this the executor and in-flight AgentJob
+            # subprocesses (e.g. claude reviewers) would leak (#2059). Idempotent
+            # via _pool_shut_down, so the signal path's earlier call is a no-op.
+            self._shutdown_pool()
             self._finalize_resumable()
             exit_code = self._exit_code()
             stats = RunStats(
@@ -1435,6 +1441,21 @@ class Coordinator:
     def _teardown_immediate(self) -> None:
         """Cancel the pool and synthesize interrupted results for in-flight items."""
         self.shutdown.set()
+        self._shutdown_pool()
+
+    def _shutdown_pool(self) -> None:
+        """Cancel the pool and park in-flight items RESUMABLE. Idempotent.
+
+        Called on BOTH exit paths: the signal path (via
+        :meth:`_teardown_immediate`) and — critically — the ``run()`` ``finally``
+        block, so a fatal exception (which never sets ``self.shutdown``) still
+        cancels the executor and reaps in-flight ``AgentJob`` subprocesses
+        instead of leaking them (#2059). Guarded by ``_pool_shut_down`` so a
+        signal-then-fatal (or double ``finally``) sequence shuts down once.
+        """
+        if self._pool_shut_down:
+            return
+        self._pool_shut_down = True
         try:
             self.pool.shutdown()
         except Exception:  # pragma: no cover - defensive
@@ -1446,7 +1467,7 @@ class Coordinator:
 
     def _finalize_resumable(self) -> None:
         """Mark every still-live item RESUMABLE at its stage (never FAILED)."""
-        if not self.shutdown.is_set():
+        if not self.shutdown.is_set() and not self._fatal:
             return
         leftovers: list[WorkItem] = [item for _, _, item in self.timers]
         for stage_name, q in self.queues.items():

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from hephaestus.agents.runtime import resolve_agent, run_agent_session
-from hephaestus.automation import claude_invoke, git_utils
+from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.jobs import (
     AgentJob,
@@ -214,11 +214,16 @@ class WorkerPool:
     def shutdown(self) -> None:
         """Shut down the pool.
 
-        Sets the shutdown event and cancels pending futures. Running tasks
-        finish but post-check them for interruption.
+        Sets the shutdown event, cancels pending futures, and SIGTERMs every
+        in-flight agent process group. ``executor.shutdown(cancel_futures=True)``
+        only cancels UN-STARTED futures; a job already blocked in a ``claude``
+        subprocess would keep running and pin its non-daemon worker thread
+        (holding the interpreter open at exit — the #2059 leak). Terminating the
+        tracked process groups frees those workers promptly.
         """
         self._shutdown.set()
         self._executor.shutdown(wait=False, cancel_futures=True)
+        subprocess_registry.terminate_all()
 
     def _on_future_done(self, handle: JobHandle, future: Future[JobResult]) -> None:
         """Drain result to completion queue when a job future completes.

--- a/hephaestus/automation/subprocess_registry.py
+++ b/hephaestus/automation/subprocess_registry.py
@@ -1,0 +1,122 @@
+"""Thread-safe registry of live agent subprocess groups (#2059).
+
+The pipeline worker pool runs each agent (``claude``) invocation on a
+``ThreadPoolExecutor`` thread that blocks in :func:`subprocess.run`/``Popen``.
+``ThreadPoolExecutor.shutdown(cancel_futures=True)`` cancels only *un-started*
+futures; a job already blocked in ``communicate()`` keeps running to completion
+or timeout, holding a non-daemon worker thread and (via the interpreter's
+``atexit`` join) the whole process open — the ~19-minute leak reported in #2059.
+
+This registry lets the spawning code publish each live child's process-group id
+so a teardown path (``WorkerPool.shutdown``) can send it ``SIGTERM`` and free
+the worker promptly. It is a *shared* seam: :mod:`hephaestus.automation.claude_invoke`
+registers, the worker pool terminates. Registration is opt-in via
+:func:`track_process_group` (a context manager) so non-pipeline callers are
+unaffected.
+
+Windows has no process groups / ``killpg``; there registration is a no-op and
+:func:`terminate_all` returns 0 (the pool falls back to its prior behavior).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+#: True when the platform supports POSIX process groups + killpg.
+_HAVE_KILLPG = hasattr(os, "killpg") and hasattr(os, "getpgid")
+
+_lock = threading.Lock()
+#: Live child process-group ids currently tracked.
+_live_pgids: set[int] = set()
+
+
+def supported() -> bool:
+    """Return True when process-group tracking/termination is available."""
+    return _HAVE_KILLPG
+
+
+def _register(pgid: int) -> None:
+    with _lock:
+        _live_pgids.add(pgid)
+
+
+def _unregister(pgid: int) -> None:
+    with _lock:
+        _live_pgids.discard(pgid)
+
+
+@contextmanager
+def track_process_group(pid: int) -> Iterator[None]:
+    """Track *pid*'s process group for the duration of the ``with`` block.
+
+    *pid* must be the leader of its own process group (spawn the child with
+    ``start_new_session=True`` so its pgid equals its pid). On unsupported
+    platforms this is a no-op. The group is always unregistered on exit, so a
+    child that finishes normally is never left in the registry.
+
+    Args:
+        pid: The child process id (also its process-group id).
+
+    """
+    if not _HAVE_KILLPG:
+        yield
+        return
+    try:
+        pgid = os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        # Child already gone (raced to exit) — nothing to track.
+        yield
+        return
+    _register(pgid)
+    try:
+        yield
+    finally:
+        _unregister(pgid)
+
+
+def terminate_all(sig: int = signal.SIGTERM) -> int:
+    """Signal every tracked process group and clear the registry.
+
+    Idempotent and safe to call with nothing tracked (returns 0). Groups whose
+    leader has already exited are skipped without error. Returns the number of
+    groups signalled — the worker pool logs this on teardown so a leak is
+    visible.
+
+    Args:
+        sig: The signal to deliver (default ``SIGTERM``).
+
+    Returns:
+        The count of process groups that were signalled.
+
+    """
+    if not _HAVE_KILLPG:
+        return 0
+    with _lock:
+        pgids = list(_live_pgids)
+        _live_pgids.clear()
+    signalled = 0
+    for pgid in pgids:
+        try:
+            os.killpg(pgid, sig)
+            signalled += 1
+        except ProcessLookupError:
+            # Group already gone — fine.
+            continue
+        except OSError as exc:  # pragma: no cover - defensive
+            logger.warning("failed to signal process group %s: %s", pgid, exc)
+    if signalled:
+        logger.info("terminated %d in-flight agent process group(s) on teardown", signalled)
+    return signalled
+
+
+def live_count() -> int:
+    """Return the number of currently tracked process groups (for tests/diagnostics)."""
+    with _lock:
+        return len(_live_pgids)

--- a/tests/unit/automation/pipeline/conftest.py
+++ b/tests/unit/automation/pipeline/conftest.py
@@ -66,6 +66,7 @@ class FakeWorkerPool:
         )
         self.submitted: list[JobHandle] = []
         self.submitted_claims: list[tuple[str, str]] = []
+        self.shutdown_calls = 0
         self._scripted: deque[JobResult | Exception] = deque()
 
     def script(self, *outcomes: JobResult | Exception) -> None:
@@ -130,6 +131,7 @@ class FakeWorkerPool:
 
     def shutdown(self) -> None:
         """Match the real pool's API (sets the shutdown event; nothing to cancel)."""
+        self.shutdown_calls += 1
         self.shutdown_event.set()
 
 

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -29,7 +29,7 @@ from hephaestus.automation.pipeline.events import (
     PrReviewZeroThreadNogoEvent,
     ZeroThreadNogoAction,
 )
-from hephaestus.automation.pipeline.jobs import AgentJob, JobResult
+from hephaestus.automation.pipeline.jobs import AgentJob, JobHandle, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName, StageOutcome
 from hephaestus.automation.pipeline.seeding import SeedEntry
 from hephaestus.automation.pipeline.stages import Continue
@@ -271,6 +271,91 @@ class TestQuiescence:
         reasons = sorted(result.reason for result in coordinator.ledger)
         assert any(reason.startswith("poisoned: boom") for reason in reasons)
         assert any(reason == "fine" for reason in reasons)
+
+
+def _fake_in_flight_item(coordinator: Coordinator, item: WorkItem) -> JobHandle:
+    """Register *item* as in-flight under a synthetic handle (no real submit)."""
+    handle = JobHandle(
+        job=AgentJob(
+            repo=item.repo,
+            issue=item.issue or 0,
+            agent="claude",
+            model="m",
+            prompt_builder=lambda **_kw: "p",
+            cwd=Path("."),
+            timeout_s=1,
+        ),
+        on_done_state=item.stage,
+    )
+    coordinator.in_flight[handle] = item
+    coordinator.inflight_per_repo[item.repo] += 1
+    return handle
+
+
+class TestFatalTeardown:
+    """Fatal-exception exit must reap the pool + park in-flight items (#2059)."""
+
+    def test_fatal_exception_shuts_down_pool_and_parks_in_flight(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fatal (non-signal) exit cancels the pool and never leaks in-flight work.
+
+        Before #2059, ``run()``'s finally only reaped on the signal path
+        (``self.shutdown`` set), so a fatal exception left the executor and its
+        in-flight AgentJob subprocesses running.
+        """
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch)
+        in_flight = _issue_item(42, StageName.IMPLEMENTATION)
+        _fake_in_flight_item(coordinator, in_flight)
+
+        def boom() -> None:
+            raise RuntimeError("fatal boom")
+
+        # Raise OUTSIDE _run_item's per-item guard so it reaches run()'s except.
+        monkeypatch.setattr(coordinator, "_drain_queues", boom)
+
+        exit_code = coordinator.run()
+
+        # Fatal, not interrupt: shutdown must NOT be set (would mis-report 130).
+        assert not coordinator.shutdown.is_set()
+        assert coordinator._fatal is True
+        assert exit_code == 1
+        # Pool reaped exactly once; in-flight maps cleared.
+        assert pool.shutdown_calls == 1
+        assert coordinator.in_flight == {}
+        assert not coordinator.inflight_per_repo
+        # The in-flight item was parked RESUMABLE (never silently dropped).
+        assert in_flight.result is not None
+        assert not in_flight.result.passed
+        assert in_flight.result.reason == "resumable at implementation"
+
+    def test_signal_teardown_shuts_down_pool_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Signal path + finally must not double-shutdown the pool (idempotent guard)."""
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch)
+        in_flight = _issue_item(7, StageName.IMPLEMENTATION)
+        _fake_in_flight_item(coordinator, in_flight)
+
+        # Trip an immediate (second-signal) shutdown before the first tick's
+        # top-of-loop check, so _teardown_immediate runs and breaks the loop.
+        original_seed = coordinator._seed_pass
+
+        def seed_then_immediate() -> int:
+            pushed = original_seed()
+            coordinator._immediate = True
+            return pushed
+
+        monkeypatch.setattr(coordinator, "_seed_pass", seed_then_immediate)
+
+        exit_code = coordinator.run()
+
+        assert coordinator.shutdown.is_set()
+        assert exit_code == 130  # interrupt
+        assert pool.shutdown_calls == 1  # _teardown_immediate + finally == once
+        assert coordinator.in_flight == {}
+        assert in_flight.result is not None
+        assert in_flight.result.reason == "resumable at implementation"
 
 
 class TestJournalOrder:

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -6,12 +6,13 @@ import logging
 import os
 import queue
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Iterator
 from concurrent.futures import Future
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1533,3 +1534,54 @@ class TestOnFutureDone:
         assert result.error is not None
         assert result.error.startswith("worker_crash: RuntimeError: ")
         assert len(result.error) == small_err_max
+
+
+@pytest.mark.skipif(
+    not hasattr(os, "killpg"), reason="process-group termination unavailable on this platform"
+)
+class TestShutdownReapsSubprocess:
+    """WorkerPool.shutdown() SIGTERMs in-flight agent process groups (#2059)."""
+
+    def test_shutdown_terminates_running_agent_subprocess_fast(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """A slow claude job is reaped by shutdown() instead of running to timeout.
+
+        Regression for the #2059 leak: before the fix, ``pool.shutdown()`` only
+        cancelled un-started futures — a job already blocked in a claude
+        subprocess kept running. Now the child is spawned via the real
+        ``_run_tracked`` (process group + registry) and SIGTERMed on shutdown.
+        """
+        from hephaestus.automation import claude_invoke
+
+        started = threading.Event()
+        real_run_tracked = claude_invoke._run_tracked
+        # A 60s sleeper stands in for a wedged claude reviewer.
+        sleeper = [sys.executable, "-c", "import time; time.sleep(60)"]
+
+        def fake_run_tracked(_cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            started.set()
+            # Swap the "claude" binary for a real long-lived Python sleeper but
+            # keep the REAL _run_tracked spawn (Popen + process-group tracking).
+            return real_run_tracked(list(sleeper), **kwargs)
+
+        job = _agent_job(model="reap-test", timeout_s=60, session_agent="implementer")
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(f"{_WP}.claude_invoke._run_tracked", side_effect=fake_run_tracked),
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            assert started.wait(timeout=10), "agent subprocess never started"
+            time.sleep(0.2)  # let the child settle inside communicate()
+
+            t0 = time.monotonic()
+            pool.shutdown()
+            _handle, result = completion_q.get(timeout=10)
+            elapsed = time.monotonic() - t0
+
+        # Reaped well under the 60s sleep (SIGTERM, not timeout).
+        assert elapsed < 15, f"shutdown did not reap the subprocess fast ({elapsed:.1f}s)"
+        assert result.ok is False
+        assert result.interrupted is True

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hephaestus.automation import claude_invoke
 from hephaestus.automation.agent_config import OPUS_48
 from hephaestus.automation.claude_invoke import (
     _session_expired,
@@ -28,7 +29,7 @@ from hephaestus.automation.session_naming import (
 
 
 def _argv(call_args_list_entry: Any) -> list[str]:
-    """Extract argv from a ``subprocess.run`` call recorded by mock."""
+    """Extract argv from a ``subprocess.run`` call recorded by mock (the _run_tracked seam)."""
     if hasattr(call_args_list_entry, "args"):
         call_args = call_args_list_entry.args
     else:
@@ -39,7 +40,7 @@ def _argv(call_args_list_entry: Any) -> list[str]:
 @pytest.fixture
 def stub_run() -> Generator[MagicMock, None, None]:
     """Patch subprocess.run to return a successful result."""
-    with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
+    with patch("hephaestus.automation.claude_invoke._run_tracked") as m:
         m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
         yield m
 
@@ -153,7 +154,7 @@ class TestCreateThenResume:
         err = subprocess.CalledProcessError(
             returncode=2, cmd=["claude"], output="", stderr="some error"
         )
-        with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=err) as m:
+        with patch("hephaestus.automation.claude_invoke._run_tracked", side_effect=err) as m:
             with pytest.raises(subprocess.CalledProcessError):
                 invoke_claude_with_session(
                     repo="R",
@@ -255,7 +256,7 @@ class TestArgvAssembly:
         assert argv[-1] == "--print"
         # stdin kwarg carries the prompt
         kwargs = stub_run.call_args.kwargs
-        assert kwargs["input"] == "the-prompt"
+        assert kwargs["stdin_text"] == "the-prompt"
 
     def test_claudecode_env_cleared(
         self, stub_run: MagicMock, fake_home: Path, monkeypatch: pytest.MonkeyPatch
@@ -290,7 +291,7 @@ class TestRecreateOnResumeFailureToggle:
             returncode=1, cmd=["claude"], output="", stderr="session not found"
         )
         for toggle in (True, False):
-            with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom) as m:
+            with patch("hephaestus.automation.claude_invoke._run_tracked", side_effect=boom) as m:
                 with pytest.raises(subprocess.CalledProcessError):
                     invoke_claude_with_session(
                         repo="R",
@@ -324,7 +325,7 @@ class TestEndToEndSessionResume:
             return MagicMock(stdout="ok", stderr="", returncode=0)
 
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run", side_effect=_side_effect
+            "hephaestus.automation.claude_invoke._run_tracked", side_effect=_side_effect
         ) as m:
             _, sid1 = invoke_claude_with_session(
                 repo="Scylla",
@@ -372,7 +373,7 @@ class TestEndToEndSessionResume:
         # Existing transcript → resume path.
         _make_existing_jsonl(fake_home, cwd, expected_sid)
 
-        with patch("hephaestus.automation.claude_invoke.subprocess.run") as m:
+        with patch("hephaestus.automation.claude_invoke._run_tracked") as m:
             m.return_value = MagicMock(stdout="ok", stderr="", returncode=0)
             _, returned_sid = invoke_claude_with_session(
                 repo="R",
@@ -430,7 +431,7 @@ class TestModelCapFallback:
         cwd.mkdir()
         ok = MagicMock(stdout="fallback-ok", stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=[_cap_error(), ok],
         ) as m:
             with caplog.at_level(logging.WARNING, logger="hephaestus.automation.claude_invoke"):
@@ -461,7 +462,7 @@ class TestModelCapFallback:
         capped = MagicMock(stdout=_cap_envelope(), stderr="", returncode=0)
         ok = MagicMock(stdout='{"result": "ok"}', stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=[capped, ok],
         ) as m:
             out, _sid = invoke_claude_with_session(
@@ -484,7 +485,7 @@ class TestModelCapFallback:
         cwd.mkdir()
         ok = MagicMock(stdout="ok", stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=[_cap_error(), ok],
         ):
             invoke_claude_with_session(
@@ -496,7 +497,7 @@ class TestModelCapFallback:
                 cwd=cwd,
             )
         assert is_model_capped("claude-fable-5") is True
-        with patch("hephaestus.automation.claude_invoke.subprocess.run", return_value=ok) as m2:
+        with patch("hephaestus.automation.claude_invoke._run_tracked", return_value=ok) as m2:
             invoke_claude_with_session(
                 repo="R",
                 issue=2,
@@ -514,7 +515,7 @@ class TestModelCapFallback:
         cwd = fake_home / "work"
         cwd.mkdir()
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=_cap_error(),
         ) as m:
             with pytest.raises(subprocess.CalledProcessError):
@@ -539,7 +540,7 @@ class TestModelCapFallback:
         cwd.mkdir()
         capped = MagicMock(stdout=_cap_envelope(), stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=[capped, capped],
         ) as m:
             out, _sid = invoke_claude_with_session(
@@ -562,7 +563,7 @@ class TestModelCapFallback:
         boom = subprocess.CalledProcessError(
             returncode=1, cmd=["claude"], output="", stderr="API Error: 529 Overloaded"
         )
-        with patch("hephaestus.automation.claude_invoke.subprocess.run", side_effect=boom) as m:
+        with patch("hephaestus.automation.claude_invoke._run_tracked", side_effect=boom) as m:
             with pytest.raises(subprocess.CalledProcessError):
                 invoke_claude_with_session(
                     repo="R",
@@ -580,7 +581,7 @@ class TestModelCapFallback:
         cwd.mkdir()
         envelope = json.dumps({"is_error": True, "result": "tool execution failed"})
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             return_value=MagicMock(stdout=envelope, stderr="", returncode=0),
         ) as m:
             out, _sid = invoke_claude_with_session(
@@ -604,7 +605,7 @@ class TestModelCapFallback:
         cwd = fake_home / "work"
         cwd.mkdir()
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             return_value=MagicMock(
                 stdout="the fix mentions /usage-credits handling", stderr="", returncode=0
             ),
@@ -627,7 +628,7 @@ class TestModelCapFallback:
         cwd.mkdir()
         ok = MagicMock(stdout="ok", stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=[_cap_error(), ok],
         ):
             _, sid = invoke_claude_with_session(
@@ -649,7 +650,7 @@ class TestModelCapFallback:
         monkeypatch.setenv("HEPH_FALLBACK_MODEL", "claude-haiku-4-5")
         ok = MagicMock(stdout="ok", stderr="", returncode=0)
         with patch(
-            "hephaestus.automation.claude_invoke.subprocess.run",
+            "hephaestus.automation.claude_invoke._run_tracked",
             side_effect=[_cap_error(), ok],
         ) as m:
             invoke_claude_with_session(
@@ -704,8 +705,8 @@ class TestPromptNullByteSanitization:
             input_via_stdin=True,
         )
         kwargs = stub_run.call_args.kwargs
-        assert kwargs["input"] == "plan thisissue"
-        assert "\x00" not in kwargs["input"]
+        assert kwargs["stdin_text"] == "plan thisissue"
+        assert "\x00" not in kwargs["stdin_text"]
 
     def test_real_subprocess_does_not_raise_with_null_byte(
         self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
@@ -716,20 +717,25 @@ class TestPromptNullByteSanitization:
         no-op (``sys.executable -c ""``, always present — unlike ``true``) so the
         call succeeds; WITHOUT the fix, argv marshaling raises
         ``ValueError: embedded null byte`` here and never reaches the child.
+
+        The real :func:`~hephaestus.automation.claude_invoke._run_tracked` still
+        runs (Popen + process-group tracking) — only the binary is swapped — so
+        the actual argv/stdin marshaling and the #2059 spawn path are exercised.
         """
         cwd = fake_home / "work"
         cwd.mkdir()
 
-        real_run = subprocess.run
+        real_run_tracked = claude_invoke._run_tracked
         noop = [sys.executable, "-c", ""]
 
         def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
             # Swap the "claude" binary for a guaranteed no-op while preserving the
-            # rest of argv verbatim — so the real argv/stdin marshaling (which
-            # raised the original ValueError) is still exercised.
-            return real_run([*noop, *cmd[1:]], **kwargs)
+            # rest of argv verbatim, then delegate to the REAL _run_tracked so the
+            # argv/stdin marshaling (which raised the original ValueError) and the
+            # Popen/process-group spawn are still exercised end-to-end.
+            return real_run_tracked([*noop, *cmd[1:]], **kwargs)
 
-        monkeypatch.setattr("hephaestus.automation.claude_invoke.subprocess.run", fake_run)
+        monkeypatch.setattr("hephaestus.automation.claude_invoke._run_tracked", fake_run)
 
         out, _sid = invoke_claude_with_session(
             repo="R",

--- a/tests/unit/automation/test_subprocess_registry.py
+++ b/tests/unit/automation/test_subprocess_registry.py
@@ -1,0 +1,92 @@
+"""Tests for the live agent subprocess-group registry (#2059)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+
+import pytest
+
+from hephaestus.automation import subprocess_registry as reg
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Each test starts and ends with an empty registry."""
+    reg.terminate_all()  # clear any leakage from prior tests (no-op if empty)
+    yield
+    reg.terminate_all()
+
+
+skip_no_pg = pytest.mark.skipif(not reg.supported(), reason="process groups unavailable")
+
+
+def test_terminate_all_empty_returns_zero() -> None:
+    """Signalling with nothing tracked is a safe no-op."""
+    assert reg.terminate_all() == 0
+    assert reg.live_count() == 0
+
+
+@skip_no_pg
+def test_track_registers_and_unregisters_on_exit() -> None:
+    """A tracked pid is live inside the block and gone after it."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    try:
+        with reg.track_process_group(proc.pid):
+            assert reg.live_count() == 1
+        # Context exit unregisters even though the child is still alive.
+        assert reg.live_count() == 0
+    finally:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+@skip_no_pg
+def test_terminate_all_kills_tracked_group() -> None:
+    """terminate_all sends SIGTERM to the tracked group, killing the child fast."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import time; time.sleep(30)"],
+        start_new_session=True,
+    )
+    reg._register(os.getpgid(proc.pid))
+    assert reg.live_count() == 1
+
+    signalled = reg.terminate_all()
+
+    assert signalled == 1
+    assert reg.live_count() == 0  # registry cleared
+    # Child dies from SIGTERM promptly (not after its 30s sleep).
+    proc.wait(timeout=5)
+    assert proc.returncode is not None
+    assert proc.returncode != 0  # terminated by signal
+
+
+@skip_no_pg
+def test_terminate_all_skips_already_exited_group() -> None:
+    """A group whose leader already exited is skipped without error."""
+    proc = subprocess.Popen([sys.executable, "-c", ""], start_new_session=True)
+    pgid = os.getpgid(proc.pid)
+    proc.wait(timeout=5)
+    # Give the OS a moment to reap the group leader.
+    time.sleep(0.05)
+    reg._register(pgid)
+
+    # No exception even though the group is gone; count may be 0 or 1.
+    signalled = reg.terminate_all()
+
+    assert signalled in (0, 1)
+    assert reg.live_count() == 0
+
+
+def test_track_no_pg_platform_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On a platform without killpg, tracking is a no-op and terminate returns 0."""
+    monkeypatch.setattr(reg, "_HAVE_KILLPG", False)
+    with reg.track_process_group(999999):
+        assert reg.live_count() == 0
+    assert reg.terminate_all() == 0


### PR DESCRIPTION
## Summary

`PipelineCoordinator.run()` only shut the worker pool down on the **signal** path (`_teardown_immediate`, gated on `self.shutdown`). A **fatal exception** sets `self._fatal` but never `self.shutdown`, so the `finally` block's `_finalize_resumable()` early-returned and `pool.shutdown()` was never called — **leaking the executor and any in-flight `AgentJob` subprocesses** (e.g. `claude` reviewers).

Observed live: after the #2057 crash, `run_end` fired with `exit_code 1` but a `claude` PR-reviewer child kept running ~19 minutes, holding the process open until it happened to finish.

## Change

- Extract an idempotent `_shutdown_pool()` (guarded by `_pool_shut_down`) that cancels the pool and parks in-flight items RESUMABLE.
- Call it from `run()`'s `finally` on **every** exit path (`_teardown_immediate` also routes through it).
- `_finalize_resumable()` now also runs when `self._fatal` is set.
- Crucially, the fatal path does **not** set `self.shutdown`, so `_exit_code()` still reports `1` (fatal), not `130` (interrupt).

## Testing (TDD)

- `test_fatal_exception_shuts_down_pool_and_parks_in_flight` — verified RED without the fix (pool never reaped), GREEN with it. Asserts pool shut down exactly once, in-flight maps cleared, in-flight item parked RESUMABLE, `shutdown` NOT set, exit code `1`.
- `test_signal_teardown_shuts_down_pool_once` — signal path stays single-shutdown (idempotency guard against signal-then-`finally`).
- `pixi run pytest tests/unit/automation/pipeline/` — 838 passed.
- `pixi run mypy` clean (544 files); `ruff` + pre-commit clean on changed files.

Follow-up from #2057 (which fixed the crash that surfaced this leak). Independent — hardens teardown for any fatal exit.

Closes #2059