### PR TITLE
docs(scripts): publish complete script catalog with executable guard

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,20 @@ through installed `hephaestus-*` console scripts.
 - **`validate_readme_commands.py`** — Validate that commands shown in README
   code blocks actually run.
 - **`check-symlinks.sh`** — Detect broken symlinks in the repo.
+- **`check_build_dir_untracked.py`** — Fail if anything becomes tracked under
+  `build/` (sanctioned gitignored scratch dir; issue #1214).
+- **`check_conventional_commit.py`** — Validate commit subjects against
+  Conventional Commits (commit-msg hook + `pr-policy` CI).
+- **`check_dco_signoff.py`** — Require a DCO `Signed-off-by` trailer on every
+  commit message (commit-msg hook + `pr-policy` CI).
+- **`check_license_compatibility.py`** — Fail CI when a distributed
+  dependency's license is incompatible with BSD-3-Clause (see `NOTICE`).
+- **`check_private_denylist.py`** — Reject strings from an operator-local
+  `.heph-private-denylist` in tracked/staged files, without echoing values.
+- **`check_security_policy_no_hardcoded_date.py`** — Reject hard-coded
+  `As of YYYY-MM-DD` stamps in `SECURITY.md` (issue #730).
+- **`check_security_version_consistency.py`** — Keep the `SECURITY.md`
+  supported-versions table anchored to the latest `vX.Y.Z` git tag.
 
 ### Markdown
 
@@ -30,6 +44,44 @@ through installed `hephaestus-*` console scripts.
 - **`update_version.py`** — Update secondary version files (`VERSION`,
   `__init__.py`) via `hephaestus.version.manager`. The canonical version comes
   from git tags via hatch-vcs — see [`../docs/RELEASING.md`](../docs/RELEASING.md).
+
+### Scaffolding / automation introspection
+
+- **`scaffold_subpackage.py`** — CLI shim for
+  `hephaestus.scripts_lib.scaffold_subpackage`: scaffold a new `hephaestus`
+  subpackage with matching test structure.
+- **`show_prompt.py`** — Display the automation-pipeline agent prompt for a
+  given GitHub issue and stage (planning, implementation, pr-review, …).
+
+### Git / GitHub workflow helpers
+
+- **`choose_merge_flag.sh`** — Sourceable `choose_merge_flag()` helper that
+  picks a permitted manual merge strategy for a repo (rebase → squash → merge).
+- **`shell/preflight_check.sh`** — Six pre-flight checks before starting work
+  on a GitHub issue (closed issue, merged PR, worktree conflict, …).
+- **`shell/cleanup-stale-worktrees.sh`** — Clean up git worktrees whose issue
+  is closed or whose branch is merged into `main`.
+- **`shell/drive_prs_green_ecosystem.sh`** — Drive failing PRs to green CI
+  across every non-fork HomericIntelligence repo, with per-repo logs.
+
+### Installation / environment
+
+- **`shell/install.sh`** — HomericIntelligence ecosystem installer: check (and
+  optionally install) all mesh dependencies by role
+  (see `../docs/INSTALLER_ARCHITECTURE.md`).
+- **`shell/lib/install_helpers.sh`** — Sourceable helper library (colors,
+  counters, check helpers) shared by the installer scripts.
+- **`shell/install_hooks.sh`** — Install this repo's git hooks via the
+  `pre-commit` framework (wraps `uv run pre-commit install`).
+- **`shell/setup_api_key.sh`** — Export `ANTHROPIC_API_KEY` from Claude CLI
+  credentials for container execution.
+
+### Forensics / crash debugging
+
+- **`shell/coredump-host-handler.sh`** — Pipe-mode `core_pattern` handler that
+  captures container coredumps to a host-side directory.
+- **`shell/run-under-gdb.sh`** — Run a command under gdb so fatal signals are
+  caught before in-process handlers swallow them.
 
 ### Benchmarks / demos
 
@@ -43,6 +95,8 @@ through installed `hephaestus-*` console scripts.
   `HEPH_PI_PROVIDER` and `HEPH_PI_MODEL` from the environment.
 - **`pi_smoke_slurm.py`** — Submit `scripts/slurm/pi_smoke.sbatch` with
   `sbatch` while exporting only env var names, not alias values.
+- **`slurm/pi_smoke.sbatch`** — Slurm batch template that invokes
+  `pi_smoke.py` on a cluster node (copy and fill partition/account locally).
 
 ## Usage
 

--- a/tests/unit/docs/test_scripts_readme_catalog.py
+++ b/tests/unit/docs/test_scripts_readme_catalog.py
@@ -1,0 +1,38 @@
+"""Guard: scripts/README.md catalogs every tracked script (issue #2168)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+README = REPO_ROOT / "scripts" / "README.md"
+
+
+def _tracked_scripts() -> list[str]:
+    """Paths under scripts/, relative to scripts/, excluding the README."""
+    out = subprocess.run(
+        ["git", "ls-files", "scripts/"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return sorted(
+        line.removeprefix("scripts/")
+        for line in out.splitlines()
+        if line and line != "scripts/README.md"
+    )
+
+
+def test_every_tracked_script_is_documented() -> None:
+    """Every tracked file under scripts/ has a catalog bullet in the README."""
+    readme = README.read_text(encoding="utf-8")
+    scripts = _tracked_scripts()
+    assert scripts, "git ls-files returned no scripts — guard cannot see its inputs"
+    missing = [s for s in scripts if f"`{s}`" not in readme]
+    assert not missing, (
+        "scripts/README.md 'Available Scripts' is missing entries for: "
+        + ", ".join(missing)
+        + ". Add a one-line catalog bullet for each (see issue #2168)."
+    )


### PR DESCRIPTION
Salvaged from a stranded automation worktree and rebased onto current main.

Adds one-line catalog entries to scripts/README.md for every previously undocumented tracked script (consistency checks, scaffolding, git/GitHub helpers, installers, forensics, Slurm template), and a guard test that fails CI when any tracked script under scripts/ is missing from the catalog. Guard passes against the current tree.

Closes #2168