### PR TITLE
[Fix] Route unmapped-stage items to finished(fail) instead of KeyError

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -413,7 +413,10 @@ class Coordinator:
             self._routes = config.scope.trimmed_routes()
             self._routes.setdefault(StageName.FINISHED, ROUTES[StageName.FINISHED])
         else:
-            self._routes = ROUTES
+            # Copy, not alias: ``ROUTES`` is a module-level shared table, so an
+            # accidental in-place edit of ``self._routes`` would corrupt every
+            # other run/test. The table is small and built once per run.
+            self._routes = dict(ROUTES)
 
         self._install_signals = install_signals
         self._seq = 0
@@ -1205,7 +1208,23 @@ class Coordinator:
 
     def _route(self, item: WorkItem, outcome: StageOutcome) -> None:
         """Apply the Disposition -> action table (plan #1817)."""
-        route = self._routes[item.stage]
+        route = self._routes.get(item.stage)
+        if route is None:
+            # A stage absent from this run's (possibly scope-trimmed) route
+            # table has no next/fail mapping — routing it would KeyError. This
+            # happens when a seeder-created REPO item is poisoned under a
+            # partial ``--phases`` scope whose ``trimmed_routes`` omits REPO
+            # (#2294). Fail closed to the sink instead of crashing the whole
+            # run, which the poison handler that called us already intends.
+            logger.error(
+                "coordinator: %s has no route in this run's stage scope; "
+                "finishing failed instead of crashing (%s)",
+                item.stage.value,
+                outcome.note or "unroutable",
+            )
+            reason = outcome.note or f"unroutable:{item.stage.value}"
+            self._finish(item, passed=False, reason=reason)
+            return
         disposition = outcome.disposition
 
         if item.stage is StageName.FINISHED:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -647,6 +647,33 @@ class TestFailBackRouting:
         assert item.stage is StageName.FINISHED
         assert item.result is not None and not item.result.passed
 
+    def test_stage_absent_from_route_table_finishes_failed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A poisoned item whose stage is not in the run's routes finishes failed (#2294).
+
+        Under a partial ``--phases`` scope, ``trimmed_routes`` can omit
+        ``StageName.REPO`` even though the seeder always pushes a REPO item.
+        Routing a poisoned REPO item must fail closed to the sink, not raise
+        ``KeyError`` and crash the whole run.
+        """
+        coordinator, _, _ = make_coordinator(tmp_path, monkeypatch)
+        # Simulate a scope-trimmed route table with no REPO entry. Assign a
+        # fresh copy so the module-level ROUTES dict (aliased by the default
+        # unscoped path) is never mutated across tests.
+        coordinator._routes = {
+            s: r for s, r in coordinator._routes.items() if s is not StageName.REPO
+        }
+        item = WorkItem(
+            repo="repo-a", kind=ItemKind.REPO, issue=None, stage=StageName.REPO, state="ENTER"
+        )
+
+        coordinator._route(item, StageOutcome(Disposition.FINISH_FAIL, "poisoned: boom"))
+
+        assert item.stage is StageName.FINISHED
+        assert item.result is not None and not item.result.passed
+        assert "poisoned: boom" in item.result.reason
+
     def test_dry_run_fail_back_finishes_instead_of_regressing(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1460,7 +1487,12 @@ class TestPipelineScopeWiring:
         assert coordinator._routes[StageName.PLAN_REVIEW].next == StageName.FINISHED
 
     def test_full_run_uses_global_routes(self, tmp_path: Path) -> None:
-        """Without a scope the coordinator routes through the full ROUTES table."""
+        """Without a scope the coordinator routes through the full ROUTES table.
+
+        It uses a COPY of ROUTES, not the shared object itself, so an
+        in-place edit of ``self._routes`` can never corrupt the module-level
+        table for other runs (#2294).
+        """
         from hephaestus.automation.pipeline.routing import ROUTES
 
         config = PipelineConfig(org="org", repos=["repo-a"], loops=1, projects_dir=tmp_path)
@@ -1468,7 +1500,8 @@ class TestPipelineScopeWiring:
             config, github=FakeStageGitHub(), pool=FakeWorkerPool(), install_signals=False
         )
 
-        assert coordinator._routes is ROUTES
+        assert coordinator._routes == ROUTES
+        assert coordinator._routes is not ROUTES
 
     def test_direct_issue_scope_hydrates_issue_context_payload(self, tmp_path: Path) -> None:
         """Explicit --issues seeding preserves the real issue title/body for prompts."""


### PR DESCRIPTION
## Summary

A `--phases drive-green` run crashed at the seeding stage:
```
ERROR coordinator: pipeline item Hephaestus poisoned at repo; routing to finished(fail)
Traceback ... coordinator._route -> route = self._routes[item.stage]
KeyError: <StageName.REPO: 'repo'>
```
`_route` indexed `self._routes[item.stage]` directly. Under a partial `--phases` scope, `trimmed_routes` omits `StageName.REPO` even though the seeder always pushes a REPO item — so a poisoned REPO item raised `KeyError` and killed the entire run (the poison handler that logged "routing to finished(fail)" could never reach the sink).

## Fix

- `_route` now routes any stage absent from the run's route table to `finished(fail)` — failing closed to the sink that the poison path already intended, instead of crashing.
- The unscoped path now uses `dict(ROUTES)` (a copy) rather than aliasing the module-level `ROUTES`, so an in-place edit of `self._routes` can never corrupt the shared table for other runs/tests.

## Tests

New `test_stage_absent_from_route_table_finishes_failed` pins the fallback (a poisoned REPO item with REPO removed from `_routes` finishes failed, no KeyError). Updated `test_full_run_uses_global_routes` to the copy contract. 951 pipeline tests pass; lint/mypy clean.

Closes #2294

🤖 Generated with [Claude Code](https://claude.com/claude-code)