### PR TITLE
[majo] Update stale canonical GitHub links in contributor templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -73,6 +73,6 @@ body:
     attributes:
       value: >
         ℹ️ On submit this issue is automatically labeled `state:needs-plan` (see
-        [auto-label-needs-plan](https://github.com/mvillmow/Hephaestus/blob/main/docs/auto-label-needs-plan.md));
+        [auto-label-needs-plan](https://github.com/HomericIntelligence/Hephaestus/blob/main/docs/auto-label-needs-plan.md));
         the planning pipeline picks it up next loop. You need not set any
         `state:*` label yourself.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/mvillmow/Hephaestus/blob/main/README.md
+    url: https://github.com/HomericIntelligence/Hephaestus/blob/main/README.md
     about: Check the README for usage and setup instructions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -55,6 +55,6 @@ body:
     attributes:
       value: >
         ℹ️ On submit this issue is automatically labeled `state:needs-plan` (see
-        [auto-label-needs-plan](https://github.com/mvillmow/Hephaestus/blob/main/docs/auto-label-needs-plan.md));
+        [auto-label-needs-plan](https://github.com/HomericIntelligence/Hephaestus/blob/main/docs/auto-label-needs-plan.md));
         the planning pipeline picks it up next loop. You need not set any
         `state:*` label yourself.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,7 +50,7 @@ Closes #
 - [ ] No new warnings introduced
 - [ ] Conventional commit message format used
 - [ ] Branch named following convention: `<issue-number>-<description>`
-- [ ] Change meets the [Definition of Done](https://github.com/mvillmow/Hephaestus/blob/main/docs/DEFINITION_OF_DONE.md)
+- [ ] Change meets the [Definition of Done](https://github.com/HomericIntelligence/Hephaestus/blob/main/docs/DEFINITION_OF_DONE.md)
 
 ## Additional Notes
 

--- a/tests/unit/github/test_contributor_template_links.py
+++ b/tests/unit/github/test_contributor_template_links.py
@@ -1,0 +1,42 @@
+"""Regression checks for canonical contributor-template links (#2136)."""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CANONICAL_REPOSITORY = "https://github.com/HomericIntelligence/Hephaestus"
+LEGACY_REPOSITORY = "https://github.com/mvillmow/Hephaestus"
+
+TEMPLATE_LINKS = (
+    (".github/ISSUE_TEMPLATE/config.yml", "blob/main/README.md"),
+    (
+        ".github/ISSUE_TEMPLATE/bug_report.yml",
+        "blob/main/docs/auto-label-needs-plan.md",
+    ),
+    (
+        ".github/ISSUE_TEMPLATE/feature_request.yml",
+        "blob/main/docs/auto-label-needs-plan.md",
+    ),
+    (".github/pull_request_template.md", "blob/main/docs/DEFINITION_OF_DONE.md"),
+)
+
+
+@pytest.mark.parametrize(("relative_path", "target"), TEMPLATE_LINKS)
+def test_contributor_template_links_use_canonical_repository(
+    relative_path: str,
+    target: str,
+) -> None:
+    """Each contributor link targets its canonical repository destination."""
+    content = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    expected = f"{CANONICAL_REPOSITORY}/{target}"
+    assert expected in content, f"{relative_path} must contain {expected}"
+
+
+@pytest.mark.parametrize("relative_path", [path for path, _target in TEMPLATE_LINKS])
+def test_contributor_templates_reject_legacy_repository(relative_path: str) -> None:
+    """Contributor templates must not restore the former repository owner."""
+    content = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+    assert LEGACY_REPOSITORY not in content, (
+        f"{relative_path} contains legacy repository URL {LEGACY_REPOSITORY}"
+    )


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: Updated four canonical template URLs and added `test_contributor_template_links.py:25`; full pytest passed (6387 passed, 230 skipped, 85.26% coverage), plus mypy, ruff, formatting, and hooks; no commit or push performed.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2136

Generated by Hephaestus automation
