### PR TITLE
Reconcile ADR-0005 direct-import policy with automation code

### DIFF
--- a/docs/adr/0017-frozen-legacy-agent-import-exceptions.md
+++ b/docs/adr/0017-frozen-legacy-agent-import-exceptions.md
@@ -1,0 +1,53 @@
+# ADR-0017: Frozen legacy agent-import exceptions
+
+- Status: Accepted
+- Date: 2026-07-28
+- Tracks: #2233
+- Supersedes: ADR-0005 (direct-import prohibition only)
+
+## Context
+
+ADR-0005 records the runtime abstraction's intended endpoint: automation code
+uses `hephaestus.agents.runtime` rather than Claude-specific helpers. The
+current migration has not reached that endpoint. Existing automation
+compatibility seams still directly import `claude_invoke` and `claude_models`.
+
+ADR-0005 is Accepted and therefore immutable. Its direct-import consequence is
+not an accurate description of the current migration state, so it must be
+superseded rather than rewritten.
+
+## Decision
+
+The existing automation consumer/module pairs for `claude_invoke` and
+`claude_models` are frozen migration exceptions. No direct
+`claude_timeouts` consumer is approved. The exception is deliberately scoped
+to whole consumer/module pairs; it does not freeze individual imported symbols
+or call sites within an existing compatibility seam.
+
+`tests/unit/validation/test_adr_0017_legacy_agent_import_pairs.py` derives all
+direct Python import statements from ASTs and requires exact equality with this
+frozen set. It resolves relative imports against the importing package, so an
+equivalent relative spelling cannot bypass the policy. Dynamic import behavior
+is not a direct-import exception and is deliberately outside this ADR's narrow,
+syntactically enforceable policy. Each completed migration removes its source
+import and its corresponding baseline entry together.
+
+## Alternatives considered
+
+- **Rewrite ADR-0005.** Rejected because Accepted ADRs are immutable historical
+  records.
+- **Freeze imported symbols and call counts.** Rejected because the migration
+  exception is intentionally defined at the consumer/module boundary; a more
+  granular policy would add brittle implementation detail without a current
+  architectural need.
+- **Rely on prose assertions.** Rejected because executable AST behavior is the
+  single policy authority, while documentation structure and links have their
+  own validation.
+
+## Consequences
+
+- The frozen consumer/module pair set may only shrink unless a future ADR
+  changes this migration policy.
+- New direct automation import pairs for a legacy module fail the executable
+  guard, regardless of absolute or relative spelling.
+- The automation-to-library dependency direction remains unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,7 +17,7 @@ numbered, and listed here.
 | [0002](0002-pep562-lazy-imports.md) | PEP 562 lazy imports back the library/product boundary | Accepted |
 | [0003](0003-dependabot-renovate-split.md) | Dependabot owns pip+actions; Renovate owns pixi/conda | Accepted (historical; superseded by 0008) |
 | [0004](0004-single-aggregator-required-checks.md) | Single aggregated required-checks gate | Accepted |
-| [0005](0005-multi-agent-runtime-abstraction.md) | Multi-agent (Claude/Codex/Pi) runtime abstraction | Accepted |
+| [0005](0005-multi-agent-runtime-abstraction.md) | Multi-agent (Claude/Codex/Pi) runtime abstraction | Accepted (direct-import prohibition superseded by 0017) |
 | [0006](0006-queue-based-in-process-automation-pipeline.md) | Queue-based in-process automation pipeline | Accepted |
 | [0007](0007-dual-surface-required-checks.md) | Dual-surface required checks | Accepted |
 | [0008](0008-uv-only-development-environment.md) | uv is the sole development environment manager | Accepted |
@@ -29,3 +29,4 @@ numbered, and listed here.
 | [0014](0014-conditional-normal-merge.md) | Conditional normal merge after loop-owned review | Accepted (historical; superseded by 0015) |
 | [0015](0015-bounded-conditional-merge-retries.md) | Bounded conditional merge retries | Accepted (historical; superseded by 0016) |
 | [0016](0016-bounded-operational-merge-readiness.md) | Bounded operational merge-readiness wait | Accepted |
+| [0017](0017-frozen-legacy-agent-import-exceptions.md) | Frozen legacy agent-import exceptions | Accepted |

--- a/tests/unit/validation/test_adr_0017_legacy_agent_import_pairs.py
+++ b/tests/unit/validation/test_adr_0017_legacy_agent_import_pairs.py
@@ -1,0 +1,165 @@
+"""Guard ADR-0017's frozen legacy consumer/module exceptions."""
+
+from __future__ import annotations
+
+import ast
+from importlib.util import resolve_name
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_AUTOMATION_ROOT = _REPO_ROOT / "hephaestus" / "automation"
+_LEGACY_MODULES = frozenset({"claude_invoke", "claude_models", "claude_timeouts"})
+
+_APPROVED_DIRECT_IMPORTS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("_followup_phase.py", "claude_models"),
+        ("_implement_phase.py", "claude_invoke"),
+        ("_implement_phase.py", "claude_models"),
+        ("_review_phase.py", "claude_invoke"),
+        ("_review_phase.py", "claude_models"),
+        ("address_review_core.py", "claude_invoke"),
+        ("address_review_core.py", "claude_models"),
+        ("advise_runner.py", "claude_invoke"),
+        ("audit_reviewer.py", "claude_invoke"),
+        ("audit_reviewer.py", "claude_models"),
+        ("ci_fix_flow.py", "claude_invoke"),
+        ("ci_fix_flow.py", "claude_models"),
+        ("ci_fix_orchestrator.py", "claude_invoke"),
+        ("ci_fix_orchestrator.py", "claude_models"),
+        ("comment_difficulty.py", "claude_invoke"),
+        ("comment_difficulty.py", "claude_models"),
+        ("learn.py", "claude_models"),
+        ("pipeline/worker_pool.py", "claude_invoke"),
+        ("plan_reviewer.py", "claude_invoke"),
+        ("plan_reviewer.py", "claude_models"),
+        ("post_merge_processor.py", "claude_invoke"),
+        ("post_merge_processor.py", "claude_models"),
+        ("pr_manager.py", "claude_invoke"),
+        ("pr_manager.py", "claude_models"),
+        ("pr_review_core.py", "claude_invoke"),
+        ("pr_review_core.py", "claude_models"),
+        ("review_validator.py", "claude_invoke"),
+        ("review_validator.py", "claude_models"),
+    }
+)
+
+
+def _resolve_from_module(relative: Path, node: ast.ImportFrom) -> str:
+    """Resolve an import-from module against its importing automation package."""
+    if not node.level:
+        return node.module or ""
+
+    package = ".".join(("hephaestus", "automation", *relative.parent.parts))
+    relative_name = f"{'.' * node.level}{node.module or ''}"
+    try:
+        return resolve_name(relative_name, package)
+    except ImportError:
+        return ""
+
+
+def _legacy_targets(relative: Path, node: ast.Import | ast.ImportFrom) -> set[str]:
+    """Return legacy automation modules imported by one AST node."""
+    if isinstance(node, ast.Import):
+        return {
+            target
+            for alias in node.names
+            for target in _LEGACY_MODULES
+            if alias.name in {target, f"hephaestus.automation.{target}"}
+        }
+
+    module = _resolve_from_module(relative, node)
+    if module in _LEGACY_MODULES:
+        return {module}
+    if module.startswith("hephaestus.automation."):
+        target = module.removeprefix("hephaestus.automation.").split(".", 1)[0]
+        return {target} if target in _LEGACY_MODULES else set()
+    if module == "hephaestus.automation":
+        return {alias.name for alias in node.names if alias.name in _LEGACY_MODULES}
+    return set()
+
+
+def test_relative_imports_resolve_legacy_modules() -> None:
+    """Relative spellings of legacy modules must be subject to the guard."""
+    cases = (
+        (Path("example.py"), "from . import claude_invoke", {"claude_invoke"}),
+        (Path("example.py"), "from .claude_models import reviewer_model", {"claude_models"}),
+        (
+            Path("pipeline/example.py"),
+            "from ...automation import claude_invoke",
+            {"claude_invoke"},
+        ),
+        (
+            Path("pipeline/stages/example.py"),
+            "from ....automation import claude_models",
+            {"claude_models"},
+        ),
+    )
+
+    for relative, statement, expected in cases:
+        node = ast.parse(statement).body[0]
+        assert isinstance(node, ast.ImportFrom)
+        assert _legacy_targets(relative, node) == expected
+
+
+def test_absolute_import_resolves_legacy_module() -> None:
+    """Absolute imports of a legacy module remain subject to the guard."""
+    node = ast.parse("from hephaestus.automation import claude_invoke").body[0]
+    assert isinstance(node, ast.ImportFrom)
+    assert _legacy_targets(Path("example.py"), node) == {"claude_invoke"}
+
+
+def test_import_statement_resolves_legacy_module() -> None:
+    """Plain import statements of a legacy module remain subject to the guard."""
+    node = ast.parse("import hephaestus.automation.claude_models").body[0]
+    assert isinstance(node, ast.Import)
+    assert _legacy_targets(Path("example.py"), node) == {"claude_models"}
+
+
+def _legacy_import_pairs(relative: Path, tree: ast.AST) -> set[tuple[str, str]]:
+    """Collect direct legacy consumer/module pairs from one parsed source tree."""
+    return {
+        (relative.as_posix(), target)
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for target in _legacy_targets(relative, node)
+    }
+
+
+def test_multiple_import_nodes_preserve_one_consumer_module_pair() -> None:
+    """The policy deliberately ignores symbols and import-node counts."""
+    tree = ast.parse(
+        "from .claude_invoke import invoke_claude_with_session\n"
+        "from .claude_invoke import ClaudeSession\n"
+    )
+    assert _legacy_import_pairs(Path("example.py"), tree) == {("example.py", "claude_invoke")}
+
+
+def _collect_direct_imports() -> set[tuple[str, str]]:
+    """Collect legacy consumer/module pairs beneath the automation product layer."""
+    imports: set[tuple[str, str]] = set()
+    for source in sorted(_AUTOMATION_ROOT.rglob("*.py")):
+        relative_path = source.relative_to(_AUTOMATION_ROOT)
+        tree = ast.parse(source.read_text(encoding="utf-8"), filename=str(source))
+        imports.update(_legacy_import_pairs(relative_path, tree))
+    return imports
+
+
+def test_direct_imports_match_frozen_migration_baseline() -> None:
+    """Source imports must exactly match ADR-0017's frozen migration debt."""
+    actual = _collect_direct_imports()
+    assert actual == _APPROVED_DIRECT_IMPORTS, (
+        "ADR-0017 consumer/module pair baseline drifted: "
+        f"added={sorted(actual - _APPROVED_DIRECT_IMPORTS)}, "
+        f"removed={sorted(_APPROVED_DIRECT_IMPORTS - actual)}"
+    )
+
+
+def test_approved_importers_stay_in_automation_product_layer() -> None:
+    """Legacy exceptions must never name library-layer consumers."""
+    root = _AUTOMATION_ROOT.resolve()
+    invalid = []
+    for relative, target in sorted(_APPROVED_DIRECT_IMPORTS):
+        source = (root / relative).resolve()
+        if not source.is_relative_to(root) or not source.is_file():
+            invalid.append((relative, target))
+    assert not invalid, f"non-automation or missing approved importers: {invalid}"


### PR DESCRIPTION
## Summary

Preserve accepted ADR-0005 and add ADR-0017 to define the active frozen legacy consumer/module exceptions.

## Changes

- Add ADR-0017 and index its limited supersession of ADR-0005 direct-import policy.
- Add an AST guard for the current legacy import pairs, including relative-import resolution.
- Remove the stale ADR-0005 prose snapshot test.

## Testing

- uv run pytest tests/unit/validation/test_adr_0017_legacy_agent_import_pairs.py tests/unit/docs/test_adr_records.py tests/unit/validation/test_automation_boundary.py tests/unit/validation/test_import_surface.py -v --override-ini=addopts=
- uv run mypy tests/unit/validation/test_adr_0017_legacy_agent_import_pairs.py
- uv run pre-commit run --files docs/adr/README.md docs/adr/0017-frozen-legacy-agent-import-exceptions.md tests/unit/validation/test_adr_0017_legacy_agent_import_pairs.py

## Closes

Closes #2233
