### PR TITLE
[mino] Add broader static security analysis

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -53,6 +53,8 @@ jobs:
     if: needs.changes-gate.outputs.code_event == 'true'
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Reject silent-failure workaround in shell/YAML/Dockerfile/justfile/HCL"
         run: |
@@ -142,6 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       # Single source of truth for linting: run the full pre-commit hook suite.
@@ -198,6 +201,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
@@ -215,6 +220,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3  # v4.0.0
         with:
@@ -234,6 +241,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Run symlink check
         run: bash scripts/check-symlinks.sh
 
@@ -247,6 +256,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Run shellcheck
@@ -495,6 +506,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           # Full history + tags so test_version_currency can resolve the
           # latest vX.Y.Z tag for the doc-version-drift guard (#1233).
           fetch-depth: 0
@@ -537,6 +549,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -563,6 +577,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -590,6 +606,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python 3.12
@@ -624,6 +641,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -662,6 +681,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       # Digest-pinned so the scan no longer depends on a transient GitHub
@@ -693,6 +713,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -718,6 +740,48 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  security-workflow-scan:
+    name: security/workflow-scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+
+      - name: Run zizmor (workflow SAST)
+        id: zizmor
+        # Offline + medium threshold: deterministic, network-free PR gate.
+        # Online audits (e.g. known-vulnerable-actions) run weekly in
+        # security.yml. Keep these flags identical to the zizmor pre-commit
+        # hook (drift-guarded by tests/unit/ci/test_zizmor_config.py).
+        run: uv run zizmor --no-online-audits --min-severity medium .github/workflows/
+
+      - name: Post zizmor summary
+        if: always()
+        env:
+          ZIZMOR_OUTCOME: ${{ steps.zizmor.outcome }}
+        run: |
+          {
+            echo "## zizmor GitHub Actions Workflow SAST"
+            echo ""
+            if [ "$ZIZMOR_OUTCOME" = "success" ]; then
+              echo "No workflow security findings at medium+ severity."
+            else
+              echo "Workflow security findings detected — see job logs for details."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   schema-validation:
     name: schema-validation
     runs-on: ubuntu-24.04
@@ -727,6 +791,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
@@ -763,6 +829,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Python 3.12
@@ -811,6 +878,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           fetch-depth: 0  # hatch-vcs needs full history to compute the version
 
       - name: Setup uv
@@ -877,6 +945,7 @@ jobs:
       - security-dependency-scan
       - security-secrets-scan
       - security-sast-scan
+      - security-workflow-scan
       - schema-validation
       - deps-version-sync
       - license-scan

--- a/.github/workflows/auto-label-severity.yml
+++ b/.github/workflows/auto-label-severity.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           enable-cache: true

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -30,7 +30,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      # Credentials are intentionally persisted here: this job pushes the
+      # resolved release tag (git push origin "${TAG}" later in the job),
+      # which requires the checkout token to remain in the local git config.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -18,6 +18,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: "3.12"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ on:
         required: false
         default: ""
 
+# Least-privilege permissions are declared per job below (zizmor
+# excessive-permissions, issue #2151): the workflow-level default is
+# read-only and each job widens only what it needs.
 permissions:
-  contents: write
-  id-token: write
-  pages: write
+  contents: read
 
 # Serialize per-tag: this workflow builds, publishes to PyPI, and creates a
 # GitHub release — none idempotent. Two runs for the SAME tag must not race
@@ -40,11 +41,12 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
-          enable-cache: true
+          enable-cache: false  # release artifacts must not read/write a shared cache (zizmor cache-poisoning)
 
       - name: Editable install (scripts/ smoke tests spawn subprocesses that import hephaestus)
         run: uv sync --all-groups --all-extras --locked
@@ -69,11 +71,12 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
-          enable-cache: true
+          enable-cache: false  # release artifacts must not read/write a shared cache (zizmor cache-poisoning)
 
       - name: Run mypy type checking
         run: uv run mypy
@@ -83,20 +86,27 @@ jobs:
     timeout-minutes: 15
     needs: [test, type-check]
     environment: testpypi
+    permissions:
+      contents: read
+      id-token: write  # TestPyPI trusted-publisher OIDC
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Resolve tag
         id: tag
         shell: bash
+        env:
+          # env indirection keeps workflow inputs out of the interpolated
+          # shell (zizmor template-injection, issue #2151).
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_TAG: ${{ github.ref }}
         run: |
           # Priority: explicit input > tag-push ref > latest tag
-          INPUT_TAG="${{ github.event.inputs.tag }}"
-          REF_TAG="${{ github.ref }}"
           if [ -n "$INPUT_TAG" ]; then
             TAG="$INPUT_TAG"
           elif [[ "$REF_TAG" == refs/tags/* ]]; then
@@ -111,7 +121,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
-          enable-cache: true
+          enable-cache: false  # release artifacts must not read/write a shared cache (zizmor cache-poisoning)
 
       - name: Build package
         shell: bash
@@ -132,7 +142,7 @@ jobs:
           ls -1 dist/
 
       - name: Upload dist for reuse by build-and-publish
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa0  # v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: release-dist
           path: dist/
@@ -198,20 +208,27 @@ jobs:
     timeout-minutes: 15
     needs: [test, type-check, publish-testpypi]
     environment: pypi
+    permissions:
+      contents: write  # Create GitHub Release / upload assets
+      id-token: write  # PyPI trusted-publisher OIDC + PEP 740 attestations
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Resolve tag
         id: tag
         shell: bash
+        env:
+          # env indirection keeps workflow inputs out of the interpolated
+          # shell (zizmor template-injection, issue #2151).
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          REF_TAG: ${{ github.ref }}
         run: |
           # Priority: explicit input > tag-push ref > latest tag
-          INPUT_TAG="${{ github.event.inputs.tag }}"
-          REF_TAG="${{ github.ref }}"
           if [ -n "$INPUT_TAG" ]; then
             TAG="$INPUT_TAG"
           elif [[ "$REF_TAG" == refs/tags/* ]]; then
@@ -226,7 +243,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
-          enable-cache: true
+          enable-cache: false  # release artifacts must not read/write a shared cache (zizmor cache-poisoning)
 
       - name: Verify tag matches package version
         shell: bash
@@ -311,6 +328,10 @@ jobs:
     needs: [build-and-publish]
     # Publish the pdoc API reference to GitHub Pages only after the package
     # release succeeds, so the online docs always match a version on PyPI.
+    permissions:
+      contents: read
+      pages: write  # Deploy to GitHub Pages
+      id-token: write  # GitHub Pages OIDC deployment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -320,6 +341,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Resolve tag
         id: tag
@@ -342,7 +364,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
-          enable-cache: true
+          enable-cache: false  # release artifacts must not read/write a shared cache (zizmor cache-poisoning)
 
       - name: Editable install (pdoc imports hephaestus to introspect signatures)
         run: uv sync --all-groups --all-extras --locked

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -73,6 +75,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
@@ -105,6 +109,46 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
+  workflow-scan:
+    name: GitHub Actions workflow security scan
+    # PR-time scan runs in _required.yml (security/workflow-scan). This weekly
+    # run additionally enables the online, API-backed audits (e.g.
+    # known-vulnerable-actions) that the offline PR gate cannot perform.
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+
+      - name: Run zizmor (workflow SAST with online audits)
+        id: zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uv run zizmor --min-severity medium .github/workflows/
+
+      - name: Post zizmor summary
+        if: always()
+        env:
+          ZIZMOR_OUTCOME: ${{ steps.zizmor.outcome }}
+        run: |
+          {
+            echo "## zizmor GitHub Actions Workflow SAST"
+            echo ""
+            if [ "$ZIZMOR_OUTCOME" = "success" ]; then
+              echo "No workflow security findings at medium+ severity."
+            else
+              echo "Workflow security findings detected — see job logs for details."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   license-scan:
     name: License compatibility scan
     # PR-time license-scan runs in _required.yml (license-scan, gated via
@@ -118,6 +162,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0  # hatch-vcs needs full history to compute the version
+          persist-credentials: false
 
       - name: Setup uv
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,19 @@ repos:
         types: [python]
         pass_filenames: false
 
+  # Security: GitHub Actions workflow SAST (issue #2151). Offline + medium
+  # threshold matches the required security/workflow-scan CI job; keep the two
+  # flag sets identical (drift-guarded by tests/unit/ci/test_zizmor_config.py).
+  - repo: local
+    hooks:
+      - id: zizmor
+        name: zizmor (GitHub Actions SAST)
+        description: Static security analysis of GitHub Actions workflows
+        entry: uv run zizmor --no-online-audits --min-severity medium .github/workflows/
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+
   # Lock file freshness
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.11.28

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,6 +54,29 @@ network-facing service. Its security posture reflects that scope:
   non-production exception. Certificate and key material must be provided as
   runtime file paths, never committed to the repository.
 
+### Static Analysis Coverage
+
+Each source surface has a dedicated, CI-gating static security scanner, so
+security analysis is not limited to the Python surface:
+
+| Surface | Tool | Gate |
+|---------|------|------|
+| Python (`hephaestus/`, `scripts/`) | Bandit (medium+) | pre-commit hook + required `security/sast-scan` |
+| GitHub Actions workflows | zizmor (medium+, offline; online audits weekly) | pre-commit hook + required `security/workflow-scan` |
+| Shell scripts (`**/*.sh`) | ShellCheck | pre-commit hook (all `.sh`) + required `shellcheck` job (`--severity=error`) |
+| Secrets | gitleaks + detect-private-key | required `security/secrets-scan` + pre-commit |
+| Dependencies | pip-audit | required `security/dependency-scan` + weekly schedule |
+
+For the workflow surface (issue #2151), zizmor is used instead of
+CodeQL/Semgrep: it is purpose-built for GitHub Actions security (template
+injection, credential persistence, cache poisoning, unpinned/vulnerable
+actions, excessive permissions), ships as a PyPI wheel locked in `uv.lock`
+under the uv-only toolchain, and runs offline for a deterministic,
+network-free PR gate. The
+weekly `Security` workflow drops the offline flag to add the API-backed online
+audits. Suppressions use inline `# zizmor: ignore[rule]` comments and must
+carry a rationale.
+
 ### Abuse & Rate Limiting
 
 Because this repository exposes no network service, there is no in-process

--- a/docs/ci/required-checks.md
+++ b/docs/ci/required-checks.md
@@ -48,6 +48,13 @@ automation authority and is not a required context.
 handles code events only; it must not gain label, review, or auto-merge event
 triggers. The automation loop handles review labels and merge-state actions.
 
+The gate fans in the `_required.yml` code-validation jobs: `lint`, `pr-policy`,
+`unit-tests`, `build`, the `security/*` scans (including `security/workflow-scan`,
+the zizmor GitHub Actions SAST gate added for issue #2151), `license-scan`, and
+more. Enumerating each one individually in branch protection is brittle: renaming
+a job, adding a job, or splitting one silently changes what's required, and nobody
+notices until something slips through.
+
 ## Live audit
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,9 @@ dev = [
     # Property-based fuzz testing of LLM-output parsers (issue #1470).
     "hypothesis>=6.0,<7",
     "bandit>=1.9.4,<2",
+    # GitHub Actions workflow security scanner (issue #2151); complements
+    # bandit (Python) and ShellCheck (shell). See SECURITY.md.
+    "zizmor>=1.27,<2",
     "pdoc>=14.0,<15",
     "pytest-watcher>=0.4,<1",
     "tomli>=2.0,<3;python_version<'3.11'",

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -560,9 +560,16 @@ class TestReleaseAttestations:
         assert self._publish_step()["with"]["generate_attestations"] is True
 
     def test_id_token_write_permission_present(self) -> None:
-        """Attestation generation requires the ``id-token: write`` permission."""
+        """Attestation generation requires the ``id-token: write`` permission.
+
+        The permission is scoped to the ``build-and-publish`` job (least
+        privilege, zizmor excessive-permissions / issue #2151) — the workflow
+        default is read-only — because that is where the PyPI publish step
+        generates PEP 740 attestations.
+        """
         workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
-        assert workflow["permissions"]["id-token"] == "write"
+        assert workflow["permissions"].get("id-token") != "write"
+        assert workflow["jobs"]["build-and-publish"]["permissions"]["id-token"] == "write"
 
 
 class TestAutomationRuntimeInstall:

--- a/tests/unit/ci/test_zizmor_config.py
+++ b/tests/unit/ci/test_zizmor_config.py
@@ -1,0 +1,120 @@
+"""Tests for the UV-managed zizmor GitHub Actions SAST configuration.
+
+zizmor is the workflow-surface complement to bandit (Python) and ShellCheck
+(shell); see issue #2151 and SECURITY.md. These guards freeze the two
+enforcement surfaces (pre-commit + required CI job) and the offline/online flag
+split so the scanner cannot silently stop gating or drift out of alignment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # type: ignore[no-redef, unused-ignore]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Offline PR-gate flags. The required CI job and the pre-commit hook MUST both
+# carry every one of these so a workflow security regression fails fast and
+# deterministically, with no network dependency.
+OFFLINE_FLAGS = ("--no-online-audits", "--min-severity", "medium")
+
+
+def _pyproject() -> dict[str, object]:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _zizmor_precommit_entry() -> str:
+    """Return the ``entry`` command of the local zizmor pre-commit hook."""
+    config = yaml.safe_load((REPO_ROOT / ".pre-commit-config.yaml").read_text())
+    hook = next(
+        hook
+        for repo in config["repos"]
+        for hook in repo.get("hooks", [])
+        if hook.get("id") == "zizmor"
+    )
+    return str(hook["entry"])
+
+
+def test_zizmor_is_a_versioned_dev_dependency() -> None:
+    """The project-managed development environment supplies zizmor."""
+    config = _pyproject()
+    dev_group = config["dependency-groups"]["dev"]  # type: ignore[index]
+    assert any(dependency.startswith("zizmor>=") for dependency in dev_group)
+
+
+def test_required_workflow_runs_zizmor_offline_at_medium() -> None:
+    """The required PR gate runs the project-managed zizmor, offline, medium+."""
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/_required.yml").read_text())
+    job = workflow["jobs"]["security-workflow-scan"]
+    assert job["name"] == "security/workflow-scan"
+    run_step = next(step for step in job["steps"] if step.get("id") == "zizmor")
+    command = run_step["run"]
+    assert "uv run zizmor" in command
+    for flag in OFFLINE_FLAGS:
+        assert flag in command, f"required workflow-scan job missing {flag!r}"
+    assert ".github/workflows/" in command
+
+
+def test_workflow_scan_job_is_wired_into_the_required_gate() -> None:
+    """security-workflow-scan must be aggregated by required-checks-gate.
+
+    Without this the offline zizmor gate would run but never block a merge.
+    The generic gate-membership guard (test_required_checks_gate.py) also
+    covers this dynamically; asserting it here documents the contract for
+    this specific scan.
+    """
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/_required.yml").read_text())
+    gate_needs = workflow["jobs"]["required-checks-gate"]["needs"]
+    assert "security-workflow-scan" in gate_needs
+
+
+def test_precommit_and_ci_zizmor_flags_match() -> None:
+    """The pre-commit hook and the CI gate use the identical offline flags.
+
+    A drift between the two would let a commit pass locally but fail in CI (or
+    vice versa); freeze them together.
+    """
+    entry = _zizmor_precommit_entry()
+    assert entry.startswith("uv run zizmor")
+    for flag in OFFLINE_FLAGS:
+        assert flag in entry, f"zizmor pre-commit hook missing {flag!r}"
+    assert ".github/workflows/" in entry
+
+
+def test_scheduled_scan_uses_online_audits() -> None:
+    """The weekly security.yml scan enables the online, API-backed audits.
+
+    It must NOT pass --no-online-audits and must supply a GH_TOKEN so audits
+    such as known-vulnerable-actions can query the GitHub API.
+    """
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/security.yml").read_text())
+    job = workflow["jobs"]["workflow-scan"]
+    run_step = next(step for step in job["steps"] if step.get("id") == "zizmor")
+    command = run_step["run"]
+    assert "uv run zizmor" in command
+    assert "--no-online-audits" not in command
+    assert "--min-severity" in command and "medium" in command
+    # Not a secret: this is the GitHub Actions expression the workflow uses to
+    # pass the ephemeral job token to zizmor's online audits.
+    assert run_step["env"]["GH_TOKEN"] == "${{ github.token }}"  # noqa: S105
+
+
+def test_security_md_documents_static_analysis_coverage() -> None:
+    """SECURITY.md documents the per-surface static-analysis coverage.
+
+    Issue #2151 requires a documented equivalent for the workflow and shell
+    surfaces; the coverage table names zizmor and ShellCheck alongside bandit.
+    """
+    security_md = (REPO_ROOT / "SECURITY.md").read_text()
+    assert "Static Analysis Coverage" in security_md
+    for tool in ("zizmor", "Bandit", "ShellCheck"):
+        assert tool in security_md, f"SECURITY.md coverage table missing {tool}"

--- a/uv.lock
+++ b/uv.lock
@@ -654,6 +654,7 @@ dev = [
     { name = "pytest-watcher" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -694,6 +695,7 @@ dev = [
     { name = "pytest-watcher", specifier = ">=0.4,<1" },
     { name = "ruff", specifier = ">=0.15,<1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0,<3" },
+    { name = "zizmor", specifier = ">=1.27,<2" },
 ]
 
 [[package]]
@@ -2222,4 +2224,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/a8/1c0c6619e213e6e1fd8323f09661542197448db2984649d2c34097997859/zizmor-1.27.0.tar.gz", hash = "sha256:ffaf8e1bb39447e643592d669761bfbc2aa636875db9079614f6a6c81cec60c8", size = 548896, upload-time = "2026-07-14T08:16:49.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/81/ba3dbd48a5e3d56d8a9693ba3dac9484df1b3f83862a453ade9f70ef21ff/zizmor-1.27.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0de272b6c19910f5bc6965ac7d4566af26db31571e983e3b567298389d0c84c7", size = 9090700, upload-time = "2026-07-14T08:16:31.04Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/18/960f032faa67427afb8b3e11877b7e911d1ccff3f3bb8bec0c416d4df42c/zizmor-1.27.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:cc94158472428e04298b879ef36cb94360b753ece38fa2303464dd7dae07bc68", size = 8673964, upload-time = "2026-07-14T08:16:33.038Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/2a/034e4d11d1ed81e23fc9e526391616848467f0db6faeaa9e1b88fb8560ec/zizmor-1.27.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:b70697ebe555a28fbd3deaa259936f059f64b9f8531020f5b1f3d99087d4f62a", size = 8777649, upload-time = "2026-07-14T08:16:34.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/27/8dce2cd076ee0c39b0d9ac129703400c9c1c21c71f1709da660e3769d628/zizmor-1.27.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0bba3eff43f919b04b9b6365b4ef17437649e11eafb73f603407873b65ad01dd", size = 8367119, upload-time = "2026-07-14T08:16:36.859Z" },
+    { url = "https://files.pythonhosted.org/packages/21/64/4e21d26a2fc910594aaab19367ac25467a4da6438b7c381f67e90c38945e/zizmor-1.27.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:afb28123882d2b8248f1e480bf6cc6d1af102e0d3fbe22a40f7f795b1aa9d435", size = 9163603, upload-time = "2026-07-14T08:16:38.591Z" },
+    { url = "https://files.pythonhosted.org/packages/92/04/17ffd2884f8d74ce747c6ffe11481de5effb35079fd00a0725fab336e57d/zizmor-1.27.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e1042dd14fb4597a1e3007c7ef3f5a017305ca50cfacf43d603f3ae870c65eb1", size = 8807297, upload-time = "2026-07-14T08:16:40.804Z" },
+    { url = "https://files.pythonhosted.org/packages/60/af/3a347da3007655c7979b4b99d6a4d309ebc344715daa7c1357f17d00d680/zizmor-1.27.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:138e65d560e3875dbbbec50eae56a9e14707f8f4e006112174e4752155c01db9", size = 8333630, upload-time = "2026-07-14T08:16:42.814Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/37/921c74ed022fe8e1f599d7e7353cab63d550dda68e410096ed735b7388db/zizmor-1.27.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90004342c3c5122d7e4e8e27ac6d3c462b878da0ea3d408ff45fa7d768139a76", size = 9253035, upload-time = "2026-07-14T08:16:44.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/9cdb03c6c2341cf273c9c34506e5193cea7e73dc50b49ccf5f93a3579bdb/zizmor-1.27.0-py3-none-win32.whl", hash = "sha256:fe8947f635c925b83ef83fcd66de5f89a012b22784bb86fcd7e2a1f4e7648c9d", size = 7538509, upload-time = "2026-07-14T08:16:46.253Z" },
+    { url = "https://files.pythonhosted.org/packages/43/42/b924e569218646684d1e211f299282c0b9a0780d6b15f9e10e4a3fdaac11/zizmor-1.27.0-py3-none-win_amd64.whl", hash = "sha256:debc723721172c170d5922171a40eaebf5787a02ff3e69d30597dafdb66a21ba", size = 8643618, upload-time = "2026-07-14T08:16:47.835Z" },
 ]


### PR DESCRIPTION
## Summary
The pre-commit suite, zizmor exit 0, and schema validation are all confirmed green. Only the full `pytest tests/unit` run remains, which is executing in the background. I'll await its completion notification.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2151

Generated by Hephaestus automation
