### PR TITLE
Accept worktree type-change status in issue 2142 commit parser

### DIFF
--- a/tests/unit/automation/test_pr_manager_commit.py
+++ b/tests/unit/automation/test_pr_manager_commit.py
@@ -87,6 +87,24 @@ class TestParsePorcelainStatus:
         with pytest.raises(RuntimeError, match="Malformed"):
             pr_manager._parse_porcelain_status(porcelain)
 
+    def test_accepts_worktree_type_change_status(self) -> None:
+        """Regression (#2228): a worktree-only type change ``" T"`` is valid.
+
+        Git reports a file whose type changed in the worktree (e.g. a regular
+        file replaced by a symlink) with an unstaged ``" T"`` status. PR #2208
+        added it to ``_PORCELAIN_STATUS_PAIRS``; this pins the behavior so a
+        future edit to that allowlist cannot silently reject the entry again.
+        """
+        porcelain = " T src/type-changed.py\0"
+
+        assert pr_manager._parse_porcelain_status(porcelain) == ((" T", "src/type-changed.py"),)
+
+    @pytest.mark.parametrize("status", ("TA", "TR", "TC"))
+    def test_rejects_invalid_type_change_status(self, status: str) -> None:
+        """An index type-change paired with add/rename/copy is not a valid pair."""
+        with pytest.raises(RuntimeError, match="Malformed"):
+            pr_manager._parse_porcelain_status(f"{status} src/type-changed.py\0")
+
 
 class TestSelectCommitPaths:
     """Tests for applying staging policy to parsed paths."""


### PR DESCRIPTION
## Summary
All gates green. The only working-tree change is the test file — the parser is untouched, as the plan required.

## Summary

**Changed:** `tests/unit/automation/test_pr_manager_commit.py` — added two focused regression tests to `TestParsePorcelainStatus` (after `test_rejects_malformed_records`):
- `test_accepts_worktree_type_change_status` — pins that `_parse_porcelain_status(" T src/type-changed.py\0")` returns `((" T", "src/type-changed.py"),)`.
- `test_rejects_invalid_type_change_status` (parametrized `"TA"/"TR"/"TC"`) — asserts unsupported index-type-change pairs still raise `RuntimeError("Malformed")`.

**Parser untouched** — the `" T"` fix already landed on `main` via PR #2208 (`_PORCELAIN_STATUS_PAIRS` at `hephaestus/automation/pr_manager.py:77`). The live gap was a *focused* regression test, since `" T"` was only covered inside a broad parametrized case.

**Verification (all evidence from actual runs):**
- New + negative tests: `12 passed` (1 positive, 3 type-change reject, 8 malformed).
- Fails-before demo: stripping `T` from the `"AMDTRC"` generator made the positive test fail (`RuntimeError` at `pr_manager.py:778`); reverting → passes. Mutation was **not committed** (parser file confirmed clean).
- Full commit-parser suite (`test_pr_manager_commit.py` + `test_pr_manager.py`): `80 passed`, no regression.
- `ruff check`: passed. `mypy`: no issues.

**Acceptance criteria mapped:** accept valid `" T"` ✅ | focused regression fails-before/passes-after ✅ | invalid status still rejected ✅ | strict-review GO is a gated pipeline step produced against the pushed head, not authored here.

Left in the working tree for the orchestrator to commit (`Closes #2228`, `test(automation):`).


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2228

Generated by Hephaestus automation
