### PR TITLE
fix(automation): implementer bypasses state:skip gate (issues #1483/#1799/#1762 et al. implemented while skip-labeled)

### DIFF
--- a/docs/runbooks/index.md
+++ b/docs/runbooks/index.md
@@ -12,6 +12,7 @@ needs hands-on recovery.
 | [Recover a corrupted worktree state](corrupted-worktree.md) | An issue's `build/.worktrees/issue-<N>` worktree is dirty, abandoned, or blocking a clean re-run. |
 | [CI-driver stall (green-but-BLOCKED)](ci-driver-stall.md) | The CI driver exits cleanly each loop but PRs stay armed, green, and un-mergeable (`mergeStateStatus == BLOCKED`). |
 | [Claude quota exhausted (429)](claude-quota-exhausted.md) | A stage emits `Verdict: ERROR` and the issue is left unlabeled because the Claude API quota / session limit was hit. |
+| [Reviving a state:skip-labeled issue](state-skip-revival.md) | An issue was labeled `state:skip` after automation already started work on it (planned or opened a PR) and you want to resume driving it. |
 | [No silent failures](no-silent-failures.md) | Policy reference: why `\|\| true`, `continue-on-error`, and advisory `::warning::` are forbidden, and how to fix a tripped hook. |
 
 ## Before you start
@@ -35,4 +36,4 @@ copy — the module is the source of truth.
 | `state:plan-no-go` | Plan reviewed and rejected; needs re-planning. |
 | `state:implementation-go` | Implementation reviewed and approved; PR may arm auto-merge. |
 | `state:implementation-no-go` | Implementation reviewed and rejected; needs re-work. |
-| `state:skip` | Work item taken out of the loop entirely — operator-applied, auto-applied when the review loop exhausts its budget without a GO, or applied to epics before exclusion. Independent of all other state labels. |
+| `state:skip` | Work item taken out of the loop entirely — operator-applied, auto-applied when the review loop exhausts its budget without a GO, or applied to epics before exclusion. Independent of all other state labels. See [Reviving a state:skip-labeled issue](state-skip-revival.md) to safely clear it. |

--- a/docs/runbooks/state-skip-revival.md
+++ b/docs/runbooks/state-skip-revival.md
@@ -1,0 +1,67 @@
+# Reviving a `state:skip`-labeled issue
+
+## When to use
+
+An issue was intentionally or accidentally labeled `state:skip` (operator
+audit, manual triage, or a prior automated run applying it on review-budget
+exhaustion — `state_labels.py` `is_skipped`) and you now want automation to
+resume planning/implementing it.
+
+## Background
+
+`state:skip` is absolute and operator-only (#1576/#1584): the pipeline's
+seeding classifier (`pipeline/seeding.py:239` `classify_issue`) excludes any
+`state:skip`-labeled issue from the work queue entirely, before any other
+state label is consulted. This is a *point-in-time* exclusion — if
+`state:skip` is applied to an issue *after* automation has already queued and
+started work on it (planned, or opened a PR), automation does not retroactively
+abort the in-flight work; the exclusion only prevents *future* passes from
+re-entering it. This is expected, not a bug (see the #1835 timeline audit:
+11/11 reported "skip-labeled implementations" had `state:skip` applied strictly
+after PR creation, never before).
+
+## Diagnose
+
+Check when `state:skip` was applied relative to PR creation:
+
+    gh api repos/<owner>/<repo>/issues/<N>/timeline --paginate \
+      --jq '.[] | select(.event=="labeled" or .event=="cross-referenced") | {event, created_at, label: .label.name, source_pr: .source.issue.number}'
+
+- `state:skip` timestamp AFTER the PR's cross-reference timestamp → expected
+  race (case a); the PR is real, already-committed work.
+- `state:skip` timestamp AT OR BEFORE PR creation → investigate as a possible
+  gate bypass (case b); file/reopen an automation bug.
+
+## Fix — reviving intentionally
+
+1. Decide the fate of any PR the pipeline already opened for the issue
+   (`gh pr list --search "linked:<N>"` or check the issue's timeline
+   cross-references). Close it or let it proceed to review manually — the
+   pipeline will not resume driving it while `state:skip` remains.
+2. Remove the label:
+
+       gh issue edit <N> --remove-label state:skip
+
+3. Leave any existing `state:plan-go`/`state:implementation-go` label as-is —
+   removing `state:skip` alone is sufficient; the pipeline's seeding
+   classifier will re-admit the issue at its current rank on the next pass
+   (`pipeline/seeding.py` `classify_issue` — no `state:needs-plan` reset
+   required).
+4. Confirm re-admission: the next automation loop pass should pick the issue
+   back up at planning or implementation depending on its current `state:*`
+   rank (`docs/AUTOMATION_LOOP_ARCHITECTURE.md` classification table).
+
+## Fix — confirming a skip was correct
+
+If the skip was intentional and should stick, no action is needed — leave
+`state:skip` in place. Automation will continue to exclude the issue and will
+log a `state:skip AND state:plan-go` (or `implementation-go`) warning on any
+stage that still encounters the contradictory label pair
+(`pipeline/stages/planning.py`, `pipeline/stages/implementation.py`) —
+this is informational only and requires no operator response unless the
+warning is unexpected.
+
+## See also
+
+- [Automation loop crashed mid-issue](automation-loop-crash.md)
+- [CI-driver stall (green-but-BLOCKED)](ci-driver-stall.md)

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -16,8 +16,11 @@ binding contract):
   agent_error retries — the doc's "agent_error -> RETRY (consumes the
   implement budget)"), ``test_fix`` = 1 (one fix attempt on red pre-PR
   tests). Both read from ROUTES via ``ctx.budget``, never hardcoded here.
-- GATE [M]: existing-PR fast path first (``_review_existing_pr``
-  semantics): a PR already carrying ``state:implementation-go`` fails back
+- GATE [M]: ``state:skip`` check first (operator-only, absolute — #1835);
+  skips the item regardless of plan-go/implementation-go, before either the
+  existing-PR fast path or the fresh-implement plan-go gate below. Then the
+  existing-PR fast path (``_review_existing_pr`` semantics): a PR already
+  carrying ``state:implementation-go`` fails back
   ``already_implementation_go_pr`` (routes to ci) with ``item.pr`` /
   ``item.branch`` set for the ci stage; a PR without it adopts the PR's
   REAL head branch, re-ensures the auto-merge deferral [durable], cuts a
@@ -84,9 +87,12 @@ from hephaestus.automation.session_naming import (
     issue_auto_impl_branch_name,
 )
 from hephaestus.automation.state_labels import (
+    STATE_IMPLEMENTATION_GO,
+    STATE_PLAN_GO,
     STATE_SKIP,
     is_implementation_go,
     is_plan_go,
+    is_skipped,
 )
 
 from .base import (
@@ -660,6 +666,38 @@ class ImplementationStage(Stage):
             part for part in (result.stdout_tail, result.stderr_tail, result.error) if part
         )
 
+    @staticmethod
+    def _skip_gate(issue: int, labels: list[str]) -> StageOutcome | None:
+        """Operator override: state:skip -> SKIP, warning on a GO contradiction.
+
+        Split out of :meth:`_gate` so the top-of-GATE check (#1835) stays a
+        single readable branch regardless of the existing-PR/fresh-implement
+        logic below it.
+
+        Args:
+            issue: The GitHub issue number (for log messages).
+            labels: The issue's current labels (already refreshed by caller).
+
+        Returns:
+            A SKIP outcome when ``state:skip`` is present, else None.
+
+        """
+        if not is_skipped(labels):
+            return None
+        if is_plan_go(labels) or is_implementation_go(labels):
+            contradicting = (
+                STATE_IMPLEMENTATION_GO if is_implementation_go(labels) else STATE_PLAN_GO
+            )
+            logger.warning(
+                "implementation:%d: state:skip AND %s both present — "
+                "skip wins; see docs/runbooks/state-skip-revival.md if "
+                "this issue should be revived",
+                issue,
+                contradicting,
+            )
+        logger.info("implementation:%d: state:skip; skipping", issue)
+        return StageOutcome(Disposition.SKIP, "state:skip")
+
     def _gate(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """GATE [M]: existing-PR fast path, then the plan-review verdict gate.
 
@@ -677,6 +715,17 @@ class ImplementationStage(Stage):
         """
         if item.issue is None:  # guarded by step(); kept for type narrowing
             return StageOutcome(Disposition.FINISH_FAIL, "no issue number")
+
+        # Operator override: state:skip -> SKIP, checked before either the
+        # existing-PR fast path or the fresh-implement plan-go gate (#1835 —
+        # the existing-PR path previously adopted PRs unconditionally with no
+        # label read at all; closes the reachable gap even though the 11
+        # incidents that raised #1835 were all confirmed skip-after-PR races,
+        # not this chokepoint).
+        gate_labels = _issue_labels(item, ctx)
+        skip_outcome = self._skip_gate(item.issue, gate_labels)
+        if skip_outcome is not None:
+            return skip_outcome
 
         # Pop the fail-back marker unconditionally: on the fresh-implement
         # path below the budget is consumed by the implement job itself, so
@@ -746,10 +795,9 @@ class ImplementationStage(Stage):
             )
             return Continue(next_state=WORKTREE_WAIT)
 
-        labels = _issue_labels(item, ctx)
         # At-or-past (never equality): plan-go OR already implementation-go
         # both satisfy the gate; anything earlier fails back to plan_review.
-        if not (is_plan_go(labels) or is_implementation_go(labels)):
+        if not (is_plan_go(gate_labels) or is_implementation_go(gate_labels)):
             logger.info("implementation:%d: plan not GO; failing back", item.issue)
             return StageOutcome(Disposition.FAIL_BACK, "plan_not_go")
 

--- a/hephaestus/automation/pipeline/stages/planning.py
+++ b/hephaestus/automation/pipeline/stages/planning.py
@@ -163,8 +163,9 @@ class PlanningStage(Stage):
     on_enter idempotency guards (re-housed from ``Planner._pr_coverage_skip``
     and ``Planner._has_existing_plan``, all ordered at-or-past checks):
 
+    - ``state:skip`` -> SKIP (checked BEFORE plan-go; skip wins over
+      everything, even a contradictory plan-go, logging a WARNing — #1835)
     - already at-or-past ``state:plan-go`` -> ADVANCE (zero jobs)
-    - ``state:skip`` -> SKIP
     - merged closing PR -> close issue as covered, SKIP
     - open PR -> SKIP (PR already covers implementation)
     - unlabeled entry -> idempotent bare add of ``state:needs-plan``; entry
@@ -196,15 +197,24 @@ class PlanningStage(Stage):
 
         labels = _issue_labels(item, ctx)
 
+        # Operator override: state:skip -> SKIP. Checked BEFORE the
+        # plan-go fast-forward — skip wins over everything (#1835), matching
+        # seeding.classify_issue's "skip wins over everything" precedent.
+        if is_skipped(labels):
+            if is_plan_go(labels):
+                logger.warning(
+                    "planning:%d: state:skip AND state:plan-go both present — "
+                    "skip wins; see docs/runbooks/state-skip-revival.md if "
+                    "this issue should be revived",
+                    item.issue,
+                )
+            logger.info("planning:%d: state:skip; skipping", item.issue)
+            return StageOutcome(Disposition.SKIP, "state:skip")
+
         # Fast-forward (at-or-past, never equality): already plan-go -> ADVANCE
         if is_plan_go(labels):
             logger.info("planning:%d: already plan-go; advancing", item.issue)
             return StageOutcome(Disposition.ADVANCE, "plan already approved")
-
-        # Operator override: state:skip -> SKIP
-        if is_skipped(labels):
-            logger.info("planning:%d: state:skip; skipping", item.issue)
-            return StageOutcome(Disposition.SKIP, "state:skip")
 
         # Re-housed _pr_coverage_skip gate A: merged closing PR covers the issue
         merged_pr = ctx.github.find_merged_closing_pr(item.issue)

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -15,7 +15,7 @@ from hephaestus.automation.pipeline.stages.implementation import (
     build_implementation_prompt,
     build_test_fix_prompt,
 )
-from hephaestus.automation.state_labels import STATE_SKIP
+from hephaestus.automation.state_labels import STATE_PLAN_GO, STATE_SKIP
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -327,6 +327,44 @@ class TestGate:
         assert isinstance(result, JobRequest)
         assert result.job.descr == "dirty_decision"
         assert result.on_done_state == "ADOPTED"
+
+
+class TestImplementationStateSkipGate:
+    """GATE checks state:skip before either the existing-PR or plan-go path (#1835)."""
+
+    def test_skip_with_existing_pr_skips_without_adoption(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """state:skip on an issue with an open PR skips before any adoption write."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=[STATE_SKIP], open_pr=42)
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=1, state="GATE")
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.SKIP
+        assert result.note == "state:skip"
+        assert github.mutation_log == []  # no defer_auto_merge call
+
+    def test_skip_with_plan_go_skips_and_warns(
+        self, make_ctx: Any, make_work_item: Any, caplog: Any
+    ) -> None:
+        """state:skip + state:plan-go, no existing PR -> SKIP with a loud WARN."""
+        stage = ImplementationStage()
+        github = FakeStageGitHub(labels=[STATE_SKIP, STATE_PLAN_GO])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=2, state="GATE")
+
+        with caplog.at_level("WARNING"):
+            result = stage.step(item, ctx)
+
+        assert isinstance(result, StageOutcome)
+        assert result.disposition == Disposition.SKIP
+        assert result.note == "state:skip"
+        assert github.mutation_log == []
+        assert any("state:skip AND state:plan-go" in record.message for record in caplog.records)
 
 
 class TestAgentErrorPingPongBound:

--- a/tests/unit/automation/pipeline/stages/test_stage_planning.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_planning.py
@@ -91,6 +91,23 @@ class TestPlanningStageEnter:
         assert outcome.disposition == Disposition.SKIP
         assert github.mutation_log == []
 
+    def test_skip_wins_over_plan_go_with_warning(
+        self, make_ctx: Any, make_work_item: Any, caplog: Any
+    ) -> None:
+        """state:skip + state:plan-go -> SKIP (not ADVANCE), with a loud WARN (#1835)."""
+        stage = PlanningStage()
+        github = FakeStageGitHub(labels=[STATE_SKIP, STATE_PLAN_GO])
+        ctx = make_ctx(github=github)
+        item = make_work_item(issue=5)
+
+        with caplog.at_level("WARNING"):
+            outcome = stage.on_enter(item, ctx)
+
+        assert outcome is not None
+        assert outcome.disposition == Disposition.SKIP
+        assert github.mutation_log == []
+        assert any("state:skip AND state:plan-go" in record.message for record in caplog.records)
+
     def test_merged_pr_closes_issue(self, make_ctx: Any, make_work_item: Any) -> None:
         """A merged closing PR closes the issue as covered (gate A)."""
         stage = PlanningStage()


### PR DESCRIPTION
## Summary
All 101 tests in the affected files still pass. The implementation from earlier in this session is complete and intact in the working tree — no further action needed.

## Status: implementation complete

The stopped-task notification was just a stale artifact from the previous full-suite verification run (already confirmed separately as 5918 passed / 24 skipped). The working tree changes are unchanged and verified:

- `docs/runbooks/state-skip-revival.md` (new runbook)
- `docs/runbooks/index.md` (registered the runbook in both tables)
- `hephaestus/automation/pipeline/stages/planning.py` (skip-before-plan-go reordering + WARN)
- `hephaestus/automation/pipeline/stages/implementation.py` (`_skip_gate` helper wired into `_gate`, deduped label read)
- Regression tests in both `test_stage_planning.py` and `test_stage_implementation.py`

Just re-ran the two affected test files: **101 passed**, and `ruff format --check` confirms the tree is already correctly formatted. Nothing further to do — leaving the working tree as-is for the orchestrator to commit.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #1835

Generated by Hephaestus automation
