### PR TITLE
feat(automation): add per-role Codex reasoning controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,12 @@ on each automation command (e.g., `--agent-timeout`, `--poll-max-wait`,
 `--git-message-timeout`, etc.). Legacy `claude_models`, `claude_timeouts`, and
 `session_naming` modules remain compatibility shims over `agent_config`.
 
+The automation loop also accepts `--planner-reasoning-effort`,
+`--implementer-reasoning-effort`, and `--reviewer-reasoning-effort` for Codex
+roles. Values are `default`, `low`, `medium`, `high`, or `xhigh`; `default`
+omits Codex's `model_reasoning_effort` setting. An omitted flag preserves the
+selected model alias's established reasoning default.
+
 ## Design Philosophy
 
 The agent topology above is not accidental — it follows a small set of design

--- a/hephaestus/agents/runtime.py
+++ b/hephaestus/agents/runtime.py
@@ -388,23 +388,42 @@ def _codex_model_config(model: str, *, use_default: bool = False) -> CodexModelC
             return CodexModelConfig(CODEX_DEFAULT_MODEL, CODEX_DEFAULT_REASONING_EFFORT)
         return CodexModelConfig("")
     lower_model = normalized.lower()
-    if lower_model in {"terra:default", f"{CODEX_GPT_56_TERRA_MODEL}:default"}:
-        return CodexModelConfig(CODEX_GPT_56_TERRA_MODEL)
-    if lower_model in {"sol", CODEX_GPT_56_SOL_MODEL}:
-        return CodexModelConfig(CODEX_GPT_56_SOL_MODEL, CODEX_FABLE_REASONING_EFFORT)
-    if lower_model in {"terra", CODEX_GPT_56_TERRA_MODEL}:
-        return CodexModelConfig(CODEX_GPT_56_TERRA_MODEL, CODEX_OPUS_REASONING_EFFORT)
-    if lower_model in {"luna", CODEX_GPT_56_LUNA_MODEL}:
-        return CodexModelConfig(CODEX_GPT_56_LUNA_MODEL, CODEX_SONNET_REASONING_EFFORT)
-    if lower_model == "fable" or lower_model.startswith("claude-fable-"):
-        return CodexModelConfig(CODEX_FABLE_MODEL, CODEX_FABLE_REASONING_EFFORT)
-    if lower_model == "opus" or lower_model.startswith("claude-opus-"):
-        return CodexModelConfig(CODEX_OPUS_MODEL, CODEX_OPUS_REASONING_EFFORT)
-    if lower_model == "sonnet" or lower_model.startswith("claude-sonnet-"):
-        return CodexModelConfig(CODEX_SONNET_MODEL, CODEX_SONNET_REASONING_EFFORT)
-    if lower_model == "haiku" or lower_model.startswith("claude-haiku-"):
-        return CodexModelConfig(CODEX_HAIKU_MODEL)
-    return CodexModelConfig(normalized)
+    base_model, separator, requested_effort = lower_model.rpartition(":")
+    original_base_model = normalized.rpartition(":")[0]
+    explicit_effort = (
+        requested_effort
+        if separator
+        and requested_effort
+        in {
+            "default",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+        }
+        else ""
+    )
+    alias_model = base_model if explicit_effort else lower_model
+    if alias_model in {"sol", CODEX_GPT_56_SOL_MODEL}:
+        config = CodexModelConfig(CODEX_GPT_56_SOL_MODEL, CODEX_FABLE_REASONING_EFFORT)
+    elif alias_model in {"terra", CODEX_GPT_56_TERRA_MODEL}:
+        config = CodexModelConfig(CODEX_GPT_56_TERRA_MODEL, CODEX_OPUS_REASONING_EFFORT)
+    elif alias_model in {"luna", CODEX_GPT_56_LUNA_MODEL}:
+        config = CodexModelConfig(CODEX_GPT_56_LUNA_MODEL, CODEX_SONNET_REASONING_EFFORT)
+    elif lower_model == "fable" or lower_model.startswith("claude-fable-"):
+        config = CodexModelConfig(CODEX_FABLE_MODEL, CODEX_FABLE_REASONING_EFFORT)
+    elif lower_model == "opus" or lower_model.startswith("claude-opus-"):
+        config = CodexModelConfig(CODEX_OPUS_MODEL, CODEX_OPUS_REASONING_EFFORT)
+    elif lower_model == "sonnet" or lower_model.startswith("claude-sonnet-"):
+        config = CodexModelConfig(CODEX_SONNET_MODEL, CODEX_SONNET_REASONING_EFFORT)
+    elif lower_model == "haiku" or lower_model.startswith("claude-haiku-"):
+        config = CodexModelConfig(CODEX_HAIKU_MODEL)
+    else:
+        config = CodexModelConfig(original_base_model if explicit_effort else normalized)
+    if explicit_effort:
+        reasoning_effort = "" if explicit_effort == "default" else explicit_effort
+        return CodexModelConfig(config.model, reasoning_effort)
+    return config
 
 
 def _codex_model_args(model: str, *, use_default: bool = False) -> list[str]:

--- a/hephaestus/automation/agent_config.py
+++ b/hephaestus/automation/agent_config.py
@@ -25,6 +25,17 @@ operator can override without code changes (e.g. when one tier's quota is
 exhausted). Unknown overrides emit a **warning** but are still accepted so
 operators can experiment with preview models without a code change.
 
+Codex reasoning overrides
+-------------------------
+``hephaestus-automation-loop`` accepts explicit per-role Codex reasoning
+controls: ``--planner-reasoning-effort``, ``--implementer-reasoning-effort``,
+and ``--reviewer-reasoning-effort``. Each takes ``default``, ``low``,
+``medium``, ``high``, or ``xhigh``. A role-specific setting takes precedence
+over that role's model alias default; ``default`` deliberately omits Codex's
+``model_reasoning_effort`` option. When a setting is omitted, the selected
+model alias retains its existing default. These controls are applied only to
+the Codex provider and never modify Claude or Pi model IDs.
+
 Timeouts
 --------
 Each phase that shells out to an agent CLI or ``gh`` has historically

--- a/hephaestus/automation/loop_runner.py
+++ b/hephaestus/automation/loop_runner.py
@@ -207,6 +207,9 @@ class LoopConfig:
     planner_model: str = ""
     reviewer_model: str = ""
     implementer_model: str = ""
+    planner_reasoning_effort: str = ""
+    reviewer_reasoning_effort: str = ""
+    implementer_reasoning_effort: str = ""
     gh_global_rate: float = 10.0
     gh_global_burst: float = 30.0
     # Org is resolved at runtime from --org / --repos / cwd detection; no
@@ -341,6 +344,16 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument("--planner-model", default="", help="HEPH_PLANNER_MODEL for child processes")
+    reasoning_help = (
+        "Explicit Codex reasoning effort for this role. Use default to omit "
+        "model_reasoning_effort; when omitted, the selected model alias keeps its default."
+    )
+    p.add_argument(
+        "--planner-reasoning-effort",
+        choices=("default", "low", "medium", "high", "xhigh"),
+        default="",
+        help=reasoning_help,
+    )
     p.add_argument(
         "--reviewer-model",
         default="",
@@ -353,6 +366,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "--implementer-model",
         default="",
         help="HEPH_IMPLEMENTER_MODEL for child processes (implement, address-review, ci-driver)",
+    )
+    p.add_argument(
+        "--reviewer-reasoning-effort",
+        choices=("default", "low", "medium", "high", "xhigh"),
+        default="",
+        help=reasoning_help,
+    )
+    p.add_argument(
+        "--implementer-reasoning-effort",
+        choices=("default", "low", "medium", "high", "xhigh"),
+        default="",
+        help=reasoning_help,
     )
     p.add_argument(
         "--org",
@@ -638,6 +663,9 @@ def _build_pipeline_config(
         planner_model=cfg.planner_model,
         reviewer_model=cfg.reviewer_model,
         implementer_model=cfg.implementer_model,
+        planner_reasoning_effort=cfg.planner_reasoning_effort,
+        reviewer_reasoning_effort=cfg.reviewer_reasoning_effort,
+        implementer_reasoning_effort=cfg.implementer_reasoning_effort,
         no_advise=cfg.no_advise,
         nitpick=cfg.nitpick,
         drive_green_all=cfg.drive_green_all,
@@ -782,6 +810,9 @@ def main(argv: list[str] | None = None) -> int:
         planner_model=args.planner_model,
         reviewer_model=args.reviewer_model,
         implementer_model=args.implementer_model,
+        planner_reasoning_effort=args.planner_reasoning_effort,
+        reviewer_reasoning_effort=args.reviewer_reasoning_effort,
+        implementer_reasoning_effort=args.implementer_reasoning_effort,
         gh_global_rate=args.gh_global_rate,
         gh_global_burst=args.gh_global_burst,
         org=org,

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -219,6 +219,9 @@ class PipelineConfig:
     planner_model: str = ""
     reviewer_model: str = ""
     implementer_model: str = ""
+    planner_reasoning_effort: str = ""
+    reviewer_reasoning_effort: str = ""
+    implementer_reasoning_effort: str = ""
     no_advise: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
@@ -284,6 +287,9 @@ class _StageRunConfig:
     planner_model: str = ""
     reviewer_model: str = ""
     implementer_model: str = ""
+    planner_reasoning_effort: str = ""
+    reviewer_reasoning_effort: str = ""
+    implementer_reasoning_effort: str = ""
     dry_run: bool = False
     nitpick: bool = False
     drive_green_all: bool = False
@@ -429,6 +435,9 @@ class Coordinator:
             planner_model=config.planner_model,
             reviewer_model=config.reviewer_model,
             implementer_model=config.implementer_model,
+            planner_reasoning_effort=config.planner_reasoning_effort,
+            reviewer_reasoning_effort=config.reviewer_reasoning_effort,
+            implementer_reasoning_effort=config.implementer_reasoning_effort,
             dry_run=config.dry_run,
             nitpick=config.nitpick,
             drive_green_all=config.drive_green_all,

--- a/hephaestus/automation/pipeline/stages/base.py
+++ b/hephaestus/automation/pipeline/stages/base.py
@@ -614,7 +614,14 @@ def stage_model(ctx: StageContext, phase: str, fallback: Callable[[], str]) -> s
     """Return a phase model override, the catch-all model, or the legacy fallback."""
     phase_value = getattr(ctx.config, f"{phase}_model", "")
     catch_all = getattr(ctx.config, "model", "")
-    return str(phase_value or catch_all or fallback())
+    model = str(phase_value or catch_all or fallback())
+    reasoning_effort = str(getattr(ctx.config, f"{phase}_reasoning_effort", "") or "")
+    if reasoning_effort and agent_provider(ctx) == "codex":
+        base_model, separator, current_effort = model.rpartition(":")
+        if separator and current_effort in {"default", "low", "medium", "high", "xhigh"}:
+            model = base_model
+        return f"{model}:{reasoning_effort}"
+    return model
 
 
 def _issue_labels(item: WorkItem, ctx: StageContext) -> list[str]:

--- a/tests/unit/agents/test_runtime.py
+++ b/tests/unit/agents/test_runtime.py
@@ -376,6 +376,34 @@ def test_codex_base_cmd_allows_terra_default_reasoning(model: str, tmp_path: Pat
 
 
 @pytest.mark.parametrize(
+    ("model", "expected_model", "reasoning_effort", "expected_reasoning"),
+    [
+        ("sol", "gpt-5.6-sol", "medium", "medium"),
+        ("gpt-5.6-terra", "gpt-5.6-terra", "xhigh", "xhigh"),
+        ("gpt-5.6-luna", "gpt-5.6-luna", "default", ""),
+        ("gpt-5.6", "gpt-5.6", "default", ""),
+        ("gpt-5.6", "gpt-5.6", "high", "high"),
+    ],
+)
+def test_codex_base_cmd_honors_explicit_reasoning_override(
+    model: str,
+    expected_model: str,
+    reasoning_effort: str,
+    expected_reasoning: str,
+    tmp_path: Path,
+) -> None:
+    """Per-role transport settings override a tier alias's default reasoning."""
+    with patch("hephaestus.agents.runtime.codex_approval_args", return_value=[]):
+        cmd = agent_runtime._codex_base_cmd(cwd=tmp_path, model=f"{model}:{reasoning_effort}")
+
+    assert cmd[cmd.index("--model") + 1] == expected_model
+    reasoning_args = [arg for arg in cmd if arg.startswith("model_reasoning_effort=")]
+    assert bool(reasoning_args) is bool(expected_reasoning)
+    if expected_reasoning:
+        assert reasoning_args == [f"model_reasoning_effort={json.dumps(expected_reasoning)}"]
+
+
+@pytest.mark.parametrize(
     "native_model",
     ["gpt-5.4-mini", "gpt-5.5", "gpt-5.6"],
 )

--- a/tests/unit/automation/pipeline/test_pipeline_flag.py
+++ b/tests/unit/automation/pipeline/test_pipeline_flag.py
@@ -10,6 +10,8 @@ The queue-based pipeline is the only automation-loop path (epic #1809, cutover
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,6 +20,7 @@ import hephaestus.automation.loop_runner as loop_runner
 import hephaestus.automation.pipeline.coordinator as coordinator_mod
 from hephaestus.automation.models import DEFAULT_STATE_DIR
 from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.stages.base import StageContext, stage_model
 from hephaestus.config.paths import DEFAULT_PROJECTS_DIR
 
 
@@ -203,6 +206,88 @@ def test_build_pipeline_config_maps_agent_and_models(
     assert config.planner_model == "gpt-plan"
     assert config.reviewer_model == "gpt-review"
     assert config.implementer_model == "gpt-impl"
+
+
+def test_build_pipeline_config_maps_per_role_reasoning_effort(
+    dispatch: dict[str, MagicMock], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The loop forwards each role's explicit reasoning setting to stages."""
+    monkeypatch.setattr(loop_runner, "resolve_agent", lambda agent: "codex")
+
+    loop_runner.main(
+        [
+            "--agent",
+            "codex",
+            "--planner-reasoning-effort",
+            "xhigh",
+            "--reviewer-reasoning-effort",
+            "default",
+            "--implementer-reasoning-effort",
+            "high",
+        ]
+    )
+
+    (config,) = dispatch["run_pipeline"].call_args.args
+    assert config.planner_reasoning_effort == "xhigh"
+    assert config.reviewer_reasoning_effort == "default"
+    assert config.implementer_reasoning_effort == "high"
+
+
+@pytest.mark.parametrize(
+    ("role", "model", "effort", "expected"),
+    [
+        ("planner", "sol", "xhigh", "sol:xhigh"),
+        ("implementer", "terra", "high", "terra:high"),
+        ("reviewer", "terra", "default", "terra:default"),
+    ],
+)
+def test_stage_model_propagates_per_role_reasoning_effort(
+    role: str, model: str, effort: str, expected: str
+) -> None:
+    """Every pipeline role transports its own reasoning setting to the runtime."""
+    config = SimpleNamespace(
+        agent="codex",
+        model="",
+        planner_model="sol" if role == "planner" else "",
+        implementer_model="terra" if role == "implementer" else "",
+        reviewer_model="terra" if role == "reviewer" else "",
+        planner_reasoning_effort="xhigh" if role == "planner" else "",
+        implementer_reasoning_effort="high" if role == "implementer" else "",
+        reviewer_reasoning_effort="default" if role == "reviewer" else "",
+    )
+
+    context = cast(StageContext, SimpleNamespace(config=config))
+    assert stage_model(context, role, lambda: model) == expected
+
+
+@pytest.mark.parametrize("agent", ["claude", "pi"])
+def test_stage_model_does_not_append_codex_reasoning_to_other_provider_model(agent: str) -> None:
+    """A Codex-only reasoning flag cannot corrupt another provider's model selection."""
+    config = SimpleNamespace(
+        agent=agent,
+        model="",
+        reviewer_model="claude-sonnet-4-6",
+        reviewer_reasoning_effort="default",
+    )
+
+    context = cast(StageContext, SimpleNamespace(config=config))
+    assert stage_model(context, "reviewer", lambda: "fallback") == ("claude-sonnet-4-6")
+
+
+@pytest.mark.parametrize("model", ["terra:default", "gpt-5.6-terra:default"])
+def test_stage_model_replaces_existing_codex_reasoning_selector(model: str) -> None:
+    """An explicit role override replaces, rather than stacks on, a model selector."""
+    config = SimpleNamespace(
+        agent="codex",
+        model="",
+        reviewer_model=model,
+        reviewer_reasoning_effort="xhigh",
+    )
+
+    context = cast(StageContext, SimpleNamespace(config=config))
+    assert stage_model(context, "reviewer", lambda: "fallback") == (
+        model.removesuffix(":default") + ":xhigh"
+    )
 
 
 def test_phase_timeout_help_documents_agent_job_scope() -> None:

--- a/tests/unit/automation/test_automation_parsers.py
+++ b/tests/unit/automation/test_automation_parsers.py
@@ -707,6 +707,17 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             help_text="HEPH_PLANNER_MODEL for child processes",
         ),
         _action_spec(
+            ("--planner-reasoning-effort",),
+            "planner_reasoning_effort",
+            "_StoreAction",
+            "",
+            choices=("default", "low", "medium", "high", "xhigh"),
+            help_text=(
+                "Explicit Codex reasoning effort for this role. Use default to omit "
+                "model_reasoning_effort; when omitted, the selected model alias keeps its default."
+            ),
+        ),
+        _action_spec(
             ("--reviewer-model",),
             "reviewer_model",
             "_StoreAction",
@@ -723,6 +734,28 @@ EXPECTED_SPECS: dict[str, tuple[ActionSpec, ...]] = {
             "",
             help_text=(
                 "HEPH_IMPLEMENTER_MODEL for child processes (implement, address-review, ci-driver)"
+            ),
+        ),
+        _action_spec(
+            ("--reviewer-reasoning-effort",),
+            "reviewer_reasoning_effort",
+            "_StoreAction",
+            "",
+            choices=("default", "low", "medium", "high", "xhigh"),
+            help_text=(
+                "Explicit Codex reasoning effort for this role. Use default to omit "
+                "model_reasoning_effort; when omitted, the selected model alias keeps its default."
+            ),
+        ),
+        _action_spec(
+            ("--implementer-reasoning-effort",),
+            "implementer_reasoning_effort",
+            "_StoreAction",
+            "",
+            choices=("default", "low", "medium", "high", "xhigh"),
+            help_text=(
+                "Explicit Codex reasoning effort for this role. Use default to omit "
+                "model_reasoning_effort; when omitted, the selected model alias keeps its default."
             ),
         ),
         _action_spec(


### PR DESCRIPTION
Closes #2195

Adds validated planner, implementer, and reviewer reasoning-effort controls for Codex. `default` omits the provider override, while omitted flags preserve alias defaults.

Validation:
- `uv run pre-commit run --all-files`
- `uv run pytest tests/unit -q --no-cov`