### PR TITLE
[MAJOR] Implement stage creates worktrees under the ambient repo, not the issue's owning repo

### DIFF
--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -313,6 +313,7 @@ class ImplementationStage(Stage):
             # _prepare_worktree_for_existing_pr :649/:693, so re-running
             # never discards pushed commits). Values coordinator-vetted.
             "refresh_base": not adopted,
+            "repo_root": str(ctx.paths.repo_root),
         }
         if adopted:
             kwargs["sync_to_remote"] = True

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -555,14 +555,25 @@ class WorkerPool:
 
     def _git_create_worktree(self, job: GitJob) -> JobResult:
         """Create a worktree and optionally sync an adopted PR branch."""
-        manager = WorktreeManager()
         kwargs = dict(job.kwargs)
         sync_to_remote = bool(kwargs.pop("sync_to_remote", False))
         pr_number = kwargs.pop("pr_number", None)
+        repo_root_kwarg = kwargs.pop("repo_root", None)
+        repo_root = Path(repo_root_kwarg) if repo_root_kwarg else get_repo_root()
+        base_dir = repo_root / "build" / ".worktrees"
+        manager = WorktreeManager(base_dir=base_dir, repo_root=repo_root)
         created = manager.create_worktree(**kwargs, timeout=job.timeout_s)
         if created is None:
             return JobResult(ok=True)
         worktree_path = Path(created)
+        if repo_root not in worktree_path.parents and worktree_path != repo_root:
+            return JobResult(
+                ok=False,
+                error=(
+                    f"worktree {worktree_path} escaped resolved repo root {repo_root} "
+                    f"for job.repo={job.repo!r}"
+                ),
+            )
         branch_name = str(kwargs.get("branch_name") or "")
         if not sync_to_remote:
             return JobResult(ok=True, value=str(worktree_path))
@@ -620,7 +631,8 @@ class WorkerPool:
                 timeout=job.timeout_s,
             )
             return JobResult(ok=True)
-        manager = WorktreeManager()
+        fallback_root = Path(str(job.kwargs.get("repo_root") or get_repo_root()))
+        manager = WorktreeManager(repo_root=fallback_root)
         manager.remove_worktree(**job.kwargs, timeout=job.timeout_s)
         return JobResult(ok=True)
 

--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -78,16 +78,27 @@ class WorktreeManager:
     Allows parallel issue implementation in isolated worktrees.
     """
 
-    def __init__(self, base_dir: Path | None = None, base_branch: str | None = None) -> None:
+    def __init__(
+        self,
+        base_dir: Path | None = None,
+        base_branch: str | None = None,
+        repo_root: Path | None = None,
+    ) -> None:
         """Initialize worktree manager.
 
         Args:
             base_dir: Base directory for worktrees (default: repo_root/build/.worktrees)
             base_branch: Base branch for worktrees (default: auto-detect from origin/HEAD
                 lazily on first use)
+            repo_root: Repository checkout to operate in (default: ambient CWD's
+                checkout via ``get_repo_root()``). Pass explicitly whenever the
+                caller may be handling a repo other than its own CWD (e.g. a
+                multi-repo pipeline worker) — every git subprocess this class
+                shells out to (``worktree add``, ``fetch``, ``prune``, ...) runs
+                with this as ``cwd``.
 
         """
-        self.repo_root = get_repo_root()
+        self.repo_root = repo_root if repo_root is not None else get_repo_root()
         if base_dir is None:
             base_dir = self.repo_root / "build" / ".worktrees"
         self.base_dir = base_dir

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -290,6 +290,7 @@ class TestGate:
             "issue_number": 1,
             "branch_name": "1-some-real-branch",
             "refresh_base": False,
+            "repo_root": "/tmp/repo",
             "sync_to_remote": True,
             "pr_number": 1001,
         }
@@ -518,6 +519,7 @@ class TestWorktreeAndAdvise:
             "issue_number": 1,
             "branch_name": "1-auto-impl",
             "refresh_base": True,
+            "repo_root": "/tmp/repo",
         }
         assert result.on_done_state == "DIRTY_DECISION_WAIT"
 

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -619,32 +619,42 @@ class TestGitOps:
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
+        tmp_path: Path,
     ) -> None:
         """create_worktree forwards kwargs to WorktreeManager.create_worktree."""
         job = GitJob(
             repo="test/repo",
             op="create_worktree",
             timeout_s=60,
-            kwargs={"issue_number": 7, "branch_name": "7-auto"},
+            kwargs={
+                "issue_number": 7,
+                "branch_name": "7-auto",
+                "repo_root": str(tmp_path),
+            },
         )
         instance = MagicMock()
-        instance.create_worktree.return_value = Path("/tmp/wt")
-        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+        instance.create_worktree.return_value = tmp_path / "wt"
+        with patch(f"{_WP}.WorktreeManager", return_value=instance) as mock_manager:
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
+        mock_manager.assert_called_once_with(
+            base_dir=tmp_path / "build" / ".worktrees",
+            repo_root=tmp_path,
+        )
         instance.create_worktree.assert_called_once_with(
             issue_number=7,
             branch_name="7-auto",
             timeout=60,
         )
         assert result.ok is True
-        assert result.value == "/tmp/wt"
+        assert result.value == str(tmp_path / "wt")
 
     def test_create_worktree_syncs_adopted_clean_branch(
         self,
         pool: WorkerPool,
         completion_q: CompletionQueue,
+        tmp_path: Path,
     ) -> None:
         """sync_to_remote is a worker concern, not leaked into WorktreeManager."""
         job = GitJob(
@@ -655,12 +665,13 @@ class TestGitOps:
                 "issue_number": 7,
                 "branch_name": "7-existing",
                 "refresh_base": False,
+                "repo_root": str(tmp_path),
                 "sync_to_remote": True,
                 "pr_number": 70,
             },
         )
         instance = MagicMock()
-        instance.create_worktree.return_value = Path("/tmp/wt")
+        instance.create_worktree.return_value = tmp_path / "wt"
         with (
             patch(f"{_WP}.WorktreeManager", return_value=instance),
             patch(f"{_WP}.git_utils.is_clean_working_tree", return_value=True) as mock_clean,
@@ -675,10 +686,72 @@ class TestGitOps:
             refresh_base=False,
             timeout=60,
         )
-        mock_clean.assert_called_once_with(Path("/tmp/wt"), timeout=60)
-        mock_sync.assert_called_once_with(Path("/tmp/wt"), "7-existing", pr_number=70, timeout=60)
+        mock_clean.assert_called_once_with(tmp_path / "wt", timeout=60)
+        mock_sync.assert_called_once_with(tmp_path / "wt", "7-existing", pr_number=70, timeout=60)
         assert result.ok is True
-        assert result.value == {"path": "/tmp/wt", "dirty": False, "status": "", "diff": ""}
+        assert result.value == {
+            "path": str(tmp_path / "wt"),
+            "dirty": False,
+            "status": "",
+            "diff": "",
+        }
+
+    def test_create_worktree_defaults_repo_root_to_ambient_cwd(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+    ) -> None:
+        """No repo_root kwarg falls back to get_repo_root() (single-repo callers)."""
+        job = GitJob(
+            repo="test/repo",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={"issue_number": 7, "branch_name": "7-auto"},
+        )
+        instance = MagicMock()
+        ambient_root = get_repo_root()
+        instance.create_worktree.return_value = ambient_root / "build" / ".worktrees" / "issue-7"
+        with (
+            patch(f"{_WP}.WorktreeManager", return_value=instance) as mock_manager,
+            patch(f"{_WP}.get_repo_root", return_value=ambient_root),
+        ):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_manager.assert_called_once_with(
+            base_dir=ambient_root / "build" / ".worktrees",
+            repo_root=ambient_root,
+        )
+        assert result.ok is True
+
+    def test_create_worktree_escaped_repo_root_fails(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """A worktree path outside the resolved repo_root is a hard failure."""
+        repo_root = tmp_path / "ProjectArgus"
+        job = GitJob(
+            repo="ProjectArgus",
+            op="create_worktree",
+            timeout_s=60,
+            kwargs={
+                "issue_number": 107,
+                "branch_name": "107-auto-impl",
+                "repo_root": str(repo_root),
+            },
+        )
+        instance = MagicMock()
+        instance.create_worktree.return_value = tmp_path / "ProjectHephaestus" / "issue-107"
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        assert result.ok is False
+        assert result.error is not None
+        assert "escaped resolved repo root" in result.error
+        assert str(repo_root) in result.error
 
     def test_remove_worktree_dispatch(
         self,
@@ -698,6 +771,28 @@ class TestGitOps:
             _, result = completion_q.get(timeout=10)
 
         instance.remove_worktree.assert_called_once_with(issue_number=7, force=True, timeout=60)
+        assert result.ok is True
+
+    def test_remove_worktree_fallback_honors_repo_root_kwarg(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        tmp_path: Path,
+    ) -> None:
+        """The manager-state fallback (no worktree_path) still scopes repo_root."""
+        other_repo = tmp_path / "ProjectArgus"
+        job = GitJob(
+            repo="ProjectArgus",
+            op="remove_worktree",
+            timeout_s=60,
+            kwargs={"issue_number": 107, "force": True, "repo_root": str(other_repo)},
+        )
+        instance = MagicMock()
+        with patch(f"{_WP}.WorktreeManager", return_value=instance) as mock_manager:
+            pool.submit(job, StageName.REPO)
+            _, result = completion_q.get(timeout=10)
+
+        mock_manager.assert_called_once_with(repo_root=other_repo)
         assert result.ok is True
 
     def test_remove_worktree_path_dispatch(
@@ -1098,7 +1193,9 @@ class TestGitLocking:
         """A completed GitJob does not leave an idle repo lock cached forever."""
         job = GitJob(repo="test/repo", op="create_worktree", timeout_s=60, kwargs={})
 
-        with patch(f"{_WP}.WorktreeManager", return_value=MagicMock()):
+        instance = MagicMock()
+        instance.create_worktree.return_value = None
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 
@@ -1163,7 +1260,9 @@ class TestGitLocking:
     ) -> None:
         """Running a GitJob creates the per-repo sentinel file in lock_dir."""
         job = GitJob(repo="test/repo", op="create_worktree", timeout_s=60, kwargs={})
-        with patch(f"{_WP}.WorktreeManager", return_value=MagicMock()):
+        instance = MagicMock()
+        instance.create_worktree.return_value = None
+        with patch(f"{_WP}.WorktreeManager", return_value=instance):
             pool.submit(job, StageName.REPO)
             _, result = completion_q.get(timeout=10)
 

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -42,6 +42,19 @@ class TestWorktreeManager:
 
         assert manager.base_dir == custom_dir
 
+    def test_initialization_explicit_repo_root(self, worktree_mocks: Any, tmp_path: Any) -> None:
+        """An explicit repo_root is used verbatim and get_repo_root is never consulted."""
+        worktree_mocks.repo_root.side_effect = AssertionError(
+            "get_repo_root() must not be called when repo_root is explicit"
+        )
+        other_repo = tmp_path / "other-repo"
+
+        manager = WorktreeManager(repo_root=other_repo)
+
+        assert manager.repo_root == other_repo
+        assert manager.base_dir == other_repo / "build" / ".worktrees"
+        worktree_mocks.repo_root.assert_not_called()
+
     def test_create_worktree_success(self, worktree_mocks: Any, tmp_path: Any) -> None:
         """Test successful worktree creation."""
         worktree_mocks.repo_root.return_value = tmp_path


### PR DESCRIPTION
## Summary
Implementation complete for issue #2064.

**Changes:**
- `hephaestus/automation/worktree_manager.py:81-98` — `WorktreeManager.__init__` gained an optional `repo_root: Path | None` param; explicit value bypasses `get_repo_root()` entirely.
- `hephaestus/automation/pipeline/worker_pool.py:_git_create_worktree` — pops `repo_root` from job kwargs, derives `base_dir = repo_root / "build" / ".worktrees"`, constructs `WorktreeManager(base_dir=..., repo_root=...)`, and now asserts the resulting worktree path is under the resolved `repo_root` (hard failure with a descriptive error if it escapes).
- `hephaestus/automation/pipeline/worker_pool.py:_git_remove_worktree` — the manager-state fallback path (no `worktree_path` kwarg) now also honors `repo_root` from job kwargs instead of defaulting to ambient CWD.
- `hephaestus/automation/pipeline/stages/implementation.py:_worktree_wait` — adds `"repo_root": str(ctx.paths.repo_root)` to the `create_worktree` job kwargs, mirroring the existing convention in `finished.py`.

**Tests:** updated 2 existing kwargs-equality assertions to include the new `repo_root` key, fixed 2 unrelated locking tests that incidentally triggered the new escape guard, and added: explicit-`repo_root` constructor test, ambient-CWD-fallback dispatch test, escaped-repo-root failure test, and `_git_remove_worktree` fallback `repo_root` test.

**Verification:** `pixi run pytest tests/unit -q` → 5921 passed, 24 skipped, 84.46% coverage (gate: 83%). `pixi run ruff check`/`format --check` and `pixi run mypy` both clean.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2064

Generated by Hephaestus automation
