### PR TITLE
fix(pipeline): _assert_branch_commits_signed crashes create_pr when branch ref unresolvable locally

### DIFF
--- a/hephaestus/automation/github_api/prs.py
+++ b/hephaestus/automation/github_api/prs.py
@@ -67,18 +67,41 @@ def _assert_branch_commits_signed(branch: str, base: str = "main") -> None:
             timeout=_api.gh_cli_timeout(),
         )
 
-    result = _api.run(
-        ["git", "log", "--format=%H %G?", f"origin/{base}..{branch}"],
-        check=False,
-        timeout=_api.gh_cli_timeout(),
+    # Enumerate commits over the branch range. At PR-create time the branch
+    # typically exists only as origin/<branch> (its checkout lives in a separate
+    # worktree), so vary BOTH the base and branch sides and take the first range
+    # that resolves. A bare local <branch> is not guaranteed to exist in the
+    # coordinator's CWD (#2108, same class as #1795/#2047).
+    candidate_ranges = (
+        f"origin/{base}..origin/{branch}",
+        f"origin/{base}..{branch}",
+        f"{base}..origin/{branch}",
+        f"{base}..{branch}",
     )
-    if result.returncode != 0:
-        # Fall back to a non-origin range if origin/<base> is unknown locally
-        result = _api.run(
-            ["git", "log", "--format=%H %G?", f"{base}..{branch}"],
-            check=True,
+    result = None
+    for rev_range in candidate_ranges:
+        attempt = _api.run(
+            ["git", "log", "--format=%H %G?", rev_range],
+            check=False,
             timeout=_api.gh_cli_timeout(),
         )
+        if attempt.returncode == 0:
+            result = attempt
+            break
+
+    if result is None:
+        # No range resolved locally — the branch ref is unavailable in this CWD
+        # (e.g. pushed to origin but checked out in a separate worktree). This is
+        # a resolution failure, NOT a policy violation: never crash create_pr and
+        # strand already-pushed, signed work. GitHub's server-side signature
+        # verification and the pr-policy gate remain the backstop. (#2108)
+        _api.logger.warning(
+            "Could not resolve any commit range for branch %r (vs %s); "
+            "skipping local sign check and deferring to GitHub verification.",
+            branch,
+            base,
+        )
+        return
 
     bad: list[tuple[str, str]] = []
     for line in (result.stdout or "").splitlines():

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1761,6 +1761,56 @@ class TestAssertBranchCommitsSignedApiFallback:
         # 'G' is locally good — no API round-trip needed.
         mock_verified.assert_not_called()
 
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified")
+    @patch("hephaestus.automation.github_api.run")
+    def test_branch_only_resolvable_as_origin_ref_does_not_crash(
+        self, mock_run: Any, mock_verified: Any
+    ) -> None:
+        """Regression #2108: bare <branch> absent, origin/<branch> present."""
+        from hephaestus.automation.github_api import _assert_branch_commits_signed
+
+        fetch_result = Mock(returncode=0, stdout="", stderr="")
+        # First candidate origin/main..origin/branch resolves; commits are signed.
+        log_ok = Mock(returncode=0, stdout="5eb2be44 G\n", stderr="")
+        mock_run.side_effect = [fetch_result, log_ok]
+
+        # Must NOT raise CalledProcessError or ValueError.
+        _assert_branch_commits_signed("2107-auto-impl", base="main")
+        mock_verified.assert_not_called()
+
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified")
+    @patch("hephaestus.automation.github_api.run")
+    def test_no_range_resolves_defers_without_crashing(
+        self, mock_run: Any, mock_verified: Any
+    ) -> None:
+        """Regression #2108: no candidate range resolves -> warn, no crash."""
+        from hephaestus.automation.github_api import _assert_branch_commits_signed
+
+        fetch_result = Mock(returncode=0, stdout="", stderr="")
+        fail = Mock(returncode=128, stdout="", stderr="fatal: ambiguous argument")
+        # fetch + 4 candidate ranges all fail.
+        mock_run.side_effect = [fetch_result, fail, fail, fail, fail]
+
+        # Must NOT raise; defers to GitHub verification.
+        _assert_branch_commits_signed("2107-auto-impl", base="main")
+        mock_verified.assert_not_called()
+
+    @patch("hephaestus.automation.github_api._gh_commit_is_verified")
+    @patch("hephaestus.automation.github_api.run")
+    def test_genuinely_unsigned_still_raises_after_resolution(
+        self, mock_run: Any, mock_verified: Any
+    ) -> None:
+        """Unsigned commits on a resolvable range still raise (unchanged)."""
+        from hephaestus.automation.github_api import _assert_branch_commits_signed
+
+        fetch_result = Mock(returncode=0, stdout="", stderr="")
+        log_bad = Mock(returncode=0, stdout="deadbeef N\n", stderr="")
+        mock_run.side_effect = [fetch_result, log_bad]
+        mock_verified.return_value = False
+
+        with pytest.raises(ValueError, match="Unsigned or invalid commits"):
+            _assert_branch_commits_signed("2107-auto-impl", base="main")
+
 
 class TestGhCommitIsVerified:
     """``_gh_commit_is_verified`` fail-safe behavior (#1426)."""


### PR DESCRIPTION
Implemented by the drive-green automation loop; branch was committed (signed) and pushed, but the loop crashed at PR-create time on the ref-resolution bug in `_assert_branch_commits_signed` (tracked in #2108). Opening manually so the completed, signed work is not stranded.

Closes #2108