### PR TITLE
chore(settings): swap hephaestus plugin → Athena marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,29 @@
 {
   "enabledPlugins": {
-    "hephaestus@ProjectHephaestus": true,
-    "safety-net@cc-marketplace": true
+    "safety-net@cc-marketplace": true,
+    "advise@Athena": true,
+    "brainstorm@Athena": true,
+    "code-review@Athena": true,
+    "create-reusable-utilities@Athena": true,
+    "finish-branch@Athena": true,
+    "git-worktrees@Athena": true,
+    "github-actions-python-cicd@Athena": true,
+    "learn@Athena": true,
+    "myrmidon-swarm@Athena": true,
+    "python-repo-modernization@Athena": true,
+    "repo-analyze@Athena": true,
+    "repo-analyze-full@Athena": true,
+    "repo-analyze-quick@Athena": true,
+    "repo-analyze-quick-full@Athena": true,
+    "repo-analyze-strict@Athena": true,
+    "repo-analyze-strict-full@Athena": true,
+    "review-pr-strict@Athena": true,
+    "skill-advisor@Athena": true,
+    "systematic-debugging@Athena": true,
+    "test-driven-development@Athena": true,
+    "tidy@Athena": true,
+    "verification@Athena": true,
+    "worktree-cleanup@Athena": true
   },
   "permissions": {
     "deny": [
@@ -22,5 +44,13 @@
       "Write(~/.aws/**)",
       "Write(~/.gnupg/**)"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "Athena": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/HomericIntelligence/Athena.git"
+      }
+    }
   }
 }


### PR DESCRIPTION
The project `.claude/settings.json` still enables the old
`hephaestus@ProjectHephaestus` plugin. That marketplace/plugin has been
carved out to `HomericIntelligence/Athena`, whose marketplace now declares
`name: "Athena"` with 23 per-skill plugin entries (one-plugin-per-skill).

The single `hephaestus@…` ref no longer resolves. Per the Claude Code plugin
docs, `enabledPlugins` keys use the *marketplace entry* `name`, and Athena
lists each skill as its own entry — so each must be enabled as
`<skill>@Athena`.

## Fix

- Replace `hephaestus@ProjectHephaestus` with the 23 `<skill>@Athena` keys.
- Register the Athena marketplace under `extraKnownMarketplaces`.
- Preserve `safety-net@cc-marketplace` and the full `permissions.deny` block.

Closes #2123
