### PR TITLE
[audit][S6 CI/CD] No TestPyPI staging gate before production PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,130 @@ jobs:
       - name: Run mypy type checking
         run: pixi run mypy
 
-  build-and-publish:
+  publish-testpypi:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [test, type-check]
+    environment: testpypi
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          # Priority: explicit input > tag-push ref > latest tag
+          INPUT_TAG="${{ github.event.inputs.tag }}"
+          REF_TAG="${{ github.ref }}"
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [[ "$REF_TAG" == refs/tags/* ]]; then
+            TAG="${REF_TAG#refs/tags/}"
+          else
+            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Releasing tag: ${TAG}"
+          git checkout "${TAG}"
+
+      - name: Install pixi
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11  # v0.9.6
+        with:
+          pixi-version: v0.69.0
+          locked: true
+          # setup-pixi already caches `.pixi` keyed exactly on the pixi.lock
+          # hash. A second actions/cache over `.pixi` with a lock-agnostic
+          # restore-keys prefix would restore a stale env on top of this
+          # --locked install, silently downgrading packages — do not add one.
+
+      - name: Build package
+        shell: bash
+        run: |
+          # This is the only build of the release dist. build-and-publish
+          # downloads the artifact produced here rather than rebuilding, so
+          # the bytes smoke-tested against TestPyPI are byte-identical to
+          # the bytes promoted to production PyPI.
+          #
+          # hatch-vcs derives the version from git; a dirty tree would taint it
+          # with a +dirty/.devN suffix and publish a wrong version.
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Working tree is dirty — refusing to build"
+            git status --porcelain
+            exit 1
+          fi
+          pixi run python -m build
+          ls -1 dist/
+
+      - name: Upload dist for reuse by build-and-publish
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa0  # v4.6.2
+        with:
+          name: release-dist
+          path: dist/
+          retention-days: 1
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+          # No skip-existing: a re-dispatch for the same tag must publish and
+          # smoke-test THIS run's freshly built dist, not silently pass by
+          # smoke-testing a stale artifact left on TestPyPI from an earlier
+          # partial run. If TestPyPI already has this exact version (e.g. a
+          # re-dispatch after a downstream failure with no code change), this
+          # step fails loudly — the fix is to yank the stale TestPyPI release
+          # or bump the version, not to skip and hope the old upload matches.
+
+      - name: Smoke-install from TestPyPI
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          EXPECTED_VERSION="${TAG#v}"
+          pixi run python -m venv /tmp/testpypi-smoke
+
+          # TestPyPI has an index-propagation delay after a successful upload
+          # before `pip` can resolve the new release. Retry on "no matching
+          # distribution" only; any other pip failure (bad deps, broken wheel)
+          # fails immediately rather than burning the full retry window.
+          ATTEMPTS=10
+          SLEEP_SECONDS=30
+          for i in $(seq 1 "$ATTEMPTS"); do
+            if OUTPUT=$(/tmp/testpypi-smoke/bin/pip install --no-cache-dir \
+                --index-url https://test.pypi.org/simple/ \
+                --extra-index-url https://pypi.org/simple/ \
+                "HomericIntelligence-Hephaestus==${EXPECTED_VERSION}" 2>&1); then
+              echo "$OUTPUT"
+              break
+            fi
+            echo "$OUTPUT"
+            if ! echo "$OUTPUT" | grep -qi "no matching distribution\|could not find a version"; then
+              echo "::error::pip install failed for a reason other than index propagation — not retrying"
+              exit 1
+            fi
+            if [ "$i" -eq "$ATTEMPTS" ]; then
+              echo "::error::TestPyPI release ${EXPECTED_VERSION} did not become installable after $((ATTEMPTS * SLEEP_SECONDS))s"
+              exit 1
+            fi
+            echo "Attempt $i/$ATTEMPTS: not yet propagated, retrying in ${SLEEP_SECONDS}s..."
+            sleep "$SLEEP_SECONDS"
+          done
+
+          INSTALLED_VERSION=$(/tmp/testpypi-smoke/bin/python -c "import hephaestus; print(hephaestus.__version__)")
+          if [ "$INSTALLED_VERSION" != "$EXPECTED_VERSION" ]; then
+            echo "::error::TestPyPI smoke-install version mismatch: expected ${EXPECTED_VERSION}, got ${INSTALLED_VERSION}"
+            exit 1
+          fi
+          echo "TestPyPI smoke-install passed: ${INSTALLED_VERSION}"
+
+  build-and-publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [test, type-check, publish-testpypi]
     environment: pypi
 
     steps:
@@ -145,18 +265,11 @@ jobs:
           fi
           echo "Version check passed: $TAG_VERSION"
 
-      - name: Build package
-        shell: bash
-        run: |
-          # hatch-vcs derives the version from git; a dirty tree would taint it
-          # with a +dirty/.devN suffix and publish a wrong version.
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "::error::Working tree is dirty — refusing to build"
-            git status --porcelain
-            exit 1
-          fi
-          pixi run python -m build
-          ls -1 dist/
+      - name: Download dist built by publish-testpypi
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v6.0.0
+        with:
+          name: release-dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,9 +18,13 @@ workflow_dispatch (Auto Tag Release)
   └─ workflow_dispatch (Release workflow, tag=vX.Y.Z)
          ├─ test job (pytest)
          ├─ type-check job (mypy)
-         └─ build-and-publish job
+         ├─ publish-testpypi job
+         │      ├─ build wheel + sdist
+         │      ├─ publish to TestPyPI (trusted publishing)
+         │      └─ smoke-install from TestPyPI (retries for index propagation)
+         └─ build-and-publish job (after publish-testpypi succeeds)
               ├─ verify tag == package version
-              ├─ build wheel + sdist
+              ├─ reuse dist built by publish-testpypi
               ├─ publish to PyPI (trusted publishing)
               └─ create GitHub Release with auto-generated notes
 ```
@@ -69,6 +73,26 @@ gh workflow run release.yml -f tag=vX.Y.Z   # the exact tag auto-tag pushed
 Never dispatch with a blank `tag` input in this state. Blank means "latest tag", which is only
 correct until another tag lands between the failure and your recovery — always name the
 stranded tag.
+
+## TestPyPI Trusted Publishing
+
+Before this staging gate can pass, a `testpypi` GitHub Environment must exist on this
+repository with its own trusted publisher registered on
+[test.pypi.org](https://test.pypi.org) (a separate index from pypi.org, requiring its
+own trusted-publisher registration — the `pypi` trusted publisher below does not cover
+it). One-time setup:
+
+1. On test.pypi.org, register a pending trusted publisher for this project: owner
+   `HomericIntelligence`, repository `Hephaestus`, workflow `release.yml`, environment
+   name `testpypi`.
+2. In the GitHub repo, create an environment named `testpypi` (Settings → Environments).
+   A required reviewer is optional here (unlike `pypi`) since a bad TestPyPI publish is
+   not user-facing.
+3. No secrets are needed — like `pypi`, this uses OIDC trusted publishing.
+
+Until this one-time setup is complete, `publish-testpypi` fails at the OIDC-publish step
+with an authorization error, and `build-and-publish` (which needs `publish-testpypi`)
+never runs.
 
 ## PyPI Trusted Publishing
 

--- a/tests/unit/ci/test_release_workflow_wiring.py
+++ b/tests/unit/ci/test_release_workflow_wiring.py
@@ -1,0 +1,136 @@
+"""Structural regression tests for the TestPyPI staging gate in release.yml.
+
+Parses the checked-in workflow YAML and asserts the job graph / artifact
+wiring introduced by the TestPyPI staging gate (issue #1475). Does not spin
+up GitHub Actions; it is a static guard against a wiring regression such as
+an artifact-name rename that silently breaks build-once/deploy-elsewhere
+reuse between ``publish-testpypi`` and ``build-and-publish``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load_workflow() -> dict[str, Any]:
+    return yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _job(name: str) -> dict[str, Any]:
+    return _load_workflow()["jobs"][name]
+
+
+def _steps(job_name: str) -> list[dict[str, Any]]:
+    return _job(job_name)["steps"]
+
+
+def _step_using(job_name: str, action_substring: str) -> dict[str, Any]:
+    matches = [s for s in _steps(job_name) if action_substring in str(s.get("uses", ""))]
+    assert len(matches) == 1, (
+        f"expected exactly one step using '{action_substring}' in job '{job_name}', "
+        f"found {len(matches)}"
+    )
+    return matches[0]
+
+
+class TestPublishTestPyPIJobExists:
+    """The staging job must exist and run before build-and-publish."""
+
+    def test_job_present(self) -> None:
+        assert "publish-testpypi" in _load_workflow()["jobs"]
+
+    def test_needs_test_and_type_check(self) -> None:
+        assert _job("publish-testpypi")["needs"] == ["test", "type-check"]
+
+    def test_uses_testpypi_environment(self) -> None:
+        assert _job("publish-testpypi")["environment"] == "testpypi"
+
+
+class TestBuildAndPublishDependsOnTestPyPI:
+    """Production publish must not proceed until the TestPyPI gate passes."""
+
+    def test_needs_includes_publish_testpypi(self) -> None:
+        assert "publish-testpypi" in _job("build-and-publish")["needs"]
+
+    def test_still_needs_test_and_type_check(self) -> None:
+        needs = _job("build-and-publish")["needs"]
+        assert "test" in needs
+        assert "type-check" in needs
+
+    def test_uses_pypi_environment(self) -> None:
+        assert _job("build-and-publish")["environment"] == "pypi"
+
+
+class TestArtifactReuse:
+    """The dist built in publish-testpypi must be the exact bytes promoted to PyPI."""
+
+    def test_publish_testpypi_uploads_release_dist(self) -> None:
+        step = _step_using("publish-testpypi", "actions/upload-artifact")
+        assert step["with"]["name"] == "release-dist"
+
+    def test_build_and_publish_downloads_release_dist(self) -> None:
+        step = _step_using("build-and-publish", "actions/download-artifact")
+        assert step["with"]["name"] == "release-dist"
+
+    def test_build_and_publish_does_not_rebuild(self) -> None:
+        """A duplicate build step would defeat byte-identical reuse."""
+        names = [s.get("name", "") for s in _steps("build-and-publish")]
+        assert not any(name == "Build package" for name in names)
+
+
+class TestTestPyPIPublishStrictness:
+    """The staging gate must test THIS run's artifact, not a stale one."""
+
+    def test_publishes_to_testpypi_index(self) -> None:
+        step = _step_using("publish-testpypi", "gh-action-pypi-publish")
+        assert step["with"]["repository-url"] == "https://test.pypi.org/legacy/"
+
+    def test_no_skip_existing_on_testpypi_publish(self) -> None:
+        """Guard against re-testing a stale artifact instead of this run's build.
+
+        skip-existing would let a re-dispatch smoke-test a stale TestPyPI
+        artifact instead of the freshly built dist, breaking the staging-gate
+        guarantee that what is smoke-tested is what gets promoted.
+        """
+        step = _step_using("publish-testpypi", "gh-action-pypi-publish")
+        assert "skip-existing" not in step.get("with", {})
+
+    def test_production_publish_remains_strict(self) -> None:
+        step = _step_using("build-and-publish", "gh-action-pypi-publish")
+        assert "skip-existing" not in step.get("with", {})
+        assert "repository-url" not in step.get("with", {})
+
+
+class TestSmokeInstallStep:
+    """The smoke-install must retry for propagation and use pixi, not ambient python."""
+
+    def _smoke_step(self) -> dict[str, Any]:
+        steps = _steps("publish-testpypi")
+        matches = [s for s in steps if s.get("name") == "Smoke-install from TestPyPI"]
+        assert len(matches) == 1
+        return matches[0]
+
+    def test_uses_pixi_run_python(self) -> None:
+        run = self._smoke_step()["run"]
+        assert "pixi run python -m venv" in run
+
+    def test_retries_on_propagation_delay(self) -> None:
+        run = self._smoke_step()["run"]
+        assert "ATTEMPTS=10" in run
+        assert "SLEEP_SECONDS=30" in run
+        assert "no matching distribution" in run.lower()
+
+    def test_fails_hard_on_non_propagation_error(self) -> None:
+        run = self._smoke_step()["run"]
+        assert "not retrying" in run
+
+    def test_verifies_installed_version_matches_tag(self) -> None:
+        run = self._smoke_step()["run"]
+        assert "import hephaestus; print(hephaestus.__version__)" in run
+        assert "version mismatch" in run.lower()


### PR DESCRIPTION
## Summary
Everything is clean, no stray files.

## Summary

Implemented the TestPyPI staging gate from issue #1475's approved plan (with a fix for the reviewer's blocking NOGO finding):

- **`.github/workflows/release.yml`**: Added a `publish-testpypi` job (runs after `test`/`type-check`) that builds the dist once, uploads it as the `release-dist` artifact, publishes to TestPyPI, and smoke-installs it into a fresh `pixi run python -m venv` environment with a bounded 10×30s retry loop tolerant of index-propagation delay but failing hard on any other error. `build-and-publish` now `needs: [test, type-check, publish-testpypi]` and downloads the same `release-dist` artifact instead of rebuilding, guaranteeing byte-identical bytes between what's smoke-tested and what's promoted to production PyPI.
  - **Fixed the plan's Major review finding**: removed `skip-existing: true` from the TestPyPI publish step. The reviewer correctly flagged that `skip-existing` would let a re-dispatch silently smoke-test a stale pre-existing TestPyPI artifact instead of the freshly built dist, breaking the staging-gate's core guarantee. Now a duplicate-version re-dispatch fails loudly instead.
- **`docs/RELEASING.md`**: Updated the pipeline diagram and added a "TestPyPI Trusted Publishing" section documenting the one-time `testpypi` GitHub Environment + trusted-publisher setup required (a repo-admin action outside this session's scope).
- **`tests/unit/ci/test_release_workflow_wiring.py`** (new): Static YAML-parsing tests asserting the job graph (`needs` edges), artifact-name matching between upload/download, no duplicate build step, absence of `skip-existing` on both TestPyPI and production publish steps, and the smoke-install step's pixi usage/retry/version-check logic — addressing the reviewer's Minor finding about wiring-test coverage gaps.

Ran `pixi run pytest tests/unit/ci/` (147 passed) and `pixi run pre-commit run` on all changed files (all hooks passed, including YAML lint, mypy, ruff, and workflow inventory). Per ADR-014, the live end-to-end proof (actual TestPyPI publish + propagation-retry behavior + artifact reuse into production) can only be observed on a real tag push once the `testpypi` environment/trusted-publisher is provisioned — that live verification is deferred, not fabricated.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1475

Generated by Hephaestus automation
