### PR TITLE
Regenerate uv.lock for issue 2149 Windows-only tzdata constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pyyaml>=6.0,<7",
     # IANA timezone data is bundled with Python on POSIX but not on Windows;
     # rate_limit.py uses ZoneInfo which needs it on Windows.
-    "tzdata; platform_system == 'Windows'",
+    "tzdata>=2026.2,<2027; platform_system == 'Windows'",
 ]
 
 # Optional-dependency groups. The `all` aggregator below intentionally lists

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0,<7" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'all'", specifier = ">=2.0,<3" },
     { name = "tomli", marker = "python_full_version < '3.11' and extra == 'toml'", specifier = ">=2.0,<3" },
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2026.2,<2027" },
 ]
 provides-extras = ["all", "automation", "github", "nats", "schema", "toml", "xml"]
 


### PR DESCRIPTION
## Summary
The test collection output was empty (likely conftest collection noise printed elsewhere), but the earlier full run already confirmed `2 passed in 3.67s`. Working tree is clean of backup files — only the two intended files are modified.

Implementation complete.

**Summary**

Per the approved plan for #2230, this regenerates `uv.lock` to match the Windows-only tzdata version constraint from issue #2149 / PR #2214.

**Changes (2 files, 2 lines):**
- `pyproject.toml:34` — applied the version specifier: `"tzdata; platform_system == 'Windows'"` → `"tzdata>=2026.2,<2027; platform_system == 'Windows'"`
- `uv.lock:676` — regenerated via `uv lock`; the `requires-dist` metadata entry now carries `specifier = ">=2026.2,<2027"` (the missing specifier that caused PR #2214's deterministic NOGO). The dependency-graph markers (`uv.lock:607`, `:676`) stay `sys_platform == 'win32'` — the uv-normalized form of `platform_system == 'Windows'`, so Windows-only scope is preserved. No hand-editing; the resolver produced the file.

**Verification (all real, all passed):**
- `uv lock --check` → exit 0, "Resolved 88 packages" (lock fresh, matches metadata)
- tzdata marker-leak grep → `scope-ok` (no non-Windows tzdata line)
- `uv run pytest tests/unit/ci/test_uv_lock_policy.py` → `2 passed` (the coverage-gate non-zero exit is an artifact of running one file at 1.6% tree coverage, not a test failure)
- `uv run pre-commit run uv-lock --all-files` → Passed (CI-parity lock-freshness hook)

**Deferred (per ADR-014):** the "fresh strict review returns unconditional GO" acceptance criterion is the queue's head-bound strict-review gate on the eventual PR head — an external gated evidence step this agent does not author. The trigger (a PR whose body contains `Closes #2230`) is left to the orchestrator.

No source or test code changed — this is a lockfile-regeneration artifact task, as the plan scoped it.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2230

Generated by Hephaestus automation
