### PR TITLE
[crit] Jinja prompt catalog crashes every agent job when templates/ are absent — add a startup preflight

### DIFF
--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -85,6 +85,8 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, TypeAlias
 
+from jinja2 import TemplateNotFound
+
 from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.pipeline import admission as _admission, seeding as _seeding
 from hephaestus.automation.pipeline.events import StageEvent, encode_stage_event
@@ -123,6 +125,7 @@ from hephaestus.automation.pipeline.work_item import (
     WorkItem,
 )
 from hephaestus.automation.state_labels import STATE_IMPLEMENTATION_GO
+from hephaestus.prompts import PromptCatalog
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +157,9 @@ _FAIL_BACK_CAP = sum(sum(route.budgets.values()) for route in ROUTES.values())
 
 _WAKE_HANDLE = object()
 
+_PROMPT_PREFLIGHT_TEMPLATE = "shared/untrusted_notice.j2"
+_PROMPT_PREFLIGHT_ERROR = "ERROR: Prompt templates missing or unreadable — reinstall: `uv sync`."
+
 #: Downstream-first drain order: finish work before admitting new (epic
 #: #1809 "drain queues downstream-first (merge_wait -> ... -> repo)"; the
 #: finished sink drains first of all so results are recorded promptly).
@@ -176,6 +182,14 @@ def _budget_lookup(name: str) -> int:
         if name in route.budgets:
             return route.budgets[name]
     return 1
+
+
+def _preflight_prompt_catalog() -> None:
+    """Fail before pipeline startup when packaged prompts cannot be loaded."""
+    try:
+        PromptCatalog.current().render(_PROMPT_PREFLIGHT_TEMPLATE)
+    except (OSError, TemplateNotFound, ValueError) as exc:
+        raise SystemExit(f"{_PROMPT_PREFLIGHT_ERROR}\nCause: {exc}") from exc
 
 
 def _json_safe(value: Any) -> Any:
@@ -1801,6 +1815,8 @@ def run_pipeline(config: PipelineConfig) -> int:
         Exit code: 130 interrupt, 1 any fail/skip/blocked, 0 clean.
 
     """
+    _preflight_prompt_catalog()
+
     # Imported here: pipeline_github maps the accessor onto the real gh
     # helpers and must stay out of the pure pipeline import surface.
     from hephaestus.automation.pipeline_github import PipelineGitHub

--- a/tests/integration/test_sdist_contents.py
+++ b/tests/integration/test_sdist_contents.py
@@ -25,6 +25,14 @@ REQUIRED_TOP_LEVEL_FILES = {
     "pyproject.toml",
 }
 
+PROMPT_TEMPLATE_PREFIX = "hephaestus/prompts/templates/default/"
+
+
+def _source_prompt_templates() -> set[str]:
+    """Return repository-relative names of every default prompt template."""
+    template_root = REPO_ROOT / PROMPT_TEMPLATE_PREFIX
+    return {path.relative_to(REPO_ROOT).as_posix() for path in template_root.rglob("*.j2")}
+
 
 def _dependency_name(requirement: str) -> str:
     """Return the normalized package name from a simple requirement string."""
@@ -51,8 +59,8 @@ def test_dev_group_includes_build_backend_for_no_isolation_sdist() -> None:
 
 
 @pytest.mark.integration
-def test_sdist_includes_notice_and_compatibility(tmp_path: Path) -> None:
-    """Building the sdist must include NOTICE and COMPATIBILITY.md (issue #765)."""
+def test_sdist_includes_notice_compatibility_and_prompt_templates(tmp_path: Path) -> None:
+    """Building the sdist must include metadata and all default prompts."""
     probe = subprocess.run(
         [sys.executable, "-m", "build", "--help"],
         cwd=REPO_ROOT.parent,
@@ -85,12 +93,21 @@ def test_sdist_includes_notice_and_compatibility(tmp_path: Path) -> None:
 
     with tarfile.open(sdists[0], "r:gz") as tf:
         # sdist members are prefixed with "<name>-<version>/"; strip the prefix.
-        top_level = {
-            Path(m.name).parts[1]
-            for m in tf.getmembers()
-            if len(Path(m.name).parts) == 2 and m.isfile()
+        members = {
+            member.name.split("/", 1)[1]
+            for member in tf.getmembers()
+            if member.isfile() and "/" in member.name
         }
+
+    top_level = {name for name in members if "/" not in name}
 
     missing = REQUIRED_TOP_LEVEL_FILES - top_level
     assert not missing, f"sdist is missing required files: {sorted(missing)}"
     assert len(top_level) > 3, f"suspiciously few top-level files: {top_level}"
+
+    expected_templates = _source_prompt_templates()
+    actual_templates = {
+        name for name in members if name.startswith(PROMPT_TEMPLATE_PREFIX) and name.endswith(".j2")
+    }
+    assert expected_templates, "source prompt catalog is empty"
+    assert actual_templates == expected_templates

--- a/tests/integration/test_wheel_contents.py
+++ b/tests/integration/test_wheel_contents.py
@@ -28,6 +28,13 @@ EXPECTED_PACKAGE_FILES = {
 }
 
 FORBIDDEN_PREFIXES = ("tests/", "scripts/", "docs/", ".github/", ".claude/")
+PROMPT_TEMPLATE_PREFIX = "hephaestus/prompts/templates/default/"
+
+
+def _source_prompt_templates() -> set[str]:
+    """Return repository-relative names of every default prompt template."""
+    template_root = REPO_ROOT / PROMPT_TEMPLATE_PREFIX
+    return {path.relative_to(REPO_ROOT).as_posix() for path in template_root.rglob("*.j2")}
 
 
 @pytest.fixture(scope="module")
@@ -93,6 +100,20 @@ def test_wheel_excludes_repo_scaffolding(wheel_path: Path) -> None:
     """Only the hephaestus package ships — no tests, scripts, docs, or CI config."""
     offenders = [m for m in _members(wheel_path) if m.startswith(FORBIDDEN_PREFIXES)]
     assert not offenders, f"wheel leaked repo scaffolding: {offenders}"
+
+
+@pytest.mark.integration
+def test_wheel_contains_all_default_prompt_templates(wheel_path: Path) -> None:
+    """Every source default prompt ships in the distributable wheel."""
+    expected_templates = _source_prompt_templates()
+    actual_templates = {
+        name
+        for name in _members(wheel_path)
+        if name.startswith(PROMPT_TEMPLATE_PREFIX) and name.endswith(".j2")
+    }
+
+    assert expected_templates, "source prompt catalog is empty"
+    assert actual_templates == expected_templates
 
 
 @pytest.mark.integration

--- a/tests/unit/automation/pipeline/test_coordinator_edges.py
+++ b/tests/unit/automation/pipeline/test_coordinator_edges.py
@@ -17,6 +17,7 @@ from typing import Any, get_type_hints
 from unittest.mock import MagicMock
 
 import pytest
+from jinja2 import TemplateNotFound, TemplateSyntaxError
 
 import hephaestus.automation.pipeline as pipeline_pkg
 import hephaestus.automation.pipeline.coordinator as coordinator_mod
@@ -26,7 +27,9 @@ import hephaestus.automation.pipeline.seeding as seeding_mod
 import hephaestus.automation.pipeline.stages.base as stage_base_mod
 import hephaestus.automation.pipeline.stages.pr_review as pr_review_mod
 import hephaestus.automation.pipeline.work_item as work_item_mod
+import hephaestus.prompts.catalog as prompt_catalog_mod
 from hephaestus.automation.state_labels import STATE_PLAN_GO
+from hephaestus.prompts import PromptCatalog
 from tests.unit.automation.pipeline.conftest import FakeWorkerPool
 from tests.unit.automation.pipeline.stages.conftest import FakeStageGitHub
 
@@ -144,6 +147,77 @@ class TestWiring:
         config = PipelineConfig(org="org", repos=["r"], dry_run=True, projects_dir=tmp_path)
 
         assert run_pipeline(config) == 7
+
+    @staticmethod
+    def _stub_pipeline_runtime(
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[MagicMock, MagicMock]:
+        """Prevent pipeline construction while asserting preflight ordering."""
+        coordinator_factory = MagicMock()
+        coordinator_factory.return_value.run.return_value = 0
+        github_factory = MagicMock()
+        monkeypatch.setattr(coordinator_mod, "Coordinator", coordinator_factory)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline_github.PipelineGitHub",
+            github_factory,
+        )
+        return coordinator_factory, github_factory
+
+    def test_run_pipeline_prompt_preflight_rejects_empty_template_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Absent packaged prompts abort before GitHub or coordinator setup."""
+        coordinator_factory, github_factory = self._stub_pipeline_runtime(monkeypatch)
+        monkeypatch.setattr(prompt_catalog_mod, "_DEFAULT_TEMPLATES_DIR", tmp_path)
+        PromptCatalog.clear_current()
+
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                run_pipeline(PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path))
+        finally:
+            PromptCatalog.clear_current()
+
+        assert exc_info.value.code != 0
+        assert "Prompt templates missing" in str(exc_info.value)
+        assert "`uv sync`" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, TemplateNotFound)
+        github_factory.assert_not_called()
+        coordinator_factory.assert_not_called()
+
+    def test_run_pipeline_prompt_preflight_translates_loader_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The observed catalog loader failure gives operators remediation."""
+        failure = ValueError(
+            "PackageLoader could not find a 'templates/default' directory "
+            "in the 'hephaestus.prompts' package."
+        )
+        monkeypatch.setattr(PromptCatalog, "current", MagicMock(side_effect=failure))
+        coordinator_factory, github_factory = self._stub_pipeline_runtime(monkeypatch)
+
+        with pytest.raises(SystemExit, match="uv sync") as exc_info:
+            run_pipeline(PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path))
+
+        assert exc_info.value.__cause__ is failure
+        github_factory.assert_not_called()
+        coordinator_factory.assert_not_called()
+
+    def test_run_pipeline_prompt_preflight_preserves_template_syntax_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Template defects remain distinguishable from missing resources."""
+        failure = TemplateSyntaxError("unexpected template token", 1)
+        catalog = MagicMock()
+        catalog.render.side_effect = failure
+        monkeypatch.setattr(PromptCatalog, "current", MagicMock(return_value=catalog))
+        coordinator_factory, github_factory = self._stub_pipeline_runtime(monkeypatch)
+
+        with pytest.raises(TemplateSyntaxError) as exc_info:
+            run_pipeline(PipelineConfig(org="org", repos=["repo"], projects_dir=tmp_path))
+
+        assert exc_info.value is failure
+        github_factory.assert_not_called()
+        coordinator_factory.assert_not_called()
 
     def test_explicit_repo_root_reaches_context_and_scoped_accessor(self, tmp_path: Path) -> None:
         """A noncanonical checkout stays authoritative throughout coordinator wiring."""


### PR DESCRIPTION
## Summary
Verdict: IMPLEMENTED — verification incomplete | Reason: focused tests, package builds, lint, and mypy pass; full `tests/` run hit the terminal’s 60-second cap.

- Added pre-dispatch prompt preflight: `coordinator.py:187`, invoked at `coordinator.py:1818`.
- Added empty-tree, loader-error, and syntax-error regressions: `test_coordinator_edges.py:166`.
- Verified exact `.j2` inclusion in sdist and wheel.
- Passed: focused tests (884), artifact tests, Ruff, mypy.

## Changes
See the PR diff for the full change set.

## Testing
uv run pytest tests/unit -q

## Closes
Closes #2283

Generated by Hephaestus automation
