### PR TITLE
[audit][S3 Architecture & Design] Late import `import re` inside CIDriver._parse_json_block at call time

### DIFF
--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -22,9 +22,10 @@ stage too — see ``IssueImplementer.run`` for the canonical call shape.
 """
 
 import logging
+import re
 from collections import defaultdict, deque
 
-from .github_api import fetch_issue_info, prefetch_issue_states
+from .github_api import fetch_issue_info, gh_issue_json, prefetch_issue_states
 from .models import DependencyGraph, IssueInfo, IssueState
 from .state_labels import is_skipped
 
@@ -136,10 +137,6 @@ class DependencyResolver:
             List of sub-issue numbers
 
         """
-        import re
-
-        from .github_api import gh_issue_json
-
         sub_issues = []
 
         # Fetch full body from GitHub


### PR DESCRIPTION
## Summary
Summary: The issue's original target (`ci_driver.py:2125`, `_CIDriverCore._parse_json_block`'s late `import re`) no longer exists — it was removed in PR #1945 when `ci_driver.py` was refactored into a thin CLI wrapper, and the surviving `parse_json_block` helper in `_review_utils.py` already imports `re` at module level. A search for the same anti-pattern across `hephaestus/` found one remaining instance: `hephaestus/automation/dependency_resolver.py:139`, where `_parse_sub_issues` did `import re` and `from .github_api import gh_issue_json` inside the function body. Moved both to module-level imports (`hephaestus/automation/dependency_resolver.py:24-28`), matching file convention.

Tests run: `tests/unit/automation/test_dependency_resolver.py` (18 passed), `tests/unit/validation/test_import_surface.py` + `test_automation_boundary.py` (3 passed), full-tree `pixi run mypy` (success, 534 files), and `pixi run ruff check` on the changed file (clean).


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1460

Generated by Hephaestus automation
