### PR TITLE
[Feat] Document every state:skip application with a reason comment

### DIFF
--- a/hephaestus/automation/_review_phase.py
+++ b/hephaestus/automation/_review_phase.py
@@ -64,6 +64,7 @@ from .git_utils import (
 from .github_api import (
     gh_current_login,
     gh_issue_add_labels,
+    gh_issue_upsert_comment,
     gh_pr_list_unresolved_threads,
 )
 from .models import PLAN_COMMENT_MARKER, ImplementationState
@@ -76,7 +77,7 @@ from .prompts import get_impl_loop_review_prompt, get_impl_resume_feedback_promp
 from .review_validator import validate_prior_comments_addressed
 from .session_naming import AGENT_IMPLEMENTER, current_trunk_githash  # noqa: F401
 from .state import review as review_state
-from .state_labels import STATE_SKIP
+from .state_labels import SKIP_REASON_MARKER, STATE_SKIP, format_skip_reason_comment
 
 if TYPE_CHECKING:
     from ._stage_context import StageContext
@@ -1203,6 +1204,16 @@ class ReviewPhase(StageMixin):
             )
             with contextlib.suppress(Exception):
                 gh_issue_add_labels(issue_number, [STATE_SKIP])
+                gh_issue_upsert_comment(
+                    issue_number,
+                    SKIP_REASON_MARKER,
+                    format_skip_reason_comment(
+                        f"the PR review loop ended without GO "
+                        f"(verdict={last_verdict!r} after {iterations_run} "
+                        f"iteration(s)); push commits addressing the review, "
+                        f"then remove this label to re-enter the loop."
+                    ),
+                )
         elif last_verdict == "ERROR":
             logger.warning(
                 "#%d: review loop ended in reviewer-infrastructure ERROR after %d "

--- a/hephaestus/automation/github_api/issues.py
+++ b/hephaestus/automation/github_api/issues.py
@@ -107,12 +107,22 @@ def gh_issue_json(issue_number: int) -> dict[str, Any]:
         raise RuntimeError(f"Failed to fetch issue #{issue_number}: {e}") from e
 
 
-def gh_issue_comment(issue_number: int, body: str) -> None:
+def _repo_args(repo: tuple[str, str] | None) -> list[str]:
+    """Return the explicit ``--repo owner/name`` selector args when given."""
+    if repo is None:
+        return []
+    owner, name = repo
+    return ["--repo", f"{owner}/{name}"]
+
+
+def gh_issue_comment(issue_number: int, body: str, repo: tuple[str, str] | None = None) -> None:
     """Post a comment to an issue.
 
     Args:
         issue_number: GitHub issue number
         body: Comment body text
+        repo: ``(owner, name)`` owning *issue_number*; ambient cwd when omitted
+            (correct only for single-repo callers, #2245/#2256)
 
     Raises:
         RuntimeError: If comment post fails
@@ -120,7 +130,9 @@ def gh_issue_comment(issue_number: int, body: str) -> None:
     """
     try:
         with _body_file(body) as path:
-            _api._gh_call(["issue", "comment", str(issue_number), "--body-file", path])
+            _api._gh_call(
+                ["issue", "comment", str(issue_number), "--body-file", path, *_repo_args(repo)]
+            )
         _api.logger.info("Posted comment to issue #%s", issue_number)
     except subprocess.CalledProcessError as e:
         raise RuntimeError(f"Failed to post comment to issue #{issue_number}: {e}") from e
@@ -217,7 +229,12 @@ def gh_issue_delete_comment(comment_id: int) -> None:
         raise RuntimeError(f"Failed to delete issue comment {comment_id}: {e}") from e
 
 
-def gh_issue_upsert_comment(issue_number: int, marker_prefix: str, body: str) -> int | None:
+def gh_issue_upsert_comment(
+    issue_number: int,
+    marker_prefix: str,
+    body: str,
+    repo: tuple[str, str] | None = None,
+) -> int | None:
     """Create-or-update the single issue comment whose body starts with ``marker_prefix``.
 
     Enforces the "one comment per role" invariant: the pipeline must keep at
@@ -244,7 +261,7 @@ def gh_issue_upsert_comment(issue_number: int, marker_prefix: str, body: str) ->
         RuntimeError: If a create/update/delete call fails.
 
     """
-    comments = _api._fetch_issue_comment_ids(issue_number)
+    comments = _api._fetch_issue_comment_ids(issue_number, repo)
     matching = [
         c
         for c in comments
@@ -253,13 +270,13 @@ def gh_issue_upsert_comment(issue_number: int, marker_prefix: str, body: str) ->
 
     if not matching:
         # No existing comment with this marker — create a fresh one.
-        _api.gh_issue_comment(issue_number, body)
+        _api.gh_issue_comment(issue_number, body, repo=repo)
         return None
 
     # Newest matching comment wins (list is chronological → last element).
     target = matching[-1]
     target_id = int(target["databaseId"])
-    owner, name = _api.get_repo_info()
+    owner, name = repo if repo is not None else _api.get_repo_info()
 
     # Delete older duplicates so only one comment with this marker remains.
     for dup in matching[:-1]:

--- a/hephaestus/automation/github_api/labels.py
+++ b/hephaestus/automation/github_api/labels.py
@@ -6,7 +6,12 @@ import json
 
 import hephaestus.automation.github_api as _api
 
-from ..state_labels import STATE_SKIP, is_skipped
+from ..state_labels import (
+    SKIP_REASON_MARKER,
+    STATE_SKIP,
+    format_skip_reason_comment,
+    is_skipped,
+)
 
 
 def _label_cache_key(repo: tuple[str, str] | None = None) -> str:
@@ -165,6 +170,18 @@ def skip_epics(epics_labels: dict[int, list[str]], repo: tuple[str, str] | None 
             continue
         _api.gh_issue_add_labels(number, [STATE_SKIP], repo=repo)
         _api.logger.info("Issue #%s is an epic/roadmap tracking issue; tagged state:skip", number)
+        try:
+            _api.gh_issue_upsert_comment(
+                number,
+                SKIP_REASON_MARKER,
+                format_skip_reason_comment(
+                    "excluded from the planning loop as an epic/roadmap tracking "
+                    "issue (checklist of child work, not a code task)"
+                ),
+                repo=repo,
+            )
+        except Exception as exc:  # pragma: no cover - defensive best-effort
+            _api.logger.warning("could not post skip-reason comment on #%s: %s", number, exc)
 
 
 def gh_issue_remove_labels(issue_number: int, labels: list[str]) -> None:

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -57,7 +57,11 @@ from pathlib import Path
 from typing import Any, Protocol, TypeAlias, runtime_checkable
 
 from hephaestus.agents.runtime import DEFAULT_AGENT
-from hephaestus.automation.state_labels import STATE_SKIP
+from hephaestus.automation.state_labels import (
+    SKIP_REASON_MARKER,
+    STATE_SKIP,
+    format_skip_reason_comment,
+)
 
 from ..events import StageEvent
 from ..jobs import AgentJob, BuildTestJob, GitJob, JobHandle, JobResult
@@ -170,6 +174,10 @@ class StageGitHub(Protocol):
 
     def close_issue_as_covered(self, issue_number: int, pr_number: int) -> None:
         """Close the issue as covered by a merged PR (``_review_utils``)."""
+        ...
+
+    def upsert_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
+        """Upsert the single issue comment keyed on ``marker`` (#2256)."""
         ...
 
     def upsert_plan_comment(self, issue_number: int, body: str) -> None:
@@ -568,15 +576,18 @@ def _terminal_pr_outcome(pr_state: dict[str, Any] | None, pr_number: int) -> Sta
     return None
 
 
-def write_skip_label(issue_number: int, ctx: StageContext) -> None:
-    """Durably apply ``state:skip``, non-fatally (legacy warn pattern).
+def write_skip_label(issue_number: int, ctx: StageContext, reason: str) -> None:
+    """Durably apply ``state:skip`` with a reason comment, non-fatally.
 
     Single home for the exhaustion/no-commits skip write (previously
-    duplicated across the implementation and pr_review stages).
+    duplicated across the implementation and pr_review stages). The reason
+    is documented on the issue via the marker-keyed skip-reason comment so
+    it survives outside ephemeral run logs (#2256).
 
     Args:
         issue_number: GitHub issue number.
         ctx: Stage context carrying the GitHub accessor.
+        reason: Human-readable explanation for the skip, posted as a comment.
 
     """
     try:
@@ -586,6 +597,16 @@ def write_skip_label(issue_number: int, ctx: StageContext) -> None:
             "pipeline:%d: failed to add label %r (non-fatal): %s",
             issue_number,
             STATE_SKIP,
+            e,
+        )
+    try:
+        ctx.github.upsert_issue_comment(
+            issue_number, SKIP_REASON_MARKER, format_skip_reason_comment(reason)
+        )
+    except Exception as e:
+        logger.warning(
+            "pipeline:%d: failed to post skip-reason comment (non-fatal): %s",
+            issue_number,
             e,
         )
 

--- a/hephaestus/automation/pipeline/stages/implementation.py
+++ b/hephaestus/automation/pipeline/stages/implementation.py
@@ -879,7 +879,14 @@ class ImplementationStage(Stage):
             logger.warning(
                 "implementation:%d: no commits vs base; applying %s", item.issue, STATE_SKIP
             )
-            write_skip_label(item.issue, ctx)
+            write_skip_label(
+                item.issue,
+                ctx,
+                "the implementation session ended with no commits versus the "
+                "base branch — there is nothing to open a PR from. Re-scope "
+                "the issue or implement manually, then remove this label to "
+                "re-enter the loop.",
+            )
             return StageOutcome(Disposition.SKIP, "no commits vs base")
         if item.payload.pop("git_error", None):
             # Push failed: transient git/network trouble — RETRY the stage

--- a/hephaestus/automation/pipeline/stages/pr_review.py
+++ b/hephaestus/automation/pipeline/stages/pr_review.py
@@ -847,7 +847,15 @@ class PrReviewStage(Stage):
             automation_unresolved,
             STATE_SKIP,
         )
-        write_skip_label(item.issue, ctx)
+        write_skip_label(
+            item.issue,
+            ctx,
+            f"PR review rounds exhausted at round {round_done} with the "
+            f"automation-unresolved thread count stuck "
+            f"({prev_unresolved} -> {automation_unresolved}); further re-review "
+            f"cannot make progress. Push new commits addressing the review "
+            f"feedback, then remove this label to re-enter the loop.",
+        )
         return StageOutcome(Disposition.SKIP, "exhaustion")
 
     @staticmethod
@@ -935,7 +943,16 @@ class PrReviewStage(Stage):
             item.issue,
             STATE_SKIP,
         )
-        write_skip_label(_issue_number(item), ctx)
+        write_skip_label(
+            _issue_number(item),
+            ctx,
+            f"the reviewer returned NOGO with zero actionable review threads "
+            f"{retries} time(s) in a row on PR #{pr_number}; the input is "
+            f"deterministic, so re-review cannot change the verdict (#2079). "
+            f"See the review-anomaly comment on the PR for the reviewer's "
+            f"summary; push new commits, then remove this label to re-enter "
+            f"the loop.",
+        )
         return StageOutcome(Disposition.SKIP, "zero_thread_nogo_exhausted")
 
     @staticmethod

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -55,12 +55,14 @@ from hephaestus.automation.review_state import (
 from hephaestus.automation.state_labels import (
     ALL_IMPLEMENTATION_STATE_LABELS,
     ALL_STATE_LABELS,
+    SKIP_REASON_MARKER,
     STATE_IMPLEMENTATION_GO,
     STATE_IMPLEMENTATION_NO_GO,
     STATE_LABEL_SPECS,
     STATE_PLAN_GO,
     STATE_PLAN_NO_GO,
     STATE_SKIP,
+    format_skip_reason_comment,
     has_label,
     is_implementation_go,
     is_plan_go,
@@ -935,15 +937,22 @@ class PipelineGitHub:
 
     def upsert_plan_comment(self, issue_number: int, body: str) -> None:
         """Upsert the single plan comment keyed on ``PLAN_COMMENT_MARKER``."""
-        if self._skip(f"upsert plan comment on #{issue_number}"):
+        self.upsert_issue_comment(issue_number, PLAN_COMMENT_MARKER, body)
+
+    def upsert_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
+        """Upsert the single issue comment keyed on ``marker`` (repo-scoped).
+
+        Generalizes the plan-comment upsert (#2256): one comment per marker,
+        updated in place, older duplicates deleted.
+        """
+        if self._skip(f"upsert {marker!r} comment on #{issue_number}"):
             return
         if self._repo_slug is not None:
             comments = self._repo_issue_comments(issue_number)
             matching = [
                 c
                 for c in comments
-                if str(c.get("body", "")).startswith(PLAN_COMMENT_MARKER)
-                and c.get("databaseId") is not None
+                if str(c.get("body", "")).startswith(marker) and c.get("databaseId") is not None
             ]
             if not matching:
                 with github_api._body_file(body) as path:
@@ -975,7 +984,7 @@ class PipelineGitHub:
                     ]
                 )
             return
-        github_api.gh_issue_upsert_comment(issue_number, PLAN_COMMENT_MARKER, body)
+        github_api.gh_issue_upsert_comment(issue_number, marker, body)
 
     def create_pr(self, issue_number: int, branch: str, title: str, body: str) -> int:
         """Durably ensure the PR exists and return its number (idempotent).
@@ -1239,6 +1248,17 @@ class PipelineGitHub:
             for number, labels in epics_labels.items():
                 if STATE_SKIP not in labels:
                     self._add_labels(number, [STATE_SKIP])
+                    try:
+                        self.upsert_issue_comment(
+                            number,
+                            SKIP_REASON_MARKER,
+                            format_skip_reason_comment(
+                                "excluded from the planning loop as an epic/roadmap "
+                                "tracking issue (checklist of child work, not a code task)"
+                            ),
+                        )
+                    except Exception as exc:  # pragma: no cover - best-effort
+                        logger.warning("could not post skip-reason comment on #%s: %s", number, exc)
             return
         github_api.skip_epics(epics_labels)
 

--- a/hephaestus/automation/state_labels.py
+++ b/hephaestus/automation/state_labels.py
@@ -63,6 +63,31 @@ ALL_IMPLEMENTATION_STATE_LABELS = (STATE_IMPLEMENTATION_NO_GO, STATE_IMPLEMENTAT
 #: selected issues that also carry ``state:plan-go`` and have no open PR.
 STATE_SKIP = "state:skip"
 
+#: Marker keying the single skip-reason comment per issue (#2256). Every
+#: ``state:skip`` application upserts one comment starting with this marker so
+#: the reason survives outside ephemeral run logs.
+SKIP_REASON_MARKER = "<!-- hephaestus-state-skip-reason -->"
+
+
+def format_skip_reason_comment(reason: str) -> str:
+    """Render the marker-keyed comment body documenting a ``state:skip`` write.
+
+    Args:
+        reason: Human-readable explanation of why automation applied the label.
+
+    Returns:
+        The full comment body, starting with :data:`SKIP_REASON_MARKER`.
+
+    """
+    return (
+        f"{SKIP_REASON_MARKER}\n"
+        f"**Automation applied `state:skip`.**\n\n"
+        f"Reason: {reason}\n\n"
+        f"Remove the label to make the issue eligible for the automation loop "
+        f"again (see docs/runbooks/state-skip-revival.md)."
+    )
+
+
 #: Label names that mark a TRACKING issue (an epic / roadmap) rather than a code
 #: task. Epics and roadmaps are checklists of child work; the planning loop must
 #: not plan or implement them directly (their deliverable is a body edit, not a

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -203,6 +203,10 @@ class FakeStageGitHub(FakeGitHub):
         labels.difference_update(remove)
         self._log("edit_labels", issue_number, tuple(add), tuple(remove))
 
+    def upsert_issue_comment(self, issue_number: int, marker: str, body: str) -> None:
+        """Mirror the generic marker-keyed comment upsert (#2256)."""
+        self.gh_issue_upsert_comment(issue_number, marker, body)
+
     def upsert_plan_comment(self, issue_number: int, body: str) -> None:
         """Mirror the coordinator plan-comment upsert (PLAN_COMMENT_MARKER-keyed).
 

--- a/tests/unit/automation/pipeline/stages/test_stage_implementation.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_implementation.py
@@ -1050,7 +1050,10 @@ class TestCommitPushAndPrCreate:
 
         assert isinstance(result, StageOutcome)
         assert result.disposition == Disposition.SKIP
-        assert github.mutation_log == [("gh_issue_add_labels", (9, (STATE_SKIP,)))]
+        assert github.mutation_log == [
+            ("gh_issue_add_labels", (9, (STATE_SKIP,))),
+            ("gh_issue_upsert_comment", (9, "<!-- hephaestus-state-skip-reason -->")),
+        ]
 
     def test_skip_label_write_is_non_fatal(self, make_ctx: Any, make_work_item: Any) -> None:
         """A failing state:skip write never turns the SKIP into a crash."""

--- a/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_pr_review.py
@@ -936,6 +936,7 @@ class TestProgressAwareBudget:
             ("mark_pr_implementation_no_go", (1001,)),
             ("defer_auto_merge", (1001,)),
             ("gh_issue_add_labels", (12, (STATE_SKIP,))),
+            ("gh_issue_upsert_comment", (12, "<!-- hephaestus-state-skip-reason -->")),
         ]
         assert item.payload["pr_review_round"] == 3
 
@@ -969,7 +970,10 @@ class TestProgressAwareBudget:
         assert item.payload["pr_review_round"] == 5
         assert item.attempts["pr_review_iter"] == 5  # lifetime audit trail
         assert item.attempts["pr_review_hard"] == 2  # extension rounds 4 and 5
-        assert github.mutation_log[-1] == ("gh_issue_add_labels", (13, (STATE_SKIP,)))
+        assert github.mutation_log[-2:] == [
+            ("gh_issue_add_labels", (13, (STATE_SKIP,))),
+            ("gh_issue_upsert_comment", (13, "<!-- hephaestus-state-skip-reason -->")),
+        ]
 
     def test_hard_cap_stops_even_with_progress(self, make_ctx: Any, make_work_item: Any) -> None:
         """Round 6 is the absolute ceiling even while threads keep decreasing."""
@@ -1227,7 +1231,10 @@ class TestFullWalks:
         assert outcome.disposition == Disposition.SKIP
         assert outcome.note == "exhaustion"
         assert item.attempts["pr_review_iter"] == 3
-        assert github.mutation_log[-1] == ("gh_issue_add_labels", (22, (STATE_SKIP,)))
+        assert github.mutation_log[-2:] == [
+            ("gh_issue_add_labels", (22, (STATE_SKIP,))),
+            ("gh_issue_upsert_comment", (22, "<!-- hephaestus-state-skip-reason -->")),
+        ]
 
     def test_zero_thread_nogo_retries_without_skip(
         self, make_ctx: Any, make_work_item: Any
@@ -1368,7 +1375,10 @@ class TestFullWalks:
         assert "agent_error_failback" not in item.payload
         assert events[-1].action is ZeroThreadNogoAction.ESCALATE_SKIP
         assert not any(entry[0] == "mark_pr_implementation_no_go" for entry in github.mutation_log)
-        assert github.mutation_log[-1] == ("gh_issue_add_labels", (25, (STATE_SKIP,)))
+        assert github.mutation_log[-2:] == [
+            ("gh_issue_add_labels", (25, (STATE_SKIP,))),
+            ("gh_issue_upsert_comment", (25, "<!-- hephaestus-state-skip-reason -->")),
+        ]
 
     def test_zero_thread_nogo_comment_failure_still_retries(
         self, make_ctx: Any, make_work_item: Any

--- a/tests/unit/automation/test_github_api.py
+++ b/tests/unit/automation/test_github_api.py
@@ -2587,7 +2587,7 @@ class TestUpsertAndDeleteComment:
         self, mock_create: Any, _mock_fetch: Any, _mock_repo: Any
     ) -> None:
         rv = gh_issue_upsert_comment(5, "# Implementation Plan", "# Implementation Plan\nbody")
-        mock_create.assert_called_once_with(5, "# Implementation Plan\nbody")
+        mock_create.assert_called_once_with(5, "# Implementation Plan\nbody", repo=None)
         assert rv is None  # fresh create: id not parsed
 
     @patch("hephaestus.automation.github_api.get_repo_info", return_value=("o", "r"))


### PR DESCRIPTION
## Summary

`state:skip` removes an issue from all planning, but the reason previously lived only in run logs. Every apply site now upserts a single marker-keyed comment (`<!-- hephaestus-state-skip-reason -->`) stating why automation parked the issue and how to revive it:

- `write_skip_label(issue, ctx, reason)` — reason is now required; the three pipeline callers (pr_review round exhaustion, zero-thread NOGO escalation, implementation no-commits) each pass a specific explanation + revival hint.
- Both `skip_epics` chokepoints post the epic-exclusion reason. The module-level path threads `(owner, name)` through `gh_issue_comment` / `gh_issue_upsert_comment` (the #2245/#2248 repo-scoping pattern) so multi-repo comment writes can't land on the wrong repo.
- `pipeline_github.upsert_plan_comment` is generalized to `upsert_issue_comment(issue, marker, body)` (plan path delegates; StageGitHub protocol + fakes extended).
- Legacy `_review_phase` exhaustion site documents verdict + iteration count.

## Verification

Full unit suite: 5,929 passed, coverage 85.10% (gate 83%). Affected suites (stages, github_api, pipeline_github, state_labels, review_phase): 801 tests pass. Lint/format/mypy clean.

Closes #2256

🤖 Generated with [Claude Code](https://claude.com/claude-code)