### PR TITLE
docs(AGENTS.md): add Design Philosophy section (heritage: ProjectOdyssey)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,35 @@ on each automation command (e.g., `--agent-timeout`, `--poll-max-wait`,
 `--git-message-timeout`, etc.). Legacy `claude_models`, `claude_timeouts`, and
 `session_naming` modules remain compatibility shims over `agent_config`.
 
+## Design Philosophy
+
+The agent topology above is not accidental — it follows a small set of design
+principles inherited from **ProjectOdyssey**, where the queue-based agent loop
+and strict plan/review gates were first incubated before being generalized into
+Hephaestus's shared tooling. Those principles, applied to agent design, are:
+
+- **Simplicity first (KISS / YAGNI).** Each queue stage owns one responsibility
+  and one reason to change; we do not add stages, providers, or abstractions
+  until a concrete workflow needs them. The deferred `AgentProtocol` and
+  resilience wiring (issues #468, #469) are intentionally *not* built yet.
+- **One-way dependencies (DRY / boundaries).** The dependency arrow points only
+  automation → library (see [`CLAUDE.md`](CLAUDE.md#library-vs-product-layer)).
+  Prompt construction lives in exactly one module (`hephaestus.automation.prompts`)
+  so untrusted-content fencing is defined once, not per call site.
+- **Substitutable providers (SOLID).** `hephaestus.agents.runtime` abstracts over
+  Claude Code and Codex behind a uniform `--agent` flag so either provider is
+  substitutable at a call site without changing orchestration logic.
+- **Least privilege, least astonishment (POLA).** Every agent call site declares
+  an explicit `--allowedTools` scope (see the permission-policy table below),
+  runs in a scoped worktree, and defers all irreversible actions (merge, tag,
+  force-push) to human-gated checkpoints.
+- **Human-in-the-loop by default.** Autonomy is bounded: skills that can act
+  destructively stop for a human gate, and every automation PR still passes
+  branch protection and the `pr-policy` check.
+
+For the full, non-agent-specific statement of these principles see
+[`CLAUDE.md`](CLAUDE.md#key-development-principles).
+
 ## Claude non-interactive permission policy
 
 Claude invocations that pass `permission_mode="dontAsk"` are non-interactive

--- a/tests/unit/automation/test_claude_dontask_policy_docs.py
+++ b/tests/unit/automation/test_claude_dontask_policy_docs.py
@@ -78,3 +78,16 @@ def test_issue_1482_dontask_sites_are_documented_in_agents_md() -> None:
     documented = _documented_rows()
     for call_key, tools in EXPECTED_DONTASK_CALLS.items():
         assert documented.get(call_key) == tools
+
+
+def test_agents_md_has_design_philosophy_section() -> None:
+    """AGENTS.md must document the agent-design philosophy (issue #2111)."""
+    agents_md = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "## Design Philosophy" in agents_md
+    # Heritage attribution required by the issue title.
+    assert "ProjectOdyssey" in agents_md
+    # Core principles the section is grounded in.
+    for principle in ("KISS", "YAGNI", "SOLID", "POLA"):
+        assert principle in agents_md, f"Design Philosophy missing {principle}"
+    # Cross-link back to the canonical principle list in CLAUDE.md.
+    assert "CLAUDE.md#key-development-principles" in agents_md


### PR DESCRIPTION
Implemented by the drive-green automation loop; branch was committed (signed) and pushed, but the loop crashed at PR-create time on the ref-resolution bug in `_assert_branch_commits_signed` (tracked in #2108). Opening manually so the completed, signed work is not stranded.

Closes #2111