### PR TITLE
[majo] Enforce uv.lock freshness and ownership

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,13 +87,13 @@ repos:
         pass_filenames: false
 
   # Lock file freshness
-  - repo: local
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.28
     hooks:
-      - id: check-uv-lock
+      - id: uv-lock
         name: Check uv lock file
-        description: Verify uv.lock is up to date
-        entry: uv lock --check
-        language: system
+        description: Verify uv.lock is up to date without modifying it
+        args: [--check]
         pass_filenames: false
         files: ^(pyproject\.toml|uv\.lock)$
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,8 +216,10 @@ computes the next semver string and prints the `git tag` commands to run.
 
 ## Dependency Updates
 
-- **Dependabot** is configured for Python and GitHub Actions updates in
-  [`.github/dependabot.yml`](.github/dependabot.yml).
+- **Dependabot** owns the root Python dependency lifecycle through the `uv`
+  ecosystem in [`.github/dependabot.yml`](.github/dependabot.yml):
+  `pyproject.toml` declarations and the committed `uv.lock`. It opens grouped
+  Python dependency PRs weekly and also manages `github-actions` updates.
 - Refresh the lockfile deliberately when updating dependencies:
 
   ```bash
@@ -227,6 +229,24 @@ computes the next semver string and prints the `git tag` commands to run.
 
   Review and commit the resulting `uv.lock` together with any corresponding
   `pyproject.toml` change. `uv lock --check` is the CI consistency check.
+
+### Python dependency and `uv.lock` lifecycle
+
+`uv.lock` is committed and must remain synchronized with the dependency
+declarations in `pyproject.toml`. Dependabot owns the routine weekly updates;
+when changing dependencies manually, regenerate and commit `uv.lock` with the
+same change:
+
+```bash
+uv lock                                  # resolve declared dependency changes
+uv lock --upgrade-package <name>         # upgrade one package deliberately
+uv lock --upgrade                         # upgrade all packages deliberately
+uv lock --check                           # verify the committed lock is fresh
+```
+
+The `uv lock --check` pre-commit hook runs for `pyproject.toml` and `uv.lock`
+changes and is enforced by the required CI lint job. The check is read-only;
+use one of the update commands above to refresh the lock before committing.
 
 ## Pull Request Process
 

--- a/tests/unit/ci/test_uv_lock_policy.py
+++ b/tests/unit/ci/test_uv_lock_policy.py
@@ -1,0 +1,50 @@
+"""Guard uv.lock freshness enforcement and lifecycle documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_uv_lock_hook_is_check_only_and_ci_enforced() -> None:
+    """The read-only uv lock check must run in the required lint job."""
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8"))
+    repo = next(
+        repo
+        for repo in config["repos"]
+        if repo["repo"] == "https://github.com/astral-sh/uv-pre-commit"
+    )
+    hook = next(hook for hook in repo["hooks"] if hook["id"] == "uv-lock")
+
+    assert repo["rev"] == "0.11.28"
+    assert hook["args"] == ["--check"]
+    assert hook["files"] == r"^(pyproject\.toml|uv\.lock)$"
+    assert hook["pass_filenames"] is False
+
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github/workflows/_required.yml").read_text(encoding="utf-8")
+    )
+    lint_steps = workflow["jobs"]["lint"]["steps"]
+    assert any("pre-commit run --all-files" in step.get("run", "") for step in lint_steps)
+
+
+def test_contributing_documents_uv_lock_lifecycle() -> None:
+    """The contributor guide must describe the complete uv lock lifecycle."""
+    text = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    heading = "### Python dependency and `uv.lock` lifecycle"
+    section = text.split(heading, 1)[1].split("\n## ", 1)[0]
+
+    for required in (
+        "Dependabot",
+        "weekly",
+        "`pyproject.toml`",
+        "`uv.lock`",
+        "uv lock",
+        "uv lock --upgrade-package <name>",
+        "uv lock --upgrade",
+        "uv lock --check",
+    ):
+        assert required in section


### PR DESCRIPTION
## Summary
Verdict: implemented | Reason: Added uv lock freshness gate and lifecycle ownership docs; tests: 6,381 passed/230 skipped, plus 5 focused post-format tests passed; `uv lock --check`, mypy, ruff, and format checks pass; remote pre-commit initialization is blocked by sandbox DNS.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2148

Generated by Hephaestus automation
