### PR TITLE
Recover automation-pr-severity-aware-gate skill file (code landed, SKILL.md did not)

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -246,17 +246,15 @@ ADDRESS_WAIT → PUSH_WAIT → EVAL → (loop) → FOLLOWUP_WAIT.
    get_address_review_prompt`.
 6. [W:G] Push (commit+force-push addressing changes).
 7. [M] **EVAL**: invoke `_evaluate_go_verdict` (parse reviewerAgent verdict:
-   GO, NOGO, AMBIGUOUS, ERROR, HUMAN_BLOCKED) + count unresolved threads;
-   an explicit NOGO with zero posted thread IDs and zero unresolved automation
-   or human threads is not a completed round: upsert the bounded
-   `<!-- hephaestus-pr-review-zero-thread-nogo -->` artifact, emit the typed
-   `pr_review_zero_thread_nogo` event, and re-enter `REVIEW_WAIT` for a fresh
-   reviewer invocation without consuming a round;
-   if GO + 0 unresolved threads → apply `state:implementation-go` label and
-   arm auto-merge [durable] → ADVANCE; if NOGO/AMBIGUOUS/ERROR and iteration
-   < 3 → RETRY; if HUMAN_BLOCKED or iteration cap exhausted → routes depend on
-   iteration (hard cap 6) and unresolved-thread progress; on exhaustion →
-   apply `state:skip` label [durable] → SKIP.
+   GO, NOGO, AMBIGUOUS, ERROR, HUMAN_BLOCKED) + `count_unresolved_threads_by_severity`
+   (returns `(blocking_automation, minor_automation, human)`, see
+   "Severity-aware GO gate" below); if GO + `human == 0` + `blocking_automation == 0`
+   → resolve any advisory (`minor_automation`) threads, apply
+   `state:implementation-go` label and arm auto-merge [durable] → ADVANCE; if
+   GO but `human > 0` → FINISH_FAIL (`human_blocked`); if NOGO/AMBIGUOUS/ERROR
+   and iteration < 3 → RETRY; if HUMAN_BLOCKED or iteration cap exhausted →
+   routes depend on iteration (hard cap 6) and unresolved-thread progress; on
+   exhaustion → apply `state:skip` label [durable] → SKIP.
 8. [W:A] **Follow-up step** (on GO only) — `prompts/follow_up.py:105
    get_follow_up_prompt`.
 
@@ -295,6 +293,42 @@ objects are rejected.
 - `prompts/implementation.py:336 get_impl_resume_feedback_prompt`
 - `prompts/address_review.py:181 get_address_review_prompt`
 - `prompts/follow_up.py:105 get_follow_up_prompt`
+
+**Severity-aware GO gate** (#1856; recovers detail from the orphaned
+`automation-pr-severity-aware-gate-implementation` skill draft, #2067):
+
+The GO gate does not treat all unresolved automation threads as equally
+blocking. Each posted review comment carries a fail-safe severity marker
+(`<!-- hephaestus-severity: X -->`, `X` in `critical|major|minor|nitpick`)
+prepended to its body at post time (`hephaestus/automation/prompts/pr_review.py`
+defines `BLOCKING_SEVERITIES = {"critical", "major"}`,
+`VALID_SEVERITIES`, `SEVERITY_MARKER_PREFIX`). Extraction
+(`_thread_severity_is_blocking`, `hephaestus/automation/pipeline_github.py:148`)
+uses line-prefix anchoring (`stripped.startswith(prefix) and
+stripped.endswith("-->")`) to avoid substring false positives, and defaults
+an unmarked or unparseable thread to blocking.
+
+`count_unresolved_threads_by_severity` (`hephaestus/automation/pipeline_github.py:625`)
+returns `(blocking_automation, minor_automation, human)`: human-authored
+threads are never downgraded regardless of marker; only automation-owned
+threads are split by severity. The gate
+(`hephaestus/automation/pipeline/stages/pr_review.py:723`) requires
+`human == 0` and `blocking_automation == 0` to arm a GO; if
+`minor_automation > 0` it calls `resolve_automation_threads`
+(`hephaestus/automation/pipeline_github.py:647`) to resolve the waved
+advisory threads before arming, so `required_review_thread_resolution`
+does not re-block the PR at the merge stage.
+
+Integration checklist for applying this pattern elsewhere: define the
+three severity constants; embed the marker with a fail-safe (unknown ⇒
+blocking) default and idempotency guard (don't double-prepend if already
+marked); extract with line-prefix anchoring; return a 3-tuple from the
+counter; gate on `blocking == 0`, not `total == 0`; resolve advisory
+threads before arming; test marker idempotency, substring false
+positives, and the fail-safe default explicitly.
+
+Related: #1554 (original minor-thread deadlock this replaces), #1575
+(no-commit detection, related thread-management work).
 
 ### 6. ci
 


### PR DESCRIPTION
## Summary
Implementation complete, per the approved plan (`state:plan-go`).

**Summary:** Since ADR-016 (#2063/#2070) removed the `skills/` surface from Hephaestus before this issue was filed, resurrecting `skills/automation-pr-severity-aware-gate-implementation/SKILL.md` would directly contradict that decision. The approved plan instead recovers the orphaned content (from commit `d99258d` on the stale `origin/skill/automation-pr-severity-aware-gate-implementation` branch) losslessly into `docs/AUTOMATION_LOOP_ARCHITECTURE.md`, section 5 (`pr_review`):

- Fixed stale step 7 (was describing the old binary "GO + 0 unresolved threads" gate) to describe the actual severity-aware logic.
- Added a new "Severity-aware GO gate" subsection carrying forward the recovered design detail (marker format, fail-safe defaults, 3-tuple counter, advisory-thread resolution, integration checklist), with all function/line references (`_thread_severity_is_blocking:148`, `count_unresolved_threads_by_severity:625`, `resolve_automation_threads:647`, gate call site `pr_review.py:723`) verified against current source.

**Tests run:**
- `tests/unit/automation/pipeline/stages/test_stage_pr_review.py` + `test_pipeline_github.py`: 166 passed
- `tests/unit/docs` (incl. `test_automation_loop_architecture.py`, which validates doc/source line-ref consistency): 26 passed
- `tests/unit/markdown` + `tests/unit/validation/test_markdown.py`: 127 passed
- Full suite `tests/unit`: 5917 passed, 24 skipped, coverage 84.48% (gate 83%)

Only `docs/AUTOMATION_LOOP_ARCHITECTURE.md` changed; no backup/temp files left in the tree.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2067

Generated by Hephaestus automation
