### PR TITLE
[Feat] Replace --max-merge-attempts with --drive-green-loops (default 5)

### DIFF
--- a/hephaestus/automation/ci_driver.py
+++ b/hephaestus/automation/ci_driver.py
@@ -232,7 +232,7 @@ Examples:
         default=1,
         help=(
             "Number of CI-fix attempts per failing PR before giving up "
-            "(default: 1). The issue-major loop passes its --max-merge-attempts "
+            "(default: 1). The issue-major loop passes its --drive-green-loops "
             "here so a PR that will not go green is abandoned after N tries."
         ),
     )

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -186,9 +186,10 @@ class LoopConfig:
     # default is ``ALL_SELECTABLE`` (set in the parser), so an operator opts
     # into the blocking drive-green by default.
     phases: tuple[str, ...] = ALL_PHASES
-    # Bound on per-issue drive-green merge attempts before the issue is tagged
-    # ``state:skip`` (#1560). Defaults to 1, matching the CIDriver default.
-    max_merge_attempts: int = 1
+    # Bound on per-issue drive-green loop iterations before the issue is
+    # tagged ``state:skip`` (#2246, previously ``max_merge_attempts`` #1560).
+    # Defaults to 5 so one transient failure no longer parks an issue.
+    drive_green_loops: int = 5
     # When True (default), never dispatch two issues whose plans touch the same
     # file concurrently — defer the later one (#1623).
     serialize_file_overlap: bool = True
@@ -248,13 +249,14 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p.add_argument("--loops", type=int, default=5, help="Number of loop iterations (default: 5)")
     p.add_argument(
-        "--max-merge-attempts",
+        "--drive-green-loops",
         type=int,
-        default=1,
+        default=5,
         help=(
-            "Per-issue drive-green merge attempts before the issue is tagged "
-            "state:skip and the worker moves on (default: 1, matching the prior "
-            "drive-green retry budget)."
+            "Per-issue drive-green loop iterations before the issue is tagged "
+            "state:skip and the worker moves on (default: 5; replaces "
+            "--max-merge-attempts, whose default of 1 skip-parked issues on a "
+            "single transient failure)."
         ),
     )
     p.add_argument(
@@ -632,7 +634,7 @@ def _build_pipeline_config(
         include_bot_prs=True,
         include_all_authors=cfg.drive_green_all,
         run_pre_pr_tests=cfg.run_pre_pr_tests,
-        budget_overrides={"merge": cfg.max_merge_attempts},
+        budget_overrides={"merge": cfg.drive_green_loops},
         serialize_file_overlap=cfg.serialize_file_overlap,
         metrics_port=cfg.metrics_port,
         circuit_breaker_snapshot_provider=circuit_breaker_snapshot_provider,
@@ -754,7 +756,7 @@ def main(argv: list[str] | None = None) -> int:
     cfg = LoopConfig(
         loops=args.loops,
         max_workers=args.max_workers,
-        max_merge_attempts=args.max_merge_attempts,
+        drive_green_loops=args.drive_green_loops,
         serialize_file_overlap=args.serialize_file_overlap,
         parallel_repos=args.parallel_repos,
         phases=phases,

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -15,11 +15,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 
-#: Default for the ``merge`` budget. Mirrors ``LoopConfig.max_merge_attempts``
-#: and the ``--max-merge-attempts`` CLI default in ``loop_runner.py``; the
+#: Default for the ``merge`` budget. Mirrors ``LoopConfig.drive_green_loops``
+#: and the ``--drive-green-loops`` CLI default in ``loop_runner.py``; the
 #: coordinator overrides it from config when the pipeline is wired up
 #: (epic #1809 coordinator slice).
-DEFAULT_MERGE_ATTEMPTS = 1
+DEFAULT_DRIVE_GREEN_LOOPS = 5
 
 
 class StageName(str, Enum):
@@ -84,8 +84,8 @@ class Route:
 #   clone=2, plan=2, plan_cycles=2,
 #   implement=2, test_fix=1, ci_fix=1,
 #   rebase=2                               <- architecture doc stage sections
-#   merge=DEFAULT_MERGE_ATTEMPTS           <- loop_runner.py LoopConfig.max_merge_attempts
-#                                             and --max-merge-attempts defaults
+#   merge=DEFAULT_DRIVE_GREEN_LOOPS        <- loop_runner.py LoopConfig.drive_green_loops
+#                                             and --drive-green-loops defaults
 ROUTES: dict[StageName, Route] = {
     # The repo item itself is terminal: it seeds discovered issues/PRs into
     # their classified entry queues and then advances to finished(pass).

--- a/hephaestus/automation/pipeline/stages/merge_wait.py
+++ b/hephaestus/automation/pipeline/stages/merge_wait.py
@@ -52,7 +52,7 @@ head-bound strict-review proof:
     ``payload["merge_wait_started_at"]`` (stamped at ARM; missing in POLL
     is an invariant failure, not a new stamp) and ``HEPH_PR_MERGE_MAX_WAIT``
     (default 1800s, exactly the legacy ``_wait_for_pr_terminal`` budget).
-    The queue CLI's ``--max-merge-attempts`` feeds the ``merge`` budget:
+    The queue CLI's ``--drive-green-loops`` feeds the ``merge`` budget:
     once pending polls reach that count, the issue is durably tagged
     ``state:skip`` and the item SKIPs.
 - LEARN_WAIT [W:A]: the drive-green learnings session (re-housed

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -162,11 +162,11 @@ def test_build_pipeline_config_maps_drive_green_phase_to_ci_scope(
     assert config.scope.stages == frozenset({StageName.CI, StageName.MERGE_WAIT})
 
 
-def test_build_pipeline_config_maps_max_merge_attempts_to_budget(
+def test_build_pipeline_config_maps_drive_green_loops_to_budget(
     dispatch: dict[str, MagicMock],
 ) -> None:
-    """The loop CLI's merge-attempt flag must tune the merge_wait budget."""
-    loop_runner.main(["--max-merge-attempts", "3"])
+    """The loop CLI's drive-green loop cap must tune the merge_wait budget."""
+    loop_runner.main(["--drive-green-loops", "3"])
 
     (config,) = dispatch["run_pipeline"].call_args.args
     assert config.budget_overrides["merge"] == 3

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -247,8 +247,8 @@ class TestROUTES:
         assert routing.__file__ is not None
         source = Path(routing.__file__).read_text(encoding="utf-8")
         assert "loop_runner.py:" not in source
-        assert "LoopConfig.max_merge_attempts" in source
-        assert "--max-merge-attempts" in source
+        assert "LoopConfig.drive_green_loops" in source
+        assert "--drive-green-loops" in source
 
 
 class TestPipelineScope:

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -453,7 +453,7 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             1,
             help_text=(
                 "Number of CI-fix attempts per failing PR before giving up (default: 1). "
-                "The issue-major loop passes its --max-merge-attempts here so a PR that "
+                "The issue-major loop passes its --drive-green-loops here so a PR that "
                 "will not go green is abandoned after N tries."
             ),
         ),
@@ -591,14 +591,15 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             default=6,
         ),
         _action_spec(
-            ("--max-merge-attempts",),
-            "max_merge_attempts",
+            ("--drive-green-loops",),
+            "drive_green_loops",
             "_StoreAction",
-            1,
+            5,
             help_text=(
-                "Per-issue drive-green merge attempts before the issue is tagged "
-                "state:skip and the worker moves on (default: 1, matching the prior "
-                "drive-green retry budget)."
+                "Per-issue drive-green loop iterations before the issue is tagged "
+                "state:skip and the worker moves on (default: 5; replaces "
+                "--max-merge-attempts, whose default of 1 skip-parked issues on a "
+                "single transient failure)."
             ),
         ),
         _action_spec(

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -132,10 +132,10 @@ def test_parse_args_accepts_github_throttle_options() -> None:
     assert args.gh_global_burst == 11.0
 
 
-def test_parse_args_accepts_max_merge_attempts() -> None:
-    """--max-merge-attempts is parsed; default is 1 (#1560)."""
-    assert loop_runner._parse_args(["--max-merge-attempts", "3"]).max_merge_attempts == 3
-    assert loop_runner._parse_args([]).max_merge_attempts == 1
+def test_parse_args_accepts_drive_green_loops() -> None:
+    """--drive-green-loops is parsed; default is 5 (#2246, was --max-merge-attempts #1560)."""
+    assert loop_runner._parse_args(["--drive-green-loops", "3"]).drive_green_loops == 3
+    assert loop_runner._parse_args([]).drive_green_loops == 5
 
 
 def test_parse_args_accepts_issue_scope() -> None:


### PR DESCRIPTION
## Summary

`--max-merge-attempts` defaulted to 1, so a single failed drive-green attempt durably tagged an issue `state:skip` and silently dropped it from all future planning. Label-timeline analysis showed one overnight run (2026-07-11) skip-parked 76 issues org-wide this way.

- Remove `--max-merge-attempts`; add `--drive-green-loops` (default **5**) feeding the same `merge` budget via `budget_overrides`.
- Rename `LoopConfig.max_merge_attempts` → `LoopConfig.drive_green_loops` (default 5).
- Update routing provenance (`DEFAULT_MERGE_ATTEMPTS` → `DEFAULT_DRIVE_GREEN_LOOPS`), `ci_driver` `--max-fix-iterations` help text, and the `merge_wait` stage docstring.
- Tests updated: parse defaults, budget mapping, routing provenance, parser spec table. 179 tests pass across the touched suites.

Closes #2246

🤖 Generated with [Claude Code](https://claude.com/claude-code)