### PR TITLE
[Fix] Scope epic skip-tag label writes to the owning repo

### DIFF
--- a/hephaestus/automation/github_api/labels.py
+++ b/hephaestus/automation/github_api/labels.py
@@ -9,12 +9,20 @@ import hephaestus.automation.github_api as _api
 from ..state_labels import STATE_SKIP, is_skipped
 
 
-def _label_cache_key() -> str:
+def _label_cache_key(repo: tuple[str, str] | None = None) -> str:
     """Repo slug ("owner/name") keying the label cache, or "" if unresolved.
 
     ``get_repo_info`` is memoized per repo root (git_utils._repo_info_cache),
     so this is a cached dict lookup after the first call, not a git subprocess.
+
+    Args:
+        repo: Explicit ``(owner, name)`` owning the labels. When omitted the
+            slug is resolved from the ambient working directory.
+
     """
+    if repo is not None:
+        owner, name = repo
+        return f"{owner}/{name}"
     try:
         owner, name = _api.get_repo_info()
     except RuntimeError:
@@ -22,7 +30,20 @@ def _label_cache_key() -> str:
     return f"{owner}/{name}"
 
 
-def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> set[str]:
+def _with_repo(cmd: list[str], repo: tuple[str, str] | None) -> list[str]:
+    """Append an explicit ``--repo owner/name`` selector when *repo* is given."""
+    if repo is None:
+        return cmd
+    owner, name = repo
+    return [*cmd, "--repo", f"{owner}/{name}"]
+
+
+def gh_list_labels(
+    refresh: bool = False,
+    *,
+    raise_on_error: bool = False,
+    repo: tuple[str, str] | None = None,
+) -> set[str]:
     """Return the set of label names that exist in the current repository.
 
     Cached per repo slug under a lock (ThreadSafeCache) so concurrent per-repo
@@ -33,15 +54,19 @@ def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> se
         refresh: If True, bypass the in-process cache for the current repo and re-fetch.
         raise_on_error: If True, propagate label-list failures instead of
             returning an empty set.
+        repo: ``(owner, name)`` of the repository to list. When omitted the
+            repo is resolved from the ambient working directory, which is
+            correct only for single-repo callers (#2245).
 
     Returns:
         Set of existing label names.
 
     """
-    key = _label_cache_key()
+    key = _label_cache_key(repo)
 
     def _fetch() -> set[str]:
-        result = _api._gh_call(["label", "list", "--json", "name", "--limit", "200"])
+        cmd = _with_repo(["label", "list", "--json", "name", "--limit", "200"], repo)
+        result = _api._gh_call(cmd)
         data = json.loads(result.stdout)
         return {item["name"] for item in data}
 
@@ -56,24 +81,35 @@ def gh_list_labels(refresh: bool = False, *, raise_on_error: bool = False) -> se
         return set()
 
 
-def gh_create_label(name: str, color: str = "ededed", description: str = "") -> None:
+def gh_create_label(
+    name: str,
+    color: str = "ededed",
+    description: str = "",
+    *,
+    repo: tuple[str, str] | None = None,
+) -> None:
     """Create a GitHub label, updating it if it already exists.
 
     Args:
         name: Label name
         color: Hex color without leading ``#`` (default: neutral grey)
         description: Optional short description
+        repo: ``(owner, name)`` of the repository to create the label in.
+            When omitted the repo is resolved from the ambient working
+            directory (#2245).
 
     """
     cmd = ["label", "create", name, "--color", color, "--force"]
     if description:
         cmd.extend(["--description", description])
-    _api._gh_call(cmd)
-    _api._label_cache.add_to_entry(_label_cache_key(), name)
+    _api._gh_call(_with_repo(cmd, repo))
+    _api._label_cache.add_to_entry(_label_cache_key(repo), name)
     _api.logger.info("Created missing label '%s'", name)
 
 
-def gh_issue_add_labels(issue_number: int, labels: list[str]) -> None:
+def gh_issue_add_labels(
+    issue_number: int, labels: list[str], repo: tuple[str, str] | None = None
+) -> None:
     """Add labels to an existing issue, auto-creating any that don't exist yet.
 
     Idempotent: applying a label the issue already has is a no-op from
@@ -83,24 +119,31 @@ def gh_issue_add_labels(issue_number: int, labels: list[str]) -> None:
     work — the first reviewer pass creates the labels).
 
     Args:
-        issue_number: Issue to label.
+        issue_number: Issue to label, meaningful only within *repo*.
         labels: Label names to add. Empty list is a no-op.
+        repo: ``(owner, name)`` of the repository owning *issue_number*. When
+            omitted the repo is resolved from the ambient working directory,
+            which is correct only for single-repo callers. The multi-repo
+            loop MUST pass this explicitly: an issue number carries no repo,
+            so ambient resolution wrote other repos' epic ``state:skip`` tags
+            onto whatever repo the loop was launched from — silently, since
+            a colliding issue number returns 200, not 404 (#2245).
 
     """
     if not labels:
         return
-    existing = _api.gh_list_labels()
+    existing = _api.gh_list_labels(repo=repo)
     for label in labels:
         if label not in existing:
-            _api.gh_create_label(label)
+            _api.gh_create_label(label, repo=repo)
     cmd = ["issue", "edit", str(issue_number)]
     for label in labels:
         cmd += ["--add-label", label]
-    _api._gh_call(cmd)
+    _api._gh_call(_with_repo(cmd, repo))
     _api.logger.info("Added labels %s to issue #%s", labels, issue_number)
 
 
-def skip_epics(epics_labels: dict[int, list[str]]) -> None:
+def skip_epics(epics_labels: dict[int, list[str]], repo: tuple[str, str] | None = None) -> None:
     """Tag excluded epic/roadmap issues with ``state:skip``, idempotently.
 
     Called by the discovery chokepoints after :func:`~hephaestus.automation.
@@ -112,12 +155,15 @@ def skip_epics(epics_labels: dict[int, list[str]]) -> None:
 
     Args:
         epics_labels: Mapping of epic issue number → its current label names.
+        repo: ``(owner, name)`` of the repository owning the epics. Required
+            for multi-repo callers; when omitted the write resolves against
+            the ambient working directory (#2245).
 
     """
     for number, labels in epics_labels.items():
         if is_skipped(labels):
             continue
-        _api.gh_issue_add_labels(number, [STATE_SKIP])
+        _api.gh_issue_add_labels(number, [STATE_SKIP], repo=repo)
         _api.logger.info("Issue #%s is an epic/roadmap tracking issue; tagged state:skip", number)
 
 

--- a/hephaestus/automation/loop_repo_manager.py
+++ b/hephaestus/automation/loop_repo_manager.py
@@ -242,8 +242,11 @@ def _list_open_issue_numbers(org: str, repo: str) -> list[int]:
             )
         epic_labels = {m["number"]: m["labels"] for m in meta if m["number"] in epic_set}
         # Best-effort skip-tagging: never let a label write break discovery.
+        # The owning repo is passed explicitly — this runs in the multi-repo
+        # parent process, where ambient cwd resolution wrote other repos'
+        # epic numbers onto the launch-directory repo (#2245).
         try:
-            skip_epics(epic_labels)
+            skip_epics(epic_labels, repo=(org, repo))
         except Exception as exc:  # pragma: no cover - defensive
             LOG.warning("[%s] could not tag excluded epics state:skip: %s", repo, exc)
     return kept

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -1237,7 +1237,7 @@ class TestGhListLabelsRepoKeyedConcurrency:
         # cache could otherwise pass by running the threads sequentially).
         overlap = threading.Barrier(2, timeout=5)
 
-        def mock_key_fn() -> str:
+        def mock_key_fn(repo: Any = None) -> str:
             """Return the currently-patched repo slug based on thread context."""
             import threading
 
@@ -1314,7 +1314,7 @@ class TestGhIssueAddLabels:
     ) -> None:
         """A label not yet present in the repo is created before the edit call."""
         gh_issue_add_labels(42, ["state:plan-go"])
-        mock_create.assert_called_once_with("state:plan-go")
+        mock_create.assert_called_once_with("state:plan-go", repo=None)
 
     @patch("hephaestus.automation.github_api._gh_call")
     @patch("hephaestus.automation.github_api.gh_list_labels", return_value={"bug"})
@@ -1343,8 +1343,8 @@ class TestSkipEpics:
         """Each epic without state:skip gets exactly one add-label call."""
         skip_epics({10: ["epic"], 11: ["roadmap", "bug"]})
         assert mock_add.call_count == 2
-        mock_add.assert_any_call(10, ["state:skip"])
-        mock_add.assert_any_call(11, ["state:skip"])
+        mock_add.assert_any_call(10, ["state:skip"], repo=None)
+        mock_add.assert_any_call(11, ["state:skip"], repo=None)
 
     @patch("hephaestus.automation.github_api.gh_issue_add_labels")
     def test_skips_already_skipped_epic(self, mock_add: Any) -> None:
@@ -1355,12 +1355,92 @@ class TestSkipEpics:
     @patch("hephaestus.automation.github_api.gh_issue_add_labels")
     def test_mixed_skipped_and_unskipped(self, mock_add: Any) -> None:
         skip_epics({10: ["epic", "state:skip"], 11: ["roadmap"]})
-        mock_add.assert_called_once_with(11, ["state:skip"])
+        mock_add.assert_called_once_with(11, ["state:skip"], repo=None)
 
     @patch("hephaestus.automation.github_api.gh_issue_add_labels")
     def test_empty_mapping_is_noop(self, mock_add: Any) -> None:
         skip_epics({})
         mock_add.assert_not_called()
+
+    @patch("hephaestus.automation.github_api.gh_issue_add_labels")
+    def test_threads_owning_repo_to_add_labels(self, mock_add: Any) -> None:
+        """An explicit (owner, name) reaches the add-label write (#2245)."""
+        skip_epics({81: ["epic"]}, repo=("HomericIntelligence", "Proteus"))
+        mock_add.assert_called_once_with(
+            81, ["state:skip"], repo=("HomericIntelligence", "Proteus")
+        )
+
+
+class TestLabelRepoScoping:
+    """Explicit-repo threading for label reads/writes (#2245).
+
+    An issue number is meaningless without a repo: ambient-cwd resolution in
+    the multi-repo loop wrote other repos' epic ``state:skip`` tags onto the
+    launch-directory repo, silently on number collision (200, not 404).
+    """
+
+    def teardown_method(self) -> None:
+        _github_api_module._label_cache.clear()
+
+    @patch("hephaestus.automation.github_api.gh_create_label")
+    @patch("hephaestus.automation.github_api.gh_list_labels", return_value={"state:skip"})
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_add_labels_appends_repo_selector(
+        self, mock_gh_call: Any, mock_list: Any, mock_create: Any
+    ) -> None:
+        """The issue-edit write carries --repo owner/name when repo is given."""
+        gh_issue_add_labels(81, ["state:skip"], repo=("HomericIntelligence", "Proteus"))
+        cmd = mock_gh_call.call_args[0][0]
+        assert cmd[:3] == ["issue", "edit", "81"]
+        assert cmd[-2:] == ["--repo", "HomericIntelligence/Proteus"]
+        mock_list.assert_called_once_with(repo=("HomericIntelligence", "Proteus"))
+        mock_create.assert_not_called()
+
+    @patch("hephaestus.automation.github_api.gh_create_label")
+    @patch("hephaestus.automation.github_api.gh_list_labels", return_value=set())
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_add_labels_creates_missing_label_in_owning_repo(
+        self, mock_gh_call: Any, mock_list: Any, mock_create: Any
+    ) -> None:
+        """Auto-created labels land in the owning repo, not the ambient one."""
+        gh_issue_add_labels(81, ["state:skip"], repo=("HomericIntelligence", "Proteus"))
+        mock_create.assert_called_once_with("state:skip", repo=("HomericIntelligence", "Proteus"))
+
+    @patch("hephaestus.automation.github_api.gh_create_label")
+    @patch("hephaestus.automation.github_api.gh_list_labels", return_value={"state:skip"})
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_add_labels_without_repo_stays_ambient(
+        self, mock_gh_call: Any, mock_list: Any, mock_create: Any
+    ) -> None:
+        """Omitting repo preserves the previous ambient-cwd behaviour."""
+        gh_issue_add_labels(81, ["state:skip"])
+        cmd = mock_gh_call.call_args[0][0]
+        assert "--repo" not in cmd
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_list_labels_scopes_fetch_and_cache_to_repo(self, mock_gh_call: Any) -> None:
+        """Explicit repo scopes the gh call and keys the cache by that slug."""
+        result = Mock()
+        result.stdout = '[{"name": "bug"}]'
+        mock_gh_call.return_value = result
+        labels = gh_list_labels(repo=("HomericIntelligence", "Proteus"))
+        assert labels == {"bug"}
+        cmd = mock_gh_call.call_args[0][0]
+        assert cmd[-2:] == ["--repo", "HomericIntelligence/Proteus"]
+        # Cached under the explicit slug — a second call for the SAME repo
+        # hits the cache, a different repo re-fetches.
+        gh_list_labels(repo=("HomericIntelligence", "Proteus"))
+        assert mock_gh_call.call_count == 1
+        gh_list_labels(repo=("HomericIntelligence", "Hermes"))
+        assert mock_gh_call.call_count == 2
+
+    @patch("hephaestus.automation.github_api._gh_call")
+    def test_create_label_appends_repo_selector(self, mock_gh_call: Any) -> None:
+        """Gh label create carries --repo owner/name when repo is given."""
+        gh_create_label("state:skip", repo=("HomericIntelligence", "Proteus"))
+        cmd = mock_gh_call.call_args[0][0]
+        assert cmd[:3] == ["label", "create", "state:skip"]
+        assert cmd[-2:] == ["--repo", "HomericIntelligence/Proteus"]
 
 
 class TestGhIssueRemoveLabels:

--- a/tests/unit/automation/test_loop_repo_manager.py
+++ b/tests/unit/automation/test_loop_repo_manager.py
@@ -371,6 +371,34 @@ class TestEnsureClone:
             _ensure_clone("MyOrg", "MyRepo", tmp_path)
 
 
+class TestListOpenIssueNumbersEpicTagging:
+    """Epic skip-tagging must target the owning repo, never the ambient cwd (#2245)."""
+
+    def test_skip_epics_receives_owning_repo(self) -> None:
+        """The (org, repo) being discovered is threaded to the label write."""
+        meta = [
+            {"number": 81, "title": "Epic: roadmap", "labels": ["epic"]},
+            {"number": 82, "title": "Fix bug", "labels": ["bug"]},
+        ]
+        with (
+            patch.object(loop_repo_manager, "_list_open_issue_meta", return_value=meta),
+            patch.object(loop_repo_manager, "skip_epics") as mock_skip,
+        ):
+            kept = loop_repo_manager._list_open_issue_numbers("MyOrg", "Proteus")
+        assert kept == [82]
+        mock_skip.assert_called_once_with({81: ["epic"]}, repo=("MyOrg", "Proteus"))
+
+    def test_no_epics_means_no_label_write(self) -> None:
+        meta = [{"number": 82, "title": "Fix bug", "labels": ["bug"]}]
+        with (
+            patch.object(loop_repo_manager, "_list_open_issue_meta", return_value=meta),
+            patch.object(loop_repo_manager, "skip_epics") as mock_skip,
+        ):
+            kept = loop_repo_manager._list_open_issue_numbers("MyOrg", "Proteus")
+        assert kept == [82]
+        mock_skip.assert_not_called()
+
+
 class TestCountOpenIssues:
     """Tests for _count_open_issues (delegates to _list_open_issue_numbers)."""
 


### PR DESCRIPTION
## Summary

The multi-repo automation loop tagged excluded epics `state:skip` via `gh issue edit` with no `--repo` selector, so the write resolved against the ambient process cwd — the launch-directory repo. Other repos' epic issue numbers were silently written onto that repo wherever numbers collide (200, not 404): Proteus#81, Telemachy#92, Hermes#316/#545 tagged Hephaestus#81/#92/#316/#545 on 2026-07-03 and again 2026-07-17. Since `state:skip` wins over everything, the mislabeled issues silently vanished from planning.

This is the silent-corruption twin of #1795 (comment lookups fixed in #2047) on the label-write side.

## Fix

- Thread an optional `(owner, name)` through `gh_issue_add_labels`, `gh_list_labels`, `gh_create_label`, and `skip_epics`; when given, append `--repo owner/name` to the gh command and key the label cache by the explicit slug.
- `loop_repo_manager._list_open_issue_numbers` (the multi-repo parent-process caller) now passes the discovered `(org, repo)` explicitly.
- Omitting the argument preserves ambient behaviour for single-repo child phases (`state/planner`), whose cwd is the target repo.

## Tests

- New `TestLabelRepoScoping` covers `--repo` threading on add/list/create, cross-repo cache keying, missing-label auto-create in the owning repo, and ambient fallback.
- New `TestListOpenIssueNumbersEpicTagging` pins the caller-side threading.
- Existing `TestSkipEpics` / auto-create / concurrency tests updated for the new signatures. 229 tests pass in the two touched files.

Closes #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)