### PR TITLE
[mino] Retire or isolate legacy pipeline compatibility branches

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -30,6 +30,22 @@ label and live PR head immediately before its one arm request. If it detects an
 arm or conflicting state owned by another process/run, it warns and stops
 processing that item; operators own reconciliation.
 
+## Legacy compatibility inventory and retirement gates
+
+“Compatibility” here means accepting durable GitHub state written before the
+head-bound strict-review pipeline. Comments that cite legacy behavior only as
+algorithm provenance are not compatibility branches.
+
+| Compatibility family | Current containment | Removal gate |
+|---|---|---|
+| `legacy_issue_impl_go_fallback` in `pipeline/seeding.py` | An issue-level implementation-GO may seed an open PR into CI only when the PR does not carry authoritative implementation-NOGO. Each use emits the named warning marker. | After #2055 is deployed, a complete supported-repository seed pass must report zero fallback observations; then remove the issue-label branch and its classifier tests. |
+| `already_implementation_go_pr` and `not_implementation_go` across `routing.py`, `implementation.py`, and `ci.py` | Legacy-GO PRs may receive bounded CI maintenance, but every entry verifies auto-merge is disabled and `merge_wait` stops at `strict_gate_unavailable`. | Remove only after #2055 reconstructs eligibility from head-bound strict-review proof and the supported repositories contain zero open legacy implementation-GO PRs. Remove both route reasons, their stage branches, architecture rows, and tests together. |
+
+The former `pr_review` follow-up mini-states were removed by #2140: queue
+mini-states are not persisted, no current transition produced those states,
+and future post-strict-review follow-up behavior must be introduced as an
+explicit transition owned by the strict-review design.
+
 ## Queue topology
 
 ### Mermaid
@@ -314,7 +330,6 @@ objects are rejected.
 - `prompts/pr_review.py get_comment_difficulty_prompt`
 - `prompts/implementation.py get_impl_resume_feedback_prompt`
 - `prompts/address_review.py get_address_review_prompt`
-- `prompts/follow_up.py get_follow_up_prompt`
 
 **Severity-aware GO gate** (#1856; recovers detail from the orphaned
 `automation-pr-severity-aware-gate-implementation` skill draft, #2067):

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -272,9 +272,23 @@ def classify_issue(facts: IssueFacts) -> Classification:
         if facts.pr_has_implementation_no_go:
             return StageName.PR_REVIEW, f"#{facts.number} open PR awaiting review"
         if _label_at_or_past(state_label, STATE_IMPLEMENTATION_GO):
+            # Legacy compatibility path (#2140): an *issue-level*
+            # IMPLEMENTATION_GO label on an open PR predates the loop-owned
+            # approval model (#2280), where the durable authorization is the
+            # PR-level label handled above (facts.pr_has_implementation_go).
+            # Post-#2280 there is no CI pipeline stage, so the legacy
+            # issue-level GO no longer auto-authorizes a merge — it is treated
+            # as an open PR awaiting review. The warning surfaces the stale
+            # label so it can be retired.
+            LOG.warning(
+                "legacy_issue_impl_go_fallback: issue #%d supplies %s for open PR #%s",
+                facts.number,
+                STATE_IMPLEMENTATION_GO,
+                facts.pr_number,
+            )
             return (
-                StageName.MERGE_WAIT,
-                f"#{facts.number} open PR with {STATE_IMPLEMENTATION_GO}",
+                StageName.PR_REVIEW,
+                f"#{facts.number} open PR with legacy issue-level {STATE_IMPLEMENTATION_GO}",
             )
         # Open PR, no implementation-go → awaiting PR review
         return StageName.PR_REVIEW, f"#{facts.number} open PR awaiting review"

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -6,6 +6,18 @@ label once, asks GitHub to arm auto-merge for the live head, and then polls
 only the arm it created.  It deliberately does not recover, confirm, retry,
 or take over an arm created by another process or run: those operational
 states are warned about and left for an operator.
+
+The implemented mini-state graph is:
+
+- Open PR: ENTER -> ARM -> FINISH_FAIL(``strict_gate_unavailable``) after
+  auto-merge disablement is verified.
+- Already-merged PR: ENTER -> ARM -> POLL -> LEARN_WAIT -> MW_FINISH,
+  preserving the exactly-once post-merge learning contract through
+  ``ctx.github.drive_green_learn_terminal``.
+
+Dirty/blocked recovery and automatic arming are not dormant branches in this
+module. Issue #2055 must introduce those transitions explicitly behind a
+head-bound strict-review proof rather than reviving undocumented legacy state.
 """
 
 from __future__ import annotations

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1,4 +1,4 @@
-"""PR-review stage: review, validate, post, address, evaluate, follow up.
+"""PR-review stage: review, validate, post, address, and evaluate.
 
 Re-houses the fused implementation-review loop from ``_review_phase.py``
 (``_run_impl_review_loop`` :671, ``_evaluate_go_verdict`` :314,
@@ -11,8 +11,8 @@ contract):
 
 - States: ENTER -> REVIEW_WAIT -> VALIDATE_WAIT -> POST -> DIFFICULTY_WAIT
   -> ADDRESS_WAIT -> PUSH_WAIT -> EVAL -> (loop to REVIEW_WAIT) or terminal
-  advance to ``merge_wait``. ``FOLLOWUP_WAIT`` remains only to drain legacy
-  persisted work; a clean GO never enters it.
+  advance to ``merge_wait``. The legacy follow-up mini-states have been
+  retired (#2140); a clean GO advances to ``merge_wait`` from EVAL.
 - Budgets: ``pr_review_iter`` = 3 (soft cap), ``pr_review_hard`` = 6 (hard
   cap; rounds 4-6 are admitted ONLY while the unresolved-thread count
   strictly decreases — the #1554 progress-aware extension, legacy
@@ -95,16 +95,13 @@ contract):
   ``prompts/pr_review.py get_pr_review_analysis_prompt`` /
   ``get_review_validation_prompt`` / ``get_comment_difficulty_prompt``,
   ``prompts/implementation.py get_impl_resume_feedback_prompt`` (fresh-PR
-  address path), ``prompts/address_review.py get_address_review_prompt``
-  (existing-PR address path), ``prompts/follow_up.py get_follow_up_prompt``.
+  address path), and ``prompts/address_review.py get_address_review_prompt``
+  (existing-PR address path).
 - Verdict and structured comments are parsed IN-WORKER (carried as the
   review job's ``parse`` callable; symbol-scoped zero-I/O exemption mirrors
   plan_review's). REVIEW_WAIT clears all stale round-scoped payload at
   submission so a failed later round can never replay an earlier round's
   verdict or threads.
-- Legacy FOLLOWUP_WAIT intentionally stores nothing in ``on_job_done``: the
-  follow-up job's output is a side effect (follow-up issues filed by the
-  agent), not a payload value any later state consumes.
 """
 
 from __future__ import annotations
@@ -119,7 +116,6 @@ from typing import Any, cast
 
 from hephaestus.automation.agent_config import (
     address_review_claude_timeout,
-    follow_up_claude_timeout,
     implementer_claude_timeout,
     implementer_model,
     pr_reviewer_claude_timeout,
@@ -127,7 +123,6 @@ from hephaestus.automation.agent_config import (
 )
 from hephaestus.automation.claude_invoke import parse_review_verdict
 from hephaestus.automation.prompts.address_review import get_address_review_prompt
-from hephaestus.automation.prompts.follow_up import get_follow_up_prompt
 from hephaestus.automation.prompts.implementation import get_impl_resume_feedback_prompt
 from hephaestus.automation.prompts.pr_review import (
     get_comment_difficulty_prompt,
@@ -201,9 +196,6 @@ DIFFICULTY_WAIT = "DIFFICULTY_WAIT"
 ADDRESS_WAIT = "ADDRESS_WAIT"
 PUSH_WAIT = "PUSH_WAIT"
 EVAL = "EVAL"
-FOLLOWUP_WAIT = "FOLLOWUP_WAIT"
-PR_FINISH = "PR_FINISH"
-FINISH = PR_FINISH
 
 _STEP_HANDLER_NAMES: dict[str, str] = {
     ENTER: "_enter",
@@ -215,8 +207,6 @@ _STEP_HANDLER_NAMES: dict[str, str] = {
     ADDRESS_WAIT: "_address",
     PUSH_WAIT: "_push_wait",
     EVAL: "_eval",
-    FOLLOWUP_WAIT: "_followup_wait",
-    PR_FINISH: "_finish",
 }
 
 
@@ -386,10 +376,7 @@ class PrReviewStage(Stage):
       feedback; existing-PR path runs the address-review session.
     - PUSH_WAIT: commit+push the addressing changes.
     - EVAL [M]: re-housed ``_evaluate_go_verdict`` + budget gate (see
-      module docstring).
-    - FOLLOWUP_WAIT (legacy persisted work only): submit the follow-up job,
-      then PR_FINISH -> FINISHED. A clean GO advances to ``merge_wait``
-      from EVAL instead.
+      module docstring). A clean GO advances to ``merge_wait`` from EVAL.
     """
 
     def on_enter(self, item: WorkItem, ctx: StageContext) -> StageOutcome | None:
@@ -669,30 +656,6 @@ class PrReviewStage(Stage):
         )
         return JobRequest(git_job, on_done_state=EVAL)
 
-    def _followup_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Drain a legacy follow-up item without granting merge eligibility."""
-        issue = _issue_number(item)
-        logger.info("pr_review:%d: requesting follow-up job", issue)
-        job = AgentJob(
-            repo=item.repo,
-            issue=issue,
-            agent=agent_provider(ctx),
-            model=stage_model(ctx, "implementer", implementer_model),
-            prompt_builder=get_follow_up_prompt,
-            cwd=_worktree_path(item, ctx),
-            timeout_s=follow_up_claude_timeout(),
-            session_agent=AGENT_IMPLEMENTER,  # resume implementer session (legacy parity)
-            prompt_kwargs={"issue_number": item.issue},
-            descr="follow_up",
-        )
-        return JobRequest(job, on_done_state=PR_FINISH)
-
-    def _finish(self, item: WorkItem, ctx: StageContext) -> StepResult:
-        """Finish a legacy follow-up item after its side-effect job completes."""
-        issue = _issue_number(item)
-        logger.info("pr_review:%d: legacy follow-up completed; advancing to finished", issue)
-        return StageOutcome(Disposition.ADVANCE, "legacy_followup_completed")
-
     def on_job_done(self, item: WorkItem, result: JobResult, ctx: StageContext) -> None:
         """Store job results on the item payload (state is still the WAIT state).
 
@@ -736,9 +699,6 @@ class PrReviewStage(Stage):
             item.payload["difficulty_tiers"] = str(result.value)
         elif item.state == ADDRESS_WAIT and result.value is not None:
             item.payload["address_output"] = str(result.value)
-        # FOLLOWUP_WAIT intentionally has no branch: the follow-up job's
-        # output is a side effect (issues filed by the agent), not a payload
-        # value any later state consumes.
 
     @staticmethod
     def _on_direct_pr_worktree_done(item: WorkItem, result: JobResult) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_finish_state_names.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from hephaestus.automation.pipeline.stages import merge_wait, plan_review, pr_review
 
 
-def test_plan_review_pr_review_and_merge_wait_finish_states_are_distinct() -> None:
-    """Each stage should use a unique finish token in persisted state."""
-    assert len({pr_review.PR_FINISH, plan_review.PLAN_FINISH, merge_wait.MW_FINISH}) == 3
+def test_active_finish_tokens_are_stage_qualified() -> None:
+    """Only stages with active finish states expose their qualified tokens."""
+    assert plan_review.PLAN_FINISH == "PLAN_FINISH"
+    assert merge_wait.MW_FINISH == "MW_FINISH"
+    assert not hasattr(pr_review, "PR_FINISH")
+    assert not hasattr(pr_review, "FINISH")

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -16,7 +16,6 @@ from hephaestus.automation.pipeline.routing import Disposition
 from hephaestus.automation.pipeline.stages import Continue, JobRequest, StageOutcome
 from hephaestus.automation.pipeline.stages.pr_review import (
     ADOPT_WORKTREE_WAIT,
-    PR_FINISH,
     REVIEW_ERROR_RETRY_CAP,
     PrReviewStage,
     _surviving_threads,
@@ -626,22 +625,18 @@ class TestPrReviewStageStep:
 
         assert result == StageOutcome(Disposition.FINISH_FAIL, "pr_head_not_writable")
 
-    def test_followup_wait_requests_follow_up(self, make_ctx: Any, make_work_item: Any) -> None:
-        """Legacy FOLLOWUP_WAIT submits the follow-up job, then finishes."""
+    @pytest.mark.parametrize("state", ["FOLLOWUP_WAIT", "PR_FINISH"])
+    def test_retired_legacy_followup_states_fail_closed(
+        self, state: str, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Retired follow-up states do not regain an active stage handler."""
         stage = PrReviewStage()
         ctx = make_ctx()
-        item = make_work_item(issue=1, pr=1001, state="FOLLOWUP_WAIT")
+        item = make_work_item(issue=1, pr=1001, state=state)
 
         result = stage.step(item, ctx)
 
-        assert isinstance(result, JobRequest)
-        assert result.job.descr == "follow_up"
-        assert result.on_done_state == PR_FINISH
-
-        item.state = PR_FINISH
-        outcome = stage.step(item, ctx)
-        assert isinstance(outcome, StageOutcome)
-        assert outcome.disposition == Disposition.ADVANCE
+        assert result == StageOutcome(Disposition.FINISH_FAIL, f"unknown state: {state}")
 
     def test_unknown_state_fails(self, make_ctx: Any, make_work_item: Any) -> None:
         """An unknown state finishes failed instead of looping silently."""
@@ -1350,19 +1345,6 @@ class TestPrReviewOnJobDone:
         item.state = "PUSH_WAIT"
         stage.on_job_done(item, JobResult(ok=False, error="push rejected"), ctx)
         assert item.payload["address_error"] is True
-
-    def test_followup_result_is_intentionally_silent(
-        self, make_ctx: Any, make_work_item: Any
-    ) -> None:
-        """FOLLOWUP output is a side effect: no payload key is written."""
-        stage = PrReviewStage()
-        ctx = make_ctx()
-        item = make_work_item(issue=1, pr=1001, state="FOLLOWUP_WAIT")
-        snapshot = dict(item.payload)
-
-        stage.on_job_done(item, JobResult(ok=True, value="filed follow-ups"), ctx)
-
-        assert item.payload == snapshot
 
 
 class TestFullWalks:

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -251,7 +251,9 @@ class TestDiscover:
 
         assert isinstance(result, Continue)
         assert github.issue_reads == [8]
-        assert repo_item.payload["products"][0]["stage"] is StageName.MERGE_WAIT
+        # Issue-level implementation-go on an open PR is a legacy compatibility
+        # label (#2140): post-#2280 it routes back to review, not merge_wait.
+        assert repo_item.payload["products"][0]["stage"] is StageName.PR_REVIEW
         assert repo_item.payload["products"][0]["pr"] == 44
 
     def test_discover_failure_finishes_fail(

--- a/tests/unit/automation/pipeline/test_coordinator_shutdown.py
+++ b/tests/unit/automation/pipeline/test_coordinator_shutdown.py
@@ -322,12 +322,16 @@ class TestCrashMatrixJournal:
                 StageName.PR_REVIEW,
             ),
             (
-                "open PR with implementation-go",
+                # Issue-level implementation-go on an open PR is a legacy
+                # compatibility label (#2140): post-#2280 the durable
+                # authorization is the PR-level label, so this routes back to
+                # review rather than arming a merge.
+                "open PR with legacy issue-level implementation-go",
                 [STATE_IMPLEMENTATION_GO],
                 78,
                 None,
                 False,
-                StageName.MERGE_WAIT,
+                StageName.PR_REVIEW,
             ),
             ("merged PR", [], None, 79, False, StageName.FINISHED),
             ("state:skip", [STATE_SKIP], None, None, False, None),

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -107,26 +107,42 @@ class TestClassifyIssue:
         assert stage is StageName.FINISHED
         assert "merged" in reason
 
-    def test_open_pr_with_impl_go_routes_to_merge_wait(self) -> None:
-        """A loop-owned approval label remains sufficient after restart."""
-        stage, reason = classify_issue(
-            _facts(labels={STATE_IMPLEMENTATION_GO}, pr_number=42, pr_is_open=True)
-        )
-        assert stage is StageName.MERGE_WAIT
-        assert "implementation-go" in reason
+    def test_open_pr_with_legacy_issue_impl_go_routes_to_pr_review_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A legacy issue-level implementation-GO on an open PR is compatibility routing.
 
-    def test_open_pr_with_pr_impl_go_routes_to_merge_wait(self) -> None:
-        """PR-level loop approval routes directly to its sole armer."""
-        stage, reason = classify_issue(
-            _facts(
-                labels={STATE_PLAN_GO},
-                pr_number=42,
-                pr_is_open=True,
-                pr_has_implementation_go=True,
+        Post-#2280 the durable authorization is the PR-level label; the older
+        issue-level label no longer auto-authorizes a merge. It is treated as
+        an open PR awaiting review and the fallback is logged so the stale
+        label can be retired (#2140).
+        """
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.pipeline.seeding"):
+            stage, reason = classify_issue(
+                _facts(labels={STATE_IMPLEMENTATION_GO}, pr_number=42, pr_is_open=True)
             )
-        )
+
+        assert stage is StageName.PR_REVIEW
+        assert "legacy issue-level" in reason
+        assert "legacy_issue_impl_go_fallback" in caplog.text
+
+    def test_open_pr_with_pr_impl_go_routes_to_merge_wait(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """PR-level loop approval routes directly to its sole armer, no legacy fallback."""
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.pipeline.seeding"):
+            stage, reason = classify_issue(
+                _facts(
+                    labels={STATE_PLAN_GO},
+                    pr_number=42,
+                    pr_is_open=True,
+                    pr_has_implementation_go=True,
+                )
+            )
         assert stage is StageName.MERGE_WAIT
         assert "implementation-go" in reason
+        assert "legacy issue-level" not in reason
+        assert "legacy_issue_impl_go_fallback" not in caplog.text
 
     def test_open_pr_without_impl_go_routes_to_pr_review(self) -> None:
         """Open PR without implementation-go awaits PR review."""
@@ -137,11 +153,35 @@ class TestClassifyIssue:
         assert "review" in reason
 
     def test_open_pr_with_impl_no_go_routes_to_pr_review(self) -> None:
-        """Open PR + state:implementation-no-go re-enters the review cycle."""
-        stage, _reason = classify_issue(
+        """Open PR + issue-level state:implementation-no-go re-enters the review cycle."""
+        stage, reason = classify_issue(
             _facts(labels={STATE_IMPLEMENTATION_NO_GO}, pr_number=42, pr_is_open=True)
         )
         assert stage is StageName.PR_REVIEW
+        assert "review" in reason
+
+    def test_pr_impl_no_go_overrides_issue_level_impl_go(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Authoritative PR no-GO prevents the legacy issue fallback from routing away.
+
+        A pre-PR-label issue snapshot may still carry implementation-GO, but a
+        PR-level no-GO is authoritative and must return the PR to review
+        without emitting the compatibility-fallback observation.
+        """
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.pipeline.seeding"):
+            stage, reason = classify_issue(
+                _facts(
+                    labels={STATE_IMPLEMENTATION_GO},
+                    pr_number=42,
+                    pr_is_open=True,
+                    pr_has_implementation_no_go=True,
+                )
+            )
+
+        assert stage is StageName.PR_REVIEW
+        assert "awaiting review" in reason
+        assert "legacy_issue_impl_go_fallback" not in caplog.text
 
     def test_no_pr_at_plan_go_routes_to_implementation(self) -> None:
         """No PR, at-or-past state:plan-go → ready for implementation."""

--- a/tests/unit/docs/test_pipeline_compatibility_retirement.py
+++ b/tests/unit/docs/test_pipeline_compatibility_retirement.py
@@ -1,0 +1,28 @@
+"""Regression tests for pipeline compatibility retirement documentation."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+ARCHITECTURE = ROOT / "docs" / "AUTOMATION_LOOP_ARCHITECTURE.md"
+PR_REVIEW = ROOT / "hephaestus" / "automation" / "pipeline" / "stages" / "pr_review.py"
+
+
+def test_retained_pipeline_compatibility_has_removal_gates() -> None:
+    """Retained compatibility branches must have observable retirement criteria."""
+    text = ARCHITECTURE.read_text(encoding="utf-8")
+
+    assert "## Legacy compatibility inventory and retirement gates" in text
+    assert "`legacy_issue_impl_go_fallback`" in text
+    assert "`already_implementation_go_pr`" in text
+    assert "`not_implementation_go`" in text
+    assert "#2055" in text
+    assert "zero fallback observations" in text
+    assert "zero open legacy implementation-GO PRs" in text
+
+
+def test_retired_followup_mini_states_are_absent_from_active_stage() -> None:
+    """The active PR-review stage must not retain unreachable follow-up states."""
+    source = PR_REVIEW.read_text(encoding="utf-8")
+
+    assert "FOLLOWUP_WAIT" not in source
+    assert "PR_FINISH" not in source


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: Retired unreachable PR-review states, documented/instrumented retained compatibility gates, and added regression coverage; full suite passed (6,381 passed, 230 skipped, 85.26% coverage), focused suite passed (210), Ruff/format/mypy passed; pre-commit was blocked only by unavailable GitHub DNS.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2140

Generated by Hephaestus automation
