### PR TITLE
feat(automation): enforce explicit pipeline agent tool scopes

### DIFF
--- a/hephaestus/automation/pipeline/tool_scopes.py
+++ b/hephaestus/automation/pipeline/tool_scopes.py
@@ -1,0 +1,94 @@
+"""Least-privilege Claude tool scopes for pipeline agent jobs (#2160).
+
+Maps each session-agent constant to the explicit ``--allowedTools`` /
+``--permission-mode`` pair the worker pool passes to every Claude
+invocation. Unknown agents fail closed to the read-only default.
+Values mirror the per-role scopes previously hardcoded at the legacy
+phase call sites. A stage that needs a bespoke grant sets
+``AgentJob.allowed_tools`` explicitly, which takes precedence.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from hephaestus.automation.session_naming import (
+    AGENT_ADDRESS_REVIEW,
+    AGENT_ADVISE,
+    AGENT_CI_DRIVER,
+    AGENT_COMMENT_CLASSIFIER,
+    AGENT_IMPLEMENTER,
+    AGENT_LEARNINGS,
+    AGENT_PLAN_REVIEWER,
+    AGENT_PLANNER,
+    AGENT_PR_REVIEWER,
+)
+
+logger = logging.getLogger(__name__)
+
+_READ_ONLY = "Read,Glob,Grep"
+_READ_EXPLORE = "Read,Glob,Grep,Bash"
+_WRITE = "Read,Write,Edit,Glob,Grep,Bash"
+
+
+@dataclass(frozen=True)
+class ToolScope:
+    """Explicit least-privilege tool grant for one agent role.
+
+    Attributes:
+        allowed_tools: Comma-separated ``--allowedTools`` value passed to the
+            Claude CLI.
+        permission_mode: ``--permission-mode`` value; ``"dontAsk"`` runs the
+            granted tools non-interactively, as everywhere else in
+            ``hephaestus.automation``.
+
+    """
+
+    allowed_tools: str
+    permission_mode: str = "dontAsk"
+
+
+#: Fail-closed scope for any agent absent from :data:`AGENT_TOOL_SCOPES`.
+DEFAULT_TOOL_SCOPE = ToolScope(_READ_ONLY)
+
+#: Per-role least-privilege scopes. Reviewers/classifiers are read-only;
+#: only implementer-class roles get ``Write,Edit,Bash``.
+AGENT_TOOL_SCOPES: Mapping[str, ToolScope] = MappingProxyType(
+    {
+        AGENT_ADVISE: ToolScope("Read,Glob,Grep,Bash,Skill,Task"),
+        AGENT_PLANNER: ToolScope(_READ_EXPLORE),
+        AGENT_PLAN_REVIEWER: ToolScope(_READ_ONLY),
+        AGENT_IMPLEMENTER: ToolScope(_WRITE),
+        AGENT_PR_REVIEWER: ToolScope(_READ_ONLY),
+        AGENT_COMMENT_CLASSIFIER: ToolScope(_READ_ONLY),
+        AGENT_ADDRESS_REVIEW: ToolScope(_WRITE + ",Task,Skill"),
+        AGENT_CI_DRIVER: ToolScope(_WRITE),
+        # The learn agent executes the /learn skill end-to-end: it commits and
+        # opens a Mnemosyne PR, so it needs the full write grant plus Skill.
+        AGENT_LEARNINGS: ToolScope(_WRITE + ",Task,Skill"),
+    }
+)
+
+
+def tool_scope_for(agent: str) -> ToolScope:
+    """Resolve the least-privilege scope for ``agent``.
+
+    Args:
+        agent: The session-agent role constant (e.g. ``AGENT_IMPLEMENTER``).
+
+    Returns:
+        The mapped :class:`ToolScope`, or :data:`DEFAULT_TOOL_SCOPE`
+        (read-only) when ``agent`` is unmapped — a security control degrades
+        to the most restrictive scope, not the most permissive. Dynamic
+        reviewer tokens (e.g. ``strict-review-<sha>-a<n>``) intentionally miss
+        the exact-match map and fall through to read-only.
+
+    """
+    scope = AGENT_TOOL_SCOPES.get(agent)
+    if scope is None:
+        logger.warning("no tool scope for agent %r; using read-only default", agent)
+        return DEFAULT_TOOL_SCOPE
+    return scope

--- a/hephaestus/automation/pipeline/worker_pool.py
+++ b/hephaestus/automation/pipeline/worker_pool.py
@@ -17,7 +17,6 @@ from contextlib import ExitStack, contextmanager
 from contextvars import copy_context
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
 
 from hephaestus.agents.runtime import resolve_agent, run_agent_session
 from hephaestus.automation import claude_invoke, git_utils, subprocess_registry
@@ -31,6 +30,11 @@ from hephaestus.automation.pipeline.jobs import (
 )
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
+from hephaestus.automation.pipeline.tool_scopes import (
+    DEFAULT_TOOL_SCOPE,
+    ToolScope,
+    tool_scope_for,
+)
 from hephaestus.automation.worktree_manager import WorktreeManager
 from hephaestus.resilience import (
     CircuitBreakerOpenError,
@@ -383,10 +387,16 @@ class WorkerPool:
 
             def _invoke() -> str:
                 if is_claude:
-                    claude_kwargs: dict[str, Any] = {}
-                    if job.sandbox == "read-only":
-                        claude_kwargs["allowed_tools"] = job.allowed_tools or "Read,Glob,Grep"
-                        claude_kwargs["permission_mode"] = "dontAsk"
+                    # Scope priority: an explicit per-job grant (a stage that
+                    # knows its exact needs, e.g. pr_review) wins; a read-only
+                    # sandbox without one clamps to the fail-closed default;
+                    # everything else resolves by session-agent role.
+                    if job.allowed_tools:
+                        scope = ToolScope(job.allowed_tools)
+                    elif job.sandbox == "read-only":
+                        scope = DEFAULT_TOOL_SCOPE
+                    else:
+                        scope = tool_scope_for(session_agent)
                     stdout, _ = claude_invoke.invoke_claude_with_session(
                         repo=job.repo,
                         issue=job.issue,
@@ -396,7 +406,8 @@ class WorkerPool:
                         cwd=job.cwd,
                         timeout=job.timeout_s,
                         output_format=job.output_format,
-                        **claude_kwargs,
+                        allowed_tools=scope.allowed_tools,
+                        permission_mode=scope.permission_mode,
                     )
                     return stdout
                 else:

--- a/tests/unit/automation/pipeline/test_tool_scopes.py
+++ b/tests/unit/automation/pipeline/test_tool_scopes.py
@@ -1,0 +1,102 @@
+"""Tests for pipeline agent tool scopes (#2160)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hephaestus.automation.pipeline.tool_scopes import (
+    AGENT_TOOL_SCOPES,
+    DEFAULT_TOOL_SCOPE,
+    ToolScope,
+    tool_scope_for,
+)
+from hephaestus.automation.session_naming import (
+    AGENT_ADDRESS_REVIEW,
+    AGENT_ADVISE,
+    AGENT_CI_DRIVER,
+    AGENT_COMMENT_CLASSIFIER,
+    AGENT_IMPLEMENTER,
+    AGENT_LEARNINGS,
+    AGENT_PLAN_REVIEWER,
+    AGENT_PLANNER,
+    AGENT_PR_REVIEWER,
+)
+
+# Every distinct session_agent= constant used at the pipeline stage call sites.
+_STAGE_AGENTS = [
+    AGENT_ADVISE,
+    AGENT_PLANNER,
+    AGENT_PLAN_REVIEWER,
+    AGENT_IMPLEMENTER,
+    AGENT_PR_REVIEWER,
+    AGENT_COMMENT_CLASSIFIER,
+    AGENT_ADDRESS_REVIEW,
+    AGENT_CI_DRIVER,
+    AGENT_LEARNINGS,
+]
+_REVIEWERS = [AGENT_PLAN_REVIEWER, AGENT_PR_REVIEWER, AGENT_COMMENT_CLASSIFIER]
+_WRITERS = [AGENT_IMPLEMENTER, AGENT_ADDRESS_REVIEW, AGENT_CI_DRIVER, AGENT_LEARNINGS]
+
+
+@pytest.mark.parametrize("agent", _STAGE_AGENTS)
+def test_every_stage_agent_has_explicit_scope(agent: str) -> None:
+    """No pipeline stage agent may fall through to the read-only default."""
+    assert agent in AGENT_TOOL_SCOPES
+
+
+@pytest.mark.parametrize("agent", _REVIEWERS)
+def test_reviewer_scopes_grant_no_write_or_exec(agent: str) -> None:
+    """Reviewers and classifiers are strictly read-only (no Write/Edit/Bash)."""
+    tools = set(AGENT_TOOL_SCOPES[agent].allowed_tools.split(","))
+    assert tools == {"Read", "Glob", "Grep"}
+
+
+@pytest.mark.parametrize("agent", _WRITERS)
+def test_writer_scopes_grant_write_and_exec(agent: str) -> None:
+    """Implementer-class roles keep their legacy Write/Edit/Bash grant."""
+    tools = set(AGENT_TOOL_SCOPES[agent].allowed_tools.split(","))
+    assert {"Read", "Write", "Edit", "Bash"} <= tools
+
+
+def test_unknown_agent_fails_closed_to_read_only() -> None:
+    """An unmapped agent resolves to the read-only default scope."""
+    assert tool_scope_for("no-such-agent") is DEFAULT_TOOL_SCOPE
+    assert DEFAULT_TOOL_SCOPE.allowed_tools == "Read,Glob,Grep"
+
+
+def test_unknown_agent_warns(caplog: pytest.LogCaptureFixture) -> None:
+    """Failing closed is logged so a missing mapping is visible."""
+    with caplog.at_level("WARNING", logger="hephaestus.automation.pipeline.tool_scopes"):
+        tool_scope_for("mystery-agent")
+    assert any("mystery-agent" in rec.message for rec in caplog.records)
+
+
+def test_mapped_agent_resolves_to_its_scope() -> None:
+    """A known agent returns its exact mapped scope object."""
+    assert tool_scope_for(AGENT_IMPLEMENTER) is AGENT_TOOL_SCOPES[AGENT_IMPLEMENTER]
+
+
+@pytest.mark.parametrize(
+    "scope", list(AGENT_TOOL_SCOPES.values()), ids=list(AGENT_TOOL_SCOPES.keys())
+)
+def test_permission_mode_is_dontask_everywhere(scope: ToolScope) -> None:
+    """Every scope runs non-interactively, matching legacy automation."""
+    assert scope.permission_mode == "dontAsk"
+
+
+def test_default_permission_mode_is_dontask() -> None:
+    """The fail-closed default also runs non-interactively."""
+    assert DEFAULT_TOOL_SCOPE.permission_mode == "dontAsk"
+
+
+def test_scope_map_is_immutable() -> None:
+    """The policy map must not be mutable at runtime."""
+    with pytest.raises(TypeError):
+        AGENT_TOOL_SCOPES["x"] = DEFAULT_TOOL_SCOPE  # type: ignore[index]
+
+
+def test_toolscope_is_frozen() -> None:
+    """A ToolScope may not be mutated after construction."""
+    scope = ToolScope("Read")
+    with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+        scope.allowed_tools = "Write"  # type: ignore[misc]

--- a/tests/unit/automation/pipeline/test_worker_pool.py
+++ b/tests/unit/automation/pipeline/test_worker_pool.py
@@ -29,6 +29,10 @@ from hephaestus.automation.pipeline.jobs import (
 from hephaestus.automation.pipeline.queues import CompletionQueue
 from hephaestus.automation.pipeline.routing import StageName
 from hephaestus.automation.pipeline.worker_pool import WorkerPool, _repo_lock_path
+from hephaestus.automation.session_naming import (
+    AGENT_IMPLEMENTER,
+    AGENT_PR_REVIEWER,
+)
 from hephaestus.prompts import PromptCatalog
 from hephaestus.resilience import CircuitBreakerOpenError, get_circuit_breaker
 from hephaestus.utils.file_lock import LockUnavailableError
@@ -1819,3 +1823,66 @@ class TestShutdownReapsSubprocess:
         assert elapsed < 15, f"shutdown did not reap the subprocess fast ({elapsed:.1f}s)"
         assert result.ok is False
         assert result.interrupted is True
+
+
+class TestAgentToolScopes:
+    """Worker pool passes explicit least-privilege scopes to Claude (#2160)."""
+
+    def _invoke_kwargs(
+        self,
+        pool: WorkerPool,
+        completion_q: CompletionQueue,
+        session_agent: str,
+    ) -> dict[str, Any]:
+        """Submit a Claude job for ``session_agent`` and return invoke kwargs."""
+        job = _agent_job(session_agent=session_agent)
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(
+                f"{_WP}.claude_invoke.invoke_claude_with_session",
+                return_value=("out", "sid"),
+            ) as invoke,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _handle, result = completion_q.get(timeout=10)
+        assert result.ok is True
+        return cast("dict[str, Any]", invoke.call_args.kwargs)
+
+    def test_reviewer_job_gets_read_only_scope(
+        self, pool: WorkerPool, completion_q: CompletionQueue
+    ) -> None:
+        kwargs = self._invoke_kwargs(pool, completion_q, AGENT_PR_REVIEWER)
+        assert kwargs["allowed_tools"] == "Read,Glob,Grep"
+        assert kwargs["permission_mode"] == "dontAsk"
+
+    def test_implementer_job_gets_write_scope(
+        self, pool: WorkerPool, completion_q: CompletionQueue
+    ) -> None:
+        kwargs = self._invoke_kwargs(pool, completion_q, AGENT_IMPLEMENTER)
+        assert kwargs["allowed_tools"] == "Read,Write,Edit,Glob,Grep,Bash"
+        assert kwargs["permission_mode"] == "dontAsk"
+
+    def test_unmapped_agent_fails_closed_to_read_only(
+        self, pool: WorkerPool, completion_q: CompletionQueue
+    ) -> None:
+        kwargs = self._invoke_kwargs(pool, completion_q, "mystery-agent")
+        assert kwargs["allowed_tools"] == "Read,Glob,Grep"
+        assert kwargs["permission_mode"] == "dontAsk"
+
+    def test_read_only_sandbox_clamps_write_agent_to_read_only(
+        self, pool: WorkerPool, completion_q: CompletionQueue
+    ) -> None:
+        """A read-only sandbox overrides a write-capable session agent."""
+        job = _agent_job(session_agent=AGENT_IMPLEMENTER, sandbox="read-only")
+        with (
+            patch(f"{_WP}.resolve_agent", return_value="claude"),
+            patch(
+                f"{_WP}.claude_invoke.invoke_claude_with_session",
+                return_value=("out", "sid"),
+            ) as invoke,
+        ):
+            pool.submit(job, StageName.IMPLEMENTATION)
+            _handle, result = completion_q.get(timeout=10)
+        assert result.ok is True
+        assert invoke.call_args.kwargs["allowed_tools"] == "Read,Glob,Grep"
+        assert invoke.call_args.kwargs["permission_mode"] == "dontAsk"


### PR DESCRIPTION
Salvaged from a stranded automation worktree and rebased onto current main.

Maps each pipeline session-agent role to an explicit least-privilege `--allowedTools`/`--permission-mode` pair (`tool_scopes.py`), failing closed to read-only for unmapped agents. The worker pool resolves every Claude invocation scope with clear priority: explicit per-job `AgentJob.allowed_tools` grant > read-only sandbox clamp > session-agent role map. The learn agent keeps its write grant since it executes the /learn workflow end-to-end.

Closes #2160