### PR TITLE
fix(ci): create build/ dir before bandit writes SAST output

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -130,7 +130,7 @@ sast = "bandit -c pyproject.toml -r hephaestus scripts --severity-level medium"
 # Full-severity audit-trail scan (issue #1481) — run weekly in CI
 # (.github/workflows/security.yml) and manually before a quarterly re-review.
 sast-audit-trail = { depends-on = ["_sast-low-report", "_sast-baseline-diff"] }
-_sast-low-report = "bandit -c pyproject.toml -r hephaestus scripts --severity-level low -f json -o build/bandit_low.json || true"
+_sast-low-report = "mkdir -p build && bandit -c pyproject.toml -r hephaestus scripts --severity-level low -f json -o build/bandit_low.json || true"
 _sast-baseline-diff = "python hephaestus/ci/bandit_baseline_check.py build/bandit_low.json hephaestus/ci/bandit_low_baseline.json"
 
 [environments]


### PR DESCRIPTION
## Problem

The weekly **Security** workflow's `Static Application Security Testing` job fails on `main`:

```
bandit: error: argument -o/--output: can't open 'build/bandit_low.json': [Errno 2] No such file or directory
FileNotFoundError: [Errno 2] No such file or directory: 'build/bandit_low.json'
```

The `_sast-low-report` pixi task (introduced in #2078, "ci(bandit): Add LOW-severity baseline tracking for audit visibility") writes bandit's JSON output to `build/bandit_low.json` but never creates `build/` first. The previous two weekly runs were green before that change landed, confirming this is a recent regression from the new output path — not a real security finding (bandit only flags pre-existing `nosec`-covered warnings).

## Fix

Minimal one-line change in `pixi.toml`: prepend `mkdir -p build &&` to the `_sast-low-report` task so the directory exists before bandit writes to it. This is the only bandit invocation in the repo that writes a JSON file to `build/` (the plain `sast` task only prints to stdout), so no other paths need the same fix.

## Verification

Reproduced the failure locally with a clean checkout (no `build/` dir) and the exact bandit invocation from `pixi.toml`:

```
$ bandit -c pyproject.toml -r hephaestus scripts --severity-level low -f json -o build/bandit_low.json
bandit: error: argument -o/--output: can't open 'build/bandit_low.json': [Errno 2] No such file or directory
```

After the fix (`mkdir -p build && bandit ...`), the same command succeeds and writes the file:

```
[json] INFO JSON output written to file: build/bandit_low.json
```

`build/` is already gitignored, so no untracked artifacts are introduced.


Closes #2126
