### PR TITLE
feat(observability): add runtime lifecycle metrics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Hephaestus/
 │   ├── logging/                # Logging utilities
 │   ├── markdown/               # Markdown linting and link fixing
 │   ├── nats/                   # NATS JetStream subscriber (event-driven workflows)
+│   ├── observability/          # Prometheus metrics, local health endpoint, and alert transitions
 │   ├── resilience/             # Circuit breaker + retry + subprocess resilience
 │   ├── scripts_lib/            # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/                 # System information collection

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Hephaestus/
 │   ├── logging/       # Logging utilities (ContextLogger, setup_logging)
 │   ├── markdown/      # Markdown linting and link fixing
 │   ├── nats/          # NATS JetStream subscriber (event-driven workflows)
+│   ├── observability/ # Prometheus metrics, local health endpoint, and alert transitions
 │   ├── resilience/    # Circuit breaker + retry + subprocess resilience primitives
 │   ├── scripts_lib/   # Standalone consistency-check scripts (CLI table, version)
 │   ├── system/        # System information collection

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -131,6 +131,17 @@ def _parse_pr_list(value: str) -> list[int]:
     return _parse_positive_int_list(value, "PR")
 
 
+def _parse_metrics_port(value: str) -> int:
+    """Parse a TCP port while rejecting values outside the socket range."""
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"metrics port must be an integer, got {value!r}") from exc
+    if not 0 <= port <= 65535:
+        raise argparse.ArgumentTypeError("metrics port must be in 0..65535")
+    return port
+
+
 def _default_phase_timeout_s() -> float:
     """Return the default per-agent-job timeout in seconds.
 
@@ -204,6 +215,10 @@ class LoopConfig:
     # (``HEPH_PHASE_TIMEOUT``); ``--phase-timeout`` overrides it and a
     # non-positive value disables the bound (``None``).
     phase_timeout_s: float | None = field(default_factory=_default_phase_timeout_s)
+    # Prometheus text + JSON health endpoint. Zero deliberately disables the
+    # listener rather than selecting an ephemeral port, so the CLI remains
+    # opt-in and operators know which port is exposed.
+    metrics_port: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -363,6 +378,16 @@ def _build_parser() -> argparse.ArgumentParser:
             "Per-phase timeout in seconds (default: HEPH_PHASE_TIMEOUT or "
             f"{int(_default_phase_timeout_s())}s). Pass 0 or a negative value to disable. "
             "This bounds each AGENT JOB the pipeline runs, not a whole phase subprocess."
+        ),
+    )
+    p.add_argument(
+        "--metrics-port",
+        type=_parse_metrics_port,
+        default=0,
+        metavar="PORT",
+        help=(
+            "Loopback-only port for the local Prometheus /metrics and /health server "
+            "(0 disables it)."
         ),
     )
     p.add_argument(
@@ -572,6 +597,14 @@ def _build_pipeline_config(
     """
     from hephaestus.automation.pipeline.coordinator import PipelineConfig
 
+    circuit_breaker_snapshot_provider = None
+    if cfg.metrics_port:
+        # Keep this capability out of the pure pipeline coordinator. It is
+        # supplied only for the explicitly enabled observability path.
+        from hephaestus.resilience import all_circuit_breaker_snapshots
+
+        circuit_breaker_snapshot_provider = all_circuit_breaker_snapshots
+
     return PipelineConfig(
         org=org,
         repos=repos,
@@ -596,6 +629,8 @@ def _build_pipeline_config(
         run_pre_pr_tests=cfg.run_pre_pr_tests,
         budget_overrides={"merge": cfg.max_merge_attempts},
         serialize_file_overlap=cfg.serialize_file_overlap,
+        metrics_port=cfg.metrics_port,
+        circuit_breaker_snapshot_provider=circuit_breaker_snapshot_provider,
         event_log_path=_pipeline_event_log_path(cfg.projects_dir, repos),
         projects_dir=cfg.projects_dir,
         json_out=args.json,
@@ -692,6 +727,7 @@ def main(argv: list[str] | None = None) -> int:
         phase_timeout_s=(
             args.phase_timeout if args.phase_timeout and args.phase_timeout > 0 else None
         ),
+        metrics_port=args.metrics_port,
     )
 
     if not repos:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -236,6 +236,16 @@ class PipelineConfig:
     pre_pr_test_argv: tuple[str, ...] = PRE_PR_TEST_ARGV
     run_pre_pr_tests: bool = False
     serialize_file_overlap: bool = True
+    # Zero disables the optional local observability server. Values are
+    # validated at the CLI boundary and again by MetricsHTTPServer on use.
+    metrics_port: int = 0
+    # Alerts are emitted only from measured queue depths and circuit-breaker
+    # snapshots. Keep the threshold explicit and non-negative.
+    alert_queue_depth_threshold: int = 100
+    # A product-layer caller supplies the library breaker snapshot reader. The
+    # coordinator remains a zero-I/O pipeline module and never imports the
+    # resilience capability directly.
+    circuit_breaker_snapshot_provider: Callable[[], dict[str, dict[str, Any]]] | None = None
     event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
     json_out: bool = False
@@ -346,6 +356,26 @@ class Coordinator:
         self.items: list[WorkItem] = []
         self.event_log: list[tuple[Any, ...]] = []
         self._event_log_disabled = False
+        # Observability is opt-in.  Keep imports and all socket setup out of
+        # the default construction path so the product layer retains its
+        # zero-I/O import contract.
+        self._metrics_registry: Any | None = None
+        self._metrics_server: Any | None = None
+        self._alert_tracker: Any | None = None
+        if config.metrics_port:
+            from hephaestus.observability.alerts import AlertTracker
+            from hephaestus.observability.metrics import MetricsRegistry
+            from hephaestus.observability.server import MetricsHTTPServer
+
+            self._metrics_registry = MetricsRegistry()
+            self._alert_tracker = AlertTracker(
+                queue_depth_threshold=config.alert_queue_depth_threshold
+            )
+            self._metrics_server = MetricsHTTPServer(
+                self._metrics_registry,
+                port=config.metrics_port,
+                health_provider=self._health_snapshot,
+            )
         self.stages: dict[StageName, Stage] = stages or self._default_stages()
         # Route table for this run: the full ROUTES, or a scope-trimmed copy
         # (out-of-scope next/fail targets rewritten to FINISHED) when the
@@ -474,6 +504,75 @@ class Coordinator:
             logger.warning("failed to write pipeline event log %s: %s", path, exc)
             self._event_log_disabled = True
 
+    def _observability_snapshot(self) -> dict[str, Any]:
+        """Read the coordinator lifecycle values that observability exposes."""
+        circuit_breakers: dict[str, dict[str, Any]] = {}
+        provider = self.config.circuit_breaker_snapshot_provider
+        if provider is not None:
+            try:
+                circuit_breakers = provider()
+            except Exception:
+                # Observability must not terminate a production automation
+                # loop if an optional diagnostic provider is broken.
+                logger.exception("circuit-breaker snapshot provider failed")
+
+        return {
+            "queue_depths": {name.value: len(queue) for name, queue in self.queues.items()},
+            "inflight_per_repo": dict(self.inflight_per_repo),
+            "inflight_jobs": len(self.in_flight),
+            "circuit_breakers": circuit_breakers,
+            "loops_run": self._loops_run,
+        }
+
+    def _health_snapshot(self) -> dict[str, Any]:
+        """Return the local server's JSON health response without external I/O."""
+        snapshot = self._observability_snapshot()
+        snapshot["status"] = "stopping" if self.shutdown.is_set() else "ok"
+        return snapshot
+
+    def _emit_observability_tick(self) -> None:
+        """Update live gauges and durably record alert state transitions."""
+        registry = self._metrics_registry
+        tracker = self._alert_tracker
+        if registry is None or tracker is None:
+            return
+        snapshot = self._observability_snapshot()
+        for stage, depth in snapshot["queue_depths"].items():
+            registry.gauge(
+                "hephaestus_pipeline_queue_depth",
+                "Queued pipeline work items by stage.",
+            ).set(depth, labels={"stage": stage})
+        registry.gauge(
+            "hephaestus_pipeline_inflight_jobs",
+            "Pipeline jobs currently owned by the worker pool.",
+        ).set(snapshot["inflight_jobs"])
+        for repo, count in snapshot["inflight_per_repo"].items():
+            registry.gauge(
+                "hephaestus_pipeline_inflight_per_repo",
+                "Pipeline jobs currently in flight by repository.",
+            ).set(count, labels={"repo": repo})
+        for name, breaker in snapshot["circuit_breakers"].items():
+            state = breaker["state"]
+            registry.gauge(
+                "hephaestus_circuit_breaker_state",
+                "Circuit-breaker lifecycle state (active state has value 1).",
+            ).set(1, labels={"name": name, "state": state})
+
+        self._record_event("metrics_snapshot", snapshot)
+        for event in tracker.observe(snapshot):
+            registry.gauge(
+                "hephaestus_pipeline_alert_active",
+                "Current active pipeline alert state (1 active, 0 resolved).",
+            ).set(int(event.status == "fired"), labels={"name": event.name})
+            self._record_event(
+                f"alert_{event.status}",
+                {
+                    "name": event.name,
+                    "severity": event.severity,
+                    "message": event.message,
+                },
+            )
+
     def _wake_completion_wait(self) -> None:
         """Wake the coordinator if it is blocked in completion_q.get()."""
         self.completion_q.put((_WAKE_HANDLE, JobResult(ok=False, interrupted=True, error="wake")))
@@ -486,6 +585,8 @@ class Coordinator:
         if self._install_signals:
             self._install_signal_handlers()
         try:
+            if self._metrics_server is not None:
+                self._metrics_server.start()
             self._record_event(
                 "run_start",
                 {
@@ -505,6 +606,7 @@ class Coordinator:
                     break
                 self._wake_timers()
                 self._drain_completions()
+                self._emit_observability_tick()
                 if self.shutdown.is_set():
                     # Graceful: stop admitting; drain in-flight to RESUMABLE.
                     if not self.in_flight:
@@ -537,17 +639,21 @@ class Coordinator:
             )
             summary_items = self._effective_items()
             preserved = self._active_preserved_worktrees()
-            self._record_event(
-                "run_end",
-                {
-                    "exit_code": exit_code,
-                    "interrupted": stats.interrupted,
-                    "items": len(summary_items),
-                    "agent_jobs": self._agent_job_count,
-                    "wall_s": stats.wall_s,
-                },
-            )
-            print_summary(summary_items, stats, preserved, json_out=self.config.json_out)
+            try:
+                self._record_event(
+                    "run_end",
+                    {
+                        "exit_code": exit_code,
+                        "interrupted": stats.interrupted,
+                        "items": len(summary_items),
+                        "agent_jobs": self._agent_job_count,
+                        "wall_s": stats.wall_s,
+                    },
+                )
+                print_summary(summary_items, stats, preserved, json_out=self.config.json_out)
+            finally:
+                if self._metrics_server is not None:
+                    self._metrics_server.stop()
         return exit_code
 
     def _effective_items(self) -> list[WorkItem]:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -362,6 +362,11 @@ class Coordinator:
         self._metrics_registry: Any | None = None
         self._metrics_server: Any | None = None
         self._alert_tracker: Any | None = None
+        # Gauges retain label series until explicitly updated.  Remember the
+        # prior tick's dynamic labels so a completed job or state transition
+        # is rendered as zero rather than as stale active work.
+        self._observed_inflight_repos: set[str] = set()
+        self._observed_circuit_breaker_states: dict[str, str] = {}
         if config.metrics_port:
             from hephaestus.observability.alerts import AlertTracker
             from hephaestus.observability.metrics import MetricsRegistry
@@ -546,17 +551,36 @@ class Coordinator:
             "hephaestus_pipeline_inflight_jobs",
             "Pipeline jobs currently owned by the worker pool.",
         ).set(snapshot["inflight_jobs"])
+        inflight_by_repo = registry.gauge(
+            "hephaestus_pipeline_inflight_per_repo",
+            "Pipeline jobs currently in flight by repository.",
+        )
+        current_repos: set[str] = set()
         for repo, count in snapshot["inflight_per_repo"].items():
-            registry.gauge(
-                "hephaestus_pipeline_inflight_per_repo",
-                "Pipeline jobs currently in flight by repository.",
-            ).set(count, labels={"repo": repo})
+            repo_name = str(repo)
+            current_repos.add(repo_name)
+            inflight_by_repo.set(count, labels={"repo": repo_name})
+        for repo in self._observed_inflight_repos - current_repos:
+            inflight_by_repo.set(0, labels={"repo": repo})
+        self._observed_inflight_repos = current_repos
+
+        breaker_states = registry.gauge(
+            "hephaestus_circuit_breaker_state",
+            "Circuit-breaker lifecycle state (active state has value 1).",
+        )
+        current_breaker_states: dict[str, str] = {}
         for name, breaker in snapshot["circuit_breakers"].items():
-            state = breaker["state"]
-            registry.gauge(
-                "hephaestus_circuit_breaker_state",
-                "Circuit-breaker lifecycle state (active state has value 1).",
-            ).set(1, labels={"name": name, "state": state})
+            breaker_name = str(name)
+            state = str(breaker["state"])
+            previous_state = self._observed_circuit_breaker_states.get(breaker_name)
+            if previous_state is not None and previous_state != state:
+                breaker_states.set(0, labels={"name": breaker_name, "state": previous_state})
+            breaker_states.set(1, labels={"name": breaker_name, "state": state})
+            current_breaker_states[breaker_name] = state
+        for name, state in self._observed_circuit_breaker_states.items():
+            if name not in current_breaker_states:
+                breaker_states.set(0, labels={"name": name, "state": state})
+        self._observed_circuit_breaker_states = current_breaker_states
 
         self._record_event("metrics_snapshot", snapshot)
         for event in tracker.observe(snapshot):

--- a/hephaestus/nats/subscriber.py
+++ b/hephaestus/nats/subscriber.py
@@ -33,7 +33,7 @@ import threading
 import time
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from hephaestus.nats.config import NATSConfig
 from hephaestus.nats.events import NATSEvent
@@ -42,6 +42,9 @@ from hephaestus.resilience import (
     CircuitBreakerOpenError,
     CircuitBreakerState,
 )
+
+if TYPE_CHECKING:
+    from hephaestus.observability.metrics import MetricsRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +141,8 @@ class NATSSubscriberThread(threading.Thread):
         config: NATSConfig,
         handler: Callable[[NATSEvent], None],
         join_timeout: float = DEFAULT_JOIN_TIMEOUT,
+        *,
+        metrics_registry: MetricsRegistry | None = None,
     ) -> None:
         """Initialize the subscriber thread.
 
@@ -149,12 +154,16 @@ class NATSSubscriberThread(threading.Thread):
                 internal ``thread.join()``.  Defaults to
                 :data:`DEFAULT_JOIN_TIMEOUT` (5.0 s).  May be overridden per
                 call via ``stop(timeout=…)``.
+            metrics_registry: Optional caller-owned registry that receives
+                subscriber state, message, and error metrics. The subscriber
+                does not create a global registry or start an HTTP server.
 
         """
         super().__init__(daemon=True, name="NATSSubscriberThread")
         self._config = config
         self._handler = handler
         self._join_timeout = join_timeout
+        self._metrics_registry = metrics_registry
         self._stop_event = threading.Event()
         self._circuit_breaker = CircuitBreaker(
             NATS_CIRCUIT_BREAKER_NAME,
@@ -168,6 +177,7 @@ class NATSSubscriberThread(threading.Thread):
         self._last_error: BaseException | None = None
         self._last_message_at: float | None = None
         self._started_at: float = time.monotonic()
+        self._emit_metrics()
 
     # ------------------------------------------------------------------
     # Public health surface
@@ -240,23 +250,87 @@ class NATSSubscriberThread(threading.Thread):
         """Transition to *new_state* under the state lock."""
         with self._state_lock:
             self._state = new_state
+        self._emit_metrics()
 
     def _record_error(self, exc: BaseException) -> None:
         """Record *exc* as the latest error and transition to DISCONNECTED."""
         with self._state_lock:
             self._last_error = exc
             self._state = SubscriberState.DISCONNECTED
+        self._increment_error_metric("connection")
+        self._emit_metrics()
 
     def _record_terminal_error(self, exc: BaseException) -> None:
         """Record *exc* as the latest error and transition to ERROR."""
         with self._state_lock:
             self._last_error = exc
             self._state = SubscriberState.ERROR
+        self._increment_error_metric("terminal")
+        self._emit_metrics()
 
     def _record_message(self) -> None:
         """Update ``last_message_at`` to the current time."""
         with self._state_lock:
             self._last_message_at = time.time()
+        registry = self._metrics_registry
+        if registry is not None:
+            registry.counter(
+                "hephaestus_nats_subscriber_messages_total",
+                "NATS messages dispatched successfully by this subscriber.",
+            ).inc()
+        self._emit_metrics()
+
+    def _record_handler_error(self, exc: BaseException) -> None:
+        """Record a handler failure while preserving at-most-once delivery."""
+        with self._state_lock:
+            self._last_error = exc
+        self._increment_error_metric("handler")
+        self._emit_metrics()
+
+    def _record_decode_error(self) -> None:
+        """Record a malformed incoming NATS message without exposing its body."""
+        self._increment_error_metric("decode")
+        self._emit_metrics()
+
+    def _increment_error_metric(self, kind: str) -> None:
+        """Increment a bounded error-kind counter when metrics are injected."""
+        registry = self._metrics_registry
+        if registry is not None:
+            registry.counter(
+                "hephaestus_nats_subscriber_errors_total",
+                "NATS subscriber errors by bounded lifecycle kind.",
+            ).inc(labels={"kind": kind})
+
+    def _emit_metrics(self) -> None:
+        """Update caller-owned metrics from the thread-safe lifecycle snapshot."""
+        registry = self._metrics_registry
+        if registry is None:
+            return
+        with self._state_lock:
+            state = self._state
+            last_message_at = self._last_message_at
+        state_gauge = registry.gauge(
+            "hephaestus_nats_subscriber_state",
+            "NATS subscriber lifecycle state (one active state has value 1).",
+        )
+        for subscriber_state in SubscriberState:
+            state_gauge.set(
+                int(subscriber_state is state), labels={"state": subscriber_state.value}
+            )
+        breaker_state = self._circuit_breaker.state
+        breaker_gauge = registry.gauge(
+            "hephaestus_nats_subscriber_circuit_breaker_state",
+            "NATS subscriber circuit-breaker state (one active state has value 1).",
+        )
+        for breaker_state_candidate in CircuitBreakerState:
+            breaker_gauge.set(
+                int(breaker_state_candidate is breaker_state),
+                labels={"state": breaker_state_candidate.value},
+            )
+        registry.gauge(
+            "hephaestus_nats_subscriber_last_message_timestamp_seconds",
+            "Unix timestamp of the last successfully dispatched NATS message (zero if none).",
+        ).set(last_message_at or 0.0)
 
     # ------------------------------------------------------------------
     # Thread lifecycle
@@ -315,9 +389,7 @@ class NATSSubscriberThread(threading.Thread):
                         self._config.max_backoff_seconds,
                     )
         except Exception as exc:
-            with self._state_lock:
-                self._last_error = exc
-                self._state = SubscriberState.ERROR
+            self._record_terminal_error(exc)
             logger.exception("NATSSubscriberThread terminated with unhandled error")
             return
 
@@ -398,6 +470,7 @@ class NATSSubscriberThread(threading.Thread):
                     try:
                         data: dict[str, Any] = json.loads(msg.data.decode())
                     except (json.JSONDecodeError, UnicodeDecodeError):
+                        self._record_decode_error()
                         logger.warning(
                             "Failed to decode message on %s (seq=%d)",
                             msg.subject,
@@ -416,8 +489,7 @@ class NATSSubscriberThread(threading.Thread):
                     try:
                         self._handler(event)
                     except Exception as exc:
-                        with self._state_lock:
-                            self._last_error = exc
+                        self._record_handler_error(exc)
                         logger.exception(
                             "Handler raised on subject %s (seq=%d)",
                             event.subject,

--- a/hephaestus/observability/__init__.py
+++ b/hephaestus/observability/__init__.py
@@ -1,0 +1,22 @@
+"""Stdlib-only runtime observability primitives.
+
+The package deliberately has no import-time I/O or optional dependencies.  A
+caller may create a registry alone, or explicitly start the local HTTP server
+when it wants a scrape endpoint.
+"""
+
+from __future__ import annotations
+
+from hephaestus.observability.alerts import AlertEvent, AlertTracker, evaluate_alerts
+from hephaestus.observability.metrics import Counter, Gauge, MetricsRegistry
+from hephaestus.observability.server import MetricsHTTPServer
+
+__all__ = [
+    "AlertEvent",
+    "AlertTracker",
+    "Counter",
+    "Gauge",
+    "MetricsHTTPServer",
+    "MetricsRegistry",
+    "evaluate_alerts",
+]

--- a/hephaestus/observability/alerts.py
+++ b/hephaestus/observability/alerts.py
@@ -1,0 +1,106 @@
+"""Transition-based alerts derived only from live coordinator lifecycle data."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AlertEvent:
+    """A durable transition for one currently observable alert condition."""
+
+    name: str
+    severity: str
+    status: str
+    message: str
+
+
+def evaluate_alerts(
+    snapshot: Mapping[str, Any], *, queue_depth_threshold: int = 100
+) -> list[AlertEvent]:
+    """Evaluate conditions that the coordinator's runtime snapshot really contains.
+
+    The function deliberately contains no speculative rules: every rule reads
+    either ``queue_depths`` or ``circuit_breakers`` emitted by the coordinator.
+    Returned events describe active conditions; :class:`AlertTracker` turns
+    those into fire/resolve transitions.
+    """
+    if queue_depth_threshold < 0:
+        raise ValueError("queue depth threshold must be non-negative")
+    events: list[AlertEvent] = []
+    raw_breakers = snapshot.get("circuit_breakers", {})
+    if isinstance(raw_breakers, Mapping):
+        opened = sorted(
+            str(name)
+            for name, value in raw_breakers.items()
+            if isinstance(value, Mapping) and value.get("state") == "open"
+        )
+        if opened:
+            events.append(
+                AlertEvent(
+                    name="circuit_breaker_open",
+                    severity="critical",
+                    status="fired",
+                    message=f"circuit breakers open: {', '.join(opened)}",
+                )
+            )
+
+    raw_depths = snapshot.get("queue_depths", {})
+    if isinstance(raw_depths, Mapping):
+        exceeded: list[str] = []
+        for stage, depth in raw_depths.items():
+            if (
+                isinstance(depth, (int, float))
+                and not isinstance(depth, bool)
+                and depth > queue_depth_threshold
+            ):
+                exceeded.append(str(stage))
+        if exceeded:
+            events.append(
+                AlertEvent(
+                    name="queue_depth_exceeds",
+                    severity="warning",
+                    status="fired",
+                    message=f"queue depth exceeds {queue_depth_threshold}: "
+                    f"{', '.join(sorted(exceeded))}",
+                )
+            )
+    return events
+
+
+class AlertTracker:
+    """Emit a durable event only when an alert condition changes state."""
+
+    def __init__(self, *, queue_depth_threshold: int = 100) -> None:
+        """Create a tracker with the coordinator's queue-depth threshold."""
+        if queue_depth_threshold < 0:
+            raise ValueError("queue depth threshold must be non-negative")
+        self._queue_depth_threshold = queue_depth_threshold
+        self._active: dict[str, AlertEvent] = {}
+        self._lock = threading.Lock()
+
+    def observe(self, snapshot: Mapping[str, Any]) -> list[AlertEvent]:
+        """Return newly fired and newly resolved conditions, never duplicates."""
+        current = {
+            event.name: event
+            for event in evaluate_alerts(
+                snapshot, queue_depth_threshold=self._queue_depth_threshold
+            )
+        }
+        with self._lock:
+            transitions = [event for name, event in current.items() if name not in self._active]
+            transitions.extend(
+                AlertEvent(
+                    name=previous.name,
+                    severity=previous.severity,
+                    status="resolved",
+                    message=f"resolved: {previous.message}",
+                )
+                for name, previous in self._active.items()
+                if name not in current
+            )
+            self._active = current
+        return sorted(transitions, key=lambda event: (event.name, event.status))

--- a/hephaestus/observability/metrics.py
+++ b/hephaestus/observability/metrics.py
@@ -1,0 +1,182 @@
+"""Small, thread-safe Prometheus text exposition primitives.
+
+The registry intentionally supports only counters and gauges, which cover the
+live lifecycle values emitted by Hephaestus.  It does not open sockets, start
+threads, or import product-layer code.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import threading
+from collections.abc import Mapping
+from typing import TypeAlias, overload
+
+_METRIC_NAME_RE = re.compile(r"[A-Za-z_:][A-Za-z0-9_:]*\Z")
+_LABEL_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+LabelValues: TypeAlias = tuple[tuple[str, str], ...]
+
+
+def _normalise_labels(labels: Mapping[str, object] | None) -> LabelValues:
+    """Validate and canonicalise a Prometheus label mapping."""
+    if labels is None:
+        return ()
+    result: list[tuple[str, str]] = []
+    for name, value in labels.items():
+        if not _LABEL_NAME_RE.fullmatch(name):
+            raise ValueError(f"invalid Prometheus label name: {name!r}")
+        result.append((name, str(value)))
+    return tuple(sorted(result))
+
+
+def _validate_metric_name(name: str) -> None:
+    """Reject invalid Prometheus metric names before they reach output."""
+    if not _METRIC_NAME_RE.fullmatch(name):
+        raise ValueError(f"invalid Prometheus metric name: {name!r}")
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape label values according to the Prometheus text format."""
+    return value.replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _escape_help(value: str) -> str:
+    """Escape HELP text according to the Prometheus text format."""
+    return value.replace("\\", "\\\\").replace("\n", "\\n")
+
+
+def _format_value(value: float) -> str:
+    """Format a finite metric value without a needless decimal suffix."""
+    if not math.isfinite(value):
+        return "+Inf" if value > 0 else "-Inf" if value < 0 else "NaN"
+    return format(value, "g")
+
+
+class _Metric:
+    """Shared storage and rendering mechanics for one metric family."""
+
+    metric_type: str
+
+    def __init__(self, name: str, help_text: str) -> None:
+        _validate_metric_name(name)
+        self.name = name
+        self.help_text = help_text
+        self._lock = threading.Lock()
+        self._samples: dict[LabelValues, float] = {(): 0.0}
+        # The first operation fixes the label schema.  Until then the initial
+        # unlabeled zero is only a convenient default for a no-label metric.
+        self._label_names: tuple[str, ...] | None = None
+
+    def _sample_key(self, labels: Mapping[str, object] | None) -> LabelValues:
+        key = _normalise_labels(labels)
+        label_names = tuple(name for name, _ in key)
+        with self._lock:
+            if self._label_names is None:
+                self._label_names = label_names
+            elif self._label_names != label_names:
+                raise ValueError(
+                    f"metric {self.name!r} was registered with labels "
+                    f"{self._label_names!r}, not {label_names!r}"
+                )
+            if self._label_names and () in self._samples:
+                del self._samples[()]
+            return key
+
+    def _render_samples(self) -> tuple[str, str, list[tuple[LabelValues, float]]]:
+        with self._lock:
+            return self.name, self.help_text, sorted(self._samples.items())
+
+
+class Counter(_Metric):
+    """A monotonically increasing Prometheus counter."""
+
+    metric_type = "counter"
+
+    def inc(self, amount: float = 1.0, *, labels: Mapping[str, object] | None = None) -> None:
+        """Increase the counter by a non-negative finite amount."""
+        numeric_amount = float(amount)
+        if not math.isfinite(numeric_amount) or numeric_amount < 0:
+            raise ValueError("counter increments must be finite and non-negative")
+        key = self._sample_key(labels)
+        with self._lock:
+            self._samples[key] = self._samples.get(key, 0.0) + numeric_amount
+
+
+class Gauge(_Metric):
+    """A Prometheus gauge that records an instantaneous finite value."""
+
+    metric_type = "gauge"
+
+    def set(self, value: float, *, labels: Mapping[str, object] | None = None) -> None:
+        """Set the gauge to a finite numeric value."""
+        numeric_value = float(value)
+        if not math.isfinite(numeric_value):
+            raise ValueError("gauge values must be finite")
+        key = self._sample_key(labels)
+        with self._lock:
+            self._samples[key] = numeric_value
+
+
+class MetricsRegistry:
+    """Thread-safe named collection of counters and gauges."""
+
+    def __init__(self) -> None:
+        """Create an empty registry without any I/O or global state."""
+        self._lock = threading.Lock()
+        self._metrics: dict[str, _Metric] = {}
+
+    def counter(self, name: str, help_text: str = "") -> Counter:
+        """Return the named counter, creating it when necessary."""
+        return self._get_or_create(name, help_text, Counter)
+
+    def gauge(self, name: str, help_text: str = "") -> Gauge:
+        """Return the named gauge, creating it when necessary."""
+        return self._get_or_create(name, help_text, Gauge)
+
+    @overload
+    def _get_or_create(self, name: str, help_text: str, cls: type[Counter]) -> Counter: ...
+
+    @overload
+    def _get_or_create(self, name: str, help_text: str, cls: type[Gauge]) -> Gauge: ...
+
+    def _get_or_create(
+        self, name: str, help_text: str, cls: type[Counter] | type[Gauge]
+    ) -> Counter | Gauge:
+        _validate_metric_name(name)
+        with self._lock:
+            metric = self._metrics.get(name)
+            if metric is None:
+                metric = cls(name, help_text)
+                self._metrics[name] = metric
+            elif not isinstance(metric, cls):
+                raise ValueError(f"metric {name!r} is already a {metric.metric_type}")
+            elif help_text and metric.help_text != help_text:
+                raise ValueError(f"metric {name!r} is already registered with different HELP text")
+            return metric
+
+    def render_prometheus(self) -> str:
+        """Render this registry in Prometheus's text exposition format."""
+        with self._lock:
+            metrics = [self._metrics[name] for name in sorted(self._metrics)]
+        lines: list[str] = []
+        for metric in metrics:
+            name, help_text, samples = metric._render_samples()
+            if help_text:
+                lines.append(f"# HELP {name} {_escape_help(help_text)}")
+            lines.append(f"# TYPE {name} {metric.metric_type}")
+            for labels, value in samples:
+                rendered_labels = ""
+                if labels:
+                    rendered_pairs = ",".join(
+                        f'{label_name}="{_escape_label_value(label_value)}"'
+                        for label_name, label_value in labels
+                    )
+                    rendered_labels = "{" + rendered_pairs + "}"
+                lines.append(f"{name}{rendered_labels} {_format_value(value)}")
+        return "\n".join(lines) + ("\n" if lines else "")
+
+
+def render_prometheus_text(registry: MetricsRegistry) -> str:
+    """Render *registry* as Prometheus text (a convenient functional API)."""
+    return registry.render_prometheus()

--- a/hephaestus/observability/server.py
+++ b/hephaestus/observability/server.py
@@ -1,0 +1,168 @@
+"""An explicit, loopback-only HTTP endpoint for metrics and health."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import socket
+import threading
+from collections.abc import Callable, Mapping
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+from hephaestus.observability.metrics import MetricsRegistry
+
+logger = logging.getLogger(__name__)
+
+
+def _validate_loopback_host(host: str) -> None:
+    """Reject hostnames and non-loopback addresses without a DNS lookup."""
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError as exc:
+        raise ValueError("metrics server host must be a literal loopback address") from exc
+    if not address.is_loopback:
+        raise ValueError("metrics server host must be a loopback address")
+
+
+def _validate_port(port: int) -> None:
+    """Validate a TCP port before opening a socket."""
+    if type(port) is not int or not 0 <= port <= 65535:
+        raise ValueError("metrics server port must be an integer in 0..65535")
+
+
+class _LoopbackHTTPServer(ThreadingHTTPServer):
+    """A quiet threaded server whose worker threads cannot block process exit."""
+
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+class MetricsHTTPServer:
+    """Serve a :class:`MetricsRegistry` on an explicitly started local endpoint.
+
+    Construction performs validation only; socket binding and the daemon thread
+    begin in :meth:`start`.  The server is deliberately restricted to literal
+    loopback addresses so the unauthenticated diagnostic endpoint cannot be
+    exposed accidentally.
+    """
+
+    def __init__(
+        self,
+        registry: MetricsRegistry,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        health_provider: Callable[[], Mapping[str, Any]] | None = None,
+    ) -> None:
+        """Store endpoint configuration without starting I/O."""
+        _validate_loopback_host(host)
+        _validate_port(port)
+        self._registry = registry
+        self._host = host
+        self._port = port
+        self._health_provider = health_provider
+        self._lock = threading.Lock()
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._bound_port = 0
+
+    @property
+    def bound_port(self) -> int:
+        """The active port, or zero while the server is stopped."""
+        with self._lock:
+            return self._bound_port
+
+    def start(self) -> None:
+        """Bind the configured loopback port and start serving in a daemon thread."""
+        with self._lock:
+            if self._server is not None:
+                return
+            handler = self._handler_type()
+            server_type: type[ThreadingHTTPServer] = _LoopbackHTTPServer
+            if ipaddress.ip_address(self._host).version == 6:
+                server_type = type(
+                    "_IPv6LoopbackHTTPServer",
+                    (_LoopbackHTTPServer,),
+                    {"address_family": socket.AF_INET6},
+                )
+            server = server_type((self._host, self._port), handler)
+            thread = threading.Thread(
+                target=server.serve_forever,
+                name="HephaestusMetricsHTTPServer",
+                daemon=True,
+            )
+            self._server = server
+            self._thread = thread
+            self._bound_port = int(server.server_address[1])
+            thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Stop serving and close the listening socket; safe to call repeatedly."""
+        with self._lock:
+            server = self._server
+            thread = self._thread
+            self._server = None
+            self._thread = None
+            self._bound_port = 0
+        if server is None:
+            return
+        server.shutdown()
+        server.server_close()
+        if thread is not None:
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                logger.warning("metrics HTTP server did not stop within %.1fs", timeout)
+
+    def _handler_type(self) -> type[BaseHTTPRequestHandler]:
+        """Build a handler closed over this server's registry and health callback."""
+        registry = self._registry
+        health_provider = self._health_provider
+
+        class Handler(BaseHTTPRequestHandler):
+            """Serve only diagnostic GET routes without request logging."""
+
+            def do_GET(self) -> None:
+                if self.path == "/metrics":
+                    self._write(
+                        HTTPStatus.OK,
+                        registry.render_prometheus().encode(),
+                        "text/plain; version=0.0.4",
+                    )
+                    return
+                if self.path == "/health":
+                    try:
+                        payload = (
+                            {"status": "ok"} if health_provider is None else dict(health_provider())
+                        )
+                        body = json.dumps(payload, sort_keys=True).encode()
+                    except Exception:
+                        logger.exception("metrics health provider failed")
+                        self._write(
+                            HTTPStatus.SERVICE_UNAVAILABLE,
+                            b'{"status": "error"}',
+                            "application/json",
+                        )
+                        return
+                    self._write(HTTPStatus.OK, body, "application/json")
+                    return
+                self._write(HTTPStatus.NOT_FOUND, b'{"status": "not_found"}', "application/json")
+
+            def do_HEAD(self) -> None:
+                self.send_error(HTTPStatus.METHOD_NOT_ALLOWED)
+
+            def _write(self, status: HTTPStatus, body: bytes, content_type: str) -> None:
+                self.send_response(status)
+                self.send_header("Content-Type", f"{content_type}; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: object) -> None:
+                """Suppress routine unauthenticated scrape request logs."""
+                del format, args
+
+        return Handler

--- a/hephaestus/resilience/__init__.py
+++ b/hephaestus/resilience/__init__.py
@@ -10,6 +10,7 @@ from hephaestus.resilience.circuit_breaker import (
     CircuitBreakerOpenError,
     CircuitBreakerOpenReason,
     CircuitBreakerState,
+    all_circuit_breaker_snapshots,
     get_circuit_breaker,
     reset_all_circuit_breakers,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "CircuitBreakerOpenError",
     "CircuitBreakerOpenReason",
     "CircuitBreakerState",
+    "all_circuit_breaker_snapshots",
     "get_circuit_breaker",
     "is_transient_subprocess_error",
     "reset_all_circuit_breakers",

--- a/hephaestus/resilience/circuit_breaker.py
+++ b/hephaestus/resilience/circuit_breaker.py
@@ -290,6 +290,17 @@ class CircuitBreaker:
             self._last_failure_time = 0.0
             logger.info("Circuit breaker '%s' reset to CLOSED", self.name)
 
+    def snapshot(self) -> dict[str, str | int | float]:
+        """Return a JSON-safe view of the breaker's current lifecycle state."""
+        with self._lock:
+            state = self._effective_state()
+            return {
+                "name": self.name,
+                "state": state.value,
+                "failure_count": self._failure_count,
+                "last_failure_time": self._last_failure_time,
+            }
+
 
 # Global registry of circuit breakers
 _registry: dict[str, CircuitBreaker] = {}
@@ -350,3 +361,10 @@ def reset_all_circuit_breakers() -> None:
         for cb in _registry.values():
             cb.reset()
         _registry.clear()
+
+
+def all_circuit_breaker_snapshots() -> dict[str, dict[str, str | int | float]]:
+    """Return point-in-time snapshots of every registered circuit breaker."""
+    with _registry_lock:
+        breakers = list(_registry.values())
+    return {breaker.name: breaker.snapshot() for breaker in breakers}

--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ audit:
 
 # Generate API reference documentation with pdoc (output: docs/api/)
 docs:
-    uv run pdoc ./hephaestus ./hephaestus/agents ./hephaestus/benchmarks ./hephaestus/ci ./hephaestus/cli ./hephaestus/config ./hephaestus/datasets ./hephaestus/discovery ./hephaestus/forensics ./hephaestus/github ./hephaestus/io ./hephaestus/logging ./hephaestus/markdown ./hephaestus/nats ./hephaestus/resilience ./hephaestus/scripts_lib ./hephaestus/system ./hephaestus/utils ./hephaestus/validation ./hephaestus/version --output-dir docs/api
+    uv run pdoc ./hephaestus ./hephaestus/agents ./hephaestus/benchmarks ./hephaestus/ci ./hephaestus/cli ./hephaestus/config ./hephaestus/datasets ./hephaestus/discovery ./hephaestus/forensics ./hephaestus/github ./hephaestus/io ./hephaestus/logging ./hephaestus/markdown ./hephaestus/nats ./hephaestus/observability ./hephaestus/resilience ./hephaestus/scripts_lib ./hephaestus/system ./hephaestus/utils ./hephaestus/validation ./hephaestus/version --output-dir docs/api
 
 # Full CI-equivalent run: bootstrap, check, and test
 all: bootstrap check test

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -40,6 +40,11 @@ from hephaestus.automation.pipeline.stages.pr_review import (
     PrReviewStage,
 )
 from hephaestus.automation.pipeline.work_item import ItemKind, WorkItem
+from hephaestus.resilience import (
+    all_circuit_breaker_snapshots,
+    get_circuit_breaker,
+    reset_all_circuit_breakers,
+)
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -123,6 +128,43 @@ def _issue_item(
 
 class TestQuiescence:
     """Full-run tests driving seeded items to the finished ledger."""
+
+    def test_metrics_server_starts_for_run_and_stops_on_teardown(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Coordinator teardown closes the explicit local listener on every normal exit."""
+        from hephaestus.observability import server as server_mod
+
+        created: list[object] = []
+
+        class FakeMetricsServer:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                del args, kwargs
+                self.started = False
+                self.stopped = False
+                created.append(self)
+
+            def start(self) -> None:
+                self.started = True
+
+            def stop(self) -> None:
+                self.stopped = True
+
+        monkeypatch.setattr(server_mod, "MetricsHTTPServer", FakeMetricsServer)
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path, metrics_port=9123
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+
+        assert coordinator.run() == 0
+        assert len(created) == 1
+        assert created[0].started is True  # type: ignore[attr-defined]
+        assert created[0].stopped is True  # type: ignore[attr-defined]
 
     def test_explicit_issue_scope_suppresses_repo_discovery_seed(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -871,6 +913,49 @@ class TestImplementationAdmission:
 
 class TestDurableEventLog:
     """Optional JSONL event log mirrors the coordinator's in-memory event log."""
+
+    def test_observability_tick_snapshots_lifecycle_and_deduplicates_alerts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A metrics-enabled coordinator durably records only alert transitions."""
+        config = PipelineConfig(
+            org="org",
+            repos=["repo-a"],
+            loops=1,
+            projects_dir=tmp_path,
+            metrics_port=9123,
+            alert_queue_depth_threshold=0,
+            circuit_breaker_snapshot_provider=all_circuit_breaker_snapshots,
+        )
+        monkeypatch.setattr(seeding_mod, "seed_from_cli", lambda r, i, p: [])
+        coordinator = Coordinator(
+            config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
+        )
+        coordinator.queues[StageName.PLANNING].push(_issue_item(44, StageName.PLANNING))
+        breaker = get_circuit_breaker("github-observed", failure_threshold=1)
+        with pytest.raises(ConnectionError):
+            breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+
+        coordinator._emit_observability_tick()
+        coordinator._emit_observability_tick()
+        coordinator.queues[StageName.PLANNING].pop()
+        reset_all_circuit_breakers()
+        coordinator._emit_observability_tick()
+
+        events = [entry for entry in coordinator.event_log if entry[0].startswith("alert_")]
+        assert [(event[0], event[1]["name"]) for event in events] == [
+            ("alert_fired", "circuit_breaker_open"),
+            ("alert_fired", "queue_depth_exceeds"),
+            ("alert_resolved", "circuit_breaker_open"),
+            ("alert_resolved", "queue_depth_exceeds"),
+        ]
+        snapshots = [entry[1] for entry in coordinator.event_log if entry[0] == "metrics_snapshot"]
+        assert snapshots[0]["queue_depths"]["planning"] == 1
+        # The registry reflects the latest resolved lifecycle state, not a stale
+        # historical high-water mark.
+        assert 'hephaestus_pipeline_queue_depth{stage="planning"} 0' in (
+            coordinator._metrics_registry.render_prometheus()
+        )
 
     def test_event_log_path_persists_queue_events(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -953,6 +953,7 @@ class TestDurableEventLog:
         assert snapshots[0]["queue_depths"]["planning"] == 1
         # The registry reflects the latest resolved lifecycle state, not a stale
         # historical high-water mark.
+        assert coordinator._metrics_registry is not None
         assert 'hephaestus_pipeline_queue_depth{stage="planning"} 0' in (
             coordinator._metrics_registry.render_prometheus()
         )

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -914,6 +914,55 @@ class TestImplementationAdmission:
 class TestDurableEventLog:
     """Optional JSONL event log mirrors the coordinator's in-memory event log."""
 
+    def test_observability_tick_zeroes_previous_circuit_breaker_state(self, tmp_path: Path) -> None:
+        """A transition leaves exactly one active state gauge for each breaker."""
+        snapshots: dict[str, dict[str, Any]] = {"github": {"state": "closed"}}
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                metrics_port=9123,
+                circuit_breaker_snapshot_provider=lambda: snapshots,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+
+        coordinator._emit_observability_tick()
+        snapshots["github"]["state"] = "open"
+        coordinator._emit_observability_tick()
+
+        assert coordinator._metrics_registry is not None
+        rendered = coordinator._metrics_registry.render_prometheus()
+        assert 'hephaestus_circuit_breaker_state{name="github",state="closed"} 0' in rendered
+        assert 'hephaestus_circuit_breaker_state{name="github",state="open"} 1' in rendered
+
+    def test_observability_tick_zeroes_removed_inflight_repo(self, tmp_path: Path) -> None:
+        """A repo that leaves the in-flight counter no longer reports active work."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                metrics_port=9123,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator.inflight_per_repo["repo-a"] = 1
+
+        coordinator._emit_observability_tick()
+        del coordinator.inflight_per_repo["repo-a"]
+        coordinator._emit_observability_tick()
+
+        assert coordinator._metrics_registry is not None
+        assert 'hephaestus_pipeline_inflight_per_repo{repo="repo-a"} 0' in (
+            coordinator._metrics_registry.render_prometheus()
+        )
+
     def test_observability_tick_snapshots_lifecycle_and_deduplicates_alerts(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -749,6 +749,16 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             ),
         ),
         _action_spec(
+            ("--metrics-port",),
+            "metrics_port",
+            "_StoreAction",
+            0,
+            help_text=(
+                "Loopback-only port for the local Prometheus /metrics and /health server "
+                "(0 disables it)."
+            ),
+        ),
+        _action_spec(
             ("--repos",),
             "repos",
             "_StoreAction",

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -529,6 +529,28 @@ def test_main_disables_phase_timeout_when_zero(monkeypatch: pytest.MonkeyPatch) 
     assert config.phase_timeout_s is None  # type: ignore[attr-defined]
 
 
+@pytest.mark.parametrize("port", [0, 65535])
+def test_metrics_port_parser_accepts_tcp_port_range(port: int) -> None:
+    """The opt-in local metrics endpoint accepts every valid TCP port."""
+    assert loop_runner._parse_args(["--metrics-port", str(port)]).metrics_port == port
+
+
+@pytest.mark.parametrize("port", [-1, 65536])
+def test_metrics_port_parser_rejects_out_of_range_values(port: int) -> None:
+    """Bad port values fail during CLI parsing, before coordinator setup."""
+    with pytest.raises(SystemExit):
+        loop_runner._parse_args(["--metrics-port", str(port)])
+
+
+def test_main_wires_metrics_port_to_pipeline_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The validated CLI port reaches the coordinator's opt-in configuration."""
+    config = _capture_config(
+        ["--repos", "Repo", "--metrics-port", "9123", "--loops", "1", "--agent", "claude"],
+        monkeypatch,
+    )
+    assert config.metrics_port == 9123  # type: ignore[attr-defined]
+
+
 def test_main_installs_sigtstp_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     """main() fixes Ctrl+Z (#1784) via the shared install_sigtstp_only helper.
 

--- a/tests/unit/nats/test_subscriber.py
+++ b/tests/unit/nats/test_subscriber.py
@@ -13,6 +13,7 @@ from hephaestus.nats.subscriber import (
     NATSSubscriberThread,
     SubscriberState,
 )
+from hephaestus.observability.metrics import MetricsRegistry
 
 
 def _config(**kwargs: object) -> NATSConfig:
@@ -73,6 +74,25 @@ class TestNATSSubscriberThread:
         config = _config(url="nats://test:4222")
         thread = NATSSubscriberThread(config=config, handler=MagicMock())
         assert thread._config.url == "nats://test:4222"
+
+    def test_injected_registry_records_lifecycle_activity_and_errors(self) -> None:
+        """An opt-in registry receives only live subscriber lifecycle values."""
+        registry = MetricsRegistry()
+        thread = NATSSubscriberThread(
+            config=_config(), handler=MagicMock(), metrics_registry=registry
+        )
+
+        thread._record_message()
+        thread._record_error(ConnectionError("nats gone"))
+        thread._record_handler_error(RuntimeError("handler failed"))
+        thread._record_decode_error()
+
+        rendered = registry.render_prometheus()
+        assert 'hephaestus_nats_subscriber_state{state="disconnected"} 1' in rendered
+        assert "hephaestus_nats_subscriber_messages_total 1" in rendered
+        assert 'hephaestus_nats_subscriber_errors_total{kind="connection"} 1' in rendered
+        assert 'hephaestus_nats_subscriber_errors_total{kind="handler"} 1' in rendered
+        assert 'hephaestus_nats_subscriber_errors_total{kind="decode"} 1' in rendered
 
 
 class TestSubscriberStateEnum:

--- a/tests/unit/observability/__init__.py
+++ b/tests/unit/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the stdlib-only observability package."""

--- a/tests/unit/observability/test_alerts.py
+++ b/tests/unit/observability/test_alerts.py
@@ -1,0 +1,29 @@
+"""Tests for lifecycle-backed alert transition tracking."""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_alert_tracker_emits_one_fire_and_one_resolution() -> None:
+    """Persistent degradation produces no repeated alert-event spam."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+    tracker = alerts.AlertTracker(queue_depth_threshold=2)
+    unhealthy = {
+        "queue_depths": {"planning": 3},
+        "circuit_breakers": {"github": {"state": "open"}},
+    }
+
+    fired = tracker.observe(unhealthy)
+    repeated = tracker.observe(unhealthy)
+    resolved = tracker.observe({"queue_depths": {"planning": 0}, "circuit_breakers": {}})
+
+    assert {(event.name, event.status) for event in fired} == {
+        ("circuit_breaker_open", "fired"),
+        ("queue_depth_exceeds", "fired"),
+    }
+    assert repeated == []
+    assert {(event.name, event.status) for event in resolved} == {
+        ("circuit_breaker_open", "resolved"),
+        ("queue_depth_exceeds", "resolved"),
+    }

--- a/tests/unit/observability/test_metrics.py
+++ b/tests/unit/observability/test_metrics.py
@@ -1,0 +1,55 @@
+"""Tests for Prometheus text metrics primitives."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+
+def test_registry_renders_counter_with_escaped_labels() -> None:
+    """Counters render valid Prometheus labels without corrupting values."""
+    metrics = importlib.import_module("hephaestus.observability.metrics")
+    registry = metrics.MetricsRegistry()
+
+    registry.counter("hephaestus_events_total", "Events processed").inc(
+        labels={"source": 'a\\b\n"quoted"'}
+    )
+
+    rendered = registry.render_prometheus()
+
+    assert "# HELP hephaestus_events_total Events processed" in rendered
+    assert "# TYPE hephaestus_events_total counter" in rendered
+    assert 'hephaestus_events_total{source="a\\\\b\\n\\"quoted\\""} 1' in rendered
+
+
+def test_observability_import_opens_no_socket() -> None:
+    """Importing the library package never starts a server or opens a socket."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import socket, ssl; OriginalSocket = socket.socket; "
+            "socket.socket = type('NoSocket', (OriginalSocket,), {'__init__': "
+            "lambda self, *a, **k: (_ for _ in ()).throw(AssertionError("
+            "'socket opened during import'))}); import hephaestus.observability",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_registry_rejects_invalid_metric_and_label_names() -> None:
+    """Untrusted names cannot produce malformed Prometheus exposition text."""
+    metrics = importlib.import_module("hephaestus.observability.metrics")
+    registry = metrics.MetricsRegistry()
+
+    with pytest.raises(ValueError, match="metric name"):
+        registry.counter("not valid")
+    with pytest.raises(ValueError, match="label name"):
+        registry.gauge("hephaestus_valid").set(1, labels={"not valid": "value"})

--- a/tests/unit/observability/test_server.py
+++ b/tests/unit/observability/test_server.py
@@ -1,0 +1,74 @@
+"""Tests for the opt-in loopback-only metrics HTTP server."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import socket
+from urllib.error import HTTPError
+from urllib.request import urlopen
+
+import pytest
+
+from hephaestus.observability.metrics import MetricsRegistry
+
+
+def test_server_serves_metrics_and_health_then_releases_port() -> None:
+    """The server has a bounded lifecycle and serves live registry state."""
+    server_module = importlib.import_module("hephaestus.observability.server")
+    registry = MetricsRegistry()
+    registry.gauge("hephaestus_queue_depth", "Queue depth").set(3, labels={"stage": "repo"})
+    server = server_module.MetricsHTTPServer(
+        registry, health_provider=lambda: {"status": "ok", "queue_depths": {"repo": 3}}
+    )
+
+    server.start()
+    bound_port = server.bound_port
+    try:
+        with urlopen(f"http://127.0.0.1:{server.bound_port}/metrics", timeout=2) as response:
+            assert response.status == 200
+            assert response.headers["Content-Type"].startswith("text/plain")
+            assert 'hephaestus_queue_depth{stage="repo"} 3' in response.read().decode()
+        with urlopen(f"http://127.0.0.1:{server.bound_port}/health", timeout=2) as response:
+            assert response.status == 200
+            assert json.loads(response.read()) == {"queue_depths": {"repo": 3}, "status": "ok"}
+    finally:
+        server.stop()
+
+    assert server.bound_port == 0
+    with socket.socket() as listener:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", bound_port))
+
+
+@pytest.mark.parametrize("port", [-1, 65536])
+def test_server_rejects_out_of_range_ports(port: int) -> None:
+    """Invalid ports fail before any socket is opened."""
+    server_module = importlib.import_module("hephaestus.observability.server")
+
+    with pytest.raises(ValueError, match="port"):
+        server_module.MetricsHTTPServer(MetricsRegistry(), port=port)
+
+
+def test_server_rejects_non_loopback_host() -> None:
+    """The scrape server may never bind an externally reachable address."""
+    server_module = importlib.import_module("hephaestus.observability.server")
+
+    with pytest.raises(ValueError, match="loopback"):
+        server_module.MetricsHTTPServer(MetricsRegistry(), host="0.0.0.0")
+
+
+def test_health_provider_failure_returns_bounded_service_unavailable() -> None:
+    """A bad health provider cannot crash the server thread or leak its error."""
+    server_module = importlib.import_module("hephaestus.observability.server")
+    server = server_module.MetricsHTTPServer(
+        MetricsRegistry(), health_provider=lambda: (_ for _ in ()).throw(RuntimeError("secret"))
+    )
+    server.start()
+    try:
+        with pytest.raises(HTTPError) as raised:
+            urlopen(f"http://127.0.0.1:{server.bound_port}/health", timeout=2)
+        assert raised.value.code == 503
+        assert json.loads(raised.value.read()) == {"status": "error"}
+    finally:
+        server.stop()

--- a/tests/unit/resilience/test_circuit_breaker.py
+++ b/tests/unit/resilience/test_circuit_breaker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -22,6 +23,23 @@ from hephaestus.resilience.circuit_breaker import (
 def _clean_registry() -> None:
     """Reset circuit breaker registry before each test."""
     reset_all_circuit_breakers()
+
+
+def test_registered_breaker_snapshots_are_json_safe_and_live() -> None:
+    """The registry exposes actual open-breaker state for observability."""
+    circuit_breaker = importlib.import_module("hephaestus.resilience.circuit_breaker")
+    breaker = get_circuit_breaker("observed", failure_threshold=1)
+    with pytest.raises(ConnectionError):
+        breaker.call(lambda: (_ for _ in ()).throw(ConnectionError("down")))
+
+    snapshots = circuit_breaker.all_circuit_breaker_snapshots()
+
+    assert snapshots["observed"] == {
+        "name": "observed",
+        "state": "open",
+        "failure_count": 1,
+        "last_failure_time": pytest.approx(snapshots["observed"]["last_failure_time"]),
+    }
 
 
 class TestCircuitBreakerIgnoredExceptions:


### PR DESCRIPTION
## Summary
- add stdlib-only metrics rendering and loopback metrics/health endpoints
- publish coordinator queue and circuit-breaker lifecycle snapshots with deduplicated alert transitions
- expose NATS subscriber lifecycle, message, and error metrics through injected registries
- validate metrics-port configuration and document the observability API target

## Status
Rebased directly onto current `main` after #2236 and #2234 were squash-merged.

## Validation
- full required pre-push suite: 6,265 passed, 25 skipped
- focused lifecycle, coordinator, NATS, resilience, parser, import-boundary, and API-doc tests
- ruff, format, and scoped mypy

Closes #1485