### PR TITLE
[majo] Repair stale repository-local skills topology documentation

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -4,8 +4,7 @@
 # Single source of truth for markdownlint. Consolidated from the former
 # .markdownlint.json (#686): both pre-commit (markdownlint-cli2 --config) and
 # CI (markdownlint-cli2-action) now reference this one file. The ruleset below
-# is the union that keeps every tracked markdown file (notably skills/**, which
-# use semantic inline-HTML tags and long prompt lines) linting clean.
+# keeps the repository's linted Markdown surface clean.
 
 default: true
 
@@ -17,62 +16,20 @@ MD003:
 MD007:
   indent: 2
 
-# Line length is intentionally unbounded: agent skill prompts embed long,
-# unwrappable instruction lines and tables that must not be reflowed.
+# Line length is intentionally unbounded for command examples, long links,
+# and tables that must not be reflowed.
 MD013: false
 
 # Duplicate headings are allowed (repeated section titles across collapsible
-# blocks and rubrics are common in skill docs).
+# blocks and rubrics are common in documentation).
 MD024: false
 
 # Exactly one top-level (H1) heading per document.
 MD025: true
 
-# Inline HTML is restricted to this allow-list. The bulk of the entries are the
-# semantic prompt tags used throughout skills/** (e.g. <system>, <task>,
-# <section>) plus the handful of real HTML elements used for layout.
-MD033:
-  allowed_elements:
-    - details
-    - summary
-    - br
-    - img
-    - a
-    - sub
-    - sup
-    - system
-    - task
-    - section
-    - sections
-    - step
-    - principle
-    - sub_principle
-    - development_principles
-    - grading_rubric
-    - audit_sections
-    - analysis_instructions
-    - output_format
-    - important_notes
-    - criteria
-    - anti_inflation_rules
-    - workflow
-    - integrations
-    - constraints
-    - agent_tiers
-    - delegation_rules
-    - agent_prompt_template
-    - brief
-    - Brief
-    - level
-    - name
-    - what
-    - issue
-    - specific
-    - suggestion
-    - old
-    - new
-    - Why
-    - bullet
+# Inline HTML remains prohibited. Angle-bracket placeholders in command
+# examples are code spans and do not require an allow-list.
+MD033: true
 
 # Emphasis-as-heading, bare code-fence language, first-line-heading, no-empty-link,
 # link-fragment, and table-column-style rules are all disabled to match the prose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 This file is a single-page map of the AI-agent topology and conventions used by
 Hephaestus and the wider HomericIntelligence ecosystem. For project-specific
 rules (commit policy, branch naming, version model) see [`CLAUDE.md`](CLAUDE.md);
-for the catalog of skills the agents invoke, see the [`skills/`](skills/) directory.
+for enabled skill plugins see [`.claude/settings.json`](.claude/settings.json),
+and for invocation guidance see the [`CLAUDE.md` skill catalog](CLAUDE.md#skill-catalog).
 
 ## Agents the codebase orchestrates
 
@@ -137,13 +138,13 @@ instructions that bypass the PR review loop. See the tests in
 
 ## Human-in-the-loop checkpoints
 
-Several skills mandate human gates that the agents must wait on:
+Several plugin-provided skills mandate human gates that the agents must wait on:
 
-- `skills/myrmidon-swarm/SKILL.md` — explicit Phase 1 "STOP HERE. Ask the user…"
+- `/athena:myrmidon-swarm` — explicit Phase 1 "STOP HERE. Ask the user…"
   before any swarm deploys.
-- `skills/skill-advisor/SKILL.md` — invoked at the start of any substantive task
+- `/athena:skill-advisor` — invoked at the start of any substantive task
   with `allowed-tools: []`, so it can route but never act autonomously.
-- `skills/finish-branch/SKILL.md`, `skills/code-review/SKILL.md` — explicit confirm
+- `/athena:finish-branch` and `/athena:code-review` — explicit confirm
   steps before tagging, force-pushing, or merging.
 
 Every PR opened by the automation pipeline goes through GitHub's normal branch
@@ -152,8 +153,9 @@ protection and the `pr-policy` required-check gate
 
 ## Skill catalog
 
-`skills/` contains 23 reusable skills the agents can invoke. See
-[`CLAUDE.md`](CLAUDE.md#skill-catalog) for the full table. Highlights:
+The Athena plugins enabled in `.claude/settings.json` provide 23 reusable skills
+the agents can invoke. See [`CLAUDE.md`](CLAUDE.md#skill-catalog) for the full
+table. Highlights:
 
 - **Workflow**: `skill-advisor`, `advise`, `brainstorm`, `test-driven-development`,
   `systematic-debugging`, `verification`, `finish-branch`, `code-review`.
@@ -165,9 +167,9 @@ protection and the `pr-policy` required-check gate
 
 ## Configuration / boundaries
 
-- Hooks and per-skill `allowed-tools` are declared in each skill's frontmatter
-  (`skills/<name>/SKILL.md`) — these are the agent permission boundaries.
-- `.claude/settings.json` carries project-level plugin enablement.
+- Skill hooks, frontmatter, and per-skill `allowed-tools` are owned by the
+  installed Athena plugins; `.claude/settings.json` is the repository-local
+  source of truth for plugin enablement.
 - **MCP** (Model Context Protocol): `.mcp.json` is the version-controlled
   configuration surface for optional project-scoped agent tooling and remains
   intentionally empty. MCP is not a Hephaestus runtime API or ecosystem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,6 @@ Hephaestus/
 │   ├── validation/             # README, schema, and structural validation
 │   └── version/                # Version management
 ├── scripts/                    # Automation and maintenance scripts
-├── skills/                     # Claude Code skill definitions (23 SKILL.md skills; kebab-case naming for plugin format)
 ├── tests/                      # Unit and integration tests
 │   ├── unit/                   # Unit tests (mirror hephaestus/ subpackages; a small sanctioned set of extra dirs covers non-package targets — scripts/, docs/, shell, top-level modules)
 │   └── integration/            # Integration tests
@@ -57,8 +56,10 @@ Hephaestus/
 └── .claude/                    # Claude Code configurations
 ```
 
-Skill directories use kebab-case (`code-review`, `git-worktrees`) per the
-Claude Code plugin format. All Python packages use lowercase_snake_case.
+Agent skills are supplied by the Athena plugins enabled in
+`.claude/settings.json`; plugin skill names use kebab-case
+(`code-review`, `git-worktrees`). All Python packages use
+lowercase_snake_case.
 
 ## Library vs product layer
 
@@ -241,43 +242,44 @@ Skip Extended Thinking for:
 
 ### Automatic Skill Selection
 
-Before beginning any substantive task, invoke `/hephaestus:skill-advisor` to determine if a structured
-skill applies. Use `Skill(skill: "hephaestus:skill-advisor", args: "<task description>")`.
+Before beginning any substantive task, invoke `/athena:skill-advisor` to determine if a structured
+skill applies. Use `Skill(skill: "athena:skill-advisor", args: "<task description>")`.
 
 If you are a myrmidon-swarm subagent with a specific task prompt, skip this and follow your prompt directly.
 
 ### Skill Catalog
 
-Invoke a skill with `Skill(skill: "hephaestus:<name>", args: "<argument>")`, or
-`/hephaestus:<name> <argument>` interactively. The **Arguments** column mirrors each
-skill's `argument-hint` frontmatter in `skills/<name>/SKILL.md`; `—` means the skill
-takes no argument.
+Invoke an Athena skill with `Skill(skill: "athena:<name>", args: "<argument>")`, or
+`/athena:<name> <argument>` interactively. The **Arguments** column mirrors the
+Athena plugin's `argument-hint` frontmatter; `—` means the skill takes no
+argument. `.claude/settings.json` is the
+repository-local source of truth for which skill plugins are enabled.
 
 | Skill | Arguments | When to Use |
 |-------|-----------|-------------|
-| `skill-advisor` | `<task description>` | Before any task — routes to the correct skill |
-| `advise` | `<task description>` | Before starting work — search Mnemosyne for prior learnings |
-| `learn` | — | After completing work — capture session learnings in Mnemosyne |
-| `myrmidon-swarm` | `<task description>` | Complex multi-step tasks requiring parallel agent coordination |
-| `brainstorm` | `<idea or feature description>` | Before implementing a new feature — design before code |
-| `test-driven-development` | `<feature or bugfix description>` | Before writing implementation code — RED-GREEN-REFACTOR |
-| `systematic-debugging` | `<description of the bug or failure>` | Before proposing fixes — root cause first |
-| `verification` | `<what you are verifying>` | Before claiming work is done — evidence before assertions |
-| `git-worktrees` | `<branch-name or feature description>` | When needing isolated branch workspace |
-| `finish-branch` | `"<optional: base branch name>"` | When implementation is complete — branch completion workflow |
-| `code-review` | `<what was implemented>` | After major feature completion — Sonnet reviewer + feedback reception |
-| `repo-analyze` | — | Comprehensive 15-dimension repository audit |
-| `repo-analyze-quick` | — | Quick repository health check |
-| `repo-analyze-strict` | — | Ruthlessly thorough repository audit |
-| `repo-analyze-full` | — | Full-coverage audit — one swarm agent per section, no sampling cap |
-| `repo-analyze-quick-full` | — | Quick health check with full file coverage |
-| `repo-analyze-strict-full` | — | Strict audit with full file coverage (swarm per section) |
-| `pr-review` | — | Athena full-coverage pull-request review |
-| `worktree-cleanup` | `"<optional: --dry-run>"` | Audit + prune git worktrees (never deletes branches) |
-| `tidy` | `"<optional: --dry-run \| --no-swarm \| --trunk BRANCH \| --max-concurrent N>"` | Rebase all local branches with swarm conflict resolution |
-| `create-reusable-utilities` | — | Port/generalize utility scripts for cross-project reuse |
-| `github-actions-python-cicd` | — | Set up a Python GitHub Actions CI/CD pipeline |
-| `python-repo-modernization` | `<path to Python repo to modernize>` | Bring a Python repo to production-grade quality |
+| `athena:skill-advisor` | `<task description>` | Before any task — routes to the correct skill |
+| `athena:advise` | `<task description>` | Before starting work — search Mnemosyne for prior learnings |
+| `athena:learn` | — | After completing work — capture session learnings in Mnemosyne |
+| `athena:myrmidon-swarm` | `<task description>` | Complex multi-step tasks requiring parallel agent coordination |
+| `athena:brainstorm` | `<idea or feature description>` | Before implementing a new feature — design before code |
+| `athena:test-driven-development` | `<feature or bugfix description>` | Before writing implementation code — RED-GREEN-REFACTOR |
+| `athena:systematic-debugging` | `<description of the bug or failure>` | Before proposing fixes — root cause first |
+| `athena:verification` | `<what you are verifying>` | Before claiming work is done — evidence before assertions |
+| `athena:git-worktrees` | `<branch-name or feature description>` | When needing isolated branch workspace |
+| `athena:finish-branch` | `"<optional: base branch name>"` | When implementation is complete — branch completion workflow |
+| `athena:code-review` | `<what was implemented>` | After major feature completion — Sonnet reviewer + feedback reception |
+| `athena:repo-analyze` | — | Comprehensive 15-dimension repository audit |
+| `athena:repo-analyze-quick` | — | Quick repository health check |
+| `athena:repo-analyze-strict` | — | Ruthlessly thorough repository audit |
+| `athena:repo-analyze-full` | — | Full-coverage audit — one swarm agent per section, no sampling cap |
+| `athena:repo-analyze-quick-full` | — | Quick health check with full file coverage |
+| `athena:repo-analyze-strict-full` | — | Strict audit with full file coverage (swarm per section) |
+| `athena:pr-review` | — | Athena full-coverage pull-request review |
+| `athena:worktree-cleanup` | `"<optional: --dry-run>"` | Audit + prune git worktrees (never deletes branches) |
+| `athena:tidy` | `"<optional: --dry-run \| --no-swarm \| --trunk BRANCH \| --max-concurrent N>"` | Rebase all local branches with swarm conflict resolution |
+| `athena:create-reusable-utilities` | — | Port/generalize utility scripts for cross-project reuse |
+| `athena:github-actions-python-cicd` | — | Set up a Python GitHub Actions CI/CD pipeline |
+| `athena:python-repo-modernization` | `<path to Python repo to modernize>` | Bring a Python repo to production-grade quality |
 
 ### Agent Skills vs Sub-Agents Decision Tree
 

--- a/tests/unit/docs/test_skill_topology.py
+++ b/tests/unit/docs/test_skill_topology.py
@@ -1,0 +1,49 @@
+"""Regression tests for repository-local skill topology documentation (#2134)."""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SKILL_GUIDES = (
+    REPO_ROOT / "AGENTS.md",
+    REPO_ROOT / "CLAUDE.md",
+)
+TOPOLOGY_FILES = (*SKILL_GUIDES, REPO_ROOT / ".markdownlint.yaml")
+
+LOCAL_SKILLS_PATH = re.compile(r"(?<![\w.-])(?:\./|Hephaestus/)?skills(?=[/\\`)])")
+
+
+def test_repository_has_no_local_skills_directory() -> None:
+    """The documented plugin topology must not depend on a local skills path."""
+    local_skills = REPO_ROOT / "skills"
+
+    assert not local_skills.exists(), (
+        "repository-local skills content must not reappear without updating "
+        "the documented plugin topology"
+    )
+
+
+def test_topology_files_have_no_local_skill_path_references() -> None:
+    """Reject local paths including skills/, ./skills/, links, and code spans."""
+    for document in TOPOLOGY_FILES:
+        text = document.read_text(encoding="utf-8")
+        assert LOCAL_SKILLS_PATH.search(text) is None, (
+            f"{document.relative_to(REPO_ROOT)} references a repository-local skills path"
+        )
+
+
+def test_skill_guides_identify_the_plugin_source_of_truth() -> None:
+    """Agent guides must direct readers to the enabled Athena plugins."""
+    for document in SKILL_GUIDES:
+        text = document.read_text(encoding="utf-8")
+        assert ".claude/settings.json" in text
+        assert "Athena" in text
+        assert "plugin" in text.lower()
+
+
+def test_markdownlint_prohibits_inline_html_without_an_allow_list() -> None:
+    """The topology no longer needs skill-specific inline-HTML exemptions."""
+    config = (REPO_ROOT / ".markdownlint.yaml").read_text(encoding="utf-8")
+
+    assert "MD033: true" in config
+    assert "allowed_elements" not in config


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: Repaired Athena plugin topology docs and added regression coverage; 32 docs tests, Ruff, mypy, and Markdownlint passed; full suite was sandbox-terminated at 17% by a 30-second process cap.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2134

Generated by Hephaestus automation
