### PR TITLE
fix(automation): defer strict review while CI is pending

### DIFF
--- a/hephaestus/automation/pipeline/stages/__init__.py
+++ b/hephaestus/automation/pipeline/stages/__init__.py
@@ -14,6 +14,7 @@ from .base import (
     StageOutcome,
     StepResult,
     StrictReviewArtifact,
+    StrictReviewCIState,
     StrictReviewEvidence,
     StrictReviewLease,
 )
@@ -44,6 +45,7 @@ __all__ = [
     "StageOutcome",
     "StepResult",
     "StrictReviewArtifact",
+    "StrictReviewCIState",
     "StrictReviewEvidence",
     "StrictReviewLease",
     "StrictReviewStage",

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -54,7 +54,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol, TypeAlias, runtime_checkable
+from typing import Any, Literal, Protocol, TypeAlias, runtime_checkable
 
 from hephaestus.agents.runtime import DEFAULT_AGENT
 from hephaestus.automation.state_labels import STATE_SKIP
@@ -84,6 +84,7 @@ __all__ = [
     "StageOutcome",
     "StepResult",
     "StrictReviewArtifact",
+    "StrictReviewCIState",
     "StrictReviewEvidence",
     "StrictReviewLease",
     "WorkItem",
@@ -132,6 +133,22 @@ class StrictReviewEvidence:
     diff: str
     ci_status: str
     prior_pr_review_verdict: str
+
+
+@dataclass(frozen=True)
+class StrictReviewCIState:
+    """Head-bound required-CI readiness for the strict-review gate.
+
+    A strict reviewer may run only when ``status`` is ``"ready"``.  A
+    ``"pending"`` result timer-parks before a lease exists, while a
+    ``"stale_head"`` result restarts the head-bound state machine.  Adapters
+    raise on unreadable policy or check state so callers fail closed instead
+    of conflating an error with an empty check list.
+    """
+
+    status: Literal["ready", "pending", "stale_head"]
+    ci_status: str = ""
+    pending_check_names: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -387,8 +404,20 @@ class StageGitHub(Protocol):
         """
         pass
 
+    def strict_review_ci_state(self, pr_number: int, head_sha: str) -> StrictReviewCIState:
+        """Return current-head strict-review CI readiness.
+
+        This is intentionally distinct from
+        :meth:`pending_required_check_names`, whose legacy empty-list
+        contract cannot distinguish a fresh GitHub ``no checks reported``
+        response from a repository with no required CI.  The strict gate
+        must make that distinction before it creates a lease or dispatches a
+        reviewer.
+        """
+        ...
+
     def strict_review_evidence(
-        self, pr_number: int, head_sha: str, issue_number: int
+        self, pr_number: int, head_sha: str, issue_number: int, *, ci_status: str | None = None
     ) -> StrictReviewEvidence | None:
         """Return bounded evidence still bound to ``head_sha``, else ``None``.
 
@@ -398,7 +427,10 @@ class StageGitHub(Protocol):
         head both before and after the read; stages fail closed when it is
         unavailable.  The linked issue title/body are part of this evidence:
         without the task requirements, a reviewer cannot judge whether the
-        diff fulfils the work it is about to authorize for merge.
+        diff fulfils the work it is about to authorize for merge.  The stage
+        supplies its just-read ``ci_status`` snapshot after the head-bound
+        readiness gate; callers that omit it cause the adapter to obtain one
+        and fail closed unless CI is ready.
         """
         ...
 

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -414,7 +414,7 @@ class StageGitHub(Protocol):
         must make that distinction before it creates a lease or dispatches a
         reviewer.
         """
-        ...
+        pass
 
     def strict_review_evidence(
         self, pr_number: int, head_sha: str, issue_number: int, *, ci_status: str | None = None

--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -67,6 +67,7 @@ from .base import (
     StageContext,
     StageOutcome,
     StepResult,
+    StrictReviewCIState,
     StrictReviewLease,
     WorkItem,
     _terminal_pr_outcome,
@@ -319,9 +320,52 @@ class StrictReviewStage(Stage):
             return JobRequest(worktree_job, on_done_state=WORKTREE_WAIT)
         return Continue(next_state=REVIEW_WAIT)
 
+    def _strict_review_ci_state(
+        self, item: WorkItem, ctx: StageContext, pr_number: int, head_sha: str
+    ) -> StrictReviewCIState | StepResult:
+        """Return ready CI state or the safe outcome for a non-ready snapshot."""
+        try:
+            ci_state = ctx.github.strict_review_ci_state(pr_number, head_sha)
+        except Exception as e:
+            logger.warning(
+                "strict_review:%s: could not read required CI status for PR #%d: %s",
+                item.issue,
+                pr_number,
+                e,
+            )
+            item.payload["retry_delay_s"] = 30
+            return StageOutcome(Disposition.RETRY, "strict_review_ci_unavailable")
+        if ci_state.status == "stale_head":
+            # The readiness read fences the same head before and after its
+            # policy/check snapshot.  It has not acquired a lease or changed
+            # remote state, so restart cleanly through HEAD_CHECK.
+            return Continue(next_state=HEAD_CHECK)
+        if ci_state.status == "pending":
+            logger.info(
+                "strict_review:%s: required CI still pending for PR #%d: %s",
+                item.issue,
+                pr_number,
+                ", ".join(ci_state.pending_check_names),
+            )
+            item.payload["retry_delay_s"] = 30
+            return StageOutcome(Disposition.RETRY, "strict_review_ci_pending")
+        if ci_state.status != "ready":
+            logger.warning(
+                "strict_review:%s: invalid required-CI readiness %r for PR #%d",
+                item.issue,
+                ci_state.status,
+                pr_number,
+            )
+            item.payload["retry_delay_s"] = 30
+            return StageOutcome(Disposition.RETRY, "strict_review_ci_unavailable")
+        return ci_state
+
     def _review_wait(self, item: WorkItem, ctx: StageContext) -> StepResult:
         """REVIEW_WAIT [W:A]: submit the read-only, per-head/per-attempt review job."""
         issue = _issue_number(item)
+        pr_number = item.pr
+        if pr_number is None:  # guarded by step(); preserve protocol narrowing
+            return StageOutcome(Disposition.FAIL_BACK, "nogo")
         head_sha = str(item.payload.get("strict_review_head") or "")
         if not head_sha:
             # Guarded by HEAD_CHECK; restart-safety fallback.
@@ -330,39 +374,22 @@ class StrictReviewStage(Stage):
         # inspected before claiming a lease so a durable NOGO is not confused
         # with a competing live lease and retried forever.  GO remains
         # merge-authorized only through the v2 GO-only accessor below.
-        terminal = ctx.github.strict_review_terminal_artifact(item.pr, head_sha)  # type: ignore[arg-type]
+        terminal = ctx.github.strict_review_terminal_artifact(pr_number, head_sha)
         if terminal is not None and not terminal.is_go:
             return self._resume_terminal_nogo(item, ctx, head_sha, terminal.verdict_body)
         # A prior durable v2 GO can survive a coordinator restart.  It is
         # already globally elected and authenticated by the accessor, so no
         # second reviewer may be dispatched merely to recreate its label.
-        existing_go = ctx.github.strict_review_artifact(item.pr, head_sha)  # type: ignore[arg-type]
+        existing_go = ctx.github.strict_review_artifact(pr_number, head_sha)
         if existing_go is not None:
             item.payload["strict_review_existing_go"] = True
             item.payload["strict_review_verdict"] = "GO"
             item.payload["strict_review_text"] = ""
             item.payload.pop("strict_review_failed", None)
             return Continue(next_state=EVAL)
-        try:
-            pending_checks = ctx.github.pending_required_check_names(item.pr)  # type: ignore[arg-type]
-        except Exception as e:
-            logger.warning(
-                "strict_review:%s: could not read required CI status for PR #%d: %s",
-                item.issue,
-                item.pr,
-                e,
-            )
-            item.payload["retry_delay_s"] = 30
-            return StageOutcome(Disposition.RETRY, "strict_review_ci_unavailable")
-        if pending_checks:
-            logger.info(
-                "strict_review:%s: required CI still pending for PR #%d: %s",
-                item.issue,
-                item.pr,
-                ", ".join(pending_checks),
-            )
-            item.payload["retry_delay_s"] = 30
-            return StageOutcome(Disposition.RETRY, "strict_review_ci_pending")
+        ci_state = self._strict_review_ci_state(item, ctx, pr_number, head_sha)
+        if not isinstance(ci_state, StrictReviewCIState):
+            return ci_state
         lease = self._lease_from_payload(item)
         if lease is None:
             try:
@@ -384,7 +411,9 @@ class StrictReviewStage(Stage):
                 return StageOutcome(Disposition.RETRY, "strict_review_lease_unavailable")
             item.payload["strict_review_lease_id"] = lease.lease_id
             item.payload["strict_review_lease_comment_id"] = lease.comment_id
-        evidence = ctx.github.strict_review_evidence(item.pr, head_sha, item.issue)  # type: ignore[arg-type]
+        evidence = ctx.github.strict_review_evidence(
+            pr_number, head_sha, issue, ci_status=ci_state.ci_status
+        )
         if evidence is None or evidence.head_sha.lower() != head_sha.lower():
             logger.warning(
                 "strict_review:%s: current-head evidence unavailable for PR #%d; invalidating",

--- a/hephaestus/automation/pipeline/stages/strict_review.py
+++ b/hephaestus/automation/pipeline/stages/strict_review.py
@@ -343,6 +343,26 @@ class StrictReviewStage(Stage):
             item.payload["strict_review_text"] = ""
             item.payload.pop("strict_review_failed", None)
             return Continue(next_state=EVAL)
+        try:
+            pending_checks = ctx.github.pending_required_check_names(item.pr)  # type: ignore[arg-type]
+        except Exception as e:
+            logger.warning(
+                "strict_review:%s: could not read required CI status for PR #%d: %s",
+                item.issue,
+                item.pr,
+                e,
+            )
+            item.payload["retry_delay_s"] = 30
+            return StageOutcome(Disposition.RETRY, "strict_review_ci_unavailable")
+        if pending_checks:
+            logger.info(
+                "strict_review:%s: required CI still pending for PR #%d: %s",
+                item.issue,
+                item.pr,
+                ", ".join(pending_checks),
+            )
+            item.payload["retry_delay_s"] = 30
+            return StageOutcome(Disposition.RETRY, "strict_review_ci_pending")
         lease = self._lease_from_payload(item)
         if lease is None:
             try:

--- a/hephaestus/automation/pipeline_github.py
+++ b/hephaestus/automation/pipeline_github.py
@@ -29,6 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from urllib.parse import quote
 from uuid import uuid4
 
 from hephaestus.automation import github_api, pr_manager
@@ -49,6 +50,7 @@ from hephaestus.automation.ci_check_inspector import CICheckInspector
 from hephaestus.automation.git_utils import issue_auto_impl_branch_name
 from hephaestus.automation.pipeline.stages.base import (
     StrictReviewArtifact,
+    StrictReviewCIState,
     StrictReviewEvidence,
     StrictReviewLease,
 )
@@ -109,6 +111,9 @@ _STRICT_REVIEW_MAX_ISSUE_BODY_BYTES = 80_000
 _NO_PRIOR_AUTOMATED_REVIEW = "No authenticated prior PR-review verdict is available."
 _PR_REVIEW_VERDICT_RE = re.compile(r"(?m)^Verdict:\s*(?:GO|NOGO)\s*$")
 _STRICT_REVIEW_LEASE_TTL_S = 3_600
+# This is the strict gate's own post-artifact authorization context.  It must
+# never be a prerequisite of the reviewer that creates its artifact.
+_STRICT_REVIEW_PROOF_CONTEXT = "strict-review-proof"
 
 
 def _split_threads(threads: list[dict[str, Any]]) -> tuple[int, int]:
@@ -700,7 +705,7 @@ class PipelineGitHub:
         return _NO_PRIOR_AUTOMATED_REVIEW
 
     def strict_review_evidence(  # noqa: C901 - every evidence channel must fail closed independently.
-        self, pr_number: int, head_sha: str, issue_number: int
+        self, pr_number: int, head_sha: str, issue_number: int, *, ci_status: str | None = None
     ) -> StrictReviewEvidence | None:
         """Fetch complete, bounded strict-review evidence for one exact head.
 
@@ -759,8 +764,12 @@ class PipelineGitHub:
             if len(diff.encode("utf-8")) > _STRICT_REVIEW_MAX_DIFF_BYTES:
                 return None
 
-            ci_status = self._strict_review_ci_status(self.pr_checks(pr_number))
             if ci_status is None:
+                ci_state = self.strict_review_ci_state(pr_number, normalized_head)
+                if ci_state.status != "ready":
+                    return None
+                ci_status = ci_state.ci_status
+            if not ci_status:
                 return None
 
             confirmed = self.gh_pr_state(pr_number)
@@ -1009,6 +1018,379 @@ class PipelineGitHub:
             required = [c for c in checks if c.get("required")] or checks
             return [c.get("name", "") for c in required if c.get("status") != "completed"]
         return self._inspector.pending_required_check_names(pr_number)
+
+    @staticmethod
+    def _required_bindings_from_rule(rule: dict[str, Any]) -> set[tuple[str, int]]:
+        """Validate one effective required-status-check rule's bindings."""
+        bindings: set[tuple[str, int]] = set()
+        parameters = rule.get("parameters")
+        if not isinstance(parameters, dict):
+            raise ValueError("required-status-check rule had no parameter object")
+        checks = parameters.get("required_status_checks")
+        if not isinstance(checks, list):
+            raise ValueError("required-status-check rule had no check list")
+        for check in checks:
+            if not isinstance(check, dict):
+                raise ValueError("required-status-check rule contained a non-object check")
+            context = check.get("context")
+            integration_id = check.get("integration_id")
+            if not isinstance(context, str) or not context.strip():
+                raise ValueError("required-status-check rule contained an invalid context")
+            if isinstance(integration_id, bool) or not isinstance(integration_id, int):
+                raise ValueError("required-status-check rule contained an invalid integration id")
+            bindings.add((context, integration_id))
+        return bindings
+
+    @classmethod
+    def _required_bindings_from_rule_pages(cls, pages: object) -> set[tuple[str, int]]:
+        """Validate paginated effective rules and retain each app binding."""
+        if not isinstance(pages, list):
+            raise ValueError("effective branch rules response was not a page list")
+        bindings: set[tuple[str, int]] = set()
+        for page in pages:
+            if not isinstance(page, list):
+                raise ValueError("effective branch rules response contained a non-list page")
+            for rule in page:
+                if not isinstance(rule, dict):
+                    raise ValueError("effective branch rules response contained a non-object rule")
+                if rule.get("type") == "required_status_checks":
+                    bindings.update(cls._required_bindings_from_rule(rule))
+        return bindings
+
+    @staticmethod
+    def _required_bindings_from_classic_protection(payload: object) -> set[tuple[str, int]]:
+        """Validate classic branch-protection contexts and their app bindings."""
+        if not isinstance(payload, dict):
+            raise ValueError("classic required-status-check response was not an object")
+        checks = payload.get("checks")
+        if not isinstance(checks, list):
+            raise ValueError("classic required-status-check response had no check list")
+        bindings: set[tuple[str, int]] = set()
+        for check in checks:
+            if not isinstance(check, dict):
+                raise ValueError(
+                    "classic required-status-check response contained a non-object check"
+                )
+            context = check.get("context")
+            app_id = check.get("app_id")
+            if not isinstance(context, str) or not context.strip():
+                raise ValueError(
+                    "classic required-status-check response contained an invalid context"
+                )
+            if isinstance(app_id, bool) or not isinstance(app_id, int):
+                raise ValueError(
+                    "classic required-status-check response contained an invalid app id"
+                )
+            bindings.add((context, app_id))
+        return bindings
+
+    @classmethod
+    def _required_bindings_from_branch(cls, payload: object) -> set[tuple[str, int]]:
+        """Extract classic status-check bindings from the readable branch snapshot."""
+        if not isinstance(payload, dict):
+            raise ValueError("branch snapshot was not an object")
+        protected = payload.get("protected")
+        protection = payload.get("protection")
+        if not isinstance(protected, bool):
+            raise ValueError("branch snapshot had no protected flag")
+        if not protected:
+            return set()
+        if not isinstance(protection, dict):
+            raise ValueError("protected branch snapshot had no protection object")
+        enabled = protection.get("enabled")
+        if not isinstance(enabled, bool):
+            raise ValueError("branch protection snapshot had no enabled flag")
+        if not enabled:
+            return set()
+        required_status_checks = protection.get("required_status_checks")
+        if required_status_checks is None:
+            return set()
+        return cls._required_bindings_from_classic_protection(required_status_checks)
+
+    def _strict_review_required_bindings(self, base_ref: str) -> set[tuple[str, int]]:
+        """Read the live union of classic/effective required check bindings.
+
+        ``rules/branches/{base}`` already contains every inherited and
+        repository ruleset that applies to the base branch.  The readable
+        branch snapshot exposes classic requirements without treating an
+        access-masked branch-protection 404 as an empty policy.
+        """
+        if self._repo_slug is None:
+            raise RuntimeError("strict-review CI readiness requires a repo-scoped adapter")
+        encoded_base = quote(base_ref, safe="")
+        rules_result = gh_call(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{self._repo_slug}/rules/branches/{encoded_base}?per_page=100",
+            ]
+        )
+        rule_pages = json.loads(rules_result.stdout or "[]")
+        bindings = self._required_bindings_from_rule_pages(rule_pages)
+        branch_result = gh_call(["api", f"repos/{self._repo_slug}/branches/{encoded_base}"])
+        branch = json.loads(branch_result.stdout or "{}")
+        bindings.update(self._required_bindings_from_branch(branch))
+        return bindings
+
+    @staticmethod
+    def _normalize_strict_review_check_run(raw_run: object) -> dict[str, Any]:
+        """Validate one app-identified Check Runs API record."""
+        if not isinstance(raw_run, dict):
+            raise ValueError("check-run response contained a non-object run")
+        name = raw_run.get("name")
+        status = raw_run.get("status")
+        conclusion = raw_run.get("conclusion")
+        app = raw_run.get("app")
+        if not isinstance(name, str) or not name.strip() or not isinstance(status, str):
+            raise ValueError("check-run response contained an invalid name or status")
+        if conclusion is not None and not isinstance(conclusion, str):
+            raise ValueError("check-run response contained an invalid conclusion")
+        if not isinstance(app, dict):
+            raise ValueError("check-run response contained no app identity")
+        app_id = app.get("id")
+        if isinstance(app_id, bool) or not isinstance(app_id, int):
+            raise ValueError("check-run response contained an invalid app identity")
+        return {
+            "name": name,
+            "status": status.lower(),
+            "conclusion": conclusion.lower() if isinstance(conclusion, str) else None,
+            "app_id": app_id,
+        }
+
+    def _strict_review_check_runs(self, head_sha: str) -> list[dict[str, Any]]:
+        """Read a bounded, app-identified current-head check-run snapshot."""
+        if self._repo_slug is None:
+            raise RuntimeError("strict-review CI readiness requires a repo-scoped adapter")
+        result = gh_call(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                (
+                    f"repos/{self._repo_slug}/commits/{quote(head_sha, safe='')}"
+                    "/check-runs?per_page=100"
+                ),
+            ]
+        )
+        pages = json.loads(result.stdout or "[]")
+        if not isinstance(pages, list):
+            raise ValueError("check-run response was not a page list")
+        runs: list[dict[str, Any]] = []
+        expected_total: int | None = None
+        for page in pages:
+            if not isinstance(page, dict):
+                raise ValueError("check-run response contained a non-object page")
+            total_count = page.get("total_count")
+            raw_runs = page.get("check_runs")
+            if isinstance(total_count, bool) or not isinstance(total_count, int):
+                raise ValueError("check-run response contained an invalid total count")
+            if not isinstance(raw_runs, list):
+                raise ValueError("check-run response contained no check-run list")
+            expected_total = (
+                total_count if expected_total is None else max(expected_total, total_count)
+            )
+            runs.extend(self._normalize_strict_review_check_run(raw_run) for raw_run in raw_runs)
+        if expected_total is None or expected_total != len(runs):
+            raise ValueError("check-run pagination was incomplete")
+        if len(runs) > _STRICT_REVIEW_MAX_CHECKS:
+            raise ValueError("check-run response exceeded the strict-review evidence limit")
+        return runs
+
+    @staticmethod
+    def _normalize_strict_review_commit_status(raw_status: object) -> dict[str, str]:
+        """Validate one Commit Statuses API record."""
+        if not isinstance(raw_status, dict):
+            raise ValueError("commit-status response contained a non-object status")
+        context = raw_status.get("context")
+        state = raw_status.get("state")
+        if not isinstance(context, str) or not context.strip() or not isinstance(state, str):
+            raise ValueError("commit-status response contained an invalid context or state")
+        normalized_state = state.lower()
+        if normalized_state not in {"success", "failure", "error", "pending"}:
+            raise ValueError("commit-status response contained an unknown state")
+        return {"context": context, "state": normalized_state}
+
+    def _strict_review_commit_statuses(self, head_sha: str) -> list[dict[str, str]]:
+        """Read a bounded current-head commit-status snapshot.
+
+        GitHub requires both a Check Run and a commit status when they share
+        a protected context, so pending statuses must be a strict-review
+        prerequisite even though their API does not expose the publisher app
+        identity used to satisfy a bound Check Run requirement.
+        """
+        if self._repo_slug is None:
+            raise RuntimeError("strict-review CI readiness requires a repo-scoped adapter")
+        result = gh_call(
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{self._repo_slug}/commits/{quote(head_sha, safe='')}/status?per_page=100",
+            ]
+        )
+        pages = json.loads(result.stdout or "[]")
+        if not isinstance(pages, list):
+            raise ValueError("commit-status response was not a page list")
+        all_statuses: list[dict[str, str]] = []
+        expected_total: int | None = None
+        for page in pages:
+            if not isinstance(page, dict):
+                raise ValueError("commit-status response contained a non-object page")
+            total_count = page.get("total_count")
+            raw_statuses = page.get("statuses")
+            if isinstance(total_count, bool) or not isinstance(total_count, int):
+                raise ValueError("commit-status response contained an invalid total count")
+            if not isinstance(raw_statuses, list):
+                raise ValueError("commit-status response contained no status list")
+            expected_total = (
+                total_count if expected_total is None else max(expected_total, total_count)
+            )
+            all_statuses.extend(
+                self._normalize_strict_review_commit_status(raw_status)
+                for raw_status in raw_statuses
+            )
+        if expected_total is None or expected_total != len(all_statuses):
+            raise ValueError("commit-status pagination was incomplete")
+        if len(all_statuses) > _STRICT_REVIEW_MAX_CHECKS:
+            raise ValueError("commit-status response exceeded the strict-review evidence limit")
+        # GitHub documents this endpoint as reverse chronological.  Branch
+        # protection evaluates the latest value for a context, not a stale
+        # queued status that an earlier reporter left behind.  Keep the first
+        # occurrence while retaining the endpoint's ordering across pages.
+        latest_by_context: set[str] = set()
+        latest_statuses: list[dict[str, str]] = []
+        for status in all_statuses:
+            if status["context"] in latest_by_context:
+                continue
+            latest_by_context.add(status["context"])
+            latest_statuses.append(status)
+        return latest_statuses
+
+    def strict_review_ci_state(self, pr_number: int, head_sha: str) -> StrictReviewCIState:
+        """Return the strict gate's head-bound required-CI readiness.
+
+        The legacy ``gh pr checks`` wrapper represents GitHub's fresh-head
+        ``no checks reported`` response as ``[]``.  Strict review needs a
+        stronger contract: it compares that snapshot with the live classic
+        and effective-ruleset required context inventory, so absent required
+        runs are timer-parked rather than dispatched to a reviewer as an
+        apparent all-clear.
+        """
+        if self._repo_slug is None:
+            raise RuntimeError("strict-review CI readiness requires a repo-scoped adapter")
+        normalized_head = head_sha.lower()
+        before = self.gh_pr_state(pr_number)
+        if (
+            before is None
+            or str(before.get("state") or "").upper() != "OPEN"
+            or str(before.get("headRefOid") or "").lower() != normalized_head
+        ):
+            return StrictReviewCIState(status="stale_head")
+        base_ref = before.get("baseRefName")
+        if not isinstance(base_ref, str) or not base_ref:
+            raise ValueError("PR base branch was unavailable for strict-review CI readiness")
+        required_bindings = self._strict_review_required_bindings(base_ref)
+        # The proof context is intentionally required for merge, but it is
+        # emitted by the trusted workflow only after this stage publishes the
+        # artifact.  Including it in the pre-review readiness set would make
+        # strict review wait on its own output forever.
+        required_bindings = {
+            binding for binding in required_bindings if binding[0] != _STRICT_REVIEW_PROOF_CONTEXT
+        }
+        if not required_bindings:
+            ci_status = "No pre-review required CI checks are configured for this PR's base branch."
+            pending: tuple[str, ...] = ()
+        else:
+            runs = self._strict_review_check_runs(normalized_head)
+            statuses = self._strict_review_commit_statuses(normalized_head)
+            required_contexts = {binding[0] for binding in required_bindings}
+
+            def _matches(binding: tuple[str, int], run: dict[str, Any]) -> bool:
+                return binding[0] == run["name"] and (
+                    binding[1] == -1 or binding[1] == run["app_id"]
+                )
+
+            required_runs = [
+                {
+                    "name": run["name"],
+                    "status": run["status"],
+                    "conclusion": run["conclusion"],
+                    "required": True,
+                }
+                for run in runs
+                if any(_matches(binding, run) for binding in required_bindings)
+            ]
+            pending_status_contexts = {
+                status["context"]
+                for status in statuses
+                if status["context"] in required_contexts and status["state"] == "pending"
+            }
+            # The Commit Status API identifies a creator but not the GitHub
+            # App id bound by branch protection.  A pending same-name status
+            # is enough to defer review safely; a terminal status cannot be
+            # accepted as evidence because its publisher cannot be bound to
+            # the required app.  Refuse to start a strict review until that
+            # ambiguous status is gone rather than treating it as a pass (or
+            # routing a potentially unrelated failure to implementation).
+            completed_ambiguous_status_contexts = {
+                status["context"]
+                for status in statuses
+                if status["context"] in required_contexts and status["state"] != "pending"
+            }
+            if completed_ambiguous_status_contexts:
+                contexts = ", ".join(sorted(completed_ambiguous_status_contexts))
+                raise ValueError(
+                    "cannot authenticate the publisher of completed required commit statuses: "
+                    f"{contexts}"
+                )
+            status_evidence = [
+                {
+                    "name": f"{status['context']} (commit status)",
+                    "status": "in_progress" if status["state"] == "pending" else "completed",
+                    "conclusion": (
+                        None
+                        if status["state"] == "pending"
+                        else "success"
+                        if status["state"] == "success"
+                        else "failure"
+                    ),
+                    "required": True,
+                }
+                for status in statuses
+                if status["context"] in required_contexts
+            ]
+            rendered_ci_status = self._strict_review_ci_status(required_runs + status_evidence)
+            if rendered_ci_status is None:
+                raise ValueError(
+                    "required check-run response was malformed for strict-review CI readiness"
+                )
+            ci_status = rendered_ci_status
+            pending = tuple(
+                sorted(
+                    {
+                        binding[0]
+                        for binding in required_bindings
+                        if not any(_matches(binding, run) for run in runs)
+                        or any(
+                            _matches(binding, run) and run["status"] != "completed" for run in runs
+                        )
+                    }
+                    | pending_status_contexts
+                )
+            )
+        after = self.gh_pr_state(pr_number)
+        if (
+            after is None
+            or str(after.get("state") or "").upper() != "OPEN"
+            or str(after.get("headRefOid") or "").lower() != normalized_head
+        ):
+            return StrictReviewCIState(status="stale_head")
+        if pending:
+            return StrictReviewCIState(
+                status="pending", ci_status=ci_status, pending_check_names=pending
+            )
+        return StrictReviewCIState(status="ready", ci_status=ci_status)
 
     def pr_checks(self, pr_number: int) -> list[dict[str, Any]]:
         """All checks for the PR (``gh_pr_checks``)."""

--- a/tests/unit/automation/pipeline/stages/conftest.py
+++ b/tests/unit/automation/pipeline/stages/conftest.py
@@ -20,6 +20,7 @@ from hephaestus.automation.pipeline.stages import (
     StageContext,
     StageGitHub,
     StrictReviewArtifact,
+    StrictReviewCIState,
     StrictReviewEvidence,
     StrictReviewLease,
 )
@@ -57,6 +58,7 @@ class FakeStageGitHub(FakeGitHub):
         pr_state: dict[str, Any] | None = None,
         failing_checks: list[str] | None = None,
         pending_checks: list[str] | None = None,
+        strict_ci_state: StrictReviewCIState | None = None,
         checks: list[dict[str, Any]] | None = None,
         pr_stuck: bool = False,
         learn_terminal: bool = False,
@@ -88,6 +90,7 @@ class FakeStageGitHub(FakeGitHub):
                 PR-state read); ``None`` mirrors a transient read failure.
             failing_checks: Canned answer for failing_required_check_names.
             pending_checks: Canned answer for pending_required_check_names.
+            strict_ci_state: Canned head-bound strict-review CI readiness.
             checks: Canned answer for pr_checks (all checks for CI polling).
             pr_stuck: Canned answer for pr_is_genuinely_stuck.
             learn_terminal: Seed answer for drive_green_learn_terminal —
@@ -117,6 +120,7 @@ class FakeStageGitHub(FakeGitHub):
         self._pr_state = pr_state
         self._failing_checks = list(failing_checks or [])
         self._pending_checks = list(pending_checks or [])
+        self._strict_ci_state = strict_ci_state
         self._checks = list(checks or [])
         self._pr_stuck = pr_stuck
         self._learn_terminal = learn_terminal
@@ -346,9 +350,10 @@ class FakeStageGitHub(FakeGitHub):
         return True
 
     def strict_review_evidence(
-        self, pr_number: int, head_sha: str, issue_number: int
+        self, pr_number: int, head_sha: str, issue_number: int, *, ci_status: str | None = None
     ) -> StrictReviewEvidence | None:
         """Return canned evidence only when it remains for the requested head."""
+        del ci_status
         self.strict_evidence_calls.append((pr_number, head_sha, issue_number))
         if self._strict_evidence is None or self._strict_evidence.head_sha != head_sha:
             return None
@@ -368,6 +373,17 @@ class FakeStageGitHub(FakeGitHub):
         """Mirror CICheckInspector.pending_required_check_names (canned answer)."""
         del pr_number  # single canned answer; not per-PR keyed
         return list(self._pending_checks)
+
+    def strict_review_ci_state(self, pr_number: int, head_sha: str) -> StrictReviewCIState:
+        """Mirror PipelineGitHub's head-bound strict-review CI readiness."""
+        del pr_number, head_sha  # single canned answer; not per-PR keyed
+        if self._strict_ci_state is not None:
+            return self._strict_ci_state
+        if self._pending_checks:
+            return StrictReviewCIState(
+                status="pending", pending_check_names=tuple(self._pending_checks)
+            )
+        return StrictReviewCIState(status="ready", ci_status="- unit: success")
 
     def pr_checks(self, pr_number: int) -> list[dict[str, Any]]:
         """Mirror gh_pr_checks (returns all checks for CI classification)."""

--- a/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+import pytest
+
 from hephaestus.automation.pipeline.jobs import AgentJob, GitJob, JobResult
 from hephaestus.automation.pipeline.routing import Disposition, StageName
 from hephaestus.automation.pipeline.stages import (
@@ -192,6 +194,77 @@ def test_review_job_receives_fresh_current_head_evidence(
     assert result.job.expected_head_sha == _NEW_HEAD
     assert result.job.sandbox == "read-only"
     assert item.payload["strict_review_lease_id"].startswith("fake-601-")
+
+
+def test_pending_required_ci_blocks_new_strict_review_work_after_durable_recovery(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """Queued or in-progress required CI must block a new strict review pass."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = FakeStageGitHub(
+        pending_checks=["unit"],
+        strict_evidence=StrictReviewEvidence(
+            head_sha=_NEW_HEAD,
+            issue_title="Task title",
+            issue_body="Task acceptance criterion.",
+            diff="diff --git a/file.py b/file.py\n+",
+            ci_status="- unit: pending",
+            prior_pr_review_verdict="Grade: A\nVerdict: GO",
+        ),
+    )
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.REVIEW_WAIT,
+        payload={"strict_review_head": _NEW_HEAD},
+    )
+
+    result = strict_review.StrictReviewStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.RETRY, "strict_review_ci_pending")
+    assert item.payload["retry_delay_s"] == 30
+    assert "strict_review_lease_id" not in item.payload
+    assert "strict_review_feedback" not in item.payload
+    assert "strict_review_attempt" not in item.payload
+    assert github.strict_evidence_calls == []
+    assert github.mutation_log == []
+
+
+def test_required_ci_status_read_failure_retries_without_strict_review_work(
+    make_ctx: Any, make_work_item: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable required-CI status must not dispatch a strict reviewer."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = FakeStageGitHub(
+        strict_evidence=StrictReviewEvidence(
+            head_sha=_NEW_HEAD,
+            issue_title="Task title",
+            issue_body="Task acceptance criterion.",
+            diff="diff --git a/file.py b/file.py\n+",
+            ci_status="- unit: unknown",
+            prior_pr_review_verdict="Grade: A\nVerdict: GO",
+        )
+    )
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.REVIEW_WAIT,
+        payload={"strict_review_head": _NEW_HEAD},
+    )
+
+    def _raise_status_read(_pr_number: int) -> list[str]:
+        raise OSError("GitHub checks unavailable")
+
+    monkeypatch.setattr(github, "pending_required_check_names", _raise_status_read)
+
+    result = strict_review.StrictReviewStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.RETRY, "strict_review_ci_unavailable")
+    assert item.payload["retry_delay_s"] == 30
+    assert "strict_review_lease_id" not in item.payload
+    assert "strict_review_attempt" not in item.payload
+    assert github.strict_evidence_calls == []
+    assert github.mutation_log == []
 
 
 def test_second_reviewer_does_not_dispatch_while_an_elected_lease_is_live(

--- a/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
+++ b/tests/unit/automation/pipeline/stages/test_stage_strict_review.py
@@ -14,6 +14,7 @@ from hephaestus.automation.pipeline.stages import (
     JobRequest,
     StageOutcome,
     StrictReviewArtifact,
+    StrictReviewCIState,
     StrictReviewEvidence,
     StrictReviewLease,
 )
@@ -252,10 +253,10 @@ def test_required_ci_status_read_failure_retries_without_strict_review_work(
         payload={"strict_review_head": _NEW_HEAD},
     )
 
-    def _raise_status_read(_pr_number: int) -> list[str]:
+    def _raise_status_read(_pr_number: int, _head_sha: str) -> StrictReviewCIState:
         raise OSError("GitHub checks unavailable")
 
-    monkeypatch.setattr(github, "pending_required_check_names", _raise_status_read)
+    monkeypatch.setattr(github, "strict_review_ci_state", _raise_status_read)
 
     result = strict_review.StrictReviewStage().step(item, make_ctx(github=github))
 
@@ -263,6 +264,26 @@ def test_required_ci_status_read_failure_retries_without_strict_review_work(
     assert item.payload["retry_delay_s"] == 30
     assert "strict_review_lease_id" not in item.payload
     assert "strict_review_attempt" not in item.payload
+    assert github.strict_evidence_calls == []
+    assert github.mutation_log == []
+
+
+def test_stale_ci_snapshot_restarts_before_creating_a_lease(
+    make_ctx: Any, make_work_item: Any
+) -> None:
+    """A push during the readiness read must restart head fencing cleanly."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = FakeStageGitHub(strict_ci_state=StrictReviewCIState(status="stale_head"))
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.REVIEW_WAIT,
+        payload={"strict_review_head": _NEW_HEAD},
+    )
+
+    result = strict_review.StrictReviewStage().step(item, make_ctx(github=github))
+
+    assert result == Continue(next_state=strict_review.HEAD_CHECK)
     assert github.strict_evidence_calls == []
     assert github.mutation_log == []
 
@@ -319,6 +340,34 @@ def test_existing_durable_go_reconciles_the_label_without_a_second_review_job(
     assert ("mark_pr_implementation_go", (601,)) in github.mutation_log
 
 
+def test_existing_durable_go_recovers_before_pending_ci_lookup(
+    make_ctx: Any, make_work_item: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A durable GO never waits on a fresh CI query or starts another review."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = FakeStageGitHub(
+        pr_state={"state": "OPEN", "headRefOid": _NEW_HEAD},
+        strict_artifact=StrictReviewArtifact(is_go=True, head_sha=_NEW_HEAD, verdict="GO"),
+    )
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.REVIEW_WAIT,
+        payload={"strict_review_head": _NEW_HEAD},
+    )
+
+    def _pending_ci_must_not_run(_pr_number: int, _head_sha: str) -> StrictReviewCIState:
+        raise AssertionError("durable GO must recover before checking pending CI")
+
+    monkeypatch.setattr(github, "strict_review_ci_state", _pending_ci_must_not_run)
+
+    result = strict_review.StrictReviewStage().step(item, make_ctx(github=github))
+
+    assert result == Continue(next_state=strict_review.EVAL)
+    assert github.strict_evidence_calls == []
+    assert not any(action == "claim_strict_review_lease" for action, _ in github.mutation_log)
+
+
 def test_existing_durable_nogo_resumes_containment_instead_of_retrying_a_live_lease(
     make_ctx: Any, make_work_item: Any
 ) -> None:
@@ -355,6 +404,39 @@ def test_existing_durable_nogo_resumes_containment_instead_of_retrying_a_live_le
     assert ("defer_auto_merge", (601,)) in github.mutation_log
     assert ("mark_pr_implementation_no_go", (601,)) in github.mutation_log
     assert item.payload["strict_review_feedback"].endswith("Grade: F\nVerdict: NOGO")
+
+
+def test_existing_terminal_nogo_recovers_before_pending_ci_lookup(
+    make_ctx: Any, make_work_item: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A durable terminal NOGO retains containment without a fresh CI query."""
+    strict_review = importlib.import_module("hephaestus.automation.pipeline.stages.strict_review")
+    github = FakeStageGitHub(
+        pr_state={"state": "OPEN", "headRefOid": _NEW_HEAD, "autoMergeRequest": None},
+        strict_artifact=StrictReviewArtifact(
+            is_go=False,
+            head_sha=_NEW_HEAD,
+            verdict="NOGO",
+            verdict_body="Missing safety check.\nGrade: F\nVerdict: NOGO",
+        ),
+    )
+    item = make_work_item(
+        stage=StageName.STRICT_REVIEW,
+        pr=601,
+        state=strict_review.REVIEW_WAIT,
+        payload={"strict_review_head": _NEW_HEAD},
+    )
+
+    def _pending_ci_must_not_run(_pr_number: int, _head_sha: str) -> StrictReviewCIState:
+        raise AssertionError("durable NOGO must recover before checking pending CI")
+
+    monkeypatch.setattr(github, "strict_review_ci_state", _pending_ci_must_not_run)
+
+    result = strict_review.StrictReviewStage().step(item, make_ctx(github=github))
+
+    assert result == StageOutcome(Disposition.FAIL_BACK, "nogo")
+    assert github.strict_evidence_calls == []
+    assert not any(action == "claim_strict_review_lease" for action, _ in github.mutation_log)
 
 
 def test_recovered_terminal_nogo_never_remediates_a_newer_head(

--- a/tests/unit/automation/test_pipeline_github.py
+++ b/tests/unit/automation/test_pipeline_github.py
@@ -1259,6 +1259,348 @@ class TestReadSurface:
         assert adapter.pending_required_check_names(7) == ["test"]
 
 
+class TestStrictReviewCiState:
+    """The strict gate must retain the distinction erased by legacy CI polling."""
+
+    _head = "a" * 40
+
+    def _adapter(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        required: set[tuple[str, int]],
+        runs: list[dict[str, Any]],
+        statuses: list[dict[str, str]] | None = None,
+        states: list[dict[str, str]] | None = None,
+    ) -> pg.PipelineGitHub:
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        snapshots = iter(
+            states
+            or [
+                {"state": "OPEN", "headRefOid": self._head, "baseRefName": "main"},
+                {"state": "OPEN", "headRefOid": self._head, "baseRefName": "main"},
+            ]
+        )
+        monkeypatch.setattr(adapter, "gh_pr_state", lambda _pr: next(snapshots))
+        monkeypatch.setattr(adapter, "_strict_review_required_bindings", lambda _base: required)
+        monkeypatch.setattr(adapter, "_strict_review_check_runs", lambda _head: runs)
+        monkeypatch.setattr(adapter, "_strict_review_commit_statuses", lambda _head: statuses or [])
+        return adapter
+
+    def test_required_contexts_with_no_reported_runs_are_pending(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fresh-head ``no checks reported`` must park, not authorize review."""
+        adapter = self._adapter(
+            tmp_path, monkeypatch, required={("lint", 15368), ("unit-tests", 15368)}, runs=[]
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "pending"
+        assert state.pending_check_names == ("lint", "unit-tests")
+
+    def test_no_required_contexts_preserve_the_no_ci_ready_case(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A repository with no CI policy remains a valid strict-review target."""
+        adapter = self._adapter(tmp_path, monkeypatch, required=set(), runs=[])
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "ready"
+        assert state.pending_check_names == ()
+
+    def test_missing_or_inflight_required_contexts_are_pending(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368), ("unit-tests", 15368)},
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "success", "app_id": 15368},
+                {
+                    "name": "unit-tests",
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "app_id": 15368,
+                },
+            ],
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "pending"
+        assert state.pending_check_names == ("unit-tests",)
+
+    def test_completed_required_failure_is_ready_for_genuine_review_containment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368)},
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "failure", "app_id": 15368}
+            ],
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "ready"
+
+    def test_same_named_check_from_another_app_remains_pending(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A context is current only when its protection-bound app published it."""
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368)},
+            runs=[{"name": "lint", "status": "completed", "conclusion": "success", "app_id": 7}],
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "pending"
+        assert state.pending_check_names == ("lint",)
+
+    def test_pending_same_name_commit_status_blocks_a_completed_check_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GitHub requires both status surfaces when a context exists on both."""
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368)},
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "success", "app_id": 15368}
+            ],
+            statuses=[{"context": "lint", "state": "pending"}],
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "pending"
+        assert state.pending_check_names == ("lint",)
+
+    def test_completed_same_name_commit_status_requires_an_authenticated_publisher(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A terminal status cannot prove that the bound app produced it."""
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368)},
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "success", "app_id": 15368}
+            ],
+            statuses=[{"context": "lint", "state": "success"}],
+        )
+
+        with pytest.raises(ValueError, match="cannot authenticate"):
+            adapter.strict_review_ci_state(71, self._head)
+
+    def test_commit_status_history_uses_only_each_contexts_latest_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A completed status must supersede its older queued submission."""
+
+        def fake_gh_call(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+            assert argv == [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/org/repo-a/commits/{self._head}/status?per_page=100",
+            ]
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    [
+                        {
+                            "total_count": 2,
+                            "statuses": [
+                                {"context": "lint", "state": "success"},
+                                {"context": "lint", "state": "pending"},
+                            ],
+                        }
+                    ]
+                )
+            )
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+
+        assert adapter._strict_review_commit_statuses(self._head) == [
+            {"context": "lint", "state": "success"}
+        ]
+
+    def test_own_post_artifact_proof_is_not_a_pre_review_dependency(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Waiting on strict-review-proof here would deadlock every fresh head."""
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368), ("strict-review-proof", 15368)},
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "success", "app_id": 15368}
+            ],
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "ready"
+
+    def test_head_drift_during_readiness_restarts_before_review(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = self._adapter(
+            tmp_path,
+            monkeypatch,
+            required={("lint", 15368)},
+            runs=[
+                {"name": "lint", "status": "completed", "conclusion": "success", "app_id": 15368}
+            ],
+            states=[
+                {"state": "OPEN", "headRefOid": self._head, "baseRefName": "main"},
+                {"state": "OPEN", "headRefOid": "b" * 40, "baseRefName": "main"},
+            ],
+        )
+
+        state = adapter.strict_review_ci_state(71, self._head)
+
+        assert state.status == "stale_head"
+
+    def test_policy_read_error_is_not_conflated_with_no_requirements(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+        snapshot = {"state": "OPEN", "headRefOid": self._head, "baseRefName": "main"}
+        monkeypatch.setattr(adapter, "gh_pr_state", lambda _pr: snapshot)
+        monkeypatch.setattr(
+            adapter,
+            "_strict_review_required_bindings",
+            lambda _base: (_ for _ in ()).throw(RuntimeError("policy unavailable")),
+        )
+
+        with pytest.raises(RuntimeError, match="policy unavailable"):
+            adapter.strict_review_ci_state(71, self._head)
+
+    def test_policy_bindings_union_every_rules_page_and_classic_protection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        calls: list[list[str]] = []
+
+        def fake_gh_call(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            if argv == [
+                "api",
+                "--paginate",
+                "--slurp",
+                "repos/org/repo-a/rules/branches/main?per_page=100",
+            ]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        [
+                            [
+                                {
+                                    "type": "required_status_checks",
+                                    "parameters": {
+                                        "required_status_checks": [
+                                            {"context": "ruleset-check", "integration_id": 15368}
+                                        ]
+                                    },
+                                }
+                            ],
+                            [
+                                {
+                                    "type": "required_status_checks",
+                                    "parameters": {
+                                        "required_status_checks": [
+                                            {
+                                                "context": "second-page-check",
+                                                "integration_id": 15368,
+                                            }
+                                        ]
+                                    },
+                                },
+                            ],
+                        ]
+                    )
+                )
+            if argv == ["api", "repos/org/repo-a/branches/main"]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        {
+                            "protected": True,
+                            "protection": {
+                                "enabled": True,
+                                "required_status_checks": {
+                                    "checks": [{"context": "classic-check", "app_id": 15368}]
+                                },
+                            },
+                        }
+                    )
+                )
+            raise AssertionError(f"unexpected gh invocation: {argv!r}")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+
+        assert adapter._strict_review_required_bindings("main") == {
+            ("classic-check", 15368),
+            ("ruleset-check", 15368),
+            ("second-page-check", 15368),
+        }
+        assert calls == [
+            [
+                "api",
+                "--paginate",
+                "--slurp",
+                "repos/org/repo-a/rules/branches/main?per_page=100",
+            ],
+            ["api", "repos/org/repo-a/branches/main"],
+        ]
+
+    def test_unprotected_branch_snapshot_preserves_ruleset_only_policy(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A readable branch snapshot distinguishes no classic policy from masked access."""
+
+        def fake_gh_call(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+            if argv[:4] == [
+                "api",
+                "--paginate",
+                "--slurp",
+                "repos/org/repo-a/rules/branches/main?per_page=100",
+            ]:
+                return SimpleNamespace(stdout=json.dumps([[]]))
+            if argv == ["api", "repos/org/repo-a/branches/main"]:
+                return SimpleNamespace(stdout=json.dumps({"protected": False, "protection": None}))
+            raise AssertionError(f"unexpected gh invocation: {argv!r}")
+
+        monkeypatch.setattr(pg, "gh_call", fake_gh_call)
+        adapter = pg.PipelineGitHub("org", repo="repo-a", repo_root=tmp_path)
+
+        assert adapter._strict_review_required_bindings("main") == set()
+
+    @pytest.mark.parametrize(
+        "snapshot",
+        [
+            {"protected": True, "protection": None},
+            {"protected": True, "protection": {}},
+        ],
+    )
+    def test_protected_branch_without_readable_protection_fails_closed(
+        self, snapshot: object
+    ) -> None:
+        """A protected branch must not turn a masked classic policy into no policy."""
+        with pytest.raises(ValueError, match="protection"):
+            pg.PipelineGitHub._required_bindings_from_branch(snapshot)
+
+
 class TestUnresolvedThreads:
     """count_unresolved_threads mirrors #1152: counts only, resolves nothing."""
 
@@ -1332,7 +1674,7 @@ class TestStrictReviewEvidence:
 
     _head = "a" * 40
 
-    def _adapter_with_responses(
+    def _adapter_with_responses(  # noqa: C901 - explicit GitHub response fixture.
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -1413,9 +1755,74 @@ class TestStrictReviewEvidence:
                         {
                             "state": "OPEN",
                             "headRefOid": final_head if final_head is not None else self._head,
+                            "baseRefName": "main",
                         }
                     )
                 )
+            if argv == [
+                "api",
+                "--paginate",
+                "--slurp",
+                "repos/org/repo-a/rules/branches/main?per_page=100",
+            ]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        [
+                            [
+                                {
+                                    "type": "required_status_checks",
+                                    "parameters": {
+                                        "required_status_checks": [
+                                            {"context": "unit", "integration_id": 15368}
+                                        ]
+                                    },
+                                }
+                            ]
+                        ]
+                    )
+                )
+            if argv == ["api", "repos/org/repo-a/branches/main"]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        {
+                            "protected": True,
+                            "protection": {
+                                "enabled": True,
+                                "required_status_checks": {"checks": []},
+                            },
+                        }
+                    )
+                )
+            if argv == [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/org/repo-a/commits/{self._head}/check-runs?per_page=100",
+            ]:
+                return SimpleNamespace(
+                    stdout=json.dumps(
+                        [
+                            {
+                                "total_count": 1,
+                                "check_runs": [
+                                    {
+                                        "name": "unit",
+                                        "status": "completed",
+                                        "conclusion": "success",
+                                        "app": {"id": 15368},
+                                    }
+                                ],
+                            }
+                        ]
+                    )
+                )
+            if argv == [
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/org/repo-a/commits/{self._head}/status?per_page=100",
+            ]:
+                return SimpleNamespace(stdout=json.dumps([{"total_count": 0, "statuses": []}]))
             raise AssertionError(f"unexpected gh invocation: {argv!r}")
 
         monkeypatch.setattr(pg, "gh_call", fake_gh_call)


### PR DESCRIPTION
## Summary

- defer new strict-review work while required CI for the exact PR head is missing, queued, or in progress
- derive required checks from live effective rules and the readable branch-protection snapshot, preserving required GitHub App identities
- fail closed on unreadable or ambiguous policy/status evidence, while preserving durable GO/NOGO recovery and current-head fencing

## Verification

- `uv run --all-extras pytest` — 6,429 passed, 7 skipped after rebase to `origin/main`
- focused strict-review and PipelineGitHub suites — 151 passed
- Ruff format/check, diff check, signed DCO commits, and independent swarm review — GO

Closes #2278
