### PR TITLE
feat(automation): support Terra default reasoning

### DIFF
--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -388,6 +388,8 @@ def _codex_model_config(model: str, *, use_default: bool = False) -> CodexModelC
             return CodexModelConfig(CODEX_DEFAULT_MODEL, CODEX_DEFAULT_REASONING_EFFORT)
         return CodexModelConfig("")
     lower_model = normalized.lower()
+    if lower_model in {"terra:default", f"{CODEX_GPT_56_TERRA_MODEL}:default"}:
+        return CodexModelConfig(CODEX_GPT_56_TERRA_MODEL)
     if lower_model in {"sol", CODEX_GPT_56_SOL_MODEL}:
         return CodexModelConfig(CODEX_GPT_56_SOL_MODEL, CODEX_FABLE_REASONING_EFFORT)
     if lower_model in {"terra", CODEX_GPT_56_TERRA_MODEL}:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -322,7 +322,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--reviewer-model",
         default="",
-        help="HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review)",
+        help=(
+            "HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review); "
+            "use terra:default to select GPT-5.6 Terra without an explicit reasoning override"
+        ),
     )
     p.add_argument(
         "--implementer-model",

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -365,6 +365,16 @@ def test_codex_base_cmd_maps_haiku_to_mini_without_reasoning_override(
     assert "model_reasoning_effort" not in cmd
 
 
+@pytest.mark.parametrize("model", ["terra:default", "gpt-5.6-terra:default"])
+def test_codex_base_cmd_allows_terra_default_reasoning(model: str, tmp_path: Path) -> None:
+    """An explicit default suffix must omit the Codex reasoning override."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model=model)
+
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.6-terra"
+    assert "model_reasoning_effort" not in cmd
+
+
 @pytest.mark.parametrize(
     "native_model",
     ["gpt-5.4-mini", "gpt-5.5", "gpt-5.6"],

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -699,7 +699,10 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "reviewer_model",
             "_StoreAction",
             "",
-            help_text="HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review)",
+            help_text=(
+                "HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review); "
+                "use terra:default to select GPT-5.6 Terra without an explicit reasoning override"
+            ),
         ),
         _action_spec(
             ("--implementer-model",),


### PR DESCRIPTION
Closes #2195

Adds the explicit `terra:default` model selector for review roles, preserving Terra while omitting Codex’s reasoning-effort override. Includes runtime and parser-contract coverage.