### PR TITLE
[Fix] Emit a valid rerun command for preserved worktrees

### DIFF
--- a/hephaestus/automation/pipeline/summary.py
+++ b/hephaestus/automation/pipeline/summary.py
@@ -57,11 +57,15 @@ def format_preserved_worktrees(preserved: Sequence[PreservedWorktree], script: s
     if not preserved:
         return []
     issue_nums = [number for _, number, _ in preserved]
-    issues_arg = " ".join(str(n) for n in issue_nums)
+    # ``--issues`` takes ONE comma-separated string (loop_runner._parse_issue_list);
+    # a space-joined list makes argparse read only the first number and reject the
+    # rest, and ``--resume`` is not an option on this CLI at all (#2281). The loop
+    # resumes a preserved worktree by re-seeding the same ``--issues``.
+    issues_arg = ",".join(str(n) for n in issue_nums)
     lines: list[str] = ["\nPreserved worktrees (contain uncommitted changes):"]
     lines.extend(f"  #{number}: {path}" for _, number, path in preserved)
     lines.append("\nRerun these issues after inspecting/cleaning the worktrees:")
-    lines.append(f"  {script} --issues {issues_arg} --resume")
+    lines.append(f"  {script} --issues {issues_arg}")
     lines.append("To discard them instead:")
     lines.extend(f"  git worktree remove --force {path}" for _, _, path in preserved)
     return lines

--- a/tests/unit/automation/pipeline/test_summary.py
+++ b/tests/unit/automation/pipeline/test_summary.py
@@ -73,11 +73,29 @@ class TestFormatPreservedWorktrees:
             "  #101: /wt/issue-101",
             "  #202: /wt/issue-202",
             "\nRerun these issues after inspecting/cleaning the worktrees:",
-            "  impl.py --issues 101 202 --resume",
+            "  impl.py --issues 101,202",
             "To discard them instead:",
             "  git worktree remove --force /wt/issue-101",
             "  git worktree remove --force /wt/issue-202",
         ]
+
+    def test_rerun_hint_actually_parses_with_the_loop_cli(self) -> None:
+        """The emitted rerun command must be valid input to the loop parser (#2281).
+
+        A byte-identical pin previously froze a command the CLI rejects
+        (space-joined ``--issues`` + a nonexistent ``--resume``). Assert the
+        real argparser accepts the emitted flags and recovers the numbers.
+        """
+        from hephaestus.automation import loop_runner
+
+        preserved = [("repo-a", 101, "/wt/issue-101"), ("repo-b", 202, "/wt/issue-202")]
+        rerun_line = next(
+            line for line in format_preserved_worktrees(preserved, "loop") if "--issues" in line
+        )
+        # Everything after the script token is the argv the operator would run.
+        argv = rerun_line.split()[1:]
+        parsed = loop_runner._parse_args(argv)
+        assert parsed.issues == [101, 202]
 
 
 class TestPrintSummaryRows:


### PR DESCRIPTION
## Summary

The preserved-worktree footer printed a rerun command the loop CLI rejects:

```
hephaestus-automation-loop --issues 2151 2146 2131 ... --resume
error: unrecognized arguments: 2146 2131 ... --resume
```

- `--issues` takes one **comma-separated** string (`_parse_issue_list`), but the summary space-joined the numbers, so argparse consumed only the first and treated the rest as invalid positionals.
- `--resume` is not an option on `hephaestus-automation-loop` (it exists only on the separate `implementer.py` CLI); the summary appended it unconditionally.

Fix: comma-join the issues and drop `--resume`. The existing pin test was a "byte-identical to legacy" pin that had frozen the broken command; it now asserts the corrected output **and** feeds the emitted argv through `loop_runner._parse_args` so a non-parseable command can never be re-pinned.

## Verification

15 summary tests pass (incl. the new parse guard); lint/format/mypy clean.

Closes #2281

🤖 Generated with [Claude Code](https://claude.com/claude-code)