### PR TITLE
[Fix] Narrow strict-review lease before artifact publication (main lint red)

### DIFF
--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -508,6 +508,8 @@ class StrictReviewStage(Stage):
             "reconciling existing" if existing_go else "publishing fenced",
         )
         if not existing_go:
+            if lease is None:  # guarded above; kept for type narrowing
+                return Continue(next_state=HEAD_CHECK)
             try:
                 published_by_us = ctx.github.publish_strict_review_artifact(
                     pr_number, head_sha, verdict_text, is_go=True, lease=lease


### PR DESCRIPTION
main lint is red at 3ad1f25: the #2242 squash landed without the rebase-time mypy narrowing fix — _handle_go passes an Optional lease to publish_strict_review_artifact. Two-line explicit narrowing (stale job without its fencing token re-enters HEAD_CHECK). mypy clean; 28 strict-review stage tests pass.

Closes #2269

🤖 Generated with [Claude Code](https://claude.com/claude-code)