### PR TITLE
Follow-up from #1815: 1 item(s) (core)

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -224,7 +224,7 @@ class StageGitHub(Protocol):
         creation is the implementation stage's journal entry (doc section 4:
         "Owned labels: PR creation is the journal entry").
         """
-        raise NotImplementedError
+        ...
 
     def post_pr_comment(self, pr_number: int, body: str) -> None:
         """Durably post an explanatory comment on the PR conversation.
@@ -233,7 +233,7 @@ class StageGitHub(Protocol):
         issue comment channel). Used by pr_review's HUMAN_BLOCKED terminal
         path to record WHY automation stood down before finishing failed.
         """
-        pass
+        ...
 
     def upsert_pr_comment(self, pr_number: int, marker_prefix: str, body: str) -> None:
         """Durably create-or-update a marker-keyed PR conversation comment.


### PR DESCRIPTION
## Summary
Fixed `hephaestus/automation/pipeline/stages/base.py:227,236` — reverted `create_pr` from `raise NotImplementedError` and `post_pr_comment` from `pass` to `...`, matching all other `Protocol` method bodies in the class. Ran pipeline unit tests (836 passed), `mypy` (clean, 534 files), and `ruff check`/`format` (clean). No new tests needed — this is a stylistic Protocol-convention revert with no behavioral change.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1848

Generated by Hephaestus automation
