### PR TITLE
[majo] ci stage rebases onto hardcoded "main" and never captures the PR's real baseRefName

### DIFF
--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -11,10 +11,13 @@ contract):
   ROUTES via ``ctx.budget``, never hardcoded here.
 - DISCOVER [M]: resolve the PR when unset (``ctx.github.find_pr_for_issue``,
   the ``pr_discovery`` semantics) — none found finishes failed ``no_pr``;
-  adopt the PR's REAL head branch; verify the PR carries
-  ``state:implementation-go`` (``ctx.github.pr_has_implementation_state_label``,
-  the legacy ``_pr_has_implementation_go`` gate) — a PR without it fails
-  back ``not_implementation_go`` (routes to pr_review).
+  adopt the PR's REAL head branch; capture the PR's real base ref
+  (``baseRefName`` from the same ``gh_pr_state`` read) into
+  ``payload["base_branch"]`` for REBASE_WAIT, mirroring merge_wait's
+  ``_route_dirty``; verify the PR carries ``state:implementation-go``
+  (``ctx.github.pr_has_implementation_state_label``, the legacy
+  ``_pr_has_implementation_go`` gate) — a PR without it fails back
+  ``not_implementation_go`` (routes to pr_review).
 - REBASE_WAIT [W:G]: optional mechanical rebase (re-housed
   ``_attempt_mechanical_rebase`` :763 — the worker pool's ``op="rebase"``
   is ``git_utils.rebase_worktree_onto``), best-effort: skipped on dry-run,
@@ -287,7 +290,11 @@ class CiStage(Stage):
         (``pr_discovery`` semantics via ``ctx.github.find_pr_for_issue``) and
         the PR must already carry ``state:implementation-go`` (the legacy
         ``_pr_has_implementation_go`` gate) — a PR that lost or never had it
-        regresses to pr_review (``not_implementation_go``), never arms.
+        regresses to pr_review (``not_implementation_go``), never arms. The
+        PR's real base ref is captured into ``payload["base_branch"]`` from
+        the same ``gh_pr_state`` read (mirrors ``merge_wait._route_dirty``'s
+        ``baseRefName`` capture), so REBASE_WAIT targets the PR's actual
+        base instead of a hardcoded ``"main"``.
         """
         if item.pr is None:
             if item.issue is None:
@@ -298,7 +305,8 @@ class CiStage(Stage):
                 logger.info("ci:%d: no open PR found; finishing failed", item.issue)
                 return StageOutcome(Disposition.FINISH_FAIL, "no_pr")
             item.pr = discovered
-        terminal = _terminal_pr_outcome(ctx.github.gh_pr_state(item.pr), item.pr)
+        gh_state = ctx.github.gh_pr_state(item.pr)
+        terminal = _terminal_pr_outcome(gh_state, item.pr)
         if terminal is not None:
             return terminal
         if not item.branch:
@@ -307,6 +315,9 @@ class CiStage(Stage):
             head_branch = ctx.github.get_pr_head_branch(item.pr)
             if head_branch:
                 item.branch = head_branch
+        # Capture the PR's real base ref for the mechanical rebase target
+        # (mirrors merge_wait._route_dirty's baseRefName read).
+        item.payload["base_branch"] = str((gh_state or {}).get("baseRefName") or "main")
         has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
         if not has_go:
             logger.info(

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -183,6 +183,33 @@ class TestCiDiscover:
         assert item.pr == 777
         assert item.branch == "real-head"
 
+    def test_discovery_captures_pr_base_branch_from_baseref(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A PR based on a non-main branch seeds payload["base_branch"] from baseRefName."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github(pr_state={"state": "OPEN", "baseRefName": "release/2.0"}))
+        item = _item(make_work_item, state=DISCOVER)
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == REBASE_WAIT
+        assert item.payload["base_branch"] == "release/2.0"
+
+    def test_discovery_defaults_base_branch_to_main_without_baseref(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """No gh_pr_state / missing baseRefName still defaults to "main" (unchanged)."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github())  # pr_state defaults to None
+        item = _item(make_work_item, state=DISCOVER)
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert item.payload["base_branch"] == "main"
+
     def test_already_merged_pr_finishes_before_branch_adoption(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:


### PR DESCRIPTION
## Summary
All 42 tests pass, lint clean, mypy clean across the whole tree.

## Summary

Fixed `hephaestus/automation/pipeline/stages/ci.py` `_discover` to capture the PR's real `baseRefName` (already fetched via `ctx.github.gh_pr_state`) into `item.payload["base_branch"]`, mirroring `merge_wait._route_dirty`. Previously nothing populated this key, so `_request_rebase` always fell back to hardcoded `"main"`, causing stacked/release-branch PRs to be rebased onto the wrong base. Updated the `_discover` and module docstrings to document the capture.

Added two tests to `tests/unit/automation/pipeline/stages/test_stage_ci.py`:
- `test_discovery_captures_pr_base_branch_from_baseref` — non-`main` `baseRefName` is captured correctly.
- `test_discovery_defaults_base_branch_to_main_without_baseref` — default to `"main"` is preserved when `gh_pr_state` is absent.

Ran: `pytest tests/unit/automation/pipeline/stages/test_stage_ci.py` (42 passed), `test_stage_merge_wait.py` (38 passed), `ruff check`/`ruff format`, and whole-tree `mypy` — all clean.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1860

Generated by Hephaestus automation
