### PR TITLE
[mino] Make just audit use the configured audit policy

### DIFF
--- a/.pip-audit-ignore.txt
+++ b/.pip-audit-ignore.txt
@@ -1,0 +1,9 @@
+# pip-audit suppression policy, consumed by `hephaestus-filter-audit`
+# (see hephaestus/validation/audit.py). One advisory ID per line;
+# `#` starts a comment.
+#
+# Carried over from the inline `--ignore-vuln` flag (introduced in #425,
+# preserved through the uv migration in #2236). No longer fires in the
+# uv-managed environment; retained for parity with the CI workflows'
+# inline suppression until those are migrated.
+PYSEC-2025-183

--- a/justfile
+++ b/justfile
@@ -64,9 +64,10 @@ precommit:
 # Run lint + format-check + typecheck
 check: lint format-check typecheck
 
-# Run pip-audit to check for known dependency vulnerabilities
+# Audit dependencies for known vulnerabilities via the configured policy
+# (hephaestus-filter-audit + .pip-audit-ignore.txt)
 audit:
-    uv run pip-audit --ignore-vuln PYSEC-2025-183
+    uv run pip-audit --format json | uv run hephaestus-filter-audit
 
 # Generate API reference documentation with pdoc (output: docs/api/)
 docs:

--- a/tests/shell/justfile/test_justfile.bats
+++ b/tests/shell/justfile/test_justfile.bats
@@ -80,6 +80,19 @@ JUSTFILE="${REPO_ROOT}/justfile"
     [[ "$output" == *"all "* ]] || [[ "$output" == *"all"$'\n'* ]]
 }
 
+@test "justfile contains 'audit' recipe" {
+    run just --justfile "$JUSTFILE" --list
+    [[ "$output" == *"audit"* ]]
+}
+
+@test "'audit' recipe pipes pip-audit through hephaestus-filter-audit" {
+    run grep -A1 '^audit:' "$JUSTFILE"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pip-audit --format json"* ]]
+    [[ "$output" == *"hephaestus-filter-audit"* ]]
+    [[ "$output" != *"--ignore-vuln"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # No heredocs (regression guard — known pitfall with just)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
All changes are in place, no backup/temp files. Done.

## Summary

Routed `just audit` through the repo's configured audit policy (`hephaestus-filter-audit` + `.pip-audit-ignore.txt`) instead of raw `pip-audit` with an inline `--ignore-vuln` flag.

**Changes:**
- **`.pip-audit-ignore.txt`** (new, repo root) — suppression policy file consumed by `load_ignore_list()`'s default path (`hephaestus/validation/audit.py:66-68`); carries `PYSEC-2025-183` with provenance comment.
- **`justfile:67-70`** — `audit` recipe now pipes `uv run pip-audit --format json | uv run hephaestus-filter-audit`.
- **`tests/shell/justfile/test_justfile.bats`** — two new tests: `audit` recipe present in `--list`, and recipe body wires the filter pipeline with no `--ignore-vuln`.

**Tests run (all pass):**
- `just audit` → `pip-audit: ignoring 1 advisory ID(s)` then `no vulnerabilities found`, exit 0 — proves the policy file is read.
- `bats tests/shell/justfile/test_justfile.bats` → 16/16 ok.
- `uv run pytest tests/unit/validation/test_audit.py` → 39 passed.
- `load_ignore_list()` end-to-end → `frozenset({'PYSEC-2025-183'})`.

The single-file pytest run reports a coverage-gate FAIL (4.10% whole-tree) — expected artifact of running one test file, not a regression; CI runs the full suite. CI workflow suppressions were left out of scope per the plan (changing their semantics would weaken the CI gate and needs its own issue).


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2167

Generated by Hephaestus automation
