### PR TITLE
[audit][S8 Security] gitleaks downloaded via wget without checksum-verified TLS certificate pinning

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -717,18 +717,25 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Digest-pinned so the scan no longer depends on a transient GitHub
+      # Releases tarball URL (audit #1483). gitleaks is not published on
+      # conda-forge or PyPI, so a Pixi-managed install cannot be locked; the
+      # container digest is the reproducible pin instead. Run via `docker
+      # run` rather than a job-level `container:` — the gitleaks image is
+      # musl-based Alpine with no Node.js runtime, which breaks
+      # actions/checkout (a glibc-linked JS action) when it executes inside
+      # the container.
       - name: Run Gitleaks
+        env:
+          GITLEAKS_IMAGE: >-
+            ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9
         run: |
-          wget -q https://github.com/gitleaks/gitleaks/releases/download/v8.30.0/gitleaks_8.30.0_linux_x64.tar.gz
-          expected_sha=79a3ab579b53f71efd634f3aaf7e04a0fa0cf206b7ed434638d1547a2470a66e
-          echo "$expected_sha  gitleaks_8.30.0_linux_x64.tar.gz" | sha256sum --check
-          tar -xzf gitleaks_8.30.0_linux_x64.tar.gz
-          chmod +x gitleaks
+          set -euo pipefail
+          args=(detect --source=. --verbose --exit-code=1)
           if [ -f .gitleaks.toml ]; then
-            ./gitleaks detect --source=. --config=.gitleaks.toml --verbose --exit-code=1
-          else
-            ./gitleaks detect --source=. --verbose --exit-code=1
+            args+=(--config=.gitleaks.toml)
           fi
+          docker run --rm -v "$PWD:/repo" -w /repo "$GITLEAKS_IMAGE" "${args[@]}"
 
   security-sast-scan:
     name: security/sast-scan

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -319,6 +319,51 @@ class TestRequiredPixiCheckWorkflow:
         assert "running unlocked" not in script
 
 
+class TestGitleaksSecretsScan:
+    """Regression tests for the required gitleaks secrets scan.
+
+    gitleaks is not published on conda-forge or PyPI, so it cannot be a
+    Pixi-managed dependency in this repo (channels are pinned to
+    conda-forge). The job instead runs a digest-addressed container image
+    via `docker run`, which removes the dependency on a transient GitHub
+    Releases tarball URL (audit #1483) without requiring an unlockable Pixi
+    package. `docker run` (not a job-level `container:`) keeps
+    actions/checkout running on the host runner, since the gitleaks image is
+    musl-based Alpine with no Node.js runtime.
+    """
+
+    def _gitleaks_step(self) -> dict[str, Any]:
+        with open(REQUIRED_WORKFLOW, encoding="utf-8") as f:
+            workflow = yaml.safe_load(f)
+        steps = workflow["jobs"]["security-secrets-scan"]["steps"]
+        return next(step for step in steps if step.get("name") == "Run Gitleaks")
+
+    def test_secrets_scan_uses_digest_pinned_image(self) -> None:
+        step = self._gitleaks_step()
+        image = step["env"]["GITLEAKS_IMAGE"]
+
+        assert image.startswith("ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:")
+        digest = image.split("@sha256:", 1)[1]
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_secrets_scan_runs_gitleaks_via_docker_run(self) -> None:
+        run_script = self._gitleaks_step()["run"]
+
+        assert "args=(detect --source=. --verbose --exit-code=1)" in run_script
+        assert "args+=(--config=.gitleaks.toml)" in run_script
+        assert 'docker run --rm -v "$PWD:/repo" -w /repo "$GITLEAKS_IMAGE"' in run_script
+
+    def test_secrets_scan_does_not_download_gitleaks_release_tarball(self) -> None:
+        run_script = self._gitleaks_step()["run"]
+
+        assert "github.com/gitleaks/gitleaks/releases" not in run_script
+        assert "wget" not in run_script
+        assert "sha256sum --check" not in run_script
+        assert "tar -xzf" not in run_script
+        assert "./gitleaks" not in run_script
+
+
 class TestPiCliSetup:
     """Regression tests for installing the real Pi CLI in test environments."""
 


### PR DESCRIPTION
## Summary
No stray files, only the two intended modifications. The implementation is complete.

## Summary

Issue #1483 flagged the gitleaks `wget`+`sha256sum` download in `.github/workflows/_required.yml` as dependent on a transient GitHub Releases URL. The originally-approved plan (Pixi-managed gitleaks) was found infeasible in a prior attempt (PR #1829, closed) — gitleaks isn't published on conda-forge or PyPI, and this repo's Pixi channels are pinned to conda-forge only. The issue's own resolution note named a fallback: a digest-pinned container image.

**Changes:**
- `.github/workflows/_required.yml`: `security-secrets-scan` now runs gitleaks via `docker run` against `ghcr.io/gitleaks/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9` (verified against the live registry), replacing the wget/tar/sha256sum sequence. I initially tried a job-level `container:` (closer to PR #1829's salvaged shape) but discovered the gitleaks image is musl-based Alpine with no Node.js runtime, which breaks the glibc-linked `actions/checkout` JS action when it runs inside that container — switched to `docker run` on the host runner instead, keeping checkout on the runner.
- `tests/unit/ci/test_workflows.py`: added `TestGitleaksSecretsScan` (3 tests) verifying the digest pin format, the `docker run` invocation shape, and the absence of the old tarball-download pattern.

**Verification:**
- `pixi run pytest tests/unit/ci/` — 134/134 pass
- `pixi run mypy` — clean (534 files)
- `pixi run ruff check`/`format --check` — clean
- `pixi run --environment lint yamllint .github/workflows/_required.yml` — clean
- Live-ran the exact production `docker run` command against this repo's real git history (1251 commits) — completed successfully, no leaks found, exit 0


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1483

Generated by Hephaestus automation
