### PR TITLE
[mino] Exercise installed console binaries in tests

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -553,7 +553,59 @@ jobs:
         run: uv sync --all-groups --all-extras --locked
 
       - name: Run integration tests
+        # uv sync installed every [project.scripts] binary into .venv/bin, so
+        # the CLI entry-point checks must never skip here (#2173).
+        env:
+          HEPHAESTUS_REQUIRE_CLI: "1"
         run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers
+
+  installed-cli-tests:
+    # Installed-artifact lane (#2173): build the wheel, install it into a
+    # fresh non-editable venv, and exercise every console binary from PATH
+    # with skipping forbidden. Proves end-users' `pip install` artifacts
+    # actually expose working CLIs — the editable uv env above cannot.
+    name: installed-cli-tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: changes-gate
+    if: needs.changes-gate.outputs.code_event == 'true'
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # hatch-vcs derives the wheel version from git tags.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
+        with:
+          enable-cache: true
+
+      - name: Build wheel
+        run: uv build --wheel
+
+      - name: Install wheel into fresh venv
+        # [automation] extra: most console scripts live under
+        # hephaestus.automation.*. pytest runs the suite; pyyaml is
+        # imported by tests/conftest.py.
+        run: |
+          uv venv build/cli-venv
+          WHEEL=(dist/*.whl)
+          uv pip install --python build/cli-venv/bin/python "${WHEEL[0]}[automation]" pytest pyyaml
+
+      - name: Run CLI entry-point tests against installed binaries
+        env:
+          HEPHAESTUS_REQUIRE_CLI: "1"
+        run: |
+          export PATH="$PWD/build/cli-venv/bin:$PATH"
+          build/cli-venv/bin/pytest tests/integration/test_cli_entry_points.py \
+            --override-ini="addopts=" -v --strict-markers
 
   shell-tests:
     name: shell-tests
@@ -873,6 +925,7 @@ jobs:
       - pr-policy
       - unit-tests
       - integration-tests
+      - installed-cli-tests
       - shell-tests
       - build
       - security-dependency-scan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,10 @@ jobs:
         # sdist-contents / package-import guarantee a merged PR does (issue #1499).
         # --override-ini clears the unit coverage addopts; --strict-markers is safe
         # because the `integration` marker is registered in pyproject.toml.
+        # uv sync installed every [project.scripts] binary, so the CLI
+        # entry-point checks must never skip here (#2173).
+        env:
+          HEPHAESTUS_REQUIRE_CLI: "1"
         run: uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers
 
   type-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,5 +104,9 @@ jobs:
 
       - name: Run integration tests
         if: matrix.test-type == 'integration'
+        # uv sync installed every [project.scripts] binary, so the CLI
+        # entry-point checks must never skip here (#2173).
+        env:
+          HEPHAESTUS_REQUIRE_CLI: "1"
         run: |
           uv run pytest tests/integration --override-ini="addopts=" -v --strict-markers

--- a/tests/integration/test_cli_entry_points.py
+++ b/tests/integration/test_cli_entry_points.py
@@ -61,6 +61,37 @@ def _cli_subprocess_env() -> dict[str, str]:
     return env
 
 
+REQUIRE_CLI_ENV = "HEPHAESTUS_REQUIRE_CLI"
+
+
+def _resolve_binary(command: str) -> str:
+    """Return the console-script path, skipping — or failing — when absent.
+
+    By default a missing binary skips (developer checkouts without an
+    install). When ``HEPHAESTUS_REQUIRE_CLI=1`` (set by CI lanes that
+    install the package first), a missing binary is a hard failure so the
+    installed-artifact checks can never silently skip (#2173).
+
+    Args:
+        command: The console-script command name to resolve on ``PATH``.
+
+    Returns:
+        The absolute path to the resolved console-script binary.
+
+    Raises:
+        Skipped: When the binary is absent and the gate is not set.
+        Failed: When the binary is absent and ``HEPHAESTUS_REQUIRE_CLI=1``.
+
+    """
+    binary = shutil.which(command)
+    if binary is None:
+        message = f"{command} not on PATH — install with `pip install -e .` or run with uv"
+        if os.environ.get(REQUIRE_CLI_ENV) == "1":
+            pytest.fail(f"{message} (skip forbidden: {REQUIRE_CLI_ENV}=1)")
+        pytest.skip(message)
+    return binary
+
+
 class TestCLITargetImportable:
     """Every entry point's target ``module:attr`` must be an importable callable."""
 
@@ -88,10 +119,7 @@ class TestCLIHelpFlag:
         # Windows operators. Skip the help-flag check on that platform.
         if sys.platform == "win32" and "automation" in module_path:
             pytest.skip("automation CLIs require POSIX stdlib (curses/fcntl)")
-        binary: str | None = shutil.which(command)
-        if binary is None:
-            pytest.skip(f"{command} not on PATH — install with `pip install -e .` or run with uv")
-        assert binary is not None  # narrow for mypy; pytest.skip already returned
+        binary = _resolve_binary(command)
 
         result = subprocess.run(
             [binary, "--help"],
@@ -124,10 +152,7 @@ class TestCLIJsonFlag:
         """
         if sys.platform == "win32" and "automation" in module_path:
             pytest.skip("automation CLIs require POSIX stdlib (curses/fcntl)")
-        binary: str | None = shutil.which(command)
-        if binary is None:
-            pytest.skip(f"{command} not on PATH — install with `pip install -e .` or run with uv")
-        assert binary is not None
+        binary = _resolve_binary(command)
 
         result = subprocess.run(
             [binary, "--help"],
@@ -158,10 +183,7 @@ class TestCLIVersionFlag:
         """``<cmd> --version`` must exit 0 and print a version line."""
         if sys.platform == "win32" and "automation" in module_path:
             pytest.skip("automation CLIs require POSIX stdlib (curses/fcntl)")
-        binary: str | None = shutil.which(command)
-        if binary is None:
-            pytest.skip(f"{command} not on PATH — install with `pip install -e .` or run with uv")
-        assert binary is not None
+        binary = _resolve_binary(command)
 
         result = subprocess.run(
             [binary, "--version"],
@@ -186,10 +208,7 @@ class TestCLIVersionFlag:
         """``<cmd> -V`` must also work (short form of --version)."""
         if sys.platform == "win32" and "automation" in module_path:
             pytest.skip("automation CLIs require POSIX stdlib (curses/fcntl)")
-        binary: str | None = shutil.which(command)
-        if binary is None:
-            pytest.skip(f"{command} not on PATH — install with `pip install -e .` or run with uv")
-        assert binary is not None
+        binary = _resolve_binary(command)
 
         result = subprocess.run(
             [binary, "-V"],
@@ -221,10 +240,7 @@ class TestMaxWorkersValidation:
 
     def test_automation_loop_rejects_zero_max_workers(self) -> None:
         """hephaestus-automation-loop --max-workers=0 exits non-zero with clear error."""
-        binary = shutil.which("hephaestus-automation-loop")
-        if binary is None:
-            pytest.skip("hephaestus-automation-loop not on PATH")
-        assert binary is not None  # narrow Optional[str] for mypy
+        binary = _resolve_binary("hephaestus-automation-loop")
 
         result = subprocess.run(
             [binary, "--max-workers", "0"],
@@ -237,3 +253,21 @@ class TestMaxWorkersValidation:
         assert result.returncode != 0, "Expected non-zero exit for --max-workers=0"
         assert "--max-workers" in result.stderr, "Error must mention --max-workers argument"
         assert "invalid choice" in result.stderr.lower(), "Error must mention invalid choice"
+
+
+class TestRequireCliGate:
+    """The HEPHAESTUS_REQUIRE_CLI gate must fail — not skip — on missing binaries."""
+
+    def test_missing_binary_skips_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(REQUIRE_CLI_ENV, raising=False)
+        with pytest.raises(pytest.skip.Exception):
+            _resolve_binary("hephaestus-definitely-not-a-real-binary")
+
+    def test_missing_binary_fails_when_required(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(REQUIRE_CLI_ENV, "1")
+        with pytest.raises(pytest.fail.Exception):
+            _resolve_binary("hephaestus-definitely-not-a-real-binary")
+
+    def test_present_binary_resolves(self) -> None:
+        # `python3` (POSIX) / `python` is always on PATH in the test env.
+        assert _resolve_binary("python3" if sys.platform != "win32" else "python")


### PR DESCRIPTION
## Summary
Clean. Implementation complete and verified. Summary below.

## Summary

Implemented issue #2173 (Section 14 MINOR — exercise installed console binaries in tests) per the approved plan.

**Changed files (4):**

- **`tests/integration/test_cli_entry_points.py`** — Added `REQUIRE_CLI_ENV` constant + `_resolve_binary()` helper (`:65-90`) that skips a missing binary by default but `pytest.fail`s when `HEPHAESTUS_REQUIRE_CLI=1`. Replaced the 5 duplicated skip blocks (`test_help_flag`, `test_json_flag_documented_in_help`, `test_version_flag`, `test_version_flag_short_form`, `TestMaxWorkersValidation`) with `_resolve_binary(...)` calls, removing the `assert binary is not None` mypy-narrowing lines. Added `TestRequireCliGate` (3 self-tests) covering skip-by-default, fail-when-required, and present-binary resolution.
- **`.github/workflows/_required.yml`** — Set `HEPHAESTUS_REQUIRE_CLI: "1"` on the existing `integration-tests` lane; added a new `installed-cli-tests` job (build wheel → fresh non-editable venv → install `dist/*.whl[automation] pytest pyyaml` → run the entry-point tests from PATH with the gate on); wired `- installed-cli-tests` into `required-checks-gate.needs`.
- **`.github/workflows/test.yml`** / **`.github/workflows/release.yml`** — Set the gate env var on their integration-test steps (both already `uv sync` first).

**Tests run (all local, all passing):**
- `HEPHAESTUS_REQUIRE_CLI=1 pytest tests/integration/test_cli_entry_points.py` → **246 passed, 0 PATH-skips** (dev-checkout uv env).
- **Installed-lane end-to-end simulation**: real wheel `homericintelligence_hephaestus-0.9.10.dev204+g9aa167313` built, installed into fresh `build/cli-venv` (48 hephaestus binaries, shebangs point at the fresh venv), tests run from that PATH → **246 passed, 0 skips**. Artifacts cleaned up.
- `tests/unit/ci/test_required_checks_gate.py` → 9 passed (gate-wiring guard confirms the new job is required).
- `tests/unit/ci/` + `tests/integration/` → 520 passed; `tests/unit/ci/test_workflows.py` + `tests/unit/validation/` → 823 passed / 16 unrelated skips.
- `ruff check`/`format`, `mypy`, `yamllint`, and full `pre-commit run --files` on all 4 files → all pass (workflow-inventory + `continue-on-error`/advisory-`::warning::` guards included).

No git/GitHub mutations performed — changes left in the working tree for the orchestrator.

Verdict: PASS | Reason: skip→fail gate + installed-artifact lane implemented; installed-wheel run verified locally with 0 skips, all local checks green.


## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2173

Generated by Hephaestus automation
