### PR TITLE
[Bug]: ctrl+c doesn't kill the script, ctrl+z doesn't pause it

### DIFF
--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -17,6 +17,7 @@ from hephaestus.agents.runtime import (
 from hephaestus.automation.agent_config import normalize_claude_model
 from hephaestus.cli.utils import add_json_arg, add_version_arg, emit_json_status
 from hephaestus.io.utils import write_secure
+from hephaestus.utils.terminal import install_sigtstp_only, terminal_guard
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -210,11 +211,23 @@ def run_agent(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the agent stage command-line interface."""
+    """Run the agent stage command-line interface.
+
+    This entrypoint makes a single blocking agent call with no internal
+    polling loop, so it deliberately does NOT install the cooperative
+    double-Ctrl+C handler (:func:`install_signal_handlers`) — that would
+    replace Python's default SIGINT disposition (instant ``KeyboardInterrupt``)
+    with a handler whose first press only sets a flag, silently absorbing a
+    single Ctrl+C instead of killing the blocking ``claude``/``gh`` subprocess.
+    Only SIGTSTP (Ctrl+Z) is wired here, plus bare terminal restoration.
+    """
     parser = build_parser()
     args = parser.parse_args(argv)
     validate_agent_flags(parser, args)
-    exit_code = run_agent(args)
+
+    install_sigtstp_only()
+    with terminal_guard():
+        exit_code = run_agent(args)
     if args.json:
         emit_json_status(exit_code, stage=args.stage, agent=args.agent)
     return exit_code

--- a/hephaestus/automation/audit_reviewer.py
+++ b/hephaestus/automation/audit_reviewer.py
@@ -15,6 +15,7 @@ import json
 import logging
 import re
 import subprocess
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +33,7 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 from hephaestus.io.utils import write_secure
+from hephaestus.utils.terminal import terminal_guard
 
 from ._review_utils import build_automation_parser, ensure_state_dir
 from .agent_config import DEFAULT_AGENT_TIMEOUT
@@ -203,6 +205,7 @@ class AuditReviewer:
     state_dir: Path | None = None
     dry_run: bool = False
     timeout: int = DEFAULT_AGENT_TIMEOUT
+    shutdown_event: threading.Event | None = None
 
     def __post_init__(self) -> None:
         """Set default state_dir if not provided."""
@@ -234,6 +237,9 @@ class AuditReviewer:
             logger.info("Audit report written to %s", report)
         print_audit_summary(audits)
         for a in audits:
+            if self.shutdown_event is not None and self.shutdown_event.is_set():
+                logger.warning("Interrupted; stopping before remaining PR postings.")
+                break
             try:
                 gh_pr_review_post(
                     pr_number=int(a["pr_number"]),
@@ -274,15 +280,24 @@ def main(argv: list[str] | None = None) -> int:
     configure_cli_logging(verbose=args.verbose)
     selected_agent = "codex" if args.codex else args.agent
     agent = (selected_agent or "claude") if args.dry_run else resolve_agent(selected_agent)
-    reviewer = AuditReviewer(
-        agent=agent,
-        pr_numbers=args.pr_numbers,
-        dry_run=args.dry_run,
-    )
-    rc, audits = reviewer.run()
-    if getattr(args, "json", False):
-        emit_json_status(rc, audits=len(audits))
-    return rc
+
+    shutdown = threading.Event()
+    with terminal_guard(shutdown.set):
+        try:
+            reviewer = AuditReviewer(
+                agent=agent,
+                pr_numbers=args.pr_numbers,
+                dry_run=args.dry_run,
+                shutdown_event=shutdown,
+            )
+            rc, audits = reviewer.run()
+            if getattr(args, "json", False):
+                emit_json_status(rc, audits=len(audits))
+            return rc
+        except KeyboardInterrupt:
+            if getattr(args, "json", False):
+                emit_json_status(130, message="interrupted")
+            return 130
 
 
 if __name__ == "__main__":

--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -282,8 +282,11 @@ def main() -> int:
     # — and the ``from hephaestus.automation.ci_driver import main`` import-cycle
     # smoke test — stays free of the coordinator's heavier import surface until
     # the CLI actually runs.
+    from hephaestus.utils.terminal import install_sigtstp_only
+
     from .pipeline.coordinator import PipelineConfig, run_pipeline
 
+    install_sigtstp_only()
     args = _parse_args()
     configure_github_throttle_from_args(args)
     _setup_logging(args.verbose)

--- a/hephaestus/automation/ensure_state_labels.py
+++ b/hephaestus/automation/ensure_state_labels.py
@@ -32,6 +32,7 @@ import json
 import logging
 import subprocess
 import sys
+import threading
 
 from hephaestus.cli.utils import (
     configure_cli_logging,
@@ -39,6 +40,7 @@ from hephaestus.cli.utils import (
     emit_json_status,
 )
 from hephaestus.github.client import gh_call
+from hephaestus.utils.terminal import terminal_guard
 
 from ._review_utils import build_automation_parser
 from .state_labels import STATE_LABEL_SPECS
@@ -187,43 +189,53 @@ def main(argv: list[str] | None = None) -> int:
     configure_github_throttle_from_args(args)
     configure_cli_logging(verbose=args.verbose)
 
-    if args.org:
-        repos = _gh_list_org_repos(args.org)
-        if not repos:
-            logger.warning("No repos returned for org %s — nothing to do.", args.org)
-            if args.json:
-                emit_json_status(0, "no-repos", org=args.org)
-            return 0
-        slugs = [f"{args.org}/{name}" for name in repos]
-        logger.info("Ensuring state:* labels on %d repos in %s", len(slugs), args.org)
-    elif args.repo:
-        slugs = [args.repo]
-    else:
-        slugs = [_detect_current_repo_slug()]
+    shutdown = threading.Event()
+    with terminal_guard(shutdown.set):
+        try:
+            if args.org:
+                repos = _gh_list_org_repos(args.org)
+                if not repos:
+                    logger.warning("No repos returned for org %s — nothing to do.", args.org)
+                    if args.json:
+                        emit_json_status(0, "no-repos", org=args.org)
+                    return 0
+                slugs = [f"{args.org}/{name}" for name in repos]
+                logger.info("Ensuring state:* labels on %d repos in %s", len(slugs), args.org)
+            elif args.repo:
+                slugs = [args.repo]
+            else:
+                slugs = [_detect_current_repo_slug()]
 
-    total_issued = 0
-    for slug in slugs:
-        total_issued += ensure_labels_on_repo(slug, dry_run=args.dry_run)
-    if args.dry_run:
-        logger.info(
-            "[dry-run] Would ensure %d labels across %d repo(s).",
-            len(STATE_LABEL_SPECS) * len(slugs),
-            len(slugs),
-        )
-    else:
-        logger.info(
-            "Ensured %d label(s) across %d repo(s).",
-            total_issued,
-            len(slugs),
-        )
-    if args.json:
-        emit_json_status(
-            0,
-            "dry-run" if args.dry_run else "ok",
-            repos=len(slugs),
-            labels_ensured=total_issued,
-        )
-    return 0
+            total_issued = 0
+            for slug in slugs:
+                if shutdown.is_set():
+                    logger.warning("Interrupted; stopping before remaining repos.")
+                    break
+                total_issued += ensure_labels_on_repo(slug, dry_run=args.dry_run)
+            if args.dry_run:
+                logger.info(
+                    "[dry-run] Would ensure %d labels across %d repo(s).",
+                    len(STATE_LABEL_SPECS) * len(slugs),
+                    len(slugs),
+                )
+            else:
+                logger.info(
+                    "Ensured %d label(s) across %d repo(s).",
+                    total_issued,
+                    len(slugs),
+                )
+            if args.json:
+                emit_json_status(
+                    0,
+                    "dry-run" if args.dry_run else "ok",
+                    repos=len(slugs),
+                    labels_ensured=total_issued,
+                )
+            return 0
+        except KeyboardInterrupt:
+            if args.json:
+                emit_json_status(130, message="interrupted")
+            return 130
 
 
 if __name__ == "__main__":

--- a/hephaestus/automation/implementer.py
+++ b/hephaestus/automation/implementer.py
@@ -464,9 +464,12 @@ def main() -> int:
     # — and the ``from hephaestus.automation.implementer import main`` import-cycle
     # smoke test — stays free of the coordinator's heavier import surface until
     # the CLI actually runs.
+    from hephaestus.utils.terminal import install_sigtstp_only
+
     from .pipeline.coordinator import PipelineConfig, run_pipeline
     from .pipeline.routing import PipelineScope, StageName
 
+    install_sigtstp_only()
     args = _parse_args()
     configure_github_throttle_from_args(args)
     agent = resolve_agent(args.agent)

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -709,6 +709,9 @@ def main(argv: list[str] | None = None) -> int:
     if cfg.prs:
         LOG.info("PRs: %s", ",".join(str(n) for n in cfg.prs))
 
+    from hephaestus.utils.terminal import install_sigtstp_only
+
+    install_sigtstp_only()
     return _dispatch_pipeline(args, cfg, org, repos)
 
 

--- a/hephaestus/automation/plan_reviewer.py
+++ b/hephaestus/automation/plan_reviewer.py
@@ -33,6 +33,7 @@ from hephaestus.automation._review_utils import (
 )
 from hephaestus.cli.utils import add_agent_timeout_arg, configure_cli_logging, emit_json_status
 from hephaestus.github.rate_limit import wait_until
+from hephaestus.utils.terminal import terminal_guard
 
 from .agent_config import DEFAULT_AGENT_TIMEOUT
 from .claude_invoke import invoke_claude_with_session, parse_review_verdict, scan_quota_reset
@@ -669,7 +670,8 @@ def main() -> int:
     log.info("Starting plan review for issues: %s", args.issues)
 
     work_units = 0
-    with work_report_context(lambda: work_units):
+    shutdown = threading.Event()
+    with work_report_context(lambda: work_units), terminal_guard(shutdown.set):
         try:
             options = PlanReviewerOptions(
                 issues=args.issues,

--- a/hephaestus/automation/planner.py
+++ b/hephaestus/automation/planner.py
@@ -168,8 +168,11 @@ def main() -> int:
     # — and the ``from hephaestus.automation.planner import main`` import-cycle
     # smoke test — stays free of the coordinator's heavier import surface until
     # the CLI actually runs.
+    from hephaestus.utils.terminal import install_sigtstp_only
+
     from .pipeline.coordinator import PipelineConfig, run_pipeline
 
+    install_sigtstp_only()
     args = _parse_args()
     configure_github_throttle_from_args(args)
     _setup_logging(args.verbose)

--- a/hephaestus/automation/pr_reviewer.py
+++ b/hephaestus/automation/pr_reviewer.py
@@ -155,8 +155,11 @@ def main() -> int:
     # — and the ``from hephaestus.automation.pr_reviewer import main`` import-cycle
     # smoke test — stays free of the coordinator's heavier import surface until
     # the CLI actually runs.
+    from hephaestus.utils.terminal import install_sigtstp_only
+
     from .pipeline.coordinator import PipelineConfig, run_pipeline
 
+    install_sigtstp_only()
     args = _parse_args()
     configure_github_throttle_from_args(args)
     _setup_logging(args.verbose)

--- a/hephaestus/utils/terminal.py
+++ b/hephaestus/utils/terminal.py
@@ -3,6 +3,7 @@
 Provides:
 - restore_terminal(): Run stty sane to fix terminal corruption
 - install_signal_handlers(): Double-Ctrl+C escalation pattern
+- install_sigtstp_only(): Ctrl+Z (SIGTSTP) handling independent of SIGINT/SIGTERM
 - terminal_guard(): Context manager combining both
 """
 
@@ -10,6 +11,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import os
 import signal
 import subprocess
 import sys
@@ -42,14 +44,40 @@ atexit.register(restore_terminal)
 _shutdown_requested: list[bool] = [False]
 
 
+def install_sigtstp_only() -> None:
+    """Install a SIGTSTP (Ctrl+Z) handler independent of SIGINT/SIGTERM.
+
+    Restores the terminal, then genuinely suspends the process (SIG_DFL +
+    self-SIGSTOP) so shell job control (``fg``/``bg``) works, then re-arms
+    itself. Safe to call alongside Python's *default* SIGINT disposition —
+    unlike :func:`install_signal_handlers`, this does not touch SIGINT/SIGTERM,
+    so a single blocking call still dies immediately on the first Ctrl+C.
+
+    No-ops on platforms without ``SIGTSTP`` (e.g. Windows).
+    """
+
+    def _sigtstp_handler(signum: int, frame: object) -> None:
+        restore_terminal()
+        signal.signal(signal.SIGTSTP, signal.SIG_DFL)
+        os.kill(os.getpid(), signal.SIGSTOP)
+        signal.signal(signal.SIGTSTP, _sigtstp_handler)
+
+    if hasattr(signal, "SIGTSTP"):
+        with contextlib.suppress(ValueError):
+            signal.signal(signal.SIGTSTP, _sigtstp_handler)
+
+
 def install_signal_handlers(shutdown_fn: Callable[[], None]) -> None:
-    """Install SIGINT/SIGTERM handlers with double-Ctrl+C escalation.
+    """Install SIGINT/SIGTERM handlers with double-Ctrl+C escalation, plus SIGTSTP.
 
     First signal: calls shutdown_fn() and prints a "press Ctrl+C again"
     message — cooperative shutdown.
 
     Second signal: restores terminal and calls sys.exit(128 + signum) —
     forceful exit.
+
+    Also installs a SIGTSTP (Ctrl+Z) handler via :func:`install_sigtstp_only`
+    so shell job control keeps working for looping entrypoints.
 
     Args:
         shutdown_fn: Callable that requests graceful shutdown (sets a flag,
@@ -75,9 +103,7 @@ def install_signal_handlers(shutdown_fn: Callable[[], None]) -> None:
 
     signal.signal(signal.SIGINT, _handler)
     signal.signal(signal.SIGTERM, _handler)
-    # Note: SIGTSTP (Ctrl+Z) is intentionally NOT handled here.
-    # It is a job-control signal; callers (e.g., cmd_run) register their
-    # own SIGTSTP handler for forceful process-group kill.
+    install_sigtstp_only()
 
 
 @contextlib.contextmanager

--- a/tests/unit/automation/test_agent_stage.py
+++ b/tests/unit/automation/test_agent_stage.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -285,6 +286,47 @@ def test_main_allows_approval_with_codex_agent(
         "on-request",
     ]
     assert agent_stage.main(argv) == 0
+
+
+def test_main_installs_sigtstp_only_not_cooperative_sigint_handler(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() must fix Ctrl+Z without swallowing a single blocking-call Ctrl+C.
+
+    agent_stage.main() makes one blocking agent call with no polling loop, so
+    it must not install the cooperative double-Ctrl+C handler (which would
+    absorb the first Ctrl+C instead of letting default SIGINT kill the
+    blocking subprocess). It must still fix Ctrl+Z via install_sigtstp_only.
+    """
+
+    def fake_run_claude_text(*a: object, **kw: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(["claude"], 0, stdout="ok", stderr="")
+
+    monkeypatch.setattr(agent_stage, "run_claude_text", fake_run_claude_text)
+    monkeypatch.setattr(agent_stage, "resolve_agent", lambda x: "claude")
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--agent",
+        "claude",
+    ]
+
+    with (
+        patch("hephaestus.automation.agent_stage.install_sigtstp_only") as mock_tstp,
+        patch("hephaestus.automation.agent_stage.terminal_guard") as mock_guard,
+    ):
+        assert agent_stage.main(argv) == 0
+        mock_tstp.assert_called_once_with()
+        mock_guard.assert_called_once_with()
 
 
 def test_main_rejects_approval_with_pi_agent(

--- a/tests/unit/automation/test_audit_reviewer.py
+++ b/tests/unit/automation/test_audit_reviewer.py
@@ -439,6 +439,63 @@ class TestAuditReviewerRun:
         assert reviewer.state_dir == tmp_path / DEFAULT_STATE_DIR
         assert reviewer.state_dir.is_dir()
 
+    @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
+    @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
+    def test_shutdown_event_stops_remaining_postings(
+        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    ) -> None:
+        """A set shutdown_event stops posting further PR reviews mid-loop."""
+        import threading
+
+        mock_fetch.return_value = [{"number": 100}, {"number": 101}]
+        mock_coord.return_value = [
+            {"pr_number": 100, "verdict": "GO", "summary": "a"},
+            {"pr_number": 101, "verdict": "GO", "summary": "b"},
+        ]
+        shutdown = threading.Event()
+        shutdown.set()
+        reviewer = AuditReviewer(shutdown_event=shutdown)
+        rc, audits = reviewer.run()
+        assert rc == 0
+        assert len(audits) == 2  # audits themselves still returned
+        mock_post.assert_not_called()  # but posting loop stopped immediately
+
+    @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
+    @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
+    def test_unset_shutdown_event_posts_all(
+        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    ) -> None:
+        """An unset shutdown_event does not interrupt the posting loop."""
+        import threading
+
+        mock_fetch.return_value = [{"number": 100}]
+        mock_coord.return_value = [{"pr_number": 100, "verdict": "GO", "summary": "a"}]
+        reviewer = AuditReviewer(shutdown_event=threading.Event())
+        rc, _audits = reviewer.run()
+        assert rc == 0
+        mock_post.assert_called_once()
+
+
+class TestAuditReviewerMainSignalWiring:
+    """main() wraps the reviewer in terminal_guard(shutdown.set)."""
+
+    @mock.patch("hephaestus.automation.audit_reviewer.fetch_open_prs")
+    @mock.patch("hephaestus.automation.audit_reviewer.run_audit_coordinator")
+    @mock.patch("hephaestus.automation.audit_reviewer.gh_pr_review_post")
+    def test_main_installs_cooperative_terminal_guard(
+        self, mock_post: mock.Mock, mock_coord: mock.Mock, mock_fetch: mock.Mock
+    ) -> None:
+        from hephaestus.automation.audit_reviewer import main
+
+        mock_fetch.return_value = []
+        with mock.patch("hephaestus.automation.audit_reviewer.terminal_guard") as mock_guard:
+            assert main(["--dry-run"]) == 0
+            mock_guard.assert_called_once()
+            (shutdown_fn,), _ = mock_guard.call_args
+            assert callable(shutdown_fn)
+
 
 class TestParser:
     """Test CLI argument parsing."""

--- a/tests/unit/automation/test_ci_driver_main.py
+++ b/tests/unit/automation/test_ci_driver_main.py
@@ -221,3 +221,12 @@ def test_main_handles_keyboard_interrupt() -> None:
         rc = ci_driver_mod.main()
 
     assert rc == 130
+
+
+def test_main_installs_sigtstp_handler() -> None:
+    """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper."""
+    with patch("hephaestus.utils.terminal.install_sigtstp_only") as mock_tstp:
+        captured = _run_main_capturing_config(["--issues", "5", "--dry-run"])
+
+    assert captured["rc"] == 0
+    mock_tstp.assert_called_once_with()

--- a/tests/unit/automation/test_ensure_state_labels.py
+++ b/tests/unit/automation/test_ensure_state_labels.py
@@ -264,3 +264,27 @@ class TestCircuitBreakerBoundary:
 
         source = Path(ensure_state_labels.__file__).read_text(encoding="utf-8")
         assert not re.search(r"subprocess\.run\(\s*\[\s*[\"']gh[\"']", source)
+
+
+class TestSignalWiring:
+    """main() must wrap the per-repo loop in terminal_guard for Ctrl+C/Ctrl+Z."""
+
+    def test_main_installs_cooperative_terminal_guard(self, mock_gh_call: MagicMock) -> None:
+        mock_gh_call.side_effect = [_ok_proc() for _ in range(len(STATE_LABEL_SPECS))]
+        with patch("hephaestus.automation.ensure_state_labels.terminal_guard") as mock_guard:
+            rc = main(["--repo", "owner/name"])
+        assert rc == 0
+        mock_guard.assert_called_once()
+        (shutdown_fn,), _ = mock_guard.call_args
+        assert callable(shutdown_fn)
+
+    def test_shutdown_event_stops_remaining_repos(self, mock_gh_call: MagicMock) -> None:
+        """A shutdown_event set before the loop starts skips all repos."""
+        import threading
+
+        real_event = threading.Event()
+        real_event.set()
+        with patch("threading.Event", return_value=real_event):
+            rc = main(["--repo", "owner/name"])
+        assert rc == 0
+        mock_gh_call.assert_not_called()

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -121,6 +121,15 @@ def test_main_returns_run_pipeline_exit_code(tmp_path: Path) -> None:
     assert captured["rc"] == 1
 
 
+def test_main_installs_sigtstp_handler(tmp_path: Path) -> None:
+    """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper."""
+    with patch("hephaestus.utils.terminal.install_sigtstp_only") as mock_tstp:
+        captured = _run_main_capturing_config(["--issues", "5", "--dry-run"], tmp_path)
+
+    assert captured["rc"] == 0
+    mock_tstp.assert_called_once_with()
+
+
 def test_main_discovers_open_issues_when_none_given(tmp_path: Path) -> None:
     """With no --issues/--epic, main() seeds the discovered open-issue list."""
     with (

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -529,6 +529,26 @@ def test_main_disables_phase_timeout_when_zero(monkeypatch: pytest.MonkeyPatch) 
     assert config.phase_timeout_s is None  # type: ignore[attr-defined]
 
 
+def test_main_installs_sigtstp_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper.
+
+    The pipeline's Coordinator already installs its own cooperative
+    SIGINT/SIGTERM/SIGHUP handlers on entry, but never wired SIGTSTP — this
+    wrapper installs it independently before dispatching to the coordinator.
+    """
+    from hephaestus.automation.pipeline import coordinator as coordinator_mod
+
+    monkeypatch.setattr(loop_runner, "_resolve_org_and_repos", lambda args: ("Org", ["Repo"], None))
+    monkeypatch.setattr(loop_runner, "_preflight_token_scopes", lambda *a, **k: None)
+    monkeypatch.setattr(coordinator_mod, "run_pipeline", lambda config: 0)
+
+    with patch("hephaestus.utils.terminal.install_sigtstp_only") as mock_tstp:
+        rc = main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
+
+    assert rc == 0
+    mock_tstp.assert_called_once_with()
+
+
 def test_main_prefers_current_checkout_parent_for_projects_dir_default(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/automation/test_plan_reviewer.py
+++ b/tests/unit/automation/test_plan_reviewer.py
@@ -803,6 +803,30 @@ class TestMain:
         assert plan_reviewer.main() == 0
         assert seen_issues == [[5]]
 
+    def test_installs_cooperative_terminal_guard(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """main() wraps the review workflow in terminal_guard(shutdown.set).
+
+        This wires up both the cooperative double-Ctrl+C escalation and the
+        SIGTSTP (Ctrl+Z) handler (#1784) for this looping, multi-issue entrypoint.
+        """
+        from hephaestus.automation import plan_reviewer
+        from hephaestus.automation.models import WorkerResult
+
+        monkeypatch.setattr(
+            "sys.argv",
+            ["plan-reviewer", "--issues", "1", "--no-ui", "--dry-run", "--agent", "claude"],
+        )
+
+        def fake_run(self: object) -> dict[int, WorkerResult]:
+            return {1: WorkerResult(issue_number=1, success=True)}
+
+        monkeypatch.setattr(plan_reviewer.PlanReviewer, "run", fake_run)
+        with patch("hephaestus.automation.plan_reviewer.terminal_guard") as mock_guard:
+            assert plan_reviewer.main() == 0
+            mock_guard.assert_called_once()
+            (shutdown_fn,), _ = mock_guard.call_args
+            assert callable(shutdown_fn)
+
 
 class TestPlanReviewerAlreadyReviewedFlag:
     """Tests for WorkerResult.already_reviewed flag (#613).

--- a/tests/unit/automation/test_planner_main.py
+++ b/tests/unit/automation/test_planner_main.py
@@ -118,6 +118,15 @@ def test_main_returns_run_pipeline_exit_code() -> None:
     assert captured["rc"] == 1
 
 
+def test_main_installs_sigtstp_handler() -> None:
+    """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper."""
+    with patch("hephaestus.utils.terminal.install_sigtstp_only") as mock_tstp:
+        captured = _run_main_capturing_config(["--issues", "5", "--dry-run"])
+
+    assert captured["rc"] == 0
+    mock_tstp.assert_called_once_with()
+
+
 def test_main_discovers_open_issues_when_none_given() -> None:
     """With no --issues, main() seeds the discovered open-issue list."""
     with (

--- a/tests/unit/automation/test_pr_reviewer_main.py
+++ b/tests/unit/automation/test_pr_reviewer_main.py
@@ -104,3 +104,12 @@ def test_parse_args_requires_issues() -> None:
     """The reviewer CLI requires --issues (build_review_parser sets required=True)."""
     with pytest.raises(SystemExit):
         pr_reviewer_mod._parse_args([])
+
+
+def test_main_installs_sigtstp_handler() -> None:
+    """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper."""
+    with patch("hephaestus.utils.terminal.install_sigtstp_only") as mock_tstp:
+        captured = _run_main_capturing_config(["--issues", "5", "--dry-run"])
+
+    assert captured["rc"] == 0
+    mock_tstp.assert_called_once_with()

--- a/tests/unit/utils/test_terminal.py
+++ b/tests/unit/utils/test_terminal.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import hephaestus.utils.terminal as terminal_module
 from hephaestus.utils.terminal import (
     install_signal_handlers,
+    install_sigtstp_only,
     restore_terminal,
     terminal_guard,
 )
@@ -82,6 +83,61 @@ class TestInstallSignalHandlers:
         terminal_module._shutdown_requested[0] = True
         install_signal_handlers(MagicMock())
         assert terminal_module._shutdown_requested[0] is False
+
+    def test_installs_sigtstp_handler(self) -> None:
+        """install_signal_handlers also wires up SIGTSTP via install_sigtstp_only."""
+        import signal as signal_module
+
+        with patch("signal.signal") as mock_signal:
+            install_signal_handlers(MagicMock())
+            registered = {call.args[0] for call in mock_signal.call_args_list}
+            assert signal_module.SIGTSTP in registered
+
+
+class TestInstallSigtstpOnly:
+    """Tests for install_sigtstp_only."""
+
+    def test_registers_only_sigtstp(self) -> None:
+        """Registers a handler for SIGTSTP and touches no other signal."""
+        import signal as signal_module
+
+        with patch("signal.signal") as mock_signal:
+            install_sigtstp_only()
+            registered = {call.args[0] for call in mock_signal.call_args_list}
+            assert registered == {signal_module.SIGTSTP}
+
+    def test_handler_restores_terminal_then_sigstops_self(self) -> None:
+        """The handler restores the terminal, self-SIGSTOPs, then re-arms."""
+        import signal as signal_module
+        from collections.abc import Callable
+
+        captured: dict[int, Callable[[int, object], None]] = {}
+
+        def fake_signal(sig: int, handler: Callable[[int, object], None]) -> None:
+            captured[sig] = handler
+
+        with (
+            patch("signal.signal", side_effect=fake_signal),
+            patch("hephaestus.utils.terminal.restore_terminal") as mock_restore,
+            patch("os.kill") as mock_kill,
+            patch("os.getpid", return_value=4242),
+        ):
+            install_sigtstp_only()
+            captured[signal_module.SIGTSTP](signal_module.SIGTSTP, None)
+            mock_restore.assert_called_once()
+            mock_kill.assert_called_once_with(4242, signal_module.SIGSTOP)
+            # Re-armed: signal.signal was called for SIGTSTP more than once
+            # (initial install + SIG_DFL + re-arm inside the handler).
+            assert captured[signal_module.SIGTSTP] is not None
+
+    def test_noop_when_sigtstp_unavailable(self) -> None:
+        """Does not raise or call signal.signal when SIGTSTP is unavailable."""
+        with (
+            patch("signal.signal") as mock_signal,
+            patch("hephaestus.utils.terminal.hasattr", return_value=False, create=True),
+        ):
+            install_sigtstp_only()
+            mock_signal.assert_not_called()
 
 
 class TestTerminalGuard:


### PR DESCRIPTION
## Summary
The implementation is complete and verified. Summary of changes for issue #1784 (Ctrl+C/Ctrl+Z reliability):

**`hephaestus/utils/terminal.py`** — added `install_sigtstp_only()`, a standalone SIGTSTP (Ctrl+Z) handler independent of SIGINT/SIGTERM (restores terminal, self-SIGSTOPs, re-arms). `install_signal_handlers()` now delegates to it, so all cooperative-shutdown callers get Ctrl+Z support automatically.

**`hephaestus/automation/agent_stage.py`** — the single-shot blocking-call entrypoint now calls `install_sigtstp_only()` + bare `terminal_guard()`, deliberately *not* installing the cooperative SIGINT handler (which would swallow the first Ctrl+C on a blocking `claude`/`gh` subprocess call).

**`hephaestus/automation/audit_reviewer.py`, `ensure_state_labels.py`, `plan_reviewer.py`** — these looping entrypoints now wrap their work in `terminal_guard(shutdown.set)`, fixing both graceful double-Ctrl+C escalation and Ctrl+Z; the first two also check `shutdown.is_set()` between per-item iterations.

**Architecture correction mid-implementation:** the original plan called for wiring `install_sigtstp_only()` directly into `pipeline/coordinator.py`, but that package is a strict zero-I/O pure-data layer (`tests/unit/automation/pipeline/test_zero_io_imports.py` forbids importing `os`, `subprocess`, or `hephaestus.utils.*`). Instead, `install_sigtstp_only()` is now called from the five thin CLI wrappers that dispatch into the coordinator (`loop_runner.py`, `ci_driver.py`, `implementer.py`, `planner.py`, `pr_reviewer.py`), which already do I/O and sit outside that boundary. The coordinator's own SIGINT/SIGTERM/SIGHUP handling is untouched.

Verification run: full `pytest tests/unit` (5931 passed, 24 skipped, 84.43% coverage ≥ 83% gate), `ruff check`/`ruff format --check` clean, `mypy` clean, and `pre-commit run` clean on all touched files. Manual interactive Ctrl+C/Ctrl+Z verification wasn't runnable in this session (requires a live TTY) — the code paths are covered by unit tests mocking `signal.signal`/`os.kill`/`os.getpid`, but real terminal behavior should be spot-checked interactively before merge.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1784

Generated by Hephaestus automation
