### PR TITLE
[Fix] Restrict is_epic title fallback to leading tokens

### DIFF
--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -149,6 +149,14 @@ def is_skipped(labels: Iterable[str]) -> bool:
     return has_label(labels, STATE_SKIP)
 
 
+#: How many leading whitespace-separated title tokens the ``is_epic`` title
+#: fallback inspects. Tracking issues LEAD with the marker ("Epic: ...",
+#: "Q3 Roadmap tracking"); an issue that merely mentions epics mid-sentence
+#: (e.g. a bug report about epic handling, #2251) is a code task and must
+#: not be excluded from planning.
+_EPIC_TITLE_LEADING_TOKENS = 3
+
+
 def is_epic(labels: Iterable[str], title: str = "") -> bool:
     """Return ``True`` iff the issue is an epic/roadmap tracking issue.
 
@@ -157,7 +165,11 @@ def is_epic(labels: Iterable[str], title: str = "") -> bool:
 
     * it carries a label whose name is in :data:`EPIC_LABELS`
       (``epic`` / ``roadmap``), **or**
-    * its ``title`` contains one of those markers as a standalone token.
+    * its ``title`` LEADS with one of those markers as a standalone token —
+      within the first :data:`_EPIC_TITLE_LEADING_TOKENS` words. A marker
+      appearing later in the title is a mention, not the naming convention
+      (#2251: a bug report titled "...tags state:skip epic labels..." was
+      skip-parked by the anywhere-in-title match).
 
     The title fallback catches the convention even when the label was not
     applied. Pure function (no I/O) so both discovery paths and unit tests can
@@ -173,9 +185,9 @@ def is_epic(labels: Iterable[str], title: str = "") -> bool:
     """
     if {label.lower() for label in labels} & set(EPIC_LABELS):
         return True
-    lowered_title = title.lower()
+    leading_title = " ".join(title.lower().split()[:_EPIC_TITLE_LEADING_TOKENS])
     return any(
-        re.search(rf"(?<![a-z0-9_]){re.escape(marker)}(?![a-z0-9_])", lowered_title)
+        re.search(rf"(?<![a-z0-9_]){re.escape(marker)}(?![a-z0-9_])", leading_title)
         for marker in EPIC_LABELS
     )
 

--- a/tests/unit/automation/test_state_labels.py
+++ b/tests/unit/automation/test_state_labels.py
@@ -174,9 +174,9 @@ class TestIsEpic:
     """``is_epic`` excludes epic/roadmap TRACKING issues from the planning loop.
 
     An issue is an epic iff it carries an ``epic``/``roadmap`` label
-    (case-insensitive) OR its title contains ``epic``/``roadmap``. Native
-    GitHub issue types are not exposed by the installed ``gh``, so label +
-    title are the only available signals.
+    (case-insensitive) OR its title LEADS with ``epic``/``roadmap`` (within
+    the first three words, #2251). Native GitHub issue types are not exposed
+    by the installed ``gh``, so label + title are the only available signals.
     """
 
     def test_epic_label_marks_epic(self) -> None:
@@ -197,6 +197,23 @@ class TestIsEpic:
     def test_title_marker_does_not_match_inside_identifier(self) -> None:
         """Function names like skip_epics are code tasks, not epic trackers."""
         assert is_epic([], title="repo _discover calls skip_epics unguarded") is False
+
+    def test_mid_title_mention_is_not_epic(self) -> None:
+        """A bug report ABOUT epic handling is a code task (#2251).
+
+        Issue #2245 was skip-parked because its title mentioned "epic
+        labels" mid-sentence; only a title that LEADS with the marker names
+        a tracking issue.
+        """
+        assert (
+            is_epic([], title="Multi-repo loop tags state:skip epic labels on the wrong repo")
+            is False
+        )
+        assert is_epic([], title="Fix discovery so the roadmap is not re-planned") is False
+
+    def test_hyphenated_leading_marker_is_epic(self) -> None:
+        """Hyphens are token boundaries: a leading roadmap-YYYY still counts."""
+        assert is_epic([], title="Roadmap-2026 planning umbrella") is True
 
     def test_title_match_is_case_insensitive(self) -> None:
         assert is_epic([], title="EPIC umbrella issue") is True


### PR DESCRIPTION
## Summary

`is_epic()` matched `epic`/`roadmap` as a standalone token **anywhere** in a title, so issues that merely mention epics were excluded from planning and durably tagged `state:skip` — bug report #2245 ("…tags state:skip **epic** labels on the wrong repo") was skip-parked by the loop on 2026-07-17.

Tracking issues lead with the marker ("Epic: …", "Q3 Roadmap tracking"), so the fallback now matches only within the first three whitespace tokens (`_EPIC_TITLE_LEADING_TOKENS`). All previously pinned cases keep their verdicts ("Epic: ship the new pipeline", "Q3 Roadmap tracking", "EPIC umbrella issue", identifier non-matches); new regression tests pin the #2245-style mid-sentence mention and hyphenated leading markers.

44 state-label tests pass; 248 tests across epic/seeding/planner/repo-manager suites pass.

Closes #2251

🤖 Generated with [Claude Code](https://claude.com/claude-code)