### PR TITLE
[majo] planning VERIFY RETRY never resets state to PLAN_WAIT, so it burns the plan budget without re-invoking the planner

### DIFF
--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -157,8 +157,8 @@ class PlanningStage(Stage):
     - PLAN_WAIT: submit the plan agent job (planner session); plan text
       lands in ``item.payload["plan_text"]``; the plan comment posted by the
       pipeline is the durable artifact.
-    - VERIFY: check the plan comment exists -> ADVANCE, else RETRY within
-      the ``plan`` budget, then FINISH_FAIL.
+    - VERIFY: check the plan comment exists -> ADVANCE, else reset to
+      ``PLAN_WAIT`` and RETRY within the ``plan`` budget, then FINISH_FAIL.
 
     on_enter idempotency guards (re-housed from ``Planner._pr_coverage_skip``
     and ``Planner._has_existing_plan``, all ordered at-or-past checks):
@@ -346,6 +346,9 @@ class PlanningStage(Stage):
                     attempt,
                     budget,
                 )
+                # RETRY requeues this stage without calling on_enter(), so the
+                # next step must request a fresh planner job rather than VERIFY again.
+                item.state = "PLAN_WAIT"
                 return StageOutcome(Disposition.RETRY, f"plan not found, retry {attempt}/{budget}")
             logger.error(
                 "planning:%d: plan not found after %d attempts; exhausted", item.issue, budget

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -500,8 +500,10 @@ class TestPlanningStageStep:
         assert "VERIFY ADVANCE gate" in doc
         assert "ctx.github.has_existing_plan(item.issue)" in doc
 
-    def test_verify_without_plan_retries(self, make_ctx: Any, make_work_item: Any) -> None:
-        """VERIFY without a plan retries while within the plan budget."""
+    def test_verify_without_plan_retries_by_requesting_fresh_plan(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A missing plan retries through PLAN_WAIT and requests a fresh plan job."""
         stage = PlanningStage()
         github = FakeStageGitHub(has_plan=False)
         ctx = make_ctx(github=github)
@@ -512,6 +514,14 @@ class TestPlanningStageStep:
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.RETRY
         assert item.attempts["plan"] == 1
+        assert item.state == "PLAN_WAIT"
+
+        retry_request = stage.step(item, ctx)
+
+        assert isinstance(retry_request, JobRequest)
+        assert isinstance(retry_request.job, AgentJob)
+        assert retry_request.job.descr == "plan"
+        assert retry_request.on_done_state == "VERIFY"
 
     def test_verify_exhausts_budget(self, make_ctx: Any, make_work_item: Any) -> None:
         """VERIFY fails after exhausting the plan budget (2)."""


### PR DESCRIPTION
## Summary
Clean mypy run tree-wide. The diff is exactly the two files from the plan, matching the intended minimal fix.

## Summary

Fixed the planning-stage VERIFY→RETRY no-op loop described in issue #1871.

**`hephaestus/automation/pipeline/stages/planning.py`**:
- In the `VERIFY` retry branch (in-budget path), added `item.state = "PLAN_WAIT"` before returning `Disposition.RETRY`, so the next coordinator tick requests a fresh planner job instead of re-checking the same missing comment forever.
- Updated the class docstring's state-machine description to reflect the reset-before-retry behavior.

**`tests/unit/automation/pipeline/stages/test_stage_planning.py`**:
- Renamed/expanded `test_verify_without_plan_retries` → `test_verify_without_plan_retries_by_requesting_fresh_plan`, asserting both `item.state == "PLAN_WAIT"` after the retry and that the following `step()` call returns a `JobRequest` for a fresh `"plan"` job with `on_done_state == "VERIFY"`.

**Tests run:**
- `pixi run pytest tests/unit/automation/pipeline/stages/test_stage_planning.py -v` → 36 passed
- `pixi run ruff check` on both changed files → clean
- `pixi run mypy` (full tree) → `Success: no issues found in 534 source files`

No other files touched; working tree has only these two modified files, ready for the orchestrator to commit.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1871

Generated by Hephaestus automation
