### PR TITLE
chore(ci): drop strict branch protection (stop require-up-to-date churn)

### DIFF
--- a/docs/adr/0004-single-aggregator-required-checks.md
+++ b/docs/adr/0004-single-aggregator-required-checks.md
@@ -22,7 +22,10 @@ job:
    `needs:` list. It PASSES when every needed job is `success` or `skipped`
    (skipped = legitimately gated off) and FAILS on `failure`/`cancelled`.
 2. Branch protection requires only that single context (alongside the two
-   `test (...)` contexts from `test.yml`), with `strict: true`.
+   `test (...)` contexts from `test.yml`), with `strict: false` — the checks
+   gate every merge, but PRs are not required to be up to date with `main`
+   (avoids rebase churn under a fast-moving `main`; see
+   `docs/ci/required-checks.md`).
 3. `if: always()` is mandatory so the gate reports a definite
    success/failure even when heavy jobs skip on label / auto-merge events.
 

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -16,11 +16,20 @@ checks** are green:
 | `test (ubuntu-latest, 3.12, unit)` | `.github/workflows/test.yml` matrix |
 | `test (ubuntu-latest, 3.12, integration)` | `.github/workflows/test.yml` matrix |
 
-Classic branch protection uses **`strict: true`**, and every active
+Branch protection uses **`strict: false`**, and every active
 `required_status_checks` ruleset that applies to `main` must use
-`strict_required_status_checks_policy: true`. Requiring the PR head to be
-tested with current `main` prevents a stale PR from merging around a gate that
-newer `main` would fail.
+`strict_required_status_checks_policy: false`. The required checks (the
+aggregator gate plus the two `test (...)` contexts) still gate every merge, but
+the PR head is **not** required to be up to date with `main` before merging.
+
+Requiring up-to-date (`strict: true`) forces every green PR to be rebased onto
+the latest `main` before it can merge. With a fast-moving `main` (the automation
+loop merges PRs continuously) this causes constant churn: mergeable PRs stall as
+`BEHIND` and must be re-rebased every time `main` advances, often faster than
+their CI can finish. The protection this bought — catching a semantic conflict
+between two independently-green PRs — is rare and caught post-merge by CI on
+`main`, so it does not justify the churn. `strict: false` lets a green PR merge
+regardless of how far behind `main` it is.
 
 ## Why a single aggregator gate
 
@@ -128,7 +137,7 @@ jq -e --argjson expected "$expected" '
   | ($status_rules | length) > 0
     and all(
       $status_rules[];
-      .parameters.strict_required_status_checks_policy == true
+      .parameters.strict_required_status_checks_policy == false
       and (.parameters.required_status_checks | type) == "array"
       and (.parameters.required_status_checks | length) > 0
       and all(
@@ -147,7 +156,7 @@ GitHub App bindings:
 gh api -X PATCH \
   -H "Accept: application/vnd.github+json" \
   "repos/$repo/branches/$branch/protection/required_status_checks" \
-  -F strict=true \
+  -F strict=false \
   > "$state_dir/branch.patch-response.json"
 ```
 
@@ -170,7 +179,7 @@ gh api --paginate --slurp \
   "repos/$repo/rules/branches/$branch?per_page=100" \
   | jq 'add' > "$state_dir/rules.after.json"
 
-jq -e '.strict == true' "$state_dir/branch.after.json"
+jq -e '.strict == false' "$state_dir/branch.after.json"
 
 jq -S '.checks | sort_by(.context)' \
   "$state_dir/branch.before.json" > "$state_dir/checks.before.json"

--- a/tests/unit/docs/test_required_checks_policy.py
+++ b/tests/unit/docs/test_required_checks_policy.py
@@ -25,12 +25,17 @@ def _reapply_section() -> str:
 
 
 def test_strict_policy_has_operational_reason() -> None:
-    """Require the documented strict policy to explain its purpose."""
+    """Require the documented strict policy to explain its purpose.
+
+    The repo runs ``strict: false`` deliberately (see the doc): required checks
+    still gate merges, but PRs are NOT required to be up to date with ``main``,
+    which avoids the rebase churn a fast-moving ``main`` would otherwise cause.
+    """
     text = _policy_text().lower()
 
-    assert "strict: true" in text
-    assert "stale pr" in text
-    assert "newer `main`" in text
+    assert "strict: false" in text
+    assert "churn" in text
+    assert "up to date" in text
 
 
 def test_repair_patches_only_strict_mode() -> None:
@@ -38,7 +43,7 @@ def test_repair_patches_only_strict_mode() -> None:
     section = _reapply_section().lower()
 
     assert "-x patch" in section
-    assert "-f strict=true" in section
+    assert "-f strict=false" in section
     assert "-x put" not in section
     assert "checks[][context]" not in section
 


### PR DESCRIPTION
## Summary

Branch protection required PRs to be **up to date with `main`** (`strict: true`)
before merging. With the automation loop merging PRs continuously, `main` advances
fast enough that green, mergeable PRs stall as `BEHIND` and must be re-rebased
repeatedly — often faster than their CI finishes.

**This keeps all required checks; it removes only the up-to-date requirement.**
`required-checks-gate` + the two `test (...)` contexts still gate every merge.
`strict: false` lets a green PR merge regardless of how far behind `main` it is.
The rare semantic-conflict-between-independent-PRs case is caught post-merge by CI
on `main`.

## Changes

- `docs/ci/required-checks.md` — the contract + re-apply runbook: all four strict
  assertions and the `gh api ... -F strict=…` PATCH flipped to `false`; rationale rewritten.
- `docs/adr/0004-single-aggregator-required-checks.md` — records the `strict: false` decision.
- `tests/unit/docs/test_required_checks_policy.py` — the drift guard, so it no longer
  reverts the change back to `strict: true`.

## Applying to live protection (repo admin, out of band)

The in-tree change stops the drift guard from reverting it, but the live setting
is flipped separately (per the runbook):

```bash
gh api -X PATCH \
  "repos/HomericIntelligence/Hephaestus/branches/main/protection/required_status_checks" \
  -F strict=false
```

## Verification

- `tests/unit/docs/test_required_checks_policy.py` + `test_required_checks_gate.py` pass (10 tests).
- No stale `strict: true` / `strict=true` assertions remain (the only other hits are unrelated `[tool.mypy] strict`).

Closes #2100