### PR TITLE
fix(automation): narrow strict-review lease publication

### DIFF
--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -508,6 +508,7 @@ class StrictReviewStage(Stage):
             "reconciling existing" if existing_go else "publishing fenced",
         )
         if not existing_go:
+            assert lease is not None  # noqa: S101  # narrowed by guard above
             try:
                 published_by_us = ctx.github.publish_strict_review_artifact(
                     pr_number, head_sha, verdict_text, is_go=True, lease=lease

--- a/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
@@ -425,6 +425,30 @@ def test_go_publishes_and_authenticates_artifact_before_applying_go_label(
     )
 
 
+def test_go_without_a_durable_lease_restarts_without_publishing_or_labeling(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A restored GO result without its fence cannot mutate PR-wide state."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = _ArtifactPublishingGitHub(pr_state={"state": "OPEN", "headRefOid": _NEW_HEAD})
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.EVAL,
+        payload={
+            "strict_review_head": _NEW_HEAD,
+            "strict_review_verdict": "GO",
+            "strict_review_text": "Grade: A\nVerdict: GO",
+        },
+    )
+
+    assert strict_review.StrictReviewStage().step(item, make_ctx(github=github)) == Continue(
+        next_state=strict_review.HEAD_CHECK
+    )
+    assert not any(action == "publish_strict_review_artifact" for action, _ in github.mutation_log)
+    assert not any(action == "mark_pr_implementation_go" for action, _ in github.mutation_log)
+
+
 def test_nogo_head_drift_restarts_without_applying_stale_feedback(
     make_ctx: Any, make_work_item: Any
 ) -> None:


### PR DESCRIPTION
## Summary

- narrow the fenced strict-review lease before publishing a GO artifact
- retain the existing fail-closed restart when a restored result lacks its lease
- restore the required mypy check on main

## Testing

- uv run --all-extras pytest tests/unit -q
- uv run --all-extras mypy hephaestus/ scripts/ tests/
- uv run --all-extras ruff check hephaestus/automation/pipeline/stages/strict_review.py tests/unit/automation/pipeline/stages/test_stage_strict_review.py

Closes #2269