### PR TITLE
[MAJOR] pr_review: a threadless NOGO verdict dead-ends the review→implement fail-back loop

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -272,9 +272,14 @@ decrease), `pr_review_hard` = 6 (hard cap; iterations 4-6 only if
 unresolved-thread count decreases).
 
 Zero-thread NOGO anomalies use the bounded reviewer-error retry cap and
-consume neither `pr_review_iter` nor `pr_review_hard`; cap exhaustion fails
-back through `agent_error` without writing `state:implementation-no-go` or
-`state:skip`. Stage-originated JSONL events use the closed schema in
+consume neither `pr_review_iter` nor `pr_review_hard`; cap exhaustion
+escalates directly with `state:skip` (never `agent_error`) and does not
+write `state:implementation-no-go`. A threadless NOGO can be a deliberate,
+deterministic reviewer verdict (prose-only, no line-anchored findings) —
+failing back through `agent_error` would re-adopt the same PR through
+implementation with nothing new to address and re-review cannot change a
+deterministic input, so cap exhaustion stands down instead of ping-ponging
+to a dead end (#2079). Stage-originated JSONL events use the closed schema in
 `pipeline/events.py`; raw reviewer text, GitHub bodies, and arbitrary event
 objects are rejected.
 

--- a/hephaestus/automation/pipeline/events.py
+++ b/hephaestus/automation/pipeline/events.py
@@ -15,7 +15,7 @@ class ZeroThreadNogoAction(str, Enum):
     """Action taken after a zero-thread NOGO anomaly."""
 
     RETRY_FRESH_REVIEW = "retry_fresh_review"
-    FAIL_BACK_AGENT_ERROR = "fail_back_agent_error"
+    ESCALATE_SKIP = "escalate_skip"
 
 
 @dataclass(frozen=True)
@@ -57,10 +57,10 @@ def encode_stage_event(event: StageEvent) -> tuple[str, dict[str, EventField]]:
     ):
         raise ValueError("fresh-review action exceeds retry cap")
     if (
-        event.action is ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR
+        event.action is ZeroThreadNogoAction.ESCALATE_SKIP
         and event.retry_attempt <= event.retry_cap
     ):
-        raise ValueError("fail-back action has not exceeded retry cap")
+        raise ValueError("escalate action has not exceeded retry cap")
     return (
         "pr_review_zero_thread_nogo",
         {

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -83,6 +83,15 @@ contract):
   implementation GATE consumes the ``implement`` budget on re-adoption —
   the cross-stage ping-pong bound (M1). ``review_error_retries`` is reset
   by ``on_enter`` on each fresh implementation cycle.
+- Zero-thread NOGO (``_handle_zero_thread_nogo``) is the ONE exception to
+  the agent_error fail-back above: it retries in-stage (bounded by
+  ``REVIEW_ERROR_RETRY_CAP``, no round burned), but at the cap it escalates
+  directly with ``state:skip`` instead of failing back. A NOGO with no
+  postable/unresolved thread is often a deterministic reviewer verdict
+  (prose-only, no line-anchored findings); failing back would re-adopt the
+  same PR through implementation with nothing new to address, exhausting
+  the ``implement`` budget for a dead end the retry could never resolve
+  (#2079).
 - Prompt functions (imported, never re-authored):
   ``prompts/pr_review.py get_pr_review_analysis_prompt`` /
   ``get_review_validation_prompt`` / ``get_comment_difficulty_prompt``,
@@ -839,7 +848,18 @@ class PrReviewStage(Stage):
     def _handle_zero_thread_nogo(
         self, item: WorkItem, ctx: StageContext, verdict: Any
     ) -> Continue | StageOutcome:
-        """Persist the anomaly and force a new reviewer invocation."""
+        """Persist the anomaly, retry fresh, then escalate rather than fail back.
+
+        A zero-thread NOGO can be a transient parse/tooling artifact (worth a
+        bounded fresh-review retry) or a deliberate reviewer verdict with no
+        line-anchored findings, which is deterministic: re-review cannot
+        change it. Fail-back would re-adopt the same PR through
+        implementation with nothing concrete to address, exhausting the
+        ``implement`` budget for a dead end (#2079). Once the retry cap is
+        exhausted, escalate directly with ``state:skip`` instead — matching
+        the existing exhaustion convention at :func:`_eval`'s hard-cap path
+        and never re-entering implementation for an unchanged input.
+        """
         if item.pr is None:
             return self._fail_back_agent_error(item)
         pr_number = item.pr
@@ -848,7 +868,7 @@ class PrReviewStage(Stage):
         action = (
             ZeroThreadNogoAction.RETRY_FRESH_REVIEW
             if retries <= REVIEW_ERROR_RETRY_CAP
-            else ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR
+            else ZeroThreadNogoAction.ESCALATE_SKIP
         )
         artifact_written = self._upsert_zero_thread_nogo_comment(
             item,
@@ -878,10 +898,14 @@ class PrReviewStage(Stage):
             )
             return Continue(next_state=REVIEW_WAIT)
         logger.error(
-            "pr_review:%s: zero-thread NOGO retry cap exhausted; failing back",
+            "pr_review:%s: zero-thread NOGO retry cap exhausted with the same "
+            "artifactless verdict; escalating %s (re-adopting cannot fix a "
+            "deterministic input)",
             item.issue,
+            STATE_SKIP,
         )
-        return self._fail_back_agent_error(item)
+        write_skip_label(_issue_number(item), ctx)
+        return StageOutcome(Disposition.SKIP, "zero_thread_nogo_exhausted")
 
     @staticmethod
     def _upsert_zero_thread_nogo_comment(
@@ -899,7 +923,12 @@ class PrReviewStage(Stage):
         action_text = (
             "A fresh reviewer invocation will be requested without consuming a review round."
             if action is ZeroThreadNogoAction.RETRY_FRESH_REVIEW
-            else "The reviewer retry cap is exhausted; the item will fail back as an agent error."
+            else (
+                "The reviewer retry cap is exhausted with the same artifactless verdict on "
+                "every attempt; automation is standing down (`state:skip`) instead of "
+                "re-adopting this PR through implementation, since a deterministic verdict "
+                "cannot be changed by re-review."
+            )
         )
         body = (
             f"{_ZERO_THREAD_NOGO_MARKER}\n"

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -1280,10 +1280,16 @@ class TestFullWalks:
         )
         assert any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
 
-    def test_zero_thread_nogo_cap_fails_back_without_rounds_or_skip(
+    def test_zero_thread_nogo_cap_escalates_skip_without_rounds_or_failback(
         self, make_ctx: Any, make_work_item: Any
     ) -> None:
-        """Repeated zero-thread NOGOs fail back without exhausting review rounds."""
+        """Repeated zero-thread NOGOs escalate to state:skip, never fail back (#2079).
+
+        A deterministic threadless NOGO cannot be fixed by re-adopting the PR
+        through implementation and re-reviewing it — the retry cap existing
+        specifically means re-review has already been exhausted. Escalating
+        directly avoids the implement-budget dead end the issue reports.
+        """
         events: list[Any] = []
         stage = PrReviewStage()
         github = FakeStageGitHub(unresolved=[(0, 0)], by_severity=[(0, 0, 0)])
@@ -1299,15 +1305,17 @@ class TestFullWalks:
         outcome = _drive(stage, item, ctx, pool)
 
         assert isinstance(outcome, StageOutcome)
-        assert outcome.disposition == Disposition.FAIL_BACK
-        assert outcome.note == "agent_error"
+        assert outcome.disposition == Disposition.SKIP
+        assert outcome.note == "zero_thread_nogo_exhausted"
         assert [handle.job.descr for handle in pool.submitted].count("review") == (
             REVIEW_ERROR_RETRY_CAP + 1
         )
         assert item.attempts["pr_review_iter"] == 0
         assert item.payload["pr_review_round"] == 0
-        assert events[-1].action is ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR
+        assert "agent_error_failback" not in item.payload
+        assert events[-1].action is ZeroThreadNogoAction.ESCALATE_SKIP
         assert not any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
+        assert github.mutation_log[-1] == ("gh_issue_add_labels", (25, (STATE_SKIP,)))
 
     def test_zero_thread_nogo_comment_failure_still_retries(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -734,7 +734,7 @@ class TestDurableEventLog:
 
         item.payload["review_error_retries"] = REVIEW_ERROR_RETRY_CAP
         second = stage.step(item, ctx)
-        assert second == StageOutcome(Disposition.FAIL_BACK, "agent_error")
+        assert second == StageOutcome(Disposition.SKIP, "zero_thread_nogo_exhausted")
 
         records = [json.loads(line) for line in event_log_path.read_text().splitlines()]
         assert [record["event"] for record in records] == [
@@ -758,7 +758,7 @@ class TestDurableEventLog:
         ]
         assert records[1]["fields"] == [
             {
-                "action": "fail_back_agent_error",
+                "action": "escalate_skip",
                 "artifact_written": True,
                 "completed_rounds": 0,
                 "issue": 1985,

--- a/tests/unit/automation/pipeline/test_events.py
+++ b/tests/unit/automation/pipeline/test_events.py
@@ -83,7 +83,7 @@ def test_encoder_rejects_invalid_fixed_fields(field: str, value: Any, match: str
 
 
 def test_encoder_rejects_action_retry_invariant_violations() -> None:
-    """Retry and fail-back actions must agree with the bounded retry counter."""
+    """Retry and escalate actions must agree with the bounded retry counter."""
     event = PrReviewZeroThreadNogoEvent(
         repo="repo-a",
         issue=1985,
@@ -99,5 +99,5 @@ def test_encoder_rejects_action_retry_invariant_violations() -> None:
         encode_stage_event(replace(event, retry_attempt=3))
     with pytest.raises(ValueError, match="has not exceeded retry cap"):
         encode_stage_event(
-            replace(event, action=ZeroThreadNogoAction.FAIL_BACK_AGENT_ERROR, retry_attempt=2)
+            replace(event, action=ZeroThreadNogoAction.ESCALATE_SKIP, retry_attempt=2)
         )


### PR DESCRIPTION
## Summary
I'll wait for the monitor notification now.


## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2079

Generated by Hephaestus automation
