### PR TITLE
[mino] Decompose PR commit orchestration

### DIFF
--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -74,7 +74,7 @@ SECRET_FILE_EXTENSIONS: frozenset[str] = frozenset({".key", ".pem", ".pfx", ".p1
 # is intentionally excluded because this call does not request ignored paths.
 _PORCELAIN_STATUS_PAIRS: frozenset[str] = frozenset(
     {"D ", "DD", "AU", "UD", "UA", "DU", "AA", "UU", "??"}
-    | {f" {worktree_status}" for worktree_status in "AMDRC"}
+    | {f" {worktree_status}" for worktree_status in "AMDTRC"}
     | {f"{index_status}{worktree_status}" for index_status in "MTARC" for worktree_status in " MTD"}
 )
 

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -70,6 +70,14 @@ SECRET_FILE_NAMES: frozenset[str] = frozenset(
 # File extensions whose presence indicates a cryptographic key or certificate.
 SECRET_FILE_EXTENSIONS: frozenset[str] = frozenset({".key", ".pem", ".pfx", ".p12"})
 
+# Valid ``git status --porcelain=v1`` status pairs for this command. ``!!``
+# is intentionally excluded because this call does not request ignored paths.
+_PORCELAIN_STATUS_PAIRS: frozenset[str] = frozenset(
+    {"D ", "DD", "AU", "UD", "UA", "DU", "AA", "UU", "??"}
+    | {f" {worktree_status}" for worktree_status in "AMDRC"}
+    | {f"{index_status}{worktree_status}" for index_status in "MTARC" for worktree_status in " MTD"}
+)
+
 _RESERVED_MESSAGE_LINE = re.compile(
     r"^\s*(?:Closes\s+#\d+|Implemented-By:|Co-Authored-By:)",
     re.IGNORECASE,
@@ -158,6 +166,14 @@ class _CommitMessageParts:
 
     subject: str
     body: str
+
+
+@dataclass(frozen=True)
+class _CommitPaths:
+    """Paths classified for ordinary and index-update staging."""
+
+    add_paths: tuple[str, ...]
+    update_paths: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -724,6 +740,118 @@ def enable_auto_merge_after_implementation_go(pr_number: int) -> None:
     )
 
 
+def _read_porcelain_status(worktree_path: Path, git_timeout: int | None) -> str:
+    """Return stable, NUL-delimited porcelain-v1 worktree status."""
+    try:
+        result = run(
+            ["git", "status", "--porcelain=v1", "-z"],
+            cwd=worktree_path,
+            capture_output=True,
+            **_git_timeout_kw(git_timeout),
+        )
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("Could not decode git status --porcelain=v1 -z output") from exc
+    return result.stdout or ""
+
+
+def _parse_porcelain_status(output: str) -> tuple[tuple[str, str], ...]:
+    """Return ``(status, target_path)`` entries from porcelain-v1 ``-z`` output."""
+    if not output:
+        return ()
+    if not output.endswith("\0"):
+        raise RuntimeError("Malformed git status --porcelain=v1 -z output")
+
+    records = output[:-1].split("\0")
+    if any(not record for record in records):
+        raise RuntimeError("Malformed git status --porcelain=v1 -z output")
+
+    entries: list[tuple[str, str]] = []
+    index = 0
+
+    while index < len(records):
+        record = records[index]
+        if len(record) < 4 or record[2] != " " or not record[3:]:
+            raise RuntimeError("Malformed git status --porcelain=v1 -z output")
+
+        status = record[:2]
+        if status not in _PORCELAIN_STATUS_PAIRS:
+            raise RuntimeError("Malformed git status --porcelain=v1 -z output")
+        entries.append((status, record[3:]))
+        index += 1
+
+        if "R" in status or "C" in status:
+            if index >= len(records):
+                raise RuntimeError("Malformed renamed path in git porcelain output")
+            index += 1
+
+    return tuple(entries)
+
+
+def _is_secret_path(path: str) -> bool:
+    """Return whether a repository-relative path matches secret-file policy."""
+    filename = Path(path).name
+    return filename in SECRET_FILE_NAMES or any(
+        filename.endswith(extension) for extension in SECRET_FILE_EXTENSIONS
+    )
+
+
+def _select_commit_paths(
+    entries: Collection[tuple[str, str]],
+    allowed_paths: Collection[str] | None,
+) -> _CommitPaths:
+    """Apply exact allowlist and secret policy to parsed status entries."""
+    allowed = set(allowed_paths) if allowed_paths is not None else None
+    add_paths: list[str] = []
+    update_paths: list[str] = []
+
+    for status, path in entries:
+        if allowed is not None and path not in allowed:
+            logger.debug("Skipping non-allowlisted file: %s", path)
+            continue
+        if _is_secret_path(path):
+            logger.warning("Skipping potential secret file: %s", path)
+            continue
+        if "D" in status:
+            update_paths.append(path)
+        else:
+            add_paths.append(path)
+
+    return _CommitPaths(tuple(add_paths), tuple(update_paths))
+
+
+def _stage_commit_paths(
+    paths: _CommitPaths,
+    worktree_path: Path,
+    git_timeout: int | None,
+) -> None:
+    """Stage selected paths without broad or implicit pathspecs."""
+    if paths.update_paths:
+        run(
+            ["git", "add", "-u", "--", *paths.update_paths],
+            cwd=worktree_path,
+            **_git_timeout_kw(git_timeout),
+        )
+    if paths.add_paths:
+        run(
+            ["git", "add", "--", *paths.add_paths],
+            cwd=worktree_path,
+            **_git_timeout_kw(git_timeout),
+        )
+
+
+def _commit_with_signature(
+    commit_message: str,
+    worktree_path: Path,
+    git_timeout: int | None,
+) -> None:
+    """Create the repository-policy signed and DCO-signed commit."""
+    run(
+        ["git", "commit", "-S", "-s", "-m", commit_message],
+        cwd=worktree_path,
+        **_git_timeout_kw(git_timeout),
+    )
+
+
 def commit_changes(
     issue_number: int,
     worktree_path: Path,
@@ -749,88 +877,25 @@ def commit_changes(
         RuntimeError: If there are no changes, or all changes are secret files.
 
     """
-    # Check if there are changes
-    result = run(
-        ["git", "status", "--porcelain"],
-        cwd=worktree_path,
-        capture_output=True,
-        **_git_timeout_kw(git_timeout),
-    )
-
-    if not result.stdout.strip():
+    porcelain = _read_porcelain_status(worktree_path, git_timeout)
+    if not porcelain:
         raise RuntimeError(
             f"No changes to commit for issue {issue_ref(issue_number)}. "
             "Check if the implementation was successful or if the plan needs revision."
         )
 
-    # Parse git status --porcelain output to get all changed files
-    # Format: XY filename or XY "quoted filename" for special chars
-    # X = index status, Y = worktree status
-    # Common codes: M (modified), A (added), D (deleted), R (renamed), ?? (untracked)
-    files_to_add = []
-    files_to_update = []
-    allowed_path_set = set(allowed_paths) if allowed_paths is not None else None
-
-    for line in result.stdout.splitlines():
-        if not line:
-            continue
-
-        # Parse status code and filename
-        # Format: "XY filename" where X and Y are status codes
-        # Position 0-1: status codes, position 2: space, position 3+: filename
-        status = line[:2]
-        filename_part = line[3:]  # Don't strip - filename starts at position 3
-
-        # Handle renamed files (format: "old -> new")
-        if status.startswith("R") and " -> " in filename_part:
-            filename_part = filename_part.split(" -> ", 1)[1]
-
-        # Handle quoted filenames (git quotes names with special chars)
-        if filename_part.startswith('"') and filename_part.endswith('"'):
-            # Remove quotes - git uses C-style escaping
-            filename_part = filename_part[1:-1]
-
-        if allowed_path_set is not None and filename_part not in allowed_path_set:
-            logger.debug("Skipping non-allowlisted file: %s", filename_part)
-            continue
-
-        # Check if file is a potential secret
-        filename = Path(filename_part).name
-
-        # Skip secret files (never stage these)
-        has_secret_ext = any(filename.endswith(ext) for ext in SECRET_FILE_EXTENSIONS)
-        if filename in SECRET_FILE_NAMES or has_secret_ext:
-            logger.warning("Skipping potential secret file: %s", filename_part)
-            continue
-
-        if "D" in status:
-            files_to_update.append(filename_part)
-        else:
-            files_to_add.append(filename_part)
-
-    if not files_to_add and not files_to_update:
+    paths = _select_commit_paths(_parse_porcelain_status(porcelain), allowed_paths)
+    if not paths.add_paths and not paths.update_paths:
         raise RuntimeError(
             f"No non-secret files to commit for issue {issue_ref(issue_number)}. "
             "All changes appear to be secret files."
         )
 
-    # Stage the files
-    if files_to_update:
-        run(
-            ["git", "add", "-u", "--", *files_to_update],
-            cwd=worktree_path,
-            **_git_timeout_kw(git_timeout),
-        )
-    if files_to_add:
-        run(
-            ["git", "add", "--", *files_to_add],
-            cwd=worktree_path,
-            **_git_timeout_kw(git_timeout),
-        )
+    _stage_commit_paths(paths, worktree_path, git_timeout)
 
     # Generate commit message
     issue = fetch_issue_info(issue_number)
-    commit_msg = _generate_commit_message(
+    commit_message = _generate_commit_message(
         issue_number=issue_number,
         issue_title=issue.title,
         issue_body=_issue_body(issue),
@@ -844,12 +909,7 @@ def commit_changes(
     # may have set, so the commit inherits the operator's verifiable identity (#2110).
     _clear_local_committer_identity(worktree_path, git_timeout)
 
-    # Commit with cryptographic signature and DCO sign-off — required by repo policy.
-    run(
-        ["git", "commit", "-S", "-s", "-m", commit_msg],
-        cwd=worktree_path,
-        **_git_timeout_kw(git_timeout),
-    )
+    _commit_with_signature(commit_message, worktree_path, git_timeout)
 
 
 def ensure_pr_created(

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -23,6 +23,11 @@ def _status(stdout: str = "", returncode: int = 0) -> MagicMock:
     return MagicMock(stdout=stdout, returncode=returncode)
 
 
+def _porcelain(*records: str) -> str:
+    """Build mocked ``git status --porcelain=v1 -z`` output."""
+    return "\0".join(records) + ("\0" if records else "")
+
+
 class TestCommitChanges:
     """Tests for commit changes."""
 
@@ -32,13 +37,13 @@ class TestCommitChanges:
                 pr_manager.commit_changes(1, Path("/tmp/wt"))
 
     def test_only_secret_files_raises(self) -> None:
-        porcelain = "?? .env\n?? id_rsa\n M secrets/foo.key\n"
+        porcelain = _porcelain("?? .env", "?? id_rsa", " M secrets/foo.key")
         with patch.object(pr_manager, "run", return_value=_status(porcelain)):
             with pytest.raises(RuntimeError, match="All changes appear to be secret"):
                 pr_manager.commit_changes(2, Path("/tmp/wt"))
 
     def test_filters_secrets_and_commits(self) -> None:
-        porcelain = " M src/foo.py\n?? .env\n?? data.key\n M src/bar.py\n"
+        porcelain = _porcelain(" M src/foo.py", "?? .env", "?? data.key", " M src/bar.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -66,7 +71,7 @@ class TestCommitChanges:
         assert "data.key" not in add_call
 
     def test_allowed_paths_prevent_staging_unlisted_artifacts(self) -> None:
-        porcelain = " M hephaestus/automation/ci_driver.py\n?? output.log\n"
+        porcelain = _porcelain(" M hephaestus/automation/ci_driver.py", "?? output.log")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -99,7 +104,7 @@ class TestCommitChanges:
         ]
 
     def test_commit_uses_cryptographic_signature_and_dco_signoff(self) -> None:
-        porcelain = " M src/foo.py\n"
+        porcelain = _porcelain(" M src/foo.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -124,7 +129,7 @@ class TestCommitChanges:
         assert "-m" in commit_cmd
 
     def test_commit_changes_threads_git_timeout(self) -> None:
-        porcelain = " M src/foo.py\n"
+        porcelain = _porcelain(" M src/foo.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -155,7 +160,7 @@ class TestCommitChanges:
         ]
 
     def test_handles_renamed_files(self) -> None:
-        porcelain = "R  old.py -> new.py\n"
+        porcelain = _porcelain("R  new.py", "old.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),
@@ -178,7 +183,7 @@ class TestCommitChanges:
         assert "new.py" in add_call
 
     def test_stages_deleted_files_without_pathspec(self) -> None:
-        porcelain = " D hephaestus/github/fleet_sync.py\n"
+        porcelain = _porcelain(" D hephaestus/github/fleet_sync.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),
@@ -202,7 +207,7 @@ class TestCommitChanges:
         assert add_call == ["git", "add", "-u", "--", "hephaestus/github/fleet_sync.py"]
 
     def test_uses_message_agent_for_commit_subject_and_body(self) -> None:
-        porcelain = " M LICENSE\n M NOTICE\n"
+        porcelain = _porcelain(" M LICENSE", " M NOTICE")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -240,7 +245,7 @@ class TestCommitChanges:
         assert "Co-Authored-By: Codex <noreply@openai.com>" in commit_msg
 
     def test_commit_message_agent_invalid_output_falls_back(self) -> None:
-        porcelain = " M src/feature.py\n"
+        porcelain = _porcelain(" M src/feature.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -268,7 +273,7 @@ class TestCommitChanges:
     def test_commit_clears_local_committer_identity(self) -> None:
         run_mock = MagicMock(
             side_effect=[
-                _status(" M src/foo.py\n"),  # git status
+                _status(_porcelain(" M src/foo.py")),  # git status
                 _status(""),  # git add
                 _status("M\tsrc/foo.py\n"),  # changed files context
                 _status(" src/foo.py | 1 +\n"),  # stat context
@@ -740,7 +745,7 @@ class TestCoAuthorLine:
     """commit_changes emits a human Co-Authored-By and a separate Implemented-By trailer (#717)."""
 
     def test_claude_coauthor_is_human_name_not_model_id(self) -> None:
-        porcelain = " M src/feature.py\n"
+        porcelain = _porcelain(" M src/feature.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -772,7 +777,7 @@ class TestCoAuthorLine:
         assert "claude-test-model-9" not in coauthor_line
 
     def test_claude_implemented_by_carries_model_id(self) -> None:
-        porcelain = " M src/feature.py\n"
+        porcelain = _porcelain(" M src/feature.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -799,7 +804,7 @@ class TestCoAuthorLine:
 
     def test_implemented_by_reflects_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HEPH_IMPLEMENTER_MODEL", "claude-env-override-5")
-        porcelain = " M foo.py\n"
+        porcelain = _porcelain(" M foo.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -830,7 +835,7 @@ class TestCoAuthorLine:
         assert coauthor_line == "Co-Authored-By: Claude Code <noreply@anthropic.com>"
 
     def test_codex_coauthor_is_codex_human_name(self) -> None:
-        porcelain = " M foo.py\n"
+        porcelain = _porcelain(" M foo.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status
@@ -862,7 +867,7 @@ class TestCoAuthorLine:
         mock_model.assert_not_called()
 
     def test_pi_coauthor_and_provenance_are_pi(self) -> None:
-        porcelain = " M foo.py\n"
+        porcelain = _porcelain(" M foo.py")
         run_mock = MagicMock(
             side_effect=[
                 _status(porcelain),  # git status

--- a/tests/unit/automation/test_pr_manager_commit.py
+++ b/tests/unit/automation/test_pr_manager_commit.py
@@ -1,0 +1,154 @@
+"""Focused tests for commit orchestration helpers in ``pr_manager``."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from hephaestus.automation import pr_manager
+
+
+def _status(stdout: str = "") -> MagicMock:
+    """Build a mocked completed subprocess result."""
+    return MagicMock(stdout=stdout)
+
+
+class TestReadPorcelainStatus:
+    """Tests for reading stable worktree status."""
+
+    def test_requests_nul_delimited_porcelain_v1(self) -> None:
+        worktree_path = Path("/tmp/worktree")
+        with patch.object(pr_manager, "run", return_value=_status("?? file.py\0")) as run_mock:
+            status = pr_manager._read_porcelain_status(worktree_path, git_timeout=17)
+
+        assert status == "?? file.py\0"
+        run_mock.assert_called_once_with(
+            ["git", "status", "--porcelain=v1", "-z"],
+            cwd=worktree_path,
+            capture_output=True,
+            timeout=17,
+        )
+
+    def test_rejects_undecodable_status_output(self) -> None:
+        decode_error = UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        with patch.object(pr_manager, "run", side_effect=decode_error):
+            with pytest.raises(RuntimeError, match="Could not decode"):
+                pr_manager._read_porcelain_status(Path("/tmp/worktree"), git_timeout=None)
+
+
+class TestParsePorcelainStatus:
+    """Tests for NUL-delimited porcelain-v1 parsing."""
+
+    @pytest.mark.parametrize(
+        ("porcelain", "expected_path"),
+        [
+            ('?? src/quote"name.py\0', 'src/quote"name.py'),
+            ("?? src/back\\slash.py\0", "src/back\\slash.py"),
+            ("?? src/tab\tname.py\0", "src/tab\tname.py"),
+            ("?? src/line\nbreak.py\0", "src/line\nbreak.py"),
+            ("?? docs/café.md\0", "docs/café.md"),
+        ],
+    )
+    def test_preserves_literal_paths(self, porcelain: str, expected_path: str) -> None:
+        assert pr_manager._parse_porcelain_status(porcelain) == (("??", expected_path),)
+
+    def test_uses_rename_destination_and_consumes_source(self) -> None:
+        porcelain = 'R  dst/quote"name.py\0src/back\\slash.py\0'
+
+        assert pr_manager._parse_porcelain_status(porcelain) == (("R ", 'dst/quote"name.py'),)
+
+    @pytest.mark.parametrize("status", (" A", " T", " R", " C", "UA", "AA"))
+    def test_accepts_documented_status_pairs(self, status: str) -> None:
+        records = [f"{status} valid-path.py"]
+        if "R" in status or "C" in status:
+            records.append("source-path.py")
+
+        assert pr_manager._parse_porcelain_status("\0".join(records) + "\0") == (
+            (status, "valid-path.py"),
+        )
+
+    @pytest.mark.parametrize(
+        "porcelain",
+        [
+            "?? missing-terminator.py",
+            "? malformed.py\0",
+            "?? \0",
+            "R  destination.py\0",
+            "\0?? accepted-after-empty.py\0",
+            "?? first.py\0\0",
+            "ZZ invalid-status.py\0",
+            "R? invalid-status-combination.py\0source.py\0",
+        ],
+    )
+    def test_rejects_malformed_records(self, porcelain: str) -> None:
+        with pytest.raises(RuntimeError, match="Malformed"):
+            pr_manager._parse_porcelain_status(porcelain)
+
+
+class TestSelectCommitPaths:
+    """Tests for applying staging policy to parsed paths."""
+
+    def test_filters_secrets_and_unallowlisted_paths(self) -> None:
+        entries = (
+            (" M", "src/keep.py"),
+            ("??", ".env"),
+            (" D", "src/delete.py"),
+            ("??", "scratch.log"),
+            ("??", "credentials.json"),
+        )
+
+        paths = pr_manager._select_commit_paths(
+            entries,
+            allowed_paths=("src/keep.py", ".env", "src/delete.py", "credentials.json"),
+        )
+
+        assert paths == pr_manager._CommitPaths(
+            add_paths=("src/keep.py",),
+            update_paths=("src/delete.py",),
+        )
+        with pytest.raises(FrozenInstanceError):
+            paths.add_paths = ()  # type: ignore[misc]
+
+
+class TestStageCommitPaths:
+    """Tests for staging selected paths."""
+
+    def test_stages_deleted_paths_before_regular_paths_with_timeout(self) -> None:
+        paths = pr_manager._CommitPaths(
+            add_paths=("src/add.py", 'src/quote"name.py'),
+            update_paths=("src/delete.py",),
+        )
+        worktree_path = Path("/tmp/worktree")
+        with patch.object(pr_manager, "run") as run_mock:
+            pr_manager._stage_commit_paths(paths, worktree_path, git_timeout=19)
+
+        assert run_mock.call_args_list == [
+            call(
+                ["git", "add", "-u", "--", "src/delete.py"],
+                cwd=worktree_path,
+                timeout=19,
+            ),
+            call(
+                ["git", "add", "--", "src/add.py", 'src/quote"name.py'],
+                cwd=worktree_path,
+                timeout=19,
+            ),
+        ]
+
+
+class TestCommitWithSignature:
+    """Tests for the final repository-policy commit command."""
+
+    def test_signs_and_signs_off_commit_with_timeout(self) -> None:
+        worktree_path = Path("/tmp/worktree")
+        with patch.object(pr_manager, "run") as run_mock:
+            pr_manager._commit_with_signature("refactor: split commit helper", worktree_path, 23)
+
+        run_mock.assert_called_once_with(
+            ["git", "commit", "-S", "-s", "-m", "refactor: split commit helper"],
+            cwd=worktree_path,
+            timeout=23,
+        )


### PR DESCRIPTION
## Summary

`commit_changes` uses focused NUL-porcelain parsing, filtering, staging, message, identity, and signing helpers. The parser now accepts Git's valid worktree-only type-change status (`" T"`) while continuing to reject malformed or unsupported status pairs.

## Testing

- `pixi run pytest --no-cov tests/unit/automation/test_pr_manager_commit.py tests/unit/automation/test_pr_manager.py -q`
- `pixi run mypy`

## Closes

Closes #2142
Refs #2228
