### PR TITLE
fix(automation): preserve direct checkout roots

### DIFF
--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -676,9 +676,15 @@ def _current_checkout_repo_roots(
     if checkout == conventional_root:
         return {}
 
-    automation_worktree_dir = conventional_root / "build" / ".worktrees"
-    if checkout.parent == automation_worktree_dir:
-        return {}
+    # An automation issue worktree always has the structural form
+    # ``<base checkout>/build/.worktrees/<issue>``.  Do not assume that the
+    # base checkout has the conventional ``projects_dir / repo`` name: swarm
+    # and manually renamed checkouts are valid.  In that noncanonical case the
+    # base checkout itself is the explicit root; using the issue worktree here
+    # would make a later implementation create nested worktrees beneath it.
+    if checkout.parent.name == ".worktrees" and checkout.parent.parent.name == "build":
+        base_checkout = checkout.parent.parent.parent
+        return {} if base_checkout == conventional_root else {repo: base_checkout}
 
     return {repo: checkout}
 

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -59,6 +59,7 @@ from hephaestus.cli.utils import (
 )
 from hephaestus.config.paths import DEFAULT_PROJECTS_DIR, resolve_projects_dir
 from hephaestus.github.client import gh_call
+from hephaestus.utils.helpers import get_repo_root
 
 LOG = logging.getLogger(__name__)
 
@@ -211,6 +212,10 @@ class LoopConfig:
     # hardcoded fallback. Always set by main() before dispatch.
     org: str = ""
     projects_dir: Path = DEFAULT_PROJECTS_DIR
+    # The loop can be launched from a checkout whose directory name does not
+    # match its remote repository.  Keep that exceptional path explicit while
+    # retaining ``projects_dir / repo`` as the normal multi-repo convention.
+    repo_roots: dict[str, Path] = field(default_factory=dict)
     # Per-agent-job timeout in seconds. Defaults to an env-overridable bound
     # (``HEPH_PHASE_TIMEOUT``); ``--phase-timeout`` overrides it and a
     # non-positive value disables the bound (``None``).
@@ -633,9 +638,49 @@ def _build_pipeline_config(
         circuit_breaker_snapshot_provider=circuit_breaker_snapshot_provider,
         event_log_path=_pipeline_event_log_path(cfg.projects_dir, repos),
         projects_dir=cfg.projects_dir,
+        repo_roots=cfg.repo_roots,
         json_out=args.json,
         scope=_pipeline_scope_for_phases(cfg.phases),
     )
+
+
+def _current_checkout_repo_roots(
+    args: argparse.Namespace, org: str, repos: list[str], projects_dir: Path
+) -> dict[str, Path]:
+    """Return an explicit root only for an eligible noncanonical cwd checkout.
+
+    A user-supplied projects root (either the CLI flag or a valid
+    ``PROJECTS_ROOT``) is an authoritative request to use conventional
+    ``projects_dir / repo`` locations.  The automatic exception exists solely
+    for running the loop from a differently named checkout, such as a swarm
+    worktree.  Automation's own ``build/.worktrees/issue-N`` checkouts are
+    already represented by the conventional base checkout and remain so.
+    """
+    if args.projects_dir is not None:
+        return {}
+
+    configured_root = os.environ.get("PROJECTS_ROOT")
+    if configured_root and Path(configured_root).is_dir():
+        return {}
+
+    detected_org, detected_repo = _detect_cwd_repo()
+    if not detected_repo or not detected_org or detected_org.casefold() != org.casefold():
+        return {}
+
+    repo = next((name for name in repos if name.casefold() == detected_repo.casefold()), None)
+    if repo is None:
+        return {}
+
+    checkout = get_repo_root()
+    conventional_root = projects_dir / repo
+    if checkout == conventional_root:
+        return {}
+
+    automation_worktree_dir = conventional_root / "build" / ".worktrees"
+    if checkout.parent == automation_worktree_dir:
+        return {}
+
+    return {repo: checkout}
 
 
 def _error_exit(args: argparse.Namespace, message: str, json_message: str | None = None) -> int:
@@ -699,6 +744,7 @@ def main(argv: list[str] | None = None) -> int:
     if err:
         return _error_exit(args, err)
 
+    projects_dir = resolve_projects_dir(args.projects_dir, prefer_cwd_parent=True)
     cfg = LoopConfig(
         loops=args.loops,
         max_workers=args.max_workers,
@@ -721,7 +767,8 @@ def main(argv: list[str] | None = None) -> int:
         gh_global_rate=args.gh_global_rate,
         gh_global_burst=args.gh_global_burst,
         org=org,
-        projects_dir=resolve_projects_dir(args.projects_dir, prefer_cwd_parent=True),
+        projects_dir=projects_dir,
+        repo_roots=_current_checkout_repo_roots(args, org, repos, projects_dir),
         # A non-positive --phase-timeout explicitly disables the bound; any
         # positive value (including the env-overridable default) applies it.
         phase_timeout_s=(

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -248,6 +248,10 @@ class PipelineConfig:
     circuit_breaker_snapshot_provider: Callable[[], dict[str, dict[str, Any]]] | None = None
     event_log_path: Path | None = None
     projects_dir: Path = field(default_factory=lambda: Path.home() / "Projects")
+    # Optional exceptions to the normal ``projects_dir / repo`` checkout
+    # layout.  The loop runner only sets an entry for a matching noncanonical
+    # cwd checkout; unlisted repositories retain the conventional fallback.
+    repo_roots: dict[str, Path] = field(default_factory=dict)
     json_out: bool = False
     # Optional contiguous stage subset. When set, the coordinator routes items
     # through ``scope.trimmed_routes()`` instead of the full ``ROUTES`` table,
@@ -292,6 +296,11 @@ class _Paths:
     repo_root: Path
     worktree: Path
     projects_dir: Path
+
+
+def _effective_repo_root(config: PipelineConfig, repo: str) -> Path:
+    """Resolve *repo* to its explicit checkout or conventional projects path."""
+    return Path(config.repo_roots.get(repo, Path(config.projects_dir) / repo))
 
 
 class Coordinator:
@@ -446,7 +455,7 @@ class Coordinator:
         """Return the (cached, per-repo) StageContext for *repo*."""
         ctx = self._ctx_cache.get(repo)
         if ctx is None:
-            root = Path(self.config.projects_dir) / repo
+            root = _effective_repo_root(self.config, repo)
             ctx = StageContext(
                 config=self._stage_config,
                 org=self.config.org,
@@ -1711,7 +1720,7 @@ def run_pipeline(config: PipelineConfig) -> int:
         )
 
     repo = config.repos[0] if config.repos else ""
-    repo_root = Path(config.projects_dir) / repo if repo else Path(config.projects_dir)
+    repo_root = _effective_repo_root(config, repo) if repo else Path(config.projects_dir)
     github = (
         _github_for(repo, repo_root) if repo else PipelineGitHub(config.org, dry_run=config.dry_run)
     )

--- a/hephaestus/automation/pipeline/stages/repo.py
+++ b/hephaestus/automation/pipeline/stages/repo.py
@@ -74,8 +74,15 @@ def _drive_green_pr_is_in_scope(
 
 
 def _repo_checkout_path(item: WorkItem, ctx: StageContext) -> Path:
-    """Return the expected local checkout path for the repo item."""
-    return Path(str(ctx.paths.projects_dir)) / item.repo
+    """Return the effective local checkout path for the repo item.
+
+    Coordinator contexts always provide a per-repository ``repo_root``.  The
+    projects-root fallback keeps legacy lightweight stage contexts compatible
+    while making an explicit noncanonical root authoritative for clone checks.
+    """
+    repo_root = Path(str(ctx.paths.repo_root))
+    projects_dir = Path(str(ctx.paths.projects_dir))
+    return projects_dir / item.repo if repo_root == projects_dir else repo_root
 
 
 def _tag_epics(repo: str, ctx: StageContext, epics_labels: dict[int, list[str]]) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_repo.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_repo.py
@@ -29,12 +29,12 @@ from .conftest import FakeStageGitHub
 
 
 class _RepoPaths:
-    """Paths stub exposing the projects_dir the repo stage anchors clones at."""
+    """Paths stub exposing a projects root and an optional explicit checkout."""
 
-    def __init__(self, projects_dir: Path) -> None:
+    def __init__(self, projects_dir: Path, *, repo_root: Path | None = None) -> None:
         self.projects_dir = projects_dir
-        self.repo_root = projects_dir
-        self.worktree = projects_dir
+        self.repo_root = repo_root or projects_dir
+        self.worktree = self.repo_root
 
 
 @pytest.fixture
@@ -111,6 +111,21 @@ class TestOnEnterAndCloneStates:
         repo_item.state = "CLONE_WAIT"
 
         result = RepoStage().step(repo_item, repo_ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == "DISCOVER"
+
+    def test_clone_skipped_when_explicit_repo_root_is_existing_checkout(
+        self, repo_item: WorkItem, tmp_path: Path, make_ctx: Callable[..., Any]
+    ) -> None:
+        """An isolated checkout is used directly instead of ``projects_dir / repo``."""
+        projects_dir = tmp_path / "projects"
+        checkout = tmp_path / "isolated" / "repo-a-worktree"
+        checkout.mkdir(parents=True)
+        ctx = make_ctx(paths=_RepoPaths(projects_dir, repo_root=checkout))
+        repo_item.state = "CLONE_WAIT"
+
+        result = RepoStage().step(repo_item, ctx)
 
         assert isinstance(result, Continue)
         assert result.next_state == "DISCOVER"

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -143,6 +143,38 @@ class TestWiring:
 
         assert run_pipeline(config) == 7
 
+    def test_explicit_repo_root_reaches_context_and_scoped_accessor(self, tmp_path: Path) -> None:
+        """A noncanonical checkout stays authoritative throughout coordinator wiring."""
+        checkout = tmp_path / "isolated" / "target-repo-worktree"
+        scoped_github = FakeStageGitHub()
+        created: list[tuple[str, Path]] = []
+
+        def github_factory(repo: str, repo_root: Path) -> FakeStageGitHub:
+            created.append((repo, repo_root))
+            return scoped_github
+
+        config = PipelineConfig(
+            org="org",
+            repos=["target-repo"],
+            projects_dir=tmp_path / "projects",
+            repo_roots={"target-repo": checkout},
+        )
+        coordinator = Coordinator(
+            config,
+            github=FakeStageGitHub(),
+            github_factory=github_factory,
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+
+        ctx = coordinator._ctx_for_repo("target-repo")
+
+        assert created == [("target-repo", checkout)]
+        assert ctx.github is scoped_github
+        assert ctx.paths.repo_root == checkout
+        assert ctx.paths.worktree == checkout
+        assert ctx.paths.projects_dir == tmp_path / "projects"
+
     def test_budget_lookup_known_and_default(self) -> None:
         assert _budget_lookup("clone") == 2
         assert _budget_lookup("nonexistent") == 1

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -696,6 +696,33 @@ def test_main_does_not_override_projects_root_for_automation_worktree(
     assert config.repo_roots == {}  # type: ignore[attr-defined]
 
 
+def test_main_uses_noncanonical_automation_worktree_base_as_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An internal worktree under a renamed checkout must not become its own base.
+
+    ``resolve_projects_dir`` correctly unwraps an automation issue worktree
+    to the parent of its base checkout.  When that base checkout itself has a
+    noncanonical name, the loop must still use the base checkout, rather than
+    creating a nested ``build/.worktrees`` tree under the issue checkout.
+    """
+    projects_dir = tmp_path / "projects"
+    base_checkout = projects_dir / "renamed-base-checkout"
+    automation_worktree = base_checkout / "build" / ".worktrees" / "issue-99"
+
+    monkeypatch.setattr(loop_runner, "_detect_cwd_repo", lambda: ("Org", "Repo"))
+    monkeypatch.setattr(loop_runner, "get_repo_root", lambda: automation_worktree)
+    with patch.object(loop_runner, "resolve_projects_dir", return_value=projects_dir):
+        config = _capture_main_config(
+            ["--repos", "Repo,Other", "--dry-run", "--loops", "1", "--agent", "claude"],
+            monkeypatch,
+        )
+
+    assert config.projects_dir == projects_dir  # type: ignore[attr-defined]
+    assert config.repo_roots == {"Repo": base_checkout}  # type: ignore[attr-defined]
+    assert "Other" not in config.repo_roots  # type: ignore[attr-defined]
+
+
 def test_main_resolves_agent_before_building_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """PipelineConfig stores the concrete auto-detected provider."""
     resolve = patch.object(loop_runner, "resolve_agent", return_value="codex")

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -510,6 +510,23 @@ def _capture_config(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> object:
     return captured["config"]
 
 
+def _capture_main_config(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> object:
+    """Run main with only its coordinator dispatch replaced."""
+    from hephaestus.automation.pipeline import coordinator as coordinator_mod
+
+    captured: dict[str, object] = {}
+
+    def capture(config: object) -> int:
+        captured["config"] = config
+        return 0
+
+    monkeypatch.setattr(loop_runner, "_preflight_token_scopes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(coordinator_mod, "run_pipeline", capture)
+
+    assert main(argv) == 0
+    return captured["config"]
+
+
 def test_main_applies_default_phase_timeout_when_flag_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -583,6 +600,100 @@ def test_main_prefers_current_checkout_parent_for_projects_dir_default(
         )
     resolve_projects_dir.assert_called_once_with(None, prefer_cwd_parent=True)
     assert config.projects_dir == projects_dir  # type: ignore[attr-defined]
+
+
+def test_main_wires_external_checkout_as_explicit_repo_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An external noncanonical checkout is not rewritten as ``projects_dir / repo``.
+
+    The loop may be launched from an isolated worktree whose path bears no
+    relationship to its remote repository name.  Its matching repo therefore
+    needs an explicit coordinator path, while other requested repos retain the
+    normal projects-root discovery fallback.
+    """
+    checkout = tmp_path / "isolated" / "automation-worktree"
+    projects_dir = tmp_path / "configured-projects"
+
+    monkeypatch.setattr(loop_runner, "_detect_cwd_repo", lambda: ("Org", "Repo"))
+    monkeypatch.setattr(loop_runner, "get_repo_root", lambda: checkout)
+    with patch.object(loop_runner, "resolve_projects_dir", return_value=projects_dir):
+        config = _capture_main_config(
+            ["--repos", "Repo,Other", "--dry-run", "--loops", "1", "--agent", "claude"],
+            monkeypatch,
+        )
+
+    assert config.projects_dir == projects_dir  # type: ignore[attr-defined]
+    assert config.repo_roots == {"Repo": checkout}  # type: ignore[attr-defined]
+    assert "Other" not in config.repo_roots  # type: ignore[attr-defined]
+
+
+def test_main_does_not_override_explicit_projects_dir_with_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit ``--projects-dir`` remains authoritative for every repo."""
+    checkout = tmp_path / "isolated" / "automation-worktree"
+    projects_dir = tmp_path / "configured-projects"
+
+    monkeypatch.setattr(loop_runner, "_detect_cwd_repo", lambda: ("Org", "Repo"))
+    monkeypatch.setattr(loop_runner, "get_repo_root", lambda: checkout)
+    config = _capture_main_config(
+        [
+            "--repos",
+            "Repo,Other",
+            "--projects-dir",
+            str(projects_dir),
+            "--dry-run",
+            "--loops",
+            "1",
+            "--agent",
+            "claude",
+        ],
+        monkeypatch,
+    )
+
+    assert config.projects_dir == projects_dir  # type: ignore[attr-defined]
+    assert config.repo_roots == {}  # type: ignore[attr-defined]
+
+
+def test_main_does_not_override_valid_projects_root_with_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A valid ``PROJECTS_ROOT`` remains authoritative for every repo."""
+    checkout = tmp_path / "isolated" / "automation-worktree"
+    projects_dir = tmp_path / "configured-projects"
+    projects_dir.mkdir()
+
+    monkeypatch.setenv("PROJECTS_ROOT", str(projects_dir))
+    monkeypatch.setattr(loop_runner, "_detect_cwd_repo", lambda: ("Org", "Repo"))
+    monkeypatch.setattr(loop_runner, "get_repo_root", lambda: checkout)
+    config = _capture_main_config(
+        ["--repos", "Repo,Other", "--dry-run", "--loops", "1", "--agent", "claude"],
+        monkeypatch,
+    )
+
+    assert config.projects_dir == projects_dir  # type: ignore[attr-defined]
+    assert config.repo_roots == {}  # type: ignore[attr-defined]
+
+
+def test_main_does_not_override_projects_root_for_automation_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Automation worktrees continue using their base checkout through projects_dir."""
+    projects_dir = tmp_path / "projects"
+    base_checkout = projects_dir / "Repo"
+    automation_worktree = base_checkout / "build" / ".worktrees" / "issue-99"
+
+    monkeypatch.setattr(loop_runner, "_detect_cwd_repo", lambda: ("Org", "Repo"))
+    monkeypatch.setattr(loop_runner, "get_repo_root", lambda: automation_worktree)
+    with patch.object(loop_runner, "resolve_projects_dir", return_value=projects_dir):
+        config = _capture_main_config(
+            ["--repos", "Repo,Other", "--dry-run", "--loops", "1", "--agent", "claude"],
+            monkeypatch,
+        )
+
+    assert config.projects_dir == projects_dir  # type: ignore[attr-defined]
+    assert config.repo_roots == {}  # type: ignore[attr-defined]
 
 
 def test_main_resolves_agent_before_building_config(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Preserves a matching direct checkout path from the automation-loop entry point through pipeline contexts and GitHub accessors, so a noncanonical worktree is not mistaken for a missing clone. Internal automation worktrees use their base checkout and explicit projects roots remain authoritative.

## Verification

- `uv run --all-extras --locked pytest -q`
- `uv run ruff check hephaestus/automation/loop_runner.py hephaestus/automation/pipeline/coordinator.py hephaestus/automation/pipeline/stages/repo.py tests/unit/automation/test_loop_runner.py tests/unit/automation/pipeline/test_coordinator_edges.py tests/unit/automation/pipeline/stages/test_stage_repo.py`
- `uv run ruff format --check hephaestus/automation/loop_runner.py hephaestus/automation/pipeline/coordinator.py hephaestus/automation/pipeline/stages/repo.py tests/unit/automation/test_loop_runner.py tests/unit/automation/pipeline/test_coordinator_edges.py tests/unit/automation/pipeline/stages/test_stage_repo.py`
- `uv run mypy hephaestus/automation/loop_runner.py hephaestus/automation/pipeline/coordinator.py hephaestus/automation/pipeline/stages/repo.py`

Closes #2238