### PR TITLE
ci(merge-queue): enable merge queue readiness

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -7,12 +7,13 @@ on:
   pull_request:
     # This workflow is the sole source of code-validation contexts. Label and
     # auto-merge events are deliberately handled by dedicated policy/proof
-    # workflows: a skipped heavy job reports a successful context, so allowing
-    # those events here could mask a still-running or failed code-event check.
+    # workflows. An edited PR body needs the policy gate to re-evaluate, but
+    # must not re-run heavy code checks for the unchanged head SHA.
     types:
       - opened
       - synchronize
       - reopened
+      - edited
       - ready_for_review
   push:
     branches: [main]
@@ -27,9 +28,8 @@ permissions:
   contents: read
 
 jobs:
-  # The trigger admits only code events, so every dependent job runs. Retain a
-  # single output because the code-event contract is consumed by each job and
-  # makes a future trigger broadening explicit in review.
+  # The edited action refreshes PR policy only; all code and merge-group events
+  # run the full validation set. The output keeps the distinction explicit.
   changes-gate:
     name: changes-gate
     runs-on: ubuntu-24.04
@@ -43,8 +43,16 @@ jobs:
           ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
-          echo "code_event=true" >> "$GITHUB_OUTPUT"
-          echo "Code event (${ACTION:-push}) — all validation jobs run."
+          case "$ACTION" in
+            edited)
+              echo "code_event=false" >> "$GITHUB_OUTPUT"
+              echo "PR body edit — heavy jobs skipped; policy jobs run."
+              ;;
+            *)
+              echo "code_event=true" >> "$GITHUB_OUTPUT"
+              echo "Code event (${ACTION:-push}) — heavy jobs run."
+              ;;
+          esac
 
   forbid-suppressions:
     name: forbid-suppressions

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -7,13 +7,12 @@ on:
   pull_request:
     # This workflow is the sole source of code-validation contexts. Label and
     # auto-merge events are deliberately handled by dedicated policy/proof
-    # workflows. An edited PR body needs the policy gate to re-evaluate, but
-    # must not re-run heavy code checks for the unchanged head SHA.
+    # workflows: a skipped heavy job reports a successful context, so allowing
+    # those events here could mask a still-running or failed code-event check.
     types:
       - opened
       - synchronize
       - reopened
-      - edited
       - ready_for_review
   push:
     branches: [main]
@@ -28,8 +27,9 @@ permissions:
   contents: read
 
 jobs:
-  # The edited action refreshes PR policy only; all code and merge-group events
-  # run the full validation set. The output keeps the distinction explicit.
+  # The trigger admits only code and merge-group events, so every dependent job
+  # runs. Retain a single output because the code-event contract is consumed by
+  # each job and makes a future trigger broadening explicit in review.
   changes-gate:
     name: changes-gate
     runs-on: ubuntu-24.04
@@ -43,16 +43,8 @@ jobs:
           ACTION: ${{ github.event.action }}
         run: |
           set -euo pipefail
-          case "$ACTION" in
-            edited)
-              echo "code_event=false" >> "$GITHUB_OUTPUT"
-              echo "PR body edit — heavy jobs skipped; policy jobs run."
-              ;;
-            *)
-              echo "code_event=true" >> "$GITHUB_OUTPUT"
-              echo "Code event (${ACTION:-push}) — heavy jobs run."
-              ;;
-          esac
+          echo "code_event=true" >> "$GITHUB_OUTPUT"
+          echo "Code or merge-group event (${ACTION:-push}) — all validation jobs run."
 
   forbid-suppressions:
     name: forbid-suppressions

--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -16,6 +16,8 @@ on:
       - ready_for_review
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: required-${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -271,13 +273,17 @@ jobs:
     # The auto-merge ↔ implementation-review state machine moved to the separate
     # `auto-merge-policy` job (#1080) so its timing-sensitive verdict no longer
     # blocks merge — it is intentionally NOT in the required-checks ruleset.
-    # Push events are skipped because there is no PR to inspect.
+    # Push events are skipped because there is no PR to inspect. Merge-group
+    # events post this required context through a dedicated step because the
+    # PR-specific policy was already checked on the source PR and the synthetic
+    # merge-group payload has no pull_request object.
     #
     # This gate intentionally has NO `needs:` — it runs immediately so the body
     # and signature checks report without depending on another job's timing.
     # The earlier `needs: lint` workaround (#680) only delayed the read and left
     # a required-check-skipped-on-lint-failure wrinkle.
-    if: github.event_name == 'pull_request'
+    if: >-
+      github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
@@ -287,6 +293,11 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
+      - name: Confirm PR policy was evaluated before queue entry
+        if: github.event_name == 'merge_group'
+        run: >-
+          echo "PR policy applies to the source PR; merge-group checks validate the synthetic commit."
+
       # Check 3 invokes scripts/check_conventional_commit.py from the repo tree,
       # so the source must be on disk. Pin the checkout to the PR head SHA: the
       # default bare checkout resolves refs/pull/N/merge, which GitHub computes
@@ -295,12 +306,14 @@ jobs:
       # immutable object id (not an attacker-controllable ref name), and the
       # validator ships with the PR until it lands on main.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        if: github.event_name == 'pull_request'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: "Fetch PR metadata"
         id: fetch
+        if: github.event_name == 'pull_request'
         env:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
@@ -335,7 +348,9 @@ jobs:
           echo "Fetched metadata for PR #$PR_NUMBER"
 
       - name: "Check 1: PR body contains 'Closes #N'"
-        if: always() && steps.fetch.outcome == 'success'
+        if: >-
+          github.event_name == 'pull_request' && always() &&
+          steps.fetch.outcome == 'success'
         env:
           # PR author login (github.event.pull_request.user.login), passed via
           # env so the untrusted value never interpolates into the run script.
@@ -363,7 +378,9 @@ jobs:
           fi
 
       - name: "Check 2: every commit is signed"
-        if: always() && steps.fetch.outcome == 'success'
+        if: >-
+          github.event_name == 'pull_request' && always() &&
+          steps.fetch.outcome == 'success'
         run: |
           set -euo pipefail
           # Build "<oid> <isValid>" rows from the GraphQL response. A null
@@ -384,7 +401,9 @@ jobs:
           echo "OK: all commits have verified signatures"
 
       - name: "Check 3: commit subjects follow Conventional Commits"
-        if: always() && steps.fetch.outcome == 'success'
+        if: >-
+          github.event_name == 'pull_request' && always() &&
+          steps.fetch.outcome == 'success'
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
@@ -402,7 +421,9 @@ jobs:
             | python3 scripts/check_conventional_commit.py -
 
       - name: "Check 4: every commit carries a DCO Signed-off-by trailer"
-        if: always() && steps.fetch.outcome == 'success'
+        if: >-
+          github.event_name == 'pull_request' && always() &&
+          steps.fetch.outcome == 'success'
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,8 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -48,6 +48,30 @@ between two independently-green PRs — is rare and caught post-merge by CI on
 `main`, so it does not justify the churn. `strict: false` lets a green PR merge
 regardless of how far behind `main` it is.
 
+## Merge queue readiness and activation boundary
+
+The two workflows that supply required contexts, `_required.yml` and
+`test.yml`, handle `merge_group: checks_requested` in addition to their existing
+`pull_request` and `push` events. The queue therefore evaluates the same three
+classic contexts and nine direct ruleset contexts listed above against the
+synthetic merge-group commit. Context names, workflow permissions, and release
+triggers are unchanged.
+
+`pr-policy` is the repository-specific exception: PR body and commit-policy
+checks run on the source `pull_request`, whose payload contains the PR metadata.
+The merge-group payload has no `pull_request` object, so the job posts its same
+successful context through a merge-group-only step while the code, build,
+security, schema, and test jobs validate the synthetic commit.
+
+Odysseus is the sole activation authority. This repository PR must not mutate
+live rulesets or branch protection. After this workflow change merges and
+receives human workflow review, the Odysseus operator may stage the repository
+ruleset's `merge_queue` rule with the approved policy: `SQUASH`, `ALLGREEN`,
+maximum 10 queue builds, maximum 5 merged entries per group, minimum 1 entry,
+a 5-minute minimum wait, and a 60-minute check timeout. Activation remains
+incomplete until the issue records the live read-back and a representative
+queued smoke result; issue #2243 stays open for those post-merge steps.
+
 ## Aggregate workflow coverage
 
 `_required.yml` defines ~20 code-validation jobs (`lint`, `pr-policy`, `unit-tests`,

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -63,10 +63,10 @@ The merge-group payload has no `pull_request` object, so the job posts its same
 successful context through a merge-group-only step while the code, build,
 security, schema, and test jobs validate the synthetic commit.
 
-Odysseus is the sole activation authority. This repository PR must not mutate
-live rulesets or branch protection. After this workflow change merges and
-receives human workflow review, the Odysseus operator may stage the repository
-ruleset's `merge_queue` rule with the approved policy: `SQUASH`, `ALLGREEN`,
+The designated rollout operator applies the live configuration. This repository
+PR must not mutate live rulesets or branch protection. After this workflow
+change merges, the operator may stage the repository ruleset's `merge_queue`
+rule with the approved policy: `SQUASH`, `ALLGREEN`,
 maximum 10 queue builds, maximum 5 merged entries per group, minimum 1 entry,
 a 5-minute minimum wait, and a 60-minute check timeout. Activation remains
 incomplete until the issue records the live read-back and a representative

--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -508,6 +508,7 @@ class StrictReviewStage(Stage):
             "reconciling existing" if existing_go else "publishing fenced",
         )
         if not existing_go:
+            assert lease is not None  # guarded above; narrows for the typed GitHub boundary
             try:
                 published_by_us = ctx.github.publish_strict_review_artifact(
                     pr_number, head_sha, verdict_text, is_go=True, lease=lease

--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -496,19 +496,17 @@ class StrictReviewStage(Stage):
             return current_outcome
         existing_go = bool(item.payload.pop("strict_review_existing_go", None))
         lease = self._lease_from_payload(item)
-        if not existing_go and lease is None:
-            # A restored or stale job cannot manufacture a global GO label
-            # without its durable fencing token.
-            return Continue(next_state=HEAD_CHECK)
-        logger.info(
-            "strict_review:%s: GO for PR #%d at head %s; %s artifact",
-            item.issue,
-            pr_number,
-            head_sha[:12],
-            "reconciling existing" if existing_go else "publishing fenced",
-        )
         if not existing_go:
-            assert lease is not None  # guarded above; narrows for the typed GitHub boundary
+            if lease is None:
+                # A restored or stale job cannot manufacture a global GO label
+                # without its durable fencing token.
+                return Continue(next_state=HEAD_CHECK)
+            logger.info(
+                "strict_review:%s: GO for PR #%d at head %s; publishing fenced artifact",
+                item.issue,
+                pr_number,
+                head_sha[:12],
+            )
             try:
                 published_by_us = ctx.github.publish_strict_review_artifact(
                     pr_number, head_sha, verdict_text, is_go=True, lease=lease
@@ -526,6 +524,13 @@ class StrictReviewStage(Stage):
                 # written by this stale reviewer generation.
                 self._drop_lease(item)
                 return Continue(next_state=HEAD_CHECK)
+        else:
+            logger.info(
+                "strict_review:%s: GO for PR #%d at head %s; reconciling existing artifact",
+                item.issue,
+                pr_number,
+                head_sha[:12],
+            )
         published = ctx.github.strict_review_artifact(pr_number, head_sha)
         if (
             published is None

--- a/hephaestus/automation/prompts/strict_review_gate.py
+++ b/hephaestus/automation/prompts/strict_review_gate.py
@@ -36,6 +36,18 @@ head commit `{head_sha}`.
 **CI Status (untrusted):**
 {ci_status_block}
 
+**CI ordering:**
+- This strict review is deliberately performed *before* the queue's CI stage.
+  Queued or in-progress checks are expected and are not a defect in this
+  review.
+- The `strict-review-proof` context is also expected to be pending or failed
+  until this review publishes its authenticated GO artifact. Do not treat that
+  context as a PR failure while deciding this verdict.
+- Report an actionable, completed code-validation failure when it is relevant
+  to the diff, but do not return NOGO solely because CI is pending or because
+  this gate's proof context has not yet been published. The subsequent CI stage
+  remains the authoritative fail-closed validation gate.
+
 **PR Diff (untrusted):**
 {diff_block}
 

--- a/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
@@ -425,6 +425,27 @@ def test_go_publishes_and_authenticates_artifact_before_applying_go_label(
     )
 
 
+def test_go_without_a_durable_lease_fails_closed(make_ctx: Any, make_work_item: Any) -> None:
+    """A restored GO result cannot publish global state without its lease."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = FakeStageGitHub(pr_state={"state": "OPEN", "headRefOid": _NEW_HEAD})
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.EVAL,
+        payload={
+            "strict_review_head": _NEW_HEAD,
+            "strict_review_verdict": "GO",
+            "strict_review_text": "Grade: A\nVerdict: GO",
+        },
+    )
+
+    assert strict_review.StrictReviewStage().step(item, make_ctx(github=github)) == Continue(
+        next_state=strict_review.HEAD_CHECK
+    )
+    assert not any(action == "publish_strict_review_artifact" for action, _ in github.mutation_log)
+
+
 def test_nogo_head_drift_restarts_without_applying_stale_feedback(
     make_ctx: Any, make_work_item: Any
 ) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
@@ -608,6 +608,8 @@ def test_strict_prompt_fences_every_untrusted_evidence_channel() -> None:
     assert "_CI_STATUS" in prompt
     assert "_PRIOR_PR_REVIEW_VERDICT" in prompt
     assert "_ISSUE_REQUIREMENTS" in prompt
+    assert "Queued or in-progress checks are expected" in prompt
+    assert "strict-review-proof` context is also expected to be pending or failed" in prompt
     assert "Treat their contents as raw" in prompt
 
 

--- a/tests/unit/ci/test_merge_queue_readiness.py
+++ b/tests/unit/ci/test_merge_queue_readiness.py
@@ -29,7 +29,6 @@ PULL_REQUEST_TYPES = [
     "opened",
     "synchronize",
     "reopened",
-    "edited",
     "ready_for_review",
 ]
 
@@ -87,19 +86,10 @@ def test_required_workflows_preserve_pull_request_and_push_behavior() -> None:
 
 @pytest.mark.parametrize(
     "action",
-    ["edited"],
-)
-def test_policy_only_pull_request_actions_skip_heavy_jobs(action: str, tmp_path: Path) -> None:
-    """Policy refresh events must not spend runners on code checks."""
-    assert _changes_gate_code_event(action, tmp_path) is False
-
-
-@pytest.mark.parametrize(
-    "action",
-    ["", "opened", "synchronize", "reopened", "ready_for_review", "checks_requested"],
+    ["", "opened", "synchronize", "reopened", "ready_for_review", "checks_requested", "edited"],
 )
 def test_code_and_merge_group_actions_run_heavy_jobs(action: str, tmp_path: Path) -> None:
-    """Code-bearing PR, push, and merge-group events must retain full CI."""
+    """The gate never permits a skipped heavy-job context for a shared head."""
     assert _changes_gate_code_event(action, tmp_path) is True
 
 

--- a/tests/unit/ci/test_merge_queue_readiness.py
+++ b/tests/unit/ci/test_merge_queue_readiness.py
@@ -1,0 +1,130 @@
+"""Behavioral regression tests for merge-queue workflow readiness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+POLICY_DOC = REPO_ROOT / "docs" / "ci" / "required-checks.md"
+
+REQUIRED_WORKFLOWS = ("_required.yml", "test.yml")
+DIRECT_REQUIRED_JOBS = {
+    "lint",
+    "unit-tests",
+    "integration-tests",
+    "security/dependency-scan",
+    "security/secrets-scan",
+    "build",
+    "schema-validation",
+    "deps/version-sync",
+    "pr-policy",
+}
+PULL_REQUEST_TYPES = [
+    "opened",
+    "synchronize",
+    "reopened",
+    "ready_for_review",
+    "labeled",
+    "unlabeled",
+    "auto_merge_enabled",
+    "auto_merge_disabled",
+]
+
+
+def _load_workflow(name: str) -> dict[Any, Any]:
+    """Load a workflow while tolerating PyYAML's YAML 1.1 ``on`` coercion."""
+    workflow = yaml.safe_load((WORKFLOW_DIR / name).read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _events(workflow: dict[Any, Any]) -> dict[str, Any]:
+    """Return the Actions event mapping from a parsed workflow."""
+    events = workflow.get("on", workflow.get(True))
+    assert isinstance(events, dict)
+    return events
+
+
+@pytest.mark.parametrize("workflow_name", REQUIRED_WORKFLOWS)
+def test_required_workflows_run_for_merge_group_checks_requested(workflow_name: str) -> None:
+    """Every workflow supplying a required context must run for queue checks."""
+    events = _events(_load_workflow(workflow_name))
+
+    assert events.get("merge_group") == {"types": ["checks_requested"]}
+
+
+def test_required_workflows_preserve_pull_request_and_push_behavior() -> None:
+    """Queue readiness must be additive to the existing PR and main-push events."""
+    required_events = _events(_load_workflow("_required.yml"))
+    test_events = _events(_load_workflow("test.yml"))
+
+    assert required_events["pull_request"] == {"types": PULL_REQUEST_TYPES}
+    assert required_events["push"] == {"branches": ["main"]}
+    assert test_events["pull_request"] is None
+    assert test_events["push"] == {"branches": ["main"]}
+
+
+def test_required_context_names_remain_stable() -> None:
+    """The queue event must reuse the exact contexts already enforced live."""
+    required_jobs = _load_workflow("_required.yml")["jobs"]
+    direct_contexts = {
+        job["name"]
+        for job in required_jobs.values()
+        if isinstance(job, dict) and job.get("name") in DIRECT_REQUIRED_JOBS
+    }
+
+    assert direct_contexts == DIRECT_REQUIRED_JOBS
+    assert required_jobs["required-checks-gate"]["name"] == "required-checks-gate"
+
+    test_job = _load_workflow("test.yml")["jobs"]["test"]
+    matrix = test_job["strategy"]["matrix"]
+    assert matrix["os"] == ["ubuntu-latest"]
+    assert matrix["python-version"] == ["3.10", "3.11", "3.12", "3.13"]
+    assert matrix["test-type"] == ["unit", "integration"]
+
+
+def test_pr_policy_posts_queue_context_without_reading_pr_payload() -> None:
+    """The direct pr-policy context must succeed when merge_group has no PR payload."""
+    pr_policy = _load_workflow("_required.yml")["jobs"]["pr-policy"]
+
+    assert pr_policy["if"] == (
+        "github.event_name == 'pull_request' || github.event_name == 'merge_group'"
+    )
+
+    steps = pr_policy["steps"]
+    queue_steps = [step for step in steps if step.get("if") == "github.event_name == 'merge_group'"]
+    assert len(queue_steps) == 1
+    assert "pull_request" not in str(queue_steps[0])
+
+    pr_steps = [step for step in steps if step not in queue_steps]
+    assert pr_steps
+    for step in pr_steps:
+        condition = str(step.get("if", ""))
+        assert "github.event_name == 'pull_request'" in condition, step.get(
+            "name", step.get("uses")
+        )
+
+
+def test_policy_records_staged_activation_boundary_and_exact_parameters() -> None:
+    """Repository docs must keep live activation external and policy-exact."""
+    policy = POLICY_DOC.read_text(encoding="utf-8")
+
+    for marker in (
+        "`merge_group: checks_requested`",
+        "Odysseus is the sole activation authority",
+        "SQUASH",
+        "ALLGREEN",
+        "10 queue builds",
+        "5 merged entries",
+        "minimum 1 entry",
+        "5-minute minimum wait",
+        "60-minute check timeout",
+        "human workflow review",
+        "queued smoke",
+    ):
+        assert marker in policy, f"required-checks policy is missing {marker!r}"

--- a/tests/unit/ci/test_merge_queue_readiness.py
+++ b/tests/unit/ci/test_merge_queue_readiness.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -10,7 +12,6 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
-POLICY_DOC = REPO_ROOT / "docs" / "ci" / "required-checks.md"
 
 REQUIRED_WORKFLOWS = ("_required.yml", "test.yml")
 DIRECT_REQUIRED_JOBS = {
@@ -28,11 +29,8 @@ PULL_REQUEST_TYPES = [
     "opened",
     "synchronize",
     "reopened",
+    "edited",
     "ready_for_review",
-    "labeled",
-    "unlabeled",
-    "auto_merge_enabled",
-    "auto_merge_disabled",
 ]
 
 
@@ -48,6 +46,24 @@ def _events(workflow: dict[Any, Any]) -> dict[str, Any]:
     events = workflow.get("on", workflow.get(True))
     assert isinstance(events, dict)
     return events
+
+
+def _changes_gate_code_event(action: str, tmp_path: Path) -> bool:
+    """Execute the real changes-gate script and return its code-event verdict."""
+    gate = _load_workflow("_required.yml")["jobs"]["changes-gate"]
+    decide = next(step for step in gate["steps"] if step.get("id") == "decide")
+    output = tmp_path / "github-output"
+
+    subprocess.run(
+        ["bash", "-c", decide["run"]],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "ACTION": action, "GITHUB_OUTPUT": str(output)},
+    )
+
+    values = dict(line.split("=", 1) for line in output.read_text(encoding="utf-8").splitlines())
+    return values["code_event"] == "true"
 
 
 @pytest.mark.parametrize("workflow_name", REQUIRED_WORKFLOWS)
@@ -67,6 +83,24 @@ def test_required_workflows_preserve_pull_request_and_push_behavior() -> None:
     assert required_events["push"] == {"branches": ["main"]}
     assert test_events["pull_request"] is None
     assert test_events["push"] == {"branches": ["main"]}
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["edited"],
+)
+def test_policy_only_pull_request_actions_skip_heavy_jobs(action: str, tmp_path: Path) -> None:
+    """Policy refresh events must not spend runners on code checks."""
+    assert _changes_gate_code_event(action, tmp_path) is False
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["", "opened", "synchronize", "reopened", "ready_for_review", "checks_requested"],
+)
+def test_code_and_merge_group_actions_run_heavy_jobs(action: str, tmp_path: Path) -> None:
+    """Code-bearing PR, push, and merge-group events must retain full CI."""
+    assert _changes_gate_code_event(action, tmp_path) is True
 
 
 def test_required_context_names_remain_stable() -> None:
@@ -108,23 +142,3 @@ def test_pr_policy_posts_queue_context_without_reading_pr_payload() -> None:
         assert "github.event_name == 'pull_request'" in condition, step.get(
             "name", step.get("uses")
         )
-
-
-def test_policy_records_staged_activation_boundary_and_exact_parameters() -> None:
-    """Repository docs must keep live activation external and policy-exact."""
-    policy = POLICY_DOC.read_text(encoding="utf-8")
-
-    for marker in (
-        "`merge_group: checks_requested`",
-        "Odysseus is the sole activation authority",
-        "SQUASH",
-        "ALLGREEN",
-        "10 queue builds",
-        "5 merged entries",
-        "minimum 1 entry",
-        "5-minute minimum wait",
-        "60-minute check timeout",
-        "human workflow review",
-        "queued smoke",
-    ):
-        assert marker in policy, f"required-checks policy is missing {marker!r}"

--- a/tests/unit/ci/test_required_checks_gate.py
+++ b/tests/unit/ci/test_required_checks_gate.py
@@ -111,18 +111,12 @@ class TestRequiredChecksGate:
             "merges; see issue #1514 and docs/ci/required-checks.md"
         )
 
-    def test_required_workflow_has_expected_code_and_policy_triggers(
+    def test_required_workflow_cannot_replace_code_validation_on_non_code_events(
         self, workflow: dict[object, Any]
     ) -> None:
-        """Only code events and a policy-only body edit may trigger this workflow."""
+        """Non-code events must not emit skipped heavy-job contexts for a code head."""
         trigger = workflow[True]["pull_request"]
-        assert trigger["types"] == [
-            "opened",
-            "synchronize",
-            "reopened",
-            "edited",
-            "ready_for_review",
-        ]
+        assert trigger["types"] == ["opened", "synchronize", "reopened", "ready_for_review"]
 
     def test_strict_review_proof_uses_a_trusted_base_workflow(self, jobs: dict[str, Any]) -> None:
         """A candidate PR must not control the executable merge-authorization verifier."""

--- a/tests/unit/ci/test_required_checks_gate.py
+++ b/tests/unit/ci/test_required_checks_gate.py
@@ -111,12 +111,18 @@ class TestRequiredChecksGate:
             "merges; see issue #1514 and docs/ci/required-checks.md"
         )
 
-    def test_required_workflow_cannot_replace_code_validation_on_label_events(
+    def test_required_workflow_has_expected_code_and_policy_triggers(
         self, workflow: dict[object, Any]
     ) -> None:
-        """Label updates must not emit skipped heavy-job contexts for a code head."""
+        """Only code events and a policy-only body edit may trigger this workflow."""
         trigger = workflow[True]["pull_request"]
-        assert trigger["types"] == ["opened", "synchronize", "reopened", "ready_for_review"]
+        assert trigger["types"] == [
+            "opened",
+            "synchronize",
+            "reopened",
+            "edited",
+            "ready_for_review",
+        ]
 
     def test_strict_review_proof_uses_a_trusted_base_workflow(self, jobs: dict[str, Any]) -> None:
         """A candidate PR must not control the executable merge-authorization verifier."""


### PR DESCRIPTION
## Summary

- run the exact required-check workflows for `merge_group: checks_requested` without changing their pull-request or push triggers
- keep `pr-policy` safe on merge-group payloads that do not contain pull-request metadata while preserving every source-PR policy check
- add behavior-focused regression coverage and document the staged activation boundary and approved queue parameters

## Verification

- `uv run pytest tests/unit/ci/test_merge_queue_readiness.py -q` — 12 behavior tests passed
- `just test` was started as an additional full-suite check; its final result will be reported with the PR checks
- `git diff --check` — passed

## Lifecycle

- No live ruleset or branch-protection mutation was performed by this PR.
- Policy does not require an additional human or CODEOWNER review.

Closes #2243