### PR TITLE
[Feat] Strict-review preconditions + operator bypass (two paths to implementation-go)

### DIFF
--- a/docs/AUTOMATION_LOOP_ARCHITECTURE.md
+++ b/docs/AUTOMATION_LOOP_ARCHITECTURE.md
@@ -352,7 +352,8 @@ Related: #1554 (original minor-thread deadlock this replaces), #1575
 
 ### 6. strict_review
 
-**States**: ENTER → HEAD_CHECK → WORKTREE_WAIT → REVIEW_WAIT → EVAL → FINISH.
+**States**: ENTER → HEAD_CHECK → WORKTREE_WAIT → (SR_REBASE_WAIT →
+SR_REBASE_PUSH_WAIT →) REVIEW_WAIT → EVAL → FINISH.
 
 **Steps**:
 
@@ -360,7 +361,13 @@ Related: #1554 (original minor-thread deadlock this replaces), #1575
    `state:implementation-go`, disable/readback auto-merge, then capture the
    live PR head. A previously captured head that changed is restarted from a
    fresh head check. A containment failure is terminal and fail-closed.
-2. [W:G] For a direct PR or a missing worktree, synchronize an isolated
+2. [M] Precondition gate (#2268): a strict review runs only on a
+   conflict-free head that is current with its base. `mergeable ==
+   CONFLICTING` fails back `merge_conflict` → implementation (a conflicting
+   mechanical pre-review rebase does the same); a merely-BEHIND head gets one
+   mechanical rebase+push (shared `rebase` lifetime budget) and re-enters
+   HEAD_CHECK so the reviewer judges the FINAL head.
+3. [W:G] For a direct PR or a missing worktree, synchronize an isolated
    worktree to the captured PR branch without refreshing it from the base
    branch. [W:A] Run an independent reviewer there in `sandbox="read-only"`,
    with a fresh per-head/per-attempt session and the expected remote SHA. The
@@ -370,19 +377,25 @@ Related: #1554 (original minor-thread deadlock this replaces), #1575
    review, and checks the head both before and after that fetch. Missing,
    malformed, oversized, or stale evidence is a fail-closed NOGO. All evidence
    is untrusted and nonce-fenced.
-3. [M] Re-read the head before publishing. A GO publishes an authenticated,
+4. [M] Re-read the head before publishing. A GO publishes an authenticated,
    exact-grammar artifact for that head, reads it back, then applies
    `state:implementation-go`; any publish/readback/label failure is terminal.
-4. [M] An explicit NOGO, infrastructure failure, or malformed verdict
+5. [M] An explicit NOGO, infrastructure failure, or malformed verdict
    publishes a head-bound NOGO invalidation, verifies auto-merge is disabled,
    records remediation, and fails back to a real implementation pass. It never
    loops through an adopted PR without implementation work. An orphan PR has
    no issue-bound implementation scope, so it remains fail-closed for manual
    remediation after containment.
 
-**Verdicts**: ADVANCE (current-head GO) → ci; FAIL_BACK (`nogo`) →
-implementation; RETRY (`head_changed`) → strict_review; containment failures
-finish failed.
+**Verdicts**: ADVANCE (current-head GO) → ci; FAIL_BACK (`nogo`,
+`merge_conflict`) → implementation; RETRY (`head_changed`) → strict_review;
+containment failures finish failed.
+
+**Operator bypass** (#2268, `--strict-review-bypass`): the second sanctioned
+path to `state:implementation-go`. REVIEW_WAIT skips the reviewer session and
+publishes a lease-fenced, head-bound GO artifact whose body records the
+bypass; the precondition gate, artifact grammar, single-producer and
+sole-armer invariants, and merge_wait revalidation are unchanged.
 
 **Budgets**: `strict_review_iter` = 1 per current-head attempt.
 
@@ -511,7 +524,7 @@ globally bounded.
 | plan_review | implementation | planning (nogo, default), finished(fail) on plan_cycles_exhausted | plan_review_iter=3, plan_cycles=2 |
 | implementation | pr_review | plan_review (plan_not_go), strict_review (already_implementation_go_pr), finished(fail) on exhaustion | implement=2, test_fix=1 |
 | pr_review | strict_review | implementation (agent_error), finished(fail) on human_blocked or failed disable verification, finished(skip) on exhaustion | pr_review_iter=3, pr_review_hard=6 |
-| strict_review | ci | implementation (nogo), strict_review (head_changed), finished(fail) on containment failure | strict_review_iter=1 |
+| strict_review | ci | implementation (nogo, merge_conflict), strict_review (head_changed), finished(fail) on containment failure | strict_review_iter=1 |
 | ci | merge_wait | implementation (fix_exhausted, missing_worktree), strict_review (not_implementation_go, not_strict_review_go), finished(fail) on no_pr or auto_merge_disable_failed | ci_fix=1, rebase=2 |
 | merge_wait | finished(pass) | strict_review on proof/head drift; finished(fail) on containment failure; existing merged PRs learn then pass | merge/poll bounded by routes |
 | finished | — | — | — |

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -200,6 +200,7 @@ class LoopConfig:
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
+    strict_review_bypass: bool = False
     run_pre_pr_tests: bool = False
     # ``model`` is the catch-all applied to every phase when set; per-phase
     # fields below take precedence over it.
@@ -312,6 +313,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "--nitpick",
         action="store_true",
         help="Pass --nitpick to review phases (reviewer emits nitpick comments)",
+    )
+    p.add_argument(
+        "--strict-review-bypass",
+        action="store_true",
+        help=(
+            "Operator bypass (#2268): accept an internal review GO as "
+            "state:implementation-go without an independent strict-review "
+            "session. The strict_review stage still claims the head-bound "
+            "lease and publishes a GO artifact recording the bypass, so "
+            "merge_wait revalidation and the single-producer/sole-armer "
+            "invariants are unchanged."
+        ),
     )
     p.add_argument(
         "--drive-green-all",
@@ -641,6 +654,7 @@ def _build_pipeline_config(
         no_advise=cfg.no_advise,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
+        strict_review_bypass=cfg.strict_review_bypass,
         include_bot_prs=True,
         include_all_authors=cfg.drive_green_all,
         run_pre_pr_tests=cfg.run_pre_pr_tests,
@@ -777,6 +791,7 @@ def main(argv: list[str] | None = None) -> int:
         no_advise=args.no_advise,
         nitpick=args.nitpick,
         drive_green_all=args.drive_green_all,
+        strict_review_bypass=args.strict_review_bypass,
         run_pre_pr_tests=args.run_pre_pr_tests,
         model=args.model,
         planner_model=args.planner_model,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -222,6 +222,9 @@ class PipelineConfig:
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
+    # Operator bypass (#2268): strict_review publishes a head-bound,
+    # lease-fenced GO artifact without a reviewer session.
+    strict_review_bypass: bool = False
     include_bot_prs: bool = True
     include_all_authors: bool = False
     # When False, the CI stage's pre-fix mechanical rebase is skipped and every
@@ -287,6 +290,9 @@ class _StageRunConfig:
     dry_run: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
+    # Operator bypass (#2268): strict_review publishes a head-bound,
+    # lease-fenced GO artifact without a reviewer session.
+    strict_review_bypass: bool = False
     include_bot_prs: bool = True
     include_all_authors: bool = False
     enable_mechanical_rebase: bool = True
@@ -432,6 +438,7 @@ class Coordinator:
             dry_run=config.dry_run,
             nitpick=config.nitpick,
             drive_green_all=config.drive_green_all,
+            strict_review_bypass=config.strict_review_bypass,
             include_bot_prs=config.include_bot_prs,
             include_all_authors=config.include_all_authors,
             enable_mechanical_rebase=config.enable_mechanical_rebase,

--- a/hephaestus/automation/pipeline/routing.py
+++ b/hephaestus/automation/pipeline/routing.py
@@ -132,6 +132,10 @@ ROUTES: dict[StageName, Route] = {
         next=StageName.CI,
         fail_routes={
             "nogo": StageName.IMPLEMENTATION,
+            # Precondition gate (#2268): unresolved conflicts (or a
+            # conflicting mechanical pre-review rebase) need a real
+            # implementation session before any strict review runs.
+            "merge_conflict": StageName.IMPLEMENTATION,
             "head_changed": StageName.STRICT_REVIEW,
             "*": StageName.STRICT_REVIEW,
         },

--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -69,6 +69,8 @@ from .base import (
     StepResult,
     StrictReviewLease,
     WorkItem,
+    _build_rebase_job,
+    _require_item_worktree,
     _terminal_pr_outcome,
     _worktree_path,
     agent_provider,
@@ -83,6 +85,8 @@ HEAD_CHECK = "HEAD_CHECK"
 WORKTREE_WAIT = "WORKTREE_WAIT"
 REVIEW_WAIT = "REVIEW_WAIT"
 EVAL = "EVAL"
+SR_REBASE_WAIT = "SR_REBASE_WAIT"
+SR_REBASE_PUSH_WAIT = "SR_REBASE_PUSH_WAIT"
 SR_FINISH = "SR_FINISH"
 FINISH = SR_FINISH
 
@@ -109,6 +113,17 @@ def parse_strict_review_verdict(text: str) -> ReviewVerdict:
     if match is None:
         return ReviewVerdict(grade=None, verdict="AMBIGUOUS", raw=text)
     return ReviewVerdict(grade=match.group(1), verdict=match.group(2), raw=text)
+
+
+def _record_rebase_job(item: WorkItem, result: JobResult) -> None:
+    """Consume the rebase budget and record the pre-review rebase result.
+
+    A failed push leaves the remote head unchanged; HEAD_CHECK re-classifies
+    the PR (still BEHIND -> budget-bounded retry or review as-is) (#2268).
+    """
+    if item.state == SR_REBASE_WAIT:
+        item.attempts["rebase"] = item.attempts.get("rebase", 0) + 1
+        item.payload["rebase_clean"] = bool(result.ok and result.value)
 
 
 def _issue_number(item: WorkItem) -> int:
@@ -251,6 +266,8 @@ class StrictReviewStage(Stage):
                 # of sending the reviewer to the shared repository root.
                 return StageOutcome(Disposition.FINISH_FAIL, "strict_review_worktree_unfinished")
             return Continue(next_state=HEAD_CHECK)
+        if item.state in (SR_REBASE_WAIT, SR_REBASE_PUSH_WAIT):
+            return self._rebase_leg(item, ctx)
         if item.state == REVIEW_WAIT:
             return self._review_wait(item, ctx)
         if item.state == EVAL:
@@ -317,7 +334,86 @@ class StrictReviewStage(Stage):
             # still in HEAD_CHECK, then transition through WORKTREE_WAIT.
             item.payload["strict_review_worktree_pending"] = True
             return JobRequest(worktree_job, on_done_state=WORKTREE_WAIT)
+        # Precondition gate (#2268): a strict review runs only on a
+        # conflict-free head that is current with its base. Conflicts need a
+        # real implementation session; a merely-BEHIND head gets ONE
+        # mechanical rebase+push first so the reviewer judges the FINAL head
+        # (this also removes the review -> ci-rebase -> head-change ->
+        # re-review churn of the pre-#2268 ordering).
+        item.payload["base_branch"] = str((pr_state or {}).get("baseRefName") or "main")
+        mergeable = str((pr_state or {}).get("mergeable") or "").upper()
+        merge_state = str((pr_state or {}).get("mergeStateStatus") or "").upper()
+        if mergeable == "CONFLICTING":
+            logger.info(
+                "strict_review:%s: PR #%d has unresolved merge conflicts; "
+                "routing to implementation before any strict review",
+                item.issue,
+                item.pr,
+            )
+            return StageOutcome(Disposition.FAIL_BACK, "merge_conflict")
+        if (
+            merge_state == "BEHIND"
+            and not ctx.dry_run
+            and item.attempts.get("rebase", 0) < ctx.budget("rebase")
+        ):
+            return Continue(next_state=SR_REBASE_WAIT)
         return Continue(next_state=REVIEW_WAIT)
+
+    def _rebase_leg(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """Dispatch the two pre-review rebase states (#2268)."""
+        if item.state == SR_REBASE_WAIT:
+            return self._request_rebase(item, ctx)
+        return self._request_rebase_push(item, ctx)
+
+    def _request_rebase(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """SR_REBASE_WAIT [W:G]: rebase a BEHIND head before it is reviewed.
+
+        Shares the ``rebase`` lifetime budget (consumed in ``on_job_done``)
+        and the mechanical rebase job with the ci/merge_wait stages, so the
+        pre-review rebase cannot loop unbounded (#2268).
+        """
+        if item.attempts.get("rebase", 0) >= ctx.budget("rebase"):
+            return Continue(next_state=REVIEW_WAIT)
+        missing_worktree = _require_item_worktree(item, "strict_review", "pre-review rebase")
+        if missing_worktree is not None:
+            return missing_worktree
+        item.payload.pop("rebase_clean", None)
+        return JobRequest(
+            _build_rebase_job(item, ctx, descr="strict_review_pre_rebase"),
+            on_done_state=SR_REBASE_PUSH_WAIT,
+        )
+
+    def _request_rebase_push(self, item: WorkItem, ctx: StageContext) -> StepResult:
+        """SR_REBASE_PUSH_WAIT [W:G]: push the clean pre-review rebase.
+
+        A conflicting mechanical rebase means the head cannot be made current
+        without a real implementation session — fail back ``merge_conflict``
+        rather than reviewing a stale head (#2268). The push lands the new
+        head; HEAD_CHECK then re-captures it (and re-syncs the reviewer
+        worktree) so the review binds to the FINAL head.
+        """
+        if not item.payload.pop("rebase_clean", None):
+            logger.info(
+                "strict_review:%s: mechanical pre-review rebase of PR #%d hit "
+                "conflicts; routing to implementation",
+                item.issue,
+                item.pr,
+            )
+            return StageOutcome(Disposition.FAIL_BACK, "merge_conflict")
+        missing_worktree = _require_item_worktree(item, "strict_review", "pre-review rebase push")
+        if missing_worktree is not None:
+            return missing_worktree
+        push_job = GitJob(
+            repo=item.repo,
+            op="push",
+            timeout_s=GIT_JOB_TIMEOUT_S,
+            kwargs={
+                "cwd": _worktree_path(item, ctx),
+                "branch": item.branch or None,
+            },
+            descr="push_strict_review_pre_rebase",
+        )
+        return JobRequest(push_job, on_done_state=HEAD_CHECK)
 
     def _review_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """REVIEW_WAIT [W:A]: submit the read-only, per-head/per-attempt review job."""
@@ -364,6 +460,28 @@ class StrictReviewStage(Stage):
                 return StageOutcome(Disposition.RETRY, "strict_review_lease_unavailable")
             item.payload["strict_review_lease_id"] = lease.lease_id
             item.payload["strict_review_lease_comment_id"] = lease.comment_id
+        if getattr(ctx.config, "strict_review_bypass", False):
+            # Operator bypass (#2268): the second sanctioned path to
+            # ``state:implementation-go``. The artifact stays lease-fenced
+            # and head-bound so the single-producer/sole-armer invariants and
+            # merge_wait revalidation are untouched; only the reviewer
+            # session is skipped, and the artifact records the bypass.
+            logger.warning(
+                "strict_review:%d: OPERATOR BYPASS (--strict-review-bypass) — "
+                "accepting internal review GO for PR #%d at head %s without "
+                "an independent strict review session",
+                issue,
+                item.pr,
+                head_sha[:12],
+            )
+            return self._handle_go(
+                item,
+                ctx,
+                head_sha,
+                "Strict review BYPASSED by operator (--strict-review-bypass): "
+                "internal review GO accepted without an independent strict "
+                "review session.\nGrade: C\nVerdict: GO",
+            )
         evidence = ctx.github.strict_review_evidence(item.pr, head_sha, item.issue)  # type: ignore[arg-type]
         if evidence is None or evidence.head_sha.lower() != head_sha.lower():
             logger.warning(
@@ -508,6 +626,8 @@ class StrictReviewStage(Stage):
             "reconciling existing" if existing_go else "publishing fenced",
         )
         if not existing_go:
+            if lease is None:  # guarded above; kept for type narrowing
+                return Continue(next_state=HEAD_CHECK)
             try:
                 published_by_us = ctx.github.publish_strict_review_artifact(
                     pr_number, head_sha, verdict_text, is_go=True, lease=lease
@@ -710,6 +830,9 @@ class StrictReviewStage(Stage):
             ctx: Stage context.
 
         """
+        if item.state in (SR_REBASE_WAIT, SR_REBASE_PUSH_WAIT):
+            _record_rebase_job(item, result)
+            return
         if item.payload.pop("strict_review_worktree_pending", None):
             if not result.ok:
                 logger.warning(

--- a/tests/unit/automation/pipeline/stages/test_reason_routes.py
+++ b/tests/unit/automation/pipeline/stages/test_reason_routes.py
@@ -47,7 +47,7 @@ _EXPECTED_REASONS: dict[StageName, set[str]] = {
     # its ROUTES row entry (-> FINISHED) documents the same destination.
     StageName.PR_REVIEW: {"agent_error"},
     # no_pr/timeout are emitted as FINISH_FAIL (terminal), not FAIL_BACK.
-    StageName.STRICT_REVIEW: {"nogo"},
+    StageName.STRICT_REVIEW: {"nogo", "merge_conflict"},
     StageName.CI: {"fix_exhausted", "not_implementation_go", "not_strict_review_go"},
     # #2054 terminalizes merge_wait; it emits no cross-stage FAIL_BACK reason.
     StageName.MERGE_WAIT: set(),

--- a/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
@@ -636,3 +636,191 @@ def test_missing_current_head_evidence_fails_closed_to_real_implementation(
         action == "publish_strict_review_artifact" and args[-1] is False
         for action, args in github.mutation_log
     )
+
+
+class _MergeStateGitHub(FakeStageGitHub):
+    """Report a fixed mergeable/mergeStateStatus alongside the live head."""
+
+    def __init__(self, *, mergeable: str = "MERGEABLE", merge_state: str = "CLEAN") -> None:
+        super().__init__()
+        self._mergeable = mergeable
+        self._merge_state = merge_state
+
+    def gh_pr_state(self, pr_number: int) -> dict[str, str]:
+        return {
+            "state": "OPEN",
+            "headRefOid": _OLD_HEAD,
+            "baseRefName": "main",
+            "mergeable": self._mergeable,
+            "mergeStateStatus": self._merge_state,
+        }
+
+
+def _synced_item(make_work_item: Any, **overrides: Any) -> Any:
+    """Build an item in HEAD_CHECK whose reviewer worktree is already synced."""
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state="HEAD_CHECK",
+        payload={
+            "strict_review_worktree_head": _OLD_HEAD,
+            **overrides.pop("payload", {}),
+        },
+        **overrides,
+    )
+    item.worktree = "/tmp/wt/601"
+    item.branch = "601-auto-impl"
+    return item
+
+
+class TestStrictReviewPreconditionGate:
+    """#2268: strict reviews run only on conflict-free, current heads."""
+
+    def test_conflicting_pr_fails_back_before_any_review(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Unresolved conflicts route to implementation, never to a reviewer."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        ctx = make_ctx(github=_MergeStateGitHub(mergeable="CONFLICTING"))
+        item = _synced_item(make_work_item)
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FAIL_BACK, "merge_conflict")
+
+    def test_behind_pr_rebases_before_review(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A BEHIND head gets the mechanical pre-review rebase leg first."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        ctx = make_ctx(github=_MergeStateGitHub(merge_state="BEHIND"))
+        item = _synced_item(make_work_item)
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == strict_review.SR_REBASE_WAIT
+
+        item.state = strict_review.SR_REBASE_WAIT
+        rebase_request = stage.step(item, ctx)
+        assert isinstance(rebase_request, JobRequest)
+        assert isinstance(rebase_request.job, GitJob)
+        assert rebase_request.job.op == "rebase"
+        assert rebase_request.on_done_state == strict_review.SR_REBASE_PUSH_WAIT
+        assert item.payload["base_branch"] == "main"
+
+    def test_current_clean_pr_proceeds_to_review(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A mergeable, current head reaches REVIEW_WAIT unchanged."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        ctx = make_ctx(github=_MergeStateGitHub())
+        item = _synced_item(make_work_item)
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == strict_review.REVIEW_WAIT
+
+    def test_conflicting_mechanical_rebase_routes_to_implementation(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """A rebase that hit conflicts must not review the stale head."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        ctx = make_ctx(github=_MergeStateGitHub(merge_state="BEHIND"))
+        item = _synced_item(make_work_item)
+        item.state = strict_review.SR_REBASE_PUSH_WAIT  # no rebase_clean flag
+
+        result = stage.step(item, ctx)
+
+        assert result == StageOutcome(Disposition.FAIL_BACK, "merge_conflict")
+
+    def test_clean_rebase_pushes_then_recaptures_head(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """The pushed rebase re-enters HEAD_CHECK so the review binds the new head."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        ctx = make_ctx(github=_MergeStateGitHub(merge_state="BEHIND"))
+        item = _synced_item(make_work_item, payload={"rebase_clean": True})
+        item.state = strict_review.SR_REBASE_PUSH_WAIT
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, GitJob)
+        assert result.job.op == "push"
+        assert result.on_done_state == strict_review.HEAD_CHECK
+
+    def test_rebase_budget_spent_reviews_as_is(self, make_ctx: Any, make_work_item: Any) -> None:
+        """A budget-exhausted BEHIND head is reviewed rather than looped."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        ctx = make_ctx(github=_MergeStateGitHub(merge_state="BEHIND"))
+        item = _synced_item(make_work_item)
+        item.attempts["rebase"] = 2  # ROUTES lifetime budget
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == strict_review.REVIEW_WAIT
+
+
+class TestStrictReviewBypass:
+    """#2268: the operator bypass is the second path to implementation-go."""
+
+    def test_bypass_publishes_fenced_go_without_reviewer_session(
+        self, make_ctx: Any, make_work_item: Any
+    ) -> None:
+        """Bypass claims the lease, publishes a head-bound GO, applies the label."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        github = _MergeStateGitHub()
+        ctx = make_ctx(github=github)
+        ctx.config.strict_review_bypass = True
+        item = _synced_item(make_work_item, payload={"strict_review_head": _OLD_HEAD})
+        item.state = strict_review.REVIEW_WAIT
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, Continue)
+        assert result.next_state == strict_review.SR_FINISH
+        published = github.strict_review_artifact(601, _OLD_HEAD)
+        assert published is not None and published.is_go
+        publish_entries = [
+            e for e in github.mutation_log if e[0] == "publish_strict_review_artifact"
+        ]
+        assert len(publish_entries) == 1
+        assert "BYPASSED by operator" in str(publish_entries[0][1][2])
+        assert ("mark_pr_implementation_go", (601,)) in github.mutation_log
+
+    def test_no_bypass_still_dispatches_reviewer(self, make_ctx: Any, make_work_item: Any) -> None:
+        """Without the flag the reviewer AgentJob path is unchanged."""
+        import hephaestus.automation.pipeline.stages.strict_review as strict_review
+
+        stage = strict_review.StrictReviewStage()
+        github = _MergeStateGitHub()
+        github._strict_evidence = StrictReviewEvidence(
+            head_sha=_OLD_HEAD,
+            issue_title="t",
+            issue_body="b",
+            diff="d",
+            ci_status="green",
+            prior_pr_review_verdict="GO",
+        )
+        ctx = make_ctx(github=github)
+        item = _synced_item(make_work_item, payload={"strict_review_head": _OLD_HEAD})
+        item.state = strict_review.REVIEW_WAIT
+
+        result = stage.step(item, ctx)
+
+        assert isinstance(result, JobRequest)
+        assert isinstance(result.job, AgentJob)
+        assert result.job.sandbox == "read-only"

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -166,6 +166,16 @@ def test_build_pipeline_config_maps_drive_green_phase_to_ci_scope(
     )
 
 
+def test_build_pipeline_config_maps_strict_review_bypass(
+    dispatch: dict[str, MagicMock],
+) -> None:
+    """The operator bypass flag must reach the pipeline config (#2268)."""
+    loop_runner.main(["--strict-review-bypass"])
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.strict_review_bypass is True
+
+
 def test_build_pipeline_config_maps_drive_green_loops_to_budget(
     dispatch: dict[str, MagicMock],
 ) -> None:

--- a/tests/unit/automation/pipeline/test_routing.py
+++ b/tests/unit/automation/pipeline/test_routing.py
@@ -200,6 +200,7 @@ class TestROUTES:
                 next=StageName.CI,
                 fail_routes={
                     "nogo": StageName.IMPLEMENTATION,
+                    "merge_conflict": StageName.IMPLEMENTATION,
                     "head_changed": StageName.STRICT_REVIEW,
                     "*": StageName.STRICT_REVIEW,
                 },

--- a/tests/unit/automation/pipeline/test_routing_properties.py
+++ b/tests/unit/automation/pipeline/test_routing_properties.py
@@ -48,6 +48,10 @@ _REASON_BUDGET: dict[str, str | None] = {
     "plan_not_go": None,
     "already_implementation_go_pr": None,
     "head_changed": None,
+    # #2268 precondition gate: the route itself consumes no budget (the
+    # mechanical pre-review rebase consumes the shared "rebase" budget in
+    # strict_review.on_job_done).
+    "merge_conflict": None,
     "agent_error": None,
     "human_blocked": None,
     "exhaustion": None,

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -664,6 +664,16 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "Pass --nitpick to review phases (reviewer emits nitpick comments)",
         ),
         _store_true(
+            "--strict-review-bypass",
+            "strict_review_bypass",
+            "Operator bypass (#2268): accept an internal review GO as "
+            "state:implementation-go without an independent strict-review "
+            "session. The strict_review stage still claims the head-bound "
+            "lease and publishes a GO artifact recording the bypass, so "
+            "merge_wait revalidation and the single-producer/sole-armer "
+            "invariants are unchanged.",
+        ),
+        _store_true(
             "--drive-green-all",
             "drive_green_all",
             "Pass --all to the drive-green phase: drive every open PR, including those "

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -132,6 +132,12 @@ def test_parse_args_accepts_github_throttle_options() -> None:
     assert args.gh_global_burst == 11.0
 
 
+def test_parse_args_accepts_strict_review_bypass() -> None:
+    """--strict-review-bypass is parsed; default is False (#2268)."""
+    assert loop_runner._parse_args(["--strict-review-bypass"]).strict_review_bypass is True
+    assert loop_runner._parse_args([]).strict_review_bypass is False
+
+
 def test_parse_args_accepts_drive_green_loops() -> None:
     """--drive-green-loops is parsed; default is 5 (#2246, was --max-merge-attempts #1560)."""
     assert loop_runner._parse_args(["--drive-green-loops", "3"]).drive_green_loops == 3


### PR DESCRIPTION
## Summary

Implements the two-path `state:implementation-go` policy (#2268):

**Path 1 (default):** internal review GO → precondition gate → strict review GO.
- New HEAD_CHECK gate: `mergeable == CONFLICTING` fails back `merge_conflict` → implementation (new ROUTES fail route) before any reviewer session is spent; a BEHIND head gets one mechanical rebase+push (shared `rebase` lifetime budget; new `SR_REBASE_WAIT`/`SR_REBASE_PUSH_WAIT` states) and re-enters HEAD_CHECK so the reviewer binds to the **final** head. A conflicting mechanical rebase also routes to implementation.
- This removes the shipped review → ci-rebase → head-change → re-review churn.
- A strict GO for a head stays terminal (existing durable-artifact reconciliation; pinned by tests).

**Path 2 (operator):** internal review GO + `--strict-review-bypass`.
- New loop flag threaded CLI → `PipelineConfig` → stage config. REVIEW_WAIT skips the reviewer session but still claims the head-bound lease and publishes a GO artifact recording the bypass — single-producer/sole-armer invariants, artifact grammar, and merge_wait revalidation unchanged and auditable.

Also includes the `_handle_go` lease narrowing (same two lines as hotfix #2270; dedupes on rebase) and updates the architecture doc (states, steps, verdicts, ROUTES table), routing pin/property/reason-lock tests, and parser spec.

## Verification

Full unit suite: 6,034 passed, 84.63% coverage. New tests: conflict fail-back, BEHIND rebase leg, conflicted-rebase routing, clean-rebase push→HEAD_CHECK, budget-exhausted review-as-is, bypass publishes fenced GO without an AgentJob, non-bypass dispatches the read-only reviewer. Lint/format/mypy clean.

Closes #2268

🤖 Generated with [Claude Code](https://claude.com/claude-code)