### PR TITLE
Repair issue 2145 performance suite collection and p95 gate

### DIFF
--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -25,6 +25,12 @@ completion, no duplicates, use of every configured worker during sustained
 load, a bounded drain, end-to-end p95 latency no higher than 500 ms, and
 four-worker capacity at least twice the one-worker control.
 
+Percentiles are computed by linear interpolation between closest ranks
+(`rank = percentile * (n - 1)`, numpy's default `linear` method), which is
+tail-inclusive: a small fraction of very slow completions cannot hide below
+the p95 gate the way a nearest-rank formula rounding down into the fast body
+would (issue #2229).
+
 ## Running locally
 
 Run the same bounded profile used by CI explicitly; the directory is excluded

--- a/tests/performance/test_percentile_regression.py
+++ b/tests/performance/test_percentile_regression.py
@@ -1,0 +1,32 @@
+"""Regression guard: p95 must include the slow tail (issue #2229)."""
+
+from __future__ import annotations
+
+from math import ceil
+
+import pytest
+
+from tests.performance.test_worker_pool_load import _latency_summary, _percentile
+
+
+def _nearest_rank_p95(samples: list[float]) -> float:
+    """Reproduce the pre-#2229 nearest-rank formula: ``ceil(n*p) - 1``, clamped."""
+    ordered = sorted(samples)
+    index = min(len(ordered) - 1, max(0, ceil(len(ordered) * 0.95) - 1))
+    return ordered[index]
+
+
+@pytest.mark.performance
+def test_prior_nearest_rank_underreported_the_tail() -> None:
+    """Document the defect: nearest-rank p95 excluded the slowest 5%."""
+    samples = [10.0] * 95 + [9_999.0] * 5
+    # Old behavior missed the entire slow tail...
+    assert _nearest_rank_p95(samples) == 10.0
+    # ...while the repaired interpolation reports a tail-inclusive value.
+    assert _latency_summary(samples).p95 > 500.0
+
+
+@pytest.mark.performance
+def test_repaired_p95_catches_a_single_slow_completion() -> None:
+    """Ten samples with one slow tenth yield an interpolated tail p95."""
+    assert _percentile([10.0] * 9 + [1_000.0], 0.95) == pytest.approx(554.5)

--- a/tests/performance/test_worker_pool_load.py
+++ b/tests/performance/test_worker_pool_load.py
@@ -9,7 +9,6 @@ import queue
 import threading
 import time
 from dataclasses import asdict, dataclass, replace
-from math import ceil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -171,30 +170,24 @@ class _LoadReport:
 
 
 def _percentile(samples: list[float], percentile: float) -> float:
-    """Return the nearest-rank percentile for non-empty millisecond samples."""
+    """Return the linearly interpolated percentile (tail-inclusive) in ms.
+
+    Uses interpolation between closest ranks (numpy's default ``linear``
+    method): ``rank = percentile * (n - 1)``. Unlike nearest-rank, this
+    straddles into the slow tail so a small fraction of very slow
+    completions cannot hide below the p95 gate (issue #2229).
+    """
     if not samples:
         return 0.0
     ordered = sorted(samples)
-    index = min(len(ordered) - 1, max(0, ceil(len(ordered) * percentile) - 1))
-    return ordered[index]
-
-
-@pytest.mark.performance
-@pytest.mark.parametrize(
-    ("percentile", "expected"),
-    [(0.50, 5.0), (0.95, 10.0), (0.99, 10.0)],
-)
-def test_percentile_uses_nearest_rank(percentile: float, expected: float) -> None:
-    """Tail percentiles use the nearest rank instead of rounding down."""
-    assert _percentile([float(value) for value in range(1, 11)], percentile) == expected
-
-
-@pytest.mark.performance
-def test_p95_nearest_rank_includes_slow_tail_completion() -> None:
-    """A single slow tenth completion must be included in p95."""
-    end_to_end_samples = [10.0] * 9 + [1_000.0]
-
-    assert _latency_summary(end_to_end_samples).p95 == 1_000.0
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = percentile * (len(ordered) - 1)
+    low = int(rank)
+    frac = rank - low
+    if low + 1 < len(ordered):
+        return ordered[low] + frac * (ordered[low + 1] - ordered[low])
+    return ordered[low]
 
 
 def _latency_summary(samples: list[float]) -> _LatencySummary:
@@ -205,6 +198,24 @@ def _latency_summary(samples: list[float]) -> _LatencySummary:
         p99=_percentile(samples, 0.99),
         maximum=max(samples, default=0.0),
     )
+
+
+@pytest.mark.performance
+@pytest.mark.parametrize(
+    ("percentile", "expected"),
+    [(0.50, 5.5), (0.95, 9.55), (0.99, 9.91)],
+)
+def test_percentile_interpolates_between_closest_ranks(percentile: float, expected: float) -> None:
+    """Percentiles interpolate between ranks instead of rounding down a tail."""
+    samples = [float(value) for value in range(1, 11)]
+    assert _percentile(samples, percentile) == pytest.approx(expected)
+
+
+@pytest.mark.performance
+def test_p95_includes_slow_tail_completion() -> None:
+    """A single slow tenth completion pulls p95 into the tail."""
+    end_to_end_samples = [10.0] * 9 + [1_000.0]
+    assert _latency_summary(end_to_end_samples).p95 == pytest.approx(554.5)
 
 
 def _write_json_report(report_path: Path, payload: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary
Implementation complete. Summary below.

## Summary

Issue #2229 asked to repair the performance suite's collection and its p95 gate. **Key finding:** the approved plan assumed PR #2212 was unmerged (prescribing "materialize files from history"), but #2212 was already merged to `main` — so its files (and the `pyproject.toml` marker registration + `-m "not performance"` deselect that make collection reliable) were already present. Collection already worked; the real defect left to fix was the p95 tail-underreporting. I therefore edited in place rather than overwriting from history.

**Changes (3 files):**
- `tests/performance/test_worker_pool_load.py` — replaced nearest-rank `_percentile` (`ceil(n·p)−1`, which rounds below the slow tail) with linear interpolation between closest ranks (`rank = p·(n−1)`, numpy's default `linear`); moved `_percentile`/`_latency_summary` above the tests (removing a forward-reference); dropped the now-unused `from math import ceil`; rewrote the two nearest-rank tests to assert the tail-inclusive interpolated values.
- `tests/performance/test_percentile_regression.py` (**new**) — encodes the "demonstrates prior underreporting" criterion: on `[10]*95 + [9999]*5`, the reproduced old formula returns `10.0` (whole 5% tail hidden) while the repaired p95 reports `>500`.
- `docs/performance-testing.md` — one paragraph describing the tail-inclusive linear-interpolation method.

**Defect proof (deterministic):** on `n=100` with a 5% slow tail, nearest-rank p95 = `10.0` (passes a 500 ms gate despite catastrophic tail); linear = `509.45`. Matches the plan's numbers.

**Verification run (all green):**
- Performance-lane collection gate (as CI runs it): 13 tests collect under `--strict-markers`.
- Default lane still collects (marker registered): 6494 tests collect.
- Percentile/regression tests: 6 passed.
- Full performance lane incl. **real-thread bounded load** (`test_worker_pool_*`, short profile): 13 passed — the p95 gate now measures a tail-inclusive value end-to-end.
- `tests/unit/ci/test_workflows.py`: 65 passed. Repo-wide `ruff check`: clean. Repo-wide `mypy`: no issues (572 files). Pre-commit hooks on changed files: all pass.

**ADR-014 note:** no measured latency/throughput number is committed. The p95-correctness criteria are proven by deterministic tests on fixed arrays; the "fresh strict GO" criterion is produced by the queue's head-bound review against the pushed head, not authored here.

No git/GitHub mutations performed. Working tree left with the three changes for the orchestrator to commit.

Verdict: DONE | Reason: p95 gate now tail-inclusive (linear interpolation), regression test proves prior underreporting, collection green, all local gates pass.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2229

Generated by Hephaestus automation
