### PR TITLE
[audit][S7 Dependencies] Renovate config:recommended enables pep621 pip manager — potential duplicate PRs with Dependabot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
-    "Renovate owns ONLY conda-forge / pixi dependencies in pixi.toml — the ecosystem Dependabot cannot parse.",
+    "Renovate owns ONLY conda-forge / pixi dependencies in pixi.toml — the ecosystem Dependabot cannot parse. This is enforced by enabledManagers:[\"pixi\"].",
     "GitHub Actions are managed exclusively by .github/dependabot.yml (github-actions ecosystem). Do NOT add a matchManagers:[github-actions] rule here: having both bump actions produces duplicate PRs (see #687). Renovate's default GitHub Actions manager is disabled below."
   ],
   "extends": [
     "config:recommended",
     ":pixi"
   ],
+  "enabledManagers": ["pixi"],
   "labels": ["dependencies"],
   "schedule": ["every week on monday"],
   "prConcurrentLimit": 5,

--- a/tests/unit/ci/test_dependency_bot_ownership.py
+++ b/tests/unit/ci/test_dependency_bot_ownership.py
@@ -1,0 +1,54 @@
+"""Guard dependency-bot ownership boundaries for Renovate and Dependabot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DEPENDABOT_OWNED_RENOVATE_MANAGERS = {"pep621", "pip_requirements", "pip-requirements"}
+
+
+def _renovate_config() -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads((REPO_ROOT / "renovate.json").read_text()))
+
+
+def _dependabot_config() -> dict[str, Any]:
+    return cast(
+        dict[str, Any],
+        yaml.safe_load((REPO_ROOT / ".github" / "dependabot.yml").read_text()),
+    )
+
+
+def test_renovate_is_limited_to_pixi_manager() -> None:
+    """Renovate must not manage pip/PEP 621 deps owned by Dependabot."""
+    config = _renovate_config()
+
+    assert config["enabledManagers"] == ["pixi"]
+    assert not (set(config["enabledManagers"]) & DEPENDABOT_OWNED_RENOVATE_MANAGERS)
+
+
+def test_renovate_package_rules_only_target_enabled_managers() -> None:
+    """Package rules must not reintroduce disabled managers."""
+    config = _renovate_config()
+    enabled_managers = set(config["enabledManagers"])
+
+    for rule in config.get("packageRules", []):
+        managers = set(rule.get("matchManagers", []))
+        assert managers <= enabled_managers, (
+            f"packageRule {rule.get('description', rule)!r} targets disabled managers: "
+            f"{sorted(managers - enabled_managers)}"
+        )
+
+
+def test_dependabot_owns_root_pip_ecosystem() -> None:
+    """The pip ecosystem remains assigned to Dependabot at the repository root."""
+    updates = _dependabot_config()["updates"]
+
+    assert any(
+        update.get("package-ecosystem") == "pip" and update.get("directory") == "/"
+        for update in updates
+    )


### PR DESCRIPTION
## Summary
Whole-tree mypy passes clean. Everything checks out.

## Summary

Implemented issue #1477 per the approved plan (Grade A, GO):

**`renovate.json`**: Added `"enabledManagers": ["pixi"]` after the `extends` block, and updated the description to reference the enforcement. This disables Renovate's `pep621`/`pip_requirements` managers so it can no longer generate competing PRs against `pyproject.toml`, leaving Dependabot as the sole owner of root pip dependencies.

**`tests/unit/ci/test_dependency_bot_ownership.py`** (new): Three guard tests —
- `test_renovate_is_limited_to_pixi_manager` — asserts `enabledManagers == ["pixi"]`
- `test_renovate_package_rules_only_target_enabled_managers` — no packageRule targets a disabled manager
- `test_dependabot_owns_root_pip_ecosystem` — dependabot.yml still owns `pip` at `/`

**Verification run:**
- `pytest tests/unit/ci/test_dependency_bot_ownership.py -v` — 3 passed
- `python3 -m json.tool renovate.json` — valid JSON
- `pre-commit run check-yaml --files .github/dependabot.yml` — passed
- `pytest tests/unit -q` — 5918 passed, 24 skipped, coverage 84.46% (≥83% gate)
- `pixi run ruff check` — all checks passed
- `pixi run mypy` (whole tree) — no issues in 535 source files

Working tree has the two changes (`renovate.json` modified, new test file added); no commits made per the git boundary policy.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1477

Generated by Hephaestus automation
