### PR TITLE
[majo] Refresh the roadmap current-focus period

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,13 +4,17 @@
 
 Hephaestus is the foundational utilities and tooling repository of the HomericIntelligence ecosystem, providing standardized components that support development across all other projects. We prioritize modularity, reliability, and consistency across a diverse set of cross-cutting concerns: configuration management, logging, GitHub automation, and agent coordination.
 
-## Current Focus (Q2 2026)
+## Current Focus (Q3 2026)
 
-The strict 2026-04-28 repository audit (Epic #310) is now **closed**. The active work is remediating findings from the follow-up strict 2026-05-28 audit, tracked as individual `audit-finding` issues. This ongoing work spans:
+Remediation of the strict 2026-05-28 audit findings (`audit-finding` issues) continues, now alongside hardening of the queue-based automation pipeline delivered under Epic #1809 and the fail-closed auto-merge bootstrap (#2054/#2055). This ongoing work spans:
 
 1. **Audit Remediation** — Addressing the open `audit-finding` issues across the 15 audit dimensions. Focus areas include documentation currency, automation module test coverage, fixing f-string logging anti-patterns, and continued hardening of the 3-stage review-PR pipeline (collapsed from the prior 6-phase design in #677/#679).
 
-2. **Automation Package Stabilization** — Refactoring and hardening the automation modules (PR review, CI driver, issue implementation) to improve single responsibility, observability, and idempotency. This includes fixing critical bugs in the CI state machine and worktree management.
+2. **Automation Pipeline Hardening** — Stabilizing the queue-based
+   plan → implement → review pipeline (Epic #1809): drive-green loop
+   behavior, orphan-PR recovery, epic/skip-tag scoping, and restoring
+   queue-owned auto-merge arming behind the #2054 fail-closed bootstrap
+   (#2055).
 
 3. **CLI Tool Coverage Expansion** — Expanding the CLI entry point test suite from 13 of 47 declared tools to full coverage, ensuring all command-line interfaces are properly validated.
 
@@ -73,4 +77,4 @@ that is the release maintainer; there is no separate roadmap committee.
 PR editing it directly). The roadmap is refreshed to reflect current focus
 areas as Epics are created or priorities shift.
 
-Last updated: 2026-07-01
+Last updated: 2026-07-18

--- a/tests/unit/docs/test_roadmap_cadence.py
+++ b/tests/unit/docs/test_roadmap_cadence.py
@@ -8,6 +8,7 @@ prose. It asserts the HARD invariant (required phrases are present), never an
 unverifiable cadence value like "monthly".
 """
 
+import datetime
 import re
 from pathlib import Path
 
@@ -18,6 +19,9 @@ _SECTION_RE = re.compile(
     r"^##\s+Updating This Roadmap\s*$(.*?)(?=^##\s|\Z)",
     re.MULTILINE | re.DOTALL,
 )
+
+_CURRENT_FOCUS_RE = re.compile(r"^##\s+Current Focus \(Q([1-4]) (\d{4})\)\s*$", re.MULTILINE)
+_LAST_UPDATED_RE = re.compile(r"^Last updated: (\d{4}-\d{2}-\d{2})\s*$", re.MULTILINE)
 
 
 def _updating_section() -> str:
@@ -53,4 +57,45 @@ def test_cadence_is_release_driven_not_vague_monthly() -> None:
     assert "maintainer" in section, (
         "The cadence section must name who is responsible for the review "
         "(the maintainer cutting the release)."
+    )
+
+
+def _stated_period() -> tuple[int, int]:
+    """Return (year, quarter) parsed from the Current Focus heading, failing loud."""
+    text = ROADMAP_MD.read_text(encoding="utf-8")
+    match = _CURRENT_FOCUS_RE.search(text)
+    assert match is not None, (
+        "ROADMAP.md must have a '## Current Focus (Q<n> <year>)' heading so the "
+        "current-period guard can parse it (issue #2158); restore the heading "
+        "or update _CURRENT_FOCUS_RE."
+    )
+    return int(match.group(2)), int(match.group(1))
+
+
+def test_current_focus_period_has_not_ended() -> None:
+    """Fail once the quarter named in 'Current Focus' is in the past (issue #2158)."""
+    today = datetime.date.today()
+    current = (today.year, (today.month - 1) // 3 + 1)
+    stated = _stated_period()
+    assert stated >= current, (
+        f"ROADMAP.md 'Current Focus' still names Q{stated[1]} {stated[0]}, but the "
+        f"current period is Q{current[1]} {current[0]}. Refresh the Current Focus "
+        "section per '## Updating This Roadmap' and bump the 'Last updated' line."
+    )
+
+
+def test_last_updated_not_before_stated_quarter() -> None:
+    """Fail if 'Last updated' predates the stated quarter (half-refreshed roadmap)."""
+    text = ROADMAP_MD.read_text(encoding="utf-8")
+    match = _LAST_UPDATED_RE.search(text)
+    assert match is not None, (
+        "ROADMAP.md must end with a 'Last updated: YYYY-MM-DD' line; restore it "
+        "or update _LAST_UPDATED_RE."
+    )
+    last_updated = datetime.date.fromisoformat(match.group(1))
+    year, quarter = _stated_period()
+    quarter_start = datetime.date(year, 3 * quarter - 2, 1)
+    assert last_updated >= quarter_start, (
+        f"ROADMAP.md says Current Focus is Q{quarter} {year} but 'Last updated' is "
+        f"{last_updated}, before that quarter began ({quarter_start}); refresh both together."
     )


### PR DESCRIPTION
## Summary
Only the two intended files are modified; no backup/temp files. Implementation complete.

## Summary

Implemented the approved plan for issue #2158 (refresh roadmap current-focus period + add cadence guard).

**Changes:**
- `docs/ROADMAP.md`
  - `docs/ROADMAP.md:7` — heading `Q2 2026` → `Q3 2026` with refreshed lead-in (audit remediation + Epic #1809 pipeline + #2054/#2055 auto-merge bootstrap)
  - `docs/ROADMAP.md:13-17` — focus item 2 rewritten as "Automation Pipeline Hardening"
  - `docs/ROADMAP.md:80` — `Last updated: 2026-07-18` (used today's actual date; plan assumed 2026-07-17 but today is 2026-07-18 — July is still Q3, so the approach is unchanged)
- `tests/unit/docs/test_roadmap_cadence.py` — added `import datetime`, two regexes, and three helpers/tests:
  - `test_current_focus_period_has_not_ended` — quarter-tuple tripwire; fails CI once the stated quarter is in the past
  - `test_last_updated_not_before_stated_quarter` — internal-consistency check catching a half-refresh (bumped heading, stale timestamp)

**Tests run (TDD RED→GREEN):**
- RED (pre-edit): `test_current_focus_period_has_not_ended` failed on the stale Q2 heading — `assert (2026, 2) >= (2026, 3)` — as intended
- GREEN (post-edit): all 3 tests in `tests/unit/docs/test_roadmap_cadence.py` pass
- `grep`: no `Q2 2026` remains; `Current Focus (Q3 2026)` and `Last updated: 2026-07-18` present
- `pre-commit run --files docs/ROADMAP.md tests/unit/docs/test_roadmap_cadence.py` — all hooks Passed (ruff, whole-tree mypy, markdownlint)

Working tree contains only the two intended files; no backup/temp files. Git/GitHub mutation left to the orchestrator.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2158

Generated by Hephaestus automation
