### PR TITLE
[mino] Add acceptance criteria and verification fields to issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,6 +42,30 @@ body:
         - hephaestus: 0.3.0
     validations:
       required: false
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: >
+        List the specific, testable outcomes that must be true for this bug
+        to be considered fixed.
+      placeholder: |
+        - [ ] Given ..., when ..., then ...
+        - [ ] The regression is covered by ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification_plan
+    attributes:
+      label: Verification Plan
+      description: >
+        For each acceptance criterion, provide the command, automated test, or
+        manual check that proves it, plus the expected evidence.
+      placeholder: |
+        - Criterion 1: `pixi run pytest ...`
+          Expected evidence: ...
+    validations:
+      required: true
   - type: dropdown
     id: severity
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -24,6 +24,30 @@ body:
       description: Any alternative solutions or workarounds you've considered.
     validations:
       required: false
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: >
+        List the specific, testable outcomes that must be true for this feature
+        to be considered complete.
+      placeholder: |
+        - [ ] Given ..., when ..., then ...
+        - [ ] The behavior is covered by ...
+    validations:
+      required: true
+  - type: textarea
+    id: verification_plan
+    attributes:
+      label: Verification Plan
+      description: >
+        For each acceptance criterion, provide the command, automated test, or
+        manual check that proves it, plus the expected evidence.
+      placeholder: |
+        - Criterion 1: `pixi run pytest ...`
+          Expected evidence: ...
+    validations:
+      required: true
   - type: dropdown
     id: severity
     attributes:

--- a/docs/auto-label-needs-plan.md
+++ b/docs/auto-label-needs-plan.md
@@ -47,6 +47,10 @@ The issue forms
   pattern (`epic` label, see [ROADMAP.md](ROADMAP.md)). **Reference only:**
   triage links it; it is not auto-consumed (free-text parsing into pipeline
   state is deliberately avoided).
+- **Acceptance Criteria** — a required Markdown checklist of specific, testable
+  outcomes that define when the issue is complete.
+- **Verification Plan** — a required criterion-by-criterion mapping to runnable
+  commands, automated tests, or manual checks and their expected evidence.
 - **Audit-section** is intentionally **not** a form field. Hephaestus has
   no per-audit-section label vocabulary (only `audit-finding`), so maintainers
   tag audit section during triage rather than via the form — avoiding an inert

--- a/tests/unit/github/test_issue_templates.py
+++ b/tests/unit/github/test_issue_templates.py
@@ -51,6 +51,35 @@ def test_parent_epic_is_optional_input() -> None:
         assert p.get("validations", {}).get("required", False) is False
 
 
+def test_acceptance_criteria_is_required_checklist_textarea() -> None:
+    """Both forms require testable completion criteria in checklist form."""
+    for form in FORMS:
+        criteria = _field(_load(form), "acceptance_criteria")
+        assert criteria["type"] == "textarea"
+        assert criteria["attributes"]["label"] == "Acceptance Criteria"
+        assert "- [ ]" in criteria["attributes"]["placeholder"]
+        assert criteria["validations"]["required"] is True
+
+
+def test_verification_plan_is_required_criterion_map() -> None:
+    """Both forms require criterion-linked verification and expected evidence."""
+    for form in FORMS:
+        plan = _field(_load(form), "verification_plan")
+        assert plan["type"] == "textarea"
+        assert plan["attributes"]["label"] == "Verification Plan"
+        assert plan["validations"]["required"] is True
+
+        guidance = " ".join(
+            (
+                plan["attributes"]["description"],
+                plan["attributes"]["placeholder"],
+            )
+        ).lower()
+        assert "acceptance criterion" in guidance
+        assert "command" in guidance
+        assert "expected evidence" in guidance
+
+
 def test_forms_seed_only_existing_labels() -> None:
     """Forms seed only provisioned default labels (no phantom labels)."""
     for form in FORMS:


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: Added required acceptance/verification form fields, tests, and intake docs; full suite passed (6,381 passed, 230 skipped); mypy, Ruff, and YAML lint passed.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2159

Generated by Hephaestus automation
