### PR TITLE
fix(ci): unblock red main (SECURITY.md drift, script catalog gap, zizmor finding)

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -591,6 +591,7 @@ jobs:
           # hatch-vcs derives the wheel version from git tags.
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: Set up Python 3.12
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Hephaestus supports **Python 3.10–3.13** (`requires-python = ">=3.10"` in
 
 | Version | Supported       |
 |---------|-----------------|
-| 0.9.x   | ✅ Supported    |
-| < 0.9   | ❌ End of life  |
+| 0.10.x  | ✅ Supported    |
+| < 0.10  | ❌ End of life  |
 
 ## Reporting a Vulnerability
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -76,6 +76,13 @@ through installed `hephaestus-*` console scripts.
 - **`shell/setup_api_key.sh`** — Export `ANTHROPIC_API_KEY` from Claude CLI
   credentials for container execution.
 
+### Disaster recovery
+
+- **`backup_state.py`** — Backup, restore, and verify tier-3 operational
+  state (`build/.issue_implementer/`); stdlib-only so it runs in a broken
+  environment. See `../docs/adr/0012-backup-and-disaster-recovery-policy.md`
+  and `../docs/runbooks/backup-restore.md`.
+
 ### Forensics / crash debugging
 
 - **`shell/coredump-host-handler.sh`** — Pipe-mode `core_pattern` handler that


### PR DESCRIPTION
Fixes three independent regressions currently failing `lint` and `unit-tests` on every fresh run against main (HEAD 5bfcc72d):

1. `SECURITY.md` supported-versions table synced to the latest v0.10 tag (0.9.x → 0.10.x).
2. `scripts/README.md` catalog entry added for `scripts/backup_state.py`, closing the drift the doc-guard test caught.
3. `.github/workflows/_required.yml`: added `persist-credentials: false` to the `installed-cli-tests` job's checkout step, matching every other checkout step in the file and clearing the zizmor `artipacked` finding.

Verified locally: `check_security_version_consistency.py`, `check_cli_table_sync`, the two previously-failing pytest cases, and `zizmor --offline .github/workflows/_required.yml` (0 findings) all pass.

Closes #2331