### PR TITLE
[Fix] Raise stage.step watchdog contract from 5s to 15s

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -129,8 +129,11 @@ from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO
 logger = logging.getLogger(__name__)
 
 #: Warn when any stage.step() call exceeds this duration (seconds) — the
-#: stage protocol promises short (<~5s) main-thread steps.
-_STEP_WATCHDOG_S = 5.0
+#: stage protocol promises short (<~15s) main-thread steps. 5s proved too
+#: tight in practice: routine repo-stage steps (clone + label reads over the
+#: network) breached it on nearly every multi-repo run, burying real stalls
+#: in noise (#2247).
+_STEP_WATCHDOG_S = 15.0
 
 #: Grace period for graceful shutdown (drain in-flight jobs up to this long).
 _DEFAULT_GRACE_S = 30.0
@@ -1125,7 +1128,7 @@ class Coordinator:
     def _step_with_watchdog(
         self, stage: Stage, item: WorkItem, ctx: StageContext
     ) -> StageStepResult:
-        """Run one stage.step, warning when it breaches the <~5s contract."""
+        """Run one stage.step, warning when it breaches the <~15s contract."""
         t0 = time.monotonic()
         result = stage.step(item, ctx)
         elapsed = time.monotonic() - t0

--- a/tests/unit/automation/pipeline/test_timer_heap.py
+++ b/tests/unit/automation/pipeline/test_timer_heap.py
@@ -145,7 +145,7 @@ class TestRetryDelayConsumption:
 
 
 class TestStepWatchdog:
-    """WARN when a stage.step breaches the <~5s protocol contract."""
+    """WARN when a stage.step breaches the <~15s protocol contract."""
 
     def test_watchdog_warns_on_slow_step(
         self,


### PR DESCRIPTION
## Summary

The coordinator's `_STEP_WATCHDOG_S` was 5.0s; routine repo-stage steps (network clone + label reads) breached it on nearly every multi-repo run (observed 6.3–126.4s on a healthy 16-repo pass), flooding logs with `stage.step stalled` warnings and burying real stalls.

- `_STEP_WATCHDOG_S` 5.0 → 15.0 with a comment explaining why 5s was too tight.
- Watchdog wrapper docstring and the timer-heap test docstring updated; the tests derive timings from the constant, so behavior coverage is unchanged (51 pass).

Closes #2247

🤖 Generated with [Claude Code](https://claude.com/claude-code)