### PR TITLE
[mino] Make the local privacy denylist policy centrally effective

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ Thumbs.db
 .env
 .env.local
 .heph-private-denylist
+# .heph-project-denylist is intentionally tracked (centrally enforced); never ignore it.
+!.heph-project-denylist
 *.pem
 credentials.json
 

--- a/.heph-project-denylist
+++ b/.heph-project-denylist
@@ -1,0 +1,6 @@
+# Project-level private/PII denylist (committed, centrally enforced).
+# One fixed string per line. Blank lines and #-comments are ignored.
+# Unlike .heph-private-denylist (local, untracked, operator secrets), this
+# file is tracked and scanned in CI for EVERY contributor. Only put patterns
+# here that are safe to name in a public repo (e.g. deprecated internal
+# hostnames, banned placeholder leaks). Genuine secrets go in the local file.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -249,11 +249,11 @@ repos:
         pass_filenames: false
         always_run: true
       - id: check-private-denylist
-        name: Check local private denylist
+        name: Check private denylist
         description: >
-          If .heph-private-denylist exists locally, reject staged or tracked
-          text containing any fixed string listed there. The denylist itself is
-          gitignored and must never be committed. Diagnostics print only
+          Reject staged or tracked text matching any fixed string in the
+          committed .heph-project-denylist (centrally enforced) or the local,
+          untracked .heph-private-denylist. Diagnostics print only
           source/path/line, never matched values.
         entry: python3 scripts/check_private_denylist.py --staged --tracked
         language: system

--- a/docs/pi-private-provider.md
+++ b/docs/pi-private-provider.md
@@ -38,3 +38,12 @@ python3 scripts/check_private_denylist.py --staged --tracked
 
 The guard prints only file paths and line numbers. It intentionally never prints
 matched values or source lines.
+
+## Project-level denylist (committed)
+
+`.heph-project-denylist` is committed to the repo and scanned in CI for every
+contributor, so the privacy policy is effective even without a local file. Add
+only patterns safe to name in a public repo (deprecated hostnames, banned
+placeholder leaks). Genuine operator secrets still go in the untracked
+`.heph-private-denylist`. Both files use one fixed string per line; blank lines
+and `#`-comments are ignored. The two lists are merged and de-duplicated.

--- a/scripts/check_private_denylist.py
+++ b/scripts/check_private_denylist.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
-"""Reject local private tokens in tracked or staged text files.
+"""Reject private/PII tokens in tracked or staged text files.
 
-Operators can create an untracked ``.heph-private-denylist`` at the repository
-root with one fixed string per line. When present, this guard scans supplied
-paths (working-tree mode), git-tracked files, or staged index content and fails
-if any denylisted string appears. Diagnostics intentionally print only
+This guard merges two denylist sources at the repository root, both one fixed
+string per line:
+
+* ``.heph-project-denylist`` — committed and centrally enforced, so the policy
+  is effective for every contributor and in CI even when no local file exists.
+  Only patterns safe to name in a public repo belong here.
+* ``.heph-private-denylist`` — optional, operator-local, and gitignored, for
+  genuine secret values known only on a given machine.
+
+When any token is present, this guard scans supplied paths (working-tree mode),
+git-tracked files, or staged index content and fails if a denylisted string
+appears. The denylist files themselves are never flagged as their own
+violation on any scan path. Diagnostics intentionally print only
 source/path/line, never the matched value or source line.
 
 Usage:
@@ -20,6 +29,7 @@ from pathlib import Path
 from typing import Literal, NamedTuple
 
 DENYLIST_FILENAME = ".heph-private-denylist"
+PROJECT_DENYLIST_FILENAME = ".heph-project-denylist"
 PRIVATE_DENYLIST_REDACTION = "<redacted-private-denylist-value>"
 ScanSource = Literal["working-tree", "tracked", "staged"]
 
@@ -42,9 +52,18 @@ def get_repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
 
-def load_denylist(repo_root: Path) -> list[str]:
-    """Return local denylist tokens, ignoring blank lines and comments."""
-    path = repo_root / DENYLIST_FILENAME
+def _is_denylist_file(repo_root: Path, path: Path) -> bool:
+    """True if *path* is either denylist file (never scanned as a violation)."""
+    candidate = path if path.is_absolute() else repo_root / path
+    denylist_paths = {
+        (repo_root / DENYLIST_FILENAME).resolve(),
+        (repo_root / PROJECT_DENYLIST_FILENAME).resolve(),
+    }
+    return candidate.resolve() in denylist_paths
+
+
+def _read_tokens(path: Path) -> list[str]:
+    """Return denylist tokens from *path*, ignoring blank lines and comments."""
     if not path.exists():
         return []
     tokens: list[str] = []
@@ -53,6 +72,23 @@ def load_denylist(repo_root: Path) -> list[str]:
         if token and not token.startswith("#"):
             tokens.append(token)
     return tokens
+
+
+def load_denylist(repo_root: Path) -> list[str]:
+    """Return merged project + local denylist tokens, project-first, de-duplicated.
+
+    Merges the committed, centrally-enforced ``.heph-project-denylist`` with the
+    optional operator-local ``.heph-private-denylist`` so the policy is effective
+    even when no local file exists. Order is stable and duplicates are removed.
+    """
+    merged: list[str] = []
+    seen: set[str] = set()
+    for filename in (PROJECT_DENYLIST_FILENAME, DENYLIST_FILENAME):
+        for token in _read_tokens(repo_root / filename):
+            if token not in seen:
+                seen.add(token)
+                merged.append(token)
+    return merged
 
 
 def _git_paths(repo_root: Path, cmd: list[str]) -> list[Path]:
@@ -131,10 +167,9 @@ def scan_paths(
     findings: list[Finding] = []
     if not tokens:
         return findings
-    denylist_path = (repo_root / DENYLIST_FILENAME).resolve()
     for path in paths:
         candidate = path if path.is_absolute() else repo_root / path
-        if candidate.resolve() == denylist_path or not candidate.is_file():
+        if _is_denylist_file(repo_root, candidate) or not candidate.is_file():
             continue
         try:
             lines = candidate.read_text(encoding="utf-8").splitlines()
@@ -182,6 +217,8 @@ def main(argv: list[str] | None = None) -> int:
             )
         if args.staged:
             for rel_path in staged_files(repo_root, pathspecs):
+                if _is_denylist_file(repo_root, rel_path):
+                    continue
                 text = staged_text(repo_root, rel_path)
                 if text is not None:
                     findings.extend(_scan_text("staged", rel_path, text, tokens))
@@ -189,12 +226,15 @@ def main(argv: list[str] | None = None) -> int:
     if not findings:
         return 0
 
-    print("ERROR: local private denylist match(es) found. Remove the value before committing:")
+    print("ERROR: private denylist match(es) found. Remove the value before committing:")
     for finding in findings:
         redacted_path = _redact_private_tokens(str(finding.path), tokens)
         print(f"  {finding.source} {redacted_path}:{finding.line_number}")
     print("\nMatched values and line contents are intentionally not printed.")
-    print(f"\nDenylist source: {DENYLIST_FILENAME} (local, untracked)")
+    print(
+        f"\nDenylist sources: {PROJECT_DENYLIST_FILENAME} (project, tracked), "
+        f"{DENYLIST_FILENAME} (local, untracked)"
+    )
     return 1
 
 

--- a/tests/unit/docs/test_pi_private_provider_docs.py
+++ b/tests/unit/docs/test_pi_private_provider_docs.py
@@ -27,6 +27,7 @@ def test_pi_private_provider_docs_are_sanitized() -> None:
     assert "~/.pi/agent/models.json" in text
     assert "HEPH_PI_MODEL" in text
     assert ".heph-private-denylist" in text
+    assert ".heph-project-denylist" in text
     assert "--staged --tracked" in text
     assert "<operator-local-alias>" in text
     assert "https://" not in text

--- a/tests/unit/scripts/test_check_project_denylist.py
+++ b/tests/unit/scripts/test_check_project_denylist.py
@@ -1,0 +1,119 @@
+"""Tests for the committed project-level denylist source in check_private_denylist.py.
+
+Issue #2179: the local ``.heph-private-denylist`` is optional and, when absent
+(the default for CI and fresh clones), the guard is a silent no-op. The
+committed ``.heph-project-denylist`` makes the privacy policy centrally
+effective for every contributor. These tests cover the merge/dedup loader, the
+central-effectiveness path, and the self-skip on the working-tree and staged
+scan paths (the tracked pattern file must never flag itself).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "check_private_denylist.py"
+_spec = importlib.util.spec_from_file_location("check_private_denylist", _SCRIPT)
+assert _spec and _spec.loader
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repository for index scan tests."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def test_load_denylist_reads_project_file_when_local_absent(tmp_path: Path) -> None:
+    """A committed project token is enforced even with no local file (core criterion)."""
+    (tmp_path / ".heph-project-denylist").write_text(
+        "# project baseline\nBANNED_PROJECT_PATTERN\n",
+        encoding="utf-8",
+    )
+
+    assert _mod.load_denylist(tmp_path) == ["BANNED_PROJECT_PATTERN"]
+
+
+def test_load_denylist_merges_and_dedupes_both_sources(tmp_path: Path) -> None:
+    """Both sources merge project-first, order-stable, with duplicates removed."""
+    (tmp_path / ".heph-project-denylist").write_text(
+        "SHARED_TOKEN\nBANNED_PROJECT_PATTERN\n",
+        encoding="utf-8",
+    )
+    (tmp_path / ".heph-private-denylist").write_text(
+        "SHARED_TOKEN\nPRIVATE_ENDPOINT_TOKEN\n",
+        encoding="utf-8",
+    )
+
+    assert _mod.load_denylist(tmp_path) == [
+        "SHARED_TOKEN",
+        "BANNED_PROJECT_PATTERN",
+        "PRIVATE_ENDPOINT_TOKEN",
+    ]
+
+
+def test_both_files_empty_is_noop(tmp_path: Path) -> None:
+    """An absent (or empty) pair of sources leaves the guard a no-op."""
+    assert _mod.load_denylist(tmp_path) == []
+
+    (tmp_path / ".heph-project-denylist").write_text("# comments only\n", encoding="utf-8")
+    assert _mod.load_denylist(tmp_path) == []
+
+
+def test_main_flags_project_token_without_local_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """main() fails on a project token with no local file, and redacts the value."""
+    (tmp_path / ".heph-project-denylist").write_text(
+        "BANNED_PROJECT_PATTERN\n",
+        encoding="utf-8",
+    )
+    source = tmp_path / "docs" / "example.md"
+    source.parent.mkdir()
+    source.write_text("This mentions BANNED_PROJECT_PATTERN.\n", encoding="utf-8")
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: tmp_path)
+
+    assert _mod.main([str(source)]) == 1
+
+    output = capsys.readouterr().out
+    assert "docs/example.md:1" in output
+    assert "BANNED_PROJECT_PATTERN" not in output
+    assert "intentionally not printed" in output
+
+
+def test_scan_paths_skips_project_denylist_file(tmp_path: Path) -> None:
+    """The committed pattern file is never flagged in the working-tree scan path."""
+    (tmp_path / ".heph-project-denylist").write_text(
+        "BANNED_PROJECT_PATTERN\n",
+        encoding="utf-8",
+    )
+    tokens = _mod.load_denylist(tmp_path)
+
+    findings = _mod.scan_paths(tmp_path, [tmp_path / ".heph-project-denylist"], tokens)
+
+    assert findings == []
+
+
+def test_staged_scan_skips_project_denylist_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Staging the populated project file must not self-flag (the central write path).
+
+    Because ``--no-verify`` is banned in this repo, staging a real pattern into
+    the tracked ``.heph-project-denylist`` must not be blocked by the guard the
+    hook runs, or the central list could never be populated.
+    """
+    repo = _init_repo(tmp_path)
+    (repo / ".heph-project-denylist").write_text(
+        "BANNED_PROJECT_PATTERN\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "add", ".heph-project-denylist"], cwd=repo, check=True)
+    monkeypatch.setattr(_mod, "get_repo_root", lambda: repo)
+
+    assert _mod.main(["--staged"]) == 0


### PR DESCRIPTION
## Summary
All changes are in the working tree; no backup files. (`.heph-project-denylist` was staged during the guard-verification step — that's harmless; the orchestrator owns the commit.)

## Summary

Issue #2179 — the local `.heph-private-denylist` was the *only* PII control, and it's gitignored, so on CI/fresh clones the guard was a silent no-op. Made the policy centrally effective by adding a committed, always-loaded project-level source.

**Changes:**
- `scripts/check_private_denylist.py`
  - Added `PROJECT_DENYLIST_FILENAME = ".heph-project-denylist"`.
  - New `_read_tokens()` (per-file reader) and `_is_denylist_file()` (single-source-of-truth self-skip predicate).
  - Rewrote `load_denylist()` to merge both sources, project-first, order-stable, de-duplicated.
  - Routed `scan_paths()`'s inline skip and — critically — the previously-unguarded `--staged` loop (`:183-187`) through `_is_denylist_file()`, so staging the tracked project file with its own token exits 0 (required because `--no-verify` is banned).
  - Updated module docstring, error header, and footer to name both sources.
- `.heph-project-denylist` (new) — header-only, no active patterns (no-op until the project adds banned literals).
- `.gitignore` — `!.heph-project-denylist` negation so it stays tracked.
- `.pre-commit-config.yaml` — hook description now covers both sources (entry unchanged).
- `docs/pi-private-provider.md` — new "Project-level denylist (committed)" section.
- `tests/unit/docs/test_pi_private_provider_docs.py` — asserts `.heph-project-denylist` is documented.
- `tests/unit/scripts/test_check_project_denylist.py` (new) — 6 tests: central effectiveness, merge/dedup, empty-noop, redacted main-flag, working-tree self-skip, and the staged-self-skip (real git repo, `main(["--staged"]) == 0`).

**Tests run (all local, no git/GitHub mutation):**
- New + existing denylist tests: 14 passed.
- `tests/unit/scripts tests/unit/ci tests/unit/docs`: 393 passed, 3 skipped.
- `python3 scripts/check_private_denylist.py --staged --tracked` on the repo (with project file staged): exit 0.
- `uv run pre-commit run --all-files`: all hooks pass (including `check-private-denylist`).
- Full `tests/unit`: **6119 passed, 22 skipped, coverage 84.72%** (≥83% gate).

RED-GREEN followed: the merge/central-effectiveness tests failed against the single-source loader before the implementation and pass after.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2179

Generated by Hephaestus automation
