### PR TITLE
[mino] Escalate NATS shutdown-timeout failures

### DIFF
--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -74,7 +74,8 @@ class SubscriberState(enum.Enum):
         CONNECTED    → STOPPING     (stop() called while connected)
         DISCONNECTED → STOPPING     (stop() called while in backoff)
         STOPPING     → STOPPED      (thread join completes)
-        any          → ERROR        (unhandled exception or open circuit breaker)
+        any          → ERROR        (unhandled exception, open circuit breaker,
+                                     or shutdown join timeout)
 
     """
 
@@ -521,9 +522,10 @@ class NATSSubscriberThread(threading.Thread):
 
         Returns:
             ``True`` if the thread joined cleanly within the timeout (or had
-            already finished); ``False`` if the join timed out and the thread
-            is still running. A ``False`` return also logs a warning so the
-            condition is visible in logs even when the caller ignores it.
+            already finished). ``False`` if the thread remains alive after the
+            timeout; in that case the subscriber enters ``ERROR`` state and
+            exposes a :class:`TimeoutError` through ``last_error`` and
+            :meth:`health_dict`.
 
         """
         effective_timeout = self._join_timeout if timeout is None else timeout
@@ -532,9 +534,11 @@ class NATSSubscriberThread(threading.Thread):
         if self.is_alive():
             self.join(timeout=effective_timeout)
             if self.is_alive():
-                logger.warning(
-                    "NATS subscriber thread did not stop within %.1fs — still running",
-                    effective_timeout,
+                error = TimeoutError(
+                    "NATS subscriber thread did not stop within "
+                    f"{effective_timeout:g}s — still running"
                 )
+                self._record_terminal_error(error)
+                logger.error("%s", error)
                 return False
         return True

--- a/tests/unit/nats/test_subscriber.py
+++ b/tests/unit/nats/test_subscriber.py
@@ -49,22 +49,34 @@ class TestNATSSubscriberThread:
         # A thread that was never started counts as "joined cleanly" (True).
         assert thread.stop() is True
 
-    def test_stop_returns_false_on_join_timeout(self) -> None:
-        """When a started thread refuses to exit within the timeout, stop() returns False.
-
-        Regression for #521: stop() previously returned None and silently
-        masked a wedged subscriber thread.
-        """
+    def test_stop_timeout_records_terminal_health_failure(self) -> None:
+        """A timed-out join leaves the live daemon observable as unhealthy."""
+        entered = threading.Event()
+        release = threading.Event()
         thread = NATSSubscriberThread(config=_config(), handler=MagicMock())
-        # Simulate a wedged thread: is_alive() returns True both before and
-        # after join(), and join() itself is a no-op so we don't need to
-        # actually start a real thread.
-        with (
-            patch.object(NATSSubscriberThread, "is_alive", return_value=True),
-            patch.object(NATSSubscriberThread, "join", return_value=None),
-        ):
-            result = thread.stop(timeout=0.01)
-        assert result is False
+
+        def blocked_run() -> None:
+            entered.set()
+            release.wait()
+
+        thread.run = blocked_run  # type: ignore[method-assign]
+        thread.start()
+        assert entered.wait(timeout=1.0)
+
+        try:
+            assert thread.stop(timeout=0.01) is False
+            assert thread.is_alive()
+            assert thread.state is SubscriberState.ERROR
+            assert isinstance(thread.last_error, TimeoutError)
+            assert thread.health_dict()["state"] == "error"
+            assert thread.health_dict()["last_error"] == (
+                "NATS subscriber thread did not stop within 0.01s — still running"
+            )
+        finally:
+            release.set()
+            thread.join(timeout=1.0)
+
+        assert not thread.is_alive()
 
     def test_stop_event_is_threading_event(self) -> None:
         thread = NATSSubscriberThread(config=_config(), handler=MagicMock())


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: shutdown timeout now records terminal `TimeoutError` health failure in [subscriber.py](/mnt/weka/home/micah.villmow/Projects/Hephaestus/build/.worktrees/issue-2156/hephaestus/nats/subscriber.py:465), covered by a real blocked-daemon test [test_subscriber.py](/mnt/weka/home/micah.villmow/Projects/Hephaestus/build/.worktrees/issue-2156/tests/unit/nats/test_subscriber.py:51); full tests passed (6,379 passed, 230 skipped, 85.26% coverage), mypy/Ruff passed; pre-commit was blocked only by the sandbox’s read-only Pixi cache.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2156

Generated by Hephaestus automation
