### PR TITLE
test(ci): add hook-registration guard for check-no-unlinked-todo

### DIFF
--- a/tests/unit/ci/test_unlinked_todo_hook.py
+++ b/tests/unit/ci/test_unlinked_todo_hook.py
@@ -1,0 +1,27 @@
+"""Tests for the local check-no-unlinked-todo pre-commit hook registration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_unlinked_todo_hook_is_registered() -> None:
+    """The hook must stay registered with its canonical entry command."""
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    hook = next(
+        h
+        for repo in config["repos"]
+        for h in repo.get("hooks", [])
+        if h.get("id") == "check-no-unlinked-todo"
+    )
+
+    assert hook["entry"] == (
+        "pixi run --environment default python3 -m hephaestus.validation.unlinked_todo"
+    )
+    assert hook["language"] == "system"
+    assert hook["pass_filenames"] is False
+    assert hook["files"] == r"^(hephaestus|scripts)/.*\.py$|^docs/TECH_DEBT\.md$"


### PR DESCRIPTION
## Summary
Lint and format both pass. Implementation is complete and matches the approved plan exactly.

**Summary:** Added `tests/unit/ci/test_unlinked_todo_hook.py`, mirroring `test_private_denylist_hook.py`'s style, asserting the `check-no-unlinked-todo` hook stays registered in `.pre-commit-config.yaml` with `entry: pixi run --environment default python3 -m hephaestus.validation.unlinked_todo` (the canonical form, not the stale pixi-console-script guess from the closed duplicate PR #1774), plus `language`, `pass_filenames`, and `files` assertions.

Tests: `pixi run pytest tests/unit/ci -v` → 132 passed. `ruff check`/`ruff format --check` on the new file → clean. No files modified besides the new test.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1834

Generated by Hephaestus automation
