### PR TITLE
[mino] Centralize release tag resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,46 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_TAG: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [[ "$REF_TAG" == refs/tags/* ]]; then
+            TAG="${REF_TAG#refs/tags/}"
+          else
+            TAG=$(git tag --list 'v*' --sort=-v:refname | sed -n '1p')
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag could be resolved"
+            exit 1
+          fi
+          if ! git show-ref --verify --quiet "refs/tags/${TAG}"; then
+            echo "::error::Resolved release tag does not exist: ${TAG}"
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Releasing tag: ${TAG}"
+
   test:
     runs-on: ubuntu-24.04
     # Unit + integration suites run here; the pixi env is cached and dev-install
@@ -34,10 +74,12 @@ jobs:
     # 15) is free insurance so a first-run integration slowdown never aborts a
     # publish (issue #1499).
     timeout-minutes: 20
+    needs: prepare
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -68,10 +110,12 @@ jobs:
   type-check:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    needs: prepare
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -91,32 +135,15 @@ jobs:
   publish-testpypi:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [test, type-check]
+    needs: [prepare, test, type-check]
     environment: testpypi
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        run: |
-          # Priority: explicit input > tag-push ref > latest tag
-          INPUT_TAG="${{ github.event.inputs.tag }}"
-          REF_TAG="${{ github.ref }}"
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$REF_TAG" == refs/tags/* ]]; then
-            TAG="${REF_TAG#refs/tags/}"
-          else
-            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Releasing tag: ${TAG}"
-          git checkout "${TAG}"
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f  # v0.10.0
@@ -169,7 +196,7 @@ jobs:
       - name: Smoke-install from TestPyPI
         shell: bash
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           EXPECTED_VERSION="${TAG#v}"
           pixi run python -m venv /tmp/testpypi-smoke
@@ -211,32 +238,15 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [test, type-check, publish-testpypi]
+    needs: [prepare, test, type-check, publish-testpypi]
     environment: pypi
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        run: |
-          # Priority: explicit input > tag-push ref > latest tag
-          INPUT_TAG="${{ github.event.inputs.tag }}"
-          REF_TAG="${{ github.ref }}"
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$REF_TAG" == refs/tags/* ]]; then
-            TAG="${REF_TAG#refs/tags/}"
-          else
-            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Releasing tag: ${TAG}"
-          git checkout "${TAG}"
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f  # v0.10.0
@@ -251,7 +261,7 @@ jobs:
       - name: Verify tag matches package version
         shell: bash
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           TAG_VERSION="${TAG#v}"
           # Resolve the version straight from hatch-vcs against the checked-out git
@@ -285,7 +295,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           # A release may already exist for this tag if it was created
           # manually or by a previous (partially failed) run of this
@@ -303,7 +313,7 @@ jobs:
         if: steps.existing.outputs.exists == 'false'
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.prepare.outputs.tag }}
           generate_release_notes: true
           files: dist/*
         env:
@@ -314,7 +324,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.prepare.outputs.tag }}
         run: |
           # The release already exists. Try to attach the freshly built
           # artifacts; an immutable release rejects uploads, so treat an
@@ -328,7 +338,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [build-and-publish]
+    needs: [prepare, build-and-publish]
     # Publish the pdoc API reference to GitHub Pages only after the package
     # release succeeds, so the online docs always match a version on PyPI.
     environment:
@@ -338,26 +348,9 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.prepare.outputs.tag }}
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          REF_TAG: ${{ github.ref }}
-        run: |
-          # Priority: explicit input > tag-push ref > latest tag (mirrors build-and-publish)
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$REF_TAG" == refs/tags/* ]]; then
-            TAG="${REF_TAG#refs/tags/}"
-          else
-            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          fi
-          echo "Releasing docs for tag: ${TAG}"
-          git checkout "${TAG}"
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f  # v0.10.0

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -388,6 +388,8 @@ def _codex_model_config(model: str, *, use_default: bool = False) -> CodexModelC
             return CodexModelConfig(CODEX_DEFAULT_MODEL, CODEX_DEFAULT_REASONING_EFFORT)
         return CodexModelConfig("")
     lower_model = normalized.lower()
+    if lower_model in {"terra:default", f"{CODEX_GPT_56_TERRA_MODEL}:default"}:
+        return CodexModelConfig(CODEX_GPT_56_TERRA_MODEL)
     if lower_model in {"sol", CODEX_GPT_56_SOL_MODEL}:
         return CodexModelConfig(CODEX_GPT_56_SOL_MODEL, CODEX_FABLE_REASONING_EFFORT)
     if lower_model in {"terra", CODEX_GPT_56_TERRA_MODEL}:

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -322,7 +322,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument(
         "--reviewer-model",
         default="",
-        help="HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review)",
+        help=(
+            "HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review); "
+            "use terra:default to select GPT-5.6 Terra without an explicit reasoning override"
+        ),
     )
     p.add_argument(
         "--implementer-model",

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -365,6 +365,16 @@ def test_codex_base_cmd_maps_haiku_to_mini_without_reasoning_override(
     assert "model_reasoning_effort" not in cmd
 
 
+@pytest.mark.parametrize("model", ["terra:default", "gpt-5.6-terra:default"])
+def test_codex_base_cmd_allows_terra_default_reasoning(model: str, tmp_path: Path) -> None:
+    """An explicit default suffix must omit the Codex reasoning override."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model=model)
+
+    assert cmd[cmd.index("--model") + 1] == "gpt-5.6-terra"
+    assert "model_reasoning_effort" not in cmd
+
+
 @pytest.mark.parametrize(
     "native_model",
     ["gpt-5.4-mini", "gpt-5.5", "gpt-5.6"],

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -699,7 +699,10 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "reviewer_model",
             "_StoreAction",
             "",
-            help_text="HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review)",
+            help_text=(
+                "HEPH_REVIEWER_MODEL for child processes (plan-review + PR-review); "
+                "use terra:default to select GPT-5.6 Terra without an explicit reasoning override"
+            ),
         ),
         _action_spec(
             ("--implementer-model",),

--- a/tests/unit/ci/test_release_tag_resolution.py
+++ b/tests/unit/ci/test_release_tag_resolution.py
@@ -1,0 +1,92 @@
+"""Regression tests for centralized release-tag resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+DOWNSTREAM_JOBS = (
+    "test",
+    "type-check",
+    "publish-testpypi",
+    "build-and-publish",
+    "deploy-docs",
+)
+PREPARED_TAG = "${{ needs.prepare.outputs.tag }}"
+
+
+def _workflow() -> dict[str, Any]:
+    """Load the release workflow."""
+    return yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _step(job_name: str, step_name: str) -> dict[str, Any]:
+    """Return one named step from a release job."""
+    matches = [
+        step for step in _workflow()["jobs"][job_name]["steps"] if step.get("name") == step_name
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
+def test_prepare_is_only_tag_resolver() -> None:
+    """Exactly one job must own tag resolution and expose its result."""
+    workflow = _workflow()
+    resolvers = [
+        job_name
+        for job_name, job in workflow["jobs"].items()
+        for step in job.get("steps", [])
+        if step.get("name") == "Resolve tag"
+    ]
+    assert resolvers == ["prepare"]
+    assert workflow["jobs"]["prepare"]["outputs"]["tag"] == ("${{ steps.tag.outputs.tag }}")
+
+
+def test_prepare_preserves_resolution_precedence_and_fails_empty() -> None:
+    """Resolution must retain input/ref/latest precedence and fail closed."""
+    script = _step("prepare", "Resolve tag")["run"]
+    assert script.index('[ -n "$INPUT_TAG" ]') < script.index('[[ "$REF_TAG" == refs/tags/* ]]')
+    assert script.index('[[ "$REF_TAG" == refs/tags/* ]]') < script.index("git tag --list 'v*'")
+    assert '[ -z "$TAG" ]' in script
+    assert "git show-ref --verify --quiet" in script
+    assert "| head -1" not in script
+    assert "| sed -n '1p'" in script
+
+
+def test_all_downstream_jobs_depend_on_prepare() -> None:
+    """Every job consuming the resolved tag must directly need prepare."""
+    jobs = _workflow()["jobs"]
+    for job_name in DOWNSTREAM_JOBS:
+        needs = jobs[job_name]["needs"]
+        needs = [needs] if isinstance(needs, str) else needs
+        assert "prepare" in needs
+
+
+def test_all_downstream_checkouts_use_prepared_tag() -> None:
+    """Validation and release jobs must checkout the identical prepared tag."""
+    for job_name in DOWNSTREAM_JOBS:
+        checkout = next(
+            step
+            for step in _workflow()["jobs"][job_name]["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        assert checkout["with"]["ref"] == PREPARED_TAG
+
+
+def test_release_tag_consumers_use_prepare_output() -> None:
+    """Publishing steps must consume the canonical prepare output."""
+    assert _step("publish-testpypi", "Smoke-install from TestPyPI")["env"]["TAG"] == (PREPARED_TAG)
+    assert (
+        _step("build-and-publish", "Verify tag matches package version")["env"]["TAG"]
+        == PREPARED_TAG
+    )
+    assert _step("build-and-publish", "Check for existing release")["env"]["TAG"] == (PREPARED_TAG)
+    assert _step("build-and-publish", "Create GitHub Release")["with"]["tag_name"] == (PREPARED_TAG)
+    assert (
+        _step("build-and-publish", "Attach build artifacts to existing release")["env"]["TAG"]
+        == PREPARED_TAG
+    )

--- a/tests/unit/ci/test_release_workflow_wiring.py
+++ b/tests/unit/ci/test_release_workflow_wiring.py
@@ -45,8 +45,12 @@ class TestPublishTestPyPIJobExists:
     def test_job_present(self) -> None:
         assert "publish-testpypi" in _load_workflow()["jobs"]
 
-    def test_needs_test_and_type_check(self) -> None:
-        assert _job("publish-testpypi")["needs"] == ["test", "type-check"]
+    def test_needs_prepare_test_and_type_check(self) -> None:
+        assert _job("publish-testpypi")["needs"] == [
+            "prepare",
+            "test",
+            "type-check",
+        ]
 
     def test_uses_testpypi_environment(self) -> None:
         assert _job("publish-testpypi")["environment"] == "testpypi"
@@ -55,8 +59,9 @@ class TestPublishTestPyPIJobExists:
 class TestBuildAndPublishDependsOnTestPyPI:
     """Production publish must not proceed until the TestPyPI gate passes."""
 
-    def test_needs_includes_publish_testpypi(self) -> None:
+    def test_needs_includes_prepare_and_publish_testpypi(self) -> None:
         assert "publish-testpypi" in _job("build-and-publish")["needs"]
+        assert "prepare" in _job("build-and-publish")["needs"]
 
     def test_still_needs_test_and_type_check(self) -> None:
         needs = _job("build-and-publish")["needs"]


### PR DESCRIPTION
## Summary
Verdict: Blocked | Reason: #2132 changes and regression tests are present; focused tests, mypy, Ruff, YAML lint, and review pass, but GitHub is unreachable and the required full `pytest tests/ -v` run is forcibly terminated by the 30-second sandbox limit.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2132

Generated by Hephaestus automation
