### PR TITLE
[mino] Preserve diagnostics in worktree branch-existence failures

### DIFF
--- a/hephaestus/automation/worktree_manager.py
+++ b/hephaestus/automation/worktree_manager.py
@@ -26,6 +26,7 @@ import contextlib
 import logging
 import os
 import shutil
+import subprocess
 import threading
 from pathlib import Path
 from typing import Any
@@ -529,6 +530,12 @@ class WorktreeManager:
         Returns:
             True if the branch resolves locally, False otherwise.
 
+        Raises:
+            Exception: If the command runner raises an error outside the
+                subprocess exception hierarchy, so unexpected failures retain
+                their traceback and reach the caller instead of being
+                misclassified as a missing branch.
+
         """
         try:
             result = run(
@@ -539,7 +546,13 @@ class WorktreeManager:
                 **_timeout_kw(timeout),
             )
             return result.returncode == 0
-        except Exception:
+        except subprocess.SubprocessError:
+            logger.warning(
+                "Local branch check failed for %s in %s; treating it as absent",
+                branch_name,
+                self.repo_root,
+                exc_info=True,
+            )
             return False
 
     def _remote_branch_exists(self, branch_name: str, *, timeout: int | None = None) -> bool:

--- a/tests/unit/automation/test_worktree_manager.py
+++ b/tests/unit/automation/test_worktree_manager.py
@@ -1121,3 +1121,48 @@ class TestCreateWorktreeBranchCollision:
         argvs = [call.args[0] for call in worktree_mocks.run.call_args_list]
         assert ["git", "worktree", "remove", "--force", str(worktree_path)] in argvs
         assert ["git", "worktree", "prune"] in argvs
+
+
+class TestLocalBranchExists:
+    """Tests for diagnostic-preserving local branch lookups."""
+
+    def test_subprocess_failure_is_logged_and_treated_as_absent(
+        self,
+        worktree_mocks: Any,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Expected subprocess failures stay fail-safe but log diagnostics."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        worktree_mocks.run.side_effect = subprocess.TimeoutExpired(
+            ["git", "rev-parse"],
+            timeout=5,
+        )
+
+        with caplog.at_level(
+            "WARNING",
+            logger="hephaestus.automation.worktree_manager",
+        ):
+            result = manager._local_branch_exists("2143-auto", timeout=5)
+
+        assert result is False
+        assert "Local branch check failed for 2143-auto" in caplog.text
+        assert str(tmp_path) in caplog.text
+        assert caplog.records[-1].exc_info is not None
+
+    def test_unexpected_runner_error_propagates_unchanged(
+        self,
+        worktree_mocks: Any,
+        tmp_path: Path,
+    ) -> None:
+        """Unexpected runner errors are re-raised unchanged, not swallowed."""
+        worktree_mocks.repo_root.return_value = tmp_path
+        manager = WorktreeManager()
+        error = RuntimeError("runner contract broken")
+        worktree_mocks.run.side_effect = error
+
+        with pytest.raises(RuntimeError, match="runner contract broken") as exc_info:
+            manager._local_branch_exists("2143-auto")
+
+        assert exc_info.value is error


### PR DESCRIPTION
## Summary
All 56 tests pass. Done.

**Summary**

- `hephaestus/automation/worktree_manager.py:542-543` — replaced the broad silent `except Exception: return False` in `_local_branch_exists` with `except subprocess.SubprocessError`, which logs a warning (branch name, repo root, `exc_info=True`) and returns `False`. Unexpected non-subprocess errors now propagate with their traceback. Added `import subprocess` and a `Raises:` note to the docstring.
- `tests/unit/automation/test_worktree_manager.py` — added `TestLocalBranchExists` with two tests: subprocess failure is logged + treated as absent; unexpected `RuntimeError` propagates unchanged.

**Tests run**
- `uv run python -m pytest tests/unit/automation/test_worktree_manager.py` → 56 passed
- `uv run ruff check` on both files → clean

Verdict: PASS | Reason: Narrowed exception handling with diagnostic logging; unexpected errors propagate; 56 tests pass, lint clean.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2143

Generated by Hephaestus automation
