### PR TITLE
[majo] count_unresolved_threads repo-path raises on GraphQL error while the legacy path fails open to (0,0) -- opposite untested semantics

### DIFF
--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -603,22 +603,27 @@ class PipelineGitHub:
         return pr_manager.pr_has_implementation_state_label(pr_number)
 
     def _unresolved_threads(self, pr_number: int) -> list[dict[str, Any]]:
-        """Fetch unresolved threads (repo-scoped or legacy). Fails open to []."""
+        """Fetch unresolved threads (repo-scoped or legacy).
+
+        Fail-closed: a fetch error (subprocess, JSON, or GraphQL error)
+        propagates to the caller on BOTH paths (#1868). The pipeline
+        coordinator already isolates a raised exception to the single
+        work item mid-step (routes it to finished(fail)) rather than
+        crashing the run, so failing closed here costs one item, not a
+        silent GO on unreviewed human threads.
+        """
         if self._repo_slug is not None:
             return self._repo_unresolved_threads(pr_number)
-        try:
-            return github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
-        except Exception as exc:  # legacy path fails open (parity with existing code)
-            logger.warning("PR #%s: could not list unresolved threads: %s", pr_number, exc)
-            return []
+        return github_api.gh_pr_list_unresolved_threads(pr_number, dry_run=False)
 
     def count_unresolved_threads(self, pr_number: int) -> tuple[int, int]:
         """Return ``(automation_unresolved, human_unresolved)`` thread counts.
 
         Mirrors ``_review_phase._count_unresolved_threads_blocking_go``
-        (#1152): resolves nothing. Current-repo legacy helpers still fail
-        open on fetch errors; repo-scoped pipeline runs query the configured
-        repo directly so unresolved human threads are not hidden.
+        (#1152): resolves nothing. Both repo-scoped and legacy fetch paths
+        fail closed (#1868): a fetch error propagates rather than being
+        swallowed, so unresolved human threads are never hidden by a
+        transient GraphQL/API blip.
         """
         return _split_threads(self._unresolved_threads(pr_number))
 

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -414,6 +414,20 @@ class TestRepoScoping:
         assert "owner=org" in calls[0]
         assert "name=repo-a" in calls[0]
 
+    def test_repo_scoped_fetch_error_fails_closed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1868: repo-scoped path must propagate GraphQL errors, matching legacy."""
+
+        def fake_gh_call(argv: list[str], **kwargs: object) -> SimpleNamespace:
+            raise RuntimeError("gh: GraphQL: Head sha can't be blank")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        with pytest.raises(RuntimeError, match="Head sha"):
+            adapter.count_unresolved_threads(7)
+
     def test_repo_scoped_upsert_plan_comment_updates_marker_comment(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -750,17 +764,23 @@ class TestUnresolvedThreads:
 
         assert adapter.count_unresolved_threads(7) == (1, 2)
 
-    def test_empty_and_error_fail_open(
+    def test_empty_result_returns_zero(
         self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(github_api_mod, "gh_pr_list_unresolved_threads", lambda n, dry_run: [])
         assert adapter.count_unresolved_threads(7) == (0, 0)
 
+    def test_legacy_fetch_error_fails_closed(
+        self, adapter: pg.PipelineGitHub, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1868: legacy path must propagate fetch errors, not fail open to (0, 0)."""
+
         def boom(n: int, dry_run: bool) -> list[dict[str, Any]]:
             raise RuntimeError("api")
 
         monkeypatch.setattr(github_api_mod, "gh_pr_list_unresolved_threads", boom)
-        assert adapter.count_unresolved_threads(7) == (0, 0)
+        with pytest.raises(RuntimeError, match="api"):
+            adapter.count_unresolved_threads(7)
 
 
 class TestGhPrState:


### PR DESCRIPTION
## Summary
Clean — only the two intended files modified.

## Summary

Implemented the approved plan for issue #1868: unified `PipelineGitHub._unresolved_threads` to fail-closed on both the repo-scoped and legacy paths.

**`hephaestus/automation/pipeline_github.py`**
- `_unresolved_threads` (line 605): removed the legacy branch's `try/except Exception → []` swallow; both branches now propagate fetch errors. Docstring documents the unified fail-closed policy and the rationale (coordinator isolates the raised exception to one work item via `finished(fail)`, not a process crash).
- `count_unresolved_threads` docstring updated to state both paths fail closed.

**`tests/unit/automation/test_pipeline_github.py`**
- Replaced `test_empty_and_error_fail_open` with `test_empty_result_returns_zero` (non-error empty case still `(0, 0)`) and `test_legacy_fetch_error_fails_closed` (fetch error now raises `RuntimeError`).
- Added `test_repo_scoped_fetch_error_fails_closed`, mirroring the existing `fake_gh_call` pattern, asserting the repo-scoped GraphQL error also propagates.

**Tests run:**
- Targeted `TestUnresolvedThreads` + repo-scoped tests: 6 passed
- Full `test_pipeline_github.py` + `test_stage_pr_review.py`: 168 passed
- Full `tests/unit/automation/`: 2727 passed, 1 skipped
- `ruff check`: clean
- `mypy`: clean (534 source files, no issues)

Grepped for other call sites relying on the old fail-open `(0, 0)` behavior (`_review_phase.py`, `address_review.py`) — those use a different function path and are unaffected.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1868

Generated by Hephaestus automation
