### PR TITLE
fix: handle merge-queue-protected repos in hephaestus-merge-prs

### DIFF
--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -336,15 +336,27 @@ def _is_merge_queue_error(exc: subprocess.CalledProcessError) -> bool:
     return _MERGE_QUEUE_REQUIRED_MARKER in blob and _HTTP_405_MARKER in blob
 
 
-def _enqueue_pr(repo_name: str, pr_number: int) -> dict[str, Any]:
+def _enqueue_pr(repo_name: str, pr_number: int, head_sha: str) -> dict[str, Any]:
     """Add ``pr_number`` to the branch's merge queue via ``gh pr merge``.
 
     The merge queue owns the merge method and rebuilds/merges the PR server-side,
     so no ``--squash``/``--merge`` flag is passed (passing one is rejected on a
-    queue-enabled branch). ``gh pr merge`` exits 0 both when it newly enqueues the
-    PR and when the PR is already queued; both are success from our perspective.
+    queue-enabled branch). ``--match-head-commit`` preserves the direct-merge
+    compare-and-swap guard, preventing a changed PR head from being enqueued.
+    ``gh pr merge`` exits 0 both when it newly enqueues the PR and when the PR is
+    already queued; both are success from our perspective.
     """
-    result = gh_call(["pr", "merge", str(pr_number), "--repo", repo_name])
+    result = gh_call(
+        [
+            "pr",
+            "merge",
+            str(pr_number),
+            "--repo",
+            repo_name,
+            "--match-head-commit",
+            head_sha,
+        ]
+    )
     blob = f"{result.stdout or ''}{getattr(result, 'stderr', '') or ''}"
     return {"queued": True, "message": blob.strip() or "enqueued in merge queue"}
 
@@ -372,7 +384,7 @@ def _merge_pr(repo_name: str, pr_number: int, head_sha: str) -> dict[str, Any]:
         )
     except subprocess.CalledProcessError as exc:
         if _is_merge_queue_error(exc):
-            return _enqueue_pr(repo_name, pr_number)
+            return _enqueue_pr(repo_name, pr_number, head_sha)
         raise
     return payload if isinstance(payload, dict) else {"merged": False, "message": str(payload)}
 

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -322,14 +322,18 @@ def _legacy_status_and_log(repo_name: str, head_sha: str) -> str:
 # GitHub returns HTTP 405 with this message from the direct merge API when the
 # base branch is protected by a merge queue: the PR cannot be merged directly and
 # must be enqueued instead. Matched case-insensitively on the message substring so
-# a wording change in the surrounding text does not break detection.
+# a wording change in the surrounding text does not break detection. Gated on the
+# "(HTTP 405)" marker `gh` appends to stderr so an unrelated failure whose message
+# happens to mention "merge queue" (e.g. in a PR title or comment echoed back by
+# the API) is not misclassified as the queue-required case.
 _MERGE_QUEUE_REQUIRED_MARKER = "merge queue"
+_HTTP_405_MARKER = "(http 405)"
 
 
 def _is_merge_queue_error(exc: subprocess.CalledProcessError) -> bool:
     """Return whether a failed direct-merge call means the repo uses a merge queue."""
     blob = f"{getattr(exc, 'stderr', '') or ''}{getattr(exc, 'stdout', '') or ''}".lower()
-    return _MERGE_QUEUE_REQUIRED_MARKER in blob
+    return _MERGE_QUEUE_REQUIRED_MARKER in blob and _HTTP_405_MARKER in blob
 
 
 def _enqueue_pr(repo_name: str, pr_number: int) -> dict[str, Any]:

--- a/hephaestus/github/pr_merge.py
+++ b/hephaestus/github/pr_merge.py
@@ -188,10 +188,12 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
         base_branch: Base branch name
 
     """
+    queued = False
     if isinstance(result, dict):
         merged = result.get("merged")
         message = result.get("message")
         sha = result.get("sha")
+        queued = bool(result.get("queued"))
     else:
         try:
             merged = getattr(result, "merged", None)
@@ -206,6 +208,10 @@ def handle_merge_result(result: Any, pr_number: int, base_branch: str) -> None:
 
     if merged:
         logger.info("  PR #%d merged into %s via squash. sha=%s", pr_number, base_branch, sha)
+    elif queued:
+        # A merge-queue repo does not merge synchronously: the PR is enqueued and
+        # the queue merges it server-side. This is success, not a failure.
+        logger.info("  PR #%d enqueued in the %s merge queue. %s", pr_number, base_branch, message)
     else:
         logger.error("  Failed to merge PR #%d. API message: %s", pr_number, message)
 
@@ -313,20 +319,57 @@ def _legacy_status_and_log(repo_name: str, head_sha: str) -> str:
     return str(payload.get("state") or "unknown")
 
 
+# GitHub returns HTTP 405 with this message from the direct merge API when the
+# base branch is protected by a merge queue: the PR cannot be merged directly and
+# must be enqueued instead. Matched case-insensitively on the message substring so
+# a wording change in the surrounding text does not break detection.
+_MERGE_QUEUE_REQUIRED_MARKER = "merge queue"
+
+
+def _is_merge_queue_error(exc: subprocess.CalledProcessError) -> bool:
+    """Return whether a failed direct-merge call means the repo uses a merge queue."""
+    blob = f"{getattr(exc, 'stderr', '') or ''}{getattr(exc, 'stdout', '') or ''}".lower()
+    return _MERGE_QUEUE_REQUIRED_MARKER in blob
+
+
+def _enqueue_pr(repo_name: str, pr_number: int) -> dict[str, Any]:
+    """Add ``pr_number`` to the branch's merge queue via ``gh pr merge``.
+
+    The merge queue owns the merge method and rebuilds/merges the PR server-side,
+    so no ``--squash``/``--merge`` flag is passed (passing one is rejected on a
+    queue-enabled branch). ``gh pr merge`` exits 0 both when it newly enqueues the
+    PR and when the PR is already queued; both are success from our perspective.
+    """
+    result = gh_call(["pr", "merge", str(pr_number), "--repo", repo_name])
+    blob = f"{result.stdout or ''}{getattr(result, 'stderr', '') or ''}"
+    return {"queued": True, "message": blob.strip() or "enqueued in merge queue"}
+
+
 def _merge_pr(repo_name: str, pr_number: int, head_sha: str) -> dict[str, Any]:
-    """Squash-merge ``pr_number`` through the GitHub REST API."""
-    payload = _gh_json(
-        [
-            "api",
-            "-X",
-            "PUT",
-            f"/repos/{repo_name}/pulls/{pr_number}/merge",
-            "-f",
-            "merge_method=squash",
-            "-f",
-            f"sha={head_sha}",
-        ]
-    )
+    """Merge ``pr_number``, using the branch's merge queue when one is required.
+
+    Tries a direct squash-merge first. If the base branch is protected by a merge
+    queue, the direct merge API returns HTTP 405; in that case the PR is enqueued
+    via ``gh pr merge`` and the result is reported as ``queued`` rather than an
+    error.
+    """
+    try:
+        payload = _gh_json(
+            [
+                "api",
+                "-X",
+                "PUT",
+                f"/repos/{repo_name}/pulls/{pr_number}/merge",
+                "-f",
+                "merge_method=squash",
+                "-f",
+                f"sha={head_sha}",
+            ]
+        )
+    except subprocess.CalledProcessError as exc:
+        if _is_merge_queue_error(exc):
+            return _enqueue_pr(repo_name, pr_number)
+        raise
     return payload if isinstance(payload, dict) else {"merged": False, "message": str(payload)}
 
 

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -713,6 +713,8 @@ class TestMergeQueueHandling:
         assert pr_merge_calls, "expected a `gh pr merge` enqueue call"
         enqueue = pr_merge_calls[0]
         assert "--squash" not in enqueue and "--merge" not in enqueue and "--rebase" not in enqueue
+        assert "--match-head-commit" in enqueue
+        assert enqueue[enqueue.index("--match-head-commit") + 1] == "deadbeef"
 
     def test_merge_pr_reraises_non_queue_error(self, monkeypatch) -> None:
         """A non-merge-queue failure is not swallowed."""
@@ -745,10 +747,20 @@ class TestMergeQueueHandling:
 
         monkeypatch.setattr(pr_merge_module, "gh_call", fake_gh_call)
 
-        out = _enqueue_pr("owner/repo", 9)
+        out = _enqueue_pr("owner/repo", 9, "cafebabe")
 
         assert out["queued"] is True
-        assert captured == [["pr", "merge", "9", "--repo", "owner/repo"]]
+        assert captured == [
+            [
+                "pr",
+                "merge",
+                "9",
+                "--repo",
+                "owner/repo",
+                "--match-head-commit",
+                "cafebabe",
+            ]
+        ]
 
     def test_handle_merge_result_logs_queued_as_success(self) -> None:
         """A queued result must not be logged as a failure."""

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -673,6 +673,20 @@ class TestMergeQueueHandling:
         exc.stdout = ""
         assert _is_merge_queue_error(exc) is False
 
+    def test_is_merge_queue_error_requires_405_even_with_matching_text(self) -> None:
+        """The message substring alone must not be enough without the 405 status."""
+        exc = subprocess.CalledProcessError(1, ["gh", "api"])
+        exc.stderr = "gh: validation failed for PR titled 'fix merge queue' (HTTP 422)"
+        exc.stdout = ""
+        assert _is_merge_queue_error(exc) is False
+
+    def test_is_merge_queue_error_requires_marker_even_with_405(self) -> None:
+        """A bare HTTP 405 without the merge-queue phrase must not match."""
+        exc = subprocess.CalledProcessError(1, ["gh", "api"])
+        exc.stderr = "gh: Method Not Allowed (HTTP 405)"
+        exc.stdout = ""
+        assert _is_merge_queue_error(exc) is False
+
     def test_merge_pr_enqueues_when_merge_queue_required(self, monkeypatch) -> None:
         """A 405 merge-queue error falls back to `gh pr merge` and reports queued."""
         calls: list[list[str]] = []

--- a/tests/unit/github/test_pr_merge.py
+++ b/tests/unit/github/test_pr_merge.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock, patch
 
 from hephaestus.github import pr_merge as pr_merge_module
 from hephaestus.github.pr_merge import (
+    _enqueue_pr,
+    _is_merge_queue_error,
+    _merge_pr,
     checks_success_and_log,
     detect_repo_from_remote,
     handle_merge_result,
@@ -649,6 +652,100 @@ class TestSquashOnlyInvariant:
         source = inspect.getsource(pr_merge)
         assert "merge_method=rebase" not in source
         assert "merge_method=squash" in source
+
+
+class TestMergeQueueHandling:
+    """A merge-queue-protected base branch must be enqueued, not treated as an error."""
+
+    @staticmethod
+    def _merge_queue_405() -> subprocess.CalledProcessError:
+        exc = subprocess.CalledProcessError(1, ["gh", "api"])
+        exc.stderr = "gh: Pull Request is in the merge queue. (HTTP 405)"
+        exc.stdout = '{"message":"Pull Request is in the merge queue.","status":"405"}'
+        return exc
+
+    def test_is_merge_queue_error_detects_405(self) -> None:
+        assert _is_merge_queue_error(self._merge_queue_405()) is True
+
+    def test_is_merge_queue_error_ignores_other_failures(self) -> None:
+        exc = subprocess.CalledProcessError(1, ["gh", "api"])
+        exc.stderr = "gh: Merge conflict (HTTP 409)"
+        exc.stdout = ""
+        assert _is_merge_queue_error(exc) is False
+
+    def test_merge_pr_enqueues_when_merge_queue_required(self, monkeypatch) -> None:
+        """A 405 merge-queue error falls back to `gh pr merge` and reports queued."""
+        calls: list[list[str]] = []
+
+        def fake_gh_call(args: list[str]) -> MagicMock:
+            calls.append(args)
+            if args[0] == "api":
+                raise self._merge_queue_405()
+            # gh pr merge <n> --repo ... : enqueue path
+            result = MagicMock()
+            result.stdout = "! Pull request owner/repo#7 is already queued to merge"
+            result.stderr = ""
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(pr_merge_module, "gh_call", fake_gh_call)
+
+        out = _merge_pr("owner/repo", 7, "deadbeef")
+
+        assert out["queued"] is True
+        assert out.get("merged") is not True
+        # The enqueue used `gh pr merge` with NO merge-method flag (queue owns it).
+        pr_merge_calls = [c for c in calls if c[:2] == ["pr", "merge"]]
+        assert pr_merge_calls, "expected a `gh pr merge` enqueue call"
+        enqueue = pr_merge_calls[0]
+        assert "--squash" not in enqueue and "--merge" not in enqueue and "--rebase" not in enqueue
+
+    def test_merge_pr_reraises_non_queue_error(self, monkeypatch) -> None:
+        """A non-merge-queue failure is not swallowed."""
+        exc = subprocess.CalledProcessError(1, ["gh", "api"])
+        exc.stderr = "gh: Not mergeable (HTTP 405)"
+        exc.stdout = ""
+
+        def fake_gh_call(args: list[str]) -> MagicMock:
+            raise exc
+
+        monkeypatch.setattr(pr_merge_module, "gh_call", fake_gh_call)
+
+        try:
+            _merge_pr("owner/repo", 7, "deadbeef")
+        except subprocess.CalledProcessError:
+            pass
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected the non-queue error to propagate")
+
+    def test_enqueue_pr_omits_merge_method_flag(self, monkeypatch) -> None:
+        captured: list[list[str]] = []
+
+        def fake_gh_call(args: list[str]) -> MagicMock:
+            captured.append(args)
+            result = MagicMock()
+            result.stdout = ""
+            result.stderr = ""
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(pr_merge_module, "gh_call", fake_gh_call)
+
+        out = _enqueue_pr("owner/repo", 9)
+
+        assert out["queued"] is True
+        assert captured == [["pr", "merge", "9", "--repo", "owner/repo"]]
+
+    def test_handle_merge_result_logs_queued_as_success(self) -> None:
+        """A queued result must not be logged as a failure."""
+        with patch.object(pr_merge_module, "logger") as mock_logger:
+            handle_merge_result(
+                {"queued": True, "message": "enqueued in merge queue"},
+                pr_number=7,
+                base_branch="main",
+            )
+        mock_logger.error.assert_not_called()
+        mock_logger.info.assert_called_once()
 
 
 class TestCanonicalGitOps:


### PR DESCRIPTION
## Summary

`hephaestus-merge-prs` merges via the direct GitHub REST merge API, which returns HTTP 405 `Pull Request is in the merge queue` on a repo whose base branch is protected by a **merge queue**. The tool treated that 405 as an error and retried, so green PRs were never merged on merge-queue repos (observed against HomericIntelligence/Mnemosyne).

## Fix

- `_merge_pr` catches the merge-queue 405 (`_is_merge_queue_error`) and falls back to `_enqueue_pr`, which runs `gh pr merge <n>` with **no** merge-method flag (the queue owns the strategy; passing `--squash` is rejected on a queued branch).
- The enqueue result is reported as `queued`; `handle_merge_result` logs it as success ("enqueued in the merge queue"), not a failure.
- Non-merge-queue failures still propagate unchanged. The existing `merge_method=squash` direct-merge path is preserved for non-queue repos.

## Tests

New `TestMergeQueueHandling`: 405 detection, non-queue-error ignored, enqueue-omits-method-flag, non-queue error re-raises, and queued-result-logged-as-success. All 53 pr_merge tests pass; `pr_merge.py` coverage 89%; ruff + mypy clean.

Closes #2311