### PR TITLE
[audit][S9 Safety & Reliability] No metrics, alerting, or observability beyond structured logs — no way to detect silent degradation at runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Hephaestus is the shared utilities and tooling repository of the HomericIntellig
 
 ```text
 Hephaestus/
-├── hephaestus/                 # Python source code (20 documented subpackages)
+├── hephaestus/                 # Python source code (21 documented subpackages)
 │   ├── agents/                 # Agent frontmatter + loader + runtime
 │   ├── automation/             # Queue-based issue planning / implementation / PR review pipeline
 │   ├── benchmarks/             # Benchmark comparison utilities
@@ -40,6 +40,7 @@ Hephaestus/
 │   ├── logging/                # Logging utilities
 │   ├── markdown/               # Markdown linting and link fixing
 │   ├── nats/                   # NATS JetStream subscriber (event-driven workflows)
+│   ├── observability/          # Metrics registry, /metrics + /health HTTP server, alert rules
 │   ├── resilience/             # Circuit breaker + retry + subprocess resilience
 │   ├── scripts_lib/            # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/                 # System information collection

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Hephaestus/
 │   ├── logging/       # Logging utilities (ContextLogger, setup_logging)
 │   ├── markdown/      # Markdown linting and link fixing
 │   ├── nats/          # NATS JetStream subscriber (event-driven workflows)
+│   ├── observability/ # Metrics registry, /metrics + /health HTTP server, alert rules
 │   ├── resilience/    # Circuit breaker + retry + subprocess resilience primitives
 │   ├── scripts_lib/   # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/        # System information collection

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,7 @@ Hephaestus is the shared utilities and tooling library for the HomericIntelligen
 - **hephaestus.logging** — Enhanced logging (ContextLogger, setup_logging)
 - **hephaestus.markdown** — Markdown linting, link fixing, anchor validation
 - **hephaestus.nats** — NATS JetStream subscriber for event-driven workflows
+- **hephaestus.observability** — Metrics registry, `/metrics` + `/health` HTTP server, alert rules
 - **hephaestus.resilience** — Circuit breaker + retry + subprocess resilience primitives
 - **hephaestus.system** — System information collection
 - **hephaestus.utils** — General utility functions (slugify, retry, subprocess and git helpers)

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -204,6 +204,9 @@ class LoopConfig:
     # (``HEPH_PHASE_TIMEOUT``); ``--phase-timeout`` overrides it and a
     # non-positive value disables the bound (``None``).
     phase_timeout_s: float | None = field(default_factory=_default_phase_timeout_s)
+    # Port for the /metrics + /health HTTP server (issue #1485). 0 (default)
+    # disables the server entirely.
+    metrics_port: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -370,6 +373,12 @@ def _build_parser() -> argparse.ArgumentParser:
             "Comma-separated repo list (e.g. `--repos foo,bar`). Overrides org "
             "enumeration. Space-separated input is NOT accepted."
         ),
+    )
+    p.add_argument(
+        "--metrics-port",
+        type=int,
+        default=0,
+        help="Port for the Prometheus /metrics + /health HTTP server (0 = disabled).",
     )
     return p
 
@@ -597,6 +606,7 @@ def _build_pipeline_config(
         projects_dir=cfg.projects_dir,
         json_out=args.json,
         scope=_pipeline_scope_for_phases(cfg.phases),
+        metrics_port=cfg.metrics_port,
     )
 
 
@@ -641,8 +651,12 @@ def _dispatch_pipeline(
     if not cfg.dry_run:
         _preflight_token_scopes(cfg.org, repos[0])
     from hephaestus.automation.pipeline.coordinator import run_pipeline
+    from hephaestus.resilience import all_circuit_breaker_snapshots
 
-    return run_pipeline(_build_pipeline_config(args, cfg, org, repos))
+    return run_pipeline(
+        _build_pipeline_config(args, cfg, org, repos),
+        circuit_breaker_snapshots=all_circuit_breaker_snapshots,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -689,6 +703,7 @@ def main(argv: list[str] | None = None) -> int:
         phase_timeout_s=(
             args.phase_timeout if args.phase_timeout and args.phase_timeout > 0 else None
         ),
+        metrics_port=args.metrics_port,
     )
 
     if not repos:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -249,6 +249,10 @@ class PipelineConfig:
     # when True, issues already at-or-past ``state:plan-go`` are re-routed to
     # PLANNING instead of being classified past the scope (and thus skipped).
     force: bool = False
+    # Port for the /metrics + /health HTTP server (issue #1485). 0 disables
+    # the server entirely — no MetricsRegistry is constructed and no port is
+    # bound, preserving existing behavior for every caller that doesn't set it.
+    metrics_port: int = 0
 
 
 @dataclass
@@ -301,6 +305,7 @@ class Coordinator:
         stages: dict[StageName, Stage] | None = None,
         github_factory: Callable[[str, Path], StageGitHub] | None = None,
         install_signals: bool = True,
+        circuit_breaker_snapshots: Callable[[], dict[str, dict[str, Any]]] | None = None,
     ) -> None:
         """Initialize coordinator state.
 
@@ -314,11 +319,18 @@ class Coordinator:
                 this so each repo context targets GitHub with an explicit repo.
             install_signals: Install SIGINT/SIGTERM/SIGHUP handlers in
                 ``run()`` (disabled in unit tests).
+            circuit_breaker_snapshots: Callable returning every registered
+                circuit breaker's live state, injected so the pure pipeline
+                layer never imports ``hephaestus.resilience`` directly
+                (``tests/unit/automation/pipeline/test_zero_io_imports.py``).
+                Defaults to an empty-dict provider when omitted; production
+                wiring in ``run_pipeline`` injects the real registry reader.
 
         """
         self.config = config
         self.github = github
         self._github_factory = github_factory
+        self._circuit_breaker_snapshots = circuit_breaker_snapshots or (lambda: {})
         self.shutdown = threading.Event()
         self.completion_q: CompletionQueue = queue_mod.Queue()
         if pool is None:
@@ -341,6 +353,22 @@ class Coordinator:
         self.timers: list[tuple[float, int, WorkItem]] = []
         self.in_flight: dict[JobHandle, WorkItem] = {}
         self.inflight_per_repo: Counter[str] = Counter()
+
+        self._metrics_registry: Any | None = None
+        self._metrics_server: Any | None = None
+        if config.metrics_port:
+            # Imported here, not module-top: hephaestus.observability does
+            # real socket I/O (http.server), which the pipeline's zero-I/O
+            # guard (test_zero_io_imports.py) forbids at module scope.
+            from hephaestus.observability import MetricsHTTPServer, MetricsRegistry
+
+            self._metrics_registry = MetricsRegistry()
+            self._metrics_server = MetricsHTTPServer(
+                self._metrics_registry,
+                port=config.metrics_port,
+                health_provider=self._health_snapshot,
+            )
+            self._metrics_server.start()
         self.ledger: list[ItemResult] = []
         self.preserved: list[PreservedWorktree] = []
         self.items: list[WorkItem] = []
@@ -478,6 +506,44 @@ class Coordinator:
         """Wake the coordinator if it is blocked in completion_q.get()."""
         self.completion_q.put((_WAKE_HANDLE, JobResult(ok=False, interrupted=True, error="wake")))
 
+    def _queue_depths(self) -> dict[str, int]:
+        """Return the current item count per stage queue, keyed by stage name."""
+        return {name.value: len(queue) for name, queue in self.queues.items()}
+
+    def _health_snapshot(self) -> dict[str, Any]:
+        """Return the JSON-serialisable payload served at ``/health``."""
+        return {
+            "loops_run": self._loops_run,
+            "queue_depths": self._queue_depths(),
+            "in_flight": len(self.in_flight),
+            "inflight_per_repo": dict(self.inflight_per_repo),
+            "circuit_breakers": self._circuit_breaker_snapshots(),
+        }
+
+    def _emit_metrics_tick(self) -> None:
+        """Update live gauges and append one ``metrics_snapshot`` event.
+
+        Reuses the existing :meth:`_record_event` JSONL writer (issue #1485)
+        instead of introducing a second periodic-emission mechanism.
+        """
+        queue_depths = self._queue_depths()
+        cb_snapshots = self._circuit_breaker_snapshots()
+        if self._metrics_registry is not None:
+            depth_gauge = self._metrics_registry.gauge(
+                "hephaestus_stage_queue_depth", "Number of items queued per pipeline stage"
+            )
+            for stage, depth in queue_depths.items():
+                depth_gauge.set(depth, labels={"stage": stage})
+            inflight_gauge = self._metrics_registry.gauge(
+                "hephaestus_inflight_per_repo", "Number of in-flight jobs per repo"
+            )
+            for repo, count in self.inflight_per_repo.items():
+                inflight_gauge.set(count, labels={"repo": repo})
+        self._record_event(
+            "metrics_snapshot",
+            {"queue_depths": queue_depths, "circuit_breakers": cb_snapshots},
+        )
+
     # -- run loop ---------------------------------------------------------------
 
     def run(self) -> int:
@@ -512,6 +578,8 @@ class Coordinator:
                     self._wait_for_completion(timeout=0.2)
                     continue
                 self._drain_queues()
+                if self._metrics_registry is not None:
+                    self._emit_metrics_tick()
                 if self._all_idle():
                     if not self._reseed_if_converged():
                         break
@@ -521,6 +589,8 @@ class Coordinator:
             logger.exception("pipeline run failed")
             self._fatal = True
         finally:
+            if self._metrics_server is not None:
+                self._metrics_server.stop()
             # Reap the pool on EVERY exit path — a fatal exception never sets
             # self.shutdown, so without this the executor and in-flight AgentJob
             # subprocesses (e.g. claude reviewers) would leak (#2059). Idempotent
@@ -1565,7 +1635,11 @@ class Coordinator:
                 self._park_resumable(item)
 
 
-def run_pipeline(config: PipelineConfig) -> int:
+def run_pipeline(
+    config: PipelineConfig,
+    *,
+    circuit_breaker_snapshots: Callable[[], dict[str, dict[str, Any]]] | None = None,
+) -> int:
     """Run the queue-based pipeline to completion.
 
     Public entry point called from ``loop_runner.main()`` on the default
@@ -1573,6 +1647,15 @@ def run_pipeline(config: PipelineConfig) -> int:
 
     Args:
         config: Pipeline configuration.
+        circuit_breaker_snapshots: Callable returning every registered
+            circuit breaker's live state, forwarded to
+            :class:`Coordinator` for ``/health`` and the periodic
+            ``metrics_snapshot`` event (issue #1485). ``hephaestus.resilience``
+            is forbidden at module scope in this file
+            (``tests/unit/automation/pipeline/test_zero_io_imports.py``), so
+            production callers (``loop_runner.py``) pass
+            ``hephaestus.resilience.all_circuit_breaker_snapshots`` in
+            explicitly; omitted, breaker state is reported empty.
 
     Returns:
         Exit code: 130 interrupt, 1 any fail/skip/blocked, 0 clean.
@@ -1595,5 +1678,10 @@ def run_pipeline(config: PipelineConfig) -> int:
     github = (
         _github_for(repo, repo_root) if repo else PipelineGitHub(config.org, dry_run=config.dry_run)
     )
-    coordinator = Coordinator(config, github=github, github_factory=_github_for)
+    coordinator = Coordinator(
+        config,
+        github=github,
+        github_factory=_github_for,
+        circuit_breaker_snapshots=circuit_breaker_snapshots,
+    )
     return coordinator.run()

--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -466,3 +466,19 @@ class NATSSubscriberThread(threading.Thread):
                 )
                 return False
         return True
+
+
+if __name__ == "__main__":
+    # Example wiring: health_dict() (issue #1485) already produces a JSON
+    # snapshot, but nothing exposed it to a monitoring system. Deferred
+    # imports keep `import hephaestus.nats.subscriber` free of any
+    # observability-server import cost when this block does not run.
+    from hephaestus.observability import MetricsHTTPServer, MetricsRegistry
+
+    example_config = NATSConfig(enabled=True, url="tls://nats.example.com:4222", subjects=["my.>"])
+    example_thread = NATSSubscriberThread(config=example_config, handler=lambda event: print(event))
+    metrics_server = MetricsHTTPServer(
+        MetricsRegistry(), port=9100, health_provider=example_thread.health_dict
+    )
+    metrics_server.start()
+    example_thread.start()

--- a/hephaestus/observability/__init__.py
+++ b/hephaestus/observability/__init__.py
@@ -1,0 +1,31 @@
+"""Observability primitives: metrics, an HTTP scrape/health server, and alerts.
+
+Stdlib-only (no ``prometheus_client`` or other third-party dependency), so
+this package is part of the base ``hephaestus`` import surface and may be
+used by library code such as :mod:`hephaestus.nats.subscriber` and
+:mod:`hephaestus.resilience.circuit_breaker`, as well as by the automation
+product layer's pipeline coordinator.
+"""
+
+from __future__ import annotations
+
+from hephaestus.observability.alerts import DEFAULT_RULES, AlertEvent, AlertRule, evaluate_alerts
+from hephaestus.observability.metrics import (
+    Counter,
+    Gauge,
+    MetricsRegistry,
+    render_prometheus_text,
+)
+from hephaestus.observability.server import MetricsHTTPServer
+
+__all__ = [
+    "DEFAULT_RULES",
+    "AlertEvent",
+    "AlertRule",
+    "Counter",
+    "Gauge",
+    "MetricsHTTPServer",
+    "MetricsRegistry",
+    "evaluate_alerts",
+    "render_prometheus_text",
+]

--- a/hephaestus/observability/alerts.py
+++ b/hephaestus/observability/alerts.py
@@ -1,0 +1,111 @@
+"""Threshold-based alert evaluation over an observability snapshot.
+
+Pure functions, no I/O: :func:`evaluate_alerts` takes a JSON-serialisable
+snapshot dict (e.g. circuit breaker states plus stage queue depths) and
+returns structured :class:`AlertEvent` objects for any :class:`AlertRule`
+whose predicate matches. Callers are expected to log the returned events
+(e.g. via the existing :class:`hephaestus.logging.formatters.JsonFormatter`)
+so an external system (Prometheus/Alertmanager) can act on them; this
+module does not push to any external alerting service.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_QUEUE_DEPTH_THRESHOLD: int = 100
+"""Default stage-queue-depth alert threshold, used when a snapshot omits one."""
+
+
+@dataclass(frozen=True)
+class AlertRule:
+    """A named threshold rule evaluated against a snapshot dict."""
+
+    name: str
+    predicate: Callable[[dict[str, Any]], bool]
+    message_template: str
+    severity: str = "warning"
+
+
+@dataclass(frozen=True)
+class AlertEvent:
+    """A fired alert: the rule that matched, plus the snapshot that triggered it."""
+
+    rule_name: str
+    severity: str
+    message: str
+    snapshot: dict[str, Any]
+
+
+def _circuit_breaker_open(snapshot: dict[str, Any]) -> bool:
+    breakers = snapshot.get("circuit_breakers", {})
+    return any(cb.get("state") == "open" for cb in breakers.values())
+
+
+def _queue_depth_exceeds(snapshot: dict[str, Any]) -> bool:
+    threshold = snapshot.get("queue_depth_threshold", DEFAULT_QUEUE_DEPTH_THRESHOLD)
+    depths = snapshot.get("queue_depths", {})
+    return any(depth > threshold for depth in depths.values())
+
+
+def _subscriber_stalled(snapshot: dict[str, Any]) -> bool:
+    health = snapshot.get("subscriber_health")
+    if not health:
+        return False
+    return bool(health.get("state") == "error")
+
+
+DEFAULT_RULES: tuple[AlertRule, ...] = (
+    AlertRule(
+        name="circuit_breaker_open",
+        predicate=_circuit_breaker_open,
+        message_template="one or more circuit breakers are OPEN",
+        severity="critical",
+    ),
+    AlertRule(
+        name="queue_depth_exceeds",
+        predicate=_queue_depth_exceeds,
+        message_template="stage queue depth exceeds threshold",
+        severity="warning",
+    ),
+    AlertRule(
+        name="subscriber_stalled",
+        predicate=_subscriber_stalled,
+        message_template="NATS subscriber is in ERROR state",
+        severity="critical",
+    ),
+)
+"""Alert rules covering the gaps called out in issue #1485: circuit breaker
+state nobody reads, unbounded stage queue growth, and a stalled NATS
+subscriber whose health_dict() is never surfaced."""
+
+
+def evaluate_alerts(
+    snapshot: dict[str, Any], rules: Sequence[AlertRule] = DEFAULT_RULES
+) -> list[AlertEvent]:
+    """Evaluate *rules* against *snapshot*, returning every rule that fires.
+
+    Args:
+        snapshot: A JSON-serialisable dict describing current system state
+            (e.g. ``circuit_breakers``, ``queue_depths``, ``subscriber_health``).
+        rules: Rules to evaluate. Defaults to :data:`DEFAULT_RULES`.
+
+    Returns:
+        One :class:`AlertEvent` per rule whose predicate returned ``True``,
+        in rule order.
+
+    """
+    events: list[AlertEvent] = []
+    for rule in rules:
+        if rule.predicate(snapshot):
+            events.append(
+                AlertEvent(
+                    rule_name=rule.name,
+                    severity=rule.severity,
+                    message=rule.message_template,
+                    snapshot=snapshot,
+                )
+            )
+    return events

--- a/hephaestus/observability/metrics.py
+++ b/hephaestus/observability/metrics.py
@@ -1,0 +1,227 @@
+"""Thread-safe metrics primitives and Prometheus text exposition.
+
+Provides :class:`Counter` and :class:`Gauge` metric primitives, a
+:class:`MetricsRegistry` that owns named instances (singleton per name,
+mirroring the pattern in :mod:`hephaestus.resilience.circuit_breaker`), and
+:func:`render_prometheus_text` which serialises a registry's state into the
+Prometheus text exposition format.
+
+Stdlib-only: no third-party dependency (e.g. ``prometheus_client``) is
+required, keeping the base ``hephaestus`` import surface unchanged.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+LabelKey = tuple[tuple[str, str], ...]
+
+
+def _label_key(labels: dict[str, str] | None) -> LabelKey:
+    """Normalise a labels dict into a hashable, order-independent key."""
+    if not labels:
+        return ()
+    return tuple(sorted(labels.items()))
+
+
+def _format_labels(labels: LabelKey) -> str:
+    """Render a label key as Prometheus ``{k="v",...}`` syntax (empty if none)."""
+    if not labels:
+        return ""
+    pairs = ",".join(f'{key}="{value}"' for key, value in labels)
+    return "{" + pairs + "}"
+
+
+class Counter:
+    """A thread-safe, monotonically increasing metric, optionally labeled."""
+
+    def __init__(self, name: str, help_text: str = "") -> None:
+        """Create a counter named *name* with optional *help_text*."""
+        self.name = name
+        self.help_text = help_text
+        self._lock = threading.Lock()
+        self._values: dict[LabelKey, float] = {}
+
+    def inc(self, amount: float = 1.0, *, labels: dict[str, str] | None = None) -> None:
+        """Increment the counter (for the given label set) by *amount*.
+
+        Args:
+            amount: Non-negative amount to add. Defaults to ``1.0``.
+            labels: Optional label key/value pairs identifying the series.
+
+        Raises:
+            ValueError: If *amount* is negative.
+
+        """
+        if amount < 0:
+            raise ValueError("Counter.inc() amount must be non-negative")
+        key = _label_key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def value(self, *, labels: dict[str, str] | None = None) -> float:
+        """Return the current value for the given label set (0.0 if unset)."""
+        key = _label_key(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def snapshot(self) -> dict[LabelKey, float]:
+        """Return a copy of all label-set values."""
+        with self._lock:
+            return dict(self._values)
+
+
+class Gauge:
+    """A thread-safe metric that can be set, incremented, or decremented."""
+
+    def __init__(self, name: str, help_text: str = "") -> None:
+        """Create a gauge named *name* with optional *help_text*."""
+        self.name = name
+        self.help_text = help_text
+        self._lock = threading.Lock()
+        self._values: dict[LabelKey, float] = {}
+
+    def set(self, value: float, *, labels: dict[str, str] | None = None) -> None:
+        """Set the gauge's value for the given label set."""
+        key = _label_key(labels)
+        with self._lock:
+            self._values[key] = value
+
+    def inc(self, amount: float = 1.0, *, labels: dict[str, str] | None = None) -> None:
+        """Increment the gauge (for the given label set) by *amount*."""
+        key = _label_key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + amount
+
+    def dec(self, amount: float = 1.0, *, labels: dict[str, str] | None = None) -> None:
+        """Decrement the gauge (for the given label set) by *amount*."""
+        self.inc(-amount, labels=labels)
+
+    def value(self, *, labels: dict[str, str] | None = None) -> float:
+        """Return the current value for the given label set (0.0 if unset)."""
+        key = _label_key(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def snapshot(self) -> dict[LabelKey, float]:
+        """Return a copy of all label-set values."""
+        with self._lock:
+            return dict(self._values)
+
+
+class MetricsRegistry:
+    """Thread-safe registry of named counters/gauges (singleton per name).
+
+    A single instance is typically shared across a process (or a component
+    such as the pipeline coordinator) so that ``/metrics`` reflects every
+    metric registered anywhere in that process.
+    """
+
+    def __init__(self) -> None:
+        """Create an empty registry."""
+        self._lock = threading.Lock()
+        self._metrics: dict[str, Counter | Gauge] = {}
+
+    def counter(self, name: str, help_text: str = "") -> Counter:
+        """Get or create a named :class:`Counter`.
+
+        Args:
+            name: Metric name. Must not already be registered as a gauge.
+            help_text: Human-readable description (used on first creation).
+
+        Returns:
+            The registered :class:`Counter` instance.
+
+        Raises:
+            TypeError: If *name* is already registered as a different metric type.
+
+        """
+        with self._lock:
+            existing = self._metrics.get(name)
+            if existing is None:
+                metric = Counter(name, help_text)
+                self._metrics[name] = metric
+                return metric
+            if not isinstance(existing, Counter):
+                existing_type = type(existing).__name__
+                raise TypeError(f"metric '{name}' is already registered as {existing_type}")
+            return existing
+
+    def gauge(self, name: str, help_text: str = "") -> Gauge:
+        """Get or create a named :class:`Gauge`.
+
+        Args:
+            name: Metric name. Must not already be registered as a counter.
+            help_text: Human-readable description (used on first creation).
+
+        Returns:
+            The registered :class:`Gauge` instance.
+
+        Raises:
+            TypeError: If *name* is already registered as a different metric type.
+
+        """
+        with self._lock:
+            existing = self._metrics.get(name)
+            if existing is None:
+                metric = Gauge(name, help_text)
+                self._metrics[name] = metric
+                return metric
+            if not isinstance(existing, Gauge):
+                existing_type = type(existing).__name__
+                raise TypeError(f"metric '{name}' is already registered as {existing_type}")
+            return existing
+
+    def snapshot(self) -> dict[str, float]:
+        """Return a flat ``name`` -> value map, summing across label sets.
+
+        Intended for lightweight in-process reads (e.g. alert evaluation)
+        where per-label detail is not needed. Use :func:`render_prometheus_text`
+        for a fully label-aware export.
+        """
+        with self._lock:
+            metrics = list(self._metrics.values())
+        return {metric.name: sum(metric.snapshot().values()) for metric in metrics}
+
+    def all_metrics(self) -> dict[str, Counter | Gauge]:
+        """Return a copy of the name -> metric mapping."""
+        with self._lock:
+            return dict(self._metrics)
+
+
+def render_prometheus_text(registry: MetricsRegistry) -> str:
+    """Render *registry*'s current state as Prometheus text exposition format.
+
+    Args:
+        registry: The registry to render.
+
+    Returns:
+        A string with one ``# HELP``/``# TYPE`` pair and one value line per
+        label set, per metric, terminated with a trailing newline.
+
+    """
+    lines: list[str] = []
+    for name, metric in sorted(registry.all_metrics().items()):
+        metric_type = "counter" if isinstance(metric, Counter) else "gauge"
+        if metric.help_text:
+            lines.append(f"# HELP {name} {metric.help_text}")
+        lines.append(f"# TYPE {name} {metric_type}")
+        values = metric.snapshot()
+        if not values:
+            continue
+        for label_key in sorted(values):
+            lines.append(f"{name}{_format_labels(label_key)} {values[label_key]}")
+    return "\n".join(lines) + "\n" if lines else ""
+
+
+def _json_safe_snapshot(registry: MetricsRegistry) -> dict[str, Any]:
+    """Return a JSON-serialisable view of *registry* (labels as nested dicts)."""
+    result: dict[str, Any] = {}
+    for name, metric in registry.all_metrics().items():
+        series = [
+            {"labels": dict(label_key), "value": value}
+            for label_key, value in metric.snapshot().items()
+        ]
+        result[name] = series
+    return result

--- a/hephaestus/observability/server.py
+++ b/hephaestus/observability/server.py
@@ -1,0 +1,134 @@
+"""Threaded HTTP server exposing ``/metrics`` and ``/health`` endpoints.
+
+Stdlib-only (``http.server``/``socketserver``), following the same
+daemon-thread pattern already used by
+:class:`hephaestus.nats.subscriber.NATSSubscriberThread`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from hephaestus.observability.metrics import MetricsRegistry, render_prometheus_text
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SHUTDOWN_TIMEOUT: float = 5.0
+"""Default timeout (seconds) for :meth:`MetricsHTTPServer.stop`."""
+
+
+def _make_handler(
+    registry: MetricsRegistry,
+    health_provider: Callable[[], dict[str, Any]] | None,
+) -> type[BaseHTTPRequestHandler]:
+    class _Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            logger.debug("%s - %s", self.address_string(), format % args)
+
+        def do_GET(self) -> None:
+            if self.path == "/metrics":
+                body = render_prometheus_text(registry).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; version=0.0.4")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif self.path == "/health":
+                payload = health_provider() if health_provider is not None else {"status": "ok"}
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+    return _Handler
+
+
+class MetricsHTTPServer:
+    """A daemon-threaded HTTP server serving ``/metrics`` and ``/health``.
+
+    Args:
+        registry: The :class:`MetricsRegistry` to expose at ``/metrics``.
+        host: Bind address. Defaults to loopback-only.
+        port: Bind port. ``0`` asks the OS for an ephemeral free port —
+            use :attr:`bound_port` after :meth:`start` to discover it.
+        health_provider: Optional callable returning a JSON-serialisable
+            health snapshot for ``/health``. Defaults to ``{"status": "ok"}``.
+
+    """
+
+    def __init__(
+        self,
+        registry: MetricsRegistry,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        health_provider: Callable[[], dict[str, Any]] | None = None,
+    ) -> None:
+        """Configure the server; call :meth:`start` to actually bind and serve."""
+        self._registry = registry
+        self._host = host
+        self._port = port
+        self._health_provider = health_provider
+        self._httpd: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Bind the port and start serving on a daemon thread.
+
+        Raises:
+            RuntimeError: If the server is already started.
+
+        """
+        if self._httpd is not None:
+            raise RuntimeError("MetricsHTTPServer is already started")
+        handler_cls = _make_handler(self._registry, self._health_provider)
+        httpd = ThreadingHTTPServer((self._host, self._port), handler_cls)
+        self._httpd = httpd
+        thread = threading.Thread(
+            target=httpd.serve_forever,
+            name="metrics-http-server",
+            daemon=True,
+        )
+        self._thread = thread
+        thread.start()
+        logger.info("metrics HTTP server listening on %s:%d", self._host, self.bound_port)
+
+    def stop(self, timeout: float = DEFAULT_SHUTDOWN_TIMEOUT) -> None:
+        """Stop serving and release the bound port.
+
+        Safe to call even if :meth:`start` was never called.
+
+        Args:
+            timeout: Maximum seconds to wait for the server thread to join.
+
+        """
+        if self._httpd is None:
+            return
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+        self._httpd = None
+        self._thread = None
+
+    @property
+    def bound_port(self) -> int:
+        """The actual bound port (resolved OS-assigned port when ``port=0``).
+
+        Raises:
+            RuntimeError: If the server has not been started.
+
+        """
+        if self._httpd is None:
+            raise RuntimeError("MetricsHTTPServer has not been started")
+        return int(self._httpd.server_address[1])

--- a/hephaestus/resilience/__init__.py
+++ b/hephaestus/resilience/__init__.py
@@ -10,6 +10,7 @@ from hephaestus.resilience.circuit_breaker import (
     CircuitBreakerOpenError,
     CircuitBreakerOpenReason,
     CircuitBreakerState,
+    all_circuit_breaker_snapshots,
     get_circuit_breaker,
     reset_all_circuit_breakers,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "CircuitBreakerOpenError",
     "CircuitBreakerOpenReason",
     "CircuitBreakerState",
+    "all_circuit_breaker_snapshots",
     "get_circuit_breaker",
     "is_transient_subprocess_error",
     "reset_all_circuit_breakers",

--- a/hephaestus/resilience/circuit_breaker.py
+++ b/hephaestus/resilience/circuit_breaker.py
@@ -290,6 +290,23 @@ class CircuitBreaker:
             self._last_failure_time = 0.0
             logger.info("Circuit breaker '%s' reset to CLOSED", self.name)
 
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serialisable snapshot of this breaker's live state.
+
+        Returns:
+            Dict with ``name``, ``state``, ``failure_count``, and
+            ``last_failure_time`` — the fields issue #1485 calls out as
+            held by the registry but never read by any monitoring system.
+
+        """
+        with self._lock:
+            return {
+                "name": self.name,
+                "state": self._effective_state().value,
+                "failure_count": self._failure_count,
+                "last_failure_time": self._last_failure_time,
+            }
+
 
 # Global registry of circuit breakers
 _registry: dict[str, CircuitBreaker] = {}
@@ -350,3 +367,15 @@ def reset_all_circuit_breakers() -> None:
         for cb in _registry.values():
             cb.reset()
         _registry.clear()
+
+
+def all_circuit_breaker_snapshots() -> dict[str, dict[str, Any]]:
+    """Return a snapshot of every registered circuit breaker.
+
+    Returns:
+        Mapping of breaker name to its :meth:`CircuitBreaker.snapshot` dict.
+
+    """
+    with _registry_lock:
+        breakers = list(_registry.values())
+    return {cb.name: cb.snapshot() for cb in breakers}

--- a/pixi.toml
+++ b/pixi.toml
@@ -18,7 +18,7 @@ mypy-pkg = "mypy hephaestus/"
 # Runs pip-audit in the lint environment without a nested `pixi run` invocation.
 # The top-level `audit` alias was removed: use `pixi run --environment lint audit`
 # or `pixi run --environment lint pip-audit` directly (as CI already does).
-docs = "pdoc ./hephaestus ./hephaestus/agents ./hephaestus/benchmarks ./hephaestus/ci ./hephaestus/cli ./hephaestus/config ./hephaestus/datasets ./hephaestus/discovery ./hephaestus/forensics ./hephaestus/github ./hephaestus/io ./hephaestus/logging ./hephaestus/markdown ./hephaestus/nats ./hephaestus/resilience ./hephaestus/scripts_lib ./hephaestus/system ./hephaestus/utils ./hephaestus/validation ./hephaestus/version --output-dir docs/api"
+docs = "pdoc ./hephaestus ./hephaestus/agents ./hephaestus/benchmarks ./hephaestus/ci ./hephaestus/cli ./hephaestus/config ./hephaestus/datasets ./hephaestus/discovery ./hephaestus/forensics ./hephaestus/github ./hephaestus/io ./hephaestus/logging ./hephaestus/markdown ./hephaestus/nats ./hephaestus/observability ./hephaestus/resilience ./hephaestus/scripts_lib ./hephaestus/system ./hephaestus/utils ./hephaestus/validation ./hephaestus/version --output-dir docs/api"
 # Editable install of this package into the pixi environment, for local dev
 # that imports `hephaestus` at runtime. Run once after `pixi install`:
 #   pixi run dev-install

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import logging
+import socket
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -1489,3 +1490,128 @@ class TestConfigWiring:
         ctx = coordinator._ctx_for_repo("repo-a")
 
         assert ctx.config.enable_mechanical_rebase is True
+
+
+def _free_port() -> int:
+    """Return a currently-unused TCP port on localhost (best-effort; racy by nature)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+class TestMetricsWiring:
+    """metrics_port=0 (default) is a no-op; a nonzero port serves /metrics + /health."""
+
+    def test_metrics_port_zero_does_not_start_a_server(self, tmp_path: Path) -> None:
+        """Default config never constructs a registry/server (issue #1485)."""
+        config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+
+        assert coordinator._metrics_registry is None
+        assert coordinator._metrics_server is None
+
+    def test_metrics_port_nonzero_starts_a_server(self, tmp_path: Path) -> None:
+        """A nonzero metrics_port binds a real MetricsHTTPServer."""
+        config = PipelineConfig(
+            org="org", repos=["repo-a"], projects_dir=tmp_path, metrics_port=_free_port()
+        )
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        try:
+            assert coordinator._metrics_registry is not None
+            assert coordinator._metrics_server is not None
+            assert coordinator._metrics_server.bound_port == config.metrics_port
+        finally:
+            if coordinator._metrics_server is not None:
+                coordinator._metrics_server.stop()
+
+    def test_metrics_endpoint_reflects_queue_depth_after_tick(self, tmp_path: Path) -> None:
+        """_emit_metrics_tick() updates the stage_queue_depth gauge for /metrics."""
+        config = PipelineConfig(
+            org="org", repos=["repo-a"], projects_dir=tmp_path, metrics_port=_free_port()
+        )
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        try:
+            item = _issue_item(44, StageName.PLANNING)
+            coordinator._push_item(item, StageName.PLANNING, enter=True)
+
+            coordinator._emit_metrics_tick()
+
+            assert coordinator._metrics_registry is not None
+            snapshot = coordinator._metrics_registry.snapshot()
+            assert snapshot["hephaestus_stage_queue_depth"] == 1.0
+        finally:
+            if coordinator._metrics_server is not None:
+                coordinator._metrics_server.stop()
+
+    def test_emit_metrics_tick_records_metrics_snapshot_event(self, tmp_path: Path) -> None:
+        """_emit_metrics_tick() appends one metrics_snapshot event via _record_event."""
+        event_log_path = tmp_path / "pipeline-events.jsonl"
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            projects_dir=tmp_path,
+            event_log_path=event_log_path,
+            metrics_port=_free_port(),
+        )
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        try:
+            coordinator._emit_metrics_tick()
+
+            assert coordinator.event_log[-1][0] == "metrics_snapshot"
+            records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
+            assert records[-1]["event"] == "metrics_snapshot"
+        finally:
+            if coordinator._metrics_server is not None:
+                coordinator._metrics_server.stop()
+
+    def test_health_snapshot_uses_injected_circuit_breaker_snapshots(self, tmp_path: Path) -> None:
+        """The injected callable feeds /health, not a hephaestus.resilience import."""
+        config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+        fake_snapshots = {"github-api": {"name": "github-api", "state": "open"}}
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+            circuit_breaker_snapshots=lambda: fake_snapshots,
+        )
+
+        health = coordinator._health_snapshot()
+
+        assert health["circuit_breakers"] == fake_snapshots
+
+    def test_health_snapshot_defaults_to_empty_circuit_breakers(self, tmp_path: Path) -> None:
+        """Without an injected callable, /health reports no circuit breaker state."""
+        config = PipelineConfig(org="org", repos=["repo-a"], projects_dir=tmp_path)
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+
+        assert coordinator._health_snapshot()["circuit_breakers"] == {}
+
+    def test_run_stops_metrics_server_on_completion(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A metrics server started for run() is stopped in the finally block."""
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        config = PipelineConfig(
+            org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path, metrics_port=_free_port()
+        )
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        coordinator._rate_budget_ok = lambda: (True, 0.0)  # type: ignore[method-assign]
+        server = coordinator._metrics_server
+        assert server is not None
+
+        coordinator.run()
+
+        assert server._httpd is None

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -755,6 +755,13 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
                 "enumeration. Space-separated input is NOT accepted."
             ),
         ),
+        _action_spec(
+            ("--metrics-port",),
+            "metrics_port",
+            "_StoreAction",
+            0,
+            help_text="Port for the Prometheus /metrics + /health HTTP server (0 = disabled).",
+        ),
         *_github_throttle_specs(),
         _verbose_spec("Enable DEBUG logging"),
         _json_spec(),

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -184,6 +184,17 @@ def test_parse_args_model_flag_wires_to_namespace() -> None:
     assert loop_runner._parse_args([]).model == ""
 
 
+def test_parse_args_metrics_port_defaults_to_disabled() -> None:
+    """Omitted --metrics-port defaults to 0 (server disabled, issue #1485)."""
+    assert loop_runner._parse_args([]).metrics_port == 0
+
+
+def test_parse_args_metrics_port_accepts_explicit_value() -> None:
+    """--metrics-port parses into args.metrics_port."""
+    args = loop_runner._parse_args(["--metrics-port", "9100"])
+    assert args.metrics_port == 9100
+
+
 # ---------------------------------------------------------------------------
 # CLI scope refinements: fork filter, comma-only --repos, cwd default, --org
 # ---------------------------------------------------------------------------
@@ -499,7 +510,7 @@ def _capture_config(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> object:
 
     captured: dict[str, object] = {}
 
-    def _capture(config: object) -> int:
+    def _capture(config: object, **kwargs: object) -> int:
         captured["config"] = config
         return 0
 
@@ -540,13 +551,64 @@ def test_main_installs_sigtstp_handler(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(loop_runner, "_resolve_org_and_repos", lambda args: ("Org", ["Repo"], None))
     monkeypatch.setattr(loop_runner, "_preflight_token_scopes", lambda *a, **k: None)
-    monkeypatch.setattr(coordinator_mod, "run_pipeline", lambda config: 0)
+    monkeypatch.setattr(coordinator_mod, "run_pipeline", lambda config, **kwargs: 0)
 
     with patch("hephaestus.utils.terminal.install_sigtstp_only") as mock_tstp:
         rc = main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
 
     assert rc == 0
     mock_tstp.assert_called_once_with()
+
+
+def test_main_metrics_port_defaults_to_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitted --metrics-port round-trips into PipelineConfig.metrics_port=0 (issue #1485)."""
+    config = _capture_config(
+        ["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"], monkeypatch
+    )
+    assert config.metrics_port == 0  # type: ignore[attr-defined]
+
+
+def test_main_metrics_port_round_trips_into_pipeline_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--metrics-port N`` reaches PipelineConfig.metrics_port unchanged."""
+    config = _capture_config(
+        [
+            "--repos",
+            "Repo",
+            "--dry-run",
+            "--loops",
+            "1",
+            "--agent",
+            "claude",
+            "--metrics-port",
+            "9100",
+        ],
+        monkeypatch,
+    )
+    assert config.metrics_port == 9100  # type: ignore[attr-defined]
+
+
+def test_dispatch_pipeline_injects_circuit_breaker_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_dispatch_pipeline passes hephaestus.resilience.all_circuit_breaker_snapshots through."""
+    from hephaestus.automation.pipeline import coordinator as coordinator_mod
+    from hephaestus.resilience import all_circuit_breaker_snapshots
+
+    captured: dict[str, object] = {}
+
+    def _capture(config: object, **kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(loop_runner, "_resolve_org_and_repos", lambda args: ("Org", ["Repo"], None))
+    monkeypatch.setattr(loop_runner, "_preflight_token_scopes", lambda *a, **k: None)
+    monkeypatch.setattr(coordinator_mod, "run_pipeline", _capture)
+
+    main(["--repos", "Repo", "--dry-run", "--loops", "1", "--agent", "claude"])
+
+    assert captured["circuit_breaker_snapshots"] is all_circuit_breaker_snapshots
 
 
 def test_main_prefers_current_checkout_parent_for_projects_dir_default(

--- a/tests/unit/observability/test_alerts.py
+++ b/tests/unit/observability/test_alerts.py
@@ -1,0 +1,161 @@
+"""Unit tests for hephaestus.observability.alerts."""
+
+from __future__ import annotations
+
+import pytest
+
+from hephaestus.observability.alerts import (
+    DEFAULT_RULES,
+    AlertEvent,
+    AlertRule,
+    evaluate_alerts,
+)
+
+
+class TestCircuitBreakerOpenRule:
+    """Tests for the circuit_breaker_open rule."""
+
+    def test_fires_when_any_breaker_open(self) -> None:
+        snapshot = {
+            "circuit_breakers": {
+                "github-api": {"state": "closed"},
+                "nats-subscriber": {"state": "open"},
+            }
+        }
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "circuit_breaker_open" in names
+
+    def test_does_not_fire_when_all_closed(self) -> None:
+        snapshot = {
+            "circuit_breakers": {
+                "github-api": {"state": "closed"},
+                "nats-subscriber": {"state": "half_open"},
+            }
+        }
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "circuit_breaker_open" not in names
+
+    def test_missing_key_does_not_fire(self) -> None:
+        events = evaluate_alerts({})
+        names = [e.rule_name for e in events]
+        assert "circuit_breaker_open" not in names
+
+    def test_fired_event_severity_and_message(self) -> None:
+        snapshot = {"circuit_breakers": {"x": {"state": "open"}}}
+        events = evaluate_alerts(snapshot)
+        event = next(e for e in events if e.rule_name == "circuit_breaker_open")
+        assert event.severity == "critical"
+        assert "OPEN" in event.message
+        assert event.snapshot is snapshot
+
+
+class TestQueueDepthExceedsRule:
+    """Tests for the queue_depth_exceeds rule."""
+
+    def test_fires_when_depth_exceeds_default_threshold(self) -> None:
+        snapshot = {"queue_depths": {"plan": 150}}
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "queue_depth_exceeds" in names
+
+    def test_does_not_fire_when_under_threshold(self) -> None:
+        snapshot = {"queue_depths": {"plan": 5}}
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "queue_depth_exceeds" not in names
+
+    def test_respects_custom_threshold(self) -> None:
+        snapshot = {"queue_depths": {"plan": 10}, "queue_depth_threshold": 5}
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "queue_depth_exceeds" in names
+
+    def test_severity_is_warning(self) -> None:
+        snapshot = {"queue_depths": {"plan": 200}}
+        events = evaluate_alerts(snapshot)
+        event = next(e for e in events if e.rule_name == "queue_depth_exceeds")
+        assert event.severity == "warning"
+
+
+class TestSubscriberStalledRule:
+    """Tests for the subscriber_stalled rule."""
+
+    def test_fires_when_state_is_error(self) -> None:
+        snapshot = {"subscriber_health": {"state": "error"}}
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "subscriber_stalled" in names
+
+    def test_does_not_fire_when_state_is_connected(self) -> None:
+        snapshot = {"subscriber_health": {"state": "connected"}}
+        events = evaluate_alerts(snapshot)
+        names = [e.rule_name for e in events]
+        assert "subscriber_stalled" not in names
+
+    def test_missing_health_does_not_fire(self) -> None:
+        events = evaluate_alerts({})
+        names = [e.rule_name for e in events]
+        assert "subscriber_stalled" not in names
+
+    def test_severity_is_critical(self) -> None:
+        snapshot = {"subscriber_health": {"state": "error"}}
+        events = evaluate_alerts(snapshot)
+        event = next(e for e in events if e.rule_name == "subscriber_stalled")
+        assert event.severity == "critical"
+
+
+class TestEvaluateAlerts:
+    """Tests for evaluate_alerts() overall behavior."""
+
+    def test_no_rules_fire_on_healthy_snapshot(self) -> None:
+        snapshot = {
+            "circuit_breakers": {"x": {"state": "closed"}},
+            "queue_depths": {"plan": 1},
+            "subscriber_health": {"state": "connected"},
+        }
+        assert evaluate_alerts(snapshot) == []
+
+    def test_multiple_rules_can_fire_together(self) -> None:
+        snapshot = {
+            "circuit_breakers": {"x": {"state": "open"}},
+            "queue_depths": {"plan": 500},
+        }
+        events = evaluate_alerts(snapshot)
+        names = {e.rule_name for e in events}
+        assert names == {"circuit_breaker_open", "queue_depth_exceeds"}
+
+    def test_default_rules_used_when_unspecified(self) -> None:
+        assert evaluate_alerts({}) == evaluate_alerts({}, DEFAULT_RULES)
+
+    def test_custom_rules_override_defaults(self) -> None:
+        custom_rule = AlertRule(
+            name="always_fires",
+            predicate=lambda snap: True,
+            message_template="custom rule fired",
+            severity="info",
+        )
+        events = evaluate_alerts({}, rules=[custom_rule])
+        assert len(events) == 1
+        assert events[0] == AlertEvent(
+            rule_name="always_fires",
+            severity="info",
+            message="custom rule fired",
+            snapshot={},
+        )
+
+    def test_rules_evaluated_in_order(self) -> None:
+        snapshot = {
+            "circuit_breakers": {"x": {"state": "open"}},
+            "subscriber_health": {"state": "error"},
+        }
+        events = evaluate_alerts(snapshot)
+        expected = [rule.name for rule in DEFAULT_RULES if rule.predicate(snapshot)]
+        assert [event.rule_name for event in events] == expected
+
+
+@pytest.mark.parametrize("rule", DEFAULT_RULES, ids=lambda r: r.name)
+def test_default_rule_severity_is_valid(rule: AlertRule) -> None:
+    """Every default rule uses a recognised severity level."""
+    assert rule.severity in {"info", "warning", "critical"}

--- a/tests/unit/observability/test_metrics.py
+++ b/tests/unit/observability/test_metrics.py
@@ -1,0 +1,229 @@
+"""Unit tests for hephaestus.observability.metrics."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from hephaestus.observability.metrics import (
+    Counter,
+    Gauge,
+    MetricsRegistry,
+    render_prometheus_text,
+)
+
+
+class TestCounter:
+    """Tests for the Counter primitive."""
+
+    def test_starts_at_zero(self) -> None:
+        counter = Counter("requests_total")
+        assert counter.value() == 0.0
+
+    def test_inc_default_amount(self) -> None:
+        counter = Counter("requests_total")
+        counter.inc()
+        assert counter.value() == 1.0
+
+    def test_inc_custom_amount(self) -> None:
+        counter = Counter("requests_total")
+        counter.inc(5.0)
+        counter.inc(2.5)
+        assert counter.value() == 7.5
+
+    def test_negative_amount_rejected(self) -> None:
+        counter = Counter("requests_total")
+        with pytest.raises(ValueError, match="non-negative"):
+            counter.inc(-1.0)
+
+    def test_labels_are_independent_series(self) -> None:
+        counter = Counter("requests_total")
+        counter.inc(labels={"stage": "plan"})
+        counter.inc(3.0, labels={"stage": "implement"})
+        assert counter.value(labels={"stage": "plan"}) == 1.0
+        assert counter.value(labels={"stage": "implement"}) == 3.0
+        assert counter.value(labels={"stage": "review"}) == 0.0
+
+    def test_label_order_does_not_matter(self) -> None:
+        counter = Counter("requests_total")
+        counter.inc(labels={"a": "1", "b": "2"})
+        counter.inc(labels={"b": "2", "a": "1"})
+        assert counter.value(labels={"a": "1", "b": "2"}) == 2.0
+
+    def test_concurrent_increments_are_thread_safe(self) -> None:
+        counter = Counter("requests_total")
+        n_threads = 20
+        n_incs = 200
+
+        def worker() -> None:
+            for _ in range(n_incs):
+                counter.inc()
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert counter.value() == n_threads * n_incs
+
+    def test_snapshot_returns_copy(self) -> None:
+        counter = Counter("requests_total")
+        counter.inc(labels={"stage": "plan"})
+        snap = counter.snapshot()
+        snap[(("stage", "mutated"),)] = 999.0
+        assert counter.value(labels={"stage": "mutated"}) == 0.0
+
+
+class TestGauge:
+    """Tests for the Gauge primitive."""
+
+    def test_starts_at_zero(self) -> None:
+        gauge = Gauge("queue_depth")
+        assert gauge.value() == 0.0
+
+    def test_set_overwrites(self) -> None:
+        gauge = Gauge("queue_depth")
+        gauge.set(5.0)
+        gauge.set(2.0)
+        assert gauge.value() == 2.0
+
+    def test_inc_and_dec(self) -> None:
+        gauge = Gauge("queue_depth")
+        gauge.inc(3.0)
+        gauge.dec(1.0)
+        assert gauge.value() == 2.0
+
+    def test_dec_can_go_negative(self) -> None:
+        gauge = Gauge("delta")
+        gauge.dec(5.0)
+        assert gauge.value() == -5.0
+
+    def test_labels_are_independent_series(self) -> None:
+        gauge = Gauge("queue_depth")
+        gauge.set(3.0, labels={"stage": "plan"})
+        gauge.set(7.0, labels={"stage": "implement"})
+        assert gauge.value(labels={"stage": "plan"}) == 3.0
+        assert gauge.value(labels={"stage": "implement"}) == 7.0
+
+    def test_concurrent_inc_dec_is_thread_safe(self) -> None:
+        gauge = Gauge("counter_like")
+        n_threads = 20
+        n_ops = 200
+
+        def worker() -> None:
+            for _ in range(n_ops):
+                gauge.inc()
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert gauge.value() == n_threads * n_ops
+
+
+class TestMetricsRegistry:
+    """Tests for the MetricsRegistry singleton-per-name behavior."""
+
+    def test_counter_is_singleton_per_name(self) -> None:
+        registry = MetricsRegistry()
+        c1 = registry.counter("requests_total")
+        c2 = registry.counter("requests_total")
+        assert c1 is c2
+
+    def test_gauge_is_singleton_per_name(self) -> None:
+        registry = MetricsRegistry()
+        g1 = registry.gauge("queue_depth")
+        g2 = registry.gauge("queue_depth")
+        assert g1 is g2
+
+    def test_help_text_set_on_first_creation(self) -> None:
+        registry = MetricsRegistry()
+        c1 = registry.counter("requests_total", "total requests")
+        c2 = registry.counter("requests_total", "ignored on second call")
+        assert c1.help_text == "total requests"
+        assert c2.help_text == "total requests"
+
+    def test_type_collision_raises(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("thing")
+        with pytest.raises(TypeError, match="already registered"):
+            registry.gauge("thing")
+
+    def test_snapshot_sums_across_labels(self) -> None:
+        registry = MetricsRegistry()
+        counter = registry.counter("requests_total")
+        counter.inc(labels={"stage": "plan"})
+        counter.inc(2.0, labels={"stage": "implement"})
+        assert registry.snapshot() == {"requests_total": 3.0}
+
+    def test_snapshot_includes_all_metrics(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("a").inc(1.0)
+        registry.gauge("b").set(2.0)
+        assert registry.snapshot() == {"a": 1.0, "b": 2.0}
+
+    def test_all_metrics_returns_copy(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("a")
+        metrics = registry.all_metrics()
+        metrics["injected"] = Counter("injected")
+        assert "injected" not in registry.all_metrics()
+
+
+class TestRenderPrometheusText:
+    """Tests for the Prometheus text exposition renderer."""
+
+    def test_empty_registry_produces_empty_string(self) -> None:
+        registry = MetricsRegistry()
+        assert render_prometheus_text(registry) == ""
+
+    def test_counter_help_and_type_lines(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("requests_total", "total requests").inc(3.0)
+        text = render_prometheus_text(registry)
+        assert "# HELP requests_total total requests" in text
+        assert "# TYPE requests_total counter" in text
+        assert "requests_total 3.0" in text
+
+    def test_gauge_type_line(self) -> None:
+        registry = MetricsRegistry()
+        registry.gauge("queue_depth").set(5.0)
+        text = render_prometheus_text(registry)
+        assert "# TYPE queue_depth gauge" in text
+        assert "queue_depth 5.0" in text
+
+    def test_labels_rendered_in_prometheus_syntax(self) -> None:
+        registry = MetricsRegistry()
+        registry.gauge("stage_queue_depth").set(4.0, labels={"stage": "plan"})
+        text = render_prometheus_text(registry)
+        assert 'stage_queue_depth{stage="plan"} 4.0' in text
+
+    def test_no_help_text_omits_help_line(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("no_help").inc()
+        text = render_prometheus_text(registry)
+        assert "# HELP" not in text
+        assert "# TYPE no_help counter" in text
+
+    def test_metric_without_values_still_emits_type_line(self) -> None:
+        registry = MetricsRegistry()
+        registry.gauge("untouched")
+        text = render_prometheus_text(registry)
+        assert "# TYPE untouched gauge" in text
+
+    def test_output_ends_with_newline(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("a").inc()
+        text = render_prometheus_text(registry)
+        assert text.endswith("\n")
+
+    def test_metrics_sorted_by_name(self) -> None:
+        registry = MetricsRegistry()
+        registry.counter("zeta").inc()
+        registry.counter("alpha").inc()
+        text = render_prometheus_text(registry)
+        assert text.index("alpha") < text.index("zeta")

--- a/tests/unit/observability/test_server.py
+++ b/tests/unit/observability/test_server.py
@@ -1,0 +1,130 @@
+"""Unit tests for hephaestus.observability.server."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+
+import pytest
+
+from hephaestus.observability.metrics import MetricsRegistry
+from hephaestus.observability.server import MetricsHTTPServer
+
+
+@pytest.fixture
+def registry() -> MetricsRegistry:
+    """Return a fresh, empty metrics registry."""
+    return MetricsRegistry()
+
+
+@pytest.fixture
+def server(registry: MetricsRegistry) -> Iterator[MetricsHTTPServer]:
+    """Start a MetricsHTTPServer on an ephemeral port and stop it on teardown."""
+    srv = MetricsHTTPServer(registry, port=0)
+    srv.start()
+    try:
+        yield srv
+    finally:
+        srv.stop()
+
+
+def _get(server: MetricsHTTPServer, path: str) -> tuple[int, dict[str, str], bytes]:
+    """Fetch *path* from *server* and return (status, headers, body)."""
+    url = f"http://127.0.0.1:{server.bound_port}{path}"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return resp.status, dict(resp.headers), resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, dict(exc.headers or {}), exc.read()
+
+
+class TestLifecycle:
+    """Tests for MetricsHTTPServer start/stop lifecycle."""
+
+    def test_bound_port_before_start_raises(self, registry: MetricsRegistry) -> None:
+        srv = MetricsHTTPServer(registry, port=0)
+        with pytest.raises(RuntimeError, match="not been started"):
+            _ = srv.bound_port
+
+    def test_start_assigns_ephemeral_port(self, registry: MetricsRegistry) -> None:
+        srv = MetricsHTTPServer(registry, port=0)
+        srv.start()
+        try:
+            assert srv.bound_port > 0
+        finally:
+            srv.stop()
+
+    def test_double_start_raises(self, server: MetricsHTTPServer) -> None:
+        with pytest.raises(RuntimeError, match="already started"):
+            server.start()
+
+    def test_stop_without_start_is_noop(self, registry: MetricsRegistry) -> None:
+        srv = MetricsHTTPServer(registry, port=0)
+        srv.stop()  # must not raise
+
+    def test_stop_releases_port_for_immediate_rebind(self, registry: MetricsRegistry) -> None:
+        srv = MetricsHTTPServer(registry, host="127.0.0.1", port=0)
+        srv.start()
+        port = srv.bound_port
+        srv.stop()
+
+        rebound = MetricsHTTPServer(registry, host="127.0.0.1", port=port)
+        rebound.start()
+        try:
+            assert rebound.bound_port == port
+        finally:
+            rebound.stop()
+
+
+class TestMetricsEndpoint:
+    """Tests for GET /metrics."""
+
+    def test_metrics_endpoint_returns_200_and_content_type(self, server: MetricsHTTPServer) -> None:
+        status, headers, _ = _get(server, "/metrics")
+        assert status == 200
+        assert headers["Content-Type"].startswith("text/plain")
+
+    def test_metrics_endpoint_reflects_registry_state(
+        self, server: MetricsHTTPServer, registry: MetricsRegistry
+    ) -> None:
+        registry.counter("requests_total", "total requests").inc(3.0)
+        _, _, body = _get(server, "/metrics")
+        text = body.decode("utf-8")
+        assert "# HELP requests_total total requests" in text
+        assert "requests_total 3.0" in text
+
+    def test_metrics_endpoint_empty_registry(self, server: MetricsHTTPServer) -> None:
+        status, _, body = _get(server, "/metrics")
+        assert status == 200
+        assert body == b""
+
+
+class TestHealthEndpoint:
+    """Tests for GET /health."""
+
+    def test_health_endpoint_default_ok(self, server: MetricsHTTPServer) -> None:
+        status, headers, body = _get(server, "/health")
+        assert status == 200
+        assert headers["Content-Type"] == "application/json"
+        assert json.loads(body) == {"status": "ok"}
+
+    def test_health_endpoint_uses_provider(self, registry: MetricsRegistry) -> None:
+        srv = MetricsHTTPServer(
+            registry, port=0, health_provider=lambda: {"state": "connected", "uptime_seconds": 42}
+        )
+        srv.start()
+        try:
+            _, _, body = _get(srv, "/health")
+            assert json.loads(body) == {"state": "connected", "uptime_seconds": 42}
+        finally:
+            srv.stop()
+
+
+class TestUnknownPath:
+    """Tests for requests to unmapped paths."""
+
+    def test_unknown_path_returns_404(self, server: MetricsHTTPServer) -> None:
+        status, _, _ = _get(server, "/nope")
+        assert status == 404

--- a/tests/unit/resilience/test_circuit_breaker.py
+++ b/tests/unit/resilience/test_circuit_breaker.py
@@ -13,6 +13,7 @@ from hephaestus.resilience.circuit_breaker import (
     CircuitBreakerOpenError,
     CircuitBreakerOpenReason,
     CircuitBreakerState,
+    all_circuit_breaker_snapshots,
     get_circuit_breaker,
     reset_all_circuit_breakers,
 )
@@ -462,6 +463,41 @@ class TestCircuitBreakerReset:
         assert cb.state == CircuitBreakerState.CLOSED
 
 
+class TestCircuitBreakerSnapshot:
+    """Tests for CircuitBreaker.snapshot()."""
+
+    def test_snapshot_of_closed_breaker(self) -> None:
+        """A fresh breaker snapshots as closed with zero failures."""
+        cb = CircuitBreaker("svc")
+        snap = cb.snapshot()
+        assert snap == {
+            "name": "svc",
+            "state": "closed",
+            "failure_count": 0,
+            "last_failure_time": 0.0,
+        }
+
+    def test_snapshot_reflects_open_state_and_failure_count(self) -> None:
+        """After tripping the breaker, snapshot reports OPEN and the failure count."""
+        cb = CircuitBreaker("svc", failure_threshold=2)
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                cb.call(MagicMock(side_effect=RuntimeError("fail")))
+
+        snap = cb.snapshot()
+        assert snap["state"] == "open"
+        assert snap["failure_count"] == 2
+        assert snap["last_failure_time"] > 0.0
+
+    def test_snapshot_uses_effective_state(self) -> None:
+        """snapshot() reflects the OPEN->HALF_OPEN auto-transition, like .state."""
+        cb = CircuitBreaker("svc", failure_threshold=1, recovery_timeout=0.0)
+        with pytest.raises(RuntimeError):
+            cb.call(MagicMock(side_effect=RuntimeError("fail")))
+
+        assert cb.snapshot()["state"] == "half_open"
+
+
 class TestCircuitBreakerRegistry:
     """Tests for the global circuit breaker registry."""
 
@@ -493,6 +529,31 @@ class TestCircuitBreakerRegistry:
         # Getting same name creates new instance
         cb3 = get_circuit_breaker("service_a")
         assert cb3 is not cb1
+
+    def test_all_circuit_breaker_snapshots_empty_registry(self) -> None:
+        """An empty registry snapshots to an empty dict."""
+        assert all_circuit_breaker_snapshots() == {}
+
+    def test_all_circuit_breaker_snapshots_covers_every_breaker(self) -> None:
+        """Every registered breaker appears, keyed by name."""
+        get_circuit_breaker("service_a")
+        get_circuit_breaker("service_b")
+
+        snapshots = all_circuit_breaker_snapshots()
+
+        assert set(snapshots) == {"service_a", "service_b"}
+        assert snapshots["service_a"]["state"] == "closed"
+        assert snapshots["service_b"]["state"] == "closed"
+
+    def test_all_circuit_breaker_snapshots_reflects_live_state(self) -> None:
+        """A tripped breaker's OPEN state is visible via the registry-wide snapshot."""
+        cb = get_circuit_breaker("flaky", failure_threshold=1)
+        with pytest.raises(RuntimeError):
+            cb.call(MagicMock(side_effect=RuntimeError("fail")))
+
+        snapshots = all_circuit_breaker_snapshots()
+        assert snapshots["flaky"]["state"] == "open"
+        assert snapshots["flaky"]["failure_count"] == 1
 
 
 class TestCircuitBreakerThreadSafety:


### PR DESCRIPTION
## Summary
## Summary

Implemented issue #1485 (no metrics/alerting/observability beyond structured logs) per the approved plan:

**New `hephaestus/observability` package** (stdlib-only, no new dependency):
- `metrics.py` — thread-safe `Counter`/`Gauge`, `MetricsRegistry` (singleton-per-name), `render_prometheus_text()` (Prometheus text exposition format)
- `server.py` — `MetricsHTTPServer` wrapping `http.server.ThreadingHTTPServer` on a daemon thread, serving `/metrics` and `/health`
- `alerts.py` — `AlertRule`/`AlertEvent` + `evaluate_alerts()`, with `DEFAULT_RULES` covering circuit-breaker-open, queue-depth-exceeded, and subscriber-stalled

**`hephaestus/resilience/circuit_breaker.py`** — added `CircuitBreaker.snapshot()` and `all_circuit_breaker_snapshots()`, closing the "nothing reads this state" gap the issue called out.

**Pipeline coordinator wiring** — `PipelineConfig.metrics_port` (0=disabled), a per-tick `_emit_metrics_tick()` that updates gauges and appends a `metrics_snapshot` event via the existing `_record_event` JSONL writer, and a `/health` endpoint. One architectural surprise: `hephaestus.resilience` and any I/O-capable import are hard-forbidden inside `hephaestus/automation/pipeline/*.py` by an AST-based test guard (`test_zero_io_imports.py`), so circuit-breaker-snapshot access is injected as a `Callable` into `Coordinator`/`run_pipeline` rather than imported directly — production wiring lives in `loop_runner.py`, which is outside that guarded directory.

**`loop_runner.py`** — new `--metrics-port` flag threaded through `LoopConfig` → `PipelineConfig`, with the real `all_circuit_breaker_snapshots` injected at the `run_pipeline()` call site.

**`nats/subscriber.py`** — added a deferred-import `__main__` example wiring `health_dict()` to `MetricsHTTPServer`.

Also fixed 4 doc/golden-snapshot tests that broke from the new subpackage and CLI flag (pdoc target list in `pixi.toml`, README/CLAUDE.md directory trees, parser action-spec snapshot).

**Tests:** 5993 passed, 24 skipped, 84.59% coverage (floor 83%). `ruff`, `mypy`, and the full `pre-commit run --all-files` are clean. Working tree has all changes staged but uncommitted per the git-boundary policy — ready for the orchestrator to commit and open the PR.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1485

Generated by Hephaestus automation
