### PR TITLE
fix(automation): add upstream idempotency guard to prevent duplicate work items

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1108,12 +1108,44 @@ class Coordinator:
                 self._pass_work_count += 1
             self._push_item(new_item, new_item.stage, enter=True)
 
+    def _live_issue_keys(self) -> set[tuple[str, int]]:
+        """Return ``(repo, issue)`` keys currently queued (any stage) or in-flight.
+
+        The identity set the upstream idempotency guard consults: an ISSUE item is
+        "live" if a WorkItem for the same ``(repo, issue)`` sits in any stage queue
+        or in ``in_flight``. Cross-repo same-number issues are distinct (#2058).
+        """
+        keys: set[tuple[str, int]] = set()
+        for q in self.queues.values():
+            for it in q.snapshot():
+                if it.kind is ItemKind.ISSUE and it.issue is not None:
+                    keys.add((it.repo, it.issue))
+        for it in self.in_flight.values():
+            if it.kind is ItemKind.ISSUE and it.issue is not None:
+                keys.add((it.repo, it.issue))
+        return keys
+
     def _push_item(self, item: WorkItem, stage: StageName, enter: bool) -> None:
         """Push *item* into *stage*'s queue (the single push chokepoint).
 
         Every durable GitHub mutation for this transition already happened
         inside the stage, immediately before the outcome that got us here.
+
+        Upstream idempotency guard (#2107): a genuinely NEW ISSUE work item whose
+        ``(repo, issue)`` is already queued (any stage) or in-flight is refused —
+        it never enters the pipeline, so the drain-level dedup (#2058) is not even
+        exercised. Object identity (``_seen_item_ids``) distinguishes a new item
+        from an already-tracked item re-pushing itself on timer/retry/fail-back/
+        advance, which must always be allowed through.
         """
+        if (
+            id(item) not in self._seen_item_ids
+            and item.kind is ItemKind.ISSUE
+            and item.issue is not None
+            and (item.repo, item.issue) in self._live_issue_keys()
+        ):
+            logger.info("seed skipped: #%s already queued/in-flight in %s", item.issue, item.repo)
+            return
         item.stage = stage
         if enter:
             item.state = "ENTER"

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -10,6 +10,7 @@ asserts-no-submit, poisoned-item isolation, and FAIL_BACK routing.
 from __future__ import annotations
 
 import json
+import logging
 from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -530,8 +531,16 @@ class TestImplementationAdmission:
         coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
         first = _issue_item(21, StageName.IMPLEMENTATION)
         duplicate = _issue_item(21, StageName.IMPLEMENTATION)
-        coordinator._push_item(first, StageName.IMPLEMENTATION, enter=True)
-        coordinator._push_item(duplicate, StageName.IMPLEMENTATION, enter=True)
+        # Inject the collision BELOW the upstream idempotency guard (#2107):
+        # push straight onto the queue (the same raw API the drain uses to
+        # re-push deferred items, coordinator.py:873) so this test exercises
+        # the drain-level safety net for a duplicate that arrived by a path
+        # the upstream guard does not cover.
+        for it in (first, duplicate):
+            it.payload["_enter_pending"] = True
+            coordinator._seen_item_ids.add(id(it))
+            coordinator.items.append(it)
+            coordinator.queues[StageName.IMPLEMENTATION].push(it)
 
         coordinator._drain_implementation()
 
@@ -543,6 +552,63 @@ class TestImplementationAdmission:
         assert duplicate.result.passed
         assert "superseded" in duplicate.result.reason
         # Implementation queue is drained — no duplicate left behind.
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
+
+    def test_reseed_while_queued_refuses_second_entry(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A new (repo, issue) already queued is refused upstream (#2107).
+
+        The drain-level dedup warning must NOT fire, proving the duplicate never
+        entered the queue in the first place.
+        """
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        first = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        reseed = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")  # new object, same key
+        coordinator._push_item(first, StageName.IMPLEMENTATION, enter=True)
+
+        with caplog.at_level(logging.INFO):
+            coordinator._push_item(reseed, StageName.IMPLEMENTATION, enter=True)
+
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [first]
+        assert "already queued/in-flight" in caplog.text
+        # The drain-level dedup net was never exercised.
+        assert "dropping duplicate work item" not in caplog.text
+
+    def test_cross_repo_same_issue_number_both_enqueue(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(#2058) same issue number in different repos remain distinct work."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        a = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        b = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(b, StageName.IMPLEMENTATION, enter=True)
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [a, b]
+
+    def test_same_item_repush_not_blocked_by_guard(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An already-tracked item re-pushing itself (retry/advance) is allowed."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        item = _issue_item(21, StageName.PLANNING, repo="repo-a")
+        coordinator._push_item(item, StageName.PLANNING, enter=True)
+        coordinator.queues[StageName.PLANNING].pop()  # simulate drain popping it
+        coordinator._push_item(item, StageName.PLANNING, enter=False)  # retry re-push
+        assert coordinator.queues[StageName.PLANNING].snapshot() == [item]
+
+    def test_reseed_while_in_flight_refused(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A (repo, issue) held in in_flight blocks a new seed of the same key."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        live = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        coordinator.in_flight[cast(Any, "h1")] = live  # simulate dispatched/in-flight
+        reseed = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
+        coordinator._push_item(reseed, StageName.IMPLEMENTATION, enter=True)
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
 
     def test_topo_order_and_overlap_reuse(


### PR DESCRIPTION
Adds an upstream idempotency guard in the coordinator so duplicate work items never reach the IMPLEMENTATION queue.

This PR was implemented, committed (signed, status `U` = acceptable), and pushed by the drive-green automation loop, but the loop crashed at PR-create time on an unrelated ref-resolution bug in `_assert_branch_commits_signed` (filed as #2108). Opening it manually so the completed, signed work is not stranded.

Closes #2107