### PR TITLE
[Fix] Key implementation dedup by (repo, issue), not issue number

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -812,39 +812,29 @@ class Coordinator:
         touching the same files while a peer is dispatched, #1623 — only
         engaged when real parallelism is possible, mirroring the legacy
         ``serialize_file_overlap`` gate).
+
+        The queue is STAGE-keyed, so one drain round can hold issues from
+        several repos (#1795), and dependency ordering runs across the whole
+        round on a shared issue-number space (``IssueInfo`` docstring). Two
+        distinct work items therefore only conflict when they share the SAME
+        ``(repo, issue)`` — that is the transient retry/fail-back re-enqueue we
+        collapse below. Two DIFFERENT repos that happen to share an issue number
+        (``A#71`` vs ``B#71``) are NOT duplicates and must both dispatch; the
+        old code (and the pre-#2057 assert) keyed on issue number alone and
+        would have silently dropped one or crashed (#2057).
         """
         q = self.queues[StageName.IMPLEMENTATION]
         if not len(q):
             return
-        items = [q.pop() for _ in range(len(q))]
-        # A transient retry/fail-back can re-enqueue an issue while a prior copy
-        # is still queued, so the implementation queue may briefly hold two work
-        # items for the same issue. Building ``issue_items`` (and the downstream
-        # dispatch) requires unique issue numbers, so collapse duplicates here —
-        # keep the first-queued item and terminalize the rest as superseded —
-        # instead of crashing the whole org-wide run (was a hard assert, #1952).
-        seen_issues: set[int] = set()
-        deduped: list[WorkItem] = []
-        for it in items:
-            if it.issue is not None and it.issue in seen_issues:
-                logger.warning(
-                    "implementation #%s already queued; dropping duplicate work item", it.issue
-                )
-                self._finish(it, passed=True, reason=f"#{it.issue} superseded by queued duplicate")
-                continue
-            if it.issue is not None:
-                seen_issues.add(it.issue)
-            deduped.append(it)
-        items = deduped
-        issue_items = {it.issue: it for it in items if it.issue is not None}
+        items = self._dedup_implementation_items([q.pop() for _ in range(len(q))])
+        issue_items, ambiguous = self._index_issue_items(items)
         infos = [
             IssueInfo(
-                number=it.issue,
-                title=str(it.payload.get("issue_title", "")),
-                dependencies=list(it.payload.get("dependencies", [])),
+                number=number,
+                title=str(item.payload.get("issue_title", "")),
+                dependencies=list(item.payload.get("dependencies", [])),
             )
-            for it in items
-            if it.issue is not None
+            for number, item in issue_items.items()
         ]
         ordered = _admission.order_for_implementation(infos)
         dispatch = ordered
@@ -860,8 +850,11 @@ class Coordinator:
             for number in deferred:
                 logger.info("implementation #%s deferred (file overlap)", number)
         ran: set[int] = set()
-        for number in dispatch:
-            item = issue_items[number]
+        # Cross-repo same-number items bypass the number-keyed gates and dispatch
+        # directly — they are distinct work that the ordering model cannot rank.
+        dispatch_items = [issue_items[number] for number in dispatch]
+        dispatch_items.extend(it for group in ambiguous.values() for it in group)
+        for item in dispatch_items:
             if self.shutdown.is_set() or not self._admit(item):
                 continue  # stays queued (re-pushed below)
             ran.add(id(item))
@@ -871,6 +864,66 @@ class Coordinator:
         for it in items:
             if id(it) not in ran:
                 q.push(it)
+
+    def _dedup_implementation_items(self, items: list[WorkItem]) -> list[WorkItem]:
+        """Drop transient duplicate work items, keyed by ``(repo, issue)`` (#2057).
+
+        A retry/fail-back can re-enqueue an issue while a prior copy is still
+        queued, so the round may briefly hold two items for the same
+        ``(repo, issue)``. Keep the first-queued and terminalize the rest as
+        superseded (was a hard assert that crashed the whole run, #1952). Keyed
+        by ``(repo, issue)`` so a cross-repo same-number pair (``A#71``/``B#71``)
+        is preserved as distinct work. ``issue is None`` items never dedup.
+        """
+        seen: set[tuple[str, int]] = set()
+        deduped: list[WorkItem] = []
+        for it in items:
+            if it.issue is None:
+                deduped.append(it)
+                continue
+            key = (it.repo, it.issue)
+            if key in seen:
+                logger.warning(
+                    "implementation %s#%s already queued; dropping duplicate work item",
+                    it.repo,
+                    it.issue,
+                )
+                self._finish(
+                    it, passed=True, reason=f"{it.repo}#{it.issue} superseded by queued duplicate"
+                )
+                continue
+            seen.add(key)
+            deduped.append(it)
+        return deduped
+
+    @staticmethod
+    def _index_issue_items(
+        items: list[WorkItem],
+    ) -> tuple[dict[int, WorkItem], dict[int, list[WorkItem]]]:
+        """Index issue items by number for number-keyed topo/overlap dispatch.
+
+        Returns ``(issue_items, ambiguous)``. Dispatch is driven by ordered issue
+        NUMBERS, so items are indexed by number to look back up. A cross-repo
+        same-number pair collides in that dict — those numbers move to
+        ``ambiguous`` (issue number → its distinct items) and dispatch directly,
+        bypassing the number-keyed topo/overlap gates, which cannot represent two
+        items under one number. The ambiguity is inherent to the shared
+        issue-number-space dependency model (``IssueInfo``); dispatching both is
+        correct — neither is a duplicate (#2057). ``issue is None`` items are
+        skipped (dispatched elsewhere / re-queued).
+        """
+        issue_items: dict[int, WorkItem] = {}
+        ambiguous: dict[int, list[WorkItem]] = {}
+        for it in items:
+            if it.issue is None:
+                continue
+            if it.issue in ambiguous:
+                ambiguous[it.issue].append(it)
+            elif it.issue in issue_items:
+                ambiguous[it.issue] = [issue_items.pop(it.issue), it]
+            else:
+                issue_items[it.issue] = it
+        return issue_items, ambiguous
 
     def _admit(self, item: WorkItem) -> bool:
         """Admission control: per-repo in-flight cap (O(1) Counter lookup)."""

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -544,6 +544,99 @@ class TestImplementationAdmission:
         assert "superseded" in duplicate.result.reason
         # Implementation queue is drained — no duplicate left behind.
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
+        # Repo-scoped reason string (#2057).
+        assert duplicate.result.reason == "repo-a#21 superseded by queued duplicate"
+
+    def test_cross_repo_same_issue_number_both_dispatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two repos sharing an issue number are DISTINCT work — never collapsed (#2057).
+
+        The implementation queue is stage-keyed, so one drain round can hold
+        ``A#71`` and ``B#71``. Dedup is per-repo: both must dispatch; neither may
+        be silently terminalized as a duplicate of the other.
+        """
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=2
+        )
+        ran: list[str] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                ran.append(f"{item.repo}#{item.issue}")
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        a71 = _issue_item(71, StageName.IMPLEMENTATION, repo="repo-a")
+        b71 = _issue_item(71, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(a71, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(b71, StageName.IMPLEMENTATION, enter=True)
+
+        coordinator._drain_implementation()
+
+        # BOTH ran — the cross-repo pair is not collapsed.
+        assert sorted(ran) == ["repo-a#71", "repo-b#71"]
+        # Neither was terminalized as a superseded duplicate.
+        assert a71.result is None or "superseded" not in (a71.result.reason or "")
+        assert b71.result is None or "superseded" not in (b71.result.reason or "")
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
+
+    def test_three_duplicates_collapse_to_first(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """3+ copies of one issue: first dispatches, ALL later copies terminalize (#2057)."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        ran: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                ran.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        first = _issue_item(21, StageName.IMPLEMENTATION)
+        dup2 = _issue_item(21, StageName.IMPLEMENTATION)
+        dup3 = _issue_item(21, StageName.IMPLEMENTATION)
+        for it in (first, dup2, dup3):
+            coordinator._push_item(it, StageName.IMPLEMENTATION, enter=True)
+
+        coordinator._drain_implementation()
+
+        assert ran == [21]  # dispatched exactly once
+        for dup in (dup2, dup3):  # every later copy terminalized
+            assert dup.stage is StageName.FINISHED
+            assert dup.result is not None
+            assert dup.result.passed
+            assert "superseded" in dup.result.reason
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == []
+
+    def test_issue_none_items_never_deduped_or_terminalized(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """issue=None items bypass issue-number dedup — never collapsed, never terminalized (#2057).
+
+        The number-keyed topo/overlap dispatch path only handles issue items, so
+        issue=None items are left queued (re-pushed) rather than dispatched here.
+        The invariant this guards: two issue=None items must NOT be treated as
+        duplicates of each other (``None == None``) and terminalized.
+        """
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        pr_a = WorkItem(
+            repo="repo-a", kind=ItemKind.PR, pr=500, stage=StageName.IMPLEMENTATION, state="ENTER"
+        )
+        pr_b = WorkItem(
+            repo="repo-a", kind=ItemKind.PR, pr=501, stage=StageName.IMPLEMENTATION, state="ENTER"
+        )
+        coordinator._push_item(pr_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(pr_b, StageName.IMPLEMENTATION, enter=True)
+
+        coordinator._drain_implementation()
+
+        # Neither was terminalized as a duplicate of the other.
+        assert pr_a.result is None
+        assert pr_b.result is None
+        # Both remain queued for their proper stage handling (order preserved).
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [pr_a, pr_b]
 
     def test_topo_order_and_overlap_reuse(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Follow-up to the merged #2058. That PR's implementation-queue dedup keyed on issue **number alone**, but the queue is stage-keyed and one drain round can hold items from several repos (#1795). Two repos sharing an issue number (`Odysseus#71` / `Scylla#71`) are **distinct work** — number-only dedup collapsed them, terminalizing one repo's real work as `passed=True` "superseded" **without running it**. Silent data loss, no error.

Surfaced by the strict PR-alignment review of #2058 (MAJOR, Dimension 5) after #2058 had already merged.

## Change

- Dedup keyed on `(repo, issue)` — only a true `(repo, issue)` duplicate (the transient retry/fail-back re-enqueue) collapses; cross-repo same-number pairs are preserved.
- Cross-repo same-number collisions routed to a separate `ambiguous` map and dispatched directly, bypassing the number-keyed topo/overlap gates that cannot represent two items under one number.
- Extracted `_dedup_implementation_items` + `_index_issue_items` (also clears a C901 complexity bump).

## Testing

- New: cross-repo same-number both-dispatch; 3+ duplicates collapse to first; `issue=None` never deduped.
- `pixi run pytest tests/unit/automation/pipeline/test_coordinator.py` — 47 passed.
- Full pipeline suite, `mypy`, `ruff`, pre-commit — clean. Signed + DCO.

Upstream idempotency guard (so duplicates never enqueue) tracked separately in #2107.

Closes #2112