### PR TITLE
[mino] Correct the documented console-script count

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -130,16 +130,16 @@ repos:
         pass_filenames: false
         files: ^(hephaestus|scripts)/.*\.py$|^docs/TECH_DEBT\.md$
 
-  # CLI table sync check
+  # CLI table and prose-count sync check
   - repo: local
     hooks:
       - id: check-cli-table-sync
-        name: Check README CLI table sync
-        description: Ensure README.md CLI table documents every pyproject.toml [project.scripts] entry
+        name: Check CLI documentation sync
+        description: Ensure the README CLI table and documented console-script counts match pyproject.toml [project.scripts]
         entry: uv run python -m hephaestus.scripts_lib.check_cli_table_sync
         language: system
         pass_filenames: false
-        files: ^(README\.md|pyproject\.toml)$
+        files: ^(README\.md|COMPATIBILITY\.md|docs/index\.md|pyproject\.toml)$
 
   # Claude settings permission path check
   - repo: local

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -59,7 +59,7 @@ may change incompatibly in a minor release.
 
 ## Console-Script Stability Tiers
 
-Hephaestus installs 53 console scripts via `[project.scripts]` in
+Hephaestus installs 48 console scripts via `[project.scripts]` in
 `pyproject.toml`. Each is classified into one of three tiers:
 
 - **Stable** — covered by the [deprecation policy](#deprecation-policy). CLI

--- a/hephaestus/scripts_lib/check_cli_table_sync.py
+++ b/hephaestus/scripts_lib/check_cli_table_sync.py
@@ -7,18 +7,20 @@ README mentions every command declared in [project.scripts] and exits non-zero
 with a clear diff otherwise.
 
 Beyond verifying that every command name appears in README.md, the script also
-verifies the prose counts in ``README.md`` (e.g. "44 console scripts") and in
-``docs/index.md`` (e.g. "44 CLI entry points") agree with the actual length of
-``[project.scripts]``.  This prevents documentation drift like #857, where
-README.md claimed 42 and docs/index.md claimed 37+ even though the real count
-was 44.
+verifies the prose counts in ``README.md`` (e.g. "44 console scripts"),
+``COMPATIBILITY.md`` (e.g. "44 console scripts"), and ``docs/index.md`` (e.g.
+"44 CLI entry points") agree with the actual length of ``[project.scripts]``.
+This prevents documentation drift like #857, where README.md claimed 42 and
+docs/index.md claimed 37+ even though the real count was 44, and like #2164,
+where COMPATIBILITY.md claimed 53.
 
 Usage:
     python3 -m hephaestus.scripts_lib.check_cli_table_sync
 
 Exit codes:
     0  All pyproject.toml scripts are documented in README.md AND the prose
-       counts in README.md / docs/index.md match the actual count.
+       counts in README.md / COMPATIBILITY.md / docs/index.md match the actual
+       count.
     1  One or more scripts are missing from the README CLI section OR a prose
        count is wrong.
 """
@@ -64,14 +66,24 @@ DOCS_INDEX = REPO_ROOT / "docs" / "index.md"
 # Regex that matches a backtick-quoted command name anywhere in the README.
 _BACKTICK_CMD_RE = re.compile(r"`(hephaestus-[a-z0-9-]+)`")
 
-# Regex that matches the README prose "<N> console scripts".
-_README_PROSE_RE = re.compile(r"(\d+)\s+console scripts")
+# Regex that matches prose of the form "<N> console scripts" (README.md and
+# COMPATIBILITY.md share this wording).
+_CONSOLE_SCRIPT_PROSE_RE = re.compile(r"(\d+)\s+console scripts")
 
 # Regex that matches the docs/index.md prose "<N>+? CLI entry points".  The
 # optional ``+`` is intentionally allowed in the pattern so legacy text like
 # "37+" parses cleanly, but the check below treats the bare integer as
 # authoritative.
 _DOCS_INDEX_PROSE_RE = re.compile(r"(\d+)\+?\s+CLI entry points")
+
+# Each guarded document, its prose regex, and the human-readable count label
+# used in mismatch diagnostics.  Extending this tuple is all that is required to
+# guard another prose count.
+_PROSE_COUNT_CHECKS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    ("README.md", _CONSOLE_SCRIPT_PROSE_RE, "console scripts"),
+    ("COMPATIBILITY.md", _CONSOLE_SCRIPT_PROSE_RE, "console scripts"),
+    ("docs/index.md", _DOCS_INDEX_PROSE_RE, "CLI entry points"),
+)
 
 
 def _load_scripts(repo_root: Path | None = None) -> set[str]:
@@ -91,11 +103,13 @@ def _readme_documented_commands(repo_root: Path | None = None) -> set[str]:
 
 
 def check_prose_counts(repo_root: Path, expected_count: int) -> tuple[bool, list[str]]:
-    """Verify the prose counts in README.md and docs/index.md match expected_count.
+    """Verify the documented CLI prose counts match ``expected_count``.
 
-    The check runs the regex against the full file text and treats a missing
-    match as a mismatch — silently dropping the prose sentence would erode the
-    guard rail that this checker exists to provide.
+    The guard covers ``README.md``, ``COMPATIBILITY.md``, and ``docs/index.md``
+    (see ``_PROSE_COUNT_CHECKS``).  The check runs each file's regex against the
+    full file text and treats a missing file or a missing match as a mismatch —
+    silently dropping the prose sentence would erode the guard rail that this
+    checker exists to provide.
 
     Args:
         repo_root: Repository root to search under.  Used so tests can point at
@@ -111,44 +125,26 @@ def check_prose_counts(repo_root: Path, expected_count: int) -> tuple[bool, list
     """
     mismatches: list[str] = []
 
-    readme = repo_root / "README.md"
-    docs_index = repo_root / "docs" / "index.md"
+    for relative_path, pattern, count_label in _PROSE_COUNT_CHECKS:
+        path = repo_root / relative_path
+        if not path.is_file():
+            mismatches.append(f"{relative_path} not found at {path}")
+            continue
 
-    if not readme.is_file():
-        mismatches.append(f"README.md not found at {readme}")
-    else:
-        readme_text = readme.read_text(encoding="utf-8")
-        match = _README_PROSE_RE.search(readme_text)
+        match = pattern.search(path.read_text(encoding="utf-8"))
         if match is None:
             mismatches.append(
-                "README.md: missing prose sentence matching "
-                "r'(\\d+)\\s+console scripts' — has the wording changed?"
+                f"{relative_path}: missing prose sentence matching "
+                f"r'{pattern.pattern}' — has the wording changed?"
             )
-        else:
-            actual = int(match.group(1))
-            if actual != expected_count:
-                mismatches.append(
-                    f"README.md: prose says '{actual} console scripts' but "
-                    f"pyproject.toml [project.scripts] has {expected_count} entries"
-                )
+            continue
 
-    if not docs_index.is_file():
-        mismatches.append(f"docs/index.md not found at {docs_index}")
-    else:
-        docs_text = docs_index.read_text(encoding="utf-8")
-        match = _DOCS_INDEX_PROSE_RE.search(docs_text)
-        if match is None:
+        actual = int(match.group(1))
+        if actual != expected_count:
             mismatches.append(
-                "docs/index.md: missing prose sentence matching "
-                "r'(\\d+)\\+?\\s+CLI entry points' — has the wording changed?"
+                f"{relative_path}: prose says '{actual} {count_label}' but "
+                f"pyproject.toml [project.scripts] has {expected_count} entries"
             )
-        else:
-            actual = int(match.group(1))
-            if actual != expected_count:
-                mismatches.append(
-                    f"docs/index.md: prose says '{actual} CLI entry points' but "
-                    f"pyproject.toml [project.scripts] has {expected_count} entries"
-                )
 
     return (len(mismatches) == 0, mismatches)
 
@@ -202,7 +198,7 @@ def main() -> int:
     if ok:
         print(
             f"OK: all {len(declared)} pyproject.toml scripts are documented in README.md, "
-            "and prose counts in README.md and docs/index.md agree."
+            "and prose counts in README.md, COMPATIBILITY.md, and docs/index.md agree."
         )
         return 0
 

--- a/tests/unit/scripts_lib/test_check_cli_table_sync.py
+++ b/tests/unit/scripts_lib/test_check_cli_table_sync.py
@@ -4,10 +4,12 @@ The script verifies two invariants:
 
 1. Every command listed in ``pyproject.toml [project.scripts]`` is mentioned
    somewhere in ``README.md`` (the original purpose of the script).
-2. The human-readable prose counts in ``README.md`` and ``docs/index.md``
-   agree with the actual ``[project.scripts]`` length.  This second check was
-   added by #857 after the README, the docs, and the table disagreed (42 vs.
-   37+ vs. 44).
+2. The human-readable prose counts in ``README.md``, ``COMPATIBILITY.md``, and
+   ``docs/index.md`` agree with the actual ``[project.scripts]`` length.  The
+   ``README.md``/``docs/index.md`` half of this check was added by #857 after
+   the README, the docs, and the table disagreed (42 vs. 37+ vs. 44).  The
+   ``COMPATIBILITY.md`` guard was added by #2164 after Section 12 claimed 53
+   console scripts while the real count was lower.
 """
 
 from __future__ import annotations
@@ -28,12 +30,13 @@ class TestCheckProseCounts:
         *,
         readme_count: str | int | None,
         docs_count: str | int | None,
+        compatibility_count: str | int | None = 44,
     ) -> Path:
         """Build a scratch repo with the requested prose counts.
 
-        Passing ``None`` for either ``readme_count`` or ``docs_count`` omits
-        the relevant prose sentence entirely so the checker can be exercised
-        against missing-sentence cases.
+        Passing ``None`` for any of ``readme_count``, ``docs_count``, or
+        ``compatibility_count`` omits the relevant prose sentence entirely so
+        the checker can be exercised against missing-sentence cases.
         """
         readme = tmp_path / "README.md"
         if readme_count is None:
@@ -54,11 +57,21 @@ class TestCheckProseCounts:
                 f"# Docs\n\nFull function signatures for all {docs_count} CLI entry points.\n"
             )
 
+        compatibility = tmp_path / "COMPATIBILITY.md"
+        if compatibility_count is None:
+            compatibility.write_text("# Compatibility\n\nNo CLI count here.\n")
+        else:
+            compatibility.write_text(
+                "## Console-Script Stability Tiers\n\n"
+                f"Hephaestus installs {compatibility_count} console scripts via "
+                "`[project.scripts]` in `pyproject.toml`.\n"
+            )
+
         return tmp_path
 
-    def test_returns_true_when_both_counts_match(self, tmp_path: Path) -> None:
-        """Matching prose counts in README and docs/index return ok=True."""
-        repo = self._make_repo(tmp_path, readme_count=44, docs_count=44)
+    def test_returns_true_when_all_counts_match(self, tmp_path: Path) -> None:
+        """Matching prose counts in all three guarded files return ok=True."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=44, compatibility_count=44)
         ok, mismatches = check_prose_counts(repo, expected_count=44)
         assert ok is True
         assert mismatches == []
@@ -112,6 +125,9 @@ class TestCheckProseCounts:
         docs = tmp_path / "docs"
         docs.mkdir()
         (docs / "index.md").write_text("Full function signatures for all 44 CLI entry points.\n")
+        (tmp_path / "COMPATIBILITY.md").write_text(
+            "Hephaestus installs 44 console scripts via `[project.scripts]`.\n"
+        )
         ok, mismatches = check_prose_counts(tmp_path, expected_count=44)
         assert ok is False
         assert any("README.md not found" in m for m in mismatches), mismatches
@@ -119,9 +135,36 @@ class TestCheckProseCounts:
     def test_missing_docs_index_file_is_a_mismatch(self, tmp_path: Path) -> None:
         """If docs/index.md does not exist at all, that is reported."""
         (tmp_path / "README.md").write_text("44 console scripts are installed.\n")
+        (tmp_path / "COMPATIBILITY.md").write_text(
+            "Hephaestus installs 44 console scripts via `[project.scripts]`.\n"
+        )
         ok, mismatches = check_prose_counts(tmp_path, expected_count=44)
         assert ok is False
         assert any("docs/index.md not found" in m for m in mismatches), mismatches
+
+    def test_returns_false_on_compatibility_mismatch(self, tmp_path: Path) -> None:
+        """A wrong COMPATIBILITY.md count produces a clear mismatch message."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=44, compatibility_count=53)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("COMPATIBILITY.md" in m and "53" in m and "44" in m for m in mismatches), (
+            mismatches
+        )
+
+    def test_missing_compatibility_prose_is_a_mismatch(self, tmp_path: Path) -> None:
+        """If the COMPATIBILITY.md prose sentence is missing, that is a mismatch."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=44, compatibility_count=None)
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("COMPATIBILITY.md" in m and "missing prose" in m for m in mismatches), mismatches
+
+    def test_missing_compatibility_file_is_a_mismatch(self, tmp_path: Path) -> None:
+        """If COMPATIBILITY.md does not exist at all, that is reported."""
+        repo = self._make_repo(tmp_path, readme_count=44, docs_count=44)
+        (repo / "COMPATIBILITY.md").unlink()
+        ok, mismatches = check_prose_counts(repo, expected_count=44)
+        assert ok is False
+        assert any("COMPATIBILITY.md not found" in m for m in mismatches), mismatches
 
 
 class TestMain:


### PR DESCRIPTION
## Summary
Full suite green: **5932 passed, 22 skipped**, coverage **85.13%** (above the 83% floor). All gates pass.

## Summary

Corrected the stale console-script count in `COMPATIBILITY.md` and extended the existing documentation-sync validator to guard it going forward. Authoritative count is **48** (from `pyproject.toml [project.scripts]`), matching `README.md:286` and `docs/index.md:39`; only `COMPATIBILITY.md` was stale (said 53). The plan referenced 51/53, but the repository's true authoritative count is 48, so I implemented to that.

**Changes:**
- `COMPATIBILITY.md:62` — `53` → `48` console scripts.
- `hephaestus/scripts_lib/check_cli_table_sync.py` — replaced the README-only prose check with a data-driven `_PROSE_COUNT_CHECKS` tuple covering `README.md`, `COMPATIBILITY.md`, and `docs/index.md`; `check_prose_counts()` now iterates it (missing file / missing prose / wrong count all fail closed). Updated docstrings and the success message.
- `tests/unit/scripts_lib/test_check_cli_table_sync.py` — extended the fixture with `compatibility_count`, renamed the match-all test, added 3 compatibility tests (stale count, missing prose, missing file), and gave the missing-file tests a control `COMPATIBILITY.md`.
- `.pre-commit-config.yaml:114` — broadened the hook name/description and file filter to `^(README\.md|COMPATIBILITY\.md|docs/index\.md|pyproject\.toml)$` so edits to any guarded doc invoke the validator (previously `COMPATIBILITY.md`/`docs/index.md` were skipped).

**Verification (all pass):**
- Targeted: `pytest tests/unit/scripts_lib/test_check_cli_table_sync.py --no-cov` — 12 passed (RED→GREEN confirmed).
- Live validator: exit 0, reports 48 across all three files.
- Pre-commit hook now triggers on `COMPATIBILITY.md` (was skipped before): Passed.
- `ruff check`, `ruff format --check`, `mypy`: clean.
- Full unit suite: 5932 passed, 22 skipped, coverage 85.13%.

Working tree contains only the 4 intended files; no backup/temp files. No git/GitHub mutations performed.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2164

Generated by Hephaestus automation
