### PR TITLE
fix(release+ci): unblock v0.10.0 release; keep agent backends out of CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,10 @@ jobs:
           enable-cache: false  # release artifacts must not read/write a shared cache (zizmor cache-poisoning)
 
       - name: Run mypy type checking
-        run: uv run mypy
+        # Explicit targets: bare `uv run mypy` errors with "Missing target"
+        # because pyproject has no default mypy `files`. Match the required
+        # `lint` pre-commit hook (uv run mypy hephaestus/ scripts/ tests/).
+        run: uv run mypy hephaestus/ scripts/ tests/
 
   publish-testpypi:
     runs-on: ubuntu-24.04

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Shared test fixtures for Hephaestus tests."""
 
+import contextlib
 import json
 
 import pytest
@@ -11,23 +12,27 @@ import yaml
 def _agents_authenticated_by_default(
     request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Stub the agent install+auth pre-flight (#1175) to pass by default.
+    """Stub agent install+auth resolution suite-wide (#1175).
 
-    ``resolve_agent`` now refuses a ``--agent claude|codex|pi`` selection unless the
-    CLI is installed AND reports authenticated (#1175) — a real guard so an
-    unauthenticated backend cannot silently produce empty output. But these CLIs
-    is installed in CI, so every test that dispatches a named agent through
-    automation, fleet-sync, tidy, etc. (mocking the actual run_* call) would
-    otherwise hit ``RuntimeError: Agent '...' is not installed``. Default the
-    pre-flight to "authenticated" suite-wide so those mocked-dispatch tests pass.
+    A real agent backend (``claude``/``codex``/``pi``) is deliberately NOT
+    installed or authenticated in CI/CD — we do not want tests to set up agent
+    accounts or spend tokens. But ``resolve_agent`` refuses a selection unless a
+    CLI is installed on PATH AND reports authenticated, so every test that
+    dispatches a named agent (mocking the actual run_* call) would otherwise hit
+    ``RuntimeError: ... not installed / not authenticated`` on an agent-free
+    runner. Stub both halves suite-wide:
 
-    EXCEPTION: ``tests/unit/agents/test_runtime.py`` tests the pre-flight machinery
-    itself (``resolve_agent``/``is_agent_authenticated``), driving the real
-    install+auth detection via patched ``shutil.which``/``subprocess.run``. Stubbing
-    ``is_agent_authenticated`` there would short-circuit the very logic under test,
-    so skip the stub for that module — it owns the real behaviour. Other tests that
-    need the unauthenticated path can likewise override this with their own
-    monkeypatch (last-writer-wins).
+    * ``is_agent_authenticated`` -> always True.
+    * ``resolve_agent`` -> return the requested backend, or ``"claude"`` when the
+      caller passed no ``--agent`` — with no PATH probe. This makes the whole
+      suite independent of whether an agent binary exists on the runner.
+
+    EXCEPTION: ``tests/unit/agents/test_runtime.py`` tests the resolution
+    machinery itself, driving real install+auth detection via patched
+    ``shutil.which``/``subprocess.run``. Stubbing it there would short-circuit the
+    logic under test, so skip the stub for that module. Other tests that need the
+    unauthenticated/uninstalled path can override with their own monkeypatch
+    (last-writer-wins).
     """
     if request.module.__name__.endswith("agents.test_runtime"):
         return
@@ -35,6 +40,18 @@ def _agents_authenticated_by_default(
         "hephaestus.agents.runtime.is_agent_authenticated",
         lambda _agent: True,
     )
+
+    def _stub_resolve_agent(agent: str | None) -> str:
+        return agent if agent is not None else "claude"
+
+    # Patch at the runtime module and at every automation module that imported
+    # ``resolve_agent`` by value (``from ...runtime import resolve_agent``).
+    monkeypatch.setattr("hephaestus.agents.runtime.resolve_agent", _stub_resolve_agent)
+    for mod in ("implementer", "loop_runner", "planner", "pr_reviewer", "audit_reviewer"):
+        target = f"hephaestus.automation.{mod}.resolve_agent"
+        # A module that does not import resolve_agent by value has nothing to patch.
+        with contextlib.suppress(AttributeError):
+            monkeypatch.setattr(target, _stub_resolve_agent)
 
 
 @pytest.fixture

--- a/tests/unit/automation/test_implementer_main.py
+++ b/tests/unit/automation/test_implementer_main.py
@@ -182,6 +182,10 @@ def test_main_health_check_short_circuits(tmp_path: Path) -> None:
     with (
         patch.object(sys, "argv", ["hephaestus-implement-issues", "--health-check"]),
         patch.object(implementer_mod, "get_repo_root", return_value=tmp_path),
+        # resolve_agent() probes PATH for a real backend; mock it so the test
+        # does not depend on `claude`/`codex`/`pi` being installed (release
+        # runners have no agent backend).
+        patch.object(implementer_mod, "resolve_agent", return_value="claude"),
         patch("hephaestus.github.client.gh_call", side_effect=OSError("missing gh")),
         patch(
             "hephaestus.automation.pipeline.coordinator.run_pipeline",

--- a/tests/unit/automation/test_loop_runner.py
+++ b/tests/unit/automation/test_loop_runner.py
@@ -734,7 +734,13 @@ def test_main_resolves_agent_before_building_config(monkeypatch: pytest.MonkeyPa
 
 def test_main_errors_on_empty_repo_list() -> None:
     """An empty resolved repo list is a clean exit-1, not a pipeline dispatch."""
-    with patch.object(loop_runner, "_resolve_org_and_repos", return_value=("Org", [], None)):
+    # resolve_agent() probes PATH for a real backend; mock it so the test does
+    # not depend on `claude`/`codex`/`pi` being installed (release runners have
+    # no agent backend).
+    with (
+        patch.object(loop_runner, "resolve_agent", return_value="claude"),
+        patch.object(loop_runner, "_resolve_org_and_repos", return_value=("Org", [], None)),
+    ):
         rc = main(["--org", "Org"])
     assert rc == 1
 


### PR DESCRIPTION
Unblocks the v0.10.0 release and ensures **CI/CD never needs a real agent backend** (no agent accounts to set up, no token charges).

**1. `type-check` job: bare `uv run mypy` has no target**
Release ran `uv run mypy` → "Missing target module." Fixed with explicit targets matching the `lint` hook: `uv run mypy hephaestus/ scripts/ tests/`. Verified: 581 files, no issues.

**2. Agent backends must not be required (or invoked) in CI**
Two release-runner failures (`test_main_health_check_short_circuits`, `test_main_errors_on_empty_repo_list`) came from `resolve_agent()` probing PATH for `claude`/`codex`/`pi` and crashing when none is installed. A real agent is deliberately never installed or authenticated in CI — we do not set up agent accounts or spend tokens there.

Fix at the root: the autouse `conftest.py` fixture now stubs `resolve_agent` suite-wide (in addition to `is_agent_authenticated`), returning the requested backend or `"claude"` with no PATH probe. The whole suite is now independent of whether an agent binary exists on the runner. `tests/unit/agents/test_runtime.py` stays exempt — it owns the real resolution logic.

**Verified: 3112 automation+agents tests pass with all agent binaries removed from PATH** (the exact CI condition).

Closes #2335

## Release path after this lands
`gh workflow run release.yml -f tag=v0.10.0` — runs the fixed workflow from main's HEAD against the existing v0.10.0 tag (no destructive tag move).