### PR TITLE
chore: drop 'Project' prefix from all repo-name references

### DIFF
--- a/.fleet.yml
+++ b/.fleet.yml
@@ -4,16 +4,16 @@ org: HomericIntelligence
 repos:
   - Odysseus
   - AchaeanFleet
-  - ProjectArgus
-  - ProjectHermes
-  - ProjectTelemachy
-  - ProjectKeystone
+  - Argus
+  - Hermes
+  - Telemachy
+  - Keystone
   - Myrmidons
-  - ProjectProteus
-  - ProjectOdyssey
-  - ProjectScylla
-  - ProjectMnemosyne
+  - Proteus
+  - Odyssey
+  - Scylla
+  - Mnemosyne
   - Hephaestus
-  - ProjectAgamemnon
-  - ProjectNestor
-  - ProjectCharybdis
+  - Agamemnon
+  - Nestor
+  - Charybdis

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,15 +10,15 @@ Hephaestus is the shared utilities and tooling repository of the HomericIntellig
 
 **Role in Ecosystem**:
 
-- ProjectOdyssey → Training and capability development
-- ProjectKeystone → Automated task DAG execution
-- ProjectScylla → Testing, measurement, and optimization
-- ProjectMnemosyne → Knowledge, skills, and memory preservation
-- ProjectHermes → Agent communication and message routing
-- ProjectArgus → Observability, monitoring, and alerting
-- ProjectProteus → Dynamic configuration and environment adaptation
-- ProjectMyrmidons → Agent swarm coordination and task distribution
-- ProjectAchaeanFleet → Multi-agent fleet orchestration
+- Odyssey → Training and capability development
+- Keystone → Automated task DAG execution
+- Scylla → Testing, measurement, and optimization
+- Mnemosyne → Knowledge, skills, and memory preservation
+- Hermes → Agent communication and message routing
+- Argus → Observability, monitoring, and alerting
+- Proteus → Dynamic configuration and environment adaptation
+- Myrmidons → Agent swarm coordination and task distribution
+- AchaeanFleet → Multi-agent fleet orchestration
 - **Hephaestus → Shared utilities, tooling, and foundational components**
 
 ## Repository Structure
@@ -254,8 +254,8 @@ takes no argument.
 | Skill | Arguments | When to Use |
 |-------|-----------|-------------|
 | `skill-advisor` | `<task description>` | Before any task — routes to the correct skill |
-| `advise` | `<task description>` | Before starting work — search ProjectMnemosyne for prior learnings |
-| `learn` | — | After completing work — capture session learnings in ProjectMnemosyne |
+| `advise` | `<task description>` | Before starting work — search Mnemosyne for prior learnings |
+| `learn` | — | After completing work — capture session learnings in Mnemosyne |
 | `myrmidon-swarm` | `<task description>` | Complex multi-step tasks requiring parallel agent coordination |
 | `brainstorm` | `<idea or feature description>` | Before implementing a new feature — design before code |
 | `test-driven-development` | `<feature or bugfix description>` | Before writing implementation code — RED-GREEN-REFACTOR |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ print(hephaestus.__version__)
 > **Upgrading?** When moving across a major version, read the
 > [migration guide](docs/MIGRATION.md) for required consumer changes.
 >
-> **Note on naming.** `pip install hephaestus` and `pip install hephaestus` will **not** find this package — both names are unowned on PyPI. The `HomericIntelligence-<Project>` prefix is the deliberate naming convention shared across the HomericIntelligence ecosystem (ProjectKeystone, ProjectOdyssey, etc.) to avoid PyPI namespace collisions. Wheel filenames are PEP 625 normalized to lowercase, so you will see `homericintelligence_hephaestus-<version>-py3-none-any.whl` on disk and in release assets.
+> **Note on naming.** `pip install hephaestus` will **not** find this package — the bare name is unowned on PyPI. The `HomericIntelligence-<Name>` prefix is the deliberate naming convention shared across the HomericIntelligence ecosystem (Keystone, Odyssey, etc.) to avoid PyPI namespace collisions; the distribution is `HomericIntelligence-Hephaestus`. Wheel filenames are PEP 625 normalized to lowercase, so you will see `homericintelligence_hephaestus-<version>-py3-none-any.whl` on disk and in release assets.
 
 ### Optional dependencies
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,17 +30,17 @@ Assuming audit remediation is complete:
    GitHub Pages on each release (pdoc). Remaining: ensure every public function carries a
    complete docstring, including stable subpackage surfaces and a full CLI reference.
 
-4. **Observability and Health Checks** — Add structured health reporting for long-running components (e.g., NATSSubscriberThread), supporting the broader ProjectArgus (observability) initiative.
+4. **Observability and Health Checks** — Add structured health reporting for long-running components (e.g., NATSSubscriberThread), supporting the broader Argus (observability) initiative.
 
 ## Long-term (4+ Quarters Out)
 
 Conservative, directional items:
 
-1. **Agent Coordination Framework** — Explore deeper integration with ProjectMyrmidons for agent swarm coordination patterns, building on existing entry points for orchestration.
+1. **Agent Coordination Framework** — Explore deeper integration with Myrmidons for agent swarm coordination patterns, building on existing entry points for orchestration.
 
 2. **Benchmark Suite Expansion** — Enhance the benchmark comparison utilities to support cross-project performance tracking and regression detection.
 
-3. **Configuration Ecosystem** — Investigate dynamic configuration patterns (ProjectProteus integration) and configuration composition across multiple environments.
+3. **Configuration Ecosystem** — Investigate dynamic configuration patterns (Proteus integration) and configuration composition across multiple environments.
 
 ## How We Plan
 
@@ -48,7 +48,7 @@ Hephaestus uses an Epic-and-children issue pattern for project planning. Major i
 
 **Exemplar:** Epic #310 (Strict audit 2026-04-28, now closed) contained 29 child issues spanning all 15 audit dimensions, with clear scoping and evidence-based requirements.
 
-We also capture session learnings in ProjectMnemosyne via the `/learn` skill, preserving team knowledge about patterns, anti-patterns, and decisions across the ecosystem.
+We also capture session learnings in Mnemosyne via the `/learn` skill, preserving team knowledge about patterns, anti-patterns, and decisions across the ecosystem.
 
 ## Updating This Roadmap
 

--- a/hephaestus/automation/_implement_phase.py
+++ b/hephaestus/automation/_implement_phase.py
@@ -79,7 +79,7 @@ class ImplementPhase(StageMixin):
         self.ctx = ctx
 
     def _run_advise(self, issue_number: int, issue_title: str, issue_body: str) -> str:
-        """Select ProjectMnemosyne skills and return prompt-ready context."""
+        """Select Mnemosyne skills and return prompt-ready context."""
 
         def _invoke(prompt: str) -> str:
             if uses_direct_agent_runner(self.options.agent):

--- a/hephaestus/automation/_plan_phase.py
+++ b/hephaestus/automation/_plan_phase.py
@@ -111,7 +111,7 @@ class PlanPhase(StageMixin):
             )
             return
 
-        # Legacy fallback: local scripts/plan_issues.py (ProjectScylla layout)
+        # Legacy fallback: local scripts/plan_issues.py (Scylla layout)
         plan_script = self.repo_root / "scripts" / "plan_issues.py"
         if plan_script.exists():
             run(

--- a/hephaestus/automation/advise_runner.py
+++ b/hephaestus/automation/advise_runner.py
@@ -1,7 +1,7 @@
 """Shared advise runner for every pipeline stage.
 
 Each of the three session-stable stages (plan, implement, drive-green) begins
-with an advise step that searches ProjectMnemosyne for relevant prior
+with an advise step that searches Mnemosyne for relevant prior
 learnings before doing any work. The Mnemosyne clone/refresh, prompt
 construction, and skip-marker conventions are identical across stages, so they
 live here once (DRY) rather than being copied into each stage's advise step.
@@ -12,7 +12,7 @@ prompt and returns the agent's JSON output; this module owns everything around
 it.
 
 Each stage gets the same result shape: a bounded ``## Selected Team Skills``
-context block assembled from local ProjectMnemosyne skill files and injected
+context block assembled from local Mnemosyne skill files and injected
 explicitly into the downstream prompt.
 """
 
@@ -79,17 +79,17 @@ def advise_skipped(reason: str) -> str:
 
 
 def default_mnemosyne_root() -> Path:
-    """Return the shared ProjectMnemosyne checkout root."""
-    return Path.home() / ".agent-brain" / "ProjectMnemosyne"
+    """Return the shared Mnemosyne checkout root."""
+    return Path.home() / ".agent-brain" / "Mnemosyne"
 
 
 def _clone_mnemosyne(mnemosyne_root: Path) -> bool:
-    """Clone the resolved ProjectMnemosyne repository into ``mnemosyne_root``.
+    """Clone the resolved Mnemosyne repository into ``mnemosyne_root``.
 
     The clone target is resolved via
     :func:`hephaestus.github.mnemosyne_repo.resolve_mnemosyne_target`, which
     prefers the gh-authenticated user's own fork (creating it if needed) and
-    falls back to the upstream ``HomericIntelligence/ProjectMnemosyne``.
+    falls back to the upstream ``HomericIntelligence/Mnemosyne``.
     """
     timeout_s = agent_clone_timeout()
     target = resolve_mnemosyne_target()
@@ -109,20 +109,20 @@ def _clone_mnemosyne(mnemosyne_root: Path) -> bool:
         return True
     except subprocess.TimeoutExpired:
         logger.warning(
-            "gh repo clone timed out after %s s; ProjectMnemosyne unavailable this run",
+            "gh repo clone timed out after %s s; Mnemosyne unavailable this run",
             timeout_s,
         )
         return False
     except subprocess.CalledProcessError as e:
-        logger.warning("Failed to clone ProjectMnemosyne: %s", e.stderr or e)
+        logger.warning("Failed to clone Mnemosyne: %s", e.stderr or e)
         return False
     except (RuntimeError, OSError) as e:
-        logger.warning("Failed to clone ProjectMnemosyne: %s", e)
+        logger.warning("Failed to clone Mnemosyne: %s", e)
         return False
 
 
 def _is_valid_mnemosyne_checkout(mnemosyne_root: Path) -> bool:
-    """Return True when an existing ProjectMnemosyne path is a usable git checkout."""
+    """Return True when an existing Mnemosyne path is a usable git checkout."""
     timeout_s = agent_git_timeout()
     try:
         result = subprocess.run(
@@ -133,11 +133,11 @@ def _is_valid_mnemosyne_checkout(mnemosyne_root: Path) -> bool:
             timeout=timeout_s,
         )
     except (subprocess.SubprocessError, OSError) as e:
-        logger.warning("Failed to validate ProjectMnemosyne checkout at %s: %s", mnemosyne_root, e)
+        logger.warning("Failed to validate Mnemosyne checkout at %s: %s", mnemosyne_root, e)
         return False
     if result.returncode != 0 or result.stdout.strip() != "true":
         logger.warning(
-            "ProjectMnemosyne checkout at %s is invalid; stderr=%s",
+            "Mnemosyne checkout at %s is invalid; stderr=%s",
             mnemosyne_root,
             (result.stderr or "").strip(),
         )
@@ -146,13 +146,13 @@ def _is_valid_mnemosyne_checkout(mnemosyne_root: Path) -> bool:
 
 
 def ensure_mnemosyne(mnemosyne_root: Path) -> bool:
-    """Clone ProjectMnemosyne if absent, else fast-forward the existing clone.
+    """Clone Mnemosyne if absent, else fast-forward the existing clone.
 
     Uses an in-process lock plus a POSIX ``fcntl`` file lock so that multiple
     parallel workers (and multiple stages) never race on the shared checkout.
 
     Args:
-        mnemosyne_root: Expected local path for ProjectMnemosyne.
+        mnemosyne_root: Expected local path for Mnemosyne.
 
     Returns:
         True if the directory exists (or was cloned successfully), else False.
@@ -173,7 +173,7 @@ def ensure_mnemosyne(mnemosyne_root: Path) -> bool:
                 if mnemosyne_root.exists():
                     if not _is_valid_mnemosyne_checkout(mnemosyne_root):
                         logger.warning(
-                            "Removing invalid ProjectMnemosyne checkout at %s before re-clone",
+                            "Removing invalid Mnemosyne checkout at %s before re-clone",
                             mnemosyne_root,
                         )
                         shutil.rmtree(mnemosyne_root, ignore_errors=True)
@@ -187,10 +187,10 @@ def ensure_mnemosyne(mnemosyne_root: Path) -> bool:
                                 text=True,
                                 timeout=timeout_s,
                             )
-                            logger.debug("ProjectMnemosyne refreshed at %s", mnemosyne_root)
+                            logger.debug("Mnemosyne refreshed at %s", mnemosyne_root)
                         except Exception as e:
                             logger.warning(
-                                "Failed to refresh ProjectMnemosyne (using existing clone): %s",
+                                "Failed to refresh Mnemosyne (using existing clone): %s",
                                 e,
                             )
                         return True
@@ -220,14 +220,14 @@ def resolve_marketplace(mnemosyne_root: Path) -> tuple[Path | None, str]:
 
     """
     if not mnemosyne_root.exists() and not ensure_mnemosyne(mnemosyne_root):
-        return None, "ProjectMnemosyne unavailable"
+        return None, "Mnemosyne unavailable"
 
     marketplace_path = mnemosyne_root / ".claude-plugin" / "marketplace.json"
     if marketplace_path.exists():
         return marketplace_path, ""
 
     logger.warning(
-        "Marketplace file not found at %s; attempting recovery re-clone of ProjectMnemosyne",
+        "Marketplace file not found at %s; attempting recovery re-clone of Mnemosyne",
         marketplace_path,
     )
     shutil.rmtree(mnemosyne_root, ignore_errors=True)
@@ -298,7 +298,7 @@ def marketplace_prompt_payload(marketplace_path: Path) -> str:
     try:
         data = json.loads(marketplace_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("Failed to read ProjectMnemosyne marketplace %s: %s", marketplace_path, exc)
+        logger.warning("Failed to read Mnemosyne marketplace %s: %s", marketplace_path, exc)
         return '{"plugins": []}'
 
     plugins = data.get("plugins")
@@ -339,7 +339,7 @@ def _validate_skill_source(mnemosyne_root: Path, source: str) -> Path | None:
     """Return a safe local skill path for a marketplace source, or ``None``."""
     source_path = Path(source)
     if source_path.is_absolute() or ".." in source_path.parts:
-        logger.warning("Ignoring unsafe ProjectMnemosyne skill source: %s", source)
+        logger.warning("Ignoring unsafe Mnemosyne skill source: %s", source)
         return None
 
     try:
@@ -347,11 +347,11 @@ def _validate_skill_source(mnemosyne_root: Path, source: str) -> Path | None:
         candidate = (mnemosyne_root / source_path).resolve(strict=False)
         candidate.relative_to(skills_root)
     except ValueError:
-        logger.warning("Ignoring non-skill ProjectMnemosyne source: %s", source)
+        logger.warning("Ignoring non-skill Mnemosyne source: %s", source)
         return None
 
     if not candidate.is_file():
-        logger.warning("Ignoring missing ProjectMnemosyne skill source: %s", candidate)
+        logger.warning("Ignoring missing Mnemosyne skill source: %s", candidate)
         return None
     return candidate
 
@@ -406,7 +406,7 @@ def format_selected_skill_context(
         [
             "## Selected Team Skills",
             "",
-            "These ProjectMnemosyne skills were selected for this issue. "
+            "These Mnemosyne skills were selected for this issue. "
             + "Apply only the relevant guidance.",
         ]
     )
@@ -424,7 +424,7 @@ def format_selected_skill_context(
         try:
             content = skill.path.read_text(encoding="utf-8", errors="replace")
         except OSError as exc:
-            logger.warning("Failed to read selected ProjectMnemosyne skill %s: %s", skill.path, exc)
+            logger.warning("Failed to read selected Mnemosyne skill %s: %s", skill.path, exc)
             continue
 
         separator_len = 1
@@ -457,7 +457,7 @@ def run_advise(
 ) -> str:
     """Run skill selection and return prompt-ready context (or a skip marker).
 
-    Locates ProjectMnemosyne (cloning/refreshing as needed), builds a compact
+    Locates Mnemosyne (cloning/refreshing as needed), builds a compact
     marketplace-selection prompt, invokes the selected agent, validates the JSON
     response, then reads the selected skill files locally. Any failure degrades
     to an :func:`advise_skipped` marker so a stage never aborts just because

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -449,7 +449,7 @@ def session_name(repo: str, issue: int | str, agent: str, model: str | None = No
     every time main advances (#841).
 
     Args:
-        repo: Repository slug without owner (e.g. ``"ProjectScylla"``).
+        repo: Repository slug without owner (e.g. ``"Scylla"``).
         issue: Issue number; leading ``#`` is stripped.
         agent: One of the ``AGENT_*`` constants in this module.
         model: Optional model id; appended to the key when given so sessions

--- a/hephaestus/automation/ci_fix_flow.py
+++ b/hephaestus/automation/ci_fix_flow.py
@@ -58,7 +58,7 @@ class CIFixFlow:
         self._get_pr_branch = get_pr_branch
 
     def run_advise(self, issue_number: int) -> str:
-        """Pull prior learnings from ProjectMnemosyne before a CI-fix loop."""
+        """Pull prior learnings from Mnemosyne before a CI-fix loop."""
         issue_data = self._gh_issue_json(issue_number)
         issue_title = issue_data.get("title", f"Issue #{issue_number}")
         issue_body = issue_data.get("body", "")

--- a/hephaestus/automation/claude_invoke.py
+++ b/hephaestus/automation/claude_invoke.py
@@ -191,7 +191,7 @@ def invoke_claude_with_session(
     existing quota/overload handling takes over.
 
     Args:
-        repo: Repository slug (e.g. ``"ProjectScylla"``).
+        repo: Repository slug (e.g. ``"Scylla"``).
         issue: Issue number — leading ``#`` is stripped by
             :func:`session_naming.session_name`.
         agent: One of the ``AGENT_*`` constants in

--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -16,7 +16,7 @@ Usage examples::
     hephaestus-ensure-state-labels
 
     # A specific repo:
-    hephaestus-ensure-state-labels --repo HomericIntelligence/ProjectScylla
+    hephaestus-ensure-state-labels --repo HomericIntelligence/Scylla
 
     # Every non-archived, non-fork repo in an org (with confirmation):
     hephaestus-ensure-state-labels --org HomericIntelligence

--- a/hephaestus/automation/learn.py
+++ b/hephaestus/automation/learn.py
@@ -45,19 +45,19 @@ _LEARN_RATE_LIMIT_MAX_RETRIES = 5
 _LEARN_UNKNOWN_RESET_BACKOFF_SECONDS = 300
 
 # Owner-agnostic: the Mnemosyne target may be the upstream
-# (HomericIntelligence/ProjectMnemosyne) or any user's fork
-# (<login>/ProjectMnemosyne). Only the repo name is fixed.
+# (HomericIntelligence/Mnemosyne) or any user's fork
+# (<login>/Mnemosyne). Only the repo name is fixed.
 _MNEMOSYNE_URL_RE = re.compile(
-    r"https://github\.com/[A-Za-z0-9._-]+/ProjectMnemosyne/(?:pull|commit)/[A-Za-z0-9._/-]+"
+    r"https://github\.com/[A-Za-z0-9._-]+/Mnemosyne/(?:pull|commit)/[A-Za-z0-9._/-]+"
 )
-_MNEMOSYNE_PR_REF_RE = re.compile(r"\b[A-Za-z0-9._-]+/ProjectMnemosyne#(?P<number>\d+)\b")
+_MNEMOSYNE_PR_REF_RE = re.compile(r"\b[A-Za-z0-9._-]+/Mnemosyne#(?P<number>\d+)\b")
 
 
 def mnemosyne_update_evidence(output: str) -> dict[str, Any]:
-    """Extract ProjectMnemosyne update evidence from a ``/learn`` response.
+    """Extract Mnemosyne update evidence from a ``/learn`` response.
 
-    A successful agent turn is not proof that ProjectMnemosyne changed. Treat
-    concrete ProjectMnemosyne PR/commit URLs or owner/repo issue-style PR refs
+    A successful agent turn is not proof that Mnemosyne changed. Treat
+    concrete Mnemosyne PR/commit URLs or owner/repo issue-style PR refs
     as confirmation; otherwise mark the update as unverified.
     """
     text = output if isinstance(output, str) else str(output or "")
@@ -114,10 +114,10 @@ def build_learn_prompt(context: str) -> str:
     suffix = f" {detail}" if detail else ""
     return (
         "/learn"
-        " EXECUTE the /learn skill-creation workflow for ProjectMnemosyne."
+        " EXECUTE the /learn skill-creation workflow for Mnemosyne."
         " Do NOT return a plan. Do NOT ask for approval."
         " Commit the results and create a PR."
-        " IMPORTANT: Only push skills to the resolved ProjectMnemosyne"
+        " IMPORTANT: Only push skills to the resolved Mnemosyne"
         " repository (the gh user's own fork when available, else upstream),"
         " and open the PR against that same repository."
         " Do NOT create files under .claude-plugin/ in this repo."

--- a/hephaestus/automation/pr_review_core.py
+++ b/hephaestus/automation/pr_review_core.py
@@ -229,7 +229,7 @@ def gather_impl_review_context(
         plan_text: The implementation PLAN comment body (or "" if absent).
         plan_review_text: The PLAN_REVIEW comment body (or "" if absent).
         diff_text: ``gh pr diff`` / cumulative branch diff for the impl.
-        advise_findings: Prior ProjectMnemosyne findings from the advise step.
+        advise_findings: Prior Mnemosyne findings from the advise step.
         include_nitpicks: Forwarded into the context so the reviewer prompt
             emits nitpick-severity comments only when ``--nitpick`` is set
             (#1083).

--- a/hephaestus/automation/prompts/_shared.py
+++ b/hephaestus/automation/prompts/_shared.py
@@ -45,7 +45,7 @@ def _relativize_path(path: str, repo_root: str | None) -> str:
     try:
         return str(Path(path).relative_to(repo_root))
     except ValueError:
-        # Benign: cross-repo paths (e.g. the ProjectMnemosyne marketplace) are
+        # Benign: cross-repo paths (e.g. the Mnemosyne marketplace) are
         # expected and the absolute path works. DEBUG, not WARNING (#1556).
         _prompts_logger.debug(
             "Path %r is not under repo_root %r; injecting absolute path into prompt.",

--- a/hephaestus/automation/prompts/advise.py
+++ b/hephaestus/automation/prompts/advise.py
@@ -7,7 +7,7 @@ from hephaestus.agents.runtime import uses_direct_agent_runner
 from ._shared import _TERSE_OUTPUT_DIRECTIVE, _relativize_path
 
 ADVISE_PROMPT = """
-Search ProjectMnemosyne for relevant prior learnings before this automation stage.
+Search Mnemosyne for relevant prior learnings before this automation stage.
 
 **Issue:** #{issue_number}: {issue_title}
 
@@ -57,7 +57,7 @@ DIRECT_AGENT_ADVISE_PROMPT = (
 
 **Direct-agent automation constraints:**
 - Do not invoke `$advise`; this prompt is already the advise step.
-- Do not clone or update ProjectMnemosyne yourself; use the marketplace path above.
+- Do not clone or update Mnemosyne yourself; use the marketplace path above.
 - Do not implement, commit, push, create a PR, or modify files.
 """
 )

--- a/hephaestus/automation/prompts/planning.py
+++ b/hephaestus/automation/prompts/planning.py
@@ -289,7 +289,7 @@ def get_plan_loop_review_prompt(
         iteration: Iteration index (0, 1, or 2).
         prior_review: Previous iteration's review text, or ``None`` on iter 0.
         advise_findings: Prior team learnings from the advise step to give the
-            reviewer the same ProjectMnemosyne context the planner received.
+            reviewer the same Mnemosyne context the planner received.
 
     Returns:
         Formatted prompt for a fresh reviewer session.

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -140,7 +140,7 @@ def get_pr_review_analysis_prompt(
         issue_body: Issue body/description
         ci_status: CI check status summary
         pr_description: PR description body
-        advise_findings: Prior team learnings from ProjectMnemosyne to give the
+        advise_findings: Prior team learnings from Mnemosyne to give the
             reviewer continuity with the advise-first implementation turn.
         include_nitpicks: When False (default), the reviewer is told to OMIT
             ``nitpick``-severity comments entirely. When True (``--nitpick``),

--- a/hephaestus/automation/state/review.py
+++ b/hephaestus/automation/state/review.py
@@ -200,7 +200,7 @@ def _fetch_issue_comments_graphql(issue_number: int) -> list[dict[str, Any]]:
         Returns an empty list on any failure.
 
     """
-    # get_repo_slug returns only the short repo name (e.g. "ProjectMnemosyne");
+    # get_repo_slug returns only the short repo name (e.g. "Mnemosyne");
     # GraphQL needs the (owner, name) pair, which get_repo_info supplies.
     # PR #575 fixed this in plan_reviewer.py but missed the identical bug here,
     # crashing every implementer-side GO-gate check (#588).

--- a/hephaestus/constants.py
+++ b/hephaestus/constants.py
@@ -131,7 +131,7 @@ def agent_git_timeout() -> int:
 
 
 def agent_clone_timeout() -> int:
-    """Return the timeout for ProjectMnemosyne clone setup in seconds."""
+    """Return the timeout for Mnemosyne clone setup in seconds."""
     return read_timeout_env("HEPH_AGENT_CLONE_TIMEOUT", AGENT_CLONE_TIMEOUT)
 
 

--- a/hephaestus/github/mnemosyne_repo.py
+++ b/hephaestus/github/mnemosyne_repo.py
@@ -1,7 +1,7 @@
-"""Resolve which ProjectMnemosyne repository to clone, push to, and PR against.
+"""Resolve which Mnemosyne repository to clone, push to, and PR against.
 
-Historically every path that touched ProjectMnemosyne hardcoded
-``HomericIntelligence/ProjectMnemosyne`` as the remote, which meant only
+Historically every path that touched Mnemosyne hardcoded
+``HomericIntelligence/Mnemosyne`` as the remote, which meant only
 members of that org could use the ``/advise`` and ``/learn`` skills (and the
 automation pipeline) against a knowledge base.
 
@@ -11,9 +11,9 @@ This module makes the target portable. The resolution ladder is:
    always wins.
 2. Otherwise use the ``gh``-authenticated login. If that login *is*
    ``HomericIntelligence`` (the upstream itself), clone upstream directly — you
-   cannot fork a repo into its own org. If ``<login>/ProjectMnemosyne`` already
+   cannot fork a repo into its own org. If ``<login>/Mnemosyne`` already
    exists on GitHub, use it. Otherwise fork
-   ``HomericIntelligence/ProjectMnemosyne`` into the login's namespace and use
+   ``HomericIntelligence/Mnemosyne`` into the login's namespace and use
    the resulting fork.
 3. If the login cannot be determined, fall back to the upstream slug.
 
@@ -39,7 +39,7 @@ from hephaestus.utils.helpers import METADATA_TIMEOUT, NETWORK_TIMEOUT
 logger = logging.getLogger(__name__)
 
 UPSTREAM_OWNER = "HomericIntelligence"
-MNEMOSYNE_REPO = "ProjectMnemosyne"
+MNEMOSYNE_REPO = "Mnemosyne"
 UPSTREAM_SLUG = f"{UPSTREAM_OWNER}/{MNEMOSYNE_REPO}"
 
 #: Environment variable that overrides the resolved owner. Mirrored by the
@@ -49,12 +49,12 @@ OWNER_ENV_VAR = "HEPH_MNEMOSYNE_OWNER"
 
 @dataclass(frozen=True)
 class MnemosyneTarget:
-    """The resolved ProjectMnemosyne repository to clone, push to, and PR against.
+    """The resolved Mnemosyne repository to clone, push to, and PR against.
 
     Attributes:
         owner: The resolved owner (the ``gh`` login, an override, or
             ``HomericIntelligence`` when falling back to upstream).
-        slug: ``owner/ProjectMnemosyne`` — the clone / push / PR target.
+        slug: ``owner/Mnemosyne`` — the clone / push / PR target.
         is_fork_of_upstream: True when ``owner`` is a fork of the upstream repo
             (i.e. not ``HomericIntelligence`` itself).
 
@@ -66,7 +66,7 @@ class MnemosyneTarget:
 
 
 def _slug_for(owner: str) -> str:
-    """Return ``owner/ProjectMnemosyne`` for the given owner."""
+    """Return ``owner/Mnemosyne`` for the given owner."""
     return f"{owner}/{MNEMOSYNE_REPO}"
 
 
@@ -126,7 +126,7 @@ def remote_repo_exists(slug: str, *, timeout: int = METADATA_TIMEOUT) -> bool:
 
 
 def fork_upstream(owner: str, *, timeout: int = NETWORK_TIMEOUT) -> bool:
-    """Fork ``HomericIntelligence/ProjectMnemosyne`` into the gh user's namespace.
+    """Fork ``HomericIntelligence/Mnemosyne`` into the gh user's namespace.
 
     ``gh repo fork`` always forks into the *authenticated* user's account, so
     ``owner`` is used only for logging/sanity — the caller is expected to pass
@@ -180,7 +180,7 @@ def resolve_mnemosyne_target(
     override_owner: str | None = None,
     allow_fork: bool = True,
 ) -> MnemosyneTarget:
-    """Decide which ProjectMnemosyne repository to clone, push to, and PR against.
+    """Decide which Mnemosyne repository to clone, push to, and PR against.
 
     See the module docstring for the full precedence ladder.
 
@@ -190,7 +190,7 @@ def resolve_mnemosyne_target(
             to ``HomericIntelligence`` (or any owner) is used verbatim, with no
             fork attempt.
         allow_fork: When True (default), fork the upstream repo if the gh user
-            has no existing ``<login>/ProjectMnemosyne``. When False, skip
+            has no existing ``<login>/Mnemosyne``. When False, skip
             forking and fall back to upstream.
 
     Returns:

--- a/hephaestus/logging/formatters.py
+++ b/hephaestus/logging/formatters.py
@@ -3,7 +3,7 @@
 
 Provides a ``logging.Formatter`` subclass that outputs each log record as a
 single JSON line, suitable for ingestion by log aggregation systems such as
-Loki/Promtail in the ProjectArgus observability stack.
+Loki/Promtail in the Argus observability stack.
 
 Usage:
     import logging

--- a/scripts/choose_merge_flag.sh
+++ b/scripts/choose_merge_flag.sh
@@ -3,8 +3,8 @@
 #
 # Usage:
 #   . "<path>/scripts/choose_merge_flag.sh"
-#   MERGE_FLAG=$(choose_merge_flag [--gh-bin hephaestus-gh] HomericIntelligence/ProjectMnemosyne) || exit 1
-#   gh pr merge "$PR" --auto "$MERGE_FLAG" --repo HomericIntelligence/ProjectMnemosyne
+#   MERGE_FLAG=$(choose_merge_flag [--gh-bin hephaestus-gh] HomericIntelligence/Mnemosyne) || exit 1
+#   gh pr merge "$PR" --auto "$MERGE_FLAG" --repo HomericIntelligence/Mnemosyne
 #
 # Preference order: rebase (linear history) -> squash -> merge commit.
 # Exit codes:

--- a/scripts/shell/install.sh
+++ b/scripts/shell/install.sh
@@ -575,9 +575,9 @@ else
     fi
 fi
 
-# Mojo (ProjectOdyssey) — installed via pixi, not as a system binary
-# The mojo binary lives in ProjectOdyssey/.pixi/envs/default/bin/mojo
-ODYSSEY_DIR="${ODYSSEY_DIR:-$HOME/ProjectOdyssey}"
+# Mojo (Odyssey) — installed via pixi, not as a system binary
+# The mojo binary lives in Odyssey/.pixi/envs/default/bin/mojo
+ODYSSEY_DIR="${ODYSSEY_DIR:-$HOME/Odyssey}"
 if has_cmd mojo; then
     check_pass "mojo $(get_version mojo --version)"
 elif [[ -x "$ODYSSEY_DIR/.pixi/envs/default/bin/mojo" ]]; then
@@ -592,12 +592,12 @@ elif [[ -d "$ODYSSEY_DIR" ]]; then
             || check_warn "mojo — pixi install failed (check $ODYSSEY_DIR/pixi.toml)"
     fi
 else
-    check_skip "mojo — $ODYSSEY_DIR not found (clone ProjectOdyssey first)"
+    check_skip "mojo — $ODYSSEY_DIR not found (clone Odyssey first)"
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Section 4: Go (Atlas dashboard — worker role)
-# Required by: infrastructure/ProjectArgus/dashboard (Atlas, port 3002)
+# Required by: infrastructure/Argus/dashboard (Atlas, port 3002)
 # ═════════════════════════════════════════════════════════════════════════════
 if should_check_worker; then
     section "Go (Atlas Dashboard)"
@@ -996,11 +996,11 @@ for pytool in pre-commit ruff mypy; do
     fi
 done
 
-# Dagger CLI (ProjectProteus pipeline engine)
+# Dagger CLI (Proteus pipeline engine)
 if has_cmd dagger; then
     check_pass "dagger $(get_version dagger version 2>/dev/null || echo installed)"
 else
-    check_warn "dagger — NOT FOUND (required by ProjectProteus)"
+    check_warn "dagger — NOT FOUND (required by Proteus)"
     if $INSTALL; then
         echo -e "    ${BLUE}→${NC} Installing Dagger CLI..."
         sha=""; goos=""; goarch=""
@@ -1033,11 +1033,11 @@ else
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
-# Section 10: Observability stack (worker role — ProjectArgus)
+# Section 10: Observability stack (worker role — Argus)
 # Checks that container images are available for the monitoring stack
 # ═════════════════════════════════════════════════════════════════════════════
 if should_check_worker; then
-    section "Observability (ProjectArgus)"
+    section "Observability (Argus)"
 
     # The observability stack runs via podman/docker compose — just verify
     # the container runtime is available (already checked in Section 6).

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -158,7 +158,7 @@ class TestAdmissionRepoScoping:
         """
         repo_of = {
             188: ("HomericIntelligence", "Myrmidons"),
-            121: ("HomericIntelligence", "ProjectNestor"),
+            121: ("HomericIntelligence", "Nestor"),
         }
         with patch(
             "hephaestus.automation.pipeline.admission._fetch_issue_comment_ids",

--- a/tests/unit/automation/state/test_review.py
+++ b/tests/unit/automation/state/test_review.py
@@ -305,7 +305,7 @@ class TestIsPlanReviewGoWithFetch:
         with (
             patch(
                 "hephaestus.automation.state.review.get_repo_info",
-                return_value=("HomericIntelligence", "ProjectMnemosyne"),
+                return_value=("HomericIntelligence", "Mnemosyne"),
             ) as mock_info,
             patch(
                 "hephaestus.automation.state.review._gh_call",
@@ -318,7 +318,7 @@ class TestIsPlanReviewGoWithFetch:
         gh_args = mock_gh.call_args[0][0]
         joined = " ".join(gh_args)
         assert "owner=HomericIntelligence" in joined
-        assert "name=ProjectMnemosyne" in joined
+        assert "name=Mnemosyne" in joined
 
     def test_fetch_issue_comments_returns_empty_on_gh_failure(self) -> None:
         """#1426: a ``_gh_call`` failure is logged and yields an empty list.
@@ -329,7 +329,7 @@ class TestIsPlanReviewGoWithFetch:
         with (
             patch(
                 "hephaestus.automation.state.review.get_repo_info",
-                return_value=("HomericIntelligence", "ProjectMnemosyne"),
+                return_value=("HomericIntelligence", "Mnemosyne"),
             ),
             patch(
                 "hephaestus.automation.state.review._gh_call",
@@ -420,7 +420,7 @@ def test_fetch_all_comments_returns_empty_map_on_gh_failure() -> None:
         patch("hephaestus.automation.state.review.get_repo_root", return_value="/tmp/repo"),
         patch(
             "hephaestus.automation.state.review.get_repo_info",
-            return_value=("HomericIntelligence", "ProjectMnemosyne"),
+            return_value=("HomericIntelligence", "Mnemosyne"),
         ),
         patch(
             "hephaestus.automation.state.review._gh_call",

--- a/tests/unit/automation/test_advise_runner.py
+++ b/tests/unit/automation/test_advise_runner.py
@@ -37,10 +37,7 @@ class TestAdviseSkipped:
 
     def test_default_mnemosyne_root_uses_agent_brain(self, tmp_path: Path) -> None:
         with patch.object(Path, "home", return_value=tmp_path):
-            assert (
-                advise_runner.default_mnemosyne_root()
-                == tmp_path / ".agent-brain" / "ProjectMnemosyne"
-            )
+            assert advise_runner.default_mnemosyne_root() == tmp_path / ".agent-brain" / "Mnemosyne"
 
 
 # ---------------------------------------------------------------------------
@@ -49,10 +46,10 @@ class TestAdviseSkipped:
 
 
 class TestEnsureMnemosyne:
-    """ProjectMnemosyne checkout setup and recovery."""
+    """Mnemosyne checkout setup and recovery."""
 
     def test_existing_valid_checkout_is_pulled(self, tmp_path: Path) -> None:
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         mnemosyne_root.mkdir()
         calls: list[list[str]] = []
 
@@ -73,7 +70,7 @@ class TestEnsureMnemosyne:
     ) -> None:
         """Git validation/refresh calls use the centralized call-time timeout."""
         monkeypatch.setenv("HEPH_AGENT_GIT_TIMEOUT", "44")
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         mnemosyne_root.mkdir()
         timeouts: list[object] = []
 
@@ -91,12 +88,12 @@ class TestEnsureMnemosyne:
     def test_clone_uses_env_configured_clone_timeout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """ProjectMnemosyne clone calls use the centralized clone timeout."""
+        """Mnemosyne clone calls use the centralized clone timeout."""
         monkeypatch.setenv("HEPH_AGENT_CLONE_TIMEOUT", "55")
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         target = MnemosyneTarget(
             owner="HomericIntelligence",
-            slug="HomericIntelligence/ProjectMnemosyne",
+            slug="HomericIntelligence/Mnemosyne",
             is_fork_of_upstream=False,
         )
 
@@ -117,14 +114,14 @@ class TestEnsureMnemosyne:
         assert gh_call.call_args[0][0][:3] == ["repo", "clone", target.slug]
 
     def test_existing_corrupt_checkout_is_removed_and_recloned(self, tmp_path: Path) -> None:
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         mnemosyne_root.mkdir()
         (mnemosyne_root / ".git").mkdir()
         calls: list[list[str]] = []
         gh_calls: list[list[str]] = []
         target = MnemosyneTarget(
             owner="HomericIntelligence",
-            slug="HomericIntelligence/ProjectMnemosyne",
+            slug="HomericIntelligence/Mnemosyne",
             is_fork_of_upstream=False,
         )
 
@@ -165,7 +162,7 @@ class TestResolveMarketplace:
     def test_returns_path_when_present(self) -> None:
         with patch.object(Path, "exists", return_value=True):
             path, reason = advise_runner.resolve_marketplace(
-                Path("/home/user/.agent-brain/ProjectMnemosyne")
+                Path("/home/user/.agent-brain/Mnemosyne")
             )
         assert path is not None
         assert path.name == "marketplace.json"
@@ -177,10 +174,10 @@ class TestResolveMarketplace:
             patch.object(advise_runner, "ensure_mnemosyne", return_value=False) as ensure,
         ):
             path, reason = advise_runner.resolve_marketplace(
-                Path("/home/user/.agent-brain/ProjectMnemosyne")
+                Path("/home/user/.agent-brain/Mnemosyne")
             )
         assert path is None
-        assert reason == "ProjectMnemosyne unavailable"
+        assert reason == "Mnemosyne unavailable"
         ensure.assert_called_once()
 
     def test_missing_marketplace_reclone_succeeds(self) -> None:
@@ -188,7 +185,7 @@ class TestResolveMarketplace:
 
         def exists(self: Path) -> bool:
             calls.append(self)
-            if self.name == "ProjectMnemosyne":
+            if self.name == "Mnemosyne":
                 return True
             # marketplace.json: absent first, present after reclone
             return calls.count(self) > 1
@@ -199,7 +196,7 @@ class TestResolveMarketplace:
             patch.object(advise_runner, "ensure_mnemosyne", return_value=True) as ensure,
         ):
             path, reason = advise_runner.resolve_marketplace(
-                Path("/home/user/.agent-brain/ProjectMnemosyne")
+                Path("/home/user/.agent-brain/Mnemosyne")
             )
         assert path is not None
         assert reason == ""
@@ -208,7 +205,7 @@ class TestResolveMarketplace:
 
     def test_missing_marketplace_reclone_fails(self) -> None:
         def exists(self: Path) -> bool:
-            if self.name == "ProjectMnemosyne":
+            if self.name == "Mnemosyne":
                 return True
             return self.name != "marketplace.json"
 
@@ -218,7 +215,7 @@ class TestResolveMarketplace:
             patch.object(advise_runner, "ensure_mnemosyne", return_value=False) as ensure,
         ):
             path, reason = advise_runner.resolve_marketplace(
-                Path("/home/user/.agent-brain/ProjectMnemosyne")
+                Path("/home/user/.agent-brain/Mnemosyne")
             )
         assert path is None
         assert "marketplace.json missing" in reason
@@ -235,7 +232,7 @@ class TestRunAdvise:
     """run_advise orchestration: success, skip, and fail-safe degradation."""
 
     def test_returns_selected_skill_context_on_success(self, tmp_path: Path) -> None:
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         skills_dir = mnemosyne_root / "skills"
         skills_dir.mkdir(parents=True)
         skill_file = skills_dir / "debugging.md"
@@ -278,7 +275,7 @@ class TestRunAdvise:
 
     def test_retries_once_on_unparseable_selector_output(self, tmp_path: Path) -> None:
         """#1587: a non-JSON first selector response is re-asked once, then parsed."""
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         skills_dir = mnemosyne_root / "skills"
         skills_dir.mkdir(parents=True)
         (skills_dir / "debugging.md").write_text("# Debugging\n", encoding="utf-8")
@@ -316,7 +313,7 @@ class TestRunAdvise:
 
     def test_unparseable_twice_degrades_to_skip(self, tmp_path: Path) -> None:
         """#1587: if the retry is ALSO unparseable, degrade to a skip (no abort)."""
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         (mnemosyne_root / "skills").mkdir(parents=True)
         with (
             patch.object(advise_runner, "get_repo_root", return_value=Path("/repo")),
@@ -342,7 +339,7 @@ class TestRunAdvise:
             patch.object(
                 advise_runner,
                 "resolve_marketplace",
-                return_value=(None, "ProjectMnemosyne unavailable"),
+                return_value=(None, "Mnemosyne unavailable"),
             ),
         ):
             called = False
@@ -359,7 +356,7 @@ class TestRunAdvise:
                 invoke=invoke,
                 build_prompt=_build_prompt,
             )
-        assert result == "<!-- advise step skipped: ProjectMnemosyne unavailable -->"
+        assert result == "<!-- advise step skipped: Mnemosyne unavailable -->"
         assert called is False
 
     def test_degrades_to_skip_on_exception(self) -> None:
@@ -447,7 +444,7 @@ class TestRunAdvise:
         assert "No conversation found" in result
 
     def test_rejects_selected_skill_outside_skills_tree(self, tmp_path: Path) -> None:
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         (mnemosyne_root / "skills").mkdir(parents=True)
         outside = mnemosyne_root / "README.md"
         outside.write_text("not a skill", encoding="utf-8")
@@ -460,7 +457,7 @@ class TestRunAdvise:
         assert selected == []
 
     def test_rejects_selected_skill_parent_traversal(self, tmp_path: Path) -> None:
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         (mnemosyne_root / "skills").mkdir(parents=True)
 
         selected = advise_runner.parse_selected_skills(
@@ -471,7 +468,7 @@ class TestRunAdvise:
         assert selected == []
 
     def test_selected_skill_context_is_bounded(self, tmp_path: Path) -> None:
-        mnemosyne_root = tmp_path / "ProjectMnemosyne"
+        mnemosyne_root = tmp_path / "Mnemosyne"
         skills_dir = mnemosyne_root / "skills"
         skills_dir.mkdir(parents=True)
         skill_file = skills_dir / "large.md"

--- a/tests/unit/automation/test_claude_invoke_session.py
+++ b/tests/unit/automation/test_claude_invoke_session.py
@@ -316,7 +316,7 @@ class TestEndToEndSessionResume:
     def test_create_then_resume_same_uuid_distinct_prompts(self, fake_home: Path) -> None:
         cwd = fake_home / "work"
         cwd.mkdir()
-        expected_sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER, "sonnet")
+        expected_sid = session_uuid("Scylla", 1944, AGENT_PLANNER, "sonnet")
 
         # First call writes the transcript so the second call's probe finds it.
         def _side_effect(*args: Any, **kwargs: Any) -> MagicMock:
@@ -327,7 +327,7 @@ class TestEndToEndSessionResume:
             "hephaestus.automation.claude_invoke.subprocess.run", side_effect=_side_effect
         ) as m:
             _, sid1 = invoke_claude_with_session(
-                repo="ProjectScylla",
+                repo="Scylla",
                 issue=1944,
                 agent=AGENT_PLANNER,
                 prompt="iter 0",
@@ -335,7 +335,7 @@ class TestEndToEndSessionResume:
                 cwd=cwd,
             )
             _, sid2 = invoke_claude_with_session(
-                repo="ProjectScylla",
+                repo="Scylla",
                 issue=1944,
                 agent=AGENT_PLANNER,
                 prompt="iter 1",

--- a/tests/unit/automation/test_ensure_state_labels.py
+++ b/tests/unit/automation/test_ensure_state_labels.py
@@ -168,7 +168,7 @@ class TestMain:
         # ``gh repo view`` discovers the repo; then one create per label runs.
         n = len(STATE_LABEL_SPECS)
         mock_gh_call.side_effect = [
-            _ok_proc(stdout="HomericIntelligence/ProjectScylla"),  # gh repo view
+            _ok_proc(stdout="HomericIntelligence/Scylla"),  # gh repo view
             *(_ok_proc() for _ in range(n)),  # one create per label
         ]
         rc = main([])

--- a/tests/unit/automation/test_learn.py
+++ b/tests/unit/automation/test_learn.py
@@ -64,27 +64,25 @@ class TestRunLearn:
 
     def test_mnemosyne_update_evidence_extracts_pr_url_and_ref(self) -> None:
         evidence = mnemosyne_update_evidence(
-            "Opened https://github.com/HomericIntelligence/ProjectMnemosyne/pull/45 "
-            "and referenced HomericIntelligence/ProjectMnemosyne#46"
+            "Opened https://github.com/HomericIntelligence/Mnemosyne/pull/45 "
+            "and referenced HomericIntelligence/Mnemosyne#46"
         )
 
         assert evidence["mnemosyne_update_status"] == "confirmed"
         assert evidence["mnemosyne_update_urls"] == [
-            "https://github.com/HomericIntelligence/ProjectMnemosyne/pull/45"
+            "https://github.com/HomericIntelligence/Mnemosyne/pull/45"
         ]
         assert evidence["mnemosyne_update_pr_numbers"] == [46]
 
     def test_mnemosyne_update_evidence_recognizes_fork_owner(self) -> None:
-        """A push to a user's fork (<login>/ProjectMnemosyne) still counts."""
+        """A push to a user's fork (<login>/Mnemosyne) still counts."""
         evidence = mnemosyne_update_evidence(
-            "Opened https://github.com/mvillmow/ProjectMnemosyne/pull/7 "
-            "and referenced mvillmow/ProjectMnemosyne#8"
+            "Opened https://github.com/mvillmow/Mnemosyne/pull/7 "
+            "and referenced mvillmow/Mnemosyne#8"
         )
 
         assert evidence["mnemosyne_update_status"] == "confirmed"
-        assert evidence["mnemosyne_update_urls"] == [
-            "https://github.com/mvillmow/ProjectMnemosyne/pull/7"
-        ]
+        assert evidence["mnemosyne_update_urls"] == ["https://github.com/mvillmow/Mnemosyne/pull/7"]
         assert evidence["mnemosyne_update_pr_numbers"] == [8]
 
     def test_build_learn_prompt_uses_user_facing_command(self) -> None:
@@ -93,7 +91,7 @@ class TestRunLearn:
         assert prompt.startswith("/learn EXECUTE")
         assert "Capture what happened." in prompt
         assert "/skills-registry-commands:learn" not in prompt
-        assert "Only push skills to the resolved ProjectMnemosyne" in prompt
+        assert "Only push skills to the resolved Mnemosyne" in prompt
         # Directives must appear before the context detail
         assert prompt.index("Do NOT return a plan") < prompt.index("Capture what happened.")
 

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -630,7 +630,7 @@ class TestFetchIssueCommentsCache:
         with (
             patch(
                 "hephaestus.automation.plan_reviewer.get_repo_info",
-                return_value=("HomericIntelligence", "ProjectMnemosyne"),
+                return_value=("HomericIntelligence", "Mnemosyne"),
             ) as mock_info,
             patch("hephaestus.automation.plan_reviewer._gh_call") as mock_gh,
         ):
@@ -641,7 +641,7 @@ class TestFetchIssueCommentsCache:
         gh_args = mock_gh.call_args[0][0]
         joined = " ".join(gh_args)
         assert "owner=HomericIntelligence" in joined
-        assert "name=ProjectMnemosyne" in joined
+        assert "name=Mnemosyne" in joined
 
 
 class TestMain:

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -323,7 +323,7 @@ class TestAdvisePrompt:
         assert not out.startswith("$advise ")
         assert "/mp.json" in out
         assert "Do not invoke `$advise`" in out
-        assert "Do not clone or update ProjectMnemosyne yourself" in out
+        assert "Do not clone or update Mnemosyne yourself" in out
         assert "/advise" not in out
         assert "#7: t" in out
         assert '"skills"' in out

--- a/tests/unit/automation/test_session_naming.py
+++ b/tests/unit/automation/test_session_naming.py
@@ -89,7 +89,7 @@ class TestSessionName:
     """
 
     def test_basic(self) -> None:
-        assert session_name("ProjectScylla", 1944, AGENT_PLANNER) == "ProjectScylla_1944_planner"
+        assert session_name("Scylla", 1944, AGENT_PLANNER) == "Scylla_1944_planner"
 
     def test_strips_hash_prefix_from_issue(self) -> None:
         assert session_name("R", "#42", AGENT_PLANNER) == "R_42_planner"
@@ -117,12 +117,12 @@ class TestSessionUUID:
     """Deterministic UUIDv5 derivation from (repo, issue, agent)."""
 
     def test_deterministic(self) -> None:
-        a = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
-        b = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
+        a = session_uuid("Scylla", 1944, AGENT_PLANNER)
+        b = session_uuid("Scylla", 1944, AGENT_PLANNER)
         assert a == b
 
     def test_returns_valid_uuid(self) -> None:
-        sid = session_uuid("ProjectScylla", 1944, AGENT_PLANNER)
+        sid = session_uuid("Scylla", 1944, AGENT_PLANNER)
         # uuid.UUID raises ValueError on invalid input.
         uuid.UUID(sid)
 

--- a/tests/unit/github/test_mnemosyne_repo.py
+++ b/tests/unit/github/test_mnemosyne_repo.py
@@ -1,6 +1,6 @@
 """Tests for hephaestus.github.mnemosyne_repo.
 
-The resolver picks which ``owner/ProjectMnemosyne`` to clone, push to, and PR
+The resolver picks which ``owner/Mnemosyne`` to clone, push to, and PR
 against. All ``gh`` calls are mocked at the module namespace so no live network
 or ``gh`` auth is required.
 """
@@ -64,15 +64,15 @@ class TestRemoteRepoExists:
 
     def test_exists(self) -> None:
         with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(0, '{"name":"x"}')):
-            assert remote_repo_exists("me/ProjectMnemosyne") is True
+            assert remote_repo_exists("me/Mnemosyne") is True
 
     def test_missing(self) -> None:
         with patch.object(mnemosyne_repo, "gh_call", return_value=_completed(1, "", "not found")):
-            assert remote_repo_exists("me/ProjectMnemosyne") is False
+            assert remote_repo_exists("me/Mnemosyne") is False
 
     def test_exception_returns_false(self) -> None:
         with patch.object(mnemosyne_repo, "gh_call", side_effect=RuntimeError("boom")):
-            assert remote_repo_exists("me/ProjectMnemosyne") is False
+            assert remote_repo_exists("me/Mnemosyne") is False
 
 
 class TestForkUpstream:
@@ -122,7 +122,7 @@ class TestResolveMnemosyneTarget:
             patch.object(mnemosyne_repo, "fork_upstream") as fork,
         ):
             target = resolve_mnemosyne_target()
-        assert target.slug == "mvillmow/ProjectMnemosyne"
+        assert target.slug == "mvillmow/Mnemosyne"
         assert target.is_fork_of_upstream is True
         fork.assert_not_called()
 
@@ -133,7 +133,7 @@ class TestResolveMnemosyneTarget:
             patch.object(mnemosyne_repo, "fork_upstream", return_value=True) as fork,
         ):
             target = resolve_mnemosyne_target()
-        assert target.slug == "mvillmow/ProjectMnemosyne"
+        assert target.slug == "mvillmow/Mnemosyne"
         assert target.is_fork_of_upstream is True
         fork.assert_called_once_with("mvillmow")
 
@@ -171,7 +171,7 @@ class TestResolveMnemosyneTarget:
             target = resolve_mnemosyne_target(override_owner="acme")
         assert target == MnemosyneTarget(
             owner="acme",
-            slug="acme/ProjectMnemosyne",
+            slug="acme/Mnemosyne",
             is_fork_of_upstream=True,
         )
         login.assert_not_called()
@@ -181,7 +181,7 @@ class TestResolveMnemosyneTarget:
         monkeypatch.setenv(mnemosyne_repo.OWNER_ENV_VAR, "acme")
         with patch.object(mnemosyne_repo, "gh_authenticated_login") as login:
             target = resolve_mnemosyne_target()
-        assert target.slug == "acme/ProjectMnemosyne"
+        assert target.slug == "acme/Mnemosyne"
         login.assert_not_called()
 
     def test_override_equal_to_upstream_is_not_marked_fork(self) -> None:

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -39,9 +39,9 @@ class TestDetectRepoFromRemote:
     @patch("hephaestus.github.pr_merge.git_remote_url")
     def test_detects_https_url(self, mock_remote_url) -> None:
         """Parses HTTPS github.com/owner/repo.git."""
-        mock_remote_url.return_value = "https://github.com/HomericIntelligence/ProjectScylla.git"
+        mock_remote_url.return_value = "https://github.com/HomericIntelligence/Scylla.git"
         result = detect_repo_from_remote()
-        assert result == "HomericIntelligence/ProjectScylla"
+        assert result == "HomericIntelligence/Scylla"
 
     @patch("hephaestus.github.pr_merge.git_remote_url")
     def test_detects_url_without_git_suffix(self, mock_remote_url) -> None:


### PR DESCRIPTION
## Summary

The org renamed every repository to drop the `Project` prefix
(`ProjectHephaestus` → `Hephaestus`, `ProjectMnemosyne` → `Mnemosyne`, …).
This updates all in-tree references to match. **The GitHub rename is now live**,
so this is safe to land.

`Project<GreekName>` → `<GreekName>` across **140 files, 492 pure renames**
(every insertion matched by a deletion — no logic change).

## Load-bearing references (not just prose)

- `MNEMOSYNE_REPO = "Mnemosyne"` and the `Mnemosyne#N` / PR-URL regexes in `learn.py`
- marketplace name `"Hephaestus"`, kept consistent with the `_strict_rubric.py` skills-path reference
- `.fleet.yml` ecosystem repo list
- `pyproject.toml` Homepage / Repository / Issues URLs

## Safety of the transformation

Anchored to `Project` + a known capitalized Greek name, so lowercase `project` /
`pyproject.toml` / `check_project_version` / `extract_pyproject_versions` are
untouched (verified in the diff). One session-name test literal
(`ProjectScylla_1944_planner`) was fixed by hand to `Scylla_1944_planner` —
`session_name()` joins the repo verbatim.

## Verification

- **5973 unit tests pass**; coverage 84.56%.
- `ruff` + `mypy` clean (544 source files).
- Base `import hephaestus` and `loop_runner.main` resolve; all JSON manifests parse.

Closes #2065