### PR TITLE
[majo] plan_review on_enter resets review_round but not review_error_retries -- a single ERROR can FINISH_FAIL a fresh cycle

### DIFF
--- a/hephaestus/automation/pipeline/stages/plan_review.py
+++ b/hephaestus/automation/pipeline/stages/plan_review.py
@@ -25,7 +25,8 @@ re-pointed at the pipeline (#1820):
   labels untouched, bounded in-stage by
   ``item.payload["review_error_retries"]`` (cap
   ``REVIEW_ERROR_RETRY_CAP`` consecutive failures, reset on any real
-  verdict). At the cap the item FINISH_FAILs — a reviewer-infrastructure
+  verdict or on entry into a new plan cycle, #1869). At the cap the item
+  FINISH_FAILs — a reviewer-infrastructure
   failure is not fixed by replanning, so failing back to planning would
   only spend ``plan_cycles`` on more doomed reviews; labels stay untouched
   on the whole ERROR path.
@@ -183,7 +184,12 @@ class PlanReviewStage(Stage):
         ``attempts["plan_cycles"]`` (recorded in ``payload["review_cycle"]``)
         so it fires exactly once per fail-back cycle: a same-cycle re-entry
         (e.g. the ERROR-path RETRY) matches the recorded cycle and keeps its
-        round count. Idempotent — a literal double on_enter is a no-op.
+        round count. A fresh cycle also restarts the consecutive
+        reviewer-failure streak (``payload["review_error_retries"]``,
+        #1869) — otherwise a leftover count from a prior transient failure
+        could let the first ERROR of the new cycle immediately exceed
+        ``REVIEW_ERROR_RETRY_CAP``. Idempotent — a literal double on_enter
+        is a no-op.
 
         No durable entry work: the doc defines no [M] entry step here, and
         nothing is written. Label fast-forward for items already at-or-past
@@ -202,6 +208,11 @@ class PlanReviewStage(Stage):
         if item.payload.get("review_cycle") != cycle:
             item.payload["review_cycle"] = cycle
             item.payload["review_round"] = 0
+            # Fresh plan cycle: the consecutive reviewer-failure streak
+            # restarts too (#1869) — a leftover count from a prior
+            # transient reviewer failure must not let the first ERROR of
+            # a new cycle immediately exceed REVIEW_ERROR_RETRY_CAP.
+            item.payload.pop("review_error_retries", None)
         return None
 
     def step(self, item: WorkItem, ctx: StageContext) -> StepResult:

--- a/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_plan_review.py
@@ -118,6 +118,43 @@ class TestPlanReviewStageOnEnter:
         assert item.payload == snapshot
         assert github.mutation_log == []
 
+    def test_on_enter_resets_error_retries_for_new_cycle(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A fresh plan cycle also clears a stale review_error_retries count (#1869).
+
+        Without this reset, a count left over from a prior transient
+        reviewer failure (persisted across the FAIL_BACK -> planning ->
+        plan_review round-trip) would let the very first ERROR of the new
+        cycle immediately exceed REVIEW_ERROR_RETRY_CAP.
+        """
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=4, state="ENTER")
+        item.attempts["plan_cycles"] = 1  # fail-back happened; new cycle
+        item.payload["review_cycle"] = 0
+        item.payload["review_round"] = 3
+        item.payload["review_error_retries"] = 2  # stale from prior cycle's ERRORs
+
+        stage.on_enter(item, ctx)
+
+        assert item.payload.get("review_error_retries", 0) == 0
+
+    def test_on_enter_same_cycle_keeps_error_retries(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Same-cycle re-entry (e.g. the ERROR-path RETRY) keeps the count."""
+        stage = PlanReviewStage()
+        ctx = make_ctx()
+        item = make_work_item(issue=5, state="ENTER")
+        item.payload["review_cycle"] = 0
+        item.payload["review_round"] = 1
+        item.payload["review_error_retries"] = 1  # one ERROR already this cycle
+
+        stage.on_enter(item, ctx)
+
+        assert item.payload["review_error_retries"] == 1  # preserved
+
 
 class TestPlanReviewStageStep:
     """step state machine: ENTER -> REVIEW_WAIT -> EVAL -> AMEND/LEARN."""
@@ -712,6 +749,39 @@ class TestCycleRelativeBudget:
         assert second.note == "plan_cycles_exhausted"
         assert item.attempts["plan_review_iter"] == 6  # lifetime audit trail
         assert item.attempts["plan_cycles"] == 2
+
+    def test_new_cycle_gets_full_error_retry_budget(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A fresh cycle's first ERROR does not FINISH_FAIL on a stale count (#1869).
+
+        Reproduces the bug scenario: review_error_retries is left at
+        REVIEW_ERROR_RETRY_CAP - 1 from transient ERRORs in a prior cycle
+        (no real verdict ever reset it), then FAIL_BACK -> planning ->
+        plan_review re-enters for a new cycle. The single ERROR in the new
+        cycle must RETRY, not immediately exceed the cap.
+        """
+        stage = PlanReviewStage()
+        github = FakeStageGitHub()
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=36, state="ENTER")
+        item.attempts["plan_cycles"] = 0
+        item.payload["review_cycle"] = 0
+        item.payload["review_error_retries"] = REVIEW_ERROR_RETRY_CAP - 1
+
+        # Simulate the fail-back into a new cycle.
+        item.attempts["plan_cycles"] = 1
+        assert stage.on_enter(item, ctx) is None
+        assert item.payload.get("review_error_retries", 0) == 0
+
+        item.state = "EVAL"
+        item.payload["review_verdict"] = _verdict("ERROR")
+        outcome = stage.step(item, ctx)
+
+        assert isinstance(outcome, StageOutcome)
+        assert outcome.disposition == Disposition.RETRY  # not FINISH_FAIL
+        assert item.payload["review_error_retries"] == 1
+        assert github.mutation_log == []
 
 
 class TestNonFatalLabelWrites:


### PR DESCRIPTION
## Summary
Clean, no stray files. Implementation complete.

## Summary

Fixed `PlanReviewStage.on_enter` in `hephaestus/automation/pipeline/stages/plan_review.py:201-208` to reset `payload["review_error_retries"]` alongside `review_round` in the cycle-change branch, mirroring the identical fix in the sibling `pr_review.py:374`. Without this, a leftover retry count from a prior transient reviewer ERROR (persisted across the FAIL_BACK → planning → plan_review round-trip) could let the first ERROR of a fresh cycle immediately exceed `REVIEW_ERROR_RETRY_CAP` and FINISH_FAIL the item.

Also updated the `on_enter` docstring and module-level docstring to document the new reset behavior (referencing #1869).

**Tests added** to `tests/unit/automation/pipeline/stages/test_stage_plan_review.py`:
- `test_on_enter_resets_error_retries_for_new_cycle` — stale count cleared on cycle change
- `test_on_enter_same_cycle_keeps_error_retries` — same-cycle re-entry preserves the count
- `test_new_cycle_gets_full_error_retry_budget` (in `TestCycleRelativeBudget`) — end-to-end reproduction of the bug scenario: a stale near-cap count from a prior cycle, then a FAIL_BACK into a new cycle, then a single ERROR verdict correctly RETRYs instead of FINISH_FAILing.

**Verification:**
- `pixi run pytest tests/unit/automation/pipeline/stages/test_stage_plan_review.py -v` — 44 passed
- `pixi run pytest tests/unit/automation/pipeline -q` — 839 passed (no regressions)
- `pixi run ruff check` / `ruff format --check` on touched files — clean
- `pixi run mypy` (whole tree) — clean (534 source files, no issues)

No git actions taken — working tree left for the orchestrator to commit/push/PR.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1869

Generated by Hephaestus automation
