### PR TITLE
[majo] --prs seeding classifies against the wrong repo (org-global label read, not the repo-scoped accessor)

### DIFF
--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -415,6 +415,7 @@ def seed_from_cli(
     repos: Sequence[str],
     issues: Sequence[int],
     prs: Sequence[int],
+    github: Any | None = None,
 ) -> list[SeedEntry]:
     """Map CLI scope args (``--repos`` / ``--issues`` / ``--prs``) to queue pushes.
 
@@ -426,11 +427,22 @@ def seed_from_cli(
       ``state:implementation-go``, else :attr:`StageName.PR_REVIEW` —
       mirroring the legacy existing-PR review semantics: GO short-circuits
       review, and a failed label fetch reads as "not yet reviewed" (→ pr_review).
+      When *github* is given (a repo-scoped accessor, e.g.
+      :class:`~hephaestus.automation.pipeline_github.PipelineGitHub`), the
+      label read is scoped to that repo via
+      ``github.pr_has_implementation_state_label`` — the same accessor
+      :func:`seed_issue_from_github` uses for ``--issues`` — instead of the
+      module-level :func:`~hephaestus.automation.github_api.gh_pr_label_names`,
+      which resolves against the ambient/current repo and can misclassify a
+      PR number that collides across repos in a multi-repo run.
 
     Args:
         repos: Repository names to seed for discovery.
         issues: Issue numbers to classify directly.
         prs: PR numbers to route by implementation-review label.
+        github: Optional repo-scoped GitHub accessor for the ``prs`` label
+            read. When ``None``, falls back to the ambient
+            :func:`~hephaestus.automation.github_api.gh_pr_label_names`.
 
     Returns:
         Planned queue pushes, in the given order (repos, issues, prs).
@@ -457,8 +469,11 @@ def seed_from_cli(
             )
         )
     for pr in prs:
-        labels = gh_pr_label_names(pr)
-        if is_implementation_go(labels):
+        if github is not None:
+            has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
+        else:
+            has_go = is_implementation_go(gh_pr_label_names(pr))
+        if has_go:
             entries.append(
                 SeedEntry(
                     kind="pr",

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -578,6 +578,36 @@ class TestSeedFromCli:
             entries = seed_from_cli([], [], [79])
         assert entries[0].stage is StageName.PR_REVIEW
 
+    def test_prs_arm_uses_repo_scoped_accessor_when_given(self) -> None:
+        """A repo-scoped github accessor routes the --prs label read through it.
+
+        Not the ambient gh_pr_label_names, closing the multi-repo misclassification (#1864).
+        """
+        github = MagicMock()
+        github.pr_has_implementation_state_label.return_value = (True, False)
+        with patch(
+            "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+            side_effect=AssertionError("must not call ambient label read when github is given"),
+        ):
+            entries = seed_from_cli([], [], [77], github=github)
+        github.pr_has_implementation_state_label.assert_called_once_with(77)
+        assert entries == [
+            SeedEntry(
+                kind="pr",
+                identifier=77,
+                stage=StageName.CI,
+                reason=f"PR #77 carries {STATE_IMPLEMENTATION_GO}",
+                pr_number=77,
+            )
+        ]
+
+    def test_prs_arm_repo_scoped_no_go_routes_to_pr_review(self) -> None:
+        """Repo-scoped accessor without impl-GO seeds into pr_review."""
+        github = MagicMock()
+        github.pr_has_implementation_state_label.return_value = (False, True)
+        entries = seed_from_cli([], [], [78], github=github)
+        assert entries[0].stage is StageName.PR_REVIEW
+
     def test_order_repos_then_issues_then_prs(self) -> None:
         """Entries preserve CLI order: repos, then issues, then prs."""
         facts = _facts(number=5)


### PR DESCRIPTION
## Summary
All 838 pipeline tests pass. Implementation complete.

## Summary

Fixed `seed_from_cli` in `hephaestus/automation/pipeline/seeding.py` to accept an optional repo-scoped `github` accessor parameter, matching the pattern already used by `seed_issue_from_github`.

**Changes:**
- `hephaestus/automation/pipeline/seeding.py:414-484` — added `github: Any | None = None` param to `seed_from_cli`; the `--prs` loop now calls `github.pr_has_implementation_state_label(pr)` when an accessor is supplied, falling back to the ambient `gh_pr_label_names(pr)` when `github is None` (preserving all existing call sites, including the coordinator's `seed_from_cli(discovery_repos, [], [])`).
- `tests/unit/automation/pipeline/test_seeding.py` — added `test_prs_arm_uses_repo_scoped_accessor_when_given` (asserts the ambient path is never called when `github` is supplied) and `test_prs_arm_repo_scoped_no_go_routes_to_pr_review`.

**Tests run:**
- `tests/unit/automation/pipeline/test_seeding.py` — 99 passed
- `tests/unit/automation/pipeline/` (full dir) — 838 passed
- `test_coordinator.py`, `test_coordinator_edges.py`, `test_coordinator_shutdown.py`, `test_timer_heap.py` — 107 passed (confirms the new optional kwarg doesn't break stubbed callers)
- `test_automation_boundary.py`, `test_omit_allowlist.py` — 2 passed
- `ruff check` / `ruff format --check` — clean
- `pixi run mypy` (whole-tree) — `Success: no issues found in 534 source files`

No coordinator call-site changes were needed since its only `seed_from_cli` call already passes an empty `prs` list (its real `--prs` handling lives in `_seed_direct_scope`, which was already repo-scoped).


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1864

Generated by Hephaestus automation
