### PR TITLE
[Feat] Adversarial review posture in the Jinja rubric templates

### DIFF
--- a/hephaestus/prompts/templates/default/pr_review/analysis.j2
+++ b/hephaestus/prompts/templates/default/pr_review/analysis.j2
@@ -36,6 +36,12 @@ Analyze PR #{{ pr_number }} using {{ review_context_kind }} #{{ issue_number }} 
 > directly using this prompt. In either case, this review is the loop's sole
 > GO/NOGO decision; `merge_wait` is the separate mechanical auto-merge armer.
 
+**Assume the code is WRONG; your job is to prove it right.** Do not review for
+plausibility — review for falsification: trace each changed execution path,
+verify the tests actually exercise the change (and would FAIL if the change
+were broken), and actively hunt for the input, state, or sequence that breaks
+it. Conclude GO only after that hunt comes up empty.
+
 Review the PR for correctness, completeness, and code quality. Identify any issues that should
 be addressed as inline review comments.
 

--- a/hephaestus/prompts/templates/default/review_rubrics/reviewer.j2
+++ b/hephaestus/prompts/templates/default/review_rubrics/reviewer.j2
@@ -9,6 +9,15 @@ GRADING (every dimension starts at F; A must be EARNED with concrete evidence):
 - D  (60-69%)  Poor / fundamental practices missing
 - F  (<60%)    Failing / misaligned / dangerous
 
+REVIEW POSTURE (mandatory):
+- Assume the submission is WRONG until you prove otherwise. Your job is not to
+  confirm it looks right — it is to try to break it and fail.
+- A GO verdict or an A/B grade is a positive claim that you actively attempted
+  to falsify the work (traced the changed paths, checked the failure modes,
+  looked for the input that breaks it) and could not.
+- If you did not perform that falsification attempt for a dimension, you may
+  not grade it above C.
+
 ANTI-INFLATION RULES (mandatory):
 - DEFAULT IS F. Find concrete evidence to justify ANY upgrade.
 - A requires ZERO critical or major findings.

--- a/tests/unit/automation/test_prompts.py
+++ b/tests/unit/automation/test_prompts.py
@@ -618,6 +618,18 @@ class TestSharedRubricConstants:
         """The anti-inflation block must restate the DEFAULT IS F rule."""
         assert "DEFAULT IS F" in prompts._REVIEW_GRADING_AND_ANTI_INFLATION
 
+    def test_reviewer_rubric_states_adversarial_posture(self) -> None:
+        """The reviewer rubric must open from a falsification posture (#2257).
+
+        Re-homed from the deleted ``test_strict_rubric`` suite: #2280 renamed
+        ``strict_rubrics/reviewer.j2`` to ``review_rubrics/reviewer.j2`` and
+        replaced ``build_strict_review_rubric`` with ``build_review_rubric``.
+        """
+        rubric = prompts._REVIEW_RUBRIC
+        assert "REVIEW POSTURE" in rubric
+        assert "Assume the submission is WRONG" in rubric
+        assert "falsify" in rubric
+
     def test_seven_principles_yagni_carves_out_toolchain_churn(self) -> None:
         """P2/YAGNI exempts toolchain churn but still flags scope creep (#1017)."""
         block = prompts._SEVEN_PRINCIPLES_DIMENSIONS


### PR DESCRIPTION
## Summary

Re-implements the adversarial review posture (#2257) against the current Jinja prompt catalog. The original PR #2258 edited the old inline-Python prompt strings, which were removed when #2273 migrated prompts to `.j2` templates — so #2258 could not be mechanically rebased.

- `strict_rubrics/reviewer.j2` gains a mandatory **REVIEW POSTURE** block: assume the submission is WRONG until proven otherwise; a GO verdict or A/B grade is a positive claim that the reviewer actively attempted to falsify the work and could not; an unfalsified dimension caps at C.
- `pr_review/analysis.j2` adds the code-specific directive: assume the code is wrong, trace changed execution paths, verify the tests would fail if the change were broken, and hunt for the breaking input before concluding GO.
- New regression test asserts the rendered rubric carries the posture (fails if it silently drops).

89 rubric/prompt tests pass; lint clean.

Closes #2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)