### PR TITLE
fix(tests): stop upstream guard from masking drain-level dedup test (main red)

### DIFF
--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -606,8 +606,17 @@ class TestImplementationAdmission:
         first = _issue_item(21, StageName.IMPLEMENTATION)
         dup2 = _issue_item(21, StageName.IMPLEMENTATION)
         dup3 = _issue_item(21, StageName.IMPLEMENTATION)
+        # Inject the collisions BELOW the upstream idempotency guard (#2107):
+        # push straight onto the queue (the same raw API the drain uses to
+        # re-push deferred items, coordinator.py:873) so this test exercises
+        # the drain-level safety net for duplicates that arrived by a path the
+        # upstream guard does not cover. (The guard would otherwise drop dup2/
+        # dup3 at push time, so they'd never reach the drain-level collapse.)
         for it in (first, dup2, dup3):
-            coordinator._push_item(it, StageName.IMPLEMENTATION, enter=True)
+            it.payload["_enter_pending"] = True
+            coordinator._seen_item_ids.add(id(it))
+            coordinator.items.append(it)
+            coordinator.queues[StageName.IMPLEMENTATION].push(it)
 
         coordinator._drain_implementation()
 


### PR DESCRIPTION
Fixes main being RED.

`test_three_duplicates_collapse_to_first` began failing once the upstream idempotency guard (#2107/#2109) started dropping duplicate `(repo, issue)` keys at `_push_item` time — the test still pushed 3 duplicates via `_push_item` expecting them to reach `_drain_implementation` and be terminalized, but the guard now drops dup2/dup3 before they enqueue.

This applies the same below-the-guard injection the guard PR already applied to the sibling test, so the drain-level dedup (#2057) is still exercised. The guard behavior is correct; only the stale test needed updating.

Closes #2118