### PR TITLE
[majo] Split review-phase orchestration into cohesive units

### DIFF
--- a/hephaestus/automation/_review_conflict_resolver.py
+++ b/hephaestus/automation/_review_conflict_resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -18,6 +19,8 @@ from .git_utils import (
     rebase_worktree_onto,
     sync_worktree_to_remote_branch,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -72,7 +75,8 @@ def build_conflict_resolution_operations(
             payload = json.loads(result.stdout or "{}")
             if not isinstance(payload, dict):
                 return "", ""
-        except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError):
+        except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch %s merge state: %s", pr_ref(pr_number), exc)
             return "", ""
         return (
             str(payload.get("mergeStateStatus") or "").upper(),
@@ -96,7 +100,8 @@ def build_conflict_resolution_operations(
             if not isinstance(payload, dict):
                 return "main"
             return str(payload.get("baseRefName") or "main")
-        except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError):
+        except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+            logger.debug("Could not fetch %s base branch: %s", pr_ref(pr_number), exc)
             return "main"
 
     return ConflictResolutionOperations(

--- a/hephaestus/automation/_review_conflict_resolver.py
+++ b/hephaestus/automation/_review_conflict_resolver.py
@@ -1,0 +1,222 @@
+"""Resolve an implementation PR's merge conflict before review begins."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hephaestus.github.client import gh_call
+
+from .git_utils import (
+    get_repo_info,
+    issue_ref,
+    pr_ref,
+    rebase_worktree_onto,
+    sync_worktree_to_remote_branch,
+)
+
+
+@dataclass(frozen=True)
+class ConflictResolutionRequest:
+    """Immutable context required to resolve a PR before it is reviewed."""
+
+    issue_number: int
+    pr_number: int
+    worktree_path: Path
+    branch_name: str
+    slot_id: int | None
+    thread_id: int | None
+
+
+@dataclass(frozen=True)
+class ConflictResolutionOperations:
+    """GitHub and Git operations used by :class:`ReviewConflictResolver`."""
+
+    merge_state: Callable[[int], tuple[str, str]]
+    base_branch: Callable[[int], str]
+    sync_worktree: Callable[[Path, str], None]
+    rebase_worktree: Callable[[Path, str], bool]
+
+
+def build_conflict_resolution_operations(
+    repo_root: Path,
+    *,
+    github_call: Callable[..., Any] = gh_call,
+    repo_info: Callable[[Path], tuple[str, str]] = get_repo_info,
+    sync_worktree: Callable[[Path, str], None] = sync_worktree_to_remote_branch,
+    rebase_worktree: Callable[[Path, str], bool] = rebase_worktree_onto,
+) -> ConflictResolutionOperations:
+    """Bind production GitHub and Git helpers behind narrow effect callbacks."""
+
+    def _repo_name_with_owner() -> str:
+        owner, repo = repo_info(repo_root)
+        return f"{owner}/{repo}"
+
+    def _merge_state(pr_number: int) -> tuple[str, str]:
+        try:
+            result = github_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--repo",
+                    _repo_name_with_owner(),
+                    "--json",
+                    "mergeStateStatus,mergeable",
+                ]
+            )
+            payload = json.loads(result.stdout or "{}")
+            if not isinstance(payload, dict):
+                return "", ""
+        except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError):
+            return "", ""
+        return (
+            str(payload.get("mergeStateStatus") or "").upper(),
+            str(payload.get("mergeable") or "").upper(),
+        )
+
+    def _base_branch(pr_number: int) -> str:
+        try:
+            result = github_call(
+                [
+                    "pr",
+                    "view",
+                    str(pr_number),
+                    "--repo",
+                    _repo_name_with_owner(),
+                    "--json",
+                    "baseRefName",
+                ]
+            )
+            payload = json.loads(result.stdout or "{}")
+            if not isinstance(payload, dict):
+                return "main"
+            return str(payload.get("baseRefName") or "main")
+        except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError):
+            return "main"
+
+    return ConflictResolutionOperations(
+        merge_state=_merge_state,
+        base_branch=_base_branch,
+        sync_worktree=sync_worktree,
+        rebase_worktree=rebase_worktree,
+    )
+
+
+class ReviewConflictResolver:
+    """Coordinate merge-conflict resolution through injected collaborators."""
+
+    def __init__(
+        self,
+        *,
+        dry_run: Callable[[], bool],
+        operations: ConflictResolutionOperations,
+        resume_implementation: Callable[[str], bool],
+        commit_changes: Callable[[], bool],
+        push_rebased_branch: Callable[[str, Path], None],
+        push_agent_branch: Callable[[str, Path], None],
+        log: Callable[[str, str, int | None], None],
+        update_slot: Callable[[int, str], None],
+    ) -> None:
+        """Store the explicit effects owned by the review-phase facade."""
+        self._dry_run = dry_run
+        self._operations = operations
+        self._resume_implementation = resume_implementation
+        self._commit_changes = commit_changes
+        self._push_rebased_branch = push_rebased_branch
+        self._push_agent_branch = push_agent_branch
+        self._log = log
+        self._update_slot = update_slot
+
+    def resolve(self, request: ConflictResolutionRequest) -> bool:
+        """Return whether the PR is safe to send to the review loop.
+
+        An unreadable initial GitHub state is fail-open so a transient read
+        failure does not strand a healthy PR.  Once a conflict is confirmed,
+        final readback is fail-closed.
+        """
+        if self._dry_run():
+            return True
+        if not self._is_conflicting(*self._operations.merge_state(request.pr_number)):
+            return True
+        self._report_conflict(request)
+        base_branch = self._operations.base_branch(request.pr_number)
+        if self._attempt_mechanical_resolution(request, base_branch):
+            return True
+        return self._attempt_agent_resolution(request, base_branch)
+
+    def _report_conflict(self, request: ConflictResolutionRequest) -> None:
+        """Publish the existing issue/PR context before mutation begins."""
+        self._log(
+            "warning",
+            f"issue #{request.issue_number}: PR #{request.pr_number} has a "
+            "merge conflict before review; resolving it first",
+            request.thread_id,
+        )
+        if request.slot_id is not None:
+            self._update_slot(request.slot_id, f"PR #{request.pr_number}: resolving merge conflict")
+
+    def _attempt_mechanical_resolution(
+        self,
+        request: ConflictResolutionRequest,
+        base_branch: str,
+    ) -> bool:
+        """Try the inexpensive rebase path before consuming an agent session."""
+        try:
+            self._operations.sync_worktree(request.worktree_path, request.branch_name)
+            if not self._operations.rebase_worktree(request.worktree_path, base_branch):
+                return False
+            self._push_rebased_branch(request.branch_name, request.worktree_path)
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            self._log(
+                "warning",
+                f"{pr_ref(request.pr_number)} mechanical rebase failed: {exc}",
+                request.thread_id,
+            )
+            return False
+        return not self._is_conflicting(*self._operations.merge_state(request.pr_number))
+
+    def _attempt_agent_resolution(
+        self,
+        request: ConflictResolutionRequest,
+        base_branch: str,
+    ) -> bool:
+        """Ask the implementer to resolve a confirmed remaining conflict."""
+        feedback = self._agent_feedback(base_branch)
+        try:
+            if self._resume_implementation(feedback) and self._commit_changes():
+                self._push_agent_branch(request.branch_name, request.worktree_path)
+        except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+            self._log(
+                "warning",
+                f"{pr_ref(request.pr_number)} agent resolution failed: {exc}",
+                request.thread_id,
+            )
+            return False
+        if not self._is_conflicting(*self._operations.merge_state(request.pr_number)):
+            return True
+        self._log(
+            "warning",
+            f"issue {issue_ref(request.issue_number)}: {pr_ref(request.pr_number)} still has an "
+            "unresolved merge conflict after resolution; skipping review",
+            request.thread_id,
+        )
+        return False
+
+    @staticmethod
+    def _agent_feedback(base_branch: str) -> str:
+        """Describe the exact merge-conflict action for the implementer session."""
+        return (
+            f"This PR has a MERGE CONFLICT with `origin/{base_branch}` and cannot merge. "
+            "Rebase the PR head branch onto the base branch, preserve both the PR intent "
+            "and the latest base changes, then commit the resolution."
+        )
+
+    @staticmethod
+    def _is_conflicting(merge_state: str, mergeable: str) -> bool:
+        """Return whether either GitHub merge-state field confirms a conflict."""
+        return merge_state in {"DIRTY", "CONFLICTING"} or mergeable == "CONFLICTING"

--- a/hephaestus/automation/_review_loop.py
+++ b/hephaestus/automation/_review_loop.py
@@ -1,0 +1,185 @@
+"""Pure state machine for the bounded implementation-review loop.
+
+The compatibility facade in :mod:`hephaestus.automation._review_phase` binds
+the side-effecting review, address, status, and finalization operations.  This
+module owns only the state transitions and therefore remains straightforward to
+exercise without GitHub, Git, agents, or persisted stage state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ReviewLoopState:
+    """State supplied to one review or address operation."""
+
+    iteration: int
+    prior_review: str | None = None
+    prior_addressed_threads: tuple[dict[str, Any], ...] = ()
+    reopened_keys: frozenset[str] = frozenset()
+    pending_unaddressed: tuple[dict[str, Any], ...] = ()
+
+
+@dataclass(frozen=True)
+class ReviewIterationOutcome:
+    """The side-effecting review operation's typed result."""
+
+    verdict: str | None
+    grade: str | None
+    review_text: str
+    posted_thread_ids: tuple[str, ...]
+    go_blocked_by_automation: bool
+    reopened: tuple[str, ...]
+    should_break: bool
+    reopened_keys: frozenset[str]
+    validator_clean: bool
+
+
+@dataclass(frozen=True)
+class AddressOutcome:
+    """The side-effecting address operation's typed result."""
+
+    prior_addressed_threads: tuple[dict[str, Any], ...]
+    addressed: bool
+
+
+@dataclass(frozen=True)
+class ReviewLoopResult:
+    """Terminal outcome returned to the review-phase compatibility facade."""
+
+    iterations_run: int
+    verdict: str | None
+    grade: str | None
+
+
+@dataclass(frozen=True)
+class ReviewLoopOperations:
+    """Effects invoked by :class:`ReviewLoopCoordinator` at explicit seams."""
+
+    resolve_conflict: Callable[[], bool]
+    review_iteration: Callable[[ReviewLoopState], ReviewIterationOutcome]
+    address_iteration: Callable[[ReviewLoopState], AddressOutcome]
+    finalize: Callable[[ReviewLoopResult], None]
+    budget_extended: Callable[[int], None]
+
+
+class ReviewLoopCoordinator:
+    """Advance the bounded review/address loop without direct I/O dependencies."""
+
+    def __init__(
+        self,
+        *,
+        soft_limit: int,
+        hard_limit: int,
+        operations: ReviewLoopOperations,
+    ) -> None:
+        """Configure the bounded state machine and its injected effects."""
+        if soft_limit < 1 or hard_limit < soft_limit:
+            raise ValueError("review-loop limits must satisfy 1 <= soft_limit <= hard_limit")
+        self._soft_limit = soft_limit
+        self._hard_limit = hard_limit
+        self._operations = operations
+
+    def run(self, *, has_pr: bool) -> ReviewLoopResult:
+        """Run conflict resolution, review iterations, and terminal finalization."""
+        if has_pr and not self._operations.resolve_conflict():
+            return self._finalize(ReviewLoopResult(0, "NOGO", None))
+
+        budget = self._soft_limit
+        made_progress = False
+        state = ReviewLoopState(iteration=0)
+        result = ReviewLoopResult(0, None, None)
+        while state.iteration < budget:
+            budget = self._extend_budget_if_earned(state, budget, made_progress)
+            made_progress = False
+            review = self._operations.review_iteration(state)
+            result = ReviewLoopResult(state.iteration + 1, review.verdict, review.grade)
+            next_state = replace(
+                state,
+                prior_review=review.review_text,
+                reopened_keys=review.reopened_keys,
+            )
+            if review.should_break:
+                break
+            if has_pr and self._should_re_review_without_address(review):
+                state = replace(next_state, iteration=state.iteration + 1)
+                continue
+            if state.iteration == budget - 1:
+                break
+            if not has_pr:
+                state = replace(next_state, iteration=state.iteration + 1)
+                continue
+            address = self._operations.address_iteration(next_state)
+            state, made_progress, should_stop = self._advance_after_address(
+                next_state,
+                address,
+                review.validator_clean,
+                budget,
+            )
+            if should_stop:
+                break
+        return self._finalize(result)
+
+    def _extend_budget_if_earned(
+        self,
+        state: ReviewLoopState,
+        budget: int,
+        made_progress: bool,
+    ) -> int:
+        """Grant one extra review when the preceding address pass made progress."""
+        if made_progress and state.iteration == budget - 1 and budget < self._hard_limit:
+            budget += 1
+            self._operations.budget_extended(budget)
+        return budget
+
+    @staticmethod
+    def _should_re_review_without_address(review: ReviewIterationOutcome) -> bool:
+        """Identify the clean no-thread NOGO convergence path."""
+        return (
+            not review.posted_thread_ids
+            and not review.reopened
+            and not review.go_blocked_by_automation
+            and review.validator_clean
+        )
+
+    @staticmethod
+    def _advance_after_address(
+        state: ReviewLoopState,
+        address: AddressOutcome,
+        validator_clean: bool,
+        budget: int,
+    ) -> tuple[ReviewLoopState, bool, bool]:
+        """Carry address results into the next review or stop a stuck loop."""
+        next_iteration = state.iteration + 1
+        if not address.addressed:
+            if address.prior_addressed_threads and state.iteration < budget - 1:
+                return (
+                    replace(
+                        state,
+                        iteration=next_iteration,
+                        prior_addressed_threads=address.prior_addressed_threads,
+                        pending_unaddressed=address.prior_addressed_threads,
+                    ),
+                    False,
+                    False,
+                )
+            return state, False, True
+        return (
+            replace(
+                state,
+                iteration=next_iteration,
+                prior_addressed_threads=address.prior_addressed_threads,
+                pending_unaddressed=(),
+            ),
+            validator_clean,
+            False,
+        )
+
+    def _finalize(self, result: ReviewLoopResult) -> ReviewLoopResult:
+        """Invoke the terminal effect once and return its immutable result."""
+        self._operations.finalize(result)
+        return result

--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -33,10 +33,22 @@ from hephaestus.agents.runtime import (
     uses_direct_agent_runner,
 )
 from hephaestus.constants import agent_git_timeout, diff_collect_timeout
-from hephaestus.github.client import ClaudeUsageCapError, gh_call
+from hephaestus.github.client import ClaudeUsageCapError
 from hephaestus.github.rate_limit import resolve_quota_reset_epoch, wait_until
 from hephaestus.io.utils import write_secure
 
+from ._review_conflict_resolver import (
+    ConflictResolutionRequest,
+    ReviewConflictResolver,
+    build_conflict_resolution_operations,
+)
+from ._review_loop import (
+    AddressOutcome,
+    ReviewIterationOutcome,
+    ReviewLoopCoordinator,
+    ReviewLoopOperations,
+    ReviewLoopState,
+)
 from ._review_utils import log_file_path
 from ._stage_context import StageMixin
 from .address_review import run_address_fix_session
@@ -51,15 +63,12 @@ from .claude_invoke import (
 from .claude_models import implementer_model, reviewer_model
 from .git_utils import (
     commit_if_changes,
-    get_repo_info,
     get_repo_slug,
     issue_ref,
     pr_ref,
     push_branch,
     push_current_branch_with_lease_on_divergence,
-    rebase_worktree_onto,
     run,
-    sync_worktree_to_remote_branch,
 )
 from .github_api import (
     gh_current_login,
@@ -184,14 +193,240 @@ def _is_automation_owned_thread(thread: dict[str, Any], current_login: str | Non
 class ReviewPhase(StageMixin):
     """Run the bounded review + address cycle and label the final verdict."""
 
-    def _repo_name_with_owner(self) -> str:
-        """Return ``OWNER/REPO`` for gh commands that require an explicit repo."""
-        owner, repo = get_repo_info(self.repo_root)
-        return f"{owner}/{repo}"
-
     def __init__(self, ctx: StageContext) -> None:
         """Store the shared :class:`StageContext`."""
         self.ctx = ctx
+
+    def _resolve_conflict_before_review(
+        self,
+        *,
+        issue_number: int,
+        pr_number: int,
+        worktree_path: Path,
+        branch_name: str,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        state: ImplementationState | None,
+    ) -> bool:
+        """Delegate the pre-review conflict gate to its focused collaborator."""
+        resolver = ReviewConflictResolver(
+            dry_run=lambda: bool(self.options.dry_run),
+            operations=build_conflict_resolution_operations(self.repo_root),
+            resume_implementation=lambda feedback: self._resume_impl_with_feedback(
+                session_id=session_id,
+                worktree_path=worktree_path,
+                issue_number=issue_number,
+                review_text=feedback,
+                prev_iteration=-1,
+                verdict="CONFLICT",
+                state=state,
+            ),
+            commit_changes=lambda: self._commit_if_changes(issue_number, worktree_path),
+            push_rebased_branch=lambda branch, path: self._push_rebased_branch(branch, path),
+            push_agent_branch=lambda branch, path: self._push_branch(branch, path),
+            log=lambda level, message, log_thread: self.impl._log(level, message, log_thread),
+            update_slot=self.status_tracker.update_slot,
+        )
+        return resolver.resolve(
+            ConflictResolutionRequest(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                worktree_path=worktree_path,
+                branch_name=branch_name,
+                slot_id=slot_id,
+                thread_id=thread_id,
+            )
+        )
+
+    def _run_impl_review_loop(
+        self,
+        *,
+        issue_number: int,
+        worktree_path: Path,
+        branch_name: str,
+        issue_title: str,
+        issue_body: str,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        state: ImplementationState | None = None,
+        pr_number: int | None = None,
+        advise_findings: str = "",
+    ) -> tuple[int, str | None, str | None]:
+        """Preserve the legacy tuple contract through the pure loop coordinator."""
+        return self._coordinate_review_loop(
+            issue_number=issue_number,
+            worktree_path=worktree_path,
+            branch_name=branch_name,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            session_id=session_id,
+            slot_id=slot_id,
+            thread_id=thread_id,
+            state=state,
+            pr_number=pr_number,
+            advise_findings=advise_findings,
+        )
+
+    def _coordinate_review_loop(
+        self,
+        *,
+        issue_number: int,
+        worktree_path: Path,
+        branch_name: str,
+        issue_title: str,
+        issue_body: str,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        state: ImplementationState | None,
+        pr_number: int | None,
+        advise_findings: str,
+    ) -> tuple[int, str | None, str | None]:
+        """Bind phase I/O to the pure review-loop state machine."""
+        operations = ReviewLoopOperations(
+            resolve_conflict=lambda: (
+                pr_number is None
+                or self._resolve_conflict_before_review(
+                    issue_number=issue_number,
+                    pr_number=pr_number,
+                    worktree_path=worktree_path,
+                    branch_name=branch_name,
+                    session_id=session_id,
+                    slot_id=slot_id,
+                    thread_id=thread_id,
+                    state=state,
+                )
+            ),
+            review_iteration=lambda loop_state: self._process_review_iteration(
+                loop_state,
+                issue_number=issue_number,
+                issue_title=issue_title,
+                issue_body=issue_body,
+                branch_name=branch_name,
+                worktree_path=worktree_path,
+                session_id=session_id,
+                slot_id=slot_id,
+                thread_id=thread_id,
+                pr_number=pr_number,
+                advise_findings=advise_findings,
+            ),
+            address_iteration=lambda loop_state: self._run_address_iteration(
+                loop_state,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                branch_name=branch_name,
+                worktree_path=worktree_path,
+                session_id=session_id,
+                slot_id=slot_id,
+                thread_id=thread_id,
+                issue_title=issue_title,
+                issue_body=issue_body,
+            ),
+            finalize=lambda result: self._apply_review_finalization(
+                issue_number=issue_number,
+                pr_number=pr_number,
+                last_verdict=result.verdict,
+                iterations_run=result.iterations_run,
+            ),
+            budget_extended=lambda budget: self.impl._log(
+                "info",
+                f"{issue_ref(issue_number)}: extending review budget to "
+                f"{budget}/{MAX_REVIEW_ITERATIONS_HARD_CAP} iteration(s)",
+                thread_id,
+            ),
+        )
+        result = ReviewLoopCoordinator(
+            soft_limit=MAX_REVIEW_ITERATIONS,
+            hard_limit=MAX_REVIEW_ITERATIONS_HARD_CAP,
+            operations=operations,
+        ).run(has_pr=pr_number is not None)
+        return result.iterations_run, result.verdict, result.grade
+
+    def _process_review_iteration(
+        self,
+        loop_state: ReviewLoopState,
+        *,
+        issue_number: int,
+        issue_title: str,
+        issue_body: str,
+        branch_name: str,
+        worktree_path: Path,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        pr_number: int | None,
+        advise_findings: str,
+    ) -> ReviewIterationOutcome:
+        """Run the phase-owned review work for one typed coordinator iteration."""
+        (
+            verdict,
+            grade,
+            review_text,
+            posted_thread_ids,
+            go_blocked_by_automation,
+            reopened,
+            should_break,
+            reopened_keys,
+            validator_clean,
+        ) = self._execute_review_iteration(
+            issue_number=issue_number,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            branch_name=branch_name,
+            worktree_path=worktree_path,
+            session_id=session_id,
+            slot_id=slot_id,
+            thread_id=thread_id,
+            pr_number=pr_number,
+            iteration=loop_state.iteration,
+            prior_review=loop_state.prior_review,
+            prior_addressed_threads=list(loop_state.prior_addressed_threads),
+            prior_reopened_keys=set(loop_state.reopened_keys),
+            advise_findings=advise_findings,
+        )
+        return ReviewIterationOutcome(
+            verdict=verdict,
+            grade=grade,
+            review_text=review_text,
+            posted_thread_ids=tuple(posted_thread_ids),
+            go_blocked_by_automation=go_blocked_by_automation,
+            reopened=tuple(reopened),
+            should_break=should_break,
+            reopened_keys=frozenset(reopened_keys),
+            validator_clean=validator_clean,
+        )
+
+    def _run_address_iteration(
+        self,
+        loop_state: ReviewLoopState,
+        *,
+        issue_number: int,
+        pr_number: int | None,
+        branch_name: str,
+        worktree_path: Path,
+        session_id: str | None,
+        slot_id: int | None,
+        thread_id: int | None,
+        issue_title: str,
+        issue_body: str,
+    ) -> AddressOutcome:
+        """Run the phase-owned address work for one typed coordinator iteration."""
+        prior_addressed_threads, addressed = self._execute_address_iteration(
+            issue_number=issue_number,
+            pr_number=pr_number,
+            branch_name=branch_name,
+            worktree_path=worktree_path,
+            iteration=loop_state.iteration,
+            session_id=session_id,
+            slot_id=slot_id,
+            thread_id=thread_id,
+            issue_title=issue_title,
+            issue_body=issue_body,
+            unaddressed_findings=list(loop_state.pending_unaddressed),
+        )
+        return AddressOutcome(tuple(prior_addressed_threads), addressed)
 
     # ------------------------------------------------------------------
     # Final-verdict labeling
@@ -494,396 +729,7 @@ class ReviewPhase(StageMixin):
         impl._save_review_iteration_state(issue_number, iteration + 1, review_text)
         return reopened, review_text, posted_thread_ids, verdict, validator_clean, reopened_keys
 
-    # ------------------------------------------------------------------
-    # Pre-review conflict gate (#1328)
-    # ------------------------------------------------------------------
-
-    def _pr_merge_state(self, pr_number: int) -> tuple[str, str]:
-        """Return ``(mergeStateStatus, mergeable)`` upper-cased for *pr_number*.
-
-        Mirrors the merge-state query the CI driver uses
-        (``ci_driver._gh_pr_state`` / ``_attempt_mechanical_rebase``). Returns
-        empty strings on any query failure so an unknown merge-state is never
-        misread as CONFLICTING.
-        """
-        try:
-            result = gh_call(
-                [
-                    "pr",
-                    "view",
-                    str(pr_number),
-                    "--repo",
-                    self._repo_name_with_owner(),
-                    "--json",
-                    "mergeStateStatus,mergeable",
-                ],
-            )
-            state = dict(json.loads(result.stdout or "{}"))
-        except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as exc:
-            logger.warning(
-                "#%d: could not fetch PR %s merge-state for conflict gate: %s",
-                pr_number,
-                pr_ref(pr_number),
-                exc,
-            )
-            return "", ""
-        return (
-            str(state.get("mergeStateStatus") or "").upper(),
-            str(state.get("mergeable") or "").upper(),
-        )
-
-    def _resolve_conflict_before_review(
-        self,
-        *,
-        issue_number: int,
-        pr_number: int,
-        worktree_path: Path,
-        branch_name: str,
-        session_id: str | None,
-        slot_id: int | None,
-        thread_id: int | None,
-        state: ImplementationState | None,
-    ) -> bool:
-        """Ensure *pr_number* is conflict-free before the review iterations (#1328).
-
-        Reviewing a PR that has a merge conflict with its base is pointless — a
-        conflicted PR can never merge, so any GO verdict would be wasted spend.
-        Per the user's instruction this resolves the conflict with the
-        IMPLEMENTATION agent BEFORE the first review iteration.
-
-        The flow reuses the SAME primitives the CI driver's ``_resolve_dirty_pr``
-        uses (``rebase_worktree_onto`` / ``push_current_branch_with_lease_on_divergence``
-        from :mod:`git_utils`, and the implementer-session resume in
-        ``_resume_impl_with_feedback``), rather than reinventing conflict
-        resolution. ``ReviewPhase`` runs under ``IssueImplementer`` — a different
-        object than ``CIDriver`` — so the helper cannot be called directly; this
-        is the smallest seam that reuses the underlying rebase/agent primitives.
-
-        Steps:
-
-        1. Query merge-state. If NOT DIRTY/CONFLICTING, return ``True`` (nothing
-           to do — proceed straight to review). An unknown merge-state also
-           returns ``True`` so a transient gh failure never strands a healthy PR.
-        2. Mechanical rebase onto the base. A clean rebase + lease-push
-           re-triggers CI; return ``True`` once the merge-state clears.
-        3. Still conflicting → dispatch the implementation agent with explicit
-           conflict-resolution instructions, commit + push, then re-check.
-        4. Return ``True`` only if the PR is conflict-free afterwards; ``False``
-           if the conflict could not be resolved (caller returns early so the PR
-           is treated as not-GO rather than reviewed).
-
-        Returns:
-            ``True`` if the PR is conflict-free (review may proceed); ``False``
-            if an unresolved merge conflict remains.
-
-        """
-        if self.options.dry_run:
-            return True
-
-        merge_state, mergeable = self._pr_merge_state(pr_number)
-        if merge_state not in ("DIRTY", "CONFLICTING") and mergeable != "CONFLICTING":
-            return True
-
-        impl = self.impl
-        impl._log(
-            "warning",
-            f"{issue_ref(issue_number)}: {pr_ref(pr_number)} is {merge_state or 'CONFLICTING'} "
-            "(merge conflict) before review — resolving with the implementation agent "
-            "before any review iteration",
-            thread_id,
-        )
-        if slot_id is not None:
-            self.status_tracker.update_slot(
-                slot_id, f"{pr_ref(pr_number)}: resolving merge conflict"
-            )
-
-        # Resolve the base branch once for both the rebase target and the agent
-        # prompt. Best-effort: default to ``main`` like ``_resolve_dirty_pr``.
-        base_branch = "main"
-        try:
-            base_result = gh_call(
-                [
-                    "pr",
-                    "view",
-                    str(pr_number),
-                    "--repo",
-                    self._repo_name_with_owner(),
-                    "--json",
-                    "baseRefName",
-                ],
-            )
-            base_branch = dict(json.loads(base_result.stdout or "{}")).get("baseRefName") or "main"
-        except (subprocess.CalledProcessError, RuntimeError, json.JSONDecodeError) as exc:
-            logger.debug(
-                "#%d: failed to determine base branch for %s; defaulting to 'main': %s",
-                issue_number,
-                pr_ref(pr_number),
-                exc,
-            )
-
-        # 1. Cheap path: mechanical rebase. A clean rebase resolves a PR that is
-        #    merely behind / non-overlapping with no agent spend.
-        with contextlib.suppress(subprocess.CalledProcessError):
-            sync_worktree_to_remote_branch(worktree_path, branch_name)
-            if rebase_worktree_onto(worktree_path, base_branch):
-                push_current_branch_with_lease_on_divergence(
-                    worktree_path,
-                    branch=branch_name,
-                    push_ref=f"HEAD:{branch_name}",
-                )
-                logger.info(
-                    "#%d: mechanically rebased %s onto %s (no agent) for conflict gate",
-                    issue_number,
-                    pr_ref(pr_number),
-                    base_branch,
-                )
-                cleared_state, cleared_mergeable = self._pr_merge_state(pr_number)
-                if cleared_state not in ("DIRTY", "CONFLICTING") and (
-                    cleared_mergeable != "CONFLICTING"
-                ):
-                    return True
-
-        # 2. Rebase still conflicts → the implementation agent resolves it. Reuse
-        #    the same conflict_context wording as ci_driver._resolve_dirty_pr.
-        #    Existing-PR review can start without a saved implementer transcript;
-        #    in that case _resume_impl_with_feedback starts/uses the deterministic
-        #    implementer session instead of dead-ending the conflict gate.
-        conflict_context = (
-            f"This PR has a MERGE CONFLICT with `origin/{base_branch}` "
-            f"(mergeStateStatus=DIRTY) — it cannot merge until the conflict is "
-            f"resolved. Rebase the PR head branch onto `origin/{base_branch}` and "
-            f"resolve every conflict, keeping both the PR's intent and the latest "
-            f"base changes. Then commit the resolution (signed). There may be NO "
-            f"failing CI checks — the conflict itself is the blocker."
-        )
-        resolved = self._resume_impl_with_feedback(
-            session_id=session_id,
-            worktree_path=worktree_path,
-            issue_number=issue_number,
-            review_text=conflict_context,
-            prev_iteration=-1,
-            verdict="CONFLICT",
-            state=state,
-        )
-        if resolved and self.runner._commit_if_changes(issue_number, worktree_path):
-            self.runner._push_branch(branch_name, worktree_path)
-
-        final_state, final_mergeable = self._pr_merge_state(pr_number)
-        if final_state in ("DIRTY", "CONFLICTING") or final_mergeable == "CONFLICTING":
-            impl._log(
-                "warning",
-                f"{issue_ref(issue_number)}: {pr_ref(pr_number)} still has an unresolved merge "
-                "conflict after agent resolution — skipping review (not-GO)",
-                thread_id,
-            )
-            return False
-        return True
-
-    def _run_impl_review_loop(
-        self,
-        *,
-        issue_number: int,
-        worktree_path: Path,
-        branch_name: str,
-        issue_title: str,
-        issue_body: str,
-        session_id: str | None,
-        slot_id: int | None,
-        thread_id: int | None,
-        state: ImplementationState | None = None,
-        pr_number: int | None = None,
-        advise_findings: str = "",
-    ) -> tuple[int, str | None, str | None]:
-        """Run the bounded in-loop review + address cycle for an implementation.
-
-        Each iteration posts inline PR review threads and returns a verdict; on
-        NOGO the implementer session is resumed to address threads. Terminates on
-        GO or zero blocking threads, or on budget exhaustion. The budget starts
-        at :data:`MAX_REVIEW_ITERATIONS` and is extended one iteration at a time —
-        up to :data:`MAX_REVIEW_ITERATIONS_HARD_CAP` — for as long as each round
-        keeps making real progress (resolves a fresh finding without the
-        validator re-opening a prior one), so a steadily-improving PR converges
-        instead of being stranded one address-pass short (#1554).
-
-        #1328: before the FIRST review iteration, a PR with a merge conflict is
-        rebased / handed to the implementation agent to resolve. A conflicted PR
-        can never merge, so reviewing it would be wasted spend; if the conflict
-        cannot be resolved the loop returns early with a non-GO verdict so the PR
-        is treated as needs-action instead of being reviewed.
-        """
-        last_verdict: str | None = None
-        last_grade: str | None = None
-        prior_review: str | None = None
-        iterations_run = 0
-        prior_addressed_threads: list[dict[str, Any]] = []
-        # #1329: stable keys of findings the validator re-opened, carried across
-        # rounds so a re-open recurring on an already-documented design decision
-        # is accepted once and never re-added (converging the loop toward GO).
-        prior_reopened_keys: set[str] = set()
-
-        # #1328: resolve any merge conflict BEFORE reviewing. Never review a
-        # conflicted PR — it cannot merge regardless of the verdict.
-        if pr_number is not None and not self._resolve_conflict_before_review(
-            issue_number=issue_number,
-            pr_number=pr_number,
-            worktree_path=worktree_path,
-            branch_name=branch_name,
-            session_id=session_id,
-            slot_id=slot_id,
-            thread_id=thread_id,
-            state=state,
-        ):
-            self._finalize_review_outcome(
-                issue_number=issue_number,
-                pr_number=pr_number,
-                last_verdict="NOGO",
-                iterations_run=0,
-            )
-            return 0, "NOGO", None
-
-        # #1554: progress-aware review budget. The loop starts with the base
-        # ``MAX_REVIEW_ITERATIONS`` budget; whenever the PREVIOUS round made
-        # genuine PROGRESS (its address step resolved a fresh finding without the
-        # validator re-opening a prior one) and the loop is about to exhaust the
-        # budget, grant one more iteration — up to ``MAX_REVIEW_ITERATIONS_HARD_CAP``
-        # — so a steadily-improving PR with more real findings than the base
-        # budget converges to a clean GO instead of being stranded one
-        # address-pass short. A stuck or oscillating reviewer makes no progress
-        # and is never extended, so it still terminates at the base budget and is
-        # tagged ``state:skip``. The extension happens at the TOP of the loop
-        # (before the address-step gate that breaks on the final budgeted
-        # iteration), keyed off the prior round's progress.
-        budget = MAX_REVIEW_ITERATIONS
-        prior_round_made_progress = False
-        # #1554: still-unresolved threads from a prior address turn that produced
-        # NO commit. Injected into the NEXT address invocation as a "Make sure to
-        # handle <finding>" directive to re-ground a resumed session that
-        # self-reported success without editing code. Empty except on the round
-        # immediately following a no-commit turn.
-        pending_unaddressed: list[dict[str, Any]] = []
-        iteration = 0
-        while iteration < budget:
-            # Extend the budget when the prior round made real progress and this
-            # would otherwise be the last budgeted iteration — so the fix the
-            # prior round landed gets a re-review (and its findings addressed).
-            if (
-                prior_round_made_progress
-                and iteration == budget - 1
-                and budget < MAX_REVIEW_ITERATIONS_HARD_CAP
-            ):
-                budget += 1
-                self.impl._log(
-                    "info",
-                    f"{issue_ref(issue_number)} R{iteration}: prior round resolved "
-                    f"finding(s); extending review budget to "
-                    f"{budget}/{MAX_REVIEW_ITERATIONS_HARD_CAP} iteration(s)",
-                    thread_id,
-                )
-            prior_round_made_progress = False
-            (
-                last_verdict,
-                last_grade,
-                review_text,
-                posted_thread_ids,
-                go_blocked_by_automation,
-                reopened,
-                should_break,
-                prior_reopened_keys,
-                validator_clean,
-            ) = self._process_review_iteration(
-                issue_number=issue_number,
-                issue_title=issue_title,
-                issue_body=issue_body,
-                branch_name=branch_name,
-                worktree_path=worktree_path,
-                session_id=session_id,
-                slot_id=slot_id,
-                thread_id=thread_id,
-                pr_number=pr_number,
-                iteration=iteration,
-                prior_review=prior_review,
-                prior_addressed_threads=prior_addressed_threads,
-                prior_reopened_keys=prior_reopened_keys,
-                advise_findings=advise_findings,
-            )
-            iterations_run = iteration + 1
-            if should_break:
-                break
-            # An unclean validator pass (#1329) — including a PR-level-only
-            # re-open that posts no inline thread id — means a prior comment is
-            # still unaddressed and must run the address step. This is distinct
-            # from a zero-thread REVIEWER non-GO (validator clean), which must
-            # simply re-review (the loop's zero-thread convergence contract).
-            if (
-                pr_number is not None
-                and not posted_thread_ids
-                and not reopened
-                and not go_blocked_by_automation
-                and validator_clean
-            ):
-                prior_review = review_text
-                iteration += 1
-                continue
-            prior_review = review_text
-            address_result = self._run_address_step_if_needed(
-                issue_number=issue_number,
-                pr_number=pr_number,
-                branch_name=branch_name,
-                worktree_path=worktree_path,
-                iteration=iteration,
-                budget=budget,
-                session_id=session_id,
-                slot_id=slot_id,
-                thread_id=thread_id,
-                issue_title=issue_title,
-                issue_body=issue_body,
-                unaddressed_findings=pending_unaddressed,
-            )
-            if address_result is None:
-                break
-            prior_addressed_threads, addressed = address_result
-            if pr_number is None:
-                iteration += 1
-                continue
-            if not addressed:
-                # #1554: the address step produced NO commit (the fix agent
-                # punted or self-reported a phantom fix). If fixable threads
-                # remain AND iterations are left, do NOT give up — re-review and
-                # retry, carrying the still-unresolved threads forward as a "Make
-                # sure to handle <finding>" directive to re-ground the next
-                # address attempt. ``prior_addressed_threads`` is the snapshot the
-                # address step already took (its current unresolved set), so we
-                # reuse it instead of issuing another network call. Only when
-                # there is nothing fixable left OR no iterations remain do we
-                # break to the existing terminal/skip handling (unchanged).
-                still_unresolved = prior_addressed_threads
-                if still_unresolved and iteration < budget - 1:
-                    pending_unaddressed = still_unresolved
-                    iteration += 1
-                    continue
-                break
-            # A progress round clears the retry directive. Progress is either a
-            # committed code change or an observed unresolved-thread count drop.
-            pending_unaddressed = []
-            # The address step made progress without the validator re-opening a
-            # prior one (``validator_clean``). Record it so the NEXT iteration
-            # can extend the budget if it would otherwise be the last — letting
-            # a PR that fixes one real bug or closes one real thread per round
-            # converge instead of being stranded one pass short of GO and
-            # wrongly skipped (#1554). The hard cap still bounds total
-            # iterations.
-            prior_round_made_progress = addressed and validator_clean
-            iteration += 1
-
-        self._finalize_review_outcome(
-            issue_number=issue_number,
-            pr_number=pr_number,
-            last_verdict=last_verdict,
-            iterations_run=iterations_run,
-        )
-        return iterations_run, last_verdict, last_grade
-
-    def _process_review_iteration(
+    def _execute_review_iteration(
         self,
         *,
         issue_number: int,
@@ -978,66 +824,7 @@ class ReviewPhase(StageMixin):
             validator_clean,
         )
 
-    def _run_address_step_if_needed(
-        self,
-        *,
-        issue_number: int,
-        pr_number: int | None,
-        branch_name: str,
-        worktree_path: Path,
-        iteration: int,
-        budget: int,
-        session_id: str | None,
-        slot_id: int | None,
-        thread_id: int | None,
-        issue_title: str,
-        issue_body: str,
-        unaddressed_findings: list[dict[str, Any]] | None = None,
-    ) -> tuple[list[dict[str, Any]], bool] | None:
-        """Run address iteration unless this is the final budgeted iteration.
-
-        Args:
-            issue_number: GitHub issue number.
-            pr_number: PR number, or None for diff-only mode.
-            branch_name: Git branch name.
-            worktree_path: Path to the checked-out worktree.
-            iteration: Current zero-based iteration index.
-            budget: Current iteration budget. Addressing is skipped on the final
-                budgeted iteration (``iteration == budget - 1``); a productive
-                round extends ``budget`` in the caller BEFORE the next pass, so a
-                steadily-improving PR still gets its findings addressed (#1554).
-            session_id: Optional implementer session ID.
-            slot_id: Worker slot for status tracking.
-            thread_id: Current thread id for logging.
-            issue_title: Issue title for context.
-            issue_body: Issue body for context.
-            unaddressed_findings: Still-unresolved threads from a prior no-commit
-                turn, injected as a "Make sure to handle <finding>" directive to
-                re-ground a resumed session (#1554).
-
-        Returns:
-            None if this is the final budgeted iteration (caller should break).
-            (prior_addressed_threads, addressed) tuple otherwise.
-
-        """
-        if iteration == budget - 1:
-            return None
-        prior_addressed_threads, addressed = self._run_address_iteration(
-            issue_number=issue_number,
-            pr_number=pr_number,
-            branch_name=branch_name,
-            worktree_path=worktree_path,
-            iteration=iteration,
-            session_id=session_id,
-            slot_id=slot_id,
-            thread_id=thread_id,
-            issue_title=issue_title,
-            issue_body=issue_body,
-            unaddressed_findings=unaddressed_findings,
-        )
-        return prior_addressed_threads, addressed
-
-    def _run_address_iteration(
+    def _execute_address_iteration(
         self,
         *,
         issue_number: int,
@@ -1140,7 +927,7 @@ class ReviewPhase(StageMixin):
             )
             return None
 
-    def _finalize_review_outcome(
+    def _apply_review_finalization(
         self,
         *,
         issue_number: int,
@@ -1556,6 +1343,14 @@ class ReviewPhase(StageMixin):
     def _push_branch(self, branch_name: str, worktree_path: Path) -> None:
         """Push *branch_name* to origin after an in-loop address step."""
         push_branch(branch_name, worktree_path)
+
+    def _push_rebased_branch(self, branch_name: str, worktree_path: Path) -> None:
+        """Publish a rebased branch without overwriting a concurrent remote update."""
+        push_current_branch_with_lease_on_divergence(
+            worktree_path,
+            branch=branch_name,
+            push_ref=f"HEAD:{branch_name}",
+        )
 
     def _resume_impl_with_feedback(
         self,

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -1,8 +1,10 @@
 """PR-review stage: review, validate, post, address, evaluate, follow up.
 
-Re-houses the fused implementation-review loop from ``_review_phase.py``
-(``_run_impl_review_loop`` :671, ``_evaluate_go_verdict`` :314,
-``_review_thread_count_decreased`` :155) and its collaborators
+Re-houses the legacy implementation-review semantics now isolated in
+``_review_loop.ReviewLoopCoordinator`` and
+``_review_conflict_resolver.ReviewConflictResolver``. The queue stage remains
+the live implementation of the review/validate/address state machine. Its
+collaborators include
 (``pr_reviewer.review_pr_inline``, ``review_validator
 .validate_prior_comments_addressed``, ``address_review
 .run_address_fix_session``) as a pipeline stage
@@ -16,8 +18,9 @@ contract):
 - Budgets: ``pr_review_iter`` = 3 (soft cap), ``pr_review_hard`` = 6 (hard
   cap; rounds 4-6 are admitted ONLY while the unresolved-thread count
   strictly decreases — the #1554 progress-aware extension, legacy
-  ``_review_thread_count_decreased`` + the budget bump at
-  ``_run_impl_review_loop:758-770``). Both read from ROUTES via
+  ``_review_thread_count_decreased`` +
+  :class:`_review_loop.ReviewLoopCoordinator`'s progress-extension contract).
+  Both read from ROUTES via
   ``ctx.budget``, never hardcoded here.
 - Iteration accounting: ``item.attempts["pr_review_iter"]`` is the
   PER-LIFETIME audit trail (routing.py contract: attempts are never

--- a/tests/unit/automation/test_review_conflict_resolver.py
+++ b/tests/unit/automation/test_review_conflict_resolver.py
@@ -1,0 +1,251 @@
+"""Regression tests for pre-review conflict resolution collaboration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from hephaestus.automation._review_conflict_resolver import (
+    ConflictResolutionOperations,
+    ConflictResolutionRequest,
+    ReviewConflictResolver,
+    build_conflict_resolution_operations,
+)
+
+
+def _request(*, slot_id: int | None = 4, thread_id: int | None = 9) -> ConflictResolutionRequest:
+    """Build a request with stable issue, PR, and worktree context."""
+    return ConflictResolutionRequest(
+        issue_number=7,
+        pr_number=12,
+        worktree_path=Path("/worktree"),
+        branch_name="7-auto-impl",
+        slot_id=slot_id,
+        thread_id=thread_id,
+    )
+
+
+@dataclass
+class ResolverFakes:
+    """Injected effects and their resolver for one deterministic test."""
+
+    resolver: ReviewConflictResolver
+    merge_state: mock.Mock
+    base_branch: mock.Mock
+    sync_worktree: mock.Mock
+    rebase_worktree: mock.Mock
+    resume: mock.Mock
+    commit: mock.Mock
+    push_rebased: mock.Mock
+    push_agent: mock.Mock
+    log: mock.Mock
+    update_slot: mock.Mock
+
+
+def _resolver(
+    *,
+    dry_run: bool = False,
+    resume_result: bool = True,
+    commit_result: bool = True,
+) -> ResolverFakes:
+    """Build a resolver using only injected, inspectable side effects."""
+    merge_state = mock.Mock(return_value=("CLEAN", "MERGEABLE"))
+    base_branch = mock.Mock(return_value="main")
+    sync_worktree = mock.Mock()
+    rebase_worktree = mock.Mock(return_value=False)
+    resume = mock.Mock(return_value=resume_result)
+    commit = mock.Mock(return_value=commit_result)
+    push_rebased = mock.Mock()
+    push_agent = mock.Mock()
+    log = mock.Mock()
+    update_slot = mock.Mock()
+    resolver = ReviewConflictResolver(
+        dry_run=lambda: dry_run,
+        operations=ConflictResolutionOperations(
+            merge_state=merge_state,
+            base_branch=base_branch,
+            sync_worktree=sync_worktree,
+            rebase_worktree=rebase_worktree,
+        ),
+        resume_implementation=resume,
+        commit_changes=commit,
+        push_rebased_branch=push_rebased,
+        push_agent_branch=push_agent,
+        log=log,
+        update_slot=update_slot,
+    )
+    return ResolverFakes(
+        resolver=resolver,
+        merge_state=merge_state,
+        base_branch=base_branch,
+        sync_worktree=sync_worktree,
+        rebase_worktree=rebase_worktree,
+        resume=resume,
+        commit=commit,
+        push_rebased=push_rebased,
+        push_agent=push_agent,
+        log=log,
+        update_slot=update_slot,
+    )
+
+
+def test_dry_run_and_clean_or_unknown_states_avoid_git_and_agent_work() -> None:
+    """Non-conflicting checks, including unknown GitHub state, are fail-open."""
+    for dry_run, merge_state in (
+        (True, ("DIRTY", "CONFLICTING")),
+        (False, ("", "")),
+        (False, ("CLEAN", "MERGEABLE")),
+    ):
+        fakes = _resolver(dry_run=dry_run)
+        fakes.merge_state.return_value = merge_state
+
+        assert fakes.resolver.resolve(_request()) is True
+
+        fakes.sync_worktree.assert_not_called()
+        fakes.resume.assert_not_called()
+        fakes.commit.assert_not_called()
+        fakes.push_rebased.assert_not_called()
+        fakes.push_agent.assert_not_called()
+
+
+def test_mechanical_rebase_uses_lease_push_then_requires_clean_readback() -> None:
+    """A mechanical rebase uses its dedicated lease-push callback and rechecks the PR."""
+    fakes = _resolver()
+    fakes.merge_state.side_effect = [("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")]
+    fakes.rebase_worktree.return_value = True
+
+    assert fakes.resolver.resolve(_request()) is True
+
+    fakes.sync_worktree.assert_called_once_with(Path("/worktree"), "7-auto-impl")
+    fakes.rebase_worktree.assert_called_once_with(Path("/worktree"), "main")
+    fakes.push_rebased.assert_called_once_with("7-auto-impl", Path("/worktree"))
+    fakes.push_agent.assert_not_called()
+    fakes.resume.assert_not_called()
+    fakes.commit.assert_not_called()
+
+
+def test_agent_fallback_runs_only_after_mechanical_resolution_fails() -> None:
+    """The implementation agent is not spent before the mechanical fast path."""
+    fakes = _resolver()
+    fakes.merge_state.side_effect = [("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")]
+
+    assert fakes.resolver.resolve(_request()) is True
+
+    fakes.resume.assert_called_once()
+    fakes.commit.assert_called_once()
+    fakes.push_rebased.assert_not_called()
+    fakes.push_agent.assert_called_once_with("7-auto-impl", Path("/worktree"))
+
+
+@pytest.mark.parametrize(
+    ("resume_result", "commit_result", "expected_pushes"),
+    [(False, True, 0), (True, False, 0), (True, True, 1)],
+)
+def test_agent_commit_and_push_require_success_and_changes(
+    resume_result: bool,
+    commit_result: bool,
+    expected_pushes: int,
+) -> None:
+    """The host pushes only a successful agent turn that produced changes."""
+    fakes = _resolver(resume_result=resume_result, commit_result=commit_result)
+    final_state = ("CLEAN", "MERGEABLE") if expected_pushes else ("DIRTY", "CONFLICTING")
+    fakes.merge_state.side_effect = [("DIRTY", "CONFLICTING"), final_state]
+
+    fakes.resolver.resolve(_request())
+
+    fakes.resume.assert_called_once()
+    assert fakes.commit.call_count == int(resume_result)
+    assert fakes.push_rebased.call_count == 0
+    assert fakes.push_agent.call_count == expected_pushes
+
+
+@pytest.mark.parametrize("stdout", ["not-json", "null", '"main"'])
+def test_base_branch_defaults_to_main_after_malformed_github_output(stdout: str) -> None:
+    """Malformed GitHub JSON never prevents a conflict-resolution attempt."""
+    github_call = mock.Mock(return_value=SimpleNamespace(stdout=stdout))
+    operations = build_conflict_resolution_operations(
+        Path("/repo"),
+        github_call=github_call,
+        repo_info=mock.Mock(return_value=("owner", "repo")),
+        sync_worktree=mock.Mock(),
+        rebase_worktree=mock.Mock(),
+    )
+
+    assert operations.base_branch(12) == "main"
+
+
+def test_base_branch_defaults_to_main_after_github_error() -> None:
+    """GitHub read failures use the same safe base-branch fallback."""
+    operations = build_conflict_resolution_operations(
+        Path("/repo"),
+        github_call=mock.Mock(side_effect=RuntimeError("gh unavailable")),
+        repo_info=mock.Mock(return_value=("owner", "repo")),
+        sync_worktree=mock.Mock(),
+        rebase_worktree=mock.Mock(),
+    )
+
+    assert operations.base_branch(12) == "main"
+
+
+def test_github_read_failures_are_logged(caplog: pytest.LogCaptureFixture) -> None:
+    """Transient GitHub lookup failures remain diagnosable at their fallbacks."""
+    operations = build_conflict_resolution_operations(
+        Path("/repo"),
+        github_call=mock.Mock(side_effect=RuntimeError("gh unavailable")),
+        repo_info=mock.Mock(return_value=("owner", "repo")),
+        sync_worktree=mock.Mock(),
+        rebase_worktree=mock.Mock(),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="hephaestus.automation._review_conflict_resolver"):
+        assert operations.merge_state(12) == ("", "")
+        assert operations.base_branch(12) == "main"
+
+    assert "Could not fetch PR #12 merge state" in caplog.messages
+    assert "Could not fetch PR #12 base branch" in caplog.messages
+
+
+@pytest.mark.parametrize("stdout", ["null", '"clean"'])
+def test_malformed_merge_state_is_fail_open(stdout: str) -> None:
+    """A non-object merge-state response is treated as unknown rather than conflicting."""
+    operations = build_conflict_resolution_operations(
+        Path("/repo"),
+        github_call=mock.Mock(return_value=SimpleNamespace(stdout=stdout)),
+        repo_info=mock.Mock(return_value=("owner", "repo")),
+        sync_worktree=mock.Mock(),
+        rebase_worktree=mock.Mock(),
+    )
+
+    assert operations.merge_state(12) == ("", "")
+
+
+@pytest.mark.parametrize("final_state", [("DIRTY", "MERGEABLE"), ("CLEAN", "CONFLICTING")])
+def test_confirmed_conflict_after_resolution_returns_false(final_state: tuple[str, str]) -> None:
+    """A confirmed conflicting final readback is fail-closed."""
+    fakes = _resolver()
+    fakes.merge_state.side_effect = [("DIRTY", "CONFLICTING"), final_state, final_state]
+    fakes.rebase_worktree.return_value = True
+
+    assert fakes.resolver.resolve(_request()) is False
+
+    assert any(
+        "unresolved merge conflict" in str(call.args[1]) for call in fakes.log.call_args_list
+    )
+
+
+def test_status_and_log_callbacks_keep_issue_and_pr_context() -> None:
+    """Operational callbacks retain the pre-existing issue/PR identifiers."""
+    fakes = _resolver()
+    fakes.merge_state.side_effect = [("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")]
+    fakes.rebase_worktree.return_value = True
+
+    assert fakes.resolver.resolve(_request()) is True
+
+    fakes.update_slot.assert_called_once_with(4, "PR #12: resolving merge conflict")
+    assert "issue #7" in str(fakes.log.call_args.args[1])
+    assert "PR #12" in str(fakes.log.call_args.args[1])

--- a/tests/unit/automation/test_review_conflict_resolver.py
+++ b/tests/unit/automation/test_review_conflict_resolver.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
@@ -206,8 +206,12 @@ def test_github_read_failures_are_logged(caplog: pytest.LogCaptureFixture) -> No
         assert operations.merge_state(12) == ("", "")
         assert operations.base_branch(12) == "main"
 
-    assert "Could not fetch PR #12 merge state" in caplog.messages
-    assert "Could not fetch PR #12 base branch" in caplog.messages
+    assert any(
+        "Could not fetch Hephaestus#12 merge state" in message for message in caplog.messages
+    )
+    assert any(
+        "Could not fetch Hephaestus#12 base branch" in message for message in caplog.messages
+    )
 
 
 @pytest.mark.parametrize("stdout", ["null", '"clean"'])

--- a/tests/unit/automation/test_review_loop.py
+++ b/tests/unit/automation/test_review_loop.py
@@ -1,0 +1,285 @@
+"""Behavioural regression tests for the pure implementation-review loop."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hephaestus.automation._review_loop import (
+    AddressOutcome,
+    ReviewIterationOutcome,
+    ReviewLoopCoordinator,
+    ReviewLoopOperations,
+    ReviewLoopResult,
+    ReviewLoopState,
+)
+
+
+def _outcome(
+    *,
+    verdict: str = "NOGO",
+    posted_thread_ids: tuple[str, ...] = ("thread",),
+    reopened: tuple[str, ...] = (),
+    should_break: bool = False,
+    reopened_keys: frozenset[str] = frozenset(),
+    validator_clean: bool = True,
+) -> ReviewIterationOutcome:
+    """Build a review outcome with the normal non-GO defaults."""
+    return ReviewIterationOutcome(
+        verdict=verdict,
+        grade="B",
+        review_text=f"review-{verdict}",
+        posted_thread_ids=posted_thread_ids,
+        go_blocked_by_automation=False,
+        reopened=reopened,
+        should_break=should_break,
+        reopened_keys=reopened_keys,
+        validator_clean=validator_clean,
+    )
+
+
+def _coordinator(
+    *,
+    resolve_conflict: Any = lambda: True,
+    review_iteration: Any = lambda _state: _outcome(),
+    address_iteration: Any = lambda _state: AddressOutcome((), True),
+    finalize: Any = lambda _result: None,
+    budget_extended: Any = lambda _budget: None,
+    soft_limit: int = 3,
+    hard_limit: int = 6,
+) -> ReviewLoopCoordinator:
+    """Build a coordinator from deterministic callback fakes."""
+    return ReviewLoopCoordinator(
+        soft_limit=soft_limit,
+        hard_limit=hard_limit,
+        operations=ReviewLoopOperations(
+            resolve_conflict=resolve_conflict,
+            review_iteration=review_iteration,
+            address_iteration=address_iteration,
+            finalize=finalize,
+            budget_extended=budget_extended,
+        ),
+    )
+
+
+def test_conflict_resolution_precedes_iteration_zero() -> None:
+    """A PR is conflict-checked before its first reviewer invocation."""
+    calls: list[str] = []
+
+    def _resolve_conflict() -> bool:
+        calls.append("conflict")
+        return True
+
+    def _review_iteration(_state: ReviewLoopState) -> ReviewIterationOutcome:
+        calls.append("review")
+        return _outcome(verdict="GO", should_break=True)
+
+    coordinator = _coordinator(
+        resolve_conflict=_resolve_conflict,
+        review_iteration=_review_iteration,
+    )
+
+    coordinator.run(has_pr=True)
+
+    assert calls == ["conflict", "review"]
+
+
+def test_unresolved_conflict_finalizes_nogo_without_reviewer() -> None:
+    """An unresolved conflict consumes no review iteration."""
+    reviews: list[ReviewLoopState] = []
+    finalizations: list[ReviewLoopResult] = []
+    coordinator = _coordinator(
+        resolve_conflict=lambda: False,
+        review_iteration=reviews.append,
+        finalize=finalizations.append,
+    )
+
+    result = coordinator.run(has_pr=True)
+
+    assert result == ReviewLoopResult(iterations_run=0, verdict="NOGO", grade=None)
+    assert reviews == []
+    assert finalizations == [result]
+
+
+def test_clean_go_terminates_without_addressing() -> None:
+    """A clean GO stops the loop immediately."""
+    addressed: list[ReviewLoopState] = []
+    coordinator = _coordinator(
+        review_iteration=lambda _state: _outcome(verdict="GO", should_break=True),
+        address_iteration=addressed.append,
+    )
+
+    result = coordinator.run(has_pr=True)
+
+    assert result == ReviewLoopResult(iterations_run=1, verdict="GO", grade="B")
+    assert addressed == []
+
+
+def test_zero_thread_clean_nogo_retries_without_addressing() -> None:
+    """A clean no-thread NOGO is re-reviewed instead of sent to an agent."""
+    outcomes = iter(
+        [
+            _outcome(posted_thread_ids=()),
+            _outcome(verdict="GO", posted_thread_ids=(), should_break=True),
+        ]
+    )
+    addressed: list[ReviewLoopState] = []
+    coordinator = _coordinator(
+        review_iteration=lambda _state: next(outcomes),
+        address_iteration=addressed.append,
+    )
+
+    result = coordinator.run(has_pr=True)
+
+    assert result.iterations_run == 2
+    assert addressed == []
+
+
+def test_validator_reopening_forces_address_path() -> None:
+    """Validator reopenings remain actionable even without reviewer threads."""
+    outcomes = iter(
+        [
+            _outcome(
+                posted_thread_ids=(),
+                reopened=("reopened",),
+                reopened_keys=frozenset({"key"}),
+                validator_clean=False,
+            ),
+            _outcome(verdict="GO", should_break=True),
+        ]
+    )
+    addressed: list[ReviewLoopState] = []
+
+    def _address_iteration(state: ReviewLoopState) -> AddressOutcome:
+        addressed.append(state)
+        return AddressOutcome(({"id": "thread"},), True)
+
+    coordinator = _coordinator(
+        review_iteration=lambda _state: next(outcomes),
+        address_iteration=_address_iteration,
+    )
+
+    coordinator.run(has_pr=True)
+
+    assert len(addressed) == 1
+    assert addressed[0].reopened_keys == frozenset({"key"})
+
+
+def test_prior_threads_and_reopened_keys_flow_to_next_iteration() -> None:
+    """Each re-review receives the previous address and validation state."""
+    observed: list[ReviewLoopState] = []
+    outcomes = iter(
+        [
+            _outcome(reopened_keys=frozenset({"key"})),
+            _outcome(verdict="GO", should_break=True),
+        ]
+    )
+
+    def _review_iteration(state: ReviewLoopState) -> ReviewIterationOutcome:
+        observed.append(state)
+        return next(outcomes)
+
+    coordinator = _coordinator(
+        review_iteration=_review_iteration,
+        address_iteration=lambda _state: AddressOutcome(({"id": "thread"},), True),
+    )
+
+    coordinator.run(has_pr=True)
+
+    assert observed[1].prior_addressed_threads == ({"id": "thread"},)
+    assert observed[1].reopened_keys == frozenset({"key"})
+
+
+def test_no_commit_turn_carries_findings_into_one_retry() -> None:
+    """A no-commit address pass supplies its unresolved findings to the retry."""
+    address_states: list[ReviewLoopState] = []
+    outcomes = iter([_outcome(), _outcome(), _outcome(verdict="GO", should_break=True)])
+
+    def _address(state: ReviewLoopState) -> AddressOutcome:
+        address_states.append(state)
+        if len(address_states) == 1:
+            return AddressOutcome(({"id": "still-open"},), False)
+        return AddressOutcome((), True)
+
+    coordinator = _coordinator(
+        review_iteration=lambda _state: next(outcomes),
+        address_iteration=_address,
+    )
+
+    coordinator.run(has_pr=True)
+
+    assert address_states[1].pending_unaddressed == ({"id": "still-open"},)
+
+
+def test_progress_extends_soft_budget_without_exceeding_hard_cap() -> None:
+    """Progress earns a re-review, but the hard iteration limit remains absolute."""
+    reviewed: list[int] = []
+    extended: list[int] = []
+    outcomes = iter([_outcome(), _outcome(), _outcome(verdict="GO", should_break=True)])
+
+    def _review_iteration(state: ReviewLoopState) -> ReviewIterationOutcome:
+        reviewed.append(state.iteration)
+        return next(outcomes)
+
+    coordinator = _coordinator(
+        soft_limit=2,
+        hard_limit=3,
+        review_iteration=_review_iteration,
+        budget_extended=extended.append,
+    )
+
+    result = coordinator.run(has_pr=True)
+
+    assert result.iterations_run == 3
+    assert reviewed == [0, 1, 2]
+    assert extended == [3]
+
+
+def test_no_progress_stops_at_soft_budget() -> None:
+    """A validator reopening prevents a soft-budget extension."""
+    reviewed: list[int] = []
+
+    def _review_iteration(state: ReviewLoopState) -> ReviewIterationOutcome:
+        reviewed.append(state.iteration)
+        return _outcome(validator_clean=False)
+
+    coordinator = _coordinator(
+        soft_limit=2,
+        hard_limit=4,
+        review_iteration=_review_iteration,
+    )
+
+    result = coordinator.run(has_pr=True)
+
+    assert result.iterations_run == 2
+    assert reviewed == [0, 1]
+
+
+def test_pr_less_mode_advances_without_address_operation() -> None:
+    """Diff-only review never invokes an address operation with no PR threads."""
+    addressed: list[ReviewLoopState] = []
+    coordinator = _coordinator(
+        soft_limit=2,
+        review_iteration=lambda _state: _outcome(posted_thread_ids=()),
+        address_iteration=addressed.append,
+    )
+
+    result = coordinator.run(has_pr=False)
+
+    assert result.iterations_run == 2
+    assert addressed == []
+
+
+@pytest.mark.parametrize("has_pr", [False, True])
+def test_finalization_occurs_once(has_pr: bool) -> None:
+    """Both loop modes report one and only one terminal result."""
+    finalizations: list[ReviewLoopResult] = []
+    coordinator = _coordinator(
+        review_iteration=lambda _state: _outcome(verdict="GO", should_break=True),
+        finalize=finalizations.append,
+    )
+
+    result = coordinator.run(has_pr=has_pr)
+
+    assert finalizations == [result]

--- a/tests/unit/automation/test_review_orchestration_architecture.py
+++ b/tests/unit/automation/test_review_orchestration_architecture.py
@@ -1,0 +1,129 @@
+"""Architecture guardrails for review-phase orchestration collaborators."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ClassBudget:
+    """Maximum size permitted for one collaborator and its methods."""
+
+    max_lines: int
+    max_method_lines: int
+
+
+_BUDGETS = {
+    "hephaestus.automation._review_conflict_resolver.ReviewConflictResolver": ClassBudget(
+        max_lines=260,
+        max_method_lines=80,
+    ),
+    "hephaestus.automation._review_loop.ReviewLoopCoordinator": ClassBudget(
+        max_lines=260,
+        max_method_lines=80,
+    ),
+}
+
+_REVIEW_PHASE_FACADE_BUDGETS = {
+    "_resolve_conflict_before_review": 60,
+    "_run_impl_review_loop": 60,
+}
+
+_FORBIDDEN_LOOP_IMPORTS = {
+    "hephaestus.agents",
+    "hephaestus.github",
+    "hephaestus.automation.git_utils",
+    "hephaestus.automation.github_api",
+    "hephaestus.automation.models",
+    "hephaestus.automation.status_tracker",
+}
+
+
+def _module_path(dotted: str) -> Path:
+    """Map a dotted module/class reference to its source file."""
+    module_name = dotted.rsplit(".", 1)[0]
+    return Path(*module_name.split(".")).with_suffix(".py")
+
+
+def _class_node(dotted: str) -> ast.ClassDef:
+    """Return the named class node from a repository source file."""
+    class_name = dotted.rsplit(".", 1)[1]
+    tree = ast.parse(_module_path(dotted).read_text())
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    raise AssertionError(f"{dotted} not found")
+
+
+def _span(node: ast.AST) -> int:
+    """Return the inclusive line span for one parsed node."""
+    start = getattr(node, "lineno", None)
+    end = getattr(node, "end_lineno", None)
+    assert isinstance(start, int)
+    assert isinstance(end, int)
+    return end - start + 1
+
+
+def _methods(node: ast.ClassDef) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return methods declared directly by a class."""
+    return [item for item in node.body if isinstance(item, ast.FunctionDef | ast.AsyncFunctionDef)]
+
+
+def test_review_collaborator_budgets() -> None:
+    """Keep extracted collaborators focused enough to retain one responsibility."""
+    failures: list[str] = []
+    for dotted, budget in _BUDGETS.items():
+        node = _class_node(dotted)
+        if _span(node) > budget.max_lines:
+            failures.append(f"{dotted}: {_span(node)} lines > {budget.max_lines}")
+        for method in _methods(node):
+            if _span(method) > budget.max_method_lines:
+                failures.append(
+                    f"{dotted}.{method.name}: {_span(method)} lines > {budget.max_method_lines}"
+                )
+    assert failures == []
+
+
+def test_review_phase_facades_remain_small() -> None:
+    """Prevent the compatibility facade from regaining loop orchestration."""
+    tree = ast.parse(Path("hephaestus/automation/_review_phase.py").read_text())
+    phase = next(
+        node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "ReviewPhase"
+    )
+    methods = {
+        method.name: method
+        for method in _methods(phase)
+        if method.name in _REVIEW_PHASE_FACADE_BUDGETS
+    }
+    assert methods.keys() == _REVIEW_PHASE_FACADE_BUDGETS.keys()
+    failures = [
+        f"{name}: {_span(methods[name])} lines > {budget}"
+        for name, budget in _REVIEW_PHASE_FACADE_BUDGETS.items()
+        if _span(methods[name]) > budget
+    ]
+    assert failures == []
+
+
+def test_pure_loop_has_no_direct_io_or_state_imports() -> None:
+    """The loop coordinator receives all effects through its operations object."""
+    tree = ast.parse(Path("hephaestus/automation/_review_loop.py").read_text())
+    imports = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+        for alias in node.names
+    }
+    imported_modules = {
+        node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module
+    }
+    offending = {
+        candidate
+        for candidate in _FORBIDDEN_LOOP_IMPORTS
+        if any(
+            module == candidate or module.startswith(f"{candidate}.") for module in imported_modules
+        )
+    }
+    assert imports
+    assert offending == set()

--- a/tests/unit/automation/test_stage_phases.py
+++ b/tests/unit/automation/test_stage_phases.py
@@ -21,6 +21,8 @@ from hephaestus.automation._followup_phase import FollowUpPhase
 from hephaestus.automation._implement_phase import ImplementPhase, _prepend_advise
 from hephaestus.automation._plan_phase import PlanPhase, _phase_env
 from hephaestus.automation._pr_create_phase import PRCreatePhase
+from hephaestus.automation._review_conflict_resolver import ConflictResolutionRequest
+from hephaestus.automation._review_loop import ReviewLoopResult
 from hephaestus.automation._review_phase import ReviewPhase, _is_automation_owned_thread
 from hephaestus.automation._stage_context import StageContext, StageMixin
 
@@ -449,6 +451,17 @@ def test_review_phase_push_branch_delegates(tmp_path: Path) -> None:
     mock_push.assert_called_once_with("b", tmp_path)
 
 
+def test_review_phase_push_rebased_branch_uses_lease(tmp_path: Path) -> None:
+    """A rebased branch is published through the force-with-lease helper."""
+    phase = ReviewPhase(_make_ctx(tmp_path))
+    with mock.patch(
+        "hephaestus.automation._review_phase.push_current_branch_with_lease_on_divergence"
+    ) as push:
+        phase._push_rebased_branch("b", tmp_path)
+
+    push.assert_called_once_with(tmp_path, branch="b", push_ref="HEAD:b")
+
+
 def test_review_phase_commit_if_changes_delegates_to_git_utils(tmp_path: Path) -> None:
     """_commit_if_changes delegates to the canonical git helper."""
     phase = ReviewPhase(_make_ctx(tmp_path))
@@ -483,220 +496,60 @@ def test_review_phase_commit_if_changes_clean_returns_false(tmp_path: Path) -> N
     )
 
 
-# ---------------------------------------------------------------------------
-# #1328: pre-review conflict gate
-# ---------------------------------------------------------------------------
-
-
-def _gh_json(payload: dict[str, Any]) -> SimpleNamespace:
-    """Stub a gh result carrying JSON stdout."""
-    return SimpleNamespace(stdout=json.dumps(payload), stderr="")
-
-
-def test_review_phase_merge_state_uses_owner_repo_slug(tmp_path: Path) -> None:
-    """``gh pr view --repo`` requires OWNER/REPO, not the short repo slug."""
+def test_review_phase_loop_facade_preserves_tuple_contract(tmp_path: Path) -> None:
+    """The review-loop compatibility facade returns its historical tuple."""
     phase = ReviewPhase(_make_ctx(tmp_path))
-    with (
-        mock.patch("hephaestus.automation._review_phase.get_repo_info", return_value=("o", "r")),
-        mock.patch(
-            "hephaestus.automation._review_phase.gh_call",
-            return_value=_gh_json({"mergeStateStatus": "dirty", "mergeable": "conflicting"}),
-        ) as gh_call,
-    ):
-        assert phase._pr_merge_state(12) == ("DIRTY", "CONFLICTING")
-    args = gh_call.call_args.args[0]
-    assert args[args.index("--repo") + 1] == "o/r"
-
-
-def test_conflict_gate_clean_pr_proceeds_without_resolution(tmp_path: Path) -> None:
-    """#1328: a non-conflicting PR returns True with no rebase/agent spend."""
-    phase = ReviewPhase(_make_ctx(tmp_path))
-    with (
-        mock.patch.object(
-            phase, "_pr_merge_state", return_value=("CLEAN", "MERGEABLE")
-        ) as merge_state,
-        mock.patch("hephaestus.automation._review_phase.rebase_worktree_onto") as rebase,
-        mock.patch.object(phase, "_resume_impl_with_feedback") as resume,
-    ):
-        result = phase._resolve_conflict_before_review(
-            issue_number=7,
-            pr_number=12,
-            worktree_path=tmp_path,
-            branch_name="b",
-            session_id="sess",
-            slot_id=None,
-            thread_id=None,
-            state=None,
-        )
-    assert result is True
-    merge_state.assert_called_once()
-    rebase.assert_not_called()
-    resume.assert_not_called()
-
-
-def test_conflict_gate_mechanical_rebase_clears_conflict(tmp_path: Path) -> None:
-    """#1328: a clean mechanical rebase clears the conflict without the agent."""
-    phase = ReviewPhase(_make_ctx(tmp_path))
-    with (
-        mock.patch.object(
-            phase,
-            "_pr_merge_state",
-            side_effect=[("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")],
-        ),
-        mock.patch(
-            "hephaestus.automation._review_phase.gh_call",
-            return_value=_gh_json({"baseRefName": "main"}),
-        ),
-        mock.patch("hephaestus.automation._review_phase.sync_worktree_to_remote_branch"),
-        mock.patch(
-            "hephaestus.automation._review_phase.rebase_worktree_onto", return_value=True
-        ) as rebase,
-        mock.patch(
-            "hephaestus.automation._review_phase.push_current_branch_with_lease_on_divergence"
-        ) as push,
-        mock.patch.object(phase, "_resume_impl_with_feedback") as resume,
-    ):
-        result = phase._resolve_conflict_before_review(
-            issue_number=7,
-            pr_number=12,
-            worktree_path=tmp_path,
-            branch_name="b",
-            session_id="sess",
-            slot_id=None,
-            thread_id=None,
-            state=None,
-        )
-    assert result is True
-    rebase.assert_called_once()
-    push.assert_called_once()
-    resume.assert_not_called()  # agent never needed — rebase cleared it
-
-
-def test_conflict_gate_dispatches_agent_when_rebase_conflicts(tmp_path: Path) -> None:
-    """#1328: a still-conflicting rebase hands off to the implementation agent."""
-    phase = ReviewPhase(_make_ctx(tmp_path))
-    runner = cast(Any, phase.ctx.runner)
-    runner._commit_if_changes = mock.Mock(return_value=True)
-    runner._push_branch = mock.Mock()
-    with (
-        mock.patch.object(
-            phase,
-            "_pr_merge_state",
-            # initial=DIRTY → rebase fails → agent resolves → final=CLEAN
-            side_effect=[("DIRTY", "CONFLICTING"), ("CLEAN", "MERGEABLE")],
-        ),
-        mock.patch(
-            "hephaestus.automation._review_phase.gh_call",
-            return_value=_gh_json({"baseRefName": "main"}),
-        ),
-        mock.patch("hephaestus.automation._review_phase.sync_worktree_to_remote_branch"),
-        mock.patch("hephaestus.automation._review_phase.rebase_worktree_onto", return_value=False),
-        mock.patch.object(phase, "_resume_impl_with_feedback", return_value=True) as resume,
-    ):
-        result = phase._resolve_conflict_before_review(
-            issue_number=7,
-            pr_number=12,
-            worktree_path=tmp_path,
-            branch_name="b",
-            session_id="sess",
-            slot_id=None,
-            thread_id=None,
-            state=None,
-        )
-    assert result is True
-    resume.assert_called_once()
-    runner._commit_if_changes.assert_called_once()
-    runner._push_branch.assert_called_once()
-
-
-def test_conflict_gate_unresolved_returns_false(tmp_path: Path) -> None:
-    """#1328: an unresolved conflict after the agent returns False (not-GO)."""
-    phase = ReviewPhase(_make_ctx(tmp_path))
-    runner = cast(Any, phase.ctx.runner)
-    runner._commit_if_changes = mock.Mock(return_value=True)
-    runner._push_branch = mock.Mock()
-    with (
-        mock.patch.object(
-            phase,
-            "_pr_merge_state",
-            side_effect=[("DIRTY", "CONFLICTING"), ("DIRTY", "CONFLICTING")],
-        ),
-        mock.patch(
-            "hephaestus.automation._review_phase.gh_call",
-            return_value=_gh_json({"baseRefName": "main"}),
-        ),
-        mock.patch("hephaestus.automation._review_phase.sync_worktree_to_remote_branch"),
-        mock.patch("hephaestus.automation._review_phase.rebase_worktree_onto", return_value=False),
-        mock.patch.object(phase, "_resume_impl_with_feedback", return_value=True),
-    ):
-        result = phase._resolve_conflict_before_review(
-            issue_number=7,
-            pr_number=12,
-            worktree_path=tmp_path,
-            branch_name="b",
-            session_id="sess",
-            slot_id=None,
-            thread_id=None,
-            state=None,
-        )
-    assert result is False
-
-
-def test_review_loop_resolves_conflict_before_first_review(tmp_path: Path) -> None:
-    """#1328: the conflict gate runs BEFORE the first review iteration."""
-    phase = ReviewPhase(_make_ctx(tmp_path))
-    call_order: list[str] = []
-
-    def _gate(**_kwargs: Any) -> bool:
-        call_order.append("gate")
-        return True
-
-    def _iter(**_kwargs: Any) -> tuple[Any, ...]:
-        call_order.append("review")
-        # verdict, grade, review_text, posted_thread_ids, go_blocked, reopened, should_break,
-        # prior_reopened_keys, validator_clean
-        return "GO", "A", "ok", [], False, [], True, set(), True
-
-    with (
-        mock.patch.object(phase, "_resolve_conflict_before_review", side_effect=_gate) as gate,
-        mock.patch.object(phase, "_process_review_iteration", side_effect=_iter),
-        mock.patch.object(phase, "_finalize_review_outcome"),
-    ):
-        phase._run_impl_review_loop(
+    outcome = ReviewLoopResult(iterations_run=2, verdict="GO", grade="A")
+    with mock.patch("hephaestus.automation._review_phase.ReviewLoopCoordinator") as coordinator:
+        coordinator.return_value.run.return_value = outcome
+        result = phase._run_impl_review_loop(
             issue_number=7,
             worktree_path=tmp_path,
             branch_name="b",
-            issue_title="t",
+            issue_title="title",
             issue_body="body",
-            session_id="sess",
+            session_id="session",
             slot_id=None,
             thread_id=None,
             pr_number=12,
         )
-    gate.assert_called_once()
-    assert call_order[0] == "gate"
-    assert "review" in call_order
+
+    assert result == (2, "GO", "A")
+    assert coordinator.return_value.run.call_args.kwargs == {"has_pr": True}
 
 
-def test_review_loop_skips_reviewer_when_conflict_unresolved(tmp_path: Path) -> None:
-    """#1328: an unresolved conflict skips the reviewer entirely (not-GO)."""
+def test_review_phase_conflict_facade_constructs_request(tmp_path: Path) -> None:
+    """The conflict facade binds phase state without exposing StageContext."""
     phase = ReviewPhase(_make_ctx(tmp_path))
     with (
-        mock.patch.object(phase, "_resolve_conflict_before_review", return_value=False),
-        mock.patch.object(phase, "_process_review_iteration") as review,
-        mock.patch.object(phase, "_finalize_review_outcome") as finalize,
+        mock.patch("hephaestus.automation._review_phase.ReviewConflictResolver") as resolver,
+        mock.patch.object(phase, "_push_rebased_branch") as push_rebased,
+        mock.patch.object(phase, "_push_branch") as push_agent,
     ):
-        iterations, verdict, grade = phase._run_impl_review_loop(
+        resolver.return_value.resolve.return_value = True
+        result = phase._resolve_conflict_before_review(
             issue_number=7,
+            pr_number=12,
             worktree_path=tmp_path,
             branch_name="b",
-            issue_title="t",
-            issue_body="body",
-            session_id="sess",
-            slot_id=None,
-            thread_id=None,
-            pr_number=12,
+            session_id="session",
+            slot_id=3,
+            thread_id=4,
+            state=None,
         )
-    review.assert_not_called()  # reviewer never runs on a conflicted PR
-    assert (iterations, verdict, grade) == (0, "NOGO", None)
-    finalize.assert_called_once()
+        resolver.call_args.kwargs["push_rebased_branch"]("b", tmp_path)
+        resolver.call_args.kwargs["push_agent_branch"]("b", tmp_path)
+
+    assert result is True
+    push_rebased.assert_called_once_with("b", tmp_path)
+    push_agent.assert_called_once_with("b", tmp_path)
+    assert resolver.return_value.resolve.call_args.args == (
+        ConflictResolutionRequest(
+            issue_number=7,
+            pr_number=12,
+            worktree_path=tmp_path,
+            branch_name="b",
+            slot_id=3,
+            thread_id=4,
+        ),
+    )


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: Extracted review loop/conflict resolver collaborators, added regression/architecture tests, and updated review-stage docs; 6,407 tests passed (230 skipped), Ruff/format/mypy passed; pre-commit was blocked by GitHub DNS.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2139

Generated by Hephaestus automation
