### PR TITLE
test: ban source-line-number assertions in doc/regression tests (root cause of #2056 stranding)

### DIFF
--- a/docs/runbooks/state-skip-revival.md
+++ b/docs/runbooks/state-skip-revival.md
@@ -10,7 +10,7 @@ resume planning/implementing it.
 ## Background
 
 `state:skip` is absolute and operator-only (#1576/#1584): the pipeline's
-seeding classifier (`pipeline/seeding.py:239` `classify_issue`) excludes any
+seeding classifier (`pipeline/seeding.py` `classify_issue`) excludes any
 `state:skip`-labeled issue from the work queue entirely, before any other
 state label is consulted. This is a *point-in-time* exclusion — if
 `state:skip` is applied to an issue *after* automation has already queued and

--- a/hephaestus/automation/ci_fix_orchestrator.py
+++ b/hephaestus/automation/ci_fix_orchestrator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -86,6 +87,36 @@ _IGNORED_UNTRACKED_PREFIXES: tuple[str, ...] = (
     "htmlcov/",
 )
 _UNMERGED_STATUS_CODES: frozenset[str] = frozenset({"DD", "AU", "UD", "UA", "DU", "AA", "UU"})
+
+# Pre-push CI-fix test gate (#2122): re-run the failing tests parsed from the CI
+# logs before force-pushing so the mesh can never push a branch that still fails
+# the exact test it claims to fix (root cause of PR #2056's stranding).
+_FAILED_TEST_LINE_RE = re.compile(r"(?:^|\s)(?:FAILED|ERROR)\s+(tests/[\w./-]+\.py(?:::[\w./-]+)*)")
+_AFFECTED_TESTS_TIMEOUT_SECONDS = 900
+# pytest exit code 5 = "no tests ran": the failing test may have been deleted by
+# the fix/rebase itself (exactly the #2056 remedy) — not a gate failure.
+_PYTEST_NO_TESTS_RAN = 5
+
+
+def extract_failing_pytest_node_ids(ci_logs: str) -> list[str]:
+    """Parse failing pytest node IDs from CI failure logs (pure; unit-tested).
+
+    Scans ``FAILED``/``ERROR`` lines for ``tests/...py[::...]`` node IDs,
+    de-duplicating while preserving first-seen order. Parametrized IDs are
+    truncated at ``[`` so the whole test function runs — a safe superset that
+    survives param renames across a rebase and avoids "unknown node id" errors.
+
+    Args:
+        ci_logs: Combined CI failure log text.
+
+    Returns:
+        Ordered, de-duplicated list of pytest node IDs (params stripped).
+
+    """
+    seen: dict[str, None] = {}
+    for match in _FAILED_TEST_LINE_RE.finditer(ci_logs):
+        seen.setdefault(match.group(1).split("[", 1)[0])
+    return list(seen)
 
 
 def _porcelain_path(line: str) -> str:
@@ -263,11 +294,16 @@ class CIFixOrchestrator:
         pr_head_branch: str,
         session_id: str | None,
         pr_base_branch: str = "main",
+        ci_logs: str = "",
     ) -> bool:
         """Check head advancement, retry if needed, then push CI fixes.
 
         Shared post-agent contract for both codex and claude providers (#846).
         Returns True if fixes were pushed, False on any failure or no-commit.
+
+        ``ci_logs`` feeds the pre-push test gate (#2122): the failing pytest
+        node IDs parsed from it are re-run in the worktree and the push is
+        refused if they still fail.
         """
         if not self._head_advanced(worktree_path, pre_agent_sha, issue_number):  # noqa: SIM102
             if not self.retry_no_commit_once(
@@ -305,6 +341,8 @@ class CIFixOrchestrator:
             return False
         if not self._ci_fix_head_is_pushable(worktree_path, issue_number, base_ref=base_ref):
             return False
+        if not self._affected_tests_pass(worktree_path, issue_number, ci_logs):
+            return False
         try:
             push_current_branch_with_lease_on_divergence(
                 worktree_path,
@@ -316,6 +354,58 @@ class CIFixOrchestrator:
         except Exception as push_err:
             logger.error("Issue #%s: git push failed after CI fix: %s", issue_number, push_err)
             return False
+
+    def _affected_tests_pass(self, worktree_path: Path, issue_number: int, ci_logs: str) -> bool:
+        """Re-run the CI-failing tests locally; refuse the push if they still fail (#2122).
+
+        Parses the failing pytest node IDs from ``ci_logs`` and re-runs them in
+        the worktree. Node IDs whose file no longer exists are dropped (a rebase
+        can legitimately delete the failing test — exactly the #2056 remedy).
+        Returns True (gate skipped) when no runnable node IDs are found, so a
+        BEHIND/green PR or an unparseable log never deadlocks the push.
+
+        Args:
+            worktree_path: Worktree the fix branch is checked out in.
+            issue_number: GitHub issue number (for logging).
+            ci_logs: Combined CI failure log text.
+
+        Returns:
+            True if the affected tests pass (or the gate does not apply),
+            False if they still fail or the run times out.
+
+        """
+        node_ids = [
+            n
+            for n in extract_failing_pytest_node_ids(ci_logs)
+            if (worktree_path / n.split("::", 1)[0]).exists()
+        ]
+        if not node_ids:
+            logger.info(
+                "Issue #%s: no runnable failing pytest node IDs in CI logs; "
+                "skipping pre-push test gate",
+                issue_number,
+            )
+            return True
+        try:
+            result = subprocess.run(
+                ["uv", "run", "python", "-m", "pytest", "-q", "--no-header", *node_ids],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+                timeout=_AFFECTED_TESTS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            logger.error("Issue #%s: pre-push test gate timed out; refusing to push", issue_number)
+            return False
+        if result.returncode not in (0, _PYTEST_NO_TESTS_RAN):
+            logger.error(
+                "Issue #%s: affected tests still failing locally; refusing to push: %s",
+                issue_number,
+                (result.stdout or result.stderr or "")[-500:],
+            )
+            return False
+        return True
 
     def _ci_fix_residual_commit_is_safe(
         self,
@@ -550,7 +640,6 @@ class CIFixOrchestrator:
             pr_head_branch,
             advise_findings,
         )
-
         try:
             agent_result = self.invoke_agent_session(
                 prompt=prompt,
@@ -586,6 +675,7 @@ class CIFixOrchestrator:
             pr_head_branch=pr_head_branch,
             pr_base_branch=pr_base_branch,
             session_id=session_id,
+            ci_logs=ci_logs,
         )
 
     def attempt_mechanical_rebase(

--- a/tests/unit/automation/test_ci_driver_architecture.py
+++ b/tests/unit/automation/test_ci_driver_architecture.py
@@ -28,7 +28,11 @@ _BUDGETS = {
     "hephaestus.automation.drive_green_state.LastCIFixStore": ClassBudget(140, 4, 60),
     "hephaestus.automation.review_thread_resolver.ReviewThreadResolver": ClassBudget(280, 7, 80),
     "hephaestus.automation.pr_discovery.PRDiscovery": ClassBudget(560, 14, 80),
-    "hephaestus.automation.ci_fix_orchestrator.CIFixOrchestrator": ClassBudget(1050, 17, 80),
+    # 18th method: _affected_tests_pass, the pre-push CI-fix test gate (#2122) —
+    # a cohesive addition to the push-contract guard family this collaborator
+    # already owns; re-runs the failing pytest node IDs before force-pushing so
+    # the mesh never pushes a branch that fails the exact test it claims to fix.
+    "hephaestus.automation.ci_fix_orchestrator.CIFixOrchestrator": ClassBudget(1050, 18, 80),
 }
 
 

--- a/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
+++ b/tests/unit/automation/test_ci_fix_orchestrator_helpers.py
@@ -15,7 +15,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hephaestus.automation.ci_fix_orchestrator import CIFixOrchestrator
+from hephaestus.automation.ci_fix_orchestrator import (
+    CIFixOrchestrator,
+    extract_failing_pytest_node_ids,
+)
 
 
 @pytest.fixture()
@@ -632,3 +635,106 @@ class TestAttemptMechanicalRebase:
             return_value=MagicMock(stdout="not json"),
         ):
             assert orchestrator.attempt_mechanical_rebase(5, 50, 0) is False
+
+
+class TestExtractFailingPytestNodeIds:
+    """Pure parser for failing pytest node IDs in CI logs (#2122)."""
+
+    def test_dedups_and_strips_params(self) -> None:
+        logs = (
+            "2026-07-16T00:00:00Z FAILED tests/unit/docs/test_x.py::test_a[param-1] - boom\n"
+            "FAILED tests/unit/docs/test_x.py::test_a[param-2]\n"
+            "ERROR tests/unit/io/test_y.py::TestC::test_b\n"
+            "PASSED tests/unit/io/test_z.py::test_ok\n"
+        )
+        assert extract_failing_pytest_node_ids(logs) == [
+            "tests/unit/docs/test_x.py::test_a",
+            "tests/unit/io/test_y.py::TestC::test_b",
+        ]
+
+    def test_empty_and_unparseable_logs_yield_no_ids(self) -> None:
+        assert extract_failing_pytest_node_ids("") == []
+        assert extract_failing_pytest_node_ids("all green, nothing failed here") == []
+
+    def test_module_level_error_without_node_is_captured(self) -> None:
+        assert extract_failing_pytest_node_ids(
+            "ERROR tests/unit/io/test_y.py - collection error"
+        ) == ["tests/unit/io/test_y.py"]
+
+
+class TestAffectedTestsPass:
+    """The pre-push CI-fix test gate re-runs failing tests before allowing push (#2122)."""
+
+    def test_empty_logs_skip_gate_without_subprocess(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        with patch("hephaestus.automation.ci_fix_orchestrator.subprocess.run") as mock_run:
+            assert orchestrator._affected_tests_pass(tmp_path, 7, "") is True
+        mock_run.assert_not_called()
+
+    def test_absent_files_drop_all_node_ids_and_skip_gate(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        logs = "FAILED tests/unit/docs/test_missing.py::test_a\n"
+        with patch("hephaestus.automation.ci_fix_orchestrator.subprocess.run") as mock_run:
+            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is True
+        mock_run.assert_not_called()
+
+    def test_passing_rerun_allows_push(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        node = "tests/unit/docs/test_x.py"
+        (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / node).write_text("def test_a():\n    pass\n")
+        logs = f"FAILED {node}::test_a\n"
+        with patch(
+            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        ) as mock_run:
+            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is True
+        assert mock_run.call_args.args[0][:5] == [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "pytest",
+        ]
+        assert f"{node}::test_a" in mock_run.call_args.args[0]
+
+    def test_failing_rerun_refuses_push(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        node = "tests/unit/docs/test_x.py"
+        (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / node).write_text("def test_a():\n    assert False\n")
+        logs = f"FAILED {node}::test_a\n"
+        with patch(
+            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
+            return_value=MagicMock(returncode=1, stdout="1 failed", stderr=""),
+        ):
+            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is False
+
+    def test_no_tests_ran_exit_code_is_treated_as_pass(
+        self, orchestrator: CIFixOrchestrator, tmp_path: Path
+    ) -> None:
+        """Exit code 5 = the failing test was deleted by the fix/rebase (#2056 remedy)."""
+        node = "tests/unit/docs/test_x.py"
+        (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / node).write_text("# test removed by the fix\n")
+        logs = f"FAILED {node}::test_a\n"
+        with patch(
+            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
+            return_value=MagicMock(returncode=5, stdout="no tests ran", stderr=""),
+        ):
+            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is True
+
+    def test_timeout_refuses_push(self, orchestrator: CIFixOrchestrator, tmp_path: Path) -> None:
+        node = "tests/unit/docs/test_x.py"
+        (tmp_path / node).parent.mkdir(parents=True, exist_ok=True)
+        (tmp_path / node).write_text("def test_a():\n    pass\n")
+        logs = f"FAILED {node}::test_a\n"
+        with patch(
+            "hephaestus.automation.ci_fix_orchestrator.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="pytest", timeout=900),
+        ):
+            assert orchestrator._affected_tests_pass(tmp_path, 7, logs) is False

--- a/tests/unit/docs/test_no_line_number_refs.py
+++ b/tests/unit/docs/test_no_line_number_refs.py
@@ -1,0 +1,59 @@
+"""Guard: living docs must not embed volatile ``path:LINE`` code refs (issue #2122).
+
+A doc that cites ``file.py:LINE`` re-breaks on every edit above that line and,
+under concurrent merging, can only be "correct" at the merge instant — the root
+cause of PR #2056's stranding. Living docs must reference ``path function``
+instead. ADRs and release notes are excluded: they are point-in-time records
+(per ``docs/adr/README.md``) whose line refs are historical citations, not
+navigable claims that must track HEAD.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_DOCS_DIR = Path(__file__).resolve().parents[3] / "docs"
+# Point-in-time record dirs whose line refs are historical, not navigable.
+_EXCLUDED_DIRS = ("adr", "release-notes")
+_LINE_REF_RE = re.compile(r"\.py:\d+")
+
+
+def _prose_lines(text: str) -> list[tuple[int, str]]:
+    """Return ``(lineno, line)`` for lines outside fenced code blocks.
+
+    Example tool output inside fences (``file.py:12: error``) is legitimate and
+    must not false-positive.
+    """
+    out: list[tuple[int, str]] = []
+    in_fence = False
+    for i, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append((i, line))
+    return out
+
+
+def test_living_docs_have_no_line_number_refs() -> None:
+    """Living docs reference ``path function``, never ``path:LINE``."""
+    violations: list[str] = []
+    for md in sorted(_DOCS_DIR.rglob("*.md")):
+        rel = md.relative_to(_DOCS_DIR)
+        if rel.parts[0] in _EXCLUDED_DIRS:
+            continue
+        for lineno, line in _prose_lines(md.read_text(encoding="utf-8")):
+            if _LINE_REF_RE.search(line):
+                violations.append(f"docs/{rel}:{lineno}: {line.strip()[:80]}")
+    assert not violations, (
+        "Docs must reference `path function`, not `path:LINE` (issue #2122):\n"
+        + "\n".join(violations)
+    )
+
+
+def test_guard_detects_synthetic_line_ref() -> None:
+    """A prose ``path:LINE`` ref trips; the same pattern inside a fence does not."""
+    text = "See `hephaestus/io/utils.py:142` for details.\n```\nfile.py:1: error\n```\n"
+    hits = [ln for ln, line in _prose_lines(text) if _LINE_REF_RE.search(line)]
+    assert hits == [1]

--- a/tests/unit/validation/test_no_source_line_assertions.py
+++ b/tests/unit/validation/test_no_source_line_assertions.py
@@ -1,0 +1,93 @@
+"""Guard: no source-line-number assertions in tests (issue #2122, root cause of #2056).
+
+Line numbers are volatile — any edit above a function shifts them, turning
+routine drift into test failures with no behavior change. Under concurrent
+merging the "correct" line is only knowable at merge instant, so a test that
+pins ``inspect.getsourcelines(fn)[1]`` (or ``fn.__code__.co_firstlineno``) to a
+literal strands every open PR carrying the change. Assert symbol *presence* /
+that the function *resolves* instead.
+
+This is an executable invariant (alongside ``test_import_surface.py``,
+``test_automation_boundary.py``, ``test_omit_allowlist.py``): an AST walk over
+``tests/`` that flags the volatile-line-number patterns, plus synthetic-source
+self-tests so the guard can never pass vacuously.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_TESTS_DIR = Path(__file__).resolve().parents[2]  # tests/
+
+# inspect functions whose return value's ``[1]`` element is a source line number.
+_BANNED_LINE_FUNCS = frozenset({"getsourcelines", "findsource"})
+# Sanctioned files (none today); mirror ``test_zero_io_imports._ALLOWLIST``.
+_ALLOWLIST: frozenset[str] = frozenset()
+
+
+def _is_banned_line_subscript(node: ast.Subscript) -> bool:
+    """Return True for ``getsourcelines(...)[1]`` / ``findsource(...)[1]``.
+
+    The ``[1]`` element of both return values is the starting line number;
+    ``[0]`` (the source text) is fine and must not trip.
+    """
+    if not (isinstance(node.slice, ast.Constant) and node.slice.value == 1):
+        return False
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    name = (
+        func.attr
+        if isinstance(func, ast.Attribute)
+        else (func.id if isinstance(func, ast.Name) else "")
+    )
+    return name in _BANNED_LINE_FUNCS
+
+
+def _collect_violations(tree: ast.AST, filename: str) -> list[str]:
+    """Return volatile-line-number violations found anywhere in *tree*."""
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr == "co_firstlineno":
+            violations.append(f"{filename}:{node.lineno}: .co_firstlineno access")
+        elif isinstance(node, ast.Subscript) and _is_banned_line_subscript(node):
+            violations.append(f"{filename}:{node.lineno}: getsourcelines/findsource(...)[1]")
+    return violations
+
+
+def test_no_source_line_number_assertions_in_tests() -> None:
+    """No test may compare a source line number to a literal / doc-derived value."""
+    violations: list[str] = []
+    for py in sorted(_TESTS_DIR.rglob("*.py")):
+        if py.name in _ALLOWLIST:
+            continue
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        violations.extend(_collect_violations(tree, str(py.relative_to(_TESTS_DIR.parent))))
+    assert not violations, (
+        "Source line numbers are volatile (issue #2122); assert symbol presence "
+        "instead of line numbers:\n" + "\n".join(violations)
+    )
+
+
+def test_guard_detects_synthetic_violations() -> None:
+    """Negative test: a broken collector must not pass vacuously.
+
+    Banned patterns living inside these string literals do not produce AST
+    ``Subscript``/``Attribute`` nodes, so this file itself never trips the
+    guard — no self-exemption is needed.
+    """
+    synthetic = (
+        "import inspect\n"
+        "assert inspect.getsourcelines(fn)[1] == 42\n"
+        "lineno = inspect.findsource(fn)[1]\n"  # indirection still trips
+        "assert fn.__code__.co_firstlineno == expected\n"
+        "src = inspect.getsourcelines(fn)[0]\n"  # [0] (source text) is fine
+    )
+    violations = _collect_violations(ast.parse(synthetic), "<synthetic>")
+    assert len(violations) == 3, violations
+    assert any(":2:" in v for v in violations)
+    assert any(":3:" in v for v in violations)
+    assert any(":4:" in v for v in violations)
+    assert not any(":5:" in v for v in violations)


### PR DESCRIPTION
## Summary
The gate is correctly placed as the last check before push (line 344), after all commit-metadata/pushable guards. This ensures the tests run against the exact commit that will be pushed. The wiring is complete and correct.

Let me wait for the test suite result notification.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2122

Generated by Hephaestus automation
