### PR TITLE
[majo] Duplicated rebase->push conflict-resolution logic diverges between ci and merge_wait

### DIFF
--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -524,6 +524,27 @@ def _require_item_worktree(item: WorkItem, stage_name: str, action: str) -> Stag
     return StageOutcome(Disposition.FAIL_BACK, "missing_worktree")
 
 
+def _build_rebase_job(item: WorkItem, ctx: StageContext, *, descr: str) -> GitJob:
+    """Build the mechanical rebase-onto-base GitJob (shared base-ref capture).
+
+    Both ``ci`` (best-effort mechanical rebase) and ``merge_wait`` (DIRTY
+    resolution) rebase the item's worktree onto the same captured
+    ``item.payload["base_branch"]`` (defaulting to ``main``) via the same
+    worker ``op="rebase"`` (``git_utils.rebase_worktree_onto``) — single home
+    so the two stages cannot diverge on this mechanic (#1861).
+    """
+    return GitJob(
+        repo=item.repo,
+        op="rebase",
+        timeout_s=GIT_JOB_TIMEOUT_S,
+        kwargs={
+            "cwd": _worktree_path(item, ctx),
+            "base_branch": str(item.payload.get("base_branch") or "main"),
+        },
+        descr=descr,
+    )
+
+
 def _terminal_pr_outcome(pr_state: dict[str, Any] | None, pr_number: int) -> StageOutcome | None:
     """Return a terminal outcome for PRs already merged/closed, if known."""
     if not pr_state:

--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -88,6 +88,7 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _build_rebase_job,
     _require_item_worktree,
     _terminal_pr_outcome,
     _worktree_path,
@@ -334,16 +335,7 @@ class CiStage(Stage):
         missing_worktree = _require_item_worktree(item, "ci", "mechanical rebase")
         if missing_worktree is not None:
             return missing_worktree
-        rebase_job = GitJob(
-            repo=item.repo,
-            op="rebase",
-            timeout_s=GIT_JOB_TIMEOUT_S,
-            kwargs={
-                "cwd": _worktree_path(item, ctx),
-                "base_branch": str(item.payload.get("base_branch") or "main"),
-            },
-            descr="mechanical_rebase",
-        )
+        rebase_job = _build_rebase_job(item, ctx, descr="mechanical_rebase")
         return JobRequest(rebase_job, on_done_state=POLL)
 
     def _poll(self, item: WorkItem, ctx: StageContext) -> StepResult:

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -93,6 +93,7 @@ from .base import (
     StageOutcome,
     StepResult,
     WorkItem,
+    _build_rebase_job,
     _require_item_worktree,
     _worktree_path,
     agent_provider,
@@ -414,16 +415,7 @@ class MergeWaitStage(Stage):
         missing_worktree = _require_item_worktree(item, "merge_wait", "dirty rebase")
         if missing_worktree is not None:
             return missing_worktree
-        rebase_job = GitJob(
-            repo=item.repo,
-            op="rebase",
-            timeout_s=GIT_JOB_TIMEOUT_S,
-            kwargs={
-                "cwd": _worktree_path(item, ctx),
-                "base_branch": str(item.payload.get("base_branch") or "main"),
-            },
-            descr="resolve_dirty_rebase",
-        )
+        rebase_job = _build_rebase_job(item, ctx, descr="resolve_dirty_rebase")
         return JobRequest(rebase_job, on_done_state=DIRTY_PUSH_WAIT)
 
     def _request_dirty_push(self, item: WorkItem, ctx: StageContext) -> StepResult:

--- a/tests/unit/automation/pipeline/stages/test_base_rebase_job.py
+++ b/tests/unit/automation/pipeline/stages/test_base_rebase_job.py
@@ -1,0 +1,47 @@
+"""Tests for the shared rebase-GitJob builder (issue #1861)."""
+
+from __future__ import annotations
+
+from hephaestus.automation.pipeline.stages.base import (
+    GIT_JOB_TIMEOUT_S,
+    _build_rebase_job,
+)
+
+
+class TestBuildRebaseJob:
+    """Tests for ``_build_rebase_job``, the shared rebase-onto-base builder."""
+
+    def test_defaults_base_branch_to_main(self, make_ctx, make_work_item):
+        ctx = make_ctx()
+        item = make_work_item(repo="o/r")
+        item.payload.pop("base_branch", None)
+        job = _build_rebase_job(item, ctx, descr="x")
+        assert job.op == "rebase"
+        assert job.kwargs["base_branch"] == "main"
+        assert job.timeout_s == GIT_JOB_TIMEOUT_S
+
+    def test_uses_captured_base_branch(self, make_ctx, make_work_item):
+        ctx = make_ctx()
+        item = make_work_item(repo="o/r")
+        item.payload["base_branch"] = "develop"
+        job = _build_rebase_job(item, ctx, descr="x")
+        assert job.kwargs["base_branch"] == "develop"
+
+    def test_descr_passthrough(self, make_ctx, make_work_item):
+        ctx = make_ctx()
+        item = make_work_item(repo="o/r")
+        job = _build_rebase_job(item, ctx, descr="resolve_dirty_rebase")
+        assert job.descr == "resolve_dirty_rebase"
+
+    def test_cwd_uses_item_worktree(self, make_ctx, make_work_item):
+        ctx = make_ctx()
+        item = make_work_item(repo="o/r")
+        item.worktree = "/tmp/repo/item-worktree"
+        job = _build_rebase_job(item, ctx, descr="x")
+        assert str(job.kwargs["cwd"]) == "/tmp/repo/item-worktree"
+
+    def test_repo_passthrough(self, make_ctx, make_work_item):
+        ctx = make_ctx()
+        item = make_work_item(repo="o/r")
+        job = _build_rebase_job(item, ctx, descr="x")
+        assert job.repo == "o/r"


### PR DESCRIPTION
## Summary
Wait — 836 previously + new 5 tests = 841, matches. Implementation complete.

## Summary

Extracted the duplicated `GitJob(op="rebase", ...)` construction into a single shared helper `_build_rebase_job(item, ctx, *, descr)` in `hephaestus/automation/pipeline/stages/base.py:530-547`, and updated both call sites to use it:

- `hephaestus/automation/pipeline/stages/ci.py:321-323` (`_request_rebase`, `descr="mechanical_rebase"`)
- `hephaestus/automation/pipeline/stages/merge_wait.py` (`_request_dirty_rebase`, `descr="resolve_dirty_rebase"`)

Scope matched the plan exactly: only the `GitJob` construction (base-ref capture + job shape) was deduplicated, not a full rebase+push pipeline, since `ci.py` has no push leg for this path. `on_done_state` stays stage-specific at each call site.

Added `tests/unit/automation/pipeline/stages/test_base_rebase_job.py` with 5 unit tests covering base-branch default/override, `descr`/`repo` passthrough, and `cwd` wiring.

**Tests run:**
- `pixi run pytest tests/unit/automation/pipeline -q --no-cov` → 841 passed
- `pixi run ruff check` / `ruff format --check` → clean
- `pixi run mypy` (whole-tree) → clean
- `pixi run pre-commit run --files <changed files>` → all hooks passed

No unused imports resulted (`GitJob`/`GIT_JOB_TIMEOUT_S` are still used by the separate push-job constructions in both files, confirmed via `ruff --select F401`).


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1861

Generated by Hephaestus automation
