### PR TITLE
[majo] Document third-party service responsibilities and SLAs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ See the [README](../README.md) for installation and development setup instructio
 - [Operations Runbooks](runbooks/index.md) — Operator recovery procedures for the automation pipeline (loop crash, corrupted worktree, drive-green stall, quota exhaustion)
 - [Performance Testing](performance-testing.md) — Bounded worker-pool load, capacity, latency, and sustained-concurrency testing
 - [Privacy, Retention, and Deletion Policy](../PRIVACY.md) — data inventory, retention periods, deletion procedures, and GDPR contact (issue #2175)
+- [Third-Party Services](third-party-services.md) — Vendor inventory, responsibility split, and availability expectations for GitHub, PyPI, and agent providers (issue #2177)
 
 ## Contributing
 

--- a/docs/third-party-services.md
+++ b/docs/third-party-services.md
@@ -1,0 +1,86 @@
+# Third-Party Services: Responsibilities and SLAs
+
+This document inventories every third-party service the Hephaestus build,
+release, and automation pipeline depends on at runtime, records the
+responsibility split between the project and each vendor, and states the
+availability expectations that actually apply. It exists so that a dependency
+on an external service can never be silently added without a documented owner,
+failure mode, and mitigation (issue #2177).
+
+## Purpose and scope
+
+A **third-party service dependency** here means an external, vendor-hosted
+SaaS or registry that the build, release, or automation pipeline calls over the
+network — GitHub, the Python Package Index, and the agent providers, plus the
+supply-chain services CI reaches during a run. Vendored third-party *code*
+(pinned GitHub Actions, npm packages) is included because its availability at
+install time is a runtime dependency, even though the code itself is pinned.
+
+Self-hosted infrastructure and in-ecosystem components are **out of scope** —
+see [Explicitly out of scope](#explicitly-out-of-scope).
+
+Related decisions: [ADR-0003](adr/0003-dependabot-renovate-split.md)
+(dependency-update bot ownership), [ADR-0004](adr/0004-single-aggregator-required-checks.md)
+and [ADR-0007](adr/0007-dual-surface-required-checks.md) (GitHub required-check
+gating), and [ADR-0008](adr/0008-uv-only-development-environment.md) (uv as the
+sole environment manager).
+
+## Availability expectations (no contractual SLAs)
+
+Hephaestus consumes every service below on a free, best-effort, or usage-tier
+basis. **None of them grant this project a contractual SLA.** The
+"Availability commitment" column therefore records each vendor's *published*
+status page or best-effort posture, not a guaranteed uptime figure. Claiming an
+SLA the project does not hold would itself be an audit finding.
+
+## Service inventory
+
+| Service | Used for | Criticality | Our responsibility | Vendor responsibility | Availability commitment / status page |
+|---|---|---|---|---|---|
+| GitHub (repo, API, Actions, Pages, Dependabot) | Source hosting, `gh` API automation, CI runners, branch protection and merge gates, API-docs hosting on Pages, `uv`/actions dependency updates | Critical — all merges and CI stop | Pin actions by commit SHA, keep the required-checks aggregator accurate (ADR-0004 / ADR-0007), respect API rate limits (`hephaestus/github/rate_limit.py`), operate the stall runbooks | Service and API availability, Actions runner fleet, correctness of API responses | <https://www.githubstatus.com/> — no contractual SLA on the free/team tier |
+| PyPI / TestPyPI | Release publishing via OIDC trusted publishing (`pypa/gh-action-pypi-publish` in `.github/workflows/release.yml`) | High — blocks releases only; development is unaffected | Maintain the trusted-publisher configuration, publish from signed `vX.Y.Z` tags, retry a failed publish by re-running the release workflow | Index availability, OIDC token exchange, package serving | <https://status.python.org/> — best-effort, no SLA |
+| Anthropic (Claude CLI / API) | Primary agent provider for the automation pipeline (the loop shells out to the `claude` CLI) | High — automation halts; manual development is unaffected | Quota monitoring, model-cap fallback to `opus-4-8` (PR #1794), circuit breaker and retry (`hephaestus/resilience/`), the [claude-quota-exhausted](runbooks/claude-quota-exhausted.md) runbook | API availability, model behavior and quotas | <https://status.anthropic.com/> — usage-tier limits, no SLA |
+| Pi private provider (optional) | Alternative OpenAI-compatible agent runtime (`docs/pi-private-provider.md`); the CLI is `@earendil-works/pi-coding-agent`, installed with `npm install -g --ignore-scripts` | Low — optional adapter, off by default | Operator-local configuration only; documentation uses placeholders (ADR-0011 / `docs/pi-private-provider.md`) | Provider-local availability | Operator-managed |
+| npm registry | Installs the pinned Pi coding-agent CLI in CI (`.github/actions/setup-pi-cli`) | Low — only the Pi integration test path | Version pinning (`@0.80.2`), install with `--ignore-scripts` | Registry availability | <https://status.npmjs.org/> — best-effort |
+| Astral (`astral-sh/setup-uv`) | Provisions the uv toolchain in CI (ADR-0008) | High for CI — uv is the sole environment manager | Pin the action by SHA; uv binaries are cached by `actions/cache` | Release-artifact availability | GitHub-hosted release artifacts — best-effort |
+| Third-party GitHub Actions (`astral-sh/setup-uv`, `pypa/gh-action-pypi-publish`, `crazy-max/ghaction-import-gpg`, `softprops/action-gh-release`, `extractions/setup-just`) | uv provisioning, PyPI publishing, GPG import, release creation, `just` provisioning | Medium — release and CI ergonomics | SHA-pinning (done — see `release.yml` and `_required.yml`), `github-actions` Dependabot updates (ADR-0003) | Correctness of the pinned action code | Not a hosted service — vendored, pinned code |
+| Dependabot (`.github/dependabot.yml`) | Automated `uv` and `github-actions` dependency-update PRs | Low — dependency hygiene | Keep the ecosystem list correct; review update PRs (ADR-0003) | Update-generation availability | GitHub-native — best-effort |
+| Renovate (Mend app) | Historically owned the pixi/conda ecosystem (ADR-0003); **currently inactive** — no `renovate.json` is tracked since the uv-only migration (ADR-0008) removed the pixi ecosystem it managed | None — no active configuration | If pixi/conda ever returns, re-add a scoped `renovate.json` per ADR-0003 (GitHub-Actions manager disabled) | App availability, when configured | Best-effort, when configured |
+
+## Responsibility policy
+
+The split is the same across every row above:
+
+- **Vendors own** the availability and correctness of their hosted service,
+  registry, or runner fleet.
+- **Hephaestus owns** everything within the project's control: pinning
+  third-party code by commit SHA, configuring authentication and authorization
+  (OIDC trusted publishing, GPG signing, GitHub branch protection), rate-limit
+  hygiene, graceful degradation (circuit breaker, retries, provider fallback),
+  and operator runbooks.
+
+**Adding a new external service requires a new inventory row.** This is
+enforced executably: `tests/unit/docs/test_third_party_services_doc.py` fails
+CI if any remote GitHub Action owner referenced by a `uses:` line in
+`.github/workflows/*.yml` is absent from this document, and if the required
+services above are not all named.
+
+## Degradation matrix
+
+For each Critical or High service, the observable failure mode, the immediate
+operator action, and the mechanism or runbook that covers it:
+
+| Service | Observable failure mode | Immediate operator action | Mechanism / runbook |
+|---|---|---|---|
+| GitHub API | 4xx/5xx responses, rate-limit exhaustion, circuit breaker open | Pause the automation loop; wait for the rate-limit window or breaker reset | `hephaestus/github/rate_limit.py`, `hephaestus/resilience/circuit_breaker.py`, [ci-driver-stall](runbooks/ci-driver-stall.md) |
+| GitHub Actions / merge gates | Required checks stuck queued or a merge gate never arms | Inspect the required-checks aggregator; re-run the workflow | ADR-0004 / ADR-0007, [ci-driver-stall](runbooks/ci-driver-stall.md) |
+| PyPI / TestPyPI | Publish step fails or the index is unreachable | Re-run the release workflow from the signed tag once the index recovers | `.github/workflows/release.yml` |
+| Anthropic (Claude) | HTTP 429 / quota exhaustion, model-cap 429 | Let the model-cap fallback and retry run; if persistent, pause the loop | Model fallback (PR #1794), `hephaestus/resilience/`, [claude-quota-exhausted](runbooks/claude-quota-exhausted.md) |
+| Astral / npm registry | CI install step fails to fetch a toolchain or CLI | Re-run the job (artifacts are cached); if persistent, wait for registry recovery | `actions/cache`, action SHA pins |
+
+## Explicitly out of scope
+
+- **NATS** — self-hosted JetStream infrastructure, not a vendor service. See
+  [NATS JetStream Configuration](nats.md).
+- **Mnemosyne knowledge backend** — an in-ecosystem HomericIntelligence
+  component, not a third-party vendor.

--- a/docs/third-party-services.md
+++ b/docs/third-party-services.md
@@ -22,8 +22,10 @@ see [Explicitly out of scope](#explicitly-out-of-scope).
 Related decisions: [ADR-0003](adr/0003-dependabot-renovate-split.md)
 (dependency-update bot ownership), [ADR-0004](adr/0004-single-aggregator-required-checks.md)
 and [ADR-0007](adr/0007-dual-surface-required-checks.md) (GitHub required-check
-gating), and [ADR-0008](adr/0008-uv-only-development-environment.md) (uv as the
-sole environment manager).
+gating), [ADR-0005](adr/0005-multi-agent-runtime-abstraction.md) (the Claude,
+Codex, and Pi runtime boundary), and
+[ADR-0008](adr/0008-uv-only-development-environment.md) (uv as the sole
+environment manager).
 
 ## Availability expectations (no contractual SLAs)
 
@@ -40,7 +42,8 @@ SLA the project does not hold would itself be an audit finding.
 | GitHub (repo, API, Actions, Pages, Dependabot) | Source hosting, `gh` API automation, CI runners, branch protection and merge gates, API-docs hosting on Pages, `uv`/actions dependency updates | Critical — all merges and CI stop | Pin actions by commit SHA, keep the required-checks aggregator accurate (ADR-0004 / ADR-0007), respect API rate limits (`hephaestus/github/rate_limit.py`), operate the stall runbooks | Service and API availability, Actions runner fleet, correctness of API responses | <https://www.githubstatus.com/> — no contractual SLA on the free/team tier |
 | PyPI / TestPyPI | Release publishing via OIDC trusted publishing (`pypa/gh-action-pypi-publish` in `.github/workflows/release.yml`) | High — blocks releases only; development is unaffected | Maintain the trusted-publisher configuration, publish from signed `vX.Y.Z` tags, retry a failed publish by re-running the release workflow | Index availability, OIDC token exchange, package serving | <https://status.python.org/> — best-effort, no SLA |
 | Anthropic (Claude CLI / API) | Primary agent provider for the automation pipeline (the loop shells out to the `claude` CLI) | High — automation halts; manual development is unaffected | Quota monitoring, model-cap fallback to `opus-4-8` (PR #1794), circuit breaker and retry (`hephaestus/resilience/`), the [claude-quota-exhausted](runbooks/claude-quota-exhausted.md) runbook | API availability, model behavior and quotas | <https://status.anthropic.com/> — usage-tier limits, no SLA |
-| Pi private provider (optional) | Alternative OpenAI-compatible agent runtime (`docs/pi-private-provider.md`); the CLI is `@earendil-works/pi-coding-agent`, installed with `npm install -g --ignore-scripts` | Low — optional adapter, off by default | Operator-local configuration only; documentation uses placeholders (ADR-0011 / `docs/pi-private-provider.md`) | Provider-local availability | Operator-managed |
+| OpenAI (Codex CLI / API) | Supported Codex agent runtime (`codex login status`) selected through the Claude/Codex/Pi abstraction | High — an affected automation run cannot continue until an operator selects another configured provider | Keep authentication and agent selection operator-controlled; pause or reroute an affected run through another configured provider | API, Codex service, model behavior, and quota availability | <https://status.openai.com/> — tier-dependent availability, no contractual SLA |
+| Pi private provider (optional) | Alternative OpenAI-compatible agent runtime (`docs/pi-private-provider.md`); the CLI is `@earendil-works/pi-coding-agent`, installed with `npm install -g --ignore-scripts` | Low — optional adapter, off by default | Operator-local configuration only; documentation uses placeholders (ADR-0005 / `docs/pi-private-provider.md`) | Provider-local availability | Operator-managed |
 | npm registry | Installs the pinned Pi coding-agent CLI in CI (`.github/actions/setup-pi-cli`) | Low — only the Pi integration test path | Version pinning (`@0.80.2`), install with `--ignore-scripts` | Registry availability | <https://status.npmjs.org/> — best-effort |
 | Astral (`astral-sh/setup-uv`) | Provisions the uv toolchain in CI (ADR-0008) | High for CI — uv is the sole environment manager | Pin the action by SHA; uv binaries are cached by `actions/cache` | Release-artifact availability | GitHub-hosted release artifacts — best-effort |
 | Third-party GitHub Actions (`astral-sh/setup-uv`, `pypa/gh-action-pypi-publish`, `crazy-max/ghaction-import-gpg`, `softprops/action-gh-release`, `extractions/setup-just`) | uv provisioning, PyPI publishing, GPG import, release creation, `just` provisioning | Medium — release and CI ergonomics | SHA-pinning (done — see `release.yml` and `_required.yml`), `github-actions` Dependabot updates (ADR-0003) | Correctness of the pinned action code | Not a hosted service — vendored, pinned code |
@@ -61,9 +64,9 @@ The split is the same across every row above:
 
 **Adding a new external service requires a new inventory row.** This is
 enforced executably: `tests/unit/docs/test_third_party_services_doc.py` fails
-CI if any remote GitHub Action owner referenced by a `uses:` line in
-`.github/workflows/*.yml` is absent from this document, and if the required
-services above are not all named.
+CI if any remote GitHub Action owner referenced by a `uses:` line in a workflow
+or composite action is absent from this document, and if the required services
+above are not all named.
 
 ## Degradation matrix
 
@@ -76,6 +79,7 @@ operator action, and the mechanism or runbook that covers it:
 | GitHub Actions / merge gates | Required checks stuck queued or a merge gate never arms | Inspect the required-checks aggregator; re-run the workflow | ADR-0004 / ADR-0007, [ci-driver-stall](runbooks/ci-driver-stall.md) |
 | PyPI / TestPyPI | Publish step fails or the index is unreachable | Re-run the release workflow from the signed tag once the index recovers | `.github/workflows/release.yml` |
 | Anthropic (Claude) | HTTP 429 / quota exhaustion, model-cap 429 | Let the model-cap fallback and retry run; if persistent, pause the loop | Model fallback (PR #1794), `hephaestus/resilience/`, [claude-quota-exhausted](runbooks/claude-quota-exhausted.md) |
+| OpenAI (Codex) | API or Codex service failure, unavailable model, or exhausted quota | Pause the affected run or select another configured provider before retrying | `hephaestus/agents/runtime.py`, [OpenAI status](https://status.openai.com/) |
 | Astral / npm registry | CI install step fails to fetch a toolchain or CLI | Re-run the job (artifacts are cached); if persistent, wait for registry recovery | `actions/cache`, action SHA pins |
 
 ## Explicitly out of scope

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -8,8 +8,6 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 DOC = REPO_ROOT / "docs" / "third-party-services.md"
 INDEX = REPO_ROOT / "docs" / "index.md"
-WORKFLOWS = REPO_ROOT / ".github" / "workflows"
-
 REQUIRED_SERVICES = (
     "GitHub",
     "PyPI",
@@ -42,7 +40,7 @@ def _documented_action_owners(repo_root: Path = REPO_ROOT) -> set[str]:
             for definition in definitions.rglob(pattern):
                 text = definition.read_text(encoding="utf-8")
                 for match in re.finditer(
-                    r"^\s*-\s*uses:\s*([\w.-]+)/[\w./-]+@", text, re.MULTILINE
+                    r"^\s*(?:-\s*)?uses:\s*([\w.-]+)/[\w./-]+@", text, re.MULTILINE
                 ):
                     owners.add(match.group(1))
     return owners
@@ -104,6 +102,20 @@ def test_composite_action_owner_is_discovered(tmp_path: Path) -> None:
     action.write_text(
         "runs:\n  using: composite\n  steps:\n"
         "    - uses: example/setup-tool@0123456789abcdef0123456789abcdef01234567\n",
+        encoding="utf-8",
+    )
+
+    assert _documented_action_owners(tmp_path) == {"example"}
+
+
+def test_named_step_action_owner_is_discovered(tmp_path: Path) -> None:
+    """A named workflow step cannot bypass the external-owner guard."""
+    workflow = tmp_path / ".github" / "workflows" / "release.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "steps:\n"
+        "  - name: Publish package\n"
+        "    uses: example/publish@0123456789abcdef0123456789abcdef01234567\n",
         encoding="utf-8",
     )
 

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -40,19 +40,42 @@ def _documented_action_owners() -> set[str]:
     return owners
 
 
-def test_inventory_names_every_required_service() -> None:
-    """Every required third-party service must appear in the inventory."""
+def _inventory_table_rows() -> list[list[str]]:
+    """Parse the ``## Service inventory`` markdown table into cell rows.
+
+    Returns the header row followed by every data row, each as a list of
+    trimmed cell strings. Raises if the section or its table is missing, so a
+    heading/format rename fails loudly instead of silently matching nothing.
+    """
     text = DOC.read_text(encoding="utf-8")
-    missing = [service for service in REQUIRED_SERVICES if service not in text]
-    assert missing == [], f"docs/third-party-services.md missing services: {missing}"
+    section = re.search(r"^## Service inventory\n(.*?)(?=^## |\Z)", text, re.MULTILINE | re.DOTALL)
+    assert section is not None, "docs/third-party-services.md has no '## Service inventory' section"
+    lines = [line for line in section.group(1).splitlines() if line.strip().startswith("|")]
+    assert len(lines) >= 2, "no markdown table found under '## Service inventory'"
+    # Row 1 is the header; row 2 is the '---' separator; skip it.
+    data_lines = [line for line in lines if not re.fullmatch(r"[\s|:-]+", line)]
+    rows = [line.strip().strip("|").split("|") for line in data_lines]
+    return [[cell.strip() for cell in row] for row in rows]
+
+
+def test_inventory_names_every_required_service() -> None:
+    """Every required third-party service must have its own inventory row."""
+    rows = _inventory_table_rows()
+    service_cells = [row[0] for row in rows[1:]]
+    missing = [
+        service
+        for service in REQUIRED_SERVICES
+        if not any(service in cell for cell in service_cells)
+    ]
+    assert missing == [], f"docs/third-party-services.md missing service rows: {missing}"
 
 
 def test_inventory_has_responsibility_and_status_columns() -> None:
-    """The inventory must split responsibility and cite status pages."""
-    text = DOC.read_text(encoding="utf-8")
-    assert "Our responsibility" in text
-    assert "Vendor responsibility" in text
-    assert "status page" in text.lower()
+    """The inventory table header must split responsibility and cite a status column."""
+    header = _inventory_table_rows()[0]
+    assert any("our responsibility" in cell.lower() for cell in header), header
+    assert any("vendor responsibility" in cell.lower() for cell in header), header
+    assert any("status" in cell.lower() for cell in header), header
 
 
 def test_every_third_party_action_owner_is_documented() -> None:

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -40,7 +40,7 @@ def _documented_action_owners(repo_root: Path = REPO_ROOT) -> set[str]:
             for definition in definitions.rglob(pattern):
                 text = definition.read_text(encoding="utf-8")
                 for match in re.finditer(
-                    r"^\s*(?:-\s*)?uses:\s*([\w.-]+)/[\w./-]+@", text, re.MULTILINE
+                    r"^\s*(?:-\s*)?uses:\s*[\"']?([\w.-]+)/[\w./-]+@", text, re.MULTILINE
                 ):
                     owners.add(match.group(1))
     return owners
@@ -120,6 +120,20 @@ def test_named_step_action_owner_is_discovered(tmp_path: Path) -> None:
     )
 
     assert _documented_action_owners(tmp_path) == {"example"}
+
+
+def test_quoted_action_owner_is_discovered(tmp_path: Path) -> None:
+    """Quoted remote action references cannot bypass the external-owner guard."""
+    workflow = tmp_path / ".github" / "workflows" / "release.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "steps:\n"
+        '  - uses: "example/publish@0123456789abcdef0123456789abcdef01234567"\n'
+        "  - uses: 'second/setup@0123456789abcdef0123456789abcdef01234567'\n",
+        encoding="utf-8",
+    )
+
+    assert _documented_action_owners(tmp_path) == {"example", "second"}
 
 
 def test_doc_is_linked_from_index() -> None:

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -80,10 +80,12 @@ def test_inventory_has_responsibility_and_status_columns() -> None:
 
 def test_every_third_party_action_owner_is_documented() -> None:
     """A new external CI vendor must be added to the inventory table."""
-    text = DOC.read_text(encoding="utf-8")
     owners = _documented_action_owners() - FIRST_PARTY_ACTION_OWNERS
     assert owners, "no remote action owners found — regex or workflow layout changed"
-    missing = sorted(owner for owner in owners if owner not in text)
+    service_cells = [row[0].lower() for row in _inventory_table_rows()[1:]]
+    missing = sorted(
+        owner for owner in owners if not any(owner.lower() in cell for cell in service_cells)
+    )
     assert missing == [], f"CI action owners absent from docs/third-party-services.md: {missing}"
 
 

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -14,6 +14,7 @@ REQUIRED_SERVICES = (
     "GitHub",
     "PyPI",
     "Anthropic",
+    "OpenAI",
     "Pi private provider",
     "npm",
     "Dependabot",
@@ -25,18 +26,25 @@ REQUIRED_SERVICES = (
 FIRST_PARTY_ACTION_OWNERS = frozenset({"actions"})
 
 
-def _documented_action_owners() -> set[str]:
-    """Remote ``uses:`` owners referenced across ``.github/workflows/*.yml``.
+def _documented_action_owners(repo_root: Path = REPO_ROOT) -> set[str]:
+    """Remote ``uses:`` owners referenced by workflows and composite actions.
 
     The trailing ``@`` in the pattern restricts matches to remote pinned
     actions (``owner/repo@ref``), excluding local composite actions referenced
     as ``uses: ./.github/actions/...``.
     """
     owners: set[str] = set()
-    for workflow in WORKFLOWS.glob("*.yml"):
-        text = workflow.read_text(encoding="utf-8")
-        for match in re.finditer(r"^\s*uses:\s*([\w.-]+)/[\w./-]+@", text, re.MULTILINE):
-            owners.add(match.group(1))
+    for definitions in (
+        repo_root / ".github" / "workflows",
+        repo_root / ".github" / "actions",
+    ):
+        for pattern in ("*.yml", "*.yaml"):
+            for definition in definitions.rglob(pattern):
+                text = definition.read_text(encoding="utf-8")
+                for match in re.finditer(
+                    r"^\s*-\s*uses:\s*([\w.-]+)/[\w./-]+@", text, re.MULTILINE
+                ):
+                    owners.add(match.group(1))
     return owners
 
 
@@ -87,6 +95,19 @@ def test_every_third_party_action_owner_is_documented() -> None:
         owner for owner in owners if not any(owner.lower() in cell for cell in service_cells)
     )
     assert missing == [], f"CI action owners absent from docs/third-party-services.md: {missing}"
+
+
+def test_composite_action_owner_is_discovered(tmp_path: Path) -> None:
+    """A nested composite action cannot bypass the external-owner guard."""
+    action = tmp_path / ".github" / "actions" / "bootstrap" / "action.yml"
+    action.parent.mkdir(parents=True)
+    action.write_text(
+        "runs:\n  using: composite\n  steps:\n"
+        "    - uses: example/setup-tool@0123456789abcdef0123456789abcdef01234567\n",
+        encoding="utf-8",
+    )
+
+    assert _documented_action_owners(tmp_path) == {"example"}
 
 
 def test_doc_is_linked_from_index() -> None:

--- a/tests/unit/docs/test_third_party_services_doc.py
+++ b/tests/unit/docs/test_third_party_services_doc.py
@@ -1,0 +1,70 @@
+"""Tests for the third-party service responsibility inventory (issue #2177)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOC = REPO_ROOT / "docs" / "third-party-services.md"
+INDEX = REPO_ROOT / "docs" / "index.md"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+REQUIRED_SERVICES = (
+    "GitHub",
+    "PyPI",
+    "Anthropic",
+    "Pi private provider",
+    "npm",
+    "Dependabot",
+    "Renovate",
+)
+
+# First-party GitHub actions (owner ``actions``) are covered by the GitHub
+# inventory row rather than listed individually.
+FIRST_PARTY_ACTION_OWNERS = frozenset({"actions"})
+
+
+def _documented_action_owners() -> set[str]:
+    """Remote ``uses:`` owners referenced across ``.github/workflows/*.yml``.
+
+    The trailing ``@`` in the pattern restricts matches to remote pinned
+    actions (``owner/repo@ref``), excluding local composite actions referenced
+    as ``uses: ./.github/actions/...``.
+    """
+    owners: set[str] = set()
+    for workflow in WORKFLOWS.glob("*.yml"):
+        text = workflow.read_text(encoding="utf-8")
+        for match in re.finditer(r"^\s*uses:\s*([\w.-]+)/[\w./-]+@", text, re.MULTILINE):
+            owners.add(match.group(1))
+    return owners
+
+
+def test_inventory_names_every_required_service() -> None:
+    """Every required third-party service must appear in the inventory."""
+    text = DOC.read_text(encoding="utf-8")
+    missing = [service for service in REQUIRED_SERVICES if service not in text]
+    assert missing == [], f"docs/third-party-services.md missing services: {missing}"
+
+
+def test_inventory_has_responsibility_and_status_columns() -> None:
+    """The inventory must split responsibility and cite status pages."""
+    text = DOC.read_text(encoding="utf-8")
+    assert "Our responsibility" in text
+    assert "Vendor responsibility" in text
+    assert "status page" in text.lower()
+
+
+def test_every_third_party_action_owner_is_documented() -> None:
+    """A new external CI vendor must be added to the inventory table."""
+    text = DOC.read_text(encoding="utf-8")
+    owners = _documented_action_owners() - FIRST_PARTY_ACTION_OWNERS
+    assert owners, "no remote action owners found — regex or workflow layout changed"
+    missing = sorted(owner for owner in owners if owner not in text)
+    assert missing == [], f"CI action owners absent from docs/third-party-services.md: {missing}"
+
+
+def test_doc_is_linked_from_index() -> None:
+    """The inventory must be discoverable from the docs index."""
+    text = INDEX.read_text(encoding="utf-8")
+    assert "third-party-services.md" in text


### PR DESCRIPTION
## Summary
Implementation complete. Left in the working tree for the orchestrator to commit.

**What changed:**
- `docs/third-party-services.md` (new) — Vendor inventory + responsibility/SLA policy: purpose/scope, availability-expectations preamble (states plainly there are **no contractual SLAs**), 9-row service inventory table (GitHub, PyPI/TestPyPI, Anthropic, Pi provider, npm, Astral, third-party Actions, Dependabot, Renovate), a responsibility-policy section with the "new service → new row" rule, a degradation matrix, and an out-of-scope section (NATS, Mnemosyne).
- `docs/index.md:57` (modified) — added the resource-list bullet linking the new doc.
- `tests/unit/docs/test_third_party_services_doc.py` (new) — 4-test executable guard.

**Grounded in the tree, not the plan verbatim** (the plan's git premises were partly stale):
- Dependabot ecosystems are `uv` + `github-actions` (plan said `pip`); doc/GitHub row corrected.
- `renovate.json` **does not exist** (removed post-uv-migration, ADR-0008); the Renovate row is marked **currently inactive** rather than implying an active integration — accurate per ADR-0003 + current tree.
- Pi CLI pin `@earendil-works/pi-coding-agent@0.80.2`, `--ignore-scripts`, and Astral `setup-uv` (ADR-0008) verified against `.github/actions/setup-pi-cli` and `release.yml`/`_required.yml`.

**Tests run:**
- `tests/unit/docs/test_third_party_services_doc.py` — 4 passed. Owner-guard proven real (fails when an owner slug is dropped, passes when present).
- `tests/unit/docs tests/unit/validation` — 790 passed, 16 skipped (no regression).
- `pre-commit` on all 3 changed files — ruff, mypy, markdownlint, and every applicable hook Passed.

Verdict: PASS | Reason: vendor inventory covering GitHub/PyPI/agent-providers added, linked from index, and CI-guarded; all local tests + hooks green.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2177

Generated by Hephaestus automation
