### PR TITLE
File-overlap admission gate livelocks: hot-file issues never progress (no starvation escape)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -906,6 +906,11 @@ Architectural contract:
 - Implementation never writes `state:implementation-go`.
 - Missing approval returns to plan review; unsafe or exhausted work terminates
   without approval.
+- When parallel file-overlap serialization is enabled, dependency order remains
+  authoritative while repeated overlap deferrals raise an item's priority among
+  dependency-ready peers. The selected plan-file snapshot is retained for the
+  full implementation-stage lifetime, across worktree, agent, test, and push
+  jobs; serial and overlap-opt-out modes perform no claim lookup or tracking.
 
 ### 5.5 PR review
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -906,11 +906,14 @@ Architectural contract:
 - Implementation never writes `state:implementation-go`.
 - Missing approval returns to plan review; unsafe or exhausted work terminates
   without approval.
-- When parallel file-overlap serialization is enabled, dependency order remains
-  authoritative while repeated overlap deferrals raise an item's priority among
-  dependency-ready peers. The selected plan-file snapshot is retained for the
-  full implementation-stage lifetime, across worktree, agent, test, and push
-  jobs; serial and overlap-opt-out modes perform no claim lookup or tracking.
+- When parallel file-overlap serialization is enabled, normal-item dependency
+  order remains authoritative while repeated overlap deferrals raise priority.
+  Cross-repo same-number items are interleaved with normal items by that age
+  through one repo-scoped claim selector; this never lets a normal dependent
+  overtake its prerequisite. The selected plan-file snapshot is retained for
+  the full implementation-stage lifetime, across worktree, agent, test, and
+  push jobs; serial and overlap-opt-out modes perform no claim lookup or
+  tracking.
 
 ### 5.5 PR review
 

--- a/hephaestus/automation/dependency_resolver.py
+++ b/hephaestus/automation/dependency_resolver.py
@@ -24,6 +24,7 @@ stage too — see ``IssueImplementer.run`` for the canonical call shape.
 import logging
 import re
 from collections import defaultdict, deque
+from heapq import heapify, heappop, heappush
 
 from .github_api import fetch_issue_info, gh_issue_json, prefetch_issue_states
 from .models import DependencyGraph, IssueInfo, IssueState
@@ -337,6 +338,10 @@ class DependencyResolver:
     def topological_sort(self) -> list[int]:
         """Perform topological sort of the dependency graph.
 
+        Among valid topological orders, retain ``add_issue`` order as a stable
+        priority. A newly ready issue therefore reclaims its original priority
+        ahead of lower-priority ready peers.
+
         Returns:
             List of issue numbers in topological order
 
@@ -361,23 +366,29 @@ class DependencyResolver:
                 reverse_deps[dep].append(issue_num)
                 in_degree[issue_num] += 1
 
-        # Find all nodes with in-degree 0 (no dependencies)
-        queue: deque[int] = deque()
-        for issue_num in self.graph.issues:
-            if in_degree[issue_num] == 0:
-                queue.append(issue_num)
+        # Keep source insertion order as the tie-breaker at every Kahn step.
+        # A FIFO queue only observes that priority once: a dependent that
+        # becomes ready after a lower-priority peer is queued would otherwise
+        # run behind it.
+        priority = {issue_num: index for index, issue_num in enumerate(self.graph.issues)}
+        ready = [
+            (priority[issue_num], issue_num)
+            for issue_num in self.graph.issues
+            if not in_degree[issue_num]
+        ]
+        heapify(ready)
 
         result: list[int] = []
 
-        while queue:
-            node = queue.popleft()
+        while ready:
+            _, node = heappop(ready)
             result.append(node)
 
             # Process all issues that depend on this node (O(1) lookup now)
             for dependent in reverse_deps[node]:
                 in_degree[dependent] -= 1
                 if in_degree[dependent] == 0:
-                    queue.append(dependent)
+                    heappush(ready, (priority[dependent], dependent))
 
         if len(result) != len(self.graph.issues):
             raise CyclicDependencyError("Graph contains cycles")

--- a/hephaestus/automation/pipeline/admission.py
+++ b/hephaestus/automation/pipeline/admission.py
@@ -33,12 +33,11 @@ from hephaestus.automation.github_api import (
     is_issue_closed,
     prefetch_issue_states,
 )
+from hephaestus.automation.models import IssueInfo
 from hephaestus.automation.review_journal import is_plan_comment
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-
-    from hephaestus.automation.models import IssueInfo
 
 LOG = logging.getLogger(__name__)
 
@@ -205,13 +204,20 @@ def order_for_implementation(issue_infos: Sequence[IssueInfo]) -> list[int]:
 
     """
     in_set = {info.number for info in issue_infos}
+    queued_infos = [
+        IssueInfo(
+            number=info.number,
+            title=info.title,
+            dependencies=[dep for dep in info.dependencies if dep in in_set],
+        )
+        for info in issue_infos
+    ]
     resolver = DependencyResolver(skip_closed=False)
-    for info in issue_infos:
+    for info in queued_infos:
         resolver.add_issue(info)
-    for info in issue_infos:
+    for info in queued_infos:
         for dep in info.dependencies:
-            if dep in in_set:
-                resolver.add_dependency(info.number, dep)
+            resolver.add_dependency(info.number, dep)
     try:
         return resolver.topological_sort()
     except CyclicDependencyError:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -30,7 +30,7 @@ poisoned item routes to finished(fail) and never kills the loop.
 Admission control: per-repo in-flight cap (= ``max_workers``), and the
 implementation queue is additionally gated by dependency topological order
 (:func:`~.admission.order_for_implementation`) and file-overlap serialization
-(:func:`~.admission._select_non_overlapping`). Pool size =
+through the coordinator's shared repo-scoped admission pass. Pool size =
 ``parallel_repos x max_workers``.
 
 ### ``--phase-timeout`` queue semantics
@@ -1715,11 +1715,12 @@ class Coordinator:
     def _drain_implementation(self) -> None:
         """Drain the implementation queue under topo order + file-overlap gating.
 
-        REUSES :func:`admission.order_for_implementation` (dependencies
-        first) and :func:`admission._select_non_overlapping` (defer plans
-        touching the same files while a peer is queued or already executing,
-        #1623/#2451 — only engaged when real parallelism is possible,
-        mirroring the legacy ``serialize_file_overlap`` gate).
+        REUSES :func:`admission.order_for_implementation` for dependency-safe
+        normal-item ordering, then applies one age-prioritized, repo-scoped
+        file-overlap admission pass to both normal and cross-repo
+        same-number items. The overlap gate is engaged only when real
+        parallelism is possible (#1623/#2451), mirroring the legacy
+        ``serialize_file_overlap`` gate.
 
         The queue is STAGE-keyed, so one drain round can hold issues from
         several repos (#1795), and dependency ordering runs across the whole
@@ -1772,7 +1773,14 @@ class Coordinator:
     def _select_implementation_dispatch(
         self, items: list[WorkItem]
     ) -> tuple[list[WorkItem], dict[int, set[_admission.PlanFileClaim]]]:
-        """Order queued work and reserve immutable snapshots for this drain."""
+        """Order queued work and reserve immutable snapshots for this drain.
+
+        Normal items keep their dependency-safe topological order. Ambiguous
+        cross-repo same-number items have no safe number-keyed dependency
+        representation, so they interleave with that normal sequence by
+        deferral age. The common overlap selector then gives every candidate
+        identical repo-scoped claim, snapshot, deferral, and warning behavior.
+        """
         issue_items, ambiguous = self._index_issue_items(items)
         infos = [
             IssueInfo(
@@ -1792,47 +1800,14 @@ class Coordinator:
             reverse=True,
         )
         ordered = _admission.order_for_implementation(infos)
-        dispatch = ordered
-        selected_claims: dict[int, set[_admission.PlanFileClaim]] = {}
-        if self._overlap_serialization_enabled() and ordered:
-            # Resolve each issue's owning repo from its own WorkItem: the queue is
-            # keyed by stage, so one round can hold issues from several repos (#1795).
-            repo_of = {
-                number: (self.config.org, item.repo)
-                for number, item in issue_items.items()
-                if item.repo
-            }
-            inflight_claims = self._active_implementation_file_claims()
-            selection_kwargs: dict[str, Any] = {
-                "repo_of": repo_of,
-                "selected_claims": selected_claims,
-            }
-            if inflight_claims:
-                selection_kwargs["initial_claims"] = inflight_claims
-            dispatch, deferred = _admission._select_non_overlapping(ordered, **selection_kwargs)
-            for number in deferred:
-                self._record_file_overlap_deferral(issue_items[number], f"#{number}")
-        dispatch_items = [issue_items[number] for number in dispatch]
-        submission_claims = {
-            id(issue_items[number]): set(claims) for number, claims in selected_claims.items()
-        }
-        # Cross-repo same-number items bypass only the number-keyed dependency
-        # ordering.  They still need their own repo-scoped overlap admission;
-        # otherwise a same-number collision could evade active reservations.
-        if self._overlap_serialization_enabled():
-            claimed = self._active_implementation_file_claims()
-            for claims in selected_claims.values():
-                claimed.update(claims)
-            ambiguous_items, ambiguous_claims = self._select_ambiguous_implementation_items(
-                ambiguous, claimed
-            )
-            dispatch_items.extend(ambiguous_items)
-            submission_claims.update(ambiguous_claims)
-        else:
+        normal_items = [issue_items[number] for number in ordered]
+        ambiguous_items = [item for group in ambiguous.values() for item in group]
+        if not self._overlap_serialization_enabled():
             # Cross-repo same-number items are distinct work even though the
             # shared issue-number dependency model cannot rank them (#2057).
-            dispatch_items.extend(it for group in ambiguous.values() for it in group)
-        return dispatch_items, submission_claims
+            return [*normal_items, *ambiguous_items], {}
+        candidates = self._merge_implementation_admission_priority(normal_items, ambiguous_items)
+        return self._select_file_overlap_implementation_items(candidates)
 
     def _overlap_serialization_enabled(self) -> bool:
         """Return whether this run needs parallel file-overlap reservations."""
@@ -1852,6 +1827,79 @@ class Coordinator:
             deferrals,
             _FILE_OVERLAP_WARNING_THRESHOLD,
         )
+
+    @staticmethod
+    def _file_overlap_deferral_age(item: WorkItem) -> int:
+        """Return an item's current overlap-deferral age for stable priority."""
+        return int(item.payload.get(_FILE_OVERLAP_DEFERRALS_KEY, 0))
+
+    def _merge_implementation_admission_priority(
+        self,
+        normal_items: list[WorkItem],
+        ambiguous_items: list[WorkItem],
+    ) -> list[tuple[WorkItem, str]]:
+        """Merge normal and ambiguous candidates without reversing dependencies.
+
+        ``normal_items`` is already dependency-safe, so its relative order is
+        immutable. Ambiguous items are independent of the number-keyed graph;
+        stable age ordering lets an aged one run before a younger normal peer
+        without allowing any normal dependent to overtake its prerequisite.
+        Equal ages retain the historical normal-before-ambiguous order.
+        """
+        ambiguous_by_age = sorted(
+            ambiguous_items,
+            key=self._file_overlap_deferral_age,
+            reverse=True,
+        )
+        normal_index = 0
+        ambiguous_index = 0
+        candidates: list[tuple[WorkItem, str]] = []
+        while normal_index < len(normal_items) or ambiguous_index < len(ambiguous_by_age):
+            if ambiguous_index >= len(ambiguous_by_age):
+                item = normal_items[normal_index]
+                candidates.append((item, f"#{item.issue}"))
+                normal_index += 1
+                continue
+            if normal_index >= len(normal_items):
+                item = ambiguous_by_age[ambiguous_index]
+                candidates.append((item, f"{item.repo}#{item.issue}"))
+                ambiguous_index += 1
+                continue
+            normal_item = normal_items[normal_index]
+            ambiguous_item = ambiguous_by_age[ambiguous_index]
+            if self._file_overlap_deferral_age(normal_item) >= self._file_overlap_deferral_age(
+                ambiguous_item
+            ):
+                candidates.append((normal_item, f"#{normal_item.issue}"))
+                normal_index += 1
+            else:
+                candidates.append((ambiguous_item, f"{ambiguous_item.repo}#{ambiguous_item.issue}"))
+                ambiguous_index += 1
+        return candidates
+
+    def _select_file_overlap_implementation_items(
+        self,
+        candidates: list[tuple[WorkItem, str]],
+    ) -> tuple[list[WorkItem], dict[int, set[_admission.PlanFileClaim]]]:
+        """Apply one repo-scoped overlap safety rule to every candidate class."""
+        claimed = self._active_implementation_file_claims()
+        dispatch: list[WorkItem] = []
+        snapshots: dict[int, set[_admission.PlanFileClaim]] = {}
+        for item, identity in candidates:
+            if item.issue is None:  # defensive: candidate construction excludes this case
+                continue
+            repo = (self.config.org, item.repo)
+            planned = _admission._fetch_planned_files(item.issue, repo=repo)
+            item_claims = {(repo, path) for path in planned} if planned else set()
+            if item_claims and (item_claims & claimed):
+                self._record_file_overlap_deferral(item, identity)
+                continue
+            claimed.update(item_claims)
+            # Preserve an empty snapshot too: unknown plans fail open, but
+            # must not be fetched again after being admitted.
+            snapshots[id(item)] = set(item_claims)
+            dispatch.append(item)
+        return dispatch, snapshots
 
     @staticmethod
     def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
@@ -1876,36 +1924,6 @@ class Coordinator:
         for active_claims in self._inflight_implementation_claims.values():
             claims.update(active_claims)
         return claims
-
-    def _select_ambiguous_implementation_items(
-        self,
-        ambiguous: dict[int, list[WorkItem]],
-        claimed: set[_admission.PlanFileClaim],
-    ) -> tuple[list[WorkItem], dict[int, set[_admission.PlanFileClaim]]]:
-        """Apply file-overlap admission to cross-repo same-number items.
-
-        Dependency order cannot represent these items under its number-only
-        keys, but file paths are repository-scoped and must still honour both
-        active reservations and earlier selections from this drain.
-        """
-        dispatch: list[WorkItem] = []
-        snapshots: dict[int, set[_admission.PlanFileClaim]] = {}
-        for group in ambiguous.values():
-            for item in group:
-                if item.issue is None:  # defensive: index construction excludes this case
-                    continue
-                repo = (self.config.org, item.repo)
-                planned = _admission._fetch_planned_files(item.issue, repo=repo)
-                item_claims = {(repo, path) for path in planned} if planned else set()
-                if item_claims and (item_claims & claimed):
-                    self._record_file_overlap_deferral(item, f"{item.repo}#{item.issue}")
-                    continue
-                claimed.update(item_claims)
-                # Preserve an empty snapshot too: unknown plans fail open,
-                # but must not be fetched again after being admitted.
-                snapshots[id(item)] = set(item_claims)
-                dispatch.append(item)
-        return dispatch, snapshots
 
     def _capture_implementation_file_claims(self, item: WorkItem) -> set[_admission.PlanFileClaim]:
         """Return the immutable claims reserved for an implementation sub-job.

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -171,9 +171,15 @@ _IDLE_POLL_S = 1.0
 _STALL_TICKS_BEFORE_FORCE = 3
 
 # Host-owned work-item payload key for the immutable plan-file snapshot that
-# admitted a queued implementation job.  It is consumed at submission and is
-# never sourced from GitHub content.
+# admitted a queued implementation item. It is retained for the whole
+# implementation-stage lifetime and is never sourced from GitHub content.
 _IMPLEMENTATION_FILE_CLAIMS_PAYLOAD = "_implementation_file_claims"
+
+#: WorkItem payload key holding consecutive file-overlap deferrals.
+_FILE_OVERLAP_DEFERRALS_KEY = "file_overlap_deferrals"
+
+#: Deferral counts strictly above this value are logged as warnings.
+_FILE_OVERLAP_WARNING_THRESHOLD = 10
 
 #: Upper bound on Continue-transitions per _run_item call (defensive: a stage
 #: that never yields a JobRequest/StageOutcome would otherwise spin forever).
@@ -549,6 +555,11 @@ class Coordinator:
         # claims for the lifetime of the submitted job.  Never reconstruct
         # this from mutable issue comments during later drain rounds (#2451).
         self._inflight_implementation_claims: dict[JobHandle, set[_admission.PlanFileClaim]] = {}
+        # An admission snapshot belongs to the WorkItem, not one of its
+        # worktree/agent/test/push jobs. Keeping it for the whole
+        # implementation stage prevents a later sub-job from re-fetching a
+        # mutable plan and changing the reservation that admitted this work.
+        self._implementation_file_claims: dict[int, set[_admission.PlanFileClaim]] = {}
         self.inflight_per_repo: Counter[str] = Counter()
         # A normal (non-implementation) drain claims instead of popping.  The
         # active lease reserves its source capacity while an item executes or
@@ -1121,6 +1132,7 @@ class Coordinator:
         result: ItemResult | None,
     ) -> None:
         """Publish a route only after its destination accepted the item."""
+        self._clear_implementation_file_claims_on_exit(item, target)
         item.stage = target
         if enter:
             item.state = "ENTER"
@@ -1742,11 +1754,6 @@ class Coordinator:
                 return
 
         items = q.snapshot()
-        # A snapshot belongs only to the drain that selected it.  Anything
-        # still queued after an admission/capacity deferral is re-evaluated on
-        # its next drain, rather than carrying an unsubmitted old reservation.
-        for queued_item in items:
-            queued_item.payload.pop(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD, None)
         dispatch_items, submission_claims = self._select_implementation_dispatch(items)
         for item in dispatch_items:
             if self.shutdown.is_set() or not self._admit(item):
@@ -1758,6 +1765,7 @@ class Coordinator:
             # it must not change the reservation that made this item eligible.
             if (claims := submission_claims.get(id(item))) is not None:
                 item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(claims)
+            item.payload.pop(_FILE_OVERLAP_DEFERRALS_KEY, None)
             self._record_event("drain", StageName.IMPLEMENTATION.value, self._item_key(item))
             self._run_item(item)
 
@@ -1774,10 +1782,19 @@ class Coordinator:
             )
             for number, item in issue_items.items()
         ]
+        # Stable sorting gives age its input priority. The priority-ready topo
+        # traversal preserves it whenever a dependent becomes ready, while
+        # still enforcing every in-queue dependency edge.
+        infos.sort(
+            key=lambda info: int(
+                issue_items[info.number].payload.get(_FILE_OVERLAP_DEFERRALS_KEY, 0)
+            ),
+            reverse=True,
+        )
         ordered = _admission.order_for_implementation(infos)
         dispatch = ordered
         selected_claims: dict[int, set[_admission.PlanFileClaim]] = {}
-        if self.config.serialize_file_overlap and self.config.max_workers > 1 and ordered:
+        if self._overlap_serialization_enabled() and ordered:
             # Resolve each issue's owning repo from its own WorkItem: the queue is
             # keyed by stage, so one round can hold issues from several repos (#1795).
             repo_of = {
@@ -1794,7 +1811,18 @@ class Coordinator:
                 selection_kwargs["initial_claims"] = inflight_claims
             dispatch, deferred = _admission._select_non_overlapping(ordered, **selection_kwargs)
             for number in deferred:
-                logger.info("implementation #%s deferred (file overlap)", number)
+                item = issue_items[number]
+                deferrals = int(item.payload.get(_FILE_OVERLAP_DEFERRALS_KEY, 0)) + 1
+                item.payload[_FILE_OVERLAP_DEFERRALS_KEY] = deferrals
+                log_deferral = (
+                    logger.warning if deferrals > _FILE_OVERLAP_WARNING_THRESHOLD else logger.info
+                )
+                log_deferral(
+                    "implementation #%s deferred (file overlap); deferrals=%s threshold=%s",
+                    number,
+                    deferrals,
+                    _FILE_OVERLAP_WARNING_THRESHOLD,
+                )
         dispatch_items = [issue_items[number] for number in dispatch]
         submission_claims = {
             id(issue_items[number]): set(claims) for number, claims in selected_claims.items()
@@ -1802,7 +1830,7 @@ class Coordinator:
         # Cross-repo same-number items bypass only the number-keyed dependency
         # ordering.  They still need their own repo-scoped overlap admission;
         # otherwise a same-number collision could evade active reservations.
-        if self.config.serialize_file_overlap and self.config.max_workers > 1:
+        if self._overlap_serialization_enabled():
             claimed = self._active_implementation_file_claims()
             for claims in selected_claims.values():
                 claimed.update(claims)
@@ -1816,6 +1844,10 @@ class Coordinator:
             # shared issue-number dependency model cannot rank them (#2057).
             dispatch_items.extend(it for group in ambiguous.values() for it in group)
         return dispatch_items, submission_claims
+
+    def _overlap_serialization_enabled(self) -> bool:
+        """Return whether this run needs parallel file-overlap reservations."""
+        return self.config.serialize_file_overlap and self.config.max_workers > 1
 
     @staticmethod
     def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
@@ -1833,8 +1865,10 @@ class Coordinator:
         return duplicates
 
     def _active_implementation_file_claims(self) -> set[_admission.PlanFileClaim]:
-        """Return the immutable plan claims held by active implementation jobs."""
+        """Return immutable plan claims held for active implementation work."""
         claims: set[_admission.PlanFileClaim] = set()
+        for item_claims in self._implementation_file_claims.values():
+            claims.update(item_claims)
         for active_claims in self._inflight_implementation_claims.values():
             claims.update(active_claims)
         return claims
@@ -1872,20 +1906,38 @@ class Coordinator:
         return dispatch, snapshots
 
     def _capture_implementation_file_claims(self, item: WorkItem) -> set[_admission.PlanFileClaim]:
-        """Return the immutable claims reserved for an implementation submission.
+        """Return the immutable claims reserved for an implementation sub-job.
 
         The parallel admission gate places its exact selection snapshot in the
-        host-owned payload.  Serial and overlap-opt-out submissions retain the
-        established one-time, fail-open lookup behavior.
+        host-owned payload. It stays with the WorkItem for every sub-job in
+        the implementation stage. Serial and overlap-opt-out modes do not
+        fetch or reserve claims because admission intentionally skips overlap
+        serialization in those configurations.
         """
-        if item.stage is not StageName.IMPLEMENTATION or item.issue is None:
+        if (
+            item.stage is not StageName.IMPLEMENTATION
+            or item.issue is None
+            or not self._overlap_serialization_enabled()
+        ):
             return set()
-        selected = item.payload.pop(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD, None)
-        if selected is not None:
-            return set(selected)
-        repo = (self.config.org, item.repo)
-        planned = _admission._fetch_planned_files(item.issue, repo=repo)
-        return {(repo, path) for path in planned} if planned else set()
+        item_id = id(item)
+        selected = self._implementation_file_claims.get(item_id)
+        if selected is None:
+            payload_claims = item.payload.get(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD)
+            if payload_claims is None:
+                repo = (self.config.org, item.repo)
+                planned = _admission._fetch_planned_files(item.issue, repo=repo)
+                payload_claims = {(repo, path) for path in planned} if planned else set()
+            selected = set(payload_claims)
+            self._implementation_file_claims[item_id] = selected
+            item.payload[_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD] = set(selected)
+        return set(selected)
+
+    def _clear_implementation_file_claims_on_exit(self, item: WorkItem, target: StageName) -> None:
+        """Drop a stage-scoped snapshot only after implementation really exits."""
+        if item.stage is StageName.IMPLEMENTATION and target is not StageName.IMPLEMENTATION:
+            self._implementation_file_claims.pop(id(item), None)
+            item.payload.pop(_IMPLEMENTATION_FILE_CLAIMS_PAYLOAD, None)
 
     def _claim_selected_implementation_item(self, item: WorkItem) -> bool:
         """Claim *item* at its current position, preserving FIFO retry order."""
@@ -2432,6 +2484,7 @@ class Coordinator:
             if defer_if_full:
                 return False
             raise OverflowError("StageQueue is full")
+        self._clear_implementation_file_claims_on_exit(item, stage)
         item.stage = stage
         if enter:
             item.state = "ENTER"
@@ -3071,6 +3124,7 @@ class Coordinator:
             self._park_resumable(item)
         self.in_flight.clear()
         self._inflight_implementation_claims.clear()
+        self._implementation_file_claims.clear()
         self.inflight_per_repo.clear()
 
     def _finalize_resumable(self) -> None:

--- a/hephaestus/automation/pipeline/coordinator.py
+++ b/hephaestus/automation/pipeline/coordinator.py
@@ -1811,18 +1811,7 @@ class Coordinator:
                 selection_kwargs["initial_claims"] = inflight_claims
             dispatch, deferred = _admission._select_non_overlapping(ordered, **selection_kwargs)
             for number in deferred:
-                item = issue_items[number]
-                deferrals = int(item.payload.get(_FILE_OVERLAP_DEFERRALS_KEY, 0)) + 1
-                item.payload[_FILE_OVERLAP_DEFERRALS_KEY] = deferrals
-                log_deferral = (
-                    logger.warning if deferrals > _FILE_OVERLAP_WARNING_THRESHOLD else logger.info
-                )
-                log_deferral(
-                    "implementation #%s deferred (file overlap); deferrals=%s threshold=%s",
-                    number,
-                    deferrals,
-                    _FILE_OVERLAP_WARNING_THRESHOLD,
-                )
+                self._record_file_overlap_deferral(issue_items[number], f"#{number}")
         dispatch_items = [issue_items[number] for number in dispatch]
         submission_claims = {
             id(issue_items[number]): set(claims) for number, claims in selected_claims.items()
@@ -1848,6 +1837,21 @@ class Coordinator:
     def _overlap_serialization_enabled(self) -> bool:
         """Return whether this run needs parallel file-overlap reservations."""
         return self.config.serialize_file_overlap and self.config.max_workers > 1
+
+    @staticmethod
+    def _record_file_overlap_deferral(item: WorkItem, identity: str) -> None:
+        """Age a deferred implementation item and report persistent contention."""
+        deferrals = int(item.payload.get(_FILE_OVERLAP_DEFERRALS_KEY, 0)) + 1
+        item.payload[_FILE_OVERLAP_DEFERRALS_KEY] = deferrals
+        log_deferral = (
+            logger.warning if deferrals > _FILE_OVERLAP_WARNING_THRESHOLD else logger.info
+        )
+        log_deferral(
+            "implementation %s deferred (file overlap); deferrals=%s threshold=%s",
+            identity,
+            deferrals,
+            _FILE_OVERLAP_WARNING_THRESHOLD,
+        )
 
     @staticmethod
     def _implementation_duplicates(items: list[WorkItem]) -> list[WorkItem]:
@@ -1894,9 +1898,7 @@ class Coordinator:
                 planned = _admission._fetch_planned_files(item.issue, repo=repo)
                 item_claims = {(repo, path) for path in planned} if planned else set()
                 if item_claims and (item_claims & claimed):
-                    logger.info(
-                        "implementation %s#%s deferred (file overlap)", item.repo, item.issue
-                    )
+                    self._record_file_overlap_deferral(item, f"{item.repo}#{item.issue}")
                     continue
                 claimed.update(item_claims)
                 # Preserve an empty snapshot too: unknown plans fail open,

--- a/tests/unit/automation/pipeline/test_admission.py
+++ b/tests/unit/automation/pipeline/test_admission.py
@@ -316,11 +316,13 @@ class TestOrderForImplementation:
         """Independent issues keep their dispatch-priority (input) order."""
         assert order_for_implementation([_info(3), _info(1), _info(2)]) == [3, 1, 2]
 
-    def test_out_of_set_dependency_ignored(self) -> None:
-        """A dependency outside the implementation queue is dropped (fail-open)."""
+    def test_out_of_set_dependency_ignored(self, caplog: pytest.LogCaptureFixture) -> None:
+        """An absent dependency cannot create a false cycle or reorder queued work."""
         # #5 depends on #999 which is not admitted — #5 must still be ordered.
-        order = order_for_implementation([_info(5, dependencies=[999]), _info(6)])
-        assert sorted(order) == [5, 6]
+        with caplog.at_level(logging.WARNING, logger="hephaestus.automation.pipeline.admission"):
+            order = order_for_implementation([_info(5, dependencies=[999]), _info(6)])
+        assert order == [5, 6]
+        assert not any("dependency cycle" in record.message for record in caplog.records)
 
     def test_chain_fully_ordered(self) -> None:
         """A → B → C chain sorts leaf-dependency first."""
@@ -328,6 +330,11 @@ class TestOrderForImplementation:
             [_info(1, dependencies=[2]), _info(2, dependencies=[3]), _info(3)]
         )
         assert order == [3, 2, 1]
+
+    def test_newly_ready_input_priority_precedes_lower_priority_peer(self) -> None:
+        """A newly ready high-priority dependent is not stranded behind a peer."""
+        order = order_for_implementation([_info(1, dependencies=[2]), _info(2), _info(3)])
+        assert order == [2, 1, 3]
 
     def test_cycle_falls_open_to_input_order(self, caplog: pytest.LogCaptureFixture) -> None:
         """A dependency cycle keeps input order and warns (never wedges the queue)."""

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1829,6 +1829,100 @@ class TestImplementationAdmission:
         assert run_repos == ["repo-b"]
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [repo_a]
 
+    def test_ambiguous_overlap_deferral_ages_then_selects_after_claim_release(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A same-number item ages while blocked and runs when its repo claim releases."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=2
+        )
+        run_repos: list[str] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_repos.append(item.repo)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active_handle = _fake_in_flight_item(
+            coordinator,
+            _issue_item(8, StageName.IMPLEMENTATION, repo="repo-a"),
+            claimed_files={"shared.py"},
+        )
+        repo_a = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-a")
+        repo_b = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(repo_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(repo_b, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"shared.py"} if repo == ("org", "repo-a") else {"other.py"},
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_repos == ["repo-b"]
+        assert repo_a.payload["file_overlap_deferrals"] == 1
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [repo_a]
+
+        coordinator._handle_completion(active_handle, JobResult(ok=True))
+        run_repos.clear()
+        coordinator._drain_implementation()
+
+        assert run_repos == ["repo-a"]
+        assert "file_overlap_deferrals" not in repo_a.payload
+
+    @pytest.mark.parametrize(
+        ("initial_deferrals", "expected_deferrals", "expected_level"),
+        [
+            (9, 10, logging.INFO),
+            (10, 11, logging.WARNING),
+            (11, 12, logging.WARNING),
+        ],
+        ids=("10-info", "11-warning", "12-warning"),
+    )
+    def test_ambiguous_overlap_deferral_uses_normal_warning_threshold(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        initial_deferrals: int,
+        expected_deferrals: int,
+        expected_level: int,
+    ) -> None:
+        """Ambiguous overlap deferrals use the normal INFO-to-WARNING boundary."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path, monkeypatch, repos=["repo-a", "repo-b"], max_workers=2
+        )
+        _fake_in_flight_item(
+            coordinator,
+            _issue_item(8, StageName.IMPLEMENTATION, repo="repo-a"),
+            claimed_files={"shared.py"},
+        )
+        repo_a = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-a")
+        repo_a.payload["file_overlap_deferrals"] = initial_deferrals
+        repo_b = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(repo_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(repo_b, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"shared.py"} if repo == ("org", "repo-a") else {"other.py"},
+        )
+
+        with caplog.at_level(logging.INFO, logger="hephaestus.automation.pipeline.coordinator"):
+            coordinator._drain_implementation()
+
+        assert repo_a.payload["file_overlap_deferrals"] == expected_deferrals
+        matching_records = [
+            record
+            for record in caplog.records
+            if record.message
+            == (
+                "implementation repo-a#7 deferred (file overlap); "
+                f"deferrals={expected_deferrals} threshold=10"
+            )
+        ]
+        assert [record.levelno for record in matching_records] == [expected_level]
+
     def test_overlap_gate_defers_queued_work_that_conflicts_with_inflight_implementation(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1600,6 +1600,37 @@ class TestImplementationAdmission:
         # Each issue is scoped to the repo of ITS OWN WorkItem, not the ambient CWD.
         assert seen_repo_of == {21: ("org", "repo-a"), 22: ("org", "repo-b")}
 
+    def test_aged_dependent_never_overtakes_its_queued_prerequisite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Aging prioritizes ready work but never reverses an in-queue dependency."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        dependent = _issue_item(21, StageName.IMPLEMENTATION)
+        dependent.payload["dependencies"] = [22, 999]
+        dependent.payload["file_overlap_deferrals"] = 100
+        prerequisite = _issue_item(22, StageName.IMPLEMENTATION)
+        coordinator._push_item(dependent, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(prerequisite, StageName.IMPLEMENTATION, enter=True)
+        seen_order: list[int] = []
+
+        def _fake_select(
+            issues: list[int],
+            repo_of: dict[int, tuple[str, str]] | None = None,
+            **_kwargs: Any,
+        ) -> tuple[list[int], list[int]]:
+            del repo_of
+            seen_order.extend(issues)
+            return issues, []
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._select_non_overlapping",
+            _fake_select,
+        )
+
+        coordinator._drain_implementation()
+
+        assert seen_order == [22, 21]
+
     def test_overlap_gate_reuses_admission_snapshot_at_parallel_submission(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1681,6 +1712,91 @@ class TestImplementationAdmission:
         assert fetches == [21, 22]
         assert len(pool.submitted) == 2
 
+    def test_overlap_gate_reuses_snapshot_for_every_implementation_subjob(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Worktree/agent/test/push turns share one admission snapshot (#2309)."""
+        coordinator, pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+
+        class MultiJobStage:
+            completed = 0
+
+            def on_enter(self, item: WorkItem, ctx: Any) -> None:
+                del item, ctx
+                return None
+
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                del ctx
+                if self.completed < 2:
+                    return JobRequest(
+                        _agent_job(item.repo, item.issue or 0), StageName.IMPLEMENTATION
+                    )
+                return StageOutcome(Disposition.SKIP, "completed")
+
+            def on_job_done(self, item: WorkItem, result: JobResult, ctx: Any) -> None:
+                del item, result, ctx
+                self.completed += 1
+
+        coordinator.stages[StageName.IMPLEMENTATION] = MultiJobStage()
+        item = _issue_item(21, StageName.IMPLEMENTATION)
+        coordinator._push_item(item, StageName.IMPLEMENTATION, enter=True)
+        fetches: list[int] = []
+
+        def _planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str]:
+            del repo
+            fetches.append(issue)
+            if len(fetches) > 1:
+                raise AssertionError(
+                    "every implementation sub-job must reuse the admission snapshot"
+                )
+            return {"hephaestus/automation/pipeline/coordinator.py"}
+
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            _planned_files,
+        )
+
+        coordinator._drain_implementation()
+        coordinator._drain_completions()
+        coordinator._drain_completions()
+
+        assert len(pool.submitted) == 2
+        assert fetches == [21]
+        assert id(item) not in coordinator._implementation_file_claims
+        assert "_implementation_file_claims" not in item.payload
+
+    @pytest.mark.parametrize(
+        ("max_workers", "serialize_file_overlap"),
+        [(1, True), (2, False)],
+    )
+    def test_overlap_claim_capture_is_off_without_parallel_serialization(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        max_workers: int,
+        serialize_file_overlap: bool,
+    ) -> None:
+        """Disabled overlap serialization makes no per-subjob plan lookup."""
+        coordinator, pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            max_workers=max_workers,
+            serialize_file_overlap=serialize_file_overlap,
+        )
+        item = _issue_item(21, StageName.IMPLEMENTATION)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("disabled overlap serialization must not fetch plan claims")
+            ),
+        )
+
+        coordinator._submit(item, JobRequest(_agent_job(item.repo, item.issue or 0), item.stage))
+
+        assert len(pool.submitted) == 1
+        assert coordinator._implementation_file_claims == {}
+        assert coordinator._inflight_implementation_claims == {}
+
     def test_overlap_gate_checks_ambiguous_numbers_against_active_claims(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1749,6 +1865,47 @@ class TestImplementationAdmission:
         assert run_order == []
         assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [queued]
         assert fetches == [21, 22]
+
+    def test_file_overlap_aging_escapes_an_actual_inflight_conflict(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deferred hot-file issue outranks a newly queued peer once released."""
+        coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
+        run_order: list[int] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active = _issue_item(20, StageName.IMPLEMENTATION)
+        active_handle = _fake_in_flight_item(
+            coordinator,
+            active,
+            claimed_files={"hephaestus/automation/pipeline/coordinator.py"},
+        )
+        starved = _issue_item(22, StageName.IMPLEMENTATION)
+        coordinator._push_item(starved, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"hephaestus/automation/pipeline/coordinator.py"},
+        )
+
+        coordinator._drain_implementation()
+
+        assert run_order == []
+        assert starved.payload["file_overlap_deferrals"] == 1
+
+        younger = _issue_item(21, StageName.IMPLEMENTATION)
+        coordinator._push_item(younger, StageName.IMPLEMENTATION, enter=True)
+        coordinator._handle_completion(active_handle, JobResult(ok=True))
+        run_order.clear()
+        coordinator._drain_implementation()
+
+        assert run_order == [22]
+        assert "file_overlap_deferrals" not in starved.payload
+        assert younger.payload["file_overlap_deferrals"] == 1
 
     def test_overlap_gate_releases_deferred_item_after_inflight_implementation_finishes(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/automation/pipeline/test_coordinator.py
+++ b/tests/unit/automation/pipeline/test_coordinator.py
@@ -1341,8 +1341,8 @@ class TestImplementationAdmission:
         coordinator._push_item(retrying, StageName.IMPLEMENTATION, enter=True)
         coordinator._push_item(deferred, StageName.IMPLEMENTATION, enter=True)
         monkeypatch.setattr(
-            "hephaestus.automation.pipeline.admission._select_non_overlapping",
-            lambda issues, repo_of=None, **_kwargs: (issues[:1], issues[1:]),
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"shared.py"},
         )
 
         coordinator._drain_implementation()
@@ -1560,7 +1560,7 @@ class TestImplementationAdmission:
     def test_topo_order_and_overlap_reuse(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """order_for_implementation and _select_non_overlapping gate dispatch."""
+        """Dependency order leads the common repo-scoped overlap admission pass."""
         coordinator, _pool, _ = make_coordinator(tmp_path, monkeypatch, max_workers=2)
         run_order: list[int] = []
 
@@ -1571,34 +1571,27 @@ class TestImplementationAdmission:
 
         coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
         # 21 depends on 22 (payload dependency): topo order runs 22 first.
-        # Distinct repos: the implementation queue is keyed by stage, not repo,
-        # so the coordinator must resolve each issue's repo from its own item (#1795).
         item_a = _issue_item(21, StageName.IMPLEMENTATION, repo="repo-a")
         item_a.payload["dependencies"] = [22]
-        item_b = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-b")
+        item_b = _issue_item(22, StageName.IMPLEMENTATION, repo="repo-a")
         coordinator._push_item(item_a, StageName.IMPLEMENTATION, enter=True)
         coordinator._push_item(item_b, StageName.IMPLEMENTATION, enter=True)
-        seen_repo_of: dict[int, tuple[str, str]] = {}
+        seen_fetches: list[tuple[int, tuple[str, str] | None]] = []
 
-        def _fake_select(
-            issues: list[int],
-            repo_of: dict[int, tuple[str, str]] | None = None,
-            **_kwargs: Any,
-        ) -> tuple[list[int], list[int]]:
-            seen_repo_of.update(repo_of or {})
-            return issues[:1], issues[1:]  # defer everything but the first
+        def _planned_files(issue: int, repo: tuple[str, str] | None = None) -> set[str]:
+            seen_fetches.append((issue, repo))
+            return {"shared.py"}
 
         monkeypatch.setattr(
-            "hephaestus.automation.pipeline.admission._select_non_overlapping",
-            _fake_select,
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            _planned_files,
         )
 
         coordinator._drain_implementation()
 
         assert run_order == [22]  # dependency first; 21 deferred by overlap
         assert len(coordinator.queues[StageName.IMPLEMENTATION]) == 1
-        # Each issue is scoped to the repo of ITS OWN WorkItem, not the ambient CWD.
-        assert seen_repo_of == {21: ("org", "repo-a"), 22: ("org", "repo-b")}
+        assert seen_fetches == [(22, ("org", "repo-a")), (21, ("org", "repo-a"))]
 
     def test_aged_dependent_never_overtakes_its_queued_prerequisite(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1611,25 +1604,22 @@ class TestImplementationAdmission:
         prerequisite = _issue_item(22, StageName.IMPLEMENTATION)
         coordinator._push_item(dependent, StageName.IMPLEMENTATION, enter=True)
         coordinator._push_item(prerequisite, StageName.IMPLEMENTATION, enter=True)
-        seen_order: list[int] = []
+        run_order: list[int] = []
 
-        def _fake_select(
-            issues: list[int],
-            repo_of: dict[int, tuple[str, str]] | None = None,
-            **_kwargs: Any,
-        ) -> tuple[list[int], list[int]]:
-            del repo_of
-            seen_order.extend(issues)
-            return issues, []
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(item.issue or 0)
+                return StageOutcome(Disposition.SKIP, "recorded")
 
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
         monkeypatch.setattr(
-            "hephaestus.automation.pipeline.admission._select_non_overlapping",
-            _fake_select,
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda issue, repo=None: {f"planned-{issue}.py"},
         )
 
         coordinator._drain_implementation()
 
-        assert seen_order == [22, 21]
+        assert run_order == [22, 21]
 
     def test_overlap_gate_reuses_admission_snapshot_at_parallel_submission(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1870,6 +1860,65 @@ class TestImplementationAdmission:
 
         assert run_repos == ["repo-a"]
         assert "file_overlap_deferrals" not in repo_a.payload
+
+    def test_ambiguous_aged_overlap_beats_a_recurring_regular_contender(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An aged same-number item claims its file before a newly recurring regular item."""
+        coordinator, _pool, _ = make_coordinator(
+            tmp_path,
+            monkeypatch,
+            repos=["repo-a", "repo-b"],
+            max_workers=2,
+            parallel_repos=2,
+        )
+        run_order: list[str] = []
+
+        class RecordingStage(StubStage):
+            def step(self, item: WorkItem, ctx: Any) -> Any:
+                run_order.append(f"{item.repo}#{item.issue}")
+                return StageOutcome(Disposition.SKIP, "recorded")
+
+        coordinator.stages[StageName.IMPLEMENTATION] = RecordingStage()
+        active_a_handle = _fake_in_flight_item(
+            coordinator,
+            _issue_item(8, StageName.IMPLEMENTATION, repo="repo-a"),
+            claimed_files={"shared.py"},
+        )
+        _fake_in_flight_item(
+            coordinator,
+            _issue_item(6, StageName.IMPLEMENTATION, repo="repo-b"),
+            claimed_files={"other.py"},
+        )
+        ambiguous_a = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-a")
+        ambiguous_b = _issue_item(7, StageName.IMPLEMENTATION, repo="repo-b")
+        coordinator._push_item(ambiguous_a, StageName.IMPLEMENTATION, enter=True)
+        coordinator._push_item(ambiguous_b, StageName.IMPLEMENTATION, enter=True)
+        monkeypatch.setattr(
+            "hephaestus.automation.pipeline.admission._fetch_planned_files",
+            lambda _issue, repo=None: {"shared.py"} if repo == ("org", "repo-a") else {"other.py"},
+        )
+
+        coordinator._drain_implementation()
+
+        assert ambiguous_a.payload["file_overlap_deferrals"] == 1
+        assert ambiguous_b.payload["file_overlap_deferrals"] == 1
+        assert run_order == []
+
+        coordinator._handle_completion(active_a_handle, JobResult(ok=True))
+        recurring_regular = _issue_item(9, StageName.IMPLEMENTATION, repo="repo-a")
+        coordinator._push_item(recurring_regular, StageName.IMPLEMENTATION, enter=True)
+        run_order.clear()
+        coordinator._drain_implementation()
+
+        assert run_order == ["repo-a#7"]
+        assert "file_overlap_deferrals" not in ambiguous_a.payload
+        assert ambiguous_b.payload["file_overlap_deferrals"] == 2
+        assert recurring_regular.payload["file_overlap_deferrals"] == 1
+        assert coordinator.queues[StageName.IMPLEMENTATION].snapshot() == [
+            ambiguous_b,
+            recurring_regular,
+        ]
 
     @pytest.mark.parametrize(
         ("initial_deferrals", "expected_deferrals", "expected_level"),
@@ -2120,11 +2169,6 @@ class TestImplementationAdmission:
         item_b = _issue_item(22, StageName.IMPLEMENTATION)
         coordinator._push_item(item_a, StageName.IMPLEMENTATION, enter=True)
         coordinator._push_item(item_b, StageName.IMPLEMENTATION, enter=True)
-        monkeypatch.setattr(
-            "hephaestus.automation.pipeline.admission._select_non_overlapping",
-            lambda issues: (_ for _ in ()).throw(AssertionError("should not serialize overlap")),
-        )
-
         coordinator._drain_implementation()
 
         assert run_order == [21, 22]


### PR DESCRIPTION
## Summary

Rebased and rebuilt the #2309 admission-starvation fix on current `main`. It preserves immutable implementation claims across the full stage lifecycle, orders ready work with age-aware dependency traversal, and avoids claim reads when overlap serialization is disabled.

## Testing

- `uv run pytest tests/unit -qq` — 6,647 passed, 24 skipped; 84.90% coverage
- `uv run --all-extras --locked pytest -q` — 7,071 passed, 6 skipped, 5 deselected; 85.06% coverage
- `uv run ruff check hephaestus tests`
- `uv run mypy hephaestus/ scripts/ tests/`

Closes #2309