### PR TITLE
fix(automation): retry epic skip labeling before exclusion

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1247,8 +1247,8 @@ class Coordinator:
                 # Epic tagging is the ONE sanctioned seeding write, executed
                 # here through the skip_epics chokepoint BEFORE the exclusion
                 # is honored (seeding.py write-path boundary).
-                if entry.reason.startswith(_seeding.EPIC_NEEDS_SKIP_TAG):
-                    self.github.skip_epics({int(entry.identifier): []})
+                if entry.skip_tag_obligation is not None:
+                    self.github.skip_epics({entry.skip_tag_obligation.issue: []})
                 logger.info("seed excluded: %s", entry.reason)
                 continue
             item = self._entry_to_item(entry, self.config.repos[0] if self.config.repos else "")
@@ -1352,20 +1352,10 @@ class Coordinator:
             issue_numbers = _admission._filter_open_issues(repo, issue_numbers)
         for issue in issue_numbers:
             facts = _seeding.seed_issue_from_github(issue, github)
-            stage, reason = _seeding.classify_issue(facts)
+            entry = _seeding.seed_entry_from_facts(facts)
+            stage, reason = entry.stage, entry.reason
             stage, reason, passed = self._scope_seed_decision(issue, stage, reason, scope_stages)
-            entries.append(
-                _seeding.SeedEntry(
-                    kind="issue",
-                    identifier=issue,
-                    stage=stage,
-                    reason=reason,
-                    pr_number=facts.pr_number if facts.pr_is_open else None,
-                    issue_title=facts.title,
-                    issue_body=facts.body,
-                    passed=passed,
-                )
-            )
+            entries.append(replace(entry, stage=stage, reason=reason, passed=passed))
         for pr in self.config.prs:
             issue_number = github.find_issue_for_pr(pr)
             scope_identifier = issue_number if issue_number is not None else pr

--- a/hephaestus/automation/pipeline/seeding.py
+++ b/hephaestus/automation/pipeline/seeding.py
@@ -23,11 +23,9 @@ Write-path boundary (epic tagging)
 Per the doc row "Epic tagging is the one seeding write; done BEFORE excluding",
 an untagged epic must receive ``state:skip``. The pipeline mutator guard
 (``tests/unit/automation/pipeline/test_pipeline_architecture.py``) forbids
-GitHub mutations in this module, so seeding only SURFACES the tag need: an
-epic without ``state:skip`` is excluded with reason prefix
-:data:`EPIC_NEEDS_SKIP_TAG`, and the caller — the coordinator slice (#1817) —
-executes the actual label write via the existing ``github_api.skip_epics``
-chokepoint before honoring the exclusion.
+GitHub mutations in this module, so seeding returns an explicit
+:class:`EpicSkipTagObligation` for the caller to discharge through the existing
+``github_api.skip_epics`` chokepoint before honoring the exclusion.
 """
 
 from __future__ import annotations
@@ -63,12 +61,6 @@ _LABEL_RANK = {
     STATE_IMPLEMENTATION_NO_GO: 3,
     STATE_IMPLEMENTATION_GO: 4,
 }
-
-#: Exclusion-reason prefix surfacing the one sanctioned seeding write to the
-#: caller: an epic that still lacks ``state:skip`` must be tagged (via the
-#: existing ``github_api.skip_epics`` chokepoint, executed by the coordinator,
-#: #1817) BEFORE the exclusion is final. See module docstring.
-EPIC_NEEDS_SKIP_TAG = "epic_needs_skip_tag"
 
 #: Classification result: ``(stage, reason)``. ``stage is None`` means the
 #: issue is EXCLUDED from the pipeline (state:skip / epic) — exclusion is NOT
@@ -118,6 +110,13 @@ class IssueFacts:
 
 
 @dataclass(frozen=True)
+class EpicSkipTagObligation:
+    """A required durable ``state:skip`` write before an epic is excluded."""
+
+    issue: int
+
+
+@dataclass(frozen=True)
 class SeedEntry:
     """One planned queue push produced by :func:`seed_from_cli`.
 
@@ -136,6 +135,8 @@ class SeedEntry:
         issue_body: Issue body copied into the issue WorkItem payload for
             planner/reviewer/implementer prompts.
         passed: Terminal result for entries clamped directly to ``finished``.
+        skip_tag_obligation: Durable write that must complete before this
+            entry's exclusion can be honored, when it is an untagged epic.
 
     """
 
@@ -148,6 +149,7 @@ class SeedEntry:
     issue_title: str = ""
     issue_body: str = ""
     passed: bool = True
+    skip_tag_obligation: EpicSkipTagObligation | None = None
 
 
 def _get_state_label(labels: set[str]) -> str | None:
@@ -241,10 +243,7 @@ def classify_issue(facts: IssueFacts) -> Classification:
         LOG.info("issue excluded: %s", reason)
         return None, reason
     if facts.is_epic:
-        # Untagged epic: surface the sanctioned write to the caller (see
-        # module docstring — the state:skip write executes at the coordinator
-        # via the existing skip_epics chokepoint, #1817).
-        reason = f"{EPIC_NEEDS_SKIP_TAG}: #{facts.number} is an epic without {STATE_SKIP}"
+        reason = f"#{facts.number} is an epic tracking issue"
         LOG.info("issue excluded: %s", reason)
         return None, reason
 
@@ -411,6 +410,39 @@ def seed_issue_from_github(issue_number: int, github: Any) -> IssueFacts:
     )
 
 
+def seed_entry_from_facts(facts: IssueFacts) -> SeedEntry:
+    """Build one issue seed entry and its required durable-write obligation.
+
+    Seeding remains pure: it can declare, but never execute, the write that
+    makes an epic exclusion durable.  Callers must discharge the typed
+    obligation before they consume the resulting ``stage=None`` entry.
+
+    Args:
+        facts: Normalized GitHub state for one issue.
+
+    Returns:
+        The classified entry, with an epic skip-tag obligation only when the
+        issue is an untagged epic.
+
+    """
+    stage, reason = classify_issue(facts)
+    obligation = (
+        EpicSkipTagObligation(issue=facts.number)
+        if facts.is_epic and STATE_SKIP not in facts.labels
+        else None
+    )
+    return SeedEntry(
+        kind="issue",
+        identifier=facts.number,
+        stage=stage,
+        reason=reason,
+        pr_number=facts.pr_number if facts.pr_is_open else None,
+        issue_title=facts.title,
+        issue_body=facts.body,
+        skip_tag_obligation=obligation,
+    )
+
+
 def seed_from_cli(
     repos: Sequence[str],
     issues: Sequence[int],
@@ -462,18 +494,7 @@ def seed_from_cli(
     ]
     for issue in issues:
         facts = seed_issue(issue)
-        stage, reason = classify_issue(facts)
-        entries.append(
-            SeedEntry(
-                kind="issue",
-                identifier=issue,
-                stage=stage,
-                reason=reason,
-                pr_number=facts.pr_number if facts.pr_is_open else None,
-                issue_title=facts.title,
-                issue_body=facts.body,
-            )
-        )
+        entries.append(seed_entry_from_facts(facts))
     for pr in prs:
         pr_state = github.gh_pr_state(pr) if github is not None else gh_pr_state(pr)
         state = str((pr_state or {}).get("state") or "").upper()
@@ -528,11 +549,12 @@ def seed_from_cli(
 
 
 __all__ = [
-    "EPIC_NEEDS_SKIP_TAG",
     "Classification",
+    "EpicSkipTagObligation",
     "IssueFacts",
     "SeedEntry",
     "classify_issue",
+    "seed_entry_from_facts",
     "seed_from_cli",
     "seed_issue",
 ]

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -78,25 +78,28 @@ def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
     return Path(str(ctx.paths.projects_dir)) / item.repo
 
 
-def _tag_epics_best_effort(
-    repo: str,
-    ctx: StageContext,
-    epics: list[int],
-    epics_labels: dict[int, list[str]],
-) -> None:
-    """Tag excluded epics without blocking repo discovery on label failures."""
-    skip_tagged = True
-    try:
-        ctx.github.skip_epics(epics_labels)
-    except Exception as exc:
-        skip_tagged = False
-        logger.warning("repo:%s: could not tag excluded epics state:skip: %s", repo, exc)
+def _tag_epics(repo: str, ctx: StageContext, epics_labels: dict[int, list[str]]) -> None:
+    """Write epic skip labels and log the resulting durable exclusions."""
+    ctx.github.skip_epics(epics_labels)
+    for number in epics_labels:
+        logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", repo, number)
 
-    for num in epics:
-        if skip_tagged:
-            logger.info("repo:%s: #%d is an epic; tagged state:skip, excluded", repo, num)
-        else:
-            logger.info("repo:%s: #%d is an epic; state:skip tag failed, excluded", repo, num)
+
+def _partition_and_tag_epics(
+    repo: str, ctx: StageContext, issues_meta: list[dict[str, Any]]
+) -> tuple[list[int], list[int]]:
+    """Return issue partitions after durably tagging every discovered epic."""
+    kept, epics = partition_epics(issues_meta)
+    if not epics:
+        return kept, epics
+    epic_set = set(epics)
+    epics_labels = {
+        int(metadata["number"]): list(metadata.get("labels") or [])
+        for metadata in issues_meta
+        if int(metadata["number"]) in epic_set
+    }
+    _tag_epics(repo, ctx, epics_labels)
+    return kept, epics
 
 
 class RepoStage(Stage):
@@ -211,15 +214,11 @@ class RepoStage(Stage):
         # Epic tagging: the ONE sanctioned seeding write, durable and BEFORE
         # the exclusion is final (doc row "Epic tagging is the one seeding
         # write; done BEFORE excluding").
-        kept, epics = partition_epics(deduped)
-        if epics:
-            epic_set = set(epics)
-            epics_labels = {
-                int(m["number"]): list(m.get("labels") or [])
-                for m in deduped
-                if int(m["number"]) in epic_set
-            }
-            _tag_epics_best_effort(item.repo, ctx, epics, epics_labels)
+        try:
+            kept, epics = _partition_and_tag_epics(item.repo, ctx, deduped)
+        except Exception as exc:
+            logger.warning("repo:%s: could not tag excluded epics state:skip: %s", item.repo, exc)
+            return StageOutcome(Disposition.FINISH_FAIL, note=f"epic skip tag failed: {exc}")
 
         products: list[dict[str, Any]] = [
             {

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -322,13 +322,13 @@ class TestDiscover:
         epic_products = [p for p in repo_item.payload["products"] if p["number"] == 5]
         assert epic_products[0]["stage"] is None
 
-    def test_skip_epics_failure_is_non_fatal_to_discovery(
+    def test_skip_epics_failure_blocks_exclusion_until_reseed(
         self,
         repo_item: WorkItem,
         repo_ctx: Any,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A failed epic label write does not block emitting discovered products."""
+        """A failed skip write leaves no excluded product; a reseed retries it."""
         meta = [
             {"number": 5, "labels": ["epic"], "title": "Epic: umbrella"},
             {"number": 6, "labels": [], "title": "real work"},
@@ -340,6 +340,7 @@ class TestDiscover:
             classifications={6: (StageName.PLANNING, "needs plan")},
         )
         gh: FakeStageGitHub = repo_ctx.github
+        original_skip_epics = gh.skip_epics
         monkeypatch.setattr(
             gh,
             "skip_epics",
@@ -349,13 +350,22 @@ class TestDiscover:
 
         result = RepoStage().step(repo_item, repo_ctx)
 
-        assert isinstance(result, Continue) and result.next_state == "SEEDED"
-        assert classified == [6]
-        products = repo_item.payload["products"]
-        assert {p["number"]: p["stage"] for p in products} == {
-            5: None,
-            6: StageName.PLANNING,
-        }
+        assert isinstance(result, StageOutcome)
+        assert result.disposition is Disposition.FINISH_FAIL
+        assert "products" not in repo_item.payload
+        assert classified == []
+        assert 5 not in gh.labels
+
+        monkeypatch.setattr(gh, "skip_epics", original_skip_epics)
+        reseed_item = WorkItem(
+            repo="repo-a", kind=ItemKind.REPO, stage=StageName.REPO, state="DISCOVER"
+        )
+
+        reseed = RepoStage().step(reseed_item, repo_ctx)
+
+        assert isinstance(reseed, Continue) and reseed.next_state == "SEEDED"
+        assert "state:skip" in gh.labels[5]
+        assert [p["number"] for p in reseed_item.payload["products"]] == [5, 6]
 
     def test_drive_green_all_routes_orphan_prs_to_ci(
         self,

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -42,8 +42,8 @@ Disposition = routing_mod.Disposition
 StageName = routing_mod.StageName
 StageOutcome = routing_mod.StageOutcome
 
-EPIC_NEEDS_SKIP_TAG = seeding_mod.EPIC_NEEDS_SKIP_TAG
 SeedEntry = seeding_mod.SeedEntry
+EpicSkipTagObligation = seeding_mod.EpicSkipTagObligation
 
 Continue = stage_base_mod.Continue
 JobRequest = stage_base_mod.JobRequest
@@ -480,16 +480,17 @@ class TestSubmitEdges:
 class TestSeedingEdges:
     """CLI-scope seeding: epic chokepoint, --prs entries, finished entries."""
 
-    def test_epic_needs_skip_tag_executes_chokepoint_write(
+    def test_epic_skip_tag_obligation_executes_chokepoint_write(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The ONE sanctioned seeding write goes through skip_epics."""
+        """The explicit seeding obligation is discharged before exclusion."""
         seed = [
             SeedEntry(
                 kind="issue",
                 identifier=44,
                 stage=None,
-                reason=f"{EPIC_NEEDS_SKIP_TAG}: #44 is an epic without state:skip",
+                reason="unrelated exclusion reason",
+                skip_tag_obligation=EpicSkipTagObligation(issue=44),
             )
         ]
         coordinator = _coordinator(tmp_path, monkeypatch, seed=seed)

--- a/tests/unit/automation/pipeline/test_seeding.py
+++ b/tests/unit/automation/pipeline/test_seeding.py
@@ -17,11 +17,12 @@ import pytest
 
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.seeding import (
-    EPIC_NEEDS_SKIP_TAG,
+    EpicSkipTagObligation,
     IssueFacts,
     SeedEntry,
     _label_at_or_past,
     classify_issue,
+    seed_entry_from_facts,
     seed_from_cli,
     seed_issue,
 )
@@ -74,24 +75,23 @@ class TestClassifyIssue:
         assert "state:skip" in reason
         assert any("excluded" in record.message for record in caplog.records)
 
-    def test_epic_excluded_with_skip_tag_flag(self, caplog: pytest.LogCaptureFixture) -> None:
-        """An UNTAGGED epic is excluded with the epic_needs_skip_tag flag for the caller.
-
-        The state:skip write itself executes at the caller (coordinator #1817)
-        via the existing skip_epics chokepoint — seeding only surfaces the need.
-        """
+    def test_untagged_epic_is_excluded_without_encoding_a_mutation_in_reason(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The pure classifier describes exclusion; seeding carries obligations separately."""
         with caplog.at_level(logging.INFO, logger="hephaestus.automation.pipeline.seeding"):
             stage, reason = classify_issue(_facts(is_epic=True))
         assert stage is None
-        assert reason.startswith(EPIC_NEEDS_SKIP_TAG)
+        assert reason == "#1 is an epic tracking issue"
         assert any("excluded" in record.message for record in caplog.records)
 
     def test_epic_already_tagged_skip_needs_no_retag(self) -> None:
         """An epic that already carries state:skip excludes via skip — no tag flag."""
-        stage, reason = classify_issue(_facts(is_epic=True, labels={STATE_SKIP}))
+        facts = _facts(is_epic=True, labels={STATE_SKIP})
+        stage, reason = classify_issue(facts)
         assert stage is None
         assert STATE_SKIP in reason
-        assert EPIC_NEEDS_SKIP_TAG not in reason
+        assert seed_entry_from_facts(facts).skip_tag_obligation is None
 
     def test_skip_wins_over_plan_go(self) -> None:
         """state:skip + state:plan-go → excluded; skip is absolute and never ranked."""
@@ -542,6 +542,14 @@ class TestSeedFromCli:
         with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
             entries = seed_from_cli([], [10], [])
         assert entries[0].stage is None
+
+    def test_untagged_epic_surfaces_a_typed_skip_tag_obligation(self) -> None:
+        """The coordinator receives an explicit durable-write obligation, not a reason prefix."""
+        facts = _facts(number=10, is_epic=True)
+        with patch("hephaestus.automation.pipeline.seeding.seed_issue", return_value=facts):
+            entry = seed_from_cli([], [10], [])[0]
+
+        assert entry.skip_tag_obligation == EpicSkipTagObligation(issue=10)
 
     def test_prs_arm_impl_go_routes_to_ci(self) -> None:
         """A PR carrying state:implementation-go seeds into ci (GO short-circuit)."""


### PR DESCRIPTION
## Summary
- make the durable epic state:skip label a typed work obligation
- fail closed and reseed if writing that label fails
- cover first-seed failure and retry behavior

## Validation
- uv run --extra dev --extra automation pytest --no-cov tests/unit/automation/pipeline -q
- required pre-push suite: 6,585 passed, 25 skipped

Closes #1866