### PR TITLE
[majo] --prs seeding diverges from _review_existing_pr: ignores implementation-no-go and never checks merged/closed state

### DIFF
--- a/hephaestus/automation/github_api/__init__.py
+++ b/hephaestus/automation/github_api/__init__.py
@@ -93,6 +93,7 @@ from .prs import (  # noqa: E402
     gh_current_login as gh_current_login,
     gh_pr_create as gh_pr_create,
     gh_pr_label_names as gh_pr_label_names,
+    gh_pr_state as gh_pr_state,
 )
 from .reviews import (  # noqa: E402
     ReviewCommentIndexKey as ReviewCommentIndexKey,
@@ -166,6 +167,7 @@ __all__ = [
     "gh_pr_list_unresolved_threads",
     "gh_pr_resolve_thread",
     "gh_pr_review_post",
+    "gh_pr_state",
     "gh_pr_update_review_comment",
     "gh_pr_wont_fix_line_index",
     "gh_rate_limit_reset_epoch",

--- a/hephaestus/automation/github_api/prs.py
+++ b/hephaestus/automation/github_api/prs.py
@@ -322,6 +322,34 @@ def gh_pr_label_names(pr_number: int) -> list[str]:
     return names
 
 
+def gh_pr_state(pr_number: int) -> dict[str, Any] | None:
+    """Return a PR's lifecycle state by number, best-effort (read-only).
+
+    Fetches ``gh pr view <n> --json state,mergedAt`` so callers can
+    distinguish merged/closed/open without importing the stage-runtime
+    ``PipelineGitHub.gh_pr_state``. Mirrors that method's read exactly so
+    pipeline seeding's ``--prs`` mapping shares its terminal-state semantics
+    (see ``_terminal_pr_outcome``, ``pipeline/stages/base.py``).
+
+    Args:
+        pr_number: GitHub PR number.
+
+    Returns:
+        ``{"state": ..., "mergedAt": ...}`` on success, ``None`` on any
+        fetch failure.
+
+    """
+    try:
+        result = _api._gh_call(
+            ["pr", "view", str(pr_number), "--json", "state,mergedAt"], check=False
+        )
+        data = cast(dict[str, Any], json.loads(result.stdout or "{}"))
+    except (json.JSONDecodeError, OSError, subprocess.SubprocessError) as exc:
+        _api.logger.warning("Could not fetch PR #%s state: %s", pr_number, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def gh_current_login() -> str | None:
     """Return the authenticated GitHub login for the current ``gh`` token."""
     try:

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from hephaestus.automation._review_utils import find_merged_pr_for_issue, find_pr_for_issue
-from hephaestus.automation.github_api import fetch_issue_info, gh_pr_label_names
+from hephaestus.automation.github_api import fetch_issue_info, gh_pr_label_names, gh_pr_state
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.state_labels import (
     STATE_IMPLEMENTATION_GO,
@@ -423,25 +423,31 @@ def seed_from_cli(
 
     - ``repos`` → one :attr:`StageName.REPO` entry each (discovery seeds).
     - ``issues`` → :func:`seed_issue` + :func:`classify_issue` per issue.
-    - ``prs`` → :attr:`StageName.CI` when the PR carries
-      ``state:implementation-go``, else :attr:`StageName.PR_REVIEW` —
-      mirroring the legacy existing-PR review semantics: GO short-circuits
-      review, and a failed label fetch reads as "not yet reviewed" (→ pr_review).
+    - ``prs`` → tri-state classification mirroring ``classify_issue``'s
+      open-PR routing: merged PR -> FINISHED (idempotent), closed PR ->
+      excluded, open PR with ``state:implementation-go`` -> CI, open PR
+      without it -> PR_REVIEW. A failed state/label fetch reads as
+      "open, not yet reviewed" (-> pr_review), matching the legacy
+      ``_review_existing_pr`` fail-open-to-review semantics.
       When *github* is given (a repo-scoped accessor, e.g.
-      :class:`~hephaestus.automation.pipeline_github.PipelineGitHub`), the
-      label read is scoped to that repo via
-      ``github.pr_has_implementation_state_label`` — the same accessor
-      :func:`seed_issue_from_github` uses for ``--issues`` — instead of the
-      module-level :func:`~hephaestus.automation.github_api.gh_pr_label_names`,
-      which resolves against the ambient/current repo and can misclassify a
-      PR number that collides across repos in a multi-repo run.
+      :class:`~hephaestus.automation.pipeline_github.PipelineGitHub`), both
+      the state read and the label read are scoped to that repo via
+      ``github.gh_pr_state`` / ``github.pr_has_implementation_state_label``
+      — the same accessor :func:`seed_issue_from_github` uses for
+      ``--issues`` — instead of the module-level
+      :func:`~hephaestus.automation.github_api.gh_pr_state` /
+      :func:`~hephaestus.automation.github_api.gh_pr_label_names`, which
+      resolve against the ambient/current repo and can misclassify a PR
+      number that collides across repos in a multi-repo run.
 
     Args:
         repos: Repository names to seed for discovery.
         issues: Issue numbers to classify directly.
-        prs: PR numbers to route by implementation-review label.
-        github: Optional repo-scoped GitHub accessor for the ``prs`` label
-            read. When ``None``, falls back to the ambient
+        prs: PR numbers to route by merge/close state, then
+            implementation-review label.
+        github: Optional repo-scoped GitHub accessor for the ``prs`` state
+            and label reads. When ``None``, falls back to the ambient
+            :func:`~hephaestus.automation.github_api.gh_pr_state` /
             :func:`~hephaestus.automation.github_api.gh_pr_label_names`.
 
     Returns:
@@ -469,6 +475,31 @@ def seed_from_cli(
             )
         )
     for pr in prs:
+        pr_state = github.gh_pr_state(pr) if github is not None else gh_pr_state(pr)
+        state = str((pr_state or {}).get("state") or "").upper()
+        if state == "MERGED" or (pr_state or {}).get("mergedAt"):
+            entries.append(
+                SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=StageName.FINISHED,
+                    reason=f"PR #{pr} merged (idempotent)",
+                    pr_number=pr,
+                )
+            )
+            continue
+        if state == "CLOSED":
+            entries.append(
+                SeedEntry(
+                    kind="pr",
+                    identifier=pr,
+                    stage=None,
+                    reason=f"PR #{pr} closed (not merged) — excluded",
+                    pr_number=pr,
+                )
+            )
+            continue
+
         if github is not None:
             has_go, _has_no_go = github.pr_has_implementation_state_label(pr)
         else:

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -545,9 +545,12 @@ class TestSeedFromCli:
 
     def test_prs_arm_impl_go_routes_to_ci(self) -> None:
         """A PR carrying state:implementation-go seeds into ci (GO short-circuit)."""
-        with patch(
-            "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
-            return_value=[STATE_IMPLEMENTATION_GO],
+        with (
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
+            patch(
+                "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+                return_value=[STATE_IMPLEMENTATION_GO],
+            ),
         ):
             entries = seed_from_cli([], [], [77])
         assert entries == [
@@ -562,9 +565,12 @@ class TestSeedFromCli:
 
     def test_prs_arm_no_go_routes_to_pr_review(self) -> None:
         """A PR without impl-GO (e.g. NO-GO) seeds into pr_review."""
-        with patch(
-            "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
-            return_value=[STATE_IMPLEMENTATION_NO_GO],
+        with (
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
+            patch(
+                "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+                return_value=[STATE_IMPLEMENTATION_NO_GO],
+            ),
         ):
             entries = seed_from_cli([], [], [78])
         assert entries[0].stage is StageName.PR_REVIEW
@@ -574,22 +580,34 @@ class TestSeedFromCli:
 
         Mirrors _review_existing_pr's (False, False) "not yet reviewed" semantics.
         """
-        with patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]):
+        with (
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]),
+        ):
             entries = seed_from_cli([], [], [79])
         assert entries[0].stage is StageName.PR_REVIEW
 
     def test_prs_arm_uses_repo_scoped_accessor_when_given(self) -> None:
-        """A repo-scoped github accessor routes the --prs label read through it.
+        """A repo-scoped github accessor routes the --prs state/label reads through it.
 
-        Not the ambient gh_pr_label_names, closing the multi-repo misclassification (#1864).
+        Not the ambient gh_pr_state/gh_pr_label_names, closing the multi-repo
+        misclassification (#1864).
         """
         github = MagicMock()
+        github.gh_pr_state.return_value = None
         github.pr_has_implementation_state_label.return_value = (True, False)
-        with patch(
-            "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
-            side_effect=AssertionError("must not call ambient label read when github is given"),
+        with (
+            patch(
+                "hephaestus.automation.pipeline.seeding.gh_pr_state",
+                side_effect=AssertionError("must not call ambient state read when github is given"),
+            ),
+            patch(
+                "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+                side_effect=AssertionError("must not call ambient label read when github is given"),
+            ),
         ):
             entries = seed_from_cli([], [], [77], github=github)
+        github.gh_pr_state.assert_called_once_with(77)
         github.pr_has_implementation_state_label.assert_called_once_with(77)
         assert entries == [
             SeedEntry(
@@ -604,15 +622,79 @@ class TestSeedFromCli:
     def test_prs_arm_repo_scoped_no_go_routes_to_pr_review(self) -> None:
         """Repo-scoped accessor without impl-GO seeds into pr_review."""
         github = MagicMock()
+        github.gh_pr_state.return_value = None
         github.pr_has_implementation_state_label.return_value = (False, True)
         entries = seed_from_cli([], [], [78], github=github)
         assert entries[0].stage is StageName.PR_REVIEW
+
+    def test_prs_arm_repo_scoped_merged_pr_routes_to_finished(self) -> None:
+        """Repo-scoped accessor: a merged PR classifies FINISHED via github.gh_pr_state (#1865)."""
+        github = MagicMock()
+        github.gh_pr_state.return_value = {"state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z"}
+        entries = seed_from_cli([], [], [80], github=github)
+        assert entries == [
+            SeedEntry(
+                kind="pr",
+                identifier=80,
+                stage=StageName.FINISHED,
+                reason="PR #80 merged (idempotent)",
+                pr_number=80,
+            )
+        ]
+        github.pr_has_implementation_state_label.assert_not_called()
+
+    def test_prs_arm_repo_scoped_closed_pr_excluded(self) -> None:
+        """Repo-scoped accessor: a closed PR is excluded via github.gh_pr_state (#1865)."""
+        github = MagicMock()
+        github.gh_pr_state.return_value = {"state": "CLOSED", "mergedAt": None}
+        entries = seed_from_cli([], [], [81], github=github)
+        assert entries[0].stage is None
+        github.pr_has_implementation_state_label.assert_not_called()
+
+    def test_prs_arm_merged_pr_routes_to_finished(self) -> None:
+        """A merged PR passed via --prs classifies FINISHED, not PR_REVIEW (#1865)."""
+        with patch(
+            "hephaestus.automation.pipeline.seeding.gh_pr_state",
+            return_value={"state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z"},
+        ):
+            entries = seed_from_cli([], [], [80])
+        assert entries == [
+            SeedEntry(
+                kind="pr",
+                identifier=80,
+                stage=StageName.FINISHED,
+                reason="PR #80 merged (idempotent)",
+                pr_number=80,
+            )
+        ]
+
+    def test_prs_arm_closed_pr_excluded(self) -> None:
+        """A closed (unmerged) PR passed via --prs is excluded, not re-reviewed (#1865)."""
+        with patch(
+            "hephaestus.automation.pipeline.seeding.gh_pr_state",
+            return_value={"state": "CLOSED", "mergedAt": None},
+        ):
+            entries = seed_from_cli([], [], [81])
+        assert entries[0].stage is None
+
+    def test_prs_arm_state_fetch_failure_falls_through_to_labels(self) -> None:
+        """A gh_pr_state read failure (None) falls through to label routing, not FINISHED."""
+        with (
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
+            patch(
+                "hephaestus.automation.pipeline.seeding.gh_pr_label_names",
+                return_value=[STATE_IMPLEMENTATION_GO],
+            ),
+        ):
+            entries = seed_from_cli([], [], [82])
+        assert entries[0].stage is StageName.CI
 
     def test_order_repos_then_issues_then_prs(self) -> None:
         """Entries preserve CLI order: repos, then issues, then prs."""
         facts = _facts(number=5)
         with (
             patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts),
+            patch("hephaestus.automation.pipeline.seeding.gh_pr_state", return_value=None),
             patch("hephaestus.automation.pipeline.seeding.gh_pr_label_names", return_value=[]),
         ):
             entries = seed_from_cli(["R"], [5], [6])

--- a/tests/unit/automation/test_github_api_package.py
+++ b/tests/unit/automation/test_github_api_package.py
@@ -17,7 +17,13 @@ def test_public_reexports_match_canonical_submodules() -> None:
         "issue_states": ["prefetch_issue_states", "_fetch_batch_states"],
         "issues": ["gh_issue_json", "gh_issue_create", "fetch_issue_info"],
         "labels": ["gh_list_labels", "gh_create_label", "_ensure_labels_exist"],
-        "prs": ["gh_pr_create", "fetch_open_prs", "gh_current_login", "gh_pr_label_names"],
+        "prs": [
+            "gh_pr_create",
+            "fetch_open_prs",
+            "gh_current_login",
+            "gh_pr_label_names",
+            "gh_pr_state",
+        ],
         "reviews": ["gh_pr_review_post", "gh_pr_inline_comment_index"],
         "threads": ["gh_pr_list_unresolved_threads", "gh_pr_resolve_thread"],
     }
@@ -76,3 +82,28 @@ def test_gh_pr_label_names_non_list_labels_yields_empty() -> None:
     result = mock.Mock(stdout=json.dumps({"labels": "oops"}))
     with mock.patch.object(gha, "_gh_call", return_value=result):
         assert gha.gh_pr_label_names(77) == []
+
+
+def test_gh_pr_state_returns_state_dict() -> None:
+    """gh_pr_state returns the parsed state/mergedAt payload."""
+    payload = {"state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z"}
+    result = mock.Mock(stdout=json.dumps(payload))
+
+    with mock.patch.object(gha, "_gh_call", return_value=result) as gh_call:
+        state = gha.gh_pr_state(80)
+
+    assert state == payload
+    gh_call.assert_called_once_with(["pr", "view", "80", "--json", "state,mergedAt"], check=False)
+
+
+def test_gh_pr_state_best_effort_none_on_failure() -> None:
+    """A fetch/JSON failure yields None (falls through to label routing)."""
+    with mock.patch.object(gha, "_gh_call", side_effect=OSError("gh down")):
+        assert gha.gh_pr_state(80) is None
+
+
+def test_gh_pr_state_non_dict_payload_yields_none() -> None:
+    """A malformed payload (not a dict) yields None rather than raising."""
+    result = mock.Mock(stdout=json.dumps(["oops"]))
+    with mock.patch.object(gha, "_gh_call", return_value=result):
+        assert gha.gh_pr_state(80) is None


### PR DESCRIPTION
## Summary
Clean, only intended files touched. Implementation complete.

## Summary

Fixed the `--prs` seeding arm in `hephaestus/automation/pipeline/seeding.py` to use the same tri-state PR classification as `classify_issue`, instead of blindly routing every non-GO PR to `PR_REVIEW`:

- **`hephaestus/automation/github_api/prs.py`**: Added `gh_pr_state(pr_number)` — a best-effort read-only `gh pr view --json state,mergedAt` fetch, mirroring `gh_pr_label_names`'s error-handling pattern.
- **`hephaestus/automation/github_api/__init__.py`**: Exported `gh_pr_state`.
- **`hephaestus/automation/pipeline/seeding.py`**: The `--prs` loop now checks state first — merged → `FINISHED`, closed (unmerged) → excluded (`stage=None`), open+GO → `CI`, open+no-GO → `PR_REVIEW` (label fetch failure still falls through to PR_REVIEW). Updated the `seed_from_cli` docstring to describe the tri-state contract.
- **Tests**: Updated the 4 existing `--prs`/order tests to patch `gh_pr_state` (returning `None`, so they still exercise label routing), added 3 new tests for merged/closed/state-fetch-failure paths in `test_seeding.py`, and added 3 tests plus a re-export entry for `gh_pr_state` in `test_github_api_package.py`.

Ran: targeted seeding + github_api package tests (109 passed), full `tests/unit/automation` suite (2731 passed, 1 skipped), pipeline architecture / automation-boundary mutator guards (8 passed), `ruff check` + `ruff format --check` (clean), and `mypy` over the whole tree (clean, 534 files).


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1865

Generated by Hephaestus automation
