### PR TITLE
[Fix] Drive orphan drive-green-all PRs instead of regressing to pr_review

### DIFF
--- a/hephaestus/automation/pipeline/stages/ci.py
+++ b/hephaestus/automation/pipeline/stages/ci.py
@@ -341,6 +341,19 @@ class CiStage(Stage):
         item.payload["base_branch"] = str((gh_state or {}).get("baseRefName") or "main")
         has_go, _has_no_go = ctx.github.pr_has_implementation_state_label(item.pr)
         if not has_go:
+            if item.issue is None:
+                # Orphan PR swept in by --drive-green-all (#2252): there is
+                # no issue-flow reviewer gate to regress to — pr_review
+                # terminates PR-only items — and the sweep's contract is
+                # mechanical drive-green (rebase + CI classification), not
+                # review. Merge containment is unaffected: defer_auto_merge
+                # ran above and merge_wait stays fail-closed (#2054).
+                logger.info(
+                    "ci:None: orphan PR #%d lacks state:implementation-go; "
+                    "proceeding with drive-green (no issue-flow gate)",
+                    item.pr,
+                )
+                return Continue(next_state=REBASE_WAIT)
             logger.info(
                 "ci:%s: PR #%d lacks state:implementation-go; regressing to pr_review",
                 item.issue,

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -294,6 +294,7 @@ class TestCiDiscover:
 
         result = stage.step(item, ctx)
 
+        assert isinstance(result, Continue)
         assert result.next_state == REBASE_WAIT
 
     def test_preset_branch_is_kept(self, make_ctx: Any, make_work_item: Any) -> None:

--- a/tests/unit/automation/pipeline/stages/test_stage_ci.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_ci.py
@@ -280,6 +280,22 @@ class TestCiDiscover:
 
         assert result == StageOutcome(Disposition.FAIL_BACK, "not_implementation_go")
 
+    def test_orphan_pr_without_go_proceeds_to_rebase(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A --drive-green-all orphan PR (no issue) is driven, not regressed (#2252).
+
+        pr_review terminates PR-only items, so the old FAIL_BACK route
+        dropped every swept-in PR instead of driving it green.
+        """
+        stage = CiStage()
+        ctx = make_ctx(github=FakeStageGitHub(pr_impl_state=(False, False)))
+        item = _item(make_work_item, state=DISCOVER, issue=None)
+
+        result = stage.step(item, ctx)
+
+        assert result.next_state == REBASE_WAIT
+
     def test_preset_branch_is_kept(self, make_ctx: Any, make_work_item: Any) -> None:
         """An item that already knows its branch never overwrites it."""
         stage = CiStage()


### PR DESCRIPTION
## Summary

`--drive-green-all` sweeps orphan open PRs (no tracked issue) into the CI stage as PR-only items. The CI entry gate regressed any PR lacking `state:implementation-go` to pr_review — but pr_review requires an issue number and terminates PR-only items, so **every swept-in PR was dropped without being rebased or CI-fixed**. The 2026-07-16 21:49 run regressed 13 orphan PRs this way and drove none of them green.

## Fix

PR-only items (`item.issue is None`) skip the implementation-go regression and proceed to REBASE_WAIT — mechanical rebase + CI classification, the legacy drive-green contract. The flag now does exactly what it says: widens *which PRs get driven*, without routing them through the reviewer pipeline. Merge containment is unchanged: `defer_auto_merge` still runs before the gate and merge_wait remains fail-closed (#2054), so driving green never arms a merge.

## Tests

New `test_orphan_pr_without_go_proceeds_to_rebase` pins the orphan path; the existing `test_missing_implementation_go_fails_back` still pins the issue-flow regression. 47 CI-stage tests and the full pipeline suite (887) pass.

Closes #2252

🤖 Generated with [Claude Code](https://claude.com/claude-code)