### PR TITLE
[mino] Strengthen vulnerability-disclosure safe-harbor guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,6 +25,58 @@ To report a vulnerability, email **<research@villmow.us>** with:
 You can expect an acknowledgement within 48 hours and a status update within 7 days.
 We will coordinate disclosure timing with you once a fix is available.
 
+### Safe Harbor & Scope Eligibility
+
+We consider security research conducted in good faith and in line with this
+policy to be authorized. For eligible research we
+**will not pursue or support legal action** against you, and we waive
+restrictions in our repository terms that would otherwise prohibit that
+research, to the extent those restrictions would conflict with it.
+
+Research is **eligible** for safe harbor when all of the following hold:
+
+- It targets the assets named in the [threat model](#threat-model): code in
+  this repository and your **own** local installation of it.
+- It respects the reporting channel above — no public disclosure before a
+  coordinated fix, and no access to, modification of, or retention of data
+  that is not yours (if you encounter such data, stop and report immediately).
+- It stays within the threat model's **in-scope** classes (unsafe
+  deserialization, command/subprocess injection, secret leakage, dependency
+  supply chain).
+
+Research is **ineligible** (voids safe harbor) when it involves:
+
+- Social engineering, phishing, or physical attacks against maintainers,
+  contributors, or infrastructure operators.
+- Denial of service or resource-exhaustion testing against shared
+  infrastructure (GitHub, PyPI, CI runners) — DoS is out of scope per the
+  threat model in any case.
+- Testing third-party services (GitHub, PyPI, NATS providers) rather than
+  this repository's code; report those to the affected vendor instead.
+- Automated scanning that generates spam issues, emails, or pull requests.
+
+If you are unsure whether planned research is eligible, email
+**<research@villmow.us>** first and we will clarify before you proceed.
+
+### Remediation Handling
+
+After the 48-hour acknowledgement, reports move through a defined lifecycle:
+
+1. **Triage** — we validate the report and assign a severity (aligned with
+   your assessment where possible) within 7 days, as part of the status
+   update promised above.
+2. **Remediation targets** — from triage, we aim to land a fix within:
+   **Critical**: 7 days · **High**: 30 days · **Medium**: 60 days ·
+   **Low**: 90 days or next scheduled release.
+3. **Release & advisory** — fixes ship in a signed `vX.Y.Z` release; for
+   Critical/High issues we publish a GitHub Security Advisory crediting the
+   reporter (unless you prefer to remain anonymous).
+4. **Coordinated disclosure** — we ask that you hold public disclosure until
+   a fix is released or **90 days** from the acknowledgement, whichever comes
+   first; we will tell you when the fix lands and coordinate timing, and we
+   may ask for a short extension for actively exploited or unusually complex
+   issues.
+
 ## Security Considerations
 
 ### Threat Model

--- a/tests/unit/docs/test_security_policy.py
+++ b/tests/unit/docs/test_security_policy.py
@@ -1,0 +1,61 @@
+"""Regression tests for the SECURITY.md disclosure safe-harbor guidance."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SECURITY_DOC = REPO_ROOT / "SECURITY.md"
+
+
+def _policy_text() -> str:
+    return SECURITY_DOC.read_text(encoding="utf-8")
+
+
+def test_safe_harbor_section_exists() -> None:
+    """The policy must carry an explicit safe-harbor section."""
+    assert re.search(r"^### Safe Harbor & Scope Eligibility\s*$", _policy_text(), re.MULTILINE)
+
+
+def test_safe_harbor_states_no_legal_action_commitment() -> None:
+    """Good-faith research must be met with a no-legal-action commitment."""
+    text = _policy_text().lower()
+    assert "good faith" in text
+    assert "will not pursue or support legal action" in text
+
+
+def test_safe_harbor_enumerates_ineligible_activities() -> None:
+    """Scope eligibility must name the activities that void safe harbor."""
+    text = _policy_text().lower()
+    for excluded in ("social engineering", "denial of service", "third-party"):
+        assert excluded in text, f"safe-harbor exclusions must mention {excluded!r}"
+
+
+def test_remediation_handling_section_exists() -> None:
+    """The policy must carry an explicit remediation-handling section."""
+    assert re.search(r"^### Remediation Handling\s*$", _policy_text(), re.MULTILINE)
+
+
+def test_remediation_targets_cover_reporting_severity_scale() -> None:
+    """Every severity the reporting section asks for has a remediation target."""
+    match = re.search(
+        r"^### Remediation Handling\s*$(.*?)(?=^##\s|\Z)",
+        _policy_text(),
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    section = match.group(1)
+    for severity in ("Critical", "High", "Medium", "Low"):
+        assert severity in section, f"missing remediation target for {severity}"
+
+
+def test_remediation_defines_disclosure_window() -> None:
+    """A coordinated-disclosure window must be spelled out."""
+    text = _policy_text()
+    assert "90 days" in text
+
+
+def test_no_hardcoded_date_stamps() -> None:
+    """New sections must not reintroduce 'As of YYYY-MM-DD' stamps (pre-commit hook)."""
+    assert not re.search(r"As of \d{4}-\d{2}-\d{2}", _policy_text())


### PR DESCRIPTION
## Summary
All 35 docs tests pass. Implementation complete.

## Summary

Implemented #2182 — strengthened SECURITY.md safe-harbor guidance (audit §15, MINOR).

**Changed:**
- `SECURITY.md:28-88` — added two subsections after the reporting flow, before `## Security Considerations`:
  - `### Safe Harbor & Scope Eligibility` — good-faith authorization + no-legal-action commitment, eligibility criteria (references the existing threat model, DRY), and an ineligible-activities list (social engineering, DoS, third-party testing, spam scanning).
  - `### Remediation Handling` — 4-step lifecycle: triage/severity within 7 days, per-severity remediation targets keyed to the reporting section's Critical/High/Medium/Low scale (7/30/60/90 days), signed-release + advisory/credit, and a 90-day coordinated-disclosure window.
- `tests/unit/docs/test_security_policy.py` (new) — 7 regression tests pinning both section headers, the no-legal-action commitment, ineligible-activity terms, per-severity remediation coverage, the disclosure window, and a no-hardcoded-date guard. Follows the `tests/unit/docs/test_required_checks_policy.py` pattern; `tests/unit/docs/` is a sanctioned extra test dir.

**Tests run (all pass):**
- `pytest tests/unit/docs/test_security_policy.py --no-cov` → 7 passed (RED→GREEN verified: 6 failed before the SECURITY.md edit)
- `pytest tests/unit/docs --no-cov` → 35 passed (no regressions)
- `pre-commit run --files SECURITY.md tests/unit/docs/test_security_policy.py` → all hooks Passed (ruff, mypy, markdownlint, both SECURITY.md guard hooks)

No absolute-date stamps introduced; the supported-versions table is untouched, so `check_security_version_consistency.py` still passes. Changes left in the working tree for the orchestrator to commit.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2182

Generated by Hephaestus automation
