### PR TITLE
[crit] Release dispatch validates a different ref than the selected tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
   resolve-release:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       sha: ${{ steps.resolve.outputs.sha }}
@@ -40,6 +42,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Resolve release tag to commit SHA
         id: resolve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,57 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve-release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      sha: ${{ steps.resolve.outputs.sha }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve release tag to commit SHA
+        id: resolve
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          elif [[ "$EVENT_REF" == refs/tags/* ]]; then
+            TAG="${EVENT_REF#refs/tags/}"
+          else
+            TAG="$(git for-each-ref \
+              --count=1 \
+              --sort=-version:refname \
+              --format='%(refname:short)' \
+              'refs/tags/v*')"
+          fi
+
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag could be resolved" >&2
+            exit 1
+          fi
+
+          if ! SHA="$(git rev-parse --verify "refs/tags/${TAG}^{commit}")"; then
+            echo "::error::Release tag ${TAG} does not resolve to a commit" >&2
+            exit 1
+          fi
+
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "Resolved release tag ${TAG} to immutable commit ${SHA}"
+
   test:
     runs-on: ubuntu-24.04
+    needs: resolve-release
     # Unit + integration suites run here; the uv env is cached and dev-install
     # already ran, so both finish well under this budget. 20 min (vs the prior
     # 15) is free insurance so a first-run integration slowdown never aborts a
@@ -39,6 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -64,11 +114,13 @@ jobs:
 
   type-check:
     runs-on: ubuntu-24.04
+    needs: resolve-release
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -84,7 +136,7 @@ jobs:
   publish-testpypi:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [test, type-check]
+    needs: [resolve-release, test, type-check]
     environment: testpypi
     permissions:
       contents: read
@@ -93,30 +145,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        env:
-          # env indirection keeps workflow inputs out of the interpolated
-          # shell (zizmor template-injection, issue #2151).
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          REF_TAG: ${{ github.ref }}
-        run: |
-          # Priority: explicit input > tag-push ref > latest tag
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$REF_TAG" == refs/tags/* ]]; then
-            TAG="${REF_TAG#refs/tags/}"
-          else
-            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Releasing tag: ${TAG}"
-          git checkout "${TAG}"
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -164,7 +196,7 @@ jobs:
       - name: Smoke-install from TestPyPI
         shell: bash
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
         run: |
           EXPECTED_VERSION="${TAG#v}"
           uv venv /tmp/testpypi-smoke
@@ -206,7 +238,7 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [test, type-check, publish-testpypi]
+    needs: [resolve-release, test, type-check, publish-testpypi]
     environment: pypi
     permissions:
       contents: write  # Create GitHub Release / upload assets
@@ -215,30 +247,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        env:
-          # env indirection keeps workflow inputs out of the interpolated
-          # shell (zizmor template-injection, issue #2151).
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          REF_TAG: ${{ github.ref }}
-        run: |
-          # Priority: explicit input > tag-push ref > latest tag
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$REF_TAG" == refs/tags/* ]]; then
-            TAG="${REF_TAG#refs/tags/}"
-          else
-            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          fi
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Releasing tag: ${TAG}"
-          git checkout "${TAG}"
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -248,7 +260,7 @@ jobs:
       - name: Verify tag matches package version
         shell: bash
         env:
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
         run: |
           TAG_VERSION="${TAG#v}"
           # Resolve the version straight from hatch-vcs against the checked-out git
@@ -282,7 +294,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
         run: |
           # A release may already exist for this tag if it was created
           # manually or by a previous (partially failed) run of this
@@ -300,7 +312,7 @@ jobs:
         if: steps.existing.outputs.exists == 'false'
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
+          tag_name: ${{ needs.resolve-release.outputs.tag }}
           generate_release_notes: true
           files: dist/*
         env:
@@ -311,7 +323,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.tag.outputs.tag }}
+          TAG: ${{ needs.resolve-release.outputs.tag }}
         run: |
           # The release already exists. Try to attach the freshly built
           # artifacts; an immutable release rejects uploads, so treat an
@@ -325,7 +337,7 @@ jobs:
   deploy-docs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
-    needs: [build-and-publish]
+    needs: [resolve-release, build-and-publish]
     # Publish the pdoc API reference to GitHub Pages only after the package
     # release succeeds, so the online docs always match a version on PyPI.
     permissions:
@@ -339,27 +351,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          ref: ${{ needs.resolve-release.outputs.sha }}
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
-
-      - name: Resolve tag
-        id: tag
-        shell: bash
-        env:
-          INPUT_TAG: ${{ github.event.inputs.tag }}
-          REF_TAG: ${{ github.ref }}
-        run: |
-          # Priority: explicit input > tag-push ref > latest tag (mirrors build-and-publish)
-          if [ -n "$INPUT_TAG" ]; then
-            TAG="$INPUT_TAG"
-          elif [[ "$REF_TAG" == refs/tags/* ]]; then
-            TAG="${REF_TAG#refs/tags/}"
-          else
-            TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          fi
-          echo "Releasing docs for tag: ${TAG}"
-          git checkout "${TAG}"
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7

--- a/tests/unit/ci/test_release_workflow_wiring.py
+++ b/tests/unit/ci/test_release_workflow_wiring.py
@@ -167,6 +167,10 @@ class TestImmutableReleaseRef:
             "sha": "${{ steps.resolve.outputs.sha }}",
         }
 
+    def test_resolver_uses_only_read_repository_permission(self) -> None:
+        """Tag resolution must not inherit publication or OIDC permissions."""
+        assert _job("resolve-release")["permissions"] == {"contents": "read"}
+
     def test_dispatch_input_has_priority_and_resolves_exact_tag_commit(self) -> None:
         step = self._resolve_step()
         run = step["run"]

--- a/tests/unit/ci/test_release_workflow_wiring.py
+++ b/tests/unit/ci/test_release_workflow_wiring.py
@@ -16,6 +16,13 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+RELEASE_JOBS = (
+    "test",
+    "type-check",
+    "publish-testpypi",
+    "build-and-publish",
+    "deploy-docs",
+)
 
 
 def _load_workflow() -> dict[str, Any]:
@@ -39,14 +46,23 @@ def _step_using(job_name: str, action_substring: str) -> dict[str, Any]:
     return matches[0]
 
 
+def _needs(job_name: str) -> list[str]:
+    needs = _job(job_name)["needs"]
+    return [needs] if isinstance(needs, str) else needs
+
+
 class TestPublishTestPyPIJobExists:
     """The staging job must exist and run before build-and-publish."""
 
     def test_job_present(self) -> None:
         assert "publish-testpypi" in _load_workflow()["jobs"]
 
-    def test_needs_test_and_type_check(self) -> None:
-        assert _job("publish-testpypi")["needs"] == ["test", "type-check"]
+    def test_needs_resolver_test_and_type_check(self) -> None:
+        assert _job("publish-testpypi")["needs"] == [
+            "resolve-release",
+            "test",
+            "type-check",
+        ]
 
     def test_uses_testpypi_environment(self) -> None:
         assert _job("publish-testpypi")["environment"] == "testpypi"
@@ -58,8 +74,9 @@ class TestBuildAndPublishDependsOnTestPyPI:
     def test_needs_includes_publish_testpypi(self) -> None:
         assert "publish-testpypi" in _job("build-and-publish")["needs"]
 
-    def test_still_needs_test_and_type_check(self) -> None:
+    def test_still_needs_resolver_test_and_type_check(self) -> None:
         needs = _job("build-and-publish")["needs"]
+        assert "resolve-release" in needs
         assert "test" in needs
         assert "type-check" in needs
 
@@ -134,3 +151,69 @@ class TestSmokeInstallStep:
         run = self._smoke_step()["run"]
         assert "import hephaestus; print(hephaestus.__version__)" in run
         assert "version mismatch" in run.lower()
+
+
+class TestImmutableReleaseRef:
+    """Every release operation must consume one centrally resolved tag commit."""
+
+    def _resolve_step(self) -> dict[str, Any]:
+        matches = [step for step in _steps("resolve-release") if step.get("id") == "resolve"]
+        assert len(matches) == 1
+        return matches[0]
+
+    def test_resolver_exports_one_tag_and_sha(self) -> None:
+        assert _job("resolve-release")["outputs"] == {
+            "tag": "${{ steps.resolve.outputs.tag }}",
+            "sha": "${{ steps.resolve.outputs.sha }}",
+        }
+
+    def test_dispatch_input_has_priority_and_resolves_exact_tag_commit(self) -> None:
+        step = self._resolve_step()
+        run = step["run"]
+
+        assert step["env"]["INPUT_TAG"] == "${{ inputs.tag }}"
+        assert run.index('if [ -n "$INPUT_TAG" ]') < run.index(
+            'elif [[ "$EVENT_REF" == refs/tags/* ]]'
+        )
+        assert 'git rev-parse --verify "refs/tags/${TAG}^{commit}"' in run
+        assert 'echo "sha=${SHA}" >> "$GITHUB_OUTPUT"' in run
+
+    def test_resolver_fails_closed_for_missing_or_noncommit_tag(self) -> None:
+        run = self._resolve_step()["run"]
+
+        assert "git for-each-ref" in run
+        assert 'if ! SHA="$(git rev-parse --verify "refs/tags/${TAG}^{commit}")"; then' in run
+        assert "::error::No release tag could be resolved" in run
+        assert "::error::Release tag ${TAG} does not resolve to a commit" in run
+
+    def test_every_release_job_checks_out_resolved_sha(self) -> None:
+        expected_ref = "${{ needs.resolve-release.outputs.sha }}"
+
+        for job_name in RELEASE_JOBS:
+            assert "resolve-release" in _needs(job_name)
+            checkout = _step_using(job_name, "actions/checkout")
+            assert checkout["with"]["ref"] == expected_ref
+
+    def test_downstream_jobs_do_not_reresolve_or_checkout_the_tag(self) -> None:
+        for job_name in RELEASE_JOBS:
+            steps = _steps(job_name)
+            scripts = "\n".join(str(step.get("run", "")) for step in steps)
+
+            assert all(step.get("name") != "Resolve tag" for step in steps)
+            for command in (
+                "git tag --list",
+                "git for-each-ref",
+                "git rev-parse",
+                "git checkout",
+            ):
+                assert command not in scripts
+
+            job_text = yaml.safe_dump(_job(job_name), sort_keys=False)
+            assert "${{ inputs.tag }}" not in job_text
+            assert "${{ github.ref }}" not in job_text
+
+    def test_downstream_tag_consumers_use_resolver_output(self) -> None:
+        workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        assert "steps.tag.outputs.tag" not in workflow_text
+        assert "${{ needs.resolve-release.outputs.tag }}" in workflow_text


### PR DESCRIPTION
## Summary

The release workflow resolves one immutable tag SHA for all release jobs, with regression coverage in `tests/unit/ci/test_release_workflow_wiring.py`.

## Testing

- `pixi run pytest --no-cov tests/unit/ci/test_release_workflow_wiring.py -q`
- changed-file pre-commit hooks

## Closes

Closes #2129
Refs #2223
