### PR TITLE
ci: pin setup-node in Pi test action

### DIFF
--- a/.github/actions/setup-pi-cli/action.yml
+++ b/.github/actions/setup-pi-cli/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Set up Node.js for Pi
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: 22.19.0
 

--- a/tests/unit/ci/test_workflows.py
+++ b/tests/unit/ci/test_workflows.py
@@ -431,6 +431,13 @@ class TestPiCliSetup:
         assert "npm install -g --ignore-scripts @earendil-works/pi-coding-agent@0.80.2" in text
         assert "pi --version" in text
 
+    def test_setup_pi_action_pins_setup_node_by_full_sha(self) -> None:
+        """The composite action must not use a mutable setup-node tag."""
+        text = SETUP_PI_ACTION.read_text(encoding="utf-8")
+        match = re.search(r"uses:\s*actions/setup-node@([^\s]+)", text)
+        assert match is not None
+        assert re.fullmatch(r"[0-9a-f]{40}", match.group(1)) is not None
+
 
 class TestAutoTagReleaseDispatch:
     """Regression tests for the one-click release workflow chain."""


### PR DESCRIPTION
Pins the shared Pi test setup action to the immutable actions/setup-node v6 commit and adds a regression test that rejects mutable tags.

Validation: 66 focused workflow tests and the full local test suite (6,470 passed, 6 skipped).

Closes #2342