### PR TITLE
[majo] ci and merge_wait assume opposite worker semantics for op="rebase" push behavior (double-push / lease race)

### DIFF
--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -5,10 +5,10 @@ merge-wait, which is :mod:`.merge_wait` — as a pipeline stage
 (docs/AUTOMATION_LOOP_ARCHITECTURE.md section "6. ci" is the binding
 contract):
 
-- States: ENTER -> DISCOVER -> REBASE_WAIT -> POLL -> FIX_WAIT ->
-  PUSH_WAIT -> (POLL). Budgets: ``ci_fix`` = 1 (max fix attempts; one
-  extra escalation via force_engagement), ``rebase`` = 2. Both read from
-  ROUTES via ``ctx.budget``, never hardcoded here.
+- States: ENTER -> DISCOVER -> REBASE_WAIT -> REBASE_PUSH_WAIT -> POLL ->
+  FIX_WAIT -> PUSH_WAIT -> (POLL). Budgets: ``ci_fix`` = 1 (max fix
+  attempts; one extra escalation via force_engagement), ``rebase`` = 2.
+  Both read from ROUTES via ``ctx.budget``, never hardcoded here.
 - DISCOVER [M]: resolve the PR when unset (``ctx.github.find_pr_for_issue``,
   the ``pr_discovery`` semantics) — none found finishes failed ``no_pr``;
   adopt the PR's REAL head branch; capture the PR's real base ref
@@ -18,11 +18,15 @@ contract):
   (``ctx.github.pr_has_implementation_state_label``, the legacy
   ``_pr_has_implementation_go`` gate) — a PR without it fails back
   ``not_implementation_go`` (routes to pr_review).
-- REBASE_WAIT [W:G]: optional mechanical rebase (re-housed
-  ``_attempt_mechanical_rebase`` :763 — the worker pool's ``op="rebase"``
-  is ``git_utils.rebase_worktree_onto``), best-effort: skipped on dry-run,
-  when ``enable_mechanical_rebase`` is off, or once the ``rebase`` budget
-  (consumed in ``on_job_done``) is spent. POLL absorbs either outcome.
+- REBASE_WAIT [W:G] -> REBASE_PUSH_WAIT [W:G]: optional mechanical rebase
+  (re-housed ``_attempt_mechanical_rebase`` :1094 — the worker pool's
+  ``op="rebase"`` is ``git_utils.rebase_worktree_onto``, which never
+  pushes) followed by a push of the clean result (``op="push"``,
+  lease-guarded) to reach GitHub and re-trigger CI — the legacy
+  rebase+push pair. Best-effort: skipped on dry-run, when
+  ``enable_mechanical_rebase`` is off, or once the ``rebase`` budget
+  (consumed in ``on_job_done``) is spent. A conflicting rebase has
+  nothing to push and re-polls immediately. POLL absorbs either outcome.
 - POLL [M], non-blocking: one ``ctx.github.pr_checks`` read classified by
   the pure :func:`~hephaestus.automation.ci_run_coordinator.classify_ci_state`
   (the sleep-free extraction of ``poll_ci_until_concluded``'s conclusion
@@ -107,6 +111,7 @@ BACKOFF_CAP_S = _BACKOFF_CAP_S
 ENTER = "ENTER"
 DISCOVER = "DISCOVER"
 REBASE_WAIT = "REBASE_WAIT"
+REBASE_PUSH_WAIT = "REBASE_PUSH_WAIT"
 POLL = "POLL"
 FIX_WAIT = "FIX_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
@@ -275,6 +280,8 @@ class CiStage(Stage):
             return self._discover(item, ctx)
         if item.state == REBASE_WAIT:
             return self._request_rebase(item, ctx)
+        if item.state == REBASE_PUSH_WAIT:
+            return self._request_rebase_push(item, ctx)
         if item.state == POLL:
             return self._poll(item, ctx)
         if item.state == FIX_WAIT:
@@ -330,13 +337,15 @@ class CiStage(Stage):
         return Continue(next_state=REBASE_WAIT)
 
     def _request_rebase(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """REBASE_WAIT [W:G]: best-effort mechanical rebase, then POLL.
+        """REBASE_WAIT [W:G]: best-effort mechanical rebase, then push-or-poll.
 
         Mirrors the ``_drive_issue`` gate (``enable_mechanical_rebase and not
         dry_run``); the ``rebase`` budget (consumed in ``on_job_done``) bounds
         the attempts across the item's lifetime. Skipping (option off,
         dry-run, or budget spent) is never an error — POLL classifies the PR
-        as it stands.
+        as it stands. A clean rebase must still be pushed
+        (``REBASE_PUSH_WAIT``) to reach GitHub and re-trigger CI — the
+        legacy ``_attempt_mechanical_rebase`` rebase+push pair.
         """
         if ctx.dry_run or not getattr(ctx.config, "enable_mechanical_rebase", True):
             return Continue(next_state=POLL)
@@ -346,8 +355,35 @@ class CiStage(Stage):
         missing_worktree = _require_item_worktree(item, "ci", "mechanical rebase")
         if missing_worktree is not None:
             return missing_worktree
+        item.payload.pop("rebase_clean", None)
         rebase_job = _build_rebase_job(item, ctx, descr="mechanical_rebase")
-        return JobRequest(rebase_job, on_done_state=POLL)
+        return JobRequest(rebase_job, on_done_state=REBASE_PUSH_WAIT)
+
+    def _request_rebase_push(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """REBASE_PUSH_WAIT [W:G]: push the clean rebase, or poll a conflicted one.
+
+        A clean mechanical rebase must be pushed (lease-guarded worker
+        ``op="push"``) to reach GitHub and re-trigger CI — the legacy
+        ``_attempt_mechanical_rebase`` rebase+push pair. A still-conflicting
+        rebase has nothing to push: POLL re-classifies the live PR state and
+        the ``rebase`` budget (already counted) bounds the loop.
+        """
+        if not item.payload.pop("rebase_clean", None):
+            return Continue(next_state=POLL)
+        missing_worktree = _require_item_worktree(item, "ci", "mechanical rebase push")
+        if missing_worktree is not None:
+            return missing_worktree
+        push_job = GitJob(
+            repo=item.repo,
+            op="push",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            kwargs={
+                "cwd": _worktree_path(item, ctx),
+                "branch": item.branch or None,
+            },
+            descr="push_mechanical_rebase",
+        )
+        return JobRequest(push_job, on_done_state=POLL)
 
     def _poll(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """POLL [M]: one non-blocking check read -> classify -> route.
@@ -514,9 +550,11 @@ class CiStage(Stage):
         implementation pattern: an interrupt never burns budget because
         interrupted results never reach this method).
 
-        - ``REBASE_WAIT``: count ``rebase``; best-effort — POLL re-classifies
-          unconditionally (a clean rebase re-triggers CI; a conflicting one
-          shows up as FAILING/DIRTY downstream).
+        - ``REBASE_WAIT``: count ``rebase``; record ``rebase_clean`` (the
+          worker's rebase result) so ``REBASE_PUSH_WAIT`` pushes only a
+          clean rebase (a clean rebase must be pushed to re-trigger CI; a
+          conflicting one has nothing to push and shows up as
+          FAILING/DIRTY downstream).
         - ``FIX_WAIT``: count ``ci_fix``; a hard job failure flags
           ``ci_fix_failed`` so PUSH_WAIT reroutes to POLL instead of pushing
           a fix that never landed.
@@ -534,6 +572,7 @@ class CiStage(Stage):
         """
         if item.state == REBASE_WAIT:
             item.attempts["rebase"] = item.attempts.get("rebase", 0) + 1
+            item.payload["rebase_clean"] = bool(result.ok and result.value)
             if not result.ok:
                 logger.warning(
                     "ci:%s: mechanical rebase failed (non-fatal): %s", item.issue, result.error

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -29,8 +29,9 @@ binding contract):
     record finishes PASS immediately, firing ``/learn`` at most once per
     merged PR, the #848 contract);
   - FAILING -> FAIL_BACK(``ci_red``) (routes to ci);
-  - DIRTY -> mechanical rebase+push (budget ``rebase``), then re-POLL;
-    exhaustion -> FINISH_FAIL(``rebase_exhausted``) (the legacy
+  - DIRTY -> mechanical rebase (op="rebase", never pushes on its own) then
+    an explicit push of the clean result (budget ``rebase``), then
+    re-POLL; exhaustion -> FINISH_FAIL(``rebase_exhausted``) (the legacy
     "unresolved merge conflict" terminal — never "timeout");
   - BLOCKED -> address unresolved threads (budget ``blocked_address``)
     then push and re-POLL; exhaustion -> FAIL_BACK(``blocked_exhausted``)

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -16,6 +16,7 @@ from hephaestus.automation.pipeline.stages.ci import (
     POLL,
     POLL_DEADLINE,
     PUSH_WAIT,
+    REBASE_PUSH_WAIT,
     REBASE_WAIT,
     CiStage,
     build_ci_fix_prompt,
@@ -328,11 +329,12 @@ class TestCiRebase:
         assert isinstance(result.job, GitJob)
         assert result.job.op == "rebase"
         assert result.job.kwargs["base_branch"] == "develop"
-        assert result.on_done_state == POLL
+        assert result.on_done_state == REBASE_PUSH_WAIT
         assert item.attempts["rebase"] == 0  # not consumed at submission
 
         stage.on_job_done(item, JobResult(ok=True, value=True), ctx)
         assert item.attempts["rebase"] == 1  # consumed on completion
+        assert item.payload["rebase_clean"] is True
 
     def test_rebase_without_item_worktree_fails_back_before_git_job(
         self, make_ctx: Any, make_work_item: Any
@@ -348,7 +350,7 @@ class TestCiRebase:
         assert result == StageOutcome(Disposition.FAIL_BACK, "missing_worktree")
 
     def test_failed_rebase_is_best_effort(self, make_ctx: Any, make_work_item: Any) -> None:
-        """A failed rebase counts the budget but records no routing flag."""
+        """A failed rebase counts the budget, records not-clean, no routing flag."""
         stage = CiStage()
         ctx = make_ctx(github=_go_github())
         item = _item(make_work_item, state=REBASE_WAIT)
@@ -356,8 +358,54 @@ class TestCiRebase:
         stage.on_job_done(item, JobResult(ok=False, error="conflict"), ctx)
 
         assert item.attempts["rebase"] == 1
+        assert item.payload["rebase_clean"] is False
         assert "push_failed" not in item.payload
         assert "ci_fix_failed" not in item.payload
+
+
+class TestCiRebasePush:
+    """REBASE_PUSH_WAIT: push a clean rebase, or poll a conflicted one."""
+
+    def test_clean_rebase_pushes_then_polls(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A clean rebase dispatches an op="push" GitJob targeting item.branch."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github())
+        item = _item(make_work_item, state=REBASE_PUSH_WAIT)
+        item.payload["rebase_clean"] = True
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "push"
+        assert result.job.kwargs["branch"] == item.branch
+        assert result.on_done_state == POLL
+        assert "rebase_clean" not in item.payload
+
+    def test_conflicting_rebase_never_pushes(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A not-clean rebase has nothing to push and re-polls immediately."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github())
+        item = _item(make_work_item, state=REBASE_PUSH_WAIT)
+        item.payload["rebase_clean"] = False
+
+        result = stage.step(item, ctx)
+
+        assert result == Continue(next_state=POLL)
+
+    def test_push_without_item_worktree_fails_back_before_git_job(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """CI must not push from the loop driver's shared checkout."""
+        stage = CiStage()
+        ctx = make_ctx(github=_go_github())
+        item = _item(make_work_item, state=REBASE_PUSH_WAIT)
+        item.payload["rebase_clean"] = True
+        item.worktree = ""
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FAIL_BACK, "missing_worktree")
 
 
 class TestCiPoll:
@@ -509,7 +557,7 @@ class TestCiWalks:
     """Pool-driven walks through the full state machine."""
 
     def test_green_path_advances_after_rebase(self, make_ctx: Any, make_work_item: Any) -> None:
-        """ENTER -> DISCOVER -> rebase job -> POLL green -> ADVANCE."""
+        """ENTER -> DISCOVER -> rebase job -> push job -> POLL green -> ADVANCE."""
         stage = CiStage()
         github = _go_github(checks=GREEN_CHECKS)
         ctx = make_ctx(github=github)
@@ -520,9 +568,8 @@ class TestCiWalks:
 
         assert isinstance(outcome, StageOutcome)
         assert outcome.disposition == Disposition.ADVANCE
-        assert len(pool.submitted) == 1
-        assert isinstance(pool.submitted[0].job, GitJob)
-        assert pool.submitted[0].job.op == "rebase"
+        git_jobs = [h.job for h in pool.submitted if isinstance(h.job, GitJob)]
+        assert [j.op for j in git_jobs] == ["rebase", "push"]
         assert item.attempts["rebase"] == 1
         assert github.mutation_log == []  # ci owns no labels
 


### PR DESCRIPTION
## Summary
Full unit suite passes: 5918 passed, 24 skipped. No backup/temp files were created. Implementation complete.

**Summary of changes:**

- `hephaestus/automation/pipeline/stages/ci.py`: Pinned the `op="rebase"` contract as never-pushing (matching `merge_wait.py` and `git_utils.rebase_worktree_onto`'s actual behavior). Added a new `REBASE_PUSH_WAIT` mini-state mirroring `merge_wait.py`'s `DIRTY_REBASE_WAIT`→`DIRTY_PUSH_WAIT` pattern: `_request_rebase` now clears `rebase_clean` and routes to `REBASE_PUSH_WAIT` instead of `POLL`; `on_job_done` records `rebase_clean` from the worker result; new `_request_rebase_push` pushes only a clean rebase (op="push", lease-guarded) or re-polls immediately if the rebase still conflicted. Updated module/method docstrings accordingly.
- `hephaestus/automation/pipeline/stages/merge_wait.py`: Docstring-only clarification that `op="rebase"` never pushes on its own (no functional change — it already implements the correct rebase-then-push split).
- `tests/unit/automation/pipeline/stages/test_stage_ci.py`: Updated `test_rebase_job_dispatched_and_budget_counted_on_done` and `test_failed_rebase_is_best_effort` for the new `on_done_state`/`rebase_clean` semantics; added `TestCiRebasePush` (clean-pushes, conflict-never-pushes, missing-worktree-fails-back); updated `test_green_path_advances_after_rebase` to expect both `rebase` and `push` GitJobs.

Tests run: `tests/unit/automation/pipeline` (839 passed), full `tests/unit` (5918 passed, 24 skipped), `ruff check` and `mypy` both clean on the modified files.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1862

Generated by Hephaestus automation
