### PR TITLE
[Docs] Bump MIGRATION.md to 0.10.0 for release

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,11 +1,15 @@
 # Migration Guide
 
-> **Status (as of 2026-07-03):** The latest released version is **0.9.9** (tag-driven
+> **Status (as of 2026-07-17):** The latest released version is **0.10.0** (tag-driven
 > via hatch-vcs). **1.0 has not been released yet** — the section below is the
 > *forthcoming* 1.0 migration guidance, published ahead of the cut so consumers can
-> prepare. There are currently **no breaking changes between 0.9.x releases**: upgrading
-> within the 0.9.x line requires no code changes for code that uses only the documented
-> public API in [`COMPATIBILITY.md`](../COMPATIBILITY.md). The `Development Status ::
+> prepare. 0.10.0's headline change is the queue pipeline's head-bound strict-review
+> merge gate (#2055): `state:implementation-go` is produced only by the strict_review
+> stage and `merge_wait` is the sole automatic armer. There are **no breaking changes
+> to the documented public API** from 0.9.x: upgrading requires no code changes for
+> code that uses only the documented public API in
+> [`COMPATIBILITY.md`](../COMPATIBILITY.md). Operators of the automation loop should
+> note `--max-merge-attempts` was replaced by `--drive-green-loops` (default 5). The `Development Status ::
 > 5 - Production/Stable` classifier in `pyproject.toml` reflects the maturity of the
 > stable public API surface, not a 1.0 tag; the package remains tag-driven and is
 > currently on the 0.9.x series.


### PR DESCRIPTION
Pre-release checklist item for v0.10.0 (docs/RELEASING.md): bump the latest-released-version line before tagging so the Release workflow migration-doc test passes (#1802 lesson). Notes the #2055 strict-review gate headline and the --drive-green-loops flag replacement.

Closes #2266

🤖 Generated with [Claude Code](https://claude.com/claude-code)