### PR TITLE
[Fix] Load default prompt templates by __file__ path, not PackageLoader

### DIFF
--- a/hephaestus/prompts/catalog.py
+++ b/hephaestus/prompts/catalog.py
@@ -13,9 +13,13 @@ from jinja2 import (
     ChoiceLoader,
     Environment,
     FileSystemLoader,
-    PackageLoader,
     StrictUndefined,
 )
+
+#: Packaged default templates, resolved by filesystem path relative to this
+#: module so loading never depends on importlib package metadata (which races
+#: an editable-install rebuild, #2308).
+_DEFAULT_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates" / "default"
 
 _ACTIVE_CATALOG: ContextVar[PromptCatalog | None] = ContextVar(
     "hephaestus_active_prompt_catalog", default=None
@@ -39,7 +43,14 @@ class PromptCatalog:
             if not resolved_override.is_dir():
                 raise ValueError(f"Prompt override directory does not exist: {override_root}")
             loaders.append(FileSystemLoader(str(resolved_override)))
-        loaders.append(PackageLoader("hephaestus.prompts", "templates/default"))
+        # Resolve the packaged templates by filesystem path relative to this
+        # module, NOT via ``PackageLoader``. PackageLoader consults importlib
+        # package metadata, which is transiently inconsistent for the few
+        # seconds after an editable-install rebuild — workers that import the
+        # catalog in that window crash with "PackageLoader could not find
+        # 'templates/default'" even though the files are on disk (#2308). A
+        # ``__file__``-relative FileSystemLoader has no metadata dependency.
+        loaders.append(FileSystemLoader(str(_DEFAULT_TEMPLATES_DIR)))
         self._environment = Environment(
             loader=ChoiceLoader(loaders),
             # Prompt templates are plain text; escaping would alter rendered

--- a/tests/unit/prompts/test_catalog.py
+++ b/tests/unit/prompts/test_catalog.py
@@ -23,6 +23,23 @@ def test_default_catalog_render_preserves_planning_compatibility() -> None:
     )
 
 
+def test_default_templates_resolve_by_filesystem_path_not_package_metadata() -> None:
+    """The default loader is ``__file__``-relative, immune to the rebuild race (#2308).
+
+    ``PackageLoader`` consults importlib package metadata, which is transiently
+    inconsistent right after an editable-install rebuild and crashed reviewer
+    workers. The default loader must resolve templates by a filesystem path
+    that exists on disk, independent of installed metadata.
+    """
+    from hephaestus.prompts.catalog import _DEFAULT_TEMPLATES_DIR
+
+    assert _DEFAULT_TEMPLATES_DIR.is_dir()
+    assert (_DEFAULT_TEMPLATES_DIR / "pr_review" / "analysis.j2").is_file()
+    # The catalog loads its templates from that path (no PackageLoader involved).
+    names = PromptCatalog()._environment.list_templates()
+    assert "pr_review/analysis.j2" in names
+
+
 def test_legacy_prompt_constant_remains_a_jinja_backed_format_template() -> None:
     """Existing ``PLAN_PROMPT.format`` callers retain their rendered prompt."""
     from hephaestus.automation.prompts import PLAN_PROMPT


### PR DESCRIPTION
## Summary

`PackageLoader("hephaestus.prompts", "templates/default")` (`catalog.py:42`) resolves the template tree via importlib package metadata, which is **transiently inconsistent for a few seconds after an editable-install rebuild**. The automation loop's launch runs `uv sync` (rebuild) and immediately spawns workers; those that import the catalog inside that window crashed with `PackageLoader could not find 'templates/default'` **even though the files are on disk** — 12 reviewer jobs died this way in one run (06:44–06:49), each misread by the pipeline as a "reviewer failure" and regressed to implementation.

## Fix

Resolve the packaged defaults with a `__file__`-relative `FileSystemLoader` (`_DEFAULT_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates" / "default"`) — no importlib-metadata dependency, immune to the rebuild race. The harness-override `FileSystemLoader` path is unchanged.

## Verification

The existing byte-hash compatibility test (`test_default_catalog_render_preserves_planning_compatibility`) confirms rendered output is **unchanged** (same SHA256). New `test_default_templates_resolve_by_filesystem_path_not_package_metadata` pins the metadata-independent resolution. 92 prompt tests pass; lint/format/mypy clean.

Closes #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)