### PR TITLE
fix(automation): dependency resolver re-implements CLOSED dependencies (state cache miss bypasses skip_closed)

### DIFF
--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -57,10 +57,21 @@ class DependencyResolver:
     def add_issue(self, issue: IssueInfo) -> None:
         """Add an issue to the dependency graph.
 
+        Refuses (and marks completed) any issue that is closed or tagged
+        ``state:skip`` when ``skip_closed`` is set — a belt-and-braces check
+        so a future call site that forgets its own closed-state check can't
+        silently reintroduce #1832 (cache-miss admission of a closed
+        dependency).
+
         Args:
             issue: IssueInfo to add
 
         """
+        if self.skip_closed and (issue.state.is_done or is_skipped(issue.labels)):
+            logger.info("Refusing to admit closed/skipped issue #%s to graph", issue.number)
+            self.mark_completed(issue.number)
+            return
+
         self.graph.add_issue(issue)
         for dep in issue.dependencies:
             self.add_dependency(issue.number, dep)

--- a/tests/unit/automation/test_dependency_resolver.py
+++ b/tests/unit/automation/test_dependency_resolver.py
@@ -6,7 +6,7 @@ from hephaestus.automation.dependency_resolver import (
     CyclicDependencyError,
     DependencyResolver,
 )
-from hephaestus.automation.models import IssueInfo
+from hephaestus.automation.models import IssueInfo, IssueState
 
 
 class TestDependencyResolver:
@@ -34,6 +34,36 @@ class TestDependencyResolver:
         resolver.add_issue(issue)
 
         assert resolver.graph.get_dependencies(123) == [100, 101]
+
+    def test_add_issue_refuses_closed_issue(self) -> None:
+        """add_issue is a belt-and-braces guard against admitting closed issues (#1832)."""
+        resolver = DependencyResolver(skip_closed=True)
+        closed = IssueInfo(number=99, title="Closed", state=IssueState.CLOSED)
+
+        resolver.add_issue(closed)
+
+        assert 99 not in resolver.graph.issues
+        assert 99 in resolver.completed
+
+    def test_add_issue_refuses_state_skip_issue(self) -> None:
+        """add_issue also refuses state:skip issues directly, not just via BFS."""
+        resolver = DependencyResolver(skip_closed=True)
+        skipped = IssueInfo(number=98, title="Skipped", labels=["state:skip"])
+
+        resolver.add_issue(skipped)
+
+        assert 98 not in resolver.graph.issues
+        assert 98 in resolver.completed
+
+    def test_add_issue_admits_closed_issue_when_skip_closed_false(self) -> None:
+        """--no-skip-closed preserves legacy behavior at the add_issue guard too."""
+        resolver = DependencyResolver(skip_closed=False)
+        closed = IssueInfo(number=97, title="Closed", state=IssueState.CLOSED)
+
+        resolver.add_issue(closed)
+
+        assert 97 in resolver.graph.issues
+        assert 97 not in resolver.completed
 
     def test_add_dependency(self) -> None:
         """Test adding a dependency through the resolver public API."""

--- a/tests/unit/automation/test_implementer_dependency_loading.py
+++ b/tests/unit/automation/test_implementer_dependency_loading.py
@@ -68,3 +68,22 @@ def test_no_skip_closed_keeps_closed_dependency_in_graph(tmp_path: Path) -> None
 
     assert 1818 not in implementer.resolver.completed
     assert 1818 in implementer.resolver.graph.issues
+
+
+def test_load_issues_dependency_absent_from_prefetch_cache_still_skipped(
+    tmp_path: Path,
+) -> None:
+    """Requesting B alone (A absent from prefetch) must not admit closed A (#1832).
+
+    Simulates the exact production failure: ``--issues 1819`` prefetches
+    states only for 1819, so the transitively-discovered dependency 1818 is
+    never in ``cached_states``. A cache miss must not bypass the closed check.
+    """
+    implementer = _implementer(tmp_path)
+    closed_dependency = IssueInfo(number=1818, title="Closed dep", state=IssueState.CLOSED)
+
+    _load_root_with_dependency(implementer, closed_dependency)
+
+    assert implementer.resolver.graph.issues.keys() == {1819}
+    assert 1818 in implementer.resolver.completed
+    assert 1818 not in implementer.resolver.graph.issues


### PR DESCRIPTION
## Summary
Clean. mypy passes tree-wide, ruff check/format pass, and all 2727 automation unit tests pass (28 new/existing tests targeting this fix included).

## Summary

Implemented the belt-and-braces guard from the approved plan for issue #1832:

- **`hephaestus/automation/dependency_resolver.py:57`** — `DependencyResolver.add_issue` now refuses (and marks completed via `mark_completed`) any issue that is closed (`state.is_done`) or tagged `state:skip`, when `skip_closed` is set. This centralizes the invariant in one place instead of relying on every call site to re-derive it, so a future caller that forgets its own check can't reintroduce the cache-miss bug.
- Confirmed the original reported bug (`_load_dependencies` skipping the closed check on cache miss) was already fixed by PR #2013 — no change needed there.

**Tests added:**
- `tests/unit/automation/test_dependency_resolver.py` — three new tests: `add_issue` refuses closed issues, refuses `state:skip` issues, and admits closed issues when `skip_closed=False` (legacy behavior preserved).
- `tests/unit/automation/test_implementer_dependency_loading.py` — added the issue's named end-to-end regression scenario (`test_load_issues_dependency_absent_from_prefetch_cache_still_skipped`): requesting issue B alone, where B depends on closed A absent from the prefetch cache, asserts only B ends up in the graph and A is marked completed.

**Verification run:**
- `pixi run pytest tests/unit/automation/test_dependency_resolver.py tests/unit/automation/test_implementer_dependency_loading.py -v` — 25 passed
- `pixi run pytest tests/unit/automation/ -q` — 2727 passed, 1 skipped
- `pixi run ruff check` / `ruff format --check` on touched files — clean
- `pixi run mypy` (full tree) — no issues

Working tree has the two file diffs left uncommitted per the git boundary policy.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1832

Generated by Hephaestus automation
