### PR TITLE
fix(automation): parse_issue_dependencies false-positives on prose containing 'dependencies'

### DIFF
--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -26,7 +26,7 @@ from collections import defaultdict, deque
 
 from .github_api import fetch_issue_info, prefetch_issue_states
 from .models import DependencyGraph, IssueInfo, IssueState
-from .state_labels import is_skipped
+from .state_labels import is_epic, is_skipped
 
 logger = logging.getLogger(__name__)
 
@@ -221,6 +221,14 @@ class DependencyResolver:
 
                 if is_skipped(dep_issue.labels):
                     logger.info("Dependency #%s is tagged state:skip, marking complete", dep_num)
+                    self.mark_completed(dep_num)
+                    continue
+
+                if is_epic(dep_issue.labels, dep_issue.title):
+                    logger.info(
+                        "Dependency #%s is an epic/roadmap issue, excluding from graph (#1830)",
+                        dep_num,
+                    )
                     self.mark_completed(dep_num)
                     continue
 

--- a/hephaestus/automation/github_api/issues.py
+++ b/hephaestus/automation/github_api/issues.py
@@ -445,13 +445,18 @@ def parse_issue_dependencies(issue_body: str) -> list[int]:
     """
     dependencies = []
 
-    # Pattern 1: Find all #numbers after dependency keywords
+    # Pattern 1: Find all #numbers after dependency keywords on the same
+    # line. Only refs at-or-after the keyword match are harvested — a #N
+    # that precedes the keyword (e.g. "Part of epic #1809. Depends on
+    # #1811.") must not be treated as a dependency, and a line that merely
+    # *mentions* the keyword with no following ref (e.g. "no dependencies.")
+    # must yield nothing (#1830).
     dep_keywords = r"(?:depends on|blocked by|requires|dependencies?:?)"
-    # Find all #123 patterns in lines containing dependency keywords
+    keyword_re = re.compile(dep_keywords, re.IGNORECASE)
     for line in issue_body.split("\n"):
-        if re.search(dep_keywords, line, re.IGNORECASE):
-            # Find all #number patterns in this line
-            for match in re.finditer(r"#(\d+)", line):
+        keyword_match = keyword_re.search(line)
+        if keyword_match:
+            for match in re.finditer(r"#(\d+)", line[keyword_match.start() :]):
                 dependencies.append(int(match.group(1)))
 
     # Pattern 2: Find issue references in lists under Dependencies heading

--- a/tests/unit/automation/test_dependency_resolver.py
+++ b/tests/unit/automation/test_dependency_resolver.py
@@ -276,3 +276,33 @@ class TestLoadDependenciesIterative:
         assert 9 in resolver.graph.issues
         assert 8 in resolver.graph.issues
         assert 7 in resolver.graph.issues
+
+    def test_epic_labeled_dependency_is_excluded_from_graph(self) -> None:
+        """A dependency labeled 'epic' is marked complete, not admitted to the graph (#1830).
+
+        Mirrors the planning-loop epic exclusion (#1669) at the implementer's
+        dependency-resolution chokepoint: even a legitimately-worded
+        "Depends on #<epic-number>" line must not pull an epic/roadmap issue
+        (and transitively its own dependency mentions) into the graph.
+        """
+        from unittest.mock import patch
+
+        resolver = DependencyResolver(skip_closed=False)
+        root = IssueInfo(number=10, title="Root", dependencies=[1809])
+        epic_issue = IssueInfo(
+            number=1809,
+            title="Epic: pipeline rework",
+            labels=["epic"],
+            dependencies=[1422],
+        )
+
+        with patch(
+            "hephaestus.automation.dependency_resolver.fetch_issue_info",
+            return_value=epic_issue,
+        ) as mock_fetch:
+            resolver._load_dependencies(root, {})
+
+        mock_fetch.assert_called_once_with(1809)
+        assert 1809 in resolver.completed
+        assert 1809 not in resolver.graph.issues
+        assert 1422 not in resolver.graph.issues

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -176,6 +176,34 @@ class TestParseIssueDependencies:
         assert len(deps) == 1
         assert 123 in deps
 
+    def test_no_dependencies_prose_with_hash_ref_not_captured(self) -> None:
+        """A '#N' ref sharing a line with 'no dependencies' prose is not harvested (#1830)."""
+        body = "Part of epic #1809. First issue of the epic — no dependencies."
+        deps = parse_issue_dependencies(body)
+
+        assert deps == []
+
+    def test_epic_ref_and_depends_on_same_line_only_captures_depends_on_target(self) -> None:
+        """A '#N' ref preceding the keyword is excluded; only refs after it are harvested."""
+        body = "Part of epic #1809. Depends on #1811."
+        deps = parse_issue_dependencies(body)
+
+        assert deps == [1811]
+
+    def test_dependencies_heading_section_still_parsed(self) -> None:
+        """The '## Dependencies' list-item scan (Pattern 2) is unaffected by the fix (#1830)."""
+        body = """
+        Part of epic #1809. No inline dependency mentions here.
+
+        ## Dependencies
+        - #100
+        - #200
+        """
+        deps = parse_issue_dependencies(body)
+
+        assert set(deps) == {100, 200}
+        assert 1809 not in deps
+
 
 class TestFetchIssueInfo:
     """Tests for fetch_issue_info function."""


### PR DESCRIPTION
## Summary
All 2727 tests pass, mypy and ruff are clean.

## Summary

Implemented both defense layers from the approved plan for issue #1830:

**Layer 1 — parser fix** (`hephaestus/automation/github_api/issues.py:446-459`): `parse_issue_dependencies` now only harvests `#N` refs from the position of the dependency-keyword match onward in a line, instead of scanning the whole line. A `#N` preceding the keyword (e.g. epic ref before "Depends on") is excluded; a line that merely mentions "dependencies" with no following ref yields nothing.

**Layer 2 — resolver chokepoint fix** (`hephaestus/automation/dependency_resolver.py`): `_load_dependencies` now imports and calls `is_epic` (mirroring the existing `is_skipped` guard) to exclude epic/roadmap-labeled issues from dependency-graph admission entirely, regardless of how the reference was harvested.

**Tests added:**
- `tests/unit/automation/test_github_api.py`: 3 new cases in `TestParseIssueDependencies` — "no dependencies" prose with a preceding `#N`, epic-ref + `Depends on` same line, and `## Dependencies` section still parses correctly.
- `tests/unit/automation/test_dependency_resolver.py`: `test_epic_labeled_dependency_is_excluded_from_graph` in `TestLoadDependenciesIterative`, confirming an epic-labeled dependency is marked complete (not added to the graph) and its own transitive dependencies are never fetched.

**Verification:** `pixi run pytest tests/unit/automation -q` → 2727 passed, 1 skipped; `pixi run mypy` → clean; `pixi run ruff check`/`format --check` → clean. All changes left uncommitted in the working tree per the git boundary policy.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1830

Generated by Hephaestus automation
