### PR TITLE
[mino] Correct Pixi platform-support documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ links to the full section below.
    strict-review GO, a maintainer performs the manual squash merge.
 
 If anything in steps 1–2 fails, see [Platform Support](#platform-support) — the
-pixi dev environment is `linux-64` only by design.
+Pixi workspace targets `linux-64` and `osx-arm64`.
 
 ## Planning artifacts
 
@@ -97,35 +97,33 @@ are cut on demand by pushing a signed `vX.Y.Z` git tag (see
 
 ### Platform Support
 
-The pixi developer environment and the published wheel intentionally cover
-different platform sets. Contributors and downstream users should know which
-they are using:
+The Pixi workspace, editable pip development environment, and published wheel
+cover different platform sets:
 
-| Install path                        | Platforms supported                    | Python      |
-| ----------------------------------- | -------------------------------------- | ----------- |
-| `pixi install` (development)        | `linux-64` only                        | 3.10 (pinned by `pixi.toml`) |
-| `pip install HomericIntelligence-Hephaestus` (wheel) | Linux, macOS, Windows (any OS) | 3.10+ (see `requires-python` in `pyproject.toml`) |
+| Install path | Platforms supported | Python |
+| --- | --- | --- |
+| `pixi install` (development) | `linux-64`; `osx-arm64` (Apple silicon macOS) | 3.10–3.13 (`>=3.10,<3.14` in `pixi.toml`) |
+| `pip install -e '.[dev]'` (development fallback) | Linux, macOS, Windows | 3.10+ |
+| `pip install HomericIntelligence-Hephaestus` (published wheel) | Linux, macOS, Windows | 3.10+ (`requires-python` in `pyproject.toml`) |
 
-Why the asymmetry:
+Why the matrices differ:
 
-- **Pixi is Linux-64 only by design.** `pixi.toml` declares
-  `platforms = ["linux-64"]` with an explicit `# Do not re-enable` comment
-  next to the other entries. Full local reproduction of the development
-  environment (lint, mypy, test, pre-commit) is only supported on Linux.
-- **The wheel supports the broader matrix advertised in `pyproject.toml`.**
-  `requires-python` in `pyproject.toml` describes what `pip install` will accept.
-  No platform-restriction classifier is published, so the wheel is installable
-  on macOS and Windows.
-- **Windows wheels pull in `tzdata` automatically.** The
+- **The Pixi workspace targets Linux x86-64 and Apple silicon macOS.**
+  `pixi.toml` declares `platforms = ["linux-64", "osx-arm64"]`; `win-64` and
+  `osx-64` remain excluded. This describes the workspace solve targets and does
+  not imply that both targets are exercised by the current CI runner matrix.
+- **Editable pip installation is the development fallback outside the Pixi
+  matrix.** On Windows or Intel macOS, create a plain virtualenv and run
+  `pip install -e '.[dev]'`. Platform-specific tests retain their documented
+  skip behavior.
+- **The published wheel supports the broader package matrix.**
+  `requires-python` in `pyproject.toml` describes what `pip install` accepts.
+  No platform-restriction classifier is published, so the pure-Python wheel is
+  installable on Linux, macOS, and Windows.
+- **Windows installations pull in `tzdata` automatically.** The
   `"tzdata; platform_system == 'Windows'"` marker in `[project.dependencies]`
-  exists because `hephaestus.github.rate_limit` uses `zoneinfo.ZoneInfo`,
-  which has no IANA database bundled on Windows. POSIX installs skip this
-  dependency.
-
-If you need to develop or run the test suite on macOS or Windows, install the
-wheel into a plain virtualenv (`pip install -e '.[dev]'`) — pixi tooling is
-not available there, and any subpackage with POSIX-only assumptions is out
-of scope for this project's supported development environment (track those separately).
+  provides the IANA database needed by `hephaestus.github.rate_limit`; POSIX
+  installations skip that dependency.
 
 ### The `build/` directory
 
@@ -185,10 +183,10 @@ assumes a POSIX-like development environment. Specifically:
   `~/.gitconfig`.
 
 These cases are tagged with the `requires_posix` pytest marker and are skipped
-automatically on `sys.platform == "win32"`. They run under macOS, Linux, and
-WSL with no extra setup beyond `pixi install`. Windows contributors using Git
-Bash / MSYS2 will execute them; pure-Windows-Python runs will skip them.
-Tracking: #742.
+automatically on `sys.platform == "win32"`. They run on the supported Pixi
+targets (`linux-64` and `osx-arm64`) and under WSL. Windows contributors using
+Git Bash/MSYS2 with the pip development environment will execute them;
+pure-Windows-Python runs will skip them. Tracking: #742.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,11 @@ Hephaestus/
 
 This project uses [Pixi](https://pixi.sh) for environment management, which automatically handles dependencies and creates isolated environments.
 
-> **Platform note:** The pixi developer environment is **Linux-64 only** (see
-> `platforms` in [`pixi.toml`](pixi.toml)). On macOS or Windows, install the
-> published wheel into a plain virtualenv instead — see
-> [From PyPI](#from-pypi) above. The
-> full comparison table (install paths, supported platforms, Python versions)
-> lives in [CONTRIBUTING.md#platform-support](CONTRIBUTING.md#platform-support).
+> **Platform note:** The Pixi developer environment targets `linux-64` and
+> `osx-arm64` (Apple silicon macOS), matching `platforms` in
+> [`pixi.toml`](pixi.toml). `win-64` and `osx-64` are not workspace targets; on
+> Windows or Intel macOS, use the pip/virtualenv development path documented in
+> [CONTRIBUTING.md#platform-support](CONTRIBUTING.md#platform-support).
 
 ### Prerequisites
 
@@ -205,8 +204,9 @@ print(size_str)  # Output: 1.0 MB
 
 Hephaestus is published to PyPI as `homericintelligence-hephaestus`.
 The wheel is pure-Python and installs on Linux, macOS, and Windows
-(see `requires-python` in [`pyproject.toml`](pyproject.toml)). This is
-the supported install path for non-Linux platforms.
+(see `requires-python` in [`pyproject.toml`](pyproject.toml)). It is the portable
+install path on all supported Python platforms, including Windows or Intel
+macOS, which are not targets of this repository's Pixi workspace.
 
 **Using pip:**
 

--- a/tests/unit/validation/test_pixi_platform_documentation.py
+++ b/tests/unit/validation/test_pixi_platform_documentation.py
@@ -1,0 +1,69 @@
+"""Keep Pixi platform documentation aligned with the workspace manifest."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import cast
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PIXI = REPO_ROOT / "pixi.toml"
+README = REPO_ROOT / "README.md"
+CONTRIBUTING = REPO_ROOT / "CONTRIBUTING.md"
+
+EXPECTED_PIXI_PLATFORMS = {"linux-64", "osx-arm64"}
+STALE_PLATFORM_CLAIMS = (
+    "linux-64 only",
+    "`linux-64` only",
+    'platforms = ["linux-64"]',
+    "only supported on linux",
+    "on macos or windows, install the published wheel",
+    "supported install path for non-linux platforms",
+    "pixi tooling is not available there",
+)
+
+
+def _pixi_platforms() -> set[str]:
+    workspace = tomllib.loads(PIXI.read_text(encoding="utf-8"))["workspace"]
+    raw_platforms = workspace["platforms"]
+    assert isinstance(raw_platforms, list)
+    assert all(isinstance(platform, str) for platform in raw_platforms)
+    return set(cast(list[str], raw_platforms))
+
+
+def _assert_declared_platforms_are_documented(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    missing = {platform for platform in _pixi_platforms() if f"`{platform}`" not in text}
+    assert not missing, f"{path.name} omits Pixi platforms: {sorted(missing)}"
+
+
+def test_pixi_manifest_declares_documented_platform_matrix() -> None:
+    """The workspace platforms remain the approved Pixi target matrix."""
+    assert _pixi_platforms() == EXPECTED_PIXI_PLATFORMS
+
+
+def test_readme_platform_guidance_matches_manifest() -> None:
+    """README names every platform declared by the Pixi workspace."""
+    _assert_declared_platforms_are_documented(README)
+
+
+def test_contributing_platform_guidance_matches_manifest() -> None:
+    """CONTRIBUTING names every platform declared by the Pixi workspace."""
+    _assert_declared_platforms_are_documented(CONTRIBUTING)
+
+
+def test_docs_remove_linux_only_claims_and_route_workspace_gaps_to_pip() -> None:
+    """Docs reserve the editable pip fallback for excluded Pixi targets."""
+    for path in (README, CONTRIBUTING):
+        text = path.read_text(encoding="utf-8").lower()
+        stale = {claim for claim in STALE_PLATFORM_CLAIMS if claim in text}
+        assert not stale, f"{path.name} retains stale claims: {sorted(stale)}"
+        assert "windows or intel macos" in text
+
+    contributing = CONTRIBUTING.read_text(encoding="utf-8")
+    assert "pip install -e '.[dev]'" in contributing

--- a/tests/unit/validation/test_readme_platform_support.py
+++ b/tests/unit/validation/test_readme_platform_support.py
@@ -1,8 +1,8 @@
-"""Regression test for README ↔ CONTRIBUTING platform-support cross-reference.
+"""Regression tests for the README ↔ CONTRIBUTING platform-support link.
 
-Issue #767: install/upgrade docs for non-Linux platforms must point readers
-from the README (the first-landed surface) to the canonical comparison table
-in CONTRIBUTING.md. This test guards both halves of that link.
+Issue #767 established CONTRIBUTING.md as the canonical comparison table.
+Issue #2135 moves manifest-parity assertions into
+test_pixi_platform_documentation.py while this file preserves the cross-link.
 """
 
 from __future__ import annotations
@@ -29,24 +29,6 @@ def test_readme_links_to_platform_support_section() -> None:
     """README must cross-link to the CONTRIBUTING Platform Support anchor."""
     text = README.read_text(encoding="utf-8")
     assert PLATFORM_SUPPORT_ANCHOR in text, (
-        f"README.md must link to {PLATFORM_SUPPORT_ANCHOR} so macOS/Windows "
-        "readers find the supported install path before running `pixi install`."
-    )
-
-
-def test_readme_flags_pixi_as_linux_only() -> None:
-    """README must warn that the pixi dev env is Linux-only before `pixi install`."""
-    text = README.read_text(encoding="utf-8")
-    pixi_section_start = text.find("## Getting Started with Pixi")
-    assert pixi_section_start != -1, (
-        "README must contain a '## Getting Started with Pixi' section heading"
-    )
-    pixi_install_pos = text.find("pixi install", pixi_section_start)
-    assert pixi_install_pos != -1, (
-        "README must contain 'pixi install' command in the Getting Started section"
-    )
-    preface = text[pixi_section_start:pixi_install_pos]
-    assert "linux-64" in preface.lower() or "linux only" in preface.lower(), (
-        "README must mention the linux-64 restriction before the first "
-        "`pixi install` command so off-Linux users do not hit a hard failure."
+        f"README.md must link to {PLATFORM_SUPPORT_ANCHOR} so contributors "
+        "can choose the correct Pixi or pip installation path."
     )


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: Docs and manifest-parity tests updated; full Pixi suite passed (6,382 passed, 230 skipped); direct lint/type/Markdown checks pass, while nested pre-commit Pixi hooks remain sandbox-blocked.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2135

Generated by Hephaestus automation
