### PR TITLE
[majo] Define monitoring alerts and SLOs for automation operations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ See the [README](../README.md) for installation and development setup instructio
 - [Audit Reviewer](audit-reviewer.md) — `hephaestus-audit-prs`: coordinator-pattern auditor for ALL open PRs (issue #994)
 - [MCP Integration Posture](mcp.md) — Capability boundary, alternative integration contracts, and project-scoped `.mcp.json` change control
 - [NATS JetStream Configuration](nats.md) - TLS defaults, certificate file paths, and local plaintext exceptions for `hephaestus.nats`
+- [Observability: metrics, alerts, and SLOs](observability.md) — Automation pipeline metric catalog, alert ownership, and SLOs
 - [Operations Runbooks](runbooks/index.md) — Operator recovery procedures for the automation pipeline (loop crash, corrupted worktree, drive-green stall, quota exhaustion)
 - [Performance Testing](performance-testing.md) — Bounded worker-pool load, capacity, latency, and sustained-concurrency testing
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,126 @@
+# Observability: metrics, alerts, and SLOs
+
+This document defines the monitoring surface for the queue-based automation
+pipeline (`hephaestus.automation.pipeline`): the metrics it exports, the alert
+rules it evaluates, the Service Level Objectives (SLOs) those metrics measure,
+and who owns responding to a fired alert.
+
+It closes the Section 9 audit finding (issue #2153): the pipeline already wrote
+structured JSONL events and served a local `/metrics` + `/health` endpoint, but
+job outcomes and stall state were not exported, and no document defined the
+metric catalog, alert ownership, or SLOs.
+
+The metric and alert names below are drift-guarded against the code by
+`tests/unit/docs/test_observability_doc.py`: every `hephaestus_*` metric emitted
+by `hephaestus/automation/pipeline/coordinator.py` and every alert rule defined
+in `hephaestus/observability/alerts.py` must appear here, so this catalog cannot
+silently fall out of sync with what the pipeline actually exposes.
+
+## Enabling monitoring
+
+Observability is **opt-in** and loopback-only. The base `import hephaestus`
+surface never pulls the metrics stack; the socket, registry, and alert tracker
+are constructed only when a metrics port is configured.
+
+- **Enable it** by passing `--metrics-port PORT` to the automation loop
+  (`hephaestus.automation.loop_runner`), or by setting
+  `PipelineConfig.metrics_port` directly. `0` (the default) disables it.
+- **`/metrics`** serves the Prometheus text exposition of every gauge and
+  counter in the catalog below. The server binds a literal loopback address
+  only (`hephaestus/observability/server.py`); it rejects any non-loopback
+  host, so the unauthenticated diagnostic endpoint is never exposed off-host.
+- **`/health`** serves the JSON snapshot returned by the coordinator's
+  `_health_snapshot`: the same lifecycle fields as the metrics, plus a
+  top-level `status` of `ok` (running) or `stopping` (shutdown requested).
+- **Structured event log (JSONL).** When a loop runs, the coordinator writes a
+  durable JSONL event log (default:
+  `build/.issue_implementer/pipeline-events-<timestamp>-<pid>.jsonl`, set via
+  `PipelineConfig.event_log_path`). Each metrics tick appends a
+  `metrics_snapshot` record, and every alert transition appends an
+  `alert_fired` or `alert_resolved` record carrying the alert `name`,
+  `severity`, and `message`. These are the lines to cite when escalating.
+
+The alert queue-depth threshold is configurable via
+`PipelineConfig.alert_queue_depth_threshold` (default `100`); the stall
+threshold defaults to `3`, matching the coordinator's own
+`_STALL_TICKS_BEFORE_FORCE`.
+
+## Metrics
+
+All metrics are namespaced `hephaestus_`. Gauges reflect the latest tick's
+value; counters accumulate over the coordinator process lifetime. Source column
+points at the emission chokepoint in `coordinator.py`.
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `hephaestus_pipeline_queue_depth` | gauge | `stage` | Queued work items waiting in each stage queue. |
+| `hephaestus_pipeline_inflight_jobs` | gauge | — | Jobs currently owned by the worker pool. |
+| `hephaestus_pipeline_inflight_per_repo` | gauge | `repo` | In-flight jobs partitioned by repository. |
+| `hephaestus_pipeline_loops_total` | gauge | — | Reseed passes run by this coordinator process. |
+| `hephaestus_pipeline_stalled_ticks` | gauge | — | Consecutive drain ticks without pipeline progress. |
+| `hephaestus_circuit_breaker_state` | gauge | `name`, `state` | Circuit-breaker lifecycle state (the active state has value `1`, others `0`). |
+| `hephaestus_pipeline_alert_active` | gauge | `name` | Whether a named alert condition is currently active (`1`) or resolved (`0`). |
+| `hephaestus_pipeline_jobs_total` | counter | `stage`, `outcome` | Completed jobs by stage and outcome (`ok`, `failed`, `interrupted`). |
+| `hephaestus_pipeline_agent_job_seconds_total` | counter | — | Cumulative agent-job wall-clock seconds (negative durations clamped to `0`). |
+
+## Alerts
+
+Alert rules read **only** live coordinator snapshot data — there are no
+speculative rules. `hephaestus/observability/alerts.py` evaluates the current
+snapshot each tick, and `AlertTracker` emits a durable transition (an
+`alert_fired` / `alert_resolved` JSONL event and an update to
+`hephaestus_pipeline_alert_active`) only when a condition changes state, so a
+persistent degradation never produces repeated event spam.
+
+| Alert | Severity | Condition | Owner | Runbook |
+| --- | --- | --- | --- | --- |
+| `circuit_breaker_open` | critical | Any circuit breaker in the snapshot reports `state == "open"`. | repository maintainer | [`docs/runbooks/automation-loop-crash.md`](runbooks/automation-loop-crash.md) |
+| `queue_depth_exceeds` | warning | Any stage queue depth exceeds `alert_queue_depth_threshold` (default `100`). | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
+| `pipeline_stalled` | warning | `stalled_ticks` reaches the stall threshold (default `3`) — drain ticks with no progress. | repository maintainer | [`docs/runbooks/ci-driver-stall.md`](runbooks/ci-driver-stall.md) |
+
+## SLOs
+
+Each SLO names the metric that measures it, so compliance is checked against
+real exported data rather than intent. Targets are per automation run.
+
+| SLO | Target | Measured by |
+| --- | --- | --- |
+| Pipeline liveness | `/health` reports `status: ok` for ≥ 99% of ticks during a run. | `/health` snapshot `status` field. |
+| Stall budget | `hephaestus_pipeline_stalled_ticks` < 3 for ≥ 99% of ticks. | `hephaestus_pipeline_stalled_ticks` gauge. |
+| Queue depth | `hephaestus_pipeline_queue_depth` ≤ the configured threshold for ≥ 99% of ticks. | `hephaestus_pipeline_queue_depth` gauge. |
+| Agent job success rate | `hephaestus_pipeline_jobs_total{outcome="ok"}` / total completed jobs ≥ 90% per run. | `hephaestus_pipeline_jobs_total` counter. |
+| Breaker budget | `circuit_breaker_open` fires ≤ 1 time per run. | `hephaestus_pipeline_alert_active{name="circuit_breaker_open"}` gauge / `alert_fired` events. |
+
+These are **targets**, not committed measurements. Their ongoing measurement
+happens operationally against the scrape endpoint below; this document defines
+what "healthy" means, and the drift test keeps the definitions honest against
+the code.
+
+## Ownership and escalation
+
+This is a single-maintainer project. The owner of every alert is the
+repository maintainer (`mvillmow`); escalation is a GitHub issue.
+
+**Response expectation by severity:**
+
+- **critical** (`circuit_breaker_open`): investigate within the same working
+  session/day. A stuck-open breaker halts progress for the affected dependency.
+- **warning** (`queue_depth_exceeds`, `pipeline_stalled`): review by the next
+  automation run; these signal degraded throughput, not a hard stop.
+
+**Escalation path:** file a GitHub issue that references the fired alert `name`
+and quotes the corresponding `alert_fired` line from the JSONL event log (see
+[Enabling monitoring](#enabling-monitoring)), then follow the runbook linked in
+the [Alerts](#alerts) table for that alert.
+
+**Ecosystem collection (Argus).** Argus is the ecosystem's monitoring repo. The
+pipeline's `/metrics` endpoint binds loopback only, so an Argus Prometheus
+scraper must run on the same host and target `127.0.0.1`:
+
+```yaml
+scrape_configs:
+  - job_name: hephaestus-automation
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["127.0.0.1:9123"]   # match --metrics-port
+```

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -535,6 +535,7 @@ class Coordinator:
             "inflight_jobs": len(self.in_flight),
             "circuit_breakers": circuit_breakers,
             "loops_run": self._loops_run,
+            "stalled_ticks": self._stalled_ticks,
         }
 
     def _health_snapshot(self) -> dict[str, Any]:
@@ -571,6 +572,15 @@ class Coordinator:
         for repo in self._observed_inflight_repos - current_repos:
             inflight_by_repo.set(0, labels={"repo": repo})
         self._observed_inflight_repos = current_repos
+
+        registry.gauge(
+            "hephaestus_pipeline_loops_total",
+            "Reseed passes run by this coordinator process.",
+        ).set(snapshot["loops_run"])
+        registry.gauge(
+            "hephaestus_pipeline_stalled_ticks",
+            "Consecutive drain ticks without pipeline progress.",
+        ).set(snapshot["stalled_ticks"])
 
         breaker_states = registry.gauge(
             "hephaestus_circuit_breaker_state",
@@ -855,6 +865,19 @@ class Coordinator:
         if isinstance(handle.job, AgentJob):
             self._agent_job_count += 1
             self._agent_job_time_s += result.duration_s
+        if self._metrics_registry is not None:
+            outcome = "interrupted" if result.interrupted else ("ok" if result.ok else "failed")
+            self._metrics_registry.counter(
+                "hephaestus_pipeline_jobs_total",
+                "Completed pipeline jobs by stage and outcome.",
+            ).inc(labels={"stage": item.stage.value, "outcome": outcome})
+            if isinstance(handle.job, AgentJob):
+                # Counter.inc rejects negative amounts; a monotonic-clock skew
+                # could yield a tiny negative duration, so clamp defensively.
+                self._metrics_registry.counter(
+                    "hephaestus_pipeline_agent_job_seconds_total",
+                    "Cumulative agent job wall-clock seconds.",
+                ).inc(max(result.duration_s, 0.0))
 
         if result.interrupted:
             self._park_resumable(item)

--- a/hephaestus/observability/alerts.py
+++ b/hephaestus/observability/alerts.py
@@ -19,17 +19,22 @@ class AlertEvent:
 
 
 def evaluate_alerts(
-    snapshot: Mapping[str, Any], *, queue_depth_threshold: int = 100
+    snapshot: Mapping[str, Any],
+    *,
+    queue_depth_threshold: int = 100,
+    stalled_ticks_threshold: int = 3,
 ) -> list[AlertEvent]:
     """Evaluate conditions that the coordinator's runtime snapshot really contains.
 
     The function deliberately contains no speculative rules: every rule reads
-    either ``queue_depths`` or ``circuit_breakers`` emitted by the coordinator.
-    Returned events describe active conditions; :class:`AlertTracker` turns
-    those into fire/resolve transitions.
+    ``queue_depths``, ``circuit_breakers``, or ``stalled_ticks`` emitted by the
+    coordinator. Returned events describe active conditions;
+    :class:`AlertTracker` turns those into fire/resolve transitions.
     """
     if queue_depth_threshold < 0:
         raise ValueError("queue depth threshold must be non-negative")
+    if stalled_ticks_threshold < 0:
+        raise ValueError("stalled ticks threshold must be non-negative")
     events: list[AlertEvent] = []
     raw_breakers = snapshot.get("circuit_breakers", {})
     if isinstance(raw_breakers, Mapping):
@@ -68,17 +73,37 @@ def evaluate_alerts(
                     f"{', '.join(sorted(exceeded))}",
                 )
             )
+
+    raw_stalled = snapshot.get("stalled_ticks")
+    if (
+        isinstance(raw_stalled, (int, float))
+        and not isinstance(raw_stalled, bool)
+        and raw_stalled >= stalled_ticks_threshold
+    ):
+        events.append(
+            AlertEvent(
+                name="pipeline_stalled",
+                severity="warning",
+                status="fired",
+                message=f"pipeline made no progress for {int(raw_stalled)} ticks",
+            )
+        )
     return events
 
 
 class AlertTracker:
     """Emit a durable event only when an alert condition changes state."""
 
-    def __init__(self, *, queue_depth_threshold: int = 100) -> None:
-        """Create a tracker with the coordinator's queue-depth threshold."""
+    def __init__(
+        self, *, queue_depth_threshold: int = 100, stalled_ticks_threshold: int = 3
+    ) -> None:
+        """Create a tracker with the coordinator's alert thresholds."""
         if queue_depth_threshold < 0:
             raise ValueError("queue depth threshold must be non-negative")
+        if stalled_ticks_threshold < 0:
+            raise ValueError("stalled ticks threshold must be non-negative")
         self._queue_depth_threshold = queue_depth_threshold
+        self._stalled_ticks_threshold = stalled_ticks_threshold
         self._active: dict[str, AlertEvent] = {}
         self._lock = threading.Lock()
 
@@ -87,7 +112,9 @@ class AlertTracker:
         current = {
             event.name: event
             for event in evaluate_alerts(
-                snapshot, queue_depth_threshold=self._queue_depth_threshold
+                snapshot,
+                queue_depth_threshold=self._queue_depth_threshold,
+                stalled_ticks_threshold=self._stalled_ticks_threshold,
             )
         }
         with self._lock:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1133,6 +1133,83 @@ class TestDurableEventLog:
             coordinator._metrics_registry.render_prometheus()
         )
 
+    def test_snapshot_and_tick_expose_stalled_ticks(self, tmp_path: Path) -> None:
+        """Stall state is exported in the snapshot and as a gauge."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                metrics_port=9123,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator._stalled_ticks = 2
+
+        assert coordinator._observability_snapshot()["stalled_ticks"] == 2
+        coordinator._emit_observability_tick()
+
+        assert coordinator._metrics_registry is not None
+        rendered = coordinator._metrics_registry.render_prometheus()
+        assert "hephaestus_pipeline_stalled_ticks 2" in rendered
+        assert "hephaestus_pipeline_loops_total 0" in rendered
+
+    def test_completion_increments_jobs_total_by_stage_and_outcome(self, tmp_path: Path) -> None:
+        """Each completed job increments the jobs_total counter by outcome."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                metrics_port=9123,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator.stages[StageName.IMPLEMENTATION] = StubStage()
+
+        ok_item = _issue_item(1, StageName.IMPLEMENTATION)
+        ok_handle = _fake_in_flight_item(coordinator, ok_item)
+        coordinator._handle_completion(ok_handle, JobResult(ok=True, duration_s=1.5))
+
+        fail_item = _issue_item(2, StageName.IMPLEMENTATION)
+        fail_handle = _fake_in_flight_item(coordinator, fail_item)
+        coordinator._handle_completion(fail_handle, JobResult(ok=False, duration_s=0.5))
+
+        assert coordinator._metrics_registry is not None
+        rendered = coordinator._metrics_registry.render_prometheus()
+        assert 'hephaestus_pipeline_jobs_total{outcome="ok",stage="implementation"} 1' in rendered
+        assert (
+            'hephaestus_pipeline_jobs_total{outcome="failed",stage="implementation"} 1' in rendered
+        )
+        assert "hephaestus_pipeline_agent_job_seconds_total 2" in rendered
+
+    def test_agent_job_seconds_counter_clamps_negative_duration(self, tmp_path: Path) -> None:
+        """A negative duration is clamped so Counter.inc never raises."""
+        coordinator = Coordinator(
+            PipelineConfig(
+                org="org",
+                repos=["repo-a"],
+                projects_dir=tmp_path,
+                metrics_port=9123,
+            ),
+            github=FakeStageGitHub(),
+            pool=FakeWorkerPool(),
+            install_signals=False,
+        )
+        coordinator.stages[StageName.IMPLEMENTATION] = StubStage()
+        item = _issue_item(3, StageName.IMPLEMENTATION)
+        handle = _fake_in_flight_item(coordinator, item)
+
+        coordinator._handle_completion(handle, JobResult(ok=True, duration_s=-1.0))
+
+        assert coordinator._metrics_registry is not None
+        rendered = coordinator._metrics_registry.render_prometheus()
+        assert "hephaestus_pipeline_agent_job_seconds_total 0" in rendered
+
     def test_event_log_path_persists_queue_events(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/docs/test_observability_doc.py
+++ b/tests/unit/docs/test_observability_doc.py
@@ -1,0 +1,46 @@
+"""Drift guards for docs/observability.md (issue #2153)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOC = REPO_ROOT / "docs" / "observability.md"
+COORDINATOR = REPO_ROOT / "hephaestus" / "automation" / "pipeline" / "coordinator.py"
+ALERTS = REPO_ROOT / "hephaestus" / "observability" / "alerts.py"
+
+_METRIC_NAME_RE = re.compile(r'"(hephaestus_[a-z0-9_]+)"')
+_ALERT_NAME_RE = re.compile(r'name="([a-z0-9_]+)"')
+
+
+def test_required_sections_present() -> None:
+    """The document must define metrics, alerts, SLOs, and ownership."""
+    text = DOC.read_text(encoding="utf-8")
+    for heading in ("## Metrics", "## Alerts", "## SLOs", "## Ownership and escalation"):
+        assert heading in text, f"docs/observability.md must contain {heading!r}"
+
+
+def test_every_emitted_metric_is_documented() -> None:
+    """Every hephaestus_* metric emitted by the coordinator is in the catalog."""
+    doc = DOC.read_text(encoding="utf-8")
+    emitted = set(_METRIC_NAME_RE.findall(COORDINATOR.read_text(encoding="utf-8")))
+    assert emitted, "expected coordinator.py to emit hephaestus_* metrics"
+    missing = sorted(name for name in emitted if name not in doc)
+    assert not missing, f"metrics emitted but undocumented: {missing}"
+
+
+def test_every_alert_rule_is_documented() -> None:
+    """Every alert rule defined in alerts.py appears in the alert catalog."""
+    doc = DOC.read_text(encoding="utf-8")
+    rules = set(_ALERT_NAME_RE.findall(ALERTS.read_text(encoding="utf-8")))
+    assert rules, "expected alerts.py to define AlertEvent rules"
+    missing = sorted(name for name in rules if name not in doc)
+    assert not missing, f"alert rules defined but undocumented: {missing}"
+
+
+def test_each_alert_has_owner_and_runbook() -> None:
+    """The document names an owner and links operator runbooks."""
+    text = DOC.read_text(encoding="utf-8")
+    assert "runbooks/" in text
+    assert "maintainer" in text.lower()

--- a/tests/unit/observability/test_alerts.py
+++ b/tests/unit/observability/test_alerts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import importlib
 
+import pytest
+
 
 def test_alert_tracker_emits_one_fire_and_one_resolution() -> None:
     """Persistent degradation produces no repeated alert-event spam."""
@@ -27,3 +29,45 @@ def test_alert_tracker_emits_one_fire_and_one_resolution() -> None:
         ("circuit_breaker_open", "resolved"),
         ("queue_depth_exceeds", "resolved"),
     }
+
+
+def test_pipeline_stalled_fires_at_threshold() -> None:
+    """A snapshot at the stall threshold yields one warning-severity event."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+
+    events = alerts.evaluate_alerts({"stalled_ticks": 3}, stalled_ticks_threshold=3)
+
+    assert [(event.name, event.severity, event.status) for event in events] == [
+        ("pipeline_stalled", "warning", "fired")
+    ]
+
+
+def test_pipeline_stalled_quiet_below_threshold_and_for_bool() -> None:
+    """Below-threshold counts and bool values never fire the stall rule."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+
+    assert alerts.evaluate_alerts({"stalled_ticks": 2}, stalled_ticks_threshold=3) == []
+    # ``True`` is an int subclass; it must not be treated as a stall count.
+    assert alerts.evaluate_alerts({"stalled_ticks": True}, stalled_ticks_threshold=1) == []
+
+
+def test_pipeline_stalled_resolves_via_tracker() -> None:
+    """The tracker turns a stall condition into fire then resolve transitions."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+    tracker = alerts.AlertTracker(stalled_ticks_threshold=3)
+
+    fired = tracker.observe({"stalled_ticks": 4})
+    resolved = tracker.observe({"stalled_ticks": 0})
+
+    assert {(event.name, event.status) for event in fired} == {("pipeline_stalled", "fired")}
+    assert {(event.name, event.status) for event in resolved} == {("pipeline_stalled", "resolved")}
+
+
+def test_negative_stalled_threshold_rejected() -> None:
+    """A negative stall threshold is rejected in both the function and tracker."""
+    alerts = importlib.import_module("hephaestus.observability.alerts")
+
+    with pytest.raises(ValueError):
+        alerts.evaluate_alerts({}, stalled_ticks_threshold=-1)
+    with pytest.raises(ValueError):
+        alerts.AlertTracker(stalled_ticks_threshold=-1)


### PR DESCRIPTION
## Summary
Full suite: **6135 passed, 22 skipped**, coverage **84.73%** (≥ 83% gate). All quality gates green. Implementation is complete.

## Summary

Implemented issue #2153 (Section 9 MAJOR — monitoring alerts and SLOs for automation operations) per the approved plan.

**Code changes:**
- `hephaestus/observability/alerts.py` — added `stalled_ticks_threshold` (default 3) to `evaluate_alerts` and `AlertTracker`; new grounded `pipeline_stalled` warning rule reading only real `stalled_ticks` snapshot data; bool-guarded and negative-threshold-validated like the existing `queue_depth` rule.
- `hephaestus/automation/pipeline/coordinator.py:557` — added `stalled_ticks` to `_observability_snapshot`; two new lifecycle gauges (`hephaestus_pipeline_loops_total`, `hephaestus_pipeline_stalled_ticks`) in `_emit_observability_tick`; guarded outcome/duration counters (`hephaestus_pipeline_jobs_total{stage,outcome}`, `hephaestus_pipeline_agent_job_seconds_total`) at the `_handle_completion` chokepoint, with negative-duration clamping. All guarded by `self._metrics_registry is not None` — zero-I/O base import contract preserved.

**Docs:**
- `docs/observability.md` (new) — metric catalog, alert catalog with ownership + runbook links, five SLOs each tied to a measuring metric, ownership/escalation model, and an Argus loopback `scrape_config`.
- `docs/index.md` — link to the new doc.

**Tests (all new tests pass):**
- `tests/unit/observability/test_alerts.py` — 4 tests (fire at threshold, quiet below/bool, tracker resolve, negative-threshold reject).
- `tests/unit/automation/pipeline/test_coordinator.py` — 3 tests (snapshot+gauge stall exposure, jobs_total by stage/outcome, negative-duration clamp).
- `tests/unit/docs/test_observability_doc.py` (new) — drift guards asserting every emitted `hephaestus_*` metric and every alert rule name appears in the doc.

**Verification run (this session):**
- Full unit suite: `6135 passed, 22 skipped`, coverage `84.73%` (≥ 83% gate).
- `ruff check`, `ruff format --check`, `mypy` (5 files): clean.
- Full `pre-commit` on all changed files: passed (mypy whole-tree, markdownlint, bandit, gitleaks, etc.).
- Import-surface + automation-boundary + omit-allowlist/justification guards: passed (no new base-path imports).

Left the changes in the working tree per the git boundary; no commits/pushes made. Note: SLO *targets* are defined in the doc — their ongoing operational *measurement* is via the scrape endpoint, not committed evidence (ADR-014 satisfied).


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2153

Generated by Hephaestus automation
