### PR TITLE
fix(automation): agents fabricate Claude Haiku <mvillmow@anthropic.com> git identity, making commits unverifiable (no_user)

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -195,10 +195,10 @@ per-repo in-flight cap.
    fast path (per `_review_existing_pr` semantics) → skip to step 8.
 2. [W:G] Create/refresh worktree (`worktree_manager.create_worktree(
    refresh_base=True)`).
-3. [W:A] **Dirty worktree decision** — `prompts/implementation.py:293
+3. [W:A] **Dirty worktree decision** — `prompts/implementation.py:299
    get_dirty_reused_worktree_decision_prompt`.
 4. [W:A] **Advise step**.
-5. [W:A] **Implement step** — `prompts/implementation.py:211
+5. [W:A] **Implement step** — `prompts/implementation.py:217
    get_implementation_prompt`.
 6. [W:B] **Test step** (optional) — `_run_tests_in_worktree` (`pixi run
    pytest`); on failure, RETRY with budget test_fix.
@@ -206,7 +206,7 @@ per-repo in-flight cap.
    with test-failure feedback → repeat step 6.
 8. [W:G] Commit and push (or no-op if existing-PR).
 9. [M] **PR_CREATE**: call `gh pr create` (idempotent for existing) with
-   `prompts/pr_review.py:339 get_pr_description` [durable] → ADVANCE.
+   `prompts/pr_review.py:352 get_pr_description` [durable] → ADVANCE.
 
 **Verdicts**: ADVANCE, RETRY, FAIL_BACK(reason).
 
@@ -221,9 +221,9 @@ per-repo in-flight cap.
 
 **Prompt functions**:
 
-- `prompts/implementation.py:293 get_dirty_reused_worktree_decision_prompt`
-- `prompts/implementation.py:211 get_implementation_prompt`
-- `prompts/pr_review.py:339 get_pr_description`
+- `prompts/implementation.py:299 get_dirty_reused_worktree_decision_prompt`
+- `prompts/implementation.py:217 get_implementation_prompt`
+- `prompts/pr_review.py:352 get_pr_description`
 
 ### 5. pr_review
 
@@ -241,7 +241,7 @@ ADDRESS_WAIT → PUSH_WAIT → EVAL → (loop) → FOLLOWUP_WAIT.
 4. [W:A] **Difficulty step** — `prompts/pr_review.py:310
    get_comment_difficulty_prompt`.
 5. [W:A] **Address step**: if fresh PR → resume implementer with
-   `prompts/implementation.py:336 get_impl_resume_feedback_prompt`; if
+   `prompts/implementation.py:342 get_impl_resume_feedback_prompt`; if
    existing-PR path → `prompts/address_review.py:181
    get_address_review_prompt`.
 6. [W:G] Push (commit+force-push addressing changes).
@@ -292,7 +292,7 @@ objects are rejected.
 - `prompts/pr_review.py:104 get_pr_review_analysis_prompt`
 - `prompts/pr_review.py:232 get_review_validation_prompt`
 - `prompts/pr_review.py:310 get_comment_difficulty_prompt`
-- `prompts/implementation.py:336 get_impl_resume_feedback_prompt`
+- `prompts/implementation.py:342 get_impl_resume_feedback_prompt`
 - `prompts/address_review.py:181 get_address_review_prompt`
 - `prompts/follow_up.py:105 get_follow_up_prompt`
 

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -96,6 +96,27 @@ def _git_timeout_kw(timeout: int | None) -> dict[str, Any]:
     return {} if timeout is None else {"timeout": timeout}
 
 
+def _clear_local_committer_identity(worktree_path: Path, git_timeout: int | None) -> None:
+    """Drop any worktree/local ``user.email``/``user.name`` override before committing.
+
+    A sub-agent that ran ``git config user.email <fabricated>`` in the worktree
+    would otherwise poison the orchestrator's commit, since git resolves local
+    config ahead of the operator's global, GitHub-verifiable identity — producing
+    ``no_user`` commits that fail the signed-commit policy gate (issue #2110).
+    ``git config --unset --local`` returns exit 5 when the key is absent, the
+    expected no-op case, so ``check=False``; ``log_errors=False`` keeps that
+    common case from emitting spurious ERROR logs on every commit.
+    """
+    for key in ("user.email", "user.name"):
+        run(
+            ["git", "config", "--unset", "--local", key],
+            cwd=worktree_path,
+            check=False,
+            log_errors=False,
+            **_git_timeout_kw(git_timeout),
+        )
+
+
 def _normalize_conventional_type(subject: str, *, default: str = "chore") -> str:
     """Rewrite a subject's leading type to an allowlisted one if it is not already.
 
@@ -832,6 +853,10 @@ def commit_changes(
         git_message_timeout=git_message_timeout,
         git_timeout=git_timeout,
     )
+
+    # Defense-in-depth: strip any fabricated worktree-local identity a sub-agent
+    # may have set, so the commit inherits the operator's verifiable identity (#2110).
+    _clear_local_committer_identity(worktree_path, git_timeout)
 
     # Commit with cryptographic signature and DCO sign-off — required by repo policy.
     run(

--- a/hephaestus/automation/prompts/implementation.py
+++ b/hephaestus/automation/prompts/implementation.py
@@ -95,6 +95,12 @@ agent turn returns.
 
 - DO NOT run `git commit`, `git push`, `gh pr create`, `gh pr merge`, or any
   other command that writes to GitHub.
+- DO NOT run `git config user.email`, `git config user.name`, or otherwise
+  override the committer identity. The orchestrator inherits the operator's
+  configured, GitHub-verifiable identity and signs the commit; a fabricated
+  identity (e.g. an `@anthropic.com` address not linked to a GitHub account)
+  makes every commit unverifiable (`no_user`) and fails the signed-commit gate.
+  Express agent attribution only via the orchestrator's `Co-Authored-By:` trailer.
 - Leave the final implementation changes in the working tree.
 - When you finish, summarize what changed and what tests you ran.
 

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -44,6 +44,8 @@ class TestCommitChanges:
                 _status(""),  # git add
                 _status("M\tsrc/foo.py\nM\tsrc/bar.py\n"),  # changed files context
                 _status(" src/foo.py | 1 +\n src/bar.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -70,6 +72,8 @@ class TestCommitChanges:
                 _status(""),  # git add
                 _status("M\thephaestus/automation/ci_driver.py\n"),  # changed files context
                 _status(" hephaestus/automation/ci_driver.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -101,6 +105,8 @@ class TestCommitChanges:
                 _status(""),  # git add
                 _status("M\tsrc/foo.py\n"),  # changed files context
                 _status(" src/foo.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -124,6 +130,8 @@ class TestCommitChanges:
                 _status(""),  # git add
                 _status("M\tsrc/foo.py\n"),  # changed files context
                 _status(" src/foo.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -141,6 +149,8 @@ class TestCommitChanges:
             42,
             42,
             42,
+            42,
+            42,
         ]
 
     def test_handles_renamed_files(self) -> None:
@@ -151,6 +161,8 @@ class TestCommitChanges:
                 _status(""),
                 _status("R\told.py\tnew.py\n"),
                 _status(" new.py | 1 +\n"),
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),
             ]
         )
@@ -172,6 +184,8 @@ class TestCommitChanges:
                 _status(""),
                 _status("D\thephaestus/github/fleet_sync.py\n"),
                 _status(" hephaestus/github/fleet_sync.py | 10 ----------\n"),
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),
             ]
         )
@@ -194,6 +208,8 @@ class TestCommitChanges:
                 _status(""),  # git add
                 _status("M\tLICENSE\nM\tNOTICE\n"),  # changed files context
                 _status(" LICENSE | 2 +-\n NOTICE | 2 +-\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -230,6 +246,8 @@ class TestCommitChanges:
                 _status(""),  # git add
                 _status("M\tsrc/feature.py\n"),  # changed files context
                 _status(" src/feature.py | 3 +++\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -245,6 +263,38 @@ class TestCommitChanges:
         commit_msg = run_mock.call_args_list[-1].args[0][-1]
         assert commit_msg.startswith("feat: Implement #10\n\nAdd feature\n")
         assert "Closes #10" in commit_msg
+
+    def test_commit_clears_local_committer_identity(self) -> None:
+        run_mock = MagicMock(
+            side_effect=[
+                _status(" M src/foo.py\n"),  # git status
+                _status(""),  # git add
+                _status("M\tsrc/foo.py\n"),  # changed files context
+                _status(" src/foo.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
+                _status(""),  # git commit
+            ]
+        )
+        issue = MagicMock(title="Add foo", body="Implement it.")
+        with (
+            patch.object(pr_manager, "run", run_mock),
+            patch.object(pr_manager, "fetch_issue_info", return_value=issue),
+            patch.object(pr_manager, "_invoke_git_message_agent", return_value="not json"),
+        ):
+            pr_manager.commit_changes(3, Path("/tmp/wt"))
+
+        cmds = [c.args[0] for c in run_mock.call_args_list]
+        assert ["git", "config", "--unset", "--local", "user.email"] in cmds
+        assert ["git", "config", "--unset", "--local", "user.name"] in cmds
+        commit_idx = next(i for i, c in enumerate(cmds) if c[:2] == ["git", "commit"])
+        unset_idxs = [i for i, c in enumerate(cmds) if c[:3] == ["git", "config", "--unset"]]
+        assert all(i < commit_idx for i in unset_idxs)
+        # Expected exit-5 no-op is tolerated AND quiet (prior-review finding #2).
+        for call in run_mock.call_args_list:
+            if call.args[0][:3] == ["git", "config", "--unset"]:
+                assert call.kwargs.get("check") is False
+                assert call.kwargs.get("log_errors") is False
 
 
 class TestEnsurePRCreated:
@@ -538,6 +588,8 @@ class TestCoAuthorLine:
                 _status(""),  # git add
                 _status("M\tsrc/feature.py\n"),  # changed files context
                 _status(" src/feature.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -568,6 +620,8 @@ class TestCoAuthorLine:
                 _status(""),  # git add
                 _status("M\tsrc/feature.py\n"),  # changed files context
                 _status(" src/feature.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -593,6 +647,8 @@ class TestCoAuthorLine:
                 _status(""),  # git add
                 _status("M\tfoo.py\n"),  # changed files context
                 _status(" foo.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -622,6 +678,8 @@ class TestCoAuthorLine:
                 _status(""),  # git add
                 _status("M\tfoo.py\n"),  # changed files context
                 _status(" foo.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )
@@ -652,6 +710,8 @@ class TestCoAuthorLine:
                 _status(""),  # git add
                 _status("M\tfoo.py\n"),  # changed files context
                 _status(" foo.py | 1 +\n"),  # stat context
+                _status(""),  # git config --unset user.email
+                _status(""),  # git config --unset user.name
                 _status(""),  # git commit
             ]
         )

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -52,6 +52,14 @@ class TestImplementationPrompt:
         assert "git push -u origin" not in out
         assert "autoMergeRequest" not in out
 
+    def test_implementation_prompt_forbids_git_config_identity(self) -> None:
+        """Implementer prompt must forbid fabricating a committer identity (#2110)."""
+        out = prompts.get_implementation_prompt(issue_number=42)
+        assert "git config user.email" in out
+        assert "git config user.name" in out
+        # Attribution stays on the orchestrator's Co-Authored-By trailer.
+        assert "Co-Authored-By" in out
+
     def test_states_task_plan_review_context_model(self) -> None:
         """The implementer prompt must declare TASK/PLAN/PLAN-REVIEW context."""
         out = prompts.get_implementation_prompt(issue_number=42)


### PR DESCRIPTION
Implemented by the drive-green automation loop; branch was committed (signed) and pushed, but the loop crashed at PR-create time on the ref-resolution bug in `_assert_branch_commits_signed` (tracked in #2108). Opening manually so the completed, signed work is not stranded.

Closes #2110