### PR TITLE
Escape control characters in skipped Git-path logs

### DIFF
--- a/hephaestus/automation/pr_manager.py
+++ b/hephaestus/automation/pr_manager.py
@@ -806,10 +806,10 @@ def _select_commit_paths(
 
     for status, path in entries:
         if allowed is not None and path not in allowed:
-            logger.debug("Skipping non-allowlisted file: %s", path)
+            logger.debug("Skipping non-allowlisted file: %r", path)
             continue
         if _is_secret_path(path):
-            logger.warning("Skipping potential secret file: %s", path)
+            logger.warning("Skipping potential secret file: %r", path)
             continue
         if "D" in status:
             update_paths.append(path)

--- a/tests/unit/automation/test_pr_manager_commit.py
+++ b/tests/unit/automation/test_pr_manager_commit.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
@@ -129,6 +130,36 @@ class TestSelectCommitPaths:
         )
         with pytest.raises(FrozenInstanceError):
             paths.add_paths = ()  # type: ignore[misc]
+
+    def test_escapes_control_characters_in_skip_logs(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        # Path payloads preserved by _parse_porcelain_status (PR #2208) may carry
+        # newlines / terminal control chars; skip logs must render them escaped so a
+        # filename cannot forge a log line or emit terminal escapes (issue #2231).
+        newline_path = "src/forged\nINJECTED log line.py"
+        # Basename stays ``.env`` so the secret (warning) branch fires on a real
+        # secret name while the control payload rides in a leading path segment.
+        control_path = "sub/\x1b]0;pwned\x07/.env"
+        entries = (
+            (" M", newline_path),
+            ("??", control_path),
+        )
+
+        with caplog.at_level(logging.DEBUG, logger=pr_manager.logger.name):
+            paths = pr_manager._select_commit_paths(entries, allowed_paths=(control_path,))
+
+        # Selection semantics unchanged: newline_path filtered (not allowlisted),
+        # control_path filtered (secret .env basename), nothing staged.
+        assert paths == pr_manager._CommitPaths(add_paths=(), update_paths=())
+
+        skip_messages = [record.getMessage() for record in caplog.records]
+        assert any(repr(newline_path) in message for message in skip_messages)
+        assert any(repr(control_path) in message for message in skip_messages)
+        # Each untrusted value is a single escaped record — no raw newline or ESC leaks.
+        for message in skip_messages:
+            assert "\n" not in message
+            assert "\x1b" not in message
 
 
 class TestStageCommitPaths:


### PR DESCRIPTION
## Summary
Implementation complete. Two files changed, no stray/backup files.

**What changed:**
- `hephaestus/automation/pr_manager.py:809,812` — `%s` → `%r` in the two `_select_commit_paths()` skip logs, so untrusted porcelain paths are `repr`-escaped (C-escapes `\n`, `\x1b`, etc. into one quoted single-line record). Matches the module's existing `!r`-for-untrusted-strings convention (589, 603, 975, 1000). Path-selection and secret-filtering semantics unchanged — only the rendered log text differs.
- `tests/unit/automation/test_pr_manager_commit.py` — added `import logging` and `TestSelectCommitPaths.test_escapes_control_characters_in_skip_logs`, exercising both skip branches (non-allowlisted debug + secret warning via a `.env` basename with a control-char path segment) and asserting each untrusted value is a single escaped record with no raw `\n` or `\x1b` leaking.

**Acceptance criteria:** (1) newline/control-char paths logged as one escaped record ✓; (2) selection + secret filtering unchanged — asserted `_CommitPaths(add_paths=(), update_paths=())` and all 28 pre-existing tests still pass ✓; (3) regression test added ✓.

**Tests run:**
- `pytest .../test_pr_manager_commit.py::TestSelectCommitPaths -v` → 2 passed
- `pytest .../test_pr_manager_commit.py --cov-fail-under=0` → **30 passed**
- `ruff check` + `ruff format --check` → clean; `mypy hephaestus/automation/pr_manager.py` → no issues

(Whole-tree coverage gate reports low % on single-file runs — expected, not a regression.)

Verdict: PASS | Reason: `%s`→`%r` in both skip logs + regression test; all 30 tests, ruff, mypy green.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2231

Generated by Hephaestus automation
