### PR TITLE
fix(automation): convert missing prompt-file errors into CLI diagnostics

### DIFF
--- a/hephaestus/automation/agent_stage.py
+++ b/hephaestus/automation/agent_stage.py
@@ -185,6 +185,25 @@ def validate_agent_flags(parser: argparse.ArgumentParser, args: argparse.Namespa
         )
 
 
+def validate_input_files(parser: argparse.ArgumentParser, args: argparse.Namespace) -> None:
+    """Reject missing prompt/skill files with a CLI diagnostic instead of a traceback.
+
+    ``run_agent`` reads these paths with a bare ``read_text`` (:func:`read_prompt`);
+    without this gate a nonexistent ``--prompt-file`` (or ``--skill-file``) surfaces
+    as an uncaught ``FileNotFoundError``, and a directory passed as a prompt raises
+    ``IsADirectoryError``. ``.is_file()`` converts both into a controlled
+    ``parser.error`` diagnostic (usage line + ``error: ...`` on stderr, exit code 2).
+    See issue #2171.
+    """
+    prompt_file = Path(args.prompt_file).expanduser().resolve()
+    if not prompt_file.is_file():
+        parser.error(f"--prompt-file does not exist or is not a file: {prompt_file}")
+    if args.skill_file:
+        skill_file = Path(args.skill_file).expanduser().resolve()
+        if not skill_file.is_file():
+            parser.error(f"--skill-file does not exist or is not a file: {skill_file}")
+
+
 def run_agent(args: argparse.Namespace) -> int:
     """Run one provider-selected automation stage and persist its output/log files."""
     repo_root = Path(args.repo_root).expanduser().resolve()
@@ -222,6 +241,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     validate_agent_flags(parser, args)
+    validate_input_files(parser, args)
 
     install_sigtstp_only()
     with terminal_guard():

--- a/tests/unit/automation/test_agent_stage.py
+++ b/tests/unit/automation/test_agent_stage.py
@@ -392,3 +392,70 @@ def test_main_rejects_approval_with_pi_agent(
         agent_stage.main(argv)
     assert exc.value.code == 2
     assert "--approval=on-request" in capsys.readouterr().err
+
+
+def test_main_rejects_missing_prompt_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A nonexistent --prompt-file must be a CLI diagnostic, not a traceback (issue #2171)."""
+    argv = [
+        "--prompt-file",
+        str(tmp_path / "missing.md"),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+    ]
+    with pytest.raises(SystemExit) as exc:
+        agent_stage.main(argv)
+    assert exc.value.code == 2
+    assert "--prompt-file does not exist" in capsys.readouterr().err
+
+
+def test_main_rejects_missing_skill_file(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A nonexistent --skill-file must be a CLI diagnostic, not a traceback (issue #2171)."""
+    prompt_file = tmp_path / "prompt.md"
+    prompt_file.write_text("p", encoding="utf-8")
+    argv = [
+        "--prompt-file",
+        str(prompt_file),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+        "--skill-file",
+        str(tmp_path / "missing-skill.md"),
+    ]
+    with pytest.raises(SystemExit) as exc:
+        agent_stage.main(argv)
+    assert exc.value.code == 2
+    assert "--skill-file does not exist" in capsys.readouterr().err
+
+
+def test_main_rejects_prompt_file_that_is_a_directory(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A directory passed as --prompt-file must be a CLI diagnostic (issue #2171)."""
+    argv = [
+        "--prompt-file",
+        str(tmp_path),
+        "--repo-root",
+        str(tmp_path),
+        "--stage",
+        "x",
+        "--output",
+        str(tmp_path / "out.txt"),
+    ]
+    with pytest.raises(SystemExit) as exc:
+        agent_stage.main(argv)
+    assert exc.value.code == 2
+    assert "--prompt-file does not exist or is not a file" in capsys.readouterr().err


### PR DESCRIPTION
Salvaged from a stranded automation worktree and rebased onto current main; all 17 agent-stage tests pass.

hephaestus-agent-stage now validates --prompt-file and --skill-file with .is_file() before run_agent reads them, so a nonexistent path (or a directory passed as a prompt) produces a controlled parser.error diagnostic (usage + error on stderr, exit 2) instead of an uncaught FileNotFoundError/IsADirectoryError traceback.

Closes #2171