### PR TITLE
[majo] Align Conventional Commit policy with enforced history

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -42,15 +42,17 @@ Builds and publishes the package to PyPI on version tag push (`v*`).
 ### Required Checks Workflow (`workflows/_required.yml`)
 
 The consolidated required-status-check gate that runs on every pull request to
-`main` (and on push to `main`). It aggregates lint, `pixi-check`,
-shellcheck, the `pr-policy` gate (enforces `Closes #N` and signed commits),
-unit/integration/shell tests, wheel build, security scans (pip-audit, Gitleaks,
-bandit), workflow-schema validation, and version-sync. It also runs the
-advisory `auto-merge-policy` job. During #2054's fail-closed bootstrap it
-signals any open PR with auto-merge armed; it is intentionally **not** a
-required check so it does not block the manually reviewed bootstrap merge.
-The privileged label-event auto-merge workflow was removed. #2055 restores
-queue-owned arming only after a head-bound independent strict-review proof.
+`main` (and on push to `main`). It aggregates lint, `pixi-check`, shellcheck,
+the `pr-policy` gate (enforces `Closes #N`, commit signatures and DCO trailers,
+the Conventional Commit PR title used for squash history, and every branch
+commit subject), unit/integration/shell tests, wheel build, security scans
+(pip-audit, Gitleaks, bandit), workflow-schema validation, and version-sync. It
+also runs the advisory `auto-merge-policy` job. During #2054's fail-closed
+bootstrap it signals any open PR with auto-merge armed; it is intentionally
+**not** a required check so it does not block the manually reviewed bootstrap
+merge. The privileged label-event auto-merge workflow was removed. #2055
+restores queue-owned arming only after a head-bound independent strict-review
+proof.
 
 ### Auto-Tag Workflow (`workflows/auto-tag.yml`)
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
-    # Dependabot auto-appends a colon after a prefix ending in ) → "chore(deps): ...".
+    # GitHub applies this prefix to commit subjects and PR titles; a trailing
+    # ) receives the Conventional Commit colon → "chore(deps): ...".
     # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
     commit-message:
       prefix: "chore(deps)"
@@ -22,6 +23,7 @@ updates:
     labels:
       - "dependencies"
       - "ci/cd"
+    # Same explicit title/subject prefix as the pip ecosystem above.
     commit-message:
       prefix: "chore(deps)"
     groups:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,7 +48,7 @@ Closes #
 - [ ] Comments added in hard-to-understand areas
 - [ ] Documentation updated (if needed)
 - [ ] No new warnings introduced
-- [ ] Conventional commit message format used
+- [ ] PR title and authored commit subjects use Conventional Commit format
 - [ ] Branch named following convention: `<issue-number>-<description>`
 - [ ] Change meets the [Definition of Done](https://github.com/mvillmow/Hephaestus/blob/main/docs/DEFINITION_OF_DONE.md)
 

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -11,15 +11,15 @@ on:
     # auto-merge-policy's check was stuck with its PR-open verdict until the
     # next push (the race that #680 papered over with `needs: lint`).
     # Re-running on auto_merge_enabled / auto_merge_disabled, labeled /
-    # unlabeled, and ready_for_review makes that gate converge on the true
-    # state with no timing reliance. See auto-merge-policy below.
+    # unlabeled, ready_for_review, and edited makes those gates converge on the
+    # true state with no timing reliance. See auto-merge-policy below.
     #
     # IMPORTANT: a pull_request trigger applies to the WHOLE workflow, so the
-    # label / auto-merge event types would otherwise re-run EVERY job on each
-    # label change. Those four actions exist solely for pr-policy /
+    # label / auto-merge / edited event types would otherwise re-run EVERY job
+    # on each metadata change. Those five actions exist solely for pr-policy /
     # auto-merge-policy to re-converge, so the `changes-gate` job below gates the
     # 16 heavy jobs to skip on labeled/unlabeled/auto_merge_enabled/
-    # auto_merge_disabled — only the two policy jobs run on those events. The
+    # auto_merge_disabled/edited — only the two policy jobs run on those events. The
     # heavy jobs' results from the last code push still stand for the SHA, so
     # branch-protection required checks remain satisfied.
     types:
@@ -31,6 +31,7 @@ on:
       - unlabeled
       - auto_merge_enabled
       - auto_merge_disabled
+      - edited
   push:
     branches: [main]
 
@@ -44,8 +45,9 @@ permissions:
 jobs:
   # Decides whether this event should run the 16 heavy jobs. A pull_request
   # trigger fires the whole workflow, but the labeled / unlabeled /
-  # auto_merge_enabled / auto_merge_disabled actions exist only so pr-policy and
-  # auto-merge-policy re-converge — the heavy jobs must NOT re-run on them. This
+  # auto_merge_enabled / auto_merge_disabled / edited actions exist only so
+  # pr-policy and auto-merge-policy re-converge — the heavy jobs must NOT re-run
+  # on them. This
   # job always runs (no gate on itself) and the heavy jobs `needs:` it.
   # ``github.event.action`` is a GitHub-controlled enum (empty on `push`), passed
   # via env: and never interpolated into the script — injection-safe.
@@ -62,12 +64,12 @@ jobs:
           ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
-          # Heavy jobs skip ONLY on label / auto-merge PR actions. `push` has no
-          # action (empty) → falls to the default → code_event=true.
+          # Heavy jobs skip on policy-only PR actions. `push` has no action
+          # (empty) → falls to the default → code_event=true.
           case "$ACTION" in
-            labeled | unlabeled | auto_merge_enabled | auto_merge_disabled)
+            labeled | unlabeled | auto_merge_enabled | auto_merge_disabled | edited)
               echo "code_event=false" >> "$GITHUB_OUTPUT"
-              echo "Label/auto-merge event ($ACTION) — heavy jobs skipped; only policy jobs run."
+              echo "Policy-only event ($ACTION) — heavy jobs skipped; only policy jobs run."
               ;;
             *)
               echo "code_event=true" >> "$GITHUB_OUTPUT"
@@ -307,10 +309,12 @@ jobs:
 
   pr-policy:
     name: pr-policy
-    # Enforces the two HARD repo PR policies on every PR. Both checks are gated
-    # by `if: always()` so one failure still surfaces the other:
+    # Enforces the hard repo PR policies on every PR. Every check is gated by
+    # `if: always()` so one failure still surfaces the others:
     #   1. PR body contains `Closes #N` on its own line.
     #   2. Every commit on the PR has a verified signature.
+    #   3. The PR title and every commit subject follow Conventional Commits.
+    #   4. Every commit has a DCO Signed-off-by trailer.
     # The auto-merge ↔ implementation-review state machine moved to the separate
     # `auto-merge-policy` job (#1080) so its timing-sensitive verdict no longer
     # blocks merge — it is intentionally NOT in the required-checks ruleset.
@@ -349,13 +353,12 @@ jobs:
           REPO_NAME: ${{ github.event.repository.name }}
         run: |
           set -euo pipefail
-          # `gh pr view --json body` exposes the PR body (for the Closes #N
-          # check) but DOES NOT expose per-commit signatures; we use the GraphQL
-          # API for that. Two separate queries are fine here — the workflow runs
-          # at most once per PR event and the policy gate must be cheap to read
-          # and debug. (The auto-merge/labels read moved to auto-merge-policy.)
+          # `gh pr view --json body,title` exposes the PR body and the title that
+          # becomes the squash subject, but not per-commit signatures; the
+          # GraphQL API supplies those. (The auto-merge/labels read moved to
+          # auto-merge-policy.)
           gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-            --json body \
+            --json body,title \
             > pr.json
           gh api graphql \
             -f query='query($owner:String!,$name:String!,$pr:Int!) {
@@ -426,20 +429,16 @@ jobs:
           fi
           echo "OK: all commits have verified signatures"
 
-      - name: "Check 3: commit subjects follow Conventional Commits"
+      - name: "Check 3: PR title and commit subjects follow Conventional Commits"
         if: always() && steps.fetch.outcome == 'success'
-        env:
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           set -euo pipefail
-          # Dependabot subjects are auto-generated; exempt like Check 1 (#1070).
-          if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
-            echo "OK: Dependabot PR — Conventional Commit check is not applicable"
-            exit 0
-          fi
-          # Subject = first line of each commit message (GraphQL .commit.message
-          # verified to resolve). Pipe on stdin, one per line, into the shared
-          # validator (DoD row 5 / issue #1209). Empty set passes by design.
+          # The required squash merge uses the PR title as the main subject;
+          # Git machinery forms are not authored titles and are rejected here.
+          jq -r '.title // ""' pr.json \
+            | python3 scripts/check_conventional_commit.py --strict -
+
+          # Branch commits retain local-hook compatibility with Git machinery.
           jq -r '.data.repository.pullRequest.commits.nodes[]
                  | .commit.message | split("\n")[0]' commits.json \
             | python3 scripts/check_conventional_commit.py -
@@ -451,7 +450,7 @@ jobs:
         run: |
           set -euo pipefail
           # Dependabot commits are bot-authored, not human DCO attestations;
-          # exempt like Check 1 / Check 3 (#1070).
+          # exempt like Check 1 (#1070).
           if [ "$PR_AUTHOR" = "dependabot[bot]" ]; then
             echo "OK: Dependabot PR — DCO sign-off check is not applicable"
             exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,11 @@ releases from signed `vX.Y.Z` tags; there are no release branches.
    `Closes:` are NOT accepted.
 2. Every commit MUST be cryptographically signed (`git commit -S`) and carry a
    DCO `Signed-off-by` trailer.
+3. The PR title MUST follow `type(scope)!: description` because it becomes the
+   squash-merge subject on `main`. Scope and `!` are optional. Check 3 also
+   validates every branch commit subject. See
+   [`docs/DEFINITION_OF_DONE.md`](docs/DEFINITION_OF_DONE.md) for accepted
+   forms and the pre-#2157 history cutover.
 
 `pr-policy` blocks PRs that fail those checks. During #2054's fail-closed
 bootstrap, auto-merge must also remain disabled: pipeline code verifies that
@@ -353,7 +358,7 @@ git push -u origin <branch-name>
 
 # 4. Create pull request
 gh pr create \
-  --title "[Type] Brief description" \
+  --title "fix(ci): align Conventional Commit enforcement" \
   --body "$(printf 'Summary of change.\n\nCloses #<issue-number>\n')"
 
 # 5. Keep auto-merge disabled. After an unconditional independent strict-review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,10 @@ links to the full section below.
 4. **Make the change test-first** ([Testing](#testing)) — write a failing test,
    make it pass, keep coverage at 83%+ (target 90%).
 5. **Open the PR** ([Pull Request Process](#pull-request-process)) — sign every
-   commit (`git commit -S`), put `Closes #<issue-number>` on its own line in the
-   body, and keep auto-merge disabled. After an unconditional independent
-   strict-review GO, a maintainer performs the manual squash merge.
+   commit (`git commit -S`), use a Conventional Commit title, put
+   `Closes #<issue-number>` on its own line in the body, and keep auto-merge
+   disabled. After an unconditional independent strict-review GO, a maintainer
+   performs the manual squash merge.
 
 If anything in steps 1–2 fails, see [Platform Support](#platform-support) — the
 pixi dev environment is `linux-64` only by design.
@@ -235,7 +236,8 @@ computes the next semver string and prints the `git tag` commands to run.
 ## Pull Request Process
 
 The `main` branch is protected. CI's `pr-policy` gate blocks a PR that lacks a
-valid issue reference, signed commits, or DCO sign-offs:
+valid issue reference, Conventional Commit title, signed commits, or DCO
+sign-offs:
 
 1. **Sign every commit**: `git commit -S`. Verify with `git log --show-signature -1`.
 2. **Reference the issue**: the PR body must contain the literal line `Closes #<n>`
@@ -243,6 +245,11 @@ valid issue reference, signed commits, or DCO sign-offs:
    `Closes:` are **not** accepted.
 3. **Sign off every commit**: include a DCO `Signed-off-by` trailer, normally
    with `git commit -s -S`.
+4. **Use a Conventional Commit PR title**:
+   `type(scope)!: concise description`. The title becomes the `main` subject
+   when the PR is squash-merged. Every authored branch commit follows the same
+   form; see the Definition of Done for the narrow Git-generated exceptions and
+   the pre-#2157 history cutover.
 
 During #2054's bootstrap, auto-merge must remain disabled. The pipeline verifies
 that state and the advisory `auto-merge-policy` reports any armed PR, but it is

--- a/README.md
+++ b/README.md
@@ -465,18 +465,20 @@ hephaestus-check-complexity --help
 ## Contributing
 
 The `main` branch is protected; all changes go through a pull request. CI blocks
-PRs that fail its issue-reference, signature, and DCO checks. During #2054,
-auto-merge remains disabled through pipeline containment and reviewer control;
-the `auto-merge-policy` check reports armed PRs but is advisory so it does not
-block the independently reviewed manual bootstrap merge.
+PRs that fail its issue-reference, Conventional Commit title, signature, and DCO
+checks. During #2054, auto-merge remains disabled through pipeline containment
+and reviewer control; the `auto-merge-policy` check reports armed PRs but is
+advisory so it does not block the independently reviewed manual bootstrap merge.
 
 1. Create a feature branch named `<issue-number>-description`
    (`git checkout -b 123-amazing-feature`).
 2. Commit your changes **signed** (`git commit -S -m "feat(scope): add amazing feature"`),
    using [conventional commit](https://www.conventionalcommits.org/) messages.
 3. Push the branch (`git push -u origin 123-amazing-feature`).
-4. Open a pull request whose body contains the literal line `Closes #123`
-   (capital `C`, no colon, on its own line — `Fixes`/`Resolves` are **not** accepted).
+4. Open a pull request titled `type(scope): concise description` whose body
+   contains the literal line `Closes #123` (capital `C`, no colon, on its own
+   line — `Fixes`/`Resolves` are **not** accepted). The title becomes the
+   squash-merge subject on `main`.
 5. Keep auto-merge disabled while #2054's fail-closed policy is active. A
    bootstrap PR requires an unconditional independent strict-review GO before
    a manual squash merge; #2055 restores queue-owned auto-merge after a

--- a/docs/DEFINITION_OF_DONE.md
+++ b/docs/DEFINITION_OF_DONE.md
@@ -15,7 +15,7 @@ A piece of work is **done** when every item below is true.
 | 2 | PR body contains the literal line `Closes #<issue-number>` (capital C, no colon, on its own line) | CI gate `pr-policy` (`.github/workflows/_required.yml`) |
 | 3 | Every commit on the branch is cryptographically signed and DCO-signed (`git commit -S -s`) | CI gate `pr-policy` |
 | 4 | Auto-merge remains disabled during #2054's fail-closed bootstrap. An unconditional independent strict-review GO is required before a manual squash merge; #2055 restores queue-owned arming. | Advisory `auto-merge-policy` and human review |
-| 5 | Commit messages follow Conventional Commits (`type(scope): description`) | CI gate `pr-policy` (Check 3) + local `commit-msg` hook `conventional-commit-msg` |
+| 5 | The PR title uses an authored Conventional Commit form because it becomes the squash subject; each branch commit uses that form or a recognized Git-generated machinery form | CI gate `pr-policy` (Check 3) + local `commit-msg` hook `conventional-commit-msg` |
 | 6 | `pixi run ruff check hephaestus/ tests/` passes | CI job `lint` |
 | 7 | `pixi run ruff format --check hephaestus/ tests/` passes (no files would be reformatted) | CI job `lint` |
 | 8 | `pixi run mypy` returns `Success: no issues found in N source files` | CI job `lint` |
@@ -40,6 +40,25 @@ A piece of work is **done** when every item below is true.
 > [`docs/ci/required-checks.md`](ci/required-checks.md) do. The aggregate gate
 > excludes advisory `auto-merge-policy` during #2054 so it cannot block the
 > independently reviewed manual bootstrap merge.
+
+### Conventional Commit history boundary
+
+Authored subjects use `type(scope)!: description`, where scope and `!` are
+optional and type is one of `build`, `chore`, `ci`, `docs`, `feat`, `fix`,
+`perf`, `refactor`, `revert`, `style`, or `test`. PR titles must use this form
+without a Git-machinery exception because the title becomes the squash-merge
+subject on `main`.
+
+The local hook and branch-commit portion of Check 3 also accept Git-generated
+merge and revert subjects (prefixed with `Merge` or `Revert` followed by a
+space), plus `fixup!` and `squash!` subjects. Those exceptions do not apply to
+PR titles.
+
+Commits already present on `main` before the PR that closes issue #2157 are
+grandfathered and must not be rewritten. Rewriting published history would
+replace commit identities and invalidate existing signatures, tags, and
+downstream references. The PR closing #2157 establishes the cutover: its title
+and every later squash-merge title must satisfy the authored form above.
 
 ## For new features
 

--- a/hephaestus/automation/commit_policy.py
+++ b/hephaestus/automation/commit_policy.py
@@ -1,0 +1,38 @@
+"""Conventional Commit policy helpers for automation-generated subjects."""
+
+from __future__ import annotations
+
+import re
+
+# This mirrors ``ALLOWED_TYPES`` in ``scripts/check_conventional_commit.py``.
+# The scripts module remains the validation boundary, while automation uses this
+# helper to ensure generated subjects are valid before creating a PR.
+ALLOWED_CONVENTIONAL_TYPES = frozenset(
+    {"feat", "fix", "docs", "refactor", "test", "chore", "ci", "build", "perf", "style", "revert"}
+)
+
+_CONVENTIONAL_PREFIX = re.compile(r"^(?P<type>[a-z]+)(?P<scope>\([^)]*\))?(?P<bang>!)?:\s")
+
+
+def normalize_conventional_type(subject: str, *, default: str = "chore") -> str:
+    """Return a subject whose leading type is accepted by the CI policy.
+
+    Args:
+        subject: The one-line commit or PR subject to normalize.
+        default: The allowlisted fallback type for unknown or absent prefixes.
+
+    Returns:
+        A subject with an allowlisted leading Conventional Commit type.
+
+    """
+    match = _CONVENTIONAL_PREFIX.match(subject)
+    if match is None:
+        return f"{default}: {subject.strip()}" if subject.strip() else f"{default}: update"
+    scope = match.group("scope") or ""
+    bang = match.group("bang") or ""
+    description = subject[match.end() :].strip()
+    scope_is_valid = not scope or bool(scope[1:-1].strip())
+    if match.group("type") in ALLOWED_CONVENTIONAL_TYPES and scope_is_valid and description:
+        return subject
+    valid_scope = scope if scope_is_valid else ""
+    return f"{default}{valid_scope}{bang}: {description or 'update'}"

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -75,6 +75,7 @@ from hephaestus.automation.agent_config import (
     implementer_claude_timeout,
     implementer_model,
 )
+from hephaestus.automation.commit_policy import normalize_conventional_type
 from hephaestus.automation.prompts.advise import get_advise_prompt_builder
 from hephaestus.automation.prompts.implementation import (
     get_dirty_reused_worktree_decision_prompt,
@@ -888,7 +889,8 @@ class ImplementationStage(Stage):
             return self._git_retry(item, "commit_push failed")
 
         if item.pr is None:
-            title = item.payload.get("issue_title") or f"[Auto] Implement issue #{item.issue}"
+            raw_title = item.payload.get("issue_title") or f"Implement issue #{item.issue}"
+            title = normalize_conventional_type(str(raw_title))
             body = get_pr_description(
                 item.issue,
                 summary=item.payload.get("implement_summary", "")

--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -28,6 +28,7 @@ from .agent_config import DEFAULT_GIT_MESSAGE_AGENT_TIMEOUT
 from .ci_check_inspector import FAILING_CHECK_CONCLUSIONS
 from .claude_invoke import invoke_claude_with_session
 from .claude_models import git_message_model, implementer_model
+from .commit_policy import ALLOWED_CONVENTIONAL_TYPES, normalize_conventional_type
 from .git_utils import get_repo_slug, issue_ref, run
 from .github_api import (
     OpenPrDiscoveryIncompleteError,
@@ -80,20 +81,6 @@ _AGENT_COMMIT_IDENTITIES = {
     "pi": ("Pi", "noreply@earendil.works"),
 }
 
-# Conventional-commit types the ``pr-policy`` CI gate accepts. MUST stay in sync
-# with ``ALLOWED_TYPES`` in ``scripts/check_conventional_commit.py`` (the gate's
-# source of truth); ``tests/.../test_pr_manager.py`` asserts the two sets match,
-# so drift fails CI rather than silently re-introducing #1587 (the automation
-# generating a ``security(audit):`` prefix the gate then rejects). The script is
-# not imported here to avoid inverting the scripts→library dependency direction.
-ALLOWED_CONVENTIONAL_TYPES = frozenset(
-    {"feat", "fix", "docs", "refactor", "test", "chore", "ci", "build", "perf", "style", "revert"}
-)
-
-# Leading ``type(scope)?: `` token of a conventional-commit subject. Scope is
-# optional; only the bare type is validated against the allowlist.
-_CONVENTIONAL_PREFIX = re.compile(r"^(?P<type>[a-z]+)(?P<scope>\([^)]*\))?(?P<bang>!)?:\s")
-
 
 def _git_timeout_kw(timeout: int | None) -> dict[str, Any]:
     """Return a ``run`` kwargs fragment only when a git timeout was provided."""
@@ -119,36 +106,6 @@ def _clear_local_committer_identity(worktree_path: Path, git_timeout: int | None
             log_errors=False,
             **_git_timeout_kw(git_timeout),
         )
-
-
-def _normalize_conventional_type(subject: str, *, default: str = "chore") -> str:
-    """Rewrite a subject's leading type to an allowlisted one if it is not already.
-
-    The commit/PR-message agent can emit a ``type(scope):`` whose type the
-    pr-policy gate forbids (e.g. ``security(audit):``), which blocks the PR and
-    triggers an expensive self-cleanup (#1587). This normalizes ONLY the leading
-    type token — scope, ``!``, and the description are preserved — to ``default``
-    when the type is not in :data:`ALLOWED_CONVENTIONAL_TYPES`. A subject with no
-    recognizable conventional prefix is prefixed with ``f"{default}: "`` so the
-    gate always sees a valid type.
-
-    Args:
-        subject: The one-line commit/PR subject from the agent.
-        default: The fallback type (must be in the allowlist).
-
-    Returns:
-        A subject whose leading type is allowlisted.
-
-    """
-    match = _CONVENTIONAL_PREFIX.match(subject)
-    if match is None:
-        return f"{default}: {subject.strip()}" if subject.strip() else f"{default}: update"
-    if match.group("type") in ALLOWED_CONVENTIONAL_TYPES:
-        return subject
-    scope = match.group("scope") or ""
-    bang = match.group("bang") or ""
-    rest = subject[match.end() :]
-    return f"{default}{scope}{bang}: {rest}"
 
 
 @dataclass(frozen=True)
@@ -466,7 +423,7 @@ def _generate_commit_message(
         # #1587: the agent can emit a type the pr-policy gate forbids
         # (e.g. ``security(audit):``). Normalize it locally so the automation
         # never produces a commit that fails its own required CI.
-        subject = _normalize_conventional_type(subject)
+        subject = normalize_conventional_type(subject)
         body = _strip_reserved_lines(_message_text(data.get("body")))
         parts = _CommitMessageParts(subject=subject, body=body)
         return _format_commit_message(
@@ -535,7 +492,7 @@ def _generate_pr_message(
             # #1587: normalize the PR title's conventional-commit type too — a
             # squash merge uses the PR title as the commit subject, so a forbidden
             # type here fails pr-policy exactly like a commit subject does.
-            title=_normalize_conventional_type(
+            title=normalize_conventional_type(
                 _single_line(data.get("title"), fallback=fallback.title, max_len=120)
             ),
             summary=_strip_reserved_lines(_message_text(data.get("summary"))) or fallback.summary,

--- a/scripts/check_conventional_commit.py
+++ b/scripts/check_conventional_commit.py
@@ -8,10 +8,14 @@ and the ``pr-policy`` CI job (each PR commit subject is piped on stdin via
 ``-``, one per line).
 
 Usage:
+    python scripts/check_conventional_commit.py [--strict] <message-file|->
+
     # commit-msg hook: validate the message file
     python scripts/check_conventional_commit.py .git/COMMIT_EDITMSG
     # CI: validate subjects piped on stdin
     printf '%s\\n' "fix(io): handle EOF" | python scripts/check_conventional_commit.py -
+    # PR title: reject Git machinery subjects
+    printf '%s\\n' "fix(io): handle EOF" | python scripts/check_conventional_commit.py --strict -
 """
 
 from __future__ import annotations
@@ -27,7 +31,7 @@ ALLOWED_TYPES = frozenset(
 _MACHINERY_PREFIXES = ("Merge ", "Revert ", "fixup!", "squash!")
 
 
-def validate_subject(subject: str) -> str | None:
+def validate_subject(subject: str, *, allow_machinery: bool = True) -> str | None:
     """Return an error string if *subject* is not a valid Conventional Commit, else None.
 
     Splits on the first colon only; extracts an optional ``(scope)`` via
@@ -35,6 +39,7 @@ def validate_subject(subject: str) -> str | None:
 
     Args:
         subject: A single commit subject line.
+        allow_machinery: Whether to accept Git-generated machinery subjects.
 
     Returns:
         ``None`` when the subject conforms, otherwise a human-readable error string.
@@ -44,7 +49,9 @@ def validate_subject(subject: str) -> str | None:
     if not subject.strip():
         return "empty commit subject"
     if subject.startswith(_MACHINERY_PREFIXES):
-        return None
+        if allow_machinery:
+            return None
+        return f"git machinery subject is not allowed in strict mode: {subject!r}"
     if ":" not in subject:
         return f"missing 'type(scope): ' prefix in: {subject!r}"
     prefix, message = subject.split(":", 1)
@@ -102,15 +109,17 @@ def main(argv: list[str] | None = None) -> int:
 
     """
     args = list(sys.argv[1:] if argv is None else argv)
-    if args[:1] in (["--help"], ["-h"]):
+    if any(arg in {"--help", "-h"} for arg in args):
         print(__doc__)
         return 0
+    strict = "--strict" in args
+    args = [arg for arg in args if arg != "--strict"]
     subjects = _subjects_from_args(args)
     # An empty subject set (no commits / empty stdin) is not a violation;
     # the pr-policy signing + Closes checks cover the empty-commits anomaly.
     failed = False
     for subject in subjects:
-        err = validate_subject(subject)
+        err = validate_subject(subject, allow_machinery=not strict)
         if err:
             print(f"FAILED: Conventional Commit check: {err}")
             failed = True

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -997,7 +997,37 @@ class TestCommitPushAndPrCreate:
         assert github.mutation_log[1] == ("defer_auto_merge", (1001,))
         # The PR body is a get_pr_description body carrying the closing line.
         assert "Closes #9" in github.prs[1001]["body"]
-        assert github.prs[1001]["title"] == "Add the widget"
+        assert github.prs[1001]["title"] == "chore: Add the widget"
+
+    def test_pr_create_preserves_conventional_issue_title(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """Already-conventional issue titles remain unchanged for the PR."""
+        github = FakeStageGitHub()
+        item = make_work_item(issue=9, state="PR_CREATE")
+        item.branch = "9-auto-impl"
+        item.payload["issue_title"] = "fix(ci): align commit enforcement"
+
+        ImplementationStage().step(item, make_ctx(github=github))
+
+        assert github.prs[1001]["title"] == "fix(ci): align commit enforcement"
+
+    def test_pr_create_normalizes_malformed_conventional_issue_title(
+        self,
+        make_ctx: Any,
+        make_work_item: Any,
+    ) -> None:
+        """Malformed authored titles cannot reach the strict PR-title gate."""
+        github = FakeStageGitHub()
+        item = make_work_item(issue=9, state="PR_CREATE")
+        item.branch = "9-auto-impl"
+        item.payload["issue_title"] = "fix(): align commit enforcement"
+
+        ImplementationStage().step(item, make_ctx(github=github))
+
+        assert github.prs[1001]["title"] == "chore: align commit enforcement"
 
     def test_pr_create_fails_explicitly_when_auto_merge_deferral_cannot_be_verified(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/test_pr_manager.py
+++ b/tests/unit/automation/test_pr_manager.py
@@ -15,6 +15,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from hephaestus.automation import pr_manager
+from hephaestus.automation.commit_policy import (
+    ALLOWED_CONVENTIONAL_TYPES,
+    normalize_conventional_type,
+)
 from hephaestus.automation.github_api import OpenPrDiscoveryIncompleteError
 from hephaestus.automation.session_naming import AGENT_COMMIT_MESSAGE, AGENT_PR_MESSAGE
 
@@ -970,29 +974,37 @@ class TestPrIsGenuinelyStuck:
 
 
 class TestNormalizeConventionalType:
-    """``_normalize_conventional_type`` keeps the commit/PR type pr-policy-legal (#1587)."""
+    """The shared normalizer keeps generated subjects pr-policy-legal (#1587)."""
 
     def test_disallowed_type_normalized_scope_preserved(self) -> None:
         assert (
-            pr_manager._normalize_conventional_type("security(audit): add threat model")
+            normalize_conventional_type("security(audit): add threat model")
             == "chore(audit): add threat model"
         )
 
     def test_allowed_type_unchanged(self) -> None:
-        assert (
-            pr_manager._normalize_conventional_type("fix(io): handle EOF") == "fix(io): handle EOF"
-        )
+        assert normalize_conventional_type("fix(io): handle EOF") == "fix(io): handle EOF"
 
     def test_no_prefix_gets_default(self) -> None:
-        assert (
-            pr_manager._normalize_conventional_type("add threat model") == "chore: add threat model"
-        )
+        assert normalize_conventional_type("add threat model") == "chore: add threat model"
 
     def test_breaking_bang_preserved(self) -> None:
-        assert pr_manager._normalize_conventional_type("security!: drop API") == "chore!: drop API"
+        assert normalize_conventional_type("security!: drop API") == "chore!: drop API"
 
     def test_disallowed_no_scope(self) -> None:
-        assert pr_manager._normalize_conventional_type("wip: stuff") == "chore: stuff"
+        assert normalize_conventional_type("wip: stuff") == "chore: stuff"
+
+    @pytest.mark.parametrize(
+        ("subject", "expected"),
+        [
+            ("fix(): repair", "chore: repair"),
+            ("fix( ): repair", "chore: repair"),
+            ("fix(\t)!: repair", "chore!: repair"),
+            ("fix: ", "chore: update"),
+        ],
+    )
+    def test_malformed_allowed_type_uses_valid_fallback(self, subject: str, expected: str) -> None:
+        assert normalize_conventional_type(subject) == expected
 
     def test_allowlist_matches_pr_policy_gate(self) -> None:
         """The mirrored allowlist MUST equal the pr-policy gate's source of truth."""
@@ -1002,4 +1014,4 @@ class TestNormalizeConventionalType:
         sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
         from check_conventional_commit import ALLOWED_TYPES
 
-        assert set(pr_manager.ALLOWED_CONVENTIONAL_TYPES) == set(ALLOWED_TYPES)
+        assert set(ALLOWED_CONVENTIONAL_TYPES) == set(ALLOWED_TYPES)

--- a/tests/unit/ci/test_conventional_commit_policy.py
+++ b/tests/unit/ci/test_conventional_commit_policy.py
@@ -1,0 +1,66 @@
+"""Cross-file regression guards for the Conventional Commit policy."""
+
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_conventional_commit import validate_subject  # noqa: E402
+
+REQUIRED_WORKFLOW = REPO_ROOT / ".github/workflows/_required.yml"
+
+
+def _yaml(path: Path) -> dict[str, Any]:
+    """Return a YAML mapping loaded from *path*."""
+    return cast(dict[str, Any], yaml.safe_load(path.read_text(encoding="utf-8")))
+
+
+def _pr_policy_step(name: str) -> dict[str, Any]:
+    """Return the named ``pr-policy`` workflow step."""
+    steps = _yaml(REQUIRED_WORKFLOW)["jobs"]["pr-policy"]["steps"]
+    return next(step for step in steps if step.get("name") == name)
+
+
+def test_pr_policy_validates_title_and_commit_subjects() -> None:
+    """The squash subject and every branch subject have the intended policy."""
+    fetch = str(_pr_policy_step("Fetch PR metadata")["run"])
+    check = _pr_policy_step("Check 3: PR title and commit subjects follow Conventional Commits")
+    run = str(check["run"])
+
+    assert "--json body,title" in fetch
+    assert "check_conventional_commit.py --strict -" in run
+    assert "commit.message | split" in run
+    assert "dependabot[bot]" not in run
+    assert "PR_AUTHOR" not in check.get("env", {})
+
+
+def test_pr_title_edits_rerun_only_the_policy_jobs() -> None:
+    """A post-CI title edit cannot bypass the squash-subject gate."""
+    text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "      - edited" in text
+    assert "auto_merge_enabled | auto_merge_disabled | edited)" in text
+    assert "Policy-only event ($ACTION)" in text
+
+
+def test_dependabot_titles_satisfy_strict_policy() -> None:
+    """Every configured Dependabot title is authored-form compatible."""
+    updates = _yaml(REPO_ROOT / ".github/dependabot.yml")["updates"]
+
+    for update in updates:
+        prefix = update["commit-message"]["prefix"]
+        assert prefix == "chore(deps)"
+        title = f"{prefix}: bump {update['package-ecosystem']} dependencies"
+        assert validate_subject(title, allow_machinery=False) is None
+
+
+def test_policy_documents_history_cutover() -> None:
+    """Published history is explicitly grandfathered at the enforcement cutover."""
+    text = (REPO_ROOT / "docs/DEFINITION_OF_DONE.md").read_text(encoding="utf-8")
+    assert "PR that closes issue #2157" in text
+    assert "grandfathered" in text
+    assert "must not be rewritten" in text

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -270,9 +270,9 @@ class TestStrictGateBootstrapWorkflow:
         assert "auto-merge policy is terminal" in text
 
     def test_pr_policy_remains_independent_from_auto_merge_state(self) -> None:
-        """The hard PR policy keeps its body-only metadata check."""
+        """The hard PR policy fetches body/title metadata, not auto-merge state."""
         text = REQUIRED_WORKFLOW.read_text(encoding="utf-8")
-        assert "--json body\n" in text or "--json body \\" in text
+        assert "--json body,title" in text
 
 
 class TestRequiredPixiCheckWorkflow:

--- a/tests/unit/scripts/test_check_conventional_commit.py
+++ b/tests/unit/scripts/test_check_conventional_commit.py
@@ -1,12 +1,16 @@
 """Tests for scripts/check_conventional_commit.py."""
 
+import io
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts"))
 
 from check_conventional_commit import (
     _subjects_from_args,
+    main,
     validate_subject,
 )
 
@@ -56,6 +60,18 @@ class TestValidateSubject:
         assert validate_subject('Revert "feat: x"') is None
         assert validate_subject("fixup! fix: x") is None
 
+    def test_rejects_machinery_when_disabled(self) -> None:
+        for subject in (
+            "Merge branch 'main'",
+            'Revert "feat: x"',
+            "fixup! fix: x",
+            "squash! fix: x",
+        ):
+            assert validate_subject(subject, allow_machinery=False) is not None
+
+    def test_accepts_machinery_by_default(self) -> None:
+        assert validate_subject("Merge branch 'main'") is None
+
 
 class TestSubjectsFromArgs:
     """Tests for the ``_subjects_from_args`` file/stdin entry-point split."""
@@ -69,3 +85,14 @@ class TestSubjectsFromArgs:
         f = tmp_path / "COMMIT_EDITMSG"
         f.write_text("# pre-filled comment\nfix: real subject\n")
         assert _subjects_from_args([str(f)]) == ["fix: real subject"]
+
+
+class TestMain:
+    """Tests for the Conventional Commit command-line entry point."""
+
+    def test_strict_mode_rejects_machinery_from_stdin(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(sys, "stdin", io.StringIO("Merge branch 'main'\n"))
+        assert main(["--strict", "-"]) == 1


### PR DESCRIPTION
## Summary
Verdict: Implemented | Reason: #2157 enforcement, migration policy, and regressions are complete in the working tree.

- Strict PR-title validation, Dependabot coverage, edit-trigger revalidation, shared title normalization, and policy documentation added.
- Verified: 6,392 passed, 230 skipped, 85.27% coverage; Ruff, mypy, YAML lint, Markdown lint, and diff checks pass.
- Direct `pixi run` could not initialize under sandbox cache/network restrictions; the full suite used the existing locked Pixi interpreter.

## Changes
See the PR diff for the full change set.

## Testing
pixi run pytest tests/unit -q

## Closes
Closes #2157

Generated by Hephaestus automation
