### PR TITLE
[Feat] Adversarial review posture: assume wrong, prove right

### DIFF
--- a/hephaestus/automation/prompts/_strict_rubric.py
+++ b/hephaestus/automation/prompts/_strict_rubric.py
@@ -57,6 +57,15 @@ GRADING (every dimension starts at F; A must be EARNED with concrete evidence):
 - D  (60-69%)  Poor / fundamental practices missing
 - F  (<60%)    Failing / misaligned / dangerous
 
+REVIEW POSTURE (mandatory):
+- Assume the submission is WRONG until you prove otherwise. Your job is not to
+  confirm it looks right — it is to try to break it and fail.
+- A GO verdict or an A/B grade is a positive claim that you actively attempted
+  to falsify the work (traced the changed paths, checked the failure modes,
+  looked for the input that breaks it) and could not.
+- If you did not perform that falsification attempt for a dimension, you may
+  not grade it above C.
+
 ANTI-INFLATION RULES (mandatory):
 - DEFAULT IS F. Find concrete evidence to justify ANY upgrade.
 - A requires ZERO critical or major findings.

--- a/hephaestus/automation/prompts/pr_review.py
+++ b/hephaestus/automation/prompts/pr_review.py
@@ -43,6 +43,12 @@ Analyze PR #{pr_number} linked to issue #{issue_number}.
 > the effective bootstrap merge control. Do NOT re-check policy here — focus
 > solely on code correctness, completeness, and quality.
 
+**Assume the code is WRONG; your job is to prove it right.** Do not review for
+plausibility — review for falsification: trace each changed execution path,
+verify the tests actually exercise the change (and would FAIL if the change
+were broken), and actively hunt for the input, state, or sequence that breaks
+it. Conclude GO only after that hunt comes up empty.
+
 Review the PR for correctness, completeness, and code quality. Identify any issues that should
 be addressed as inline review comments.
 


### PR DESCRIPTION
## Summary

Review prompts now open from an adversarial posture instead of a neutral one:

- `build_strict_review_rubric()` (composed into the plan-loop, impl-loop, and PR strict rubrics) gains a mandatory **REVIEW POSTURE** block: assume the submission is WRONG until proven otherwise; a GO verdict or A/B grade is a positive claim that the reviewer actively attempted to falsify the work and could not; a dimension without a falsification attempt caps at C.
- `PR_REVIEW_ANALYSIS_PROMPT` adds the code-specific directive: assume the code is wrong — trace each changed execution path, verify the tests would fail if the change were broken, and hunt for the breaking input/state/sequence before concluding GO.

88 prompt/rubric tests pass; lint/format/mypy clean.

Closes #2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)